### PR TITLE
refactor: presence-based reset semantics for quality_override

### DIFF
--- a/album_source.py
+++ b/album_source.py
@@ -288,14 +288,14 @@ class DatabaseSource:
 
         db = self._get_db()
         dl = download_info if isinstance(download_info, DownloadInfo) else DownloadInfo()
-        if quality_override is None:
-            req = db.get_request(request_id)
-            quality_override = req.get("quality_override") if req else None
         from lib.transitions import apply_transition
-        apply_transition(db, request_id, "wanted",
-                         beets_distance=bv_result.distance,
-                         beets_scenario=bv_result.scenario,
-                         quality_override=quality_override)
+        transition_kwargs: dict[str, object] = dict(
+            beets_distance=bv_result.distance,
+            beets_scenario=bv_result.scenario,
+        )
+        if quality_override is not None:
+            transition_kwargs["quality_override"] = quality_override
+        apply_transition(db, request_id, "wanted", **transition_kwargs)
         db.record_attempt(request_id, "validation")
 
         db.log_download(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -339,10 +339,12 @@ def dispatch_import(album_data: GrabListEntry, bv_result: ValidationResult, dest
 
             if action.requeue:
                 db = ctx.pipeline_db_source._get_db()
-                apply_transition(
-                    db, request_id, "wanted",
-                    quality_override=intent_to_quality_override(QualityIntent.upgrade),
-                    min_bitrate=new_br if action.mark_done else None)
+                requeue_fields: dict[str, object] = {
+                    "quality_override": intent_to_quality_override(QualityIntent.upgrade),
+                }
+                if action.mark_done and new_br is not None:
+                    requeue_fields["min_bitrate"] = new_br
+                apply_transition(db, request_id, "wanted", **requeue_fields)
 
             if action.run_quality_gate:
                 _check_quality_gate(album_data, request_id, ctx)

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -372,40 +372,37 @@ class PipelineDB:
         """Write spectral state pairs together, including explicit NULLs."""
         self.update_request_fields(request_id, **update.as_update_fields())
 
-    def reset_to_wanted(self, request_id, quality_override=None, min_bitrate=None):
+    def reset_to_wanted(self, request_id: int, **fields: Any) -> None:
+        """Reset to wanted, clearing retry counters.
+
+        Only fields explicitly passed are updated — omitted fields are
+        preserved.  Pass ``quality_override=None`` to clear the column;
+        omitting it leaves the existing value untouched.
+        """
         now = datetime.now(timezone.utc)
-        if min_bitrate is not None:
-            # Upgrading: save current as prev, set new
-            self._execute("""
-                UPDATE album_requests
-                SET status = 'wanted',
-                    search_attempts = 0,
-                    download_attempts = 0,
-                    validation_attempts = 0,
-                    next_retry_after = NULL,
-                    last_attempt_at = NULL,
-                    active_download_state = NULL,
-                    quality_override = %s,
-                    prev_min_bitrate = COALESCE(min_bitrate, prev_min_bitrate),
-                    min_bitrate = %s,
-                    updated_at = %s
-                WHERE id = %s
-            """, (quality_override, min_bitrate, now, request_id))
-        else:
-            # No new bitrate info — keep existing values
-            self._execute("""
-                UPDATE album_requests
-                SET status = 'wanted',
-                    search_attempts = 0,
-                    download_attempts = 0,
-                    validation_attempts = 0,
-                    next_retry_after = NULL,
-                    last_attempt_at = NULL,
-                    active_download_state = NULL,
-                    quality_override = %s,
-                    updated_at = %s
-                WHERE id = %s
-            """, (quality_override, now, request_id))
+        sets = [
+            "status = 'wanted'",
+            "search_attempts = 0",
+            "download_attempts = 0",
+            "validation_attempts = 0",
+            "next_retry_after = NULL",
+            "last_attempt_at = NULL",
+            "active_download_state = NULL",
+            "updated_at = %s",
+        ]
+        params: list[object] = [now]
+        if "quality_override" in fields:
+            sets.append("quality_override = %s")
+            params.append(fields["quality_override"])
+        if "min_bitrate" in fields:
+            sets.append("prev_min_bitrate = COALESCE(min_bitrate, prev_min_bitrate)")
+            sets.append("min_bitrate = %s")
+            params.append(fields["min_bitrate"])
+        params.append(request_id)
+        self._execute(
+            f"UPDATE album_requests SET {', '.join(sets)} WHERE id = %s",
+            params,
+        )
         self.conn.commit()
 
     # --- Downloading state ---

--- a/lib/transitions.py
+++ b/lib/transitions.py
@@ -100,8 +100,12 @@ def apply_transition(
     from_status = extra.pop("from_status", None)
     if from_status is not None:
         from_status = str(from_status)
-    quality_override = extra.pop("quality_override", None)
-    min_bitrate = extra.pop("min_bitrate", None)
+    # Presence-based: only fields explicitly passed get written.
+    # Omitted fields are preserved by reset_to_wanted / update_status.
+    transition_fields: dict[str, object] = {}
+    for _key in ("quality_override", "min_bitrate", "prev_min_bitrate"):
+        if _key in extra:
+            transition_fields[_key] = extra.pop(_key)
     state_json = extra.pop("state_json", None)
     attempt_type = extra.pop("attempt_type", None)
     if from_status is None:
@@ -130,27 +134,19 @@ def apply_transition(
 
     # → wanted with counter reset: use reset_to_wanted
     if to_status == "wanted" and fx.clear_retry_counters:
-        db.reset_to_wanted(request_id,
-                           quality_override=quality_override,
-                           min_bitrate=min_bitrate)
+        db.reset_to_wanted(request_id, **transition_fields)
         if fx.record_attempt and attempt_type:
             db.record_attempt(request_id, attempt_type)
         return
 
     # downloading → wanted: reset + record attempt
     if from_status == "downloading" and to_status == "wanted":
-        db.reset_to_wanted(request_id,
-                           quality_override=quality_override,
-                           min_bitrate=min_bitrate)
+        db.reset_to_wanted(request_id, **transition_fields)
         if attempt_type:
             db.record_attempt(request_id, attempt_type)
         return
 
     # All other transitions: use update_status
-    # Forward named params as extra fields when not consumed by reset_to_wanted
     all_extra: dict[str, object] = dict(extra)
-    if min_bitrate is not None:
-        all_extra["min_bitrate"] = min_bitrate
-    if quality_override is not None:
-        all_extra["quality_override"] = quality_override
+    all_extra.update(transition_fields)
     db.update_status(request_id, to_status, **all_extra)

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -461,14 +461,18 @@ class TestResetToWanted(unittest.TestCase):
     def tearDown(self):
         self.db.close()
 
-    def test_reset_to_wanted(self):
+    def _make_request(self, suffix: str = "") -> int:
         req_id = self.db.add_request(
-            mb_release_id="reset-uuid",
+            mb_release_id=f"reset-{suffix}-uuid",
             artist_name="A",
             album_title="B",
             source="request",
         )
         self.db.update_status(req_id, "imported")
+        return req_id
+
+    def test_reset_to_wanted(self):
+        req_id = self._make_request("basic")
         self.db.reset_to_wanted(req_id)
         req = self.db.get_request(req_id)
         assert req is not None
@@ -477,6 +481,99 @@ class TestResetToWanted(unittest.TestCase):
         self.assertEqual(req["search_attempts"], 0)
         self.assertEqual(req["download_attempts"], 0)
         self.assertEqual(req["validation_attempts"], 0)
+
+    def test_preserves_quality_override_when_omitted(self):
+        req_id = self._make_request("preserve-qo")
+        self.db.update_request_fields(req_id, quality_override="flac,mp3 v0")
+        self.db.reset_to_wanted(req_id)
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["quality_override"], "flac,mp3 v0")
+
+    def test_sets_quality_override_when_passed(self):
+        req_id = self._make_request("set-qo")
+        self.db.update_request_fields(req_id, quality_override="flac,mp3 v0,mp3 320")
+        self.db.reset_to_wanted(req_id, quality_override="flac,mp3 v0")
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["quality_override"], "flac,mp3 v0")
+
+    def test_clears_quality_override_when_none(self):
+        req_id = self._make_request("clear-qo")
+        self.db.update_request_fields(req_id, quality_override="flac")
+        self.db.reset_to_wanted(req_id, quality_override=None)
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertIsNone(req["quality_override"])
+
+    def test_preserves_min_bitrate_when_omitted(self):
+        req_id = self._make_request("preserve-br")
+        self.db.update_request_fields(req_id, min_bitrate=320)
+        self.db.reset_to_wanted(req_id)
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["min_bitrate"], 320)
+
+    def test_sets_min_bitrate_when_passed(self):
+        req_id = self._make_request("set-br")
+        self.db.update_request_fields(req_id, min_bitrate=192)
+        self.db.reset_to_wanted(req_id, min_bitrate=320)
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["min_bitrate"], 320)
+        self.assertEqual(req["prev_min_bitrate"], 192)
+
+
+@requires_postgres
+class TestApplyTransitionDB(unittest.TestCase):
+    """DB-backed contract tests for apply_transition preserve semantics."""
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def _make_request(self, suffix: str = "", **extra: object) -> int:
+        from lib.transitions import apply_transition
+        req_id = self.db.add_request(
+            mb_release_id=f"transition-{suffix}-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        if extra:
+            self.db.update_request_fields(req_id, **extra)
+        # Move to imported so we can transition to wanted
+        apply_transition(self.db, req_id, "imported", from_status="wanted")
+        return req_id
+
+    def test_transition_to_wanted_preserves_override(self):
+        from lib.transitions import apply_transition
+        req_id = self._make_request("preserve", quality_override="flac,mp3 v0")
+        apply_transition(self.db, req_id, "wanted", from_status="imported")
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["quality_override"], "flac,mp3 v0")
+
+    def test_transition_to_wanted_with_narrowed_override(self):
+        from lib.transitions import apply_transition
+        req_id = self._make_request("narrow", quality_override="flac,mp3 v0,mp3 320")
+        apply_transition(self.db, req_id, "wanted", from_status="imported",
+                         quality_override="flac,mp3 v0")
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["quality_override"], "flac,mp3 v0")
+
+    def test_transition_to_imported_clears_override(self):
+        from lib.transitions import apply_transition
+        req_id = self._make_request("clear", quality_override="flac")
+        apply_transition(self.db, req_id, "wanted", from_status="imported")
+        apply_transition(self.db, req_id, "imported", from_status="wanted",
+                         quality_override=None)
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertIsNone(req["quality_override"])
 
 
 @requires_postgres

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -158,7 +158,7 @@ class TestApplyTransition(unittest.TestCase):
         apply_transition(db, 1, "wanted", from_status="downloading",
                          quality_override="flac", attempt_type="download")
         db.reset_to_wanted.assert_called_once_with(
-            1, quality_override="flac", min_bitrate=None)
+            1, quality_override="flac")
         db.record_attempt.assert_called_once_with(1, "download")
 
     def test_imported_to_wanted_calls_reset(self):

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -310,9 +310,12 @@ def post_pipeline_update(h, body: dict) -> None:
             if b.album_exists(mbid):
                 quality = intent_to_quality_override(QualityIntent.upgrade)
                 min_br = b.get_min_bitrate(mbid)
-        apply_transition(s._db(), int(req_id), "wanted",
-                         from_status=req["status"],
-                         quality_override=quality, min_bitrate=min_br)
+        kwargs: dict[str, object] = {"from_status": req["status"]}
+        if quality is not None:
+            kwargs["quality_override"] = quality
+        if min_br is not None:
+            kwargs["min_bitrate"] = min_br
+        apply_transition(s._db(), int(req_id), "wanted", **kwargs)
     else:
         apply_transition(s._db(), int(req_id), new_status,
                          from_status=req["status"])
@@ -512,9 +515,12 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     if req:
         quality = req.get("quality_override") or intent_to_quality_override(QualityIntent.upgrade)
         min_br = req.get("min_bitrate")
-        apply_transition(s._db(), int(req_id), "wanted",
-                         from_status=req["status"],
-                         quality_override=quality, min_bitrate=min_br)
+        ban_kwargs: dict[str, object] = {"from_status": req["status"]}
+        if quality is not None:
+            ban_kwargs["quality_override"] = quality
+        if min_br is not None:
+            ban_kwargs["min_bitrate"] = min_br
+        apply_transition(s._db(), int(req_id), "wanted", **ban_kwargs)
 
     h._json({
         "status": "ok",


### PR DESCRIPTION
## Summary

Addresses #28 items B (unsafe reset semantics) and E (DB-backed contract tests).

- `reset_to_wanted()` now takes `**fields` — omitted fields are preserved, explicit values (including `None`) are written
- `apply_transition()` uses presence-based extraction instead of lossy `None` defaults
- `mark_failed()` DB-read workaround removed — no longer needed
- Fixes latent bug where `update_status` path silently dropped `quality_override=None` (the one caller that intentionally clears was broken)
- 8 new DB-backed contract tests verify preserve/set/clear semantics through real PostgreSQL

## Test plan

- [x] 1201 tests pass (net +8), pyright clean
- [x] DB-backed: reset without field → preserves existing
- [x] DB-backed: reset with value → sets it
- [x] DB-backed: reset with None → clears
- [x] DB-backed: apply_transition through real PostgreSQL → same semantics
- [ ] Deploy and verify on next soularr timer cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)