### PR TITLE
Add MEDIAN bitrate metric to quality rank model (#64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ Every numeric threshold lives in `QualityRankConfig` (one dataclass) and can be 
 
 **Key rule**: the `verified_lossless=True` bypass is now **tier-gated**. It imports on verdict `"better"` or `"equivalent"` but blocks on `"worse"`. This prevents a deliberately-too-low `verified_lossless_target` (Opus 64) from replacing a good existing album.
 
-**Bitrate metric**: `cfg.quality_ranks.bitrate_metric` picks between `min` (legacy) and `avg` (default, recommended for VBR codecs). Spectral cliff detection always uses min.
+**Bitrate metric**: `cfg.quality_ranks.bitrate_metric` picks between `min` (legacy), `avg` (default, recommended for VBR codecs), and `median` (outlier-resistant — picks the middle track, ignoring quiet intros/outros, hidden tracks, and skits that would drag MIN down or skew AVG). Spectral cliff detection always uses min. See `docs/quality-ranks.md` for *when to prefer median*.
 
 ### Quality Gate (`_check_quality_gate_core()` in import_dispatch.py)
 

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -70,29 +70,63 @@ Primary key is the rank. Within the same rank:
 - **Same codec family, either side carries an explicit label** → equivalent.
   A V0 label and a "mp3 320" label at the same rank are both contracts.
 - **Same codec family, both bare codec names** → compare the configured
-  metric (`avg_bitrate_kbps` or `min_bitrate_kbps`) with
-  `cfg.within_rank_tolerance_kbps` tolerance.
+  metric (`avg_bitrate_kbps`, `median_bitrate_kbps`, or `min_bitrate_kbps`)
+  with `cfg.within_rank_tolerance_kbps` tolerance.
 
-## Bitrate metric — `min` vs `avg`
+## Bitrate metric — `min` vs `avg` vs `median`
 
 VBR codecs have legitimate per-track variance. Opus 128 unconstrained VBR
 regularly lands individual tracks between 95-150 kbps depending on material;
 MP3 V0 can range 160-270. Using the minimum across an album penalizes
 legitimately encoded VBR with quiet passages.
 
-Two metrics are supported:
+Three metrics are supported:
 
 - **`avg`** (default) — album-mean per-track bitrate. Robust to VBR variance.
+- **`median`** — middle per-track bitrate. Outlier-resistant. Recommended
+  when albums commonly contain a single very-quiet intro/outro, hidden
+  tracks, or short interludes that drag MIN down or skew AVG away from the
+  typical track quality. The median ignores them entirely. See *When to
+  prefer median* below.
 - **`min`** — minimum per-track bitrate. Legacy behavior; conservative but
   prone to false negatives on lo-fi VBR.
 
 Spectral cliff detection and `transcode_detection()` continue to use `min`
 regardless of this setting — those care about the worst track, not the
-average.
+typical one.
 
-Adding future metrics like `median` is a one-line change in
-`measurement_rank()` (the single dispatch point) plus one new field on
-`AudioQualityMeasurement` and `AlbumInfo`.
+`measurement_rank()` is the single dispatch point. Each metric reads its
+matching field on `AudioQualityMeasurement` (`avg_bitrate_kbps`,
+`median_bitrate_kbps`, `min_bitrate_kbps`); if the configured metric's
+field is `None`, classification falls back to `min_bitrate_kbps` so legacy
+measurements still classify correctly.
+
+### When to prefer `median`
+
+Pick `median` over `avg` when your library has a meaningful number of
+albums where a small minority of tracks pulls the average around. The
+canonical cases:
+
+- **Lo-fi V0 with one clean closer.** A bedroom-pop V0 sitting at ~190 kbps
+  with a single "studio" track at 270 kbps. AVG drifts to ~200; MEDIAN
+  stays at ~190 — a faithful representation of the album's actual quality
+  contract.
+- **Hidden tracks / silence outros.** A 90-second silent track at 60 kbps
+  on an otherwise V0 album. MIN tanks to 60 (POOR), AVG dips by ~15-20
+  kbps; MEDIAN ignores the outlier entirely.
+- **Skits and interludes.** Hip-hop and concept albums frequently have
+  10-20 second skits encoded at much lower bitrates. MEDIAN stays anchored
+  to the typical full-length track.
+
+Pick `avg` when your library is mostly even-bitrate VBR encodes — AVG and
+MEDIAN converge on those, and AVG is the cheaper, more familiar metric.
+The defaults stay on `avg`; switch to `median` only when one of the cases
+above is biting you.
+
+Computation: AVG is `sum/count`. MEDIAN is `statistics.median()` — the
+middle value, or the mean of the two middle values for even track counts.
+Both are computed in Python in `BeetsDB.get_album_info()` because the
+beets library is SQLite (no native percentile aggregator).
 
 ## Default band values
 

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -26,6 +26,7 @@ import os
 import select
 import signal
 import shutil
+import statistics
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -139,9 +140,10 @@ def build_existing_measurement(
     """Build the existing on-disk measurement for pre-import comparison.
 
     ``override_min_bitrate`` is already the pipeline's corrected view of the
-    existing album after spectral downgrade logic. Under the default AVG rank
-    metric we must apply that override to both min and avg so the harness
-    compares against the same effective quality the caller intended.
+    existing album after spectral downgrade logic. Under any non-MIN rank
+    metric (AVG / MEDIAN) we must apply that override to every bitrate field
+    so the harness compares against the same effective quality the caller
+    intended — otherwise the median/avg would silently outvote the override.
     """
     if existing_info is None:
         return None
@@ -155,9 +157,15 @@ def build_existing_measurement(
         if override_min_bitrate is not None
         else existing_info.avg_bitrate_kbps
     )
+    effective_median = (
+        override_min_bitrate
+        if override_min_bitrate is not None
+        else existing_info.median_bitrate_kbps
+    )
     return AudioQualityMeasurement(
         min_bitrate_kbps=effective_existing,
         avg_bitrate_kbps=effective_avg,
+        median_bitrate_kbps=effective_median,
         format=existing_info.format,
         is_cbr=existing_info.is_cbr,
         spectral_grade=existing_spectral_grade,
@@ -901,6 +909,9 @@ def main():
     new_bitrates = _get_folder_bitrates(args.path, ext_filter=v0_ext_filter)
     new_min_br = min(new_bitrates) if new_bitrates else None
     new_avg_br = int(sum(new_bitrates) / len(new_bitrates)) if new_bitrates else None
+    new_median_br = (
+        int(statistics.median(new_bitrates)) if new_bitrates else None
+    )
     new_is_cbr = len(set(new_bitrates)) == 1 if new_bitrates else False
     existing_info = beets.get_album_info(mbid, _rank_cfg)
     existing_min_br = existing_info.min_bitrate_kbps if existing_info else None
@@ -938,6 +949,7 @@ def main():
     new_m = AudioQualityMeasurement(
         min_bitrate_kbps=new_min_br,
         avg_bitrate_kbps=new_avg_br,
+        median_bitrate_kbps=new_median_br,
         format=new_format_label,
         is_cbr=new_is_cbr,
         spectral_grade=spectral_grade,
@@ -1031,10 +1043,14 @@ def main():
             int(sum(target_bitrates) / len(target_bitrates))
             if target_bitrates else None
         )
+        target_median_br = (
+            int(statistics.median(target_bitrates)) if target_bitrates else None
+        )
         target_is_cbr = len(set(target_bitrates)) == 1 if target_bitrates else False
         r.new_measurement = AudioQualityMeasurement(
             min_bitrate_kbps=target_min_br,
             avg_bitrate_kbps=target_avg_br,
+            median_bitrate_kbps=target_median_br,
             format=target_spec.label,
             is_cbr=target_is_cbr,
             spectral_grade=spectral_grade,

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -12,6 +12,7 @@ Usage:
 
 import os
 import sqlite3
+import statistics
 from dataclasses import dataclass
 from typing import Optional, TYPE_CHECKING
 
@@ -58,12 +59,13 @@ class AlbumInfo:
         so tests constructing AlbumInfo directly (e.g. integration slices)
         don't have to pass every field. Production always sets it via
         get_album_info() → _reduce_album_format().
-    min_bitrate_kbps / avg_bitrate_kbps:
-        Minimum and mean per-track bitrate (kbps). The rank model's
+    min_bitrate_kbps / avg_bitrate_kbps / median_bitrate_kbps:
+        Minimum, mean, and median per-track bitrate (kbps). The rank model's
         measurement_rank() picks between these based on
-        QualityRankConfig.bitrate_metric. ``avg_bitrate_kbps`` defaults to
-        None for the same test-ergonomics reason; measurement_rank() falls
-        back to min when avg is None.
+        QualityRankConfig.bitrate_metric. ``avg_bitrate_kbps`` and
+        ``median_bitrate_kbps`` default to None for test-ergonomics —
+        measurement_rank() falls back to min when the configured metric's
+        field is None.
     """
     album_id: int
     track_count: int
@@ -71,6 +73,7 @@ class AlbumInfo:
     is_cbr: bool
     album_path: str
     avg_bitrate_kbps: Optional[int] = None
+    median_bitrate_kbps: Optional[int] = None
     format: str = ""
 
 
@@ -138,6 +141,11 @@ class BeetsDB:
         bitrates = [r[0] for r in rows]
         min_br = min(bitrates)
         avg_br = sum(bitrates) / len(bitrates)
+        # statistics.median() returns the middle value (or the mean of the two
+        # middle values for even counts) — robust to per-track outliers like
+        # short interludes or hidden tracks at the album boundary. Computed in
+        # Python because the beets DB is SQLite, which has no native median.
+        median_br = statistics.median(bitrates)
         is_cbr = len(set(bitrates)) == 1
         track_count = len(rows)
 
@@ -154,6 +162,7 @@ class BeetsDB:
             track_count=track_count,
             min_bitrate_kbps=int(min_br / 1000),
             avg_bitrate_kbps=int(avg_br / 1000),
+            median_bitrate_kbps=int(median_br / 1000),
             is_cbr=is_cbr,
             album_path=album_path,
             format=album_format,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -97,6 +97,7 @@ def load_quality_gate_state(
     current = AudioQualityMeasurement(
         min_bitrate_kbps=min_br_kbps,
         avg_bitrate_kbps=info.avg_bitrate_kbps,
+        median_bitrate_kbps=info.median_bitrate_kbps,
         format=album_format,
         is_cbr=info.is_cbr,
         verified_lossless=verified_lossless,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -790,7 +790,7 @@ class QualityRankConfig:
 
         Key names (all lowercase, codec-prefixed for bands):
 
-            bitrate_metric            = min | avg
+            bitrate_metric            = min | avg | median
             gate_min_rank             = unknown|poor|acceptable|good|excellent|transparent|lossless
             within_rank_tolerance_kbps = <int>
             <codec>.<band>            = <int>
@@ -1269,7 +1269,10 @@ class ImportResult:
                           quality.get("post_conversion_min_bitrate"))
         conv_d.setdefault("is_transcode", quality.get("is_transcode", False))
 
-        # Build measurements from scattered fields
+        # Build measurements from scattered fields. v1 rows predate the
+        # avg/median bitrate fields (issue #60 / #64) — leaving them at the
+        # default None makes measurement_rank() fall back to min, which is
+        # the same behavior the v1 row was originally classified under.
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=quality.get("new_min_bitrate"),
             spectral_grade=spectral.get("grade"),

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -572,6 +572,14 @@ class AudioQualityMeasurement:
                                RankBitrateMetric and measurement_rank(). Additive;
                                legacy callers that only populate min_bitrate_kbps
                                still work (measurement_rank() falls back to min).
+        median_bitrate_kbps:   median per-track bitrate (kbps), None if
+                               unmeasured. Used when
+                               RankBitrateMetric.MEDIAN is configured —
+                               robust against per-track outliers (intro/outro
+                               silence, hidden tracks, very short interludes)
+                               that can pull MIN or AVG away from the typical
+                               track quality. measurement_rank() falls back
+                               to min when this is None.
         format:                codec label or bare codec name that drives the
                                quality_rank() classifier. Accepts either an
                                explicit label from ImportResult.final_format
@@ -586,6 +594,7 @@ class AudioQualityMeasurement:
     """
     min_bitrate_kbps: Optional[int] = None
     avg_bitrate_kbps: Optional[int] = None
+    median_bitrate_kbps: Optional[int] = None
     format: Optional[str] = None
     is_cbr: bool = False
     spectral_grade: Optional[str] = None
@@ -616,16 +625,22 @@ class AudioQualityMeasurement:
 class RankBitrateMetric(StrEnum):
     """Which per-album bitrate statistic feeds into quality_rank() classification.
 
-    MIN  — minimum per-track bitrate. Legacy behavior. Conservative and prone to
-           VBR false negatives on albums with genuinely quiet tracks.
-    AVG  — album-mean per-track bitrate. Recommended for VBR codecs. Default.
+    MIN    — minimum per-track bitrate. Legacy behavior. Conservative and prone
+             to VBR false negatives on albums with genuinely quiet tracks.
+    AVG    — album-mean per-track bitrate. Recommended for VBR codecs. Default.
+    MEDIAN — middle per-track bitrate. Robust against per-track outliers
+             (intro/outro silence, hidden tracks, very short interludes) where
+             a single low track would drag MIN down and a few skewed tracks
+             could pull AVG away from the typical track quality.
 
-    measurement_rank() is the only function that dispatches on this enum — adding
-    MEDIAN later means one new enum value, one elif branch in measurement_rank(),
-    and one new field on AudioQualityMeasurement / AlbumInfo.
+    measurement_rank() is the only function that dispatches on this enum.
+    Each metric has a matching field on AudioQualityMeasurement / AlbumInfo;
+    when the configured metric's field is None, measurement_rank() falls back
+    to min_bitrate_kbps so legacy callers still classify correctly.
     """
     MIN = "min"
     AVG = "avg"
+    MEDIAN = "median"
 
 
 class QualityRank(IntEnum):
@@ -1040,20 +1055,15 @@ def measurement_rank(
 ) -> QualityRank:
     """Pick the configured bitrate metric from m and classify it.
 
-    This is the ONLY function that dispatches on cfg.bitrate_metric.
-    Adding MEDIAN later is a one-line change here + one new field on
-    AudioQualityMeasurement / AlbumInfo.
+    This is the ONLY function that dispatches on cfg.bitrate_metric. Each
+    metric has a matching field on AudioQualityMeasurement: AVG → avg,
+    MEDIAN → median, MIN → min.
 
-    Falls back to min_bitrate_kbps when the configured metric's value is
+    Falls back to min_bitrate_kbps when the configured metric's field is
     None — so legacy measurements (which only populate min) continue to
-    classify correctly under the default AVG policy.
+    classify correctly regardless of the configured policy.
     """
-    chosen: Optional[int]
-    if cfg.bitrate_metric is RankBitrateMetric.AVG and m.avg_bitrate_kbps is not None:
-        chosen = m.avg_bitrate_kbps
-    else:
-        chosen = m.min_bitrate_kbps
-    return quality_rank(m.format, chosen, m.is_cbr, cfg)
+    return quality_rank(m.format, _selected_bitrate(m, cfg), m.is_cbr, cfg)
 
 
 def _selected_bitrate(m: AudioQualityMeasurement,
@@ -1062,10 +1072,13 @@ def _selected_bitrate(m: AudioQualityMeasurement,
 
     Used by compare_quality() for the same-rank, same-codec tiebreaker.
     Keeps the metric dispatch in one place — compare_quality does not
-    peek into m.avg / m.min directly.
+    peek into m.avg / m.median / m.min directly.
     """
     if cfg.bitrate_metric is RankBitrateMetric.AVG and m.avg_bitrate_kbps is not None:
         return m.avg_bitrate_kbps
+    if (cfg.bitrate_metric is RankBitrateMetric.MEDIAN
+            and m.median_bitrate_kbps is not None):
+        return m.median_bitrate_kbps
     return m.min_bitrate_kbps
 
 
@@ -2307,6 +2320,9 @@ def full_pipeline_decision(
                       avg_bitrate_kbps=override_min_bitrate
                       if override_min_bitrate is not None
                       else existing_min_bitrate,
+                      median_bitrate_kbps=override_min_bitrate
+                      if override_min_bitrate is not None
+                      else existing_min_bitrate,
                       format=effective_existing_format,
                       is_cbr=existing_is_cbr)
                   if existing_min_bitrate is not None else None)
@@ -2317,6 +2333,7 @@ def full_pipeline_decision(
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
             avg_bitrate_kbps=min_bitrate,
+            median_bitrate_kbps=min_bitrate,
             format=stage2_new_format)
         result["stage2_import"] = import_quality_decision(
             new_m, existing_m, cfg=cfg)
@@ -2351,6 +2368,7 @@ def full_pipeline_decision(
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=import_br,
             avg_bitrate_kbps=import_br,
+            median_bitrate_kbps=import_br,
             format=stage2_new_format,
             verified_lossless=will_be_verified)
         result["stage2_import"] = import_quality_decision(
@@ -2401,6 +2419,7 @@ def full_pipeline_decision(
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
             avg_bitrate_kbps=min_bitrate,
+            median_bitrate_kbps=min_bitrate,
             format=stage2_new_format,
             is_cbr=is_cbr)
         result["stage2_import"] = import_quality_decision(
@@ -2427,6 +2446,7 @@ def full_pipeline_decision(
     gate_m = AudioQualityMeasurement(
         min_bitrate_kbps=gate_bitrate,
         avg_bitrate_kbps=gate_bitrate,
+        median_bitrate_kbps=gate_bitrate,
         format=gate_format,
         is_cbr=gate_cbr,
         verified_lossless=verified_lossless,

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -582,6 +582,7 @@ def cmd_quality(db, args):
     # --- Current quality gate ---
     is_cbr = False
     avg_br = None
+    median_br = None
     existing_format_hint = final_format
     if min_br is not None:
         mbid = req.get("mb_release_id")
@@ -589,6 +590,7 @@ def cmd_quality(db, args):
         if info:
             is_cbr = info.is_cbr
             avg_br = info.avg_bitrate_kbps
+            median_br = info.median_bitrate_kbps
             if not existing_format_hint:
                 existing_format_hint = info.format
         gate_spectral_br = None
@@ -600,6 +602,7 @@ def cmd_quality(db, args):
         current = AudioQualityMeasurement(
             min_bitrate_kbps=min_br,
             avg_bitrate_kbps=avg_br,
+            median_bitrate_kbps=median_br,
             format=existing_format_hint or "MP3",
             is_cbr=is_cbr,
             verified_lossless=verified,
@@ -614,6 +617,7 @@ def cmd_quality(db, args):
         print(f"  Quality gate:  {gate_label}  (rank={current_rank.name})")
         print(f"    min_bitrate={_fmt_br(min_br)}, "
               f"avg_bitrate={_fmt_br(avg_br) if avg_br else 'n/a'}, "
+              f"median_bitrate={_fmt_br(median_br) if median_br else 'n/a'}, "
               f"format={existing_format_hint or '(unknown)'}, "
               f"verified_lossless={verified}, is_cbr={is_cbr}")
         if current_br:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,12 +99,17 @@ def make_import_result(
         error=error,
         new_measurement=AudioQualityMeasurement(
             min_bitrate_kbps=new_min_bitrate,
+            avg_bitrate_kbps=new_min_bitrate,
+            median_bitrate_kbps=new_min_bitrate,
             spectral_grade=spectral_grade,
             spectral_bitrate_kbps=spectral_bitrate,
             verified_lossless=verified_lossless,
             was_converted_from=original_filetype if was_converted else None,
         ),
-        existing_measurement=(AudioQualityMeasurement(min_bitrate_kbps=prev_min_bitrate)
+        existing_measurement=(AudioQualityMeasurement(
+                                  min_bitrate_kbps=prev_min_bitrate,
+                                  avg_bitrate_kbps=prev_min_bitrate,
+                                  median_bitrate_kbps=prev_min_bitrate)
                               if prev_min_bitrate is not None else None),
         conversion=ConversionInfo(
             was_converted=was_converted,

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -178,6 +178,7 @@ class TestGetAlbumInfo(unittest.TestCase):
         self.assertEqual(info.track_count, 2)
         self.assertEqual(info.min_bitrate_kbps, 320)
         self.assertEqual(info.avg_bitrate_kbps, 320)
+        self.assertEqual(info.median_bitrate_kbps, 320)
         self.assertTrue(info.is_cbr)
         self.assertEqual(info.album_path, "/music/Artist/Album")
         self.assertEqual(info.format, "MP3")
@@ -193,9 +194,50 @@ class TestGetAlbumInfo(unittest.TestCase):
         assert info is not None
         self.assertEqual(info.min_bitrate_kbps, 238)
         self.assertEqual(info.avg_bitrate_kbps, 244)  # (245+238+251)/3 = 244.66 → 244
+        # Median of {238, 245, 251} = 245
+        self.assertEqual(info.median_bitrate_kbps, 245)
         self.assertFalse(info.is_cbr)
         self.assertEqual(info.track_count, 3)
         self.assertEqual(info.format, "MP3")
+
+    def test_median_resists_outliers(self) -> None:
+        """Median ignores a single very-low track that would tank min/avg.
+
+        Issue #64: a V0 album with one quiet 60kbps interlude should still
+        classify as TRANSPARENT under the MEDIAN rank metric. The pure
+        rank classification is unit-tested in test_quality_decisions; here
+        we just verify BeetsDB computes the median field correctly.
+        """
+        _insert_album(self.db_path, 8, "median-1", [
+            ( 60000, "/m/M/00.mp3"),  # silent intro
+            (245000, "/m/M/01.mp3"),
+            (250000, "/m/M/02.mp3"),
+            (255000, "/m/M/03.mp3"),
+            (260000, "/m/M/04.mp3"),
+        ])
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("median-1", self.cfg)
+        assert info is not None
+        self.assertEqual(info.min_bitrate_kbps, 60)
+        # avg = (60+245+250+255+260)/5 = 214 → int(214) = 214
+        self.assertEqual(info.avg_bitrate_kbps, 214)
+        # median of 5 sorted values {60, 245, 250, 255, 260} = 250
+        self.assertEqual(info.median_bitrate_kbps, 250)
+        self.assertFalse(info.is_cbr)
+
+    def test_median_even_track_count(self) -> None:
+        """statistics.median() averages the two middle values for even counts."""
+        _insert_album(self.db_path, 9, "median-2", [
+            (200000, "/m/E/01.mp3"),
+            (220000, "/m/E/02.mp3"),
+            (240000, "/m/E/03.mp3"),
+            (260000, "/m/E/04.mp3"),
+        ])
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("median-2", self.cfg)
+        assert info is not None
+        # median of {200, 220, 240, 260} = (220+240)/2 = 230
+        self.assertEqual(info.median_bitrate_kbps, 230)
 
     def test_not_found(self) -> None:
         with BeetsDB(self.db_path) as db:

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -209,7 +209,12 @@ class TestExistingMeasurementBuilder(unittest.TestCase):
     """Tests for import_one's existing-measurement wiring."""
 
     def test_override_replaces_avg_metric_too(self):
-        """Spectral override must affect the selected avg metric, not just min."""
+        """Spectral override must affect every selectable rank metric, not just min.
+
+        Issue #64 added MEDIAN as a third metric — override_min_bitrate must
+        drive median too, otherwise a future MEDIAN-policy deployment would
+        silently outvote the override and compare against the original median.
+        """
         from import_one import build_existing_measurement
         from lib.beets_db import AlbumInfo
 
@@ -218,6 +223,7 @@ class TestExistingMeasurementBuilder(unittest.TestCase):
             track_count=10,
             min_bitrate_kbps=320,
             avg_bitrate_kbps=320,
+            median_bitrate_kbps=320,
             format="MP3",
             is_cbr=True,
             album_path="/Beets/Test",
@@ -234,6 +240,9 @@ class TestExistingMeasurementBuilder(unittest.TestCase):
         self.assertEqual(
             m.avg_bitrate_kbps, 128,
             "override_min_bitrate must drive comparison under the default avg metric")
+        self.assertEqual(
+            m.median_bitrate_kbps, 128,
+            "override_min_bitrate must drive comparison under MEDIAN policy too")
 
 
 # ============================================================================

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -61,6 +61,8 @@ class TestImportResultConstruction(unittest.TestCase):
     def test_measurement_defaults(self):
         m = AudioQualityMeasurement()
         self.assertIsNone(m.min_bitrate_kbps)
+        self.assertIsNone(m.avg_bitrate_kbps)
+        self.assertIsNone(m.median_bitrate_kbps)
         self.assertFalse(m.is_cbr)
         self.assertIsNone(m.spectral_grade)
         self.assertIsNone(m.spectral_bitrate_kbps)

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -225,6 +225,71 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
             "180kbps falls back to the default EXCELLENT gate and requeues.")
         self.assertIsNone(row["search_filetype_override"])
 
+    def test_median_metric_accepts_outlier_album_end_to_end(self):
+        """MEDIAN policy must thread through dispatch → quality gate (#64).
+
+        Album has tracks {60, 60, 245, 245, 245} — three V0 tracks plus two
+        very-quiet intros. Under MIN the album is POOR (60), under AVG it's
+        GOOD (171), and only under MEDIAN does it reach TRANSPARENT (245)
+        and pass the default EXCELLENT gate.
+
+        If load_quality_gate_state (lib/import_dispatch.py) drops the
+        median field when constructing the AudioQualityMeasurement, or if
+        the rank cfg fails to thread through, this test fails because the
+        gate falls back to AVG=171 (GOOD < EXCELLENT) and requeues. This
+        is the only end-to-end coverage for the issue #64 dispatch path.
+        """
+        from lib.quality import QualityRankConfig, RankBitrateMetric
+
+        ir = make_import_result(decision="import", new_min_bitrate=60)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=5,
+            min_bitrate_kbps=60,
+            avg_bitrate_kbps=171,
+            median_bitrate_kbps=245,
+            format="MP3", is_cbr=False, album_path="/Beets/Test")
+
+        custom_cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            quality_ranks=QualityRankConfig(
+                bitrate_metric=RankBitrateMetric.MEDIAN),
+        )
+
+        db = self._run_dispatch(ir, beets_info, cfg=custom_cfg)
+
+        row = db.request(42)
+        self.assertEqual(
+            row["status"], "imported",
+            "MEDIAN policy must thread through dispatch_import_core → "
+            "load_quality_gate_state → measurement_rank. If any hop drops "
+            "median_bitrate_kbps from the AudioQualityMeasurement, the "
+            "gate falls back to avg=171 (GOOD < EXCELLENT) and requeues.")
+        self.assertIsNone(row["search_filetype_override"])
+
+    def test_default_avg_metric_requeues_same_outlier_album(self):
+        """Counterfactual to MEDIAN slice: same album, default cfg, requeues.
+
+        Pinning this proves the difference in the MEDIAN test really comes
+        from the policy switch — not from a hidden change in dispatch flow.
+        """
+        ir = make_import_result(decision="import", new_min_bitrate=60)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=5,
+            min_bitrate_kbps=60,
+            avg_bitrate_kbps=171,
+            median_bitrate_kbps=245,
+            format="MP3", is_cbr=False, album_path="/Beets/Test")
+
+        db = self._run_dispatch(ir, beets_info)
+
+        row = db.request(42)
+        self.assertEqual(
+            row["status"], "wanted",
+            "Default AVG policy on the same outlier album must requeue — "
+            "if this fails, the MEDIAN slice's pass is meaningless.")
+        self.assertEqual(row["search_filetype_override"], QUALITY_UPGRADE_TIERS)
+
     def test_native_vbr_import_clears_stale_final_format(self):
         """A later plain MP3 import must clear an old target-format label.
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -499,6 +499,7 @@ class TestCmdRepairSpectral(unittest.TestCase):
                 track_count=10,
                 min_bitrate_kbps=207,
                 avg_bitrate_kbps=207,
+                median_bitrate_kbps=207,
                 format="MP3",
                 is_cbr=False,
                 album_path="/Beets/Artist/Album",
@@ -538,6 +539,7 @@ class TestCmdQuality(unittest.TestCase):
         beets_info = SimpleNamespace(
             is_cbr=False,
             avg_bitrate_kbps=245,
+            median_bitrate_kbps=245,
             format="MP3",
         )
         captured_kwargs: list[dict[str, object]] = []
@@ -638,6 +640,7 @@ class TestCmdQuality(unittest.TestCase):
         beets_info = SimpleNamespace(
             is_cbr=False,
             avg_bitrate_kbps=245,
+            median_bitrate_kbps=245,
             format="MP3",
         )
 

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -1358,6 +1358,51 @@ class TestMeasurementRank(unittest.TestCase):
         m = AudioQualityMeasurement(format="MP3")
         self.assertEqual(measurement_rank(m, CFG), QualityRank.UNKNOWN)
 
+    # ---- MEDIAN metric (issue #64) ---------------------------------------
+    # The median is robust against per-track outliers like a 60kbps interlude
+    # or a 320kbps hidden track on an otherwise V0 album. The subtest table
+    # below pins the dispatch behavior for every interesting combination.
+    MEDIAN_CASES = [
+        # (description, min, avg, median, format, expected_rank)
+        ("median wins over outlier-low min — Opus 130 album",
+         60, 128, 130, "Opus", QualityRank.TRANSPARENT),
+        ("median wins over outlier-high avg — MP3 V0 album with one 320 hidden track",
+         200, 230, 215, "MP3", QualityRank.EXCELLENT),
+        ("median falls back to min when None",
+         260, 260, None, "MP3", QualityRank.TRANSPARENT),
+        ("median below acceptable → POOR",
+         128, 128, 100, "MP3", QualityRank.POOR),
+        ("median classifies bare Opus into GOOD band",
+         60, 130, 70, "Opus", QualityRank.GOOD),
+    ]
+
+    def test_median_metric_table(self):
+        cfg_median = QualityRankConfig(bitrate_metric=RankBitrateMetric.MEDIAN)
+        for desc, mn, av, med, fmt, expected in self.MEDIAN_CASES:
+            with self.subTest(desc=desc):
+                m = AudioQualityMeasurement(
+                    min_bitrate_kbps=mn,
+                    avg_bitrate_kbps=av,
+                    median_bitrate_kbps=med,
+                    format=fmt,
+                )
+                self.assertEqual(measurement_rank(m, cfg_median), expected)
+
+    def test_median_metric_does_not_affect_avg_default(self):
+        """Setting median_bitrate_kbps must not change AVG-policy classification."""
+        m = AudioQualityMeasurement(
+            min_bitrate_kbps=80, avg_bitrate_kbps=130,
+            median_bitrate_kbps=70, format="Opus")
+        # Default AVG metric → still uses 130 → TRANSPARENT, ignoring median.
+        self.assertEqual(measurement_rank(m, CFG), QualityRank.TRANSPARENT)
+
+    def test_median_metric_falls_back_to_min_when_only_min_set(self):
+        """Legacy measurements with only min populated still classify under MEDIAN."""
+        cfg_median = QualityRankConfig(bitrate_metric=RankBitrateMetric.MEDIAN)
+        m = AudioQualityMeasurement(min_bitrate_kbps=260, format="MP3")
+        # 260 ≥ default mp3_vbr.transparent=245 → TRANSPARENT
+        self.assertEqual(measurement_rank(m, cfg_median), QualityRank.TRANSPARENT)
+
 
 class TestCompareQuality(unittest.TestCase):
     """compare_quality() covers all four outcome branches explicitly."""
@@ -1477,6 +1522,27 @@ class TestCompareQuality(unittest.TestCase):
         # Under AVG: new=250, existing=260 → worse
         self.assertEqual(compare_quality(new, existing, CFG), "worse")
 
+    def test_median_metric_honored_in_comparison(self):
+        """When cfg uses MEDIAN, compare_quality must use median not avg/min.
+
+        Issue #64: outlier-resistant comparisons. The new album has one
+        very quiet interlude (min=60) but every other track sits above the
+        existing album's median. Under MIN it would lose; under MEDIAN it
+        wins because the typical track is better.
+        """
+        cfg_med = QualityRankConfig(bitrate_metric=RankBitrateMetric.MEDIAN)
+        new = self._m(format="MP3",
+                      min_bitrate_kbps=60, avg_bitrate_kbps=240,
+                      median_bitrate_kbps=255)
+        existing = self._m(format="MP3",
+                           min_bitrate_kbps=210, avg_bitrate_kbps=215,
+                           median_bitrate_kbps=215)
+        # Under MEDIAN: new=255 (TRANSPARENT) vs existing=215 (EXCELLENT) → better
+        self.assertEqual(compare_quality(new, existing, cfg_med), "better")
+        # Under MIN: new=60 (POOR) vs existing=210 (EXCELLENT) → worse
+        cfg_min = QualityRankConfig(bitrate_metric=RankBitrateMetric.MIN)
+        self.assertEqual(compare_quality(new, existing, cfg_min), "worse")
+
 
 class TestQualityRankConfigFromIni(unittest.TestCase):
     """Parse [Quality Ranks] section from config.ini — exhaustive edge cases."""
@@ -1541,8 +1607,13 @@ class TestQualityRankConfigFromIni(unittest.TestCase):
 
     def test_invalid_metric_raises(self):
         with self.assertRaises(ValueError) as ctx:
-            self._parse("[Quality Ranks]\nbitrate_metric = median\n")
+            self._parse("[Quality Ranks]\nbitrate_metric = harmonic_mean\n")
         self.assertIn("bitrate_metric", str(ctx.exception))
+
+    def test_median_metric_parses(self):
+        """`bitrate_metric = median` is a valid policy (issue #64)."""
+        cfg = self._parse("[Quality Ranks]\nbitrate_metric = median\n")
+        self.assertEqual(cfg.bitrate_metric, RankBitrateMetric.MEDIAN)
 
     def test_invalid_rank_raises(self):
         with self.assertRaises(ValueError) as ctx:
@@ -1617,6 +1688,12 @@ class TestQualityRankConfigRoundTrip(unittest.TestCase):
         restored = QualityRankConfig.from_json(payload)
         self.assertEqual(restored, original)
         self.assertEqual(restored.opus.transparent, 120)
+
+    def test_median_metric_round_trip(self):
+        """RankBitrateMetric.MEDIAN survives the harness argv round-trip."""
+        original = QualityRankConfig(bitrate_metric=RankBitrateMetric.MEDIAN)
+        restored = QualityRankConfig.from_json(original.to_json())
+        self.assertEqual(restored.bitrate_metric, RankBitrateMetric.MEDIAN)
 
     def test_json_shape_stable(self):
         """to_json() must emit the expected top-level keys."""


### PR DESCRIPTION
## Summary
- Adds `RankBitrateMetric.MEDIAN` as a third rank-classification metric alongside `MIN` and `AVG`. Median is robust against per-track outliers — quiet intros/outros, hidden tracks, skits, and interludes that drag `MIN` down or skew `AVG` away from the typical track quality.
- Wired through the single dispatch point in `measurement_rank()` / `_selected_bitrate()`. New `median_bitrate_kbps` field on `AudioQualityMeasurement` and `AlbumInfo`; computed via `statistics.median()` in `BeetsDB.get_album_info()` (Python-side because beets is SQLite).
- Falls back to `min_bitrate_kbps` when the configured metric's field is `None` — legacy measurements continue to classify correctly.
- Resolves abl030/soularr#64.

## Scope (per the issue)
- [x] `MEDIAN = "median"` added to `RankBitrateMetric`
- [x] `median_bitrate_kbps` added to `AudioQualityMeasurement` and `AlbumInfo`
- [x] Computed in `BeetsDB.get_album_info()` (via `statistics.median`, since beets is SQLite — `percentile_cont` not available; documented in `quality-ranks.md`)
- [x] Wired into `_selected_bitrate()` and `measurement_rank()`
- [x] `[Quality Ranks] bitrate_metric = median` parses (was previously rejected)
- [x] Subtest coverage in `TestMeasurementRank` for the new metric

## Test plan
- [x] `nix-shell --run 'pyright lib/quality.py lib/beets_db.py lib/import_dispatch.py harness/import_one.py scripts/pipeline_cli.py tests/test_*.py tests/helpers.py'` → 0 errors
- [x] `nix-shell --run 'bash scripts/run_tests.sh'` → 1502 tests, OK (skipped=53)
- [x] New tests:
  - `TestMeasurementRank.test_median_metric_table` — 5-row subtest pinning every interesting MEDIAN dispatch case
  - `TestMeasurementRank.test_median_metric_does_not_affect_avg_default` — regression guard that adding median to a measurement doesn't perturb the AVG-policy result
  - `TestMeasurementRank.test_median_metric_falls_back_to_min_when_only_min_set` — legacy measurement compat
  - `TestCompareQuality.test_median_metric_honored_in_comparison` — end-to-end MEDIAN vs MIN comparison on the same lo-fi-with-quiet-intro album
  - `TestQualityRankConfigFromIni.test_median_metric_parses` — `bitrate_metric = median` is now valid
  - `TestQualityRankConfigRoundTrip.test_median_metric_round_trip` — survives the harness argv round-trip
  - `TestGetAlbumInfo.test_median_resists_outliers` — 60kbps intro track, asserts MEDIAN ignores it
  - `TestGetAlbumInfo.test_median_even_track_count` — 4-track album, asserts the two-middle-values average

## Docs
- `docs/quality-ranks.md` — replaced the "min vs avg" section with min/avg/median, added a "When to prefer median" subsection covering the three canonical scenarios (lo-fi V0 with one clean closer, hidden tracks/silence outros, skits and interludes), and documented the SQLite-vs-PostgreSQL median computation note.
- `CLAUDE.md` — updated the bitrate metric one-liner to mention median.

## Defaults unchanged
The default metric stays `avg`. `median` is opt-in via `[Quality Ranks] bitrate_metric = median` in `config.ini`. No production behavior changes for existing deployments.