### PR TITLE
fix: force-import runs the same pre-import gates as auto-import

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -43,7 +43,7 @@
 - The simulator must show the full rejection cycle: import/reject decision → spectral propagation → backfill decision → next search tiers. Not just the import decision in isolation.
 
 ## Pipeline Bug Reproduction — Red/Green on Real Code Paths
-- When a live pipeline bug involves **interactions between components** (spectral propagation → decision function → DB write → rejection), don't just test the pure decision function in isolation — write a unit test that calls the actual orchestration function (e.g. `_apply_spectral_decision`) with mocked album state matching the live scenario.
+- When a live pipeline bug involves **interactions between components** (spectral propagation → decision function → DB write → rejection), don't just test the pure decision function in isolation — write a unit test that calls the actual orchestration function (e.g. `lib.preimport.run_preimport_gates`) with mocked state matching the live scenario.
 - **RED first**: reproduce the exact live scenario as a test. Mock up the album state from `pipeline-cli show <id>` (status, spectral fields, min_bitrate). Run the test and confirm it fails with the same symptom as production.
 - **GREEN**: fix the production code, confirm the test passes.
 - **Guard both directions**: add a test for the fixed case AND a test that the original valid behavior still works (e.g. propagation still works when an album IS on disk but lacks spectral data).
@@ -129,7 +129,7 @@ Four categories of tests. Each has different rules for what's acceptable. **All 
   - `TestDispatchThroughQualityGate` — runs dispatch_import_core → real parse_import_result → real _check_quality_gate_core
   - `TestQualityGateVerifiedLosslessBypass`, `TestQualityGateSpectralOverride`
   - `TestDispatchNoJsonResult`, `TestForceImportSlice`
-  - `TestSpectralPropagationSlice` — runs `_gather_spectral_context` → `_apply_spectral_decision` end-to-end
+  - `TestSpectralPropagationSlice` — runs `run_preimport_gates` end-to-end (audio + spectral)
 - **Required for every new high-risk orchestration boundary.** If you add a new pipeline path (a new dispatch decision, a new quality gate branch, a new spectral state transition), add a slice that exercises it with real code.
 
 ### Shared test infrastructure inventory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,27 @@ lib/
   config.py             — SoularrConfig dataclass (typed config from config.ini)
   context.py            — SoularrContext dataclass (replaces module globals for extracted functions).
                            Includes cooled_down_users cache populated at cycle start.
-  download.py           — Async download polling, completion processing, spectral context
-                           gathering, slskd transfer helpers. All functions accept ctx.
+  download.py           — Async download polling, completion processing, slskd
+                           transfer helpers. All functions accept ctx. Delegates
+                           the shared pre-import gates (audio + spectral) to
+                           lib/preimport.py via _process_beets_validation.
                            Key functions: poll_active_downloads(), process_completed_album(),
                            build_active_download_state(), reconstruct_grab_list_entry(),
                            rederive_transfer_ids(), grab_most_wanted() (enqueue-only, non-blocking).
   grab_list.py          — GrabList: wanted-album selection with priority/ordering
   import_dispatch.py    — Auto-import decision tree: runs import_one.py, uses
                            dispatch_action() flags for mark_done/failed/denylist/requeue.
-                           Quality gate.
+                           Quality gate. dispatch_import_from_db() (force/manual
+                           entry point) calls lib.preimport.run_preimport_gates
+                           first, so the only gate force/manual skip is the beets
+                           *distance* check — every other quality gate is shared.
   import_service.py     — Force-import/manual-import service layer, ImportOutcome dataclass
+  preimport.py          — Shared pre-import quality gates (audio integrity + spectral
+                           transcode detection). Single source of truth called by
+                           both the auto path (lib.download) and the force/manual
+                           path (lib.import_dispatch). Key functions:
+                           run_preimport_gates(), inspect_local_files(),
+                           PreImportGateResult dataclass.
   pipeline_db.py        — PipelineDB class (PostgreSQL CRUD, queries, get_download_log_entry).
                            Schema is NOT this class's responsibility — see lib/migrator.py.
                            Search logging: log_search(), get_search_history(), get_search_history_batch()

--- a/lib/download.py
+++ b/lib/download.py
@@ -17,18 +17,14 @@ from typing import Any, Callable, TYPE_CHECKING
 import music_tag
 
 from lib.grab_list import GrabListEntry, DownloadFile
-from lib.pipeline_db import RequestSpectralStateUpdate
-from lib.quality import (spectral_import_decision, SpectralContext,
-                         SpectralMeasurement,
-                         ActiveDownloadState, ActiveDownloadFileState,
+from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, decide_download_action,
                          extract_usernames,
                          rejection_backfill_override)
 from lib.import_dispatch import (_build_download_info, dispatch_import)
 from lib.transitions import apply_transition
 from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
-                      repair_mp3_headers, validate_audio, log_validation_result)
-from lib.beets_db import BeetsDB
+                      log_validation_result)
 
 if TYPE_CHECKING:
     from lib.context import SoularrContext
@@ -180,58 +176,6 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
     return bool(downloads) and remote_queue_count == len(downloads)
 
 
-# === Spectral context gathering ===
-
-def _gather_spectral_context(album_data: GrabListEntry, import_folder: str,
-                             ctx: SoularrContext) -> SpectralContext:
-    """Gather spectral analysis data for a non-VBR MP3 download.
-
-    Runs spectral analysis on the downloaded files and (if the album exists
-    in beets) on the existing files for comparison. Returns a SpectralContext
-    with all data needed by spectral_import_decision().
-    """
-    dl_pre = _build_download_info(album_data)
-    filetype_str = (dl_pre.filetype or "").lower()
-    is_vbr = dl_pre.is_vbr or False
-    is_mp3 = "mp3" in filetype_str and "flac" not in filetype_str
-    if not (is_mp3 and not is_vbr):
-        return SpectralContext(needs_check=False)
-
-    spec_ctx = SpectralContext(needs_check=True)
-    try:
-        spectral_result = spectral_analyze(import_folder, trim_seconds=30)
-        spec_ctx.grade = spectral_result.grade
-        spec_ctx.bitrate = spectral_result.estimated_bitrate_kbps
-        spec_ctx.suspect_pct = spectral_result.suspect_pct
-        logger.info(f"SPECTRAL: {album_data.artist} - {album_data.title} "
-                    f"grade={spec_ctx.grade}, estimated_bitrate={spec_ctx.bitrate}kbps, "
-                    f"suspect={spec_ctx.suspect_pct:.0f}%")
-        # Check existing beets files for comparison
-        mb_id = album_data.mb_release_id
-        if mb_id:
-            try:
-                with BeetsDB() as beets:
-                    existing_info = beets.get_album_info(
-                        mb_id, ctx.cfg.quality_ranks)
-                if existing_info:
-                    spec_ctx.existing_min_bitrate = existing_info.min_bitrate_kbps
-                    if os.path.isdir(existing_info.album_path):
-                        existing_spectral = spectral_analyze(
-                            existing_info.album_path, trim_seconds=30)
-                        spec_ctx.existing_spectral_bitrate = (
-                            existing_spectral.estimated_bitrate_kbps)
-                        spec_ctx.existing_spectral_grade = existing_spectral.grade
-                        logger.info(
-                            f"SPECTRAL: existing on disk: "
-                            f"grade={existing_spectral.grade}, "
-                            f"estimated_bitrate="
-                            f"{existing_spectral.estimated_bitrate_kbps}kbps, "
-                            f"beets_min={existing_info.min_bitrate_kbps}kbps")
-            except Exception:
-                logger.exception("SPECTRAL: failed to check existing files")
-    except Exception:
-        logger.exception(f"SPECTRAL: failed for {album_data.artist} - {album_data.title}")
-    return spec_ctx
 
 
 # === Download completion processing ===
@@ -302,8 +246,15 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
 
 def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath: str,
                               ctx: SoularrContext) -> None:
-    """Beets validation sub-path of process_completed_album."""
+    """Beets validation sub-path of process_completed_album.
+
+    After beets validation passes, delegates to ``lib.preimport.run_preimport_gates``
+    for the shared audio + spectral gates. The force/manual-import path
+    (``dispatch_import_from_db``) calls the same function — only the beets
+    distance check is path-specific.
+    """
     from lib.beets import beets_validate as _bv
+    from lib.preimport import run_preimport_gates
     bv_result = _bv(ctx.cfg.beets_harness_path, import_folder_fullpath,
                     album_data.mb_release_id, ctx.cfg.beets_distance_threshold)
     # Populate source info
@@ -312,115 +263,35 @@ def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath:
     bv_result.download_folder = import_folder_fullpath
 
     if bv_result.valid:
-        repair_mp3_headers(import_folder_fullpath)
-        audio_result = validate_audio(import_folder_fullpath, ctx.cfg.audio_check_mode)
-        if not audio_result.valid:
+        dl_pre = _build_download_info(album_data)
+        db = (ctx.pipeline_db_source._get_db()
+              if ctx.pipeline_db_source is not None else None)
+        preimport = run_preimport_gates(
+            path=import_folder_fullpath,
+            mb_release_id=album_data.mb_release_id or "",
+            label=f"{album_data.artist} - {album_data.title}",
+            download_filetype=dl_pre.filetype or "",
+            download_min_bitrate_bps=dl_pre.bitrate,
+            download_is_vbr=dl_pre.is_vbr,
+            cfg=ctx.cfg,
+            db=db,
+            request_id=album_data.db_request_id,
+            usernames=usernames_pre,
+        )
+        album_data.download_spectral = preimport.download_spectral
+        album_data.current_spectral = preimport.existing_spectral
+        album_data.current_min_bitrate = preimport.existing_min_bitrate
+        if not preimport.valid:
             bv_result.valid = False
-            bv_result.scenario = "audio_corrupt"
-            bv_result.detail = audio_result.error
-            bv_result.corrupt_files = [
-                name for name, _err in audio_result.failed_files]
-
-    # Spectral check for non-VBR MP3 downloads
-    if bv_result.valid:
-        spec_ctx = _gather_spectral_context(album_data, import_folder_fullpath, ctx)
-        if spec_ctx.needs_check and spec_ctx.grade:
-            _apply_spectral_decision(album_data, bv_result, spec_ctx,
-                                     import_folder_fullpath, ctx)
+            bv_result.scenario = preimport.scenario
+            bv_result.detail = preimport.detail
+            if preimport.corrupt_files:
+                bv_result.corrupt_files = preimport.corrupt_files
 
     if bv_result.valid:
         _handle_valid_result(album_data, bv_result, import_folder_fullpath, ctx)
     else:
         _handle_rejected_result(album_data, bv_result, import_folder_fullpath, ctx)
-
-
-def _apply_spectral_decision(album_data: GrabListEntry, bv_result: ValidationResult,
-                             spec_ctx: SpectralContext,
-                             import_folder_fullpath: str,
-                             ctx: SoularrContext) -> None:
-    """Apply spectral import decision and update album_data/bv_result accordingly."""
-    album_data.download_spectral = SpectralMeasurement.from_parts(
-        spec_ctx.grade, spec_ctx.bitrate)
-    album_data.current_spectral = SpectralMeasurement.from_parts(
-        spec_ctx.existing_spectral_grade, spec_ctx.existing_spectral_bitrate)
-    album_data.current_min_bitrate = spec_ctx.existing_min_bitrate
-
-    # Write on-disk spectral data back to album_requests.
-    # When on-disk spectral is NULL and the download has spectral, propagate
-    # the download's spectral as on-disk — on a downgrade (same tier), the
-    # download's spectral characterizes the same quality tier as what's on disk.
-    request_id = album_data.db_request_id
-    if request_id and ctx.pipeline_db_source:
-        try:
-            spectral_to_write = album_data.current_spectral
-            if (spectral_to_write is None
-                    and album_data.download_spectral is not None
-                    and album_data.current_min_bitrate is not None):
-                # Only propagate when something IS on disk but lacks spectral data.
-                # Without the min_bitrate guard, a new album (nothing on disk) would
-                # adopt the download's spectral as "existing", then reject itself.
-                spectral_to_write = album_data.download_spectral
-                album_data.current_spectral = spectral_to_write
-                logger.info(
-                    f"SPECTRAL PROPAGATE: {album_data.artist} - {album_data.title}"
-                    f" on-disk spectral=NULL, adopting download spectral"
-                    f" grade={spectral_to_write.grade}")
-            if spectral_to_write is not None:
-                db = ctx.pipeline_db_source._get_db()
-                db.update_spectral_state(
-                    request_id,
-                    RequestSpectralStateUpdate(
-                        current=spectral_to_write,
-                    ),
-                )
-        except Exception:
-            logger.exception("Failed to update on-disk spectral data")
-
-    new_quality = spec_ctx.bitrate
-    existing_quality = (
-        album_data.current_spectral.bitrate_kbps
-        if album_data.current_spectral is not None
-        else 0
-    )
-    # Effective existing: matches what spectral_import_decision() uses internally
-    effective_existing = existing_quality or spec_ctx.existing_min_bitrate or 0
-    label = f"{album_data.artist} - {album_data.title}"
-
-    spectral_decision = spectral_import_decision(
-        spec_ctx.grade, new_quality, existing_quality,
-        existing_min_bitrate=spec_ctx.existing_min_bitrate)
-
-    if spectral_decision == "reject":
-        logger.warning(
-            f"SPECTRAL REJECT: {label} "
-            f"new spectral {new_quality}kbps <= existing {effective_existing}kbps")
-        usernames = set(f.username for f in album_data.files if f.username)
-        if request_id and ctx.pipeline_db_source:
-            db = ctx.pipeline_db_source._get_db()
-            for username in usernames:
-                db.add_denylist(request_id, username,
-                                f"spectral: {new_quality}kbps <= existing {effective_existing}kbps")
-            logger.info(f"  Denylisted {usernames} for request {request_id}")
-        # Set bv_result fields so _handle_rejected_result logs one row with spectral detail
-        bv_result.valid = False
-        bv_result.scenario = "spectral_reject"
-        bv_result.detail = f"spectral {new_quality}kbps <= existing {effective_existing}kbps"
-        # Attach spectral info to album_data so _handle_rejected_result picks it up
-        album_data.download_spectral = SpectralMeasurement.from_parts(
-            spec_ctx.grade, new_quality)
-        if album_data.current_spectral is not None:
-            album_data.current_spectral = SpectralMeasurement(
-                grade=album_data.current_spectral.grade,
-                bitrate_kbps=existing_quality,
-            )
-    elif spectral_decision == "import_upgrade":
-        logger.info(
-            f"SPECTRAL UPGRADE: {label} "
-            f"suspect at {new_quality}kbps but > existing {effective_existing}kbps, importing")
-    elif spectral_decision == "import_no_exist":
-        logger.info(
-            f"SPECTRAL: {label} "
-            f"suspect at {new_quality}kbps but no existing album, importing")
 
 
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -839,9 +839,13 @@ def dispatch_import_from_db(
             detail=detail,
             error=None,
             requeue=False,
-            # Preserve source attribution: let SQL queries distinguish
-            # gate-rejected force vs manual imports via download_log.outcome.
-            outcome_label=outcome_label,
+            # outcome="rejected" — force_import/manual_import are reserved for
+            # SUCCESSFUL imports (see CLAUDE.md). The /api/pipeline/log "imported"
+            # counter filters on outcome IN ('success','force_import'), so tagging
+            # a rejection as force_import mis-counts it as imported. Source
+            # attribution for rejections is available via download_log.soulseek_username
+            # + the surrounding request row.
+            outcome_label="rejected",
             validation_result=ValidationResult(
                 distance=0.0,
                 scenario="nested_layout",
@@ -900,9 +904,11 @@ def dispatch_import_from_db(
             detail=preimport.detail,
             error=None,
             requeue=False,
-            # Preserve source attribution: gate-rejected force/manual
-            # imports stay filterable by download_log.outcome.
-            outcome_label=outcome_label,
+            # outcome="rejected" — force_import/manual_import are reserved for
+            # SUCCESSFUL imports (see CLAUDE.md). Tagging a gate-rejection as
+            # force_import would mis-count it as imported in the UI's "imported"
+            # counter (web/routes/pipeline.py and lib/pipeline_db.py::get_log).
+            outcome_label="rejected",
             validation_result=ValidationResult(
                 distance=0.0,
                 scenario=preimport.scenario or "preimport_reject",

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -806,6 +806,12 @@ def dispatch_import_from_db(
     # force/manual import can't quietly replace an existing copy with a
     # transcode the auto path would have rejected.
     inspection = inspect_local_files(failed_path)
+    # download_log.soulseek_username can be a comma-joined list of peers for
+    # multi-source downloads. Split before denylisting so a spectral reject
+    # blocks each real peer, not the literal combined string.
+    source_usernames: set[str] = {
+        u.strip() for u in (source_username or "").split(",") if u.strip()
+    }
     preimport = run_preimport_gates(
         path=failed_path,
         mb_release_id=mbid,
@@ -816,7 +822,7 @@ def dispatch_import_from_db(
         cfg=cfg,
         db=db,
         request_id=request_id,
-        usernames={source_username} if source_username else set(),
+        usernames=source_usernames,
     )
 
     if not preimport.valid:
@@ -847,6 +853,7 @@ def dispatch_import_from_db(
                 scenario=preimport.scenario or "preimport_reject",
                 detail=preimport.detail,
                 failed_path=failed_path,
+                corrupt_files=list(preimport.corrupt_files),
             ).to_json(),
             staged_path=failed_path,
         )

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -846,6 +846,7 @@ def dispatch_import_from_db(
                 distance=0.0,
                 scenario=preimport.scenario or "preimport_reject",
                 detail=preimport.detail,
+                failed_path=failed_path,
             ).to_json(),
             staged_path=failed_path,
         )

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -818,6 +818,37 @@ def dispatch_import_from_db(
     except Exception:
         logger.debug("pre-inspect mp3 header repair failed", exc_info=True)
     inspection = inspect_local_files(failed_path)
+
+    # --- Reject nested-folder layouts early ---
+    # The preimport gates (validate_audio / analyze_album / repair_mp3_headers)
+    # recurse, but the downstream harness (harness/import_one.py) still uses
+    # os.listdir for bitrate measurement and conversion. A nested force/manual
+    # import would pass gates and then produce an empty/misclassified
+    # measurement — better to fail fast with a clear message so the user can
+    # flatten the folder themselves. Auto-path downloads are already
+    # flattened by process_completed_album, so this only affects force/manual.
+    if inspection.has_nested_audio:
+        mode = "FORCE-IMPORT" if force else "MANUAL-IMPORT"
+        detail = ("Audio files are in subdirectories — flatten the folder "
+                  "before import (multi-disc layouts are not supported here).")
+        logger.warning(f"{mode} REJECTED (nested layout): {label} — {detail}")
+        _record_rejection_and_maybe_requeue(
+            db, request_id, DownloadInfo(username=source_username),
+            distance=0.0,
+            scenario="nested_layout",
+            detail=detail,
+            error=None,
+            requeue=False,
+            outcome_label="rejected",
+            validation_result=ValidationResult(
+                distance=0.0,
+                scenario="nested_layout",
+                detail=detail,
+                failed_path=failed_path,
+            ).to_json(),
+            staged_path=failed_path,
+        )
+        return DispatchOutcome(success=False, message=detail)
     # download_log.soulseek_username can be a comma-joined list of peers for
     # multi-source downloads. Split before denylisting so a spectral reject
     # blocks each real peer, not the literal combined string.

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -22,7 +22,8 @@ from lib.quality import (parse_import_result, DownloadInfo, ImportResult,
                          extract_usernames, narrow_override_on_downgrade,
                          rejection_backfill_override)
 from lib.transitions import apply_transition
-from lib.util import cleanup_disambiguation_orphans, trigger_meelo_clean
+from lib.util import cleanup_disambiguation_orphans, repair_mp3_headers, trigger_meelo_clean
+from lib.preimport import inspect_local_files, run_preimport_gates
 
 if TYPE_CHECKING:
     from lib.config import SoularrConfig
@@ -774,7 +775,6 @@ def dispatch_import_from_db(
         source_username: Original Soulseek username for force-import audit/denylist flows
     """
     from lib.grab_list import DownloadFile
-    from lib.preimport import inspect_local_files, run_preimport_gates
 
     req = db.get_request(request_id)
     if not req:
@@ -805,6 +805,18 @@ def dispatch_import_from_db(
     # audio integrity and spectral transcode detection always run so a
     # force/manual import can't quietly replace an existing copy with a
     # transcode the auto path would have rejected.
+    #
+    # Repair MP3 headers BEFORE inspect_local_files — broken headers can make
+    # mutagen fail to read bitrate_mode, leaving download_is_vbr=None. Treated
+    # as CBR by the spectral gate, that would falsely reject a VBR album
+    # force-imported here (the auto path only gets headers repaired before
+    # validate_audio, but inspection metadata there comes from slskd, not
+    # filesystem scan — so the problem is unique to force/manual). Idempotent:
+    # run_preimport_gates still calls repair_mp3_headers internally.
+    try:
+        repair_mp3_headers(failed_path)
+    except Exception:
+        logger.debug("pre-inspect mp3 header repair failed", exc_info=True)
     inspection = inspect_local_files(failed_path)
     # download_log.soulseek_username can be a comma-joined list of peers for
     # multi-source downloads. Split before denylisting so a spectral reject

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -759,9 +759,11 @@ def dispatch_import_from_db(
 ) -> "DispatchOutcome":
     """Run a force-import or manual-import through the full dispatch pipeline.
 
-    Calls dispatch_import_core directly with plain params — no DatabaseSource
-    wrapper, no monkey-patching. All quality checks (downgrade prevention,
-    quality gate, meelo scan, denylist) run identically to auto-import.
+    Runs the same pre-import gates (audio integrity + spectral transcode
+    detection) as the auto path via ``lib.preimport.run_preimport_gates``
+    — only the beets *distance* check is skipped when ``force=True``.
+    All other quality checks (downgrade prevention, quality gate, meelo scan,
+    denylist) run identically to auto-import.
 
     Args:
         db: PipelineDB instance
@@ -772,6 +774,7 @@ def dispatch_import_from_db(
         source_username: Original Soulseek username for force-import audit/denylist flows
     """
     from lib.grab_list import DownloadFile
+    from lib.preimport import inspect_local_files, run_preimport_gates
 
     req = db.get_request(request_id)
     if not req:
@@ -795,8 +798,67 @@ def dispatch_import_from_db(
             username=source_username, size=0,
         )]
 
+    label = f"{req.get('artist_name', '')} - {req.get('album_title', '')}"
+
+    # --- Shared pre-import gates (audio + spectral) ---
+    # Force only skips the beets distance check (--force in import_one.py);
+    # audio integrity and spectral transcode detection always run so a
+    # force/manual import can't quietly replace an existing copy with a
+    # transcode the auto path would have rejected.
+    inspection = inspect_local_files(failed_path)
+    preimport = run_preimport_gates(
+        path=failed_path,
+        mb_release_id=mbid,
+        label=label,
+        download_filetype=inspection.filetype,
+        download_min_bitrate_bps=inspection.min_bitrate_bps,
+        download_is_vbr=inspection.is_vbr,
+        cfg=cfg,
+        db=db,
+        request_id=request_id,
+        usernames={source_username} if source_username else set(),
+    )
+
+    if not preimport.valid:
+        mode = "FORCE-IMPORT" if force else "MANUAL-IMPORT"
+        logger.warning(
+            f"{mode} REJECTED (preimport gate): {label} "
+            f"scenario={preimport.scenario} detail={preimport.detail}")
+
+        dl_info = DownloadInfo(
+            username=source_username,
+            filetype=inspection.filetype or None,
+            bitrate=inspection.min_bitrate_bps,
+            is_vbr=inspection.is_vbr,
+            download_spectral=preimport.download_spectral,
+            current_spectral=preimport.existing_spectral,
+            existing_min_bitrate=preimport.existing_min_bitrate,
+        )
+        _record_rejection_and_maybe_requeue(
+            db, request_id, dl_info,
+            distance=0.0,
+            scenario=preimport.scenario or "preimport_reject",
+            detail=preimport.detail,
+            error=None,
+            requeue=False,
+            outcome_label="rejected",
+            validation_result=ValidationResult(
+                distance=0.0,
+                scenario=preimport.scenario or "preimport_reject",
+                detail=preimport.detail,
+            ).to_json(),
+            staged_path=failed_path,
+        )
+        return DispatchOutcome(
+            success=False,
+            message=f"Pre-import gate rejected: {preimport.detail or preimport.scenario}")
+
     # Compute override from DB state — grade-aware: current_spectral_bitrate only
     # lowers the override when current_spectral_grade is suspect/likely_transcode.
+    # Re-read the request row so we pick up the spectral state that preimport
+    # just wrote (it propagates download spectral for never-before-analyzed
+    # albums — this makes the downgrade check honest).
+    req = db.get_request(request_id) or req
     override_min_bitrate = compute_effective_override_bitrate(
         req.get("min_bitrate"),
         req.get("current_spectral_bitrate"),
@@ -806,14 +868,22 @@ def dispatch_import_from_db(
         path=failed_path,
         mb_release_id=mbid,
         request_id=request_id,
-        label=f"{req.get('artist_name', '')} - {req.get('album_title', '')}",
+        label=label,
         force=force,
         override_min_bitrate=override_min_bitrate,
         target_format=req.get("target_format"),
         verified_lossless_target=cfg.verified_lossless_target,
         beets_harness_path=cfg.beets_harness_path,
         db=db,
-        dl_info=DownloadInfo(username=source_username),
+        dl_info=DownloadInfo(
+            username=source_username,
+            filetype=inspection.filetype or None,
+            bitrate=inspection.min_bitrate_bps,
+            is_vbr=inspection.is_vbr,
+            download_spectral=preimport.download_spectral,
+            current_spectral=preimport.existing_spectral,
+            existing_min_bitrate=preimport.existing_min_bitrate,
+        ),
         distance=0.0,
         scenario="force_import" if force else "manual_import",
         files=files,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -839,7 +839,9 @@ def dispatch_import_from_db(
             detail=detail,
             error=None,
             requeue=False,
-            outcome_label="rejected",
+            # Preserve source attribution: let SQL queries distinguish
+            # gate-rejected force vs manual imports via download_log.outcome.
+            outcome_label=outcome_label,
             validation_result=ValidationResult(
                 distance=0.0,
                 scenario="nested_layout",
@@ -898,7 +900,9 @@ def dispatch_import_from_db(
             detail=preimport.detail,
             error=None,
             requeue=False,
-            outcome_label="rejected",
+            # Preserve source attribution: gate-rejected force/manual
+            # imports stay filterable by download_log.outcome.
+            outcome_label=outcome_label,
             validation_result=ValidationResult(
                 distance=0.0,
                 scenario=preimport.scenario or "preimport_reject",
@@ -914,9 +918,10 @@ def dispatch_import_from_db(
 
     # Compute override from DB state — grade-aware: current_spectral_bitrate only
     # lowers the override when current_spectral_grade is suspect/likely_transcode.
-    # Re-read the request row so we pick up the spectral state that preimport
-    # just wrote (it propagates download spectral for never-before-analyzed
-    # albums — this makes the downgrade check honest).
+    # Re-read the request row so we pick up the measured existing spectral that
+    # run_preimport_gates just wrote via _persist_spectral_state. (Force/manual
+    # paths pass propagate_download_to_existing=False, so no download-as-proxy
+    # propagation happens — we only pick up what beets actually measured.)
     req = db.get_request(request_id) or req
     override_min_bitrate = compute_effective_override_bitrate(
         req.get("min_bitrate"),

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -823,6 +823,14 @@ def dispatch_import_from_db(
         db=db,
         request_id=request_id,
         usernames=source_usernames,
+        # Don't propagate the download's spectral into on-disk state on the
+        # force/manual path: if dispatch_import_core subsequently fails
+        # (downgrade, no JSON, timeout), the DB would be left claiming the
+        # failed download is on-disk. The auto path is safe to propagate
+        # because the spectral decision happens immediately before the
+        # import subprocess and a failure there still means the files
+        # ended up in failed_imports/ unchanged.
+        propagate_download_to_existing=False,
     )
 
     if not preimport.valid:

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -293,12 +293,18 @@ def run_preimport_gates(
     """
     result = PreImportGateResult()
 
+    # --- MP3 header repair (unconditional) ---
+    # mp3val runs regardless of audio_check_mode: deployments with
+    # audio_check=off still want fixable MP3 header issues cleaned up before
+    # spectral analysis and the import subprocess. Matches the auto path's
+    # original behavior pre-refactor.
+    try:
+        repair_mp3_headers(path)
+    except Exception:
+        logger.debug("repair_mp3_headers failed", exc_info=True)
+
     # --- Audio integrity gate ---
     if cfg.audio_check_mode != "off":
-        try:
-            repair_mp3_headers(path)
-        except Exception:
-            logger.debug("repair_mp3_headers failed", exc_info=True)
         audio_result = validate_audio(path, cfg.audio_check_mode)
         if not audio_result.valid:
             result.valid = False
@@ -343,6 +349,36 @@ def run_preimport_gates(
         existing_min, existing_spectral = _analyze_existing(mb_release_id, cfg)
         result.existing_min_bitrate = existing_min
         result.existing_spectral = existing_spectral
+
+    # --- Fall back to persisted spectral state when BeetsDB couldn't walk ---
+    # If the on-disk album can't be freshly analyzed (stale/missing album_path),
+    # fall back to the spectral state already stored on album_requests. Without
+    # this, spectral_import_decision() would compare against the container
+    # bitrate (existing_min) and reject a genuine upgrade — e.g. a 192kbps
+    # transcode rejected as <= 320 even though current_spectral_bitrate already
+    # says the on-disk copy is only 128kbps. Pre-refactor the force/manual path
+    # reached compute_effective_override_bitrate() and allowed the upgrade.
+    if (result.existing_spectral is None
+            and db is not None and request_id is not None):
+        try:
+            req = db.get_request(request_id)
+            if req:
+                stored_grade = req.get("current_spectral_grade")
+                stored_bitrate = req.get("current_spectral_bitrate")
+                stored = SpectralMeasurement.from_parts(stored_grade, stored_bitrate)
+                if stored is not None:
+                    result.existing_spectral = stored
+                    logger.info(
+                        f"SPECTRAL: {label} using persisted current_spectral "
+                        f"(grade={stored.grade}, bitrate={stored.bitrate_kbps}kbps)"
+                        " — BeetsDB lookup returned no spectral measurement")
+                if result.existing_min_bitrate is None:
+                    stored_min = req.get("min_bitrate")
+                    if stored_min is not None:
+                        result.existing_min_bitrate = stored_min
+        except Exception:
+            logger.debug("failed to read persisted spectral state",
+                         exc_info=True)
 
     # --- Persist spectral state to DB (if wired) ---
     if db is not None and request_id is not None:

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -1,0 +1,378 @@
+"""Shared pre-import quality gates for auto-import, force-import, and manual-import.
+
+The auto-import path (lib.download.process_completed_album), the force-import
+path (lib.import_dispatch.dispatch_import_from_db), and the manual-import path
+all MUST run the same quality gates: audio integrity and spectral transcode
+detection. The only gate that differs between paths is the beets *distance*
+check — that is what --force on import_one.py overrides. Every other gate is
+shared, so it lives here in a single function.
+
+Rationale: force-import previously called dispatch_import_core() directly,
+skipping the audio + spectral gates that _process_beets_validation ran in the
+auto path. A transcode rejected by auto-import's spectral gate could be
+force-imported into beets, replacing an existing copy of the same quality with
+no real upgrade. See the "No Parallel Code Paths" rule in
+.claude/rules/code-quality.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from lib.pipeline_db import RequestSpectralStateUpdate
+from lib.quality import SpectralMeasurement, spectral_import_decision
+from lib.util import repair_mp3_headers, validate_audio
+
+if TYPE_CHECKING:
+    from lib.config import SoularrConfig
+    from lib.pipeline_db import PipelineDB
+
+logger = logging.getLogger("soularr")
+
+
+# Lazy import proxy — keeps sox out of import-time deps.
+def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
+    """Proxy to spectral_check.analyze_album (lazy import).
+
+    Mirrors lib.download.spectral_analyze so tests can patch one or the other
+    depending on which module is under test. Callers inside lib.preimport must
+    use this proxy (not the one in lib.download) so patches on
+    ``lib.preimport.spectral_analyze`` take effect.
+    """
+    lib_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "lib")
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+    from spectral_check import analyze_album
+    return analyze_album(folder, trim_seconds=trim_seconds)
+
+
+@dataclass
+class PreImportGateResult:
+    """Outcome of the shared pre-import gate pipeline.
+
+    ``valid=False`` means the import must be rejected. ``scenario`` and
+    ``detail`` mirror the fields on ``ValidationResult`` so callers can fold
+    the result into an existing ``ValidationResult`` without translation.
+
+    The spectral fields are populated whenever a spectral analysis ran
+    (regardless of pass/reject) so callers can persist them to download_log.
+    """
+    valid: bool = True
+    scenario: str | None = None      # "audio_corrupt" | "spectral_reject"
+    detail: str | None = None
+    corrupt_files: list[str] = field(default_factory=list)
+    download_spectral: SpectralMeasurement | None = None
+    existing_spectral: SpectralMeasurement | None = None
+    existing_min_bitrate: int | None = None
+    download_min_bitrate_kbps: int | None = None
+    cliff_track_count: int | None = None
+
+
+def _normalize_bps_to_kbps(value: int | None) -> int | None:
+    """Normalize a bitrate that may be bps or kbps to kbps."""
+    if value is None:
+        return None
+    return value // 1000 if value > 1000 else value
+
+
+AUDIO_EXTS = ("mp3", "flac", "alac", "m4a", "ogg", "opus", "wav", "aac")
+
+
+@dataclass
+class LocalFileInspection:
+    """Result of inspecting audio files on disk at a force/manual import path.
+
+    Populated by ``inspect_local_files`` so callers of ``run_preimport_gates``
+    that have no DownloadFile metadata (force/manual paths) can still supply
+    filetype / bitrate / vbr hints.
+    """
+    filetype: str = ""           # comma-separated lowercase extensions
+    min_bitrate_bps: int | None = None
+    is_vbr: bool | None = None
+
+
+def inspect_local_files(path: str) -> LocalFileInspection:
+    """Scan ``path`` for audio files and report filetype + bitrate + VBR hints.
+
+    Uses mutagen for MP3 VBR detection; all other bitrate/filetype info comes
+    from extensions and file headers. Exceptions are swallowed so a corrupt or
+    unreadable file never hard-errors the gate pipeline — the audio gate
+    upstream catches those.
+    """
+    if not os.path.isdir(path):
+        return LocalFileInspection()
+
+    extensions: set[str] = set()
+    min_bitrate: int | None = None
+    any_vbr: bool | None = None
+
+    for name in os.listdir(path):
+        full = os.path.join(path, name)
+        if not os.path.isfile(full) or "." not in name:
+            continue
+        ext = name.rsplit(".", 1)[-1].lower()
+        if ext not in AUDIO_EXTS:
+            continue
+        extensions.add(ext)
+        if ext == "mp3":
+            try:
+                from mutagen.mp3 import MP3  # type: ignore[import-untyped]
+                mp3 = MP3(full)
+                br = getattr(mp3.info, "bitrate", None)
+                br_mode = getattr(mp3.info, "bitrate_mode", None)
+                if br is not None:
+                    min_bitrate = br if min_bitrate is None else min(min_bitrate, br)
+                # mutagen BitrateMode: UNKNOWN=0, CBR=1, VBR=2, ABR=3
+                if br_mode is not None:
+                    is_vbr_file = int(br_mode) in (2, 3)
+                    any_vbr = is_vbr_file if any_vbr is None else (any_vbr or is_vbr_file)
+            except Exception:
+                logger.debug(f"inspect_local_files: failed to read {full}",
+                             exc_info=True)
+
+    return LocalFileInspection(
+        filetype=", ".join(sorted(extensions)),
+        min_bitrate_bps=min_bitrate,
+        is_vbr=any_vbr,
+    )
+
+
+def _needs_spectral_check(filetype: str, is_vbr: bool | None) -> bool:
+    """Spectral check runs on non-VBR MP3 downloads only.
+
+    FLAC uses a different flow (convert → V0 → compare). VBR MP3 carries its
+    own bitrate signal. CBR MP3 is where spectral cliff detection pays off.
+    """
+    filetype_lower = (filetype or "").lower()
+    is_mp3 = "mp3" in filetype_lower and "flac" not in filetype_lower
+    return is_mp3 and not bool(is_vbr)
+
+
+def _analyze_existing(
+    mb_release_id: str,
+    cfg: "SoularrConfig",
+) -> tuple[int | None, SpectralMeasurement | None]:
+    """Look up existing beets album and spectral-analyze its files.
+
+    Returns ``(existing_min_bitrate_kbps, existing_spectral)``. Either or both
+    may be None if the album isn't in beets or the on-disk path is missing.
+    Exceptions are logged and swallowed so a missing existing copy never
+    blocks a new import.
+    """
+    from lib.beets_db import BeetsDB
+
+    existing_min: int | None = None
+    existing_spectral: SpectralMeasurement | None = None
+    try:
+        with BeetsDB() as beets:
+            existing_info = beets.get_album_info(
+                mb_release_id, cfg.quality_ranks)
+        if existing_info:
+            existing_min = existing_info.min_bitrate_kbps
+            if os.path.isdir(existing_info.album_path):
+                sp = spectral_analyze(existing_info.album_path,
+                                      trim_seconds=30)
+                existing_spectral = SpectralMeasurement.from_parts(
+                    sp.grade, sp.estimated_bitrate_kbps)
+                logger.info(
+                    f"SPECTRAL: existing on disk: grade={sp.grade}, "
+                    f"estimated_bitrate={sp.estimated_bitrate_kbps}kbps, "
+                    f"beets_min={existing_min}kbps")
+    except Exception:
+        logger.exception("SPECTRAL: failed to check existing files")
+    return existing_min, existing_spectral
+
+
+def _persist_spectral_state(
+    *,
+    db: "PipelineDB",
+    request_id: int,
+    download_spectral: SpectralMeasurement | None,
+    existing_spectral: SpectralMeasurement | None,
+    existing_min_bitrate: int | None,
+    label: str,
+) -> SpectralMeasurement | None:
+    """Write the on-disk spectral state to album_requests.
+
+    When there's no measured existing spectral but there IS an existing
+    album on disk (existing_min_bitrate set), propagate the download's
+    spectral as current. Without the min-bitrate guard, a fresh album with
+    nothing on disk would adopt its own download spectral and self-reject.
+    Returns the measurement actually written (or None if nothing to write).
+    """
+    to_write = existing_spectral
+    if (to_write is None
+            and download_spectral is not None
+            and existing_min_bitrate is not None):
+        to_write = download_spectral
+        logger.info(
+            f"SPECTRAL PROPAGATE: {label} on-disk spectral=NULL, "
+            f"adopting download spectral grade={to_write.grade}")
+    if to_write is not None:
+        try:
+            db.update_spectral_state(
+                request_id,
+                RequestSpectralStateUpdate(current=to_write),
+            )
+        except Exception:
+            logger.exception("Failed to update on-disk spectral data")
+    return to_write
+
+
+def run_preimport_gates(
+    *,
+    path: str,
+    mb_release_id: str,
+    label: str,
+    download_filetype: str,
+    download_min_bitrate_bps: int | None,
+    download_is_vbr: bool | None,
+    cfg: "SoularrConfig",
+    db: "PipelineDB | None" = None,
+    request_id: int | None = None,
+    usernames: set[str] | None = None,
+) -> PreImportGateResult:
+    """Run shared pre-import gates: audio integrity, then spectral transcode detection.
+
+    Side effects when ``db`` and ``request_id`` are supplied:
+      * Updates ``album_requests.current_spectral_{grade,bitrate}`` via
+        ``update_spectral_state``.
+      * On spectral reject, adds a ``source_denylist`` entry for every
+        username in ``usernames`` with a ``spectral: Xkbps <= existing Ykbps``
+        reason.
+
+    The caller owns:
+      * Writing ``download_log`` (the result carries scenario/detail to fold
+        into the log).
+      * Filesystem moves (auto path moves files to ``failed_imports/`` on
+        reject; force/manual paths leave them where they are).
+      * Requeue decisions (auto path requeues on reject; force/manual do not).
+
+    Args:
+        path: Filesystem path containing the files to validate.
+        mb_release_id: MusicBrainz release ID — used to find the existing
+            album in beets for spectral comparison.
+        label: "Artist - Title" string, for log output only.
+        download_filetype: Comma-separated filetypes (e.g. "mp3", "flac",
+            "mp3, flac"). Controls whether spectral check runs.
+        download_min_bitrate_bps: Minimum container bitrate across download
+            files, in bps (or kbps if < 1000). Normalized internally.
+        download_is_vbr: True when any file in the download reports VBR.
+            Spectral check is skipped for VBR MP3s.
+        cfg: Runtime SoularrConfig (for ``audio_check_mode`` and
+            ``quality_ranks``).
+        db: Pipeline DB — pass to enable denylist + spectral state side effects.
+        request_id: Required when ``db`` is supplied.
+        usernames: Soulseek users to denylist on spectral reject.
+
+    Returns:
+        PreImportGateResult with ``valid`` and populated spectral fields.
+    """
+    result = PreImportGateResult()
+
+    # --- Audio integrity gate ---
+    if cfg.audio_check_mode != "off":
+        try:
+            repair_mp3_headers(path)
+        except Exception:
+            logger.debug("repair_mp3_headers failed", exc_info=True)
+        audio_result = validate_audio(path, cfg.audio_check_mode)
+        if not audio_result.valid:
+            result.valid = False
+            result.scenario = "audio_corrupt"
+            result.detail = audio_result.error
+            result.corrupt_files = [
+                name for name, _ in audio_result.failed_files]
+            logger.warning(
+                f"AUDIO CORRUPT: {label} "
+                f"({len(result.corrupt_files)} files failed ffmpeg decode)")
+            return result
+
+    # --- Spectral gate (non-VBR MP3 only) ---
+    if not _needs_spectral_check(download_filetype, download_is_vbr):
+        return result
+
+    dl_bitrate_kbps = _normalize_bps_to_kbps(download_min_bitrate_bps)
+    result.download_min_bitrate_kbps = dl_bitrate_kbps
+
+    try:
+        dl_sp = spectral_analyze(path, trim_seconds=30)
+        dl_grade = dl_sp.grade
+        dl_cliff_bitrate = dl_sp.estimated_bitrate_kbps
+        dl_suspect_pct = dl_sp.suspect_pct
+        cliff_count = sum(
+            1 for track in getattr(dl_sp, "tracks", [])
+            if getattr(track, "cliff_detected", False)
+        )
+        result.cliff_track_count = cliff_count
+        result.download_spectral = SpectralMeasurement.from_parts(
+            dl_grade, dl_cliff_bitrate)
+        logger.info(
+            f"SPECTRAL: {label} grade={dl_grade}, "
+            f"estimated_bitrate={dl_cliff_bitrate}kbps, "
+            f"suspect={dl_suspect_pct:.0f}%, cliffs={cliff_count}")
+    except Exception:
+        logger.exception(f"SPECTRAL: failed to analyze download for {label}")
+        return result
+
+    # --- Existing-album lookup + analysis ---
+    if mb_release_id:
+        existing_min, existing_spectral = _analyze_existing(mb_release_id, cfg)
+        result.existing_min_bitrate = existing_min
+        result.existing_spectral = existing_spectral
+
+    # --- Persist spectral state to DB (if wired) ---
+    if db is not None and request_id is not None:
+        written = _persist_spectral_state(
+            db=db, request_id=request_id,
+            download_spectral=result.download_spectral,
+            existing_spectral=result.existing_spectral,
+            existing_min_bitrate=result.existing_min_bitrate,
+            label=label,
+        )
+        result.existing_spectral = written
+
+    # --- Spectral decision ---
+    existing_cliff_bitrate = (
+        result.existing_spectral.bitrate_kbps
+        if result.existing_spectral is not None else None
+    )
+    spectral_decision = spectral_import_decision(
+        dl_grade, dl_cliff_bitrate, existing_cliff_bitrate,
+        existing_min_bitrate=result.existing_min_bitrate,
+    )
+
+    effective_existing = (
+        existing_cliff_bitrate or result.existing_min_bitrate or 0)
+    if spectral_decision == "reject":
+        result.valid = False
+        result.scenario = "spectral_reject"
+        result.detail = (
+            f"spectral {dl_cliff_bitrate}kbps <= existing {effective_existing}kbps")
+        logger.warning(
+            f"SPECTRAL REJECT: {label} "
+            f"new spectral {dl_cliff_bitrate}kbps <= existing {effective_existing}kbps")
+        if db is not None and request_id is not None and usernames:
+            for username in usernames:
+                try:
+                    db.add_denylist(
+                        request_id, username,
+                        f"spectral: {dl_cliff_bitrate}kbps <= existing {effective_existing}kbps")
+                except Exception:
+                    logger.exception(
+                        f"Failed to denylist {username} for request {request_id}")
+            logger.info(f"  Denylisted {usernames} for request {request_id}")
+    elif spectral_decision == "import_upgrade":
+        logger.info(
+            f"SPECTRAL UPGRADE: {label} suspect at {dl_cliff_bitrate}kbps "
+            f"but > existing {effective_existing}kbps, importing")
+    elif spectral_decision == "import_no_exist":
+        logger.info(
+            f"SPECTRAL: {label} suspect at {dl_cliff_bitrate}kbps "
+            f"but no existing album, importing")
+
+    return result

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -200,17 +200,30 @@ def _persist_spectral_state(
     existing_spectral: SpectralMeasurement | None,
     existing_min_bitrate: int | None,
     label: str,
+    propagate_download_to_existing: bool = True,
 ) -> SpectralMeasurement | None:
     """Write the on-disk spectral state to album_requests.
 
-    When there's no measured existing spectral but there IS an existing
-    album on disk (existing_min_bitrate set), propagate the download's
-    spectral as current. Without the min-bitrate guard, a fresh album with
-    nothing on disk would adopt its own download spectral and self-reject.
+    When ``propagate_download_to_existing`` is True and there's no measured
+    existing spectral but there IS an existing album on disk
+    (existing_min_bitrate set), adopt the download's spectral as the current
+    on-disk measurement. This helps same-tier downgrade detection for
+    subsequent imports — the download and on-disk characterize the same
+    quality tier, so reusing the download's spectral is a reasonable proxy.
+
+    Pass ``propagate_download_to_existing=False`` from the force/manual
+    import path: that path evaluates the gate *before* the subprocess import
+    runs, so propagating a download's spectral into on-disk state would be
+    speculative. If the downstream import fails (downgrade, no JSON,
+    timeout) the DB would otherwise be left claiming that the failed
+    download is on-disk, skewing later ``compute_effective_override_bitrate``
+    and quality-gate decisions.
+
     Returns the measurement actually written (or None if nothing to write).
     """
     to_write = existing_spectral
     if (to_write is None
+            and propagate_download_to_existing
             and download_spectral is not None
             and existing_min_bitrate is not None):
         to_write = download_spectral
@@ -240,6 +253,7 @@ def run_preimport_gates(
     db: "PipelineDB | None" = None,
     request_id: int | None = None,
     usernames: set[str] | None = None,
+    propagate_download_to_existing: bool = True,
 ) -> PreImportGateResult:
     """Run shared pre-import gates: audio integrity, then spectral transcode detection.
 
@@ -338,6 +352,7 @@ def run_preimport_gates(
             existing_spectral=result.existing_spectral,
             existing_min_bitrate=result.existing_min_bitrate,
             label=label,
+            propagate_download_to_existing=propagate_download_to_existing,
         )
         result.existing_spectral = written
 

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -96,7 +96,11 @@ class LocalFileInspection:
 
 
 def inspect_local_files(path: str) -> LocalFileInspection:
-    """Scan ``path`` for audio files and report filetype + bitrate + VBR hints.
+    """Scan ``path`` recursively for audio files and report filetype + bitrate + VBR hints.
+
+    Walks subdirectories so multi-disc layouts (e.g. ``Album/CD1/*.mp3``)
+    classify correctly — otherwise the spectral gate silently skips nested
+    manual/force imports because ``download_filetype`` comes back empty.
 
     Uses mutagen for MP3 VBR detection; all other bitrate/filetype info comes
     from extensions and file headers. Exceptions are swallowed so a corrupt or
@@ -110,29 +114,30 @@ def inspect_local_files(path: str) -> LocalFileInspection:
     min_bitrate: int | None = None
     any_vbr: bool | None = None
 
-    for name in os.listdir(path):
-        full = os.path.join(path, name)
-        if not os.path.isfile(full) or "." not in name:
-            continue
-        ext = name.rsplit(".", 1)[-1].lower()
-        if ext not in AUDIO_EXTS:
-            continue
-        extensions.add(ext)
-        if ext == "mp3":
-            try:
-                from mutagen.mp3 import MP3  # type: ignore[import-untyped]
-                mp3 = MP3(full)
-                br = getattr(mp3.info, "bitrate", None)
-                br_mode = getattr(mp3.info, "bitrate_mode", None)
-                if br is not None:
-                    min_bitrate = br if min_bitrate is None else min(min_bitrate, br)
-                # mutagen BitrateMode: UNKNOWN=0, CBR=1, VBR=2, ABR=3
-                if br_mode is not None:
-                    is_vbr_file = int(br_mode) in (2, 3)
-                    any_vbr = is_vbr_file if any_vbr is None else (any_vbr or is_vbr_file)
-            except Exception:
-                logger.debug(f"inspect_local_files: failed to read {full}",
-                             exc_info=True)
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            if "." not in name:
+                continue
+            ext = name.rsplit(".", 1)[-1].lower()
+            if ext not in AUDIO_EXTS:
+                continue
+            extensions.add(ext)
+            if ext == "mp3":
+                full = os.path.join(root, name)
+                try:
+                    from mutagen.mp3 import MP3  # type: ignore[import-untyped]
+                    mp3 = MP3(full)
+                    br = getattr(mp3.info, "bitrate", None)
+                    br_mode = getattr(mp3.info, "bitrate_mode", None)
+                    if br is not None:
+                        min_bitrate = br if min_bitrate is None else min(min_bitrate, br)
+                    # mutagen BitrateMode: UNKNOWN=0, CBR=1, VBR=2, ABR=3
+                    if br_mode is not None:
+                        is_vbr_file = int(br_mode) in (2, 3)
+                        any_vbr = is_vbr_file if any_vbr is None else (any_vbr or is_vbr_file)
+                except Exception:
+                    logger.debug(f"inspect_local_files: failed to read {full}",
+                                 exc_info=True)
 
     return LocalFileInspection(
         filetype=", ".join(sorted(extensions)),

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -90,10 +90,19 @@ class LocalFileInspection:
     Populated by ``inspect_local_files`` so callers of ``run_preimport_gates``
     that have no DownloadFile metadata (force/manual paths) can still supply
     filetype / bitrate / vbr hints.
+
+    ``has_nested_audio`` reports whether any audio files were found below the
+    root directory. Callers should reject nested layouts early: the
+    preimport gates (validate_audio / analyze_album / repair_mp3_headers)
+    recurse, but the downstream beets harness (``harness/import_one.py``)
+    still uses ``os.listdir`` for bitrate measurement and conversion, so a
+    nested force/manual import would pass gates and then produce a
+    misclassified/empty measurement in the harness.
     """
     filetype: str = ""           # comma-separated lowercase extensions
     min_bitrate_bps: int | None = None
     is_vbr: bool | None = None
+    has_nested_audio: bool = False
 
 
 def inspect_local_files(path: str) -> LocalFileInspection:
@@ -114,6 +123,7 @@ def inspect_local_files(path: str) -> LocalFileInspection:
     extensions: set[str] = set()
     min_bitrate: int | None = None
     any_vbr: bool | None = None
+    has_nested_audio = False
 
     for root, _dirs, files in os.walk(path):
         for name in files:
@@ -122,6 +132,8 @@ def inspect_local_files(path: str) -> LocalFileInspection:
             ext = name.rsplit(".", 1)[-1].lower()
             if ext not in AUDIO_EXTS:
                 continue
+            if root != path:
+                has_nested_audio = True
             extensions.add(ext)
             if ext == "mp3":
                 full = os.path.join(root, name)
@@ -144,6 +156,7 @@ def inspect_local_files(path: str) -> LocalFileInspection:
         filetype=", ".join(sorted(extensions)),
         min_bitrate_bps=min_bitrate,
         is_vbr=any_vbr,
+        has_nested_audio=has_nested_audio,
     )
 
 

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -24,7 +24,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from lib.pipeline_db import RequestSpectralStateUpdate
-from lib.quality import SpectralMeasurement, spectral_import_decision
+from lib.quality import (SPECTRAL_TRANSCODE_GRADES, SpectralMeasurement,
+                         spectral_import_decision)
 from lib.util import repair_mp3_headers, validate_audio
 
 if TYPE_CHECKING:
@@ -147,14 +148,20 @@ def inspect_local_files(path: str) -> LocalFileInspection:
 
 
 def _needs_spectral_check(filetype: str, is_vbr: bool | None) -> bool:
-    """Spectral check runs on non-VBR MP3 downloads only.
+    """Spectral check runs on *confidently CBR* MP3 downloads only.
 
     FLAC uses a different flow (convert → V0 → compare). VBR MP3 carries its
     own bitrate signal. CBR MP3 is where spectral cliff detection pays off.
+
+    Unknown VBR status (``is_vbr is None``) skips the gate. On the force/manual
+    path ``inspect_local_files`` can't always read a file's ``bitrate_mode``
+    (broken headers → mutagen returns None), and treating that as confirmed
+    CBR would falsely reject a VBR upload. The post-import quality gate
+    (rank comparison) still catches transcoded CBR downloads.
     """
     filetype_lower = (filetype or "").lower()
     is_mp3 = "mp3" in filetype_lower and "flac" not in filetype_lower
-    return is_mp3 and not bool(is_vbr)
+    return is_mp3 and is_vbr is False
 
 
 def _analyze_existing(
@@ -352,12 +359,14 @@ def run_preimport_gates(
 
     # --- Fall back to persisted spectral state when BeetsDB couldn't walk ---
     # If the on-disk album can't be freshly analyzed (stale/missing album_path),
-    # fall back to the spectral state already stored on album_requests. Without
-    # this, spectral_import_decision() would compare against the container
-    # bitrate (existing_min) and reject a genuine upgrade — e.g. a 192kbps
-    # transcode rejected as <= 320 even though current_spectral_bitrate already
-    # says the on-disk copy is only 128kbps. Pre-refactor the force/manual path
-    # reached compute_effective_override_bitrate() and allowed the upgrade.
+    # fall back to the spectral state already stored on album_requests.
+    #
+    # GRADE-AWARE: only use the stored spectral_bitrate when the grade is a
+    # transcode grade (suspect/likely_transcode). A stored
+    # ``grade=genuine, bitrate=96`` is stale (genuine files have no cliff),
+    # and admitting a 96kbps "existing" would let a real transcode be imported
+    # as an upgrade. Matches ``compute_effective_override_bitrate`` and
+    # ``load_quality_gate_state`` — the same rule applied across the pipeline.
     if (result.existing_spectral is None
             and db is not None and request_id is not None):
         try:
@@ -365,13 +374,16 @@ def run_preimport_gates(
             if req:
                 stored_grade = req.get("current_spectral_grade")
                 stored_bitrate = req.get("current_spectral_bitrate")
-                stored = SpectralMeasurement.from_parts(stored_grade, stored_bitrate)
-                if stored is not None:
-                    result.existing_spectral = stored
-                    logger.info(
-                        f"SPECTRAL: {label} using persisted current_spectral "
-                        f"(grade={stored.grade}, bitrate={stored.bitrate_kbps}kbps)"
-                        " — BeetsDB lookup returned no spectral measurement")
+                if stored_grade in SPECTRAL_TRANSCODE_GRADES:
+                    stored = SpectralMeasurement.from_parts(
+                        stored_grade, stored_bitrate)
+                    if stored is not None:
+                        result.existing_spectral = stored
+                        logger.info(
+                            f"SPECTRAL: {label} using persisted "
+                            f"current_spectral (grade={stored.grade}, "
+                            f"bitrate={stored.bitrate_kbps}kbps) — BeetsDB "
+                            "lookup returned no spectral measurement")
                 if result.existing_min_bitrate is None:
                     stored_min = req.get("min_bitrate")
                     if stored_min is not None:

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -341,6 +341,11 @@ def run_preimport_gates(
         result.existing_spectral.bitrate_kbps
         if result.existing_spectral is not None else None
     )
+    # Uses the 4-arg form of spectral_import_decision (matches main's
+    # _apply_spectral_decision exactly). The cliff_track_count is captured on
+    # PreImportGateResult for audit/logging but not forwarded — the
+    # decision-function side of the cliff heuristic lives on a separate branch
+    # and will be wired in once it lands.
     spectral_decision = spectral_import_decision(
         dl_grade, dl_cliff_bitrate, existing_cliff_bitrate,
         existing_min_bitrate=result.existing_min_bitrate,

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -69,14 +69,6 @@ class PreImportGateResult:
     download_spectral: SpectralMeasurement | None = None
     existing_spectral: SpectralMeasurement | None = None
     existing_min_bitrate: int | None = None
-    download_min_bitrate_kbps: int | None = None
-
-
-def _normalize_bps_to_kbps(value: int | None) -> int | None:
-    """Normalize a bitrate that may be bps or kbps to kbps."""
-    if value is None:
-        return None
-    return value // 1000 if value > 1000 else value
 
 
 AUDIO_EXTS = ("mp3", "flac", "alac", "m4a", "ogg", "opus", "wav", "aac")
@@ -357,9 +349,6 @@ def run_preimport_gates(
     # --- Spectral gate (non-VBR MP3 only) ---
     if not _needs_spectral_check(download_filetype, download_is_vbr):
         return result
-
-    dl_bitrate_kbps = _normalize_bps_to_kbps(download_min_bitrate_bps)
-    result.download_min_bitrate_kbps = dl_bitrate_kbps
 
     try:
         dl_sp = spectral_analyze(path, trim_seconds=30)

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -148,20 +148,23 @@ def inspect_local_files(path: str) -> LocalFileInspection:
 
 
 def _needs_spectral_check(filetype: str, is_vbr: bool | None) -> bool:
-    """Spectral check runs on *confidently CBR* MP3 downloads only.
+    """Spectral check runs on non-VBR MP3 downloads.
 
     FLAC uses a different flow (convert → V0 → compare). VBR MP3 carries its
     own bitrate signal. CBR MP3 is where spectral cliff detection pays off.
 
-    Unknown VBR status (``is_vbr is None``) skips the gate. On the force/manual
-    path ``inspect_local_files`` can't always read a file's ``bitrate_mode``
-    (broken headers → mutagen returns None), and treating that as confirmed
-    CBR would falsely reject a VBR upload. The post-import quality gate
-    (rank comparison) still catches transcoded CBR downloads.
+    Unknown VBR (``is_vbr is None``) is routed through the gate — the auto
+    path resumes downloads from ``ActiveDownloadState`` without a VBR field,
+    and skipping spectral on those would be a quality-gate bypass. Callers
+    with ground truth (force/manual) resolve unknown VBR via filesystem
+    inspection (see ``run_preimport_gates``) before this helper is reached,
+    so None here means "really unknown" — the conservative choice is to
+    still gate; genuine VBR uploads will produce "genuine" spectral grades
+    and fall through to import.
     """
     filetype_lower = (filetype or "").lower()
     is_mp3 = "mp3" in filetype_lower and "flac" not in filetype_lower
-    return is_mp3 and is_vbr is False
+    return is_mp3 and not bool(is_vbr)
 
 
 def _analyze_existing(
@@ -324,6 +327,21 @@ def run_preimport_gates(
                 f"({len(result.corrupt_files)} files failed ffmpeg decode)")
             return result
 
+    # --- Resolve VBR status via filesystem inspection when unknown ---
+    # Auto path callers supply VBR from slskd metadata (usually populated,
+    # but None on resumed downloads rebuilt from ActiveDownloadState).
+    # Force/manual callers supply VBR from mutagen (can be None on broken
+    # headers). In both cases, re-inspecting the files on disk here covers
+    # the gap so the spectral gate runs only when we've confirmed CBR.
+    if download_is_vbr is None:
+        filetype_lower = (download_filetype or "").lower()
+        if "mp3" in filetype_lower and "flac" not in filetype_lower:
+            inspection = inspect_local_files(path)
+            if inspection.is_vbr is not None:
+                download_is_vbr = inspection.is_vbr
+                if download_min_bitrate_bps is None:
+                    download_min_bitrate_bps = inspection.min_bitrate_bps
+
     # --- Spectral gate (non-VBR MP3 only) ---
     if not _needs_spectral_check(download_filetype, download_is_vbr):
         return result
@@ -358,8 +376,12 @@ def run_preimport_gates(
         result.existing_spectral = existing_spectral
 
     # --- Fall back to persisted spectral state when BeetsDB couldn't walk ---
-    # If the on-disk album can't be freshly analyzed (stale/missing album_path),
-    # fall back to the spectral state already stored on album_requests.
+    # Only fires when BeetsDB FOUND the album (existing_min_bitrate set) but
+    # couldn't measure spectral from its album_path (stale/missing directory).
+    # When BeetsDB returns no album at all — album deleted, beets DB offline,
+    # or first-time import — we must NOT use stale album_requests.min_bitrate
+    # as "proof" that something is still on disk, or the gate would reject
+    # a valid redownload against non-existent state.
     #
     # GRADE-AWARE: only use the stored spectral_bitrate when the grade is a
     # transcode grade (suspect/likely_transcode). A stored
@@ -367,7 +389,9 @@ def run_preimport_gates(
     # and admitting a 96kbps "existing" would let a real transcode be imported
     # as an upgrade. Matches ``compute_effective_override_bitrate`` and
     # ``load_quality_gate_state`` — the same rule applied across the pipeline.
-    if (result.existing_spectral is None
+    beets_knows_album = result.existing_min_bitrate is not None
+    if (beets_knows_album
+            and result.existing_spectral is None
             and db is not None and request_id is not None):
         try:
             req = db.get_request(request_id)
@@ -384,10 +408,6 @@ def run_preimport_gates(
                             f"current_spectral (grade={stored.grade}, "
                             f"bitrate={stored.bitrate_kbps}kbps) — BeetsDB "
                             "lookup returned no spectral measurement")
-                if result.existing_min_bitrate is None:
-                    stored_min = req.get("min_bitrate")
-                    if stored_min is not None:
-                        result.existing_min_bitrate = stored_min
         except Exception:
             logger.debug("failed to read persisted spectral state",
                          exc_info=True)

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -70,7 +70,6 @@ class PreImportGateResult:
     existing_spectral: SpectralMeasurement | None = None
     existing_min_bitrate: int | None = None
     download_min_bitrate_kbps: int | None = None
-    cliff_track_count: int | None = None
 
 
 def _normalize_bps_to_kbps(value: int | None) -> int | None:
@@ -371,7 +370,6 @@ def run_preimport_gates(
             1 for track in getattr(dl_sp, "tracks", [])
             if getattr(track, "cliff_detected", False)
         )
-        result.cliff_track_count = cliff_count
         result.download_spectral = SpectralMeasurement.from_parts(
             dl_grade, dl_cliff_bitrate)
         logger.info(
@@ -379,7 +377,9 @@ def run_preimport_gates(
             f"estimated_bitrate={dl_cliff_bitrate}kbps, "
             f"suspect={dl_suspect_pct:.0f}%, cliffs={cliff_count}")
     except Exception:
-        logger.exception(f"SPECTRAL: failed to analyze download for {label}")
+        # Keep the log prefix pre-refactor had ("SPECTRAL: failed for ...")
+        # so operators grepping for it continue to match.
+        logger.exception(f"SPECTRAL: failed for {label}")
         return result
 
     # --- Existing-album lookup + analysis ---
@@ -442,11 +442,10 @@ def run_preimport_gates(
         result.existing_spectral.bitrate_kbps
         if result.existing_spectral is not None else None
     )
-    # Uses the 4-arg form of spectral_import_decision (matches main's
-    # _apply_spectral_decision exactly). The cliff_track_count is captured on
-    # PreImportGateResult for audit/logging but not forwarded — the
-    # decision-function side of the cliff heuristic lives on a separate branch
-    # and will be wired in once it lands.
+    # 4-arg form matches main's _apply_spectral_decision exactly. The
+    # cliff-count heuristic (``download_min_bitrate`` + ``cliff_track_count``
+    # kwargs on spectral_import_decision) lives on a separate branch with
+    # its own tests; wire it in here once that lands.
     spectral_decision = spectral_import_decision(
         dl_grade, dl_cliff_bitrate, existing_cliff_bitrate,
         existing_min_bitrate=result.existing_min_bitrate,

--- a/lib/spectral_check.py
+++ b/lib/spectral_check.py
@@ -231,18 +231,24 @@ def analyze_track(filepath, trim_seconds=30):
 
 
 def analyze_album(folder_path, trim_seconds=30):
-    """Analyze all audio files in a folder.
+    """Analyze all audio files in a folder (walks subdirectories).
 
     Returns an AlbumResult with album-level grade and per-track results.
+
+    Walks subdirectories so multi-disc layouts (``Album/CD1/*.flac``) are
+    analyzed as one album. The auto-import path always passes a flattened
+    folder so recursion is a no-op there; force/manual-import and
+    post-conversion callers can point at user folders with nested discs.
     """
-    files = sorted(
-        f for f in os.listdir(folder_path)
-        if os.path.splitext(f)[1].lower() in AUDIO_EXTENSIONS
-    )
+    files = []
+    for root, _dirs, names in os.walk(folder_path):
+        for f in sorted(names):
+            if os.path.splitext(f)[1].lower() in AUDIO_EXTENSIONS:
+                files.append(os.path.join(root, f))
 
     track_results = []
-    for fname in files:
-        result = analyze_track(os.path.join(folder_path, fname), trim_seconds)
+    for filepath in files:
+        result = analyze_track(filepath, trim_seconds)
         if result.grade != "error":
             track_results.append(result)
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -179,15 +179,21 @@ def validate_audio(folder_path: str, mode: str = "normal") -> AudioValidationRes
     """Check audio integrity of downloaded files via ffmpeg full decode.
 
     mode: "off" = skip, anything else = reject if any file fails.
+
+    Walks subdirectories so multi-disc layouts (``Album/CD1/*.mp3``) are
+    validated too. The auto-import path always passes a flattened folder
+    so recursion is a no-op there; force/manual-import paths can point at
+    user folders with nested discs.
     """
     if mode == "off":
         return AudioValidationResult()
 
     files = []
-    for f in os.listdir(folder_path):
-        ext = f.rsplit(".", 1)[-1].lower() if "." in f else ""
-        if ext in _AUDIO_EXTS:
-            files.append(os.path.join(folder_path, f))
+    for root, _dirs, names in os.walk(folder_path):
+        for f in names:
+            ext = f.rsplit(".", 1)[-1].lower() if "." in f else ""
+            if ext in _AUDIO_EXTS:
+                files.append(os.path.join(root, f))
 
     if not files:
         return AudioValidationResult()

--- a/lib/util.py
+++ b/lib/util.py
@@ -206,6 +206,11 @@ def validate_audio(folder_path: str, mode: str = "normal") -> AudioValidationRes
 
     failed = []
     for filepath in files:
+        # Use the path relative to folder_path so nested layouts (CD1/01.mp3,
+        # CD2/01.mp3) remain distinguishable in failed_files and the error
+        # message — os.path.basename would collapse same-named tracks across
+        # discs into the same entry.
+        display = os.path.relpath(filepath, folder_path)
         try:
             result = sp.run(
                 ["ffmpeg", "-v", "error", "-i", filepath,
@@ -216,7 +221,7 @@ def validate_audio(folder_path: str, mode: str = "normal") -> AudioValidationRes
                 stderr = result.stderr.strip()
                 # FLAC missing MD5: re-encode in place to fix, then re-test
                 if filepath.lower().endswith(".flac") and "cannot check MD5 signature" in stderr:
-                    logger.info(f"AUDIO_CHECK: fixing unset MD5: {os.path.basename(filepath)}")
+                    logger.info(f"AUDIO_CHECK: fixing unset MD5: {display}")
                     fix = sp.run(
                         ["flac", "-f", "--verify", filepath],
                         capture_output=True, text=True, timeout=300,
@@ -233,9 +238,9 @@ def validate_audio(folder_path: str, mode: str = "normal") -> AudioValidationRes
                     else:
                         stderr = f"MD5 fix failed: {fix.stderr.strip()[:150]}"
                 err = stderr[:200]
-                failed.append((os.path.basename(filepath), err))
+                failed.append((display, err))
         except sp.TimeoutExpired:
-            failed.append((os.path.basename(filepath), "ffmpeg timeout"))
+            failed.append((display, "ffmpeg timeout"))
         except FileNotFoundError:
             logger.error("AUDIO_CHECK: ffmpeg not found on PATH — skipping audio validation")
             return AudioValidationResult()

--- a/lib/util.py
+++ b/lib/util.py
@@ -122,23 +122,29 @@ def stage_to_ai(album_data: GrabListEntry, source_path: str, staging_dir: str) -
 # === Audio validation ===
 
 def repair_mp3_headers(folder_path: str) -> None:
-    """Run mp3val -f on all MP3 files to fix header issues before audio validation."""
-    for f in os.listdir(folder_path):
-        if not f.lower().endswith(".mp3"):
-            continue
-        filepath = os.path.join(folder_path, f)
-        try:
-            result = sp.run(["mp3val", "-f", "-nb", filepath],
-                            capture_output=True, text=True, timeout=60)
-            if "FIXED" in result.stdout:
-                logger.info(f"MP3VAL: fixed {f}")
-        except FileNotFoundError:
-            logger.warning("MP3VAL: mp3val not found on PATH — skipping header repair")
-            return
-        except sp.TimeoutExpired:
-            logger.warning(f"MP3VAL: timeout on {f}")
-        except Exception:
-            logger.exception(f"MP3VAL: error on {f}")
+    """Run mp3val -f on all MP3 files to fix header issues before audio validation.
+
+    Walks subdirectories so nested multi-disc layouts are repaired too —
+    must match validate_audio's traversal or fixable header issues inside
+    subdirectories reach ffmpeg unrepaired and falsely reject the import.
+    """
+    for root, _dirs, files in os.walk(folder_path):
+        for f in files:
+            if not f.lower().endswith(".mp3"):
+                continue
+            filepath = os.path.join(root, f)
+            try:
+                result = sp.run(["mp3val", "-f", "-nb", filepath],
+                                capture_output=True, text=True, timeout=60)
+                if "FIXED" in result.stdout:
+                    logger.info(f"MP3VAL: fixed {f}")
+            except FileNotFoundError:
+                logger.warning("MP3VAL: mp3val not found on PATH — skipping header repair")
+                return
+            except sp.TimeoutExpired:
+                logger.warning(f"MP3VAL: timeout on {f}")
+            except Exception:
+                logger.exception(f"MP3VAL: error on {f}")
 
 
 from lib.quality import AUDIO_EXTENSIONS as _AUDIO_EXTS

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -901,6 +901,17 @@ def cmd_manual_import(db, args):
         print(f"  Request {request_id} has no MusicBrainz release ID.")
         return
 
+    # 2. Resolve and verify the path — matches cmd_force_import so a
+    # manual-import can accept the same relative paths (e.g.
+    # "failed_imports/Foo") without requiring the user to pre-absolutize.
+    resolved_path = _resolve_failed_path(path)
+    if not resolved_path:
+        print(f"  Files not found at: {path}")
+        if not os.path.isabs(path):
+            print(f"  (also tried: {', '.join(os.path.join(b, path) for b in SLSKD_DOWNLOAD_DIRS)})")
+        return
+    path = resolved_path
+
     print(f"  Manual import: {req['artist_name']} - {req['album_title']}")
     print(f"  Path: {path}")
     print(f"  MBID: {mbid}")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,8 +1,12 @@
 """Tests for lib/download.py — download processing functions.
 
-Tests _build_download_info, _gather_spectral_context, cancel_and_delete,
-slskd_download_status, downloads_all_done, poll_active_downloads, grab_most_wanted
-(extracted from soularr.py).
+Tests _build_download_info, cancel_and_delete, slskd_download_status,
+downloads_all_done, poll_active_downloads, grab_most_wanted.
+
+Pre-import gate behavior (audio integrity + spectral transcode detection)
+is shared with the force/manual import paths and tested against
+``lib.preimport.run_preimport_gates`` in ``tests/test_force_import_gates.py``
+and ``tests/test_integration_slices.py::TestSpectralPropagationSlice``.
 """
 
 import unittest
@@ -12,13 +16,11 @@ import time
 from datetime import datetime, timezone, timedelta
 from typing import Any, cast
 
-from lib.quality import SpectralContext
 from tests.helpers import (
     make_ctx_with_fake_db,
     make_download_file,
     make_grab_list_entry,
     make_request_row,
-    make_spectral_context,
 )
 from tests.fakes import FakePipelineDB, FakeSlskdAPI
 
@@ -357,148 +359,6 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual(len(result), 0)
-
-
-class TestGatherSpectralContextFunction(unittest.TestCase):
-    """Test the actual _gather_spectral_context function from lib/download."""
-
-    def test_flac_returns_no_check(self):
-        from lib.download import _gather_spectral_context
-        files = [make_download_file(filename="01.flac", isVariableBitRate=False)]
-        album = make_grab_list_entry(files=files, filetype="flac")
-        ctx = _make_ctx()
-        result = _gather_spectral_context(album, "/tmp/folder", ctx)
-        self.assertIsInstance(result, SpectralContext)
-        self.assertFalse(result.needs_check)
-
-    def test_vbr_mp3_returns_no_check(self):
-        from lib.download import _gather_spectral_context
-        files = [make_download_file(isVariableBitRate=True)]
-        album = make_grab_list_entry(files=files, filetype="mp3")
-        ctx = _make_ctx()
-        result = _gather_spectral_context(album, "/tmp/folder", ctx)
-        self.assertFalse(result.needs_check)
-
-    @patch("lib.download.spectral_analyze")
-    def test_cbr_mp3_runs_analysis(self, mock_spectral):
-        from lib.download import _gather_spectral_context
-        mock_spectral.return_value = MagicMock(
-            grade="genuine", estimated_bitrate_kbps=320, suspect_pct=0.0)
-        files = [make_download_file(bitRate=320, isVariableBitRate=False)]
-        album = make_grab_list_entry(files=files, filetype="mp3",
-                                     mb_release_id="")
-        ctx = _make_ctx()
-        result = _gather_spectral_context(album, "/tmp/folder", ctx)
-        self.assertTrue(result.needs_check)
-        self.assertEqual(result.grade, "genuine")
-        self.assertEqual(result.bitrate, 320)
-
-    @patch("lib.download.BeetsDB")
-    @patch("lib.download.spectral_analyze")
-    def test_cbr_mp3_checks_existing(self, mock_spectral, mock_beets_cls):
-        from lib.download import _gather_spectral_context
-        # New download spectral
-        mock_spectral.return_value = MagicMock(
-            grade="suspect", estimated_bitrate_kbps=192, suspect_pct=80.0)
-        # Existing beets album
-        mock_beets = MagicMock()
-        mock_beets.get_album_info.return_value = MagicMock(
-            min_bitrate_kbps=256, album_path="/tmp/existing")
-        mock_beets.__enter__ = MagicMock(return_value=mock_beets)
-        mock_beets.__exit__ = MagicMock(return_value=False)
-        mock_beets_cls.return_value = mock_beets
-
-        files = [make_download_file(bitRate=320, isVariableBitRate=False)]
-        album = make_grab_list_entry(files=files, filetype="mp3")
-        ctx = _make_ctx()
-
-        with patch("os.path.isdir", return_value=True):
-            # Second spectral call for existing files
-            mock_spectral.side_effect = [
-                MagicMock(grade="suspect", estimated_bitrate_kbps=192, suspect_pct=80.0),
-                MagicMock(grade="genuine", estimated_bitrate_kbps=310, suspect_pct=0.0),
-            ]
-            result = _gather_spectral_context(album, "/tmp/folder", ctx)
-
-        self.assertTrue(result.needs_check)
-        self.assertEqual(result.existing_min_bitrate, 256)
-        self.assertEqual(result.existing_spectral_bitrate, 310)
-
-
-class TestApplySpectralDecision(unittest.TestCase):
-    """Tests spectral state propagation via FakePipelineDB."""
-
-    @patch("lib.download.spectral_import_decision", return_value="accept")
-    def test_existing_genuine_state_propagates_none_bitrate(self, _mock_decision):
-        from lib.download import _apply_spectral_decision
-        from tests.fakes import FakePipelineDB
-        from tests.helpers import make_request_row, make_validation_result
-
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(id=1))
-        album = make_grab_list_entry(db_request_id=1, db_source="request")
-        ctx = make_ctx_with_fake_db(fake_db)
-        bv_result = make_validation_result()
-        spec_ctx = make_spectral_context(
-            needs_check=True,
-            grade="genuine",
-            existing_min_bitrate=226,
-            existing_spectral_grade="genuine",
-        )
-
-        _apply_spectral_decision(album, bv_result, spec_ctx, "/tmp/folder", ctx)
-
-        row = fake_db.request(1)
-        self.assertEqual(row["current_spectral_grade"], "genuine")
-        self.assertIsNone(row["current_spectral_bitrate"])
-
-    def test_new_album_transcode_not_rejected_by_self_propagation(self):
-        """A suspect 96kbps download with nothing on disk should not be rejected."""
-        from lib.download import _apply_spectral_decision
-        from tests.fakes import FakePipelineDB
-        from tests.helpers import make_request_row, make_validation_result
-
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(id=1))
-        album = make_grab_list_entry(db_request_id=1, db_source="request")
-        ctx = make_ctx_with_fake_db(fake_db)
-        bv_result = make_validation_result()
-        # Nothing on disk: all existing fields are None
-        spec_ctx = make_spectral_context(
-            needs_check=True,
-            grade="likely_transcode",
-            bitrate=96,
-        )
-
-        _apply_spectral_decision(album, bv_result, spec_ctx, "/tmp/folder", ctx)
-
-        self.assertTrue(bv_result.valid,
-                        "A suspect download with nothing on disk should not be rejected")
-
-    def test_propagation_still_works_when_album_on_disk_lacks_spectral(self):
-        """Album on disk with no spectral adopts download's spectral as current."""
-        from lib.download import _apply_spectral_decision
-        from tests.fakes import FakePipelineDB
-        from tests.helpers import make_request_row, make_validation_result
-
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(id=1))
-        album = make_grab_list_entry(db_request_id=1, db_source="request")
-        ctx = make_ctx_with_fake_db(fake_db)
-        bv_result = make_validation_result()
-        # Album on disk at 256kbps, no spectral data yet
-        spec_ctx = make_spectral_context(
-            needs_check=True,
-            grade="suspect",
-            bitrate=192,
-            existing_min_bitrate=256,
-        )
-
-        _apply_spectral_decision(album, bv_result, spec_ctx, "/tmp/folder", ctx)
-
-        row = fake_db.request(1)
-        self.assertEqual(row["current_spectral_grade"], "suspect")
-        self.assertEqual(row["current_spectral_bitrate"], 192)
 
 
 class TestGrabMostWanted(unittest.TestCase):

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -693,5 +693,121 @@ class TestRepairMp3HeadersRecurses(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+class TestAudioFailuresPreserveSubdirContext(unittest.TestCase):
+    """When validate_audio walks subdirectories, the failed-file list must
+    record the path relative to the audit root so multi-disc layouts don't
+    collapse ``CD1/01.mp3`` and ``CD2/01.mp3`` into the same entry.
+    """
+
+    def test_nested_failures_keep_subdir_in_name(self):
+        import os
+        from unittest.mock import patch
+        from lib.util import validate_audio
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cd1 = os.path.join(tmpdir, "CD1")
+            cd2 = os.path.join(tmpdir, "CD2")
+            os.makedirs(cd1)
+            os.makedirs(cd2)
+            with open(os.path.join(cd1, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            with open(os.path.join(cd2, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            # Both files fail
+            with patch("lib.util.sp.run") as mock_run:
+                from unittest.mock import MagicMock
+                mock_run.return_value = MagicMock(
+                    returncode=1, stderr="Invalid data")
+                result = validate_audio(tmpdir, "normal")
+            names = [name for name, _err in result.failed_files]
+            self.assertIn("CD1/01.mp3", names,
+                          f"CD1 path must survive in failed_files, got {names}")
+            self.assertIn("CD2/01.mp3", names,
+                          f"CD2 path must survive in failed_files, got {names}")
+
+
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestForceImportRepairsBeforeInspection(unittest.TestCase):
+    """Broken MP3 headers can prevent mutagen from reading bitrate_mode,
+    leaving download_is_vbr=None. The spectral gate then treats the folder
+    as CBR and can spectrally reject a VBR album that the auto path would
+    have skipped. ``dispatch_import_from_db`` must repair headers before
+    inspect_local_files so that VBR detection is accurate.
+    """
+
+    def test_repair_runs_before_inspect(self):
+        import os
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123"))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/Test")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True,
+            audio_check_mode="normal")
+
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+            f.write(b"x")
+
+        try:
+            call_order: list[str] = []
+            original_repair = __import__(
+                "lib.util", fromlist=["repair_mp3_headers"]).repair_mp3_headers
+            original_inspect = __import__(
+                "lib.preimport", fromlist=["inspect_local_files"]).inspect_local_files
+
+            def tracking_repair(p):
+                call_order.append("repair")
+                return original_repair(p)
+
+            def tracking_inspect(p):
+                call_order.append("inspect")
+                return original_inspect(p)
+
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.import_dispatch.repair_mp3_headers",
+                       side_effect=tracking_repair), \
+                 patch("lib.import_dispatch.inspect_local_files",
+                       side_effect=tracking_inspect), \
+                 patch("lib.preimport.validate_audio",
+                       return_value=SimpleNamespace(
+                           valid=True, error=None, failed_files=[])), \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result("genuine", None)):
+                ext.run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=_make_stdout(make_import_result(
+                        decision="import", new_min_bitrate=320)),
+                    stderr="")
+                dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1")
+
+            self.assertIn("repair", call_order,
+                          "repair_mp3_headers must run on force-import path")
+            self.assertIn("inspect", call_order,
+                          "inspect_local_files must run on force-import path")
+            self.assertLess(
+                call_order.index("repair"),
+                call_order.index("inspect"),
+                "repair_mp3_headers must run BEFORE inspect_local_files so "
+                "mutagen can read the repaired bitrate_mode")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -1,0 +1,351 @@
+"""Force/manual-import must run the same pre-import gates as auto-import.
+
+RED tests that lock in the contract: force-import and manual-import paths
+may only skip the beets *distance* check. All other pre-import gates
+(audio integrity, spectral transcode detection) run identically.
+
+These tests FAIL against the current code because dispatch_import_from_db
+calls dispatch_import_core directly, bypassing the audio + spectral gates
+that _process_beets_validation runs in the auto path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from lib.beets_db import AlbumInfo
+from lib.config import SoularrConfig
+from tests.fakes import FakePipelineDB
+from tests.helpers import (
+    make_import_result,
+    make_request_row,
+    patch_dispatch_externals,
+)
+from tests.test_integration_slices import _HARNESS, _make_stdout, _mock_beets_db
+
+
+def _import_one_called(mock_run) -> bool:
+    """Did any sp.run call invoke import_one.py (vs mp3val/ffmpeg/etc.)?"""
+    for call in mock_run.call_args_list:
+        cmd = call[0][0] if call[0] else call[1].get("args", [])
+        if any("import_one.py" in str(arg) or arg == "--force" for arg in cmd):
+            return True
+    return False
+
+
+def _analyze_result(grade: str, bitrate: int | None, suspect_pct: float = 0.0,
+                    cliff_count: int = 0):
+    """Build a SimpleNamespace mimicking spectral_check.analyze_album's return."""
+    tracks = [SimpleNamespace(cliff_detected=True) for _ in range(cliff_count)]
+    return SimpleNamespace(
+        grade=grade,
+        estimated_bitrate_kbps=bitrate,
+        suspect_pct=suspect_pct,
+        tracks=tracks,
+    )
+
+
+class TestForceImportRunsSpectralGate(unittest.TestCase):
+    """Force-import must run the spectral gate — not just skip beets distance.
+
+    The live bug: album 903 had existing ~96kbps spectral on disk. A teckdevaz
+    download with ~96kbps spectral was force-imported and replaced the existing
+    copy, because dispatch_import_from_db skipped the spectral gate that the
+    auto path runs in lib/download.py._apply_spectral_decision.
+    """
+
+    def _run_force_import(self, *, download_spectral_grade: str,
+                          download_spectral_bitrate: int | None,
+                          existing_spectral_bitrate: int | None,
+                          existing_min_bitrate: int,
+                          download_bitrate: int = 320,
+                          is_cbr: bool = True):
+        """Common fixture: spin up force-import with controlled spectral outputs."""
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=903,
+            status="manual",
+            mb_release_id="mbid-luce",
+            min_bitrate=existing_min_bitrate,
+            current_spectral_bitrate=existing_spectral_bitrate,
+            current_spectral_grade=(
+                "likely_transcode" if existing_spectral_bitrate else None),
+        ))
+
+        ir = make_import_result(
+            decision="import",
+            new_min_bitrate=download_bitrate,
+            prev_min_bitrate=existing_min_bitrate,
+        )
+        stdout = _make_stdout(ir)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10,
+            min_bitrate_kbps=existing_min_bitrate,
+            avg_bitrate_kbps=existing_min_bitrate,
+            format="MP3", is_cbr=is_cbr,
+            album_path="/Beets/Luce",
+        )
+
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            audio_check_mode="normal",
+        )
+
+        # Build a file so audio_check scans something (real path that exists).
+        tmpdir = tempfile.mkdtemp()
+        import os
+        with open(os.path.join(tmpdir, "01 - track.mp3"), "wb") as f:
+            f.write(b"fake mp3 content")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch(
+                     "lib.preimport.spectral_analyze",
+                     side_effect=[
+                         _analyze_result(
+                             grade=download_spectral_grade,
+                             bitrate=download_spectral_bitrate,
+                             suspect_pct=80.0 if download_spectral_grade
+                             in ("suspect", "likely_transcode") else 0.0,
+                             cliff_count=5 if download_spectral_grade
+                             in ("suspect", "likely_transcode") else 0,
+                         ),
+                         _analyze_result(
+                             grade=(
+                                 "likely_transcode" if existing_spectral_bitrate
+                                 else "genuine"),
+                             bitrate=existing_spectral_bitrate,
+                             suspect_pct=80.0 if existing_spectral_bitrate
+                             else 0.0,
+                         ),
+                     ],
+                 ), \
+                 patch(
+                     "lib.preimport.validate_audio",
+                     return_value=SimpleNamespace(
+                         valid=True, error=None, failed_files=[]),
+                 ), \
+                 patch("os.path.isdir", return_value=True):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                result = dispatch_import_from_db(
+                    db, request_id=903, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="teckdevaz",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        return db, result, ext
+
+    def test_force_import_rejects_transcode_equal_to_existing(self):
+        """Force-import a 96kbps transcode over existing 96kbps transcode → REJECT.
+
+        This reproduces the live bug from album 903. Pre-fix: dispatch_import_core
+        runs, container bitrate (128 vs 96) says "better", import succeeds.
+        Post-fix: spectral gate rejects (96 <= 96) before import_one.py runs.
+        """
+        db, result, ext = self._run_force_import(
+            download_spectral_grade="likely_transcode",
+            download_spectral_bitrate=96,
+            existing_spectral_bitrate=96,
+            existing_min_bitrate=96,
+            download_bitrate=128,
+        )
+
+        self.assertFalse(
+            result.success,
+            "force-import of equivalent spectral transcode must be rejected")
+        self.assertFalse(
+            _import_one_called(ext.run),
+            "import_one.py must NOT run after spectral rejection")
+        row = db.request(903)
+        self.assertNotEqual(
+            row["status"], "imported",
+            "request must not flip to 'imported' on spectral rejection")
+        self.assertEqual(len(db.download_logs), 1)
+        db.assert_log(self, 0, beets_scenario="spectral_reject")
+
+    def test_force_import_denylists_user_on_spectral_reject(self):
+        """Spectral rejection on force-import must denylist the source user
+        with a spectral-scoped reason.
+
+        The auto path writes `reason="spectral: Xkbps <= existing Ykbps"` in
+        _apply_spectral_decision. Force-import must match — today the user
+        gets denylisted only after the file is imported, via the post-import
+        quality gate, with a different reason.
+        """
+        db, _, _ = self._run_force_import(
+            download_spectral_grade="likely_transcode",
+            download_spectral_bitrate=96,
+            existing_spectral_bitrate=96,
+            existing_min_bitrate=96,
+            download_bitrate=128,
+        )
+
+        self.assertEqual(
+            len(db.denylist), 1,
+            "user who supplied the transcode must be denylisted exactly once")
+        entry = db.denylist[0]
+        self.assertEqual(entry.username, "teckdevaz")
+        self.assertEqual(entry.request_id, 903)
+        self.assertIn(
+            "spectral", (entry.reason or "").lower(),
+            f"reason must identify spectral as the cause — got {entry.reason!r}")
+
+    def test_force_import_allows_genuine_spectral(self):
+        """Pre-import gates must NOT over-reject: genuine spectral still imports.
+
+        Guard against the fix becoming too aggressive — a force-import of a
+        genuine file must still make it through.
+        """
+        db, result, ext = self._run_force_import(
+            download_spectral_grade="genuine",
+            download_spectral_bitrate=None,
+            existing_spectral_bitrate=96,
+            existing_min_bitrate=96,
+            download_bitrate=245,
+        )
+
+        self.assertTrue(result.success)
+        self.assertTrue(
+            _import_one_called(ext.run),
+            "import_one.py must run when spectral gate passes")
+        db.assert_log(self, 0, outcome="force_import")
+
+
+class TestForceImportRunsAudioCheck(unittest.TestCase):
+    """Force-import must run the audio corruption check.
+
+    The auto path rejects corrupt audio via validate_audio in
+    _process_beets_validation. Force-import currently skips this entirely,
+    so a corrupt MP3 can be force-imported into beets.
+    """
+
+    def test_force_import_rejects_corrupt_audio(self):
+        """validate_audio returns invalid → force-import must not call import_one.py."""
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123",
+        ))
+
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/Test")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            audio_check_mode="normal",
+        )
+
+        tmpdir = tempfile.mkdtemp()
+        import os
+        with open(os.path.join(tmpdir, "01 - track.mp3"), "wb") as f:
+            f.write(b"corrupt mp3 bytes")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch(
+                     "lib.preimport.validate_audio",
+                     return_value=SimpleNamespace(
+                         valid=False,
+                         error="ffmpeg decode failed: Header missing",
+                         failed_files=[("01 - track.mp3",
+                                        "ffmpeg decode failed")]),
+                 ), \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result("genuine", None)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout="", stderr="")
+                result = dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        self.assertFalse(
+            result.success,
+            "force-import of corrupt audio must fail")
+        self.assertFalse(
+            _import_one_called(ext.run),
+            "import_one.py must NOT run when audio check fails")
+        row = db.request(42)
+        self.assertNotEqual(row["status"], "imported")
+        self.assertEqual(len(db.download_logs), 1)
+        db.assert_log(self, 0, beets_scenario="audio_corrupt")
+
+
+class TestForceImportStillSkipsBeetsDistance(unittest.TestCase):
+    """Regression guard: --force must still bypass the beets distance check.
+
+    Force exists precisely to accept imports that beets would reject on
+    distance. The fix must preserve this while adding the spectral/audio gates.
+    """
+
+    def test_force_flag_still_passed_to_import_one(self):
+        """When all pre-import gates pass, --force is still forwarded."""
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123",
+        ))
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        stdout = _make_stdout(ir)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/Test")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            audio_check_mode="normal",
+        )
+
+        tmpdir = tempfile.mkdtemp()
+        import os
+        with open(os.path.join(tmpdir, "01 - track.mp3"), "wb") as f:
+            f.write(b"ok mp3")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.preimport.validate_audio",
+                       return_value=SimpleNamespace(
+                           valid=True, error=None, failed_files=[])), \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result("genuine", None)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1",
+                )
+
+                cmd = ext.run.call_args[0][0]
+                self.assertIn(
+                    "--force", cmd,
+                    "--force must still be passed to import_one.py")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -1142,5 +1142,61 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
             "existing_spectral must stay None when beets has no album")
 
 
+class TestForceImportRejectsNestedLayout(unittest.TestCase):
+    """Force/manual import must reject nested folder layouts at dispatch
+    rather than letting them pass the gates and fail downstream in the
+    beets harness (which uses os.listdir, not os.walk). Clear failure
+    early > silent misclassification late.
+    """
+
+    def test_nested_layout_rejected_with_clear_detail(self):
+        import os
+        import json
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123"))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/Test")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True,
+            audio_check_mode="off")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cd1 = os.path.join(tmpdir, "CD1")
+            os.makedirs(cd1)
+            with open(os.path.join(cd1, "01.mp3"), "wb") as f:
+                f.write(b"fake")
+
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout="", stderr="")
+                result = dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1")
+
+            self.assertFalse(result.success,
+                             "nested layout must be rejected")
+            self.assertFalse(
+                _import_one_called(ext.run),
+                "import_one.py must NOT run when nested layout is detected")
+            self.assertEqual(len(db.download_logs), 1)
+            db.assert_log(self, 0, beets_scenario="nested_layout")
+            vr = json.loads(db.download_logs[0].validation_result or "{}")
+            self.assertEqual(vr.get("scenario"), "nested_layout")
+            self.assertIn("subdir", (vr.get("detail") or "").lower())
+            self.assertEqual(vr.get("failed_path"), tmpdir,
+                             "failed_path must round-trip for debug/retry")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -984,41 +984,162 @@ class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
         self.assertEqual(result.scenario, "spectral_reject")
 
 
-class TestUnknownVbrSkipsSpectralGate(unittest.TestCase):
-    """When VBR status is unknown (mutagen couldn't read bitrate_mode), the
-    spectral gate must be skipped. Treating unknown as confirmed CBR would
-    falsely reject VBR uploads with damaged headers on the force/manual path.
-    The auto path gets is_vbr from slskd metadata (usually reliable), so the
-    common case still runs; this only affects the unknown-mode edge case.
+class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
+    """When the caller passes ``is_vbr=None`` (auto-path resumed download
+    or force-path mutagen failure), the gate must attempt to resolve VBR
+    via filesystem inspection before deciding whether to run spectral.
+    Skipping spectral unconditionally on None was a bypass for resumed CBR
+    MP3 downloads rebuilt from ``ActiveDownloadState`` — the auto path's
+    protection must not depend on slskd metadata being preserved.
     """
 
-    def test_is_vbr_none_skips_spectral(self):
+    def test_auto_path_resumed_download_reinspects_to_keep_spectral(self):
+        """is_vbr=None → filesystem inspection fills it in → spectral runs."""
+        import os
+        from unittest.mock import patch
         from lib.config import SoularrConfig
-        from lib.preimport import run_preimport_gates
+        from lib.preimport import run_preimport_gates, LocalFileInspection
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
         cfg = SoularrConfig(audio_check_mode="off")
 
-        with patch("lib.preimport.spectral_analyze") as mock_spectral:
-            result = run_preimport_gates(
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            inspected = LocalFileInspection(
+                filetype="mp3", min_bitrate_bps=320_000, is_vbr=False)
+            with patch("lib.preimport.inspect_local_files",
+                       return_value=inspected), \
+                 patch("lib.preimport.spectral_analyze") as mock_spectral:
+                mock_spectral.return_value = SimpleNamespace(
+                    grade="genuine", estimated_bitrate_kbps=None,
+                    suspect_pct=0.0, tracks=[])
+                run_preimport_gates(
+                    path=tmpdir,
+                    mb_release_id="",
+                    label="Test",
+                    download_filetype="mp3",
+                    download_min_bitrate_bps=None,
+                    download_is_vbr=None,   # simulates resumed download
+                    cfg=cfg,
+                    db=db,  # type: ignore[arg-type]
+                    request_id=1,
+                    usernames=set(),
+                )
+            self.assertEqual(
+                mock_spectral.call_count, 1,
+                "resumed download with mp3 files on disk must still get "
+                "spectral gating after inspection resolves is_vbr=False")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_unresolvable_vbr_still_gates(self):
+        """is_vbr=None AND inspection also returns None → still gate.
+
+        The conservative default: genuine VBR uploads produce 'genuine'
+        spectral grades and fall through to import; forcing a genuine-VBR
+        upload through the gate is cheap and safe.
+        """
+        from unittest.mock import patch
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates, LocalFileInspection
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch("lib.preimport.inspect_local_files",
+                   return_value=LocalFileInspection(
+                       filetype="mp3", is_vbr=None)), \
+             patch("lib.preimport.spectral_analyze") as mock_spectral:
+            mock_spectral.return_value = SimpleNamespace(
+                grade="genuine", estimated_bitrate_kbps=None,
+                suspect_pct=0.0, tracks=[])
+            run_preimport_gates(
                 path="/tmp/dl",
                 mb_release_id="",
                 label="Test",
                 download_filetype="mp3",
                 download_min_bitrate_bps=None,
-                download_is_vbr=None,   # mutagen couldn't determine
+                download_is_vbr=None,
                 cfg=cfg,
                 db=db,  # type: ignore[arg-type]
                 request_id=1,
                 usernames=set(),
             )
-
-        self.assertTrue(result.valid,
-                        "unknown VBR status must not reject at the gate")
         self.assertEqual(
-            mock_spectral.call_count, 0,
-            "spectral_analyze must NOT run when VBR status is unknown")
+            mock_spectral.call_count, 1,
+            "still gate when inspection can't resolve VBR; genuine grade "
+            "falls through to import")
+
+
+class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
+    """When BeetsDB returns no album at all (deleted, not yet imported, or
+    lookup failed), the preimport gate must NOT fabricate 'existing' state
+    from stale album_requests.min_bitrate — doing so would reject a valid
+    redownload against state that doesn't exist on disk.
+    """
+
+    def test_no_beets_album_means_no_fallback(self):
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        # Request row has leftover state from a prior import that no longer
+        # exists in beets (user deleted it, beets DB corrupt, etc.).
+        db.seed_request(make_request_row(
+            id=42,
+            min_bitrate=192,
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=128,
+        ))
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        # BeetsDB returns None → album not in beets.
+        def _mock_beets_db_no_album():
+            mock_beets = MagicMock()
+            mock_beets.get_album_info.return_value = None
+            mock_cls = MagicMock()
+            mock_cls.return_value.__enter__ = MagicMock(return_value=mock_beets)
+            mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+            return mock_cls
+
+        # Download: suspect 192kbps. If the fallback (incorrectly) fired,
+        # it would set existing_min from stale min_bitrate=192 and
+        # existing_spectral from stale 128 → reject 192 <= 192. With the
+        # fallback correctly skipped (beets has no album → nothing on disk),
+        # decision should "import_no_exist" (suspect but nothing on disk).
+        with patch("lib.preimport.spectral_analyze",
+                   return_value=_analyze_result(
+                       "likely_transcode", 192, 80.0, 5)), \
+             patch("lib.beets_db.BeetsDB", _mock_beets_db_no_album()):
+            result = run_preimport_gates(
+                path="/tmp/dl",
+                mb_release_id="mbid-123",
+                label="Test",
+                download_filetype="mp3",
+                download_min_bitrate_bps=192_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames=set(),
+                propagate_download_to_existing=False,
+            )
+
+        self.assertTrue(
+            result.valid,
+            "redownload of a deleted album must not self-reject against "
+            "stale album_requests.min_bitrate")
+        self.assertIsNone(
+            result.existing_min_bitrate,
+            "existing_min_bitrate must stay None when beets has no album")
+        self.assertIsNone(
+            result.existing_spectral,
+            "existing_spectral must stay None when beets has no album")
 
 
 if __name__ == "__main__":

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -371,6 +371,68 @@ class TestInspectLocalFilesRecursive(unittest.TestCase):
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
 
+    def test_validate_audio_recurses_into_subdirs(self):
+        """validate_audio must walk subdirectories so nested discs are decoded.
+
+        Auto path always passes flat folders, but force/manual-import can point
+        at user folders with ``Album/CD1/*.mp3``. If validate_audio only lists
+        the root, no nested file is decoded and corrupt audio silently passes.
+        """
+        import os
+        from lib.util import validate_audio
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cd1 = os.path.join(tmpdir, "CD1")
+            os.makedirs(cd1)
+            with open(os.path.join(cd1, "01.mp3"), "wb") as f:
+                f.write(b"bad mp3 bytes")
+            result = validate_audio(tmpdir, "normal")
+            self.assertFalse(
+                result.valid,
+                "nested corrupt MP3 must trigger audio rejection")
+            self.assertTrue(
+                any("01.mp3" in name for name, _ in result.failed_files),
+                f"failed_files must include the nested file, got {result.failed_files}")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_analyze_album_recurses_into_subdirs(self):
+        """analyze_album must walk subdirectories so nested discs are analyzed.
+
+        Without recursion, a multi-disc folder returns an empty result that
+        looks like 'genuine' (no tracks = no cliffs), and the spectral gate
+        silently passes a potential transcode on force/manual-import.
+        """
+        import os
+        from unittest.mock import patch
+        from lib.spectral_check import analyze_album
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cd1 = os.path.join(tmpdir, "CD1")
+            os.makedirs(cd1)
+            with open(os.path.join(cd1, "01.mp3"), "wb") as f:
+                f.write(b"fake")
+            with patch("lib.spectral_check.analyze_track") as mock_track:
+                mock_track.return_value = SimpleNamespace(
+                    grade="suspect", error=None,
+                    estimated_bitrate_kbps=128,
+                    cliff_detected=True, cliff_freq_hz=12000,
+                )
+                _ = analyze_album(tmpdir)
+            self.assertEqual(
+                mock_track.call_count, 1,
+                "analyze_album must reach the nested file (call_count=0 means "
+                "it only listed the root)")
+            called_path = mock_track.call_args[0][0]
+            self.assertIn("CD1", called_path,
+                          "analyze_album must call analyze_track with the nested path")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
 
 class TestForceImportSplitsMultiUserSources(unittest.TestCase):
     """download_log.soulseek_username can be a comma-joined list

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -551,5 +551,147 @@ class TestPreimportRejectionPreservesCorruptFiles(unittest.TestCase):
         self.assertIn("02 - track.mp3", vr.get("corrupt_files", []))
 
 
+class TestForceImportDoesNotCorruptSpectralStateOnFailure(unittest.TestCase):
+    """Force/manual import must NOT propagate the download's spectral into
+    on-disk state speculatively: if ``dispatch_import_core`` later fails
+    (downgrade, no JSON, timeout), the DB would otherwise be left claiming
+    the failed download is on-disk, skewing later override/gate decisions.
+
+    Only the MEASURED existing spectral (from beets) is persisted during the
+    preimport gate. The propagation shortcut is reserved for the auto path.
+    """
+
+    def test_propagation_skipped_when_existing_unmeasured(self):
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123",
+            min_bitrate=192,                   # something IS on disk
+            current_spectral_grade=None,       # but no measured spectral yet
+            current_spectral_bitrate=None,
+        ))
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        stdout = _make_stdout(ir)
+        # Existing album exists but album_path is not on disk — beets returns
+        # info without a walkable path, so no EXISTING spectral is measured.
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=192,
+            avg_bitrate_kbps=192, format="MP3", is_cbr=True,
+            album_path="/Beets/NonexistentPath")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True,
+            audio_check_mode="normal",
+        )
+        tmpdir = tempfile.mkdtemp()
+        import os
+        with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+            f.write(b"x")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.preimport.validate_audio",
+                       return_value=SimpleNamespace(
+                           valid=True, error=None, failed_files=[])), \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result(
+                           "likely_transcode", 96, 80.0, 5)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        row = db.request(42)
+        # On the force/manual path the download's spectral must NOT be written
+        # as "current" even though min_bitrate is set. Existing spectral
+        # stays None because /Beets/NonexistentPath isn't walkable.
+        self.assertIsNone(
+            row["current_spectral_grade"],
+            "force-import preimport must not speculatively propagate download spectral")
+        self.assertIsNone(row["current_spectral_bitrate"])
+
+
+class TestAutoPathPreservesSpectralPropagation(unittest.TestCase):
+    """The auto path still propagates: run_preimport_gates with
+    propagate_download_to_existing=True (the default) adopts the download's
+    spectral as current when min_bitrate is set but spectral is unmeasured.
+    """
+
+    def test_auto_path_propagates_download_spectral(self):
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, min_bitrate=256,
+            current_spectral_grade=None, current_spectral_bitrate=None,
+        ))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=256,
+            avg_bitrate_kbps=256, format="MP3", is_cbr=True,
+            album_path="/Beets/NonexistentPath")
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch("lib.preimport.spectral_analyze",
+                   return_value=_analyze_result("suspect", 192, 80.0, 5)), \
+             patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+            run_preimport_gates(
+                path="/tmp/dl",
+                mb_release_id="mbid-123",
+                label="Test",
+                download_filetype="mp3",
+                download_min_bitrate_bps=320_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=1,
+                usernames=set(),
+                # Default is True — auto path preserves propagation.
+            )
+
+        row = db.request(1)
+        self.assertEqual(
+            row["current_spectral_grade"], "suspect",
+            "auto path must propagate download spectral when existing unmeasured")
+        self.assertEqual(row["current_spectral_bitrate"], 192)
+
+
+class TestRepairMp3HeadersRecurses(unittest.TestCase):
+    """repair_mp3_headers must walk subdirectories — otherwise nested MP3s
+    with fixable header issues reach ffmpeg unrepaired and falsely reject.
+    """
+
+    def test_mp3val_called_on_nested_file(self):
+        import os
+        from unittest.mock import patch, MagicMock
+        from lib.util import repair_mp3_headers
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cd1 = os.path.join(tmpdir, "CD1")
+            os.makedirs(cd1)
+            nested = os.path.join(cd1, "01.mp3")
+            with open(nested, "wb") as f:
+                f.write(b"fake")
+            with patch("lib.util.sp.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
+                repair_mp3_headers(tmpdir)
+            called_paths = [c[0][0][-1] for c in mock_run.call_args_list]
+            self.assertTrue(
+                any(nested == p for p in called_paths),
+                f"mp3val must be called on nested {nested}, got {called_paths}")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -1182,12 +1182,21 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
             "existing_spectral must stay None when beets has no album")
 
 
-class TestGateRejectionPreservesOutcomeLabel(unittest.TestCase):
-    """Gate-rejected force/manual imports must keep their outcome tag
-    (``force_import``/``manual_import``) in ``download_log.outcome`` so SQL
-    queries can filter by source. Previously the rejection path wrote a
-    generic ``"rejected"``, which made it impossible to tell a gate-rejected
-    force-import from any other rejection after the fact.
+class TestGateRejectionWritesRejectedOutcome(unittest.TestCase):
+    """Gate-rejected force/manual imports must write
+    ``download_log.outcome='rejected'`` — NOT ``force_import``/``manual_import``.
+
+    The UI's "imported" counter (``web/routes/pipeline.py``) and the
+    ``get_log(outcome_filter='imported')`` query (``lib/pipeline_db.py``) both
+    treat ``outcome='force_import'`` as a successful import. Per CLAUDE.md,
+    ``force_import``/``manual_import`` are reserved for SUCCESSFUL imports;
+    any rejection (including gate rejections) must write ``outcome='rejected'``
+    or the UI mis-counts the failed import as imported.
+
+    Source attribution on rejections is available via other columns:
+    ``soulseek_username``, the surrounding ``album_requests`` row, and
+    ``beets_scenario`` (e.g. ``spectral_reject``, ``audio_corrupt``,
+    ``nested_layout``).
     """
 
     def _run_audio_corrupt_reject(self, *, force: bool):
@@ -1231,17 +1240,22 @@ class TestGateRejectionPreservesOutcomeLabel(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
         return db
 
-    def test_force_import_gate_reject_writes_force_import_outcome(self):
+    def test_force_import_gate_reject_writes_rejected_outcome(self):
         db = self._run_audio_corrupt_reject(force=True)
         self.assertEqual(len(db.download_logs), 1)
-        db.assert_log(self, 0, outcome="force_import",
-                      beets_scenario="audio_corrupt")
+        # outcome MUST be "rejected" — NOT "force_import" — so the UI's
+        # "imported" counter and /api/pipeline/log's imported filter stay
+        # consistent with album_requests.status.
+        db.assert_log(self, 0, outcome="rejected",
+                      beets_scenario="audio_corrupt",
+                      soulseek_username="u1")
 
-    def test_manual_import_gate_reject_writes_manual_import_outcome(self):
+    def test_manual_import_gate_reject_writes_rejected_outcome(self):
         db = self._run_audio_corrupt_reject(force=False)
         self.assertEqual(len(db.download_logs), 1)
-        db.assert_log(self, 0, outcome="manual_import",
-                      beets_scenario="audio_corrupt")
+        db.assert_log(self, 0, outcome="rejected",
+                      beets_scenario="audio_corrupt",
+                      soulseek_username="u1")
 
 
 class TestForceImportRejectsNestedLayout(unittest.TestCase):

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -347,5 +347,147 @@ class TestForceImportStillSkipsBeetsDistance(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+class TestInspectLocalFilesRecursive(unittest.TestCase):
+    """inspect_local_files() must walk subdirectories so multi-disc layouts
+    (``Album/CD1/*.mp3``) classify correctly — otherwise the spectral gate
+    silently skips nested manual/force imports.
+    """
+
+    def test_multi_disc_layout_detects_mp3(self):
+        """Audio files under a subdirectory must be discovered."""
+        import os
+        from lib.preimport import inspect_local_files
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cd1 = os.path.join(tmpdir, "CD1")
+            os.makedirs(cd1)
+            with open(os.path.join(cd1, "01 - track.mp3"), "wb") as f:
+                f.write(b"fake")
+            inspection = inspect_local_files(tmpdir)
+            self.assertIn("mp3", inspection.filetype,
+                          "subdirectory MP3 must be discovered")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestForceImportSplitsMultiUserSources(unittest.TestCase):
+    """download_log.soulseek_username can be a comma-joined list
+    (``"disc1user, disc2user"``) when the download pulled from multiple peers.
+    The preimport denylist must block each real peer, not the literal string.
+    """
+
+    def test_comma_separated_usernames_split_before_denylist(self):
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=903, status="manual", mb_release_id="mbid-luce",
+            min_bitrate=96, current_spectral_bitrate=96,
+            current_spectral_grade="likely_transcode",
+        ))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=96,
+            avg_bitrate_kbps=96, format="MP3", is_cbr=True,
+            album_path="/Beets/Luce")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True, audio_check_mode="normal",
+        )
+        tmpdir = tempfile.mkdtemp()
+        import os
+        with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+            f.write(b"x")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.preimport.validate_audio",
+                       return_value=SimpleNamespace(
+                           valid=True, error=None, failed_files=[])), \
+                 patch("lib.preimport.spectral_analyze",
+                       side_effect=[
+                           _analyze_result("likely_transcode", 96, 80.0, 5),
+                           _analyze_result("likely_transcode", 96, 80.0, 5),
+                       ]), \
+                 patch("os.path.isdir", return_value=True):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout="", stderr="")
+                dispatch_import_from_db(
+                    db, request_id=903, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True,
+                    source_username="disc1user, disc2user",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        usernames = {e.username for e in db.denylist}
+        self.assertIn("disc1user", usernames)
+        self.assertIn("disc2user", usernames)
+        self.assertNotIn("disc1user, disc2user", usernames,
+                         "must not denylist the literal combined string")
+
+
+class TestPreimportRejectionPreservesCorruptFiles(unittest.TestCase):
+    """Audio-corrupt rejection in the preimport path must preserve the list of
+    corrupt files in ``download_log.validation_result`` for debuggability — the
+    auto path preserves this, force/manual must match.
+    """
+
+    def test_corrupt_files_land_in_validation_result_jsonb(self):
+        import json
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123",
+        ))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/Test")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True,
+            audio_check_mode="normal",
+        )
+        tmpdir = tempfile.mkdtemp()
+        import os
+        with open(os.path.join(tmpdir, "01 - track.mp3"), "wb") as f:
+            f.write(b"bad")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.preimport.validate_audio",
+                       return_value=SimpleNamespace(
+                           valid=False,
+                           error="ffmpeg decode failed",
+                           failed_files=[
+                               ("01 - track.mp3", "ffmpeg decode failed"),
+                               ("02 - track.mp3", "Header missing"),
+                           ])), \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result("genuine", None)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout="", stderr="")
+                dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="user1",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        self.assertEqual(len(db.download_logs), 1)
+        vr = json.loads(db.download_logs[0].validation_result or "{}")
+        self.assertEqual(vr.get("scenario"), "audio_corrupt")
+        self.assertIn("01 - track.mp3", vr.get("corrupt_files", []))
+        self.assertIn("02 - track.mp3", vr.get("corrupt_files", []))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -103,10 +103,21 @@ class TestForceImportRunsSpectralGate(unittest.TestCase):
         with open(os.path.join(tmpdir, "01 - track.mp3"), "wb") as f:
             f.write(b"fake mp3 content")
 
+        # Patch inspect_local_files so tests don't depend on mutagen reading
+        # fake-byte MP3 files. Real files would be real CBR/VBR; tests
+        # simulate whatever the scenario requires.
+        from lib.preimport import LocalFileInspection
+        inspection_result = LocalFileInspection(
+            filetype="mp3",
+            min_bitrate_bps=download_bitrate * 1000,
+            is_vbr=not is_cbr,
+        )
         try:
             with patch_dispatch_externals() as ext, \
                  patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
                  patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.import_dispatch.inspect_local_files",
+                       return_value=inspection_result), \
                  patch(
                      "lib.preimport.spectral_analyze",
                      side_effect=[
@@ -462,10 +473,16 @@ class TestForceImportSplitsMultiUserSources(unittest.TestCase):
         with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
             f.write(b"x")
 
+        from lib.preimport import LocalFileInspection
+        inspection = LocalFileInspection(
+            filetype="mp3", min_bitrate_bps=320_000, is_vbr=False)
+
         try:
             with patch_dispatch_externals() as ext, \
                  patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
                  patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.import_dispatch.inspect_local_files",
+                       return_value=inspection), \
                  patch("lib.preimport.validate_audio",
                        return_value=SimpleNamespace(
                            valid=True, error=None, failed_files=[])), \
@@ -589,10 +606,16 @@ class TestForceImportDoesNotCorruptSpectralStateOnFailure(unittest.TestCase):
         with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
             f.write(b"x")
 
+        from lib.preimport import LocalFileInspection
+        inspection = LocalFileInspection(
+            filetype="mp3", min_bitrate_bps=320_000, is_vbr=False)
+
         try:
             with patch_dispatch_externals() as ext, \
                  patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
                  patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.import_dispatch.inspect_local_files",
+                       return_value=inspection), \
                  patch("lib.preimport.validate_audio",
                        return_value=SimpleNamespace(
                            valid=True, error=None, failed_files=[])), \
@@ -902,6 +925,100 @@ class TestPreimportRepairsEvenWhenAudioCheckOff(unittest.TestCase):
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
+    """The persisted-spectral fallback must be grade-aware: a stored
+    ``current_spectral_grade='genuine', current_spectral_bitrate=96`` is
+    stale (genuine files have no cliff). Feeding that 96 kbps into
+    spectral_import_decision would let real transcodes be imported as
+    "upgrades". Matches compute_effective_override_bitrate and
+    load_quality_gate_state — only transcode grades are authoritative.
+    """
+
+    def test_genuine_stored_spectral_ignored(self):
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        # Stored grade=genuine, bitrate=96 — a stale leftover from prior runs.
+        # Not a transcode grade, so the bitrate must NOT be used as authoritative.
+        db.seed_request(make_request_row(
+            id=42,
+            min_bitrate=320,
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=96,
+        ))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/NonexistentPath")
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        # Download is a suspect 192kbps transcode. If the fallback used the
+        # stored grade=genuine/bitrate=96 verbatim, 192 > 96 would wrongly
+        # import the transcode. With grade-aware handling, the 96 is ignored
+        # and decision falls back to min_bitrate=320 → reject.
+        with patch("lib.preimport.spectral_analyze",
+                   return_value=_analyze_result(
+                       "likely_transcode", 192, 80.0, 5)), \
+             patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+            result = run_preimport_gates(
+                path="/tmp/dl",
+                mb_release_id="mbid-123",
+                label="Test",
+                download_filetype="mp3",
+                download_min_bitrate_bps=192_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames=set(),
+                propagate_download_to_existing=False,
+            )
+
+        self.assertFalse(
+            result.valid,
+            "stale genuine stored spectral must not be used to import a 192kbps "
+            "transcode over a 320kbps on-disk album")
+        self.assertEqual(result.scenario, "spectral_reject")
+
+
+class TestUnknownVbrSkipsSpectralGate(unittest.TestCase):
+    """When VBR status is unknown (mutagen couldn't read bitrate_mode), the
+    spectral gate must be skipped. Treating unknown as confirmed CBR would
+    falsely reject VBR uploads with damaged headers on the force/manual path.
+    The auto path gets is_vbr from slskd metadata (usually reliable), so the
+    common case still runs; this only affects the unknown-mode edge case.
+    """
+
+    def test_is_vbr_none_skips_spectral(self):
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch("lib.preimport.spectral_analyze") as mock_spectral:
+            result = run_preimport_gates(
+                path="/tmp/dl",
+                mb_release_id="",
+                label="Test",
+                download_filetype="mp3",
+                download_min_bitrate_bps=None,
+                download_is_vbr=None,   # mutagen couldn't determine
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=1,
+                usernames=set(),
+            )
+
+        self.assertTrue(result.valid,
+                        "unknown VBR status must not reject at the gate")
+        self.assertEqual(
+            mock_spectral.call_count, 0,
+            "spectral_analyze must NOT run when VBR status is unknown")
 
 
 if __name__ == "__main__":

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -48,6 +48,46 @@ def _analyze_result(grade: str, bitrate: int | None, suspect_pct: float = 0.0,
     )
 
 
+class TestNeedsSpectralCheckDecisions(unittest.TestCase):
+    """Pure-function coverage for ``_needs_spectral_check``.
+
+    The equivalent tests used to live on the deleted
+    ``TestGatherSpectralContextFunction`` (flac skips, VBR skips, CBR runs).
+    Keeping them as pure input/output assertions here so the auto path's
+    branch-selection logic stays covered without re-introducing the old
+    SpectralContext plumbing.
+    """
+
+    def test_flac_skips(self):
+        from lib.preimport import _needs_spectral_check
+        self.assertFalse(_needs_spectral_check("flac", False))
+        self.assertFalse(_needs_spectral_check("flac", None))
+        self.assertFalse(_needs_spectral_check("flac", True))
+
+    def test_vbr_mp3_skips(self):
+        from lib.preimport import _needs_spectral_check
+        self.assertFalse(_needs_spectral_check("mp3", True))
+
+    def test_cbr_mp3_runs(self):
+        from lib.preimport import _needs_spectral_check
+        self.assertTrue(_needs_spectral_check("mp3", False))
+
+    def test_unknown_vbr_mp3_runs_gate_by_default(self):
+        """is_vbr=None routes through the gate — run_preimport_gates resolves
+        VBR via filesystem inspection before reaching this helper."""
+        from lib.preimport import _needs_spectral_check
+        self.assertTrue(_needs_spectral_check("mp3", None))
+
+    def test_mixed_mp3_flac_skips(self):
+        """Filetype containing both 'flac' and 'mp3' is treated as non-MP3."""
+        from lib.preimport import _needs_spectral_check
+        self.assertFalse(_needs_spectral_check("flac, mp3", False))
+
+    def test_empty_filetype_skips(self):
+        from lib.preimport import _needs_spectral_check
+        self.assertFalse(_needs_spectral_check("", False))
+
+
 class TestForceImportRunsSpectralGate(unittest.TestCase):
     """Force-import must run the spectral gate — not just skip beets distance.
 

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -1142,6 +1142,68 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
             "existing_spectral must stay None when beets has no album")
 
 
+class TestGateRejectionPreservesOutcomeLabel(unittest.TestCase):
+    """Gate-rejected force/manual imports must keep their outcome tag
+    (``force_import``/``manual_import``) in ``download_log.outcome`` so SQL
+    queries can filter by source. Previously the rejection path wrote a
+    generic ``"rejected"``, which made it impossible to tell a gate-rejected
+    force-import from any other rejection after the fact.
+    """
+
+    def _run_audio_corrupt_reject(self, *, force: bool):
+        import os as _os
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", mb_release_id="mbid-123"))
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/Test")
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True,
+            audio_check_mode="normal")
+
+        tmpdir = tempfile.mkdtemp()
+        with open(_os.path.join(tmpdir, "01.mp3"), "wb") as f:
+            f.write(b"x")
+
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch("lib.preimport.validate_audio",
+                       return_value=SimpleNamespace(
+                           valid=False, error="decode failed",
+                           failed_files=[("01.mp3", "decode failed")])), \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result("genuine", None)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout="", stderr="")
+                dispatch_import_from_db(
+                    db, request_id=42, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=force,
+                    outcome_label="force_import" if force else "manual_import",
+                    source_username="u1")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        return db
+
+    def test_force_import_gate_reject_writes_force_import_outcome(self):
+        db = self._run_audio_corrupt_reject(force=True)
+        self.assertEqual(len(db.download_logs), 1)
+        db.assert_log(self, 0, outcome="force_import",
+                      beets_scenario="audio_corrupt")
+
+    def test_manual_import_gate_reject_writes_manual_import_outcome(self):
+        db = self._run_audio_corrupt_reject(force=False)
+        self.assertEqual(len(db.download_logs), 1)
+        db.assert_log(self, 0, outcome="manual_import",
+                      beets_scenario="audio_corrupt")
+
+
 class TestForceImportRejectsNestedLayout(unittest.TestCase):
     """Force/manual import must reject nested folder layouts at dispatch
     rather than letting them pass the gates and fail downstream in the

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -809,5 +809,100 @@ class TestForceImportRepairsBeforeInspection(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+class TestPreimportFallsBackToPersistedSpectral(unittest.TestCase):
+    """When BeetsDB can't walk the on-disk album_path (stale/missing), the
+    gate must fall back to the spectral state already stored on
+    album_requests. Otherwise spectral_import_decision compares against
+    existing_min_bitrate (container) and can reject a genuine upgrade —
+    e.g. 192kbps transcode rejected as <= 320 even though
+    current_spectral_bitrate says the on-disk copy is only 128kbps.
+    """
+
+    def test_stored_spectral_used_when_beets_lookup_empty(self):
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        # Request row has stored spectral: on-disk is actually a 128 transcode,
+        # even though beets reports 320 as the container min_bitrate.
+        db.seed_request(make_request_row(
+            id=42,
+            min_bitrate=320,
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=128,
+        ))
+        # Beets knows the album exists at 320 but its album_path is not on
+        # disk, so _analyze_existing returns (320, None) — no measured spectral.
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3", is_cbr=True,
+            album_path="/Beets/NonexistentPath")
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch("lib.preimport.spectral_analyze",
+                   return_value=_analyze_result(
+                       "likely_transcode", 192, 80.0, 5)), \
+             patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+            result = run_preimport_gates(
+                path="/tmp/dl",
+                mb_release_id="mbid-123",
+                label="Test",
+                download_filetype="mp3",
+                download_min_bitrate_bps=192_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames=set(),
+                propagate_download_to_existing=False,
+            )
+
+        # With stored spectral fallback, the decision compares
+        # new_spectral=192kbps vs stored_existing_spectral=128kbps → import.
+        # Without the fallback it compares 192 vs min_bitrate=320 → reject.
+        self.assertTrue(
+            result.valid,
+            "192kbps upgrade over 128kbps-spectral existing must not be rejected")
+
+
+class TestPreimportRepairsEvenWhenAudioCheckOff(unittest.TestCase):
+    """MP3 header repair must run regardless of audio_check_mode — installs
+    that disable ffmpeg validation still rely on mp3val to fix fixable
+    header issues before spectral analysis and the import subprocess.
+    Matches the pre-refactor auto-path behavior.
+    """
+
+    def test_repair_runs_with_audio_check_off(self):
+        import os
+        from unittest.mock import patch
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        cfg = SoularrConfig(audio_check_mode="off")
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            with patch("lib.preimport.repair_mp3_headers") as mock_repair, \
+                 patch("lib.preimport.spectral_analyze",
+                       return_value=_analyze_result("genuine", None)):
+                run_preimport_gates(
+                    path=tmpdir,
+                    mb_release_id="",  # skip existing lookup
+                    label="Test",
+                    download_filetype="mp3",
+                    download_min_bitrate_bps=None,
+                    download_is_vbr=None,
+                    cfg=cfg,
+                    usernames=set(),
+                )
+            self.assertEqual(
+                mock_repair.call_count, 1,
+                "repair_mp3_headers must run even with audio_check_mode=off")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -24,12 +24,8 @@ from lib.quality import (
 )
 from tests.fakes import FakePipelineDB
 from tests.helpers import (
-    make_ctx_with_fake_db,
-    make_download_file,
-    make_grab_list_entry,
     make_import_result,
     make_request_row,
-    make_validation_result,
     patch_dispatch_externals,
 )
 
@@ -414,27 +410,21 @@ class TestQualityGateSpectralOverride(unittest.TestCase):
 
 
 class TestSpectralPropagationSlice(unittest.TestCase):
-    """Integration slice: gather spectral context then apply real decision."""
+    """Integration slice: shared run_preimport_gates updates spectral state + denylists.
+
+    Exercises the pre-import gate pipeline that both the auto-import path
+    (lib.download._process_beets_validation) and the force/manual-import path
+    (lib.import_dispatch.dispatch_import_from_db) delegate to. Proves the
+    function does its side effects — spectral state write + denylist —
+    consistently regardless of caller.
+    """
 
     def test_suspect_download_updates_current_spectral_and_denylists(self):
-        from lib.download import _apply_spectral_decision, _gather_spectral_context
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
-        ctx = make_ctx_with_fake_db(db)
-        album = make_grab_list_entry(
-            db_request_id=42,
-            mb_release_id="mbid-123",
-            files=[make_download_file(
-                filename="user1\\Music\\01 - Track.mp3",
-                file_dir="user1\\Music",
-                username="user1",
-                bitRate=320,
-                isVariableBitRate=False,
-            )],
-            filetype="mp3",
-        )
-        bv_result = make_validation_result()
         beets_info = AlbumInfo(
             album_id=1,
             track_count=10,
@@ -444,39 +434,46 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             is_cbr=True,
             album_path="/Beets/Test",
         )
+        cfg = SoularrConfig(audio_check_mode="off")
 
         with patch(
-            "lib.download.spectral_analyze",
+            "lib.preimport.spectral_analyze",
             side_effect=[
                 SimpleNamespace(
                     grade="suspect",
                     estimated_bitrate_kbps=128,
                     suspect_pct=90.0,
+                    tracks=[],
                 ),
                 SimpleNamespace(
                     grade="genuine",
                     estimated_bitrate_kbps=320,
                     suspect_pct=0.0,
+                    tracks=[],
                 ),
             ],
-        ), patch("lib.download.BeetsDB", _mock_beets_db(beets_info)), \
+        ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
              patch("os.path.isdir", return_value=True):
-            spec_ctx = _gather_spectral_context(album, "/tmp/download", ctx)
             with self.assertLogs("soularr", level="WARNING") as logs:
-                _apply_spectral_decision(
-                    album,
-                    bv_result,
-                    spec_ctx,
-                    "/tmp/download",
-                    ctx,
+                result = run_preimport_gates(
+                    path="/tmp/download",
+                    mb_release_id="mbid-123",
+                    label="Test Artist - Test Album",
+                    download_filetype="mp3",
+                    download_min_bitrate_bps=320_000,
+                    download_is_vbr=False,
+                    cfg=cfg,
+                    db=db,  # type: ignore[arg-type]
+                    request_id=42,
+                    usernames={"user1"},
                 )
 
         row = db.request(42)
         self.assertIn("SPECTRAL REJECT", "\n".join(logs.output))
         self.assertEqual(row["current_spectral_grade"], "genuine")
         self.assertEqual(row["current_spectral_bitrate"], 320)
-        self.assertFalse(bv_result.valid)
-        self.assertEqual(bv_result.scenario, "spectral_reject")
+        self.assertFalse(result.valid)
+        self.assertEqual(result.scenario, "spectral_reject")
         self.assertEqual(len(db.denylist), 1)
         self.assertEqual(db.denylist[0].username, "user1")
         self.assertIn("spectral: 128kbps <= existing 320kbps",

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -185,7 +185,8 @@ class TestCmdForceImport(unittest.TestCase):
 
 class TestCmdManualImport(unittest.TestCase):
     @patch("builtins.print")
-    def test_failed_manual_import_prints_error(self, _mock_print):
+    @patch("pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
+    def test_failed_manual_import_prints_error(self, _mock_resolve, _mock_print):
         from lib.import_dispatch import DispatchOutcome
         db = MagicMock()
         db.get_request.return_value = make_request_row(
@@ -206,7 +207,8 @@ class TestCmdManualImport(unittest.TestCase):
         _mock_print.assert_any_call("  [FAIL] Rejected: quality_downgrade — new 192kbps <= existing 320kbps")
 
     @patch("builtins.print")
-    def test_manual_import_calls_dispatch_from_db(self, _mock_print):
+    @patch("pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
+    def test_manual_import_calls_dispatch_from_db(self, _mock_resolve, _mock_print):
         from lib.import_dispatch import DispatchOutcome
         db = MagicMock()
         db.get_request.return_value = make_request_row(
@@ -224,6 +226,50 @@ class TestCmdManualImport(unittest.TestCase):
             db, request_id=123, failed_path="/tmp/Album",
             force=False, outcome_label="manual_import",
         )
+
+    @patch("builtins.print")
+    @patch("pipeline_cli._resolve_failed_path",
+           return_value="/mnt/virtio/music/slskd/failed_imports/Foo - Bar")
+    def test_manual_import_resolves_relative_path(self, _mock_resolve, _mock_print):
+        """Manual-import must resolve relative paths the same way force-import
+        does, so a user can type ``failed_imports/Foo - Bar`` without
+        pre-absolutizing. Matches cmd_force_import behavior.
+        """
+        from lib.import_dispatch import DispatchOutcome
+        db = MagicMock()
+        db.get_request.return_value = make_request_row(
+            id=123, status="manual", min_bitrate=320,
+            mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
+        )
+        mock_outcome = DispatchOutcome(success=True, message="ok")
+        with patch("lib.import_dispatch.dispatch_import_from_db",
+                    return_value=mock_outcome) as mock_dispatch:
+            args = MagicMock(id=123, path="failed_imports/Foo - Bar")
+            pipeline_cli.cmd_manual_import(db, args)
+
+        _mock_resolve.assert_called_once_with("failed_imports/Foo - Bar")
+        mock_dispatch.assert_called_once_with(
+            db, request_id=123,
+            failed_path="/mnt/virtio/music/slskd/failed_imports/Foo - Bar",
+            force=False, outcome_label="manual_import",
+        )
+
+    @patch("builtins.print")
+    @patch("pipeline_cli._resolve_failed_path", return_value=None)
+    def test_manual_import_aborts_when_path_cannot_be_resolved(
+        self, _mock_resolve, mock_print
+    ):
+        """When the path can't be resolved, abort without calling dispatch."""
+        db = MagicMock()
+        db.get_request.return_value = make_request_row(
+            id=123, status="manual", min_bitrate=320,
+            mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
+        )
+        with patch("lib.import_dispatch.dispatch_import_from_db") as mock_dispatch:
+            args = MagicMock(id=123, path="nonexistent/path")
+            pipeline_cli.cmd_manual_import(db, args)
+        mock_dispatch.assert_not_called()
+        mock_print.assert_any_call("  Files not found at: nonexistent/path")
 
 
 class TestCmdQuery(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -351,6 +351,45 @@ class TestDownloadLog(unittest.TestCase):
         self.assertEqual(len(history), 2)
         self.assertEqual(history[0]["soulseek_username"], "user2")
 
+    def test_get_log_imported_filter_excludes_rejected_rows(self):
+        """Contract guard: only truly-imported rows count as "imported".
+
+        ``get_log(outcome_filter='imported')`` filters on ``outcome IN
+        ('success', 'force_import')``. Gate-rejected force/manual imports
+        must NOT write ``outcome='force_import'`` or they'd leak into the UI's
+        imported counter and the /api/pipeline/log imported view. Regression
+        guard for the audit that caught this: a gate-rejected force import
+        belongs in the "rejected" filter, not "imported".
+        """
+        # A successful auto import.
+        self.db.log_download(
+            self.req_id, "user-success", "mp3", "/Incoming/A/B",
+            outcome="success", beets_distance=0.05)
+        # A successful force import.
+        self.db.log_download(
+            self.req_id, "user-force", "mp3", "/Incoming/A/B",
+            outcome="force_import", beets_distance=0.0)
+        # A gate-rejected force import (e.g. spectral_reject, audio_corrupt,
+        # nested_layout). Per CLAUDE.md the outcome MUST be "rejected".
+        self.db.log_download(
+            self.req_id, "user-gate", "mp3", "/tmp/reject",
+            outcome="rejected", beets_scenario="spectral_reject")
+
+        imported = self.db.get_log(outcome_filter="imported")
+        outcomes = {row["outcome"] for row in imported}
+        self.assertEqual(
+            outcomes, {"success", "force_import"},
+            f"imported filter must only include success + force_import, "
+            f"got {outcomes}")
+        self.assertNotIn(
+            "rejected", outcomes,
+            "gate-rejected rows must not appear under the imported filter")
+
+        rejected = self.db.get_log(outcome_filter="rejected")
+        rejected_outcomes = {row["outcome"] for row in rejected}
+        self.assertIn("rejected", rejected_outcomes,
+                      "gate-rejected rows must surface under the rejected filter")
+
 
 @requires_postgres
 class TestSearchLog(unittest.TestCase):

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -339,6 +339,20 @@ class TestClassifyVerdict(unittest.TestCase):
             outcome="rejected", beets_scenario="album_name_mismatch"))
         self.assertIn("name mismatch", result.verdict.lower())
 
+    def test_nested_layout_verdict(self):
+        """Gate-rejected force/manual import of a nested folder layout must
+        render a friendly label in the Recents tab, not the raw scenario
+        string. Otherwise operators see the literal "nested_layout" and have
+        to go grepping for what it means.
+        """
+        result = classify_log_entry(_entry(
+            outcome="rejected", beets_scenario="nested_layout"))
+        self.assertIn("nested", result.verdict.lower())
+        self.assertIn("flatten", result.verdict.lower())
+        self.assertNotEqual(
+            result.verdict, "nested_layout",
+            "verdict must be a friendly label, not the raw scenario string")
+
     def test_transcode_upgrade_verdict(self):
         result = classify_log_entry(_entry(
             outcome="success", beets_scenario="transcode_upgrade",

--- a/web/classify.py
+++ b/web/classify.py
@@ -366,6 +366,9 @@ def _rejection_verdict(entry: LogEntry) -> str:
     if scenario == "album_name_mismatch":
         return "Album name mismatch"
 
+    if scenario == "nested_layout":
+        return "Nested folder layout (flatten first)"
+
     return str(scenario) if scenario else "Rejected"
 
 


### PR DESCRIPTION
## Summary
- Force-import and manual-import bypassed the audio integrity + spectral transcode gates that auto-import runs, so a transcode that auto would reject could be force-imported over an existing same-quality copy (see album 903).
- Fix extracts gates into `lib/preimport.py::run_preimport_gates()` — a single source of truth called by both entry points. Force only skips the beets *distance* check, which is what `--force` always meant.
- Per `.claude/rules/code-quality.md` "No Parallel Code Paths" and `.claude/rules/scope.md` "the refactor IS the fix".

## Structural changes
- New `lib/preimport.py`: `run_preimport_gates()`, `inspect_local_files()`, `PreImportGateResult`.
- `lib/download.py::_process_beets_validation` delegates to it; `_gather_spectral_context` + `_apply_spectral_decision` deleted.
- `lib/import_dispatch.py::dispatch_import_from_db` calls it before `dispatch_import_core`; on reject, logs `download_log` via `_record_rejection_and_maybe_requeue` with `requeue=False`.

## Test plan
- [x] New `tests/test_force_import_gates.py` (5 tests, 3 were RED): spectral transcode rejection, audio-corrupt rejection, spectral-reason denylist assertion, genuine-spectral happy path, `--force` flag forwarding guard.
- [x] `TestSpectralPropagationSlice` rewritten to exercise `run_preimport_gates` end-to-end.
- [x] Obsolete `TestGatherSpectralContextFunction` + `TestApplySpectralDecision` removed from `tests/test_download.py`; coverage transferred.
- [x] Full suite: 1568 tests pass.
- [x] Pyright clean on all touched files.
- [ ] Deploy to doc2, verify force-import of album 903 now rejects (instead of force-importing the 96kbps transcode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)