### PR TITLE
Tighten codec-aware follow-ups (#70 review)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,9 +345,9 @@ Every numeric threshold lives in `QualityRankConfig` (one dataclass) and can be 
 
 ### Quality Gate (`_check_quality_gate_core()` in import_dispatch.py)
 
-After every import, the quality gate runs `quality_gate_decision(current, cfg=cfg.quality_ranks)` which delegates to `measurement_rank()`:
+After every import, the quality gate runs `quality_gate_decision(current, cfg=cfg.quality_ranks)` which delegates to `gate_rank()` (the single source of truth for the rank-with-clamp computation, also called by the `pipeline-cli quality` simulator so the displayed label and the actual gate verdict can never disagree):
 
-1. Classify the current measurement into a `QualityRank` via format label or bare-codec band table.
+1. Classify the current measurement into a `QualityRank` via format label or bare-codec band table (`measurement_rank()`).
 2. If a spectral estimate is set, clamp the rank to the minimum of (rank, spectral_rank) — catches fake 320s.
 3. **Rank < `cfg.gate_min_rank`** → `requeue_upgrade`.
 4. **CBR on disk + not verified_lossless + below LOSSLESS** → `requeue_lossless` (search for a FLAC source).

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -127,6 +127,11 @@ so bare-codec MP3 VBR measurements from beets keep behaving as they did
 before the rank model. 245 adds a "V0 target" band above. The V0/V2/V4/etc.
 mapping via `mp3_vbr_levels` handles labeled conversions separately.
 
+`QUALITY_MIN_BITRATE_KBPS` is now defaults-only — gate behavior is driven
+by `cfg.quality_ranks.gate_min_rank`, and every numeric threshold (including
+this 210) lives in `QualityRankConfig` and can be retuned in the
+`[Quality Ranks]` section of `config.ini`.
+
 ### MP3 CBR
 
 | Band | Threshold (kbps) |

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -346,7 +346,7 @@ def _check_quality_gate_core(
     don't care about mixed-format reduction still work. Commit 5 will thread
     the real runtime config through from dispatch_import_core().
     """
-    from lib.quality import quality_gate_decision, QualityRankConfig
+    from lib.quality import quality_gate_decision, QualityRankConfig, gate_rank
 
     if quality_ranks is None:
         quality_ranks = QualityRankConfig.defaults()
@@ -375,7 +375,6 @@ def _check_quality_gate_core(
         spectral_note = f" (spectral={spectral_br}kbps)" if spectral_br else ""
 
         if decision == "requeue_upgrade":
-            from lib.quality import gate_rank
             upgrade_override = QUALITY_UPGRADE_TIERS
             apply_transition(db, request_id, "wanted",
                              from_status="imported",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1786,5 +1786,88 @@ class TestReconstructGrabListEntry(unittest.TestCase):
         self.assertEqual(entry.year, "")
 
 
+# ============================================================================
+# _compute_rejection_backfill — orchestration test for cfg threading
+# ============================================================================
+#
+# Pins that ctx.cfg.quality_ranks actually reaches rejection_backfill_override.
+# Pure-function tests in test_quality_decisions.py cover the decision logic
+# itself; this test guards the wiring layer between download.py and
+# lib/quality.py so a future refactor can't silently drop the cfg argument.
+
+class TestComputeRejectionBackfillCfgThreading(unittest.TestCase):
+    """_compute_rejection_backfill must thread ctx.cfg.quality_ranks through
+    to rejection_backfill_override."""
+
+    def _setup(self, *, gate_min_rank, on_disk_min_bitrate=180):
+        """Build the fixtures: fake DB with a genuine non-lossless request,
+        a ctx with the requested gate_min_rank, and a mock BeetsDB returning
+        an MP3 VBR album at on_disk_min_bitrate."""
+        from lib.quality import QualityRankConfig
+        from lib.beets_db import AlbumInfo
+
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-test",
+            current_spectral_grade="genuine",
+            verified_lossless=False,
+            search_filetype_override=None,
+        ))
+
+        # Real SoularrConfig is heavy; a SimpleNamespace with quality_ranks
+        # is enough — _compute_rejection_backfill only reads ctx.cfg.quality_ranks.
+        from types import SimpleNamespace
+        cfg = SimpleNamespace(
+            quality_ranks=QualityRankConfig(gate_min_rank=gate_min_rank),
+        )
+        ctx = make_ctx_with_fake_db(fake_db, cfg=cfg)
+
+        album_data = make_grab_list_entry(
+            db_request_id=42,
+            db_search_filetype_override=None,
+            mb_release_id="mbid-test",
+        )
+
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10,
+            min_bitrate_kbps=on_disk_min_bitrate,
+            avg_bitrate_kbps=on_disk_min_bitrate,
+            format="MP3", is_cbr=False,
+            album_path="/Beets/A/B",
+        )
+        return album_data, ctx, beets_info
+
+    def _run(self, album_data, ctx, beets_info):
+        from lib.download import _compute_rejection_backfill
+        with patch("lib.beets_db.BeetsDB") as mock_beets_cls:
+            mock_beets = MagicMock()
+            mock_beets.__enter__ = MagicMock(return_value=mock_beets)
+            mock_beets.__exit__ = MagicMock(return_value=False)
+            mock_beets.get_album_info.return_value = beets_info
+            mock_beets_cls.return_value = mock_beets
+            return _compute_rejection_backfill(album_data, ctx)
+
+    def test_lenient_gate_min_rank_fires_backfill(self):
+        """gate_min_rank=GOOD: 180kbps VBR genuine → GOOD rank → backfill fires."""
+        from lib.quality import QualityRank, QUALITY_LOSSLESS
+        album_data, ctx, beets_info = self._setup(
+            gate_min_rank=QualityRank.GOOD)
+        result = self._run(album_data, ctx, beets_info)
+        self.assertEqual(result, QUALITY_LOSSLESS,
+                         "lenient cfg must reach rejection_backfill_override")
+
+    def test_default_gate_min_rank_blocks_backfill(self):
+        """Default gate_min_rank=EXCELLENT: same 180kbps blocks (GOOD < EXCELLENT)."""
+        from lib.quality import QualityRank
+        album_data, ctx, beets_info = self._setup(
+            gate_min_rank=QualityRank.EXCELLENT)
+        result = self._run(album_data, ctx, beets_info)
+        self.assertIsNone(result,
+                          "strict cfg must also reach rejection_backfill_override "
+                          "— if cfg threading were broken, both branches would "
+                          "use the same default and this assertion would silently pass")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -364,28 +364,20 @@ class TestGateRank(unittest.TestCase):
         # And quality_gate_decision agrees
         self.assertEqual(quality_gate_decision(m, cfg), "requeue_upgrade")
 
-    def test_gate_decision_uses_gate_rank(self):
-        """quality_gate_decision must consult gate_rank, not raw measurement_rank.
+    def test_gate_decision_matches_pinned_cases(self):
+        """quality_gate_decision must agree with TestQualityGateDecision.CASES.
 
-        Cross-check: every CASE in TestQualityGateDecision must produce the
-        same verdict whether we compute the rank via gate_rank() and apply
-        the gate threshold by hand, or call quality_gate_decision() directly.
+        Direct cross-check: call quality_gate_decision() (which internally
+        consults gate_rank) and compare against the pinned CASE expectation.
+        Avoids re-implementing the gate body in test code so the test can't
+        silently drift if the gate logic changes.
         """
         cfg = QualityRankConfig.defaults()
         for desc, kwargs, expected in TestQualityGateDecision.CASES:
             with self.subTest(desc=desc):
                 m = AudioQualityMeasurement(**kwargs)
-                rank = gate_rank(m, cfg)
-                expected_via_rank = (
-                    "requeue_upgrade"
-                    if rank == QualityRank.UNKNOWN or rank < cfg.gate_min_rank
-                    else "requeue_lossless"
-                    if (not m.verified_lossless and m.is_cbr
-                        and rank < QualityRank.LOSSLESS)
-                    else "accept"
-                )
-                self.assertEqual(expected_via_rank, expected,
-                                 f"{desc}: gate_rank-derived verdict diverges from CASE expectation")
+                self.assertEqual(quality_gate_decision(m, cfg), expected,
+                                 f"{desc}: quality_gate_decision diverges from CASE expectation")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Five small cleanups from the post-deploy reflection on PR #70. **No behavior change** under defaults — all production paths and persisted reason text are identical. The new orchestration test catches a future refactor that drops the cfg argument; the strengthened cross-check test catches a future drift in the gate body.

## Findings addressed

1. **CLAUDE.md:348 stale wording** — `quality_gate_decision` was described as delegating to `measurement_rank()`. PR #70's docs commit missed the rename. Now correctly described as delegating to `gate_rank()` which applies the spectral clamp on top of `measurement_rank()`.

2. **`gate_rank` import hoisted** (`lib/import_dispatch.py`) — moved from inside the `requeue_upgrade` branch up to the function-top import line in `_check_quality_gate_core`, alongside its siblings (`quality_gate_decision`, `QualityRankConfig`). One-line consistency fix.

3. **Strengthened cross-check test** (`tests/test_quality_decisions.py`) — `test_gate_decision_uses_gate_rank` re-implemented the gate's if/elif body in test code. A future change to `quality_gate_decision()` could pass the test as long as `CASES` weren't updated. Replaced the re-derivation with a direct `assertEqual(quality_gate_decision(m, cfg), expected)`. Renamed to `test_gate_decision_matches_pinned_cases` to reflect the new contract.

4. **Orchestration test for cfg threading** (`tests/test_download.py`) — `_compute_rejection_backfill` had no direct test. The cfg flowed through `ctx.cfg.quality_ranks → rejection_backfill_override(cfg=...)` but nothing pinned that wiring. New `TestComputeRejectionBackfillCfgThreading` exercises both branches against the same on-disk state (180kbps VBR genuine):
   - `gate_min_rank=GOOD` → backfill fires (GOOD rank ≥ GOOD threshold)
   - `gate_min_rank=EXCELLENT` (default) → backfill blocks (GOOD < EXCELLENT)

   If cfg threading were broken, both branches would silently use defaults and the lenient case would fail.

5. **`docs/quality-ranks.md`** — added a one-liner noting that `QUALITY_MIN_BITRATE_KBPS` is now defaults-only and gate behavior is driven by `cfg.quality_ranks.gate_min_rank`. Section was historically accurate but read like the constant was still load-bearing.

## Verification

\`\`\`bash
nix-shell --run "bash scripts/run_tests.sh"
# → Ran 1494 tests in 10.124s; OK (skipped=53)  [+2 from new orchestration test]

nix-shell --run "pyright lib/quality.py lib/import_dispatch.py lib/download.py \\
    scripts/pipeline_cli.py tests/test_quality_decisions.py \\
    tests/test_import_dispatch.py tests/test_pipeline_cli.py tests/test_download.py"
# → 0 errors, 0 warnings, 0 informations
\`\`\`

## Test plan

- [x] Pre-merge: full test suite + pyright clean
- [x] Pre-merge: new orchestration test exercises both lenient/strict cfg branches
- [ ] Post-merge: deploy via /deploy flow
- [ ] Post-merge: \`ssh doc2 'pipeline-cli quality 1683'\` still shows the rank-aware label (regression check from #70 still holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)