### PR TITLE
Fix verdict showing spectral estimate instead of real bitrate

### DIFF
--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -639,5 +639,139 @@ class TestSearchFiletypeOverride(unittest.TestCase):
         self.assertIn("OPUS", result.verdict)
 
 
+# ============================================================================
+# Spectral fallback bug — verdict must use real bitrate, not spectral estimate
+# ============================================================================
+
+class TestVerdictSpectralFallback(unittest.TestCase):
+    """Verdicts must show real file bitrate, not the spectral cliff estimate.
+
+    When actual_min_bitrate is NULL (rejected downloads that were never
+    imported), the or-chain in _rejection_verdict falls through to
+    spectral_bitrate — a cliff estimate that answers "what was the original
+    source quality?" not "what bitrate are these files?".
+
+    These tests reproduce exact live scenarios where the UI showed misleading
+    numbers (e.g. "96kbps is not better than existing 128kbps" when both
+    downloads were actually 128kbps min).
+    """
+
+    def test_quality_downgrade_uses_real_bitrate_not_spectral(self):
+        """The Ataris / Welcome the Night bug: actual_min_bitrate is NULL,
+        spectral_bitrate is 96, but the real download is 128kbps min.
+        The import_result JSONB has the correct new_measurement."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="quality_downgrade",
+            actual_min_bitrate=None,
+            spectral_bitrate=96,
+            existing_min_bitrate=128,
+            existing_spectral_bitrate=96,
+            bitrate=128000,
+            import_result={
+                "version": 2,
+                "exit_code": 5,
+                "decision": "downgrade",
+                "new_measurement": {
+                    "min_bitrate_kbps": 128,
+                    "avg_bitrate_kbps": 187,
+                    "median_bitrate_kbps": 192,
+                    "spectral_bitrate_kbps": 96,
+                    "format": "MP3",
+                    "is_cbr": False,
+                    "verified_lossless": False,
+                },
+                "existing_measurement": {
+                    "min_bitrate_kbps": 128,
+                    "avg_bitrate_kbps": 187,
+                    "median_bitrate_kbps": 192,
+                    "spectral_bitrate_kbps": 96,
+                    "format": "MP3",
+                    "is_cbr": False,
+                    "verified_lossless": False,
+                },
+            },
+        ))
+        # Verdict must say 128, not 96
+        self.assertIn("128", result.verdict)
+        self.assertNotIn("96", result.verdict)
+
+    def test_quality_downgrade_without_import_result_uses_container_bitrate(self):
+        """When there's no import_result at all, fall back to bitrate field
+        (container bitrate in bps), not spectral_bitrate."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="quality_downgrade",
+            actual_min_bitrate=None,
+            spectral_bitrate=96,
+            existing_min_bitrate=128,
+            existing_spectral_bitrate=96,
+            bitrate=128000,
+            import_result=None,
+        ))
+        self.assertIn("128", result.verdict)
+        self.assertNotIn("96", result.verdict)
+
+    def test_transcode_downgrade_uses_real_bitrate_not_spectral(self):
+        """Same spectral fallback bug in transcode_downgrade scenario."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="transcode_downgrade",
+            actual_min_bitrate=None,
+            spectral_bitrate=96,
+            existing_min_bitrate=240,
+            existing_spectral_bitrate=None,
+            bitrate=192000,
+            import_result={
+                "version": 2,
+                "exit_code": 6,
+                "decision": "transcode_downgrade",
+                "new_measurement": {"min_bitrate_kbps": 192},
+                "existing_measurement": {"min_bitrate_kbps": 240},
+            },
+        ))
+        self.assertIn("192", result.verdict)
+        self.assertNotIn("96", result.verdict)
+
+    def test_transcode_classify_uses_real_bitrate_not_spectral(self):
+        """_classify_transcode has the same or-chain bug for success transcodes."""
+        result = classify_log_entry(_entry(
+            outcome="success",
+            beets_scenario="transcode_upgrade",
+            actual_min_bitrate=None,
+            spectral_bitrate=96,
+            existing_min_bitrate=192,
+            bitrate=210000,
+            was_converted=True,
+        ))
+        # Should show 210 (bitrate // 1000), not 96 (spectral)
+        self.assertIn("210", result.verdict)
+        self.assertNotIn("96", result.verdict)
+
+    def test_summary_also_uses_real_bitrate(self):
+        """The summary line (collapsed card) inherits from the verdict.
+        If the verdict is wrong, the summary is wrong too."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="quality_downgrade",
+            actual_min_bitrate=None,
+            spectral_bitrate=96,
+            existing_min_bitrate=128,
+            existing_spectral_bitrate=96,
+            bitrate=128000,
+            soulseek_username="nexus15",
+            import_result={
+                "version": 2,
+                "exit_code": 5,
+                "decision": "downgrade",
+                "new_measurement": {"min_bitrate_kbps": 128},
+                "existing_measurement": {"min_bitrate_kbps": 128},
+            },
+        ))
+        self.assertIn("128", result.summary)
+        self.assertNotIn("96", result.summary)
+        self.assertIn("nexus15", result.summary)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/classify.py
+++ b/web/classify.py
@@ -159,7 +159,7 @@ def _classify(entry: LogEntry) -> tuple[str, str, str, str]:
         elif entry.error_message:
             verdict = f"Import error: {entry.error_message}"
         else:
-            verdict = _failure_verdict_from_import_result(entry) or "Import error"
+            verdict = _quality_verdict_from_import_result(entry) or "Import error"
         return ("Failed", "badge-failed", "#a33", verdict)
 
     # --- Force import ---
@@ -205,20 +205,53 @@ def _classify(entry: LogEntry) -> tuple[str, str, str, str]:
     return (label, "badge-rejected", "#444", str(entry.outcome or "Unknown outcome"))
 
 
-def _failure_verdict_from_import_result(entry: LogEntry) -> str | None:
-    """Recover a useful verdict from ImportResult JSON for failed rows."""
+def _parse_import_result(entry: LogEntry) -> ImportResult | None:
+    """Parse the import_result JSONB from a LogEntry, or None."""
     raw = entry.import_result
     if raw is None:
         return None
-
     try:
         if isinstance(raw, dict):
-            ir = ImportResult.from_dict(raw)
+            return ImportResult.from_dict(raw)
         elif isinstance(raw, str):
-            ir = ImportResult.from_json(raw)
-        else:
-            return None
+            return ImportResult.from_json(raw)
+        return None
     except (json.JSONDecodeError, TypeError, KeyError):
+        return None
+
+
+def _real_bitrate_kbps(entry: LogEntry) -> int | None:
+    """Best available actual file bitrate in kbps, excluding spectral.
+
+    spectral_bitrate is a cliff estimate ("what was the original source?"),
+    not the file's actual bitrate. It must never appear in non-spectral
+    verdicts. This matches the chain in _build_downloaded_label.
+    """
+    return (entry.actual_min_bitrate
+            or (entry.bitrate // 1000 if entry.bitrate else None))
+
+
+def _comparison_verdict(
+    new_kbps: int | None,
+    old_kbps: int | None,
+    prefix: str = "",
+) -> str:
+    """Build a '… is not better than existing …' verdict string."""
+    new_s = f"{new_kbps}kbps" if new_kbps is not None else "unknown"
+    old_s = f"{old_kbps}kbps" if old_kbps is not None else "unknown"
+    if prefix:
+        return f"{prefix} {new_s} — not better than existing {old_s}"
+    return f"{new_s} is not better than existing {old_s}"
+
+
+def _quality_verdict_from_import_result(entry: LogEntry) -> str | None:
+    """Derive a quality comparison verdict from ImportResult JSONB.
+
+    Used by both rejected and failed outcomes — single source of truth
+    for "X is not better than Y" messages.
+    """
+    ir = _parse_import_result(entry)
+    if ir is None:
         return None
 
     new_m = ir.new_measurement
@@ -231,14 +264,10 @@ def _failure_verdict_from_import_result(entry: LogEntry) -> str | None:
                     else existing_m.spectral_bitrate_kbps)
 
     if ir.decision == "downgrade":
-        new_s = f"{new_kbps}kbps" if new_kbps is not None else "unknown"
-        old_s = f"{old_kbps}kbps" if old_kbps is not None else "unknown"
-        return f"{new_s} is not better than existing {old_s}"
+        return _comparison_verdict(new_kbps, old_kbps)
 
     if ir.decision == "transcode_downgrade":
-        new_s = f"{new_kbps}kbps" if new_kbps is not None else "unknown"
-        old_s = f"{old_kbps}kbps" if old_kbps is not None else "unknown"
-        return f"Transcode at {new_s} - not better than existing {old_s}"
+        return _comparison_verdict(new_kbps, old_kbps, prefix="Transcode at")
 
     if ir.error:
         return f"Import error: {ir.error}"
@@ -251,9 +280,7 @@ def _failure_verdict_from_import_result(entry: LogEntry) -> str | None:
 
 def _classify_transcode(entry: LogEntry) -> tuple[str, str, str, str]:
     """Classify a transcode_upgrade or transcode_first success."""
-    br = (entry.actual_min_bitrate
-          or entry.spectral_bitrate
-          or (entry.bitrate // 1000 if entry.bitrate else None))
+    br = _real_bitrate_kbps(entry)
     br_str = f"{br}kbps" if br else "unknown bitrate"
     if entry.beets_scenario == "transcode_upgrade":
         ex = entry.existing_min_bitrate or entry.existing_spectral_bitrate
@@ -300,33 +327,30 @@ def _new_import_verdict(entry: LogEntry, is_verified_lossless: bool) -> str:
 def _rejection_verdict(entry: LogEntry) -> str:
     """Build human-readable verdict for a rejected entry.
 
-    Bitrate fields have gaps — actual_min_bitrate is often NULL while
-    bitrate (bps) or spectral_bitrate has the value. Fall through all
-    available sources.
+    For quality comparisons (downgrade, transcode_downgrade), prefer the
+    ImportResult JSONB which has accurate measurements. Fall back to
+    LogEntry fields only when JSONB is unavailable — and never use
+    spectral_bitrate as a proxy for actual file bitrate.
     """
     scenario = entry.beets_scenario
-    # Best available "new" bitrate in kbps
-    new_kbps = (entry.actual_min_bitrate
-                or entry.spectral_bitrate
-                or (entry.bitrate // 1000 if entry.bitrate else None))
-    # Best available "existing" bitrate in kbps
-    old_kbps = entry.existing_min_bitrate or entry.existing_spectral_bitrate
 
-    if scenario == "quality_downgrade":
-        new = f"{new_kbps}kbps" if new_kbps else "unknown"
-        old = f"{old_kbps}kbps" if old_kbps else "unknown"
-        return f"{new} is not better than existing {old}"
+    # Quality comparison scenarios — delegate to ImportResult when available
+    if scenario in ("quality_downgrade", "transcode_downgrade"):
+        ir_verdict = _quality_verdict_from_import_result(entry)
+        if ir_verdict is not None:
+            return ir_verdict
+        # Fallback: use real file bitrate, not spectral
+        new_kbps = _real_bitrate_kbps(entry)
+        old_kbps = entry.existing_min_bitrate or entry.existing_spectral_bitrate
+        if scenario == "transcode_downgrade":
+            return _comparison_verdict(new_kbps, old_kbps, prefix="Transcode at")
+        return _comparison_verdict(new_kbps, old_kbps)
 
     if scenario == "spectral_reject":
-        new = f"{entry.spectral_bitrate}kbps" if entry.spectral_bitrate else "unknown"
+        # Spectral scenario — spectral_bitrate IS the right field here
         old_kbps = entry.existing_spectral_bitrate or entry.existing_min_bitrate
-        old = f"{old_kbps}kbps" if old_kbps else "unknown"
-        return f"Spectral: {new} is not better than existing {old}"
-
-    if scenario == "transcode_downgrade":
-        new = f"{new_kbps}kbps" if new_kbps else "unknown"
-        old = f"{old_kbps}kbps" if old_kbps else "unknown"
-        return f"Transcode at {new} — not better than existing {old}"
+        return _comparison_verdict(
+            entry.spectral_bitrate, old_kbps, prefix="Spectral:")
 
     if scenario == "high_distance":
         dist = (f"{float(entry.beets_distance):.3f}"


### PR DESCRIPTION
## Summary
- **Bug**: Rejected download verdicts showed the spectral cliff estimate (e.g. 96kbps) instead of the actual file bitrate (128kbps), making the UI misleading — "96kbps is not better than existing 128kbps" when both were 128kbps
- **Root cause**: `_rejection_verdict()` and `_classify_transcode()` had `actual_min_bitrate or spectral_bitrate or ...` fallback chains. When `actual_min_bitrate` was NULL (common for rejected downloads), `spectral_bitrate` won — a cliff estimate that answers "what was the original source quality?", not "what bitrate are these files?"
- **Fix**: Refactored to eliminate 5 duplicated verdict-building paths into 3 shared helpers (`_real_bitrate_kbps`, `_comparison_verdict`, `_quality_verdict_from_import_result`). Rejected quality verdicts now try ImportResult JSONB first (has accurate measurements), fall back to container bitrate — never spectral

## Test plan
- [x] 5 new RED tests reproducing exact live scenario (The Ataris / Welcome the Night from nexus15)
- [x] All 5 GREEN after fix
- [x] 83/83 recents tests pass (zero regressions)
- [x] 1539/1539 full suite pass
- [x] pyright clean on both changed files
- [ ] Deploy and verify the Ataris entry on music.ablz.au recents tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)