### PR TITLE
fix: preserve quality-gate override on user-initiated requeue

### DIFF
--- a/lib/quality.py
+++ b/lib/quality.py
@@ -82,6 +82,24 @@ def should_clear_lossless_search_override(
     )
 
 
+def resolve_user_requeue_override(existing_override: str | None) -> str:
+    """Pick ``search_filetype_override`` for a user-initiated requeue.
+
+    Preserves a stricter existing override — e.g. ``"lossless"`` set by the
+    quality gate after a CBR 320 import — so user actions (Upgrade button,
+    status reset back to wanted, ban-source) don't re-open search tiers the
+    gate intentionally closed. Falls back to :data:`QUALITY_UPGRADE_TIERS`
+    only when no override is currently set.
+
+    Without this, clicking Upgrade on an imported album would overwrite a
+    gate-narrowed ``"lossless"`` with the full ``"lossless,mp3 v0,mp3 320"``
+    ladder, re-enqueuing MP3 320 sources that the pipeline has already
+    established can't produce an upgrade — each one gets rejected as a
+    downgrade and the user sees a loop.
+    """
+    return existing_override or QUALITY_UPGRADE_TIERS
+
+
 QUALITY_MIN_BITRATE_KBPS = 210  # V0 floor — below this triggers upgrade
 TRANSCODE_MIN_BITRATE_KBPS = 210  # V0 from genuine lossless is always >= this
 

--- a/tests/test_quality_intent.py
+++ b/tests/test_quality_intent.py
@@ -150,5 +150,44 @@ class TestNarrowSearchContract(unittest.TestCase):
         self.assertTrue(catch_all)
 
 
+class TestResolveUserRequeueOverride(unittest.TestCase):
+    """resolve_user_requeue_override: pick override for user-initiated requeue.
+
+    The quality gate narrows search_filetype_override to a stricter value
+    (e.g. 'lossless' for CBR 320 that needs verified lossless). User
+    actions that re-queue for search (Upgrade button, status reset, ban
+    source) must preserve that narrowing — otherwise the same tier the
+    gate intentionally closed gets re-opened and the pipeline re-downloads
+    the same quality, which gets rejected as a downgrade in a loop.
+
+    Returns QUALITY_UPGRADE_TIERS only when no override is currently set.
+    """
+
+    def _resolve(self, existing):
+        from lib.quality import resolve_user_requeue_override
+        return resolve_user_requeue_override(existing)
+
+    def test_none_falls_back_to_full_tiers(self):
+        self.assertEqual(self._resolve(None), QUALITY_UPGRADE_TIERS)
+
+    def test_empty_string_falls_back_to_full_tiers(self):
+        """Empty string is treated like NULL — no prior narrowing to preserve."""
+        self.assertEqual(self._resolve(""), QUALITY_UPGRADE_TIERS)
+
+    def test_lossless_preserved(self):
+        """Quality gate set 'lossless' after CBR 320 import → preserve."""
+        self.assertEqual(self._resolve("lossless"), "lossless")
+
+    def test_narrowed_preserved(self):
+        """narrow_override_on_downgrade output survives user requeue clicks."""
+        self.assertEqual(
+            self._resolve("lossless,mp3 v0"), "lossless,mp3 v0")
+
+    def test_full_tiers_preserved_even_when_matches_default(self):
+        """If the existing value already equals the fallback, pass it through unchanged."""
+        self.assertEqual(
+            self._resolve(QUALITY_UPGRADE_TIERS), QUALITY_UPGRADE_TIERS)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1140,6 +1140,144 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
                                 "pipeline delete response")
 
 
+class TestUserRequeueOverridePreservation(_WebServerCase):
+    """User-initiated requeue endpoints must preserve a stricter existing
+    search_filetype_override — e.g. 'lossless' set by the quality gate after a
+    CBR 320 import. Clicking Upgrade or flipping status back to wanted must not
+    re-open MP3 tiers the gate intentionally closed (which would trigger
+    redundant re-downloads of the same-or-worse quality).
+
+    ban_source already does the right thing via `req.get(...) or QUALITY_UPGRADE_TIERS`;
+    this class guards upgrade + update against regressing to a blind clobber,
+    and pins ban_source's behaviour so future refactors don't drop it.
+    """
+
+    RELEASE_ID = "c6cd62c4-da2a-4a89-a219-adba66d6c7d4"
+
+    def setUp(self) -> None:
+        import web.server as srv
+        self._srv = srv
+        self._orig_beets = srv._beets
+        # Beets stub: update() only hits this via album_exists / get_min_bitrate.
+        # A live beets DB is the usual preceding state for a requeue.
+        self._beets = MagicMock()
+        self._beets.album_exists.return_value = True
+        self._beets.get_min_bitrate.return_value = 320
+        srv._beets = self._beets
+
+    def tearDown(self) -> None:
+        self._srv._beets = self._orig_beets
+
+    def _override_passed(self, mock_transition) -> object:
+        """Extract the search_filetype_override kwarg from the last apply_transition call."""
+        self.assertTrue(mock_transition.call_args_list,
+                        "apply_transition was not called")
+        last = mock_transition.call_args_list[-1]
+        return last.kwargs.get("search_filetype_override", "<MISSING>")
+
+    # -- Upgrade --------------------------------------------------------
+
+    @patch("routes.pipeline.apply_transition")
+    def test_upgrade_preserves_stricter_override(self, mock_transition):
+        """Upgrade on an imported album with override='lossless' must keep it."""
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=1704, status="imported", min_bitrate=320,
+            search_filetype_override="lossless",
+        )
+
+        status, _data = self._post("/api/pipeline/upgrade",
+                                    {"mb_release_id": self.RELEASE_ID})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self._override_passed(mock_transition), "lossless")
+
+    @patch("routes.pipeline.apply_transition")
+    def test_upgrade_preserves_narrowed_override(self, mock_transition):
+        """Upgrade must preserve a post-downgrade-narrow like 'lossless,mp3 v0'."""
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=1704, status="imported", min_bitrate=320,
+            search_filetype_override="lossless,mp3 v0",
+        )
+
+        status, _data = self._post("/api/pipeline/upgrade",
+                                    {"mb_release_id": self.RELEASE_ID})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self._override_passed(mock_transition), "lossless,mp3 v0")
+
+    @patch("routes.pipeline.apply_transition")
+    def test_upgrade_falls_back_to_full_tiers_when_no_override(self, mock_transition):
+        """Upgrade on an imported album with no override falls back to the full ladder."""
+        from lib.quality import QUALITY_UPGRADE_TIERS
+
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=1704, status="imported", min_bitrate=160,
+            search_filetype_override=None,
+        )
+
+        status, _data = self._post("/api/pipeline/upgrade",
+                                    {"mb_release_id": self.RELEASE_ID})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self._override_passed(mock_transition),
+                         QUALITY_UPGRADE_TIERS)
+
+    # -- Update (status → wanted) ---------------------------------------
+
+    @patch("routes.pipeline.apply_transition")
+    def test_update_to_wanted_preserves_stricter_override(self, mock_transition):
+        """Flipping an imported album back to wanted must preserve 'lossless'."""
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id=self.RELEASE_ID,
+            min_bitrate=320,
+            search_filetype_override="lossless",
+        )
+
+        status, _data = self._post("/api/pipeline/update",
+                                    {"id": 1704, "status": "wanted"})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self._override_passed(mock_transition), "lossless")
+
+    @patch("routes.pipeline.apply_transition")
+    def test_update_to_wanted_falls_back_to_full_tiers_when_no_override(
+            self, mock_transition):
+        """Flipping imported→wanted with no override uses the full upgrade ladder."""
+        from lib.quality import QUALITY_UPGRADE_TIERS
+
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id=self.RELEASE_ID,
+            min_bitrate=160,
+            search_filetype_override=None,
+        )
+
+        status, _data = self._post("/api/pipeline/update",
+                                    {"id": 1704, "status": "wanted"})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self._override_passed(mock_transition),
+                         QUALITY_UPGRADE_TIERS)
+
+    # -- Ban source (regression pin) ------------------------------------
+
+    @patch("routes.pipeline.apply_transition")
+    def test_ban_source_preserves_stricter_override(self, mock_transition):
+        """Pin: ban_source already preserves override. Guard against future regression."""
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id=self.RELEASE_ID,
+            min_bitrate=320,
+            search_filetype_override="lossless",
+        )
+
+        status, _data = self._post("/api/pipeline/ban-source", {
+            "request_id": 1704, "username": "baduser",
+            "mb_release_id": self.RELEASE_ID,
+        })
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self._override_passed(mock_transition), "lossless")
+
+
 class TestManualImportRouteContracts(_WebServerCase):
     """Contract tests for manual import routes."""
 

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -319,7 +319,8 @@ export async function upgradeAlbum(mbid, btn) {
       btn.style.color = '#6a9';
       updatePipelineStatus(mbid, 'wanted', data.id);
       const br = data.min_bitrate ? ` from ${data.min_bitrate}kbps` : '';
-      toast(`Upgrade queued${br} — searching flac, v0, 320`);
+      const tiers = data.search_filetype_override || 'default';
+      toast(`Upgrade queued${br} — searching ${tiers}`);
     } else {
       btn.textContent = 'Error';
       toast(data.error || 'Upgrade failed', true);

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from classify import classify_log_entry, LogEntry  # type: ignore[import-not-found]
 from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,  # type: ignore[import-not-found]
+                         resolve_user_requeue_override,
                          should_clear_lossless_search_override,
                          get_decision_tree, full_pipeline_decision,
                          detect_release_source)
@@ -391,7 +392,11 @@ def post_pipeline_update(h, body: dict) -> None:
         b = s._beets_db()
         if mbid and b:
             if b.album_exists(mbid):
-                quality = QUALITY_UPGRADE_TIERS
+                # Preserve a stricter existing override (e.g. "lossless"
+                # set by the quality gate) — reverting status shouldn't
+                # re-open tiers the gate intentionally closed.
+                quality = resolve_user_requeue_override(
+                    req.get("search_filetype_override"))
                 min_br = b.get_min_bitrate(mbid)
         kwargs: dict[str, object] = {"from_status": req["status"]}
         if quality is not None:
@@ -413,7 +418,6 @@ def post_pipeline_upgrade(h, body: dict) -> None:
         h._error("Missing mb_release_id")
         return
 
-    quality = QUALITY_UPGRADE_TIERS
     source = detect_release_source(mbid)
 
     min_bitrate = None
@@ -425,6 +429,13 @@ def post_pipeline_upgrade(h, body: dict) -> None:
     if not existing and source == "discogs":
         existing = s._db().get_request_by_discogs_release_id(mbid)
     if existing:
+        # Preserve a stricter existing override (e.g. "lossless" set by
+        # the quality gate after a CBR 320 import) so clicking Upgrade
+        # doesn't re-open tiers the gate already closed, which would
+        # re-enqueue same-quality MP3 sources that get rejected as
+        # downgrades in a loop.
+        quality = resolve_user_requeue_override(
+            existing.get("search_filetype_override"))
         req_id = existing["id"]
         apply_transition(s._db(), req_id, "wanted",
                          from_status=existing["status"],
@@ -437,6 +448,8 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             "search_filetype_override": quality,
         })
     else:
+        # Brand-new request — no prior override to preserve.
+        quality = QUALITY_UPGRADE_TIERS
         if source == "discogs":
             release = discogs_api.get_release(int(mbid))
             req_id = s._db().add_request(
@@ -623,11 +636,13 @@ def post_pipeline_ban_source(h, body: dict) -> None:
 
     req = s._db().get_request(int(req_id))
     if req:
-        quality = req.get("search_filetype_override") or QUALITY_UPGRADE_TIERS
+        quality = resolve_user_requeue_override(
+            req.get("search_filetype_override"))
         min_br = req.get("min_bitrate")
-        ban_kwargs: dict[str, object] = {"from_status": req["status"]}
-        if quality is not None:
-            ban_kwargs["search_filetype_override"] = quality
+        ban_kwargs: dict[str, object] = {
+            "from_status": req["status"],
+            "search_filetype_override": quality,
+        }
         if min_br is not None:
             ban_kwargs["min_bitrate"] = min_br
         apply_transition(s._db(), int(req_id), "wanted", **ban_kwargs)


### PR DESCRIPTION
## Summary

- Quality gate correctly narrows `search_filetype_override` to `lossless` after a CBR 320 import (so the next search looks only for a verifiable lossless source), but two web handlers then silently overwrote that narrowing with the full `lossless,mp3 v0,mp3 320` ladder. The next search re-enqueued same-quality MP3 sources that got rejected as downgrades — looks like a loop to the user.
- Extracted `resolve_user_requeue_override()` in `lib/quality.py` — preserves the existing override and falls back to `QUALITY_UPGRADE_TIERS` only when NULL. Wired through `post_pipeline_upgrade`, `post_pipeline_update`, and `post_pipeline_ban_source` (which already used the correct inline idiom).
- Live evidence: request 1704 (Blueline Medic — A Working Title in Green). Gate set override to `lossless` at 07:45; agent clicked Upgrade at 08:52 → override became `lossless,mp3 v0,mp3 320`; MP3 320 re-downloaded at 09:17 and 13:16, both rejected.

## Test plan

- [x] `TestResolveUserRequeueOverride` — 5 pure tests for the new helper (NULL/empty → fallback, lossless preserved, narrowed preserved, full-tiers passthrough).
- [x] `TestUserRequeueOverridePreservation` — 6 route contract tests: upgrade + update preserve stricter override, upgrade + update fall back to full tiers when NULL, ban-source pinned to correct behaviour. Confirmed RED before the fix, GREEN after.
- [x] `pyright` clean on all touched files.
- [x] Full suite: 1635 passing, 1 pre-existing unrelated failure (`test_discogs_artist_contract`, reproduces on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)