### PR TITLE
[codex] Complete soularr.py ctx cleanup and split

### DIFF
--- a/lib/browse.py
+++ b/lib/browse.py
@@ -1,0 +1,129 @@
+"""Directory browsing and file filtering helpers for Soularr."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.config import SoularrConfig
+    from soularr import SlskdDirectory
+
+
+logger = logging.getLogger("soularr")
+
+
+def download_filter(
+    allowed_filetype: str,
+    directory: SlskdDirectory,
+    download_cfg: SoularrConfig,
+) -> SlskdDirectory:
+    """Return a filtered directory listing without mutating the input."""
+    logging.debug("download_filtering")
+    if download_cfg.download_filtering:
+        from lib.quality import parse_filetype_config, AUDIO_EXTENSIONS as _all_audio
+
+        spec = parse_filetype_config(allowed_filetype)
+        whitelist = []
+        if download_cfg.use_extension_whitelist:
+            whitelist = list(download_cfg.extensions_whitelist)
+        if spec.extension == "*":
+            whitelist.extend(_all_audio)
+        else:
+            whitelist.append(spec.extension)
+        unwanted = []
+        logger.debug(f"Accepted extensions: {whitelist}")
+        for file in directory["files"]:
+            for extension in whitelist:
+                if file["filename"].split(".")[-1].lower() == extension.lower():
+                    break
+            else:
+                unwanted.append(file["filename"])
+                logger.debug(f"Unwanted file: {file['filename']}")
+        if len(unwanted) > 0:
+            temp = []
+            logger.debug(f"Unwanted Files: {unwanted}")
+            for file in directory["files"]:
+                if file["filename"] not in unwanted:
+                    logger.debug(f"Added file to queue: {file['filename']}")
+                    temp.append(file)
+            for files in temp:
+                logger.debug(f"File in final list: {files['filename']}")
+            return {**directory, "files": temp}
+    return directory
+
+
+_PENALTY_KEYWORDS = (
+    "archive", "best of", "greatest hits", "magazine", "compilation",
+    "singles", "soundtrack", "various", "bootleg", "discography",
+)
+
+
+def rank_candidate_dirs(
+    file_dirs: list[str], album_title: str, artist_name: str
+) -> list[str]:
+    """Sort candidate directories by likelihood of being the correct album."""
+    title_lower = album_title.lower()
+    artist_lower = artist_name.lower()
+
+    def _score(d: str) -> int:
+        d_lower = d.lower()
+        score = 0
+        if title_lower in d_lower:
+            score += 2
+        if artist_lower in d_lower:
+            score += 1
+        for kw in _PENALTY_KEYWORDS:
+            if kw in d_lower:
+                score -= 3
+                break
+        return score
+
+    return sorted(file_dirs, key=_score, reverse=True)
+
+
+def _browse_one(
+    username: str,
+    file_dir: str,
+    slskd_client: Any,
+) -> tuple[str, Any | None]:
+    """Browse a single directory from slskd."""
+    try:
+        directory = slskd_client.users.directory(
+            username=username,
+            directory=file_dir,
+        )[0]
+        return file_dir, directory
+    except Exception:
+        logger.exception(f'Error getting directory from user: "{username}"')
+        return file_dir, None
+
+
+def _browse_directories(
+    dirs_to_browse: list[str],
+    username: str,
+    slskd_client: Any,
+    max_workers: int = 4,
+) -> dict[str, Any]:
+    """Browse multiple directories in parallel."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    if not dirs_to_browse:
+        return {}
+
+    if len(dirs_to_browse) == 1:
+        file_dir, result = _browse_one(username, dirs_to_browse[0], slskd_client)
+        return {file_dir: result} if result is not None else {}
+
+    results: dict[str, Any] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(_browse_one, username, d, slskd_client): d
+            for d in dirs_to_browse
+        }
+        for future in as_completed(futures):
+            file_dir, result = future.result()
+            if result is not None:
+                results[file_dir] = result
+
+    return results

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -1,0 +1,414 @@
+"""Release selection and enqueue helpers extracted from soularr.py."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Sequence, cast
+
+from lib.browse import download_filter
+from lib.download import cancel_and_delete, slskd_do_enqueue
+from lib.grab_list import GrabListEntry
+from lib.matching import check_for_match, get_album_by_id
+
+if TYPE_CHECKING:
+    from soularr import SlskdDirectory, TrackRecord
+    from lib.config import SoularrConfig
+    from lib.context import SoularrContext
+
+
+logger = logging.getLogger("soularr")
+
+
+def release_trackcount_mode(releases: list[Any]) -> Any:
+    """Return the most common track count among candidate releases."""
+    track_count: dict[Any, int] = {}
+
+    for release in releases:
+        trackcount = release.track_count
+        if trackcount in track_count:
+            track_count[trackcount] += 1
+        else:
+            track_count[trackcount] = 1
+
+    most_common_trackcount = None
+    max_count = 0
+
+    for trackcount, count in track_count.items():
+        if count > max_count:
+            max_count = count
+            most_common_trackcount = trackcount
+
+    return most_common_trackcount
+
+
+def choose_release(
+    artist_name: str,
+    releases: list[Any],
+    release_cfg: SoularrConfig,
+) -> Any:
+    """Choose the best release candidate to try first."""
+    most_common_trackcount = release_trackcount_mode(releases)
+
+    for release in releases:
+        if not release.monitored:
+            continue
+        country = release.country[0] if release.country else None
+        if release.format[1] == "x" and release_cfg.allow_multi_disc:
+            format_accepted = (
+                release.format.split("x", 1)[1] in release_cfg.accepted_formats
+            )
+        else:
+            format_accepted = release.format in release_cfg.accepted_formats
+        if format_accepted:
+            logger.info(
+                f"Selected monitored release for {artist_name}: {release.status}, "
+                f"{country}, {release.format}, Mediums: {release.medium_count}, "
+                f"Tracks: {release.track_count}, ID: {release.id}"
+            )
+            return release
+
+    for release in releases:
+        country = release.country[0] if release.country else None
+
+        if release.format[1] == "x" and release_cfg.allow_multi_disc:
+            format_accepted = (
+                release.format.split("x", 1)[1] in release_cfg.accepted_formats
+            )
+        else:
+            format_accepted = release.format in release_cfg.accepted_formats
+
+        if release_cfg.use_most_common_tracknum:
+            track_count_bool = release.track_count == most_common_trackcount
+        else:
+            track_count_bool = True
+
+        if (
+            (release_cfg.skip_region_check or country in release_cfg.accepted_countries)
+            and format_accepted
+            and release.status == "Official"
+            and track_count_bool
+        ):
+            logger.info(
+                ", ".join(
+                    [
+                        f"Selected release for {artist_name}: {release.status}",
+                        str(country),
+                        release.format,
+                        f"Mediums: {release.medium_count}",
+                        f"Tracks: {release.track_count}",
+                        f"ID: {release.id}",
+                    ]
+                )
+            )
+            return release
+
+    if release_cfg.use_most_common_tracknum:
+        for release in releases:
+            if release.track_count == most_common_trackcount:
+                return release
+
+    return releases[0]
+
+
+def _get_denied_users(album_id: int, ctx: SoularrContext) -> set[str]:
+    """Get denied users from the pipeline DB source_denylist."""
+    request_id = abs(album_id)
+    if request_id in ctx.denied_users_cache:
+        return ctx.denied_users_cache[request_id]
+    denied: set[str] = set()
+    try:
+        db = ctx.pipeline_db_source._get_db()
+        denied.update(e["username"] for e in db.get_denylisted_users(request_id))
+    except Exception:
+        pass
+    ctx.denied_users_cache[request_id] = denied
+    return denied
+
+
+def _get_user_dirs(
+    results_for_user: dict[str, list[str]],
+    allowed_filetype: str,
+) -> list[str] | None:
+    """Get candidate directories for a user, handling catch-all merging."""
+    if allowed_filetype == "*":
+        seen: set[str] = set()
+        file_dirs: list[str] = []
+        for ft_dirs in results_for_user.values():
+            for d in ft_dirs:
+                if d not in seen:
+                    seen.add(d)
+                    file_dirs.append(d)
+        return file_dirs or None
+    if allowed_filetype not in results_for_user:
+        return None
+    return results_for_user[allowed_filetype]
+
+
+def _prefixed_directory_files(
+    directory: SlskdDirectory,
+    file_dir: str,
+) -> list[dict[str, Any]]:
+    """Build enqueue payloads without mutating cached browse results."""
+    return [
+        {**file, "filename": file_dir + "\\" + file["filename"]}
+        for file in directory["files"]
+    ]
+
+
+def get_album_tracks(album: Any, ctx: SoularrContext) -> list[TrackRecord]:
+    """Get tracks for an album from the pipeline DB source."""
+    return cast("list[TrackRecord]", ctx.pipeline_db_source.get_tracks(album))
+
+
+def try_enqueue(
+    all_tracks: Sequence[TrackRecord],
+    results: dict[str, dict[str, list[str]]],
+    allowed_filetype: str,
+    ctx: SoularrContext,
+) -> tuple[bool, list[Any] | None]:
+    """Single album match and enqueue."""
+    album_id = all_tracks[0]["albumId"]
+    album = get_album_by_id(album_id, ctx)
+    album_name = album.title
+    artist_name = album.artist_name
+    denied_users = _get_denied_users(album_id, ctx)
+    sorted_users = sorted(
+        results.keys(),
+        key=lambda u: ctx.user_upload_speed.get(u, 0),
+        reverse=True,
+    )
+    for username in sorted_users:
+        if username in denied_users:
+            logger.info(
+                f"Skipping user '{username}' for album ID {album_id}: denylisted "
+                f"(previously provided mislabeled quality)"
+            )
+            continue
+        file_dirs = _get_user_dirs(results[username], allowed_filetype)
+        if file_dirs is None:
+            continue
+        logger.debug(f"Parsing result from user: {username}")
+        found, directory, file_dir = check_for_match(
+            all_tracks, allowed_filetype, file_dirs, username, ctx
+        )
+        if found:
+            directory = download_filter(allowed_filetype, directory, ctx.cfg)
+            files_to_enqueue = _prefixed_directory_files(directory, file_dir)
+            try:
+                downloads = slskd_do_enqueue(
+                    username=username,
+                    files=files_to_enqueue,
+                    file_dir=file_dir,
+                    ctx=ctx,
+                )
+                if downloads is not None:
+                    return True, downloads
+                logger.info(
+                    f"Failed to enqueue download to slskd for "
+                    f"{artist_name} - {album_name} from {username}"
+                )
+            except Exception as e:
+                logger.warning(f"Exception enqueueing tracks: {e}")
+                logger.info(
+                    f"Exception enqueueing download to slskd for "
+                    f"{artist_name} - {album_name} from {username}"
+                )
+    logger.info(f"Failed to enqueue {artist_name} - {album_name}")
+    return False, None
+
+
+def try_multi_enqueue(
+    release: Any,
+    all_tracks: Sequence[TrackRecord],
+    results: dict[str, dict[str, list[str]]],
+    allowed_filetype: str,
+    ctx: SoularrContext,
+) -> tuple[bool, list[Any] | None]:
+    """Locate and enqueue a multi-disc album."""
+    split_release: list[dict[str, Any]] = []
+    for media in release.media:
+        disk: dict[str, Any] = {}
+        disk["source"] = None
+        disk["tracks"] = []
+        disk["disk_no"] = media.medium_number
+        disk["disk_count"] = len(release.media)
+        for track in all_tracks:
+            if track["mediumNumber"] == media.medium_number:
+                disk["tracks"].append(track)
+        split_release.append(disk)
+    total = len(split_release)
+    count_found = 0
+    album_id = all_tracks[0]["albumId"]
+    album = get_album_by_id(album_id, ctx)
+    album_name = album.title
+    artist_name = album.artist_name
+    denied_users = _get_denied_users(album_id, ctx)
+    for disk in split_release:
+        ctx.negative_matches.clear()
+        for username in results:
+            if username in denied_users:
+                logger.info(
+                    f"Skipping user '{username}' for album ID {album_id} "
+                    f"(multi-disc): denylisted (previously provided mislabeled quality)"
+                )
+                continue
+            file_dirs = _get_user_dirs(results[username], allowed_filetype)
+            if file_dirs is None:
+                continue
+            found, directory, file_dir = check_for_match(
+                disk["tracks"], allowed_filetype, file_dirs, username, ctx
+            )
+            if found:
+                directory = download_filter(allowed_filetype, directory, ctx.cfg)
+                disk["source"] = (username, directory, file_dir)
+                count_found += 1
+                break
+        else:
+            return False, None
+    if count_found == total:
+        all_downloads = []
+        enqueued = 0
+        for disk in split_release:
+            username, directory, file_dir = disk["source"]
+            files_to_enqueue = _prefixed_directory_files(directory, file_dir)
+            try:
+                downloads = slskd_do_enqueue(
+                    username=username,
+                    files=files_to_enqueue,
+                    file_dir=file_dir,
+                    ctx=ctx,
+                )
+                if downloads is not None:
+                    for file in downloads:
+                        file.disk_no = disk["disk_no"]
+                        file.disk_count = disk["disk_count"]
+                    all_downloads.extend(downloads)
+                    enqueued += 1
+                else:
+                    logger.info(
+                        f"Failed to enqueue download to slskd for "
+                        f"{artist_name} - {album_name} from {username}"
+                    )
+                    if len(all_downloads) > 0:
+                        cancel_and_delete(all_downloads, ctx)
+                        return False, None
+            except Exception:
+                logger.exception("Exception enqueueing tracks")
+                logger.info(
+                    f"Exception enqueueing download to slskd for "
+                    f"{artist_name} - {album_name} from {username}"
+                )
+                if len(all_downloads) > 0:
+                    cancel_and_delete(all_downloads, ctx)
+                    return False, None
+        if enqueued == total:
+            return True, all_downloads
+        if len(all_downloads) > 0:
+            cancel_and_delete(all_downloads, ctx)
+        return False, None
+
+    return False, None
+
+
+def _try_filetype(
+    album: Any,
+    results: dict[str, dict[str, list[str]]],
+    allowed_filetype: str,
+    grab_list: dict[int, GrabListEntry],
+    ctx: SoularrContext,
+) -> bool:
+    """Try to match and enqueue an album at a specific filetype quality."""
+    album_id = album.id
+    artist_name = album.artist_name
+    releases = list(album.releases)
+    has_monitored = any(r.monitored for r in releases)
+
+    for _ in range(len(releases)):
+        if not releases:
+            break
+        release = choose_release(artist_name, releases, ctx.cfg)
+        releases.remove(release)
+        all_tracks = get_album_tracks(album, ctx)
+        if not all_tracks:
+            logger.warning(
+                f"No tracks for {artist_name} - {album.title} "
+                f"(release {release.id}) — skipping"
+            )
+            continue
+
+        found, downloads = try_enqueue(all_tracks, results, allowed_filetype, ctx)
+        if not found and len(release.media) > 1:
+            found, downloads = try_multi_enqueue(
+                release, all_tracks, results, allowed_filetype, ctx
+            )
+
+        if found:
+            assert downloads is not None
+            grab_list[album_id] = GrabListEntry(
+                album_id=album_id,
+                files=downloads,
+                filetype=allowed_filetype,
+                title=album.title,
+                artist=artist_name,
+                year=album.release_date[0:4],
+                mb_release_id=release.foreign_release_id,
+                db_request_id=album.db_request_id,
+                db_source=album.db_source,
+                db_quality_override=album.db_quality_override,
+            )
+            return True
+
+        if has_monitored and release.monitored:
+            logger.info(
+                f"Monitored release ({release.track_count} tracks) not found on "
+                f"Soulseek for {artist_name} - {album.title} at quality "
+                f"{allowed_filetype}, skipping non-monitored releases"
+            )
+            break
+        if has_monitored and not release.monitored:
+            break
+
+    return False
+
+
+def find_download(
+    album: Any,
+    grab_list: dict[int, GrabListEntry],
+    ctx: SoularrContext,
+) -> bool:
+    """Walk search results and enqueue the best matching download."""
+    album_id = album.id
+    artist_name = album.artist_name
+    results = ctx.search_cache[album_id]
+
+    ctx.negative_matches.clear()
+    ctx.current_album_cache[album_id] = album
+
+    from lib.quality import derive_intent, intent_allows_catch_all, search_filetypes
+
+    intent = derive_intent(album.db_quality_override)
+    filetypes_to_try = search_filetypes(intent, list(ctx.cfg.allowed_filetypes))
+
+    if album.db_quality_override:
+        logger.info(
+            f"Quality override for {artist_name} - {album.title}: "
+            f"intent={intent.value}, searching {filetypes_to_try}"
+        )
+
+    for allowed_filetype in filetypes_to_try:
+        logger.info(f"Checking for Quality: {allowed_filetype}")
+        if _try_filetype(album, results, allowed_filetype, grab_list, ctx):
+            return True
+
+    if (
+        intent_allows_catch_all(intent)
+        and "*" not in [ft.strip() for ft in (ctx.cfg.allowed_filetypes or ())]
+    ):
+        logger.info(
+            f"No match at preferred quality for {artist_name} - {album.title}, "
+            f"trying catch-all (any audio format)"
+        )
+        if _try_filetype(album, results, "*", grab_list, ctx):
+            return True
+
+    return False

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -1,0 +1,253 @@
+"""Matching helpers extracted from soularr.py."""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import time
+from typing import Any, Sequence, TYPE_CHECKING
+
+from lib.browse import _browse_directories, rank_candidate_dirs
+from lib.util import _track_titles_cross_check
+
+if TYPE_CHECKING:
+    from lib.config import SoularrConfig
+    from lib.context import SoularrContext
+    from soularr import SlskdDirectory, SlskdFile, TrackRecord
+
+
+logger = logging.getLogger("soularr")
+
+
+def get_album_by_id(album_id: int, ctx: SoularrContext) -> Any:
+    """Get album data by ID from the context cache."""
+    if album_id in ctx.current_album_cache:
+        return ctx.current_album_cache[album_id]
+    raise KeyError(f"Album {album_id} not found in cache")
+
+
+def album_match(
+    expected_tracks: Sequence[TrackRecord],
+    slskd_tracks: Sequence[SlskdFile],
+    username: str,
+    filetype: str,
+    ctx: SoularrContext,
+) -> bool:
+    """Check whether the browsed directory matches the expected album."""
+    match_cfg = ctx.cfg
+    counted = []
+    total_match = 0.0
+
+    album_info = get_album_by_id(expected_tracks[0]["albumId"], ctx)
+    album_name = album_info.title
+
+    from lib.quality import parse_filetype_config
+
+    spec = parse_filetype_config(filetype)
+    is_catch_all = spec.extension == "*"
+    for expected_track in expected_tracks:
+        best_match = 0.0
+        expected_filename = expected_track["title"]
+
+        for slskd_track in slskd_tracks:
+            if is_catch_all:
+                slskd_ext = (
+                    slskd_track["filename"].rsplit(".", 1)[-1].lower()
+                    if "." in slskd_track["filename"]
+                    else ""
+                )
+                expected_filename = expected_track["title"] + "." + slskd_ext
+            else:
+                expected_filename = expected_track["title"] + "." + spec.extension
+            slskd_filename = slskd_track["filename"]
+
+            ratio = difflib.SequenceMatcher(
+                None, expected_filename, slskd_filename
+            ).ratio()
+            ratio = check_ratio(
+                " ", ratio, expected_filename, slskd_filename,
+                match_cfg.minimum_match_ratio,
+            )
+            ratio = check_ratio(
+                "_", ratio, expected_filename, slskd_filename,
+                match_cfg.minimum_match_ratio,
+            )
+            ratio = check_ratio(
+                "", ratio, album_name + " " + expected_filename,
+                slskd_filename, match_cfg.minimum_match_ratio,
+            )
+            ratio = check_ratio(
+                " ", ratio, album_name + " " + expected_filename,
+                slskd_filename, match_cfg.minimum_match_ratio,
+            )
+            ratio = check_ratio(
+                "_", ratio, album_name + " " + expected_filename,
+                slskd_filename, match_cfg.minimum_match_ratio,
+            )
+
+            if ratio > best_match:
+                best_match = ratio
+
+        if best_match > match_cfg.minimum_match_ratio:
+            counted.append(expected_filename)
+            total_match += best_match
+
+    if len(counted) == len(expected_tracks) and username not in match_cfg.ignored_users:
+        logger.info(
+            f"Found match from user: {username} for {len(counted)} tracks! "
+            f"Track attributes: {filetype}"
+        )
+        logger.info(f"Average sequence match ratio: {total_match / len(counted)}")
+        logger.info("SUCCESSFUL MATCH")
+        logger.info("-------------------")
+        return True
+
+    return False
+
+
+def check_ratio(
+    separator: str,
+    ratio: float,
+    expected_filename: str,
+    slskd_filename: str,
+    minimum_match_ratio: float,
+) -> float:
+    """Retry a weak filename match with trimmed prefixes."""
+    if ratio < minimum_match_ratio:
+        if separator != "":
+            expected_filename_word_count = len(expected_filename.split()) * -1
+            truncated_slskd_filename = " ".join(
+                slskd_filename.split(separator)[expected_filename_word_count:]
+            )
+            ratio = difflib.SequenceMatcher(
+                None, expected_filename, truncated_slskd_filename
+            ).ratio()
+        else:
+            ratio = difflib.SequenceMatcher(
+                None, expected_filename, slskd_filename
+            ).ratio()
+
+    return ratio
+
+
+def album_track_num(
+    directory: SlskdDirectory,
+    match_cfg: SoularrConfig,
+) -> dict[str, Any]:
+    """Count matching audio tracks and infer a consistent filetype."""
+    from lib.quality import AUDIO_EXTENSIONS as _all_audio_exts
+
+    files = directory["files"]
+    specs = match_cfg.allowed_specs
+    has_catch_all = any(s.extension == "*" for s in specs)
+    allowed_exts = (
+        list(_all_audio_exts)
+        if has_catch_all
+        else [s.extension for s in specs]
+    )
+    count = 0
+    index = -1
+    filetype = ""
+    for file in files:
+        ext = file["filename"].split(".")[-1].lower()
+        if ext in allowed_exts:
+            if has_catch_all:
+                if index == -1:
+                    filetype = ext
+                count += 1
+            else:
+                new_index = allowed_exts.index(ext)
+                if index == -1:
+                    index = new_index
+                    filetype = allowed_exts[index]
+                elif new_index != index:
+                    filetype = ""
+                    break
+                count += 1
+
+    return {"count": count, "filetype": filetype}
+
+
+def check_for_match(
+    tracks: Sequence[TrackRecord],
+    allowed_filetype: str,
+    file_dirs: list[str],
+    username: str,
+    ctx: SoularrContext,
+) -> tuple[bool, Any, str]:
+    """Check candidate directories for an album match."""
+    logger.debug(f"Current broken users {ctx.broken_user}")
+    if username in ctx.broken_user:
+        return False, {}, ""
+    track_num = len(tracks)
+    album_info = get_album_by_id(tracks[0]["albumId"], ctx)
+    ranked_dirs = rank_candidate_dirs(file_dirs, album_info.title, album_info.artist_name)
+
+    dirs_to_try: list[str] = []
+    for file_dir in ranked_dirs:
+        neg_key = (username, file_dir, track_num, allowed_filetype)
+        if neg_key in ctx.negative_matches:
+            logger.debug(
+                f"Negative cache hit: {username} {file_dir} "
+                f"({track_num} tracks, {allowed_filetype})"
+            )
+            continue
+
+        user_counts = ctx.search_dir_audio_count.get(username)
+        if user_counts and file_dir in user_counts:
+            search_count = user_counts[file_dir]
+            if abs(search_count - track_num) > 2:
+                logger.debug(
+                    f"Pre-filter skip: {username} {file_dir} has {search_count} "
+                    f"audio files, need {track_num} tracks"
+                )
+                ctx.negative_matches.add(neg_key)
+                continue
+
+        dirs_to_try.append(file_dir)
+
+    if not dirs_to_try:
+        return False, {}, ""
+
+    if username not in ctx.folder_cache:
+        ctx.folder_cache[username] = {}
+
+    uncached = [d for d in dirs_to_try if d not in ctx.folder_cache[username]]
+    if uncached:
+        logger.info(
+            f"Browsing {len(uncached)} dirs from {username} "
+            f"(parallelism={ctx.cfg.browse_parallelism})"
+        )
+        browsed = _browse_directories(
+            uncached,
+            username,
+            ctx.slskd,
+            ctx.cfg.browse_parallelism,
+        )
+        for d, result in browsed.items():
+            ctx.folder_cache[username][d] = result
+            ctx._folder_cache_ts.setdefault(username, {})[d] = time.time()
+
+        if not browsed and len(uncached) == len(dirs_to_try):
+            ctx.broken_user.append(username)
+            logger.debug(f"All browses failed for {username}, marked as broken")
+            return False, {}, ""
+
+    for file_dir in dirs_to_try:
+        if file_dir not in ctx.folder_cache[username]:
+            continue
+
+        directory = ctx.folder_cache[username][file_dir]
+        tracks_info = album_track_num(directory, ctx.cfg)
+        neg_key = (username, file_dir, track_num, allowed_filetype)
+
+        if tracks_info["count"] == track_num and tracks_info["filetype"] != "":
+            if album_match(tracks, directory["files"], username, allowed_filetype, ctx):
+                if _track_titles_cross_check(tracks, directory["files"]):
+                    return True, directory, file_dir
+                logger.warning(
+                    f"Track title cross-check FAILED for user {username}, "
+                    f"dir {file_dir} — skipping (wrong pressing?)"
+                )
+        ctx.negative_matches.add(neg_key)
+    return False, {}, ""

--- a/soularr.py
+++ b/soularr.py
@@ -5,11 +5,9 @@ import argparse
 import os
 import sys
 import time
-import difflib
 import configparser
 import logging
 from typing import Any, Sequence, TYPE_CHECKING, TypedDict
-import copy
 import slskd_api
 
 if TYPE_CHECKING:
@@ -78,410 +76,49 @@ pipeline_db_source: "DatabaseSource" = None  # type: ignore[assignment]  # Set i
 # All matching/search functions receive ctx explicitly.
 _module_ctx: Any = None  # SoularrContext — set in main()
 
-
-def album_match(expected_tracks: Sequence[TrackRecord], slskd_tracks: Sequence[SlskdFile], username: str, filetype: str, ctx: SoularrContext) -> bool:
-    counted = []
-    total_match = 0.0
-
-    album_info = get_album_by_id(expected_tracks[0]["albumId"], ctx)
-    album_name = album_info.title
-    artist_name = album_info.artist_name
-
-    from lib.quality import parse_filetype_config
-    spec = parse_filetype_config(filetype)
-    is_catch_all = spec.extension == "*"
-    for expected_track in expected_tracks:
-        best_match = 0.0
-        expected_filename = expected_track["title"]  # fallback for empty slskd_tracks
-
-        for slskd_track in slskd_tracks:
-            # For catch-all, use the actual extension from the slskd track
-            if is_catch_all:
-                slskd_ext = slskd_track["filename"].rsplit(".", 1)[-1].lower() if "." in slskd_track["filename"] else ""
-                expected_filename = expected_track["title"] + "." + slskd_ext
-            else:
-                expected_filename = expected_track["title"] + "." + spec.extension
-            slskd_filename = slskd_track["filename"]
-
-            # Try to match the ratio with the exact filenames
-            ratio = difflib.SequenceMatcher(None, expected_filename, slskd_filename).ratio()
-
-            # If ratio is a bad match try and split off (with " " as the separator) the garbage at the start of the slskd_filename and try again
-            ratio = check_ratio(" ", ratio, expected_filename, slskd_filename)
-            # Same but with "_" as the separator
-            ratio = check_ratio("_", ratio, expected_filename, slskd_filename)
-
-            # Same checks but preappend album name.
-            ratio = check_ratio("", ratio, album_name + " " + expected_filename, slskd_filename)
-            ratio = check_ratio(" ", ratio, album_name + " " + expected_filename, slskd_filename)
-            ratio = check_ratio("_", ratio, album_name + " " + expected_filename, slskd_filename)
-
-            if ratio > best_match:
-                best_match = ratio
-
-        if best_match > cfg.minimum_match_ratio:
-            counted.append(expected_filename)
-            total_match += best_match
-
-    if len(counted) == len(expected_tracks) and username not in cfg.ignored_users:
-        logger.info(f"Found match from user: {username} for {len(counted)} tracks! Track attributes: {filetype}")
-        logger.info(f"Average sequence match ratio: {total_match / len(counted)}")
-        logger.info("SUCCESSFUL MATCH")
-        logger.info("-------------------")
-        return True
-
-    return False
-
-
-def check_ratio(separator, ratio, expected_filename, slskd_filename):
-    if ratio < cfg.minimum_match_ratio:
-        if separator != "":
-            expected_filename_word_count = len(expected_filename.split()) * -1
-            truncated_slskd_filename = " ".join(slskd_filename.split(separator)[expected_filename_word_count:])
-            ratio = difflib.SequenceMatcher(None, expected_filename, truncated_slskd_filename).ratio()
-        else:
-            ratio = difflib.SequenceMatcher(None, expected_filename, slskd_filename).ratio()
-
-        return ratio
-    return ratio
-
-
-def album_track_num(directory: SlskdDirectory) -> dict[str, Any]:
-    from lib.quality import AUDIO_EXTENSIONS as _all_audio_exts
-    files = directory["files"]
-    specs = cfg.allowed_specs
-    # Check if any spec is catch-all ("*")
-    has_catch_all = any(s.extension == "*" for s in specs)
-    allowed_exts = list(_all_audio_exts) if has_catch_all else [s.extension for s in specs]
-    count = 0
-    index = -1
-    filetype = ""
-    for file in files:
-        ext = file["filename"].split(".")[-1].lower()
-        if ext in allowed_exts:
-            if has_catch_all:
-                # Catch-all: count all audio files, track majority extension
-                if index == -1:
-                    filetype = ext
-                count += 1
-            else:
-                new_index = allowed_exts.index(ext)
-                if index == -1:
-                    index = new_index
-                    filetype = allowed_exts[index]
-                elif new_index != index:
-                    filetype = ""
-                    break
-                count += 1
-
-    return_data = {"count": count, "filetype": filetype}
-    return return_data
-
-
-def release_trackcount_mode(releases):
-    track_count = {}
-
-    for release in releases:
-        trackcount = release.track_count
-        if trackcount in track_count:
-            track_count[trackcount] += 1
-        else:
-            track_count[trackcount] = 1
-
-    most_common_trackcount = None
-    max_count = 0
-
-    for trackcount, count in track_count.items():
-        if count > max_count:
-            max_count = count
-            most_common_trackcount = trackcount
-
-    return most_common_trackcount
-
-
-def choose_release(artist_name, releases):
-    most_common_trackcount = release_trackcount_mode(releases)
-
-    # Prefer the release marked as monitored — this is the one the
-    # user explicitly selected in the UI and represents the edition they want.
-    for release in releases:
-        if not release.monitored:
-            continue
-        country = release.country[0] if release.country else None
-        if release.format[1] == "x" and cfg.allow_multi_disc:
-            format_accepted = release.format.split("x", 1)[1] in cfg.accepted_formats
-        else:
-            format_accepted = release.format in cfg.accepted_formats
-        if format_accepted:
-            logger.info(
-                f"Selected monitored release for {artist_name}: {release.status}, "
-                f"{country}, {release.format}, Mediums: {release.medium_count}, "
-                f"Tracks: {release.track_count}, ID: {release.id}"
-            )
-            return release
-
-    for release in releases:
-        country = release.country[0] if release.country else None
-
-        if release.format[1] == "x" and cfg.allow_multi_disc:
-            format_accepted = release.format.split("x", 1)[1] in cfg.accepted_formats
-        else:
-            format_accepted = release.format in cfg.accepted_formats
-
-        if cfg.use_most_common_tracknum:
-            if release.track_count == most_common_trackcount:
-                track_count_bool = True
-            else:
-                track_count_bool = False
-        else:
-            track_count_bool = True
-
-        if (cfg.skip_region_check or country in cfg.accepted_countries) and format_accepted and release.status == "Official" and track_count_bool:
-            logger.info(
-                ", ".join(
-                    [
-                        f"Selected release for {artist_name}: {release.status}",
-                        str(country),
-                        release.format,
-                        f"Mediums: {release.medium_count}",
-                        f"Tracks: {release.track_count}",
-                        f"ID: {release.id}",
-                    ]
-                )
-            )
-
-            return release
-
-    if cfg.use_most_common_tracknum:
-        for release in releases:
-            if release.track_count == most_common_trackcount:
-                return release
-        else:
-            default_release = releases[0]
-
-    else:
-        default_release = releases[0]
-
-    return default_release
-
-
-
-
-def download_filter(allowed_filetype: str, directory: SlskdDirectory) -> SlskdDirectory:
-    """
-    Filters the directory listing from SLSKD using the filetype whitelist.
-    If not using the whitelist it will only return the audio files of the allowed filetype.
-    This is to prevent downloading m3u,cue,txt,jpg,etc. files that are sometimes stored in
-    the same folders as the music files.
-    """
-    logging.debug("download_filtering")
-    if cfg.download_filtering:
-        from lib.quality import parse_filetype_config, AUDIO_EXTENSIONS as _all_audio
-        spec = parse_filetype_config(allowed_filetype)
-        whitelist = []  # Init an empty list to take just the allowed_filetype
-        if cfg.use_extension_whitelist:
-            whitelist = list(cfg.extensions_whitelist)
-        if spec.extension == "*":
-            whitelist.extend(_all_audio)
-        else:
-            whitelist.append(spec.extension)
-        unwanted = []
-        logger.debug(f"Accepted extensions: {whitelist}")
-        for file in directory["files"]:
-            for extension in whitelist:
-                if file["filename"].split(".")[-1].lower() == extension.lower():
-                    break  # Jump out and don't add wanted files to the unwanted list
-            else:
-                unwanted.append(file["filename"])  # Add to list of files to remove from the wanted list
-                logger.debug(f"Unwanted file: {file['filename']}")
-        if len(unwanted) > 0:
-            temp = []
-            logger.debug(f"Unwanted Files: {unwanted}")
-            for file in directory["files"]:
-                if file["filename"] not in unwanted:
-                    logger.debug(f"Added file to queue: {file['filename']}")
-                    temp.append(file)
-            for files in temp:
-                logger.debug(f"File in final list: {files['filename']}")
-            return {**directory, "files": temp}  # New dict — never mutate the input
-    return directory
-
-
-
-_PENALTY_KEYWORDS = (
-    "archive", "best of", "greatest hits", "magazine", "compilation",
-    "singles", "soundtrack", "various", "bootleg", "discography",
+from lib.browse import (
+    _browse_directories,
+    _browse_one,
+    download_filter,
+    rank_candidate_dirs,
+)
+from lib.enqueue import (
+    _get_denied_users,
+    _get_user_dirs,
+    _prefixed_directory_files,
+    _try_filetype,
+    choose_release,
+    find_download,
+    get_album_tracks,
+    release_trackcount_mode,
+    try_enqueue,
+    try_multi_enqueue,
+)
+from lib.matching import (
+    album_match,
+    album_track_num,
+    check_for_match,
+    check_ratio,
+    get_album_by_id,
 )
 
 
-def rank_candidate_dirs(
-    file_dirs: list[str], album_title: str, artist_name: str
-) -> list[str]:
-    """Sort candidate directories by likelihood of being the correct album.
-
-    Promotes paths containing the album or artist name; demotes paths with
-    penalty keywords (compilations, archives, etc.). Stable sort — equal
-    scores preserve original order.
-    """
-    title_lower = album_title.lower()
-    artist_lower = artist_name.lower()
-
-    def _score(d: str) -> int:
-        d_lower = d.lower()
-        score = 0
-        if title_lower in d_lower:
-            score += 2
-        if artist_lower in d_lower:
-            score += 1
-        for kw in _PENALTY_KEYWORDS:
-            if kw in d_lower:
-                score -= 3
-                break  # one penalty is enough
-        return score
-
-    return sorted(file_dirs, key=_score, reverse=True)
-
-
-def _browse_one(username: str, file_dir: str) -> tuple[str, Any | None]:
-    """Browse a single directory from slskd. Returns (file_dir, result_or_None)."""
-    try:
-        directory = slskd.users.directory(username=username, directory=file_dir)[0]
-        return file_dir, directory
-    except Exception:
-        logger.exception(f'Error getting directory from user: "{username}"')
-        return file_dir, None
-
-
-def _browse_directories(
-    dirs_to_browse: list[str], username: str, max_workers: int = 4
-) -> dict[str, Any]:
-    """Browse multiple directories in parallel. Returns {file_dir: directory}.
-
-    Failed browses are omitted from the result dict.
-    """
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    if not dirs_to_browse:
-        return {}
-
-    # Single dir — don't bother with thread pool
-    if len(dirs_to_browse) == 1:
-        file_dir, result = _browse_one(username, dirs_to_browse[0])
-        return {file_dir: result} if result is not None else {}
-
-    results: dict[str, Any] = {}
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {
-            pool.submit(_browse_one, username, d): d
-            for d in dirs_to_browse
-        }
-        for future in as_completed(futures):
-            file_dir, result = future.result()
-            if result is not None:
-                results[file_dir] = result
-
-    return results
-
-
-def check_for_match(tracks: Sequence[TrackRecord], allowed_filetype: str, file_dirs: list[str], username: str, ctx: SoularrContext) -> tuple[bool, Any, str]:
-    """
-    Does the actual match checking on a single disk/album.
-
-    Phase 1: Filter dirs (negative cache, pre-filter by audio count).
-    Phase 2: Browse uncached dirs in parallel.
-    Phase 3: Match serially (early exit on first match).
-    """
-    logger.debug(f"Current broken users {ctx.broken_user}")
-    if username in ctx.broken_user:
-        return False, {}, ""
-    track_num = len(tracks)
-    album_info = get_album_by_id(tracks[0]["albumId"], ctx)
-    ranked_dirs = rank_candidate_dirs(file_dirs, album_info.title, album_info.artist_name)
-
-    # Phase 1: Filter — determine which dirs need browsing
-    dirs_to_try: list[str] = []
-    for file_dir in ranked_dirs:
-        neg_key = (username, file_dir, track_num, allowed_filetype)
-        if neg_key in ctx.negative_matches:
-            logger.debug(f"Negative cache hit: {username} {file_dir} ({track_num} tracks, {allowed_filetype})")
-            continue
-
-        user_counts = ctx.search_dir_audio_count.get(username)
-        if user_counts and file_dir in user_counts:
-            search_count = user_counts[file_dir]
-            if abs(search_count - track_num) > 2:
-                logger.debug(
-                    f"Pre-filter skip: {username} {file_dir} has {search_count} "
-                    f"audio files, need {track_num} tracks"
-                )
-                ctx.negative_matches.add(neg_key)
-                continue
-
-        dirs_to_try.append(file_dir)
-
-    if not dirs_to_try:
-        return False, {}, ""
-
-    # Phase 2: Browse uncached dirs in parallel
-    if username not in ctx.folder_cache:
-        ctx.folder_cache[username] = {}
-
-    uncached = [d for d in dirs_to_try if d not in ctx.folder_cache[username]]
-    if uncached:
-        logger.info(
-            f"Browsing {len(uncached)} dirs from {username} "
-            f"(parallelism={cfg.browse_parallelism})"
-        )
-        browsed = _browse_directories(uncached, username, cfg.browse_parallelism)
-        for d, result in browsed.items():
-            ctx.folder_cache[username][d] = result
-            ctx._folder_cache_ts.setdefault(username, {})[d] = time.time()
-
-        # If ALL browses failed, mark user as broken
-        if not browsed and len(uncached) == len(dirs_to_try):
-            ctx.broken_user.append(username)
-            logger.debug(f"All browses failed for {username}, marked as broken")
-            return False, {}, ""
-
-    # Phase 3: Match serially — early exit on first match
-    for file_dir in dirs_to_try:
-        if file_dir not in ctx.folder_cache[username]:
-            # Browse failed for this dir
-            continue
-
-        directory = ctx.folder_cache[username][file_dir]
-        tracks_info = album_track_num(directory)
-        neg_key = (username, file_dir, track_num, allowed_filetype)
-
-        if tracks_info["count"] == track_num and tracks_info["filetype"] != "":
-            if album_match(tracks, directory["files"], username, allowed_filetype, ctx):
-                if _track_titles_cross_check(tracks, directory["files"]):
-                    return True, copy.deepcopy(directory), file_dir
-                else:
-                    logger.warning(
-                        f"Track title cross-check FAILED for user {username}, "
-                        f"dir {file_dir} — skipping (wrong pressing?)"
-                    )
-        ctx.negative_matches.add(neg_key)
-    return False, {}, ""
-
-
-def is_blacklisted(title: str) -> bool:
-    for word in cfg.title_blacklist:
+def is_blacklisted(title: str, title_blacklist: Sequence[str]) -> bool:
+    for word in title_blacklist:
         if word and word.lower() in title.lower():
             logger.info(f"Skipping {title} due to blacklisted word: {word}")
             return True
     return False
 
 
-def filter_list(albums):
+def filter_list(albums, filter_cfg: SoularrConfig):
     """
     Helper to do all the various filtering in one go and in one place. Same net effect as the previous multi-stage approach
     Just neater and easier to work on.
     """
     list_to_download = []
     for album in albums:
-        if is_blacklisted(album.title):
+        if is_blacklisted(album.title, filter_cfg.title_blacklist):
             logger.info(f"Skipping blacklisted album: {album.artist_name} - {album.title} (ID: {album.id}")
             continue
         else:
@@ -716,18 +353,6 @@ def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client
     )
 
 
-def _execute_search(album, search_cfg, slskd_client):
-    """Submit + wait for one search. Used by sequential path."""
-    result = _submit_search(album, search_cfg, slskd_client)
-    if result is None:
-        from lib.search import SearchResult
-        return SearchResult(album_id=album.id, success=False,
-                            query=album.title)
-    search_id, query, album_id = result
-    return _collect_search_results(search_id, query, album_id,
-                                   search_cfg, slskd_client)
-
-
 def _merge_search_result(result, ctx):
     """Merge a SearchResult into ctx caches.
 
@@ -759,281 +384,6 @@ def _merge_search_result(result, ctx):
             existing = ctx.search_dir_audio_count[username].get(d, 0)
             ctx.search_dir_audio_count[username][d] = max(existing, count)
             ctx._dir_audio_count_ts.setdefault(username, {})[d] = time.time()
-
-
-def _get_denied_users(album_id, ctx):
-    """Get denied users from pipeline DB source_denylist. Cached per album per run."""
-    request_id = abs(album_id)
-    if request_id in ctx.denied_users_cache:
-        return ctx.denied_users_cache[request_id]
-    denied = set()
-    try:
-        db = pipeline_db_source._get_db()
-        denied.update(e["username"] for e in db.get_denylisted_users(request_id))
-    except Exception:
-        pass
-    ctx.denied_users_cache[request_id] = denied
-    return denied
-
-
-def _get_user_dirs(results_for_user: dict[str, list[str]], allowed_filetype: str) -> list[str] | None:
-    """Get candidate directories for a user, handling catch-all merging.
-
-    Returns None if the user has no dirs for the requested filetype.
-    """
-    if allowed_filetype == "*":
-        seen: set[str] = set()
-        file_dirs: list[str] = []
-        for ft_dirs in results_for_user.values():
-            for d in ft_dirs:
-                if d not in seen:
-                    seen.add(d)
-                    file_dirs.append(d)
-        return file_dirs or None
-    if allowed_filetype not in results_for_user:
-        return None
-    return results_for_user[allowed_filetype]
-
-
-def try_enqueue(all_tracks, results, allowed_filetype, ctx):
-    """
-    Single album match and enqueue.
-    Iterates over all users and enqueues a found match
-    """
-    album_id = all_tracks[0]["albumId"]
-    denied_users = _get_denied_users(album_id, ctx)
-    # Sort users by upload speed (fastest first) for quicker downloads
-    sorted_users = sorted(results.keys(), key=lambda u: ctx.user_upload_speed.get(u, 0), reverse=True)
-    for username in sorted_users:
-        if username in denied_users:
-            logger.info(f"Skipping user '{username}' for album ID {album_id}: denylisted (previously provided mislabeled quality)")
-            continue
-        file_dirs = _get_user_dirs(results[username], allowed_filetype)
-        if file_dirs is None:
-            continue
-        logger.debug(f"Parsing result from user: {username}")
-        found, directory, file_dir = check_for_match(all_tracks, allowed_filetype, file_dirs, username, ctx)
-        if found:
-            directory = download_filter(allowed_filetype, directory)
-            for i in range(0, len(directory["files"])):
-                directory["files"][i]["filename"] = file_dir + "\\" + directory["files"][i]["filename"]
-            try:
-                downloads = slskd_do_enqueue(username=username, files=directory["files"], file_dir=file_dir)
-                if downloads is not None:
-                    return True, downloads
-                else:
-                    album = get_album_by_id(all_tracks[0]["albumId"], ctx)
-                    album_name = album.title
-                    artist_name = album.artist_name
-                    logger.info(f"Failed to enqueue download to slskd for {artist_name} - {album_name} from {username}")
-            except Exception as e:
-                album = get_album_by_id(all_tracks[0]["albumId"], ctx)
-                album_name = album.title
-                artist_name = album.artist_name
-
-                logger.warning(f"Exception enqueueing tracks: {e}")
-                logger.info(f"Exception enqueueing download to slskd for {artist_name} - {album_name} from {username}")
-    album = get_album_by_id(all_tracks[0]["albumId"], ctx)
-    album_name = album.title
-    artist_name = album.artist_name
-    logger.info(f"Failed to enqueue {artist_name} - {album_name}")
-    return False, None
-
-
-def try_multi_enqueue(release, all_tracks, results, allowed_filetype, ctx):
-    """
-    This is the multi-disk/media path for locating and enqueueing an album
-    It does a flat search first. Then it does a split search.
-    Otherwise it's basically the same as the single album search.
-    """
-    split_release = []
-    for media in release.media:
-        disk = {}
-        disk["source"] = None
-        disk["tracks"] = []
-        disk["disk_no"] = media.medium_number
-        disk["disk_count"] = len(release.media)
-        for track in all_tracks:
-            if track["mediumNumber"] == media.medium_number:
-                disk["tracks"].append(track)
-        split_release.append(disk)
-    total = len(split_release)
-    count_found = 0
-    album_id = all_tracks[0]["albumId"]
-    denied_users = _get_denied_users(album_id, ctx)
-    for disk in split_release:
-        ctx.negative_matches.clear()  # each disc has different expected titles
-        for username in results:
-            if username in denied_users:
-                logger.info(f"Skipping user '{username}' for album ID {album_id} (multi-disc): denylisted (previously provided mislabeled quality)")
-                continue
-            file_dirs = _get_user_dirs(results[username], allowed_filetype)
-            if file_dirs is None:
-                continue
-            found, directory, file_dir = check_for_match(disk["tracks"], allowed_filetype, file_dirs, username, ctx)
-            if found:
-                directory = download_filter(allowed_filetype, directory)
-                disk["source"] = (username, directory, file_dir)
-                count_found += 1
-                break
-        else:
-            return (
-                False,
-                None,
-            )  # Only runs if we complete the loop without finding a source for the current disk regardless of how many other disks we located. All or nothing.
-    if count_found == total:
-        all_downloads = []
-        enqueued = 0
-        for disk in split_release:
-            username, directory, file_dir = disk["source"]
-            for i in range(0, len(directory["files"])):
-                directory["files"][i]["filename"] = file_dir + "\\" + directory["files"][i]["filename"]
-            try:
-                downloads = slskd_do_enqueue(username=username, files=directory["files"], file_dir=file_dir)
-                if downloads is not None:
-                    for file in downloads:
-                        file.disk_no = disk["disk_no"]
-                        file.disk_count = disk["disk_count"]
-                    all_downloads.extend(downloads)
-                    enqueued += 1
-                else:
-                    album = get_album_by_id(all_tracks[0]["albumId"], ctx)
-                    album_name = album.title
-                    artist_name = album.artist_name
-                    logger.info(f"Failed to enqueue download to slskd for {artist_name} - {album_name} from {username}")
-                    if len(all_downloads) > 0:
-                        cancel_and_delete(all_downloads)
-                        return False, None
-            except Exception:
-                album = get_album_by_id(all_tracks[0]["albumId"], ctx)
-                album_name = album.title
-                artist_name = album.artist_name
-
-                logger.exception("Exception enqueueing tracks")
-                logger.info(f"Exception enqueueing download to slskd for {artist_name} - {album_name} from {username}")
-                if len(all_downloads) > 0:
-                    cancel_and_delete(all_downloads)
-                    return False, None
-        if enqueued == total:
-            return True, all_downloads
-        else:
-            # Delete all other downloads
-            if len(all_downloads) > 0:
-                cancel_and_delete(all_downloads)
-            return False, None
-
-    else:
-        return False, None
-
-
-def get_album_tracks(album, release_id=None):
-    """Get tracks for an album from pipeline DB."""
-    return pipeline_db_source.get_tracks(album)
-
-
-def get_album_by_id(album_id, ctx):
-    """Get album data by ID from context cache."""
-    if album_id in ctx.current_album_cache:
-        return ctx.current_album_cache[album_id]
-    raise KeyError(f"Album {album_id} not found in cache")
-
-
-def _try_filetype(album, results, allowed_filetype, grab_list, ctx) -> bool:
-    """Try to match and enqueue an album at a specific filetype quality.
-
-    Iterates releases (monitored first), tries single-album then multi-disc.
-    Returns True and populates grab_list on success.
-    """
-    album_id = album.id
-    artist_name = album.artist_name
-    releases = list(album.releases)
-    has_monitored = any(r.monitored for r in releases)
-
-    for _ in range(len(releases)):
-        if not releases:
-            break
-        release = choose_release(artist_name, releases)
-        releases.remove(release)
-        all_tracks = get_album_tracks(album, release_id=release.id)
-        if not all_tracks:
-            logger.warning(f"No tracks for {artist_name} - {album.title} (release {release.id}) — skipping")
-            continue
-
-        found, downloads = try_enqueue(all_tracks, results, allowed_filetype, ctx)
-        if not found and len(release.media) > 1:
-            found, downloads = try_multi_enqueue(release, all_tracks, results, allowed_filetype, ctx)
-
-        if found:
-            assert downloads is not None
-            grab_list[album_id] = GrabListEntry(
-                album_id=album_id,
-                files=downloads,
-                filetype=allowed_filetype,
-                title=album.title,
-                artist=artist_name,
-                year=album.release_date[0:4],
-                mb_release_id=release.foreign_release_id,
-                db_request_id=album.db_request_id,
-                db_source=album.db_source,
-                db_quality_override=album.db_quality_override,
-            )
-            return True
-
-        if has_monitored and release.monitored:
-            logger.info(
-                f"Monitored release ({release.track_count} tracks) not found on "
-                f"Soulseek for {artist_name} - {album.title} at quality "
-                f"{allowed_filetype}, skipping non-monitored releases"
-            )
-            break
-        if has_monitored and not release.monitored:
-            break
-
-    return False
-
-
-def find_download(album, grab_list, ctx):
-    """
-    This does the main loop over search results and user directories
-    It has two paths it can take. One is the "single album" path
-    The other is the multi-media path.
-    """
-    album_id = album.id
-    artist_name = album.artist_name
-    results = ctx.search_cache[album_id]
-
-    # Clear negative match cache per-album — same dir could match a different album
-    ctx.negative_matches.clear()
-
-    # Cache album so get_album_by_id() works during matching
-    ctx.current_album_cache[album_id] = album
-
-    from lib.quality import derive_intent, search_filetypes, intent_allows_catch_all
-
-    intent = derive_intent(album.db_quality_override)
-    filetypes_to_try = search_filetypes(intent, list(cfg.allowed_filetypes))
-
-    if album.db_quality_override:
-        logger.info(
-            f"Quality override for {artist_name} - {album.title}: "
-            f"intent={intent.value}, searching {filetypes_to_try}"
-        )
-
-    for allowed_filetype in filetypes_to_try:
-        logger.info(f"Checking for Quality: {allowed_filetype}")
-        if _try_filetype(album, results, allowed_filetype, grab_list, ctx):
-            return True
-
-    # Catch-all fallback: only best_effort allows falling back to any format.
-    if intent_allows_catch_all(intent) and "*" not in [ft.strip() for ft in (cfg.allowed_filetypes or ())]:
-        logger.info(
-            f"No match at preferred quality for {artist_name} - {album.title}, "
-            f"trying catch-all (any audio format)"
-        )
-        if _try_filetype(album, results, "*", grab_list, ctx):
-            return True
-
-    return False
 
 
 def search_and_queue(albums, ctx):
@@ -1146,8 +496,6 @@ def _search_and_queue_parallel(albums, ctx):
 
     return grab_list, failed_search, failed_grab
 
-
-from lib.grab_list import GrabListEntry
 
 from lib.download import (cancel_and_delete as _cancel_and_delete_impl,
                           slskd_do_enqueue as _slskd_do_enqueue_impl,
@@ -1311,7 +659,7 @@ def main():
             failed = 0
             if len(wanted_records) > 0:
                 try:
-                    filtered = filter_list(wanted_records)
+                    filtered = filter_list(wanted_records, cfg)
                     if filtered is not None:
                         failed = grab_most_wanted(filtered)
                     else:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,7 @@ Uses realistic slskd API fixtures with mocked API calls. Catches type
 mismatches at the boundary between raw slskd dicts and DownloadFile instances.
 """
 
+import copy
 import json
 import os
 import shutil
@@ -25,6 +26,7 @@ sys.modules["slskd_api.apis.users"] = MagicMock()
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import soularr
+from lib import enqueue as enqueue_module
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.download import (cancel_and_delete, slskd_download_status,
                           slskd_do_enqueue, downloads_all_done)
@@ -297,7 +299,7 @@ class TestRawDictBoundary(unittest.TestCase):
                 {"filename": "02 - Track.flac", "size": 100},
                 {"filename": "cover.jpg", "size": 50},
             ])
-            result = soularr.album_track_num(directory)
+            result = soularr.album_track_num(directory, soularr.cfg)
             self.assertEqual(result["count"], 2)
             self.assertEqual(result["filetype"], "flac")
         finally:
@@ -317,7 +319,7 @@ class TestRawDictBoundary(unittest.TestCase):
                 {"filename": "cover.jpg", "size": 50},
                 {"filename": "info.nfo", "size": 10},
             ])
-            filtered = soularr.download_filter("flac", directory)
+            filtered = soularr.download_filter("flac", directory, soularr.cfg)
             filenames = [f["filename"] for f in filtered["files"]]
             self.assertIn("01 - Track.flac", filenames)
             self.assertIn("cover.jpg", filenames)
@@ -326,6 +328,86 @@ class TestRawDictBoundary(unittest.TestCase):
             self.assertEqual(len(directory["files"]), 3)
         finally:
             soularr.cfg = orig_cfg
+
+
+class TestContextDependencyPropagation(unittest.TestCase):
+    """Verify matching/enqueue helpers use ctx dependencies, not module globals."""
+
+    def setUp(self):
+        self._orig_cfg = soularr.cfg
+        self._orig_pdb = soularr.pipeline_db_source
+
+    def tearDown(self):
+        soularr.cfg = self._orig_cfg
+        soularr.pipeline_db_source = self._orig_pdb
+
+    def test_check_for_match_uses_ctx_cfg(self):
+        """Matching should read config from ctx, not the module-level cfg."""
+        soularr.cfg = _make_matching_cfg(
+            allowed_filetypes=("mp3",),
+            minimum_match_ratio=0.99,
+            ignored_users=("user1",),
+        )
+        ctx_cfg = _make_matching_cfg(
+            allowed_filetypes=("flac",),
+            minimum_match_ratio=0.5,
+            ignored_users=(),
+        )
+        ctx = _make_ctx(cfg=ctx_cfg)
+        ctx.folder_cache["user1"] = {
+            "Music\\Album": make_directory("Music\\Album", [
+                {"filename": "01 - Track One.flac", "size": 100},
+            ])
+        }
+        ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
+
+        found, _, _ = soularr.check_for_match(
+            make_tracks((1, "Track One", 1)),
+            "flac",
+            ["Music\\Album"],
+            "user1",
+            ctx,
+        )
+
+        self.assertTrue(found)
+
+    def test_get_denied_users_uses_ctx_pipeline_db_source(self):
+        """Denylist lookups should use ctx.pipeline_db_source."""
+        ctx_source = MagicMock()
+        ctx_db = MagicMock()
+        ctx_db.get_denylisted_users.return_value = [{"username": "baduser"}]
+        ctx_source._get_db.return_value = ctx_db
+        ctx = _make_ctx(pipeline_db_source=ctx_source)
+
+        global_source = MagicMock()
+        global_db = MagicMock()
+        global_db.get_denylisted_users.return_value = [{"username": "wrong"}]
+        global_source._get_db.return_value = global_db
+        soularr.pipeline_db_source = global_source
+
+        denied = soularr._get_denied_users(12, ctx)
+
+        self.assertEqual(denied, {"baduser"})
+        ctx_source._get_db.assert_called_once()
+        global_source._get_db.assert_not_called()
+
+    def test_get_album_tracks_uses_ctx_pipeline_db_source(self):
+        """Track lookups should use ctx.pipeline_db_source."""
+        album = MagicMock()
+        expected_tracks = make_tracks((1, "Track One", 1))
+        ctx_source = MagicMock()
+        ctx_source.get_tracks.return_value = expected_tracks
+        ctx = _make_ctx(pipeline_db_source=ctx_source)
+
+        global_source = MagicMock()
+        global_source.get_tracks.return_value = []
+        soularr.pipeline_db_source = global_source
+
+        tracks = soularr.get_album_tracks(album, ctx)
+
+        self.assertEqual(tracks, expected_tracks)
+        ctx_source.get_tracks.assert_called_once_with(album)
+        global_source.get_tracks.assert_not_called()
 
 
 class TestSlskdDoEnqueue(unittest.TestCase):
@@ -586,14 +668,75 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
 
         tracks = make_tracks((1, "Track One", 1), (1, "Track Two", 2))
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
+        dir1 = make_directory("Music\\Disc1", [{"filename": "01 - Track.flac", "size": 100}])
+        dir2 = make_directory("Music\\Disc2", [{"filename": "01 - Track.flac", "size": 100}])
 
-        soularr.try_multi_enqueue(release, tracks, results, "flac", self.ctx)
+        with patch.object(
+            enqueue_module,
+            "check_for_match",
+            side_effect=[
+                (True, dir1, "Music\\Disc1"),
+                (True, dir2, "Music\\Disc2"),
+            ],
+        ), patch.object(
+            enqueue_module,
+            "slskd_do_enqueue",
+            side_effect=[[MagicMock()], [MagicMock()]],
+        ):
+            soularr.try_multi_enqueue(release, tracks, results, "flac", self.ctx)
 
         self.assertEqual(results, original_results)
 
+    def test_directory_file_entries_not_mutated_when_prefixing_paths(self):
+        """try_multi_enqueue should build prefixed file copies, not mutate cached dirs."""
+        release = MagicMock()
+        media1 = MagicMock()
+        media1.medium_number = 1
+        media2 = MagicMock()
+        media2.medium_number = 2
+        release.media = [media1, media2]
+
+        tracks = make_tracks((1, "Track One", 1), (1, "Track Two", 2))
+        self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
+        results = {"user1": {"flac": ["Music\\Disc1", "Music\\Disc2"]}}
+
+        dir1 = make_directory("Music\\Disc1", [{"filename": "01 - Track.flac", "size": 100}])
+        dir2 = make_directory("Music\\Disc2", [{"filename": "01 - Track.flac", "size": 100}])
+        download1 = MagicMock()
+        download2 = MagicMock()
+
+        with patch.object(
+            enqueue_module,
+            "check_for_match",
+            side_effect=[
+                (True, dir1, "Music\\Disc1"),
+                (True, dir2, "Music\\Disc2"),
+            ],
+        ), patch.object(
+            enqueue_module,
+            "slskd_do_enqueue",
+            side_effect=[[download1], [download2]],
+        ) as enqueue_mock:
+            found, downloads = soularr.try_multi_enqueue(
+                release, tracks, results, "flac", self.ctx
+            )
+
+        self.assertTrue(found)
+        self.assertEqual(downloads, [download1, download2])
+        self.assertEqual(dir1["files"][0]["filename"], "01 - Track.flac")
+        self.assertEqual(dir2["files"][0]["filename"], "01 - Track.flac")
+        self.assertEqual(
+            enqueue_mock.call_args_list[0].kwargs["files"][0]["filename"],
+            "Music\\Disc1\\01 - Track.flac",
+        )
+        self.assertEqual(
+            enqueue_mock.call_args_list[1].kwargs["files"][0]["filename"],
+            "Music\\Disc2\\01 - Track.flac",
+        )
+
 
 class TestDeepcopyDeferredToMatch(unittest.TestCase):
-    """Verify deepcopy only happens for matched directories, not every lookup."""
+    """Verify successful matches do not corrupt cached directory data."""
 
     def setUp(self):
         self._orig_cfg = soularr.cfg
@@ -643,7 +786,7 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
         self.assertTrue(found)
 
         # Mutate the returned directory via download_filter (as try_enqueue does)
-        soularr.download_filter("flac", directory)
+        soularr.download_filter("flac", directory, self.ctx.cfg)
 
         # folder_cache should still have ALL 3 files (including .nfo)
         cached = self.ctx.folder_cache["testuser"]["Music\\Album"]
@@ -671,7 +814,7 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
         self.assertTrue(found1)
 
         # Mutate it
-        soularr.download_filter("flac", dir1)
+        soularr.download_filter("flac", dir1, self.ctx.cfg)
 
         # Second match on the same cached dir should still succeed
         found2, dir2, _ = soularr.check_for_match(
@@ -680,6 +823,81 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
         self.assertTrue(found2)
         # And should have both files (not the filtered version)
         self.assertEqual(len(dir2["files"]), 2)
+
+    def test_successful_match_does_not_call_deepcopy(self):
+        """check_for_match should return the cached directory directly on success."""
+        self.ctx.folder_cache["testuser"] = {
+            "Music\\Album": make_directory("Music\\Album", [
+                {"filename": "01 - Track One.flac", "size": 100},
+            ])
+        }
+        self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
+
+        with patch.object(
+            copy,
+            "deepcopy",
+            side_effect=AssertionError("deepcopy should not be used"),
+        ):
+            found, directory, file_dir = soularr.check_for_match(
+                make_tracks((1, "Track One", 1)),
+                "flac",
+                ["Music\\Album"],
+                "testuser",
+                self.ctx,
+            )
+
+        self.assertTrue(found)
+        self.assertEqual(file_dir, "Music\\Album")
+        self.assertIs(directory, self.ctx.folder_cache["testuser"]["Music\\Album"])
+
+
+class TestSingleEnqueuePathPrefixing(unittest.TestCase):
+    """Verify try_enqueue prefixes file paths without mutating the source directory."""
+
+    def setUp(self):
+        self._orig_cfg = soularr.cfg
+        soularr.cfg = _make_matching_cfg()
+        source = MagicMock()
+        db = MagicMock()
+        db.get_denylisted_users.return_value = []
+        source._get_db.return_value = db
+        self.ctx = _make_ctx(cfg=soularr.cfg, pipeline_db_source=source)
+        self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
+        self.ctx.user_upload_speed["user1"] = 10
+
+    def tearDown(self):
+        soularr.cfg = self._orig_cfg
+
+    def test_try_enqueue_builds_prefixed_file_copies(self):
+        directory = make_directory("Music\\Album", [
+            {"filename": "01 - Track.flac", "size": 100},
+        ])
+        results = {"user1": {"flac": ["Music\\Album"]}}
+        downloads = [MagicMock()]
+
+        with patch.object(
+            enqueue_module,
+            "check_for_match",
+            return_value=(True, directory, "Music\\Album"),
+        ), patch.object(
+            enqueue_module,
+            "slskd_do_enqueue",
+            return_value=downloads,
+        ) as enqueue_mock:
+            found, actual_downloads = soularr.try_enqueue(
+                make_tracks((1, "Track One", 1)),
+                results,
+                "flac",
+                self.ctx,
+            )
+
+        self.assertTrue(found)
+        self.assertEqual(actual_downloads, downloads)
+        self.assertEqual(directory["files"][0]["filename"], "01 - Track.flac")
+        self.assertEqual(
+            enqueue_mock.call_args.kwargs["files"][0]["filename"],
+            "Music\\Album\\01 - Track.flac",
+        )
 
 
 class TestNegativeMatchCache(unittest.TestCase):
@@ -939,7 +1157,9 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
         self.mock_slskd.users.directory.side_effect = mock_directory
 
         dirs_to_browse = ["Music\\Dir1", "Music\\Dir2", "Music\\Dir3"]
-        results = soularr._browse_directories(dirs_to_browse, "user1", max_workers=2)
+        results = soularr._browse_directories(
+            dirs_to_browse, "user1", self.mock_slskd, max_workers=2
+        )
 
         self.assertEqual(len(results), 3)
         self.assertIn("Music\\Dir1", results)
@@ -961,7 +1181,9 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
         self.mock_slskd.users.directory.side_effect = mock_directory
 
         dirs_to_browse = ["Music\\Dir1", "Music\\Dir2", "Music\\Dir3"]
-        results = soularr._browse_directories(dirs_to_browse, "user1", max_workers=2)
+        results = soularr._browse_directories(
+            dirs_to_browse, "user1", self.mock_slskd, max_workers=2
+        )
 
         # Dir1 and Dir3 should succeed, Dir2 should fail
         self.assertEqual(len(results), 2)


### PR DESCRIPTION
## Summary
- complete the remaining `ctx` propagation and explicit dependency cleanup for the matching, browse, and enqueue helpers from issue `#14`
- remove the dead `_execute_search` path, drop the unused `release_id` parameter, and stop mutating cached directory file dicts during enqueue
- split the helper groups into `lib/browse.py`, `lib/matching.py`, and `lib/enqueue.py`, leaving `soularr.py` as the orchestration layer

## Why
Issue `#14` called out that `soularr.py` still mixed orchestration with helper logic, depended on a dual ctx/global interface, and mutated cached browse results. That made follow-up changes riskier and required the success-path `deepcopy` workaround.

## Impact
- matching, browse, and enqueue helpers now depend on `ctx` or explicit config/client parameters instead of module state
- enqueue path prefixing no longer corrupts cached folder entries
- `soularr.py` is reduced to the search/orchestration entrypoint while the helper logic is grouped by responsibility under `lib/`

## Validation
- `nix-shell --run "python3 -m unittest tests.test_integration -v"`
- `nix-shell --run "bash scripts/run_tests.sh"`
- `nix-shell --run "pyright soularr.py lib/browse.py lib/matching.py lib/enqueue.py tests/test_integration.py"`

Closes #14.