### PR TITLE
refactor(quality): msgspec.Struct at the harness wire boundary (#99)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -8,6 +8,17 @@
 - Inner data structures must also be typed — no `list[dict]` when a dataclass exists
 - Verify with: `pyright <files>` on every touched file before committing
 
+## Wire-boundary types — use `msgspec.Struct`, not `@dataclass`
+Any type whose **input comes from outside our Python code** (harness stdout, an HTTP response, a JSONB blob coming back from the DB, a subprocess's stdout) must be a `msgspec.Struct` so the deserializer validates the typed contract at the boundary. Pyright does not see inside `dict.get()` — only runtime validation catches int-vs-str drift, mis-typed fields, or missing required data. This is the lesson of issue #99 / PR #98 (every Discogs validation silently logged `mbid_not_found` because a dataclass said `str` but the wire carried `int`).
+
+- **Use `msgspec.Struct`** for: harness/subprocess JSON messages, external API responses, DB JSONB rows we read back and type-check, any other "decode this blob into a typed object" site.
+- **Keep `@dataclass`** for: types we construct entirely from our own typed Python code (`ImportResult`, `QualityRankConfig`, `SoularrConfig`, `ActiveDownloadState` when we're the only writer). Their inputs are already typed — the strict boundary buys nothing.
+- **Decode at exactly one site.** The wire boundary is the one place the untyped blob becomes a typed object. After that, every downstream consumer works with the Struct directly — no defensive coercion, no `dict.get()`, no re-validation. If you find yourself writing a `_coerce_x` helper on the consumer side, the boundary is in the wrong place.
+- **Strict ≠ coerce.** Declare fields as the type you want (`str`, not `str | int`). `msgspec.ValidationError` at the boundary is the detector. Do not use `strict=False` to silently coerce away real type drift.
+- **Normalise early if the external source is untidy.** Harness-side `_id_str` in `harness/beets_harness.py` coerces int IDs to str *before* emitting — so the wire is always clean, and the downstream Struct validation never trips in the happy path. Keep normalisation at the source, not at the consumer.
+- Reference implementation: `HarnessItem`, `HarnessTrackInfo`, `TrackMapping`, `CandidateSummary`, `ChooseMatchMessage` in `lib/quality.py`; decoded at `lib/beets.py::beets_validate` via `msgspec.convert(msg, type=ChooseMatchMessage)`.
+- Tests owe: at least one RED test that feeds the wrong type at the boundary and asserts `msgspec.ValidationError`. This is the regression guard that makes the boundary worth having.
+
 ## Testing — Red/Green TDD
 - Write tests FIRST (RED), then implement (GREEN)
 - Every new function, dataclass, and decision branch needs test coverage

--- a/.claude/rules/harness.md
+++ b/.claude/rules/harness.md
@@ -9,6 +9,7 @@ paths:
 
 - The harness runs in the beets Python environment (Nix Home Manager on doc1), NOT in the dev shell
 - `_serialize_album_candidate()` must capture EVERY field from AlbumMatch — never discard data
-- All harness output types must be typed dataclasses: HarnessItem, HarnessTrackInfo, TrackMapping
+- **Harness-emitted types are `msgspec.Struct`, not `@dataclass`** — `HarnessItem`, `HarnessTrackInfo`, `TrackMapping`, `CandidateSummary`, `ChooseMatchMessage`. Decoded at the wire boundary in `lib/beets.py::beets_validate` via `msgspec.convert(msg, type=ChooseMatchMessage)`. The strict-typed decoder is what catches int-vs-str drift (PR #98 bug, issue #99). See the `Wire-boundary types` section in `.claude/rules/code-quality.md` for the full policy.
+- **Never normalise on the consumer side.** If beets emits an int where our Struct says str, fix `_id_str` in `harness/beets_harness.py`. Defensive coercion downstream defeats the boundary.
 - import_one.py emits ImportResult as a `__IMPORT_RESULT__` sentinel JSON line on stdout, human logging on stderr
 - Use `beets-docs` skill (`.claude/commands/beets-docs.md`) to look up beets internals

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ WHERE id = <id>;
 All types in `lib/quality.py`, fully typed with pyright, JSON round-trip serialization:
 
 - **Import path**: `ImportResult` → `AudioQualityMeasurement` (new/existing), `ConversionInfo`, `SpectralDetail`, `PostflightInfo`
-- **Validation path**: `ValidationResult` → `CandidateSummary` → `HarnessTrackInfo`, `HarnessItem`, `TrackMapping`
+- **Validation path**: `ValidationResult` → `CandidateSummary` → `HarnessTrackInfo`, `HarnessItem`, `TrackMapping`. The four harness wire-boundary types plus `ChooseMatchMessage` are `msgspec.Struct`, not `@dataclass` — the strict-typed decoder at `lib/beets.py::beets_validate` catches int/null/type drift on the wire (issue #99). See `.claude/rules/code-quality.md` § "Wire-boundary types".
 - **Dispatch path**: `DispatchAction` (action flags from `dispatch_action()`), `StageResult` (in `import_one.py` — pure stage decisions)
 - **Async download path**: `ActiveDownloadState` → `ActiveDownloadFileState` (persisted to `album_requests.active_download_state` JSONB)
 - **Spectral state**: `SpectralMeasurement` (grade + bitrate pair), `RequestSpectralStateUpdate` (typed DB write for last_download + current spectral)

--- a/lib/beets.py
+++ b/lib/beets.py
@@ -11,27 +11,16 @@ import subprocess as sp
 import os
 import sys
 
+import msgspec
+
 # Ensure lib/ is importable whether called from project root or lib/
 _lib_dir = os.path.dirname(os.path.abspath(__file__))
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
-from quality import ValidationResult, CandidateSummary
+from quality import ValidationResult, ChooseMatchMessage
 
 logger = logging.getLogger("soularr")
-
-
-def _candidate_from_harness(cand: dict, target_mbid: str) -> CandidateSummary:
-    """Build a CandidateSummary from a beets harness candidate dict.
-
-    Defensive str-coercion on `album_id` for the `is_target` flag — the
-    harness already coerces (post-fix) but Discogs candidates can carry
-    int IDs from older logs or alternate code paths. Belt-and-braces so
-    str/int drift can never re-introduce the "mbid_not_found" bug.
-    """
-    is_target = str(cand.get("album_id", "")) == str(target_mbid)
-    d = {**cand, "is_target": is_target}
-    return CandidateSummary.from_dict(d)
 
 
 def beets_validate(harness_path, album_path, mb_release_id, distance_threshold=0.15):
@@ -90,45 +79,57 @@ def beets_validate(harness_path, album_path, mb_release_id, distance_threshold=0
 
             if msg_type == "choose_match":
                 got_choose_match = True
-                raw_candidates = msg.get("candidates", [])
-                result.candidate_count = len(raw_candidates)
-                result.candidates = [
-                    _candidate_from_harness(c, mb_release_id)
-                    for c in raw_candidates
-                ]
-                # Store local file info and beets recommendation
-                result.items = msg.get("items", [])
-                result.local_track_count = msg.get("item_count")
-                result.recommendation = msg.get("recommendation")
-                result.path = msg.get("path")
-                logger.info(f"BEETS_VALIDATE: {len(raw_candidates)} candidates, "
+                # Strict-typed decode at the wire boundary. The harness
+                # has already normalised IDs to str via `_id_str`; any
+                # int/null/type-mismatch here means the harness regressed
+                # and we surface it loud instead of silently mismatching
+                # downstream (the PR #98 bug).
+                try:
+                    cm = msgspec.convert(msg, type=ChooseMatchMessage)
+                except msgspec.ValidationError as e:
+                    result.error = f"harness schema violation: {e}"
+                    logger.error(f"BEETS_VALIDATE: {result.error}")
+                    proc.stdin.write('{"action":"skip"}\n')
+                    proc.stdin.flush()
+                    continue
+
+                result.candidate_count = cm.candidate_count or len(cm.candidates)
+                result.candidates = list(cm.candidates)
+                # items is stored as list[dict] on ValidationResult
+                # (out-of-scope wire type for #99); round-trip through
+                # msgspec to get plain dicts from the typed HarnessItem
+                # structs.
+                result.items = [msgspec.to_builtins(i) for i in cm.items]
+                result.local_track_count = cm.item_count
+                result.recommendation = cm.recommendation
+                result.path = cm.path
+
+                logger.info(f"BEETS_VALIDATE: {len(cm.candidates)} candidates, "
                             f"looking for mbid={mb_release_id}")
-                for i, cand in enumerate(raw_candidates):
-                    cand_mbid = cand.get("album_id", "")
-                    cand_dist = cand.get("distance", "?")
-                    cand_album = cand.get("album", "?")
+                for i, cand in enumerate(cm.candidates):
                     logger.info(f"BEETS_VALIDATE:   candidate[{i}]: "
-                                f"mbid={cand_mbid}, dist={cand_dist}, album={cand_album}")
-                # Check if target MBID was found and distance is acceptable.
-                # str() on both sides — Discogs candidates can carry int
-                # album_ids and DB-stored mb_release_ids are always str.
-                for cand in raw_candidates:
-                    if str(cand.get("album_id", "")) == str(mb_release_id):
+                                f"mbid={cand.mbid}, dist={cand.distance}, "
+                                f"album={cand.album}")
+
+                # Find the target MBID. Both sides are str (msgspec has
+                # validated `cand.mbid` as str; `mb_release_id` comes
+                # from the DB TEXT column).
+                for cand in cm.candidates:
+                    if cand.mbid == mb_release_id:
+                        cand.is_target = True
                         result.mbid_found = True
-                        result.distance = cand["distance"]
-                        extra_tracks_raw = cand.get("extra_tracks", [])
-                        # Handle both old (int) and new (list) format
-                        n_extra = len(extra_tracks_raw) if isinstance(extra_tracks_raw, list) else extra_tracks_raw
+                        result.distance = cand.distance
+                        n_extra = len(cand.extra_tracks)
                         if n_extra > 0:
                             result.scenario = "extra_tracks"
                             result.detail = f"MB has {n_extra} more tracks than local files"
-                        elif cand["distance"] <= distance_threshold:
+                        elif cand.distance <= distance_threshold:
                             result.valid = True
                             result.scenario = "strong_match"
-                            result.detail = f"distance={cand['distance']}"
+                            result.detail = f"distance={cand.distance}"
                         else:
                             result.scenario = "high_distance"
-                            result.detail = f"distance={cand['distance']}"
+                            result.detail = f"distance={cand.distance}"
                         break
                 if not result.mbid_found:
                     result.scenario = "mbid_not_found"

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field, asdict
 from enum import IntEnum, StrEnum
 from typing import Any, Literal, Optional
 
+import msgspec
+
 QUALITY_UPGRADE_TIERS = "lossless,mp3 v0,mp3 320"
 QUALITY_LOSSLESS = "lossless"
 
@@ -199,34 +201,37 @@ def decide_download_action(
     return DownloadVerdict(DownloadDecision.in_progress)
 
 
-def _coerce_id(value) -> str:
-    """Defensive ID coercion for harness consumers.
+# ---------------------------------------------------------------------------
+# Harness wire-boundary types — msgspec.Struct with strict `str` validation.
+#
+# Beets' Discogs plugin returns integer album_id / track_id values; beets'
+# MusicBrainz plugin returns UUID strings. Every downstream consumer in the
+# pipeline compares these against DB-stored TEXT release IDs with `==`, so a
+# mixed-type wire format silently fails (that was the "mbid_not_found" bug
+# for every Discogs validation — fixed in PR #98, guarded here).
+#
+# The harness normalises IDs to str via `_id_str` in beets_harness.py before
+# emitting. These Structs declare `str` and msgspec validates at decode time
+# — an int on the wire raises `msgspec.ValidationError` inside
+# `lib/beets.py::beets_validate`, which surfaces it as `result.error`. Loud
+# failure instead of a silent miss.
+#
+# Why msgspec.Struct (not @dataclass):
+#   1. msgspec.json.decode(blob, type=Foo) validates types at the boundary.
+#      @dataclass has no runtime schema enforcement; you'd have to hand-roll
+#      a from_dict that coerces every field, and that coercion becomes
+#      defensive cruft downstream.
+#   2. Wire-shape changes are detected by tests, not by production bugs.
+#   3. Near-zero overhead.
+#
+# Only types whose inputs come from outside our Python code (harness stdout,
+# in this case) belong here. Types we construct entirely in-process (e.g.
+# ImportResult, QualityRankConfig) stay as dataclasses — their inputs are
+# our own typed data, not a wire protocol.
+# ---------------------------------------------------------------------------
 
-    The harness already coerces ID-like values to str at the wire
-    boundary (`harness/beets_harness.py::_id_str`). This is a safety net
-    in case any future caller bypasses the harness — beets' Discogs
-    plugin emits integer IDs and our typed dataclasses say `str`.
-    """
-    return str(value) if value else ""
 
-
-def _coerce_track_ids(track: dict) -> dict:
-    """Return a copy of a track dict with `track_id` and
-    `release_track_id` coerced to str. Used inside CandidateSummary
-    deserialization so HarnessTrackInfo's typed `str` contract holds
-    even when callers feed raw dicts from sources other than the
-    harness.
-    """
-    out = dict(track)
-    if "track_id" in out:
-        out["track_id"] = _coerce_id(out["track_id"])
-    if "release_track_id" in out:
-        out["release_track_id"] = _coerce_id(out["release_track_id"])
-    return out
-
-
-@dataclass
-class HarnessItem:
+class HarnessItem(msgspec.Struct):
     """Local file as seen by the beets harness during matching."""
     path: str = ""
     title: str = ""
@@ -241,9 +246,13 @@ class HarnessItem:
     data_source: str = ""
 
 
-@dataclass
-class HarnessTrackInfo:
-    """MusicBrainz track info as seen by the beets harness."""
+class HarnessTrackInfo(msgspec.Struct):
+    """MusicBrainz / Discogs track info as seen by the beets harness.
+
+    `track_id` and `release_track_id` are declared `str`; msgspec raises
+    ValidationError if beets leaks an int through (regression guard for
+    the PR #98 bug).
+    """
     title: str = ""
     artist: str = ""
     index: Optional[int] = None
@@ -258,35 +267,30 @@ class HarnessTrackInfo:
     data_source: str = ""
 
 
-@dataclass
-class TrackMapping:
-    """Which local item matched which MB track."""
-    item: HarnessItem = field(default_factory=HarnessItem)
-    track: HarnessTrackInfo = field(default_factory=HarnessTrackInfo)
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "TrackMapping":
-        return cls(
-            item=HarnessItem(**d["item"]) if "item" in d else HarnessItem(),
-            track=HarnessTrackInfo(**_coerce_track_ids(d["track"]))
-                  if "track" in d else HarnessTrackInfo(),
-        )
+class TrackMapping(msgspec.Struct):
+    """Which local item matched which MB/Discogs track."""
+    item: HarnessItem = msgspec.field(default_factory=HarnessItem)
+    track: HarnessTrackInfo = msgspec.field(default_factory=HarnessTrackInfo)
 
 
-@dataclass
-class CandidateSummary:
+class CandidateSummary(msgspec.Struct, rename={"mbid": "album_id"}):
     """Full beets candidate match data for audit logging.
 
     Stores everything the harness sends — every field from AlbumInfo,
-    the distance breakdown, track mapping, and extra items/tracks
-    with full detail.
+    the distance breakdown, track mapping, and extra items/tracks with
+    full detail.
+
+    Wire ↔ attribute mapping: the harness emits the JSON key `album_id`
+    (beets' own field name); this Struct exposes it as `.mbid` for
+    continuity with existing Python callers. msgspec handles both the
+    rename and the strict `str` validation.
     """
     # Core identity
     mbid: str = ""
     artist: str = ""
     album: str = ""
     distance: float = 0.0
-    distance_breakdown: dict[str, float] = field(default_factory=dict)
+    distance_breakdown: dict[str, float] = {}
     is_target: bool = False
     # AlbumInfo metadata
     albumdisambig: str = ""
@@ -298,7 +302,7 @@ class CandidateSummary:
     media: Optional[str] = None
     mediums: Optional[int] = None
     albumtype: Optional[str] = None
-    albumtypes: list[str] = field(default_factory=list)
+    albumtypes: list[str] = []
     albumstatus: Optional[str] = None
     releasegroup_id: str = ""
     release_group_title: str = ""
@@ -310,58 +314,27 @@ class CandidateSummary:
     asin: str = ""
     # Tracks and mapping
     track_count: int = 0
-    tracks: list[HarnessTrackInfo] = field(default_factory=list)
-    mapping: list[TrackMapping] = field(default_factory=list)
-    extra_items: list[HarnessItem] = field(default_factory=list)
-    extra_tracks: list[HarnessTrackInfo] = field(default_factory=list)
+    tracks: list[HarnessTrackInfo] = []
+    mapping: list[TrackMapping] = []
+    extra_items: list[HarnessItem] = []
+    extra_tracks: list[HarnessTrackInfo] = []
 
-    @classmethod
-    def from_dict(cls, d: dict) -> "CandidateSummary":
-        """Deserialize from a dict, constructing typed inner objects.
 
-        ID-like fields (mbid/album_id, releasegroup_id, plus track_id and
-        release_track_id inside each track) are coerced to str via
-        _coerce_id() — beets' Discogs plugin emits integers and the
-        typed contract is str. Defensive in case a future caller bypasses
-        the harness boundary.
-        """
-        tracks = [HarnessTrackInfo(**_coerce_track_ids(t)) for t in d.get("tracks", [])]
-        mapping = [TrackMapping.from_dict(m) for m in d.get("mapping", [])]
-        extra_items = [HarnessItem(**i) for i in d.get("extra_items", [])]
-        extra_tracks = [HarnessTrackInfo(**_coerce_track_ids(t))
-                        for t in d.get("extra_tracks", [])]
-        return cls(
-            mbid=_coerce_id(d.get("mbid", d.get("album_id", ""))),
-            artist=d.get("artist", ""),
-            album=d.get("album", ""),
-            distance=d.get("distance", 0.0),
-            distance_breakdown=d.get("distance_breakdown", {}),
-            is_target=d.get("is_target", False),
-            albumdisambig=d.get("albumdisambig", ""),
-            year=d.get("year"),
-            original_year=d.get("original_year"),
-            country=d.get("country"),
-            label=d.get("label"),
-            catalognum=d.get("catalognum"),
-            media=d.get("media"),
-            mediums=d.get("mediums"),
-            albumtype=d.get("albumtype"),
-            albumtypes=d.get("albumtypes", []),
-            albumstatus=d.get("albumstatus"),
-            releasegroup_id=_coerce_id(d.get("releasegroup_id", "")),
-            release_group_title=d.get("release_group_title", ""),
-            va=d.get("va", False),
-            language=d.get("language"),
-            script=d.get("script"),
-            data_source=d.get("data_source", ""),
-            barcode=d.get("barcode", ""),
-            asin=d.get("asin", ""),
-            track_count=d.get("track_count", 0),
-            tracks=tracks,
-            mapping=mapping,
-            extra_items=extra_items,
-            extra_tracks=extra_tracks,
-        )
+class ChooseMatchMessage(msgspec.Struct):
+    """Full schema of the harness `choose_match` JSON message. Decoded in
+    one shot at the wire boundary (`lib/beets.py::beets_validate`) via
+    `msgspec.convert(msg, type=ChooseMatchMessage)` — any type drift in
+    any nested field raises `msgspec.ValidationError` immediately.
+    """
+    task_id: int = 0
+    path: str = ""
+    cur_artist: str = ""
+    cur_album: str = ""
+    item_count: int = 0
+    items: list[HarnessItem] = []
+    recommendation: str = "none"
+    candidate_count: int = 0
+    candidates: list[CandidateSummary] = []
 
 
 @dataclass
@@ -398,40 +371,22 @@ class ValidationResult:
     error: Optional[str] = None
 
     def to_json(self) -> str:
-        """Serialize to JSON string."""
-        return json.dumps(asdict(self))
+        """Serialize to JSON string. Uses msgspec because the
+        `candidates` field holds msgspec.Struct instances which
+        dataclasses.asdict does not know how to recurse into."""
+        return msgspec.json.encode(self).decode()
 
     @classmethod
     def from_dict(cls, d: dict) -> "ValidationResult":
-        """Construct from a dict (e.g. parsed JSON)."""
-        candidates = [
-            CandidateSummary.from_dict(c) for c in d.get("candidates", [])
-        ]
-        return cls(
-            valid=d.get("valid", False),
-            distance=d.get("distance"),
-            scenario=d.get("scenario"),
-            detail=d.get("detail"),
-            mbid_found=d.get("mbid_found", False),
-            target_mbid=d.get("target_mbid"),
-            candidate_count=d.get("candidate_count", 0),
-            candidates=candidates,
-            items=d.get("items", []),
-            local_track_count=d.get("local_track_count"),
-            recommendation=d.get("recommendation"),
-            path=d.get("path"),
-            soulseek_username=d.get("soulseek_username"),
-            download_folder=d.get("download_folder"),
-            failed_path=d.get("failed_path"),
-            denylisted_users=d.get("denylisted_users", []),
-            corrupt_files=d.get("corrupt_files", []),
-            error=d.get("error"),
-        )
+        """Construct from a dict. Uses msgspec.convert so the nested
+        CandidateSummary / TrackMapping / HarnessItem / HarnessTrackInfo
+        structs are validated at their typed `str` contract."""
+        return msgspec.convert(d, type=cls)
 
     @classmethod
     def from_json(cls, s: str) -> "ValidationResult":
         """Deserialize from JSON string."""
-        return cls.from_dict(json.loads(s))
+        return msgspec.json.decode(s.encode(), type=cls)
 
 
 @dataclass

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ pkgs.mkShell {
       ps.psycopg2
       ps.music-tag
       ps.beets
+      ps.msgspec
       slskd-api
     ]))
     pkgs.sox                 # spectral analysis tests

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -288,21 +288,21 @@ class TestBeetsValidate(unittest.TestCase):
         self.assertTrue(result.valid)
 
     @patch("lib.beets.sp.Popen")
-    def test_discogs_int_album_id_matches_str_target(self, mock_popen):
-        """Discogs plugin returns album_id as int; target_mbid is str
-        from the DB (column type TEXT). Int-vs-str equality must succeed
-        so mbid_found=True and the candidate is matched.
+    def test_discogs_numeric_str_album_id_matches(self, mock_popen):
+        """Harness-emitted numeric-str album_id matches str target_mbid.
 
-        This was the live bug: every Discogs validation logged
-        scenario='mbid_not_found' because `2085134 != "2085134"` in Python.
+        This is the happy path for Discogs: beets' plugin returns
+        album_id as int, the harness normalises it to str via
+        `_id_str`, and msgspec decodes it straight into .mbid. The
+        strict-typed boundary does not need to coerce — the harness
+        has already done its job.
         """
         target_mbid = "2085134"  # numeric Discogs ID stored as str in DB
         proc = MagicMock()
-        # candidate from beets' discogs plugin — album_id is an INT
         candidates = [{
             "index": 0, "distance": 0.05, "artist": "Blueline Medic",
             "album": "The Apology Wars",
-            "album_id": 2085134,  # ← int, not str
+            "album_id": "2085134",  # harness-emitted str
             "year": 2001, "country": "AU", "track_count": 11,
             "albumstatus": "Official", "data_source": "Discogs",
         }]
@@ -318,16 +318,53 @@ class TestBeetsValidate(unittest.TestCase):
 
         result = beets_validate(self.HARNESS, "/test/album", target_mbid, 0.15)
 
-        self.assertTrue(result.mbid_found,
-                        "int album_id from Discogs plugin must match "
-                        "str target_mbid from DB")
+        self.assertTrue(result.mbid_found)
         self.assertTrue(result.valid)
         self.assertAlmostEqual(result.distance, 0.05)
         self.assertEqual(result.scenario, "strong_match")
-        # The CandidateSummary.is_target flag must also be True
         self.assertTrue(result.candidates[0].is_target)
-        # And mbid is normalised to str on the typed dataclass
         self.assertEqual(result.candidates[0].mbid, "2085134")
+        self.assertIsNone(result.error)
+
+    @patch("lib.beets.sp.Popen")
+    def test_int_album_id_trips_msgspec_boundary(self, mock_popen):
+        """Regression guard for PR #98: an int album_id on the wire
+        should never reach downstream consumers. msgspec.convert raises
+        ValidationError, beets_validate surfaces it as result.error,
+        and returns an empty (invalid) result — loud failure instead of
+        the silent `mbid_not_found` miss that was the original bug.
+
+        In production the harness-side `_id_str` normalises all IDs to
+        str so this path is unreachable; if it ever trips, the harness
+        has regressed and we want to know immediately.
+        """
+        target_mbid = "2085134"
+        proc = MagicMock()
+        # int album_id — the shape of the live bug
+        candidates = [{
+            "index": 0, "distance": 0.05, "artist": "X",
+            "album": "Y", "album_id": 2085134,
+            "track_count": 11, "albumstatus": "Official",
+        }]
+        msg = json.dumps({
+            "type": "choose_match", "task_id": 0, "path": "/test/path",
+            "cur_artist": "X", "cur_album": "Y",
+            "item_count": 11, "candidates": candidates,
+        })
+        proc.stdout = iter([msg + "\n", make_session_end() + "\n"])
+        proc.stdin = MagicMock()
+        proc.wait.return_value = 0
+        mock_popen.return_value = proc
+
+        result = beets_validate(self.HARNESS, "/test/album", target_mbid, 0.15)
+
+        self.assertFalse(result.valid)
+        self.assertFalse(result.mbid_found)
+        self.assertIsNotNone(result.error)
+        # Error message should name the offending field so operators
+        # can see exactly what broke.
+        assert result.error is not None  # for pyright
+        self.assertIn("album_id", result.error)
 
     @patch("lib.beets.sp.Popen")
     def test_artist_collab_match(self, mock_popen):

--- a/tests/test_validation_result.py
+++ b/tests/test_validation_result.py
@@ -9,6 +9,8 @@ import os
 import sys
 import unittest
 
+import msgspec
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.quality import (ValidationResult, CandidateSummary,
@@ -155,8 +157,8 @@ class TestCandidateSummary(unittest.TestCase):
                 {"title": "Rock Me Baby", "length": 244.1, "track_id": "t2"},
             ],
         }
-        # Use from_dict — same path as real code (JSON → dict → typed)
-        c = CandidateSummary.from_dict(harness_cand)
+        # Use msgspec.convert — same path as real code (JSON → dict → typed Struct)
+        c = msgspec.convert(harness_cand, type=CandidateSummary)
         self.assertEqual(c.mbid, "abc-123")
         self.assertEqual(c.distance, 0.02)
         self.assertEqual(c.label, "Philips")
@@ -218,64 +220,98 @@ class TestCandidateSummary(unittest.TestCase):
 
 
 # ============================================================================
-# Discogs int-ID coercion (the typed contract says str, harness can emit int)
+# Strict-typed wire boundary — msgspec validates ID fields as `str`
 # ============================================================================
 
-class TestCandidateSummaryIdCoercion(unittest.TestCase):
-    """CandidateSummary.mbid is typed as str. Beets' Discogs plugin emits
-    integer album_ids; if the harness ever leaks an int through, from_dict
-    must normalise it so downstream `==` comparisons against the str
-    target_mbid (DB column type TEXT) don't silently fail.
+class TestCandidateSummaryIdContract(unittest.TestCase):
+    """CandidateSummary is a msgspec.Struct. Every ID field is typed `str`.
+    The int-vs-str bug (every Discogs validation logging `mbid_not_found`)
+    is now caught at decode time by msgspec.ValidationError rather than
+    silently producing wrong `==` comparisons downstream.
 
-    This is the int-vs-str bug that caused every Discogs validation to log
-    `scenario: "mbid_not_found"`.
-    """
+    The harness emits `album_id` as JSON wire key; msgspec renames it to the
+    struct attribute `.mbid`. All other ID fields are validated as `str` —
+    int at the boundary = ValidationError.
 
-    def test_int_album_id_coerced_to_str(self) -> None:
-        """int album_id → str on the typed dataclass."""
-        c = CandidateSummary.from_dict({"album_id": 2085134, "artist": "X"})
+    Harness-side `_id_str` in beets_harness.py still normalises every ID to
+    str before emitting, so in the happy path the strict boundary never
+    trips; it exists to catch regressions."""
+
+    def test_str_album_id_accepted(self) -> None:
+        """UUID album_id decodes into .mbid."""
+        c = msgspec.convert(
+            {"album_id": "f100b6b0-6daa-4c9b-b33a-3e14c564cf58"},
+            type=CandidateSummary,
+        )
+        self.assertEqual(c.mbid, "f100b6b0-6daa-4c9b-b33a-3e14c564cf58")
+
+    def test_numeric_str_album_id_accepted(self) -> None:
+        """Discogs numeric ID-as-string decodes fine (harness emits this)."""
+        c = msgspec.convert({"album_id": "2085134"}, type=CandidateSummary)
         self.assertEqual(c.mbid, "2085134")
         self.assertIsInstance(c.mbid, str)
 
-    def test_str_album_id_unchanged(self) -> None:
-        """UUID album_id stays str (no double-quoting)."""
-        c = CandidateSummary.from_dict({
-            "album_id": "f100b6b0-6daa-4c9b-b33a-3e14c564cf58",
-        })
-        self.assertEqual(c.mbid, "f100b6b0-6daa-4c9b-b33a-3e14c564cf58")
+    def test_int_album_id_rejected(self) -> None:
+        """int album_id raises ValidationError — the whole point of the
+        strict boundary. This is the exact shape of the bug PR #98 fixed."""
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert({"album_id": 2085134}, type=CandidateSummary)
 
-    def test_int_releasegroup_id_coerced_to_str(self) -> None:
-        c = CandidateSummary.from_dict({
-            "album_id": 2085134, "releasegroup_id": 339103,
-        })
-        self.assertEqual(c.releasegroup_id, "339103")
-        self.assertIsInstance(c.releasegroup_id, str)
+    def test_int_releasegroup_id_rejected(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert(
+                {"album_id": "2085134", "releasegroup_id": 339103},
+                type=CandidateSummary,
+            )
 
-    def test_int_track_id_coerced_to_str(self) -> None:
-        """Discogs tracks have integer track_ids too."""
-        c = CandidateSummary.from_dict({
-            "album_id": 2085134,
-            "tracks": [{"title": "Cathedral", "track_id": 12345678}],
-        })
-        self.assertEqual(c.tracks[0].track_id, "12345678")
-        self.assertIsInstance(c.tracks[0].track_id, str)
+    def test_int_track_id_rejected(self) -> None:
+        """Discogs tracks with int track_ids trip at decode too."""
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert(
+                {"album_id": "2085134",
+                 "tracks": [{"title": "X", "track_id": 12345678}]},
+                type=CandidateSummary,
+            )
 
-    def test_int_release_track_id_coerced_to_str(self) -> None:
-        c = CandidateSummary.from_dict({
-            "album_id": 2085134,
-            "tracks": [{"title": "X", "release_track_id": 87654321}],
-        })
-        self.assertEqual(c.tracks[0].release_track_id, "87654321")
+    def test_int_release_track_id_rejected(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert(
+                {"album_id": "2085134",
+                 "tracks": [{"title": "X", "release_track_id": 87654321}]},
+                type=CandidateSummary,
+            )
 
-    def test_none_ids_become_empty_string(self) -> None:
-        """None must become "" so the typed field stays str."""
-        c = CandidateSummary.from_dict({
-            "album_id": None, "releasegroup_id": None,
-            "tracks": [{"title": "X", "track_id": None}],
-        })
-        self.assertEqual(c.mbid, "")
-        self.assertEqual(c.releasegroup_id, "")
-        self.assertEqual(c.tracks[0].track_id, "")
+    def test_null_id_rejected(self) -> None:
+        """null on a required-str field is a contract violation — the
+        harness-side `_id_str` always emits `""` for falsy IDs, so null
+        at the wire means something bypassed the harness."""
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert({"album_id": None}, type=CandidateSummary)
+
+    def test_int_nested_item_path_rejected(self) -> None:
+        """HarnessItem.path is str too; int at wire = ValidationError."""
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert(
+                {"album_id": "abc",
+                 "mapping": [{"item": {"path": 12345}, "track": {}}]},
+                type=CandidateSummary,
+            )
+
+
+class TestStructIsMsgspec(unittest.TestCase):
+    """The four harness wire-boundary types are msgspec.Struct."""
+
+    def test_harness_item_is_struct(self) -> None:
+        self.assertTrue(issubclass(HarnessItem, msgspec.Struct))
+
+    def test_harness_track_info_is_struct(self) -> None:
+        self.assertTrue(issubclass(HarnessTrackInfo, msgspec.Struct))
+
+    def test_track_mapping_is_struct(self) -> None:
+        self.assertTrue(issubclass(TrackMapping, msgspec.Struct))
+
+    def test_candidate_summary_is_struct(self) -> None:
+        self.assertTrue(issubclass(CandidateSummary, msgspec.Struct))
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #99.

## Summary
- Replaces hand-rolled `from_dict` + defensive int→str coercion on the four harness wire-boundary dataclasses (`HarnessItem`, `HarnessTrackInfo`, `TrackMapping`, `CandidateSummary`) with `msgspec.Struct`. Adds `ChooseMatchMessage` so the whole `choose_match` line decodes in one strict-typed step at `lib/beets.py::beets_validate`.
- Turns the class of bug PR #98 fixed (typed dataclass says `str`, JSON carries `int`, equality silently fails → every Discogs validation logs `mbid_not_found`) from invisible-to-pyright drift into a loud `msgspec.ValidationError` at one well-defined boundary. The harness-side `_id_str` still normalises IDs to str before emitting so the strict boundary never trips in the happy path; it exists to catch regressions.
- Adds a new code-quality rule (`.claude/rules/code-quality.md` § "Wire-boundary types") documenting the policy for future wire-level deserialization: `msgspec.Struct` at boundaries, `@dataclass` for in-process types, normalise early (at the source), never coerce on the consumer side.

## Shape of the change
- **Deleted**: `_coerce_id`, `_coerce_track_ids`, `_candidate_from_harness`, `CandidateSummary.from_dict`, `TrackMapping.from_dict`.
- **`ValidationResult`** stays `@dataclass` (out of scope per the issue) but its `to_json` / `from_dict` / `from_json` now delegate to msgspec so the Struct children round-trip correctly.
- **`CandidateSummary`** uses `rename={"mbid": "album_id"}` so the JSON key matches beets' own naming while Python callers keep `.mbid` (no consumer-side churn).
- **Regression guards** in `test_validation_result.py` and `test_beets_validation.py` assert `msgspec.ValidationError` on int/null ID inputs — the detector that makes the boundary worth having. The live-bug reproduction test is now flipped: feeding an int `album_id` asserts `result.error` is set and names the offending field, rather than silently coercing to match.

## Out of scope (per issue #99)
- `ValidationResult`, `ImportResult`, `ConversionInfo`, `SpectralDetail`, `PostflightInfo`, `ActiveDownloadState`, `DownloadInfo`, etc. all stay `@dataclass` — their inputs are constructed entirely in our own Python code, so strict runtime validation buys nothing.

## Nix
- `ps.msgspec` added to `shell.nix` (already on nixpkgs 0.20.0).
- `nixosconfig/modules/nixos/services/soularr.nix` needs the same one-line addition — will land as a separate commit on doc1 before merging/deploying so the module is updated in lockstep.

## Test plan
- [x] `nix-shell --run "bash scripts/run_tests.sh"` → 1672 tests, all pass (53 skipped as usual)
- [x] `pyright lib/quality.py lib/beets.py tests/test_validation_result.py tests/test_beets_validation.py` → 0 errors
- [x] New test `test_int_album_id_trips_msgspec_boundary` in `test_beets_validation.py` asserts the strict boundary catches an int `album_id` and surfaces it as `result.error` with the offending field name
- [x] New tests in `TestCandidateSummaryIdContract` assert `msgspec.ValidationError` on int/null ID inputs at every ID-typed field (mbid/releasegroup_id/track_id/release_track_id/nested HarnessItem.path)
- [x] New `TestStructIsMsgspec` pins the four types as `msgspec.Struct` subclasses
- [ ] Codex review (fix-bug skill) — scheduled before merge
- [ ] Deploy verification on doc2 after nixosconfig update

🤖 Generated with [Claude Code](https://claude.com/claude-code)