### PR TITLE
Make transcode_detection() spectral-fallback threshold configurable (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ All quality decisions are pure functions in `lib/quality.py` — no I/O, no data
 
 1. **`spectral_import_decision()`** — Pre-import: should we import this MP3/CBR download? (genuine/suspect/reject)
 2. **`import_quality_decision()`** — Import-time: is this an upgrade or downgrade? (import/downgrade/transcode)
-3. **`transcode_detection(spectral_grade)`** — Post-conversion: was this FLAC actually a transcode? Spectral grade is authoritative when available (suspect/likely_transcode = transcode, genuine/marginal = not transcode). Bitrate < 210kbps threshold is fallback only when spectral is unavailable.
+3. **`transcode_detection(spectral_grade, cfg)`** — Post-conversion: was this FLAC actually a transcode? Spectral grade is authoritative when available (suspect/likely_transcode = transcode, genuine/marginal = not transcode). Bitrate fallback uses `cfg.mp3_vbr.excellent` (default 210 kbps) only when spectral is unavailable — tracks retuning automatically (#66).
 4. **`quality_gate_decision()`** — Post-import: accept, or re-queue for better quality?
 5. **`determine_verified_lossless()`** — Single source of truth for verified lossless status. `is_verified_lossless()` is the legacy fallback for old download_log rows.
 6. **`dispatch_action()`** — Post-import_one.py: map decision string to action flags (mark_done/failed, denylist, requeue, trigger_meelo, quality_gate). Used by `dispatch_import()`.

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -93,7 +93,11 @@ Three metrics are supported:
 
 Spectral cliff detection and `transcode_detection()` continue to use `min`
 regardless of this setting — those care about the worst track, not the
-typical one.
+typical one. The transcode-detection spectral-fallback threshold is now
+derived from `cfg.mp3_vbr.excellent` (issue #66) so it tracks any retuning
+of the gate threshold automatically — operators who lower the gate to
+accept lower-quality V0 also implicitly lower what counts as "credible
+V0" for the spectral fallback.
 
 `measurement_rank()` is the single dispatch point. Each metric reads its
 matching field on `AudioQualityMeasurement` (`avg_bitrate_kbps`,

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -49,7 +49,6 @@ from lib.beets_db import AlbumInfo, BeetsDB
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, ImportResult,
                          PostflightInfo, QualityRankConfig,
-                         TRANSCODE_MIN_BITRATE_KBPS,
                          comparison_format_hint,
                          determine_verified_lossless,
                          import_quality_decision, transcode_detection)
@@ -865,12 +864,16 @@ def main():
         v0_ext_filter = {".mp3"} if has_target and converted > 0 else None
         post_conv_br = _get_folder_min_bitrate(args.path, ext_filter=v0_ext_filter) if converted > 0 else None
         r.conversion.post_conversion_min_bitrate = post_conv_br
-        is_transcode = transcode_detection(converted, post_conv_br,
-                                           spectral_grade=spectral_grade)
+        is_transcode = transcode_detection(
+            converted, post_conv_br,
+            spectral_grade=spectral_grade, cfg=_rank_cfg)
         r.conversion.is_transcode = is_transcode
         if is_transcode:
+            # Threshold tracks the runtime cfg (issue #66) — log the value
+            # the decision actually used so retuned deployments stay
+            # auditable.
             _log(f"[TRANSCODE] converted FLAC min bitrate {post_conv_br}kbps "
-                 f"< {TRANSCODE_MIN_BITRATE_KBPS}kbps — source was not lossless")
+                 f"< {_rank_cfg.mp3_vbr.excellent}kbps — source was not lossless")
         if post_conv_br is not None:
             _log(f"  post_conversion_min_bitrate={post_conv_br}")
     else:

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1526,7 +1526,8 @@ def import_quality_decision(
 
 
 def transcode_detection(converted_count, post_conversion_min_bitrate,
-                        spectral_grade=None):
+                        spectral_grade=None,
+                        cfg: "QualityRankConfig | None" = None):
     """Detect whether a FLAC→V0 conversion produced a transcode.
 
     Called in import_one.py after convert_flac_to_v0().
@@ -1535,9 +1536,16 @@ def transcode_detection(converted_count, post_conversion_min_bitrate,
     (MP3 wrapped in FLAC container).
 
     Inputs:
-        converted_count:            number of FLAC files converted
+        converted_count:             number of FLAC files converted
         post_conversion_min_bitrate: min bitrate after conversion (kbps), or None
-        spectral_grade:             album spectral grade, or None if unavailable
+        spectral_grade:              album spectral grade, or None if unavailable
+        cfg:                         QualityRankConfig — the spectral-fallback
+                                     threshold is taken from
+                                     ``cfg.mp3_vbr.excellent``. When omitted,
+                                     falls back to the legacy
+                                     ``TRANSCODE_MIN_BITRATE_KBPS`` constant
+                                     (210) so existing callers stay
+                                     bit-for-bit compatible. Issue #66.
     """
     if converted_count == 0:
         return False
@@ -1550,8 +1558,13 @@ def transcode_detection(converted_count, post_conversion_min_bitrate,
             return True
         # No cliff = not a transcode (lo-fi lossless produces low V0 bitrates)
         return False
-    # No spectral data — fall back to bitrate threshold
-    return post_conversion_min_bitrate < TRANSCODE_MIN_BITRATE_KBPS
+    # No spectral data — fall back to bitrate threshold. Derived from cfg
+    # so the threshold tracks gate retuning automatically: an operator who
+    # lowers mp3_vbr.excellent to accept lower-quality V0 also implicitly
+    # lowers what counts as "credible V0" for the spectral fallback.
+    threshold = (cfg.mp3_vbr.excellent if cfg is not None
+                 else TRANSCODE_MIN_BITRATE_KBPS)
+    return post_conversion_min_bitrate < threshold
 
 
 # ---------------------------------------------------------------------------
@@ -2412,8 +2425,9 @@ def full_pipeline_decision(
         gate_format = stage2_new_format  # "flac"
     elif is_flac:
         # FLAC path: convert first, then decide
-        is_transcode = transcode_detection(converted_count, post_conversion_min_bitrate,
-                                           spectral_grade=spectral_grade)
+        is_transcode = transcode_detection(
+            converted_count, post_conversion_min_bitrate,
+            spectral_grade=spectral_grade, cfg=cfg)
         import_br = post_conversion_min_bitrate if post_conversion_min_bitrate else min_bitrate
 
         will_be_verified = (converted_count > 0 and not is_transcode)

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -237,6 +237,68 @@ class TestTranscodeDetection(unittest.TestCase):
                     expected,
                 )
 
+    # ---- Issue #66: configurable spectral-fallback threshold -------------
+
+    def test_default_constant_matches_default_cfg_mp3_vbr_excellent(self):
+        """Legacy module constant must equal the default cfg's mp3_vbr.excellent.
+
+        These are two different surfaces for the same number — if a future
+        change tunes mp3_vbr.excellent without updating the legacy constant,
+        the contract tests in test_decision_tree_constants_match_code break
+        and the displayed transcode threshold drifts from the runtime
+        threshold. Pin the equality so the divergence is loud.
+        """
+        defaults_excellent = QualityRankConfig.defaults().mp3_vbr.excellent
+        self.assertEqual(TRANSCODE_MIN_BITRATE_KBPS, defaults_excellent)
+
+    def test_transcode_detection_uses_cfg_mp3_vbr_excellent(self):
+        """Custom cfg must shift the spectral-fallback threshold."""
+        # Default cfg → threshold 210 → 200 is a transcode.
+        default_cfg = QualityRankConfig.defaults()
+        self.assertTrue(transcode_detection(
+            10, 200, spectral_grade=None, cfg=default_cfg))
+
+        # Lower the threshold to 180 → 200 is no longer a transcode.
+        loose_cfg = QualityRankConfig(
+            mp3_vbr=CodecRankBands(
+                transparent=245, excellent=180, good=140, acceptable=100))
+        self.assertFalse(transcode_detection(
+            10, 200, spectral_grade=None, cfg=loose_cfg))
+
+        # Raise the threshold to 240 → 230 becomes a transcode.
+        strict_cfg = QualityRankConfig(
+            mp3_vbr=CodecRankBands(
+                transparent=300, excellent=240, good=180, acceptable=140))
+        self.assertTrue(transcode_detection(
+            10, 230, spectral_grade=None, cfg=strict_cfg))
+        # And just above the strict threshold passes.
+        self.assertFalse(transcode_detection(
+            10, 240, spectral_grade=None, cfg=strict_cfg))
+
+    def test_transcode_detection_cfg_does_not_override_spectral(self):
+        """Spectral grade is still authoritative even with a custom cfg."""
+        loose_cfg = QualityRankConfig(
+            mp3_vbr=CodecRankBands(
+                transparent=245, excellent=180, good=140, acceptable=100))
+        # Spectral=suspect → transcode regardless of bitrate (240 > threshold).
+        self.assertTrue(transcode_detection(
+            10, 240, spectral_grade="suspect", cfg=loose_cfg))
+        # Spectral=genuine → not transcode even when bitrate < threshold.
+        self.assertFalse(transcode_detection(
+            10, 100, spectral_grade="genuine", cfg=loose_cfg))
+
+    def test_transcode_detection_default_cfg_when_omitted(self):
+        """Omitting cfg must reproduce the legacy hardcoded behavior.
+
+        Critical for backward compatibility — every existing caller that
+        doesn't pass cfg keeps using the 210 kbps threshold.
+        """
+        # Same as the legacy "below threshold" case (210 - 20 = 190).
+        self.assertTrue(transcode_detection(10, 190, spectral_grade=None))
+        # Same as the legacy "at threshold" case.
+        self.assertFalse(transcode_detection(
+            10, TRANSCODE_MIN_BITRATE_KBPS, spectral_grade=None))
+
 
 # ============================================================================
 # quality_gate_decision


### PR DESCRIPTION
## Summary
- Resolves abl030/soularr#66. The legacy hardcoded `TRANSCODE_MIN_BITRATE_KBPS=210` was the only piece of the rank model that didn't track cfg. `transcode_detection()` now accepts an optional `cfg: QualityRankConfig | None` and derives the spectral-fallback threshold from `cfg.mp3_vbr.excellent`.
- Wiring choice: **derive from `cfg.mp3_vbr.excellent`** rather than adding a separate `transcode_fallback_min_kbps` field. They're conceptually the same number — "the floor for credible V0" — so making one cfg knob control both keeps the policy coherent. An operator who lowers the gate to accept lower-quality V0 also implicitly lowers what counts as "credible V0" for the spectral fallback.
- Backward compatible: when `cfg` is omitted, falls back to the legacy module constant. Every existing caller stays bit-for-bit compatible.

## What changes
- `lib/quality.py:transcode_detection()` — new optional `cfg` keyword.
- `lib/quality.py:full_pipeline_decision()` — passes `cfg` through (already in scope).
- `harness/import_one.py` — passes module-level `_rank_cfg` from the harness JSON argv, log message uses the dynamic threshold so retuned deployments stay auditable. Removes the now-unused `TRANSCODE_MIN_BITRATE_KBPS` import.

## Backward compatibility
- The legacy `TRANSCODE_MIN_BITRATE_KBPS` module constant is preserved as the documented default value (referenced by `get_decision_tree`'s constants endpoint and the contract test in `test_decision_tree_constants_match_code`).
- A new pin test (`test_default_constant_matches_default_cfg_mp3_vbr_excellent`) fails loudly if a future change desyncs the constant from `QualityRankConfig.defaults().mp3_vbr.excellent`.

## Issue scope
- [x] Plumb `cfg` into `transcode_detection()` (was a free function with no config)
- [x] Update callers in `harness/import_one.py` and `lib/quality.py` (full_pipeline_decision)
- [x] Subtest coverage in `TestTranscodeDetection`
- [x] Derives from `cfg.mp3_vbr.excellent` per the issue's "or, better" suggestion

## Test plan
- [x] `nix-shell --run 'pyright lib/quality.py harness/import_one.py tests/test_quality_decisions.py'` → 0 errors
- [x] `nix-shell --run 'bash scripts/run_tests.sh'` → 1498 tests, OK
- [x] 4 new test methods in `TestTranscodeDetection`:
  - `test_default_constant_matches_default_cfg_mp3_vbr_excellent` — pins the legacy constant against the default cfg so future divergence is loud
  - `test_transcode_detection_uses_cfg_mp3_vbr_excellent` — loose cfg (excellent=180) makes 200 not a transcode; strict cfg (excellent=240) makes 230 a transcode
  - `test_transcode_detection_cfg_does_not_override_spectral` — spectral grade is still authoritative even under a custom cfg
  - `test_transcode_detection_default_cfg_when_omitted` — back-compat: omitting cfg reproduces the legacy 210kbps threshold exactly

## Notes
This PR is independent of abl030/soularr#72 (median bitrate metric) and abl030/soularr#73 (collection field parsing). They can be reviewed and merged in any order.