### PR TITLE
refactor: kill QualityIntent enum, use CSV directly

### DIFF
--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -384,16 +384,15 @@ def find_download(
     ctx.negative_matches.clear()
     ctx.current_album_cache[album_id] = album
 
-    from lib.quality import resolve_search_intent
+    from lib.quality import search_tiers
 
-    resolved = resolve_search_intent(album.db_quality_override,
-                                     list(ctx.cfg.allowed_filetypes))
-    filetypes_to_try = resolved.search_tiers
+    filetypes_to_try, catch_all = search_tiers(
+        album.db_quality_override, list(ctx.cfg.allowed_filetypes))
 
     if album.db_quality_override:
         logger.info(
             f"Quality override for {artist_name} - {album.title}: "
-            f"intent={resolved.intent.value}, searching {filetypes_to_try}"
+            f"searching {filetypes_to_try}"
         )
 
     for allowed_filetype in filetypes_to_try:
@@ -402,7 +401,7 @@ def find_download(
             return True
 
     if (
-        resolved.catch_all
+        catch_all
         and "*" not in [ft.strip() for ft in (ctx.cfg.allowed_filetypes or ())]
     ):
         logger.info(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -17,7 +17,7 @@ from lib.quality import (parse_import_result, DownloadInfo, ImportResult,
                          SpectralMeasurement,
                          ValidationResult,
                          QUALITY_MIN_BITRATE_KBPS,
-                         QualityIntent, intent_to_quality_override,
+                         QUALITY_UPGRADE_TIERS, QUALITY_FLAC_ONLY,
                          dispatch_action, compute_effective_override_bitrate,
                          extract_usernames, narrow_override_on_downgrade)
 from lib.transitions import apply_transition
@@ -149,7 +149,7 @@ def _check_quality_gate(album_data: GrabListEntry, request_id: int,
                     min_bitrate=min_br_kbps,
                 )
                 return
-            upgrade_override = intent_to_quality_override(QualityIntent.upgrade)
+            upgrade_override = QUALITY_UPGRADE_TIERS
             db = ctx.pipeline_db_source._get_db()
             apply_transition(db, request_id, "wanted",
                              from_status="imported",
@@ -170,7 +170,7 @@ def _check_quality_gate(album_data: GrabListEntry, request_id: int,
                 f"queued for upgrade, denylisted {usernames} "
                 f"(searching {upgrade_override})")
         elif decision == "requeue_flac":
-            flac_override = intent_to_quality_override(QualityIntent.flac_only)
+            flac_override = QUALITY_FLAC_ONLY
             db = ctx.pipeline_db_source._get_db()
             apply_transition(db, request_id, "wanted",
                              from_status="imported",
@@ -188,6 +188,7 @@ def _check_quality_gate(album_data: GrabListEntry, request_id: int,
                 "imported",
                 from_status="imported",
                 min_bitrate=min_br_kbps,
+                quality_override=None,  # done searching
             )
             if verified_lossless:
                 logger.info(f"QUALITY GATE: {label} min_bitrate={min_br_kbps}kbps — quality OK")
@@ -340,7 +341,7 @@ def dispatch_import(album_data: GrabListEntry, bv_result: ValidationResult, dest
             if action.requeue:
                 db = ctx.pipeline_db_source._get_db()
                 requeue_fields: dict[str, object] = {
-                    "quality_override": intent_to_quality_override(QualityIntent.upgrade),
+                    "quality_override": QUALITY_UPGRADE_TIERS,
                 }
                 if action.mark_done and new_br is not None:
                     requeue_fields["min_bitrate"] = new_br

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -276,6 +276,15 @@ class PipelineDB:
                         CHECK(status IN ('wanted', 'downloading', 'imported', 'manual'));
                 END $$;
             """)
+            # Migrate symbolic intent names to concrete CSV values
+            cur.execute("""
+                UPDATE album_requests SET quality_override = 'flac,mp3 v0,mp3 320'
+                WHERE quality_override IN ('flac_preferred', 'upgrade');
+            """)
+            cur.execute("""
+                UPDATE album_requests SET quality_override = NULL
+                WHERE quality_override = 'best_effort';
+            """)
         mig_conn.close()
 
     def close(self):

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -10,131 +10,27 @@ from dataclasses import dataclass, field, asdict
 from typing import Any, Optional
 
 QUALITY_UPGRADE_TIERS = "flac,mp3 v0,mp3 320"
-_QUALITY_UPGRADE_LIST = [ft.strip() for ft in QUALITY_UPGRADE_TIERS.split(",")]
+QUALITY_FLAC_ONLY = "flac"
+
+# Friendly names for CLI/web UI → quality_override DB values
+INTENT_NAMES: dict[str, str | None] = {
+    "best_effort": None,
+    "flac_only": QUALITY_FLAC_ONLY,
+    "flac": QUALITY_FLAC_ONLY,
+    "upgrade": QUALITY_UPGRADE_TIERS,
+}
 
 
-class QualityIntent(enum.Enum):
-    """Explicit quality intent for a pipeline request.
+def search_tiers(quality_override: str | None,
+                 config_allowed: list[str]) -> tuple[list[str], bool]:
+    """Return (filetypes_to_search, allow_catch_all) from a quality_override.
 
-    Replaces the ad-hoc quality_override CSV with a semantic model that
-    search, import, and quality gate logic can branch on directly.
-    """
-    best_effort = "best_effort"
-    flac_only = "flac_only"
-    flac_preferred = "flac_preferred"
-    upgrade = "upgrade"
-
-
-def search_filetypes(intent: QualityIntent, config_allowed: list[str]) -> list[str]:
-    """Map a quality intent to the ordered list of filetypes to search.
-
-    Pure function — no I/O. The returned list is tried in order by the search
-    loop in soularr.py; the first match wins.
-
-    Prefer resolve_search_intent() for new call sites — it handles narrowed
-    CSV overrides correctly and returns catch_all in one call.
-    """
-    if intent == QualityIntent.best_effort:
-        return list(config_allowed)
-    if intent == QualityIntent.flac_only:
-        return ["flac"]
-    if intent == QualityIntent.flac_preferred:
-        return list(_QUALITY_UPGRADE_LIST)
-    # upgrade
-    return list(_QUALITY_UPGRADE_LIST)
-
-
-def intent_allows_catch_all(intent: QualityIntent) -> bool:
-    """Whether this intent permits falling back to any audio format.
-
-    Only best_effort allows catch-all — all other intents restrict quality.
-    """
-    return intent == QualityIntent.best_effort
-
-
-def derive_intent(quality_override: str | None) -> QualityIntent:
-    """Derive a QualityIntent from an existing quality_override DB value.
-
-    Backward-compatible bridge: recognizes all existing DB values
-    (None, "flac", "flac,mp3 v0,mp3 320") and maps them to intents.
-    Also recognizes literal intent names ("flac_only", "flac_preferred").
+    NULL override = use global config + allow catch-all fallback.
+    Any CSV override = search exactly those tiers, no catch-all.
     """
     if not quality_override:
-        return QualityIntent.best_effort
-
-    stripped = quality_override.strip()
-
-    # Literal intent names (new path)
-    try:
-        return QualityIntent(stripped)
-    except ValueError:
-        pass
-
-    # Legacy DB values
-    if stripped == "flac":
-        return QualityIntent.flac_only
-
-    # Any multi-value CSV (including QUALITY_UPGRADE_TIERS) is an upgrade
-    normalized = [ft.strip() for ft in stripped.split(",")]
-    if len(normalized) > 1:
-        return QualityIntent.upgrade
-
-    # Single unknown value — treat as best_effort
-    return QualityIntent.best_effort
-
-
-def intent_to_quality_override(intent: QualityIntent) -> str | None:
-    """Convert a QualityIntent to the quality_override DB string.
-
-    This is the reverse of derive_intent — used when writing to the DB.
-    """
-    if intent == QualityIntent.best_effort:
-        return None
-    if intent == QualityIntent.flac_only:
-        return "flac"
-    if intent == QualityIntent.flac_preferred:
-        # Store the literal intent name so it round-trips through derive_intent.
-        # Legacy code that splits on commas won't encounter this value — it's
-        # only written by the new intent-aware path (Commit 2).
-        return "flac_preferred"
-    # upgrade — keep the CSV for backward compat with existing DB rows
-    return QUALITY_UPGRADE_TIERS
-
-
-@dataclass(frozen=True)
-class ResolvedIntent:
-    """Complete search plan resolved from quality_override + config.
-
-    Replaces the lossy derive_intent() → search_filetypes() → intent_allows_catch_all()
-    three-call pattern. Carries the literal tier list so narrowed CSV overrides
-    (e.g. "flac,mp3 v0" after removing mp3 320) are honored without information loss.
-    """
-    intent: QualityIntent
-    search_tiers: list[str]
-    catch_all: bool
-
-
-def resolve_search_intent(quality_override: str | None,
-                          config_allowed: list[str]) -> ResolvedIntent:
-    """Resolve quality_override + config into a complete search plan.
-
-    Single entry point for the search-time read path. Handles narrowed CSV
-    overrides correctly — "flac,mp3 v0" produces ["flac", "mp3 v0"], not the
-    full QUALITY_UPGRADE_TIERS.
-    """
-    intent = derive_intent(quality_override)
-    if intent == QualityIntent.best_effort:
-        return ResolvedIntent(intent, list(config_allowed), catch_all=True)
-    if intent == QualityIntent.flac_only:
-        return ResolvedIntent(intent, ["flac"], catch_all=False)
-    if intent == QualityIntent.flac_preferred:
-        return ResolvedIntent(intent, list(_QUALITY_UPGRADE_LIST), catch_all=False)
-    # upgrade — use literal CSV if available (narrowed overrides), else default
-    if quality_override and "," in quality_override:
-        tiers = [t.strip() for t in quality_override.split(",")]
-    else:
-        tiers = list(_QUALITY_UPGRADE_LIST)
-    return ResolvedIntent(intent, tiers, catch_all=False)
+        return list(config_allowed), True
+    return [t.strip() for t in quality_override.split(",")], False
 
 
 QUALITY_MIN_BITRATE_KBPS = 210  # V0 floor — below this triggers upgrade
@@ -1061,16 +957,6 @@ def rejected_download_tier(dl_info: "DownloadInfo") -> str | None:
     return None
 
 
-def _quality_override_tiers(quality_override: str | None) -> list[str] | None:
-    """Expand a stored quality_override into the concrete search tiers it means."""
-    if not quality_override:
-        return None
-    resolved = resolve_search_intent(quality_override, [])
-    if resolved.intent == QualityIntent.best_effort:
-        return None
-    return list(resolved.search_tiers)
-
-
 def narrow_override_on_downgrade(quality_override: str | None,
                                  dl_info: "DownloadInfo") -> str | None:
     """Remove the rejected filetype tier from quality_override after downgrade.
@@ -1081,12 +967,12 @@ def narrow_override_on_downgrade(quality_override: str | None,
 
     Returns the narrowed override string, or None if no change is needed.
     """
+    if not quality_override:
+        return None
     tier = rejected_download_tier(dl_info)
     if not tier:
         return None
-    tiers = _quality_override_tiers(quality_override)
-    if not tiers:
-        return None
+    tiers = [t.strip() for t in quality_override.split(",")]
     if tier not in tiers:
         return None
     narrowed = [t for t in tiers if t != tier]

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -199,7 +199,7 @@ def cmd_set(db, args):
 
 def cmd_set_intent(db, args):
     """Set quality intent for a request."""
-    from lib.quality import QualityIntent, intent_to_quality_override
+    from lib.quality import INTENT_NAMES
     from lib.transitions import apply_transition
     req = db.get_request(args.id)
     if not req:
@@ -208,8 +208,7 @@ def cmd_set_intent(db, args):
     if req["status"] == "downloading":
         print(f"  Cannot set intent while album is downloading.")
         return
-    intent = QualityIntent(args.intent)
-    quality_override = intent_to_quality_override(intent)
+    quality_override = INTENT_NAMES[args.intent]
     old_override = req.get("quality_override")
 
     if req["status"] == "imported":
@@ -218,14 +217,14 @@ def cmd_set_intent(db, args):
                          quality_override=quality_override,
                          min_bitrate=min_br)
         print(f"  [{args.id}] {req['artist_name']} - {req['album_title']}: "
-              f"intent={intent.value}, re-queued for search")
+              f"intent={args.intent}, re-queued for search")
     else:
         db._execute(
             "UPDATE album_requests SET quality_override = %s, updated_at = NOW() WHERE id = %s",
             (quality_override, args.id),
         )
         print(f"  [{args.id}] {req['artist_name']} - {req['album_title']}: "
-              f"intent={intent.value} (override: {old_override} → {quality_override})")
+              f"intent={args.intent} (override: {old_override} → {quality_override})")
 
 
 def _fmt_br(kbps):
@@ -842,7 +841,7 @@ def main():
     # set-intent
     p_intent = sub.add_parser("set-intent", help="Set quality intent for a request")
     p_intent.add_argument("id", type=int, help="Request ID")
-    p_intent.add_argument("intent", choices=["best_effort", "flac_only", "flac_preferred", "upgrade"],
+    p_intent.add_argument("intent", choices=["best_effort", "flac_only", "flac", "upgrade"],
                           help="Quality intent")
 
     # force-import

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -201,7 +201,7 @@ class TestDatabaseSource(unittest.TestCase):
             album_title="B",
             source="request",
         )
-        db.update_request_fields(req_id, quality_override="flac_preferred")
+        db.update_request_fields(req_id, quality_override="flac,mp3 v0,mp3 320")
         record = _make_record(db_request_id=req_id, db_source="request")
         bv_result = ValidationResult(valid=False, distance=0.35, scenario="high_distance")
 
@@ -209,7 +209,7 @@ class TestDatabaseSource(unittest.TestCase):
 
         req = db.get_request(req_id)
         assert req is not None
-        self.assertEqual(req["quality_override"], "flac_preferred")
+        self.assertEqual(req["quality_override"], "flac,mp3 v0,mp3 320")
 
     def test_mark_failed_uses_explicit_narrowed_override(self):
         source, db = self._make_source()
@@ -219,7 +219,7 @@ class TestDatabaseSource(unittest.TestCase):
             album_title="B",
             source="request",
         )
-        db.update_request_fields(req_id, quality_override="flac_preferred")
+        db.update_request_fields(req_id, quality_override="flac,mp3 v0,mp3 320")
         record = _make_record(db_request_id=req_id, db_source="request")
         bv_result = ValidationResult(valid=False, distance=0.35, scenario="quality_downgrade")
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -13,8 +13,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 from lib.quality import (DownloadInfo, ImportResult, ConversionInfo,
                          AudioQualityMeasurement, PostflightInfo,
                          SpectralMeasurement,
-                         QUALITY_UPGRADE_TIERS,
-                         QualityIntent, intent_to_quality_override)
+                         QUALITY_UPGRADE_TIERS, QUALITY_FLAC_ONLY)
 from tests.helpers import make_request_row
 
 
@@ -222,20 +221,22 @@ class TestDispatchImport(unittest.TestCase):
         call_kwargs = result["pipeline_db_source"].mark_failed.call_args.kwargs
         self.assertEqual(call_kwargs.get("quality_override"), "flac,mp3 v0")
 
-    def test_downgrade_narrows_flac_preferred_before_mark_failed(self):
+    def test_downgrade_preserves_override_when_tier_not_matched(self):
+        """320 downgrade with flac-only override → no narrowing (tier not in CSV)."""
         ir = _make_import_result(decision="downgrade", new_min_bitrate=320,
                                  prev_min_bitrate=320)
         ctx = _make_ctx()
         db = ctx.pipeline_db_source._get_db()
         db.get_request.return_value = make_request_row(
             status="downloading",
-            quality_override="flac_preferred",
+            quality_override="flac",
         )
 
         result = self._dispatch(ir, ctx=ctx)
 
         call_kwargs = result["pipeline_db_source"].mark_failed.call_args.kwargs
-        self.assertEqual(call_kwargs.get("quality_override"), "flac,mp3 v0")
+        # narrowing returns None (mp3 320 not in "flac"), so no override passed
+        self.assertIsNone(call_kwargs.get("quality_override"))
 
     def test_transcode_upgrade(self):
         ir = _make_import_result(decision="transcode_upgrade",
@@ -358,7 +359,7 @@ class TestOverrideMinBitrate(unittest.TestCase):
 
 
 class TestQualityGateUsesIntent(unittest.TestCase):
-    """Verify _check_quality_gate uses intent_to_quality_override."""
+    """Verify _check_quality_gate uses quality constants."""
 
     def _run_quality_gate(self, gate_decision, **extra_req_fields):
         """Run _check_quality_gate with a mocked quality_gate_decision."""
@@ -384,12 +385,12 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         return db
 
     def test_requeue_upgrade_uses_intent(self):
-        """requeue_upgrade should use intent_to_quality_override(upgrade)."""
+        """requeue_upgrade should use quality constants(upgrade)."""
         db = self._run_quality_gate("requeue_upgrade")
         call_args = db.reset_to_wanted.call_args
         self.assertEqual(
             call_args.kwargs.get("quality_override") or call_args[1].get("quality_override"),
-            intent_to_quality_override(QualityIntent.upgrade),
+            QUALITY_UPGRADE_TIERS,
         )
 
     def test_requeue_upgrade_verified_lossless_accepts(self):
@@ -401,12 +402,12 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         db.add_denylist.assert_not_called()
 
     def test_requeue_flac_uses_intent(self):
-        """requeue_flac should use intent_to_quality_override(flac_only)."""
+        """requeue_flac should use quality constants(flac_only)."""
         db = self._run_quality_gate("requeue_flac")
         call_args = db.reset_to_wanted.call_args
         self.assertEqual(
             call_args.kwargs.get("quality_override") or call_args[1].get("quality_override"),
-            intent_to_quality_override(QualityIntent.flac_only),
+            QUALITY_FLAC_ONLY,
         )
 
     def test_quality_gate_reads_current_spectral_not_last_download(self):
@@ -496,7 +497,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         db.reset_to_wanted.assert_not_called()
 
     def test_dispatch_requeue_uses_intent(self):
-        """dispatch_import requeue path should use intent_to_quality_override."""
+        """dispatch_import requeue path should use quality constants."""
         ir = _make_import_result(decision="transcode_upgrade",
                                  new_min_bitrate=227)
         album_data = _make_album_data()
@@ -519,7 +520,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         call_args = db.reset_to_wanted.call_args
         self.assertEqual(
             call_args.kwargs.get("quality_override") or call_args[1].get("quality_override"),
-            intent_to_quality_override(QualityIntent.upgrade),
+            QUALITY_UPGRADE_TIERS,
         )
 
 

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -81,7 +81,7 @@ assertEqual(overrideToIntent(null), 'best_effort', 'null → best_effort');
 assertEqual(overrideToIntent(undefined), 'best_effort', 'undefined → best_effort');
 assertEqual(overrideToIntent(''), 'best_effort', 'empty string → best_effort');
 assertEqual(overrideToIntent('flac'), 'flac_only', '"flac" → flac_only');
-assertEqual(overrideToIntent('flac_preferred'), 'flac_preferred', '"flac_preferred" → flac_preferred');
+assertEqual(overrideToIntent('flac_preferred'), 'upgrade', '"flac_preferred" (legacy) → upgrade');
 assertEqual(overrideToIntent('flac,mp3 v0,mp3 320'), 'upgrade', 'CSV upgrade tiers → upgrade');
 assertEqual(overrideToIntent('flac,mp3 v0'), 'upgrade', 'partial CSV → upgrade');
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -355,11 +355,11 @@ class TestCmdSetIntent(unittest.TestCase):
             id=2, status="imported", artist_name="A", album_title="B",
             min_bitrate=245,
         )
-        args = MagicMock(id=2, intent="flac_preferred")
+        args = MagicMock(id=2, intent="upgrade")
         pipeline_cli.cmd_set_intent(db, args)
         db.reset_to_wanted.assert_called_once()
         call_kwargs = db.reset_to_wanted.call_args.kwargs if db.reset_to_wanted.call_args.kwargs else db.reset_to_wanted.call_args[1]
-        self.assertEqual(call_kwargs.get("quality_override"), "flac_preferred")
+        self.assertEqual(call_kwargs.get("quality_override"), "flac,mp3 v0,mp3 320")
 
     @patch("builtins.print")
     def test_set_intent_refuses_downloading(self, _mock_print):

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -900,11 +900,6 @@ class TestNarrowOverrideOnDowngrade(unittest.TestCase):
         result = narrow_override_on_downgrade("flac,mp3 v0", dl)
         self.assertEqual(result, "mp3 v0")
 
-    def test_removes_320_from_flac_preferred(self):
-        dl = DownloadInfo(slskd_filetype="mp3", is_vbr=False, bitrate=320000)
-        result = narrow_override_on_downgrade("flac_preferred", dl)
-        self.assertEqual(result, "flac,mp3 v0")
-
     def test_removes_v0_from_override(self):
         dl = DownloadInfo(slskd_filetype="mp3", is_vbr=True, bitrate=245000)
         result = narrow_override_on_downgrade("flac,mp3 v0,mp3 320", dl)

--- a/tests/test_quality_intent.py
+++ b/tests/test_quality_intent.py
@@ -1,282 +1,97 @@
-"""Tests for QualityIntent enum and associated pure functions."""
+"""Tests for search_tiers, INTENT_NAMES, and quality override narrowing contracts."""
 
 import unittest
 
 from lib.quality import (
-    QualityIntent,
     QUALITY_UPGRADE_TIERS,
-    search_filetypes,
-    intent_allows_catch_all,
-    derive_intent,
-    intent_to_quality_override,
-    ResolvedIntent,
-    resolve_search_intent,
+    QUALITY_FLAC_ONLY,
+    INTENT_NAMES,
+    search_tiers,
+    narrow_override_on_downgrade,
+    DownloadInfo,
 )
 
 
-class TestQualityIntentEnum(unittest.TestCase):
-    """QualityIntent has exactly four values."""
+class TestSearchTiers(unittest.TestCase):
+    """search_tiers: CSV → (filetype list, catch_all)."""
 
-    def test_enum_values(self):
-        self.assertEqual(QualityIntent.best_effort.value, "best_effort")
-        self.assertEqual(QualityIntent.flac_only.value, "flac_only")
-        self.assertEqual(QualityIntent.flac_preferred.value, "flac_preferred")
-        self.assertEqual(QualityIntent.upgrade.value, "upgrade")
+    def test_none_returns_config_with_catch_all(self):
+        tiers, catch_all = search_tiers(None, ["flac", "mp3"])
+        self.assertEqual(tiers, ["flac", "mp3"])
+        self.assertTrue(catch_all)
 
-    def test_enum_count(self):
-        self.assertEqual(len(QualityIntent), 4)
-
-
-class TestSearchFiletypes(unittest.TestCase):
-    """search_filetypes maps intent to ordered filetype lists."""
-
-    def test_best_effort_returns_config(self):
-        result = search_filetypes(QualityIntent.best_effort, ["flac", "mp3"])
-        self.assertEqual(result, ["flac", "mp3"])
-
-    def test_best_effort_preserves_order(self):
-        result = search_filetypes(QualityIntent.best_effort, ["mp3", "flac"])
-        self.assertEqual(result, ["mp3", "flac"])
+    def test_empty_string_returns_config_with_catch_all(self):
+        tiers, catch_all = search_tiers("", ["flac", "mp3"])
+        self.assertEqual(tiers, ["flac", "mp3"])
+        self.assertTrue(catch_all)
 
     def test_flac_only(self):
-        result = search_filetypes(QualityIntent.flac_only, ["flac", "mp3"])
-        self.assertEqual(result, ["flac"])
+        tiers, catch_all = search_tiers("flac", ["flac", "mp3"])
+        self.assertEqual(tiers, ["flac"])
+        self.assertFalse(catch_all)
 
-    def test_flac_only_ignores_config(self):
-        result = search_filetypes(QualityIntent.flac_only, ["mp3"])
-        self.assertEqual(result, ["flac"])
+    def test_upgrade_tiers(self):
+        tiers, catch_all = search_tiers("flac,mp3 v0,mp3 320", [])
+        self.assertEqual(tiers, ["flac", "mp3 v0", "mp3 320"])
+        self.assertFalse(catch_all)
 
-    def test_flac_preferred_flac_first_then_lossy(self):
-        result = search_filetypes(QualityIntent.flac_preferred, ["flac", "mp3"])
-        self.assertEqual(result, ["flac", "mp3 v0", "mp3 320"])
+    def test_narrowed_csv(self):
+        tiers, catch_all = search_tiers("flac,mp3 v0", ["flac", "mp3"])
+        self.assertEqual(tiers, ["flac", "mp3 v0"])
+        self.assertFalse(catch_all)
 
-    def test_flac_preferred_ignores_config_beyond_flac(self):
-        """flac_preferred always produces the same list regardless of config."""
-        result = search_filetypes(QualityIntent.flac_preferred, ["mp3"])
-        self.assertEqual(result, ["flac", "mp3 v0", "mp3 320"])
+    def test_whitespace_in_csv(self):
+        tiers, _ = search_tiers("flac, mp3 v0, mp3 320", [])
+        self.assertEqual(tiers, ["flac", "mp3 v0", "mp3 320"])
 
-    def test_upgrade(self):
-        expected = [ft.strip() for ft in QUALITY_UPGRADE_TIERS.split(",")]
-        result = search_filetypes(QualityIntent.upgrade, ["flac", "mp3"])
-        self.assertEqual(result, expected)
-
-    def test_upgrade_matches_constant(self):
-        result = search_filetypes(QualityIntent.upgrade, [])
-        self.assertEqual(result, ["flac", "mp3 v0", "mp3 320"])
+    def test_config_order_preserved(self):
+        tiers, _ = search_tiers(None, ["mp3", "flac"])
+        self.assertEqual(tiers, ["mp3", "flac"])
 
 
-class TestIntentAllowsCatchAll(unittest.TestCase):
-    """Only best_effort allows catch-all fallback."""
-
-    def test_best_effort_allows(self):
-        self.assertTrue(intent_allows_catch_all(QualityIntent.best_effort))
-
-    def test_flac_only_disallows(self):
-        self.assertFalse(intent_allows_catch_all(QualityIntent.flac_only))
-
-    def test_flac_preferred_disallows(self):
-        self.assertFalse(intent_allows_catch_all(QualityIntent.flac_preferred))
-
-    def test_upgrade_disallows(self):
-        self.assertFalse(intent_allows_catch_all(QualityIntent.upgrade))
-
-
-class TestDeriveIntent(unittest.TestCase):
-    """derive_intent maps existing quality_override DB values to intents."""
-
-    def test_none_is_best_effort(self):
-        self.assertEqual(derive_intent(None), QualityIntent.best_effort)
-
-    def test_empty_string_is_best_effort(self):
-        self.assertEqual(derive_intent(""), QualityIntent.best_effort)
-
-    def test_flac_is_flac_only(self):
-        self.assertEqual(derive_intent("flac"), QualityIntent.flac_only)
-
-    def test_upgrade_tiers_is_upgrade(self):
-        self.assertEqual(derive_intent(QUALITY_UPGRADE_TIERS), QualityIntent.upgrade)
-
-    def test_explicit_upgrade_tiers_string(self):
-        self.assertEqual(derive_intent("flac,mp3 v0,mp3 320"), QualityIntent.upgrade)
-
-    def test_whitespace_variants(self):
-        """Handles minor whitespace differences in CSV."""
-        self.assertEqual(derive_intent("flac, mp3 v0, mp3 320"), QualityIntent.upgrade)
-
-    def test_flac_preferred_string(self):
-        """derive_intent recognizes 'flac_preferred' as a literal intent value."""
-        self.assertEqual(derive_intent("flac_preferred"), QualityIntent.flac_preferred)
-
-    def test_flac_only_string(self):
-        """derive_intent recognizes 'flac_only' as a literal intent value."""
-        self.assertEqual(derive_intent("flac_only"), QualityIntent.flac_only)
-
-    def test_best_effort_string(self):
-        """derive_intent recognizes 'best_effort' as a literal intent value."""
-        self.assertEqual(derive_intent("best_effort"), QualityIntent.best_effort)
-
-    def test_upgrade_string(self):
-        """derive_intent recognizes 'upgrade' as a literal intent value."""
-        self.assertEqual(derive_intent("upgrade"), QualityIntent.upgrade)
-
-    def test_unknown_csv_falls_back_to_upgrade(self):
-        """Unrecognized multi-value CSV treated as upgrade (custom override)."""
-        self.assertEqual(derive_intent("flac,mp3 v2"), QualityIntent.upgrade)
-
-
-class TestIntentToQualityOverride(unittest.TestCase):
-    """intent_to_quality_override maps intents back to DB strings."""
+class TestIntentNames(unittest.TestCase):
+    """INTENT_NAMES maps friendly CLI/web names to DB values."""
 
     def test_best_effort_is_none(self):
-        self.assertIsNone(intent_to_quality_override(QualityIntent.best_effort))
+        self.assertIsNone(INTENT_NAMES["best_effort"])
 
     def test_flac_only(self):
-        self.assertEqual(intent_to_quality_override(QualityIntent.flac_only), "flac")
+        self.assertEqual(INTENT_NAMES["flac_only"], QUALITY_FLAC_ONLY)
 
-    def test_flac_preferred(self):
-        self.assertEqual(
-            intent_to_quality_override(QualityIntent.flac_preferred),
-            "flac_preferred",
-        )
+    def test_flac_alias(self):
+        self.assertEqual(INTENT_NAMES["flac"], QUALITY_FLAC_ONLY)
 
     def test_upgrade(self):
-        self.assertEqual(
-            intent_to_quality_override(QualityIntent.upgrade),
-            QUALITY_UPGRADE_TIERS,
-        )
+        self.assertEqual(INTENT_NAMES["upgrade"], QUALITY_UPGRADE_TIERS)
+
+    def test_all_values_are_string_or_none(self):
+        for name, val in INTENT_NAMES.items():
+            self.assertTrue(val is None or isinstance(val, str),
+                            f"{name!r} has value {val!r}")
 
 
-class TestRoundTrip(unittest.TestCase):
-    """Existing DB values round-trip through derive -> intent_to_override."""
-
-    def test_none_roundtrip(self):
-        override = intent_to_quality_override(derive_intent(None))
-        self.assertIsNone(override)
-
-    def test_flac_roundtrip(self):
-        override = intent_to_quality_override(derive_intent("flac"))
-        self.assertEqual(override, "flac")
-
-    def test_upgrade_tiers_roundtrip(self):
-        override = intent_to_quality_override(derive_intent(QUALITY_UPGRADE_TIERS))
-        self.assertEqual(override, QUALITY_UPGRADE_TIERS)
-
-    def test_flac_preferred_roundtrip(self):
-        """flac_preferred survives a DB write/read cycle."""
-        override = intent_to_quality_override(derive_intent("flac_preferred"))
-        intent = derive_intent(override)
-        self.assertEqual(intent, QualityIntent.flac_preferred)
-
-
-class TestResolveSearchIntent(unittest.TestCase):
-    """resolve_search_intent combines derive + search + catch_all in one call."""
-
-    def test_best_effort_returns_config_with_catch_all(self):
-        r = resolve_search_intent(None, ["flac", "mp3"])
-        self.assertEqual(r.intent, QualityIntent.best_effort)
-        self.assertEqual(r.search_tiers, ["flac", "mp3"])
-        self.assertTrue(r.catch_all)
-
-    def test_best_effort_empty_string(self):
-        r = resolve_search_intent("", ["flac", "mp3"])
-        self.assertEqual(r.intent, QualityIntent.best_effort)
-        self.assertTrue(r.catch_all)
-
-    def test_flac_only(self):
-        r = resolve_search_intent("flac", ["flac", "mp3"])
-        self.assertEqual(r.intent, QualityIntent.flac_only)
-        self.assertEqual(r.search_tiers, ["flac"])
-        self.assertFalse(r.catch_all)
-
-    def test_flac_only_literal_intent(self):
-        r = resolve_search_intent("flac_only", ["mp3"])
-        self.assertEqual(r.search_tiers, ["flac"])
-        self.assertFalse(r.catch_all)
-
-    def test_flac_preferred(self):
-        r = resolve_search_intent("flac_preferred", ["mp3"])
-        self.assertEqual(r.intent, QualityIntent.flac_preferred)
-        self.assertEqual(r.search_tiers, ["flac", "mp3 v0", "mp3 320"])
-        self.assertFalse(r.catch_all)
-
-    def test_upgrade_full_csv(self):
-        r = resolve_search_intent("flac,mp3 v0,mp3 320", [])
-        self.assertEqual(r.intent, QualityIntent.upgrade)
-        self.assertEqual(r.search_tiers, ["flac", "mp3 v0", "mp3 320"])
-        self.assertFalse(r.catch_all)
-
-    def test_upgrade_narrowed_csv(self):
-        """Narrowed CSV is used literally — the core fix."""
-        r = resolve_search_intent("flac,mp3 v0", ["flac", "mp3"])
-        self.assertEqual(r.intent, QualityIntent.upgrade)
-        self.assertEqual(r.search_tiers, ["flac", "mp3 v0"])
-        self.assertFalse(r.catch_all)
-
-    def test_upgrade_literal_intent_name(self):
-        """Literal 'upgrade' (no comma) falls through to default tiers."""
-        r = resolve_search_intent("upgrade", [])
-        self.assertEqual(r.search_tiers, ["flac", "mp3 v0", "mp3 320"])
-
-    def test_upgrade_none_is_best_effort(self):
-        r = resolve_search_intent(None, ["flac"])
-        self.assertEqual(r.intent, QualityIntent.best_effort)
-
-    def test_catch_all_matches_intent(self):
-        """catch_all is True only for best_effort."""
-        cases = [
-            (None, True),
-            ("flac", False),
-            ("flac_preferred", False),
-            ("flac,mp3 v0,mp3 320", False),
-        ]
-        for override, expected in cases:
-            r = resolve_search_intent(override, ["flac", "mp3"])
-            self.assertEqual(r.catch_all, expected,
-                             f"catch_all wrong for override={override!r}")
-
-    def test_frozen(self):
-        r = resolve_search_intent(None, ["flac"])
-        with self.assertRaises(AttributeError):
-            r.catch_all = False  # type: ignore[misc]
-
-
-class TestNarrowOverrideSearchContract(unittest.TestCase):
-    """Contract tests: verify overrides are honored across subsystem boundaries."""
+class TestNarrowSearchContract(unittest.TestCase):
+    """Contract: narrowed override → search_tiers excludes removed tier."""
 
     def test_narrowed_320_excluded_from_search(self):
-        """After narrow_override_on_downgrade removes mp3 320, search excludes it."""
-        from lib.quality import narrow_override_on_downgrade, DownloadInfo
         dl = DownloadInfo(slskd_filetype="mp3", is_vbr=False, bitrate=320000)
         narrowed = narrow_override_on_downgrade("flac,mp3 v0,mp3 320", dl)
         self.assertEqual(narrowed, "flac,mp3 v0")
 
-        resolved = resolve_search_intent(narrowed, ["flac", "mp3 v0", "mp3 320"])
-        self.assertNotIn("mp3 320", resolved.search_tiers)
-        self.assertEqual(resolved.search_tiers, ["flac", "mp3 v0"])
-        self.assertFalse(resolved.catch_all)
+        tiers, catch_all = search_tiers(narrowed, ["flac", "mp3 v0", "mp3 320"])
+        self.assertNotIn("mp3 320", tiers)
+        self.assertEqual(tiers, ["flac", "mp3 v0"])
+        self.assertFalse(catch_all)
 
-    def test_full_override_still_includes_all_tiers(self):
-        resolved = resolve_search_intent("flac,mp3 v0,mp3 320", [])
-        self.assertEqual(resolved.search_tiers, ["flac", "mp3 v0", "mp3 320"])
+    def test_full_override_includes_all_tiers(self):
+        tiers, _ = search_tiers("flac,mp3 v0,mp3 320", [])
+        self.assertEqual(tiers, ["flac", "mp3 v0", "mp3 320"])
 
-    def test_import_genuine_320_quality_gate_narrows_to_flac(self):
-        """After importing genuine CBR 320, quality gate → requeue_flac → search excludes mp3 320."""
-        from lib.quality import quality_gate_decision, AudioQualityMeasurement
-        # CBR 320, not verified lossless → quality gate says requeue_flac
-        measurement = AudioQualityMeasurement(
-            min_bitrate_kbps=320, is_cbr=True, verified_lossless=False)
-        decision = quality_gate_decision(measurement)
-        self.assertEqual(decision, "requeue_flac")
-
-        # requeue_flac writes override = "flac"
-        flac_override = intent_to_quality_override(QualityIntent.flac_only)
-        self.assertEqual(flac_override, "flac")
-
-        # Next search must exclude mp3 320
-        resolved = resolve_search_intent(flac_override, ["flac", "mp3 v0", "mp3 320"])
-        self.assertNotIn("mp3 320", resolved.search_tiers)
-        self.assertNotIn("mp3 v0", resolved.search_tiers)
-        self.assertEqual(resolved.search_tiers, ["flac"])
+    def test_quality_gate_accept_clears_override(self):
+        """After quality gate accepts, override=None → search uses global config."""
+        tiers, catch_all = search_tiers(None, ["flac", "mp3 v0", "mp3 320"])
+        self.assertEqual(tiers, ["flac", "mp3 v0", "mp3 320"])
+        self.assertTrue(catch_all)
 
 
 if __name__ == "__main__":

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -187,7 +187,6 @@ export async function toggleLibDetail(id) {
         <select id="lib-intent-${id}" style="padding:2px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:0.8em;" onclick="event.stopPropagation()" onchange="event.stopPropagation(); window.setIntent(${data.pipeline_id}, this.value)">
           <option value="best_effort"${currentIntent === 'best_effort' ? ' selected' : ''}>Best effort</option>
           <option value="flac_only"${currentIntent === 'flac_only' ? ' selected' : ''}>FLAC only</option>
-          <option value="flac_preferred"${currentIntent === 'flac_preferred' ? ' selected' : ''}>FLAC preferred</option>
           <option value="upgrade"${currentIntent === 'upgrade' ? ' selected' : ''}>Upgrade</option>
         </select>
       </div>`;

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -43,14 +43,13 @@ export function awstTime(isoStr) { return toAWST(isoStr).slice(11, 16); }
 export function awstDateTime(isoStr) { return toAWST(isoStr).slice(0, 16).replace('T', ' '); }
 
 /**
- * Reverse-map quality_override DB string to QualityIntent enum value.
+ * Reverse-map quality_override DB string to a friendly intent name.
  * @param {string|null|undefined} override
  * @returns {string}
  */
 export function overrideToIntent(override) {
   if (!override) return 'best_effort';
   if (override === 'flac') return 'flac_only';
-  if (override === 'flac_preferred') return 'flac_preferred';
   return 'upgrade';  // CSV like "flac,mp3 v0,mp3 320"
 }
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from classify import classify_log_entry, LogEntry  # type: ignore[import-not-found]
 from lib.import_service import run_import, log_and_update_import  # type: ignore[import-not-found]
-from lib.quality import QualityIntent, intent_to_quality_override  # type: ignore[import-not-found]
+from lib.quality import QUALITY_UPGRADE_TIERS, QUALITY_FLAC_ONLY, INTENT_NAMES  # type: ignore[import-not-found]
 from lib.transitions import apply_transition  # type: ignore[import-not-found]
 from quality import get_decision_tree, full_pipeline_decision  # type: ignore[import-not-found]
 from spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,  # type: ignore[import-not-found]
@@ -308,7 +308,7 @@ def post_pipeline_update(h, body: dict) -> None:
         b = s._beets_db()
         if mbid and b:
             if b.album_exists(mbid):
-                quality = intent_to_quality_override(QualityIntent.upgrade)
+                quality = QUALITY_UPGRADE_TIERS
                 min_br = b.get_min_bitrate(mbid)
         kwargs: dict[str, object] = {"from_status": req["status"]}
         if quality is not None:
@@ -330,7 +330,7 @@ def post_pipeline_upgrade(h, body: dict) -> None:
         h._error("Missing mb_release_id")
         return
 
-    quality = intent_to_quality_override(QualityIntent.upgrade)
+    quality = QUALITY_UPGRADE_TIERS
 
     min_bitrate = None
     b = s._beets_db()
@@ -440,18 +440,16 @@ def post_pipeline_set_intent(h, body: dict) -> None:
         h._error("Missing id")
         return
 
-    valid_intents = [i.value for i in QualityIntent]
-    if intent_str not in valid_intents:
-        h._error(f"Invalid intent: {intent_str!r}. Valid: {valid_intents}")
+    if intent_str not in INTENT_NAMES:
+        h._error(f"Invalid intent: {intent_str!r}. Valid: {list(INTENT_NAMES)}")
         return
 
-    intent = QualityIntent(intent_str)
     req = s._db().get_request(int(req_id))
     if not req:
         h._error("Not found", 404)
         return
 
-    quality_override = intent_to_quality_override(intent)
+    quality_override = INTENT_NAMES[intent_str]
 
     if req["status"] == "downloading":
         h._error("Cannot set intent while album is downloading")
@@ -513,7 +511,7 @@ def post_pipeline_ban_source(h, body: dict) -> None:
 
     req = s._db().get_request(int(req_id))
     if req:
-        quality = req.get("quality_override") or intent_to_quality_override(QualityIntent.upgrade)
+        quality = req.get("quality_override") or QUALITY_UPGRADE_TIERS
         min_br = req.get("min_bitrate")
         ban_kwargs: dict[str, object] = {"from_status": req["status"]}
         if quality is not None:


### PR DESCRIPTION
## Summary

Addresses #28 item A. The `QualityIntent` enum was a lossy abstraction that caused three rounds of bugs in #26 — it compressed different CSV values into the same enum, then guessed the original back.

**Deleted** (9 functions/types, -427 lines):
- `QualityIntent` enum, `derive_intent()`, `search_filetypes()`, `intent_to_quality_override()`, `intent_allows_catch_all()`, `ResolvedIntent`, `resolve_search_intent()`, `_quality_override_tiers()`

**Added** (+128 lines):
- `search_tiers(override, config) → (list, catch_all)` — 4 lines, replaces 7 functions
- `INTENT_NAMES` dict — CLI/web friendly names → DB values
- `QUALITY_FLAC_ONLY` constant
- Quality gate accept now clears `quality_override` (the Deloris bug)
- DB migration: `flac_preferred`/`upgrade`/`best_effort` → concrete CSV values

Net: **-299 lines**

## Test plan

- [x] 1168 tests pass (net -33 deleted intent tests), pyright clean
- [x] JS tests updated (flac_preferred removed from UI dropdown)
- [x] Contract tests still verify: narrowed override → search excludes tier
- [ ] Deploy and verify quality gate clears override on accept

🤖 Generated with [Claude Code](https://claude.com/claude-code)