### PR TITLE
Wire mp3_vbr_levels / lossless_codecs / mixed_format_precedence through INI parser (#65)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -107,6 +107,28 @@ aac.excellent = 144
 aac.good = 112
 aac.acceptable = 80
 
+# --- Collection fields (issue #65) -------------------------------------------
+# All three are CSV. Missing keys fall back to the dataclass defaults — almost
+# nobody will need to retune these. Examples are commented out.
+
+# LAME VBR V-level → rank mapping. Exactly 10 entries (V0..V9). Rank names are
+# case-insensitive: unknown, poor, acceptable, good, excellent, transparent,
+# lossless. Default ladder: V0=TRANSPARENT, V1-V2=EXCELLENT, V3-V4=GOOD,
+# V5-V9=ACCEPTABLE. Tighten or loosen if you disagree with the LAME defaults.
+# mp3_vbr_levels = TRANSPARENT,EXCELLENT,EXCELLENT,GOOD,GOOD,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE
+
+# Codec strings that classify as LOSSLESS regardless of measured bitrate.
+# Lowercased and deduplicated. Default: flac, lossless, alac, wav. Add more if
+# your library carries them (ape, dsf, wavpack, ...).
+# lossless_codecs = flac,alac,wav,ape,dsf,wavpack
+
+# Mixed-format album precedence. When an album on disk has tracks in multiple
+# codecs (rare), the worst-rank codec wins for classification. ORDER MATTERS:
+# the first codec in this list that appears on the album becomes the album's
+# canonical codec. Lowercased. Default: mp3,aac,opus,flac (so a mixed FLAC+MP3
+# album classifies as MP3).
+# mixed_format_precedence = mp3,aac,opus,flac
+
 [Pipeline DB]
 enabled = False
 dsn = postgresql://soularr:soularr@localhost:5432/soularr

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -201,7 +201,50 @@ aac.transparent = 192
 aac.excellent = 144
 aac.good = 112
 aac.acceptable = 80
+
+# Collection fields (issue #65). All three are CSV. Defaults are sensible —
+# you almost certainly do not need to set these.
+mp3_vbr_levels = TRANSPARENT,EXCELLENT,EXCELLENT,GOOD,GOOD,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE
+lossless_codecs = flac,lossless,alac,wav
+mixed_format_precedence = mp3,aac,opus,flac
 ```
+
+### Collection fields (mp3_vbr_levels / lossless_codecs / mixed_format_precedence)
+
+These three fields configure rank-model behavior at the codec-identity layer
+rather than the bitrate-band layer. They were previously dataclass-only;
+issue #65 wires them through the INI parser.
+
+- **`mp3_vbr_levels`** — comma-separated list of exactly 10 rank names
+  (V0..V9). Maps each LAME VBR V-level to a rank when the format hint is
+  an explicit `mp3 v0` / `mp3 v3` / etc. label. Defaults assume LAME's
+  documented V-level quality contract:
+  - V0 → TRANSPARENT, V1-V2 → EXCELLENT, V3-V4 → GOOD, V5-V9 → ACCEPTABLE.
+  - Tighten if you don't trust LAME's claim that V2 is transparent.
+  - Loosen if you encode at V4 and want it to pass the gate.
+- **`lossless_codecs`** — comma-separated set of codec strings (lowercased,
+  deduplicated). The first token of `format_hint` is checked against this
+  set; a match short-circuits to LOSSLESS. Default: `flac, lossless, alac,
+  wav`. Add `ape, dsf, wavpack` if your library carries them.
+- **`mixed_format_precedence`** — comma-separated **ordered** tuple. When an
+  album has tracks in multiple codecs (rare — usually a manually merged
+  album), `_reduce_album_format()` walks this list in order and picks the
+  first codec that appears on disk. The default `mp3, aac, opus, flac` is
+  worst-first, so a mixed FLAC+MP3 album classifies as MP3 (the
+  conservative choice). Reorder if you want a different "canonical codec"
+  policy.
+
+Validation:
+
+- `mp3_vbr_levels` must have **exactly 10** entries; any other count raises
+  `ValueError` at startup.
+- Each `mp3_vbr_levels` entry must be a valid `QualityRank` name
+  (case-insensitive).
+- Empty values (`key = `) fall through to the default; an explicit list
+  containing only whitespace/commas raises so the user gets a diagnostic
+  instead of silently losing all entries.
+- All codec strings are lowercased on parse — `FLAC,Alac,WAV` is identical
+  to `flac,alac,wav`.
 
 Reload by restarting `soularr-web` (the web simulator reads this file on
 every request) and waiting for the next `soularr.timer` fire (5 min).

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -781,6 +781,9 @@ class QualityRankConfig:
             <codec>.<band>            = <int>
               codecs: opus, mp3_vbr, mp3_cbr, aac
               bands:  transparent, excellent, good, acceptable
+            mp3_vbr_levels            = <rank>,<rank>,... (exactly 10, V0..V9)
+            lossless_codecs           = <codec>,<codec>,... (set, lowercased)
+            mixed_format_precedence   = <codec>,<codec>,... (ordered list, lowercased)
 
         Invalid values raise ValueError at parse time with a diagnostic that
         names the offending key. Missing section silently returns defaults.
@@ -846,6 +849,59 @@ class QualityRankConfig:
             # with section context.
             raise ValueError(f"[{section}] invalid codec bands: {exc}") from exc
 
+        # --- Collection fields (issue #65) ---
+        # CSV with leading/trailing whitespace tolerated. An unset key (raw
+        # is None) and an empty `key = ` both fall through to the default;
+        # an explicit list with no usable values (e.g. just commas) is a
+        # config error so the user gets a diagnostic instead of silently
+        # losing all lossless codecs.
+        def _split_csv(key: str) -> list[str] | None:
+            raw = parser.get(section, key, fallback=None)
+            if raw is None or raw.strip() == "":
+                return None
+            parts = [p.strip() for p in raw.split(",")]
+            parts = [p for p in parts if p]
+            if not parts:
+                raise ValueError(
+                    f"[{section}] {key}: list contains no usable entries "
+                    f"(got {raw!r})")
+            return parts
+
+        # mp3_vbr_levels — exactly 10 entries, each a QualityRank name.
+        levels_parts = _split_csv("mp3_vbr_levels")
+        if levels_parts is None:
+            mp3_vbr_levels = base.mp3_vbr_levels
+        else:
+            if len(levels_parts) != 10:
+                raise ValueError(
+                    f"[{section}] mp3_vbr_levels: expected exactly 10 ranks "
+                    f"(V0..V9), got {len(levels_parts)}")
+            parsed_levels: list[QualityRank] = []
+            for i, name in enumerate(levels_parts):
+                key_norm = name.lower()
+                if key_norm not in _RANK_NAME_TO_VALUE:
+                    raise ValueError(
+                        f"[{section}] mp3_vbr_levels: entry {i} (V{i}) "
+                        f"is {name!r}, expected one of "
+                        f"{sorted(_RANK_NAME_TO_VALUE.keys())}")
+                parsed_levels.append(_RANK_NAME_TO_VALUE[key_norm])
+            mp3_vbr_levels = tuple(parsed_levels)
+
+        # lossless_codecs — frozenset, lowercased, deduplicated.
+        lossless_parts = _split_csv("lossless_codecs")
+        if lossless_parts is None:
+            lossless_codecs = base.lossless_codecs
+        else:
+            lossless_codecs = frozenset(p.lower() for p in lossless_parts)
+
+        # mixed_format_precedence — ordered tuple, lowercased. Order matters
+        # because _reduce_album_format takes the first match.
+        precedence_parts = _split_csv("mixed_format_precedence")
+        if precedence_parts is None:
+            mixed_format_precedence = base.mixed_format_precedence
+        else:
+            mixed_format_precedence = tuple(p.lower() for p in precedence_parts)
+
         return cls(
             bitrate_metric=metric,
             gate_min_rank=gate_min_rank,
@@ -854,9 +910,9 @@ class QualityRankConfig:
             mp3_vbr=mp3_vbr,
             mp3_cbr=mp3_cbr,
             aac=aac,
-            mp3_vbr_levels=base.mp3_vbr_levels,
-            lossless_codecs=base.lossless_codecs,
-            mixed_format_precedence=base.mixed_format_precedence,
+            mp3_vbr_levels=mp3_vbr_levels,
+            lossless_codecs=lossless_codecs,
+            mixed_format_precedence=mixed_format_precedence,
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -1597,6 +1597,132 @@ class TestQualityRankConfigFromIni(unittest.TestCase):
         # Repo template uses the defaults — assert round-trip equality.
         self.assertEqual(cfg, QualityRankConfig.defaults())
 
+    # ---- Issue #65: collection field parsing -----------------------------
+    # mp3_vbr_levels / lossless_codecs / mixed_format_precedence are now
+    # parseable from [Quality Ranks] as comma-separated values.
+
+    def test_mp3_vbr_levels_parses_full_override(self):
+        """All 10 V-level entries (V0..V9) must parse into the tuple."""
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "mp3_vbr_levels = TRANSPARENT,EXCELLENT,EXCELLENT,GOOD,GOOD,"
+            "ACCEPTABLE,ACCEPTABLE,POOR,POOR,POOR\n"
+        )
+        self.assertEqual(len(cfg.mp3_vbr_levels), 10)
+        self.assertEqual(cfg.mp3_vbr_levels[0], QualityRank.TRANSPARENT)
+        self.assertEqual(cfg.mp3_vbr_levels[2], QualityRank.EXCELLENT)
+        self.assertEqual(cfg.mp3_vbr_levels[7], QualityRank.POOR)
+
+    def test_mp3_vbr_levels_case_insensitive_and_whitespace_tolerant(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "mp3_vbr_levels =  transparent , Excellent ,EXCELLENT, good,good,"
+            " acceptable,ACCEPTABLE,acceptable,Acceptable,acceptable\n"
+        )
+        self.assertEqual(cfg.mp3_vbr_levels,
+                         QualityRankConfig.defaults().mp3_vbr_levels)
+
+    def test_mp3_vbr_levels_wrong_length_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(
+                "[Quality Ranks]\n"
+                "mp3_vbr_levels = TRANSPARENT,EXCELLENT,GOOD\n"
+            )
+        self.assertIn("mp3_vbr_levels", str(ctx.exception))
+        self.assertIn("10", str(ctx.exception))
+
+    def test_mp3_vbr_levels_invalid_rank_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(
+                "[Quality Ranks]\n"
+                "mp3_vbr_levels = TRANSPARENT,EXCELLENT,EXCELLENT,GOOD,GOOD,"
+                "ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,WHOOPS,ACCEPTABLE\n"
+            )
+        self.assertIn("mp3_vbr_levels", str(ctx.exception))
+        self.assertIn("whoops", str(ctx.exception).lower())
+
+    def test_lossless_codecs_parses(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "lossless_codecs = flac,alac,wav,ape,wavpack\n"
+        )
+        self.assertEqual(cfg.lossless_codecs,
+                         frozenset({"flac", "alac", "wav", "ape", "wavpack"}))
+
+    def test_lossless_codecs_lowercased_and_deduped(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "lossless_codecs = FLAC, Alac , wav , flac\n"
+        )
+        self.assertEqual(cfg.lossless_codecs,
+                         frozenset({"flac", "alac", "wav"}))
+
+    def test_lossless_codecs_empty_falls_through_to_default(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "lossless_codecs = \n"
+        )
+        self.assertEqual(cfg.lossless_codecs,
+                         QualityRankConfig.defaults().lossless_codecs)
+
+    def test_lossless_codecs_empty_list_raises(self):
+        """An explicit empty list (just whitespace/commas) is a config error.
+
+        Distinct from `key = ` (which means "use the default") because here
+        the user is clearly trying to set the field but produced no values.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(
+                "[Quality Ranks]\n"
+                "lossless_codecs = , ,\n"
+            )
+        self.assertIn("lossless_codecs", str(ctx.exception))
+
+    def test_mixed_format_precedence_parses_and_preserves_order(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "mixed_format_precedence = aac, opus, mp3, flac\n"
+        )
+        # Order matters — the first match wins in _reduce_album_format.
+        self.assertEqual(
+            cfg.mixed_format_precedence, ("aac", "opus", "mp3", "flac"))
+
+    def test_mixed_format_precedence_lowercased(self):
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "mixed_format_precedence = MP3,AAC,Opus,FLAC\n"
+        )
+        self.assertEqual(
+            cfg.mixed_format_precedence, ("mp3", "aac", "opus", "flac"))
+
+    def test_collection_partial_override(self):
+        """Setting only one collection field leaves the others at defaults."""
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "lossless_codecs = flac,alac,ape\n"
+        )
+        defaults = QualityRankConfig.defaults()
+        self.assertEqual(cfg.lossless_codecs,
+                         frozenset({"flac", "alac", "ape"}))
+        self.assertEqual(cfg.mp3_vbr_levels, defaults.mp3_vbr_levels)
+        self.assertEqual(cfg.mixed_format_precedence,
+                         defaults.mixed_format_precedence)
+
+    def test_collection_full_override_round_trips_through_from_ini(self):
+        """End-to-end: set all three collection fields and verify each one."""
+        cfg = self._parse(
+            "[Quality Ranks]\n"
+            "mp3_vbr_levels = EXCELLENT,EXCELLENT,GOOD,GOOD,ACCEPTABLE,"
+            "ACCEPTABLE,POOR,POOR,POOR,POOR\n"
+            "lossless_codecs = flac,alac,wav,ape,dsf,wavpack\n"
+            "mixed_format_precedence = aac,mp3,opus,flac\n"
+        )
+        self.assertEqual(cfg.mp3_vbr_levels[0], QualityRank.EXCELLENT)
+        self.assertEqual(cfg.mp3_vbr_levels[6], QualityRank.POOR)
+        self.assertIn("ape", cfg.lossless_codecs)
+        self.assertEqual(
+            cfg.mixed_format_precedence, ("aac", "mp3", "opus", "flac"))
+
 
 class TestQualityRankConfigRoundTrip(unittest.TestCase):
     """to_json / from_json must round-trip identically."""


### PR DESCRIPTION
## Summary
- Resolves abl030/soularr#65. The three collection fields on `QualityRankConfig` (`mp3_vbr_levels`, `lossless_codecs`, `mixed_format_precedence`) are now parseable from `[Quality Ranks]` in `config.ini`. Format: comma-separated values.
- All three are validated at parse time with diagnostic errors that name the offending key.
- Defaults unchanged. The repo template ships with the new keys commented out — existing deployments are unaffected.

## Format

```ini
[Quality Ranks]
mp3_vbr_levels = TRANSPARENT,EXCELLENT,EXCELLENT,GOOD,GOOD,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE,ACCEPTABLE
lossless_codecs = flac,alac,wav,ape,dsf,wavpack
mixed_format_precedence = mp3,aac,opus,flac
```

## Validation rules
- `mp3_vbr_levels` requires **exactly 10** entries (V0..V9). Length mismatches and unknown rank names raise `ValueError` naming the offending position.
- `lossless_codecs` is lowercased and deduplicated into a `frozenset`.
- `mixed_format_precedence` is lowercased into an ordered tuple — order is preserved because `_reduce_album_format` takes the first match.
- Empty (`key = `) falls through to the default. Explicit "no usable values" (just whitespace/commas) raises so the user gets a diagnostic instead of silently emptying the field.
- Partial overrides work — setting just `lossless_codecs` leaves `mp3_vbr_levels` and `mixed_format_precedence` at defaults.

## Issue scope
- [x] Parse `mp3_vbr_levels`, `lossless_codecs`, `mixed_format_precedence` in `from_ini()`
- [x] Extend `config.ini` template with documented commented-out examples
- [x] Add subtest coverage to `TestQualityRankConfigFromIni`: parse, partial override, malformed input, CSV parsing for sets/lists
- [x] Update `docs/quality-ranks.md` to document the new INI keys
- [x] Acceptance: setting `mp3_vbr_levels = TRANSPARENT,EXCELLENT,GOOD,...` works
- [x] Acceptance: setting `lossless_codecs = flac,alac,wav,ape` works
- [x] Acceptance: setting `mixed_format_precedence = AAC,Opus,MP3,FLAC` works
- [x] Acceptance: missing keys fall through to defaults

## Test plan
- [x] `nix-shell --run 'pyright lib/quality.py tests/test_quality_decisions.py'` → 0 errors
- [x] `nix-shell --run 'bash scripts/run_tests.sh'` → 1506 tests, OK
- [x] 13 new test methods covering every branch of the new parser:
  - `test_mp3_vbr_levels_parses_full_override`
  - `test_mp3_vbr_levels_case_insensitive_and_whitespace_tolerant`
  - `test_mp3_vbr_levels_wrong_length_raises`
  - `test_mp3_vbr_levels_invalid_rank_raises`
  - `test_lossless_codecs_parses`
  - `test_lossless_codecs_lowercased_and_deduped`
  - `test_lossless_codecs_empty_falls_through_to_default`
  - `test_lossless_codecs_empty_list_raises`
  - `test_mixed_format_precedence_parses_and_preserves_order`
  - `test_mixed_format_precedence_lowercased`
  - `test_collection_partial_override`
  - `test_collection_full_override_round_trips_through_from_ini`
- [x] `test_repo_config_ini_parses_cleanly` still passes — the new keys ship commented out so the template still equals defaults.

## Notes
This PR is independent of abl030/soularr#72 (median bitrate metric) and abl030/soularr#66 (transcode fallback threshold). They can be reviewed and merged in any order.