### PR TITLE
Make import override bitrate grade-aware (#61)

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -276,18 +276,23 @@ def _check_quality_gate_core(
         is_cbr = info.is_cbr
 
         spectral_br: int | None = None
+        spectral_grade: str | None = None
         req = None
         try:
             req = db.get_request(request_id)
             spectral_grade = req.get("current_spectral_grade") if req else None
             raw_br = req.get("current_spectral_bitrate") if req else None
-            if spectral_grade == "suspect":
-                spectral_br = raw_br if isinstance(raw_br, int) else None
-            if spectral_br is not None:
-                effective = compute_effective_override_bitrate(min_br_kbps, spectral_br)
-                if effective is not None and effective < min_br_kbps:
-                    logger.info(f"QUALITY GATE: using current_spectral={spectral_br}kbps "
-                                f"(lower than beets min_bitrate={min_br_kbps}kbps)")
+            raw_br_int = raw_br if isinstance(raw_br, int) else None
+            # Grade-aware: helper returns container_bitrate unchanged for
+            # non-transcode grades. spectral_br is set only when the helper
+            # actually lowered the effective bitrate (see issue #61).
+            effective = compute_effective_override_bitrate(
+                min_br_kbps, raw_br_int, spectral_grade)
+            if effective is not None and effective < min_br_kbps:
+                spectral_br = raw_br_int
+                logger.info(f"QUALITY GATE: using current_spectral={spectral_br}kbps "
+                            f"(lower than beets min_bitrate={min_br_kbps}kbps, "
+                            f"grade={spectral_grade})")
         except Exception:
             logger.debug("QUALITY GATE: DB lookup failed for spectral override")
         verified_lossless = bool(req.get("verified_lossless")) if req else False
@@ -319,7 +324,8 @@ def _check_quality_gate_core(
                              search_filetype_override=upgrade_override,
                              min_bitrate=min_br_kbps)
             usernames = extract_usernames(files)
-            gate_br = compute_effective_override_bitrate(min_br_kbps, spectral_br) or min_br_kbps
+            gate_br = compute_effective_override_bitrate(
+                min_br_kbps, spectral_br, spectral_grade) or min_br_kbps
             if spectral_br and spectral_br < min_br_kbps:
                 reason = (f"quality gate: spectral {spectral_br}kbps "
                           f"(beets {min_br_kbps}kbps) < {QUALITY_MIN_BITRATE_KBPS}kbps")
@@ -629,13 +635,16 @@ def dispatch_import(album_data: "GrabListEntry", bv_result: ValidationResult, de
     """
     db = ctx.pipeline_db_source._get_db()
 
-    # Compute override_min_bitrate from DB
+    # Compute override_min_bitrate from DB — grade-aware: current_spectral_bitrate
+    # only lowers the override when current_spectral_grade is suspect/likely_transcode.
     override_min_bitrate: int | None = None
     try:
         req = db.get_request(request_id)
         if req:
             override_min_bitrate = compute_effective_override_bitrate(
-                req.get("min_bitrate"), req.get("current_spectral_bitrate"))
+                req.get("min_bitrate"),
+                req.get("current_spectral_bitrate"),
+                req.get("current_spectral_grade"))
     except Exception:
         logger.debug("DB lookup failed for override-min-bitrate")
 
@@ -730,9 +739,12 @@ def dispatch_import_from_db(
             username=source_username, size=0,
         )]
 
-    # Compute override from DB state
+    # Compute override from DB state — grade-aware: current_spectral_bitrate only
+    # lowers the override when current_spectral_grade is suspect/likely_transcode.
     override_min_bitrate = compute_effective_override_bitrate(
-        req.get("min_bitrate"), req.get("current_spectral_bitrate"))
+        req.get("min_bitrate"),
+        req.get("current_spectral_bitrate"),
+        req.get("current_spectral_grade"))
 
     return dispatch_import_core(
         path=failed_path,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1528,9 +1528,9 @@ def get_decision_tree() -> dict[str, Any]:
                 "when": "After successful beets import",
                 "inputs": ["current: AudioQualityMeasurement"],
                 "rules": [
-                    {"condition": "gate_br = min(current.min_bitrate_kbps, current.spectral_bitrate_kbps)",
+                    {"condition": "gate_br = min(container, spectral) only when spectral grade is suspect/likely_transcode",
                      "result": "(computed)", "color": "green",
-                     "effect": "spectral overrides container if lower"},
+                     "effect": "spectral overrides container if lower and grade is transcode-like"},
                     {"condition": f"current.verified_lossless AND gate_br < "
                                   f"{QUALITY_MIN_BITRATE_KBPS}",
                      "result": f"gate_br = {QUALITY_MIN_BITRATE_KBPS}",
@@ -1730,9 +1730,16 @@ def full_pipeline_decision(
         gate_cbr = is_cbr
 
     # --- Stage 3: Post-import quality gate ---
+    gate_spectral_bitrate = None
+    effective_gate_bitrate = compute_effective_override_bitrate(
+        gate_bitrate, spectral_bitrate, spectral_grade)
+    if (gate_bitrate is not None
+            and effective_gate_bitrate is not None
+            and effective_gate_bitrate < gate_bitrate):
+        gate_spectral_bitrate = spectral_bitrate
     gate_m = AudioQualityMeasurement(min_bitrate_kbps=gate_bitrate, is_cbr=gate_cbr,
                                      verified_lossless=verified_lossless,
-                                     spectral_bitrate_kbps=spectral_bitrate)
+                                     spectral_bitrate_kbps=gate_spectral_bitrate)
     result["stage3_quality_gate"] = quality_gate_decision(gate_m)
 
     if result["stage3_quality_gate"] == "accept":

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -991,16 +991,38 @@ def dispatch_action(decision: str) -> DispatchAction:
         return DispatchAction(record_rejection=True)
 
 
+SPECTRAL_TRANSCODE_GRADES: frozenset[str] = frozenset({"suspect", "likely_transcode"})
+"""Spectral grades that authorize the spectral bitrate as an override input.
+
+Only these grades mean "this is a transcode and the spectral cliff is a
+legitimate low-bound on original quality". Genuine/marginal/error/None/unknown
+grades must leave the container bitrate untouched — a genuine lo-fi file
+(e.g. Mountain Goats boombox) can produce a low spectral cliff estimate that
+is NOT a quality signal and would falsely drag the import comparison down.
+See issue #61 for the motivating incident.
+"""
+
+
 def compute_effective_override_bitrate(
     container_bitrate: int | None,
     spectral_bitrate: int | None,
+    spectral_grade: str | None,
 ) -> int | None:
-    """Compute the effective override bitrate from container and spectral data.
+    """Compute the grade-aware effective override bitrate.
 
-    Returns the lower of the two when both are available (more conservative).
-    Used by dispatch_import() to pass --override-min-bitrate to import_one.py,
-    and by _check_quality_gate() for spectral override.
+    Spectral bitrate only participates when ``spectral_grade`` is in
+    ``SPECTRAL_TRANSCODE_GRADES`` (``suspect`` / ``likely_transcode``). For any
+    other grade — ``genuine``, ``marginal``, ``error``, ``None``, or an unknown
+    future value — the spectral input is ignored and the container bitrate is
+    returned untouched.
+
+    When spectral is authorized, the function returns the lower of the two
+    available values (conservative). Used by ``dispatch_import()`` to derive
+    ``--override-min-bitrate`` for ``import_one.py`` and by the quality gate
+    to determine whether to apply a spectral override to the gate bitrate.
     """
+    if spectral_grade not in SPECTRAL_TRANSCODE_GRADES:
+        return container_bitrate
     if container_bitrate is None and spectral_bitrate is None:
         return None
     if container_bitrate is None:

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -512,7 +512,7 @@ def cmd_quality(db, args):
     """Show quality state and simulate decisions for common download scenarios."""
     from quality import (full_pipeline_decision, quality_gate_decision,
                          AudioQualityMeasurement, rejection_backfill_override,
-                         search_tiers)
+                         search_tiers, compute_effective_override_bitrate)
 
     req = db.get_request(args.id)
     if not req:
@@ -543,10 +543,16 @@ def cmd_quality(db, args):
                     is_cbr = info.is_cbr
             except Exception:
                 pass
+        gate_spectral_br = None
+        effective_gate_br = compute_effective_override_bitrate(
+            min_br, current_br, spectral_grade)
+        if (min_br is not None and effective_gate_br is not None
+                and effective_gate_br < min_br):
+            gate_spectral_br = current_br
         current = AudioQualityMeasurement(
             min_bitrate_kbps=min_br, is_cbr=is_cbr,
             verified_lossless=verified,
-            spectral_bitrate_kbps=current_br)
+            spectral_bitrate_kbps=gate_spectral_br)
         gate = quality_gate_decision(current)
         gate_label = {"accept": "DONE", "requeue_upgrade": "NEEDS UPGRADE",
                       "requeue_lossless": "NEEDS LOSSLESS"}[gate]
@@ -574,9 +580,12 @@ def cmd_quality(db, args):
         print(f"  Backfill:      won't fire (conditions not met)")
 
     # --- Simulate common scenarios ---
-    effective_existing = min_br
-    if current_br and min_br and current_br < min_br:
-        effective_existing = current_br
+    effective_existing = compute_effective_override_bitrate(
+        min_br, current_br, spectral_grade)
+    override_min_bitrate = None
+    if (effective_existing is not None and min_br is not None
+            and effective_existing != min_br):
+        override_min_bitrate = effective_existing
 
     scenarios = [
         # --- FLAC downloads ---
@@ -635,9 +644,9 @@ def cmd_quality(db, args):
     print(f"\n  What would happen if we downloaded:")
     for name, params in scenarios:
         result = full_pipeline_decision(
-            existing_min_bitrate=effective_existing,
+            existing_min_bitrate=min_br,
             existing_spectral_bitrate=current_br,
-            override_min_bitrate=current_br if current_br and min_br and current_br < min_br else None,
+            override_min_bitrate=override_min_bitrate,
             verified_lossless=verified,
             **params)
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -298,6 +298,10 @@ class TestOverrideMinBitrate(unittest.TestCase):
 
     Tests the dispatch_import() adapter's override computation. Will break
     if import_one becomes a library call (#48).
+
+    The override must be grade-aware: spectral bitrate only participates when
+    current_spectral_grade is in {suspect, likely_transcode}. Genuine/marginal/
+    None grades must leave the container bitrate untouched — see issue #61.
     """
 
     def _get_override_value(self, db_fields):
@@ -322,25 +326,35 @@ class TestOverrideMinBitrate(unittest.TestCase):
                 return int(cmd[i + 1])
         return None
 
-    def test_uses_spectral_when_lower(self):
-        val = self._get_override_value(
-            make_request_row(min_bitrate=320, current_spectral_bitrate=128))
-        self.assertEqual(val, 128)
+    # (description, min_bitrate, current_spectral_bitrate, current_spectral_grade, expected)
+    CASES = [
+        ("suspect spectral lower wins",             320, 128, "suspect",          128),
+        ("likely_transcode spectral lower wins",    320, 128, "likely_transcode", 128),
+        ("genuine spectral ignored even if lower",  320, 128, "genuine",          320),
+        ("marginal spectral ignored even if lower", 320, 128, "marginal",         320),
+        ("grade None ignores spectral",             320, 128, None,               320),
+        ("suspect grade but spectral higher",       192, 256, "suspect",          192),
+        ("no spectral, grade genuine",              320, None, "genuine",         320),
+        ("no spectral, grade None",                 320, None, None,              320),
+        ("no container no spectral",                None, None, None,             None),
+        ("no container, suspect spectral",          None, 128, "suspect",         128),
+        ("no container, genuine spectral ignored",  None, 128, "genuine",         None),
+    ]
 
-    def test_uses_container_when_no_spectral(self):
-        val = self._get_override_value(
-            make_request_row(min_bitrate=320, current_spectral_bitrate=None))
-        self.assertEqual(val, 320)
-
-    def test_uses_container_when_spectral_higher(self):
-        val = self._get_override_value(
-            make_request_row(min_bitrate=192, current_spectral_bitrate=256))
-        self.assertEqual(val, 192)
-
-    def test_no_override_when_no_bitrate(self):
-        val = self._get_override_value(
-            make_request_row(min_bitrate=None, current_spectral_bitrate=None))
-        self.assertIsNone(val)
+    def test_override_from_db_table(self):
+        for desc, min_br, spectral_br, grade, expected in self.CASES:
+            with self.subTest(desc=desc):
+                row = make_request_row(
+                    min_bitrate=min_br,
+                    current_spectral_bitrate=spectral_br,
+                    current_spectral_grade=grade,
+                )
+                self.assertEqual(
+                    self._get_override_value(row), expected,
+                    f"{desc}: override from min_bitrate={min_br!r} "
+                    f"spectral_bitrate={spectral_br!r} grade={grade!r} "
+                    f"expected {expected!r}",
+                )
 
 
 class TestQualityGateUsesIntent(unittest.TestCase):
@@ -479,6 +493,66 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         self.assertIsNone(m.spectral_bitrate_kbps)
         self.assertEqual(quality_gate_decision(m), "accept")
         # Should stay imported (not requeued)
+        self.assertEqual(db.request(42)["status"], "imported")
+
+    def _capture_gate_measurement(self, *, current_spectral_grade,
+                                  current_spectral_bitrate,
+                                  beets_min_bitrate_kbps):
+        """Run _check_quality_gate_core and capture the AudioQualityMeasurement."""
+        from lib.import_dispatch import _check_quality_gate_core
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="imported",
+            current_spectral_grade=current_spectral_grade,
+            current_spectral_bitrate=current_spectral_bitrate,
+            verified_lossless=False,
+        ))
+        captured = {}
+
+        def capture(measurement):
+            captured["m"] = measurement
+            return "accept"
+
+        with patch("lib.beets_db.BeetsDB") as mock_beets_cls, \
+             patch("lib.quality.quality_gate_decision", side_effect=capture):
+            mock_beets = MagicMock()
+            mock_beets.__enter__ = MagicMock(return_value=mock_beets)
+            mock_beets.__exit__ = MagicMock(return_value=False)
+            mock_beets.get_album_info.return_value = MagicMock(
+                min_bitrate_kbps=beets_min_bitrate_kbps, is_cbr=False)
+            mock_beets_cls.return_value = mock_beets
+            _check_quality_gate_core(
+                mb_id="test-mbid", label="Test Artist - Test Album",
+                request_id=42, files=[],
+                db=db)  # type: ignore[arg-type]
+        return db, captured["m"]
+
+    def test_quality_gate_uses_likely_transcode_spectral(self):
+        """likely_transcode album grade must feed into the gate, not just suspect.
+
+        Regression for issue #61: _check_quality_gate_core previously only
+        accepted "suspect", silently ignoring the album-level "likely_transcode"
+        grade produced by classify_album when >=60% of tracks are suspect.
+        """
+        _, m = self._capture_gate_measurement(
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=180,
+            beets_min_bitrate_kbps=226,
+        )
+        self.assertEqual(m.spectral_bitrate_kbps, 180)
+
+    def test_quality_gate_ignores_genuine_low_spectral(self):
+        """Genuine grade with low spectral estimate must NOT lower the gate bitrate.
+
+        Guards the original #31 fix: a lo-fi genuine V0 (e.g. ~160kbps cliff
+        estimate) must not trigger a requeue loop when beets reports 226kbps.
+        """
+        db, m = self._capture_gate_measurement(
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=160,
+            beets_min_bitrate_kbps=226,
+        )
+        self.assertIsNone(m.spectral_bitrate_kbps)
         self.assertEqual(db.request(42)["status"], "imported")
 
     def test_dispatch_requeue_uses_intent(self):

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -382,6 +382,27 @@ class TestFullPipelineContract(unittest.TestCase):
             self.assertIn(r["stage3_quality_gate"], VALID_STAGE3,
                           f"Unexpected stage3 value: {r['stage3_quality_gate']} for {kwargs}")
 
+    def test_stage3_grade_aware_spectral_gate(self):
+        """Full simulator must match production's grade-aware quality gate."""
+        cases = [
+            ("genuine ignores low spectral", "genuine", 160, "accept", "imported"),
+            ("marginal ignores low spectral", "marginal", 160, "accept", "imported"),
+            ("likely_transcode uses low spectral", "likely_transcode", 160,
+             "requeue_upgrade", "wanted"),
+            ("suspect uses low spectral", "suspect", 160, "requeue_upgrade", "wanted"),
+        ]
+        for desc, grade, spectral_br, expected_gate, expected_status in cases:
+            with self.subTest(desc=desc):
+                r = full_pipeline_decision(
+                    is_flac=False,
+                    min_bitrate=226,
+                    is_cbr=False,
+                    spectral_grade=grade,
+                    spectral_bitrate=spectral_br,
+                )
+                self.assertEqual(r["stage3_quality_gate"], expected_gate)
+                self.assertEqual(r["final_status"], expected_status)
+
     def test_final_status_values_in_contract(self):
         """final_status must be from the known set."""
         r1 = full_pipeline_decision(is_flac=False, min_bitrate=256, is_cbr=False)

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -539,26 +539,54 @@ class TestFullPipelineTargetFormat(unittest.TestCase):
 # ============================================================================
 
 class TestComputeEffectiveOverrideBitrate(unittest.TestCase):
-    """Test the spectral/container override computation (pure)."""
+    """Grade-aware spectral/container override computation (pure).
 
-    def _compute(self, container, spectral):
+    Spectral bitrate only participates when grade is in SPECTRAL_TRANSCODE_GRADES
+    (suspect / likely_transcode). For genuine/marginal/error/None/unknown grades
+    the helper must return the container bitrate untouched — a genuine file with
+    a low spectral cliff estimate must not drag the comparison bitrate down.
+    """
+
+    # (description, container, spectral, grade, expected)
+    CASES = [
+        ("spectral ignored when grade None",             320, 128, None,               320),
+        ("spectral ignored when grade genuine",          320, 128, "genuine",          320),
+        ("spectral ignored when grade marginal",         320, 128, "marginal",         320),
+        ("spectral ignored when grade error",            320, 128, "error",            320),
+        ("unknown grade treated as non-transcode",       320, 128, "weird_new_grade",  320),
+        ("spectral lower wins when suspect",             320, 128, "suspect",          128),
+        ("spectral lower wins when likely_transcode",    320, 128, "likely_transcode", 128),
+        ("container lower wins when suspect",            192, 256, "suspect",          192),
+        ("container lower wins when likely_transcode",   192, 256, "likely_transcode", 192),
+        ("equal values when suspect",                    200, 200, "suspect",          200),
+        ("no spectral returns container (genuine)",      320, None, "genuine",         320),
+        ("no spectral returns container (suspect)",      320, None, "suspect",         320),
+        ("no container, suspect spectral",               None, 128, "suspect",         128),
+        ("no container, likely_transcode spectral",      None, 128, "likely_transcode", 128),
+        ("no container, genuine spectral ignored",       None, 128, "genuine",         None),
+        ("no container, grade None ignored",             None, 128, None,              None),
+        ("both None, genuine",                           None, None, "genuine",        None),
+        ("both None, suspect",                           None, None, "suspect",        None),
+        ("both None, grade None",                        None, None, None,             None),
+    ]
+
+    def test_grade_aware_table(self):
         from lib.quality import compute_effective_override_bitrate
-        return compute_effective_override_bitrate(container, spectral)
+        for desc, container, spectral, grade, expected in self.CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    compute_effective_override_bitrate(container, spectral, grade),
+                    expected,
+                    f"{desc}: compute_effective_override_bitrate"
+                    f"({container!r}, {spectral!r}, {grade!r}) "
+                    f"expected {expected!r}",
+                )
 
-    def test_spectral_lower_wins(self):
-        self.assertEqual(self._compute(320, 128), 128)
-
-    def test_container_lower_wins(self):
-        self.assertEqual(self._compute(192, 256), 192)
-
-    def test_no_spectral_returns_container(self):
-        self.assertEqual(self._compute(320, None), 320)
-
-    def test_no_container_no_spectral(self):
-        self.assertIsNone(self._compute(None, None))
-
-    def test_no_container_with_spectral(self):
-        self.assertEqual(self._compute(None, 128), 128)
+    def test_spectral_transcode_grades_constant(self):
+        """Locks the set of grades that authorize spectral override."""
+        from lib.quality import SPECTRAL_TRANSCODE_GRADES
+        self.assertEqual(SPECTRAL_TRANSCODE_GRADES,
+                         frozenset({"suspect", "likely_transcode"}))
 
 
 # ============================================================================

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.quality import (
+    compute_effective_override_bitrate,
     full_pipeline_decision,
     rejection_backfill_override,
     search_tiers,
@@ -157,16 +158,19 @@ def simulate(album: AlbumState, download: DownloadScenario,
              verified_lossless_target: str | None = None) -> SimResult:
     """Run full_pipeline_decision + rejection backfill."""
     # Derive existing state params (same logic as cmd_quality)
-    existing_min_bitrate = album.min_bitrate
     existing_spectral_bitrate = album.spectral_bitrate
+    effective_existing = compute_effective_override_bitrate(
+        album.min_bitrate,
+        album.spectral_bitrate,
+        album.spectral_grade,
+    )
     override = None
-    if (album.spectral_bitrate is not None and album.min_bitrate is not None
-            and album.spectral_bitrate < album.min_bitrate):
-        override = album.spectral_bitrate
-        existing_min_bitrate = override
+    if (effective_existing is not None and album.min_bitrate is not None
+            and effective_existing != album.min_bitrate):
+        override = effective_existing
 
     result = full_pipeline_decision(
-        existing_min_bitrate=existing_min_bitrate,
+        existing_min_bitrate=album.min_bitrate,
         existing_spectral_bitrate=existing_spectral_bitrate,
         override_min_bitrate=override,
         verified_lossless=album.verified_lossless,
@@ -365,11 +369,11 @@ class TestNamedRegressions(unittest.TestCase):
         self.assertFalse(allow_catch_all)
 
     def test_springsteen_genuine_but_96kbps(self):
-        """CBR 320 genuine + spectral_bitrate=96 -> effective existing is 96kbps.
+        """CBR 320 genuine + spectral_bitrate=96 ignores the stale low estimate.
 
         Contradictory state: genuine spectral grade but 96kbps spectral bitrate.
-        The spectral truth (96kbps) is used as effective existing, so almost any
-        download is an upgrade.
+        Genuine grade means the spectral bitrate is not a transcode-quality
+        estimate, so comparisons use the 320kbps container bitrate.
         """
         album = ALBUM_MAP["cbr_320_genuine_spectral96"]
 
@@ -379,14 +383,15 @@ class TestNamedRegressions(unittest.TestCase):
         self.assertEqual(r1.final_status, "imported")
         self.assertFalse(r1.keep_searching)
 
-        # MP3 V0 240 imports (240 > 96 effective)
+        # MP3 V0 240 is still lower than the 320kbps container bitrate.
         r2 = simulate(album, DL_MAP["mp3_v0_240"])
-        self.assertTrue(r2.imported)
-        self.assertEqual(r2.stage2_import, "import")
+        self.assertFalse(r2.imported)
+        self.assertEqual(r2.stage2_import, "downgrade")
 
-        # Even low V0 205 imports (205 > 96 effective)
+        # Low V0 205 is also a downgrade; the stale 96kbps estimate is ignored.
         r3 = simulate(album, DL_MAP["mp3_v0_low_205"])
-        self.assertTrue(r3.imported)
+        self.assertFalse(r3.imported)
+        self.assertEqual(r3.stage2_import, "downgrade")
 
     def test_scientists_no_spectral_loop(self):
         """CBR 320 no spectral + CBR 320 genuine download -> propagation -> backfill.


### PR DESCRIPTION
## Summary

Closes #61. Follow-up from #31.

`compute_effective_override_bitrate()` now requires a `spectral_grade` argument and only applies the spectral bitrate when the grade is in `SPECTRAL_TRANSCODE_GRADES` (`suspect` / `likely_transcode`). Genuine/marginal/`None`/unknown grades return the container bitrate untouched, so stale or low-cliff-estimate spectral values on genuine audio can no longer silently drag the import comparison bitrate down.

Both code paths that derive `--override-min-bitrate` (`dispatch_import`, `dispatch_import_from_db`) and the quality gate's internal spectral override now share the exact same rule. As a side effect of unifying them, `_check_quality_gate_core()` now honors album-level `"likely_transcode"` (previously only `"suspect"` made it through the gate's manual guard).

## Files

- `lib/quality.py` — add `SPECTRAL_TRANSCODE_GRADES` constant, add required `spectral_grade` parameter
- `lib/import_dispatch.py` — wire grade through all 4 call sites, delete manual `== "suspect"` gating
- `tests/test_quality_decisions.py` — rewrite `TestComputeEffectiveOverrideBitrate` as a 19-row subTest table
- `tests/test_import_dispatch.py` — rewrite `TestOverrideMinBitrate` as an 11-row subTest table; add `test_quality_gate_uses_likely_transcode_spectral` (RED on main) and `test_quality_gate_ignores_genuine_low_spectral` (guard)

## Acceptance criteria (from #61)

- [x] Genuine/marginal current spectral state cannot lower the import comparison bitrate
- [x] Suspect/likely_transcode current spectral state still lowers the comparison bitrate
- [x] Existing stale-spectral repair behavior remains intact (no writes touched)
- [x] Focused quality decision and import dispatch tests pass in nix-shell

## Test plan

- [x] ``nix-shell --run "python3 -m unittest tests.test_quality_decisions.TestComputeEffectiveOverrideBitrate tests.test_import_dispatch.TestOverrideMinBitrate tests.test_import_dispatch.TestQualityGateUsesIntent -v"`` — all pass
- [x] ``nix-shell --run "bash scripts/run_tests.sh"`` — 1410 tests, 0 failures, 53 skipped
- [x] ``nix-shell --run "pyright lib/quality.py lib/import_dispatch.py tests/test_quality_decisions.py tests/test_import_dispatch.py"`` — 0 errors, 0 warnings
- [x] RED-before-GREEN verified: updated tests failed against main (5 failures) before the helper change, pass after.
- [ ] Post-deploy sanity: ``pipeline-cli quality <id>`` on an album with `current_spectral_grade='genuine'` + non-null `current_spectral_bitrate` — simulator should no longer apply the spectral override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)