### PR TITLE
[codex] Finish issue 51 test-layer fakes

### DIFF
--- a/harness/beets_harness.py
+++ b/harness/beets_harness.py
@@ -182,6 +182,7 @@ class HarnessImportSession(ImportSession):
         self._task_counter += 1
 
         # Build the task description
+        candidates = task.candidates or []
         msg = {
             "type": "choose_match",
             "task_id": task_id,
@@ -191,10 +192,10 @@ class HarnessImportSession(ImportSession):
             "item_count": len(task.items),
             "items": [_serialize_item(item) for item in task.items],
             "recommendation": task.rec.name if task.rec else "none",
-            "candidate_count": len(task.candidates),
+            "candidate_count": len(candidates),
             "candidates": [
                 _serialize_album_candidate(i, c)
-                for i, c in enumerate(task.candidates)
+                for i, c in enumerate(candidates)
             ],
         }
         _send(msg)
@@ -208,6 +209,7 @@ class HarnessImportSession(ImportSession):
         task_id = self._task_counter
         self._task_counter += 1
 
+        candidates = task.candidates or []
         msg = {
             "type": "choose_item",
             "task_id": task_id,
@@ -216,10 +218,10 @@ class HarnessImportSession(ImportSession):
             "cur_title": getattr(getattr(task, "item", None), "title", "") if hasattr(task, "item") else "",
             "item": _serialize_item(getattr(task, "item")) if hasattr(task, "item") else {},
             "recommendation": task.rec.name if task.rec else "none",
-            "candidate_count": len(task.candidates),
+            "candidate_count": len(candidates),
             "candidates": [
                 _serialize_track_candidate(i, c)
-                for i, c in enumerate(task.candidates)
+                for i, c in enumerate(candidates)
             ],
         }
         _send(msg)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -45,6 +45,175 @@ class DenylistEntry:
     reason: str | None = None
 
 
+@dataclass
+class EnqueueCall:
+    """One slskd enqueue call captured by FakeSlskdAPI."""
+    username: str
+    files: list[dict[str, Any]]
+
+
+@dataclass
+class CancelDownloadCall:
+    """One slskd cancel_download call captured by FakeSlskdAPI."""
+    username: str
+    id: str
+
+
+class FakeSlskdTransfers:
+    """Stateful fake for the slskd transfers API."""
+
+    def __init__(self, api: "FakeSlskdAPI") -> None:
+        self._api = api
+        self.enqueue_calls: list[EnqueueCall] = []
+        self.get_all_downloads_calls: list[bool] = []
+        self.get_download_calls: list[tuple[str, str]] = []
+        self.get_downloads_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.cancel_download_calls: list[CancelDownloadCall] = []
+        self.enqueue_result = True
+        self.enqueue_error: Exception | None = None
+        self.get_all_downloads_error: Exception | None = None
+        self.get_download_error: Exception | None = None
+        self.cancel_download_error: Exception | None = None
+
+    def enqueue(self, username: str, files: list[dict[str, Any]]) -> bool:
+        self.enqueue_calls.append(EnqueueCall(username, copy.deepcopy(files)))
+        if self.enqueue_error is not None:
+            raise self.enqueue_error
+        return self.enqueue_result
+
+    def get_all_downloads(self, includeRemoved: bool = False) -> list[dict[str, Any]]:
+        self.get_all_downloads_calls.append(includeRemoved)
+        if self.get_all_downloads_error is not None:
+            raise self.get_all_downloads_error
+        return self._api._next_download_snapshot()
+
+    def get_downloads(self, *args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.get_downloads_calls.append((args, copy.deepcopy(kwargs)))
+        return self.get_all_downloads(
+            includeRemoved=bool(kwargs.get("includeRemoved", False)))
+
+    def get_download(self, username: str, id: str) -> dict[str, Any]:
+        self.get_download_calls.append((username, id))
+        if self.get_download_error is not None:
+            raise self.get_download_error
+        transfer = self._api._find_transfer(username, id)
+        if transfer is None:
+            raise KeyError(f"No transfer {id!r} for {username!r}")
+        return transfer
+
+    def cancel_download(self, username: str, id: str) -> bool:
+        self.cancel_download_calls.append(CancelDownloadCall(username, id))
+        if self.cancel_download_error is not None:
+            raise self.cancel_download_error
+        return True
+
+
+class FakeSlskdUsers:
+    """Stateful fake for the slskd users API."""
+
+    def __init__(self) -> None:
+        self.directory_calls: list[tuple[str, str]] = []
+        self.directory_error: Exception | None = None
+        self._directories: dict[tuple[str, str], list[dict[str, Any]]] = {}
+
+    def set_directory(
+        self,
+        username: str,
+        directory: str,
+        result: list[dict[str, Any]],
+    ) -> None:
+        self._directories[(username, directory)] = copy.deepcopy(result)
+
+    def directory(self, username: str, directory: str) -> list[dict[str, Any]]:
+        self.directory_calls.append((username, directory))
+        if self.directory_error is not None:
+            raise self.directory_error
+        return copy.deepcopy(self._directories.get((username, directory), []))
+
+
+class FakeSlskdAPI:
+    """In-memory fake for slskd API clients used by download tests."""
+
+    def __init__(
+        self,
+        *,
+        downloads: list[dict[str, Any]] | None = None,
+        download_snapshots: list[list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self.transfers = FakeSlskdTransfers(self)
+        self.users = FakeSlskdUsers()
+        self._downloads = copy.deepcopy(downloads or [])
+        self._download_snapshots = [
+            copy.deepcopy(snapshot) for snapshot in (download_snapshots or [])
+        ]
+
+    def set_downloads(self, downloads: list[dict[str, Any]]) -> None:
+        self._downloads = copy.deepcopy(downloads)
+        self._download_snapshots = []
+
+    def queue_download_snapshots(self, *snapshots: list[dict[str, Any]]) -> None:
+        self._download_snapshots.extend(copy.deepcopy(list(snapshots)))
+
+    def add_transfer(
+        self,
+        *,
+        username: str,
+        directory: str,
+        filename: str,
+        id: str,
+        state: str | None = None,
+        size: int | None = None,
+        bytesTransferred: int | None = None,
+        **extra: Any,
+    ) -> None:
+        group = self._find_or_create_group(username)
+        directory_row = self._find_or_create_directory(group, directory)
+        transfer: dict[str, Any] = {"filename": filename, "id": id}
+        if state is not None:
+            transfer["state"] = state
+        if size is not None:
+            transfer["size"] = size
+        if bytesTransferred is not None:
+            transfer["bytesTransferred"] = bytesTransferred
+        transfer.update(extra)
+        directory_row.setdefault("files", []).append(transfer)
+
+    def _next_download_snapshot(self) -> list[dict[str, Any]]:
+        if self._download_snapshots:
+            self._downloads = self._download_snapshots.pop(0)
+        return copy.deepcopy(self._downloads)
+
+    def _find_transfer(self, username: str, transfer_id: str) -> dict[str, Any] | None:
+        for group in self._downloads:
+            if group.get("username") not in (None, "", username):
+                continue
+            for directory in group.get("directories", []):
+                for transfer in directory.get("files", []):
+                    if transfer.get("id") == transfer_id:
+                        return copy.deepcopy(transfer)
+        return None
+
+    def _find_or_create_group(self, username: str) -> dict[str, Any]:
+        for group in self._downloads:
+            if group.get("username") == username:
+                return group
+        group = {"username": username, "directories": []}
+        self._downloads.append(group)
+        return group
+
+    @staticmethod
+    def _find_or_create_directory(
+        group: dict[str, Any],
+        directory: str,
+    ) -> dict[str, Any]:
+        for row in group.setdefault("directories", []):
+            if row.get("directory") == directory:
+                return row
+        row = {"directory": directory, "files": []}
+        group["directories"].append(row)
+        return row
+
+
 class FakePipelineDB:
     """In-memory fake for PipelineDB — records mutations for test assertions.
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -8,6 +8,7 @@ instead of MagicMock call shapes.
 from __future__ import annotations
 
 import copy
+import json
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -247,6 +248,9 @@ class FakePipelineDB:
         self.denylist: list[DenylistEntry] = []
         self.cooldowns_applied: list[str] = []
         self.recorded_attempts: list[tuple[int, str]] = []
+        self.status_history: list[tuple[int, str]] = []
+        self.update_download_state_calls: list[tuple[int, str]] = []
+        self.clear_download_state_calls: list[int] = []
         self._cooldown_result: bool | Callable[[str], bool] = False
 
     # --- Seeding ---
@@ -282,6 +286,7 @@ class FakePipelineDB:
         row["updated_at"] = _utcnow()
         for key, val in extra.items():
             row[key] = val
+        self.status_history.append((request_id, status))
 
     def reset_to_wanted(self, request_id: int, **fields: Any) -> None:
         row = self._requests.get(request_id)
@@ -303,6 +308,7 @@ class FakePipelineDB:
             if current_min_bitrate is not None:
                 row["prev_min_bitrate"] = current_min_bitrate
             row["min_bitrate"] = fields["min_bitrate"]
+        self.status_history.append((request_id, "wanted"))
 
     def set_downloading(self, request_id: int, state_json: str) -> bool:
         row = self._requests.get(request_id)
@@ -313,12 +319,24 @@ class FakePipelineDB:
         row["active_download_state"] = state_json
         row["last_attempt_at"] = now
         row["updated_at"] = now
+        self.status_history.append((request_id, "downloading"))
         return True
 
     def clear_download_state(self, request_id: int) -> None:
         row = self._requests.get(request_id)
         if row:
             row["active_download_state"] = None
+            row["updated_at"] = _utcnow()
+        self.clear_download_state_calls.append(request_id)
+
+    def update_download_state(self, request_id: int, state_json: str) -> None:
+        row = self._requests.get(request_id)
+        self.update_download_state_calls.append((request_id, state_json))
+        if row:
+            try:
+                row["active_download_state"] = json.loads(state_json)
+            except json.JSONDecodeError:
+                row["active_download_state"] = state_json
             row["updated_at"] = _utcnow()
 
     def log_download(self, request_id: int, **kwargs: Any) -> None:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -114,20 +114,32 @@ class FakeSlskdUsers:
     def __init__(self) -> None:
         self.directory_calls: list[tuple[str, str]] = []
         self.directory_error: Exception | None = None
-        self._directories: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        self._directories: dict[tuple[str, str], list[Any]] = {}
+        self._directory_errors: dict[tuple[str, str], Exception] = {}
 
     def set_directory(
         self,
         username: str,
         directory: str,
-        result: list[dict[str, Any]],
+        result: list[Any],
     ) -> None:
         self._directories[(username, directory)] = copy.deepcopy(result)
 
-    def directory(self, username: str, directory: str) -> list[dict[str, Any]]:
+    def set_directory_error(
+        self,
+        username: str,
+        directory: str,
+        error: Exception,
+    ) -> None:
+        self._directory_errors[(username, directory)] = error
+
+    def directory(self, username: str, directory: str) -> list[Any]:
         self.directory_calls.append((username, directory))
         if self.directory_error is not None:
             raise self.directory_error
+        directory_error = self._directory_errors.get((username, directory))
+        if directory_error is not None:
+            raise directory_error
         return copy.deepcopy(self._directories.get((username, directory), []))
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -237,7 +237,12 @@ def make_spectral_context(
 # Shared context wiring
 # ---------------------------------------------------------------------------
 
-def make_ctx_with_fake_db(fake_db: Any, *, cfg: Any = None) -> Any:
+def make_ctx_with_fake_db(
+    fake_db: Any,
+    *,
+    cfg: Any = None,
+    slskd: Any = None,
+) -> Any:
     """Build a SoularrContext wired to a FakePipelineDB.
 
     The fake is wired via pipeline_db_source._get_db() so production code
@@ -248,7 +253,7 @@ def make_ctx_with_fake_db(fake_db: Any, *, cfg: Any = None) -> Any:
     mock_source._get_db.return_value = fake_db
     return SoularrContext(
         cfg=cfg if cfg is not None else MagicMock(),
-        slskd=MagicMock(),
+        slskd=slskd if slskd is not None else MagicMock(),
         pipeline_db_source=mock_source,
     )
 

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -450,8 +450,10 @@ class TestGetAlbumDetail(unittest.TestCase):
         self.assertEqual(detail["album"], "Test Album")
         self.assertEqual(detail["artist"], "Artist A")
         self.assertIn("tracks", detail)
-        self.assertEqual(len(detail["tracks"]), 2)
-        self.assertEqual(detail["tracks"][0]["title"], "Track 1")
+        tracks = detail["tracks"]
+        assert isinstance(tracks, list)
+        self.assertEqual(len(tracks), 2)
+        self.assertEqual(tracks[0]["title"], "Track 1")
 
     def test_nonexistent_returns_none(self) -> None:
         with BeetsDB(self.db_path) as db:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1388,16 +1388,23 @@ class TestPollActiveDownloads(unittest.TestCase):
             }
             for i in range(5)
         ]
-        cast(FakeSlskdAPI, ctx.slskd).set_downloads([{
+        slskd = cast(FakeSlskdAPI, ctx.slskd)
+        slskd.set_downloads([{
             "username": "user1",
             "directories": [{"directory": "user1\\Music", "files": slskd_files}],
         }])
+        slskd.transfers.enqueue_result = False
 
-        with patch("lib.download.slskd_do_enqueue", return_value=None):
+        with self.assertLogs("soularr", level="WARNING") as logs:
             poll_active_downloads(ctx)
 
         # Should NOT process — 7 files vanished (errored), album not complete
         mock_process.assert_not_called()
+        self.assertEqual(
+            "\n".join(logs.output).count("Failed to re-enqueue file"),
+            7,
+        )
+        self.assertEqual(len(slskd.transfers.enqueue_calls), 7)
         self.assertEqual(fake_db.clear_download_state_calls, [])
         self.assertEqual(fake_db.download_logs, [])
         self.assertEqual(fake_db.request(1)["status"], "downloading")
@@ -1421,10 +1428,14 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, fake_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, fake_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[],
+        )
 
-        # All 3 files have transfers in slskd
-        cast(FakeSlskdAPI, ctx.slskd).set_downloads([{
+        # First snapshot is the poll cycle; second snapshot is the
+        # post-requeue transfer-id lookup.
+        poll_snapshot = [{
             "username": "user1",
             "directories": [{"directory": "user1\\Music", "files": [
                 {
@@ -1443,27 +1454,32 @@ class TestPollActiveDownloads(unittest.TestCase):
                     "state": "Completed, Errored",
                 },
             ]}],
-        }])
+        }]
+        requeue_snapshot = [{
+            "username": "user1",
+            "directories": [{"directory": "user1\\Music", "files": [{
+                "filename": "user1\\Music\\03.flac",
+                "id": "new-tid-3",
+                "state": "Queued, Locally",
+            }]}],
+        }]
+        slskd = cast(FakeSlskdAPI, ctx.slskd)
+        slskd.queue_download_snapshots(poll_snapshot, requeue_snapshot)
 
-        requeue_file = make_download_file(
-            filename="user1\\Music\\03.flac",
-            id="new-tid-3",
-            file_dir="user1\\Music",
-            username="user1",
-            size=20000000,
-        )
-        with patch("lib.download.slskd_do_enqueue",
-                   return_value=[requeue_file]) as mock_enqueue:
+        with patch("time.sleep"):
             poll_active_downloads(ctx)
 
         # Should NOT process (not all done) and NOT timeout
         mock_process.assert_not_called()
         self.assertEqual(fake_db.download_logs, [])
         # Should re-enqueue the errored file
-        mock_enqueue.assert_called_once()
-        call_args = mock_enqueue.call_args
-        self.assertEqual(call_args[0][0], "user1")  # username
-        self.assertEqual(call_args[0][1][0]["filename"], "user1\\Music\\03.flac")
+        self.assertEqual(len(slskd.transfers.enqueue_calls), 1)
+        enqueue_call = slskd.transfers.enqueue_calls[0]
+        self.assertEqual(enqueue_call.username, "user1")
+        self.assertEqual(
+            enqueue_call.files,
+            [{"filename": "user1\\Music\\03.flac", "size": 20000000}],
+        )
         persisted = self._download_state(fake_db)
         self.assertEqual(persisted["files"][2]["retry_count"], 1)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -189,24 +189,36 @@ class TestCancelAndDelete(unittest.TestCase):
 
     def test_cancels_and_removes_dir(self):
         from lib.download import cancel_and_delete
-        ctx = _make_ctx()
-        f = _make_transfer_mock(file_dir="someuser\\Album Folder")
+        slskd = FakeSlskdAPI()
+        ctx = _make_ctx(slskd=slskd)
+        f = make_download_file(file_dir="someuser\\Album Folder")
         with patch("os.path.isdir", return_value=True), \
              patch("shutil.rmtree") as mock_rm:
             cancel_and_delete([f], ctx)
-        ctx.slskd.transfers.cancel_download.assert_called_once_with(
-            username="user1", id="file-id-1")
-        mock_rm.assert_called_once()
+        self.assertEqual(
+            [(call.username, call.id)
+             for call in slskd.transfers.cancel_download_calls],
+            [("user1", "file-id-1")],
+        )
+        mock_rm.assert_called_once_with(
+            os.path.join("/tmp/test_downloads", "Album Folder"))
 
     def test_cancel_failure_continues(self):
         """Should not raise if cancel_download throws."""
         from lib.download import cancel_and_delete
-        ctx = _make_ctx()
-        ctx.slskd.transfers.cancel_download.side_effect = Exception("network error")
-        f = _make_transfer_mock()
-        with patch("os.path.exists", return_value=False), \
-             patch("os.chdir"):
+        slskd = FakeSlskdAPI()
+        slskd.transfers.cancel_download_error = Exception("network error")
+        ctx = _make_ctx(slskd=slskd)
+        f = make_download_file()
+        with self.assertLogs("soularr", level="WARNING") as logs, \
+             patch("os.path.isdir", return_value=False):
             cancel_and_delete([f], ctx)  # should not raise
+        self.assertIn("Failed to cancel download", "\n".join(logs.output))
+        self.assertEqual(
+            [(call.username, call.id)
+             for call in slskd.transfers.cancel_download_calls],
+            [("user1", "file-id-1")],
+        )
 
 
 class TestSlskdDownloadStatus(unittest.TestCase):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -591,19 +591,27 @@ class TestGrabMostWanted(unittest.TestCase):
     def test_no_blocking_monitor(self):
         """grab_most_wanted returns immediately without blocking."""
         from lib.download import grab_most_wanted
-        from lib.grab_list import GrabListEntry, DownloadFile
         import time as _time
-        entry = GrabListEntry(
-            album_id=1, filetype="flac", title="T", artist="A", year="2020",
-            mb_release_id="mbid", db_request_id=42, db_source="request",
-            files=[
-                DownloadFile(filename="u\\M\\01.flac", id="tid-1",
-                             file_dir="u\\M", username="user1", size=30000000),
-            ],
+        entry = make_grab_list_entry(
+            album_id=1,
+            filetype="flac",
+            title="T",
+            artist="A",
+            year="2020",
+            mb_release_id="mbid",
+            db_request_id=42,
+            db_source="request",
+            files=[make_download_file(
+                filename="u\\M\\01.flac",
+                id="tid-1",
+                file_dir="u\\M",
+                username="user1",
+                size=30000000,
+            )],
         )
-        ctx = _make_ctx()
-        mock_db = MagicMock()
-        cast(Any, ctx.pipeline_db_source._get_db).return_value = mock_db
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(id=42, status="wanted"))
+        ctx = make_ctx_with_fake_db(fake_db)
         search_fn = MagicMock(return_value=({1: entry}, [], []))
         start = _time.time()
         grab_most_wanted([], search_fn, ctx)
@@ -930,7 +938,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         }
 
     def _make_poll_ctx(self, downloading_rows=None, slskd_downloads=None):
-        """Build context with mocked DB + fake slskd for polling."""
+        """Build context with fake DB + fake slskd for polling."""
         if slskd_downloads is None:
             # Default: return transfers that match the files
             slskd_downloads = [{
@@ -944,27 +952,35 @@ class TestPollActiveDownloads(unittest.TestCase):
                     },
                 ]}],
             }]
-        ctx = _make_ctx(slskd=FakeSlskdAPI(downloads=slskd_downloads))
-        mock_db = MagicMock()
-        mock_db.get_downloading.return_value = downloading_rows or []
-        mock_db.get_request.return_value = None  # default: album not found after processing
-        cast(Any, ctx.pipeline_db_source._get_db).return_value = mock_db
+        fake_db = FakePipelineDB()
+        for row in downloading_rows or []:
+            fake_db.seed_request(row)
+        cfg = _make_ctx().cfg
+        ctx = make_ctx_with_fake_db(
+            fake_db,
+            cfg=cfg,
+            slskd=FakeSlskdAPI(downloads=slskd_downloads),
+        )
+        return ctx, fake_db
 
-        return ctx, mock_db
+    def _download_state(self, fake_db: FakePipelineDB, request_id: int = 1):
+        state = fake_db.request(request_id)["active_download_state"]
+        assert isinstance(state, dict)
+        return state
 
     def test_poll_active_no_downloading(self):
         """No downloading albums → no-op."""
         from lib.download import poll_active_downloads
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[])
+        ctx, fake_db = self._make_poll_ctx(downloading_rows=[])
         poll_active_downloads(ctx)
-        mock_db.clear_download_state.assert_not_called()
+        self.assertEqual(fake_db.clear_download_state_calls, [])
 
     @patch("lib.download.process_completed_album")
     def test_poll_active_all_complete(self, mock_process):
         """1 downloading album, all files complete → calls process_completed_album."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -977,12 +993,15 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        mock_process.return_value = True
-        # After process_completed_album, DB shows status='imported'
-        mock_db.get_request.return_value = {"id": 1, "status": "imported"}
+        def mark_imported(*args):
+            fake_db.update_status(1, "imported")
+            return True
+
+        mock_process.side_effect = mark_imported
         poll_active_downloads(ctx)
 
-        mock_db.update_download_state.assert_called_once()
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        self.assertEqual(fake_db.request(1)["status"], "imported")
         mock_process.assert_called_once()
 
     @patch("lib.download.process_completed_album")
@@ -990,7 +1009,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         """beets_validation_enabled=False → process returns True, poll sets imported."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1004,12 +1023,11 @@ class TestPollActiveDownloads(unittest.TestCase):
         )
 
         mock_process.return_value = True
-        # After process_completed_album, status still 'downloading' (no beets)
-        mock_db.get_request.return_value = {"id": 1, "status": "downloading"}
         poll_active_downloads(ctx)
 
-        mock_db.update_download_state.assert_called_once()
-        mock_db.update_status.assert_called_once_with(1, "imported")
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        self.assertEqual(fake_db.request(1)["status"], "imported")
+        self.assertIsNone(fake_db.request(1)["active_download_state"])
 
     def test_poll_active_timeout(self):
         """No byte/state progress for stalled_timeout → cancel, log, reset to wanted."""
@@ -1026,7 +1044,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1042,12 +1060,9 @@ class TestPollActiveDownloads(unittest.TestCase):
         with patch("lib.download.cancel_and_delete"):
             poll_active_downloads(ctx)
 
-        # Should have logged a timeout download and reset to wanted
-        mock_db.log_download.assert_called_once()
-        kwargs = mock_db.log_download.call_args.kwargs
-        self.assertEqual(kwargs["outcome"], "timeout")
-        # Check apply_transition called reset_to_wanted
-        mock_db.reset_to_wanted.assert_called_once()
+        fake_db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
+        self.assertEqual(fake_db.recorded_attempts, [(1, "download")])
 
     def test_poll_active_old_album_with_progress_does_not_timeout(self):
         """Fresh byte progress should refresh stall timer even for an old album."""
@@ -1064,7 +1079,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1079,17 +1094,17 @@ class TestPollActiveDownloads(unittest.TestCase):
 
         poll_active_downloads(ctx)
 
-        mock_db.log_download.assert_not_called()
-        mock_db.update_download_state.assert_called_once()
-        persisted_json = mock_db.update_download_state.call_args[0][1]
-        self.assertIn('"bytes_transferred": 22345', persisted_json)
-        self.assertIn('"last_progress_at"', persisted_json)
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        persisted = self._download_state(fake_db)
+        self.assertEqual(persisted["files"][0]["bytes_transferred"], 22345)
+        self.assertIsNotNone(persisted["last_progress_at"])
 
     def test_poll_active_transfer_vanished_all(self):
         """slskd returns no matching transfers → treat as timeout."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1099,17 +1114,15 @@ class TestPollActiveDownloads(unittest.TestCase):
         with patch("lib.download.cancel_and_delete"):
             poll_active_downloads(ctx)
 
-        mock_db.log_download.assert_called_once()
-        # Check outcome is timeout
-        kwargs = mock_db.log_download.call_args.kwargs
-        self.assertEqual(kwargs["outcome"], "timeout")
+        fake_db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
 
     @patch("lib.download.process_completed_album")
     def test_poll_active_completed_removed_transfer_uses_snapshot_status(self, mock_process):
         """Completed transfers from includeRemoved=true should import, not timeout."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1125,21 +1138,25 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        mock_process.return_value = True
-        mock_db.get_request.return_value = {"id": 1, "status": "imported"}
+        def mark_imported(*args):
+            fake_db.update_status(1, "imported")
+            return True
+
+        mock_process.side_effect = mark_imported
 
         with patch("lib.download.slskd_download_status") as mock_status:
             poll_active_downloads(ctx)
 
         mock_status.assert_not_called()
         mock_process.assert_called_once()
-        mock_db.log_download.assert_not_called()
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.request(1)["status"], "imported")
 
     def test_poll_active_in_progress(self):
         """Files still downloading with fresh state transition → persist progress snapshot."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1155,8 +1172,9 @@ class TestPollActiveDownloads(unittest.TestCase):
         poll_active_downloads(ctx)
 
         # Should NOT process or timeout
-        mock_db.update_download_state.assert_called_once()
-        mock_db.log_download.assert_not_called()
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
 
     @patch("lib.download.process_completed_album")
     def test_poll_active_multiple_albums(self, mock_process):
@@ -1175,7 +1193,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         row2["album_title"] = "Album 2"
         row2["artist_name"] = "Artist 2"
 
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row1, row2],
             slskd_downloads=[
                 {
@@ -1202,18 +1220,21 @@ class TestPollActiveDownloads(unittest.TestCase):
         # slskd returns transfers for both users
         self.assertEqual(cast(FakeSlskdAPI, ctx.slskd).transfers.get_all_downloads_calls, [])
 
-        mock_process.return_value = True
-        mock_db.get_request.side_effect = lambda request_id: {
-            "id": request_id,
-            "status": "imported" if request_id == 1 else "downloading",
-        }
+        def mark_imported(*args):
+            fake_db.update_status(1, "imported")
+            return True
+
+        mock_process.side_effect = mark_imported
         poll_active_downloads(ctx)
 
         # Album 1 persists processing_started_at, album 2 persists progress.
-        self.assertEqual(mock_db.update_download_state.call_count, 2)
-        update_request_ids = [call.args[0] for call in mock_db.update_download_state.call_args_list]
+        self.assertEqual(len(fake_db.update_download_state_calls), 2)
+        update_request_ids = [
+            request_id for request_id, _ in fake_db.update_download_state_calls
+        ]
         self.assertEqual(update_request_ids, [1, 2])
-        self.assertIn('"processing_started_at"', mock_db.update_download_state.call_args_list[0].args[1])
+        self.assertIsNone(fake_db.request(1)["active_download_state"])
+        self.assertIsNotNone(self._download_state(fake_db, 2)["last_progress_at"])
         mock_process.assert_called_once()
 
     def test_poll_crash_recovery_no_state(self):
@@ -1221,19 +1242,20 @@ class TestPollActiveDownloads(unittest.TestCase):
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         row["active_download_state"] = None  # Simulates crash
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, fake_db = self._make_poll_ctx(downloading_rows=[row])
 
         poll_active_downloads(ctx)
 
         # apply_transition calls reset_to_wanted for downloading→wanted
-        mock_db.reset_to_wanted.assert_called_once()
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
+        self.assertEqual(fake_db.status_history, [(1, "wanted")])
 
     @patch("lib.download.process_completed_album")
     def test_poll_active_all_errors(self, mock_process):
         """All files errored → timeout the album."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1250,7 +1272,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             poll_active_downloads(ctx)
 
         mock_process.assert_not_called()
-        mock_db.log_download.assert_called_once()
+        fake_db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
 
     def test_poll_active_remote_queue_timeout(self):
         """All files queued remotely past timeout → timeout."""
@@ -1267,7 +1290,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1285,9 +1308,8 @@ class TestPollActiveDownloads(unittest.TestCase):
         with patch("lib.download.cancel_and_delete"):
             poll_active_downloads(ctx)
 
-        mock_db.log_download.assert_called_once()
-        kwargs = mock_db.log_download.call_args.kwargs
-        self.assertEqual(kwargs["outcome"], "timeout")
+        fake_db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
 
     def test_poll_active_remote_queue_does_not_use_stalled_timeout(self):
         """Fully remote-queued albums should not hit stalled_timeout first."""
@@ -1305,7 +1327,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1323,7 +1345,9 @@ class TestPollActiveDownloads(unittest.TestCase):
         with patch("lib.download.cancel_and_delete"):
             poll_active_downloads(ctx)
 
-        mock_db.log_download.assert_not_called()
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.update_download_state_calls, [])
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
 
     @patch("lib.download.process_completed_album")
     def test_poll_transfer_vanished_partial(self, mock_process):
@@ -1341,7 +1365,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             "files": files,
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, fake_db = self._make_poll_ctx(downloading_rows=[row])
 
         # Only files 0-4 have transfers in slskd
         slskd_files = [
@@ -1362,7 +1386,9 @@ class TestPollActiveDownloads(unittest.TestCase):
 
         # Should NOT process — 7 files vanished (errored), album not complete
         mock_process.assert_not_called()
-        mock_db.clear_download_state.assert_not_called()
+        self.assertEqual(fake_db.clear_download_state_calls, [])
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
 
 
     @patch("lib.download.process_completed_album")
@@ -1383,7 +1409,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, fake_db = self._make_poll_ctx(downloading_rows=[row])
 
         # All 3 files have transfers in slskd
         cast(FakeSlskdAPI, ctx.slskd).set_downloads([{
@@ -1420,20 +1446,20 @@ class TestPollActiveDownloads(unittest.TestCase):
 
         # Should NOT process (not all done) and NOT timeout
         mock_process.assert_not_called()
-        mock_db.log_download.assert_not_called()
+        self.assertEqual(fake_db.download_logs, [])
         # Should re-enqueue the errored file
         mock_enqueue.assert_called_once()
         call_args = mock_enqueue.call_args
         self.assertEqual(call_args[0][0], "user1")  # username
         self.assertEqual(call_args[0][1][0]["filename"], "user1\\Music\\03.flac")
-        persisted_json = mock_db.update_download_state.call_args[0][1]
-        self.assertIn('"retry_count": 1', persisted_json)
+        persisted = self._download_state(fake_db)
+        self.assertEqual(persisted["files"][2]["retry_count"], 1)
 
     def test_poll_active_get_all_downloads_api_error_waits_for_next_cycle(self):
         """Transient bulk-download API failures must not be treated as vanished transfers."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, fake_db = self._make_poll_ctx(downloading_rows=[row])
         cast(FakeSlskdAPI, ctx.slskd).transfers.get_all_downloads_error = (
             RuntimeError("temporary slskd failure")
         )
@@ -1442,18 +1468,17 @@ class TestPollActiveDownloads(unittest.TestCase):
             poll_active_downloads(ctx)
 
         mock_cancel.assert_not_called()
-        mock_db.log_download.assert_not_called()
-        mock_db.update_download_state.assert_not_called()
-        reset_calls = [c for c in mock_db._execute.call_args_list
-                       if "wanted" in str(c)]
-        self.assertEqual(reset_calls, [])
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.update_download_state_calls, [])
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
+        self.assertEqual(fake_db.status_history, [])
 
     @patch("lib.download.process_completed_album")
     def test_poll_active_completion_exception_persists_processing_state(self, mock_process):
         """Exceptions after completion should leave persisted state for the next cycle to resume."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1469,18 +1494,18 @@ class TestPollActiveDownloads(unittest.TestCase):
         mock_process.side_effect = RuntimeError("boom")
         poll_active_downloads(ctx)
 
-        mock_db.log_download.assert_not_called()
-        mock_db.update_status.assert_not_called()
-        mock_db.update_download_state.assert_called_once()
-        persisted_json = mock_db.update_download_state.call_args[0][1]
-        self.assertIn('"processing_started_at"', persisted_json)
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.status_history, [])
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        persisted = self._download_state(fake_db)
+        self.assertIsNotNone(persisted["processing_started_at"])
 
     @patch("lib.download.process_completed_album")
     def test_poll_no_redownload_window(self, mock_process):
         """Album stays 'downloading' during process_completed_album — no redownload window."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(
+        ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
                 "username": "user1",
@@ -1493,33 +1518,18 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        # After process_completed_album, mark_done set status to 'imported'
-        mock_db.get_request.return_value = {"id": 1, "status": "imported"}
+        def mark_imported(*args):
+            fake_db.update_status(1, "imported")
+            return True
 
-        # Track all update_status and _reset_to_wanted calls to verify
-        # album was never set to 'wanted' during processing
-        status_updates = []
-        original_update = mock_db.update_status.side_effect
-        def track_update(*args, **kwargs):
-            status_updates.append(args)
-        mock_db.update_status.side_effect = track_update
-
-        mock_process.return_value = True
+        mock_process.side_effect = mark_imported
         poll_active_downloads(ctx)
 
         # process_completed_album ran
         mock_process.assert_called_once()
-        mock_db.update_download_state.assert_called_once()
-        # The album was NEVER set to 'wanted' before processing
-        for args in status_updates:
-            if len(args) >= 2:
-                self.assertNotEqual(args[1], "wanted",
-                                  "Album should never be set to 'wanted' during processing")
-        # _reset_to_wanted uses _execute, not update_status — check no 'wanted' SQL
-        for call in mock_db._execute.call_args_list:
-            sql = str(call[0][0]) if call[0] else ""
-            if "wanted" in sql:
-                self.fail("Album was reset to 'wanted' during processing — redownload window!")
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        self.assertNotIn((1, "wanted"), fake_db.status_history)
+        self.assertEqual(fake_db.request(1)["status"], "imported")
 
 
 class TestBuildActiveDownloadState(unittest.TestCase):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -17,9 +17,10 @@ from tests.helpers import (
     make_ctx_with_fake_db,
     make_download_file,
     make_grab_list_entry,
+    make_request_row,
     make_spectral_context,
 )
-from tests.fakes import FakeSlskdAPI
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
 
 
 def _utc_now_iso() -> str:
@@ -529,44 +530,61 @@ class TestGrabMostWanted(unittest.TestCase):
     def test_sets_downloading_status(self):
         """After enqueue, album_requests.status = 'downloading'."""
         from lib.download import grab_most_wanted
-        from lib.grab_list import GrabListEntry, DownloadFile
-        entry = GrabListEntry(
-            album_id=1, filetype="flac", title="T", artist="A", year="2020",
-            mb_release_id="mbid", db_request_id=42, db_source="request",
-            files=[
-                DownloadFile(filename="u\\M\\01.flac", id="tid-1",
-                             file_dir="u\\M", username="user1", size=30000000),
-            ],
+        entry = make_grab_list_entry(
+            album_id=1,
+            filetype="flac",
+            title="T",
+            artist="A",
+            year="2020",
+            mb_release_id="mbid",
+            db_request_id=42,
+            db_source="request",
+            files=[make_download_file(
+                filename="u\\M\\01.flac",
+                id="tid-1",
+                file_dir="u\\M",
+                username="user1",
+                size=30000000,
+            )],
         )
-        ctx = _make_ctx()
-        mock_db = MagicMock()
-        cast(Any, ctx.pipeline_db_source._get_db).return_value = mock_db
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(id=42, status="wanted"))
+        ctx = make_ctx_with_fake_db(fake_db)
         search_fn = MagicMock(return_value=({1: entry}, [], []))
         grab_most_wanted([], search_fn, ctx)
-        mock_db.set_downloading.assert_called_once()
-        call_args = mock_db.set_downloading.call_args
-        self.assertEqual(call_args[0][0], 42)  # request_id
+        row = fake_db.request(42)
+        self.assertEqual(row["status"], "downloading")
+        self.assertEqual(fake_db.status_history, [(42, "downloading")])
 
     def test_writes_active_download_state(self):
         """JSONB written with correct structure."""
         from lib.download import grab_most_wanted
-        from lib.grab_list import GrabListEntry, DownloadFile
         import json
-        entry = GrabListEntry(
-            album_id=1, filetype="mp3 v0", title="T", artist="A", year="2020",
-            mb_release_id="mbid", db_request_id=42, db_source="request",
-            files=[
-                DownloadFile(filename="u\\M\\01.mp3", id="tid-1",
-                             file_dir="u\\M", username="user1", size=5000000),
-            ],
+        entry = make_grab_list_entry(
+            album_id=1,
+            filetype="mp3 v0",
+            title="T",
+            artist="A",
+            year="2020",
+            mb_release_id="mbid",
+            db_request_id=42,
+            db_source="request",
+            files=[make_download_file(
+                filename="u\\M\\01.mp3",
+                id="tid-1",
+                file_dir="u\\M",
+                username="user1",
+                size=5000000,
+            )],
         )
-        ctx = _make_ctx()
-        mock_db = MagicMock()
-        cast(Any, ctx.pipeline_db_source._get_db).return_value = mock_db
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(id=42, status="wanted"))
+        ctx = make_ctx_with_fake_db(fake_db)
         search_fn = MagicMock(return_value=({1: entry}, [], []))
         grab_most_wanted([], search_fn, ctx)
-        state_json = mock_db.set_downloading.call_args[0][1]
-        state = json.loads(state_json)
+        state_raw = fake_db.request(42)["active_download_state"]
+        assert isinstance(state_raw, str)
+        state = json.loads(state_raw)
         self.assertEqual(state["filetype"], "mp3 v0")
         self.assertEqual(len(state["files"]), 1)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -912,23 +912,26 @@ class TestPollActiveDownloads(unittest.TestCase):
         }
 
     def _make_poll_ctx(self, downloading_rows=None, slskd_downloads=None):
-        """Build context with mocked DB + slskd for polling."""
-        ctx = _make_ctx()
+        """Build context with mocked DB + fake slskd for polling."""
+        if slskd_downloads is None:
+            # Default: return transfers that match the files
+            slskd_downloads = [{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [
+                    {
+                        "filename": "user1\\Music\\01.flac",
+                        "id": "tid-1",
+                        "state": "InProgress",
+                        "bytesTransferred": 1,
+                    },
+                ]}],
+            }]
+        ctx = _make_ctx(slskd=FakeSlskdAPI(downloads=slskd_downloads))
         mock_db = MagicMock()
         mock_db.get_downloading.return_value = downloading_rows or []
         mock_db.get_request.return_value = None  # default: album not found after processing
         cast(Any, ctx.pipeline_db_source._get_db).return_value = mock_db
 
-        if slskd_downloads is not None:
-            ctx.slskd.transfers.get_all_downloads.return_value = slskd_downloads
-        else:
-            # Default: return transfers that match the files
-            ctx.slskd.transfers.get_all_downloads.return_value = [{
-                "username": "user1",
-                "directories": [{"directory": "user1\\Music", "files": [
-                    {"filename": "user1\\Music\\01.flac", "id": "tid-1"},
-                ]}],
-            }]
         return ctx, mock_db
 
     def test_poll_active_no_downloading(self):
@@ -943,18 +946,23 @@ class TestPollActiveDownloads(unittest.TestCase):
         """1 downloading album, all files complete → calls process_completed_album."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                }]}],
+            }],
+        )
 
-        # Mock slskd status: file is complete
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Completed, Succeeded"}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            mock_process.return_value = True
-            # After process_completed_album, DB shows status='imported'
-            mock_db.get_request.return_value = {"id": 1, "status": "imported"}
-            poll_active_downloads(ctx)
+        mock_process.return_value = True
+        # After process_completed_album, DB shows status='imported'
+        mock_db.get_request.return_value = {"id": 1, "status": "imported"}
+        poll_active_downloads(ctx)
 
         mock_db.update_download_state.assert_called_once()
         mock_process.assert_called_once()
@@ -964,17 +972,23 @@ class TestPollActiveDownloads(unittest.TestCase):
         """beets_validation_enabled=False → process returns True, poll sets imported."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                }]}],
+            }],
+        )
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Completed, Succeeded"}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            mock_process.return_value = True
-            # After process_completed_album, status still 'downloading' (no beets)
-            mock_db.get_request.return_value = {"id": 1, "status": "downloading"}
-            poll_active_downloads(ctx)
+        mock_process.return_value = True
+        # After process_completed_album, status still 'downloading' (no beets)
+        mock_db.get_request.return_value = {"id": 1, "status": "downloading"}
+        poll_active_downloads(ctx)
 
         mock_db.update_download_state.assert_called_once()
         mock_db.update_status.assert_called_once_with(1, "imported")
@@ -994,15 +1008,21 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "InProgress",
+                    "bytesTransferred": 12345,
+                }]}],
+            }],
+        )
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "InProgress", "bytesTransferred": 12345}
-            return True
         with patch("lib.download.cancel_and_delete"):
-            with patch("lib.download.slskd_download_status", side_effect=mock_status):
-                poll_active_downloads(ctx)
+            poll_active_downloads(ctx)
 
         # Should have logged a timeout download and reset to wanted
         mock_db.log_download.assert_called_once()
@@ -1026,14 +1046,20 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "InProgress",
+                    "bytesTransferred": 22345,
+                }]}],
+            }],
+        )
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "InProgress", "bytesTransferred": 22345}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            poll_active_downloads(ctx)
+        poll_active_downloads(ctx)
 
         mock_db.log_download.assert_not_called()
         mock_db.update_download_state.assert_called_once()
@@ -1095,14 +1121,20 @@ class TestPollActiveDownloads(unittest.TestCase):
         """Files still downloading with fresh state transition → persist progress snapshot."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "InProgress",
+                    "bytesTransferred": 2048,
+                }]}],
+            }],
+        )
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "InProgress", "bytesTransferred": 2048}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            poll_active_downloads(ctx)
+        poll_active_downloads(ctx)
 
         # Should NOT process or timeout
         mock_db.update_download_state.assert_called_once()
@@ -1125,38 +1157,39 @@ class TestPollActiveDownloads(unittest.TestCase):
         row2["album_title"] = "Album 2"
         row2["artist_name"] = "Artist 2"
 
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row1, row2])
-
-        # slskd returns transfers for both users
-        def get_downloads_side_effect(includeRemoved=None):
-            return [{
-                "username": "user1",
-                "directories": [{"directory": "user1\\Music", "files": [
-                    {"filename": "user1\\Music\\01.flac", "id": "tid-1"},
-                ]}]},
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row1, row2],
+            slskd_downloads=[
+                {
+                    "username": "user1",
+                    "directories": [{"directory": "user1\\Music", "files": [{
+                        "filename": "user1\\Music\\01.flac",
+                        "id": "tid-1",
+                        "state": "Completed, Succeeded",
+                        "bytesTransferred": 30000000,
+                    }]}],
+                },
                 {
                     "username": "user2",
-                    "directories": [{"directory": "user2\\Music", "files": [
-                    {"filename": "user2\\Music\\01.mp3", "id": "tid-2"},
-                ]}]},
-            ]
-        ctx.slskd.transfers.get_all_downloads.side_effect = get_downloads_side_effect
+                    "directories": [{"directory": "user2\\Music", "files": [{
+                        "filename": "user2\\Music\\01.mp3",
+                        "id": "tid-2",
+                        "state": "InProgress",
+                        "bytesTransferred": 2048,
+                    }]}],
+                },
+            ],
+        )
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                if f.username == "user1":
-                    f.status = {"state": "Completed, Succeeded"}
-                else:
-                    f.status = {"state": "InProgress"}
-            return True
+        # slskd returns transfers for both users
+        self.assertEqual(cast(FakeSlskdAPI, ctx.slskd).transfers.get_all_downloads_calls, [])
 
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            mock_process.return_value = True
-            mock_db.get_request.side_effect = lambda request_id: {
-                "id": request_id,
-                "status": "imported" if request_id == 1 else "downloading",
-            }
-            poll_active_downloads(ctx)
+        mock_process.return_value = True
+        mock_db.get_request.side_effect = lambda request_id: {
+            "id": request_id,
+            "status": "imported" if request_id == 1 else "downloading",
+        }
+        poll_active_downloads(ctx)
 
         # Album 1 persists processing_started_at, album 2 persists progress.
         self.assertEqual(mock_db.update_download_state.call_count, 2)
@@ -1182,15 +1215,21 @@ class TestPollActiveDownloads(unittest.TestCase):
         """All files errored → timeout the album."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
-
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Completed, Errored"}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            with patch("lib.download.cancel_and_delete"):
-                poll_active_downloads(ctx)
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [
+                    {
+                        "filename": "user1\\Music\\01.flac",
+                        "id": "tid-1",
+                        "state": "Completed, Errored",
+                    },
+                ]}],
+            }],
+        )
+        with patch("lib.download.cancel_and_delete"):
+            poll_active_downloads(ctx)
 
         mock_process.assert_not_called()
         mock_db.log_download.assert_called_once()
@@ -1210,18 +1249,23 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Queued, Remotely",
+                }]}],
+            }],
+        )
         cfg = cast(Any, ctx.cfg)
         cfg.remote_queue_timeout = 120  # 2 minutes
         cfg.stalled_timeout = 600  # 10 minutes (not exceeded)
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Queued, Remotely"}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            with patch("lib.download.cancel_and_delete"):
-                poll_active_downloads(ctx)
+        with patch("lib.download.cancel_and_delete"):
+            poll_active_downloads(ctx)
 
         mock_db.log_download.assert_called_once()
         kwargs = mock_db.log_download.call_args.kwargs
@@ -1243,19 +1287,23 @@ class TestPollActiveDownloads(unittest.TestCase):
             ],
         }
         row = self._make_downloading_row(state_dict=state_dict)
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Queued, Remotely",
+                }]}],
+            }],
+        )
         cfg = cast(Any, ctx.cfg)
         cfg.remote_queue_timeout = 3600
         cfg.stalled_timeout = 120
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Queued, Remotely"}
-            return True
-
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            with patch("lib.download.cancel_and_delete"):
-                poll_active_downloads(ctx)
+        with patch("lib.download.cancel_and_delete"):
+            poll_active_downloads(ctx)
 
         mock_db.log_download.assert_not_called()
 
@@ -1278,21 +1326,21 @@ class TestPollActiveDownloads(unittest.TestCase):
         ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
 
         # Only files 0-4 have transfers in slskd
-        slskd_files = [{"filename": f"user1\\Music\\{i:02d}.flac", "id": f"tid-{i}"}
-                       for i in range(5)]
-        ctx.slskd.transfers.get_all_downloads.return_value = [{
+        slskd_files = [
+            {
+                "filename": f"user1\\Music\\{i:02d}.flac",
+                "id": f"tid-{i}",
+                "state": "InProgress",
+            }
+            for i in range(5)
+        ]
+        cast(FakeSlskdAPI, ctx.slskd).set_downloads([{
             "username": "user1",
             "directories": [{"directory": "user1\\Music", "files": slskd_files}],
-        }]
+        }])
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                if f.id:  # Only files with IDs get polled
-                    f.status = {"state": "InProgress"}
-            return True
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            with patch("lib.download.slskd_do_enqueue", return_value=None):
-                poll_active_downloads(ctx)
+        with patch("lib.download.slskd_do_enqueue", return_value=None):
+            poll_active_downloads(ctx)
 
         # Should NOT process — 7 files vanished (errored), album not complete
         mock_process.assert_not_called()
@@ -1320,28 +1368,37 @@ class TestPollActiveDownloads(unittest.TestCase):
         ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
 
         # All 3 files have transfers in slskd
-        ctx.slskd.transfers.get_all_downloads.return_value = [{
+        cast(FakeSlskdAPI, ctx.slskd).set_downloads([{
             "username": "user1",
             "directories": [{"directory": "user1\\Music", "files": [
-                {"filename": "user1\\Music\\01.flac", "id": "tid-1"},
-                {"filename": "user1\\Music\\02.flac", "id": "tid-2"},
-                {"filename": "user1\\Music\\03.flac", "id": "tid-3"},
+                {
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                },
+                {
+                    "filename": "user1\\Music\\02.flac",
+                    "id": "tid-2",
+                    "state": "Completed, Succeeded",
+                },
+                {
+                    "filename": "user1\\Music\\03.flac",
+                    "id": "tid-3",
+                    "state": "Completed, Errored",
+                },
             ]}],
-        }]
+        }])
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                if f.filename.endswith("03.flac"):
-                    f.status = {"state": "Completed, Errored"}
-                else:
-                    f.status = {"state": "Completed, Succeeded"}
-            return True
-
-        mock_requeue_file = MagicMock()
-        mock_requeue_file.id = "new-tid-3"
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            with patch("lib.download.slskd_do_enqueue", return_value=[mock_requeue_file]) as mock_enqueue:
-                poll_active_downloads(ctx)
+        requeue_file = make_download_file(
+            filename="user1\\Music\\03.flac",
+            id="new-tid-3",
+            file_dir="user1\\Music",
+            username="user1",
+            size=20000000,
+        )
+        with patch("lib.download.slskd_do_enqueue",
+                   return_value=[requeue_file]) as mock_enqueue:
+            poll_active_downloads(ctx)
 
         # Should NOT process (not all done) and NOT timeout
         mock_process.assert_not_called()
@@ -1359,8 +1416,8 @@ class TestPollActiveDownloads(unittest.TestCase):
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
-        ctx.slskd.transfers.get_all_downloads.side_effect = RuntimeError(
-            "temporary slskd failure"
+        cast(FakeSlskdAPI, ctx.slskd).transfers.get_all_downloads_error = (
+            RuntimeError("temporary slskd failure")
         )
 
         with patch("lib.download.cancel_and_delete") as mock_cancel:
@@ -1378,16 +1435,21 @@ class TestPollActiveDownloads(unittest.TestCase):
         """Exceptions after completion should leave persisted state for the next cycle to resume."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                }]}],
+            }],
+        )
 
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Completed, Succeeded"}
-            return True
-
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            mock_process.side_effect = RuntimeError("boom")
-            poll_active_downloads(ctx)
+        mock_process.side_effect = RuntimeError("boom")
+        poll_active_downloads(ctx)
 
         mock_db.log_download.assert_not_called()
         mock_db.update_status.assert_not_called()
@@ -1400,12 +1462,18 @@ class TestPollActiveDownloads(unittest.TestCase):
         """Album stays 'downloading' during process_completed_album — no redownload window."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
-        ctx, mock_db = self._make_poll_ctx(downloading_rows=[row])
-
-        def mock_status(downloads, ctx_arg, **kwargs):
-            for f in downloads:
-                f.status = {"state": "Completed, Succeeded"}
-            return True
+        ctx, mock_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                }]}],
+            }],
+        )
 
         # After process_completed_album, mark_done set status to 'imported'
         mock_db.get_request.return_value = {"id": 1, "status": "imported"}
@@ -1418,9 +1486,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             status_updates.append(args)
         mock_db.update_status.side_effect = track_update
 
-        with patch("lib.download.slskd_download_status", side_effect=mock_status):
-            mock_process.return_value = True
-            poll_active_downloads(ctx)
+        mock_process.return_value = True
+        poll_active_downloads(ctx)
 
         # process_completed_album ran
         mock_process.assert_called_once()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -19,6 +19,7 @@ from tests.helpers import (
     make_grab_list_entry,
     make_spectral_context,
 )
+from tests.fakes import FakeSlskdAPI
 
 
 def _utc_now_iso() -> str:
@@ -211,18 +212,29 @@ class TestSlskdDownloadStatus(unittest.TestCase):
 
     def test_populates_status(self):
         from lib.download import slskd_download_status
-        ctx = _make_ctx()
-        ctx.slskd.transfers.get_download.return_value = {"state": "Completed, Succeeded"}
-        f = _make_transfer_mock()
+        slskd = FakeSlskdAPI()
+        slskd.add_transfer(
+            username="user1",
+            directory="user1\\Music",
+            filename="01 - Track.mp3",
+            id="file-id-1",
+            state="Completed, Succeeded",
+        )
+        ctx = _make_ctx(slskd=slskd)
+        f = make_download_file(id="file-id-1")
         ok = slskd_download_status([f], ctx)
         self.assertTrue(ok)
+        self.assertIsNotNone(f.status)
+        assert f.status is not None
         self.assertEqual(f.status["state"], "Completed, Succeeded")
+        self.assertEqual(slskd.transfers.get_download_calls, [("user1", "file-id-1")])
 
     def test_error_sets_none(self):
         from lib.download import slskd_download_status
-        ctx = _make_ctx()
-        ctx.slskd.transfers.get_download.side_effect = Exception("fail")
-        f = _make_transfer_mock()
+        slskd = FakeSlskdAPI()
+        slskd.transfers.get_download_error = Exception("fail")
+        ctx = _make_ctx(slskd=slskd)
+        f = make_download_file(id="file-id-1")
         ok = slskd_download_status([f], ctx)
         self.assertFalse(ok)
         self.assertIsNone(f.status)
@@ -230,8 +242,9 @@ class TestSlskdDownloadStatus(unittest.TestCase):
     def test_bulk_snapshot_populates_status(self):
         """When snapshot is provided, use match_transfer instead of per-file API."""
         from lib.download import slskd_download_status
-        ctx = _make_ctx()
-        f = _make_transfer_mock(filename="Music\\01 - Track.mp3", username="user1")
+        slskd = FakeSlskdAPI()
+        ctx = _make_ctx(slskd=slskd)
+        f = make_download_file(filename="Music\\01 - Track.mp3", username="user1")
         snapshot = [{
             "username": "user1",
             "directories": [{"files": [{
@@ -243,15 +256,17 @@ class TestSlskdDownloadStatus(unittest.TestCase):
         }]
         ok = slskd_download_status([f], ctx, snapshot=snapshot)
         self.assertTrue(ok)
+        self.assertIsNotNone(f.status)
+        assert f.status is not None
         self.assertEqual(f.status["state"], "Completed, Succeeded")
         # No per-file API calls should have been made
-        ctx.slskd.transfers.get_download.assert_not_called()
+        self.assertEqual(slskd.transfers.get_download_calls, [])
 
     def test_bulk_snapshot_file_not_found(self):
         """When snapshot doesn't contain the file, status is None, returns False."""
         from lib.download import slskd_download_status
-        ctx = _make_ctx()
-        f = _make_transfer_mock(filename="Music\\missing.mp3", username="user1")
+        ctx = _make_ctx(slskd=FakeSlskdAPI())
+        f = make_download_file(filename="Music\\missing.mp3", username="user1")
         snapshot = [{"username": "user1", "directories": [{"files": []}]}]
         ok = slskd_download_status([f], ctx, snapshot=snapshot)
         self.assertFalse(ok)
@@ -262,15 +277,14 @@ class TestSlskdDoEnqueue(unittest.TestCase):
 
     def test_successful_enqueue(self):
         from lib.download import slskd_do_enqueue
-        ctx = _make_ctx()
-        ctx.slskd.transfers.enqueue.return_value = True
-        ctx.slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "user1",
             "directories": [{
                 "directory": "user1\\Music",
                 "files": [{"filename": "track.mp3", "id": "new-id"}],
             }],
-        }]
+        }])
+        ctx = _make_ctx(slskd=slskd)
         files = [{"filename": "track.mp3", "size": 5000000}]
         with patch("time.sleep"):
             result = slskd_do_enqueue("user1", files, "user1\\Music", ctx)
@@ -278,12 +292,14 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         assert result is not None
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, "new-id")
-        ctx.slskd.transfers.get_all_downloads.assert_called_once_with(includeRemoved=True)
+        self.assertEqual(slskd.transfers.enqueue_calls[0].files, files)
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [True])
 
     def test_enqueue_failure_returns_none(self):
         from lib.download import slskd_do_enqueue
-        ctx = _make_ctx()
-        ctx.slskd.transfers.enqueue.side_effect = Exception("fail")
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = Exception("fail")
+        ctx = _make_ctx(slskd=slskd)
         with patch("time.sleep"):
             result = slskd_do_enqueue("user1", [], "dir", ctx)
         self.assertIsNone(result)
@@ -291,8 +307,6 @@ class TestSlskdDoEnqueue(unittest.TestCase):
     def test_enqueue_polls_until_ids_found(self):
         """Transfer IDs appear on 2nd poll — should resolve in 2 iterations, not 5s."""
         from lib.download import slskd_do_enqueue
-        ctx = _make_ctx()
-        ctx.slskd.transfers.enqueue.return_value = True
         snapshot_with_id = [{
             "username": "user1",
             "directories": [{"files": [{"filename": "track.mp3", "id": "tid-1"}]}],
@@ -301,10 +315,9 @@ class TestSlskdDoEnqueue(unittest.TestCase):
             "username": "user1",
             "directories": [{"files": []}],
         }]
-        ctx.slskd.transfers.get_all_downloads.side_effect = [
-            snapshot_without_id,  # 1st poll: not ready
-            snapshot_with_id,     # 2nd poll: ready
-        ]
+        slskd = FakeSlskdAPI(
+            download_snapshots=[snapshot_without_id, snapshot_with_id])
+        ctx = _make_ctx(slskd=slskd)
         files = [{"filename": "track.mp3", "size": 5000000}]
         with patch("time.sleep"):
             result = slskd_do_enqueue("user1", files, "user1\\Music", ctx)
@@ -313,18 +326,17 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, "tid-1")
         # Should have polled twice
-        self.assertEqual(ctx.slskd.transfers.get_all_downloads.call_count, 2)
+        self.assertEqual(len(slskd.transfers.get_all_downloads_calls), 2)
 
     def test_enqueue_timeout_returns_partial(self):
         """Transfer IDs never appear — should return whatever we have after timeout."""
         from lib.download import slskd_do_enqueue
-        ctx = _make_ctx()
-        ctx.slskd.transfers.enqueue.return_value = True
         # Never returns the transfer ID
-        ctx.slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "user1",
             "directories": [{"files": []}],
-        }]
+        }])
+        ctx = _make_ctx(slskd=slskd)
         files = [{"filename": "track.mp3", "size": 5000000}]
         with patch("time.sleep"):
             result = slskd_do_enqueue("user1", files, "user1\\Music", ctx)
@@ -709,18 +721,17 @@ class TestRederiveTransferIds(unittest.TestCase):
             filetype="flac", title="T", artist="A", year="2020",
             mb_release_id="mbid",
         )
-        mock_slskd = MagicMock()
-        mock_slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "user1",
             "directories": [{"directory": "u\\M", "files": [
                 {"filename": "u\\M\\01.flac", "id": "new-id-1"},
                 {"filename": "u\\M\\02.flac", "id": "new-id-2"},
             ]}],
-        }]
-        rederive_transfer_ids(entry, mock_slskd)
+        }])
+        rederive_transfer_ids(entry, slskd)
         self.assertEqual(entry.files[0].id, "new-id-1")
         self.assertEqual(entry.files[1].id, "new-id-2")
-        mock_slskd.transfers.get_all_downloads.assert_called_once_with(includeRemoved=True)
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [True])
 
     def test_missing_transfer_keeps_empty_id(self):
         from lib.download import rederive_transfer_ids
@@ -733,12 +744,11 @@ class TestRederiveTransferIds(unittest.TestCase):
             filetype="flac", title="T", artist="A", year="2020",
             mb_release_id="mbid",
         )
-        mock_slskd = MagicMock()
-        mock_slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "user1",
             "directories": [{"directory": "u\\M", "files": []}],
-        }]
-        rederive_transfer_ids(entry, mock_slskd)
+        }])
+        rederive_transfer_ids(entry, slskd)
         self.assertEqual(entry.files[0].id, "")
 
     def test_uses_bulk_downloads_for_spacey_usernames(self):
@@ -768,8 +778,7 @@ class TestRederiveTransferIds(unittest.TestCase):
             year="2020",
             mb_release_id="mbid",
         )
-        mock_slskd = MagicMock()
-        mock_slskd.transfers.get_all_downloads.return_value = [
+        slskd = FakeSlskdAPI(downloads=[
             {
                 "username": "Mr. Odd",
                 "directories": [{"directory": "Mr. Odd\\Album", "files": [
@@ -782,13 +791,13 @@ class TestRederiveTransferIds(unittest.TestCase):
                     {"filename": "Miick Starr\\Album\\01.flac", "id": "starr-id"},
                 ]}],
             },
-        ]
+        ])
 
-        rederive_transfer_ids(entry, mock_slskd)
+        rederive_transfer_ids(entry, slskd)
 
         self.assertEqual(entry.files[0].id, "starr-id")
         self.assertEqual(entry.files[1].id, "odd-id")
-        mock_slskd.transfers.get_downloads.assert_not_called()
+        self.assertEqual(slskd.transfers.get_downloads_calls, [])
 
     def test_terminal_snapshot_sets_file_status(self):
         from lib.download import rederive_transfer_ids
@@ -810,8 +819,7 @@ class TestRederiveTransferIds(unittest.TestCase):
             year="2020",
             mb_release_id="mbid",
         )
-        mock_slskd = MagicMock()
-        mock_slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "user1",
             "directories": [{"directory": "user1\\Album", "files": [
                 {
@@ -821,9 +829,9 @@ class TestRederiveTransferIds(unittest.TestCase):
                     "bytesTransferred": 1000,
                 },
             ]}],
-        }]
+        }])
 
-        rederive_transfer_ids(entry, mock_slskd)
+        rederive_transfer_ids(entry, slskd)
 
         self.assertEqual(entry.files[0].id, "done-id")
         status = entry.files[0].status

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -125,6 +125,24 @@ class TestFakeSlskdAPI(unittest.TestCase):
         self.assertEqual(slskd.transfers.enqueue_calls[0].files, files)
         self.assertEqual(slskd.transfers.cancel_download_calls[0].id, "tid-1")
 
+    def test_user_directories_record_results_and_errors(self):
+        slskd = FakeSlskdAPI()
+        directory = [{"directory": "Music\\Album", "files": []}]
+        slskd.users.set_directory("user1", "Music\\Album", directory)
+        slskd.users.set_directory_error(
+            "user1",
+            "Music\\Broken",
+            Exception("Peer offline"),
+        )
+
+        self.assertEqual(slskd.users.directory("user1", "Music\\Album"), directory)
+        with self.assertRaises(Exception):
+            slskd.users.directory("user1", "Music\\Broken")
+        self.assertEqual(slskd.users.directory_calls, [
+            ("user1", "Music\\Album"),
+            ("user1", "Music\\Broken"),
+        ])
+
 
 class TestBuilders(unittest.TestCase):
     def test_make_download_file_defaults(self):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -44,6 +44,21 @@ class TestFakePipelineDB(unittest.TestCase):
             row["active_download_state"],
             '{"enqueued_at":"2026-01-01T00:00:00+00:00"}',
         )
+        self.assertEqual(db.status_history, [(42, "downloading")])
+
+    def test_update_download_state_rewrites_json_state(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+
+        db.update_download_state(42, '{"filetype":"flac"}')
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "downloading")
+        self.assertEqual(row["active_download_state"], {"filetype": "flac"})
+        self.assertEqual(
+            db.update_download_state_calls,
+            [(42, '{"filetype":"flac"}')],
+        )
 
     def test_update_spectral_state(self):
         db = FakePipelineDB()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -5,7 +5,7 @@ import unittest
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.pipeline_db import RequestSpectralStateUpdate
 from lib.quality import SpectralContext, SpectralMeasurement, ValidationResult
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
 from tests.helpers import (
     make_download_file,
     make_grab_list_entry,
@@ -83,6 +83,47 @@ class TestFakePipelineDB(unittest.TestCase):
         db.assert_log(self, 0, outcome="success")
         # Extra field goes into .extra dict
         self.assertEqual(db.download_logs[0].extra["spectral_grade"], "genuine")
+
+
+class TestFakeSlskdAPI(unittest.TestCase):
+    def test_get_downloads_returns_queued_snapshots(self):
+        first = [{"username": "user1", "directories": [{"files": []}]}]
+        second = [{"username": "user1", "directories": [{"files": [
+            {"filename": "track.mp3", "id": "tid-1"},
+        ]}]}]
+        slskd = FakeSlskdAPI(download_snapshots=[first, second])
+
+        self.assertEqual(slskd.transfers.get_all_downloads(includeRemoved=True), first)
+        self.assertEqual(slskd.transfers.get_all_downloads(includeRemoved=True), second)
+        self.assertEqual(slskd.transfers.get_all_downloads(includeRemoved=True), second)
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [True, True, True])
+
+    def test_get_download_matches_username_and_id(self):
+        slskd = FakeSlskdAPI()
+        slskd.add_transfer(
+            username="user1",
+            directory="user1\\Music",
+            filename="user1\\Music\\01.flac",
+            id="tid-1",
+            state="Completed, Succeeded",
+        )
+
+        transfer = slskd.transfers.get_download("user1", "tid-1")
+
+        self.assertEqual(transfer["filename"], "user1\\Music\\01.flac")
+        self.assertEqual(transfer["state"], "Completed, Succeeded")
+        self.assertEqual(slskd.transfers.get_download_calls, [("user1", "tid-1")])
+
+    def test_records_enqueue_and_cancel_calls(self):
+        slskd = FakeSlskdAPI()
+        files = [{"filename": "track.mp3", "size": 1000}]
+
+        self.assertTrue(slskd.transfers.enqueue("user1", files))
+        self.assertTrue(slskd.transfers.cancel_download("user1", "tid-1"))
+
+        self.assertEqual(slskd.transfers.enqueue_calls[0].username, "user1")
+        self.assertEqual(slskd.transfers.enqueue_calls[0].files, files)
+        self.assertEqual(slskd.transfers.cancel_download_calls[0].id, "tid-1")
 
 
 class TestBuilders(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,6 @@
 """Integration tests — exercise the full search→enqueue→download→process flow.
 
-Uses realistic slskd API fixtures with mocked API calls. Catches type
+Uses realistic slskd API fixtures with lightweight API fakes. Catches type
 mismatches at the boundary between raw slskd dicts and DownloadFile instances.
 """
 
@@ -32,6 +32,7 @@ from lib.download import (cancel_and_delete, slskd_download_status,
                           slskd_do_enqueue, downloads_all_done)
 from lib.import_dispatch import _build_download_info
 from lib.context import SoularrContext
+from tests.fakes import FakeSlskdAPI
 
 
 def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None, **cache_overrides):
@@ -415,12 +416,9 @@ class TestSlskdDoEnqueue(unittest.TestCase):
 
     def test_returns_download_files(self):
         """slskd_do_enqueue should return list of DownloadFile, not dicts."""
-        ctx = _make_ctx()
         file_dir = "Music\\Artist\\Album"
         files = [{"filename": file_dir + "\\01 - Track.flac", "size": 52428800}]
-
-        ctx.slskd.transfers.enqueue.return_value = True
-        ctx.slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "testuser",
             "directories": make_download_list([
                 make_directory(file_dir, [
@@ -428,9 +426,11 @@ class TestSlskdDoEnqueue(unittest.TestCase):
                      "id": "xfer-1", "size": 52428800},
                 ])
             ])["directories"],
-        }]
+        }])
+        ctx = _make_ctx(slskd=slskd)
 
-        result = slskd_do_enqueue("testuser", files, file_dir, ctx)
+        with patch("time.sleep"):
+            result = slskd_do_enqueue("testuser", files, file_dir, ctx)
 
         self.assertIsNotNone(result)
         assert result is not None
@@ -442,20 +442,21 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         self.assertEqual(result[0].size, 52428800)
 
     def test_enqueue_failure_returns_none(self):
-        ctx = _make_ctx()
-        ctx.slskd.transfers.enqueue.side_effect = Exception("connection error")
-        result = slskd_do_enqueue("user", [{"filename": "f", "size": 1}], "dir", ctx)
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = Exception("connection error")
+        ctx = _make_ctx(slskd=slskd)
+        with patch("time.sleep"):
+            result = slskd_do_enqueue(
+                "user", [{"filename": "f", "size": 1}], "dir", ctx)
         self.assertIsNone(result)
 
     def test_multiple_files(self):
-        ctx = _make_ctx()
         file_dir = "Music\\Album"
         files = [
             {"filename": file_dir + "\\01 - A.flac", "size": 100},
             {"filename": file_dir + "\\02 - B.flac", "size": 200},
         ]
-        ctx.slskd.transfers.enqueue.return_value = True
-        ctx.slskd.transfers.get_all_downloads.return_value = [{
+        slskd = FakeSlskdAPI(downloads=[{
             "username": "user",
             "directories": make_download_list([
                 make_directory(file_dir, [
@@ -463,9 +464,11 @@ class TestSlskdDoEnqueue(unittest.TestCase):
                     {"filename": file_dir + "\\02 - B.flac", "id": "id2", "size": 200},
                 ])
             ])["directories"],
-        }]
+        }])
+        ctx = _make_ctx(slskd=slskd)
 
-        result = slskd_do_enqueue("user", files, file_dir, ctx)
+        with patch("time.sleep"):
+            result = slskd_do_enqueue("user", files, file_dir, ctx)
         assert result is not None
         self.assertEqual(len(result), 2)
         self.assertIsInstance(result[0], DownloadFile)
@@ -477,10 +480,17 @@ class TestDownloadStatusFlow(unittest.TestCase):
 
     def test_status_set_on_download_file(self):
         """slskd_download_status sets .status on DownloadFile instances."""
-        ctx = _make_ctx()
+        slskd = FakeSlskdAPI()
+        slskd.add_transfer(
+            username="user",
+            directory="dir",
+            filename="track.flac",
+            id="xfer-1",
+            state="Completed, Succeeded",
+        )
+        ctx = _make_ctx(slskd=slskd)
         f = DownloadFile(filename="track.flac", id="xfer-1",
                          file_dir="dir", username="user", size=100)
-        ctx.slskd.transfers.get_download.return_value = DOWNLOAD_STATUS_DONE
 
         ok = slskd_download_status([f], ctx)
 
@@ -578,15 +588,18 @@ class TestCancelAndDelete(unittest.TestCase):
     """Verify cancel_and_delete works with DownloadFile instances."""
 
     def test_cancels_download_files(self):
-        ctx = _make_ctx(cfg=_make_matching_cfg(slskd_download_dir=tempfile.mkdtemp()))
+        slskd = FakeSlskdAPI()
+        ctx = _make_ctx(
+            cfg=_make_matching_cfg(slskd_download_dir=tempfile.mkdtemp()),
+            slskd=slskd,
+        )
         files = [
             DownloadFile(filename="track.flac", id="xfer-1",
                          file_dir="Music\\Album", username="user1", size=100),
         ]
         cancel_and_delete(files, ctx)
-        ctx.slskd.transfers.cancel_download.assert_called_once_with(
-            username="user1", id="xfer-1"
-        )
+        self.assertEqual(slskd.transfers.cancel_download_calls[0].username, "user1")
+        self.assertEqual(slskd.transfers.cancel_download_calls[0].id, "xfer-1")
 
 
 class TestAlbumRecordAttrAccess(unittest.TestCase):
@@ -630,19 +643,19 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
         mock_cfg = _make_matching_cfg()
         soularr.cfg = mock_cfg
 
-        mock_slskd = MagicMock()
-        mock_slskd.users.directory.return_value = [
+        slskd = FakeSlskdAPI()
+        slskd.users.set_directory("user1", "Music\\Disc1", [
             make_directory("Music\\Disc1", [
                 {"filename": "01 - Track.flac", "size": 100},
             ])
-        ]
-        soularr.slskd = mock_slskd
+        ])
+        soularr.slskd = slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
         soularr.pipeline_db_source = mock_pdb
 
-        self.ctx = _make_ctx(cfg=mock_cfg, slskd=mock_slskd, pipeline_db_source=mock_pdb)
+        self.ctx = _make_ctx(cfg=mock_cfg, slskd=slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
         soularr.cfg = self._orig_cfg
@@ -750,14 +763,14 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
         )
         soularr.cfg = mock_cfg
 
-        mock_slskd = MagicMock()
-        soularr.slskd = mock_slskd
+        slskd = FakeSlskdAPI()
+        soularr.slskd = slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
         soularr.pipeline_db_source = mock_pdb
 
-        self.ctx = _make_ctx(cfg=mock_cfg, slskd=mock_slskd, pipeline_db_source=mock_pdb)
+        self.ctx = _make_ctx(cfg=mock_cfg, slskd=slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
         soularr.cfg = self._orig_cfg
@@ -1004,14 +1017,14 @@ class TestNegativeMatchCache(unittest.TestCase):
         mock_cfg = _make_matching_cfg()
         soularr.cfg = mock_cfg
 
-        mock_slskd = MagicMock()
-        soularr.slskd = mock_slskd
+        slskd = FakeSlskdAPI()
+        soularr.slskd = slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
         soularr.pipeline_db_source = mock_pdb
 
-        self.ctx = _make_ctx(cfg=mock_cfg, slskd=mock_slskd, pipeline_db_source=mock_pdb)
+        self.ctx = _make_ctx(cfg=mock_cfg, slskd=slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
         soularr.cfg = self._orig_cfg
@@ -1095,14 +1108,14 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         mock_cfg = _make_matching_cfg()
         soularr.cfg = mock_cfg
 
-        self.mock_slskd = MagicMock()
-        soularr.slskd = self.mock_slskd
+        self.slskd = FakeSlskdAPI()
+        soularr.slskd = self.slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
         soularr.pipeline_db_source = mock_pdb
 
-        self.ctx = _make_ctx(cfg=mock_cfg, slskd=self.mock_slskd, pipeline_db_source=mock_pdb)
+        self.ctx = _make_ctx(cfg=mock_cfg, slskd=self.slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
         soularr.cfg = self._orig_cfg
@@ -1121,7 +1134,7 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # Should NOT have called slskd.users.directory — skipped before browse
-        self.mock_slskd.users.directory.assert_not_called()
+        self.assertEqual(self.slskd.users.directory_calls, [])
 
     def test_dir_with_close_count_not_skipped(self):
         """Directory with 13 audio files should NOT be skipped for 12 tracks (tolerance +-2)."""
@@ -1129,32 +1142,38 @@ class TestSearchResultPreFiltering(unittest.TestCase):
             "user1": {"Music\\Album": 13}
         }
         # Set up directory return for when it does browse
-        self.mock_slskd.users.directory.return_value = [
+        self.slskd.users.set_directory("user1", "Music\\Album", [
             make_directory("Music\\Album", [
                 {"filename": f"0{i} - Track.flac", "size": 100} for i in range(13)
             ])
-        ]
+        ])
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
         tracks: list[soularr.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
         soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # SHOULD have browsed — count is close enough
-        self.mock_slskd.users.directory.assert_called_once()
+        self.assertEqual(
+            self.slskd.users.directory_calls,
+            [("user1", "Music\\Album")],
+        )
 
     def test_dir_without_metadata_not_skipped(self):
         """Directory with no search metadata should still be browsed."""
         # ctx.search_dir_audio_count is empty by default
-        self.mock_slskd.users.directory.return_value = [
+        self.slskd.users.set_directory("user1", "Music\\Album", [
             make_directory("Music\\Album", [{"filename": "01.flac", "size": 100}])
-        ]
+        ])
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
         tracks: list[soularr.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
         soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # Should browse — no metadata to pre-filter
-        self.mock_slskd.users.directory.assert_called_once()
+        self.assertEqual(
+            self.slskd.users.directory_calls,
+            [("user1", "Music\\Album")],
+        )
 
 
 class TestRankCandidateDirs(unittest.TestCase):
@@ -1226,14 +1245,14 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
         mock_cfg = _make_matching_cfg()
         soularr.cfg = mock_cfg
 
-        self.mock_slskd = MagicMock()
-        soularr.slskd = self.mock_slskd
+        self.slskd = FakeSlskdAPI()
+        soularr.slskd = self.slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
         soularr.pipeline_db_source = mock_pdb
 
-        self.ctx = _make_ctx(cfg=mock_cfg, slskd=self.mock_slskd, pipeline_db_source=mock_pdb)
+        self.ctx = _make_ctx(cfg=mock_cfg, slskd=self.slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
         soularr.cfg = self._orig_cfg
@@ -1242,40 +1261,45 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
 
     def test_parallel_browse_populates_cache(self):
         """_browse_directories should populate folder_cache for all dirs."""
-        def mock_directory(username, directory):
-            return [make_directory(directory, [
-                {"filename": "01 - Track.flac", "size": 100}
-            ])]
-
-        self.mock_slskd.users.directory.side_effect = mock_directory
-
         dirs_to_browse = ["Music\\Dir1", "Music\\Dir2", "Music\\Dir3"]
+        for directory in dirs_to_browse:
+            self.slskd.users.set_directory("user1", directory, [
+                make_directory(directory, [
+                    {"filename": "01 - Track.flac", "size": 100}
+                ])
+            ])
+
         results = soularr._browse_directories(
-            dirs_to_browse, "user1", self.mock_slskd, max_workers=2
+            dirs_to_browse, "user1", self.slskd, max_workers=2
         )
 
         self.assertEqual(len(results), 3)
         self.assertIn("Music\\Dir1", results)
         self.assertIn("Music\\Dir2", results)
         self.assertIn("Music\\Dir3", results)
+        self.assertCountEqual(self.slskd.users.directory_calls, [
+            ("user1", "Music\\Dir1"),
+            ("user1", "Music\\Dir2"),
+            ("user1", "Music\\Dir3"),
+        ])
 
     def test_parallel_browse_handles_failures(self):
         """Failed browses should be collected, not crash."""
-        call_count = [0]
-
-        def mock_directory(username, directory):
-            call_count[0] += 1
-            if "Dir2" in directory:
-                raise Exception("Peer offline")
-            return [make_directory(directory, [
-                {"filename": "01 - Track.flac", "size": 100}
-            ])]
-
-        self.mock_slskd.users.directory.side_effect = mock_directory
-
         dirs_to_browse = ["Music\\Dir1", "Music\\Dir2", "Music\\Dir3"]
+        for directory in ["Music\\Dir1", "Music\\Dir3"]:
+            self.slskd.users.set_directory("user1", directory, [
+                make_directory(directory, [
+                    {"filename": "01 - Track.flac", "size": 100}
+                ])
+            ])
+        self.slskd.users.set_directory_error(
+            "user1",
+            "Music\\Dir2",
+            Exception("Peer offline"),
+        )
+
         results = soularr._browse_directories(
-            dirs_to_browse, "user1", self.mock_slskd, max_workers=2
+            dirs_to_browse, "user1", self.slskd, max_workers=2
         )
 
         # Dir1 and Dir3 should succeed, Dir2 should fail
@@ -1283,10 +1307,15 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
         self.assertIn("Music\\Dir1", results)
         self.assertNotIn("Music\\Dir2", results)
         self.assertIn("Music\\Dir3", results)
+        self.assertCountEqual(self.slskd.users.directory_calls, [
+            ("user1", "Music\\Dir1"),
+            ("user1", "Music\\Dir2"),
+            ("user1", "Music\\Dir3"),
+        ])
 
     def test_browse_all_fail_marks_broken(self):
         """If all browses for a user fail, they should be marked broken."""
-        self.mock_slskd.users.directory.side_effect = Exception("Peer gone")
+        self.slskd.users.directory_error = Exception("Peer gone")
 
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         tracks = make_tracks((1, "Track One", 1))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,12 +27,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import soularr
 from lib import enqueue as enqueue_module
-from lib.grab_list import GrabListEntry, DownloadFile
+from lib.grab_list import DownloadFile
 from lib.download import (cancel_and_delete, slskd_download_status,
                           slskd_do_enqueue, downloads_all_done)
 from lib.import_dispatch import _build_download_info
 from lib.context import SoularrContext
 from tests.fakes import FakeSlskdAPI
+from tests.helpers import make_download_file, make_grab_list_entry
 
 
 def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None, **cache_overrides):
@@ -489,8 +490,13 @@ class TestDownloadStatusFlow(unittest.TestCase):
             state="Completed, Succeeded",
         )
         ctx = _make_ctx(slskd=slskd)
-        f = DownloadFile(filename="track.flac", id="xfer-1",
-                         file_dir="dir", username="user", size=100)
+        f = make_download_file(
+            filename="track.flac",
+            id="xfer-1",
+            file_dir="dir",
+            username="user",
+            size=100,
+        )
 
         ok = slskd_download_status([f], ctx)
 
@@ -501,8 +507,10 @@ class TestDownloadStatusFlow(unittest.TestCase):
 
     def test_downloads_all_done(self):
         """downloads_all_done reads .status on DownloadFile instances."""
-        f1 = DownloadFile(filename="a.flac", id="1", file_dir="d", username="u", size=1)
-        f2 = DownloadFile(filename="b.flac", id="2", file_dir="d", username="u", size=1)
+        f1 = make_download_file(filename="a.flac", id="1", file_dir="d",
+                                username="u", size=1)
+        f2 = make_download_file(filename="b.flac", id="2", file_dir="d",
+                                username="u", size=1)
         f1.status = DOWNLOAD_STATUS_DONE
         f2.status = DOWNLOAD_STATUS_DONE
 
@@ -513,8 +521,10 @@ class TestDownloadStatusFlow(unittest.TestCase):
         self.assertEqual(queued, 0)
 
     def test_downloads_partial_queued(self):
-        f1 = DownloadFile(filename="a.flac", id="1", file_dir="d", username="u", size=1)
-        f2 = DownloadFile(filename="b.flac", id="2", file_dir="d", username="u", size=1)
+        f1 = make_download_file(filename="a.flac", id="1", file_dir="d",
+                                username="u", size=1)
+        f2 = make_download_file(filename="b.flac", id="2", file_dir="d",
+                                username="u", size=1)
         f1.status = DOWNLOAD_STATUS_DONE
         f2.status = DOWNLOAD_STATUS_QUEUED
 
@@ -524,7 +534,8 @@ class TestDownloadStatusFlow(unittest.TestCase):
         self.assertEqual(queued, 1)
 
     def test_downloads_with_errors(self):
-        f1 = DownloadFile(filename="a.flac", id="1", file_dir="d", username="u", size=1)
+        f1 = make_download_file(filename="a.flac", id="1", file_dir="d",
+                                username="u", size=1)
         f1.status = DOWNLOAD_STATUS_FAILED
 
         done, problems, queued = downloads_all_done([f1])
@@ -539,18 +550,24 @@ class TestBuildDownloadInfo(unittest.TestCase):
     """Verify _build_download_info reads from DownloadFile instances."""
 
     def test_extracts_metadata(self):
-        entry = GrabListEntry(
+        entry = make_grab_list_entry(
             album_id=-1,
-            files=[
-                DownloadFile(
-                    filename="Music\\01 - Track.flac", id="1",
-                    file_dir="Music", username="user1", size=100,
-                    bitRate=1411000, sampleRate=44100, bitDepth=16,
-                    isVariableBitRate=False,
-                ),
-            ],
-            filetype="flac", title="T", artist="A",
-            year="2024", mb_release_id="x",
+            files=[make_download_file(
+                filename="Music\\01 - Track.flac",
+                id="1",
+                file_dir="Music",
+                username="user1",
+                size=100,
+                bitRate=1411000,
+                sampleRate=44100,
+                bitDepth=16,
+                isVariableBitRate=False,
+            )],
+            filetype="flac",
+            title="T",
+            artist="A",
+            year="2024",
+            mb_release_id="x",
         )
 
         info = _build_download_info(entry)
@@ -565,16 +582,22 @@ class TestBuildDownloadInfo(unittest.TestCase):
 
     def test_handles_missing_metadata(self):
         """Audio metadata is optional — shouldn't crash when absent."""
-        entry = GrabListEntry(
+        entry = make_grab_list_entry(
             album_id=-1,
-            files=[
-                DownloadFile(
-                    filename="Music\\01 - Track.mp3", id="1",
-                    file_dir="Music", username="user1", size=100,
-                ),
-            ],
-            filetype="mp3", title="T", artist="A",
-            year="2024", mb_release_id="x",
+            files=[make_download_file(
+                filename="Music\\01 - Track.mp3",
+                id="1",
+                file_dir="Music",
+                username="user1",
+                size=100,
+                bitRate=None,
+                sampleRate=None,
+            )],
+            filetype="mp3",
+            title="T",
+            artist="A",
+            year="2024",
+            mb_release_id="x",
         )
 
         info = _build_download_info(entry)
@@ -593,10 +616,13 @@ class TestCancelAndDelete(unittest.TestCase):
             cfg=_make_matching_cfg(slskd_download_dir=tempfile.mkdtemp()),
             slskd=slskd,
         )
-        files = [
-            DownloadFile(filename="track.flac", id="xfer-1",
-                         file_dir="Music\\Album", username="user1", size=100),
-        ]
+        files = [make_download_file(
+            filename="track.flac",
+            id="xfer-1",
+            file_dir="Music\\Album",
+            username="user1",
+            size=100,
+        )]
         cancel_and_delete(files, ctx)
         self.assertEqual(slskd.transfers.cancel_download_calls[0].username, "user1")
         self.assertEqual(slskd.transfers.cancel_download_calls[0].id, "xfer-1")
@@ -621,9 +647,15 @@ class TestAlbumRecordAttrAccess(unittest.TestCase):
 
     def test_get_tracks_with_grab_list_entry(self):
         """get_tracks also works with GrabListEntry via getattr."""
-        entry = GrabListEntry(
-            album_id=-1, files=[], filetype="mp3", title="T", artist="A",
-            year="2024", mb_release_id="x", db_request_id=None,
+        entry = make_grab_list_entry(
+            album_id=-1,
+            files=[],
+            filetype="mp3",
+            title="T",
+            artist="A",
+            year="2024",
+            mb_release_id="x",
+            db_request_id=None,
         )
         from album_source import DatabaseSource
         source = DatabaseSource.__new__(DatabaseSource)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -681,6 +681,7 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
                 {"filename": "01 - Track.flac", "size": 100},
             ])
         ])
+        self.slskd = slskd
         soularr.slskd = slskd
 
         mock_pdb = MagicMock()
@@ -715,6 +716,24 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         dir1 = make_directory("Music\\Disc1", [{"filename": "01 - Track.flac", "size": 100}])
         dir2 = make_directory("Music\\Disc2", [{"filename": "01 - Track.flac", "size": 100}])
+        self.slskd.queue_download_snapshots(
+            [{
+                "username": "user1",
+                "directories": [{"directory": "Music\\Disc1", "files": [{
+                    "filename": "Music\\Disc1\\01 - Track.flac",
+                    "id": "disc1-track",
+                    "size": 100,
+                }]}],
+            }],
+            [{
+                "username": "user1",
+                "directories": [{"directory": "Music\\Disc2", "files": [{
+                    "filename": "Music\\Disc2\\01 - Track.flac",
+                    "id": "disc2-track",
+                    "size": 100,
+                }]}],
+            }],
+        )
 
         with patch.object(
             enqueue_module,
@@ -723,11 +742,7 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
                 (True, dir1, "Music\\Disc1"),
                 (True, dir2, "Music\\Disc2"),
             ],
-        ), patch.object(
-            enqueue_module,
-            "slskd_do_enqueue",
-            side_effect=[[MagicMock()], [MagicMock()]],
-        ):
+        ), patch("time.sleep"):
             soularr.try_multi_enqueue(release, tracks, results, "flac", self.ctx)
 
         self.assertEqual(results, original_results)
@@ -747,8 +762,24 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
 
         dir1 = make_directory("Music\\Disc1", [{"filename": "01 - Track.flac", "size": 100}])
         dir2 = make_directory("Music\\Disc2", [{"filename": "01 - Track.flac", "size": 100}])
-        download1 = MagicMock()
-        download2 = MagicMock()
+        self.slskd.queue_download_snapshots(
+            [{
+                "username": "user1",
+                "directories": [{"directory": "Music\\Disc1", "files": [{
+                    "filename": "Music\\Disc1\\01 - Track.flac",
+                    "id": "disc1-track",
+                    "size": 100,
+                }]}],
+            }],
+            [{
+                "username": "user1",
+                "directories": [{"directory": "Music\\Disc2", "files": [{
+                    "filename": "Music\\Disc2\\01 - Track.flac",
+                    "id": "disc2-track",
+                    "size": 100,
+                }]}],
+            }],
+        )
 
         with patch.object(
             enqueue_module,
@@ -757,25 +788,24 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
                 (True, dir1, "Music\\Disc1"),
                 (True, dir2, "Music\\Disc2"),
             ],
-        ), patch.object(
-            enqueue_module,
-            "slskd_do_enqueue",
-            side_effect=[[download1], [download2]],
-        ) as enqueue_mock:
+        ), patch("time.sleep"):
             attempt = soularr.try_multi_enqueue(
                 release, tracks, results, "flac", self.ctx
             )
 
         self.assertTrue(attempt.matched)
-        self.assertEqual(attempt.downloads, [download1, download2])
+        self.assertIsNotNone(attempt.downloads)
+        assert attempt.downloads is not None
+        self.assertEqual([download.id for download in attempt.downloads],
+                         ["disc1-track", "disc2-track"])
         self.assertEqual(dir1["files"][0]["filename"], "01 - Track.flac")
         self.assertEqual(dir2["files"][0]["filename"], "01 - Track.flac")
         self.assertEqual(
-            enqueue_mock.call_args_list[0].kwargs["files"][0]["filename"],
+            self.slskd.transfers.enqueue_calls[0].files[0]["filename"],
             "Music\\Disc1\\01 - Track.flac",
         )
         self.assertEqual(
-            enqueue_mock.call_args_list[1].kwargs["files"][0]["filename"],
+            self.slskd.transfers.enqueue_calls[1].files[0]["filename"],
             "Music\\Disc2\\01 - Track.flac",
         )
 
@@ -906,7 +936,12 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
         db = MagicMock()
         db.get_denylisted_users.return_value = []
         source._get_db.return_value = db
-        self.ctx = _make_ctx(cfg=soularr.cfg, pipeline_db_source=source)
+        self.slskd = FakeSlskdAPI()
+        self.ctx = _make_ctx(
+            cfg=soularr.cfg,
+            slskd=self.slskd,
+            pipeline_db_source=source,
+        )
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         self.ctx.user_upload_speed["user1"] = 10
 
@@ -918,17 +953,20 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
             {"filename": "01 - Track.flac", "size": 100},
         ])
         results = {"user1": {"flac": ["Music\\Album"]}}
-        downloads = [MagicMock()]
+        self.slskd.queue_download_snapshots([{
+            "username": "user1",
+            "directories": [{"directory": "Music\\Album", "files": [{
+                "filename": "Music\\Album\\01 - Track.flac",
+                "id": "album-track",
+                "size": 100,
+            }]}],
+        }])
 
         with patch.object(
             enqueue_module,
             "check_for_match",
             return_value=(True, directory, "Music\\Album"),
-        ), patch.object(
-            enqueue_module,
-            "slskd_do_enqueue",
-            return_value=downloads,
-        ) as enqueue_mock:
+        ), patch("time.sleep"):
             attempt = soularr.try_enqueue(
                 make_tracks((1, "Track One", 1)),
                 results,
@@ -937,10 +975,12 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
             )
 
         self.assertTrue(attempt.matched)
-        self.assertEqual(attempt.downloads, downloads)
+        self.assertIsNotNone(attempt.downloads)
+        assert attempt.downloads is not None
+        self.assertEqual(attempt.downloads[0].id, "album-track")
         self.assertEqual(directory["files"][0]["filename"], "01 - Track.flac")
         self.assertEqual(
-            enqueue_mock.call_args.kwargs["files"][0]["filename"],
+            self.slskd.transfers.enqueue_calls[0].files[0]["filename"],
             "Music\\Album\\01 - Track.flac",
         )
 
@@ -1008,7 +1048,9 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
         db = MagicMock()
         db.get_denylisted_users.return_value = []
         source._get_db.return_value = db
-        ctx = _make_ctx(cfg=soularr.cfg, pipeline_db_source=source)
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_result = False
+        ctx = _make_ctx(cfg=soularr.cfg, slskd=slskd, pipeline_db_source=source)
         ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         ctx.user_upload_speed["user1"] = 10
 
@@ -1021,10 +1063,6 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
             enqueue_module,
             "check_for_match",
             return_value=(True, directory, "Music\\Album"),
-        ), patch.object(
-            enqueue_module,
-            "slskd_do_enqueue",
-            return_value=None,
         ):
             attempt = soularr.try_enqueue(
                 make_tracks((1, "Track One", 1)),
@@ -1036,6 +1074,10 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
         self.assertFalse(attempt.matched)
         self.assertTrue(attempt.enqueue_failed)
         self.assertIsNone(attempt.downloads)
+        self.assertEqual(
+            slskd.transfers.enqueue_calls[0].files,
+            [{"filename": "Music\\Album\\01 - Track.flac", "size": 100}],
+        )
 
 
 class TestNegativeMatchCache(unittest.TestCase):

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -325,53 +325,33 @@ class TestQualityGateDecision(unittest.TestCase):
 class TestIsVerifiedLossless(unittest.TestCase):
     """Test verified_lossless derivation."""
 
-    def test_gold_standard(self):
-        """Converted FLAC + genuine spectral = verified."""
-        self.assertTrue(is_verified_lossless(True, "flac", "genuine"))
+    CASES = [
+        ("gold standard", True, "flac", "genuine", True),
+        ("uppercase flac", True, "FLAC", "genuine", True),
+        ("not converted", False, None, "genuine", False),
+        ("not lossless source", True, "mp3", "genuine", False),
+        ("suspect spectral", True, "flac", "suspect", False),
+        ("likely transcode", True, "flac", "likely_transcode", False),
+        ("marginal spectral", True, "flac", "marginal", False),
+        ("none spectral", True, "flac", None, False),
+        ("none filetype", True, None, "genuine", False),
+        ("all none", False, None, None, False),
+        ("alac m4a verified", True, "m4a", "genuine", True),
+        ("wav verified", True, "wav", "genuine", True),
+        ("alac suspect not verified", True, "m4a", "suspect", False),
+    ]
 
-    def test_flac_uppercase(self):
-        self.assertTrue(is_verified_lossless(True, "FLAC", "genuine"))
-
-    def test_not_converted(self):
-        """MP3 download, no conversion — never verified."""
-        self.assertFalse(is_verified_lossless(False, None, "genuine"))
-
-    def test_not_flac_source(self):
-        """Converted from something other than FLAC — not verified."""
-        self.assertFalse(is_verified_lossless(True, "mp3", "genuine"))
-
-    def test_suspect_spectral(self):
-        """FLAC converted but spectral says suspect — fake FLAC, not verified."""
-        self.assertFalse(is_verified_lossless(True, "flac", "suspect"))
-
-    def test_likely_transcode(self):
-        self.assertFalse(is_verified_lossless(True, "flac", "likely_transcode"))
-
-    def test_marginal_spectral(self):
-        """Marginal spectral is NOT verified — only genuine counts."""
-        self.assertFalse(is_verified_lossless(True, "flac", "marginal"))
-
-    def test_none_spectral(self):
-        """No spectral data — can't verify."""
-        self.assertFalse(is_verified_lossless(True, "flac", None))
-
-    def test_none_filetype(self):
-        self.assertFalse(is_verified_lossless(True, None, "genuine"))
-
-    def test_all_none(self):
-        self.assertFalse(is_verified_lossless(False, None, None))
-
-    def test_alac_m4a_verified(self):
-        """Converted ALAC (m4a) + genuine spectral = verified lossless."""
-        self.assertTrue(is_verified_lossless(True, "m4a", "genuine"))
-
-    def test_wav_verified(self):
-        """Converted WAV + genuine spectral = verified lossless."""
-        self.assertTrue(is_verified_lossless(True, "wav", "genuine"))
-
-    def test_alac_suspect_not_verified(self):
-        """ALAC converted but spectral suspect — not verified."""
-        self.assertFalse(is_verified_lossless(True, "m4a", "suspect"))
+    def test_verified_lossless_cases(self):
+        for desc, was_converted, original_filetype, spectral_grade, expected in self.CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    is_verified_lossless(
+                        was_converted,
+                        original_filetype,
+                        spectral_grade,
+                    ),
+                    expected,
+                )
 
 
 # ============================================================================

--- a/tests/test_slskd_live.py
+++ b/tests/test_slskd_live.py
@@ -126,6 +126,7 @@ class TestSlskdSearchShapes(unittest.TestCase):
         # Mock cfg to avoid global state issues
         from unittest.mock import MagicMock
         import soularr
+        from lib.quality import verify_filetype
         orig_cfg = soularr.cfg
         soularr.cfg = MagicMock()
         try:
@@ -133,7 +134,7 @@ class TestSlskdSearchShapes(unittest.TestCase):
                 for f in r.get("files", [])[:3]:
                     # Should not crash — this is the exact pattern that broke in prod
                     try:
-                        soularr.verify_filetype(f, "flac")
+                        verify_filetype(f, "flac")
                     except (KeyError, ValueError):
                         pass  # Wrong type is fine — crashing is not
         finally:

--- a/web/server.py
+++ b/web/server.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 if __name__ == "__main__" or "web.server" not in sys.modules:
     sys.modules["web.server"] = sys.modules[__name__]
 
-import cache
+import web.cache as cache
 import mb as mb_api
 from beets_db import BeetsDB
 from pipeline_db import PipelineDB


### PR DESCRIPTION
## Summary

Advances #51 by auditing the remaining mock-shaped download/integration tests and moving stateful collaborators to fakes:

- adds `FakeSlskdAPI` with stateful `transfers` and `users` fakes, queued download snapshots, transfer lookup, enqueue/cancel call recording, configurable API errors, and per-directory browse errors
- extends `FakePipelineDB` with status history, download-state update/clear recording, and JSON state persistence used by download orchestration tests
- migrates low-level slskd status/enqueue/cancel tests in `tests/test_download.py` from raw `MagicMock` API setup to `FakeSlskdAPI` plus real `DownloadFile` builders
- migrates `grab_most_wanted()` and `poll_active_downloads()` coverage to `FakePipelineDB` domain-state assertions instead of DB mock call shapes
- migrates poller retry/requeue paths to real `slskd_do_enqueue()` against `FakeSlskdAPI` snapshots
- migrates slskd enqueue/status/cancel and directory-browsing integration tests in `tests/test_integration.py` to the fake API surface
- adopts shared `make_download_file()` / `make_grab_list_entry()` builders in integration download tests
- rewrites `TestIsVerifiedLossless` as a table-driven `subTest()` matrix

Also includes a separate cleanup commit fixing **all 24 pre-existing pyright baseline errors** across the repo (`harness/beets_harness.py`, `tests/test_beets_db.py`, `tests/test_slskd_live.py`, `web/server.py` cache module name collision).

## Note on issue #51 closure

This PR delivers the bulk of the remaining issue-51 work but does **not** fully close the issue. Three small follow-ups remain — see the issue comment for details. Issue #51 will stay open until those land.

## Validation

- `nix-shell --run "pyright"` — **0 errors across the entire repo** (was 24 baseline errors)
- `nix-shell --run "bash scripts/run_tests.sh"` — pass, 1,414 tests plus JS checks, 53 fixture-dependent skips