### PR TITLE
Codec-aware quality comparison + verified-lossless guardrails (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,14 +329,31 @@ The pipeline automatically upgrades album quality toward VBR V0 from verified lo
 
 The target quality for every album is: **FLAC downloaded from Soulseek → spectral analysis confirms genuine lossless → convert to VBR V0**. The VBR bitrate acts as a permanent quality fingerprint (genuine CD rips → ~240-260kbps, transcodes → ~190kbps). CBR 320 is never a final state — it's unverifiable.
 
-### Quality Gate (`_check_quality_gate()` in import_dispatch.py)
+### Codec-Aware Quality Ranks (issue #60, shipped 2026-04-11)
 
-After every import, the quality gate decides what to do next. It checks these conditions in order:
+Quality comparison is now **rank-based**, not raw-bitrate-based. Every measurement classifies into a `QualityRank` band (UNKNOWN / POOR / ACCEPTABLE / GOOD / EXCELLENT / TRANSPARENT / LOSSLESS) via `lib.quality.quality_rank()`, and `compare_quality()` uses the rank as the primary comparison key. The quality gate compares against `cfg.quality_ranks.gate_min_rank` (default EXCELLENT). Cross-codec cases now work correctly:
 
-1. **`verified_lossless=TRUE` + any bitrate** → **DONE**. We verified this from genuine FLAC. Low V0 bitrate (e.g. 207kbps) on lo-fi music is fine — the source is proven lossless.
-2. **`min_bitrate < 210kbps`** → **RE-QUEUE** for upgrade. Bad quality, search for better.
-3. **CBR on disk** (all tracks same bitrate) **+ not verified_lossless** → **RE-QUEUE for lossless** (`search_filetype_override="lossless"`). CBR is unverifiable — spectral analysis can detect obvious upsamples but cannot prove a CBR file came from lossless source. The `"lossless"` tier matches FLAC, ALAC, and WAV sources.
-4. **VBR above 210kbps** → **DONE**. VBR bitrate is trustworthy.
+- **Opus 128 ≡ MP3 V0** (both TRANSPARENT) → "equivalent"
+- **FLAC > any lossy** (LOSSLESS > TRANSPARENT)
+- **Unverifiable CBR 320** → TRANSPARENT but still `requeue_lossless` via the `is_cbr && !verified_lossless` branch
+
+Every numeric threshold lives in `QualityRankConfig` (one dataclass) and can be retuned in the `[Quality Ranks]` section of `config.ini`. The default `mp3_vbr.excellent=210` preserves the legacy 210kbps gate threshold for bare-codec measurements. Full rationale and tuning guide in `docs/quality-ranks.md`.
+
+**Key rule**: the `verified_lossless=True` bypass is now **tier-gated**. It imports on verdict `"better"` or `"equivalent"` but blocks on `"worse"`. This prevents a deliberately-too-low `verified_lossless_target` (Opus 64) from replacing a good existing album.
+
+**Bitrate metric**: `cfg.quality_ranks.bitrate_metric` picks between `min` (legacy) and `avg` (default, recommended for VBR codecs). Spectral cliff detection always uses min.
+
+### Quality Gate (`_check_quality_gate_core()` in import_dispatch.py)
+
+After every import, the quality gate runs `quality_gate_decision(current, cfg=cfg.quality_ranks)` which delegates to `measurement_rank()`:
+
+1. Classify the current measurement into a `QualityRank` via format label or bare-codec band table.
+2. If a spectral estimate is set, clamp the rank to the minimum of (rank, spectral_rank) — catches fake 320s.
+3. **Rank < `cfg.gate_min_rank`** → `requeue_upgrade`.
+4. **CBR on disk + not verified_lossless + below LOSSLESS** → `requeue_lossless` (search for a FLAC source).
+5. Otherwise → `accept`.
+
+Lo-fi V0 at 207kbps now passes the gate via the `"mp3 v0"` label contract (`cfg.mp3_vbr_levels[0] = TRANSPARENT`) without needing the old `verified_lossless` blanket bypass.
 
 ### Two Key Concepts (don't confuse them)
 

--- a/album_source.py
+++ b/album_source.py
@@ -220,16 +220,18 @@ class DatabaseSource:
             beets_scenario=bv_result.scenario,
             imported_path=dest_path,
         )
-        if dl.verified_lossless_override is not None:
-            # import_one.py computed this — trust it over re-derivation
-            if dl.verified_lossless_override:
-                update_fields["verified_lossless"] = True
-        elif is_verified_lossless(
-            dl.was_converted,
-            dl.original_filetype,
-            dl.download_spectral.grade if dl.download_spectral else None,
-        ):
-            update_fields["verified_lossless"] = True
+        verified_lossless = (
+            bool(dl.verified_lossless_override)
+            if dl.verified_lossless_override is not None
+            else is_verified_lossless(
+                dl.was_converted,
+                dl.original_filetype,
+                dl.download_spectral.grade if dl.download_spectral else None,
+            )
+        )
+        # Persist the full current quality state, not only truthy upgrades.
+        # Otherwise old verified/final-format labels leak into later imports.
+        update_fields["verified_lossless"] = verified_lossless
         if dl.download_spectral is not None:
             current_spectral = dl.download_spectral
             if update_fields.get("verified_lossless") and dl.bitrate:
@@ -245,8 +247,7 @@ class DatabaseSource:
                     current=current_spectral,
                 ).as_update_fields()
             )
-        if dl.final_format:
-            update_fields["final_format"] = dl.final_format
+        update_fields["final_format"] = dl.final_format
         from lib.transitions import apply_transition
         apply_transition(db, request_id, "imported", **update_fields)
 

--- a/album_source.py
+++ b/album_source.py
@@ -205,82 +205,22 @@ class DatabaseSource:
     def mark_done(self, album_record, bv_result, dest_path=None,
                   download_info=None):
         """Mark album as imported."""
-        from lib.quality import DownloadInfo, SpectralMeasurement, is_verified_lossless
-        from lib.pipeline_db import RequestSpectralStateUpdate
+        from lib.import_dispatch import _do_mark_done
+        from lib.quality import DownloadInfo
         request_id = getattr(album_record, "db_request_id", None)
         if not request_id:
             return
 
         db = self._get_db()
-        distance = bv_result.distance
         dl = download_info if isinstance(download_info, DownloadInfo) else DownloadInfo()
-
-        update_fields = dict(
-            beets_distance=distance,
-            beets_scenario=bv_result.scenario,
-            imported_path=dest_path,
-        )
-        verified_lossless = (
-            bool(dl.verified_lossless_override)
-            if dl.verified_lossless_override is not None
-            else is_verified_lossless(
-                dl.was_converted,
-                dl.original_filetype,
-                dl.download_spectral.grade if dl.download_spectral else None,
-            )
-        )
-        # Persist the full current quality state, not only truthy upgrades.
-        # Otherwise old verified/final-format labels leak into later imports.
-        update_fields["verified_lossless"] = verified_lossless
-        if dl.download_spectral is not None:
-            current_spectral = dl.download_spectral
-            if update_fields.get("verified_lossless") and dl.bitrate:
-                # Verified lossless: V0 bitrate is the real quality fingerprint,
-                # not the spectral cliff estimate (which can miscalibrate)
-                current_spectral = SpectralMeasurement(
-                    grade=dl.download_spectral.grade,
-                    bitrate_kbps=dl.bitrate // 1000,
-                )
-            update_fields.update(
-                RequestSpectralStateUpdate(
-                    last_download=dl.download_spectral,
-                    current=current_spectral,
-                ).as_update_fields()
-            )
-        update_fields["final_format"] = dl.final_format
-        from lib.transitions import apply_transition
-        apply_transition(db, request_id, "imported", **update_fields)
-
-        db.log_download(
+        _do_mark_done(
+            db=db,
             request_id=request_id,
-            soulseek_username=dl.username,
-            filetype=dl.filetype,
-            beets_distance=distance,
-            beets_scenario=bv_result.scenario,
-            beets_detail=bv_result.detail,
-            outcome="success",
-            staged_path=dest_path,
-            bitrate=dl.bitrate,
-            sample_rate=dl.sample_rate,
-            bit_depth=dl.bit_depth,
-            is_vbr=dl.is_vbr,
-            was_converted=dl.was_converted,
-            original_filetype=dl.original_filetype,
-            slskd_filetype=dl.slskd_filetype,
-            slskd_bitrate=dl.slskd_bitrate,
-            actual_filetype=dl.actual_filetype,
-            actual_min_bitrate=dl.actual_min_bitrate,
-            spectral_grade=dl.download_spectral.grade if dl.download_spectral else None,
-            spectral_bitrate=(
-                dl.download_spectral.bitrate_kbps if dl.download_spectral else None
-            ),
-            existing_min_bitrate=dl.existing_min_bitrate,
-            existing_spectral_bitrate=(
-                dl.current_spectral.bitrate_kbps if dl.current_spectral else None
-            ),
-            import_result=dl.import_result,
-            validation_result=dl.validation_result,
-            final_format=dl.final_format,
+            dl_info=dl,
+            distance=bv_result.distance,
+            scenario=bv_result.scenario,
+            dest_path=dest_path,
+            detail=bv_result.detail,
         )
 
     def reject_and_requeue(self, album_record, bv_result, usernames=None,

--- a/config.ini
+++ b/config.ini
@@ -44,6 +44,69 @@ distance_threshold = 0.15
 staging_dir = /path/to/staging
 tracking_file = /path/to/beets-validated.jsonl
 
+[Quality Ranks]
+# Codec-aware quality comparison model (issue #60). See docs/quality-ranks.md
+# for the full rationale. Every key in this section is optional — missing keys
+# fall back to the hardcoded defaults in lib/quality.QualityRankConfig.
+
+# Which bitrate metric to use for rank classification.
+# "avg" (recommended) — album-average per-track bitrate, robust to VBR per-track
+#                       variance. Default.
+# "min" — minimum per-track bitrate. Legacy. Penalizes legitimately encoded VBR
+#         albums with quiet passages because one sparse track drags the whole
+#         album down a rank.
+bitrate_metric = avg
+
+# Minimum rank required for the post-import quality gate to accept an album.
+# Values (lowest → highest):
+#   unknown, poor, acceptable, good, excellent, transparent, lossless
+gate_min_rank = excellent
+
+# Same-codec bitrate equivalence window (kbps). When two bare-codec measurements
+# sit in the same rank tier, a difference within this tolerance is "equivalent"
+# rather than "better"/"worse".
+within_rank_tolerance_kbps = 5
+
+# Per-codec bitrate thresholds (kbps). An album is classified at the highest
+# rank whose threshold the configured metric meets or exceeds. Thresholds must
+# be monotonically non-increasing within a codec (transparent >= excellent >=
+# good >= acceptable >= 0).
+#
+# Defaults track the hydrogenaudio / Kamedo2 / Xiph consensus captured in
+# docs/opus-encoding.md (2026-04-08). Tweak to taste — tighter thresholds will
+# requeue more albums; looser thresholds accept more marginal sources.
+
+# Opus (unconstrained VBR). 112 leaves headroom for genuine sparse material
+# because `ffmpeg -b:a 128k` unconstrained VBR averages 120-135 kbps per album
+# but can land 95-150 kbps on individual tracks.
+opus.transparent = 112
+opus.excellent = 88
+opus.good = 64
+opus.acceptable = 48
+
+# MP3 VBR (LAME V0 target), classified by measured album-average bitrate when
+# the format is a bare "MP3" string from beets. When the format is an explicit
+# V-level label like "mp3 v0", the V-level map (hardcoded in QualityRankConfig
+# because V-levels are a LAME encoder contract) overrides this table.
+mp3_vbr.transparent = 210
+mp3_vbr.excellent = 170
+mp3_vbr.good = 130
+mp3_vbr.acceptable = 90
+
+# MP3 CBR. Unverifiable CBR only reaches TRANSPARENT at 320 because we can't
+# prove a CBR file came from lossless source.
+mp3_cbr.transparent = 320
+mp3_cbr.excellent = 256
+mp3_cbr.good = 192
+mp3_cbr.acceptable = 128
+
+# AAC. Hydrogenaudio consensus places the "not worth going higher" ceiling for
+# music at 192 kbps.
+aac.transparent = 192
+aac.excellent = 144
+aac.good = 112
+aac.acceptable = 80
+
 [Pipeline DB]
 enabled = False
 dsn = postgresql://soularr:soularr@localhost:5432/soularr

--- a/config.ini
+++ b/config.ini
@@ -88,10 +88,10 @@ opus.acceptable = 48
 # the format is a bare "MP3" string from beets. When the format is an explicit
 # V-level label like "mp3 v0", the V-level map (hardcoded in QualityRankConfig
 # because V-levels are a LAME encoder contract) overrides this table.
-mp3_vbr.transparent = 210
-mp3_vbr.excellent = 170
-mp3_vbr.good = 130
-mp3_vbr.acceptable = 90
+mp3_vbr.transparent = 245
+mp3_vbr.excellent = 210
+mp3_vbr.good = 170
+mp3_vbr.acceptable = 130
 
 # MP3 CBR. Unverifiable CBR only reaches TRANSPARENT at 320 because we can't
 # prove a CBR file came from lossless source.

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -1,0 +1,219 @@
+# Codec-Aware Quality Ranks
+
+**Issue #60** introduced a rank-based comparison model so the pipeline can
+compare audio quality across codecs correctly. This page documents the model,
+the default band values, and how to retune them via `config.ini`.
+
+## Why ranks instead of raw bitrate
+
+The legacy pipeline compared quality using `min_bitrate_kbps` alone. Two bugs
+fell out of that:
+
+1. **Cross-codec downgrade loop.** After a FLAC → Opus 128 conversion, the
+   measured Opus bitrate lands around 95-135 kbps. Beets stores that. On the
+   next cycle, a new MP3 V0 download (~245 kbps) "won" the raw bitrate
+   comparison and replaced the perceptually equivalent Opus with MP3.
+2. **Too-low verified-lossless target silently won.**
+   `verified_lossless_target = "opus 64"` produced a 64 kbps Opus file that
+   bypassed every downgrade check because `verified_lossless=True` was a
+   blanket override.
+
+The rank model fixes both by classifying every measurement into a perceptual
+band (`QualityRank`) and comparing bands first, bitrates second.
+
+## The `QualityRank` bands
+
+```
+LOSSLESS     100   FLAC, ALAC, WAV
+TRANSPARENT   60   MP3 V0, MP3 CBR 320, Opus 128+, AAC 192+
+EXCELLENT     50   MP3 V1-V2, MP3 CBR 256, Opus 96, AAC 144+
+GOOD          40   MP3 V3-V4, MP3 CBR 192, Opus 64, AAC 112+
+ACCEPTABLE    30   MP3 V5-V9, MP3 CBR 128, Opus 48, AAC 80+
+POOR          20   below acceptable floor
+UNKNOWN        0   not enough info to classify
+```
+
+Integer spacing leaves room for inserting new bands later. The rank is never
+persisted — it's always recomputed from `(format, bitrate, is_cbr)` + config.
+
+## Label vs bare-codec resolution
+
+`quality_rank(format_hint, bitrate_kbps, is_cbr, cfg)` resolves a measurement
+through six steps, in order:
+
+1. Both `format_hint` and `bitrate_kbps` are `None` → `UNKNOWN`.
+2. `format_hint` first token in `cfg.lossless_codecs` → `LOSSLESS`.
+3. Explicit VBR label (`"mp3 v0"`, `"mp3 v2"`, ...) → index into
+   `cfg.mp3_vbr_levels` (10-tuple indexed by V0..V9). VBR labels are
+   self-certifying — the bitrate is irrelevant because V0 is V0.
+4. Explicit bitrate label (`"opus 128"`, `"mp3 320"`, `"aac 192"`) → classify
+   the declared numeric bitrate against the matching codec's `CodecRankBands`.
+   The label is a contract; the actual measured bitrate is ignored.
+5. Bare codec name (`"MP3"`, `"Opus"`, `"AAC"` from beets `items.format`) →
+   classify the measured `bitrate_kbps` against the band table. `"MP3"`
+   with `is_cbr=True` uses `cfg.mp3_cbr`, otherwise `cfg.mp3_vbr`.
+6. Unknown codec → `UNKNOWN`.
+
+The **label path** (step 3-4) is what makes lo-fi V0 imports work without the
+old `verified_lossless` blanket bypass: a 207 kbps file with `format="mp3 v0"`
+still classifies as `TRANSPARENT` because V0 is V0 regardless of what the
+encoder actually produced on quiet material.
+
+## `compare_quality()` semantics
+
+Primary key is the rank. Within the same rank:
+
+- **LOSSLESS always equivalent** — FLAC bitrate variance (800-1100) has no
+  quality meaning.
+- **Different codec families** (Opus vs MP3 vs AAC vs FLAC) → **equivalent**.
+  This is the core cross-codec parity fix.
+- **Same codec family, either side carries an explicit label** → equivalent.
+  A V0 label and a "mp3 320" label at the same rank are both contracts.
+- **Same codec family, both bare codec names** → compare the configured
+  metric (`avg_bitrate_kbps` or `min_bitrate_kbps`) with
+  `cfg.within_rank_tolerance_kbps` tolerance.
+
+## Bitrate metric — `min` vs `avg`
+
+VBR codecs have legitimate per-track variance. Opus 128 unconstrained VBR
+regularly lands individual tracks between 95-150 kbps depending on material;
+MP3 V0 can range 160-270. Using the minimum across an album penalizes
+legitimately encoded VBR with quiet passages.
+
+Two metrics are supported:
+
+- **`avg`** (default) — album-mean per-track bitrate. Robust to VBR variance.
+- **`min`** — minimum per-track bitrate. Legacy behavior; conservative but
+  prone to false negatives on lo-fi VBR.
+
+Spectral cliff detection and `transcode_detection()` continue to use `min`
+regardless of this setting — those care about the worst track, not the
+average.
+
+Adding future metrics like `median` is a one-line change in
+`measurement_rank()` (the single dispatch point) plus one new field on
+`AudioQualityMeasurement` and `AlbumInfo`.
+
+## Default band values
+
+All numbers live in `lib.quality.QualityRankConfig` defaults and in the
+`[Quality Ranks]` section of `config.ini`.
+
+### Opus (unconstrained VBR)
+
+| Band | Threshold (kbps) |
+|------|------------------|
+| transparent | 112 |
+| excellent | 88 |
+| good | 64 |
+| acceptable | 48 |
+
+**Why 112 for transparent?** `ffmpeg -b:a 128k` unconstrained VBR averages
+120-135 kbps on typical music — 112 leaves headroom for legitimate sparse
+material. `excellent=88` matches Opus 96 quality (hydrogenaudio/Kamedo2
+4.65/5 listening test). Full rationale in `docs/opus-encoding.md`.
+
+### MP3 VBR (LAME V0-V9 targets)
+
+| Band | Threshold (kbps) |
+|------|------------------|
+| transparent | 245 |
+| excellent | 210 |
+| good | 170 |
+| acceptable | 130 |
+
+The 210 threshold matches the legacy `QUALITY_MIN_BITRATE_KBPS=210` constant,
+so bare-codec MP3 VBR measurements from beets keep behaving as they did
+before the rank model. 245 adds a "V0 target" band above. The V0/V2/V4/etc.
+mapping via `mp3_vbr_levels` handles labeled conversions separately.
+
+### MP3 CBR
+
+| Band | Threshold (kbps) |
+|------|------------------|
+| transparent | 320 |
+| excellent | 256 |
+| good | 192 |
+| acceptable | 128 |
+
+Unverifiable CBR only reaches TRANSPARENT at 320 because the pipeline can't
+prove a CBR file came from lossless source. Spectral cliff detection may
+clamp it down further.
+
+### AAC
+
+| Band | Threshold (kbps) |
+|------|------------------|
+| transparent | 192 |
+| excellent | 144 |
+| good | 112 |
+| acceptable | 80 |
+
+Hydrogenaudio consensus places the "not worth going higher for music" ceiling
+for AAC at 192.
+
+## The verified-lossless guardrail
+
+`import_quality_decision()` used to blanket-bypass on `verified_lossless=True`.
+It now tier-gates the bypass:
+
+- `verified_lossless=True` + verdict `"better"` or `"equivalent"` → import.
+- `verified_lossless=True` + verdict `"worse"` → **downgrade** (blocked).
+
+This prevents a deliberately-too-low `verified_lossless_target` (Opus 64,
+Opus 48) from replacing a good existing album. The soularr process also logs
+a warning at startup when `verified_lossless_target` classifies below
+`gate_min_rank`, so operators see the contradiction before it bites.
+
+## Tuning via config.ini
+
+Every knob is optional — missing keys fall back to the dataclass defaults.
+Partial overrides work (e.g. set only `opus.transparent = 120` and everything
+else stays at defaults).
+
+```ini
+[Quality Ranks]
+bitrate_metric = avg
+gate_min_rank = excellent
+within_rank_tolerance_kbps = 5
+
+opus.transparent = 112
+opus.excellent = 88
+opus.good = 64
+opus.acceptable = 48
+
+mp3_vbr.transparent = 245
+mp3_vbr.excellent = 210
+mp3_vbr.good = 170
+mp3_vbr.acceptable = 130
+
+mp3_cbr.transparent = 320
+mp3_cbr.excellent = 256
+mp3_cbr.good = 192
+mp3_cbr.acceptable = 128
+
+aac.transparent = 192
+aac.excellent = 144
+aac.good = 112
+aac.acceptable = 80
+```
+
+Reload by restarting `soularr-web` (the web simulator reads this file on
+every request) and waiting for the next `soularr.timer` fire (5 min).
+
+## Diagnostic tooling
+
+- `pipeline-cli quality <request_id>` — shows the current rank, the
+  configured policy, and simulates every common download scenario against
+  the runtime cfg.
+- `/api/pipeline/constants` (web) — surfaces `rank_gate_min_rank` and
+  `rank_bitrate_metric` alongside other constants for the Decisions tab UI.
+- `/api/pipeline/simulate?...` (web) — accepts the same params as
+  `full_pipeline_decision()` plus `existing_format`, `existing_is_cbr`,
+  `new_format` so the web simulator classifies the same way production does.
+
+## Related
+
+- Issue #60 (this PR)
+- Issue #31 — original quality pipeline bugs that drove this rewrite
+- `docs/opus-encoding.md` — Opus 128 rationale and listening test references

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -44,11 +44,12 @@ def _bootstrap_import_paths() -> None:
 
 _bootstrap_import_paths()
 
-from lib.beets_db import BeetsDB
+from lib.beets_db import AlbumInfo, BeetsDB
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, ImportResult,
                          PostflightInfo, QualityRankConfig,
                          TRANSCODE_MIN_BITRATE_KBPS,
+                         comparison_format_hint,
                          determine_verified_lossless,
                          import_quality_decision, transcode_detection)
 HARNESS = os.path.join(os.path.dirname(__file__), "..", "harness", "run_beets_harness.sh")
@@ -126,6 +127,42 @@ def quality_decision_stage(
         return StageResult(decision="transcode_downgrade", exit_code=6, terminal=True)
     # import, transcode_upgrade, transcode_first all proceed to import
     return StageResult(decision=decision, exit_code=0)
+
+
+def build_existing_measurement(
+    existing_info: AlbumInfo | None,
+    *,
+    override_min_bitrate: int | None,
+    existing_spectral_grade: str | None,
+    existing_spectral_bitrate: int | None,
+) -> AudioQualityMeasurement | None:
+    """Build the existing on-disk measurement for pre-import comparison.
+
+    ``override_min_bitrate`` is already the pipeline's corrected view of the
+    existing album after spectral downgrade logic. Under the default AVG rank
+    metric we must apply that override to both min and avg so the harness
+    compares against the same effective quality the caller intended.
+    """
+    if existing_info is None:
+        return None
+    effective_existing = (
+        override_min_bitrate
+        if override_min_bitrate is not None
+        else existing_info.min_bitrate_kbps
+    )
+    effective_avg = (
+        override_min_bitrate
+        if override_min_bitrate is not None
+        else existing_info.avg_bitrate_kbps
+    )
+    return AudioQualityMeasurement(
+        min_bitrate_kbps=effective_existing,
+        avg_bitrate_kbps=effective_avg,
+        format=existing_info.format,
+        is_cbr=existing_info.is_cbr,
+        spectral_grade=existing_spectral_grade,
+        spectral_bitrate_kbps=existing_spectral_bitrate,
+    )
 
 
 def conversion_target(target_format: str | None,
@@ -861,13 +898,12 @@ def main():
         _emit_and_exit(r)
 
     # --- Quality comparison ---
-    new_min_br = _get_folder_min_bitrate(args.path, ext_filter=v0_ext_filter)
-    new_avg_br = _get_folder_avg_bitrate(args.path, ext_filter=v0_ext_filter)
+    new_bitrates = _get_folder_bitrates(args.path, ext_filter=v0_ext_filter)
+    new_min_br = min(new_bitrates) if new_bitrates else None
+    new_avg_br = int(sum(new_bitrates) / len(new_bitrates)) if new_bitrates else None
+    new_is_cbr = len(set(new_bitrates)) == 1 if new_bitrates else False
     existing_info = beets.get_album_info(mbid, _rank_cfg)
     existing_min_br = existing_info.min_bitrate_kbps if existing_info else None
-    existing_avg_br = existing_info.avg_bitrate_kbps if existing_info else None
-    existing_format = existing_info.format if existing_info else None
-    existing_is_cbr = existing_info.is_cbr if existing_info else False
     if args.override_min_bitrate is not None and existing_min_br is not None:
         if args.override_min_bitrate != existing_min_br:
             _log(f"  [OVERRIDE] pipeline says {args.override_min_bitrate}kbps, "
@@ -890,40 +926,31 @@ def main():
     new_conv_target = conversion_target(
         args.target_format, will_be_verified_lossless,
         args.verified_lossless_target)
-    if args.target_format in ("flac", "lossless"):
-        new_format_label: str | None = "flac"
-    elif new_conv_target:
-        # Post-commit-4 the measurement still reflects the V0 verification
-        # state at decision time; commit 5 will use this label for rank-based
-        # comparison, and the target-conversion block below updates it once
-        # the target conversion actually runs.
-        new_format_label = V0_SPEC.label if converted > 0 else None
-    elif converted > 0:
-        new_format_label = V0_SPEC.label
-    else:
-        # Native MP3 download — we don't know the exact VBR level / CBR
-        # without extra probing. Leave as None so the rank model falls back
-        # to bare-codec classification against the measured bitrate.
-        new_format_label = None
+    new_format_label = comparison_format_hint(
+        target_format=args.target_format,
+        verified_lossless_target=new_conv_target,
+        converted_count=converted,
+        is_transcode=is_transcode,
+        native_codec_family="MP3",
+    )
 
     # --- Build measurements ---
     new_m = AudioQualityMeasurement(
         min_bitrate_kbps=new_min_br,
         avg_bitrate_kbps=new_avg_br,
         format=new_format_label,
+        is_cbr=new_is_cbr,
         spectral_grade=spectral_grade,
         spectral_bitrate_kbps=spectral_bitrate,
         verified_lossless=will_be_verified_lossless,
         was_converted_from=(original_ext or "flac") if converted > 0 else None,
     )
-    existing_m = (AudioQualityMeasurement(
-        min_bitrate_kbps=effective_existing,
-        avg_bitrate_kbps=existing_avg_br,
-        format=existing_format,
-        is_cbr=existing_is_cbr,
-        spectral_grade=existing_spectral_grade,
-        spectral_bitrate_kbps=existing_spectral_bitrate,
-    ) if existing_min_br is not None else None)
+    existing_m = build_existing_measurement(
+        existing_info,
+        override_min_bitrate=args.override_min_bitrate,
+        existing_spectral_grade=existing_spectral_grade,
+        existing_spectral_bitrate=existing_spectral_bitrate,
+    )
     r.new_measurement = new_m
     r.existing_measurement = existing_m
 
@@ -935,16 +962,19 @@ def main():
 
     if qd.is_terminal:
         r.exit_code = qd.exit_code
-        _log(f"[QUALITY DOWNGRADE] new {new_min_br}kbps <= existing "
-             f"{effective_existing}kbps — skipping import"
+        _log(f"[QUALITY DOWNGRADE] new format={new_m.format or 'unknown'} "
+             f"min={new_min_br}kbps vs existing format="
+             f"{existing_m.format if existing_m else 'none'} "
+             f"min={effective_existing}kbps — skipping import"
              f"{' (transcode)' if decision == 'transcode_downgrade' else ''}")
         _emit_and_exit(r)
 
     # Non-terminal quality decisions — log and proceed to import
     if decision == "import":
         if will_be_verified_lossless and effective_existing is not None:
-            _log(f"  [QUALITY] genuine FLAC→V0 at {new_min_br}kbps — "
-                 f"always upgrade over existing {effective_existing}kbps")
+            _log(f"  [QUALITY] verified-lossless target "
+                 f"{new_m.format or V0_SPEC.label} accepted over existing "
+                 f"{effective_existing}kbps")
         elif effective_existing is not None:
             _log(f"  [QUALITY] new {new_min_br}kbps > existing {effective_existing}kbps — upgrading")
     elif decision == "transcode_upgrade":
@@ -952,6 +982,13 @@ def main():
              f"{effective_existing}kbps — upgrading (transcode)")
     elif decision == "transcode_first":
         _log(f"  [QUALITY] no existing album in beets — importing transcode")
+
+    if (will_be_verified_lossless and converted > 0
+            and not should_run_target_conversion(new_conv_target)):
+        # Persist the V0 label for the post-import quality gate and any
+        # downstream UI/CLI consumers. Beets only stores the bare "MP3"
+        # codec family, which is not enough to recover the V0 contract later.
+        r.final_format = V0_SPEC.label
 
     # --- Target format conversion (after V0 verdict, before import) ---
     # conv_target was hoisted above for issue #60 (so new_m.format is
@@ -988,12 +1025,18 @@ def main():
         # rank model classifies against the contract (e.g. "opus 128")
         # rather than the measured VBR number (which lands 95-150 kbps
         # depending on material).
-        target_min_br = _get_folder_min_bitrate(args.path)
-        target_avg_br = _get_folder_avg_bitrate(args.path)
+        target_bitrates = _get_folder_bitrates(args.path)
+        target_min_br = min(target_bitrates) if target_bitrates else None
+        target_avg_br = (
+            int(sum(target_bitrates) / len(target_bitrates))
+            if target_bitrates else None
+        )
+        target_is_cbr = len(set(target_bitrates)) == 1 if target_bitrates else False
         r.new_measurement = AudioQualityMeasurement(
             min_bitrate_kbps=target_min_br,
             avg_bitrate_kbps=target_avg_br,
             format=target_spec.label,
+            is_cbr=target_is_cbr,
             spectral_grade=spectral_grade,
             spectral_bitrate_kbps=spectral_bitrate,
             verified_lossless=True,

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -59,11 +59,11 @@ IMPORT_TIMEOUT = 1800
 MAX_DISTANCE = 0.5
 _current_result: ImportResult | None = None
 
-# Rank config used for BeetsDB.get_album_info() reduction of mixed-format
-# albums. Commit 4 will overwrite this with the deserialized runtime config
-# from the --quality-rank-config argv blob. For commit 3 it's the defaults
-# so behavior is unchanged — get_album_info() now takes cfg but mixed-format
-# reduction uses the default precedence tuple.
+# Rank config for BeetsDB.get_album_info() mixed-format reduction + (commit 5)
+# quality_rank() / compare_quality() / quality_gate_decision(). main() replaces
+# this with the deserialized --quality-rank-config argv blob passed by
+# lib.import_dispatch.dispatch_import_core. Missing or malformed argv falls
+# back to the hardcoded defaults.
 _rank_cfg: QualityRankConfig = QualityRankConfig.defaults()
 
 
@@ -291,16 +291,21 @@ def parse_verified_lossless_target(spec: str) -> ConversionSpec:
 # ---------------------------------------------------------------------------
 
 
-def _get_folder_min_bitrate(folder_path, ext_filter: set[str] | None = None):
-    """Get min bitrate (kbps) of audio files in a folder via ffprobe.
+def _get_folder_bitrates(folder_path,
+                         ext_filter: set[str] | None = None) -> list[int]:
+    """Probe per-track bitrates (kbps) for audio files in a folder via ffprobe.
 
     Uses audio stream bitrate (excludes cover art overhead). Falls back
     to format bitrate for VBR MP3s where stream bitrate is N/A.
 
     ext_filter: if provided, only measure files with these extensions
     (e.g. {".mp3"} to measure only V0 files when FLAC coexists).
+
+    Returns a list of strictly-positive bitrates (kbps) in filesystem-listed
+    order. Use _get_folder_min_bitrate() / _get_folder_avg_bitrate() for the
+    aggregate helpers.
     """
-    min_br = None
+    bitrates: list[int] = []
     for fname in os.listdir(folder_path):
         ext = os.path.splitext(fname)[1].lower()
         if ext not in AUDIO_EXTENSIONS:
@@ -329,11 +334,32 @@ def _get_folder_min_bitrate(folder_path, ext_filter: set[str] | None = None):
                 br_str = result.stdout.strip().rstrip(",")
             if br_str and br_str.isdigit():
                 br_kbps = int(br_str) // 1000
-                if br_kbps > 0 and (min_br is None or br_kbps < min_br):
-                    min_br = br_kbps
+                if br_kbps > 0:
+                    bitrates.append(br_kbps)
         except Exception:
             continue
-    return min_br
+    return bitrates
+
+
+def _get_folder_min_bitrate(folder_path,
+                            ext_filter: set[str] | None = None) -> int | None:
+    """Legacy alias: minimum per-file bitrate (kbps), or None if none probed."""
+    bitrates = _get_folder_bitrates(folder_path, ext_filter=ext_filter)
+    return min(bitrates) if bitrates else None
+
+
+def _get_folder_avg_bitrate(folder_path,
+                            ext_filter: set[str] | None = None) -> int | None:
+    """Mean per-file bitrate (kbps), or None if no probable files.
+
+    Truncated to int. Used by the codec-aware rank model as the preferred
+    metric for VBR codecs (issue #60) — album-mean is more robust to
+    legitimate per-track VBR variance than the min.
+    """
+    bitrates = _get_folder_bitrates(folder_path, ext_filter=ext_filter)
+    if not bitrates:
+        return None
+    return int(sum(bitrates) / len(bitrates))
 
 
 # ---------------------------------------------------------------------------
@@ -647,11 +673,31 @@ def main():
                         help="Target format after verified lossless (e.g. 'opus 128', 'mp3 v2')")
     parser.add_argument("--target-format", default=None,
                         help="Desired format on disk (e.g. 'flac' to skip conversion)")
+    parser.add_argument("--quality-rank-config", default=None,
+                        help="Serialized QualityRankConfig (JSON). Provided by "
+                             "lib.import_dispatch.dispatch_import_core so the "
+                             "harness's rank classification matches the caller's "
+                             "runtime config. Missing/empty falls back to defaults.")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
     mbid = args.mb_release_id
     request_id = args.request_id
+
+    # Parse --quality-rank-config and replace the module-level _rank_cfg default.
+    # Used by BeetsDB.get_album_info() mixed-format reduction + (commit 5)
+    # quality_rank()/compare_quality()/quality_gate_decision().
+    global _rank_cfg  # noqa: PLW0603
+    if args.quality_rank_config:
+        try:
+            _rank_cfg = QualityRankConfig.from_json(args.quality_rank_config)
+            _log(f"[CONFIG] quality_rank_config: "
+                 f"metric={_rank_cfg.bitrate_metric.value}, "
+                 f"gate_min_rank={_rank_cfg.gate_min_rank.name}")
+        except (ValueError, KeyError) as exc:
+            _log(f"[WARN] --quality-rank-config parse failed ({exc}); "
+                 f"falling back to defaults")
+            _rank_cfg = QualityRankConfig.defaults()
 
     # --force: raise distance threshold so high-distance candidates are accepted
     global MAX_DISTANCE
@@ -812,7 +858,12 @@ def main():
 
     # --- Quality comparison ---
     new_min_br = _get_folder_min_bitrate(args.path, ext_filter=v0_ext_filter)
-    existing_min_br = beets.get_min_bitrate(mbid)
+    new_avg_br = _get_folder_avg_bitrate(args.path, ext_filter=v0_ext_filter)
+    existing_info = beets.get_album_info(mbid, _rank_cfg)
+    existing_min_br = existing_info.min_bitrate_kbps if existing_info else None
+    existing_avg_br = existing_info.avg_bitrate_kbps if existing_info else None
+    existing_format = existing_info.format if existing_info else None
+    existing_is_cbr = existing_info.is_cbr if existing_info else False
     if args.override_min_bitrate is not None and existing_min_br is not None:
         if args.override_min_bitrate != existing_min_br:
             _log(f"  [OVERRIDE] pipeline says {args.override_min_bitrate}kbps, "
@@ -822,14 +873,40 @@ def main():
         _log(f"  prev_min_bitrate={effective_existing}")
     if new_min_br is not None:
         _log(f"  new_min_bitrate={new_min_br}")
+    if new_avg_br is not None:
+        _log(f"  new_avg_bitrate={new_avg_br}")
 
     # Verified lossless: single source of truth in quality.py
     will_be_verified_lossless = determine_verified_lossless(
         args.target_format, spectral_grade, converted, is_transcode)
 
+    # Final format label for the NEW measurement. Compute conv_target early
+    # (originally it was computed after the quality decision — hoisted for
+    # issue #60 so the rank model sees the correct target label).
+    new_conv_target = conversion_target(
+        args.target_format, will_be_verified_lossless,
+        args.verified_lossless_target)
+    if args.target_format in ("flac", "lossless"):
+        new_format_label: str | None = "flac"
+    elif new_conv_target:
+        # Post-commit-4 the measurement still reflects the V0 verification
+        # state at decision time; commit 5 will use this label for rank-based
+        # comparison, and the target-conversion block below updates it once
+        # the target conversion actually runs.
+        new_format_label = V0_SPEC.label if converted > 0 else None
+    elif converted > 0:
+        new_format_label = V0_SPEC.label
+    else:
+        # Native MP3 download — we don't know the exact VBR level / CBR
+        # without extra probing. Leave as None so the rank model falls back
+        # to bare-codec classification against the measured bitrate.
+        new_format_label = None
+
     # --- Build measurements ---
     new_m = AudioQualityMeasurement(
         min_bitrate_kbps=new_min_br,
+        avg_bitrate_kbps=new_avg_br,
+        format=new_format_label,
         spectral_grade=spectral_grade,
         spectral_bitrate_kbps=spectral_bitrate,
         verified_lossless=will_be_verified_lossless,
@@ -837,6 +914,9 @@ def main():
     )
     existing_m = (AudioQualityMeasurement(
         min_bitrate_kbps=effective_existing,
+        avg_bitrate_kbps=existing_avg_br,
+        format=existing_format,
+        is_cbr=existing_is_cbr,
         spectral_grade=existing_spectral_grade,
         spectral_bitrate_kbps=existing_spectral_bitrate,
     ) if existing_min_br is not None else None)
@@ -869,8 +949,10 @@ def main():
         _log(f"  [QUALITY] no existing album in beets — importing transcode")
 
     # --- Target format conversion (after V0 verdict, before import) ---
-    conv_target = conversion_target(args.target_format, will_be_verified_lossless,
-                                    args.verified_lossless_target)
+    # conv_target was hoisted above for issue #60 (so new_m.format is
+    # available at the quality decision). Re-use it here instead of
+    # re-computing.
+    conv_target = new_conv_target
     target_achieved = False
     if should_run_target_conversion(conv_target):
         assert conv_target is not None
@@ -896,10 +978,17 @@ def main():
             _remove_files_by_ext(args.path, "." + V0_SPEC.extension)
         # Remove original lossless files (consumed by target conversion)
         _remove_lossless_files(args.path)
-        # Update measurements for target format
+        # Update measurements for the target format — include both the
+        # measured min/avg bitrate and the declared format label so the
+        # rank model classifies against the contract (e.g. "opus 128")
+        # rather than the measured VBR number (which lands 95-150 kbps
+        # depending on material).
         target_min_br = _get_folder_min_bitrate(args.path)
+        target_avg_br = _get_folder_avg_bitrate(args.path)
         r.new_measurement = AudioQualityMeasurement(
             min_bitrate_kbps=target_min_br,
+            avg_bitrate_kbps=target_avg_br,
+            format=target_spec.label,
             spectral_grade=spectral_grade,
             spectral_bitrate_kbps=spectral_bitrate,
             verified_lossless=True,
@@ -908,7 +997,7 @@ def main():
         r.conversion.target_filetype = target_spec.extension
         r.final_format = target_spec.label
         _log(f"  {target_spec.label} conversion complete: {target_converted} files, "
-             f"min_bitrate={target_min_br}kbps")
+             f"min_bitrate={target_min_br}kbps, avg_bitrate={target_avg_br}kbps")
         _log(f"  V0 verification bitrate: {post_conv_br}kbps")
 
     # --- Clean up kept source files if target was skipped (transcode path) ---

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -47,7 +47,8 @@ _bootstrap_import_paths()
 from lib.beets_db import BeetsDB
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, ImportResult,
-                         PostflightInfo, TRANSCODE_MIN_BITRATE_KBPS,
+                         PostflightInfo, QualityRankConfig,
+                         TRANSCODE_MIN_BITRATE_KBPS,
                          determine_verified_lossless,
                          import_quality_decision, transcode_detection)
 HARNESS = os.path.join(os.path.dirname(__file__), "..", "harness", "run_beets_harness.sh")
@@ -57,6 +58,13 @@ HARNESS_TIMEOUT = 300
 IMPORT_TIMEOUT = 1800
 MAX_DISTANCE = 0.5
 _current_result: ImportResult | None = None
+
+# Rank config used for BeetsDB.get_album_info() reduction of mixed-format
+# albums. Commit 4 will overwrite this with the deserialized runtime config
+# from the --quality-rank-config argv blob. For commit 3 it's the defaults
+# so behavior is unchanged — get_album_info() now takes cfg but mixed-format
+# reduction uses the default precedence tuple.
+_rank_cfg: QualityRankConfig = QualityRankConfig.defaults()
 
 
 # ---------------------------------------------------------------------------
@@ -674,7 +682,7 @@ def main():
         if pf.decision == "preflight_existing":
             _log(f"[PRE-FLIGHT] No new files, keeping existing import")
             if request_id:
-                info = beets.get_album_info(mbid)
+                info = beets.get_album_info(mbid, _rank_cfg)
                 if info:
                     r.postflight = PostflightInfo(
                         beets_id=info.album_id,
@@ -922,7 +930,7 @@ def main():
         _emit_and_exit(r)
 
     # --- Post-flight verification ---
-    pf_info = beets.get_album_info(mbid)
+    pf_info = beets.get_album_info(mbid, _rank_cfg)
     if not pf_info:
         r.exit_code = 2
         r.decision = "import_failed"
@@ -952,7 +960,7 @@ def main():
         )
         if move_result.returncode == 0:
             # Re-read path from beets DB — it may have changed
-            pf_info_after = beets.get_album_info(mbid)
+            pf_info_after = beets.get_album_info(mbid, _rank_cfg)
             if pf_info_after:
                 new_path = pf_info_after.album_path
                 if new_path != album_path:

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -108,13 +108,17 @@ def quality_decision_stage(
     new: AudioQualityMeasurement,
     existing: AudioQualityMeasurement | None,
     is_transcode: bool,
+    cfg: QualityRankConfig | None = None,
 ) -> StageResult:
     """Run quality comparison and map to exit codes (pure wrapper).
 
     Delegates to import_quality_decision() and maps terminal decisions
     to exit codes: downgrade→5, transcode_downgrade→6.
+
+    ``cfg`` flows through to import_quality_decision for codec-aware
+    comparison. Falls back to QualityRankConfig.defaults() when omitted.
     """
-    decision = import_quality_decision(new, existing, is_transcode)
+    decision = import_quality_decision(new, existing, is_transcode, cfg=cfg)
 
     if decision == "downgrade":
         return StageResult(decision="downgrade", exit_code=5, terminal=True)
@@ -924,7 +928,8 @@ def main():
     r.existing_measurement = existing_m
 
     # --- Quality comparison (pure decision) ---
-    qd = quality_decision_stage(new_m, existing_m, is_transcode=is_transcode)
+    qd = quality_decision_stage(new_m, existing_m, is_transcode=is_transcode,
+                                cfg=_rank_cfg)
     decision = qd.decision
     r.decision = decision
 

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -5,27 +5,73 @@ sqlite3.connect() calls from soularr.py and import_one.py.
 
 Usage:
     with BeetsDB() as db:
-        info = db.get_album_info("mbid-here")
+        info = db.get_album_info("mbid-here", cfg.quality_ranks)
         if info:
-            print(info.min_bitrate_kbps, info.is_cbr)
+            print(info.format, info.min_bitrate_kbps, info.avg_bitrate_kbps, info.is_cbr)
 """
 
 import os
 import sqlite3
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.quality import QualityRankConfig
 
 DEFAULT_BEETS_DB = os.environ.get("BEETS_DB", "/mnt/virtio/Music/beets-library.db")
 
 
+def _reduce_album_format(
+    formats_on_disk: set[str],
+    cfg: "QualityRankConfig",
+) -> str:
+    """Reduce a set of beets format strings to a single canonical one.
+
+    Uses cfg.mixed_format_precedence (worst-first). If the album contains
+    any codec listed in the precedence tuple, the first match wins. Otherwise
+    returns the first format alphabetically (stable but not meaningful) or
+    an empty string if the set is empty.
+    """
+    if not formats_on_disk:
+        return ""
+    # Normalized lookup: lowercase -> original.
+    normalized: dict[str, str] = {f.lower(): f for f in formats_on_disk if f}
+    for preferred in cfg.mixed_format_precedence:
+        if preferred in normalized:
+            return normalized[preferred]
+    # No precedence match — pick a deterministic fallback.
+    return sorted(formats_on_disk)[0]
+
+
 @dataclass
 class AlbumInfo:
-    """Query result from beets DB for a single album."""
+    """Query result from beets DB for a single album.
+
+    format:
+        The canonical codec family for the album, derived from
+        beets.items.format (e.g. "MP3", "FLAC", "Opus", "AAC"). When an album
+        has multiple codecs on disk (rare — manually merged album), the
+        worst-ranked codec wins per QualityRankConfig.mixed_format_precedence.
+        This is the bare codec string for quality_rank() — the pipeline
+        carries the richer "opus 128" / "mp3 v0" labels via ImportResult /
+        album_requests.final_format when available. Defaults to empty string
+        so tests constructing AlbumInfo directly (e.g. integration slices)
+        don't have to pass every field. Production always sets it via
+        get_album_info() → _reduce_album_format().
+    min_bitrate_kbps / avg_bitrate_kbps:
+        Minimum and mean per-track bitrate (kbps). The rank model's
+        measurement_rank() picks between these based on
+        QualityRankConfig.bitrate_metric. ``avg_bitrate_kbps`` defaults to
+        None for the same test-ergonomics reason; measurement_rank() falls
+        back to min when avg is None.
+    """
     album_id: int
     track_count: int
     min_bitrate_kbps: int
     is_cbr: bool
-    album_path: str  # directory containing the tracks
+    album_path: str
+    avg_bitrate_kbps: Optional[int] = None
+    format: str = ""
 
 
 class BeetsDB:
@@ -59,10 +105,19 @@ class BeetsDB:
         ).fetchone()
         return row is not None
 
-    def get_album_info(self, mb_release_id: str) -> Optional[AlbumInfo]:
+    def get_album_info(
+        self,
+        mb_release_id: str,
+        cfg: "QualityRankConfig",
+    ) -> Optional[AlbumInfo]:
         """Get full album info for quality gate / postflight verification.
 
         Returns None if the MBID isn't in beets or has no tracks.
+
+        Mixed-format albums (rare: manually merged albums with tracks in
+        multiple codecs) are reduced to a single canonical format using
+        ``cfg.mixed_format_precedence`` — the worst codec in that tuple wins
+        so the rank stays conservative.
         """
         album_row = self._conn.execute(
             "SELECT id FROM albums WHERE mb_albumid = ?", (mb_release_id,)
@@ -71,9 +126,10 @@ class BeetsDB:
             return None
         album_id: int = album_row[0]
 
-        # Get bitrate stats (exclude 0-bitrate tracks)
+        # Get bitrate + format stats (exclude 0-bitrate tracks)
         rows = self._conn.execute(
-            "SELECT bitrate, path FROM items WHERE album_id = ? AND bitrate > 0",
+            "SELECT bitrate, path, format FROM items "
+            "WHERE album_id = ? AND bitrate > 0",
             (album_id,)
         ).fetchall()
         if not rows:
@@ -81,6 +137,7 @@ class BeetsDB:
 
         bitrates = [r[0] for r in rows]
         min_br = min(bitrates)
+        avg_br = sum(bitrates) / len(bitrates)
         is_cbr = len(set(bitrates)) == 1
         track_count = len(rows)
 
@@ -88,12 +145,18 @@ class BeetsDB:
         first_path = self._decode_path(rows[0][1])
         album_path = os.path.dirname(first_path)
 
+        # Reduce multi-format albums via cfg.mixed_format_precedence.
+        formats_on_disk = {r[2] for r in rows if r[2]}
+        album_format = _reduce_album_format(formats_on_disk, cfg)
+
         return AlbumInfo(
             album_id=album_id,
             track_count=track_count,
             min_bitrate_kbps=int(min_br / 1000),
+            avg_bitrate_kbps=int(avg_br / 1000),
             is_cbr=is_cbr,
             album_path=album_path,
+            format=album_format,
         )
 
     def get_min_bitrate(self, mb_release_id: str) -> Optional[int]:

--- a/lib/config.py
+++ b/lib/config.py
@@ -9,6 +9,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional, TYPE_CHECKING
 
+from lib.quality import QualityRankConfig
+
 if TYPE_CHECKING:
     from lib.quality import AudioFileSpec
 
@@ -65,6 +67,9 @@ class SoularrConfig:
     audio_check_mode: str = "normal"
     beets_tracking_file: str = ""
     verified_lossless_target: str = ""  # Target format after verified lossless (e.g. "opus 128", "mp3 v2")
+
+    # --- Quality Ranks (codec-aware comparison model, issue #60) ---
+    quality_ranks: QualityRankConfig = field(default_factory=QualityRankConfig.defaults)
 
     # --- Pipeline DB ---
     pipeline_db_enabled: bool = False
@@ -184,6 +189,9 @@ class SoularrConfig:
             audio_check_mode=get("Beets Validation", "audio_check", "normal"),
             beets_tracking_file=get("Beets Validation", "tracking_file", ""),
             verified_lossless_target=get("Beets Validation", "verified_lossless_target", ""),
+            # Quality Ranks — codec-aware comparison policy. Missing section
+            # yields the default QualityRankConfig (see lib/quality.py).
+            quality_ranks=QualityRankConfig.from_ini(config),
             # Pipeline DB
             pipeline_db_enabled=getbool("Pipeline DB", "enabled", False),
             pipeline_db_dsn=get("Pipeline DB", "dsn", "postgresql://soularr@localhost/soularr"),

--- a/lib/config.py
+++ b/lib/config.py
@@ -211,6 +211,44 @@ class SoularrConfig:
         )
 
 
+DEFAULT_RUNTIME_CONFIG_PATH = "/var/lib/soularr/config.ini"
+
+
+def _runtime_config_path(config_path: str | None = None) -> str:
+    """Resolve the active runtime config.ini path."""
+    return config_path or os.environ.get("SOULARR_RUNTIME_CONFIG") or DEFAULT_RUNTIME_CONFIG_PATH
+
+
+def read_runtime_config(config_path: str | None = None) -> SoularrConfig:
+    """Read the active runtime config.ini into a full SoularrConfig.
+
+    Manual-import, force-import, the CLI, and web simulator all need the same
+    runtime config the main soularr process reads. Missing or unreadable config
+    returns a default SoularrConfig so callers degrade safely.
+    """
+    path = _runtime_config_path(config_path)
+    if not path or not os.path.exists(path):
+        return SoularrConfig()
+
+    parser = configparser.RawConfigParser()
+    try:
+        parser.read(path)
+    except (configparser.Error, OSError):
+        return SoularrConfig()
+
+    runtime_dir = os.path.dirname(path)
+    return SoularrConfig.from_ini(
+        parser,
+        config_dir=runtime_dir,
+        var_dir=runtime_dir,
+    )
+
+
+def read_runtime_rank_config(config_path: str | None = None) -> QualityRankConfig:
+    """Read the active runtime QualityRankConfig."""
+    return read_runtime_config(config_path).quality_ranks
+
+
 def read_verified_lossless_target(config_path: str | None = None) -> str:
     """Read verified_lossless_target from the runtime config file.
 
@@ -218,15 +256,4 @@ def read_verified_lossless_target(config_path: str | None = None) -> str:
     need a small helper to discover the same runtime setting. Callers may pass an
     explicit path, otherwise the standard doc2 runtime config is used.
     """
-    path = config_path or os.environ.get("SOULARR_RUNTIME_CONFIG") or "/var/lib/soularr/config.ini"
-    if not path or not os.path.exists(path):
-        return ""
-
-    parser = configparser.ConfigParser(
-        interpolation=configparser.BasicInterpolation()
-    )
-    try:
-        parser.read(path)
-    except (configparser.Error, OSError):
-        return ""
-    return parser.get("Beets Validation", "verified_lossless_target", fallback="").strip()
+    return read_runtime_config(config_path).verified_lossless_target

--- a/lib/download.py
+++ b/lib/download.py
@@ -211,7 +211,8 @@ def _gather_spectral_context(album_data: GrabListEntry, import_folder: str,
         if mb_id:
             try:
                 with BeetsDB() as beets:
-                    existing_info = beets.get_album_info(mb_id)
+                    existing_info = beets.get_album_info(
+                        mb_id, ctx.cfg.quality_ranks)
                 if existing_info:
                     spec_ctx.existing_min_bitrate = existing_info.min_bitrate_kbps
                     if os.path.isdir(existing_info.album_path):
@@ -506,7 +507,8 @@ def _compute_rejection_backfill(album_data: GrabListEntry,
             return None
         from lib.beets_db import BeetsDB
         with BeetsDB() as beets:
-            info = beets.get_album_info(album_data.mb_release_id)
+            info = beets.get_album_info(
+                album_data.mb_release_id, ctx.cfg.quality_ranks)
         if not info:
             return None
         override = rejection_backfill_override(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -285,7 +285,9 @@ def _check_quality_gate_core(
         if not info:
             return
         min_br_kbps = info.min_bitrate_kbps
+        avg_br_kbps = info.avg_bitrate_kbps
         is_cbr = info.is_cbr
+        album_format = info.format
 
         spectral_br: int | None = None
         spectral_grade: str | None = None
@@ -310,10 +312,13 @@ def _check_quality_gate_core(
         verified_lossless = bool(req.get("verified_lossless")) if req else False
 
         current = AudioQualityMeasurement(
-            min_bitrate_kbps=min_br_kbps, is_cbr=is_cbr,
+            min_bitrate_kbps=min_br_kbps,
+            avg_bitrate_kbps=avg_br_kbps,
+            format=album_format,
+            is_cbr=is_cbr,
             verified_lossless=verified_lossless,
             spectral_bitrate_kbps=spectral_br)
-        decision = quality_gate_decision(current)
+        decision = quality_gate_decision(current, cfg=quality_ranks)
 
         spectral_note = f" (spectral={spectral_br}kbps)" if spectral_br else ""
 
@@ -604,6 +609,7 @@ def dispatch_import_core(
                     request_id=request_id,
                     files=list(file_list),
                     db=db,
+                    quality_ranks=cfg.quality_ranks if cfg is not None else None,
                 )
             if action.trigger_meelo and cfg is not None:
                 _trigger_meelo(cfg)

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -6,7 +6,6 @@ that runs import_one.py and dispatches on the ImportResult decision.
 
 from __future__ import annotations
 
-import configparser
 import logging
 import os
 import shutil
@@ -117,8 +116,8 @@ def _do_mark_done(
     request_id: int,
     dl_info: DownloadInfo,
     distance: float,
-    scenario: str,
-    dest_path: str,
+    scenario: str | None,
+    dest_path: str | None,
     outcome_label: str = "success",
     detail: str | None = None,
 ) -> None:
@@ -745,25 +744,6 @@ class DispatchOutcome:
     success: bool
     message: str
 
-
-def _read_runtime_config() -> "SoularrConfig":
-    """Read the full runtime config for force/manual import.
-
-    Same config.ini that the main soularr process uses, so force-import
-    behaves identically (Plex, Meelo, quality settings, etc.).
-    """
-    from lib.config import SoularrConfig
-    path = os.environ.get("SOULARR_RUNTIME_CONFIG") or "/var/lib/soularr/config.ini"
-    if not os.path.exists(path):
-        return SoularrConfig()
-    parser = configparser.ConfigParser(interpolation=configparser.BasicInterpolation())
-    try:
-        parser.read(path)
-    except (configparser.Error, OSError):
-        return SoularrConfig()
-    return SoularrConfig.from_ini(parser, var_dir=os.path.dirname(path))
-
-
 def dispatch_import_from_db(
     db: "PipelineDB",
     request_id: int,
@@ -800,7 +780,9 @@ def dispatch_import_from_db(
     if not os.path.isdir(failed_path):
         return DispatchOutcome(success=False, message=f"Path not found: {failed_path}")
 
-    cfg = _read_runtime_config()
+    from lib.config import read_runtime_config
+
+    cfg = read_runtime_config()
 
     files: list[DownloadFile] = []
     if source_username:

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -31,9 +31,85 @@ if TYPE_CHECKING:
     from lib.context import SoularrContext
     from lib.grab_list import GrabListEntry
     from lib.pipeline_db import PipelineDB
-    from lib.quality import QualityRankConfig
+    from lib.quality import AudioQualityMeasurement, QualityRankConfig
 
 logger = logging.getLogger("soularr")
+
+
+@dataclass(frozen=True)
+class QualityGateState:
+    """Resolved on-disk state for a quality-gate evaluation."""
+    measurement: AudioQualityMeasurement
+    min_bitrate_kbps: int
+    spectral_bitrate_kbps: int | None
+    spectral_grade: str | None
+
+
+def load_quality_gate_state(
+    *,
+    request_id: int,
+    db: "PipelineDB",
+    mb_id: str | None = None,
+    quality_ranks: "QualityRankConfig | None" = None,
+) -> QualityGateState | None:
+    """Load the current on-disk measurement for quality-gate evaluation.
+
+    Shared adapter for all post-import quality-gate callers. This is the
+    single place that combines:
+    - Beets on-disk metadata (min/avg/format/is_cbr)
+    - request-row overrides (`final_format`, `verified_lossless`)
+    - grade-aware spectral override logic
+    """
+    from lib.beets_db import BeetsDB
+    from lib.quality import AudioQualityMeasurement, QualityRankConfig
+
+    if quality_ranks is None:
+        quality_ranks = QualityRankConfig.defaults()
+
+    req = None
+    try:
+        req = db.get_request(request_id)
+    except Exception:
+        logger.debug("QUALITY GATE: DB lookup failed for request row")
+
+    resolved_mb_id = mb_id or (str(req["mb_release_id"]) if req and req.get("mb_release_id") else None)
+    if not resolved_mb_id:
+        return None
+
+    with BeetsDB() as beets:
+        info = beets.get_album_info(resolved_mb_id, quality_ranks)
+    if not info:
+        return None
+
+    min_br_kbps = info.min_bitrate_kbps
+    spectral_grade = req.get("current_spectral_grade") if req else None
+    raw_br = req.get("current_spectral_bitrate") if req else None
+    raw_br_int = raw_br if isinstance(raw_br, int) else None
+    spectral_br: int | None = None
+    effective = compute_effective_override_bitrate(
+        min_br_kbps, raw_br_int, spectral_grade)
+    if effective is not None and effective < min_br_kbps:
+        spectral_br = raw_br_int
+
+    album_format = info.format
+    verified_lossless = bool(req.get("verified_lossless")) if req else False
+    if req and req.get("final_format"):
+        album_format = str(req["final_format"])
+
+    current = AudioQualityMeasurement(
+        min_bitrate_kbps=min_br_kbps,
+        avg_bitrate_kbps=info.avg_bitrate_kbps,
+        format=album_format,
+        is_cbr=info.is_cbr,
+        verified_lossless=verified_lossless,
+        spectral_bitrate_kbps=spectral_br,
+    )
+    return QualityGateState(
+        measurement=current,
+        min_bitrate_kbps=min_br_kbps,
+        spectral_bitrate_kbps=spectral_br,
+        spectral_grade=spectral_grade,
+    )
 
 
 def _do_mark_done(
@@ -270,9 +346,7 @@ def _check_quality_gate_core(
     don't care about mixed-format reduction still work. Commit 5 will thread
     the real runtime config through from dispatch_import_core().
     """
-    from lib.quality import (
-        quality_gate_decision, AudioQualityMeasurement, QualityRankConfig)
-    from lib.beets_db import BeetsDB
+    from lib.quality import quality_gate_decision, QualityRankConfig
 
     if quality_ranks is None:
         quality_ranks = QualityRankConfig.defaults()
@@ -280,46 +354,22 @@ def _check_quality_gate_core(
     if not mb_id:
         return
     try:
-        with BeetsDB() as beets:
-            info = beets.get_album_info(mb_id, quality_ranks)
-        if not info:
+        state = load_quality_gate_state(
+            request_id=request_id,
+            db=db,
+            mb_id=mb_id,
+            quality_ranks=quality_ranks,
+        )
+        if not state:
             return
-        min_br_kbps = info.min_bitrate_kbps
-        avg_br_kbps = info.avg_bitrate_kbps
-        is_cbr = info.is_cbr
-        album_format = info.format
-
-        spectral_br: int | None = None
-        spectral_grade: str | None = None
-        req = None
-        try:
-            req = db.get_request(request_id)
-            spectral_grade = req.get("current_spectral_grade") if req else None
-            raw_br = req.get("current_spectral_bitrate") if req else None
-            raw_br_int = raw_br if isinstance(raw_br, int) else None
-            # Grade-aware: helper returns container_bitrate unchanged for
-            # non-transcode grades. spectral_br is set only when the helper
-            # actually lowered the effective bitrate (see issue #61).
-            effective = compute_effective_override_bitrate(
-                min_br_kbps, raw_br_int, spectral_grade)
-            if effective is not None and effective < min_br_kbps:
-                spectral_br = raw_br_int
-                logger.info(f"QUALITY GATE: using current_spectral={spectral_br}kbps "
-                            f"(lower than beets min_bitrate={min_br_kbps}kbps, "
-                            f"grade={spectral_grade})")
-        except Exception:
-            logger.debug("QUALITY GATE: DB lookup failed for spectral override")
-        verified_lossless = bool(req.get("verified_lossless")) if req else False
-        if req and req.get("final_format"):
-            album_format = str(req["final_format"])
-
-        current = AudioQualityMeasurement(
-            min_bitrate_kbps=min_br_kbps,
-            avg_bitrate_kbps=avg_br_kbps,
-            format=album_format,
-            is_cbr=is_cbr,
-            verified_lossless=verified_lossless,
-            spectral_bitrate_kbps=spectral_br)
+        current = state.measurement
+        min_br_kbps = state.min_bitrate_kbps
+        spectral_br = state.spectral_bitrate_kbps
+        spectral_grade = state.spectral_grade
+        if spectral_br is not None:
+            logger.info(f"QUALITY GATE: using current_spectral={spectral_br}kbps "
+                        f"(lower than beets min_bitrate={min_br_kbps}kbps, "
+                        f"grade={spectral_grade})")
         decision = quality_gate_decision(current, cfg=quality_ranks)
 
         spectral_note = f" (spectral={spectral_br}kbps)" if spectral_br else ""
@@ -364,7 +414,7 @@ def _check_quality_gate_core(
                 min_bitrate=min_br_kbps,
                 search_filetype_override=None,  # done searching
             )
-            if verified_lossless:
+            if current.verified_lossless:
                 logger.info(f"QUALITY GATE: {label} min_bitrate={min_br_kbps}kbps — quality OK")
             else:
                 logger.info(f"QUALITY GATE: {label} min_bitrate={min_br_kbps}kbps VBR — quality OK")

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -135,15 +135,18 @@ def _do_mark_done(
         beets_scenario=scenario,
         imported_path=dest_path,
     )
-    if dl_info.verified_lossless_override is not None:
-        if dl_info.verified_lossless_override:
-            update_fields["verified_lossless"] = True
-    elif is_verified_lossless(
-        dl_info.was_converted,
-        dl_info.original_filetype,
-        dl_info.download_spectral.grade if dl_info.download_spectral else None,
-    ):
-        update_fields["verified_lossless"] = True
+    verified_lossless = (
+        bool(dl_info.verified_lossless_override)
+        if dl_info.verified_lossless_override is not None
+        else is_verified_lossless(
+            dl_info.was_converted,
+            dl_info.original_filetype,
+            dl_info.download_spectral.grade if dl_info.download_spectral else None,
+        )
+    )
+    # Persist the full current quality state, not only truthy upgrades.
+    # Otherwise old verified/final-format labels leak into later imports.
+    update_fields["verified_lossless"] = verified_lossless
     if dl_info.download_spectral is not None:
         current_spectral = dl_info.download_spectral
         if update_fields.get("verified_lossless") and dl_info.bitrate:
@@ -155,10 +158,9 @@ def _do_mark_done(
             RequestSpectralStateUpdate(
                 last_download=dl_info.download_spectral,
                 current=current_spectral,
-            ).as_update_fields()
+                ).as_update_fields()
         )
-    if dl_info.final_format:
-        update_fields["final_format"] = dl_info.final_format
+    update_fields["final_format"] = dl_info.final_format
     apply_transition(db, request_id, "imported", **update_fields)
 
     db.log_download(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -434,6 +434,11 @@ def dispatch_import_core(
             cmd.extend(["--target-format", target_format])
         if override_min_bitrate is not None:
             cmd.extend(["--override-min-bitrate", str(override_min_bitrate)])
+        # Serialize the runtime QualityRankConfig so the harness classifies
+        # with the same policy as the caller. Missing cfg (e.g. legacy test
+        # path) → harness falls back to QualityRankConfig.defaults().
+        if cfg is not None:
+            cmd.extend(["--quality-rank-config", cfg.quality_ranks.to_json()])
         import_env = {**os.environ, "HOME": "/home/abl030"}
         result = sp.run(cmd, capture_output=True, text=True,
                         timeout=1800, env=import_env)

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from lib.context import SoularrContext
     from lib.grab_list import GrabListEntry
     from lib.pipeline_db import PipelineDB
+    from lib.quality import QualityRankConfig
 
 logger = logging.getLogger("soularr")
 
@@ -256,20 +257,31 @@ def _check_quality_gate_core(
     request_id: int,
     files: Sequence[object],
     db: "PipelineDB",
+    quality_ranks: "QualityRankConfig | None" = None,
 ) -> None:
     """Post-import quality gate — standalone version taking plain params + PipelineDB.
 
     Reads beets DB for on-disk quality, runs quality_gate_decision, dispatches
     requeue/accept. Used by both auto-import (via wrapper) and core dispatch.
+
+    ``quality_ranks`` is used by ``BeetsDB.get_album_info()`` to reduce
+    mixed-format albums via ``cfg.mixed_format_precedence``. Defaults to
+    ``QualityRankConfig.defaults()`` so existing tests and callers that
+    don't care about mixed-format reduction still work. Commit 5 will thread
+    the real runtime config through from dispatch_import_core().
     """
-    from lib.quality import quality_gate_decision, AudioQualityMeasurement
+    from lib.quality import (
+        quality_gate_decision, AudioQualityMeasurement, QualityRankConfig)
     from lib.beets_db import BeetsDB
+
+    if quality_ranks is None:
+        quality_ranks = QualityRankConfig.defaults()
 
     if not mb_id:
         return
     try:
         with BeetsDB() as beets:
-            info = beets.get_album_info(mb_id)
+            info = beets.get_album_info(mb_id, quality_ranks)
         if not info:
             return
         min_br_kbps = info.min_bitrate_kbps
@@ -508,8 +520,13 @@ def dispatch_import_core(
                             current_override, dl_info)
                         if narrowed_override is None and current_override is None and req_row:
                             from lib.beets_db import BeetsDB
+                            from lib.quality import QualityRankConfig
+                            _gate_cfg = (
+                                cfg.quality_ranks if cfg is not None
+                                else QualityRankConfig.defaults())
                             with BeetsDB() as beets:
-                                beets_info = beets.get_album_info(mb_release_id)
+                                beets_info = beets.get_album_info(
+                                    mb_release_id, _gate_cfg)
                             if beets_info:
                                 narrowed_override = rejection_backfill_override(
                                     is_cbr=beets_info.is_cbr,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -310,6 +310,8 @@ def _check_quality_gate_core(
         except Exception:
             logger.debug("QUALITY GATE: DB lookup failed for spectral override")
         verified_lossless = bool(req.get("verified_lossless")) if req else False
+        if req and req.get("final_format"):
+            album_format = str(req["final_format"])
 
         current = AudioQualityMeasurement(
             min_bitrate_kbps=min_br_kbps,
@@ -323,18 +325,6 @@ def _check_quality_gate_core(
         spectral_note = f" (spectral={spectral_br}kbps)" if spectral_br else ""
 
         if decision == "requeue_upgrade":
-            if verified_lossless:
-                logger.info(
-                    f"QUALITY GATE: {label} gate_bitrate < {QUALITY_MIN_BITRATE_KBPS}kbps "
-                    f"but verified_lossless=True — accepting")
-                apply_transition(
-                    db,
-                    request_id,
-                    "imported",
-                    from_status="imported",
-                    min_bitrate=min_br_kbps,
-                )
-                return
             upgrade_override = QUALITY_UPGRADE_TIERS
             apply_transition(db, request_id, "wanted",
                              from_status="imported",

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1085,6 +1085,32 @@ def _is_explicit_label(format_hint: Optional[str]) -> bool:
     return False
 
 
+def comparison_format_hint(
+    *,
+    explicit_format: str | None = None,
+    target_format: str | None = None,
+    verified_lossless_target: str | None = None,
+    converted_count: int = 0,
+    is_transcode: bool = False,
+    native_codec_family: str | None = None,
+) -> str | None:
+    """Format hint to use for the pre-import quality comparison.
+
+    This keeps production import_one.py and the simulator on the same rules:
+    compare the quality of what would actually end up on disk, not just the
+    temporary V0 verification artifact.
+    """
+    if explicit_format is not None:
+        return explicit_format
+    if target_format in ("flac", "lossless"):
+        return "flac"
+    if converted_count > 0 and not is_transcode:
+        return verified_lossless_target or "mp3 v0"
+    if converted_count > 0:
+        return "MP3"
+    return native_codec_family
+
+
 def compare_quality(
     new: AudioQualityMeasurement,
     existing: AudioQualityMeasurement,
@@ -2086,18 +2112,18 @@ def get_decision_tree() -> dict[str, Any]:
                            "existing: AudioQualityMeasurement | None",
                            "is_transcode"],
                 "rules": [
-                    {"condition": "new.verified_lossless = true",
+                    {"condition": "new.verified_lossless = true AND compare_quality(new, existing) in {better,equivalent}",
                      "result": "import", "color": "green",
-                     "effect": "V0 from genuine FLAC always wins"},
-                    {"condition": "new > existing AND is_transcode",
+                     "effect": "verified-lossless imports only when it is not worse"},
+                    {"condition": "compare_quality(new, existing) = better AND is_transcode",
                      "result": "transcode_upgrade", "color": "amber",
                      "effect": "import + denylist + keep searching"},
-                    {"condition": "new > existing AND NOT is_transcode",
+                    {"condition": "compare_quality(new, existing) = better AND NOT is_transcode",
                      "result": "import", "color": "green"},
-                    {"condition": "new <= existing AND is_transcode",
+                    {"condition": "compare_quality(new, existing) in {worse,equivalent} AND is_transcode",
                      "result": "transcode_downgrade", "color": "red",
                      "effect": "reject + denylist"},
-                    {"condition": "new <= existing",
+                    {"condition": "compare_quality(new, existing) in {worse,equivalent}",
                      "result": "downgrade", "color": "red",
                      "effect": "reject"},
                     {"condition": "existing is None AND is_transcode",
@@ -2118,18 +2144,13 @@ def get_decision_tree() -> dict[str, Any]:
                 "when": "After successful beets import",
                 "inputs": ["current: AudioQualityMeasurement"],
                 "rules": [
-                    {"condition": "gate_br = min(container, spectral) only when spectral grade is suspect/likely_transcode",
+                    {"condition": "rank = measurement_rank(current); spectral clamp applies only when spectral grade is suspect/likely_transcode",
                      "result": "(computed)", "color": "green",
-                     "effect": "spectral overrides container if lower and grade is transcode-like"},
-                    {"condition": f"current.verified_lossless AND gate_br < "
-                                  f"{QUALITY_MIN_BITRATE_KBPS}",
-                     "result": f"gate_br = {QUALITY_MIN_BITRATE_KBPS}",
-                     "color": "green",
-                     "effect": "lo-fi pass"},
-                    {"condition": f"gate_br < {QUALITY_MIN_BITRATE_KBPS}kbps",
+                     "effect": "spectral only lowers the rank when the current on-disk file looks transcode-like"},
+                    {"condition": "rank = UNKNOWN OR rank < cfg.gate_min_rank",
                      "result": "requeue_upgrade", "color": "amber",
                      "effect": f"search {QUALITY_UPGRADE_TIERS}"},
-                    {"condition": "current.is_cbr AND NOT current.verified_lossless",
+                    {"condition": "current.is_cbr AND NOT current.verified_lossless AND rank < LOSSLESS",
                      "result": "requeue_lossless", "color": "amber",
                      "effect": "search lossless only"},
                     {"condition": "else",
@@ -2297,13 +2318,13 @@ def full_pipeline_decision(
         import_br = post_conversion_min_bitrate if post_conversion_min_bitrate else min_bitrate
 
         will_be_verified = (converted_count > 0 and not is_transcode)
-        # The V0 label is a CONTRACT for verified lossless conversions only —
-        # a transcoded FLAC→V0 is not actually "mp3 v0" quality, just a V0
-        # container wrapping transcode-grade audio. Fall back to bare codec
-        # classification for transcodes so the rank reflects measured bitrate.
-        stage2_new_format = new_format or (
-            "mp3 v0" if (converted_count > 0 and not is_transcode) else
-            "MP3" if converted_count > 0 else None)
+        stage2_new_format = comparison_format_hint(
+            explicit_format=new_format,
+            verified_lossless_target=(
+                verified_lossless_target if will_be_verified else None),
+            converted_count=converted_count,
+            is_transcode=is_transcode,
+        )
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=import_br,
             avg_bitrate_kbps=import_br,
@@ -2350,12 +2371,10 @@ def full_pipeline_decision(
         # MP3 path: import directly. No format label for native MP3 downloads
         # unless the caller provided one — the rank model falls back to the
         # bare-codec bitrate classification via `new_format=None`.
-        stage2_new_format = new_format
-        if stage2_new_format is None and is_cbr:
-            # Bare-codec bitrate path; compare against existing bare MP3 CBR.
-            stage2_new_format = "MP3"
-        elif stage2_new_format is None:
-            stage2_new_format = "MP3"
+        stage2_new_format = comparison_format_hint(
+            explicit_format=new_format,
+            native_codec_family="MP3",
+        )
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
             avg_bitrate_kbps=min_bitrate,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -876,20 +876,37 @@ class QualityRankConfig:
 
     @classmethod
     def from_json(cls, raw: str) -> "QualityRankConfig":
-        """Inverse of to_json(). Missing keys raise KeyError."""
-        payload = json.loads(raw)
-        return cls(
-            bitrate_metric=RankBitrateMetric(payload["bitrate_metric"]),
-            gate_min_rank=QualityRank(int(payload["gate_min_rank"])),
-            within_rank_tolerance_kbps=int(payload["within_rank_tolerance_kbps"]),
-            opus=CodecRankBands(**payload["opus"]),
-            mp3_vbr=CodecRankBands(**payload["mp3_vbr"]),
-            mp3_cbr=CodecRankBands(**payload["mp3_cbr"]),
-            aac=CodecRankBands(**payload["aac"]),
-            mp3_vbr_levels=tuple(QualityRank(int(r)) for r in payload["mp3_vbr_levels"]),
-            lossless_codecs=frozenset(payload["lossless_codecs"]),
-            mixed_format_precedence=tuple(payload["mixed_format_precedence"]),
-        )
+        """Inverse of to_json().
+
+        Missing keys / invalid enum values raise ValueError with a
+        QualityRankConfig-qualified diagnostic so the harness operator can
+        identify which field corrupted the argv round-trip. Used by
+        harness/import_one.py to deserialize the --quality-rank-config argv
+        blob emitted by dispatch_import_core().
+        """
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"QualityRankConfig.from_json: invalid JSON: {exc}") from exc
+        try:
+            return cls(
+                bitrate_metric=RankBitrateMetric(payload["bitrate_metric"]),
+                gate_min_rank=QualityRank(int(payload["gate_min_rank"])),
+                within_rank_tolerance_kbps=int(payload["within_rank_tolerance_kbps"]),
+                opus=CodecRankBands(**payload["opus"]),
+                mp3_vbr=CodecRankBands(**payload["mp3_vbr"]),
+                mp3_cbr=CodecRankBands(**payload["mp3_cbr"]),
+                aac=CodecRankBands(**payload["aac"]),
+                mp3_vbr_levels=tuple(
+                    QualityRank(int(r)) for r in payload["mp3_vbr_levels"]),
+                lossless_codecs=frozenset(payload["lossless_codecs"]),
+                mixed_format_precedence=tuple(payload["mixed_format_precedence"]),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(
+                f"QualityRankConfig.from_json: failed to reconstruct config: "
+                f"{type(exc).__name__}: {exc}") from exc
 
 
 # Known codec family names produced by _codec_family_of().

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -4,6 +4,7 @@ Pure functions — no database, no filesystem, no external dependencies.
 Used by soularr.py and import_one.py, tested directly against real audio fixtures.
 """
 
+import configparser
 import enum
 import json
 from dataclasses import dataclass, field, asdict
@@ -750,6 +751,145 @@ class QualityRankConfig:
     @classmethod
     def defaults(cls) -> "QualityRankConfig":
         return cls()
+
+    # ------------------------------------------------------------------
+    # [Quality Ranks] config.ini parsing
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_ini(
+        cls,
+        parser: configparser.RawConfigParser,
+        section: str = "Quality Ranks",
+    ) -> "QualityRankConfig":
+        """Parse a [Quality Ranks] section into a QualityRankConfig.
+
+        Every key is optional — missing keys fall back to the field's default
+        value, so users can customize one codec or one band without writing
+        out the entire section.
+
+        Key names (all lowercase, codec-prefixed for bands):
+
+            bitrate_metric            = min | avg
+            gate_min_rank             = unknown|poor|acceptable|good|excellent|transparent|lossless
+            within_rank_tolerance_kbps = <int>
+            <codec>.<band>            = <int>
+              codecs: opus, mp3_vbr, mp3_cbr, aac
+              bands:  transparent, excellent, good, acceptable
+
+        Invalid values raise ValueError at parse time with a diagnostic that
+        names the offending key. Missing section silently returns defaults.
+        """
+        base = cls.defaults()
+        if not parser.has_section(section):
+            return base
+
+        def _get_str(key: str, default: str) -> str:
+            raw = parser.get(section, key, fallback=None)
+            if raw is None or raw.strip() == "":
+                return default
+            return raw.strip()
+
+        def _get_int(key: str, default: int) -> int:
+            raw = parser.get(section, key, fallback=None)
+            if raw is None or raw.strip() == "":
+                return default
+            try:
+                return int(raw.strip())
+            except ValueError as exc:
+                raise ValueError(
+                    f"[{section}] {key}: expected integer, got {raw!r}") from exc
+
+        # --- Policy ---
+        metric_str = _get_str("bitrate_metric", base.bitrate_metric.value).lower()
+        try:
+            metric = RankBitrateMetric(metric_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"[{section}] bitrate_metric: expected one of "
+                f"{[m.value for m in RankBitrateMetric]}, got {metric_str!r}"
+            ) from exc
+
+        rank_str = _get_str("gate_min_rank", base.gate_min_rank.name.lower()).lower()
+        if rank_str not in _RANK_NAME_TO_VALUE:
+            raise ValueError(
+                f"[{section}] gate_min_rank: expected one of "
+                f"{sorted(_RANK_NAME_TO_VALUE.keys())}, got {rank_str!r}")
+        gate_min_rank = _RANK_NAME_TO_VALUE[rank_str]
+
+        tolerance = _get_int("within_rank_tolerance_kbps", base.within_rank_tolerance_kbps)
+        if tolerance < 0:
+            raise ValueError(
+                f"[{section}] within_rank_tolerance_kbps: must be >= 0, got {tolerance}")
+
+        # --- Codec bands ---
+        def _get_bands(codec: str, default: CodecRankBands) -> CodecRankBands:
+            return CodecRankBands(
+                transparent=_get_int(f"{codec}.transparent", default.transparent),
+                excellent=_get_int(f"{codec}.excellent", default.excellent),
+                good=_get_int(f"{codec}.good", default.good),
+                acceptable=_get_int(f"{codec}.acceptable", default.acceptable),
+            )
+
+        try:
+            opus = _get_bands("opus", base.opus)
+            mp3_vbr = _get_bands("mp3_vbr", base.mp3_vbr)
+            mp3_cbr = _get_bands("mp3_cbr", base.mp3_cbr)
+            aac = _get_bands("aac", base.aac)
+        except ValueError as exc:
+            # CodecRankBands.__post_init__ raises on non-monotonic; re-wrap
+            # with section context.
+            raise ValueError(f"[{section}] invalid codec bands: {exc}") from exc
+
+        return cls(
+            bitrate_metric=metric,
+            gate_min_rank=gate_min_rank,
+            within_rank_tolerance_kbps=tolerance,
+            opus=opus,
+            mp3_vbr=mp3_vbr,
+            mp3_cbr=mp3_cbr,
+            aac=aac,
+            mp3_vbr_levels=base.mp3_vbr_levels,
+            lossless_codecs=base.lossless_codecs,
+            mixed_format_precedence=base.mixed_format_precedence,
+        )
+
+    # ------------------------------------------------------------------
+    # JSON round-trip (used by the import_one.py argv protocol)
+    # ------------------------------------------------------------------
+
+    def to_json(self) -> str:
+        """Serialize to JSON for the --quality-rank-config harness argv."""
+        payload: dict[str, Any] = {
+            "bitrate_metric": self.bitrate_metric.value,
+            "gate_min_rank": int(self.gate_min_rank),
+            "within_rank_tolerance_kbps": self.within_rank_tolerance_kbps,
+            "opus": asdict(self.opus),
+            "mp3_vbr": asdict(self.mp3_vbr),
+            "mp3_cbr": asdict(self.mp3_cbr),
+            "aac": asdict(self.aac),
+            "mp3_vbr_levels": [int(r) for r in self.mp3_vbr_levels],
+            "lossless_codecs": sorted(self.lossless_codecs),
+            "mixed_format_precedence": list(self.mixed_format_precedence),
+        }
+        return json.dumps(payload, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "QualityRankConfig":
+        """Inverse of to_json(). Missing keys raise KeyError."""
+        payload = json.loads(raw)
+        return cls(
+            bitrate_metric=RankBitrateMetric(payload["bitrate_metric"]),
+            gate_min_rank=QualityRank(int(payload["gate_min_rank"])),
+            within_rank_tolerance_kbps=int(payload["within_rank_tolerance_kbps"]),
+            opus=CodecRankBands(**payload["opus"]),
+            mp3_vbr=CodecRankBands(**payload["mp3_vbr"]),
+            mp3_cbr=CodecRankBands(**payload["mp3_cbr"]),
+            aac=CodecRankBands(**payload["aac"]),
+            mp3_vbr_levels=tuple(QualityRank(int(r)) for r in payload["mp3_vbr_levels"]),
+            lossless_codecs=frozenset(payload["lossless_codecs"]),
+            mixed_format_precedence=tuple(payload["mixed_format_precedence"]),
+        )
 
 
 # Known codec family names produced by _codec_family_of().

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -7,7 +7,8 @@ Used by soularr.py and import_one.py, tested directly against real audio fixture
 import enum
 import json
 from dataclasses import dataclass, field, asdict
-from typing import Any, Optional
+from enum import IntEnum, StrEnum
+from typing import Any, Literal, Optional
 
 QUALITY_UPGRADE_TIERS = "lossless,mp3 v0,mp3 320"
 QUALITY_LOSSLESS = "lossless"
@@ -564,7 +565,18 @@ class AudioQualityMeasurement:
     outcomes.
 
     Fields:
-        min_bitrate_kbps:      min track bitrate (kbps), None if unmeasurable
+        min_bitrate_kbps:      min per-track bitrate (kbps), None if unmeasurable
+        avg_bitrate_kbps:      mean per-track bitrate (kbps), None if unmeasured.
+                               Preferred by the rank model for VBR codecs — see
+                               RankBitrateMetric and measurement_rank(). Additive;
+                               legacy callers that only populate min_bitrate_kbps
+                               still work (measurement_rank() falls back to min).
+        format:                codec label or bare codec name that drives the
+                               quality_rank() classifier. Accepts either an
+                               explicit label from ImportResult.final_format
+                               ("opus 128", "mp3 v0", "mp3 320", "flac") or a
+                               bare codec string from beets items.format ("MP3",
+                               "Opus", "FLAC", "AAC"). None → UNKNOWN rank.
         is_cbr:                True if all tracks have the same bitrate
         spectral_grade:        spectral analysis result (genuine/marginal/suspect)
         spectral_bitrate_kbps: estimated original bitrate from spectral cliff
@@ -572,11 +584,400 @@ class AudioQualityMeasurement:
         was_converted_from:    source format before conversion (flac/m4a/wav), None if MP3
     """
     min_bitrate_kbps: Optional[int] = None
+    avg_bitrate_kbps: Optional[int] = None
+    format: Optional[str] = None
     is_cbr: bool = False
     spectral_grade: Optional[str] = None
     spectral_bitrate_kbps: Optional[int] = None
     verified_lossless: bool = False
     was_converted_from: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Codec-aware quality rank model (issue #60)
+# ---------------------------------------------------------------------------
+#
+# The pipeline needs to compare audio quality across codecs (Opus 128 ≈ MP3 V0)
+# and apply a tier floor when verified_lossless targets would otherwise bypass
+# all guardrails (e.g. a FLAC → Opus 64 target replacing a genuine MP3 V0).
+#
+# Every numeric threshold, codec set, and policy knob lives in QualityRankConfig.
+# Grep the decision path for a bare kbps value and you should find zero hits
+# outside log strings — everything routes through cfg.quality_ranks.<field>.
+#
+# Spectral cliff detection and transcode_detection() continue to use min
+# bitrate regardless of QualityRankConfig.bitrate_metric — those care about
+# the worst track, not the album average. Rank classification is different
+# because a single quiet track in a legitimately encoded VBR album should not
+# drag the whole album down a rank.
+
+
+class RankBitrateMetric(StrEnum):
+    """Which per-album bitrate statistic feeds into quality_rank() classification.
+
+    MIN  — minimum per-track bitrate. Legacy behavior. Conservative and prone to
+           VBR false negatives on albums with genuinely quiet tracks.
+    AVG  — album-mean per-track bitrate. Recommended for VBR codecs. Default.
+
+    measurement_rank() is the only function that dispatches on this enum — adding
+    MEDIAN later means one new enum value, one elif branch in measurement_rank(),
+    and one new field on AudioQualityMeasurement / AlbumInfo.
+    """
+    MIN = "min"
+    AVG = "avg"
+
+
+class QualityRank(IntEnum):
+    """Perceptual quality bands. IntEnum so > / >= comparisons work naturally.
+
+    Integer spacing leaves room for inserting new bands without reshuffling.
+    Nothing persists the integer value — rank is always recomputed from a
+    measurement + config, so a future insertion is safe.
+    """
+    UNKNOWN     = 0
+    POOR        = 20
+    ACCEPTABLE  = 30
+    GOOD        = 40
+    EXCELLENT   = 50
+    TRANSPARENT = 60
+    LOSSLESS    = 100
+
+
+_RANK_NAME_TO_VALUE: dict[str, QualityRank] = {
+    "unknown":     QualityRank.UNKNOWN,
+    "poor":        QualityRank.POOR,
+    "acceptable":  QualityRank.ACCEPTABLE,
+    "good":        QualityRank.GOOD,
+    "excellent":   QualityRank.EXCELLENT,
+    "transparent": QualityRank.TRANSPARENT,
+    "lossless":    QualityRank.LOSSLESS,
+}
+
+
+@dataclass(frozen=True)
+class CodecRankBands:
+    """Bitrate thresholds (kbps) for a single codec family.
+
+    A measurement's rank is the highest band whose threshold the configured
+    metric meets or exceeds. Thresholds must be monotonically non-increasing:
+    transparent >= excellent >= good >= acceptable >= 0.
+    Values below ``acceptable`` are classified POOR.
+    """
+    transparent: int
+    excellent: int
+    good: int
+    acceptable: int
+
+    def __post_init__(self) -> None:
+        if not (self.transparent >= self.excellent >= self.good
+                >= self.acceptable >= 0):
+            raise ValueError(
+                f"CodecRankBands must be monotonic "
+                f"(transparent >= excellent >= good >= acceptable >= 0): {self}")
+
+    def rank_for(self, bitrate_kbps: Optional[int]) -> QualityRank:
+        """Classify a bitrate against this codec's band table."""
+        if bitrate_kbps is None:
+            return QualityRank.UNKNOWN
+        if bitrate_kbps >= self.transparent:
+            return QualityRank.TRANSPARENT
+        if bitrate_kbps >= self.excellent:
+            return QualityRank.EXCELLENT
+        if bitrate_kbps >= self.good:
+            return QualityRank.GOOD
+        if bitrate_kbps >= self.acceptable:
+            return QualityRank.ACCEPTABLE
+        return QualityRank.POOR
+
+
+@dataclass(frozen=True)
+class QualityRankConfig:
+    """Every knob for the codec-aware rank model.
+
+    This is the ONLY place numeric quality thresholds live. If you grep the
+    rank decision path for a hardcoded kbps value you should find zero hits
+    outside log strings — everything routes through cfg.quality_ranks.<field>.
+
+    Defaults are documented in docs/quality-ranks.md. Summary:
+
+    - Opus ``transparent=112``: ``ffmpeg -b:a 128k`` unconstrained VBR averages
+      120-135 kbps on typical music; 112 leaves headroom for sparse material.
+      ``excellent=88`` matches Opus 96 quality (hydrogenaudio/Kamedo2 4.65/5).
+    - MP3 VBR ``transparent=210``: matches the legacy
+      ``QUALITY_MIN_BITRATE_KBPS`` constant; V2 averages ~190 → excellent at 170.
+    - MP3 CBR ``transparent=320``: unverifiable CBR is only transparent at 320.
+    - AAC ``transparent=192``: hydrogenaudio consensus ceiling for music.
+    """
+    # --- Policy ---
+    bitrate_metric: RankBitrateMetric = RankBitrateMetric.AVG
+    gate_min_rank: QualityRank = QualityRank.EXCELLENT
+    within_rank_tolerance_kbps: int = 5
+
+    # --- Per-codec band tables ---
+    opus:    CodecRankBands = field(default_factory=lambda: CodecRankBands(
+        transparent=112, excellent=88, good=64, acceptable=48))
+    mp3_vbr: CodecRankBands = field(default_factory=lambda: CodecRankBands(
+        transparent=210, excellent=170, good=130, acceptable=90))
+    mp3_cbr: CodecRankBands = field(default_factory=lambda: CodecRankBands(
+        transparent=320, excellent=256, good=192, acceptable=128))
+    aac:     CodecRankBands = field(default_factory=lambda: CodecRankBands(
+        transparent=192, excellent=144, good=112, acceptable=80))
+
+    # --- LAME VBR V-level → rank (10-tuple indexed by V0..V9) ---
+    # V-level semantics are a LAME encoder contract, but surfacing them here
+    # keeps the entire policy in one dataclass per the no-magic-numbers rule.
+    mp3_vbr_levels: tuple[QualityRank, ...] = (
+        QualityRank.TRANSPARENT,  # V0
+        QualityRank.EXCELLENT,    # V1
+        QualityRank.EXCELLENT,    # V2
+        QualityRank.GOOD,         # V3
+        QualityRank.GOOD,         # V4
+        QualityRank.ACCEPTABLE,   # V5
+        QualityRank.ACCEPTABLE,   # V6
+        QualityRank.ACCEPTABLE,   # V7
+        QualityRank.ACCEPTABLE,   # V8
+        QualityRank.ACCEPTABLE,   # V9
+    )
+
+    # --- Lossless codec identity ---
+    lossless_codecs: frozenset[str] = frozenset({"flac", "lossless", "alac", "wav"})
+
+    # --- Mixed-format album precedence (worst codec wins for classification) ---
+    # When an album has multiple formats on disk (rare), pick the lowest-rank
+    # codec as the album's "canonical" codec so the rank stays conservative.
+    mixed_format_precedence: tuple[str, ...] = ("mp3", "aac", "opus", "flac")
+
+    @classmethod
+    def defaults(cls) -> "QualityRankConfig":
+        return cls()
+
+
+# Known codec family names produced by _codec_family_of().
+_KNOWN_CODEC_FAMILIES: frozenset[str] = frozenset(
+    {"opus", "mp3", "aac", "flac", "alac", "wav", "lossless", "unknown"})
+
+
+def _codec_family_of(format_hint: Optional[str]) -> str:
+    """First token of format, lowercased — "opus 128" → "opus", "MP3" → "mp3"."""
+    if format_hint is None:
+        return "unknown"
+    first = format_hint.strip().lower().split(None, 1)
+    if not first or not first[0]:
+        return "unknown"
+    token = first[0]
+    if token in _KNOWN_CODEC_FAMILIES:
+        return token
+    return "unknown"
+
+
+def _parse_vbr_level(format_hint: str) -> Optional[int]:
+    """Parse V-level from a label like "mp3 v0" / "mp3 v9". Returns None otherwise."""
+    parts = format_hint.strip().lower().split()
+    if len(parts) < 2 or parts[0] != "mp3":
+        return None
+    quality = parts[1]
+    if len(quality) >= 2 and quality[0] == "v" and quality[1:].isdigit():
+        level = int(quality[1:])
+        if 0 <= level <= 9:
+            return level
+    return None
+
+
+def _parse_bitrate_label(format_hint: str) -> Optional[int]:
+    """Parse a numeric bitrate from a label like "opus 128" / "mp3 320"."""
+    parts = format_hint.strip().lower().split()
+    if len(parts) < 2:
+        return None
+    quality = parts[1]
+    if quality.isdigit():
+        return int(quality)
+    return None
+
+
+def quality_rank(
+    format_hint: Optional[str],
+    bitrate_kbps: Optional[int],
+    is_cbr: bool,
+    cfg: QualityRankConfig,
+) -> QualityRank:
+    """Classify a measurement into a QualityRank (pure, no I/O).
+
+    Args:
+        format_hint: Either a label like "opus 128" / "mp3 v0" / "mp3 320" /
+            "flac" (from ImportResult.final_format / album_requests.final_format)
+            OR a bare codec string like "MP3" / "Opus" / "FLAC" / "AAC" (from
+            beets items.format). None → UNKNOWN.
+        bitrate_kbps: The bitrate value to classify. The caller has already
+            selected this value per cfg.bitrate_metric — this function does
+            NOT dispatch on the metric. Use measurement_rank() as the entry
+            point for measurements.
+        is_cbr: True if all tracks share the same bitrate. Affects MP3 family
+            routing (VBR vs CBR bands).
+        cfg: Rank bands and policy.
+
+    Resolution order:
+        1. format_hint is None and bitrate_kbps is None → UNKNOWN.
+        2. First token of format_hint in cfg.lossless_codecs → LOSSLESS.
+        3. Explicit VBR label ("mp3 v0"): index into cfg.mp3_vbr_levels.
+           Label is self-certifying — bitrate is irrelevant here.
+        4. Explicit bitrate label ("opus 128"): classify declared bitrate
+           against the matching codec's CodecRankBands. The label is a
+           contract — we converted to this target, so the declaration wins
+           over any measured bitrate.
+        5. Bare codec name ("MP3" / "Opus" / "AAC"): classify the measured
+           bitrate_kbps against the matching band table. "MP3" + is_cbr=True
+           → cfg.mp3_cbr, otherwise cfg.mp3_vbr. Opus and AAC always use
+           their own VBR-ish bands.
+        6. Unknown codec → UNKNOWN (never promote garbage).
+    """
+    if format_hint is None and bitrate_kbps is None:
+        return QualityRank.UNKNOWN
+
+    family = _codec_family_of(format_hint)
+
+    # Step 2 — lossless
+    if family in cfg.lossless_codecs:
+        return QualityRank.LOSSLESS
+
+    # Step 3 — explicit VBR V-level label
+    if format_hint is not None:
+        vbr_level = _parse_vbr_level(format_hint)
+        if vbr_level is not None:
+            return cfg.mp3_vbr_levels[vbr_level]
+
+    # Step 4 — explicit bitrate label ("opus 128" / "mp3 320" / "aac 192")
+    if format_hint is not None:
+        declared = _parse_bitrate_label(format_hint)
+        if declared is not None:
+            if family == "opus":
+                return cfg.opus.rank_for(declared)
+            if family == "mp3":
+                # A "mp3 320"-style label is by convention CBR.
+                return cfg.mp3_cbr.rank_for(declared)
+            if family == "aac":
+                return cfg.aac.rank_for(declared)
+            return QualityRank.UNKNOWN
+
+    # Step 5 — bare codec name + measured bitrate
+    if family == "opus":
+        return cfg.opus.rank_for(bitrate_kbps)
+    if family == "aac":
+        return cfg.aac.rank_for(bitrate_kbps)
+    if family == "mp3":
+        if is_cbr:
+            return cfg.mp3_cbr.rank_for(bitrate_kbps)
+        return cfg.mp3_vbr.rank_for(bitrate_kbps)
+
+    # Step 6 — unknown codec, refuse to promote
+    return QualityRank.UNKNOWN
+
+
+def measurement_rank(
+    m: AudioQualityMeasurement,
+    cfg: QualityRankConfig,
+) -> QualityRank:
+    """Pick the configured bitrate metric from m and classify it.
+
+    This is the ONLY function that dispatches on cfg.bitrate_metric.
+    Adding MEDIAN later is a one-line change here + one new field on
+    AudioQualityMeasurement / AlbumInfo.
+
+    Falls back to min_bitrate_kbps when the configured metric's value is
+    None — so legacy measurements (which only populate min) continue to
+    classify correctly under the default AVG policy.
+    """
+    chosen: Optional[int]
+    if cfg.bitrate_metric is RankBitrateMetric.AVG and m.avg_bitrate_kbps is not None:
+        chosen = m.avg_bitrate_kbps
+    else:
+        chosen = m.min_bitrate_kbps
+    return quality_rank(m.format, chosen, m.is_cbr, cfg)
+
+
+def _selected_bitrate(m: AudioQualityMeasurement,
+                      cfg: QualityRankConfig) -> Optional[int]:
+    """Return the bitrate value measurement_rank() would classify for m.
+
+    Used by compare_quality() for the same-rank, same-codec tiebreaker.
+    Keeps the metric dispatch in one place — compare_quality does not
+    peek into m.avg / m.min directly.
+    """
+    if cfg.bitrate_metric is RankBitrateMetric.AVG and m.avg_bitrate_kbps is not None:
+        return m.avg_bitrate_kbps
+    return m.min_bitrate_kbps
+
+
+def _is_explicit_label(format_hint: Optional[str]) -> bool:
+    """True if format_hint carries an explicit quality contract (VBR or bitrate).
+
+    "mp3 v0" / "opus 128" / "mp3 320" are contracts. "MP3" / "Opus" / "FLAC"
+    are bare codec names from beets items.format. Within the same rank tier,
+    a contract + anything is equivalent — only bare-vs-bare compares on bitrate.
+    """
+    if format_hint is None:
+        return False
+    if _parse_vbr_level(format_hint) is not None:
+        return True
+    if _parse_bitrate_label(format_hint) is not None:
+        return True
+    return False
+
+
+def compare_quality(
+    new: AudioQualityMeasurement,
+    existing: AudioQualityMeasurement,
+    cfg: QualityRankConfig,
+) -> Literal["better", "worse", "equivalent"]:
+    """Codec-aware quality comparison.
+
+    Primary key is the QualityRank. Within the same rank:
+    - LOSSLESS → always "equivalent" (bitrate variance has no quality meaning).
+    - Different codec families → "equivalent" (Opus 128 vs MP3 V0 are
+      perceptually indistinguishable at the TRANSPARENT band).
+    - Same codec family, either side carries an explicit label ("mp3 v0" /
+      "opus 128" / "mp3 320") → "equivalent". Labels are quality contracts
+      and within the same rank tier are perceptually equivalent regardless of
+      bitrate deltas (a 207 kbps V0 on lo-fi and a 245 kbps V0 on dense material
+      are both TRANSPARENT — this is the lo-fi genuine V0 case).
+    - Same codec family, both bare codec names → compare the configured metric
+      with cfg.within_rank_tolerance_kbps tolerance.
+
+    Pure function. No I/O, no hardcoded numbers — every threshold comes from cfg.
+    """
+    new_rank = measurement_rank(new, cfg)
+    existing_rank = measurement_rank(existing, cfg)
+
+    if new_rank > existing_rank:
+        return "better"
+    if new_rank < existing_rank:
+        return "worse"
+
+    # Same rank. LOSSLESS is always equivalent — FLAC bitrates vary with sample
+    # rate and bit depth, not quality.
+    if new_rank == QualityRank.LOSSLESS:
+        return "equivalent"
+
+    new_family = _codec_family_of(new.format)
+    existing_family = _codec_family_of(existing.format)
+
+    # Different codec families at the same rank: perceptually equivalent.
+    if new_family != existing_family:
+        return "equivalent"
+
+    # Same codec family. If either side has an explicit label, the label is
+    # authoritative — within the same rank tier they are equivalent.
+    if _is_explicit_label(new.format) or _is_explicit_label(existing.format):
+        return "equivalent"
+
+    # Both bare codec names — compare the chosen metric with tolerance.
+    new_br = _selected_bitrate(new, cfg)
+    existing_br = _selected_bitrate(existing, cfg)
+    if new_br is None or existing_br is None:
+        return "equivalent"
+    delta = new_br - existing_br
+    if abs(delta) <= cfg.within_rank_tolerance_kbps:
+        return "equivalent"
+    return "better" if delta > 0 else "worse"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -715,10 +715,15 @@ class QualityRankConfig:
     within_rank_tolerance_kbps: int = 5
 
     # --- Per-codec band tables ---
+    # Defaults are tuned to preserve the legacy 210 kbps gate threshold for
+    # bare-codec MP3 VBR measurements (old QUALITY_MIN_BITRATE_KBPS) while
+    # adding perceptual tiers above and below. Explicit labels like "mp3 v0"
+    # / "opus 128" bypass the band tables via the V-level / declared-bitrate
+    # resolution steps — those classify by contract.
     opus:    CodecRankBands = field(default_factory=lambda: CodecRankBands(
         transparent=112, excellent=88, good=64, acceptable=48))
     mp3_vbr: CodecRankBands = field(default_factory=lambda: CodecRankBands(
-        transparent=210, excellent=170, good=130, acceptable=90))
+        transparent=245, excellent=210, good=170, acceptable=130))
     mp3_cbr: CodecRankBands = field(default_factory=lambda: CodecRankBands(
         transparent=320, excellent=256, good=192, acceptable=128))
     aac:     CodecRankBands = field(default_factory=lambda: CodecRankBands(
@@ -1365,13 +1370,26 @@ def spectral_import_decision(spectral_grade, spectral_bitrate, existing_spectral
 # import_one.py decisions (FLAC conversion path)
 # ---------------------------------------------------------------------------
 
-def import_quality_decision(new: AudioQualityMeasurement,
-                            existing: "AudioQualityMeasurement | None",
-                            is_transcode: bool = False) -> str:
-    """Decide whether to import based on bitrate comparison.
+def import_quality_decision(
+    new: AudioQualityMeasurement,
+    existing: "AudioQualityMeasurement | None",
+    is_transcode: bool = False,
+    cfg: "QualityRankConfig | None" = None,
+) -> str:
+    """Decide whether to import based on codec-aware quality comparison (issue #60).
 
     Called in import_one.py after FLAC→V0 conversion (if applicable)
     and before running the beets harness.
+
+    Uses compare_quality() which classifies both measurements into
+    QualityRank bands (via quality_rank/measurement_rank), so cross-codec
+    comparisons (Opus 128 vs MP3 V0) are correctly treated as equivalent.
+
+    The verified_lossless bypass is now a tier-gated preference:
+    ``verified_lossless=True`` still forces an import when the verdict is
+    "better" or "equivalent", but NOT when it would be a downgrade — this
+    blocks a deliberately too-low ``verified_lossless_target`` (e.g. Opus
+    64) from replacing a good existing album.
 
     Returns one of:
         "import"              — new files are better (or no existing), proceed
@@ -1380,32 +1398,33 @@ def import_quality_decision(new: AudioQualityMeasurement,
         "transcode_downgrade" — transcode and not better, skip + denylist (exit 6)
         "transcode_first"     — transcode but nothing on disk yet, import (exit 6)
 
-    Inputs:
-        new:           measurement of the new download
-        existing:      measurement of what's already in beets, or None
-                       (caller resolves override_min_bitrate into existing.min_bitrate_kbps)
-        is_transcode:  True if FLAC→V0 produced a transcode (from transcode_detection)
+    Args:
+        new: measurement of the new download
+        existing: measurement of what's already in beets, or None
+                  (caller resolves override_min_bitrate into existing.min_bitrate_kbps)
+        is_transcode: True if FLAC→V0 produced a transcode (from transcode_detection)
+        cfg: QualityRankConfig. Defaults to QualityRankConfig.defaults().
     """
-    # Genuine FLAC→V0 always wins — V0 bitrate is numerically lower than
-    # CBR 320 but objectively better quality (verified lossless source).
-    if new.verified_lossless:
-        return "import"
+    if cfg is None:
+        cfg = QualityRankConfig.defaults()
 
-    existing_br = existing.min_bitrate_kbps if existing is not None else None
+    if existing is None:
+        return "transcode_first" if is_transcode else "import"
 
-    if existing_br is not None and new.min_bitrate_kbps is not None:
-        if new.min_bitrate_kbps <= existing_br:
-            if is_transcode:
-                return "transcode_downgrade"
-            return "downgrade"
-        else:
-            if is_transcode:
-                return "transcode_upgrade"
-            return "import"
-    elif existing is None and is_transcode:
-        return "transcode_first"
-    else:
-        return "import"
+    verdict = compare_quality(new, existing, cfg)
+
+    # verified_lossless is a soft preference: "better" or "equivalent" still
+    # import, but "worse" is blocked regardless of verified_lossless status.
+    # This prevents a deliberately too-low verified-lossless target from
+    # blindly replacing a good existing album (issue #60 acceptance criterion).
+    if new.verified_lossless and verdict in ("better", "equivalent"):
+        return "transcode_upgrade" if is_transcode else "import"
+
+    if verdict == "better":
+        return "transcode_upgrade" if is_transcode else "import"
+
+    # "worse" or "equivalent" without verified_lossless bypass → reject.
+    return "transcode_downgrade" if is_transcode else "downgrade"
 
 
 def transcode_detection(converted_count, post_conversion_min_bitrate,
@@ -1484,32 +1503,45 @@ def is_verified_lossless(was_converted: bool, original_filetype: Optional[str],
 # Post-import quality gate (runs after successful import in soularr.py)
 # ---------------------------------------------------------------------------
 
-def quality_gate_decision(current: AudioQualityMeasurement) -> str:
-    """Pure decision logic for the post-import quality gate.
+def quality_gate_decision(
+    current: AudioQualityMeasurement,
+    cfg: "QualityRankConfig | None" = None,
+) -> str:
+    """Codec-aware post-import quality gate (issue #60).
+
+    Classifies ``current`` into a QualityRank via measurement_rank() and
+    compares against ``cfg.gate_min_rank``. Spectral bitrate can clamp the
+    rank down (catches fake 320s) by classifying the spectral estimate with
+    the MP3 VBR band table.
 
     Returns one of: "accept", "requeue_upgrade", "requeue_lossless".
 
-    Input:
+    Args:
         current: measurement of the files now on disk (from beets DB + spectral)
+        cfg: QualityRankConfig. Defaults to QualityRankConfig.defaults().
     """
-    gate_br = current.min_bitrate_kbps
-    if gate_br is None:
+    if cfg is None:
+        cfg = QualityRankConfig.defaults()
+
+    rank = measurement_rank(current, cfg)
+
+    # Spectral clamp: when the current measurement carries a spectral
+    # estimate (set upstream only when the grade is suspect/likely_transcode
+    # — see _check_quality_gate_core()), classify that estimate against the
+    # MP3 VBR band table and take the lower rank. This catches fake 320s
+    # and legacy low-spectral transcodes.
+    if current.spectral_bitrate_kbps is not None:
+        spectral_rank = quality_rank(
+            "mp3", current.spectral_bitrate_kbps, is_cbr=False, cfg=cfg)
+        if spectral_rank < rank:
+            rank = spectral_rank
+
+    if rank == QualityRank.UNKNOWN or rank < cfg.gate_min_rank:
         return "requeue_upgrade"
-
-    # Spectral bitrate overrides if lower (catches fake 320s)
-    if current.spectral_bitrate_kbps is not None and current.spectral_bitrate_kbps < gate_br:
-        gate_br = current.spectral_bitrate_kbps
-
-    # Verified lossless overrides low bitrate (quiet/simple music is fine)
-    if current.verified_lossless and gate_br < QUALITY_MIN_BITRATE_KBPS:
-        gate_br = QUALITY_MIN_BITRATE_KBPS  # force pass
-
-    if gate_br < QUALITY_MIN_BITRATE_KBPS:
-        return "requeue_upgrade"
-    elif not current.verified_lossless and current.is_cbr:
+    if (not current.verified_lossless and current.is_cbr
+            and rank < QualityRank.LOSSLESS):
         return "requeue_lossless"
-    else:
-        return "accept"
+    return "accept"
 
 
 # ---------------------------------------------------------------------------
@@ -2155,6 +2187,8 @@ def full_pipeline_decision(
     existing_min_bitrate=None,
     existing_spectral_bitrate=None,
     override_min_bitrate=None,
+    existing_format: str | None = None,
+    existing_is_cbr: bool = False,
     # Post-conversion (FLAC path only)
     post_conversion_min_bitrate=None,
     converted_count=0,
@@ -2164,11 +2198,20 @@ def full_pipeline_decision(
     verified_lossless_target=None,
     # Target format (user intent — "flac" skips conversion)
     target_format=None,
+    # New download format label (codec-aware, passed through to measurements)
+    new_format: str | None = None,
+    # Rank-model config (defaults() for legacy callers)
+    cfg: "QualityRankConfig | None" = None,
 ):
     """Run the full decision chain and return the final outcome.
 
     This simulates what happens when a download completes and flows through
     process_completed_album → import_one.py → _check_quality_gate.
+
+    Codec-aware: when ``new_format`` / ``existing_format`` are supplied, the
+    simulator classifies both measurements via quality_rank() — matching
+    production dispatch behavior. Legacy callers that omit them still get
+    sensible defaults derived from ``is_flac``/``target_format``/``is_cbr``.
 
     Returns a dict:
         {
@@ -2181,6 +2224,8 @@ def full_pipeline_decision(
             "keep_searching": bool,     # whether the system keeps looking for better
         }
     """
+    if cfg is None:
+        cfg = QualityRankConfig.defaults()
     result = {
         "stage1_spectral": None,
         "stage2_import": None,
@@ -2206,19 +2251,31 @@ def full_pipeline_decision(
             return result
 
     # --- Stage 2: Import decision ---
+    # Existing measurement — carries format if the caller provided one,
+    # otherwise defaults to "MP3" so legacy simulator scenarios (which only
+    # carry a min_bitrate) still classify against the MP3 VBR/CBR band
+    # tables. Production always provides a real format via BeetsDB.
+    effective_existing_format = existing_format if existing_format is not None else "MP3"
     existing_m = (AudioQualityMeasurement(
                       min_bitrate_kbps=override_min_bitrate
                       if override_min_bitrate is not None
-                      else existing_min_bitrate)
+                      else existing_min_bitrate,
+                      avg_bitrate_kbps=override_min_bitrate
+                      if override_min_bitrate is not None
+                      else existing_min_bitrate,
+                      format=effective_existing_format,
+                      is_cbr=existing_is_cbr)
                   if existing_min_bitrate is not None else None)
 
     if is_flac and target_format in ("flac", "lossless"):
-        # FLAC kept on disk (no conversion) — use raw FLAC bitrate.
-        # Don't set verified_lossless on new_m for comparison — that would
-        # auto-win over existing FLAC at the same bitrate. Use plain bitrate
-        # comparison. verified_lossless is set on the album after import.
-        new_m = AudioQualityMeasurement(min_bitrate_kbps=min_bitrate)
-        result["stage2_import"] = import_quality_decision(new_m, existing_m)
+        # FLAC kept on disk (no conversion).
+        stage2_new_format = new_format or "flac"
+        new_m = AudioQualityMeasurement(
+            min_bitrate_kbps=min_bitrate,
+            avg_bitrate_kbps=min_bitrate,
+            format=stage2_new_format)
+        result["stage2_import"] = import_quality_decision(
+            new_m, existing_m, cfg=cfg)
 
         if result["stage2_import"] == "downgrade":
             result["final_status"] = "imported"
@@ -2232,6 +2289,7 @@ def full_pipeline_decision(
 
         gate_bitrate = min_bitrate
         gate_cbr = False
+        gate_format = stage2_new_format  # "flac"
     elif is_flac:
         # FLAC path: convert first, then decide
         is_transcode = transcode_detection(converted_count, post_conversion_min_bitrate,
@@ -2239,10 +2297,20 @@ def full_pipeline_decision(
         import_br = post_conversion_min_bitrate if post_conversion_min_bitrate else min_bitrate
 
         will_be_verified = (converted_count > 0 and not is_transcode)
-        new_m = AudioQualityMeasurement(min_bitrate_kbps=import_br,
-                                        verified_lossless=will_be_verified)
+        # The V0 label is a CONTRACT for verified lossless conversions only —
+        # a transcoded FLAC→V0 is not actually "mp3 v0" quality, just a V0
+        # container wrapping transcode-grade audio. Fall back to bare codec
+        # classification for transcodes so the rank reflects measured bitrate.
+        stage2_new_format = new_format or (
+            "mp3 v0" if (converted_count > 0 and not is_transcode) else
+            "MP3" if converted_count > 0 else None)
+        new_m = AudioQualityMeasurement(
+            min_bitrate_kbps=import_br,
+            avg_bitrate_kbps=import_br,
+            format=stage2_new_format,
+            verified_lossless=will_be_verified)
         result["stage2_import"] = import_quality_decision(
-            new_m, existing_m, is_transcode)
+            new_m, existing_m, is_transcode, cfg=cfg)
 
         if result["stage2_import"] == "downgrade":
             result["final_status"] = "imported"  # keeps existing
@@ -2266,17 +2334,35 @@ def full_pipeline_decision(
                 spectral_grade in ("genuine", "marginal", None)):
             verified_lossless = True
 
-        # Target format conversion: if verified lossless + target configured
+        # Target format conversion: if verified lossless + target configured,
+        # use the target label for the quality gate (e.g. "opus 128") so the
+        # rank model classifies against the actual on-disk contract.
         if verified_lossless and verified_lossless_target:
             result["target_final_format"] = verified_lossless_target
+            gate_format = verified_lossless_target
+        else:
+            gate_format = stage2_new_format
 
         # Use post-conversion bitrate for quality gate
         gate_bitrate = post_conversion_min_bitrate or min_bitrate
         gate_cbr = False  # V0 conversion always produces VBR
     else:
-        # MP3 path: import directly
-        new_m = AudioQualityMeasurement(min_bitrate_kbps=min_bitrate)
-        result["stage2_import"] = import_quality_decision(new_m, existing_m)
+        # MP3 path: import directly. No format label for native MP3 downloads
+        # unless the caller provided one — the rank model falls back to the
+        # bare-codec bitrate classification via `new_format=None`.
+        stage2_new_format = new_format
+        if stage2_new_format is None and is_cbr:
+            # Bare-codec bitrate path; compare against existing bare MP3 CBR.
+            stage2_new_format = "MP3"
+        elif stage2_new_format is None:
+            stage2_new_format = "MP3"
+        new_m = AudioQualityMeasurement(
+            min_bitrate_kbps=min_bitrate,
+            avg_bitrate_kbps=min_bitrate,
+            format=stage2_new_format,
+            is_cbr=is_cbr)
+        result["stage2_import"] = import_quality_decision(
+            new_m, existing_m, cfg=cfg)
 
         if result["stage2_import"] == "downgrade":
             result["final_status"] = "imported"  # keeps existing
@@ -2286,6 +2372,7 @@ def full_pipeline_decision(
         result["imported"] = True
         gate_bitrate = min_bitrate
         gate_cbr = is_cbr
+        gate_format = stage2_new_format
 
     # --- Stage 3: Post-import quality gate ---
     gate_spectral_bitrate = None
@@ -2295,10 +2382,14 @@ def full_pipeline_decision(
             and effective_gate_bitrate is not None
             and effective_gate_bitrate < gate_bitrate):
         gate_spectral_bitrate = spectral_bitrate
-    gate_m = AudioQualityMeasurement(min_bitrate_kbps=gate_bitrate, is_cbr=gate_cbr,
-                                     verified_lossless=verified_lossless,
-                                     spectral_bitrate_kbps=gate_spectral_bitrate)
-    result["stage3_quality_gate"] = quality_gate_decision(gate_m)
+    gate_m = AudioQualityMeasurement(
+        min_bitrate_kbps=gate_bitrate,
+        avg_bitrate_kbps=gate_bitrate,
+        format=gate_format,
+        is_cbr=gate_cbr,
+        verified_lossless=verified_lossless,
+        spectral_bitrate_kbps=gate_spectral_bitrate)
+    result["stage3_quality_gate"] = quality_gate_decision(gate_m, cfg=cfg)
 
     if result["stage3_quality_gate"] == "accept":
         result["final_status"] = "imported"

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -856,7 +856,8 @@ def cmd_repair_spectral(db, args):
     current_spectral_bitrate still holds a stale transcode estimate,
     causing the quality gate to requeue indefinitely (issue #18).
     """
-    from quality import AudioQualityMeasurement, quality_gate_decision
+    from lib.import_dispatch import load_quality_gate_state
+    from quality import quality_gate_decision
 
     rank_cfg = _load_runtime_rank_config()
 
@@ -884,30 +885,27 @@ def cmd_repair_spectral(db, args):
     for req in candidates:
         rid = req["id"]
         label = f"{req['artist_name']} - {req['album_title']}"
-        beets_info = _load_beets_album_info(req.get("mb_release_id"), rank_cfg)
-        min_br = req["min_bitrate"]
-        effective_min_br = (
-            min_br if min_br is not None
-            else (beets_info.min_bitrate_kbps if beets_info else None)
-        )
         stale_br = req["current_spectral_bitrate"]
+        state = load_quality_gate_state(
+            request_id=rid,
+            db=db,
+            quality_ranks=rank_cfg,
+        )
+        effective_min_br = (
+            state.min_bitrate_kbps
+            if state is not None
+            else req["min_bitrate"]
+        )
         print(f"  [{rid:>4}] {label}")
         print(f"         min_bitrate={effective_min_br}kbps, "
               f"stale current_spectral={stale_br}kbps")
 
         # Check what quality gate would decide after clearing stale data
-        existing_format = req.get("final_format")
-        if not existing_format and beets_info:
-            existing_format = beets_info.format
-        measurement = AudioQualityMeasurement(
-            min_bitrate_kbps=effective_min_br,
-            avg_bitrate_kbps=(beets_info.avg_bitrate_kbps if beets_info else None),
-            format=existing_format or "MP3",
-            is_cbr=(beets_info.is_cbr if beets_info else False),
-            verified_lossless=bool(req.get("verified_lossless")),
-            spectral_bitrate_kbps=None,  # cleared
+        decision = (
+            quality_gate_decision(state.measurement, cfg=rank_cfg)
+            if state is not None
+            else "requeue_upgrade"
         )
-        decision = quality_gate_decision(measurement, cfg=rank_cfg)
         print(f"         after repair: quality_gate_decision → {decision}")
 
         if args.dry_run:

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -534,11 +534,13 @@ def cmd_quality(db, args):
     is_cbr = False
     if min_br is not None:
         from beets_db import BeetsDB
+        from quality import QualityRankConfig
         mbid = req.get("mb_release_id")
         if mbid:
             try:
                 with BeetsDB() as beets:
-                    info = beets.get_album_info(mbid)
+                    info = beets.get_album_info(
+                        mbid, QualityRankConfig.defaults())
                 if info:
                     is_cbr = info.is_cbr
             except Exception:

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -61,6 +61,25 @@ def _load_runtime_rank_config():
     return rank_cfg
 
 
+def _load_runtime_verified_lossless_target() -> str:
+    """Load the runtime verified_lossless_target from the active config.ini."""
+    from config import read_verified_lossless_target
+
+    return read_verified_lossless_target()
+
+
+def _quality_preview_target_label(
+    target_format: str | None,
+    verified_lossless_target: str | None,
+) -> str:
+    """Human label for the on-disk destination used in quality previews."""
+    if target_format in ("flac", "lossless"):
+        return "flac"
+    if verified_lossless_target:
+        return verified_lossless_target
+    return "V0"
+
+
 def _load_beets_album_info(mb_release_id, rank_cfg):
     """Best-effort Beets album lookup for current quality metadata."""
     from beets_db import BeetsDB
@@ -561,11 +580,15 @@ def cmd_quality(db, args):
     q_override = req.get("search_filetype_override")
     spectral_grade = req.get("current_spectral_grade")
     final_format = req.get("final_format")
+    target_format = req.get("target_format")
+    verified_lossless_target = _load_runtime_verified_lossless_target() or None
 
     print(f"  {label}")
     print(f"  Status: {req['status']}")
     print(f"  Rank config: metric={rank_cfg.bitrate_metric.value}, "
           f"gate_min_rank={rank_cfg.gate_min_rank.name}")
+    print(f"  Verified-lossless output: "
+          f"{_quality_preview_target_label(target_format, verified_lossless_target)}")
     print()
 
     # --- Current quality gate ---
@@ -630,17 +653,19 @@ def cmd_quality(db, args):
             and effective_existing != min_br):
         override_min_bitrate = effective_existing
 
+    lossless_target_label = _quality_preview_target_label(
+        target_format, verified_lossless_target)
     scenarios = [
         # --- FLAC downloads ---
-        ("Genuine FLAC → V0 (high bitrate)", dict(
+        (f"Genuine FLAC → {lossless_target_label} (high bitrate)", dict(
             is_flac=True, min_bitrate=245, is_cbr=False,
             spectral_grade="genuine", converted_count=12,
             post_conversion_min_bitrate=245)),
-        ("Genuine FLAC → V0 (lo-fi, 207kbps)", dict(
+        (f"Genuine FLAC → {lossless_target_label} (lo-fi, 207kbps)", dict(
             is_flac=True, min_bitrate=207, is_cbr=False,
             spectral_grade="genuine", converted_count=12,
             post_conversion_min_bitrate=207)),
-        ("Marginal FLAC → V0", dict(
+        (f"Marginal FLAC → {lossless_target_label}", dict(
             is_flac=True, min_bitrate=240, is_cbr=False,
             spectral_grade="marginal", converted_count=12,
             post_conversion_min_bitrate=240)),
@@ -693,6 +718,8 @@ def cmd_quality(db, args):
             existing_format=existing_format_hint,
             existing_is_cbr=is_cbr,
             verified_lossless=verified,
+            target_format=target_format,
+            verified_lossless_target=verified_lossless_target,
             cfg=rank_cfg,
             **params)
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -511,8 +511,26 @@ def cmd_show(db, args):
 def cmd_quality(db, args):
     """Show quality state and simulate decisions for common download scenarios."""
     from quality import (full_pipeline_decision, quality_gate_decision,
-                         AudioQualityMeasurement, rejection_backfill_override,
+                         AudioQualityMeasurement, measurement_rank,
+                         rejection_backfill_override,
                          search_tiers, compute_effective_override_bitrate)
+    from quality import QualityRankConfig
+
+    # Load the runtime SoularrConfig (same [Quality Ranks] section that
+    # production dispatch reads), so the simulator output matches what
+    # actually happens in _check_quality_gate_core().
+    import configparser
+    import os as _os
+    rank_cfg = QualityRankConfig.defaults()
+    cfg_path = (_os.environ.get("SOULARR_RUNTIME_CONFIG")
+                or "/var/lib/soularr/config.ini")
+    if _os.path.exists(cfg_path):
+        try:
+            _parser = configparser.RawConfigParser()
+            _parser.read(cfg_path)
+            rank_cfg = QualityRankConfig.from_ini(_parser)
+        except Exception:
+            pass  # Fall through to defaults
 
     req = db.get_request(args.id)
     if not req:
@@ -525,24 +543,30 @@ def cmd_quality(db, args):
     current_br = req.get("current_spectral_bitrate")
     q_override = req.get("search_filetype_override")
     spectral_grade = req.get("current_spectral_grade")
+    final_format = req.get("final_format")
 
     print(f"  {label}")
     print(f"  Status: {req['status']}")
+    print(f"  Rank config: metric={rank_cfg.bitrate_metric.value}, "
+          f"gate_min_rank={rank_cfg.gate_min_rank.name}")
     print()
 
     # --- Current quality gate ---
     is_cbr = False
+    avg_br = None
+    existing_format_hint = final_format
     if min_br is not None:
         from beets_db import BeetsDB
-        from quality import QualityRankConfig
         mbid = req.get("mb_release_id")
         if mbid:
             try:
                 with BeetsDB() as beets:
-                    info = beets.get_album_info(
-                        mbid, QualityRankConfig.defaults())
+                    info = beets.get_album_info(mbid, rank_cfg)
                 if info:
                     is_cbr = info.is_cbr
+                    avg_br = info.avg_bitrate_kbps
+                    if not existing_format_hint:
+                        existing_format_hint = info.format
             except Exception:
                 pass
         gate_spectral_br = None
@@ -552,15 +576,21 @@ def cmd_quality(db, args):
                 and effective_gate_br < min_br):
             gate_spectral_br = current_br
         current = AudioQualityMeasurement(
-            min_bitrate_kbps=min_br, is_cbr=is_cbr,
+            min_bitrate_kbps=min_br,
+            avg_bitrate_kbps=avg_br,
+            format=existing_format_hint or "MP3",
+            is_cbr=is_cbr,
             verified_lossless=verified,
             spectral_bitrate_kbps=gate_spectral_br)
-        gate = quality_gate_decision(current)
+        current_rank = measurement_rank(current, rank_cfg)
+        gate = quality_gate_decision(current, cfg=rank_cfg)
         gate_label = {"accept": "DONE", "requeue_upgrade": "NEEDS UPGRADE",
                       "requeue_lossless": "NEEDS LOSSLESS"}[gate]
-        print(f"  Quality gate:  {gate_label}")
-        print(f"    min_bitrate={_fmt_br(min_br)}, verified_lossless={verified}, "
-              f"is_cbr={is_cbr}")
+        print(f"  Quality gate:  {gate_label}  (rank={current_rank.name})")
+        print(f"    min_bitrate={_fmt_br(min_br)}, "
+              f"avg_bitrate={_fmt_br(avg_br) if avg_br else 'n/a'}, "
+              f"format={existing_format_hint or '(unknown)'}, "
+              f"verified_lossless={verified}, is_cbr={is_cbr}")
         if current_br:
             print(f"    current_spectral_bitrate={current_br}kbps")
         if spectral_grade:
@@ -649,7 +679,10 @@ def cmd_quality(db, args):
             existing_min_bitrate=min_br,
             existing_spectral_bitrate=current_br,
             override_min_bitrate=override_min_bitrate,
+            existing_format=existing_format_hint,
+            existing_is_cbr=is_cbr,
             verified_lossless=verified,
+            cfg=rank_cfg,
             **params)
 
         imported = "IMPORT" if result["imported"] else "REJECT"

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -42,6 +42,38 @@ from util import resolve_failed_path as _shared_resolve_failed_path
 MB_API = "http://192.168.1.35:5200/ws/2"
 
 
+def _load_runtime_rank_config():
+    """Load the runtime QualityRankConfig from the active config.ini."""
+    from quality import QualityRankConfig
+
+    import configparser
+
+    rank_cfg = QualityRankConfig.defaults()
+    cfg_path = (os.environ.get("SOULARR_RUNTIME_CONFIG")
+                or "/var/lib/soularr/config.ini")
+    if os.path.exists(cfg_path):
+        try:
+            parser = configparser.RawConfigParser()
+            parser.read(cfg_path)
+            rank_cfg = QualityRankConfig.from_ini(parser)
+        except Exception:
+            pass
+    return rank_cfg
+
+
+def _load_beets_album_info(mb_release_id, rank_cfg):
+    """Best-effort Beets album lookup for current quality metadata."""
+    from beets_db import BeetsDB
+
+    if not mb_release_id:
+        return None
+    try:
+        with BeetsDB() as beets:
+            return beets.get_album_info(mb_release_id, rank_cfg)
+    except Exception:
+        return None
+
+
 def fetch_mb_release(mb_release_id):
     """Fetch release metadata + tracks from MusicBrainz API."""
     url = f"{MB_API}/release/{mb_release_id}?inc=recordings+artist-credits&fmt=json"
@@ -514,23 +546,8 @@ def cmd_quality(db, args):
                          AudioQualityMeasurement, measurement_rank,
                          rejection_backfill_override,
                          search_tiers, compute_effective_override_bitrate)
-    from quality import QualityRankConfig
 
-    # Load the runtime SoularrConfig (same [Quality Ranks] section that
-    # production dispatch reads), so the simulator output matches what
-    # actually happens in _check_quality_gate_core().
-    import configparser
-    import os as _os
-    rank_cfg = QualityRankConfig.defaults()
-    cfg_path = (_os.environ.get("SOULARR_RUNTIME_CONFIG")
-                or "/var/lib/soularr/config.ini")
-    if _os.path.exists(cfg_path):
-        try:
-            _parser = configparser.RawConfigParser()
-            _parser.read(cfg_path)
-            rank_cfg = QualityRankConfig.from_ini(_parser)
-        except Exception:
-            pass  # Fall through to defaults
+    rank_cfg = _load_runtime_rank_config()
 
     req = db.get_request(args.id)
     if not req:
@@ -556,19 +573,13 @@ def cmd_quality(db, args):
     avg_br = None
     existing_format_hint = final_format
     if min_br is not None:
-        from beets_db import BeetsDB
         mbid = req.get("mb_release_id")
-        if mbid:
-            try:
-                with BeetsDB() as beets:
-                    info = beets.get_album_info(mbid, rank_cfg)
-                if info:
-                    is_cbr = info.is_cbr
-                    avg_br = info.avg_bitrate_kbps
-                    if not existing_format_hint:
-                        existing_format_hint = info.format
-            except Exception:
-                pass
+        info = _load_beets_album_info(mbid, rank_cfg)
+        if info:
+            is_cbr = info.is_cbr
+            avg_br = info.avg_bitrate_kbps
+            if not existing_format_hint:
+                existing_format_hint = info.format
         gate_spectral_br = None
         effective_gate_br = compute_effective_override_bitrate(
             min_br, current_br, spectral_grade)
@@ -847,6 +858,8 @@ def cmd_repair_spectral(db, args):
     """
     from quality import AudioQualityMeasurement, quality_gate_decision
 
+    rank_cfg = _load_runtime_rank_config()
+
     # Find candidates: genuine on disk but spectral bitrate < min_bitrate
     # (genuine files should have no spectral cliff → bitrate should be NULL)
     cur = db._execute("""
@@ -871,19 +884,30 @@ def cmd_repair_spectral(db, args):
     for req in candidates:
         rid = req["id"]
         label = f"{req['artist_name']} - {req['album_title']}"
+        beets_info = _load_beets_album_info(req.get("mb_release_id"), rank_cfg)
         min_br = req["min_bitrate"]
+        effective_min_br = (
+            min_br if min_br is not None
+            else (beets_info.min_bitrate_kbps if beets_info else None)
+        )
         stale_br = req["current_spectral_bitrate"]
         print(f"  [{rid:>4}] {label}")
-        print(f"         min_bitrate={min_br}kbps, stale current_spectral={stale_br}kbps")
+        print(f"         min_bitrate={effective_min_br}kbps, "
+              f"stale current_spectral={stale_br}kbps")
 
         # Check what quality gate would decide after clearing stale data
+        existing_format = req.get("final_format")
+        if not existing_format and beets_info:
+            existing_format = beets_info.format
         measurement = AudioQualityMeasurement(
-            min_bitrate_kbps=min_br or 0,
-            is_cbr=False,  # if they're genuine, they're VBR V0
+            min_bitrate_kbps=effective_min_br,
+            avg_bitrate_kbps=(beets_info.avg_bitrate_kbps if beets_info else None),
+            format=existing_format or "MP3",
+            is_cbr=(beets_info.is_cbr if beets_info else False),
             verified_lossless=bool(req.get("verified_lossless")),
             spectral_bitrate_kbps=None,  # cleared
         )
-        decision = quality_gate_decision(measurement)
+        decision = quality_gate_decision(measurement, cfg=rank_cfg)
         print(f"         after repair: quality_gate_decision → {decision}")
 
         if args.dry_run:
@@ -912,14 +936,14 @@ def cmd_repair_spectral(db, args):
             print(f"         un-denylisted: {entry['username']} ({entry['reason']})")
 
         # If quality gate would accept, transition to imported
-        if decision == "accept" and min_br:
+        if decision == "accept" and effective_min_br is not None:
             db._execute("""
                 UPDATE album_requests
                 SET status = 'imported',
                     min_bitrate = %s,
                     updated_at = NOW()
                 WHERE id = %s
-            """, (min_br, rid))
+            """, (effective_min_br, rid))
             print(f"         → transitioned to imported")
         else:
             print(f"         → remains wanted (gate says {decision})")

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -44,21 +44,9 @@ MB_API = "http://192.168.1.35:5200/ws/2"
 
 def _load_runtime_rank_config():
     """Load the runtime QualityRankConfig from the active config.ini."""
-    from quality import QualityRankConfig
+    from config import read_runtime_rank_config
 
-    import configparser
-
-    rank_cfg = QualityRankConfig.defaults()
-    cfg_path = (os.environ.get("SOULARR_RUNTIME_CONFIG")
-                or "/var/lib/soularr/config.ini")
-    if os.path.exists(cfg_path):
-        try:
-            parser = configparser.RawConfigParser()
-            parser.read(cfg_path)
-            rank_cfg = QualityRankConfig.from_ini(parser)
-        except Exception:
-            pass
-    return rank_cfg
+    return read_runtime_rank_config()
 
 
 def _load_runtime_verified_lossless_target() -> str:

--- a/soularr.py
+++ b/soularr.py
@@ -595,6 +595,32 @@ def main():
             logger.info(f"Beets validation ENABLED: harness={cfg.beets_harness_path}, "
                         f"threshold={cfg.beets_distance_threshold}, staging={cfg.beets_staging_dir}")
 
+        # --- Soft warning for sub-gate verified_lossless_target (issue #60) ---
+        # When the configured verified_lossless_target has a declared rank
+        # below gate_min_rank, the resulting imports will fail the quality
+        # gate and be re-queued for upgrade — meaning they'll never stabilize
+        # as "imported". Log loudly at startup so operators see this before
+        # it surprises them downstream.
+        if cfg.verified_lossless_target:
+            try:
+                from lib.quality import quality_rank, QualityRank
+                target_rank = quality_rank(
+                    cfg.verified_lossless_target,
+                    bitrate_kbps=None, is_cbr=False, cfg=cfg.quality_ranks)
+                if (target_rank != QualityRank.UNKNOWN
+                        and target_rank < cfg.quality_ranks.gate_min_rank):
+                    logger.warning(
+                        f"verified_lossless_target={cfg.verified_lossless_target!r} "
+                        f"has rank {target_rank.name}, below configured "
+                        f"gate_min_rank={cfg.quality_ranks.gate_min_rank.name}. "
+                        f"Files converted to this target will fail the quality "
+                        f"gate and be re-queued for upgrade. Either raise the "
+                        f"target format or lower gate_min_rank in config.ini "
+                        f"[Quality Ranks]."
+                    )
+            except Exception as exc:
+                logger.debug(f"verified_lossless_target rank check failed: {exc}")
+
         from album_source import DatabaseSource
         pipeline_db_source = DatabaseSource(cfg.pipeline_db_dsn)
         logger.info(f"Pipeline DB: {cfg.pipeline_db_dsn}")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,10 +14,14 @@ from unittest.mock import MagicMock, patch
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.quality import (
     AudioQualityMeasurement,
+    CodecRankBands,
     ConversionInfo,
     DownloadInfo,
     ImportResult,
     PostflightInfo,
+    QualityRank,
+    QualityRankConfig,
+    RankBitrateMetric,
     SpectralContext,
     SpectralMeasurement,
     ValidationResult,
@@ -112,6 +116,42 @@ def make_import_result(
             disambiguated=disambiguated,
         ),
         final_format=final_format,
+    )
+
+
+def make_quality_rank_config(
+    *,
+    bitrate_metric: RankBitrateMetric | None = None,
+    gate_min_rank: QualityRank | None = None,
+    within_rank_tolerance_kbps: int | None = None,
+    opus: CodecRankBands | None = None,
+    mp3_vbr: CodecRankBands | None = None,
+    mp3_cbr: CodecRankBands | None = None,
+    aac: CodecRankBands | None = None,
+) -> QualityRankConfig:
+    """Build a QualityRankConfig with test-friendly overrides.
+
+    Defaults match QualityRankConfig.defaults() — override individual fields
+    to test metric swaps, alternate gate floors, or custom codec bands. Use
+    this instead of constructing QualityRankConfig directly so tests stay
+    stable when the dataclass grows new fields.
+    """
+    base = QualityRankConfig.defaults()
+    return QualityRankConfig(
+        bitrate_metric=bitrate_metric if bitrate_metric is not None else base.bitrate_metric,
+        gate_min_rank=gate_min_rank if gate_min_rank is not None else base.gate_min_rank,
+        within_rank_tolerance_kbps=(
+            within_rank_tolerance_kbps
+            if within_rank_tolerance_kbps is not None
+            else base.within_rank_tolerance_kbps
+        ),
+        opus=opus if opus is not None else base.opus,
+        mp3_vbr=mp3_vbr if mp3_vbr is not None else base.mp3_vbr,
+        mp3_cbr=mp3_cbr if mp3_cbr is not None else base.mp3_cbr,
+        aac=aac if aac is not None else base.aac,
+        mp3_vbr_levels=base.mp3_vbr_levels,
+        lossless_codecs=base.lossless_codecs,
+        mixed_format_precedence=base.mixed_format_precedence,
     )
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -306,7 +306,7 @@ def patch_dispatch_externals():
     trigger_plex_scan, cleanup_disambiguation_orphans.
 
     Does NOT patch parse_import_result, _check_quality_gate_core,
-    BeetsDB, or _read_runtime_config — callers nest those as needed.
+    BeetsDB, or read_runtime_config — callers nest those as needed.
 
     Yields a SimpleNamespace with attributes: run, cleanup, meelo, plex, orphans.
     run is pre-configured with returncode=0, stdout="", stderr="".

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tagging-
 
 from album_source import AlbumRecord, DatabaseSource
 from lib.grab_list import GrabListEntry, DownloadFile
-from lib.quality import ValidationResult
+from lib.quality import DownloadInfo, ValidationResult
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 
@@ -170,6 +170,37 @@ class TestDatabaseSource(unittest.TestCase):
         req = db.get_request(req_id)
         assert req is not None
         self.assertEqual(req["status"], "imported")
+
+    @patch("lib.import_dispatch._do_mark_done")
+    def test_mark_done_delegates_to_shared_helper(self, mock_mark_done):
+        source, db = self._make_source()
+        req_id = db.add_request(
+            mb_release_id="delegate-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        record = _make_record(db_request_id=req_id, db_source="request")
+        bv_result = ValidationResult(
+            valid=True, distance=0.05, scenario="strong_match", detail="ok")
+        dl = DownloadInfo(username="user1", filetype="mp3")
+
+        source.mark_done(
+            record,
+            bv_result,
+            dest_path="/Incoming/A/B",
+            download_info=dl,
+        )
+
+        mock_mark_done.assert_called_once_with(
+            db=db,
+            request_id=req_id,
+            dl_info=dl,
+            distance=0.05,
+            scenario="strong_match",
+            dest_path="/Incoming/A/B",
+            detail="ok",
+        )
 
     def test_reject_and_requeue_updates_status_and_denylists(self):
         source, db = self._make_source()

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -57,9 +57,13 @@ def _create_test_db(path: str) -> None:
 
 
 def _insert_album(path: str, album_id: int, mbid: str,
-                   tracks: list[tuple[int, str]], **kwargs: object) -> None:
+                   tracks: list[tuple[int, str]],
+                   track_format: str = "MP3",
+                   **kwargs: object) -> None:
     """Insert an album with tracks. tracks = [(bitrate_bps, path_str), ...]
     Extra kwargs are set as album columns (e.g. album='Foo', albumartist='Bar').
+    ``track_format`` is written to every item's format column — defaults to
+    "MP3" for historical tests.
     """
     conn = sqlite3.connect(path)
     cols = "id, mb_albumid"
@@ -71,8 +75,9 @@ def _insert_album(path: str, album_id: int, mbid: str,
     conn.execute(f"INSERT INTO albums ({cols}) VALUES ({placeholders})", vals)
     for i, (bitrate, track_path) in enumerate(tracks):
         conn.execute(
-            "INSERT INTO items (album_id, bitrate, path) VALUES (?, ?, ?)",
-            (album_id, bitrate, track_path.encode()))
+            "INSERT INTO items (album_id, bitrate, path, format) "
+            "VALUES (?, ?, ?, ?)",
+            (album_id, bitrate, track_path.encode(), track_format))
     conn.commit()
     conn.close()
 
@@ -158,6 +163,8 @@ class TestGetAlbumInfo(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self.tmpdir, "test.db")
         _create_test_db(self.db_path)
+        from lib.quality import QualityRankConfig
+        self.cfg = QualityRankConfig.defaults()
 
     def test_single_album(self) -> None:
         _insert_album(self.db_path, 1, "abc-123", [
@@ -165,13 +172,15 @@ class TestGetAlbumInfo(unittest.TestCase):
             (320000, "/music/Artist/Album/02.mp3"),
         ])
         with BeetsDB(self.db_path) as db:
-            info = db.get_album_info("abc-123")
+            info = db.get_album_info("abc-123", self.cfg)
         assert info is not None
         self.assertEqual(info.album_id, 1)
         self.assertEqual(info.track_count, 2)
         self.assertEqual(info.min_bitrate_kbps, 320)
+        self.assertEqual(info.avg_bitrate_kbps, 320)
         self.assertTrue(info.is_cbr)
         self.assertEqual(info.album_path, "/music/Artist/Album")
+        self.assertEqual(info.format, "MP3")
 
     def test_vbr_album(self) -> None:
         _insert_album(self.db_path, 2, "def-456", [
@@ -180,15 +189,17 @@ class TestGetAlbumInfo(unittest.TestCase):
             (251000, "/music/A/B/03.mp3"),
         ])
         with BeetsDB(self.db_path) as db:
-            info = db.get_album_info("def-456")
+            info = db.get_album_info("def-456", self.cfg)
         assert info is not None
         self.assertEqual(info.min_bitrate_kbps, 238)
+        self.assertEqual(info.avg_bitrate_kbps, 244)  # (245+238+251)/3 = 244.66 → 244
         self.assertFalse(info.is_cbr)
         self.assertEqual(info.track_count, 3)
+        self.assertEqual(info.format, "MP3")
 
     def test_not_found(self) -> None:
         with BeetsDB(self.db_path) as db:
-            info = db.get_album_info("nonexistent")
+            info = db.get_album_info("nonexistent", self.cfg)
         self.assertIsNone(info)
 
     def test_album_no_tracks(self) -> None:
@@ -198,7 +209,7 @@ class TestGetAlbumInfo(unittest.TestCase):
         conn.commit()
         conn.close()
         with BeetsDB(self.db_path) as db:
-            info = db.get_album_info("empty-1")
+            info = db.get_album_info("empty-1", self.cfg)
         self.assertIsNone(info)
 
     def test_zero_bitrate_ignored(self) -> None:
@@ -208,7 +219,7 @@ class TestGetAlbumInfo(unittest.TestCase):
             (256000, "/music/A/B/02.mp3"),
         ])
         with BeetsDB(self.db_path) as db:
-            info = db.get_album_info("ghi-789")
+            info = db.get_album_info("ghi-789", self.cfg)
         assert info is not None
         self.assertEqual(info.min_bitrate_kbps, 256)
 
@@ -218,9 +229,101 @@ class TestGetAlbumInfo(unittest.TestCase):
             (320000, "/music/Ärtiöst/Albüm/01.mp3"),
         ])
         with BeetsDB(self.db_path) as db:
-            info = db.get_album_info("jkl-012")
+            info = db.get_album_info("jkl-012", self.cfg)
         assert info is not None
         self.assertIn("Albüm", info.album_path)
+
+    def test_opus_album_format(self) -> None:
+        """Opus tracks report format='Opus'."""
+        _insert_album(self.db_path, 5, "opus-1", [
+            (128000, "/m/O/01.opus"),
+            (120000, "/m/O/02.opus"),
+            (135000, "/m/O/03.opus"),
+        ], track_format="Opus")
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("opus-1", self.cfg)
+        assert info is not None
+        self.assertEqual(info.format, "Opus")
+        self.assertEqual(info.min_bitrate_kbps, 120)
+        self.assertEqual(info.avg_bitrate_kbps, 127)  # (128+120+135)/3 = 127.66 → 127
+        self.assertFalse(info.is_cbr)
+
+    def test_flac_album_format(self) -> None:
+        """FLAC tracks report format='FLAC'."""
+        _insert_album(self.db_path, 6, "flac-1", [
+            (900000, "/m/F/01.flac"),
+        ], track_format="FLAC")
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("flac-1", self.cfg)
+        assert info is not None
+        self.assertEqual(info.format, "FLAC")
+
+    def test_mixed_format_album_reduces_via_precedence(self) -> None:
+        """Mixed-format album picks worst codec per cfg.mixed_format_precedence."""
+        # Insert manually because _insert_album uses a single format per album
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO albums (id, mb_albumid) VALUES (7, 'mixed-1')")
+        conn.execute(
+            "INSERT INTO items (album_id, bitrate, path, format) "
+            "VALUES (?, ?, ?, ?)",
+            (7, 1000000, b"/m/mix/01.flac", "FLAC"))
+        conn.execute(
+            "INSERT INTO items (album_id, bitrate, path, format) "
+            "VALUES (?, ?, ?, ?)",
+            (7, 245000, b"/m/mix/02.mp3", "MP3"))
+        conn.commit()
+        conn.close()
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("mixed-1", self.cfg)
+        assert info is not None
+        # Default precedence is ("mp3", "aac", "opus", "flac") — MP3 wins.
+        self.assertEqual(info.format, "MP3")
+
+
+class TestReduceAlbumFormat(unittest.TestCase):
+    """Direct unit tests for _reduce_album_format — pure function, no DB."""
+
+    def setUp(self) -> None:
+        from lib.quality import QualityRankConfig
+        self.cfg = QualityRankConfig.defaults()
+
+    def test_single_format_passes_through(self) -> None:
+        from lib.beets_db import _reduce_album_format
+        self.assertEqual(_reduce_album_format({"MP3"}, self.cfg), "MP3")
+
+    def test_empty_set_returns_empty_string(self) -> None:
+        from lib.beets_db import _reduce_album_format
+        self.assertEqual(_reduce_album_format(set(), self.cfg), "")
+
+    def test_alphabetical_fallback_when_no_precedence_match(self) -> None:
+        """Unknown codecs fall back to sorted()[0]."""
+        from lib.beets_db import _reduce_album_format
+        # Default precedence: ("mp3", "aac", "opus", "flac") — neither matches
+        self.assertEqual(
+            _reduce_album_format({"Vorbis", "WAV"}, self.cfg), "Vorbis")
+
+    def test_precedence_beats_alphabetical(self) -> None:
+        """A precedence-match wins over an alphabetically earlier unknown codec."""
+        from lib.beets_db import _reduce_album_format
+        # "AAC" is earlier alphabetically than "Vorbis" AND is in precedence
+        self.assertEqual(
+            _reduce_album_format({"Vorbis", "AAC"}, self.cfg), "AAC")
+
+    def test_case_insensitive_precedence_match(self) -> None:
+        """Lowercase beets format ("flac") still matches precedence."""
+        from lib.beets_db import _reduce_album_format
+        self.assertEqual(
+            _reduce_album_format({"flac"}, self.cfg), "flac")
+        # Mixed case
+        self.assertEqual(
+            _reduce_album_format({"flac", "mp3"}, self.cfg), "mp3")
+
+    def test_three_way_mix(self) -> None:
+        """{FLAC, Opus, AAC} → AAC (first precedence match)."""
+        from lib.beets_db import _reduce_album_format
+        self.assertEqual(
+            _reduce_album_format({"FLAC", "Opus", "AAC"}, self.cfg), "AAC")
 
 
 class TestGetMinBitrate(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,12 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from lib.config import SoularrConfig, read_verified_lossless_target
+from lib.config import (
+    SoularrConfig,
+    read_runtime_config,
+    read_runtime_rank_config,
+    read_verified_lossless_target,
+)
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 TEST_CONFIG = os.path.join(FIXTURES_DIR, "test_config.ini")
@@ -256,6 +261,60 @@ class TestReadVerifiedLosslessTarget(unittest.TestCase):
             with open(path, "w", encoding="utf-8") as f:
                 f.write("[Beets Validation]\nverified_lossless_target = aac 128\n")
             self.assertEqual(read_verified_lossless_target(path), "aac 128")
+
+
+class TestReadRuntimeConfig(unittest.TestCase):
+    def test_missing_config_returns_default(self):
+        cfg = read_runtime_config("/nonexistent/config.ini")
+        self.assertEqual(cfg.beets_harness_path, "")
+
+    def test_reads_full_runtime_config(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".ini") as tmp:
+            tmp.write(
+                "[Beets Validation]\n"
+                "harness_path = /nix/store/test/run_beets_harness.sh\n"
+                "verified_lossless_target = opus 128\n"
+                "[Meelo]\n"
+                "url = http://meelo.test\n"
+                "[Plex]\n"
+                "url = http://plex.test\n"
+                "token = test-token\n"
+            )
+            config_path = tmp.name
+        try:
+            cfg = read_runtime_config(config_path)
+        finally:
+            os.unlink(config_path)
+
+        self.assertEqual(cfg.beets_harness_path, "/nix/store/test/run_beets_harness.sh")
+        self.assertEqual(cfg.verified_lossless_target, "opus 128")
+        self.assertEqual(cfg.meelo_url, "http://meelo.test")
+        self.assertEqual(cfg.plex_url, "http://plex.test")
+        self.assertEqual(cfg.plex_token, "test-token")
+
+
+class TestReadRuntimeRankConfig(unittest.TestCase):
+    def test_missing_config_returns_defaults(self):
+        cfg = read_runtime_rank_config("/nonexistent/config.ini")
+        self.assertEqual(cfg.gate_min_rank.name, "EXCELLENT")
+
+    def test_reads_quality_ranks_from_runtime_config(self):
+        from lib.quality import QualityRank
+
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".ini") as tmp:
+            tmp.write(
+                "[Quality Ranks]\n"
+                "gate_min_rank = good\n"
+                "bitrate_metric = min\n"
+            )
+            config_path = tmp.name
+        try:
+            cfg = read_runtime_rank_config(config_path)
+        finally:
+            os.unlink(config_path)
+
+        self.assertEqual(cfg.gate_min_rank, QualityRank.GOOD)
+        self.assertEqual(cfg.bitrate_metric.value, "min")
 
 
 class TestRawConfigParserRegression(unittest.TestCase):

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -43,7 +43,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
             with patch_dispatch_externals() as ext, \
                  patch("lib.import_dispatch._check_quality_gate_core") as mock_gate, \
                  patch("lib.import_dispatch.parse_import_result", return_value=ir), \
-                 patch("lib.import_dispatch._read_runtime_config",
+                 patch("lib.config.read_runtime_config",
                        return_value=SoularrConfig(
                            beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
                            pipeline_db_enabled=True,
@@ -158,39 +158,41 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         self.assertTrue(hasattr(r["result"], "success"))
         self.assertTrue(hasattr(r["result"], "message"))
 
+class TestDispatchFromDbRuntimeConfigSeam(unittest.TestCase):
+    def test_dispatch_import_from_db_uses_shared_runtime_config_reader(self):
+        from lib.import_dispatch import dispatch_import_from_db
 
-class TestReadRuntimeConfig(unittest.TestCase):
-    def test_missing_config_returns_default(self):
-        from lib.import_dispatch import _read_runtime_config
-        with patch.dict(os.environ, {"SOULARR_RUNTIME_CONFIG": "/nonexistent/config.ini"}):
-            cfg = _read_runtime_config()
-        self.assertEqual(cfg.beets_harness_path, "")
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-123",
+            status="manual",
+            artist_name="Artist",
+            album_title="Album",
+        ))
 
-    def test_reads_full_config(self):
-        from lib.import_dispatch import _read_runtime_config
-        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".ini") as tmp:
-            tmp.write(
-                "[Beets Validation]\n"
-                "harness_path = /nix/store/test/run_beets_harness.sh\n"
-                "verified_lossless_target = opus 128\n"
-                "[Meelo]\n"
-                "url = http://meelo.test\n"
-                "[Plex]\n"
-                "url = http://plex.test\n"
-                "token = test-token\n"
-            )
-            config_path = tmp.name
+        cfg = SoularrConfig(
+            beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
+            pipeline_db_enabled=True,
+        )
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        tmpdir = tempfile.mkdtemp()
         try:
-            with patch.dict(os.environ, {"SOULARR_RUNTIME_CONFIG": config_path}):
-                cfg = _read_runtime_config()
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.import_dispatch._check_quality_gate_core"), \
+                 patch("lib.import_dispatch.parse_import_result", return_value=ir), \
+                 patch("lib.config.read_runtime_config", return_value=cfg) as mock_read:
+                dispatch_import_from_db(
+                    db,  # type: ignore[arg-type]
+                    request_id=42,
+                    failed_path=tmpdir,
+                    force=True,
+                )
         finally:
-            os.unlink(config_path)
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
-        self.assertEqual(cfg.beets_harness_path, "/nix/store/test/run_beets_harness.sh")
-        self.assertEqual(cfg.verified_lossless_target, "opus 128")
-        self.assertEqual(cfg.meelo_url, "http://meelo.test")
-        self.assertEqual(cfg.plex_url, "http://plex.test")
-        self.assertEqual(cfg.plex_token, "test-token")
+        mock_read.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -436,6 +436,57 @@ class TestDispatchRankConfigArgv(unittest.TestCase):
         self.assertNotIn("--quality-rank-config", cmd)
 
 
+class TestLoadQualityGateState(unittest.TestCase):
+    """Direct tests for the shared quality-gate state adapter."""
+
+    def test_uses_full_request_row_to_apply_final_format(self):
+        """The shared adapter must honor persisted final_format labels."""
+        from lib.beets_db import AlbumInfo
+        from lib.import_dispatch import load_quality_gate_state
+        from lib.quality import QualityRankConfig
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="wanted",
+            mb_release_id="mbid-123",
+            verified_lossless=True,
+            final_format="mp3 v0",
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=96,
+        ))
+
+        with patch("lib.beets_db.BeetsDB") as mock_beets_cls:
+            mock_beets = MagicMock()
+            mock_beets.__enter__ = MagicMock(return_value=mock_beets)
+            mock_beets.__exit__ = MagicMock(return_value=False)
+            mock_beets.get_album_info.return_value = AlbumInfo(
+                album_id=1,
+                track_count=10,
+                min_bitrate_kbps=207,
+                avg_bitrate_kbps=207,
+                format="MP3",
+                is_cbr=False,
+                album_path="/Beets/Artist/Album",
+            )
+            mock_beets_cls.return_value = mock_beets
+
+            state = load_quality_gate_state(
+                request_id=42,
+                db=db,  # type: ignore[arg-type]
+                quality_ranks=QualityRankConfig.defaults(),
+            )
+
+        self.assertIsNotNone(state)
+        assert state is not None
+        self.assertEqual(state.min_bitrate_kbps, 207)
+        self.assertEqual(state.measurement.format, "mp3 v0")
+        self.assertEqual(state.measurement.avg_bitrate_kbps, 207)
+        self.assertFalse(state.measurement.is_cbr)
+        self.assertTrue(state.measurement.verified_lossless)
+        self.assertIsNone(state.spectral_bitrate_kbps)
+
+
 class TestQualityGateUsesIntent(unittest.TestCase):
     """Orchestration tests for _check_quality_gate_core via FakePipelineDB."""
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -508,7 +508,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
 
         captured_measurement = {}
 
-        def capture_decision(measurement):
+        def capture_decision(measurement, cfg=None):
             captured_measurement["m"] = measurement
             return "accept"
 
@@ -548,7 +548,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
 
         captured = {}
 
-        def capture_and_decide(measurement):
+        def capture_and_decide(measurement, cfg=None):
             captured["m"] = measurement
             return quality_gate_decision(measurement)
 
@@ -559,7 +559,8 @@ class TestQualityGateUsesIntent(unittest.TestCase):
             mock_beets.__enter__ = MagicMock(return_value=mock_beets)
             mock_beets.__exit__ = MagicMock(return_value=False)
             mock_beets.get_album_info.return_value = MagicMock(
-                min_bitrate_kbps=226, is_cbr=False)
+                min_bitrate_kbps=226, avg_bitrate_kbps=226,
+                format="MP3", is_cbr=False)
             mock_beets_cls.return_value = mock_beets
             _check_quality_gate_core(
                 mb_id="test-mbid", label="Test Artist - Test Album",
@@ -588,7 +589,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         ))
         captured = {}
 
-        def capture(measurement):
+        def capture(measurement, cfg=None):
             captured["m"] = measurement
             return "accept"
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -357,6 +357,85 @@ class TestOverrideMinBitrate(unittest.TestCase):
                 )
 
 
+class TestDispatchRankConfigArgv(unittest.TestCase):
+    """Seam test — harness argv must carry --quality-rank-config JSON.
+
+    Verifies the QualityRankConfig round-trips through the subprocess
+    boundary unchanged, so the harness's rank classification matches the
+    caller's runtime config. Will break if import_one becomes a library
+    call (#48) or if QualityRankConfig.to_json() changes shape.
+    """
+
+    def _run_dispatch_capture_cmd(self, cfg_obj):
+        """Call dispatch_import_core with cfg_obj, return captured argv."""
+        from lib.import_dispatch import dispatch_import_core
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        ir = make_import_result(decision="import")
+
+        with patch_dispatch_externals() as ext, \
+             patch("lib.import_dispatch._check_quality_gate_core"), \
+             patch("lib.import_dispatch.parse_import_result", return_value=ir):
+            dispatch_import_core(
+                path="/tmp/dest", mb_release_id="mbid-1",
+                request_id=42, label="Test Artist - Test Album",
+                beets_harness_path=_HARNESS,
+                cfg=cfg_obj,
+                db=db,  # type: ignore[arg-type]
+                dl_info=DownloadInfo(filetype="mp3"),
+                files=[MagicMock(username="user1", filename="01.mp3")],
+            )
+            return ext.run.call_args[0][0]
+
+    def _extract_rank_config_json(self, cmd):
+        for i, arg in enumerate(cmd):
+            if arg == "--quality-rank-config" and i + 1 < len(cmd):
+                return cmd[i + 1]
+        return None
+
+    def test_default_cfg_serializes_to_argv(self):
+        """Default QualityRankConfig → argv contains the round-trip JSON."""
+        from lib.config import SoularrConfig
+        from lib.quality import QualityRankConfig
+        cfg = SoularrConfig(beets_harness_path=_HARNESS)
+        cmd = self._run_dispatch_capture_cmd(cfg)
+        raw = self._extract_rank_config_json(cmd)
+        self.assertIsNotNone(raw)
+        assert raw is not None  # for pyright
+        # Round-trip must produce an equal QualityRankConfig
+        restored = QualityRankConfig.from_json(raw)
+        self.assertEqual(restored, cfg.quality_ranks)
+
+    def test_custom_cfg_serializes_to_argv(self):
+        """Custom gate_min_rank + metric survive the argv round-trip."""
+        from lib.config import SoularrConfig
+        from lib.quality import (QualityRank, QualityRankConfig,
+                                 RankBitrateMetric)
+        custom_ranks = QualityRankConfig(
+            bitrate_metric=RankBitrateMetric.MIN,
+            gate_min_rank=QualityRank.GOOD,
+            within_rank_tolerance_kbps=15,
+        )
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, quality_ranks=custom_ranks)
+        cmd = self._run_dispatch_capture_cmd(cfg)
+        raw = self._extract_rank_config_json(cmd)
+        self.assertIsNotNone(raw)
+        assert raw is not None  # for pyright
+        restored = QualityRankConfig.from_json(raw)
+        self.assertEqual(restored.bitrate_metric, RankBitrateMetric.MIN)
+        self.assertEqual(restored.gate_min_rank, QualityRank.GOOD)
+        self.assertEqual(restored.within_rank_tolerance_kbps, 15)
+
+    def test_missing_cfg_omits_argv(self):
+        """When cfg=None, the --quality-rank-config argv is not emitted.
+
+        Harness falls back to QualityRankConfig.defaults() in that case.
+        """
+        cmd = self._run_dispatch_capture_cmd(None)
+        self.assertNotIn("--quality-rank-config", cmd)
+
+
 class TestQualityGateUsesIntent(unittest.TestCase):
     """Orchestration tests for _check_quality_gate_core via FakePipelineDB."""
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -482,11 +482,20 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         self.assertEqual(row["status"], "wanted")
         self.assertEqual(row["search_filetype_override"], QUALITY_UPGRADE_TIERS)
 
-    def test_requeue_upgrade_verified_lossless_accepts(self):
+    def test_requeue_upgrade_verified_lossless_still_requeues(self):
         db = self._run_quality_gate("requeue_upgrade", verified_lossless=True)
         row = db.request(42)
-        self.assertEqual(row["status"], "imported")
-        self.assertEqual(len(db.denylist), 0)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_filetype_override"], QUALITY_UPGRADE_TIERS)
+
+    def test_requeue_upgrade_verified_lossless_denylist_reason_preserved(self):
+        db = self._run_quality_gate(
+            "requeue_upgrade",
+            verified_lossless=True,
+            current_spectral_grade=None,
+        )
+        self.assertEqual(len(db.denylist), 1)
+        self.assertIn("quality gate", db.denylist[0].reason or "")
 
     def test_requeue_lossless_uses_intent(self):
         db = self._run_quality_gate("requeue_lossless")

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -205,6 +205,37 @@ class TestQualityDecisionStage(unittest.TestCase):
         self.assertFalse(r.is_terminal)
 
 
+class TestExistingMeasurementBuilder(unittest.TestCase):
+    """Tests for import_one's existing-measurement wiring."""
+
+    def test_override_replaces_avg_metric_too(self):
+        """Spectral override must affect the selected avg metric, not just min."""
+        from import_one import build_existing_measurement
+        from lib.beets_db import AlbumInfo
+
+        info = AlbumInfo(
+            album_id=1,
+            track_count=10,
+            min_bitrate_kbps=320,
+            avg_bitrate_kbps=320,
+            format="MP3",
+            is_cbr=True,
+            album_path="/Beets/Test",
+        )
+        m = build_existing_measurement(
+            info,
+            override_min_bitrate=128,
+            existing_spectral_grade=None,
+            existing_spectral_bitrate=None,
+        )
+        self.assertIsNotNone(m)
+        assert m is not None
+        self.assertEqual(m.min_bitrate_kbps, 128)
+        self.assertEqual(
+            m.avg_bitrate_kbps, 128,
+            "override_min_bitrate must drive comparison under the default avg metric")
+
+
 # ============================================================================
 # final_exit_decision
 # ============================================================================

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -225,6 +225,60 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
             "180kbps falls back to the default EXCELLENT gate and requeues.")
         self.assertIsNone(row["search_filetype_override"])
 
+    def test_native_vbr_import_clears_stale_final_format(self):
+        """A later plain MP3 import must clear an old target-format label.
+
+        If `final_format='opus 64'` is left behind from a previous import,
+        the rank gate misclassifies the new on-disk MP3 as GOOD and requeues
+        it forever. The success path must clear stale `final_format` when the
+        new import does not carry an explicit label.
+        """
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+
+        db = self._run_dispatch(
+            ir,
+            beets_info,
+            request_overrides={"final_format": "opus 64"},
+        )
+
+        row = db.request(42)
+        self.assertEqual(
+            row["status"], "imported",
+            "stale final_format labels must be cleared so the quality gate "
+            "uses the new beets codec metadata")
+        self.assertIsNone(row["search_filetype_override"])
+        self.assertIsNone(row.get("final_format"))
+
+    def test_native_cbr_import_clears_stale_verified_lossless(self):
+        """A later non-verified import must clear an old verified flag.
+
+        Otherwise a plain CBR 320 replacement inherits `verified_lossless=True`
+        from the previous album and incorrectly skips the lossless requeue path.
+        """
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
+            is_cbr=True, album_path="/Beets/Test")
+
+        db = self._run_dispatch(
+            ir,
+            beets_info,
+            request_overrides={"verified_lossless": True},
+        )
+
+        row = db.request(42)
+        self.assertEqual(
+            row["status"], "wanted",
+            "stale verified_lossless=True must be cleared so native CBR "
+            "imports still requeue for lossless verification")
+        self.assertEqual(row["search_filetype_override"], QUALITY_LOSSLESS)
+        self.assertFalse(row["verified_lossless"])
+
 
 class TestQualityGateVerifiedLosslessBypass(unittest.TestCase):
     """Integration slice: quality gate honors persisted final_format labels."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -61,7 +61,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
     _check_quality_gate_core, quality_gate_decision, apply_transition.
     """
 
-    def _run_dispatch(self, ir, beets_info, request_overrides=None):
+    def _run_dispatch(self, ir, beets_info, request_overrides=None, cfg=None):
         """Dispatch an import and return the FakePipelineDB state."""
         from lib.import_dispatch import dispatch_import_core
 
@@ -71,10 +71,11 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
             **(request_overrides or {}),
         ))
 
-        cfg = SoularrConfig(
-            beets_harness_path=_HARNESS,
-            pipeline_db_enabled=True,
-        )
+        if cfg is None:
+            cfg = SoularrConfig(
+                beets_harness_path=_HARNESS,
+                pipeline_db_enabled=True,
+            )
         dl_info = DownloadInfo(username="user1")
         stdout = _make_stdout(ir)
 
@@ -109,6 +110,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         ir = make_import_result(decision="import", new_min_bitrate=245)
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         db = self._run_dispatch(ir, beets_info)
@@ -125,6 +127,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         ir = make_import_result(decision="import", new_min_bitrate=180)
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=180,
+            avg_bitrate_kbps=180, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         db = self._run_dispatch(ir, beets_info)
@@ -143,6 +146,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         ir = make_import_result(decision="import", new_min_bitrate=320)
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
             is_cbr=True, album_path="/Beets/Test")
 
         db = self._run_dispatch(ir, beets_info)
@@ -157,6 +161,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         ir = make_import_result(decision="transcode_upgrade", new_min_bitrate=227)
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=227,
+            avg_bitrate_kbps=227, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         db = self._run_dispatch(ir, beets_info)
@@ -175,6 +180,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
                                 new_min_bitrate=128, prev_min_bitrate=320)
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=128,
+            avg_bitrate_kbps=128, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         db = self._run_dispatch(ir, beets_info)
@@ -184,21 +190,64 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         self.assertTrue(len(db.denylist) >= 1)
         db.assert_log(self, 0, outcome="rejected")
 
+    def test_custom_gate_min_rank_accepts_lower(self):
+        """Custom gate_min_rank=GOOD must flip requeue → accept end-to-end.
+
+        Locks the runtime config threading: cfg.quality_ranks → dispatch
+        → _check_quality_gate_core → quality_gate_decision. If any hop
+        drops cfg, this test fails because the gate falls back to
+        default EXCELLENT and 180kbps still requeues.
+        """
+        from lib.quality import QualityRank, QualityRankConfig
+
+        ir = make_import_result(decision="import", new_min_bitrate=180)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=180,
+            avg_bitrate_kbps=180, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+
+        custom_cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            quality_ranks=QualityRankConfig(gate_min_rank=QualityRank.GOOD),
+        )
+
+        db = self._run_dispatch(ir, beets_info, cfg=custom_cfg)
+
+        row = db.request(42)
+        # Under default gate_min_rank=EXCELLENT, 180 MP3 VBR = GOOD → requeue.
+        # Under the custom cfg (gate_min_rank=GOOD), 180 passes.
+        self.assertEqual(
+            row["status"], "imported",
+            "cfg.quality_ranks.gate_min_rank=GOOD must thread through "
+            "dispatch_import_core → _check_quality_gate_core → "
+            "quality_gate_decision. If cfg is dropped at any hop, "
+            "180kbps falls back to the default EXCELLENT gate and requeues.")
+        self.assertIsNone(row["search_filetype_override"])
+
 
 class TestQualityGateVerifiedLosslessBypass(unittest.TestCase):
     """Integration slice: quality gate stays imported for verified_lossless
     even when bitrate < 210."""
 
     def test_verified_lossless_low_bitrate_accepts(self):
-        """207kbps VBR from verified FLAC → accepted despite < 210 threshold."""
+        """207kbps V0 from verified FLAC → accepted (label = TRANSPARENT)."""
         from lib.import_dispatch import _check_quality_gate_core
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42, status="imported", verified_lossless=True))
 
+        # Under the codec-aware rank model, lo-fi V0 is accepted via the
+        # "mp3 v0" label (TRANSPARENT rank regardless of bitrate), so we
+        # seed the AlbumInfo with format="MP3" and it classifies via the
+        # VBR band table (207 is still below 210 → EXCELLENT not TRANSPARENT).
+        # To accept at 207 under the new rules, the format must be the V0
+        # label contract, which is only known from import_one.py. Simulating
+        # that via format="MP3" here — 207 MP3 VBR is EXCELLENT ≥ gate.
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=207,
+            avg_bitrate_kbps=207, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
@@ -233,6 +282,7 @@ class TestQualityGateSpectralOverride(unittest.TestCase):
 
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
@@ -277,6 +327,8 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             album_id=1,
             track_count=10,
             min_bitrate_kbps=320,
+            avg_bitrate_kbps=320,
+            format="MP3",
             is_cbr=True,
             album_path="/Beets/Test",
         )
@@ -377,6 +429,7 @@ class TestForceImportSlice(unittest.TestCase):
         stdout = _make_stdout(ir)
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
         cfg = SoularrConfig(

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -488,7 +488,7 @@ class TestForceImportSlice(unittest.TestCase):
         try:
             with patch_dispatch_externals() as ext, \
                  patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
-                 patch("lib.import_dispatch._read_runtime_config",
+                 patch("lib.config.read_runtime_config",
                        return_value=cfg):
                 ext.run.return_value = MagicMock(
                     returncode=0, stdout=stdout, stderr="")

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -227,24 +227,17 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
 
 
 class TestQualityGateVerifiedLosslessBypass(unittest.TestCase):
-    """Integration slice: quality gate stays imported for verified_lossless
-    even when bitrate < 210."""
+    """Integration slice: quality gate honors persisted final_format labels."""
 
     def test_verified_lossless_low_bitrate_accepts(self):
-        """207kbps V0 from verified FLAC → accepted (label = TRANSPARENT)."""
+        """207kbps V0 from verified FLAC → accepted via final_format='mp3 v0'."""
         from lib.import_dispatch import _check_quality_gate_core
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=42, status="imported", verified_lossless=True))
+            id=42, status="imported", verified_lossless=True,
+            final_format="mp3 v0"))
 
-        # Under the codec-aware rank model, lo-fi V0 is accepted via the
-        # "mp3 v0" label (TRANSPARENT rank regardless of bitrate), so we
-        # seed the AlbumInfo with format="MP3" and it classifies via the
-        # VBR band table (207 is still below 210 → EXCELLENT not TRANSPARENT).
-        # To accept at 207 under the new rules, the format must be the V0
-        # label contract, which is only known from import_one.py. Simulating
-        # that via format="MP3" here — 207 MP3 VBR is EXCELLENT ≥ gate.
         beets_info = AlbumInfo(
             album_id=1, track_count=10, min_bitrate_kbps=207,
             avg_bitrate_kbps=207, format="MP3",

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -443,8 +443,8 @@ class TestCmdSetIntent(unittest.TestCase):
 class TestCmdRepairSpectral(unittest.TestCase):
     """Regression tests for the rank-model repair flow."""
 
-    def test_repair_spectral_uses_beets_format_and_runtime_rank_config(self):
-        """A GOOD-rank VBR album should repair to imported under a GOOD gate."""
+    def test_repair_spectral_reloads_full_request_metadata(self):
+        """Lo-fi V0 repair must reload full request metadata, not trust the partial row."""
         from lib.beets_db import AlbumInfo
 
         cfg_fd, cfg_path = tempfile.mkstemp(prefix="quality-ranks-", suffix=".ini")
@@ -452,26 +452,40 @@ class TestCmdRepairSpectral(unittest.TestCase):
         try:
             with open(cfg_path, "w", encoding="utf-8") as f:
                 f.write("[Quality Ranks]\n")
-                f.write("gate_min_rank = good\n")
 
+            # Mirror the real repair query shape: it does NOT include
+            # mb_release_id/final_format, so the command must re-load the
+            # full request row instead of depending on the partial result.
             candidate_cur = MagicMock()
-            candidate_cur.fetchall.return_value = [make_request_row(
-                id=42,
-                status="wanted",
-                mb_release_id="mbid-123",
-                artist_name="Artist",
-                album_title="Album",
-                min_bitrate=180,
-                current_spectral_grade="genuine",
-                current_spectral_bitrate=96,
-                verified_lossless=False,
-            )]
+            candidate_cur.fetchall.return_value = [{
+                "id": 42,
+                "artist_name": "Artist",
+                "album_title": "Album",
+                "min_bitrate": 207,
+                "current_spectral_grade": "genuine",
+                "current_spectral_bitrate": 96,
+                "last_download_spectral_bitrate": None,
+                "last_download_spectral_grade": None,
+                "verified_lossless": True,
+            }]
             clear_cur = MagicMock()
             delete_cur = MagicMock()
             delete_cur.fetchall.return_value = []
             import_cur = MagicMock()
 
             db = MagicMock()
+            db.get_request.return_value = make_request_row(
+                id=42,
+                status="wanted",
+                mb_release_id="mbid-123",
+                artist_name="Artist",
+                album_title="Album",
+                min_bitrate=207,
+                current_spectral_grade="genuine",
+                current_spectral_bitrate=96,
+                verified_lossless=True,
+                final_format="mp3 v0",
+            )
             db._execute.side_effect = [
                 candidate_cur,
                 clear_cur,
@@ -482,8 +496,8 @@ class TestCmdRepairSpectral(unittest.TestCase):
             beets_info = AlbumInfo(
                 album_id=1,
                 track_count=10,
-                min_bitrate_kbps=180,
-                avg_bitrate_kbps=180,
+                min_bitrate_kbps=207,
+                avg_bitrate_kbps=207,
                 format="MP3",
                 is_cbr=False,
                 album_path="/Beets/Artist/Album",
@@ -496,7 +510,7 @@ class TestCmdRepairSpectral(unittest.TestCase):
             args = MagicMock(dry_run=False)
             stdout = io.StringIO()
             with patch.dict(os.environ, {"SOULARR_RUNTIME_CONFIG": cfg_path}), \
-                 patch("beets_db.BeetsDB", return_value=mock_beets), \
+                 patch("lib.beets_db.BeetsDB", return_value=mock_beets), \
                  redirect_stdout(stdout):
                 pipeline_cli.cmd_repair_spectral(db, args)
 
@@ -506,7 +520,7 @@ class TestCmdRepairSpectral(unittest.TestCase):
             self.assertEqual(db._execute.call_count, 4)
             imported_sql, imported_params = db._execute.call_args_list[3][0]
             self.assertIn("SET status = 'imported'", imported_sql)
-            self.assertEqual(imported_params, (180, 42))
+            self.assertEqual(imported_params, (207, 42))
         finally:
             os.unlink(cfg_path)
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 # Bootstrap ephemeral PostgreSQL if available
@@ -523,6 +524,92 @@ class TestCmdRepairSpectral(unittest.TestCase):
             self.assertEqual(imported_params, (207, 42))
         finally:
             os.unlink(cfg_path)
+
+
+class TestCmdQuality(unittest.TestCase):
+    """Regression tests for pipeline-cli quality simulator parity."""
+
+    def _run_quality(self, request_row, *, runtime_target: str | None):
+        from lib.quality import QualityRankConfig
+
+        db = MagicMock()
+        db.get_request.return_value = request_row
+
+        beets_info = SimpleNamespace(
+            is_cbr=False,
+            avg_bitrate_kbps=245,
+            format="MP3",
+        )
+        captured_kwargs: list[dict[str, object]] = []
+
+        def fake_full_pipeline_decision(**kwargs):
+            captured_kwargs.append(kwargs)
+            return {
+                "stage1_spectral": None,
+                "stage2_import": "import",
+                "stage3_quality_gate": "accept",
+                "final_status": "imported",
+                "imported": True,
+                "denylisted": False,
+                "keep_searching": False,
+                "target_final_format": kwargs.get("target_format")
+                or kwargs.get("verified_lossless_target"),
+            }
+
+        stdout = io.StringIO()
+        with patch("pipeline_cli._load_runtime_rank_config",
+                   return_value=QualityRankConfig.defaults()), \
+             patch("pipeline_cli._load_runtime_verified_lossless_target",
+                   return_value=runtime_target or ""), \
+             patch("pipeline_cli._load_beets_album_info",
+                   return_value=beets_info), \
+             patch("quality.full_pipeline_decision",
+                   side_effect=fake_full_pipeline_decision), \
+             redirect_stdout(stdout):
+            pipeline_cli.cmd_quality(db, MagicMock(id=request_row["id"]))
+
+        return stdout.getvalue(), captured_kwargs
+
+    def test_quality_threads_runtime_verified_lossless_target(self):
+        request_row = make_request_row(
+            id=7,
+            status="imported",
+            mb_release_id="mbid-123",
+            artist_name="Artist",
+            album_title="Album",
+            min_bitrate=245,
+            verified_lossless=True,
+            final_format="mp3 v0",
+            target_format=None,
+        )
+
+        output, calls = self._run_quality(request_row, runtime_target="opus 128")
+
+        self.assertTrue(calls)
+        self.assertTrue(all(
+            call["verified_lossless_target"] == "opus 128" for call in calls))
+        self.assertIn("Verified-lossless output: opus 128", output)
+        self.assertIn("Genuine FLAC → opus 128 (high bitrate):", output)
+
+    def test_quality_threads_request_target_format(self):
+        request_row = make_request_row(
+            id=8,
+            status="imported",
+            mb_release_id="mbid-123",
+            artist_name="Artist",
+            album_title="Album",
+            min_bitrate=245,
+            verified_lossless=True,
+            final_format="mp3 v0",
+            target_format="flac",
+        )
+
+        output, calls = self._run_quality(request_row, runtime_target="opus 128")
+
+        self.assertTrue(calls)
+        self.assertTrue(all(call["target_format"] == "flac" for call in calls))
+        self.assertIn("Verified-lossless output: flac", output)
+        self.assertIn("Genuine FLAC → flac (high bitrate):", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -3,6 +3,7 @@
 import io
 import os
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from unittest.mock import patch, MagicMock
@@ -437,6 +438,77 @@ class TestCmdSetIntent(unittest.TestCase):
         args = MagicMock(id=99, intent="lossless")
         pipeline_cli.cmd_set_intent(db, args)
         db.update_request_fields.assert_not_called()
+
+
+class TestCmdRepairSpectral(unittest.TestCase):
+    """Regression tests for the rank-model repair flow."""
+
+    def test_repair_spectral_uses_beets_format_and_runtime_rank_config(self):
+        """A GOOD-rank VBR album should repair to imported under a GOOD gate."""
+        from lib.beets_db import AlbumInfo
+
+        cfg_fd, cfg_path = tempfile.mkstemp(prefix="quality-ranks-", suffix=".ini")
+        os.close(cfg_fd)
+        try:
+            with open(cfg_path, "w", encoding="utf-8") as f:
+                f.write("[Quality Ranks]\n")
+                f.write("gate_min_rank = good\n")
+
+            candidate_cur = MagicMock()
+            candidate_cur.fetchall.return_value = [make_request_row(
+                id=42,
+                status="wanted",
+                mb_release_id="mbid-123",
+                artist_name="Artist",
+                album_title="Album",
+                min_bitrate=180,
+                current_spectral_grade="genuine",
+                current_spectral_bitrate=96,
+                verified_lossless=False,
+            )]
+            clear_cur = MagicMock()
+            delete_cur = MagicMock()
+            delete_cur.fetchall.return_value = []
+            import_cur = MagicMock()
+
+            db = MagicMock()
+            db._execute.side_effect = [
+                candidate_cur,
+                clear_cur,
+                delete_cur,
+                import_cur,
+            ]
+
+            beets_info = AlbumInfo(
+                album_id=1,
+                track_count=10,
+                min_bitrate_kbps=180,
+                avg_bitrate_kbps=180,
+                format="MP3",
+                is_cbr=False,
+                album_path="/Beets/Artist/Album",
+            )
+            mock_beets = MagicMock()
+            mock_beets.__enter__ = MagicMock(return_value=mock_beets)
+            mock_beets.__exit__ = MagicMock(return_value=False)
+            mock_beets.get_album_info.return_value = beets_info
+
+            args = MagicMock(dry_run=False)
+            stdout = io.StringIO()
+            with patch.dict(os.environ, {"SOULARR_RUNTIME_CONFIG": cfg_path}), \
+                 patch("beets_db.BeetsDB", return_value=mock_beets), \
+                 redirect_stdout(stdout):
+                pipeline_cli.cmd_repair_spectral(db, args)
+
+            output = stdout.getvalue()
+            self.assertIn("quality_gate_decision → accept", output)
+            self.assertIn("→ transitioned to imported", output)
+            self.assertEqual(db._execute.call_count, 4)
+            imported_sql, imported_params = db._execute.call_args_list[3][0]
+            self.assertIn("SET status = 'imported'", imported_sql)
+            self.assertEqual(imported_params, (180, 42))
+        finally:
+            os.unlink(cfg_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -85,29 +85,98 @@ class TestSpectralImportDecision(unittest.TestCase):
 # ============================================================================
 
 class TestImportQualityDecision(unittest.TestCase):
-    """Test import decision (FLAC conversion / bitrate comparison path).
+    """Codec-aware import decision (issue #60).
 
-    Uses AudioQualityMeasurement objects for new/existing.
-    The override concept is gone — callers construct existing with
-    the resolved bitrate.
+    Every row explicitly sets ``format`` + ``avg_bitrate_kbps`` on both
+    measurements so the rank model has what it needs. The old blanket
+    verified_lossless bypass is replaced by a tier-gated preference:
+    ``verified_lossless=True`` still imports on "better" or "equivalent",
+    but a "worse" verdict is blocked regardless — this prevents a
+    deliberately-too-low verified_lossless_target from replacing a good
+    existing album.
     """
 
     CASES = [
         # desc, new_kwargs, existing_kwargs, is_transcode, expected
-        ("verified lossless wins", dict(min_bitrate_kbps=240, verified_lossless=True), dict(min_bitrate_kbps=320), False, "import"),
-        ("verified lossless lower bitrate wins", dict(min_bitrate_kbps=207, verified_lossless=True), dict(min_bitrate_kbps=320), False, "import"),
-        ("verified lossless no existing", dict(min_bitrate_kbps=240, verified_lossless=True), None, False, "import"),
-        ("normal upgrade", dict(min_bitrate_kbps=256), dict(min_bitrate_kbps=192), False, "import"),
-        ("equal bitrate downgrade", dict(min_bitrate_kbps=320), dict(min_bitrate_kbps=320), False, "downgrade"),
-        ("lower bitrate downgrade", dict(min_bitrate_kbps=192), dict(min_bitrate_kbps=320), False, "downgrade"),
-        ("override already resolved as upgrade", dict(min_bitrate_kbps=240), dict(min_bitrate_kbps=128), False, "import"),
-        ("override already resolved as downgrade", dict(min_bitrate_kbps=100), dict(min_bitrate_kbps=128), False, "downgrade"),
-        ("transcode upgrade", dict(min_bitrate_kbps=192), dict(min_bitrate_kbps=128), True, "transcode_upgrade"),
-        ("transcode downgrade", dict(min_bitrate_kbps=128), dict(min_bitrate_kbps=192), True, "transcode_downgrade"),
-        ("transcode equal downgrade", dict(min_bitrate_kbps=128), dict(min_bitrate_kbps=128), True, "transcode_downgrade"),
-        ("transcode first import", dict(min_bitrate_kbps=150), None, True, "transcode_first"),
-        ("first import", dict(min_bitrate_kbps=240), None, False, "import"),
-        ("first import no bitrates", dict(), None, False, "import"),
+
+        # --- Same-codec mono-codec regression cases ---
+        ("V0 beats V2 (same codec family, different rank)",
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         dict(format="mp3 v2", avg_bitrate_kbps=190),
+         False, "import"),
+        ("V2 loses to V0",
+         dict(format="mp3 v2", avg_bitrate_kbps=190),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         False, "downgrade"),
+        ("equal V0 labels → equivalent → downgrade without verified_lossless",
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         False, "downgrade"),
+        ("equal CBR 320 → equivalent → downgrade",
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True),
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True),
+         False, "downgrade"),
+        ("CBR 192 loses to CBR 320",
+         dict(format="mp3 192", avg_bitrate_kbps=192, is_cbr=True),
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True),
+         False, "downgrade"),
+
+        # --- Cross-codec equivalence (core #60 fix) ---
+        ("Opus 128 equivalent to MP3 V0 → no verified → downgrade",
+         dict(format="opus 128", avg_bitrate_kbps=130),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         False, "downgrade"),
+        ("Opus 128 equivalent to MP3 V0 + verified_lossless → import",
+         dict(format="opus 128", avg_bitrate_kbps=130, verified_lossless=True),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         False, "import"),
+        ("FLAC→Opus 128 equivalent to MP3 CBR 320 + verified_lossless → import",
+         dict(format="opus 128", avg_bitrate_kbps=130, verified_lossless=True),
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True),
+         False, "import"),
+
+        # --- verified_lossless guardrail (core #60 fix) ---
+        ("Opus 64 verified CANNOT replace MP3 V0 245",
+         dict(format="opus 64", avg_bitrate_kbps=64, verified_lossless=True),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         False, "downgrade"),
+        ("Opus 48 verified CANNOT replace MP3 CBR 320",
+         dict(format="opus 48", avg_bitrate_kbps=48, verified_lossless=True),
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True),
+         False, "downgrade"),
+
+        # --- Lo-fi genuine V0 (label semantics preserved) ---
+        ("lo-fi V0 (207) equivalent to dense V0 (245) + verified → import",
+         dict(format="mp3 v0", avg_bitrate_kbps=207, verified_lossless=True),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         False, "import"),
+
+        # --- No existing album ---
+        ("no existing → import",
+         dict(format="mp3 v0", avg_bitrate_kbps=240), None, False, "import"),
+        ("no existing transcode → transcode_first",
+         dict(format="mp3 v0", avg_bitrate_kbps=150), None, True, "transcode_first"),
+
+        # --- Transcode semantics ---
+        ("transcode upgrade (better rank)",
+         dict(format="mp3 v0", avg_bitrate_kbps=192),
+         dict(format="mp3 192", avg_bitrate_kbps=128, is_cbr=True),
+         True, "transcode_upgrade"),
+        ("transcode downgrade (worse rank)",
+         dict(format="mp3 128", avg_bitrate_kbps=128, is_cbr=True),
+         dict(format="mp3 v0", avg_bitrate_kbps=192),
+         True, "transcode_downgrade"),
+
+        # --- Legacy format-less fallback via bare-codec path ---
+        # When format is None on both sides, measurements fall to UNKNOWN rank
+        # and compare_quality() uses the bare-codec bitrate tiebreaker with
+        # tolerance. Tests here document that fallback explicitly.
+        ("legacy no-format tie → equivalent → downgrade",
+         dict(min_bitrate_kbps=320), dict(min_bitrate_kbps=320),
+         False, "downgrade"),
+        ("legacy no-format worse → downgrade",
+         dict(min_bitrate_kbps=192), dict(min_bitrate_kbps=320),
+         False, "downgrade"),
     ]
 
     def test_import_quality_decisions(self):
@@ -126,7 +195,8 @@ class TestImportQualityDecision(unittest.TestCase):
                         is_transcode=is_transcode,
                     ),
                     expected,
-                )
+                    f"{desc}: new={new_kwargs} existing={existing_kwargs} "
+                    f"is_transcode={is_transcode} expected {expected!r}")
 
 
 # ============================================================================
@@ -172,35 +242,69 @@ class TestTranscodeDetection(unittest.TestCase):
 # ============================================================================
 
 class TestQualityGateDecision(unittest.TestCase):
-    """Test post-import quality gate via subTest table."""
+    """Codec-aware post-import quality gate (issue #60).
+
+    Every row explicitly sets the ``format`` field so quality_rank()
+    classifies against the right band table. The legacy blanket
+    ``verified_lossless`` bypass is replaced by the rank model — lo-fi
+    V0 reads as TRANSPARENT from the label, so the bypass is no longer
+    needed for genuine lo-fi.
+    """
 
     CASES = [
         # (description, measurement_kwargs, expected_decision)
-        # --- accept ---
-        ("VBR above threshold", dict(min_bitrate_kbps=240, is_cbr=False), "accept"),
-        ("VBR at threshold", dict(min_bitrate_kbps=QUALITY_MIN_BITRATE_KBPS, is_cbr=False), "accept"),
-        ("verified lossless low bitrate", dict(min_bitrate_kbps=180, verified_lossless=True), "accept"),
-        ("verified lossless CBR", dict(min_bitrate_kbps=320, is_cbr=True, verified_lossless=True), "accept"),
-        ("verified lossless overrides spectral", dict(min_bitrate_kbps=180, verified_lossless=True, spectral_bitrate_kbps=150), "accept"),
-        ("opus 128 verified lossless", dict(min_bitrate_kbps=128, verified_lossless=True), "accept"),
-        # --- requeue_upgrade ---
-        ("below threshold", dict(min_bitrate_kbps=190), "requeue_upgrade"),
-        ("way below threshold", dict(min_bitrate_kbps=96), "requeue_upgrade"),
-        ("spectral override CBR", dict(min_bitrate_kbps=320, is_cbr=True, spectral_bitrate_kbps=128), "requeue_upgrade"),
-        ("spectral higher ignored", dict(min_bitrate_kbps=192, spectral_bitrate_kbps=256), "requeue_upgrade"),
-        ("CBR below threshold", dict(min_bitrate_kbps=192, is_cbr=True), "requeue_upgrade"),
-        ("opus 128 not verified", dict(min_bitrate_kbps=128), "requeue_upgrade"),
-        ("none bitrate", dict(), "requeue_upgrade"),
-        # --- requeue_lossless ---
-        ("CBR above threshold", dict(min_bitrate_kbps=320, is_cbr=True), "requeue_lossless"),
-        ("CBR 256", dict(min_bitrate_kbps=256, is_cbr=True), "requeue_lossless"),
+
+        # --- accept: labels with TRANSPARENT rank (cross-codec equivalence) ---
+        ("MP3 V0 label lo-fi accepts without bypass",
+         dict(format="mp3 v0", avg_bitrate_kbps=207), "accept"),
+        ("MP3 V0 label dense",
+         dict(format="mp3 v0", avg_bitrate_kbps=245), "accept"),
+        ("Opus 128 verified lossless",
+         dict(format="opus 128", avg_bitrate_kbps=130, verified_lossless=True), "accept"),
+        ("Opus 128 not verified (label still transparent)",
+         dict(format="opus 128", avg_bitrate_kbps=130), "accept"),
+        ("bare MP3 VBR above rank",
+         dict(format="MP3", avg_bitrate_kbps=240, is_cbr=False), "accept"),
+
+        # --- requeue_upgrade: rank below gate_min_rank (EXCELLENT) ---
+        ("bare MP3 VBR below rank",
+         dict(format="MP3", avg_bitrate_kbps=150, is_cbr=False), "requeue_upgrade"),
+        ("Opus 64 verified (target too low)",
+         dict(format="opus 64", avg_bitrate_kbps=64, verified_lossless=True), "requeue_upgrade"),
+        ("Opus 48 verified (target far too low)",
+         dict(format="opus 48", avg_bitrate_kbps=48, verified_lossless=True), "requeue_upgrade"),
+        ("spectral clamp pulls CBR 320 down",
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True,
+              spectral_bitrate_kbps=128), "requeue_upgrade"),
+        ("no format no bitrate → UNKNOWN",
+         dict(), "requeue_upgrade"),
+
+        # --- requeue_lossless: CBR at TRANSPARENT but unverified ---
+        ("CBR 320 unverified → requeue_lossless",
+         dict(format="mp3 320", avg_bitrate_kbps=320, is_cbr=True), "requeue_lossless"),
+        ("bare MP3 CBR 320 unverified → requeue_lossless",
+         dict(format="MP3", avg_bitrate_kbps=320, is_cbr=True), "requeue_lossless"),
+        ("bare MP3 CBR 256 unverified → requeue_lossless",
+         dict(format="MP3", avg_bitrate_kbps=256, is_cbr=True), "requeue_lossless"),
+
+        # --- lossless accepts regardless ---
+        ("FLAC accepts",
+         dict(format="FLAC", avg_bitrate_kbps=900), "accept"),
+        ("lossless label accepts with no bitrate",
+         dict(format="flac"), "accept"),
+
+        # --- legacy verified_lossless cases (still honoured via label if present) ---
+        ("legacy no format, verified_lossless → UNKNOWN → requeue_upgrade",
+         dict(min_bitrate_kbps=180, verified_lossless=True), "requeue_upgrade"),
     ]
 
     def test_quality_gate_decisions(self):
         for desc, kwargs, expected in self.CASES:
             with self.subTest(desc=desc):
                 m = AudioQualityMeasurement(**kwargs)
-                self.assertEqual(quality_gate_decision(m), expected)
+                self.assertEqual(
+                    quality_gate_decision(m), expected,
+                    f"{desc}: {kwargs} expected {expected!r}")
 
 
 # ============================================================================
@@ -316,9 +420,11 @@ EXPECTED_PARAMS = {
     "spectral_grade", "spectral_bitrate",
     "existing_min_bitrate", "existing_spectral_bitrate",
     "override_min_bitrate",
+    "existing_format", "existing_is_cbr",
     "post_conversion_min_bitrate", "converted_count",
     "verified_lossless", "verified_lossless_target",
     "target_format",
+    "new_format", "cfg",
 }
 
 
@@ -1044,11 +1150,16 @@ class TestQualityRank(unittest.TestCase):
         ("aac 80 label",                           "aac 80",          80, False, QualityRank.ACCEPTABLE),
 
         # --- Step 5: bare codec name + measured bitrate (beets items.format path) ---
-        ("MP3 VBR beets 240",                      "MP3",            240, False, QualityRank.TRANSPARENT),
-        ("MP3 VBR beets 200",                      "MP3",            200, False, QualityRank.EXCELLENT),
-        ("MP3 VBR beets 150",                      "MP3",            150, False, QualityRank.GOOD),
-        ("MP3 VBR beets 100",                      "MP3",            100, False, QualityRank.ACCEPTABLE),
-        ("MP3 VBR beets 80",                       "MP3",             80, False, QualityRank.POOR),
+        # Default mp3_vbr bands: transparent=245, excellent=210, good=170, acceptable=130
+        ("MP3 VBR beets 260",                      "MP3",            260, False, QualityRank.TRANSPARENT),
+        ("MP3 VBR beets 245",                      "MP3",            245, False, QualityRank.TRANSPARENT),
+        ("MP3 VBR beets 220",                      "MP3",            220, False, QualityRank.EXCELLENT),
+        ("MP3 VBR beets 210",                      "MP3",            210, False, QualityRank.EXCELLENT),
+        ("MP3 VBR beets 180",                      "MP3",            180, False, QualityRank.GOOD),
+        ("MP3 VBR beets 170",                      "MP3",            170, False, QualityRank.GOOD),
+        ("MP3 VBR beets 140",                      "MP3",            140, False, QualityRank.ACCEPTABLE),
+        ("MP3 VBR beets 130",                      "MP3",            130, False, QualityRank.ACCEPTABLE),
+        ("MP3 VBR beets 100",                      "MP3",            100, False, QualityRank.POOR),
         ("MP3 CBR beets 320",                      "MP3",            320, True,  QualityRank.TRANSPARENT),
         ("MP3 CBR beets 256",                      "MP3",            256, True,  QualityRank.EXCELLENT),
         ("MP3 CBR beets 192",                      "MP3",            192, True,  QualityRank.GOOD),
@@ -1094,8 +1205,9 @@ class TestMeasurementRank(unittest.TestCase):
 
     def test_falls_back_to_min_when_avg_is_none(self):
         m = AudioQualityMeasurement(
-            min_bitrate_kbps=240, avg_bitrate_kbps=None, format="MP3")
-        # Legacy measurement — AVG metric falls back to min
+            min_bitrate_kbps=260, avg_bitrate_kbps=None, format="MP3")
+        # Legacy measurement — AVG metric falls back to min.
+        # 260 is above default mp3_vbr.transparent=245 → TRANSPARENT.
         self.assertEqual(measurement_rank(m, CFG), QualityRank.TRANSPARENT)
 
     def test_min_metric_uses_min(self):
@@ -1161,17 +1273,18 @@ class TestCompareQuality(unittest.TestCase):
          "equivalent"),
 
         # --- Same rank, same bare codec family, measurable bitrate ---
-        ("bare MP3 245 > MP3 225 (same rank TRANSPARENT)",
-         dict(format="MP3", avg_bitrate_kbps=245),
-         dict(format="MP3", avg_bitrate_kbps=225),
+        # Default mp3_vbr bands: transparent=245, excellent=210
+        ("bare MP3 260 > MP3 250 (same rank TRANSPARENT)",
+         dict(format="MP3", avg_bitrate_kbps=260),
+         dict(format="MP3", avg_bitrate_kbps=250),
          "better"),
-        ("bare MP3 225 < MP3 245 (same rank)",
-         dict(format="MP3", avg_bitrate_kbps=225),
-         dict(format="MP3", avg_bitrate_kbps=245),
+        ("bare MP3 250 < MP3 260 (same rank)",
+         dict(format="MP3", avg_bitrate_kbps=250),
+         dict(format="MP3", avg_bitrate_kbps=260),
          "worse"),
         ("bare MP3 within tolerance → equivalent",
-         dict(format="MP3", avg_bitrate_kbps=242),
-         dict(format="MP3", avg_bitrate_kbps=245),
+         dict(format="MP3", avg_bitrate_kbps=257),
+         dict(format="MP3", avg_bitrate_kbps=260),
          "equivalent"),
         ("bare Opus 130 == Opus 128 within tolerance",
          dict(format="Opus", avg_bitrate_kbps=130),

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -621,6 +621,20 @@ class TestFullPipelineContract(unittest.TestCase):
             verified_lossless_target="mp3 v2")
         self.assertIsNone(r["target_final_format"])
 
+    def test_target_conversion_guardrail_blocks_low_target_before_import(self):
+        """Low verified-lossless target must lose the import comparison itself."""
+        r = full_pipeline_decision(
+            is_flac=True, min_bitrate=0, is_cbr=False,
+            spectral_grade="genuine", converted_count=10,
+            post_conversion_min_bitrate=245,
+            existing_min_bitrate=245,
+            existing_format="mp3 v0",
+            verified_lossless_target="opus 64")
+        self.assertEqual(r["stage2_import"], "downgrade")
+        self.assertFalse(r["imported"])
+        self.assertEqual(r["final_status"], "imported")
+        self.assertTrue(r["keep_searching"])
+
 
 # ============================================================================
 # full_pipeline_decision with target_format

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -5,6 +5,7 @@ These test every branch of the four decision functions directly,
 independent of real audio fixtures or the full_pipeline_decision integrator.
 """
 
+import json
 import os
 import sys
 import unittest
@@ -1225,6 +1226,164 @@ class TestCompareQuality(unittest.TestCase):
         self.assertEqual(compare_quality(new, existing, cfg_min), "better")
         # Under AVG: new=250, existing=260 → worse
         self.assertEqual(compare_quality(new, existing, CFG), "worse")
+
+
+class TestQualityRankConfigFromIni(unittest.TestCase):
+    """Parse [Quality Ranks] section from config.ini — exhaustive edge cases."""
+
+    def _parse(self, ini_body: str) -> QualityRankConfig:
+        import configparser
+        parser = configparser.RawConfigParser()
+        parser.read_string(ini_body)
+        return QualityRankConfig.from_ini(parser)
+
+    def test_missing_section_returns_defaults(self):
+        cfg = self._parse("[Other Section]\nkey = value\n")
+        self.assertEqual(cfg, QualityRankConfig.defaults())
+
+    def test_empty_section_returns_defaults(self):
+        cfg = self._parse("[Quality Ranks]\n")
+        self.assertEqual(cfg, QualityRankConfig.defaults())
+
+    def test_partial_override_one_band(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "opus.transparent = 120\n"
+        )
+        self.assertEqual(cfg.opus.transparent, 120)
+        # All other opus values stay at default
+        self.assertEqual(cfg.opus.excellent, 88)
+        self.assertEqual(cfg.opus.good, 64)
+        self.assertEqual(cfg.opus.acceptable, 48)
+        # And other codecs untouched
+        self.assertEqual(cfg.mp3_vbr, QualityRankConfig.defaults().mp3_vbr)
+
+    def test_full_override(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "bitrate_metric = min\n"
+            "gate_min_rank = good\n"
+            "within_rank_tolerance_kbps = 10\n"
+            "opus.transparent = 120\n"
+            "opus.excellent = 100\n"
+            "opus.good = 80\n"
+            "opus.acceptable = 60\n"
+            "mp3_vbr.transparent = 220\n"
+            "mp3_vbr.excellent = 180\n"
+            "mp3_vbr.good = 140\n"
+            "mp3_vbr.acceptable = 100\n"
+            "mp3_cbr.transparent = 320\n"
+            "mp3_cbr.excellent = 250\n"
+            "mp3_cbr.good = 200\n"
+            "mp3_cbr.acceptable = 130\n"
+            "aac.transparent = 200\n"
+            "aac.excellent = 150\n"
+            "aac.good = 120\n"
+            "aac.acceptable = 90\n"
+        )
+        self.assertEqual(cfg.bitrate_metric, RankBitrateMetric.MIN)
+        self.assertEqual(cfg.gate_min_rank, QualityRank.GOOD)
+        self.assertEqual(cfg.within_rank_tolerance_kbps, 10)
+        self.assertEqual(cfg.opus.transparent, 120)
+        self.assertEqual(cfg.mp3_vbr.transparent, 220)
+        self.assertEqual(cfg.mp3_cbr.excellent, 250)
+        self.assertEqual(cfg.aac.acceptable, 90)
+
+    def test_invalid_metric_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("[Quality Ranks]\nbitrate_metric = median\n")
+        self.assertIn("bitrate_metric", str(ctx.exception))
+
+    def test_invalid_rank_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("[Quality Ranks]\ngate_min_rank = perfect\n")
+        self.assertIn("gate_min_rank", str(ctx.exception))
+
+    def test_non_integer_band_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("[Quality Ranks]\nopus.transparent = not_a_number\n")
+        self.assertIn("opus.transparent", str(ctx.exception))
+
+    def test_non_monotonic_bands_raise(self):
+        with self.assertRaises(ValueError):
+            self._parse(
+                "[Quality Ranks]\n"
+                "opus.transparent = 50\n"
+                "opus.excellent = 100\n"
+            )
+
+    def test_negative_tolerance_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("[Quality Ranks]\nwithin_rank_tolerance_kbps = -3\n")
+        self.assertIn("within_rank_tolerance_kbps", str(ctx.exception))
+
+    def test_case_insensitive_metric_and_rank(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "bitrate_metric = AVG\n"
+            "gate_min_rank = TRANSPARENT\n"
+        )
+        self.assertEqual(cfg.bitrate_metric, RankBitrateMetric.AVG)
+        self.assertEqual(cfg.gate_min_rank, QualityRank.TRANSPARENT)
+
+    def test_empty_value_falls_through_to_default(self):
+        """Empty `key =` should yield the default, matching _get_int behavior."""
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "bitrate_metric = \n"
+            "gate_min_rank =    \n"
+        )
+        self.assertEqual(cfg.bitrate_metric, RankBitrateMetric.AVG)
+        self.assertEqual(cfg.gate_min_rank, QualityRank.EXCELLENT)
+
+    def test_repo_config_ini_parses_cleanly(self):
+        """The in-repo config.ini template must parse to a valid QualityRankConfig."""
+        import configparser
+        import os
+        parser = configparser.RawConfigParser()
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        parser.read(os.path.join(repo_root, "config.ini"))
+        cfg = QualityRankConfig.from_ini(parser)
+        # Repo template uses the defaults — assert round-trip equality.
+        self.assertEqual(cfg, QualityRankConfig.defaults())
+
+
+class TestQualityRankConfigRoundTrip(unittest.TestCase):
+    """to_json / from_json must round-trip identically."""
+
+    def test_defaults_round_trip(self):
+        original = QualityRankConfig.defaults()
+        restored = QualityRankConfig.from_json(original.to_json())
+        self.assertEqual(restored, original)
+
+    def test_custom_round_trip(self):
+        original = QualityRankConfig(
+            bitrate_metric=RankBitrateMetric.MIN,
+            gate_min_rank=QualityRank.TRANSPARENT,
+            within_rank_tolerance_kbps=8,
+            opus=CodecRankBands(transparent=120, excellent=100, good=80, acceptable=60),
+        )
+        payload = original.to_json()
+        restored = QualityRankConfig.from_json(payload)
+        self.assertEqual(restored, original)
+        self.assertEqual(restored.opus.transparent, 120)
+
+    def test_json_shape_stable(self):
+        """to_json() must emit the expected top-level keys."""
+        import json
+        payload = json.loads(QualityRankConfig.defaults().to_json())
+        expected_keys = {
+            "bitrate_metric", "gate_min_rank", "within_rank_tolerance_kbps",
+            "opus", "mp3_vbr", "mp3_cbr", "aac",
+            "mp3_vbr_levels", "lossless_codecs", "mixed_format_precedence",
+        }
+        self.assertEqual(set(payload.keys()), expected_keys)
+
+    def test_json_rank_is_int(self):
+        payload = json.loads(QualityRankConfig.defaults().to_json())
+        self.assertIsInstance(payload["gate_min_rank"], int)
+        for r in payload["mp3_vbr_levels"]:
+            self.assertIsInstance(r, int)
 
 
 class TestQualityRankConfigDefaults(unittest.TestCase):

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -8,6 +8,7 @@ independent of real audio fixtures or the full_pipeline_decision integrator.
 import os
 import sys
 import unittest
+from typing import Any
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -24,6 +25,14 @@ from lib.quality import (
     narrow_override_on_downgrade,
     QUALITY_MIN_BITRATE_KBPS,
     TRANSCODE_MIN_BITRATE_KBPS,
+    # Codec-aware rank model (issue #60)
+    QualityRank,
+    RankBitrateMetric,
+    CodecRankBands,
+    QualityRankConfig,
+    quality_rank,
+    measurement_rank,
+    compare_quality,
 )
 
 
@@ -935,6 +944,321 @@ class TestRejectionBackfillOverride(unittest.TestCase):
             is_cbr=True, min_bitrate_kbps=320,
             spectral_grade="suspect", verified_lossless=False)
         self.assertIsNone(result)
+
+
+# ============================================================================
+# Codec-aware quality rank model (issue #60)
+# ============================================================================
+#
+# Every branch of quality_rank / measurement_rank / compare_quality has a
+# direct subTest row. No numeric thresholds are hardcoded in the tests —
+# we reference CFG = QualityRankConfig.defaults() so if a band moves in the
+# defaults the tests move with it automatically.
+
+CFG = QualityRankConfig.defaults()
+
+
+class TestCodecRankBands(unittest.TestCase):
+    """rank_for() exhaustively, plus the monotonic invariant."""
+
+    # (description, transparent, excellent, good, acceptable, bitrate, expected)
+    CASES = [
+        ("exactly transparent threshold",   112, 88, 64, 48, 112, QualityRank.TRANSPARENT),
+        ("above transparent",               112, 88, 64, 48, 200, QualityRank.TRANSPARENT),
+        ("exactly excellent threshold",     112, 88, 64, 48,  88, QualityRank.EXCELLENT),
+        ("between excellent and transparent", 112, 88, 64, 48, 100, QualityRank.EXCELLENT),
+        ("exactly good threshold",          112, 88, 64, 48,  64, QualityRank.GOOD),
+        ("between good and excellent",      112, 88, 64, 48,  80, QualityRank.GOOD),
+        ("exactly acceptable threshold",    112, 88, 64, 48,  48, QualityRank.ACCEPTABLE),
+        ("between acceptable and good",     112, 88, 64, 48,  56, QualityRank.ACCEPTABLE),
+        ("below acceptable",                112, 88, 64, 48,  32, QualityRank.POOR),
+        ("zero",                            112, 88, 64, 48,   0, QualityRank.POOR),
+        ("None bitrate",                    112, 88, 64, 48,  None, QualityRank.UNKNOWN),
+    ]
+
+    def test_rank_for_table(self):
+        for desc, t, e, g, a, br, expected in self.CASES:
+            with self.subTest(desc=desc):
+                bands = CodecRankBands(transparent=t, excellent=e, good=g, acceptable=a)
+                self.assertEqual(bands.rank_for(br), expected)
+
+    def test_monotonic_invariant(self):
+        # Non-monotonic bands must raise at construction time.
+        with self.assertRaises(ValueError):
+            CodecRankBands(transparent=100, excellent=150, good=50, acceptable=25)
+        with self.assertRaises(ValueError):
+            CodecRankBands(transparent=100, excellent=90, good=95, acceptable=50)
+        with self.assertRaises(ValueError):
+            CodecRankBands(transparent=100, excellent=90, good=80, acceptable=-5)
+
+
+class TestQualityRank(unittest.TestCase):
+    """quality_rank() across every codec, every band, every resolution step.
+
+    Uses default QualityRankConfig values for the classification — if the
+    defaults change, individual rows may need updating, which is intentional
+    (the defaults are the contract).
+    """
+
+    # (description, format_hint, bitrate_kbps, is_cbr, expected_rank)
+    CASES = [
+        # --- Step 1: both None → UNKNOWN ---
+        ("None format + None bitrate",             None,            None, False, QualityRank.UNKNOWN),
+
+        # --- Step 2: lossless family ---
+        ("FLAC label",                             "FLAC",          1000, False, QualityRank.LOSSLESS),
+        ("flac label lowercase",                   "flac",          1200, False, QualityRank.LOSSLESS),
+        ("lossless label",                         "lossless",      1100, False, QualityRank.LOSSLESS),
+        ("ALAC label",                             "ALAC",           900, False, QualityRank.LOSSLESS),
+        ("WAV label",                              "WAV",           1411, False, QualityRank.LOSSLESS),
+        ("flac with None bitrate",                 "flac",          None, False, QualityRank.LOSSLESS),
+
+        # --- Step 3: explicit MP3 VBR quality label ---
+        ("mp3 v0 lo-fi",                           "mp3 v0",         207, False, QualityRank.TRANSPARENT),
+        ("mp3 v0 dense",                           "mp3 v0",         260, False, QualityRank.TRANSPARENT),
+        ("mp3 v1 label",                           "mp3 v1",         220, False, QualityRank.EXCELLENT),
+        ("mp3 v2 label",                           "mp3 v2",         190, False, QualityRank.EXCELLENT),
+        ("mp3 v3 label",                           "mp3 v3",         170, False, QualityRank.GOOD),
+        ("mp3 v4 label",                           "mp3 v4",         155, False, QualityRank.GOOD),
+        ("mp3 v5 label",                           "mp3 v5",         130, False, QualityRank.ACCEPTABLE),
+        ("mp3 v9 label",                           "mp3 v9",          65, False, QualityRank.ACCEPTABLE),
+
+        # --- Step 4: explicit Opus bitrate label ---
+        ("opus 128 label",                         "opus 128",        95, False, QualityRank.TRANSPARENT),
+        ("opus 96 label",                          "opus 96",        100, False, QualityRank.EXCELLENT),
+        ("opus 64 label",                          "opus 64",        100, False, QualityRank.GOOD),
+        ("opus 48 label",                          "opus 48",        100, False, QualityRank.ACCEPTABLE),
+        ("opus 32 label",                          "opus 32",        100, False, QualityRank.POOR),
+
+        # --- Step 4: explicit MP3 CBR bitrate label (used for "mp3 320" style) ---
+        ("mp3 320 label",                          "mp3 320",        320, True,  QualityRank.TRANSPARENT),
+        ("mp3 256 label",                          "mp3 256",        256, True,  QualityRank.EXCELLENT),
+        ("mp3 192 label",                          "mp3 192",        192, True,  QualityRank.GOOD),
+        ("mp3 128 label",                          "mp3 128",        128, True,  QualityRank.ACCEPTABLE),
+
+        # --- Step 4: explicit AAC bitrate label ---
+        ("aac 192 label",                          "aac 192",        192, False, QualityRank.TRANSPARENT),
+        ("aac 144 label",                          "aac 144",        144, False, QualityRank.EXCELLENT),
+        ("aac 112 label",                          "aac 112",        112, False, QualityRank.GOOD),
+        ("aac 80 label",                           "aac 80",          80, False, QualityRank.ACCEPTABLE),
+
+        # --- Step 5: bare codec name + measured bitrate (beets items.format path) ---
+        ("MP3 VBR beets 240",                      "MP3",            240, False, QualityRank.TRANSPARENT),
+        ("MP3 VBR beets 200",                      "MP3",            200, False, QualityRank.EXCELLENT),
+        ("MP3 VBR beets 150",                      "MP3",            150, False, QualityRank.GOOD),
+        ("MP3 VBR beets 100",                      "MP3",            100, False, QualityRank.ACCEPTABLE),
+        ("MP3 VBR beets 80",                       "MP3",             80, False, QualityRank.POOR),
+        ("MP3 CBR beets 320",                      "MP3",            320, True,  QualityRank.TRANSPARENT),
+        ("MP3 CBR beets 256",                      "MP3",            256, True,  QualityRank.EXCELLENT),
+        ("MP3 CBR beets 192",                      "MP3",            192, True,  QualityRank.GOOD),
+        ("MP3 CBR beets 128",                      "MP3",            128, True,  QualityRank.ACCEPTABLE),
+        ("Opus beets 120",                         "Opus",           120, False, QualityRank.TRANSPARENT),
+        ("Opus beets 95",                          "Opus",            95, False, QualityRank.EXCELLENT),
+        ("Opus beets 70",                          "Opus",            70, False, QualityRank.GOOD),
+        ("Opus beets 50",                          "Opus",            50, False, QualityRank.ACCEPTABLE),
+        ("AAC beets 200",                          "AAC",            200, False, QualityRank.TRANSPARENT),
+        ("AAC beets 150",                          "AAC",            150, False, QualityRank.EXCELLENT),
+        ("AAC beets 120",                          "AAC",            120, False, QualityRank.GOOD),
+
+        # --- Step 6: unknown codec family ---
+        ("unknown codec",                          "vorbis",         200, False, QualityRank.UNKNOWN),
+        ("unknown codec with bitrate label",       "vorbis 192",     None, False, QualityRank.UNKNOWN),
+        ("unknown codec with vbr-ish label",       "wma v0",         None, False, QualityRank.UNKNOWN),
+        ("empty string format",                    "",               200, False, QualityRank.UNKNOWN),
+        ("whitespace-only format",                 "   ",            200, False, QualityRank.UNKNOWN),
+
+        # --- Edge: bare codec with None bitrate → UNKNOWN ---
+        ("bare MP3 no bitrate",                    "MP3",            None, False, QualityRank.UNKNOWN),
+        ("bare Opus no bitrate",                   "Opus",           None, False, QualityRank.UNKNOWN),
+    ]
+
+    def test_quality_rank_table(self):
+        for desc, fmt, br, is_cbr, expected in self.CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    quality_rank(fmt, br, is_cbr, CFG), expected,
+                    f"{desc}: quality_rank({fmt!r}, {br!r}, {is_cbr!r}) "
+                    f"expected {expected!r}",
+                )
+
+
+class TestMeasurementRank(unittest.TestCase):
+    """measurement_rank() — metric dispatch lives ONLY here."""
+
+    def test_avg_preferred_over_min_when_both_present(self):
+        m = AudioQualityMeasurement(
+            min_bitrate_kbps=80, avg_bitrate_kbps=130, format="Opus")
+        # Default config uses AVG; 130 → TRANSPARENT for Opus
+        self.assertEqual(measurement_rank(m, CFG), QualityRank.TRANSPARENT)
+
+    def test_falls_back_to_min_when_avg_is_none(self):
+        m = AudioQualityMeasurement(
+            min_bitrate_kbps=240, avg_bitrate_kbps=None, format="MP3")
+        # Legacy measurement — AVG metric falls back to min
+        self.assertEqual(measurement_rank(m, CFG), QualityRank.TRANSPARENT)
+
+    def test_min_metric_uses_min(self):
+        cfg = QualityRankConfig(bitrate_metric=RankBitrateMetric.MIN)
+        m = AudioQualityMeasurement(
+            min_bitrate_kbps=80, avg_bitrate_kbps=130, format="Opus")
+        # MIN metric ignores the higher avg
+        self.assertEqual(measurement_rank(m, cfg), QualityRank.GOOD)
+
+    def test_none_both_bitrates(self):
+        m = AudioQualityMeasurement(format="MP3")
+        self.assertEqual(measurement_rank(m, CFG), QualityRank.UNKNOWN)
+
+
+class TestCompareQuality(unittest.TestCase):
+    """compare_quality() covers all four outcome branches explicitly."""
+
+    def _m(self, **kwargs: Any) -> AudioQualityMeasurement:
+        return AudioQualityMeasurement(**kwargs)
+
+    # (description, new_kwargs, existing_kwargs, expected)
+    CASES = [
+        # --- Different rank → trivial ---
+        ("V0 beats V4",
+         dict(format="mp3 v0", avg_bitrate_kbps=240),
+         dict(format="mp3 v4", avg_bitrate_kbps=150),
+         "better"),
+        ("V4 loses to V0",
+         dict(format="mp3 v4", avg_bitrate_kbps=150),
+         dict(format="mp3 v0", avg_bitrate_kbps=240),
+         "worse"),
+        ("Opus 128 beats Opus 64",
+         dict(format="opus 128", avg_bitrate_kbps=130),
+         dict(format="opus 64",  avg_bitrate_kbps=60),
+         "better"),
+
+        # --- Same rank, different codec family → equivalent ---
+        ("Opus 128 == MP3 V0",
+         dict(format="opus 128", avg_bitrate_kbps=130),
+         dict(format="mp3 v0",   avg_bitrate_kbps=240),
+         "equivalent"),
+        ("MP3 V0 == Opus 128 (reverse)",
+         dict(format="mp3 v0",   avg_bitrate_kbps=240),
+         dict(format="opus 128", avg_bitrate_kbps=130),
+         "equivalent"),
+        ("MP3 V0 == MP3 CBR 320",
+         dict(format="mp3 v0",   avg_bitrate_kbps=240, is_cbr=False),
+         dict(format="mp3 320",  avg_bitrate_kbps=320, is_cbr=True),
+         "equivalent"),
+        ("Opus 128 == AAC 192",
+         dict(format="opus 128", avg_bitrate_kbps=130),
+         dict(format="aac 192",  avg_bitrate_kbps=192),
+         "equivalent"),
+
+        # --- Same rank, same VBR label → equivalent regardless of bitrate ---
+        ("lo-fi V0 == dense V0 (label rule)",
+         dict(format="mp3 v0",   avg_bitrate_kbps=207),
+         dict(format="mp3 v0",   avg_bitrate_kbps=245),
+         "equivalent"),
+        ("lo-fi V0 ≠ 'worse' even though 207 < 245",
+         dict(format="mp3 v0",   avg_bitrate_kbps=207),
+         dict(format="mp3 v0",   avg_bitrate_kbps=260),
+         "equivalent"),
+
+        # --- Same rank, same bare codec family, measurable bitrate ---
+        ("bare MP3 245 > MP3 225 (same rank TRANSPARENT)",
+         dict(format="MP3", avg_bitrate_kbps=245),
+         dict(format="MP3", avg_bitrate_kbps=225),
+         "better"),
+        ("bare MP3 225 < MP3 245 (same rank)",
+         dict(format="MP3", avg_bitrate_kbps=225),
+         dict(format="MP3", avg_bitrate_kbps=245),
+         "worse"),
+        ("bare MP3 within tolerance → equivalent",
+         dict(format="MP3", avg_bitrate_kbps=242),
+         dict(format="MP3", avg_bitrate_kbps=245),
+         "equivalent"),
+        ("bare Opus 130 == Opus 128 within tolerance",
+         dict(format="Opus", avg_bitrate_kbps=130),
+         dict(format="Opus", avg_bitrate_kbps=128),
+         "equivalent"),
+
+        # --- Unknown measurements fall through ---
+        ("both unknown format",
+         dict(format=None, avg_bitrate_kbps=None),
+         dict(format=None, avg_bitrate_kbps=None),
+         "equivalent"),
+        ("bare MP3 both None bitrate → equivalent guard",
+         dict(format="MP3"),
+         dict(format="MP3"),
+         "equivalent"),
+        ("bare Opus both None bitrate → equivalent guard",
+         dict(format="Opus"),
+         dict(format="Opus"),
+         "equivalent"),
+
+        # --- Lossless beats anything else ---
+        ("FLAC beats MP3 V0",
+         dict(format="FLAC", avg_bitrate_kbps=900),
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         "better"),
+        ("MP3 V0 loses to FLAC",
+         dict(format="mp3 v0", avg_bitrate_kbps=245),
+         dict(format="FLAC", avg_bitrate_kbps=900),
+         "worse"),
+        ("FLAC == FLAC",
+         dict(format="FLAC", avg_bitrate_kbps=900),
+         dict(format="FLAC", avg_bitrate_kbps=1100),
+         "equivalent"),
+    ]
+
+    def test_compare_quality_table(self):
+        for desc, new_kw, existing_kw, expected in self.CASES:
+            with self.subTest(desc=desc):
+                result = compare_quality(
+                    self._m(**new_kw), self._m(**existing_kw), CFG)
+                self.assertEqual(
+                    result, expected,
+                    f"{desc}: new={new_kw} existing={existing_kw} "
+                    f"expected {expected!r} got {result!r}")
+
+    def test_min_metric_honored_in_comparison(self):
+        """When cfg uses MIN, compare_quality must use min not avg."""
+        cfg_min = QualityRankConfig(bitrate_metric=RankBitrateMetric.MIN)
+        new = self._m(format="MP3", min_bitrate_kbps=240, avg_bitrate_kbps=250)
+        existing = self._m(format="MP3", min_bitrate_kbps=210, avg_bitrate_kbps=260)
+        # Under MIN: new=240, existing=210 → better
+        self.assertEqual(compare_quality(new, existing, cfg_min), "better")
+        # Under AVG: new=250, existing=260 → worse
+        self.assertEqual(compare_quality(new, existing, CFG), "worse")
+
+
+class TestQualityRankConfigDefaults(unittest.TestCase):
+    """Lock the default policy values so changes are explicit."""
+
+    def test_default_metric_is_avg(self):
+        self.assertEqual(CFG.bitrate_metric, RankBitrateMetric.AVG)
+
+    def test_default_gate_min_rank_is_excellent(self):
+        self.assertEqual(CFG.gate_min_rank, QualityRank.EXCELLENT)
+
+    def test_default_within_rank_tolerance(self):
+        self.assertEqual(CFG.within_rank_tolerance_kbps, 5)
+
+    def test_default_lossless_codecs(self):
+        self.assertEqual(
+            CFG.lossless_codecs,
+            frozenset({"flac", "lossless", "alac", "wav"}))
+
+    def test_default_mixed_format_precedence_worst_first(self):
+        # MP3 is the "worst" (least trustworthy cross-codec) so it wins ties.
+        self.assertEqual(CFG.mixed_format_precedence, ("mp3", "aac", "opus", "flac"))
+
+    def test_default_mp3_vbr_levels_length_is_ten(self):
+        self.assertEqual(len(CFG.mp3_vbr_levels), 10)
+
+    def test_default_mp3_v0_is_transparent(self):
+        self.assertEqual(CFG.mp3_vbr_levels[0], QualityRank.TRANSPARENT)
+
+    def test_default_opus_bands(self):
+        self.assertEqual(CFG.opus.transparent, 112)
+        self.assertEqual(CFG.opus.excellent, 88)
+        self.assertEqual(CFG.opus.good, 64)
+        self.assertEqual(CFG.opus.acceptable, 48)
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -1385,6 +1385,46 @@ class TestQualityRankConfigRoundTrip(unittest.TestCase):
         for r in payload["mp3_vbr_levels"]:
             self.assertIsInstance(r, int)
 
+    def test_custom_collections_round_trip(self):
+        """Non-default mp3_vbr_levels / lossless_codecs / mixed_format_precedence
+        survive JSON round-trip unchanged."""
+        original = QualityRankConfig(
+            mp3_vbr_levels=(
+                QualityRank.EXCELLENT, QualityRank.GOOD, QualityRank.GOOD,
+                QualityRank.ACCEPTABLE, QualityRank.ACCEPTABLE, QualityRank.POOR,
+                QualityRank.POOR, QualityRank.POOR, QualityRank.POOR,
+                QualityRank.POOR,
+            ),
+            lossless_codecs=frozenset({"flac", "ape", "dsf", "wavpack"}),
+            mixed_format_precedence=("opus", "mp3", "flac"),
+        )
+        restored = QualityRankConfig.from_json(original.to_json())
+        self.assertEqual(restored, original)
+        self.assertEqual(restored.mp3_vbr_levels[0], QualityRank.EXCELLENT)
+        self.assertIn("ape", restored.lossless_codecs)
+        self.assertEqual(restored.mixed_format_precedence, ("opus", "mp3", "flac"))
+
+    def test_from_json_invalid_json_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            QualityRankConfig.from_json("not valid json {")
+        self.assertIn("invalid JSON", str(ctx.exception))
+
+    def test_from_json_missing_key_raises_value_error(self):
+        """Missing keys produce a value error, not a bare KeyError."""
+        raw = '{"bitrate_metric": "avg"}'
+        with self.assertRaises(ValueError) as ctx:
+            QualityRankConfig.from_json(raw)
+        self.assertIn("failed to reconstruct", str(ctx.exception))
+
+    def test_from_json_invalid_rank_int_raises_value_error(self):
+        """Out-of-range QualityRank ints raise ValueError, not blow up."""
+        import json as _json
+        payload = _json.loads(QualityRankConfig.defaults().to_json())
+        payload["gate_min_rank"] = 9999  # invalid enum value
+        with self.assertRaises(ValueError) as ctx:
+            QualityRankConfig.from_json(_json.dumps(payload))
+        self.assertIn("failed to reconstruct", str(ctx.exception))
+
 
 class TestQualityRankConfigDefaults(unittest.TestCase):
     """Lock the default policy values so changes are explicit."""

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -39,6 +39,26 @@ class AlbumState:
     verified_lossless: bool
     search_filetype_override: str | None  # search_filetype_override (transient search filter)
     target_format: str | None = None  # persistent user intent
+    existing_format: str | None = None  # beets items.format ("MP3"/"FLAC"/"Opus"/None)
+
+
+def _derive_album_format(album: "AlbumState") -> str | None:
+    """Derive a codec-aware format hint for an AlbumState.
+
+    Legacy simulator fixtures don't carry a format field — derive one from
+    ``verified_lossless`` (heuristic for FLAC-on-disk albums) / ``is_cbr`` /
+    min bitrate so the rank model has what it needs without rewriting 14
+    fixture rows. ``existing_format`` overrides everything.
+    """
+    if album.existing_format is not None:
+        return album.existing_format
+    if album.min_bitrate is None:
+        return None
+    # verified_lossless with raw FLAC-range bitrate (≥500) → FLAC on disk.
+    if album.verified_lossless and album.min_bitrate >= 500:
+        return "FLAC"
+    # Otherwise assume MP3 — band table classifies via is_cbr.
+    return "MP3"
 
 
 @dataclass(frozen=True)
@@ -52,6 +72,7 @@ class DownloadScenario:
     spectral_bitrate: int | None = None
     converted_count: int = 0
     post_conversion_min_bitrate: int | None = None
+    new_format: str | None = None  # explicit format hint for the rank model
 
     def dl_params(self) -> dict:
         """Download-side kwargs for full_pipeline_decision()."""
@@ -63,6 +84,7 @@ class DownloadScenario:
             "spectral_bitrate": self.spectral_bitrate,
             "converted_count": self.converted_count,
             "post_conversion_min_bitrate": self.post_conversion_min_bitrate,
+            "new_format": self.new_format,
         }
 
 
@@ -173,6 +195,8 @@ def simulate(album: AlbumState, download: DownloadScenario,
         existing_min_bitrate=album.min_bitrate,
         existing_spectral_bitrate=existing_spectral_bitrate,
         override_min_bitrate=override,
+        existing_format=_derive_album_format(album),
+        existing_is_cbr=album.is_cbr,
         verified_lossless=album.verified_lossless,
         verified_lossless_target=verified_lossless_target,
         target_format=album.target_format,

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -552,6 +552,99 @@ class TestNamedRegressions(unittest.TestCase):
                 self.assertEqual(r.backfill_override, "lossless",
                                  f"{dl_name} must propagate genuine spectral -> backfill")
 
+    # ------------------------------------------------------------------
+    # Issue #60 — codec-aware cross-codec regressions
+    # ------------------------------------------------------------------
+
+    def test_opus_128_equivalent_to_mp3_v0(self):
+        """Opus 128 reads as equivalent to MP3 V0 under the rank model.
+
+        Simulates an existing MP3 V0 (245kbps) album, then dispatches a
+        FLAC→Opus 128 verified lossless conversion. Under the old raw-
+        bitrate model, Opus 128 (~120kbps) would lose to MP3 V0 (245) as a
+        downgrade. Under the rank model, both classify TRANSPARENT and
+        compare as equivalent, so the verified_lossless preference imports.
+        """
+        from lib.quality import (
+            AudioQualityMeasurement, compare_quality, QualityRankConfig)
+        cfg = QualityRankConfig.defaults()
+        opus_128 = AudioQualityMeasurement(
+            format="opus 128", avg_bitrate_kbps=130, verified_lossless=True)
+        mp3_v0 = AudioQualityMeasurement(
+            format="mp3 v0", avg_bitrate_kbps=245)
+        # compare_quality uses label-based rank → both TRANSPARENT
+        self.assertEqual(compare_quality(opus_128, mp3_v0, cfg), "equivalent")
+        # import_quality_decision honors the verified_lossless preference
+        from lib.quality import import_quality_decision
+        self.assertEqual(
+            import_quality_decision(opus_128, mp3_v0, cfg=cfg), "import")
+
+    def test_opus_64_cannot_replace_mp3_v0(self):
+        """Too-low verified_lossless target Opus 64 is blocked by rank floor.
+
+        Issue #60 guardrail. Opus 64 from a verified FLAC lands at GOOD rank
+        (below EXCELLENT), while existing MP3 V0 is TRANSPARENT. Verdict is
+        "worse", and the verified_lossless bypass is tier-gated so the
+        import is rejected.
+        """
+        from lib.quality import (
+            AudioQualityMeasurement, import_quality_decision,
+            QualityRankConfig)
+        cfg = QualityRankConfig.defaults()
+        opus_64 = AudioQualityMeasurement(
+            format="opus 64", avg_bitrate_kbps=64, verified_lossless=True)
+        mp3_v0 = AudioQualityMeasurement(
+            format="mp3 v0", avg_bitrate_kbps=245)
+        self.assertEqual(
+            import_quality_decision(opus_64, mp3_v0, cfg=cfg), "downgrade")
+
+    def test_flac_to_opus_128_replaces_cbr_320(self):
+        """Verified Opus 128 replaces unverified CBR 320 (codec parity)."""
+        from lib.quality import (
+            AudioQualityMeasurement, import_quality_decision,
+            QualityRankConfig)
+        cfg = QualityRankConfig.defaults()
+        opus_128 = AudioQualityMeasurement(
+            format="opus 128", avg_bitrate_kbps=130, verified_lossless=True)
+        cbr_320 = AudioQualityMeasurement(
+            format="mp3 320", avg_bitrate_kbps=320, is_cbr=True)
+        self.assertEqual(
+            import_quality_decision(opus_128, cbr_320, cfg=cfg), "import")
+
+    def test_lofi_v0_still_imports(self):
+        """Lo-fi V0 (207kbps) imports under the rank model via the label.
+
+        Issue #60: ``verified_lossless=True`` used to be a blanket bypass
+        that let lo-fi V0 through the gate. Under the rank model the same
+        case works because "mp3 v0" classifies as TRANSPARENT via
+        cfg.mp3_vbr_levels[0] regardless of bitrate.
+        """
+        from lib.quality import (
+            AudioQualityMeasurement, quality_gate_decision, QualityRankConfig)
+        cfg = QualityRankConfig.defaults()
+        current = AudioQualityMeasurement(
+            format="mp3 v0", min_bitrate_kbps=207, avg_bitrate_kbps=207,
+            verified_lossless=True)
+        self.assertEqual(quality_gate_decision(current, cfg=cfg), "accept")
+
+    def test_gate_min_rank_good_accepts_lower_cfg(self):
+        """Custom cfg.gate_min_rank=GOOD lets 180kbps VBR pass the gate.
+
+        Locks the runtime-config threading through the gate. Under default
+        EXCELLENT the same measurement requeues; under GOOD it accepts.
+        """
+        from lib.quality import (
+            AudioQualityMeasurement, quality_gate_decision,
+            QualityRank, QualityRankConfig)
+        default_cfg = QualityRankConfig.defaults()
+        lenient_cfg = QualityRankConfig(gate_min_rank=QualityRank.GOOD)
+        current = AudioQualityMeasurement(
+            format="MP3", min_bitrate_kbps=180, avg_bitrate_kbps=180)
+        self.assertEqual(
+            quality_gate_decision(current, cfg=default_cfg), "requeue_upgrade")
+        self.assertEqual(
+            quality_gate_decision(current, cfg=lenient_cfg), "accept")
+
 
 # ============================================================================
 # Fresh request matrix — exact outcomes for all 16 scenarios

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -721,6 +721,27 @@ class TestPipelineRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SIMULATE_REQUIRED_FIELDS,
                                 "pipeline simulate response")
 
+    @patch("routes.pipeline.full_pipeline_decision")
+    def test_pipeline_simulate_threads_target_format(self, mock_simulate):
+        mock_simulate.return_value = {
+            "stage1_spectral": None,
+            "stage2_import": "import",
+            "stage3_quality_gate": "accept",
+            "final_status": "imported",
+            "imported": True,
+            "denylisted": False,
+            "keep_searching": False,
+            "target_final_format": "flac",
+        }
+
+        status, _data = self._get(
+            "/api/pipeline/simulate?is_flac=true&min_bitrate=900&target_format=flac"
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            mock_simulate.call_args.kwargs["target_format"], "flac")
+
 
 class TestPipelineMutationRouteContracts(_WebServerCase):
     """Contract tests for frontend-consumed pipeline mutation routes."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -708,6 +708,9 @@ class TestPipelineRouteContracts(_WebServerCase):
                                 "pipeline constants response")
         _assert_required_fields(self, data["stages"][0], self.STAGE_REQUIRED_FIELDS,
                                 "pipeline constants stage")
+        # Issue #60: rank config surfaced to UI for the Decisions tab
+        self.assertIn("rank_gate_min_rank", data["constants"])
+        self.assertIn("rank_bitrate_metric", data["constants"])
 
     def test_pipeline_simulate_contract(self):
         status, data = self._get(

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -229,6 +229,7 @@ def get_pipeline_simulate(h, params: dict[str, list[str]]) -> None:
         post_conversion_min_bitrate=_int("post_conversion_min_bitrate"),
         converted_count=_int("converted_count") or 0,
         verified_lossless=_bool("verified_lossless"),
+        target_format=_str("target_format"),
         verified_lossless_target=_str("verified_lossless_target"),
         cfg=_runtime_rank_config(),
     )

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -165,6 +165,24 @@ def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
     h._json(all_data)
 
 
+def _runtime_rank_config():
+    """Load the runtime QualityRankConfig from the same config.ini the main
+    soularr process reads, so web simulator matches production dispatch."""
+    import configparser
+    import os
+    from quality import QualityRankConfig  # type: ignore[import-not-found]
+    cfg = QualityRankConfig.defaults()
+    path = os.environ.get("SOULARR_RUNTIME_CONFIG") or "/var/lib/soularr/config.ini"
+    if os.path.exists(path):
+        try:
+            parser = configparser.RawConfigParser()
+            parser.read(path)
+            cfg = QualityRankConfig.from_ini(parser)
+        except Exception:
+            pass
+    return cfg
+
+
 def get_pipeline_constants(h, params: dict[str, list[str]]) -> None:
     """Return decision tree structure + thresholds for the diagram."""
     tree = get_decision_tree()
@@ -173,6 +191,11 @@ def get_pipeline_constants(h, params: dict[str, list[str]]) -> None:
     tree["constants"]["ALBUM_SUSPECT_PCT"] = ALBUM_SUSPECT_PCT
     tree["constants"]["MIN_CLIFF_SLICES"] = MIN_CLIFF_SLICES
     tree["constants"]["CLIFF_THRESHOLD_DB_PER_KHZ"] = CLIFF_THRESHOLD_DB_PER_KHZ
+    # Expose the runtime rank config to the UI so the Decisions tab shows
+    # the configured gate_min_rank and bitrate_metric.
+    rank_cfg = _runtime_rank_config()
+    tree["constants"]["rank_gate_min_rank"] = rank_cfg.gate_min_rank.name
+    tree["constants"]["rank_bitrate_metric"] = rank_cfg.bitrate_metric.value
     h._json(tree)
 
 
@@ -200,10 +223,14 @@ def get_pipeline_simulate(h, params: dict[str, list[str]]) -> None:
         existing_min_bitrate=_int("existing_min_bitrate"),
         existing_spectral_bitrate=_int("existing_spectral_bitrate"),
         override_min_bitrate=_int("override_min_bitrate"),
+        existing_format=_str("existing_format"),
+        existing_is_cbr=_bool("existing_is_cbr"),
+        new_format=_str("new_format"),
         post_conversion_min_bitrate=_int("post_conversion_min_bitrate"),
         converted_count=_int("converted_count") or 0,
         verified_lossless=_bool("verified_lossless"),
         verified_lossless_target=_str("verified_lossless_target"),
+        cfg=_runtime_rank_config(),
     )
     h._json(result)
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -168,19 +168,9 @@ def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
 def _runtime_rank_config():
     """Load the runtime QualityRankConfig from the same config.ini the main
     soularr process reads, so web simulator matches production dispatch."""
-    import configparser
-    import os
-    from quality import QualityRankConfig  # type: ignore[import-not-found]
-    cfg = QualityRankConfig.defaults()
-    path = os.environ.get("SOULARR_RUNTIME_CONFIG") or "/var/lib/soularr/config.ini"
-    if os.path.exists(path):
-        try:
-            parser = configparser.RawConfigParser()
-            parser.read(path)
-            cfg = QualityRankConfig.from_ini(parser)
-        except Exception:
-            pass
-    return cfg
+    from lib.config import read_runtime_rank_config  # type: ignore[import-not-found]
+
+    return read_runtime_rank_config()
 
 
 def get_pipeline_constants(h, params: dict[str, list[str]]) -> None:


### PR DESCRIPTION
## Summary

Closes #60. Implements a codec-aware `QualityRank` model that replaces raw-bitrate comparisons in `import_quality_decision()`, `quality_gate_decision()`, and `full_pipeline_decision()`. The pipeline now correctly treats Opus 128 as equivalent to MP3 V0 (same perceptual band) and enforces a tier floor on the `verified_lossless` bypass so a too-low `verified_lossless_target` (Opus 64/90) can't silently replace a good existing album.

Also carries follow-ups from #31 and #36:
- Every numeric quality threshold now lives in exactly one dataclass (`QualityRankConfig`), tunable via `config.ini` `[Quality Ranks]` section.
- The bitrate metric is explicit (`min` vs `avg`) with a future `median` extension point already designed in.
- CLI, web, and production dispatch all load the same `QualityRankConfig` from the same `config.ini` — no simulator/production drift.

## Why

Two concrete bugs fell out of raw-bitrate comparisons:

1. **Cross-codec downgrade loop.** After a FLAC→Opus 128 conversion, `album_requests.min_bitrate` stored the Opus measured bitrate (~120 kbps). On the next cycle, a new MP3 V0 download (~245 kbps) won the `245 > 120` comparison and replaced the perceptually equivalent Opus with MP3.
2. **Too-low verified_lossless_target silently won.** Setting `verified_lossless_target = "opus 64"` produced a 64 kbps Opus file that bypassed every downgrade check because `verified_lossless=True` was a blanket override.

Full context in `docs/quality-ranks.md`.

## Commits (13 total)

### Original #60 sequence (7 commits)

| # | Commit | Scope |
|---|--------|-------|
| 1 | `8f353d8` | Pure rank model: `QualityRank` / `RankBitrateMetric` / `CodecRankBands` / `QualityRankConfig`, `quality_rank()` / `measurement_rank()` / `compare_quality()`, `AudioQualityMeasurement.format` + `avg_bitrate_kbps` fields, 17 new subTest-table tests. No behavior change. |
| 2 | `f1c5d35` | Config plumbing: `SoularrConfig.quality_ranks`, `QualityRankConfig.from_ini()` / `to_json()` / `from_json()`, `config.ini` `[Quality Ranks]` section. 15 new tests (parse errors, round-trip, partial overrides). |
| 3 | `23da4df` | BeetsDB format/avg plumbing: `AlbumInfo.format` + `AlbumInfo.avg_bitrate_kbps`, mixed-format album reduction via `cfg.mixed_format_precedence`. Updated 3 production callers. |
| 4 | `d8bf632` | `import_one.py` format-aware measurements: `_get_folder_avg_bitrate()`, hoisted `conversion_target()`, `new_m.format` / `existing_m.format` wired from beets. New `--quality-rank-config` argv serializes runtime `cfg.quality_ranks` into the harness subprocess boundary. Seam test locks the JSON round-trip. |
| 5 | `1633778` | **Decision function rewrites (the behavior change).** `import_quality_decision()` now delegates to `compare_quality()`, `quality_gate_decision()` to `measurement_rank()`. `verified_lossless` bypass is tier-gated (imports on `better`/`equivalent`, blocks on `worse`). 19 rewritten `TestImportQualityDecision` rows + 16 rewritten `TestQualityGateDecision` rows covering cross-codec, tier-floor, lo-fi V0, legacy fallback. End-to-end cfg threading integration slice (`test_custom_gate_min_rank_accepts_lower`). |
| 6 | `fa864f3` | Simulator + CLI parity: `pipeline-cli quality` loads runtime config, shows rank name + configured policy. Web routes (`/api/pipeline/constants`, `/api/pipeline/simulate`) surface rank config. 5 new `TestNamedRegressions` rows for every #60 acceptance criterion. Contract test covers new fields. |
| 7 | `d6ea16c` | Startup warning for sub-gate `verified_lossless_target`, `docs/quality-ranks.md` (219-line reference), CLAUDE.md update. |

### Post-review follow-up fixes (6 commits)

These were caught by a post-7-commit review pass and shipped as their own focused commits so the bug-fix history stays legible on `main` after rebase merge.

| # | Commit | Scope |
|---|--------|-------|
| 8 | `97f1f1d` | **Fix quality-rank wiring for target and gate labels.** `harness/import_one.py` was building `new_m.format` from the V0 intermediate instead of the configured target. Hoists `conversion_target()` so the rank comparison uses the target format (e.g. `"opus 128"`), which is what the user actually ends up with on disk. Adds `build_existing_measurement()` so override_min_bitrate corrections apply to both `min` and `avg` for rank parity. |
| 9 | `c26c327` | **Fix repair-spectral rank-model metadata.** `pipeline-cli repair-spectral` was emitting incomplete measurements (missing `format` / `avg_bitrate_kbps`), so the rank model fell back to bare-codec ranks. Now reloads the full request metadata via the canonical loader. Regression test in `TestCmdRepairSpectral`. |
| 10 | `dc60754` | **Refactor shared quality gate state loading.** Extracts `_load_quality_gate_state()` so dispatch and force-import use the same state-loading path. Eliminates duplicated DB queries between the two callers. |
| 11 | `60d6830` | **Fix simulator target intent parity.** `pipeline-cli quality` and `/api/pipeline/simulate` were diverging from production on the `target_format="lossless"` intent path because each had its own ad-hoc `target_intent` resolution. Both now route through the same helper. |
| 12 | `0a84761` | **Clear stale quality state on import success.** `_do_mark_done()` now unconditionally writes `verified_lossless` and `final_format` (including explicit cleared values), so a non-lossless re-import can't inherit a stale `verified_lossless=true` from the previous run. Two integration regressions cover both stale_final_format and stale_verified_lossless. |
| 13 | `10931c8` | **Refactor runtime config and import success seams.** Extracts `lib/config.py:read_runtime_config()` / `read_runtime_rank_config()` as the canonical loaders. CLI (`pipeline_cli.py`), web (`web/routes/pipeline.py`), and force-import (`lib/import_dispatch.py:dispatch_import_from_db`) now all go through them — eliminates the last hand-rolled inline config parser. |

## Default rank bands (retunable in `config.ini`)

| Codec | Transparent | Excellent | Good | Acceptable |
|-------|------------|-----------|------|------------|
| Opus | 112 | 88 | 64 | 48 |
| MP3 VBR | 245 | 210 | 170 | 130 |
| MP3 CBR | 320 | 256 | 192 | 128 |
| AAC | 192 | 144 | 112 | 80 |

`mp3_vbr.excellent=210` preserves the legacy `QUALITY_MIN_BITRATE_KBPS=210` gate threshold for bare-codec measurements, so unverified VBR 180 still requeues as it did before. Full rationale in `docs/quality-ranks.md`.

## Acceptance criteria (from #60)

Each criterion is traceable to a specific test row:

- [x] **Opus 128 from verified lossless compares as equivalent/better than MP3 V0 / MP3 320** → `TestImportQualityDecision::Opus 128 equivalent to MP3 V0 + verified_lossless → import` and `FLAC→Opus 128 equivalent to MP3 CBR 320 + verified_lossless → import`; `TestNamedRegressions::test_opus_128_equivalent_to_mp3_v0` and `::test_flac_to_opus_128_replaces_cbr_320`.
- [x] **Deliberately too-low verified-lossless target (Opus 90/64) does not blindly replace a good album** → `TestImportQualityDecision::Opus 64 verified CANNOT replace MP3 V0 245`, `TestNamedRegressions::test_opus_64_cannot_replace_mp3_v0`. Plus startup warning in `soularr.py main()`.
- [x] **verified_lossless=True remains enough to trust genuine lo-fi V0 cases** → `TestImportQualityDecision::lo-fi V0 (207) equivalent to dense V0 (245) + verified → import`, `TestQualityGateDecision::MP3 V0 label lo-fi accepts without bypass`, `TestNamedRegressions::test_lofi_v0_still_imports`. Lo-fi V0 now passes via the `"mp3 v0"` label contract (`cfg.mp3_vbr_levels[0] = TRANSPARENT`) without needing the old blanket bypass.
- [x] **Existing raw bitrate fields remain available for display/audit** → `min_bitrate_kbps` untouched; `avg_bitrate_kbps` is additive; `final_format` column already existed (from #36).
- [x] **Pure decision tests cover MP3 V0, MP3 CBR, Opus 128, lower Opus/AAC targets, lo-fi verified-lossless** → `TestQualityRank` 74-row subTest table + `TestCompareQuality` 34-row table.
- [x] **Simulator scenario tests cover at least one cross-codec replacement case** → 5 new `TestNamedRegressions` rows: `test_opus_128_equivalent_to_mp3_v0`, `test_opus_64_cannot_replace_mp3_v0`, `test_flac_to_opus_128_replaces_cbr_320`, `test_lofi_v0_still_imports`, `test_gate_min_rank_good_accepts_lower_cfg`.

## End-to-end cfg threading (verified)

All 4 rank-decision code paths load and thread the runtime `QualityRankConfig` from the same `config.ini`:

1. **Production dispatch**: `dispatch_import_core → _check_quality_gate_core(quality_ranks=cfg.quality_ranks) → quality_gate_decision(current, cfg=quality_ranks)`
2. **Production harness**: `dispatch_import_core → --quality-rank-config argv → main() → _rank_cfg → quality_decision_stage(cfg=_rank_cfg) → import_quality_decision(..., cfg)`
3. **CLI simulator**: `pipeline-cli quality → read_runtime_rank_config() → full_pipeline_decision(cfg=rank_cfg)`
4. **Web simulator**: `/api/pipeline/simulate → _runtime_rank_config() → full_pipeline_decision(cfg)`

After commit `10931c8`, paths 3 and 4 both delegate to `lib/config.py:read_runtime_rank_config()` — there is exactly one runtime-config loader on the entire branch.

Locked by `tests/test_integration_slices.py::test_custom_gate_min_rank_accepts_lower`, which sets `gate_min_rank=GOOD` and asserts the same 180 kbps measurement flips from requeue (default EXCELLENT) to accept (lenient cfg).

## Review gates

Every commit passed an Opus code-review subagent gate before the next commit started (7 gates for the original sequence + 6 gates for the follow-up fixes = 13 gates total). A final whole-PR review pass on the 13-commit tip surfaced no remaining blockers — only documentation/PR-body housekeeping (which this update closes).

## Verification

```bash
nix-shell --run "bash scripts/run_tests.sh"
grep "^Ran \|^OK\|^FAIL" /tmp/soularr-test-output.txt
# → Ran 1480 tests in ~11s; OK (skipped=53)

nix-shell --run "pyright lib/quality.py lib/config.py lib/beets_db.py lib/import_dispatch.py \
    lib/download.py harness/import_one.py soularr.py scripts/pipeline_cli.py \
    web/routes/pipeline.py tests/test_quality_decisions.py tests/test_simulator_scenarios.py \
    tests/test_integration_slices.py tests/test_import_dispatch.py tests/test_beets_db.py \
    tests/test_web_server.py tests/helpers.py tests/test_config.py tests/test_pipeline_cli.py"
# → 0 errors, 0 warnings, 0 informations
```

## Post-deploy live verification (for the /deploy step after merge)

```bash
# Deployed code has the new types
ssh doc2 'grep -c QualityRankConfig /nix/store/ry*-source/lib/quality.py'

# Live config parse
ssh doc2 'sudo cat /var/lib/soularr/config.ini | grep -A 20 "\[Quality Ranks\]"'

# Lo-fi V0 album still accepts (rank via label, no bypass)
ssh doc2 'pipeline-cli quality <lofi_v0_id>'

# Cross-codec: verified Opus 128 album shows rank TRANSPARENT
ssh doc2 \"pipeline-cli query \\\"SELECT id, artist_name, album_title, min_bitrate, final_format FROM album_requests WHERE final_format LIKE 'opus%' LIMIT 3\\\"\"

# Watch one cycle for unexpected downgrade rejections
ssh doc2 'sudo journalctl -u soularr -f --since \"5 sec ago\"'
```

## Deferred / out of scope (future work)

Each item is being filed as an individual follow-up issue when this PR merges so nothing gets lost:

1. **`median` bitrate metric** — `RankBitrateMetric` enum only has `MIN` and `AVG` today. `measurement_rank()` is the single dispatch point; adding `MEDIAN` is a one-line change there + one new field on `AudioQualityMeasurement` and `AlbumInfo`. Explicitly designed-in but not shipped.
2. **`mp3_vbr_levels` / `lossless_codecs` / `mixed_format_precedence` via `[Quality Ranks]` INI parser** — `QualityRankConfig` dataclass supports all three but `from_ini()` only reads the policy + band-table fields. These three are constants-of-taste that almost no operator will retune; ship as dataclass-only for now and wire the INI surface if/when someone asks.
3. **`transcode_detection()` spectral-fallback threshold** — still uses `min_bitrate_kbps < TRANSCODE_MIN_BITRATE_KBPS` (210) when spectral is unavailable. Low-risk because spectral is nearly always available in practice. Independent from the rank model; listed in `docs/quality-ranks.md` as out-of-scope.
4. **Nix module options for `[Quality Ranks]`** — `modules/nixos/services/soularr.nix` does NOT yet expose Nix options under `homelab.services.soularr.qualityRanks.*`. Defaults match `QualityRankConfig.defaults()` so an unmodified Nix config is a no-op and this PR ships working defaults out of the box. **Follow-up PR required on the nixosconfig repo** if operators want declarative tuning.
5. **Discogs-sourced albums** — still can't use the rank pipeline (numeric IDs, not MB UUIDs). Pre-existing limitation documented in CLAUDE.md `Known Issues`. Not in this PR's scope.
6. **Web Decisions tab visualization** — the constants endpoint now surfaces `rank_gate_min_rank` and `rank_bitrate_metric`, but the frontend Decisions tab doesn't yet render them as a labeled badge. Minor presentation work.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 1480 tests OK
- [x] `pyright` clean on all 17 touched files
- [x] Every commit individually green (tests + pyright) before the next commit started
- [x] End-to-end cfg threading locked by `test_custom_gate_min_rank_accepts_lower`
- [x] Each of 13 commits reviewed by an Opus code-reviewer subagent before advancing
- [x] Final whole-PR review pass on the 13-commit tip
- [ ] Post-merge `/deploy` sequence (human-gated)
- [ ] Post-merge `pipeline-cli quality <id>` spot check on 3 real albums: lo-fi V0, verified Opus, unverified CBR 320
- [ ] Post-merge `sudo journalctl -u soularr -f` cycle watch for unexpected downgrade rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)