### PR TITLE
Codec-aware follow-ups: gate_rank, rank-aware backfill + denylist reasons (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,17 +369,17 @@ Lo-fi V0 at 207kbps now passes the gate via the `"mp3 v0"` label contract (`cfg.
 4. Compare new V0 bitrate against existing on disk (override = `min(pipeline DB min_bitrate, current_spectral_bitrate)` — catches fake 320s)
 5. If verified lossless AND `verified_lossless_target` configured (e.g. "opus 128"): convert original FLAC → target format, discard V0 (ephemeral verification artifact)
 6. If upgrade → import to beets. `verified_lossless` set by import_one.py's verdict (not re-derived). When verified lossless, `current_spectral_bitrate` = actual min bitrate (not spectral cliff estimate).
-7. Quality gate accepts regardless of bitrate if verified_lossless
+7. Quality gate ranks the imported measurement; the `verified_lossless=True` bypass is **tier-gated** — it imports on rank-comparison verdict `better`/`equivalent` but blocks on `worse` (so a too-low `verified_lossless_target` like Opus 64 cannot replace a good existing album). See `docs/quality-ranks.md`.
 
 **MP3 VBR downloads** (V0/V2):
 1. No spectral check needed — VBR bitrate IS the quality signal
-2. Import directly, quality gate checks min_bitrate against 210kbps threshold
+2. Import directly, quality gate classifies the measurement into a `QualityRank` (mp3_vbr band table) and accepts if the rank is at or above `cfg.quality_ranks.gate_min_rank` (default `EXCELLENT` ≈ 210kbps)
 
 **MP3 CBR downloads** (320, 256, etc.):
 1. Spectral check runs in `process_completed_album()` (soularr.py) — detects upsampled garbage via cliff detection
 2. If spectral says SUSPECT → reject, denylist user
 3. If spectral says genuine or marginal → import (something is better than nothing)
-4. Quality gate sees CBR + not verified_lossless → re-queues with `search_filetype_override="lossless"` to find lossless source
+4. Quality gate: even when CBR rank is TRANSPARENT, the `is_cbr && !verified_lossless && rank < LOSSLESS` branch fires → re-queues with `search_filetype_override="lossless"` to find a verifiable lossless source
 
 ### Spectral Analysis (`lib/spectral_check.py`)
 
@@ -437,8 +437,8 @@ Uses `sox` bandpass filtering to detect transcodes. Measures RMS energy in 16 x 
 
 ### Edge Cases
 
-- **Lo-fi recordings** (Mountain Goats boombox era): Genuine V0 from verified FLAC can produce ~207kbps. `verified_lossless=TRUE` lets this pass the quality gate.
-- **Mixed-source CBR** (e.g. 13 tracks at 320 + 1 track at 192): Looks like VBR to `COUNT(DISTINCT bitrate)` but isn't genuine V0. Quality gate uses min_bitrate (192 < 210) → re-queues.
+- **Lo-fi recordings** (Mountain Goats boombox era): Genuine V0 from verified FLAC can produce ~207kbps. The `"mp3 v0"` label classifies as `TRANSPARENT` via `cfg.mp3_vbr_levels[0]` regardless of bitrate, so the gate accepts without needing a `verified_lossless` blanket bypass.
+- **Mixed-source CBR** (e.g. 13 tracks at 320 + 1 track at 192): Looks like VBR to `COUNT(DISTINCT bitrate)` but isn't genuine V0. Quality gate ranks against the bare-codec band table — 192 lands in `GOOD` (< default `EXCELLENT`) → re-queues for upgrade.
 - **Fake FLACs**: MP3 wrapped in FLAC container. Spectral detects cliff pre-conversion, V0 bitrate confirms post-conversion. Source denylisted, but file imported if better than existing.
 - **Discogs-sourced albums**: Numeric IDs instead of MB UUIDs. Cannot use upgrade pipeline. See `TODO.md`.
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -516,6 +516,7 @@ def _compute_rejection_backfill(album_data: GrabListEntry,
             min_bitrate_kbps=info.min_bitrate_kbps,
             spectral_grade=req.get("current_spectral_grade"),
             verified_lossless=bool(req.get("verified_lossless")),
+            cfg=ctx.cfg.quality_ranks,
         )
         if override:
             logger.info(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -17,7 +17,6 @@ from typing import Sequence, TYPE_CHECKING
 from lib.quality import (parse_import_result, DownloadInfo, ImportResult,
                          SpectralMeasurement,
                          ValidationResult,
-                         QUALITY_MIN_BITRATE_KBPS,
                          QUALITY_UPGRADE_TIERS, QUALITY_LOSSLESS,
                          dispatch_action, compute_effective_override_bitrate,
                          extract_usernames, narrow_override_on_downgrade,
@@ -376,6 +375,7 @@ def _check_quality_gate_core(
         spectral_note = f" (spectral={spectral_br}kbps)" if spectral_br else ""
 
         if decision == "requeue_upgrade":
+            from lib.quality import gate_rank
             upgrade_override = QUALITY_UPGRADE_TIERS
             apply_transition(db, request_id, "wanted",
                              from_status="imported",
@@ -384,16 +384,19 @@ def _check_quality_gate_core(
             usernames = extract_usernames(files)
             gate_br = compute_effective_override_bitrate(
                 min_br_kbps, spectral_br, spectral_grade) or min_br_kbps
-            if spectral_br and spectral_br < min_br_kbps:
-                reason = (f"quality gate: spectral {spectral_br}kbps "
-                          f"(beets {min_br_kbps}kbps) < {QUALITY_MIN_BITRATE_KBPS}kbps")
-            else:
-                reason = f"quality gate: {min_br_kbps}kbps < {QUALITY_MIN_BITRATE_KBPS}kbps"
+            actual_rank = gate_rank(current, quality_ranks)
+            gate_min = quality_ranks.gate_min_rank
+            br_note = (f"spectral {spectral_br}kbps (beets {min_br_kbps}kbps)"
+                       if spectral_br and spectral_br < min_br_kbps
+                       else f"{min_br_kbps}kbps")
+            reason = (f"quality gate: rank {actual_rank.name} < {gate_min.name} "
+                      f"({br_note})")
             for username in usernames:
                 db.add_denylist(request_id, username, reason)
             logger.info(
                 f"QUALITY GATE: {label} "
-                f"gate_bitrate={gate_br}kbps{spectral_note} < {QUALITY_MIN_BITRATE_KBPS}kbps, "
+                f"rank={actual_rank.name} < {gate_min.name} "
+                f"(gate_bitrate={gate_br}kbps{spectral_note}), "
                 f"queued for upgrade, denylisted {usernames} "
                 f"(searching {upgrade_override})")
         elif decision == "requeue_lossless":
@@ -586,6 +589,7 @@ def dispatch_import_core(
                                         "current_spectral_grade"),
                                     verified_lossless=bool(
                                         req_row.get("verified_lossless")),
+                                    cfg=_gate_cfg,
                                 )
                                 if narrowed_override:
                                     logger.info(

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1529,16 +1529,41 @@ def is_verified_lossless(was_converted: bool, original_filetype: Optional[str],
 # Post-import quality gate (runs after successful import in soularr.py)
 # ---------------------------------------------------------------------------
 
+def gate_rank(
+    current: AudioQualityMeasurement,
+    cfg: "QualityRankConfig",
+) -> QualityRank:
+    """Rank used by ``quality_gate_decision()`` — measurement rank with the
+    spectral clamp applied.
+
+    This is the single source of truth for "what rank does the gate see".
+    Both ``quality_gate_decision()`` and the simulator (``pipeline-cli quality``)
+    call this so the displayed rank label and the actual gate verdict can
+    never disagree.
+
+    Spectral clamp: when the current measurement carries a spectral estimate
+    (set upstream only when the grade is suspect/likely_transcode — see
+    ``_check_quality_gate_core()``), classify that estimate against the MP3
+    VBR band table and take the lower rank. This catches fake 320s and
+    legacy low-spectral transcodes.
+    """
+    rank = measurement_rank(current, cfg)
+    if current.spectral_bitrate_kbps is not None:
+        spectral_rank = quality_rank(
+            "mp3", current.spectral_bitrate_kbps, is_cbr=False, cfg=cfg)
+        if spectral_rank < rank:
+            rank = spectral_rank
+    return rank
+
+
 def quality_gate_decision(
     current: AudioQualityMeasurement,
     cfg: "QualityRankConfig | None" = None,
 ) -> str:
     """Codec-aware post-import quality gate (issue #60).
 
-    Classifies ``current`` into a QualityRank via measurement_rank() and
-    compares against ``cfg.gate_min_rank``. Spectral bitrate can clamp the
-    rank down (catches fake 320s) by classifying the spectral estimate with
-    the MP3 VBR band table.
+    Classifies ``current`` via ``gate_rank()`` (which applies the spectral
+    clamp) and compares against ``cfg.gate_min_rank``.
 
     Returns one of: "accept", "requeue_upgrade", "requeue_lossless".
 
@@ -1549,18 +1574,7 @@ def quality_gate_decision(
     if cfg is None:
         cfg = QualityRankConfig.defaults()
 
-    rank = measurement_rank(current, cfg)
-
-    # Spectral clamp: when the current measurement carries a spectral
-    # estimate (set upstream only when the grade is suspect/likely_transcode
-    # — see _check_quality_gate_core()), classify that estimate against the
-    # MP3 VBR band table and take the lower rank. This catches fake 320s
-    # and legacy low-spectral transcodes.
-    if current.spectral_bitrate_kbps is not None:
-        spectral_rank = quality_rank(
-            "mp3", current.spectral_bitrate_kbps, is_cbr=False, cfg=cfg)
-        if spectral_rank < rank:
-            rank = spectral_rank
+    rank = gate_rank(current, cfg)
 
     if rank == QualityRank.UNKNOWN or rank < cfg.gate_min_rank:
         return "requeue_upgrade"
@@ -1703,6 +1717,7 @@ def rejection_backfill_override(
     min_bitrate_kbps: int | None,
     spectral_grade: str | None,
     verified_lossless: bool,
+    cfg: "QualityRankConfig | None" = None,
 ) -> str | None:
     """Backfill search_filetype_override for pre-quality-gate albums stuck in download loops.
 
@@ -1710,16 +1725,24 @@ def rejection_backfill_override(
     albums with decent quality on disk keep downloading the same tier forever
     because the quality gate only fires after successful imports.
 
-    Returns QUALITY_LOSSLESS when the on-disk state is good enough that only
-    a verified lossless source would be an upgrade. Returns None otherwise.
+    Returns QUALITY_LOSSLESS when the on-disk rank is at or above
+    ``cfg.gate_min_rank`` (the same threshold the post-import quality gate
+    uses) — the only upgrade left is a verified lossless source.
+
+    ``cfg`` defaults to ``QualityRankConfig.defaults()``. Threading the live
+    runtime cfg keeps backfill in lockstep with the gate when an operator
+    tunes ``gate_min_rank``.
     """
+    if cfg is None:
+        cfg = QualityRankConfig.defaults()
     if verified_lossless:
         return None
     if spectral_grade != "genuine":
         return None
     if min_bitrate_kbps is None:
         return None
-    if min_bitrate_kbps >= QUALITY_MIN_BITRATE_KBPS:
+    rank = quality_rank("mp3", min_bitrate_kbps, is_cbr=is_cbr, cfg=cfg)
+    if rank >= cfg.gate_min_rank:
         return QUALITY_LOSSLESS
     return None
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -550,7 +550,7 @@ def cmd_show(db, args):
 def cmd_quality(db, args):
     """Show quality state and simulate decisions for common download scenarios."""
     from quality import (full_pipeline_decision, quality_gate_decision,
-                         AudioQualityMeasurement, measurement_rank,
+                         AudioQualityMeasurement, gate_rank,
                          rejection_backfill_override,
                          search_tiers, compute_effective_override_bitrate)
 
@@ -604,7 +604,10 @@ def cmd_quality(db, args):
             is_cbr=is_cbr,
             verified_lossless=verified,
             spectral_bitrate_kbps=gate_spectral_br)
-        current_rank = measurement_rank(current, rank_cfg)
+        # gate_rank centralizes the spectral clamp the gate applies, so the
+        # displayed label always matches the verdict (no more EXCELLENT next
+        # to NEEDS UPGRADE on a fake CBR 320).
+        current_rank = gate_rank(current, rank_cfg)
         gate = quality_gate_decision(current, cfg=rank_cfg)
         gate_label = {"accept": "DONE", "requeue_upgrade": "NEEDS UPGRADE",
                       "requeue_lossless": "NEEDS LOSSLESS"}[gate]
@@ -625,7 +628,8 @@ def cmd_quality(db, args):
     # --- Rejection backfill status ---
     backfill = rejection_backfill_override(
         is_cbr=is_cbr, min_bitrate_kbps=min_br,
-        spectral_grade=spectral_grade, verified_lossless=verified)
+        spectral_grade=spectral_grade, verified_lossless=verified,
+        cfg=rank_cfg)
     if backfill and not q_override:
         print(f"  Backfill:      would set search_filetype_override='{backfill}' on next rejection")
     elif q_override:
@@ -742,6 +746,7 @@ def cmd_quality(db, args):
                     min_bitrate_kbps=min_br,
                     spectral_grade=dl_spectral if dl_spectral else spectral_grade,
                     verified_lossless=verified,
+                    cfg=rank_cfg,
                 )
                 if propagated:
                     tiers, _ = search_tiers(propagated, [])

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -548,6 +548,99 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         self.assertEqual(len(db.denylist), 1)
         self.assertIn("quality gate", db.denylist[0].reason or "")
 
+    def test_requeue_upgrade_denylist_reason_is_rank_aware(self):
+        """Denylist reason text must reflect the actual rank/threshold, not the
+        legacy hardcoded 210kbps constant.
+
+        The reason is persisted to the DB and surfaces in operator-facing
+        history. Before this fix, every requeue_upgrade row was tagged with
+        '< 210kbps' regardless of cfg.gate_min_rank. After the fix the reason
+        carries the rank name + the configured gate threshold.
+        """
+        from lib.import_dispatch import _check_quality_gate_core
+        from lib.quality import QualityRankConfig
+        from lib.beets_db import AlbumInfo
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="imported", verified_lossless=False,
+            current_spectral_bitrate=None, current_spectral_grade=None,
+            mb_release_id="mbid-low",
+        ))
+
+        # Bare MP3 at 150kbps avg → ACCEPTABLE rank, below default EXCELLENT gate.
+        with patch("lib.beets_db.BeetsDB") as mock_beets_cls:
+            mock_beets = MagicMock()
+            mock_beets.__enter__ = MagicMock(return_value=mock_beets)
+            mock_beets.__exit__ = MagicMock(return_value=False)
+            mock_beets.get_album_info.return_value = AlbumInfo(
+                album_id=1, track_count=10,
+                min_bitrate_kbps=150, avg_bitrate_kbps=150,
+                format="MP3", is_cbr=False,
+                album_path="/Beets/Artist/Album",
+            )
+            mock_beets_cls.return_value = mock_beets
+            _check_quality_gate_core(
+                mb_id="mbid-low", label="Artist - Album",
+                request_id=42,
+                files=[MagicMock(username="loweruser", filename="01.mp3")],
+                db=db,  # type: ignore[arg-type]
+                quality_ranks=QualityRankConfig.defaults(),
+            )
+
+        self.assertEqual(len(db.denylist), 1)
+        reason = db.denylist[0].reason or ""
+        # New format: includes the actual rank name and gate threshold
+        self.assertIn("ACCEPTABLE", reason,
+                      f"reason should name the actual rank, got: {reason}")
+        self.assertIn("EXCELLENT", reason,
+                      f"reason should name the configured gate threshold, got: {reason}")
+        # Old format pinned the legacy 210kbps constant — must NOT appear
+        self.assertNotIn("< 210kbps", reason,
+                         f"reason still references legacy 210kbps: {reason}")
+
+    def test_requeue_upgrade_denylist_reason_honours_custom_gate(self):
+        """Custom gate_min_rank=GOOD must surface in the persisted reason.
+
+        Verifies the reason text actually threads cfg through to the
+        denylist entry, not just the decision.
+        """
+        from lib.import_dispatch import _check_quality_gate_core
+        from lib.quality import QualityRankConfig, QualityRank
+        from lib.beets_db import AlbumInfo
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=43, status="imported", verified_lossless=False,
+            current_spectral_bitrate=None, current_spectral_grade=None,
+            mb_release_id="mbid-mid",
+        ))
+
+        # 140 kbps avg → ACCEPTABLE under any cfg, below GOOD threshold.
+        with patch("lib.beets_db.BeetsDB") as mock_beets_cls:
+            mock_beets = MagicMock()
+            mock_beets.__enter__ = MagicMock(return_value=mock_beets)
+            mock_beets.__exit__ = MagicMock(return_value=False)
+            mock_beets.get_album_info.return_value = AlbumInfo(
+                album_id=1, track_count=10,
+                min_bitrate_kbps=140, avg_bitrate_kbps=140,
+                format="MP3", is_cbr=False,
+                album_path="/Beets/Artist/Album",
+            )
+            mock_beets_cls.return_value = mock_beets
+            _check_quality_gate_core(
+                mb_id="mbid-mid", label="Artist - Album",
+                request_id=43,
+                files=[MagicMock(username="middleuser", filename="01.mp3")],
+                db=db,  # type: ignore[arg-type]
+                quality_ranks=QualityRankConfig(gate_min_rank=QualityRank.GOOD),
+            )
+
+        self.assertEqual(len(db.denylist), 1)
+        reason = db.denylist[0].reason or ""
+        self.assertIn("GOOD", reason,
+                      f"reason should name the custom gate_min_rank=GOOD, got: {reason}")
+
     def test_requeue_lossless_uses_intent(self):
         db = self._run_quality_gate("requeue_lossless")
         row = db.request(42)

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -611,6 +611,73 @@ class TestCmdQuality(unittest.TestCase):
         self.assertIn("Verified-lossless output: flac", output)
         self.assertIn("Genuine FLAC → flac (high bitrate):", output)
 
+    def test_quality_label_matches_gate_after_spectral_clamp(self):
+        """AFX Analord 09 regression: displayed rank label must match the gate verdict.
+
+        Reproduces the exact post-deploy scenario: VBR ~245kbps + spectral=160
+        likely_transcode. Without the spectral clamp, the displayed label
+        showed `rank=EXCELLENT` next to `NEEDS UPGRADE` — self-contradictory.
+        After the fix, the displayed rank is the post-clamp rank that the
+        gate actually used.
+        """
+        from lib.quality import QualityRankConfig
+
+        request_row = make_request_row(
+            id=9,
+            status="imported",
+            mb_release_id="mbid-afx",
+            artist_name="AFX",
+            album_title="Analord 09",
+            min_bitrate=213,
+            current_spectral_bitrate=160,
+            current_spectral_grade="likely_transcode",
+            verified_lossless=False,
+            final_format=None,
+        )
+
+        beets_info = SimpleNamespace(
+            is_cbr=False,
+            avg_bitrate_kbps=245,
+            format="MP3",
+        )
+
+        def fake_full_pipeline_decision(**kwargs):
+            return {
+                "stage1_spectral": None,
+                "stage2_import": "import",
+                "stage3_quality_gate": "accept",
+                "final_status": "imported",
+                "imported": True,
+                "denylisted": False,
+                "keep_searching": False,
+                "target_final_format": kwargs.get("target_format")
+                or kwargs.get("verified_lossless_target"),
+            }
+
+        db = MagicMock()
+        db.get_request.return_value = request_row
+        stdout = io.StringIO()
+        with patch("pipeline_cli._load_runtime_rank_config",
+                   return_value=QualityRankConfig.defaults()), \
+             patch("pipeline_cli._load_runtime_verified_lossless_target",
+                   return_value=""), \
+             patch("pipeline_cli._load_beets_album_info",
+                   return_value=beets_info), \
+             patch("quality.full_pipeline_decision",
+                   side_effect=fake_full_pipeline_decision), \
+             redirect_stdout(stdout):
+            pipeline_cli.cmd_quality(db, MagicMock(id=9))
+
+        output = stdout.getvalue()
+        # The gate must say NEEDS UPGRADE (not DONE)
+        self.assertIn("NEEDS UPGRADE", output)
+        # And the displayed rank must agree — post-clamp 160kbps lands ACCEPTABLE.
+        # Use parenthesized form to disambiguate from `gate_min_rank=EXCELLENT`
+        # in the cfg display line.
+        self.assertIn("(rank=ACCEPTABLE)", output)
+        self.assertNotIn("(rank=TRANSPARENT)", output)
+        self.assertNotIn("(rank=EXCELLENT)", output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -33,6 +33,7 @@ from lib.quality import (
     QualityRankConfig,
     quality_rank,
     measurement_rank,
+    gate_rank,
     compare_quality,
 )
 
@@ -305,6 +306,86 @@ class TestQualityGateDecision(unittest.TestCase):
                 self.assertEqual(
                     quality_gate_decision(m), expected,
                     f"{desc}: {kwargs} expected {expected!r}")
+
+
+# ============================================================================
+# gate_rank — single source of truth for the gate's classified rank
+# ============================================================================
+#
+# gate_rank() centralizes the spectral clamp that quality_gate_decision()
+# previously inlined. The simulator and the gate must always agree on the
+# displayed/decision rank — these tests pin that contract.
+
+class TestGateRank(unittest.TestCase):
+    """gate_rank: measurement_rank with the spectral clamp applied."""
+
+    def test_no_spectral_matches_measurement_rank(self):
+        """Without spectral, gate_rank must equal measurement_rank."""
+        m = AudioQualityMeasurement(format="mp3 v0", avg_bitrate_kbps=245)
+        cfg = QualityRankConfig.defaults()
+        self.assertEqual(gate_rank(m, cfg), measurement_rank(m, cfg))
+
+    def test_clamp_pulls_fake_cbr_down(self):
+        """Fake CBR 320 with spectral=128 must clamp from TRANSPARENT to POOR."""
+        m = AudioQualityMeasurement(
+            format="mp3 320", avg_bitrate_kbps=320, is_cbr=True,
+            spectral_bitrate_kbps=128)
+        cfg = QualityRankConfig.defaults()
+        # Without clamp, label "mp3 320" → TRANSPARENT
+        self.assertEqual(measurement_rank(m, cfg), QualityRank.TRANSPARENT)
+        # With clamp, spectral 128 against mp3_vbr.acceptable=130 → POOR
+        self.assertEqual(gate_rank(m, cfg), QualityRank.POOR)
+
+    def test_clamp_does_nothing_when_higher(self):
+        """Spectral above measurement rank: no clamp."""
+        m = AudioQualityMeasurement(
+            format="mp3", avg_bitrate_kbps=140, is_cbr=False,
+            spectral_bitrate_kbps=240)
+        cfg = QualityRankConfig.defaults()
+        # measurement: 140 → ACCEPTABLE; spectral 240 → EXCELLENT (higher); no clamp
+        self.assertEqual(gate_rank(m, cfg), QualityRank.ACCEPTABLE)
+
+    def test_afx_analord_regression(self):
+        """AFX Analord 09 live scenario: VBR 245kbps + spectral=160 likely_transcode.
+
+        Reproduces the exact case from the post-deploy reflection. The bare
+        MP3 label at 245 kbps is TRANSPARENT, but the spectral clamp must
+        pull it down to ACCEPTABLE so the gate's NEEDS UPGRADE verdict and
+        the displayed rank label agree.
+        """
+        m = AudioQualityMeasurement(
+            min_bitrate_kbps=213, avg_bitrate_kbps=245,
+            format="MP3", is_cbr=False,
+            spectral_bitrate_kbps=160)
+        cfg = QualityRankConfig.defaults()
+        rank = gate_rank(m, cfg)
+        # Spectral 160 → mp3_vbr.acceptable=130, between acceptable/good → ACCEPTABLE
+        self.assertEqual(rank, QualityRank.ACCEPTABLE)
+        # And quality_gate_decision agrees
+        self.assertEqual(quality_gate_decision(m, cfg), "requeue_upgrade")
+
+    def test_gate_decision_uses_gate_rank(self):
+        """quality_gate_decision must consult gate_rank, not raw measurement_rank.
+
+        Cross-check: every CASE in TestQualityGateDecision must produce the
+        same verdict whether we compute the rank via gate_rank() and apply
+        the gate threshold by hand, or call quality_gate_decision() directly.
+        """
+        cfg = QualityRankConfig.defaults()
+        for desc, kwargs, expected in TestQualityGateDecision.CASES:
+            with self.subTest(desc=desc):
+                m = AudioQualityMeasurement(**kwargs)
+                rank = gate_rank(m, cfg)
+                expected_via_rank = (
+                    "requeue_upgrade"
+                    if rank == QualityRank.UNKNOWN or rank < cfg.gate_min_rank
+                    else "requeue_lossless"
+                    if (not m.verified_lossless and m.is_cbr
+                        and rank < QualityRank.LOSSLESS)
+                    else "accept"
+                )
+                self.assertEqual(expected_via_rank, expected,
+                                 f"{desc}: gate_rank-derived verdict diverges from CASE expectation")
 
 
 # ============================================================================
@@ -1065,6 +1146,56 @@ class TestRejectionBackfillOverride(unittest.TestCase):
             is_cbr=True, min_bitrate_kbps=320,
             spectral_grade="suspect", verified_lossless=False)
         self.assertIsNone(result)
+
+    # --- Rank-aware: cfg threading (post-deploy follow-up) ---
+    #
+    # Before this fix, rejection_backfill_override hardcoded
+    # `min_bitrate_kbps >= QUALITY_MIN_BITRATE_KBPS` (210). Custom
+    # gate_min_rank settings did not propagate to the backfill decision
+    # — a cfg.gate_min_rank=GOOD operator would still see backfill fire
+    # only above 210kbps. Decision functions must thread cfg.
+
+    def test_custom_good_gate_lets_lower_vbr_backfill(self):
+        """gate_min_rank=GOOD lowers the bar: 180kbps VBR genuine → backfill fires."""
+        from lib.quality import rejection_backfill_override, QUALITY_LOSSLESS
+        lenient = QualityRankConfig(gate_min_rank=QualityRank.GOOD)
+        result = rejection_backfill_override(
+            is_cbr=False, min_bitrate_kbps=180,
+            spectral_grade="genuine", verified_lossless=False,
+            cfg=lenient)
+        # 180 against mp3_vbr (good=170) → GOOD, GOOD >= GOOD → backfill
+        self.assertEqual(result, QUALITY_LOSSLESS)
+
+    def test_custom_good_gate_default_blocks_lower_vbr(self):
+        """Default gate_min_rank=EXCELLENT blocks the same 180kbps VBR."""
+        from lib.quality import rejection_backfill_override
+        result = rejection_backfill_override(
+            is_cbr=False, min_bitrate_kbps=180,
+            spectral_grade="genuine", verified_lossless=False)
+        # 180 → GOOD, GOOD < EXCELLENT → no backfill
+        self.assertIsNone(result)
+
+    def test_custom_transparent_gate_blocks_excellent_cbr(self):
+        """gate_min_rank=TRANSPARENT raises the bar: CBR 256 (EXCELLENT) no longer backfills."""
+        from lib.quality import rejection_backfill_override
+        strict = QualityRankConfig(gate_min_rank=QualityRank.TRANSPARENT)
+        result = rejection_backfill_override(
+            is_cbr=True, min_bitrate_kbps=256,
+            spectral_grade="genuine", verified_lossless=False,
+            cfg=strict)
+        # 256 against mp3_cbr (transparent=320, excellent=256) → EXCELLENT,
+        # EXCELLENT < TRANSPARENT → no backfill
+        self.assertIsNone(result)
+
+    def test_custom_transparent_gate_still_backfills_cbr_320(self):
+        """gate_min_rank=TRANSPARENT still backfills CBR 320 (TRANSPARENT rank)."""
+        from lib.quality import rejection_backfill_override, QUALITY_LOSSLESS
+        strict = QualityRankConfig(gate_min_rank=QualityRank.TRANSPARENT)
+        result = rejection_backfill_override(
+            is_cbr=True, min_bitrate_kbps=320,
+            spectral_grade="genuine", verified_lossless=False,
+            cfg=strict)
+        self.assertEqual(result, QUALITY_LOSSLESS)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Three post-deploy follow-ups from PR #63 / issue #60. The post-deploy reflection ([this comment](https://github.com/abl030/soularr/pull/63#issue-1)) caught three sites where the rank model wasn't fully threaded — production was correct under default cfg, but custom `gate_min_rank` settings could not propagate and the simulator could disagree with the gate it was supposed to mirror.

Each fix lands as a focused commit with regression tests. The CLAUDE.md mechanism descriptions are updated in a separate docs commit.

## Findings addressed

### 1. Simulator rank label could disagree with the gate verdict (significant)
`pipeline-cli quality` displayed `measurement_rank()` (no spectral clamp) while the gate's verdict came from `quality_gate_decision()` (with the clamp). On the AFX Analord 09 live case (213 kbps avg + spectral=160 likely_transcode) this rendered:

```
Quality gate:  NEEDS UPGRADE  (rank=EXCELLENT)
```

— self-contradictory. The exact debugging tool CLAUDE.md tells operators to trust first was lying.

**Fix**: extract `gate_rank()` as the single source of truth for the rank-with-clamp computation. Both `quality_gate_decision()` and the simulator now call it.

### 2. Denylist reason strings still hardcoded `< 210kbps` (significant)
`lib/import_dispatch.py:387-396` wrote denylist reasons like `quality gate: 180kbps < 210kbps` referencing the legacy `QUALITY_MIN_BITRATE_KBPS` constant. These strings are persisted to `denylist.reason` and surface in operator history, so a custom `gate_min_rank=GOOD` would silently mislabel every requeue_upgrade.

**Fix**: replace with `quality gate: rank ACCEPTABLE < EXCELLENT (150kbps)` — names the actual classified rank and the configured gate threshold.

### 3. `rejection_backfill_override()` was not rank-aware (significant)
`lib/quality.py:1722` gated on `min_bitrate_kbps >= QUALITY_MIN_BITRATE_KBPS` inside a **decision function**. Custom `gate_min_rank` could not reach this branch. Defaults worked only by coincidence (`mp3_vbr.excellent=210` happens to match the legacy constant).

**Fix**: add `cfg` parameter, classify against the rank bands, compare to `cfg.gate_min_rank`. All four call sites (pipeline_cli.py x2, import_dispatch.py, download.py) thread `cfg.quality_ranks`. Existing 14 `TestRejectionBackfillOverride` rows still pass under defaults; 4 new rows pin the cfg threading.

### 4. Stale CLAUDE.md mechanism descriptions (minor)
Three sections described the pre-#60 mechanism (210 kbps gate threshold, blanket `verified_lossless` bypass, mixed-source CBR re-queue rationale). Outcomes were unchanged under defaults but the mechanism narrative was wrong.

**Fix**: rewrite to reference `QualityRank`, `gate_min_rank`, the tier-gated bypass, and the `mp3_vbr_levels[0] = TRANSPARENT` label contract.

## Commits (2)

| # | Commit | Scope |
|---|--------|-------|
| 1 | `706e8d4` | Production fixes: `gate_rank()` extraction + simulator wire-up, rank-aware denylist reasons, `rejection_backfill_override` cfg threading. 12 new tests across 3 modules. |
| 2 | `cf8e80f` | CLAUDE.md mechanism descriptions updated to match the rank model. |

## New tests

- **`TestGateRank`** in `tests/test_quality_decisions.py` — pure tests for the extracted rank-with-clamp function:
  - `test_no_spectral_matches_measurement_rank` — invariant: no clamp, no divergence
  - `test_clamp_pulls_fake_cbr_down` — fake CBR 320 + spectral=128 → POOR (clamps from TRANSPARENT)
  - `test_clamp_does_nothing_when_higher` — spectral above measurement: no clamp
  - `test_afx_analord_regression` — exact reproduction of the live scenario from the post-deploy reflection
  - `test_gate_decision_uses_gate_rank` — cross-check that every existing `TestQualityGateDecision` row produces a verdict consistent with `gate_rank`'s classification (locks the contract)

- **`TestRejectionBackfillOverride`** new rows:
  - `test_custom_good_gate_lets_lower_vbr_backfill` — `gate_min_rank=GOOD` lets 180 kbps VBR genuine fire backfill
  - `test_custom_good_gate_default_blocks_lower_vbr` — default `EXCELLENT` blocks the same 180 kbps
  - `test_custom_transparent_gate_blocks_excellent_cbr` — `gate_min_rank=TRANSPARENT` no longer backfills CBR 256
  - `test_custom_transparent_gate_still_backfills_cbr_320` — but still backfills CBR 320

- **`test_pipeline_cli.py`** new row:
  - `test_quality_label_matches_gate_after_spectral_clamp` — simulator rendering regression for AFX Analord 09. Asserts `(rank=ACCEPTABLE)` next to `NEEDS UPGRADE` and the absence of `(rank=TRANSPARENT)` / `(rank=EXCELLENT)`.

- **`test_import_dispatch.py`** new rows:
  - `test_requeue_upgrade_denylist_reason_is_rank_aware` — pins the new reason text format (`ACCEPTABLE`, `EXCELLENT`) and asserts the legacy `< 210kbps` substring no longer appears
  - `test_requeue_upgrade_denylist_reason_honours_custom_gate` — cfg threading regression: `gate_min_rank=GOOD` surfaces in the persisted reason

## Verification

```bash
nix-shell --run "bash scripts/run_tests.sh"
# → Ran 1492 tests in ~10s; OK (skipped=53)

nix-shell --run "pyright lib/quality.py lib/import_dispatch.py lib/download.py \
    scripts/pipeline_cli.py tests/test_quality_decisions.py \
    tests/test_import_dispatch.py tests/test_pipeline_cli.py"
# → 0 errors, 0 warnings, 0 informations
```

## Test plan

- [x] Pre-merge: full test suite + pyright clean
- [x] Pre-merge: simulator label fix verified locally via the new pure + rendering tests
- [ ] Post-merge: deploy via `/deploy` flow
- [ ] Post-merge: `ssh doc2 'pipeline-cli quality 1683'` should now show `(rank=ACCEPTABLE)` next to `NEEDS UPGRADE` (live AFX regression)
- [ ] Post-merge: trigger one cycle and confirm new denylist rows have the rank-aware reason format

## Out of scope

Issues #64-#69 (median metric, INI parser fields, transcode threshold, NixOS module options, Decisions tab badges, Discogs pipeline) remain deferred. None of them are load-bearing for the bugs fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)