### PR TITLE
fix: issue #93 — imported_path dest + VBR avg-threshold gate

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -891,6 +891,9 @@ def dispatch_import_from_db(
         # import subprocess and a failure there still means the files
         # ended up in failed_imports/ unchanged.
         propagate_download_to_existing=False,
+        # Reuse the inspection computed for the nested-layout gate to
+        # avoid a second mutagen walk (~100ms per album).
+        precomputed_inspection=inspection,
     )
 
     if not preimport.valid:

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -121,11 +121,21 @@ def _do_mark_done(
     dest_path: str | None,
     outcome_label: str = "success",
     detail: str | None = None,
+    imported_path: str | None = None,
 ) -> None:
     """Mark album as imported — standalone version of DatabaseSource.mark_done.
 
     Takes PipelineDB directly instead of going through DatabaseSource.
     Uses outcome_label for download_log (e.g. "force_import" instead of "success").
+
+    ``imported_path`` is the beets destination (from
+    ``ImportResult.postflight.imported_path``) — what shows up in the UI's
+    "Imported to" label. ``dest_path`` is the source/staging path passed to
+    the importer. When callers have both (auto/force/manual paths that ran
+    beets), they pass ``imported_path`` so ``album_requests.imported_path``
+    reflects the actual on-disk location. Callers that only stage for manual
+    review (``album_source.mark_done``) leave ``imported_path=None``; it
+    falls back to ``dest_path`` so legacy behavior is preserved (issue #93).
     """
     from lib.quality import SpectralMeasurement, is_verified_lossless
     from lib.pipeline_db import RequestSpectralStateUpdate
@@ -133,7 +143,7 @@ def _do_mark_done(
     update_fields: dict[str, object] = dict(
         beets_distance=distance,
         beets_scenario=scenario,
-        imported_path=dest_path,
+        imported_path=imported_path if imported_path else dest_path,
     )
     verified_lossless = (
         bool(dl_info.verified_lossless_override)
@@ -536,7 +546,8 @@ def dispatch_import_core(
                 _do_mark_done(
                     db, request_id, dl_info,
                     distance=distance, scenario=scenario,
-                    dest_path=path, outcome_label=outcome_label)
+                    dest_path=path, outcome_label=outcome_label,
+                    imported_path=ir.postflight.imported_path)
                 if decision in ("import", "preflight_existing"):
                     if prev_br is not None or new_br is not None:
                         try:

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -295,6 +295,7 @@ def run_preimport_gates(
     request_id: int | None = None,
     usernames: set[str] | None = None,
     propagate_download_to_existing: bool = True,
+    precomputed_inspection: "LocalFileInspection | None" = None,
 ) -> PreImportGateResult:
     """Run shared pre-import gates: audio integrity, then spectral transcode detection.
 
@@ -369,10 +370,23 @@ def run_preimport_gates(
     # VBR transcode masquerading as V0 (~180kbps avg). Always inspect MP3
     # downloads so we have avg data; a mutagen walk on a 12-track album is
     # ~100ms and far cheaper than the spectral analysis it might save.
+    #
+    # Asymmetry note: slskd's ``is_vbr`` wins over inspection (only fills
+    # when the caller passed None). This preserves uploader intent — slskd
+    # reports what the uploader tagged the file as, and overriding that
+    # with mutagen's readout on potentially-repaired headers could flip a
+    # genuine CBR to VBR or vice versa. The force/manual path passes
+    # inspection's ``is_vbr`` as ``download_is_vbr`` directly, so neither
+    # source is lost.
+    #
+    # ``precomputed_inspection`` lets the force/manual path (which already
+    # inspected to decide the nested-layout gate) avoid a second mutagen
+    # walk. Auto path passes None and does the walk here.
     avg_bitrate_bps: int | None = None
     filetype_lower = (download_filetype or "").lower()
     if "mp3" in filetype_lower and "flac" not in filetype_lower:
-        inspection = inspect_local_files(path)
+        inspection = (precomputed_inspection if precomputed_inspection is not None
+                      else inspect_local_files(path))
         if download_is_vbr is None and inspection.is_vbr is not None:
             download_is_vbr = inspection.is_vbr
         if download_min_bitrate_bps is None:

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -89,9 +89,14 @@ class LocalFileInspection:
     still uses ``os.listdir`` for bitrate measurement and conversion, so a
     nested force/manual import would pass gates and then produce a
     misclassified/empty measurement in the harness.
+
+    ``avg_bitrate_bps`` is the mean bitrate across all readable MP3 files —
+    used by the VBR spectral-gate threshold (issue #93). Genuine V0 averages
+    ~240-260kbps; VBR transcodes masquerading as V0 average well below that.
     """
     filetype: str = ""           # comma-separated lowercase extensions
     min_bitrate_bps: int | None = None
+    avg_bitrate_bps: int | None = None
     is_vbr: bool | None = None
     has_nested_audio: bool = False
 
@@ -113,6 +118,7 @@ def inspect_local_files(path: str) -> LocalFileInspection:
 
     extensions: set[str] = set()
     min_bitrate: int | None = None
+    mp3_bitrates: list[int] = []
     any_vbr: bool | None = None
     has_nested_audio = False
 
@@ -135,6 +141,7 @@ def inspect_local_files(path: str) -> LocalFileInspection:
                     br_mode = getattr(mp3.info, "bitrate_mode", None)
                     if br is not None:
                         min_bitrate = br if min_bitrate is None else min(min_bitrate, br)
+                        mp3_bitrates.append(br)
                     # mutagen BitrateMode: UNKNOWN=0, CBR=1, VBR=2, ABR=3
                     if br_mode is not None:
                         is_vbr_file = int(br_mode) in (2, 3)
@@ -143,32 +150,52 @@ def inspect_local_files(path: str) -> LocalFileInspection:
                     logger.debug(f"inspect_local_files: failed to read {full}",
                                  exc_info=True)
 
+    avg_bitrate = sum(mp3_bitrates) // len(mp3_bitrates) if mp3_bitrates else None
+
     return LocalFileInspection(
         filetype=", ".join(sorted(extensions)),
         min_bitrate_bps=min_bitrate,
+        avg_bitrate_bps=avg_bitrate,
         is_vbr=any_vbr,
         has_nested_audio=has_nested_audio,
     )
 
 
-def _needs_spectral_check(filetype: str, is_vbr: bool | None) -> bool:
-    """Spectral check runs on non-VBR MP3 downloads.
+def _needs_spectral_check(
+    filetype: str,
+    is_vbr: bool | None,
+    *,
+    avg_bitrate_kbps: int | None = None,
+    vbr_threshold_kbps: int | None = None,
+) -> bool:
+    """Decide whether to run spectral analysis as a preimport gate.
 
-    FLAC uses a different flow (convert → V0 → compare). VBR MP3 carries its
-    own bitrate signal. CBR MP3 is where spectral cliff detection pays off.
+    Rules:
+      - Non-MP3 (FLAC, ALAC, ...) → skip. FLAC uses a different flow (convert
+        → V0 → compare); other codecs have no cliff-detection calibration.
+      - CBR MP3 or unknown VBR (is_vbr is None) → run. CBR is the classic
+        transcode-cliff case; unknown VBR is the conservative default
+        (issue #39: resumed downloads without slskd metadata).
+      - VBR MP3 → run only when ``avg_bitrate_kbps`` is unknown (conservative)
+        or below ``vbr_threshold_kbps``. Issue #93: a VBR MP3 at avg 182kbps
+        (well below genuine V0's ~240-260kbps range) was an obvious transcode
+        that the old ``is_vbr``-only gate let through. The threshold comes
+        from ``cfg.quality_ranks.mp3_vbr.excellent`` — the same value
+        ``transcode_detection()`` already uses as its VBR transcode boundary.
 
-    Unknown VBR (``is_vbr is None``) is routed through the gate — the auto
-    path resumes downloads from ``ActiveDownloadState`` without a VBR field,
-    and skipping spectral on those would be a quality-gate bypass. Callers
-    with ground truth (force/manual) resolve unknown VBR via filesystem
-    inspection (see ``run_preimport_gates``) before this helper is reached,
-    so None here means "really unknown" — the conservative choice is to
-    still gate; genuine VBR uploads will produce "genuine" spectral grades
-    and fall through to import.
+    ``avg_bitrate_kbps`` / ``vbr_threshold_kbps`` are keyword-only to keep
+    the call site self-documenting: the VBR branch requires both to skip, so
+    callers pass both or neither.
     """
     filetype_lower = (filetype or "").lower()
     is_mp3 = "mp3" in filetype_lower and "flac" not in filetype_lower
-    return is_mp3 and not bool(is_vbr)
+    if not is_mp3:
+        return False
+    if not bool(is_vbr):
+        return True
+    if avg_bitrate_kbps is None or vbr_threshold_kbps is None:
+        return True
+    return avg_bitrate_kbps < vbr_threshold_kbps
 
 
 def _analyze_existing(
@@ -331,23 +358,37 @@ def run_preimport_gates(
                 f"({len(result.corrupt_files)} files failed ffmpeg decode)")
             return result
 
-    # --- Resolve VBR status via filesystem inspection when unknown ---
-    # Auto path callers supply VBR from slskd metadata (usually populated,
-    # but None on resumed downloads rebuilt from ActiveDownloadState).
-    # Force/manual callers supply VBR from mutagen (can be None on broken
-    # headers). In both cases, re-inspecting the files on disk here covers
-    # the gap so the spectral gate runs only when we've confirmed CBR.
-    if download_is_vbr is None:
-        filetype_lower = (download_filetype or "").lower()
-        if "mp3" in filetype_lower and "flac" not in filetype_lower:
-            inspection = inspect_local_files(path)
-            if inspection.is_vbr is not None:
-                download_is_vbr = inspection.is_vbr
-                if download_min_bitrate_bps is None:
-                    download_min_bitrate_bps = inspection.min_bitrate_bps
+    # --- Resolve VBR status and avg bitrate via filesystem inspection ---
+    # Callers supply VBR/min_bitrate from different sources:
+    #   * Auto path → slskd metadata (usually populated, but None on resumed
+    #     downloads rebuilt from ActiveDownloadState).
+    #   * Force/manual path → mutagen on the local files (can be None on
+    #     broken headers).
+    # Neither source provides an average bitrate, which the VBR threshold
+    # gate (issue #93) needs to tell genuine V0 (~245kbps avg) apart from a
+    # VBR transcode masquerading as V0 (~180kbps avg). Always inspect MP3
+    # downloads so we have avg data; a mutagen walk on a 12-track album is
+    # ~100ms and far cheaper than the spectral analysis it might save.
+    avg_bitrate_bps: int | None = None
+    filetype_lower = (download_filetype or "").lower()
+    if "mp3" in filetype_lower and "flac" not in filetype_lower:
+        inspection = inspect_local_files(path)
+        if download_is_vbr is None and inspection.is_vbr is not None:
+            download_is_vbr = inspection.is_vbr
+        if download_min_bitrate_bps is None:
+            download_min_bitrate_bps = inspection.min_bitrate_bps
+        avg_bitrate_bps = inspection.avg_bitrate_bps
 
-    # --- Spectral gate (non-VBR MP3 only) ---
-    if not _needs_spectral_check(download_filetype, download_is_vbr):
+    # --- Spectral gate ---
+    # Threshold: cfg.quality_ranks.mp3_vbr.excellent (the same V0 boundary
+    # transcode_detection() uses). Single source of truth per the
+    # "No Parallel Code Paths" rule — retuning one also retunes the other.
+    avg_bitrate_kbps = (avg_bitrate_bps // 1000) if avg_bitrate_bps else None
+    if not _needs_spectral_check(
+        download_filetype, download_is_vbr,
+        avg_bitrate_kbps=avg_bitrate_kbps,
+        vbr_threshold_kbps=cfg.quality_ranks.mp3_vbr.excellent,
+    ):
         return result
 
     try:

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1441,6 +1441,45 @@ def parse_import_result(stdout_text: str) -> Optional[ImportResult]:
 # Pre-import spectral decision (MP3/CBR path in process_completed_album)
 # ---------------------------------------------------------------------------
 
+def spectral_gate_trigger(
+    *,
+    is_flac: bool,
+    is_cbr: bool | None,
+    is_vbr: bool | None = None,
+    avg_bitrate_kbps: int | None = None,
+    vbr_threshold_kbps: int,
+) -> str:
+    """Decide whether the preimport spectral gate would run on this file.
+
+    Mirrors ``lib.preimport._needs_spectral_check`` but operates on the
+    simulator's booleans (``is_flac`` / ``is_cbr``) instead of a filetype
+    string, so ``full_pipeline_decision`` and the web UI Decisions tab can
+    explain why the gate fired (or didn't) for a given file.
+
+    Returns one of:
+        "skipped_flac"          — FLACs use convert → V0 → transcode_detection,
+                                  not the MP3 preimport spectral gate
+        "skipped_vbr_high_avg"  — VBR MP3 with avg bitrate >= threshold;
+                                  genuine V0 falls through without analysis
+        "would_run"             — CBR MP3, unknown VBR, or VBR MP3 with avg
+                                  below / equal to / unknown
+
+    When ``is_vbr`` is None but ``is_cbr`` is known, ``is_vbr`` is derived
+    as ``not is_cbr``. Callers that have genuine ambiguity (mutagen failed
+    to read bitrate_mode) pass ``is_vbr=None`` AND ``is_cbr=None`` and the
+    function routes to "would_run" — the conservative choice.
+    """
+    if is_flac:
+        return "skipped_flac"
+    if is_vbr is None and is_cbr is not None:
+        is_vbr = not is_cbr
+    if not is_vbr:
+        return "would_run"
+    if avg_bitrate_kbps is not None and avg_bitrate_kbps >= vbr_threshold_kbps:
+        return "skipped_vbr_high_avg"
+    return "would_run"
+
+
 def spectral_import_decision(spectral_grade, spectral_bitrate, existing_spectral_bitrate,
                              existing_min_bitrate=None):
     """Decide whether to import a download based on spectral analysis.
@@ -2207,11 +2246,39 @@ def get_decision_tree(
                         "may be Opus, MP3, AAC, or any other supported format.",
             },
             {
+                "id": "mp3_spectral_gate",
+                "title": "Spectral Gate Trigger",
+                "path": "mp3",
+                "function": "spectral_gate_trigger",
+                "when": "MP3 downloads (pre-analysis decision, issue #93)",
+                "inputs": ["is_cbr", "is_vbr", "avg_bitrate",
+                           "cfg.mp3_vbr.excellent"],
+                "rules": [
+                    {"condition": "CBR MP3",
+                     "result": "would_run", "color": "amber",
+                     "effect": "classic transcode-cliff case"},
+                    {"condition": "VBR MP3 AND avg unknown",
+                     "result": "would_run", "color": "amber",
+                     "effect": "conservative default"},
+                    {"condition": f"VBR MP3 AND avg < {transcode_threshold}kbps",
+                     "result": "would_run", "color": "amber",
+                     "effect": "fake V0 transcode territory — analyze"},
+                    {"condition": f"VBR MP3 AND avg >= {transcode_threshold}kbps",
+                     "result": "skipped_vbr_high_avg", "color": "green",
+                     "effect": "genuine V0 range — skip to Quality Comparison"},
+                ],
+                "outcomes": ["would_run", "skipped_vbr_high_avg",
+                             "skipped_flac"],
+                "note": f"Threshold ({transcode_threshold}kbps) comes from "
+                        f"cfg.mp3_vbr.excellent — same V0 boundary "
+                        f"transcode_detection() uses (single source of truth)",
+            },
+            {
                 "id": "mp3_spectral",
-                "title": "CBR Spectral Check",
+                "title": "Spectral Decision",
                 "path": "mp3",
                 "function": "spectral_import_decision",
-                "when": "CBR MP3 downloads only (VBR skips this)",
+                "when": "MP3 downloads where the gate trigger said would_run",
                 "inputs": ["spectral_grade", "spectral_bitrate",
                            "existing_spectral_bitrate"],
                 "rules": [
@@ -2229,18 +2296,6 @@ def get_decision_tree(
                 ],
                 "outcomes": ["import", "import_upgrade", "import_no_exist",
                              "reject"],
-            },
-            {
-                "id": "mp3_vbr_note",
-                "title": "VBR MP3",
-                "path": "mp3",
-                "function": "(no spectral check)",
-                "when": "VBR MP3 downloads",
-                "inputs": [],
-                "rules": [
-                    {"condition": "VBR bitrate IS the quality signal",
-                     "result": "skip to Quality Comparison", "color": "green"},
-                ],
             },
             {
                 "id": "import_decision",
@@ -2341,6 +2396,13 @@ def full_pipeline_decision(
     is_flac,
     min_bitrate,
     is_cbr,
+    # VBR + avg bitrate for the preimport spectral gate trigger (issue #93).
+    # ``is_vbr`` defaults to ``not is_cbr`` when omitted so legacy callers
+    # retain current behavior. ``avg_bitrate`` gates VBR MP3 through spectral
+    # when below cfg.mp3_vbr.excellent — genuine V0 (~245kbps avg) skips,
+    # fake V0 (~180kbps avg) gets analyzed.
+    is_vbr: bool | None = None,
+    avg_bitrate: int | None = None,
     # Spectral analysis
     spectral_grade=None,
     spectral_bitrate=None,
@@ -2376,18 +2438,20 @@ def full_pipeline_decision(
 
     Returns a dict:
         {
-            "stage1_spectral": str,     # pre-import spectral decision
-            "stage2_import": str,       # import/downgrade/transcode decision
-            "stage3_quality_gate": str,  # post-import quality gate decision
-            "final_status": str,        # what the pipeline DB ends up as
-            "imported": bool,           # whether files were imported to beets
-            "denylisted": bool,         # whether source user gets denylisted
-            "keep_searching": bool,     # whether the system keeps looking for better
+            "stage0_spectral_gate": str,  # would spectral analysis run?
+            "stage1_spectral": str,       # pre-import spectral decision (None when gate skipped)
+            "stage2_import": str,         # import/downgrade/transcode decision
+            "stage3_quality_gate": str,   # post-import quality gate decision
+            "final_status": str,          # what the pipeline DB ends up as
+            "imported": bool,             # whether files were imported to beets
+            "denylisted": bool,           # whether source user gets denylisted
+            "keep_searching": bool,       # whether the system keeps looking for better
         }
     """
     if cfg is None:
         cfg = QualityRankConfig.defaults()
     result = {
+        "stage0_spectral_gate": None,
         "stage1_spectral": None,
         "stage2_import": None,
         "stage3_quality_gate": None,
@@ -2398,10 +2462,30 @@ def full_pipeline_decision(
         "target_final_format": None,
     }
 
+    # --- Stage 0: Spectral gate trigger (issue #93) ---
+    # Mirrors lib.preimport._needs_spectral_check. Tells the operator
+    # whether the preimport spectral gate would even run on this file,
+    # so a VBR MP3 transcode masquerading as V0 (avg < threshold) is
+    # distinguishable from genuine V0 in simulator output.
+    gate = spectral_gate_trigger(
+        is_flac=bool(is_flac),
+        is_cbr=is_cbr,
+        is_vbr=is_vbr,
+        avg_bitrate_kbps=avg_bitrate,
+        vbr_threshold_kbps=cfg.mp3_vbr.excellent,
+    )
+    result["stage0_spectral_gate"] = gate
+
     # --- Stage 1: Pre-import spectral (MP3/CBR path) ---
     # For FLACs, spectral runs inside import_one.py instead, but the
     # logic is the same: detect transcodes before importing.
-    if spectral_grade:
+    #
+    # Only run stage 1 when the gate would actually execute. For VBR MP3
+    # with high avg bitrate, production skips spectral entirely — so even
+    # if the caller supplies a spectral_grade, simulating that gate firing
+    # would misrepresent production behavior.
+    stage0_gates_stage1 = gate == "would_run" or is_flac
+    if spectral_grade and stage0_gates_stage1:
         result["stage1_spectral"] = spectral_import_decision(
             spectral_grade, spectral_bitrate, existing_spectral_bitrate or 0)
 
@@ -2630,26 +2714,24 @@ def find_inconsistencies(db_rows: list[dict[str, Any]]) -> list[OrphanInfo]:
 
     Checks:
     - downloading row with no active_download_state (corrupt crash recovery)
-    - wanted/manual row with stale imported_path
+
+    ``imported_path`` is NOT checked against status: it means "files are on
+    disk at this path" and survives a status=wanted re-queue (transcode
+    upgrade, quality-gate upgrade search). Clearing it on status=wanted
+    would wipe the correct beets destination for any album the pipeline is
+    actively searching for a better version of. See issue #93.
     """
     issues: list[OrphanInfo] = []
     for row in db_rows:
         rid = row["id"]
         status = row["status"]
         state = row.get("active_download_state")
-        path = row.get("imported_path")
 
         if status == "downloading" and not state:
             issues.append(OrphanInfo(
                 request_id=rid,
                 issue_type="corrupt_downloading",
                 detail="downloading with no active_download_state"))
-
-        if status in ("wanted", "manual") and path:
-            issues.append(OrphanInfo(
-                request_id=rid,
-                issue_type="stale_imported_path",
-                detail=f"status={status} but imported_path={path}"))
 
     return issues
 
@@ -2661,11 +2743,6 @@ def suggest_repair(issue: OrphanInfo) -> RepairAction:
             request_id=issue.request_id,
             action="reset_to_wanted",
             detail="Reset downloading row to wanted (transfers gone)")
-    elif issue.issue_type == "stale_imported_path":
-        return RepairAction(
-            request_id=issue.request_id,
-            action="clear_imported_path",
-            detail="Clear stale imported_path on non-imported row")
     else:
         return RepairAction(
             request_id=issue.request_id,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2408,6 +2408,7 @@ def full_pipeline_decision(
     spectral_bitrate=None,
     # Existing state
     existing_min_bitrate=None,
+    existing_avg_bitrate: int | None = None,
     existing_spectral_bitrate=None,
     override_min_bitrate=None,
     existing_format: str | None = None,
@@ -2500,17 +2501,25 @@ def full_pipeline_decision(
     # otherwise defaults to "MP3" so legacy simulator scenarios (which only
     # carry a min_bitrate) still classify against the MP3 VBR/CBR band
     # tables. Production always provides a real format via BeetsDB.
+    #
+    # avg/median fall back to min_bitrate when the caller didn't supply a
+    # separate avg (legacy scenarios). Supplying existing_avg_bitrate matters
+    # under the default cfg.bitrate_metric=AVG policy — otherwise a VBR album
+    # with avg=245 but min=180 gets ranked off min=180 (GOOD instead of
+    # TRANSPARENT) and downstream comparisons misrepresent production.
     effective_existing_format = existing_format if existing_format is not None else "MP3"
+    _effective_existing_min = (override_min_bitrate
+                               if override_min_bitrate is not None
+                               else existing_min_bitrate)
+    _effective_existing_avg = (override_min_bitrate
+                               if override_min_bitrate is not None
+                               else (existing_avg_bitrate
+                                     if existing_avg_bitrate is not None
+                                     else existing_min_bitrate))
     existing_m = (AudioQualityMeasurement(
-                      min_bitrate_kbps=override_min_bitrate
-                      if override_min_bitrate is not None
-                      else existing_min_bitrate,
-                      avg_bitrate_kbps=override_min_bitrate
-                      if override_min_bitrate is not None
-                      else existing_min_bitrate,
-                      median_bitrate_kbps=override_min_bitrate
-                      if override_min_bitrate is not None
-                      else existing_min_bitrate,
+                      min_bitrate_kbps=_effective_existing_min,
+                      avg_bitrate_kbps=_effective_existing_avg,
+                      median_bitrate_kbps=_effective_existing_avg,
                       format=effective_existing_format,
                       is_cbr=existing_is_cbr)
                   if existing_min_bitrate is not None else None)
@@ -2537,6 +2546,7 @@ def full_pipeline_decision(
             verified_lossless = True
 
         gate_bitrate = min_bitrate
+        gate_avg_bitrate = min_bitrate  # FLAC: lossless, avg == min is fine
         gate_cbr = False
         gate_format = stage2_new_format  # "flac"
     elif is_flac:
@@ -2594,21 +2604,31 @@ def full_pipeline_decision(
         else:
             gate_format = stage2_new_format
 
-        # Use post-conversion bitrate for quality gate
+        # Use post-conversion bitrate for quality gate. The simulator
+        # doesn't take a separate post-conversion avg, so avg == min here;
+        # in production the real avg comes from beets after import.
         gate_bitrate = post_conversion_min_bitrate or min_bitrate
+        gate_avg_bitrate = gate_bitrate
         gate_cbr = False  # V0 conversion always produces VBR
     else:
         # MP3 path: import directly. No format label for native MP3 downloads
         # unless the caller provided one — the rank model falls back to the
         # bare-codec bitrate classification via `new_format=None`.
+        #
+        # Use the caller-supplied avg_bitrate when present (falls back to
+        # min_bitrate otherwise). Under the default cfg.bitrate_metric=AVG
+        # policy a VBR V0 at min=200/avg=245 must rank on avg=245 — otherwise
+        # the import/downgrade comparison and the post-import gate both see
+        # the wrong tier.
         stage2_new_format = comparison_format_hint(
             explicit_format=new_format,
             native_codec_family="MP3",
         )
+        _mp3_avg = avg_bitrate if avg_bitrate is not None else min_bitrate
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
-            avg_bitrate_kbps=min_bitrate,
-            median_bitrate_kbps=min_bitrate,
+            avg_bitrate_kbps=_mp3_avg,
+            median_bitrate_kbps=_mp3_avg,
             format=stage2_new_format,
             is_cbr=is_cbr)
         result["stage2_import"] = import_quality_decision(
@@ -2621,6 +2641,7 @@ def full_pipeline_decision(
 
         result["imported"] = True
         gate_bitrate = min_bitrate
+        gate_avg_bitrate = _mp3_avg
         gate_cbr = is_cbr
         gate_format = stage2_new_format
 
@@ -2634,8 +2655,8 @@ def full_pipeline_decision(
         gate_spectral_bitrate = spectral_bitrate
     gate_m = AudioQualityMeasurement(
         min_bitrate_kbps=gate_bitrate,
-        avg_bitrate_kbps=gate_bitrate,
-        median_bitrate_kbps=gate_bitrate,
+        avg_bitrate_kbps=gate_avg_bitrate,
+        median_bitrate_kbps=gate_avg_bitrate,
         format=gate_format,
         is_cbr=gate_cbr,
         verified_lossless=verified_lossless,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2682,7 +2682,7 @@ def full_pipeline_decision(
 class OrphanInfo:
     """A detected inconsistency in pipeline DB state."""
     request_id: int
-    issue_type: str  # "corrupt_downloading", "stale_imported_path"
+    issue_type: str  # "corrupt_downloading", "orphaned_download"
     detail: str
 
 
@@ -2690,7 +2690,7 @@ class OrphanInfo:
 class RepairAction:
     """Suggested repair for a detected inconsistency."""
     request_id: int
-    action: str  # "reset_to_wanted", "clear_imported_path", "manual_review"
+    action: str  # "reset_to_wanted", "manual_review"
     detail: str
 
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -716,12 +716,22 @@ def cmd_quality(db, args):
             spectral_grade="suspect", converted_count=12,
             post_conversion_min_bitrate=245)),
         # --- MP3 VBR downloads ---
-        ("MP3 V0 (240kbps)", dict(
-            is_flac=False, min_bitrate=240, is_cbr=False)),
-        ("MP3 V0 (low, 205kbps)", dict(
-            is_flac=False, min_bitrate=205, is_cbr=False)),
-        ("MP3 V2 (190kbps)", dict(
-            is_flac=False, min_bitrate=190, is_cbr=False)),
+        # avg_bitrate drives the new preimport spectral gate (issue #93):
+        # VBR with avg >= cfg.mp3_vbr.excellent skips spectral entirely,
+        # below gates through analysis even without a spectral_grade input.
+        ("MP3 V0 genuine (avg 245kbps, gate skips)", dict(
+            is_flac=False, min_bitrate=240, is_cbr=False,
+            is_vbr=True, avg_bitrate=245)),
+        ("MP3 V0 (low, avg 205kbps, gate runs)", dict(
+            is_flac=False, min_bitrate=205, is_cbr=False,
+            is_vbr=True, avg_bitrate=205)),
+        ("VBR transcode (Go! Team shape, avg 182kbps)", dict(
+            is_flac=False, min_bitrate=126, is_cbr=False,
+            is_vbr=True, avg_bitrate=182,
+            spectral_grade="likely_transcode", spectral_bitrate=96)),
+        ("MP3 V2 (avg 190kbps, gate runs)", dict(
+            is_flac=False, min_bitrate=190, is_cbr=False,
+            is_vbr=True, avg_bitrate=190)),
         # --- MP3 CBR downloads (no spectral) ---
         ("CBR 320 (no spectral)", dict(
             is_flac=False, min_bitrate=320, is_cbr=True)),
@@ -769,7 +779,9 @@ def cmd_quality(db, args):
             parts.append("keep searching")
         final = result["final_status"] or "?"
         decision_chain = " → ".join(
-            f"{s}={result[s]}" for s in ["stage1_spectral", "stage2_import", "stage3_quality_gate"]
+            f"{s}={result[s]}"
+            for s in ["stage0_spectral_gate", "stage1_spectral",
+                      "stage2_import", "stage3_quality_gate"]
             if result[s] is not None)
 
         print(f"    {name}:")

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -761,6 +761,11 @@ def cmd_quality(db, args):
     for name, params in scenarios:
         result = full_pipeline_decision(
             existing_min_bitrate=min_br,
+            # Forward avg_bitrate too — under the default AVG policy the
+            # simulator must compare against the real album avg, not min,
+            # or VBR albums rank at the wrong tier in stage 2/3 output
+            # (issue #93 codex round 4).
+            existing_avg_bitrate=avg_br,
             existing_spectral_bitrate=current_br,
             override_min_bitrate=override_min_bitrate,
             existing_format=existing_format_hint,

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -104,13 +104,6 @@ def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
             apply_transition(db, issue.request_id, "wanted",
                              from_status="downloading")
             print(f"  [{issue.request_id}] Reset to wanted ({issue.issue_type})")
-        elif repair.action == "clear_imported_path":
-            db._execute(
-                "UPDATE album_requests SET imported_path = NULL, updated_at = NOW() "
-                "WHERE id = %s",
-                (issue.request_id,),
-            )
-            print(f"  [{issue.request_id}] Cleared stale imported_path")
         else:
             print(f"  [{issue.request_id}] Skipped: {repair.action} (manual review required)")
 

--- a/tests/test_do_mark.py
+++ b/tests/test_do_mark.py
@@ -69,6 +69,39 @@ class TestDoMarkDone(unittest.TestCase):
         assert log.beets_distance is not None
         self.assertAlmostEqual(log.beets_distance, 0.05)
 
+    def test_imported_path_falls_back_to_dest_when_unset(self):
+        """Legacy behavior: album_requests.imported_path = dest_path when
+        no explicit imported_path is supplied (non-beets paths, like
+        staged-for-manual-review via album_source.mark_done)."""
+        db = self._call()
+        self.assertEqual(
+            db.request(42)["imported_path"],
+            "/tmp/staged/Artist - Album",
+            "legacy callers without an explicit imported_path fall through")
+
+    def test_imported_path_param_overrides_dest(self):
+        """Issue #93: dispatch must propagate ir.postflight.imported_path
+        (actual beets destination) instead of dest_path (source/staging).
+
+        Pre-fix: album_requests.imported_path showed
+        /mnt/virtio/music/slskd/failed_imports/... (source)
+        Post-fix: it shows /mnt/virtio/Music/Beets/Artist/Album (destination)."""
+        db = self._call(
+            imported_path="/Beets/Artist/2005 - Album_",
+        )
+        self.assertEqual(
+            db.request(42)["imported_path"],
+            "/Beets/Artist/2005 - Album_",
+            "explicit imported_path (from ImportResult.postflight) must win")
+
+    def test_imported_path_none_still_falls_back(self):
+        """Explicit imported_path=None is equivalent to omitting — fall back
+        to dest_path. Protects callers that conditionally pass None."""
+        db = self._call(imported_path=None)
+        self.assertEqual(
+            db.request(42)["imported_path"],
+            "/tmp/staged/Artist - Album")
+
 
 class TestRecordRejectionAndMaybeRequeue(unittest.TestCase):
     """Rejection recording must log failure and optionally requeue."""

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -56,36 +56,72 @@ class TestNeedsSpectralCheckDecisions(unittest.TestCase):
     Keeping them as pure input/output assertions here so the auto path's
     branch-selection logic stays covered without re-introducing the old
     SpectralContext plumbing.
+
+    Signature (see lib/preimport.py::_needs_spectral_check):
+        _needs_spectral_check(filetype, is_vbr, avg_bitrate_kbps,
+                              vbr_threshold_kbps) -> bool
+
+    The VBR branch is gated on ``avg_bitrate_kbps < vbr_threshold_kbps``
+    so transcodes uploaded as fake V0 (avg ~180kbps) are still analyzed.
+    Genuine V0 (avg ~245kbps+) falls through unchanged.
     """
 
+    # Threshold matches cfg.quality_ranks.mp3_vbr.excellent default (210).
+    THRESHOLD = 210
+
+    def _run(self, filetype, is_vbr, avg_kbps=None, threshold=None):
+        from lib.preimport import _needs_spectral_check
+        return _needs_spectral_check(
+            filetype, is_vbr,
+            avg_bitrate_kbps=avg_kbps,
+            vbr_threshold_kbps=threshold if threshold is not None else self.THRESHOLD,
+        )
+
     def test_flac_skips(self):
-        from lib.preimport import _needs_spectral_check
-        self.assertFalse(_needs_spectral_check("flac", False))
-        self.assertFalse(_needs_spectral_check("flac", None))
-        self.assertFalse(_needs_spectral_check("flac", True))
+        # FLAC uses a different flow (convert → V0 → compare).
+        self.assertFalse(self._run("flac", False))
+        self.assertFalse(self._run("flac", None))
+        self.assertFalse(self._run("flac", True))
+        self.assertFalse(self._run("flac", True, avg_kbps=150))
 
-    def test_vbr_mp3_skips(self):
-        from lib.preimport import _needs_spectral_check
-        self.assertFalse(_needs_spectral_check("mp3", True))
+    def test_cbr_mp3_always_runs(self):
+        """CBR MP3 always runs spectral — avg bitrate irrelevant."""
+        self.assertTrue(self._run("mp3", False))
+        self.assertTrue(self._run("mp3", False, avg_kbps=320))
+        self.assertTrue(self._run("mp3", False, avg_kbps=128))
 
-    def test_cbr_mp3_runs(self):
-        from lib.preimport import _needs_spectral_check
-        self.assertTrue(_needs_spectral_check("mp3", False))
-
-    def test_unknown_vbr_mp3_runs_gate_by_default(self):
-        """is_vbr=None routes through the gate — run_preimport_gates resolves
-        VBR via filesystem inspection before reaching this helper."""
-        from lib.preimport import _needs_spectral_check
-        self.assertTrue(_needs_spectral_check("mp3", None))
+    def test_unknown_vbr_mp3_always_runs(self):
+        """is_vbr=None → run (conservative). run_preimport_gates reinspects
+        first, so None here means truly unresolvable."""
+        self.assertTrue(self._run("mp3", None))
+        self.assertTrue(self._run("mp3", None, avg_kbps=245))
 
     def test_mixed_mp3_flac_skips(self):
         """Filetype containing both 'flac' and 'mp3' is treated as non-MP3."""
-        from lib.preimport import _needs_spectral_check
-        self.assertFalse(_needs_spectral_check("flac, mp3", False))
+        self.assertFalse(self._run("flac, mp3", False))
 
     def test_empty_filetype_skips(self):
-        from lib.preimport import _needs_spectral_check
-        self.assertFalse(_needs_spectral_check("", False))
+        self.assertFalse(self._run("", False))
+
+    def test_vbr_threshold_table(self):
+        """VBR branch: gate only when avg is unknown or < threshold."""
+        CASES = [
+            # (desc, avg_kbps, expected)
+            ("avg unknown → gate (conservative)",          None, True),
+            ("go_team case — avg 182 < 210 → gate",         182, True),
+            ("live issue #93 avg 182kbps transcode",        182, True),
+            ("just below threshold — 200 → gate",           200, True),
+            ("at threshold — 210 is NOT below → skip",      210, False),
+            ("genuine V0 avg ~245 → skip",                  245, False),
+            ("genuine V0 avg ~260 → skip",                  260, False),
+            ("very low 96kbps → gate",                       96, True),
+        ]
+        for desc, avg, expected in CASES:
+            with self.subTest(desc=desc, avg=avg):
+                got = self._run("mp3", True, avg_kbps=avg)
+                self.assertEqual(
+                    got, expected,
+                    f"VBR avg={avg} expected {expected}, got {got}")
 
 
 class TestForceImportRunsSpectralGate(unittest.TestCase):
@@ -418,6 +454,68 @@ class TestInspectLocalFilesRecursive(unittest.TestCase):
             inspection = inspect_local_files(tmpdir)
             self.assertIn("mp3", inspection.filetype,
                           "subdirectory MP3 must be discovered")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_inspect_reports_avg_bitrate(self):
+        """inspect_local_files must also return avg_bitrate_bps across all
+        MP3 files so run_preimport_gates can decide whether to gate a VBR
+        upload against cfg.quality_ranks.mp3_vbr.excellent.
+
+        A VBR MP3 transcode at avg 182kbps (issue #93, The Go! Team) must be
+        distinguishable from a genuine V0 at avg ~245kbps. Container min
+        alone is not enough — lo-fi V0 can have low-bitrate silent tracks
+        that look identical to a transcode's min.
+        """
+        import os
+        from unittest.mock import patch
+        from lib.preimport import inspect_local_files
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            paths = []
+            for i in range(3):
+                p = os.path.join(tmpdir, f"{i:02}.mp3")
+                with open(p, "wb") as f:
+                    f.write(b"fake mp3")
+                paths.append(p)
+
+            # Simulate three tracks: two at ~240kbps, one at ~260kbps → avg 247.
+            def fake_mp3_open(path):
+                mapping = {
+                    paths[0]: 240_000,
+                    paths[1]: 240_000,
+                    paths[2]: 260_000,
+                }
+                return SimpleNamespace(info=SimpleNamespace(
+                    bitrate=mapping[path], bitrate_mode=2))  # VBR
+
+            with patch("mutagen.mp3.MP3", side_effect=fake_mp3_open):
+                inspection = inspect_local_files(tmpdir)
+
+            self.assertIsNotNone(inspection.avg_bitrate_bps,
+                                 "avg_bitrate_bps must be populated for MP3")
+            assert inspection.avg_bitrate_bps is not None
+            self.assertEqual(inspection.avg_bitrate_bps, (240_000 + 240_000 + 260_000) // 3)
+            self.assertEqual(inspection.min_bitrate_bps, 240_000)
+            self.assertTrue(inspection.is_vbr)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_inspect_avg_bitrate_none_when_no_mp3(self):
+        """Non-MP3 downloads leave avg_bitrate_bps=None (no mutagen walk)."""
+        import os
+        from lib.preimport import inspect_local_files
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.flac"), "wb") as f:
+                f.write(b"fake flac")
+            inspection = inspect_local_files(tmpdir)
+            self.assertIsNone(inspection.avg_bitrate_bps,
+                              "avg_bitrate_bps stays None without any MP3 to read")
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -1072,6 +1170,172 @@ class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
                 mock_spectral.call_count, 1,
                 "resumed download with mp3 files on disk must still get "
                 "spectral gating after inspection resolves is_vbr=False")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_low_avg_vbr_mp3_runs_spectral(self):
+        """Issue #93: VBR MP3 at avg 182kbps (below 210 threshold) MUST gate.
+
+        The Go! Team - Are You Ready for More?: uploaded as VBR MP3 with
+        126min / 182avg kbps. Current gate skips all VBR MP3 → transcode
+        imports through. Post-fix: the gate runs spectral because avg
+        (182) < cfg.quality_ranks.mp3_vbr.excellent (210) → transcode
+        correctly caught.
+        """
+        import os
+        from unittest.mock import patch
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates, LocalFileInspection
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            # Inspected: VBR MP3, avg 182kbps — the live issue #93 shape.
+            inspected = LocalFileInspection(
+                filetype="mp3",
+                min_bitrate_bps=126_000,
+                avg_bitrate_bps=182_000,
+                is_vbr=True,
+            )
+            with patch("lib.preimport.inspect_local_files",
+                       return_value=inspected), \
+                 patch("lib.preimport.spectral_analyze") as mock_spectral:
+                mock_spectral.return_value = SimpleNamespace(
+                    grade="likely_transcode",
+                    estimated_bitrate_kbps=96,
+                    suspect_pct=80.0,
+                    tracks=[SimpleNamespace(cliff_detected=True)
+                            for _ in range(5)])
+                result = run_preimport_gates(
+                    path=tmpdir,
+                    mb_release_id="",   # no existing album
+                    label="Go! Team - Are You Ready for More?",
+                    download_filetype="mp3",
+                    download_min_bitrate_bps=126_000,
+                    download_is_vbr=True,
+                    cfg=cfg,
+                    db=db,  # type: ignore[arg-type]
+                    request_id=1,
+                    usernames=set(),
+                )
+            self.assertEqual(
+                mock_spectral.call_count, 1,
+                "VBR MP3 at avg 182kbps (< 210kbps threshold) must run "
+                "spectral — this is the live issue #93 bug: current code "
+                "skips all VBR MP3 and lets transcodes through")
+            # Grade came back likely_transcode → should populate download_spectral
+            self.assertIsNotNone(
+                result.download_spectral,
+                "download_spectral must be populated after gate runs")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_high_avg_vbr_mp3_skips_spectral(self):
+        """Genuine V0 at avg 245kbps (>= 210 threshold) must keep skipping.
+
+        Guard: the threshold fix must not over-gate. Genuine V0 uploads
+        have high avg bitrates; trusting the VBR metadata here preserves
+        current behavior and avoids unnecessary ~8s-per-track spectral
+        analysis on every genuine VBR download.
+        """
+        import os
+        from unittest.mock import patch
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates, LocalFileInspection
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            inspected = LocalFileInspection(
+                filetype="mp3",
+                min_bitrate_bps=220_000,
+                avg_bitrate_bps=245_000,   # genuine V0 range
+                is_vbr=True,
+            )
+            with patch("lib.preimport.inspect_local_files",
+                       return_value=inspected), \
+                 patch("lib.preimport.spectral_analyze") as mock_spectral:
+                run_preimport_gates(
+                    path=tmpdir,
+                    mb_release_id="",
+                    label="Genuine V0 Album",
+                    download_filetype="mp3",
+                    download_min_bitrate_bps=220_000,
+                    download_is_vbr=True,
+                    cfg=cfg,
+                    db=db,  # type: ignore[arg-type]
+                    request_id=1,
+                    usernames=set(),
+                )
+            self.assertEqual(
+                mock_spectral.call_count, 0,
+                "genuine V0 (avg 245kbps >= 210kbps) must skip spectral "
+                "to avoid wasted analysis on good files")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_vbr_mp3_without_avg_still_gates(self):
+        """VBR MP3 with avg=None → still gate (conservative).
+
+        When mutagen can't compute avg (corrupt files, empty folder), the
+        gate must fall through to running spectral rather than skipping.
+        Matches the ``is_vbr=None`` handling — err on the side of analyzing.
+        """
+        import os
+        from unittest.mock import patch
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates, LocalFileInspection
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
+                f.write(b"x")
+            inspected = LocalFileInspection(
+                filetype="mp3",
+                min_bitrate_bps=None,
+                avg_bitrate_bps=None,   # mutagen couldn't read
+                is_vbr=True,
+            )
+            with patch("lib.preimport.inspect_local_files",
+                       return_value=inspected), \
+                 patch("lib.preimport.spectral_analyze") as mock_spectral:
+                mock_spectral.return_value = SimpleNamespace(
+                    grade="genuine", estimated_bitrate_kbps=None,
+                    suspect_pct=0.0, tracks=[])
+                run_preimport_gates(
+                    path=tmpdir,
+                    mb_release_id="",
+                    label="Unknown Avg",
+                    download_filetype="mp3",
+                    download_min_bitrate_bps=None,
+                    download_is_vbr=True,
+                    cfg=cfg,
+                    db=db,  # type: ignore[arg-type]
+                    request_id=1,
+                    usernames=set(),
+                )
+            self.assertEqual(
+                mock_spectral.call_count, 1,
+                "VBR MP3 with unknown avg must still gate — conservative "
+                "default; genuine VBR uploads produce 'genuine' spectral "
+                "grades and fall through")
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -597,6 +597,61 @@ class TestForceImportSlice(unittest.TestCase):
         self.assertEqual(row["status"], "imported")
         db.assert_log(self, 0, outcome="force_import")
 
+    def test_force_import_imported_path_reflects_beets_destination(self):
+        """Issue #93 was reported against force-import specifically:
+        album_requests.imported_path must reflect the beets destination
+        (ir.postflight.imported_path), not the source failed_imports/ path.
+
+        Guards that the fix propagates through dispatch_import_from_db →
+        dispatch_import_core → _do_mark_done end-to-end. Parallel to
+        TestDispatchThroughQualityGate.test_imported_path_reflects_beets_destination
+        which covers the auto path.
+        """
+        from lib.import_dispatch import dispatch_import_from_db
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=833, status="manual", mb_release_id="mbid-go-team",
+            imported_path="/mnt/virtio/music/slskd/failed_imports/stale-source",
+        ))
+
+        # The beets destination lives in ir.postflight.imported_path.
+        ir = make_import_result(
+            decision="import",
+            new_min_bitrate=320,
+            imported_path="/Beets/The Go! Team/2005 - Are You Ready for More_",
+        )
+        stdout = _make_stdout(ir)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+
+        cfg = SoularrConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True)
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+                 patch("lib.config.read_runtime_config", return_value=cfg):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                dispatch_import_from_db(
+                    db, request_id=833, failed_path=tmpdir,  # type: ignore[arg-type]
+                    force=True, source_username="ttttsv",
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        row = db.request(833)
+        self.assertEqual(
+            row["imported_path"],
+            "/Beets/The Go! Team/2005 - Are You Ready for More_",
+            "force-import must overwrite the stale source path with "
+            "ir.postflight.imported_path (the actual beets destination)")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -118,6 +118,36 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         self.assertEqual(len(db.download_logs), 1)
         db.assert_log(self, 0, outcome="success", request_id=42)
 
+    def test_imported_path_reflects_beets_destination(self):
+        """Issue #93: ``album_requests.imported_path`` must be the beets
+        destination (``ir.postflight.imported_path``), not the source/staging
+        path passed to dispatch_import_core.
+
+        Pre-fix: ``imported_path`` stored the source
+        ``/mnt/virtio/music/slskd/failed_imports/...`` even though beets
+        moved files to ``/mnt/virtio/Music/Beets/...``. UI's "Imported to"
+        label displayed the source, confusing users.
+        """
+        ir = make_import_result(
+            decision="import",
+            new_min_bitrate=245,
+            imported_path="/Beets/Test Artist/2005 - Test Album_",
+        )
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+
+        db = self._run_dispatch(ir, beets_info)
+
+        row = db.request(42)
+        self.assertEqual(
+            row["imported_path"],
+            "/Beets/Test Artist/2005 - Test Album_",
+            "album_requests.imported_path must reflect the beets "
+            "destination from ImportResult.postflight, not dispatch's "
+            "source path (the /tmp staging/failed_imports dir)")
+
     def test_import_quality_requeue_upgrade(self):
         """VBR 180kbps → quality gate requeues for upgrade → wanted, denylist."""
         ir = make_import_result(decision="import", new_min_bitrate=180)

--- a/tests/test_js_decisions.mjs
+++ b/tests/test_js_decisions.mjs
@@ -11,7 +11,7 @@
  * (loadDecisions, renderSimulatorForm) stay deferred to live deploy.
  */
 
-import { loadDecisions, renderPolicyBadges } from '../web/js/decisions.js';
+import { loadDecisions, renderPolicyBadges, DS_PRESETS } from '../web/js/decisions.js';
 import { state } from '../web/js/state.js';
 
 let passed = 0;
@@ -152,6 +152,26 @@ await loadDecisions();
 assert(fetchCalls === 2, `expected loadDecisions() to fetch twice, got ${fetchCalls}`);
 assertContains(decisionsEl.innerHTML, 'GOOD', 'second tab open renders fresh gate rank');
 assertContains(decisionsEl.innerHTML, '10 kbps', 'second tab open renders fresh tolerance');
+
+// --- DS_PRESETS contract: avg_bitrate must be explicit in every preset ---
+// Issue #93 round 3: presets that omit avg_bitrate inherit a stale value
+// from a prior run, silently producing the wrong stage0_spectral_gate.
+// This pins the contract: every preset sets avg_bitrate (even to '' for FLAC).
+console.log('\nDS_PRESETS contract');
+for (const [name, preset] of Object.entries(DS_PRESETS)) {
+  assert('avg_bitrate' in preset,
+         `preset "${name}" missing avg_bitrate — stale field inherited from prior preset`);
+}
+
+// The vbr_v0 preset must represent genuine V0 (high avg → gate skips)
+assert(DS_PRESETS.vbr_v0.avg_bitrate === '245',
+       `vbr_v0 preset must have avg_bitrate='245' (genuine V0), got ${DS_PRESETS.vbr_v0.avg_bitrate}`);
+
+// The vbr_transcode preset must trigger the gate (low avg)
+assert(DS_PRESETS.vbr_transcode !== undefined,
+       'vbr_transcode preset missing — documents the Go! Team shape from issue #93');
+assert(DS_PRESETS.vbr_transcode.avg_bitrate === '182',
+       `vbr_transcode preset must have avg_bitrate='182' (below 210 threshold), got ${DS_PRESETS.vbr_transcode.avg_bitrate}`);
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_decisions.mjs
+++ b/tests/test_js_decisions.mjs
@@ -161,6 +161,8 @@ console.log('\nDS_PRESETS contract');
 for (const [name, preset] of Object.entries(DS_PRESETS)) {
   assert('avg_bitrate' in preset,
          `preset "${name}" missing avg_bitrate — stale field inherited from prior preset`);
+  assert('existing_avg_bitrate' in preset,
+         `preset "${name}" missing existing_avg_bitrate — stale field inherited from prior preset`);
 }
 
 // The vbr_v0 preset must represent genuine V0 (high avg → gate skips)

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -593,6 +593,7 @@ class TestCmdQuality(unittest.TestCase):
         def fake_full_pipeline_decision(**kwargs):
             captured_kwargs.append(kwargs)
             return {
+                "stage0_spectral_gate": "would_run",
                 "stage1_spectral": None,
                 "stage2_import": "import",
                 "stage3_quality_gate": "accept",
@@ -692,6 +693,7 @@ class TestCmdQuality(unittest.TestCase):
 
         def fake_full_pipeline_decision(**kwargs):
             return {
+                "stage0_spectral_gate": "would_run",
                 "stage1_spectral": None,
                 "stage2_import": "import",
                 "stage3_quality_gate": "accept",

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -42,6 +42,77 @@ from lib.quality import (
 # spectral_import_decision
 # ============================================================================
 
+class TestSpectralGateTrigger(unittest.TestCase):
+    """Test the pre-analysis "would spectral run?" decision (issue #93).
+
+    Mirrors the live gate in lib.preimport._needs_spectral_check. Delivers
+    the input the UI Decisions tab and pipeline-cli quality simulator need
+    to explain which files go through spectral vs. skip.
+    """
+
+    THRESHOLD = 210
+
+    def _run(self, *, is_flac, is_cbr, is_vbr=None, avg=None):
+        from lib.quality import spectral_gate_trigger
+        return spectral_gate_trigger(
+            is_flac=is_flac, is_cbr=is_cbr, is_vbr=is_vbr,
+            avg_bitrate_kbps=avg, vbr_threshold_kbps=self.THRESHOLD,
+        )
+
+    def test_flac_skips(self):
+        """FLAC has its own flow (convert → V0 → transcode_detection)."""
+        self.assertEqual(self._run(is_flac=True, is_cbr=False), "skipped_flac")
+        self.assertEqual(self._run(is_flac=True, is_cbr=True), "skipped_flac")
+        self.assertEqual(
+            self._run(is_flac=True, is_cbr=False, is_vbr=True, avg=245),
+            "skipped_flac",
+            "FLAC always takes precedence over VBR avg")
+
+    def test_cbr_mp3_always_runs(self):
+        """CBR MP3 is the classic transcode-cliff case."""
+        self.assertEqual(
+            self._run(is_flac=False, is_cbr=True), "would_run")
+        self.assertEqual(
+            self._run(is_flac=False, is_cbr=True, avg=320), "would_run")
+        self.assertEqual(
+            self._run(is_flac=False, is_cbr=True, avg=128), "would_run")
+
+    def test_vbr_threshold_table(self):
+        """VBR MP3: gate skips only when avg is known and >= threshold."""
+        CASES = [
+            # (desc, avg, expected)
+            ("avg unknown → would_run (conservative)",  None, "would_run"),
+            ("Go! Team avg 182 < 210",                   182, "would_run"),
+            ("just below threshold 209",                 209, "would_run"),
+            ("at threshold 210 → high avg skip",         210, "skipped_vbr_high_avg"),
+            ("genuine V0 245 → skip",                    245, "skipped_vbr_high_avg"),
+            ("genuine V0 260 → skip",                    260, "skipped_vbr_high_avg"),
+            ("lowfi 96 → would_run",                      96, "would_run"),
+        ]
+        for desc, avg, expected in CASES:
+            with self.subTest(desc=desc, avg=avg):
+                got = self._run(is_flac=False, is_cbr=False,
+                                is_vbr=True, avg=avg)
+                self.assertEqual(got, expected)
+
+    def test_is_vbr_derived_from_is_cbr_when_omitted(self):
+        """Legacy simulator callers that pass is_cbr without is_vbr get
+        sensible default: is_vbr = not is_cbr."""
+        self.assertEqual(
+            self._run(is_flac=False, is_cbr=False), "would_run",
+            "derived is_vbr=True with avg=None → gate still runs")
+        self.assertEqual(
+            self._run(is_flac=False, is_cbr=False, avg=245),
+            "skipped_vbr_high_avg",
+            "derived is_vbr=True with high avg → skip")
+
+    def test_both_unknown_falls_back_to_would_run(self):
+        """is_cbr=None AND is_vbr=None → conservative default."""
+        self.assertEqual(
+            self._run(is_flac=False, is_cbr=None),
+            "would_run")
+
+
 class TestSpectralImportDecision(unittest.TestCase):
     """Test pre-import spectral decision (MP3/CBR path)."""
 
@@ -536,12 +607,14 @@ import inspect
 
 # The exact keys the simulator reads from the result dict
 EXPECTED_RESULT_KEYS = {
+    "stage0_spectral_gate",
     "stage1_spectral", "stage2_import", "stage3_quality_gate",
     "final_status", "imported", "denylisted", "keep_searching",
     "target_final_format",
 }
 
 # Valid values for each stage (None means stage was skipped)
+VALID_STAGE0 = {None, "would_run", "skipped_vbr_high_avg", "skipped_flac"}
 VALID_STAGE1 = {None, "import", "import_upgrade", "import_no_exist", "reject"}
 VALID_STAGE2 = {None, "import", "downgrade", "transcode_upgrade",
                 "transcode_downgrade", "transcode_first",
@@ -552,6 +625,7 @@ VALID_FINAL_STATUS = {None, "imported", "wanted"}
 # The exact parameter names the simulator form submits
 EXPECTED_PARAMS = {
     "is_flac", "min_bitrate", "is_cbr",
+    "is_vbr", "avg_bitrate",
     "spectral_grade", "spectral_bitrate",
     "existing_min_bitrate", "existing_spectral_bitrate",
     "override_min_bitrate",
@@ -670,14 +744,103 @@ class TestFullPipelineContract(unittest.TestCase):
         for key in ("imported", "denylisted", "keep_searching"):
             self.assertIsInstance(r[key], bool, f"{key} should be bool")
 
+    def test_stage0_values_in_contract(self):
+        """Stage 0 gate trigger must be from the known set for every scenario."""
+        # Each call is written out so pyright can type-check against the
+        # full_pipeline_decision signature (bool vs int) — a **kwargs dict
+        # collapses bool→int and breaks type narrowing.
+        results = [
+            # FLAC always skips the MP3 gate
+            full_pipeline_decision(is_flac=True, min_bitrate=0, is_cbr=False),
+            # CBR MP3 always gates
+            full_pipeline_decision(is_flac=False, min_bitrate=320, is_cbr=True),
+            # VBR MP3 with low avg gates (issue #93 Go! Team)
+            full_pipeline_decision(is_flac=False, min_bitrate=126, is_cbr=False,
+                                   is_vbr=True, avg_bitrate=182),
+            # VBR MP3 with high avg skips (genuine V0)
+            full_pipeline_decision(is_flac=False, min_bitrate=220, is_cbr=False,
+                                   is_vbr=True, avg_bitrate=245),
+            # VBR MP3 unknown avg (legacy or resumed) gates
+            full_pipeline_decision(is_flac=False, min_bitrate=200, is_cbr=False,
+                                   is_vbr=True),
+        ]
+        for r in results:
+            self.assertIn(r["stage0_spectral_gate"], VALID_STAGE0,
+                          f"Unexpected stage0 value: {r['stage0_spectral_gate']}")
+
+    def test_stage0_high_avg_vbr_skips_stage1(self):
+        """When stage 0 says skip, stage 1 must be None even if spectral
+        was (accidentally) supplied — otherwise the simulator would
+        misrepresent production behavior, which skips spectral entirely."""
+        r = full_pipeline_decision(
+            is_flac=False, min_bitrate=220, is_cbr=False,
+            is_vbr=True, avg_bitrate=245,
+            # Caller supplied spectral_grade, but stage 0 says don't gate.
+            spectral_grade="suspect", spectral_bitrate=192,
+            existing_spectral_bitrate=100,
+        )
+        self.assertEqual(r["stage0_spectral_gate"], "skipped_vbr_high_avg")
+        self.assertIsNone(
+            r["stage1_spectral"],
+            "stage 1 must not run when the gate trigger said skip — "
+            "production's _needs_spectral_check would short-circuit before "
+            "spectral_analyze is even called")
+
+    def test_stage0_low_avg_vbr_runs_stage1(self):
+        """Go! Team case: VBR avg 182 < 210 → stage 0 would_run → if
+        spectral is provided, stage 1 executes and can reject."""
+        r = full_pipeline_decision(
+            is_flac=False, min_bitrate=126, is_cbr=False,
+            is_vbr=True, avg_bitrate=182,
+            spectral_grade="likely_transcode", spectral_bitrate=96,
+            existing_spectral_bitrate=128,
+        )
+        self.assertEqual(r["stage0_spectral_gate"], "would_run")
+        # 96 <= 128 → reject in stage 1
+        self.assertEqual(r["stage1_spectral"], "reject")
+        self.assertEqual(r["final_status"], "wanted")
+        self.assertTrue(r["keep_searching"])
+
+    def test_stage0_flac_preserves_stage1(self):
+        """FLAC path: stage 0 says skipped_flac but stage 1 (modeled as
+        the FLAC post-conversion spectral decision) must still run when
+        spectral data is provided."""
+        r = full_pipeline_decision(
+            is_flac=True, min_bitrate=0, is_cbr=False,
+            spectral_grade="genuine",
+            converted_count=10, post_conversion_min_bitrate=245,
+        )
+        self.assertEqual(r["stage0_spectral_gate"], "skipped_flac")
+        # Genuine → stage 1 runs and says import
+        self.assertEqual(r["stage1_spectral"], "import")
+
     def test_decision_tree_stage_ids(self):
         """Decision tree must have the expected stages in order."""
         tree = get_decision_tree()
         ids = [s["id"] for s in tree["stages"]]
         self.assertEqual(ids, ["flac_spectral", "flac_convert", "transcode",
                                "verified_lossless", "target_conversion",
-                               "mp3_spectral", "mp3_vbr_note",
+                               "mp3_spectral_gate", "mp3_spectral",
                                "import_decision", "quality_gate", "dispatch"])
+
+    def test_decision_tree_mp3_gate_exposes_threshold(self):
+        """The new mp3_spectral_gate stage must surface the VBR threshold
+        (issue #93) so the UI Decisions tab shows the same cutoff as the
+        live production gate in lib/preimport._needs_spectral_check."""
+        tree = get_decision_tree()
+        stage_map = {s["id"]: s for s in tree["stages"]}
+        self.assertIn("mp3_spectral_gate", stage_map,
+                      "mp3_spectral_gate stage must exist")
+        gate = stage_map["mp3_spectral_gate"]
+        self.assertEqual(gate["function"], "spectral_gate_trigger")
+        outcomes = set(gate["outcomes"])
+        self.assertEqual(outcomes,
+                         {"would_run", "skipped_vbr_high_avg", "skipped_flac"})
+        # Threshold surfaces as part of at least one rule/note
+        threshold = tree["constants"]["TRANSCODE_MIN_BITRATE_KBPS"]
+        tree_text = str(gate["rules"]) + str(gate.get("note", ""))
+        self.assertIn(str(threshold), tree_text,
+                      f"threshold {threshold} must appear in gate stage text")
 
     def test_decision_tree_outcomes_match_valid_values(self):
         """Outcomes declared in the tree must match what the contract allows."""

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -627,7 +627,8 @@ EXPECTED_PARAMS = {
     "is_flac", "min_bitrate", "is_cbr",
     "is_vbr", "avg_bitrate",
     "spectral_grade", "spectral_bitrate",
-    "existing_min_bitrate", "existing_spectral_bitrate",
+    "existing_min_bitrate", "existing_avg_bitrate",
+    "existing_spectral_bitrate",
     "override_min_bitrate",
     "existing_format", "existing_is_cbr",
     "post_conversion_min_bitrate", "converted_count",
@@ -800,6 +801,51 @@ class TestFullPipelineContract(unittest.TestCase):
         self.assertEqual(r["stage1_spectral"], "reject")
         self.assertEqual(r["final_status"], "wanted")
         self.assertTrue(r["keep_searching"])
+
+    def test_avg_bitrate_flows_into_stage3_rank(self):
+        """Issue #93 round 4: avg_bitrate must flow past stage 0 into the
+        rank comparison. Under the default cfg.bitrate_metric=AVG policy,
+        a VBR V0 at min=200 / avg=245 must rank as TRANSPARENT (accepts).
+        Pre-fix: simulator used min=200 as avg → GOOD < EXCELLENT → requeue.
+        """
+        r = full_pipeline_decision(
+            is_flac=False, min_bitrate=200, is_cbr=False,
+            is_vbr=True, avg_bitrate=245,
+        )
+        # Stage 0: avg >= threshold → skip
+        self.assertEqual(r["stage0_spectral_gate"], "skipped_vbr_high_avg")
+        # Stage 2 uses AVG metric → 245 → TRANSPARENT → import
+        self.assertEqual(r["stage2_import"], "import")
+        # Stage 3 gate: AVG=245 passes EXCELLENT threshold → accept
+        self.assertEqual(r["stage3_quality_gate"], "accept")
+        self.assertEqual(r["final_status"], "imported")
+
+    def test_missing_avg_bitrate_falls_back_to_min(self):
+        """Backward-compat: callers that don't pass avg_bitrate get the
+        legacy behavior (avg == min). Protects existing scenarios that
+        only supply min_bitrate."""
+        # Same min=200 but no avg supplied → ranks on min=200 (GOOD < EXCELLENT)
+        # so the gate requeues for upgrade.
+        r = full_pipeline_decision(
+            is_flac=False, min_bitrate=200, is_cbr=False,
+        )
+        self.assertEqual(r["stage3_quality_gate"], "requeue_upgrade")
+        self.assertEqual(r["final_status"], "wanted")
+
+    def test_existing_avg_bitrate_used_in_comparison(self):
+        """existing_avg_bitrate flows into the existing measurement so the
+        Stage 2 comparison uses the right metric under AVG policy."""
+        # Existing is a VBR album at min=200 / avg=245 (TRANSPARENT).
+        # Incoming MP3 at min=210 / avg=210 (EXCELLENT) → worse, reject.
+        r = full_pipeline_decision(
+            is_flac=False, min_bitrate=210, is_cbr=False,
+            is_vbr=True, avg_bitrate=210,
+            existing_min_bitrate=200,
+            existing_avg_bitrate=245,
+        )
+        # Stage 2 compares avg=210 (EXCELLENT) to existing avg=245 (TRANSPARENT)
+        # → worse → downgrade
+        self.assertEqual(r["stage2_import"], "downgrade")
 
     def test_stage0_flac_preserves_stage1(self):
         """FLAC path: stage 0 says skipped_flac but stage 1 (modeled as

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -4,7 +4,6 @@ import unittest
 
 from lib.quality import (
     OrphanInfo,
-    RepairAction,
     find_inconsistencies,
     find_orphaned_downloads,
     suggest_repair,
@@ -29,13 +28,29 @@ class TestFindInconsistencies(unittest.TestCase):
         issues = find_inconsistencies(rows)
         self.assertEqual(len(issues), 0)
 
-    def test_wanted_with_stale_imported_path(self):
+    def test_wanted_with_imported_path_is_fine(self):
+        """Issue #93: transcode_upgrade / quality-gate upgrade flows
+        mark_done (persisting imported_path to the real beets destination),
+        then re-queue the row to ``wanted`` to search for something better.
+        The files genuinely live at imported_path during that search, so
+        flagging the row as stale would wipe correct data on the next
+        ``repair.py fix``.
+        """
         rows = [{"id": 2, "status": "wanted",
                  "active_download_state": None,
-                 "imported_path": "/some/path"}]
+                 "imported_path": "/Beets/Artist/Album"}]
         issues = find_inconsistencies(rows)
-        self.assertEqual(len(issues), 1)
-        self.assertEqual(issues[0].issue_type, "stale_imported_path")
+        self.assertEqual(len(issues), 0,
+                         "wanted + imported_path is a valid upgrade-search state")
+
+    def test_manual_with_imported_path_is_fine(self):
+        """Same rationale as wanted: manual status after a force-import
+        could legitimately carry imported_path until the row is cleared."""
+        rows = [{"id": 4, "status": "manual",
+                 "active_download_state": None,
+                 "imported_path": "/Beets/Artist/Album"}]
+        issues = find_inconsistencies(rows)
+        self.assertEqual(len(issues), 0)
 
     def test_imported_with_path_is_fine(self):
         rows = [{"id": 3, "status": "imported",
@@ -48,8 +63,8 @@ class TestFindInconsistencies(unittest.TestCase):
         rows = [
             {"id": 1, "status": "downloading", "active_download_state": None,
              "imported_path": None},
-            {"id": 2, "status": "wanted", "active_download_state": None,
-             "imported_path": "/stale"},
+            {"id": 2, "status": "downloading", "active_download_state": None,
+             "imported_path": None},
         ]
         issues = find_inconsistencies(rows)
         self.assertEqual(len(issues), 2)
@@ -133,12 +148,6 @@ class TestSuggestRepair(unittest.TestCase):
                            detail="no active_download_state")
         action = suggest_repair(issue)
         self.assertEqual(action.action, "reset_to_wanted")
-
-    def test_stale_imported_path(self):
-        issue = OrphanInfo(request_id=2, issue_type="stale_imported_path",
-                           detail="wanted but has imported_path")
-        action = suggest_repair(issue)
-        self.assertEqual(action.action, "clear_imported_path")
 
     def test_unknown_issue_type(self):
         issue = OrphanInfo(request_id=3, issue_type="unknown",

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -73,6 +73,11 @@ class DownloadScenario:
     converted_count: int = 0
     post_conversion_min_bitrate: int | None = None
     new_format: str | None = None  # explicit format hint for the rank model
+    # VBR + avg bitrate drive the preimport spectral gate (issue #93).
+    # is_vbr defaults to None (simulator derives it from is_cbr); pass
+    # explicitly only for scenarios where is_vbr != not is_cbr.
+    is_vbr: bool | None = None
+    avg_bitrate: int | None = None
 
     def dl_params(self) -> dict:
         """Download-side kwargs for full_pipeline_decision()."""
@@ -80,6 +85,8 @@ class DownloadScenario:
             "is_flac": self.is_flac,
             "min_bitrate": self.min_bitrate,
             "is_cbr": self.is_cbr,
+            "is_vbr": self.is_vbr,
+            "avg_bitrate": self.avg_bitrate,
             "spectral_grade": self.spectral_grade,
             "spectral_bitrate": self.spectral_bitrate,
             "converted_count": self.converted_count,
@@ -95,6 +102,7 @@ class SimResult:
     keep_searching: bool
     denylisted: bool
     final_status: str | None
+    stage0_spectral_gate: str | None
     stage1_spectral: str | None
     stage2_import: str | None
     stage3_quality_gate: str | None
@@ -148,10 +156,19 @@ DOWNLOAD_SCENARIOS = [
                      spectral_grade="genuine",
                      converted_count=0,
                      post_conversion_min_bitrate=None),
-    # MP3 VBR
-    DownloadScenario("mp3_v0_240", False, 240, False),
-    DownloadScenario("mp3_v0_low_205", False, 205, False),
-    DownloadScenario("mp3_v2_190", False, 190, False),
+    # MP3 VBR (avg_bitrate drives the preimport spectral gate — issue #93)
+    DownloadScenario("mp3_v0_240", False, 240, False,
+                     is_vbr=True, avg_bitrate=245),
+    DownloadScenario("mp3_v0_low_205", False, 205, False,
+                     is_vbr=True, avg_bitrate=205),
+    DownloadScenario("mp3_v2_190", False, 190, False,
+                     is_vbr=True, avg_bitrate=190),
+    # VBR transcode masquerading as V0 (Go! Team shape from issue #93).
+    # Low avg + likely_transcode spectral → stage 0 gates, stage 1 rejects.
+    DownloadScenario("vbr_transcode_go_team_shape", False, 126, False,
+                     is_vbr=True, avg_bitrate=182,
+                     spectral_grade="likely_transcode",
+                     spectral_bitrate=96),
     # CBR no spectral
     DownloadScenario("cbr_320_no_spectral", False, 320, True),
     DownloadScenario("cbr_256_no_spectral", False, 256, True),
@@ -241,6 +258,7 @@ def simulate(album: AlbumState, download: DownloadScenario,
         keep_searching=result["keep_searching"],
         denylisted=result["denylisted"],
         final_status=result["final_status"],
+        stage0_spectral_gate=result["stage0_spectral_gate"],
         stage1_spectral=result["stage1_spectral"],
         stage2_import=result["stage2_import"],
         stage3_quality_gate=result["stage3_quality_gate"],
@@ -264,6 +282,39 @@ class TestSimulatorInvariants(unittest.TestCase):
         # No duplicate names
         self.assertEqual(len(ALBUM_MAP), len(ALBUM_STATES))
         self.assertEqual(len(DL_MAP), len(DOWNLOAD_SCENARIOS))
+
+    def test_stage0_gate_propagates(self):
+        """Issue #93: every simulation must populate stage0_spectral_gate
+        so the CLI + web UI can explain why spectral ran or didn't."""
+        VALID = {"would_run", "skipped_vbr_high_avg", "skipped_flac"}
+        album = ALBUM_MAP["fresh_request"]
+        for dl in DOWNLOAD_SCENARIOS:
+            with self.subTest(dl=dl.name):
+                r = simulate(album, dl)
+                self.assertIn(r.stage0_spectral_gate, VALID,
+                              f"{dl.name}: stage0={r.stage0_spectral_gate}")
+
+    def test_vbr_high_avg_skips_spectral_stage(self):
+        """Genuine V0 download (avg 245) must have stage0=skipped_vbr_high_avg
+        AND stage1 must not run. This locks the production semantic the CLI
+        simulator must explain: 'we trust the VBR bitrate signal, no analysis'."""
+        album = ALBUM_MAP["fresh_request"]
+        r = simulate(album, DL_MAP["mp3_v0_240"])
+        self.assertEqual(r.stage0_spectral_gate, "skipped_vbr_high_avg")
+        self.assertIsNone(
+            r.stage1_spectral,
+            "high-avg VBR must skip spectral entirely, not model a "
+            "decision on it")
+
+    def test_vbr_low_avg_runs_spectral_stage(self):
+        """Go! Team shape: VBR avg 182 + likely_transcode spectral → stage 0
+        gates, stage 1 fires and rejects. The live issue #93 scenario."""
+        album = ALBUM_MAP["vbr_v0_no_spectral"]
+        r = simulate(album, DL_MAP["vbr_transcode_go_team_shape"])
+        self.assertEqual(r.stage0_spectral_gate, "would_run")
+        self.assertIn(r.stage1_spectral,
+                      ("reject", "import_upgrade", "import_no_exist"),
+                      "gate fired, stage 1 must have a real spectral decision")
 
     def test_final_status_always_set(self):
         """Every simulation must produce a definitive final_status."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -627,6 +627,7 @@ class TestPipelineRouteContracts(_WebServerCase):
         "id", "title", "path", "function", "when", "inputs", "rules",
     }
     SIMULATE_REQUIRED_FIELDS = {
+        "stage0_spectral_gate",
         "stage1_spectral", "stage2_import", "stage3_quality_gate",
         "final_status", "imported", "denylisted", "keep_searching",
         "target_final_format",
@@ -735,6 +736,7 @@ class TestPipelineRouteContracts(_WebServerCase):
     @patch("routes.pipeline.full_pipeline_decision")
     def test_pipeline_simulate_threads_target_format(self, mock_simulate):
         mock_simulate.return_value = {
+            "stage0_spectral_gate": "skipped_flac",
             "stage1_spectral": None,
             "stage2_import": "import",
             "stage3_quality_gate": "accept",
@@ -752,6 +754,31 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(
             mock_simulate.call_args.kwargs["target_format"], "flac")
+
+    def test_pipeline_simulate_threads_avg_bitrate_to_stage0(self):
+        """Issue #93: the web simulator must accept avg_bitrate and return
+        stage0_spectral_gate so the UI can drive/display the new gate.
+        """
+        # VBR MP3 with high avg → stage 0 must say skipped_vbr_high_avg
+        status, data = self._get(
+            "/api/pipeline/simulate?"
+            "is_flac=false&min_bitrate=240&is_cbr=false&is_vbr=true&avg_bitrate=245"
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            data["stage0_spectral_gate"], "skipped_vbr_high_avg",
+            "high-avg VBR must short-circuit the spectral gate in the "
+            "web simulator (matches production lib.preimport)")
+
+        # VBR MP3 with low avg → stage 0 must say would_run
+        status, data = self._get(
+            "/api/pipeline/simulate?"
+            "is_flac=false&min_bitrate=126&is_cbr=false&is_vbr=true&avg_bitrate=182"
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            data["stage0_spectral_gate"], "would_run",
+            "Go! Team-shape transcode must trigger the gate in the simulator")
 
 
 class TestPipelineMutationRouteContracts(_WebServerCase):

--- a/web/js/decisions.js
+++ b/web/js/decisions.js
@@ -185,6 +185,10 @@ export function renderSimulatorForm() {
         </select>
       </div>
       <div class="ds-field">
+        <label>Avg bitrate (kbps, VBR gate)</label>
+        <input type="number" id="ds-avg_bitrate" placeholder="gate threshold 210">
+      </div>
+      <div class="ds-field">
         <label>Spectral grade</label>
         <select id="ds-spectral_grade">
           <option value="">(none)</option>
@@ -304,7 +308,8 @@ export function dsPreset(name) {
  * Run the decision simulator with current form values.
  */
 export async function runSimulator() {
-  const fields = ['is_flac','min_bitrate','is_cbr','spectral_grade','spectral_bitrate',
+  const fields = ['is_flac','min_bitrate','is_cbr','avg_bitrate',
+    'spectral_grade','spectral_bitrate',
     'existing_min_bitrate','existing_spectral_bitrate','override_min_bitrate',
     'post_conversion_min_bitrate','converted_count','verified_lossless',
     'target_format','verified_lossless_target'];
@@ -333,7 +338,8 @@ export function renderSimulatorResults(r) {
   function stageColor(val) {
     if (!val) return 'ds-skip';
     if (['import', 'import_upgrade', 'import_no_exist', 'accept',
-         'preflight_existing'].includes(val)) return 'ds-green';
+         'preflight_existing',
+         'skipped_vbr_high_avg', 'skipped_flac'].includes(val)) return 'ds-green';
     if (['reject', 'downgrade', 'transcode_downgrade'].includes(val)) return 'ds-red';
     return 'ds-amber';
   }
@@ -349,6 +355,7 @@ export function renderSimulatorResults(r) {
   }
 
   let html = '<div class="ds-results">';
+  html += stageHtml('Stage 0: Spectral Gate Trigger', r.stage0_spectral_gate);
   html += stageHtml('Stage 1: Pre-import Spectral', r.stage1_spectral);
   html += stageHtml('Stage 2: Import Decision', r.stage2_import);
   html += stageHtml('Stage 3: Quality Gate', r.stage3_quality_gate);

--- a/web/js/decisions.js
+++ b/web/js/decisions.js
@@ -208,6 +208,10 @@ export function renderSimulatorForm() {
         <input type="number" id="ds-existing_min_bitrate" placeholder="in beets">
       </div>
       <div class="ds-field">
+        <label>Existing avg bitrate (kbps)</label>
+        <input type="number" id="ds-existing_avg_bitrate" placeholder="AVG policy">
+      </div>
+      <div class="ds-field">
         <label>Existing spectral bitrate</label>
         <input type="number" id="ds-existing_spectral_bitrate" placeholder="on disk">
       </div>
@@ -256,7 +260,8 @@ export const DS_PRESETS = {
   virginia: {
     is_flac: 'true', min_bitrate: '', is_cbr: 'false', avg_bitrate: '',
     spectral_grade: 'genuine', spectral_bitrate: '',
-    existing_min_bitrate: '192', existing_spectral_bitrate: '',
+    existing_min_bitrate: '192', existing_avg_bitrate: '',
+    existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '209',
     converted_count: '12', verified_lossless: 'false',
     target_format: '', verified_lossless_target: '',
@@ -264,7 +269,8 @@ export const DS_PRESETS = {
   mtngoats: {
     is_flac: 'false', min_bitrate: '138', is_cbr: 'false', avg_bitrate: '138',
     spectral_grade: 'genuine', spectral_bitrate: '128',
-    existing_min_bitrate: '173', existing_spectral_bitrate: '128',
+    existing_min_bitrate: '173', existing_avg_bitrate: '',
+    existing_spectral_bitrate: '128',
     override_min_bitrate: '320', post_conversion_min_bitrate: '',
     converted_count: '0', verified_lossless: 'false',
     target_format: '', verified_lossless_target: '',
@@ -272,7 +278,8 @@ export const DS_PRESETS = {
   genuine_flac: {
     is_flac: 'true', min_bitrate: '', is_cbr: 'false', avg_bitrate: '',
     spectral_grade: 'genuine', spectral_bitrate: '',
-    existing_min_bitrate: '192', existing_spectral_bitrate: '',
+    existing_min_bitrate: '192', existing_avg_bitrate: '',
+    existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '245',
     converted_count: '12', verified_lossless: 'false',
     target_format: '', verified_lossless_target: 'opus 128',
@@ -280,7 +287,8 @@ export const DS_PRESETS = {
   cbr320: {
     is_flac: 'false', min_bitrate: '320', is_cbr: 'true', avg_bitrate: '320',
     spectral_grade: '', spectral_bitrate: '',
-    existing_min_bitrate: '', existing_spectral_bitrate: '',
+    existing_min_bitrate: '', existing_avg_bitrate: '',
+    existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '',
     converted_count: '0', verified_lossless: 'false',
     target_format: '', verified_lossless_target: '',
@@ -289,7 +297,8 @@ export const DS_PRESETS = {
     // Genuine V0: avg 245 >= threshold → stage 0 = skipped_vbr_high_avg.
     is_flac: 'false', min_bitrate: '245', is_cbr: 'false', avg_bitrate: '245',
     spectral_grade: '', spectral_bitrate: '',
-    existing_min_bitrate: '', existing_spectral_bitrate: '',
+    existing_min_bitrate: '', existing_avg_bitrate: '',
+    existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '',
     converted_count: '0', verified_lossless: 'false',
     target_format: '', verified_lossless_target: '',
@@ -299,7 +308,8 @@ export const DS_PRESETS = {
     // then stage 1 rejects on the supplied likely_transcode spectral.
     is_flac: 'false', min_bitrate: '126', is_cbr: 'false', avg_bitrate: '182',
     spectral_grade: 'likely_transcode', spectral_bitrate: '96',
-    existing_min_bitrate: '', existing_spectral_bitrate: '',
+    existing_min_bitrate: '', existing_avg_bitrate: '',
+    existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '',
     converted_count: '0', verified_lossless: 'false',
     target_format: '', verified_lossless_target: '',
@@ -326,7 +336,8 @@ export function dsPreset(name) {
 export async function runSimulator() {
   const fields = ['is_flac','min_bitrate','is_cbr','avg_bitrate',
     'spectral_grade','spectral_bitrate',
-    'existing_min_bitrate','existing_spectral_bitrate','override_min_bitrate',
+    'existing_min_bitrate','existing_avg_bitrate',
+    'existing_spectral_bitrate','override_min_bitrate',
     'post_conversion_min_bitrate','converted_count','verified_lossless',
     'target_format','verified_lossless_target'];
   const params = new URLSearchParams();

--- a/web/js/decisions.js
+++ b/web/js/decisions.js
@@ -164,6 +164,7 @@ export function renderSimulatorForm() {
       <span class="ds-preset" onclick="window.dsPreset('genuine_flac')">Genuine FLAC</span>
       <span class="ds-preset" onclick="window.dsPreset('cbr320')">CBR 320 (no spectral)</span>
       <span class="ds-preset" onclick="window.dsPreset('vbr_v0')">VBR V0 MP3</span>
+      <span class="ds-preset" onclick="window.dsPreset('vbr_transcode')">VBR Transcode (#93)</span>
     </div>
     <div class="ds-form" id="ds-form">
       <div class="ds-field">
@@ -247,9 +248,13 @@ export function renderSimulatorForm() {
 }
 
 /** @type {Object<string, Object<string, string>>} */
+// Every preset explicitly sets avg_bitrate so switching presets resets
+// the field — a stale value from a prior run would otherwise produce the
+// wrong stage0_spectral_gate decision (issue #93 codex round 3).
+// FLAC presets set avg_bitrate='' since the gate skips FLAC unconditionally.
 export const DS_PRESETS = {
   virginia: {
-    is_flac: 'true', min_bitrate: '', is_cbr: 'false',
+    is_flac: 'true', min_bitrate: '', is_cbr: 'false', avg_bitrate: '',
     spectral_grade: 'genuine', spectral_bitrate: '',
     existing_min_bitrate: '192', existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '209',
@@ -257,7 +262,7 @@ export const DS_PRESETS = {
     target_format: '', verified_lossless_target: '',
   },
   mtngoats: {
-    is_flac: 'false', min_bitrate: '138', is_cbr: 'false',
+    is_flac: 'false', min_bitrate: '138', is_cbr: 'false', avg_bitrate: '138',
     spectral_grade: 'genuine', spectral_bitrate: '128',
     existing_min_bitrate: '173', existing_spectral_bitrate: '128',
     override_min_bitrate: '320', post_conversion_min_bitrate: '',
@@ -265,7 +270,7 @@ export const DS_PRESETS = {
     target_format: '', verified_lossless_target: '',
   },
   genuine_flac: {
-    is_flac: 'true', min_bitrate: '', is_cbr: 'false',
+    is_flac: 'true', min_bitrate: '', is_cbr: 'false', avg_bitrate: '',
     spectral_grade: 'genuine', spectral_bitrate: '',
     existing_min_bitrate: '192', existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '245',
@@ -273,7 +278,7 @@ export const DS_PRESETS = {
     target_format: '', verified_lossless_target: 'opus 128',
   },
   cbr320: {
-    is_flac: 'false', min_bitrate: '320', is_cbr: 'true',
+    is_flac: 'false', min_bitrate: '320', is_cbr: 'true', avg_bitrate: '320',
     spectral_grade: '', spectral_bitrate: '',
     existing_min_bitrate: '', existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '',
@@ -281,8 +286,19 @@ export const DS_PRESETS = {
     target_format: '', verified_lossless_target: '',
   },
   vbr_v0: {
-    is_flac: 'false', min_bitrate: '245', is_cbr: 'false',
+    // Genuine V0: avg 245 >= threshold → stage 0 = skipped_vbr_high_avg.
+    is_flac: 'false', min_bitrate: '245', is_cbr: 'false', avg_bitrate: '245',
     spectral_grade: '', spectral_bitrate: '',
+    existing_min_bitrate: '', existing_spectral_bitrate: '',
+    override_min_bitrate: '', post_conversion_min_bitrate: '',
+    converted_count: '0', verified_lossless: 'false',
+    target_format: '', verified_lossless_target: '',
+  },
+  vbr_transcode: {
+    // Go! Team shape (issue #93): avg 182 < threshold → stage 0 = would_run,
+    // then stage 1 rejects on the supplied likely_transcode spectral.
+    is_flac: 'false', min_bitrate: '126', is_cbr: 'false', avg_bitrate: '182',
+    spectral_grade: 'likely_transcode', spectral_bitrate: '96',
     existing_min_bitrate: '', existing_spectral_bitrate: '',
     override_min_bitrate: '', post_conversion_min_bitrate: '',
     converted_count: '0', verified_lossless: 'false',

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -216,10 +216,20 @@ def get_pipeline_simulate(h, params: dict[str, list[str]]) -> None:
         v = _str(key)
         return v in ("true", "1", "yes") if v else False
 
+    # is_vbr defaults to None (not False) so the simulator can tell
+    # "not supplied, derive from is_cbr" apart from "explicit CBR".
+    def _opt_bool(key: str) -> bool | None:
+        v = _str(key)
+        if v is None:
+            return None
+        return v in ("true", "1", "yes")
+
     result = full_pipeline_decision(
         is_flac=_bool("is_flac"),
         min_bitrate=_int("min_bitrate") or 0,
         is_cbr=_bool("is_cbr"),
+        is_vbr=_opt_bool("is_vbr"),
+        avg_bitrate=_int("avg_bitrate"),
         spectral_grade=_str("spectral_grade"),
         spectral_bitrate=_int("spectral_bitrate"),
         existing_min_bitrate=_int("existing_min_bitrate"),

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -233,6 +233,7 @@ def get_pipeline_simulate(h, params: dict[str, list[str]]) -> None:
         spectral_grade=_str("spectral_grade"),
         spectral_bitrate=_int("spectral_bitrate"),
         existing_min_bitrate=_int("existing_min_bitrate"),
+        existing_avg_bitrate=_int("existing_avg_bitrate"),
         existing_spectral_bitrate=_int("existing_spectral_bitrate"),
         override_min_bitrate=_int("override_min_bitrate"),
         existing_format=_str("existing_format"),


### PR DESCRIPTION
## Summary

Fixes two bugs that surfaced together on force-import of a VBR MP3 transcode (issue #93).

1. **`album_requests.imported_path` stored the SOURCE path, not the beets destination.**
   `_do_mark_done` was overwriting the correct value `harness/import_one.py` had just written. Now dispatch passes `ir.postflight.imported_path` through explicitly; legacy `album_source.mark_done` staging paths fall back to `dest_path`.

2. **Preimport spectral gate skipped all VBR MP3 regardless of bitrate.**
   A VBR transcode at avg 182kbps (The Go! Team — Are You Ready for More?) passed the gate even though its spectral grade was `likely_transcode ~96kbps`. VBR MP3 is now gated when `avg_bitrate < cfg.quality_ranks.mp3_vbr.excellent` (210kbps — the same V0 boundary `transcode_detection()` already uses). Genuine V0 averages ~245kbps+ and still falls through.

Structural changes:
- `LocalFileInspection` gains `avg_bitrate_bps` (mean across readable MP3 tracks).
- `run_preimport_gates` always inspects MP3 downloads (not just when `is_vbr` is unknown) so avg is available for the threshold.
- `_needs_spectral_check` takes keyword-only `avg_bitrate_kbps` / `vbr_threshold_kbps`; the VBR skip branch requires both.

## Test plan

- [x] RED then GREEN for both bugs (17 errors + 1 failure → 0 on first green run)
- [x] Pure subTest table: `test_vbr_threshold_table` covers Go! Team avg=182, at-threshold=210, genuine V0 avg=245/260, unknown avg, very low 96
- [x] Pure: `inspect_local_files` avg population + None for non-MP3
- [x] Orchestration: `_do_mark_done` imported_path param with fallback semantics (3 cases)
- [x] Integration slice: `dispatch_import_core` propagates `ir.postflight.imported_path` end-to-end
- [x] Integration: `run_preimport_gates` VBR threshold — low avg gates, high avg skips, unknown avg gates
- [x] Full suite: 1598 tests pass (53 skipped env-dependent), pyright clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)