### PR TITLE
Thread live rank cfg through get_decision_tree() + doc cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ Lo-fi V0 at 207kbps now passes the gate via the `"mp3 v0"` label contract (`cfg.
 **FLAC downloads** (in `import_one.py`):
 1. Spectral check on raw FLAC → grade stored on album_requests
 2. Convert FLAC → V0 via `convert_lossless(path, V0_SPEC)` for verification
-3. Transcode detection: spectral grade is authoritative (genuine/marginal = not transcode, suspect = transcode). Bitrate < 210kbps threshold is fallback only when spectral unavailable.
+3. Transcode detection: spectral grade is authoritative (genuine/marginal = not transcode, suspect = transcode). Bitrate fallback threshold (`cfg.mp3_vbr.excellent`, default 210 kbps) is used only when spectral is unavailable — tracks retuning automatically (#66).
 4. Compare new V0 bitrate against existing on disk (override = `min(pipeline DB min_bitrate, current_spectral_bitrate)` — catches fake 320s)
 5. If verified lossless AND `verified_lossless_target` configured (e.g. "opus 128"): convert original FLAC → target format, discard V0 (ephemeral verification artifact)
 6. If upgrade → import to beets. `verified_lossless` set by import_one.py's verdict (not re-derived). When verified lossless, `current_spectral_bitrate` = actual min bitrate (not spectral cliff estimate).

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Supported formats:
 | `aac 128` | AAC VBR 128kbps | `.m4a` | Apple ecosystem |
 | *(empty)* | *(none)* | `.mp3` | Keep V0 — the default |
 
-The V0 verification step always runs first regardless of target format. The V0 bitrate proves the FLAC was genuine lossless (>210kbps = genuine, <210kbps = transcode). Only after verification does the target conversion run from the original FLAC. If the FLAC is a transcode, the target conversion is skipped and V0 is kept.
+The V0 verification step always runs first regardless of target format. Genuineness is judged by `transcode_detection()`: spectral cliff analysis is authoritative when available (suspect grade → transcode, genuine/marginal → not), and the post-conversion V0 bitrate is a fallback only when spectral is unavailable. The fallback threshold defaults to `cfg.mp3_vbr.excellent` (210 kbps) and tracks retuning of `[Quality Ranks]` automatically. Only after verification does the target conversion run from the original FLAC. If the FLAC is a transcode, the target conversion is skipped and V0 is kept.
 
 ## Running tests
 

--- a/config.ini
+++ b/config.ini
@@ -52,6 +52,12 @@ tracking_file = /path/to/beets-validated.jsonl
 # Which bitrate metric to use for rank classification.
 # "avg" (recommended) — album-average per-track bitrate, robust to VBR per-track
 #                       variance. Default.
+# "median" — middle per-track bitrate. Outlier-resistant. Prefer over "avg"
+#            when your library contains albums with quiet intros/outros, hidden
+#            tracks, or short interludes that would skew the average away from
+#            the typical track quality. See docs/quality-ranks.md "When to
+#            prefer median" for the canonical cases (lo-fi V0 with clean
+#            closer, hidden tracks, skits).
 # "min" — minimum per-track bitrate. Legacy. Penalizes legitimately encoded VBR
 #         albums with quiet passages because one sparse track drags the whole
 #         album down a rank.

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -20,7 +20,7 @@ After FLAC-to-V0 conversion, the resulting bitrate reveals source quality:
 - **Transcode from ~192kbps**: ~190-210kbps
 - **Transcode from ~128kbps**: ~160-180kbps
 
-Threshold: `TRANSCODE_MIN_BITRATE_KBPS = 210` in `import_one.py`
+Threshold: `cfg.mp3_vbr.excellent` (default 210 kbps), read by `transcode_detection()` in `lib/quality.py`. The legacy `TRANSCODE_MIN_BITRATE_KBPS = 210` module constant is still exported as the default and used when no cfg is passed; operators who retune `[Quality Ranks] mp3_vbr.excellent` in `config.ini` automatically move both the gate threshold and this fallback (#66).
 
 Limitation: Only works when we download FLAC and convert. Doesn't catch bad MP3 downloads (e.g. 320kbps that was upsampled from 128kbps).
 
@@ -149,7 +149,7 @@ The wide-band energy ratio approach (v1) produces too many false positives on lo
 
 1. **FLAC downloads**: Run spectral check pre-conversion. If cliff detected → transcode in container. Still convert to V0 — if bitrate > existing on disk, import as upgrade.
 2. **MP3 downloads (especially CBR 320)**: Run spectral check post-download. Cliff + high deficit = upsampled garbage.
-3. **Already converted V0 with good bitrate (>210kbps)**: Skip spectral check — the V0 conversion already proved source quality.
+3. **Already converted V0 with good bitrate (≥ `cfg.mp3_vbr.excellent`, default 210 kbps)**: Skip spectral check — the V0 conversion already proved source quality.
 
 ### Tuning results (Mountain Goats library, 65 albums)
 
@@ -161,7 +161,7 @@ At `HF_DEFICIT_SUSPECT=60dB + cliff detection`:
 - **0 false positives** on albums with verified good sources
 - Successfully catches: cliffs at 16kHz (128kbps transcodes), cliffs at 18kHz (192kbps), upsampled CBR 320, terrible pre-pipeline rips
 
-Albums that were downloaded as FLAC, converted to V0 at >210kbps, and have no cliff: always pass — confirming the V0 conversion is the primary quality proof.
+Albums that were downloaded as FLAC, converted to V0 at or above the `cfg.mp3_vbr.excellent` threshold (default 210 kbps), and have no cliff: always pass — confirming the V0 conversion is the primary quality proof.
 
 ### What the spectral check catches that V0 conversion doesn't
 
@@ -187,6 +187,6 @@ Albums that were downloaded as FLAC, converted to V0 at >210kbps, and have no cl
 - [ ] Add spectral quality score to pipeline DB (new column) and web UI display
 - [ ] Run spectral check on CBR 320 MP3 downloads post-download
 - [ ] Run spectral check on FLACs pre-conversion to catch transcodes early
-- [ ] Skip spectral check for albums that already passed V0 conversion (>210kbps)
+- [ ] Skip spectral check for albums that already passed V0 conversion (≥ `cfg.mp3_vbr.excellent`, default 210 kbps)
 - [ ] Test `spectro` pip package as second-opinion validation
 - [ ] Performance: 16 sox calls per track x 30s trim ≈ 8s/track, ~100s per 12-track album

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2068,17 +2068,33 @@ def verify_filetype(file: dict[str, Any] | Any, allowed_filetype: str) -> bool:
 # Decision tree metadata — consumed by the web UI diagram
 # ---------------------------------------------------------------------------
 
-def get_decision_tree() -> dict[str, Any]:
+def get_decision_tree(
+    cfg: "QualityRankConfig | None" = None,
+) -> dict[str, Any]:
     """Return the full pipeline decision structure as data.
 
     The web UI renders this as a diagram. Contract tests verify this matches
     the actual decision functions. When a function changes, update this too —
     the tests will catch divergence.
+
+    ``cfg`` drives the thresholds that depend on the runtime rank model.
+    When omitted, ``QualityRankConfig.defaults()`` is used so the legacy
+    "show the hardcoded defaults" behavior still works. The web route at
+    ``web/routes/pipeline.py:get_pipeline_constants`` passes the live
+    runtime cfg so operators who retune ``mp3_vbr.excellent`` see the
+    Decisions tab update in lockstep with ``transcode_detection()``
+    (issue #66 follow-up).
     """
+    effective_cfg = cfg if cfg is not None else QualityRankConfig.defaults()
+    # The spectral-fallback threshold for transcode_detection() is derived
+    # from cfg.mp3_vbr.excellent (see #66). Expose it as the "live" constant
+    # so the web UI's Decisions tab reflects the runtime rank model instead
+    # of a stale module-level default.
+    transcode_threshold = effective_cfg.mp3_vbr.excellent
     return {
         "constants": {
             "QUALITY_MIN_BITRATE_KBPS": QUALITY_MIN_BITRATE_KBPS,
-            "TRANSCODE_MIN_BITRATE_KBPS": TRANSCODE_MIN_BITRATE_KBPS,
+            "TRANSCODE_MIN_BITRATE_KBPS": transcode_threshold,
             "QUALITY_UPGRADE_TIERS": QUALITY_UPGRADE_TIERS,
         },
         "paths": ["flac", "mp3"],
@@ -2131,12 +2147,13 @@ def get_decision_tree() -> dict[str, Any]:
                     {"condition": "spectral = genuine/marginal",
                      "result": "is_transcode = false", "color": "green",
                      "effect": "no cliff = not transcode (lo-fi OK)"},
-                    {"condition": f"no spectral: post_conv_br < {TRANSCODE_MIN_BITRATE_KBPS}kbps",
+                    {"condition": f"no spectral: post_conv_br < {transcode_threshold}kbps",
                      "result": "is_transcode = true", "color": "red",
                      "effect": "fallback when spectral unavailable"},
                 ],
                 "note": f"Spectral grade is authoritative when available. "
-                        f"Bitrate threshold ({TRANSCODE_MIN_BITRATE_KBPS}kbps) is fallback only",
+                        f"Bitrate threshold ({transcode_threshold}kbps, "
+                        f"derived from cfg.mp3_vbr.excellent) is fallback only",
             },
             {
                 "id": "verified_lossless",

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -697,13 +697,67 @@ class TestFullPipelineContract(unittest.TestCase):
                         f"Tree gate outcomes {gate_outcomes} not in {VALID_STAGE3}")
 
     def test_decision_tree_constants_match_code(self):
-        """Tree constants must match the actual module constants."""
+        """Tree constants must match the actual module constants under default cfg.
+
+        With no cfg passed, get_decision_tree falls back to
+        QualityRankConfig.defaults(), whose mp3_vbr.excellent equals the
+        legacy TRANSCODE_MIN_BITRATE_KBPS constant (pinned by
+        test_default_constant_matches_default_cfg_mp3_vbr_excellent).
+        """
         tree = get_decision_tree()
         consts = tree["constants"]
         self.assertEqual(consts["QUALITY_MIN_BITRATE_KBPS"],
                          QUALITY_MIN_BITRATE_KBPS)
         self.assertEqual(consts["TRANSCODE_MIN_BITRATE_KBPS"],
                          TRANSCODE_MIN_BITRATE_KBPS)
+
+    def test_decision_tree_custom_cfg_drives_transcode_threshold(self):
+        """get_decision_tree(cfg=...) must surface cfg.mp3_vbr.excellent in
+        the transcode stage so the web Decisions tab tracks runtime retuning.
+
+        Issue #66 made transcode_detection() read cfg.mp3_vbr.excellent at
+        call time, but the decision tree previously hardcoded the legacy
+        constant. An operator who set mp3_vbr.excellent=170 would see a
+        stale "< 210kbps" threshold in the UI while the actual gate ran
+        at 170. This test pins the fix: the threshold surfaced to the UI
+        must come from the same cfg the gate uses.
+        """
+        from lib.quality import CodecRankBands, QualityRankConfig
+
+        custom_cfg = QualityRankConfig(
+            mp3_vbr=CodecRankBands(
+                transparent=245, excellent=170, good=140, acceptable=100))
+        tree = get_decision_tree(cfg=custom_cfg)
+        self.assertEqual(tree["constants"]["TRANSCODE_MIN_BITRATE_KBPS"], 170)
+
+        # The transcode stage's rule text and note must also reference the
+        # custom threshold — the UI reads these strings directly.
+        transcode_stage = next(
+            s for s in tree["stages"] if s["id"] == "transcode")
+        fallback_rule = next(
+            r for r in transcode_stage["rules"]
+            if "no spectral" in r["condition"])
+        self.assertIn("170kbps", fallback_rule["condition"])
+        self.assertIn("170kbps", transcode_stage["note"])
+        self.assertNotIn(f"{TRANSCODE_MIN_BITRATE_KBPS}kbps",
+                         fallback_rule["condition"])
+
+    def test_decision_tree_default_cfg_matches_legacy_constant(self):
+        """Explicit None cfg must reproduce the legacy hardcoded threshold.
+
+        Back-compat guard: any existing caller passing no cfg (or None)
+        should see the same payload they saw before #66's follow-up. Pins
+        the default surface against TRANSCODE_MIN_BITRATE_KBPS.
+        """
+        default_tree = get_decision_tree(cfg=None)
+        self.assertEqual(
+            default_tree["constants"]["TRANSCODE_MIN_BITRATE_KBPS"],
+            TRANSCODE_MIN_BITRATE_KBPS)
+        transcode_stage = next(
+            s for s in default_tree["stages"] if s["id"] == "transcode")
+        self.assertIn(
+            f"{TRANSCODE_MIN_BITRATE_KBPS}kbps",
+            transcode_stage["note"])
 
     def test_decision_tree_every_stage_has_rules(self):
         """Every stage must have at least one rule."""

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -174,8 +174,16 @@ def _runtime_rank_config():
 
 
 def get_pipeline_constants(h, params: dict[str, list[str]]) -> None:
-    """Return decision tree structure + thresholds for the diagram."""
-    tree = get_decision_tree()
+    """Return decision tree structure + thresholds for the diagram.
+
+    The runtime rank config is threaded into ``get_decision_tree`` so the
+    transcode-detection threshold displayed in the UI tracks the live
+    ``cfg.mp3_vbr.excellent`` (issue #66 follow-up). Without this, an
+    operator who retuned the gate would see a stale Decisions tab while
+    the actual pipeline ran at the new threshold.
+    """
+    rank_cfg = _runtime_rank_config()
+    tree = get_decision_tree(cfg=rank_cfg)
     tree["constants"]["HF_DEFICIT_SUSPECT"] = HF_DEFICIT_SUSPECT
     tree["constants"]["HF_DEFICIT_MARGINAL"] = HF_DEFICIT_MARGINAL
     tree["constants"]["ALBUM_SUSPECT_PCT"] = ALBUM_SUSPECT_PCT
@@ -183,7 +191,6 @@ def get_pipeline_constants(h, params: dict[str, list[str]]) -> None:
     tree["constants"]["CLIFF_THRESHOLD_DB_PER_KHZ"] = CLIFF_THRESHOLD_DB_PER_KHZ
     # Expose the runtime rank config to the UI so the Decisions tab shows
     # the configured gate_min_rank and bitrate_metric.
-    rank_cfg = _runtime_rank_config()
     tree["constants"]["rank_gate_min_rank"] = rank_cfg.gate_min_rank.name
     tree["constants"]["rank_bitrate_metric"] = rank_cfg.bitrate_metric.value
     h._json(tree)


### PR DESCRIPTION
## Summary

Post-deploy audit of #64/#65/#66 surfaced one runtime inconsistency plus a set of stale doc references. This PR fixes both as one logical change (per `.claude/rules/scope.md`).

### The bug

After #66, `transcode_detection()` reads its spectral-fallback threshold from `cfg.mp3_vbr.excellent` at call time. But `get_decision_tree()` — which drives the web UI's Decisions tab — was still hardcoding the module-level `TRANSCODE_MIN_BITRATE_KBPS` constant. So an operator who set `[Quality Ranks] mp3_vbr.excellent = 170` would see:

- **Runtime gate**: runs at 170 kbps (correct)
- **Decisions tab**: displays "< 210kbps" (stale, misleading)

The symptom is silent drift: the UI lies about what the live pipeline is doing.

### Fix

- `get_decision_tree(cfg: QualityRankConfig | None = None)`. When `None`, falls back to `QualityRankConfig.defaults()` so legacy callers stay bit-for-bit identical.
- The transcode stage rule condition and note interpolate `cfg.mp3_vbr.excellent` at render time instead of reading the legacy constant.
- `web/routes/pipeline.py:get_pipeline_constants` now passes the same `_runtime_rank_config()` it already reads for `rank_gate_min_rank`/`rank_bitrate_metric`, so every constant displayed in the Decisions tab comes from one coherent cfg snapshot.

### Tests

1. **`test_decision_tree_custom_cfg_drives_transcode_threshold`** — pins the retune path: a custom cfg with `excellent=170` must surface 170 in `tree["constants"]["TRANSCODE_MIN_BITRATE_KBPS"]`, in the rule condition, and in the note. Also asserts the legacy constant (`210`) does **not** appear — guards against half-retuning.
2. **`test_decision_tree_default_cfg_matches_legacy_constant`** — back-compat guard that `cfg=None` reproduces `TRANSCODE_MIN_BITRATE_KBPS` exactly.
3. **`test_decision_tree_constants_match_code`** docstring updated to explain the default-cfg pinning is grounded by the existing `test_default_constant_matches_default_cfg_mp3_vbr_excellent` equality pin (PR #74).

Existing `test_pipeline_constants_contract` in `test_web_server.py` continues to cover the route contract — the new cfg threading is wire-compatible.

## Doc cleanup (same commit)

Same logical change per scope rule: the bug was "hardcoded 210 scattered across code and docs", so the fix updates all surfaces.

- **`config.ini`** `[Quality Ranks] bitrate_metric` block now documents `median` alongside `avg`/`min`. #64 shipped the parser but the template comment never mentioned median, so users editing config.ini would never discover the option exists.
- **`README.md:163`** — rephrased away from the literal ">210kbps = genuine" rule. The rank model is spectral-authoritative with a cfg-driven bitrate fallback; the old wording predated the rank model.
- **`CLAUDE.md:368`** — reworded to match line 277 (the #66 follow-up line). Both now cite `cfg.mp3_vbr.excellent` so the same document is no longer self-contradictory.
- **`docs/quality-verification.md`** — four 210-kbps references (threshold description, two-tier verification step 3, tuning results, TODO bullet) updated to reference `cfg.mp3_vbr.excellent` with 210 called out as the default. The exported module constant is noted as the fallback when no cfg is passed.

## Test plan
- [x] `nix-shell --run "bash scripts/run_tests.sh"` → 1522 tests, OK (skipped=53)
- [x] `nix-shell --run "pyright lib/quality.py web/routes/pipeline.py tests/test_quality_decisions.py"` → 0 errors
- [x] New tests land in `TestFullPipelineContract` alongside the existing decision-tree contract tests — no bespoke harness
- [ ] Deploy to doc2, hit `/api/pipeline/constants` from the browser, confirm the transcode stage now surfaces the live `cfg.mp3_vbr.excellent` value

## Not in scope
- `get_pipeline_simulate` does not currently pass `cfg` to `full_pipeline_decision()`. That's a pre-existing gap the audit did not flag, and fixing it would expand this PR beyond the "stop the Decisions tab from lying" bug. Separate issue if we care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)