### PR TITLE
Test infra Tier 1: shared helpers, slices, table-driven tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,10 @@ hand-rolling dicts or dataclass constructors with many fields.
 
 from __future__ import annotations
 
+import types
+from contextlib import contextmanager
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.quality import (
@@ -228,3 +231,47 @@ def make_spectral_context(
         existing_spectral_bitrate=existing_spectral_bitrate,
         existing_spectral_grade=existing_spectral_grade,
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared context wiring
+# ---------------------------------------------------------------------------
+
+def make_ctx_with_fake_db(fake_db: Any, *, cfg: Any = None) -> Any:
+    """Build a SoularrContext wired to a FakePipelineDB.
+
+    The fake is wired via pipeline_db_source._get_db() so production code
+    that calls ctx.pipeline_db_source._get_db() gets the fake.
+    """
+    from lib.context import SoularrContext
+    mock_source = MagicMock()
+    mock_source._get_db.return_value = fake_db
+    return SoularrContext(
+        cfg=cfg if cfg is not None else MagicMock(),
+        slskd=MagicMock(),
+        pipeline_db_source=mock_source,
+    )
+
+
+@contextmanager
+def patch_dispatch_externals():
+    """Patch external edges shared by all dispatch_import_core tests.
+
+    Patches: sp.run, _cleanup_staged_dir, trigger_meelo_scan,
+    trigger_plex_scan, cleanup_disambiguation_orphans.
+
+    Does NOT patch parse_import_result, _check_quality_gate_core,
+    BeetsDB, or _read_runtime_config — callers nest those as needed.
+
+    Yields a SimpleNamespace with attributes: run, cleanup, meelo, plex, orphans.
+    run is pre-configured with returncode=0, stdout="", stderr="".
+    """
+    with patch("lib.import_dispatch.sp.run") as run, \
+         patch("lib.import_dispatch._cleanup_staged_dir") as cleanup, \
+         patch("lib.util.trigger_meelo_scan") as meelo, \
+         patch("lib.util.trigger_plex_scan") as plex, \
+         patch("lib.import_dispatch.cleanup_disambiguation_orphans",
+               return_value=[]) as orphans:
+        run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        yield types.SimpleNamespace(
+            run=run, cleanup=cleanup, meelo=meelo, plex=plex, orphans=orphans)

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -8,7 +8,12 @@ from lib.context import SoularrContext
 from lib.quality import CooldownConfig, should_cooldown
 from soularr import TrackRecord
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_download_file, make_grab_list_entry, make_request_row
+from tests.helpers import (
+    make_ctx_with_fake_db,
+    make_download_file,
+    make_grab_list_entry,
+    make_request_row,
+)
 
 
 class TestShouldCooldown(unittest.TestCase):
@@ -146,12 +151,6 @@ class TestEnqueueCooldownFiltering(unittest.TestCase):
 class TestCooldownTriggerOnTimeout(unittest.TestCase):
     """_timeout_album() should call check_and_apply_cooldown after logging."""
 
-    def _make_ctx_with_db(self, fake_db):
-        mock_source = MagicMock()
-        mock_source._get_db.return_value = fake_db
-        return SoularrContext(
-            cfg=MagicMock(), slskd=MagicMock(), pipeline_db_source=mock_source)
-
     def test_timeout_triggers_cooldown_check(self):
         from lib.download import _timeout_album
 
@@ -165,7 +164,7 @@ class TestCooldownTriggerOnTimeout(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
         db.set_cooldown_result(True)
-        ctx = self._make_ctx_with_db(db)
+        ctx = make_ctx_with_fake_db(db)
 
         with patch("lib.download.cancel_and_delete"), \
              patch("lib.download.apply_transition"):
@@ -195,7 +194,7 @@ class TestCooldownTriggerOnTimeout(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
         db.set_cooldown_result(lambda u: u == "disc1user")
-        ctx = self._make_ctx_with_db(db)
+        ctx = make_ctx_with_fake_db(db)
 
         with patch("lib.download.cancel_and_delete"), \
              patch("lib.download.apply_transition"):
@@ -217,7 +216,7 @@ class TestCooldownTriggerOnTimeout(unittest.TestCase):
         )
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
-        ctx = self._make_ctx_with_db(db)
+        ctx = make_ctx_with_fake_db(db)
 
         with patch("lib.download.cancel_and_delete"), \
              patch("lib.download.apply_transition"):

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -232,9 +232,12 @@ class TestCooldownTriggerOnRejection(unittest.TestCase):
         from album_source import DatabaseSource
         from lib.quality import DownloadInfo
 
-        mock_db = MagicMock()
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(id=42, status="downloading"))
+        fake_db.set_cooldown_result(True)
+
         source = DatabaseSource.__new__(DatabaseSource)
-        source._db = mock_db
+        source._db = fake_db  # type: ignore[assignment]
 
         album_record = MagicMock()
         album_record.db_request_id = 42
@@ -247,17 +250,19 @@ class TestCooldownTriggerOnRejection(unittest.TestCase):
 
         dl = DownloadInfo(username="baduser")
         cooled_down_users: set[str] = set()
-        mock_db.check_and_apply_cooldown.return_value = True
 
-        with patch("lib.transitions.apply_transition"):
-            source.mark_failed(album_record, bv_result,
-                               usernames=["baduser"], download_info=dl,
-                               cooled_down_users=cooled_down_users)
+        source.mark_failed(album_record, bv_result,
+                           usernames=["baduser"], download_info=dl,
+                           cooled_down_users=cooled_down_users)
 
-        mock_db.log_download.assert_called_once()
-        self.assertEqual(mock_db.log_download.call_args.kwargs["outcome"], "rejected")
-        mock_db.check_and_apply_cooldown.assert_called_once_with("baduser")
+        # Domain state assertions
+        self.assertEqual(fake_db.request(42)["status"], "wanted")
+        self.assertEqual(len(fake_db.download_logs), 1)
+        fake_db.assert_log(self, 0, outcome="rejected")
+        self.assertIn("baduser", fake_db.cooldowns_applied)
         self.assertEqual(cooled_down_users, {"baduser"})
+        self.assertEqual(len(fake_db.denylist), 1)
+        self.assertEqual(fake_db.denylist[0].username, "baduser")
 
 
 if __name__ == "__main__":

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -11,8 +11,8 @@ from unittest.mock import MagicMock, patch
 
 from lib.config import SoularrConfig
 from lib.quality import DownloadInfo
-from tests.helpers import make_request_row, make_import_result
 from tests.fakes import FakePipelineDB
+from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
 
 
 _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"
@@ -47,15 +47,9 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
 
         tmpdir = tempfile.mkdtemp()
         try:
-            with patch("lib.import_dispatch.sp.run") as mock_run, \
-                 patch("lib.import_dispatch._cleanup_staged_dir"), \
+            with patch_dispatch_externals() as ext, \
                  patch("lib.import_dispatch._check_quality_gate_core"), \
-                 patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-                 patch("lib.util.trigger_meelo_scan"), \
-                 patch("lib.util.trigger_plex_scan"), \
-                 patch("lib.import_dispatch.cleanup_disambiguation_orphans",
-                       return_value=[]):
-                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+                 patch("lib.import_dispatch.parse_import_result", return_value=ir):
                 result = dispatch_import_core(
                     path=tmpdir,
                     mb_release_id="mbid-123",
@@ -76,7 +70,7 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
                     outcome_label=outcome_label,
                     requeue_on_failure=requeue_on_failure,
                 )
-                cmd = mock_run.call_args[0][0] if mock_run.call_args else []
+                cmd = ext.run.call_args[0][0] if ext.run.call_args else []
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -195,15 +189,9 @@ class TestDispatchCoreSeams(unittest.TestCase):
         )
         tmpdir = tempfile.mkdtemp()
         try:
-            with patch("lib.import_dispatch.sp.run") as mock_run, \
-                 patch("lib.import_dispatch._cleanup_staged_dir"), \
+            with patch_dispatch_externals() as ext, \
                  patch("lib.import_dispatch._check_quality_gate_core"), \
-                 patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-                 patch("lib.util.trigger_meelo_scan"), \
-                 patch("lib.util.trigger_plex_scan"), \
-                 patch("lib.import_dispatch.cleanup_disambiguation_orphans",
-                       return_value=[]):
-                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+                 patch("lib.import_dispatch.parse_import_result", return_value=ir):
                 dispatch_import_core(
                     path=tmpdir,
                     mb_release_id="mbid-123",
@@ -215,7 +203,7 @@ class TestDispatchCoreSeams(unittest.TestCase):
                     cfg=cfg,
                     **kwargs,
                 )
-                return mock_run.call_args[0][0] if mock_run.call_args else []
+                return ext.run.call_args[0][0] if ext.run.call_args else []
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -10,7 +10,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from lib.config import SoularrConfig
-from tests.helpers import make_request_row, make_import_result
+from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
 from tests.fakes import FakePipelineDB
 
 
@@ -40,26 +40,20 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
 
         tmpdir = tempfile.mkdtemp()
         try:
-            with patch("lib.import_dispatch.sp.run") as mock_run, \
-                 patch("lib.import_dispatch._cleanup_staged_dir"), \
-                 patch("lib.util.trigger_meelo_scan") as mock_meelo, \
+            with patch_dispatch_externals() as ext, \
                  patch("lib.import_dispatch._check_quality_gate_core") as mock_gate, \
                  patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-                 patch("lib.util.trigger_plex_scan"), \
-                 patch("lib.import_dispatch.cleanup_disambiguation_orphans",
-                       return_value=[]), \
                  patch("lib.import_dispatch._read_runtime_config",
                        return_value=SoularrConfig(
                            beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
                            pipeline_db_enabled=True,
                        )):
-                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
                 result = dispatch_import_from_db(
                     db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
                     force=force, source_username=source_username,
                     outcome_label=outcome_label,
                 )
-                cmd = mock_run.call_args[0][0] if mock_run.call_args else []
+                cmd = ext.run.call_args[0][0] if ext.run.call_args else []
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -70,7 +64,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
             "db": db,
             "path": tmpdir,
             "mock_gate": mock_gate,
-            "mock_meelo": mock_meelo,
+            "mock_meelo": ext.meelo,
         }
 
     # --- Success path ---

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 
 from lib.quality import SpectralContext
 from tests.helpers import (
+    make_ctx_with_fake_db,
     make_download_file,
     make_grab_list_entry,
     make_spectral_context,
@@ -402,12 +403,6 @@ class TestGatherSpectralContextFunction(unittest.TestCase):
 class TestApplySpectralDecision(unittest.TestCase):
     """Tests spectral state propagation via FakePipelineDB."""
 
-    def _make_ctx_with_fake_db(self, fake_db):
-        """Build SoularrContext wired to a FakePipelineDB."""
-        ctx = _make_ctx()
-        cast(Any, ctx.pipeline_db_source)._get_db.return_value = fake_db
-        return ctx
-
     @patch("lib.download.spectral_import_decision", return_value="accept")
     def test_existing_genuine_state_propagates_none_bitrate(self, _mock_decision):
         from lib.download import _apply_spectral_decision
@@ -417,7 +412,7 @@ class TestApplySpectralDecision(unittest.TestCase):
         fake_db = FakePipelineDB()
         fake_db.seed_request(make_request_row(id=1))
         album = make_grab_list_entry(db_request_id=1, db_source="request")
-        ctx = self._make_ctx_with_fake_db(fake_db)
+        ctx = make_ctx_with_fake_db(fake_db)
         bv_result = make_validation_result()
         spec_ctx = make_spectral_context(
             needs_check=True,
@@ -441,7 +436,7 @@ class TestApplySpectralDecision(unittest.TestCase):
         fake_db = FakePipelineDB()
         fake_db.seed_request(make_request_row(id=1))
         album = make_grab_list_entry(db_request_id=1, db_source="request")
-        ctx = self._make_ctx_with_fake_db(fake_db)
+        ctx = make_ctx_with_fake_db(fake_db)
         bv_result = make_validation_result()
         # Nothing on disk: all existing fields are None
         spec_ctx = make_spectral_context(
@@ -464,7 +459,7 @@ class TestApplySpectralDecision(unittest.TestCase):
         fake_db = FakePipelineDB()
         fake_db.seed_request(make_request_row(id=1))
         album = make_grab_list_entry(db_request_id=1, db_source="request")
-        ctx = self._make_ctx_with_fake_db(fake_db)
+        ctx = make_ctx_with_fake_db(fake_db)
         bv_result = make_validation_result()
         # Album on disk at 256kbps, no spectral data yet
         spec_ctx = make_spectral_context(

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -18,7 +18,7 @@ from lib.quality import (DownloadInfo, ImportResult, ConversionInfo,
                          AudioQualityMeasurement,
                          QUALITY_UPGRADE_TIERS, QUALITY_FLAC_ONLY)
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_request_row, make_import_result
+from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
 
 
 # --- Local helpers for seam tests that call dispatch_import() (adapter) ---
@@ -146,16 +146,9 @@ class TestDispatchImport(unittest.TestCase):
 
         tmpdir = tempfile.mkdtemp()
         try:
-            with patch("lib.import_dispatch.sp.run") as mock_run, \
-                 patch("lib.import_dispatch._cleanup_staged_dir") as mock_cleanup, \
-                 patch("lib.util.trigger_meelo_scan") as mock_meelo, \
-                 patch("lib.util.trigger_plex_scan"), \
+            with patch_dispatch_externals() as ext, \
                  patch("lib.import_dispatch._check_quality_gate_core") as mock_gate, \
-                 patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-                 patch("lib.import_dispatch.cleanup_disambiguation_orphans",
-                       return_value=[]):
-                mock_run.return_value = MagicMock(
-                    returncode=0, stdout="", stderr="")
+                 patch("lib.import_dispatch.parse_import_result", return_value=ir):
                 dispatch_import_core(
                     path=tmpdir,
                     mb_release_id="test-mbid",
@@ -175,8 +168,8 @@ class TestDispatchImport(unittest.TestCase):
 
         return {
             "db": db,
-            "mock_cleanup": mock_cleanup,
-            "mock_meelo": mock_meelo,
+            "mock_cleanup": ext.cleanup,
+            "mock_meelo": ext.meelo,
             "mock_gate": mock_gate,
         }
 
@@ -317,18 +310,12 @@ class TestOverrideMinBitrate(unittest.TestCase):
         dl_info = DownloadInfo(filetype="mp3")
         ir = make_import_result(decision="import")
 
-        with patch("lib.import_dispatch.sp.run") as mock_run, \
-             patch("lib.import_dispatch._cleanup_staged_dir"), \
-             patch("lib.util.trigger_meelo_scan"), \
-             patch("lib.util.trigger_plex_scan"), \
+        with patch_dispatch_externals() as ext, \
              patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-             patch("lib.import_dispatch.cleanup_disambiguation_orphans", return_value=[]):
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr="")
+             patch("lib.import_dispatch.parse_import_result", return_value=ir):
             dispatch_import(album_data, bv_result, "/tmp/dest", dl_info,
                             42, ctx)
-            cmd = mock_run.call_args[0][0]
+            cmd = ext.run.call_args[0][0]
 
         for i, arg in enumerate(cmd):
             if arg == "--override-min-bitrate" and i + 1 < len(cmd):
@@ -502,16 +489,9 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         ir = make_import_result(decision="transcode_upgrade",
                                 new_min_bitrate=227)
 
-        with patch("lib.import_dispatch.sp.run") as mock_run, \
-             patch("lib.import_dispatch._cleanup_staged_dir"), \
-             patch("lib.util.trigger_meelo_scan"), \
-             patch("lib.util.trigger_plex_scan"), \
+        with patch_dispatch_externals(), \
              patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-             patch("lib.import_dispatch.cleanup_disambiguation_orphans",
-                   return_value=[]):
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr="")
+             patch("lib.import_dispatch.parse_import_result", return_value=ir):
             dispatch_import_core(
                 path="/tmp/dest", mb_release_id="test-mbid",
                 request_id=42, label="Test",
@@ -580,18 +560,12 @@ class TestOpusConversionDispatch(unittest.TestCase):
         ir = make_import_result(decision="import", was_converted=True,
                                 original_filetype="flac", target_filetype="mp3")
 
-        with patch("lib.import_dispatch.sp.run") as mock_run, \
-             patch("lib.import_dispatch._cleanup_staged_dir"), \
-             patch("lib.util.trigger_meelo_scan"), \
-             patch("lib.util.trigger_plex_scan"), \
+        with patch_dispatch_externals() as ext, \
              patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-             patch("lib.import_dispatch.cleanup_disambiguation_orphans", return_value=[]):
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr="")
+             patch("lib.import_dispatch.parse_import_result", return_value=ir):
             dispatch_import(album_data, bv_result, "/tmp/dest", dl_info,
                             42, ctx)
-            return mock_run.call_args[0][0]
+            return ext.run.call_args[0][0]
 
     def test_target_flag_passed_when_set(self):
         cmd = self._get_cmd(verified_lossless_target="opus 128")
@@ -641,18 +615,12 @@ class TestTargetFormatDispatch(unittest.TestCase):
         dl_info = DownloadInfo(filetype="flac")
         ir = make_import_result(decision="import")
 
-        with patch("lib.import_dispatch.sp.run") as mock_run, \
-             patch("lib.import_dispatch._cleanup_staged_dir"), \
-             patch("lib.util.trigger_meelo_scan"), \
-             patch("lib.util.trigger_plex_scan"), \
+        with patch_dispatch_externals() as ext, \
              patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-             patch("lib.import_dispatch.cleanup_disambiguation_orphans", return_value=[]):
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr="")
+             patch("lib.import_dispatch.parse_import_result", return_value=ir):
             dispatch_import(album_data, bv_result, "/tmp/dest", dl_info,
                             42, ctx)
-            return mock_run.call_args[0][0]
+            return ext.run.call_args[0][0]
 
     def test_target_format_passed_when_set(self):
         cmd = self._get_cmd(target_format="flac")

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -10,7 +10,6 @@ and _check_quality_gate_core run for real, not patched.
 
 import tempfile
 import unittest
-from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from lib.beets_db import AlbumInfo
@@ -23,7 +22,7 @@ from lib.quality import (
     ImportResult,
 )
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_import_result, make_request_row
+from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
 
 
 _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"
@@ -34,27 +33,14 @@ def _make_stdout(ir: ImportResult) -> str:
     return f"some log output\n{IMPORT_RESULT_SENTINEL}{ir.to_json()}\n"
 
 
-@contextmanager
-def _patch_dispatch_externals(beets_info=None):
-    """Patch external edges for dispatch_import_core integration slices.
-
-    Patches: sp.run, cleanup, meelo, plex, disambiguation orphans, BeetsDB.
-    Does NOT patch parse_import_result or _check_quality_gate_core.
-    """
-    with patch("lib.import_dispatch.sp.run") as mock_run, \
-         patch("lib.import_dispatch._cleanup_staged_dir"), \
-         patch("lib.util.trigger_meelo_scan"), \
-         patch("lib.util.trigger_plex_scan"), \
-         patch("lib.import_dispatch.cleanup_disambiguation_orphans",
-               return_value=[]), \
-         patch("lib.beets_db.BeetsDB") as mock_beets_cls:
-        # Configure BeetsDB context manager
-        mock_beets_instance = MagicMock()
-        mock_beets_cls.return_value.__enter__ = MagicMock(
-            return_value=mock_beets_instance)
-        mock_beets_cls.return_value.__exit__ = MagicMock(return_value=False)
-        mock_beets_instance.get_album_info.return_value = beets_info
-        yield mock_run
+def _mock_beets_db(beets_info):
+    """Configure a mocked BeetsDB context manager returning beets_info."""
+    mock_beets_instance = MagicMock()
+    mock_beets_instance.get_album_info.return_value = beets_info
+    mock_cls = MagicMock()
+    mock_cls.return_value.__enter__ = MagicMock(return_value=mock_beets_instance)
+    mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cls
 
 
 class TestDispatchThroughQualityGate(unittest.TestCase):
@@ -85,8 +71,9 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
 
         tmpdir = tempfile.mkdtemp()
         try:
-            with _patch_dispatch_externals(beets_info=beets_info) as mock_run:
-                mock_run.return_value = MagicMock(
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
                     returncode=0, stdout=stdout, stderr="")
                 dispatch_import_core(
                     path=tmpdir,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -143,6 +143,39 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         self.assertEqual(row["search_filetype_override"], QUALITY_LOSSLESS)
 
 
+    def test_transcode_upgrade_requeues_with_denylist(self):
+        """Transcode upgrade → mark_done + requeue to upgrade tiers + denylist."""
+        ir = make_import_result(decision="transcode_upgrade", new_min_bitrate=227)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=227,
+            is_cbr=False, album_path="/Beets/Test")
+
+        db = self._run_dispatch(ir, beets_info)
+
+        row = db.request(42)
+        # Transcode upgrade requeues directly (no quality gate)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_filetype_override"], QUALITY_UPGRADE_TIERS)
+        # Transcode source denylisted
+        self.assertTrue(len(db.denylist) >= 1)
+        db.assert_log(self, 0, outcome="success")
+
+    def test_downgrade_prevented(self):
+        """Downgrade → mark_failed + denylist, no quality gate."""
+        ir = make_import_result(decision="downgrade",
+                                new_min_bitrate=128, prev_min_bitrate=320)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=128,
+            is_cbr=False, album_path="/Beets/Test")
+
+        db = self._run_dispatch(ir, beets_info)
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertTrue(len(db.denylist) >= 1)
+        db.assert_log(self, 0, outcome="rejected")
+
+
 class TestQualityGateVerifiedLosslessBypass(unittest.TestCase):
     """Integration slice: quality gate stays imported for verified_lossless
     even when bitrate < 210."""
@@ -159,13 +192,7 @@ class TestQualityGateVerifiedLosslessBypass(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=207,
             is_cbr=False, album_path="/Beets/Test")
 
-        with patch("lib.beets_db.BeetsDB") as mock_beets_cls:
-            mock_beets_instance = MagicMock()
-            mock_beets_cls.return_value.__enter__ = MagicMock(
-                return_value=mock_beets_instance)
-            mock_beets_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_beets_instance.get_album_info.return_value = beets_info
-
+        with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
             _check_quality_gate_core(
                 mb_id="mbid-123",
                 label="Lo-Fi Album",
@@ -177,7 +204,6 @@ class TestQualityGateVerifiedLosslessBypass(unittest.TestCase):
         row = db.request(42)
         self.assertEqual(row["status"], "imported")
         self.assertEqual(row["min_bitrate"], 207)
-        # No denylist — accepted
         self.assertEqual(len(db.denylist), 0)
 
 
@@ -200,13 +226,7 @@ class TestQualityGateSpectralOverride(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             is_cbr=False, album_path="/Beets/Test")
 
-        with patch("lib.beets_db.BeetsDB") as mock_beets_cls:
-            mock_beets_instance = MagicMock()
-            mock_beets_cls.return_value.__enter__ = MagicMock(
-                return_value=mock_beets_instance)
-            mock_beets_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_beets_instance.get_album_info.return_value = beets_info
-
+        with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
             _check_quality_gate_core(
                 mb_id="mbid-123",
                 label="Fake 320 Album",
@@ -218,9 +238,95 @@ class TestQualityGateSpectralOverride(unittest.TestCase):
         row = db.request(42)
         self.assertEqual(row["status"], "wanted")
         self.assertEqual(row["search_filetype_override"], QUALITY_UPGRADE_TIERS)
-        # Source denylisted for quality gate failure
         self.assertEqual(len(db.denylist), 1)
         self.assertIn("spectral", db.denylist[0].reason or "")
+
+
+class TestDispatchNoJsonResult(unittest.TestCase):
+    """Integration slice: sp.run returns no sentinel → mark_failed."""
+
+    def test_no_json_marks_failed_and_requeues(self):
+        """No __IMPORT_RESULT__ in stdout → scenario=no_json_result, requeue."""
+        from lib.import_dispatch import dispatch_import_core
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(None)):
+                ext.run.return_value = MagicMock(
+                    returncode=1, stdout="some error\n", stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id="mbid-123",
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=DownloadInfo(username="user1"),
+                    cfg=cfg,
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(len(db.download_logs), 1)
+        db.assert_log(self, 0, outcome="failed")
+
+
+class TestForceImportSlice(unittest.TestCase):
+    """Integration slice: dispatch_import_from_db with force=True."""
+
+    def test_force_import_success(self):
+        """Force-import → imported, download_log outcome=force_import."""
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123",
+            min_bitrate=180, current_spectral_bitrate=128,
+        ))
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        stdout = _make_stdout(ir)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            is_cbr=False, album_path="/Beets/Test")
+
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.import_dispatch._read_runtime_config",
+                       return_value=cfg):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                result = dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        self.assertTrue(result.success)
+        row = db.request(42)
+        self.assertEqual(row["status"], "imported")
+        db.assert_log(self, 0, outcome="force_import")
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -287,96 +287,35 @@ class TestTranscodeDetection(unittest.TestCase):
 # ============================================================================
 
 class TestQualityGateDecision(unittest.TestCase):
-    """Test post-import quality gate.
+    """Test post-import quality gate via subTest table."""
 
-    Uses AudioQualityMeasurement to carry all params in one object.
-    """
+    CASES = [
+        # (description, measurement_kwargs, expected_decision)
+        # --- accept ---
+        ("VBR above threshold", dict(min_bitrate_kbps=240, is_cbr=False), "accept"),
+        ("VBR at threshold", dict(min_bitrate_kbps=QUALITY_MIN_BITRATE_KBPS, is_cbr=False), "accept"),
+        ("verified lossless low bitrate", dict(min_bitrate_kbps=180, verified_lossless=True), "accept"),
+        ("verified lossless CBR", dict(min_bitrate_kbps=320, is_cbr=True, verified_lossless=True), "accept"),
+        ("verified lossless overrides spectral", dict(min_bitrate_kbps=180, verified_lossless=True, spectral_bitrate_kbps=150), "accept"),
+        ("opus 128 verified lossless", dict(min_bitrate_kbps=128, verified_lossless=True), "accept"),
+        # --- requeue_upgrade ---
+        ("below threshold", dict(min_bitrate_kbps=190), "requeue_upgrade"),
+        ("way below threshold", dict(min_bitrate_kbps=96), "requeue_upgrade"),
+        ("spectral override CBR", dict(min_bitrate_kbps=320, is_cbr=True, spectral_bitrate_kbps=128), "requeue_upgrade"),
+        ("spectral higher ignored", dict(min_bitrate_kbps=192, spectral_bitrate_kbps=256), "requeue_upgrade"),
+        ("CBR below threshold", dict(min_bitrate_kbps=192, is_cbr=True), "requeue_upgrade"),
+        ("opus 128 not verified", dict(min_bitrate_kbps=128), "requeue_upgrade"),
+        ("none bitrate", dict(), "requeue_upgrade"),
+        # --- requeue_lossless ---
+        ("CBR above threshold", dict(min_bitrate_kbps=320, is_cbr=True), "requeue_lossless"),
+        ("CBR 256", dict(min_bitrate_kbps=256, is_cbr=True), "requeue_lossless"),
+    ]
 
-    # --- accept cases ---
-
-    def test_vbr_above_threshold_accepts(self):
-        m = AudioQualityMeasurement(min_bitrate_kbps=240, is_cbr=False)
-        self.assertEqual(quality_gate_decision(m), "accept")
-
-    def test_vbr_at_threshold_accepts(self):
-        m = AudioQualityMeasurement(min_bitrate_kbps=QUALITY_MIN_BITRATE_KBPS, is_cbr=False)
-        self.assertEqual(quality_gate_decision(m), "accept")
-
-    def test_verified_lossless_accepts_regardless(self):
-        """Verified lossless with low bitrate (quiet music) still accepts."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=180, verified_lossless=True)
-        self.assertEqual(quality_gate_decision(m), "accept")
-
-    def test_verified_lossless_cbr_accepts(self):
-        """verified_lossless + CBR = accept (we verified it)."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=320, is_cbr=True, verified_lossless=True)
-        self.assertEqual(quality_gate_decision(m), "accept")
-
-    # --- requeue_upgrade cases ---
-
-    def test_below_threshold_requeues_upgrade(self):
-        m = AudioQualityMeasurement(min_bitrate_kbps=190)
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
-
-    def test_way_below_threshold_requeues(self):
-        m = AudioQualityMeasurement(min_bitrate_kbps=96)
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
-
-    def test_spectral_override_requeues(self):
-        """Beets says 320 but spectral says 128 → use spectral → requeue."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=320, is_cbr=True,
-                                    spectral_bitrate_kbps=128)
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
-
-    def test_spectral_higher_than_bitrate_ignored(self):
-        """Spectral says 256 but beets says 192 → use beets (lower) → requeue."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=192, spectral_bitrate_kbps=256)
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
-
-    # --- requeue_lossless cases ---
-
-    def test_cbr_above_threshold_requeues_lossless(self):
-        m = AudioQualityMeasurement(min_bitrate_kbps=320, is_cbr=True)
-        self.assertEqual(quality_gate_decision(m), "requeue_lossless")
-
-    def test_cbr_256_requeues_lossless(self):
-        m = AudioQualityMeasurement(min_bitrate_kbps=256, is_cbr=True)
-        self.assertEqual(quality_gate_decision(m), "requeue_lossless")
-
-    # --- edge: CBR below threshold → requeue_upgrade (not flac) ---
-
-    def test_cbr_below_threshold_requeues_upgrade_not_flac(self):
-        """CBR 192 → below threshold takes priority over CBR path."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=192, is_cbr=True)
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
-
-    # --- verified_lossless + spectral interaction ---
-
-    def test_verified_lossless_overrides_spectral(self):
-        """Verified lossless at 180kbps with spectral_bitrate=150 → still accept.
-        verified_lossless forces gate_br to threshold after spectral override."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=180, verified_lossless=True,
-                                    spectral_bitrate_kbps=150)
-        self.assertEqual(quality_gate_decision(m), "accept")
-
-    # --- Opus path ---
-
-    def test_opus_128_verified_lossless_accepts(self):
-        """Opus 128kbps from verified lossless is the endgame — always accept."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=128, verified_lossless=True)
-        self.assertEqual(quality_gate_decision(m), "accept")
-
-    def test_opus_128_not_verified_requeues(self):
-        """Opus 128kbps without verified_lossless should requeue (below threshold)."""
-        m = AudioQualityMeasurement(min_bitrate_kbps=128)
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
-
-    # --- None min_bitrate ---
-
-    def test_none_bitrate_requeues(self):
-        """No measurable bitrate → requeue for upgrade."""
-        m = AudioQualityMeasurement()
-        self.assertEqual(quality_gate_decision(m), "requeue_upgrade")
+    def test_quality_gate_decisions(self):
+        for desc, kwargs, expected in self.CASES:
+            with self.subTest(desc=desc):
+                m = AudioQualityMeasurement(**kwargs)
+                self.assertEqual(quality_gate_decision(m), expected)
 
 
 # ============================================================================
@@ -772,71 +711,38 @@ class TestComputeEffectiveOverrideBitrate(unittest.TestCase):
 # ============================================================================
 
 class TestDispatchAction(unittest.TestCase):
-    """Test dispatch_action: map decision string to action flags."""
+    """Test dispatch_action: map decision string to action flags via subTest table."""
 
-    def _action(self, decision):
+    # (decision, {flag: expected_value, ...})
+    CASES = [
+        ("import", dict(mark_done=True, mark_failed=False, denylist=False,
+                        requeue=False, cleanup=True, trigger_meelo=True,
+                        run_quality_gate=True)),
+        ("preflight_existing", dict(mark_done=True, trigger_meelo=True,
+                                    run_quality_gate=True)),
+        ("downgrade", dict(mark_done=False, mark_failed=True, denylist=True,
+                           requeue=False, cleanup=True)),
+        ("transcode_upgrade", dict(mark_done=True, denylist=True, requeue=True,
+                                   trigger_meelo=True)),
+        ("transcode_downgrade", dict(mark_done=False, mark_failed=True,
+                                     denylist=True, requeue=True)),
+        ("transcode_first", dict(mark_done=True, denylist=True, requeue=True,
+                                 trigger_meelo=True)),
+        ("conversion_failed", dict(mark_failed=True, denylist=False)),
+        ("import_failed", dict(mark_failed=True)),
+        ("target_conversion_failed", dict(mark_failed=True, denylist=False)),
+    ]
+
+    def test_dispatch_action_flags(self):
         from lib.quality import dispatch_action
-        return dispatch_action(decision)
-
-    def test_import_action(self):
-        a = self._action("import")
-        self.assertTrue(a.mark_done)
-        self.assertFalse(a.mark_failed)
-        self.assertFalse(a.denylist)
-        self.assertFalse(a.requeue)
-        self.assertTrue(a.cleanup)
-        self.assertTrue(a.trigger_meelo)
-        self.assertTrue(a.run_quality_gate)
-
-    def test_preflight_existing_action(self):
-        a = self._action("preflight_existing")
-        self.assertTrue(a.mark_done)
-        self.assertTrue(a.trigger_meelo)
-        self.assertTrue(a.run_quality_gate)
-
-    def test_downgrade_action(self):
-        a = self._action("downgrade")
-        self.assertFalse(a.mark_done)
-        self.assertTrue(a.mark_failed)
-        self.assertTrue(a.denylist)
-        self.assertFalse(a.requeue)
-        self.assertTrue(a.cleanup)
-
-    def test_transcode_upgrade_action(self):
-        a = self._action("transcode_upgrade")
-        self.assertTrue(a.mark_done)
-        self.assertTrue(a.denylist)
-        self.assertTrue(a.requeue)
-        self.assertTrue(a.trigger_meelo)
-
-    def test_transcode_downgrade_action(self):
-        a = self._action("transcode_downgrade")
-        self.assertFalse(a.mark_done)
-        self.assertTrue(a.mark_failed)
-        self.assertTrue(a.denylist)
-        self.assertTrue(a.requeue)
-
-    def test_transcode_first_action(self):
-        a = self._action("transcode_first")
-        self.assertTrue(a.mark_done)
-        self.assertTrue(a.denylist)
-        self.assertTrue(a.requeue)
-        self.assertTrue(a.trigger_meelo)
-
-    def test_unknown_decision_marks_failed(self):
-        a = self._action("conversion_failed")
-        self.assertTrue(a.mark_failed)
-        self.assertFalse(a.denylist)
-
-    def test_import_failed_action(self):
-        a = self._action("import_failed")
-        self.assertTrue(a.mark_failed)
-
-    def test_target_conversion_failed_marks_failed(self):
-        """Target conversion failure falls into catch-all → mark_failed."""
-        a = self._action("target_conversion_failed")
-        self.assertTrue(a.mark_failed)
-        self.assertFalse(a.denylist)
+        for decision, expected in self.CASES:
+            with self.subTest(decision=decision):
+                action = dispatch_action(decision)
+                for flag, value in expected.items():
+                    self.assertEqual(
+                        getattr(action, flag), value,
+                        f"dispatch_action({decision!r}).{flag}: "
+                        f"expected {value!r}, got {getattr(action, flag)!r}")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Continues #51 test infrastructure improvements (Tier 1 quick wins after PR #53).

- **Shared `patch_dispatch_externals()`** context manager extracts the 5-patch stack duplicated across 4 dispatch test files. Yields `SimpleNamespace` with mock refs; callers nest their own test-specific patches
- **Shared `make_ctx_with_fake_db()`** replaces 2 duplicated per-class helpers wiring FakePipelineDB into SoularrContext
- **TestCooldownTriggerOnRejection** migrated to FakePipelineDB — `apply_transition` runs for real, mock call assertions → domain state
- **4 new integration slices**: transcode upgrade (requeue + denylist), downgrade prevention, no-JSON result (parse_import_result runs for real), force-import via `dispatch_import_from_db`
- **Table-driven subTest rewrites**: TestDispatchAction (9→1), TestQualityGateDecision (15→1) — same coverage, less copy-paste

Net: -116 lines, 4 new integration paths exercised, 24 individual test methods consolidated into 2 table-driven methods.

## Test plan

- [x] Full test suite passes (1421 tests, 0 failures, 53 skipped)
- [x] pyright 0 errors on all changed files
- [x] Code review agent found no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)