### PR TITLE
fix(beets): set HOME on beets_validate harness subprocess (+ refactor)

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -47,6 +47,7 @@ _bootstrap_import_paths()
 
 from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
+from lib.util import beets_subprocess_env
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, ImportResult,
                          PostflightInfo, QualityRankConfig,
@@ -565,10 +566,10 @@ def run_import(path, mb_release_id):
     cmd = [HARNESS, "--noincremental", "--search-id", mb_release_id, path]
     print(f"  [HARNESS] {' '.join(cmd)}", file=sys.stderr)
 
-    env = {**os.environ, "HOME": "/home/abl030"}
     proc = subprocess.Popen(
         cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, text=True, preexec_fn=os.setsid, env=env,
+        stderr=subprocess.PIPE, text=True, preexec_fn=os.setsid,
+        env=beets_subprocess_env(),
     )
     assert proc.stdin is not None
     assert proc.stdout is not None
@@ -1125,7 +1126,7 @@ def main():
         move_result = subprocess.run(
             [BEET_BIN, "move", f"mb_albumid:{mbid}"],
             capture_output=True, text=True, timeout=120,
-            env={**os.environ, "HOME": "/home/abl030"},
+            env=beets_subprocess_env(),
         )
         if move_result.returncode == 0:
             # Re-read path from beets DB — it may have changed

--- a/lib/beets.py
+++ b/lib/beets.py
@@ -19,6 +19,7 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from quality import ValidationResult, ChooseMatchMessage
+from util import beets_subprocess_env
 
 logger = logging.getLogger("soularr")
 
@@ -43,7 +44,8 @@ def beets_validate(harness_path, album_path, mb_release_id, distance_threshold=0
     logger.info(f"BEETS_VALIDATE: cmd={' '.join(cmd)}")
 
     try:
-        proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, text=True)
+        proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, text=True,
+                        env=beets_subprocess_env())
     except Exception as e:
         result.error = f"Failed to start harness: {e}"
         logger.error(f"BEETS_VALIDATE: {result.error}")

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -22,7 +22,8 @@ from lib.quality import (parse_import_result, DownloadInfo, ImportResult,
                          extract_usernames, narrow_override_on_downgrade,
                          rejection_backfill_override)
 from lib.transitions import apply_transition
-from lib.util import cleanup_disambiguation_orphans, repair_mp3_headers, trigger_meelo_clean
+from lib.util import (beets_subprocess_env, cleanup_disambiguation_orphans,
+                      repair_mp3_headers, trigger_meelo_clean)
 from lib.preimport import inspect_local_files, run_preimport_gates
 
 if TYPE_CHECKING:
@@ -500,9 +501,8 @@ def dispatch_import_core(
         # path) → harness falls back to QualityRankConfig.defaults().
         if cfg is not None:
             cmd.extend(["--quality-rank-config", cfg.quality_ranks.to_json()])
-        import_env = {**os.environ, "HOME": "/home/abl030"}
         result = sp.run(cmd, capture_output=True, text=True,
-                        timeout=1800, env=import_env)
+                        timeout=1800, env=beets_subprocess_env())
         for line in (result.stderr or "").strip().split("\n"):
             if line.strip():
                 logger.info(f"  [import] {line}")

--- a/lib/util.py
+++ b/lib/util.py
@@ -34,6 +34,33 @@ class AudioValidationResult:
     failed_files: list[tuple[str, str]] = field(default_factory=list)
 
 
+# === Subprocess env for beets ===
+
+def beets_subprocess_env() -> dict[str, str]:
+    """Env for subprocesses that invoke beets (directly or via the harness
+    and import_one.py). Single source of truth for the HOME override.
+
+    Beets resolves its config from `$HOME/.config/beets/config.yaml`. The
+    soularr systemd service runs as root with HOME=/root; the Nix Home
+    Manager beets config (including the Discogs plugin token and the patched
+    base URL for the local Discogs mirror) lives at /home/abl030/.config/.
+    Without the override, the Discogs plugin silently returns 0 candidates
+    for every --search-id <numeric_id> → scenario=mbid_not_found on every
+    Discogs validation. This hit every Blueline Medic - Apology Wars
+    attempt (download_log 3604–3616) post-PR #100.
+
+    Every subprocess that runs beets must use this env:
+      - lib/beets.py::beets_validate (harness for validation)
+      - lib/import_dispatch.py (launches import_one.py)
+      - harness/import_one.py (launches the harness + `beet move`)
+      - web/routes/pipeline.py (ban-source `beet remove`)
+
+    os.environ is snapshotted at CALL time, not import time, so tests that
+    patch the environment see the patched values.
+    """
+    return {**os.environ, "HOME": "/home/abl030"}
+
+
 # === Filesystem utilities ===
 
 def sanitize_folder_name(folder_name: str) -> str:

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -163,6 +163,45 @@ class TestBeetsValidate(unittest.TestCase):
         self.assertIn("Failed to start harness", result.error)
 
     @patch("lib.beets.sp.Popen")
+    def test_launches_harness_with_beets_subprocess_env(self, mock_popen):
+        """Regression guard: the harness subprocess MUST receive the beets
+        env (HOME override). When soularr runs as the systemd service (root,
+        HOME=/root) without this, beets' Discogs plugin can't find its
+        config at `~/.config/beets/` and returns 0 candidates for every
+        --search-id — scenario=mbid_not_found on every Discogs validation.
+
+        Live failures: download_log ids 3604, 3607, 3610, 3611, 3613, 3615,
+        3616 for request ids 1710, 1711 (Blueline Medic - The Apology Wars).
+        """
+        from lib.util import beets_subprocess_env
+        mbid = "12345678-1234-1234-1234-123456789abc"
+        proc = MagicMock()
+        proc.stdout = iter([
+            make_choose_match_msg(mbid, 0.05) + "\n",
+            make_session_end() + "\n",
+        ])
+        proc.stdin = MagicMock()
+        proc.wait.return_value = 0
+        mock_popen.return_value = proc
+
+        beets_validate(self.HARNESS, "/test/album", mbid, 0.15)
+
+        # Inspect the kwargs passed to sp.Popen
+        self.assertTrue(mock_popen.called, "sp.Popen was never called")
+        _, kwargs = mock_popen.call_args
+        self.assertIn("env", kwargs,
+                      "Popen called without env=; Discogs plugin will fail "
+                      "under the systemd service (HOME=/root)")
+        env = kwargs["env"]
+        self.assertEqual(
+            env.get("HOME"), "/home/abl030",
+            "HOME must point to the Home Manager profile where beets config "
+            "lives; see lib.util.beets_subprocess_env()")
+        # Should be the exact env shape used elsewhere — single source of
+        # truth lives in lib.util.beets_subprocess_env().
+        self.assertEqual(env.get("HOME"), beets_subprocess_env()["HOME"])
+
+    @patch("lib.beets.sp.Popen")
     def test_handles_should_resume_then_choose_match(self, mock_popen):
         """should_resume followed by choose_match → handles both correctly."""
         mbid = "12345678-1234-1234-1234-123456789abc"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -586,5 +586,48 @@ class TestTriggerJellyfinScan(unittest.TestCase):
         trigger_jellyfin_scan(self._make_cfg())  # best-effort, no raise
 
 
+class TestBeetsSubprocessEnv(unittest.TestCase):
+    """beets_subprocess_env() is the single source of truth for the env dict
+    used by every subprocess that invokes beets (directly or via the harness
+    / import_one.py). Beets reads `~/.config/beets/config.yaml`; when soularr
+    runs as the systemd service (root, HOME=/root), the Nix Home Manager
+    beets config isn't there and the Discogs plugin returns 0 candidates for
+    every --search-id. See live failures in download_log for Blueline Medic.
+    """
+
+    def test_helper_exists_and_returns_dict(self) -> None:
+        from lib.util import beets_subprocess_env
+        env = beets_subprocess_env()
+        self.assertIsInstance(env, dict)
+
+    def test_home_overridden_to_home_manager_profile(self) -> None:
+        """HOME must point to the user profile where beets config lives,
+        regardless of what HOME is in the caller's environment."""
+        from lib.util import beets_subprocess_env
+        with patch.dict(os.environ, {"HOME": "/root"}, clear=False):
+            env = beets_subprocess_env()
+        self.assertEqual(env["HOME"], "/home/abl030")
+
+    def test_inherits_other_env_vars(self) -> None:
+        """Non-HOME vars pass through unchanged — PATH, PYTHONPATH etc. must
+        still reach the subprocess."""
+        from lib.util import beets_subprocess_env
+        sentinel = "SOULARR_TEST_SENTINEL_VAR_XYZ"
+        with patch.dict(os.environ, {sentinel: "present"}, clear=False):
+            env = beets_subprocess_env()
+        self.assertEqual(env.get(sentinel), "present")
+
+    def test_picks_up_environ_at_call_time(self) -> None:
+        """Not a frozen module-level snapshot — os.environ is read fresh
+        each call so test-time patching works and any late-set var shows up."""
+        from lib.util import beets_subprocess_env
+        with patch.dict(os.environ, {"LATE_BOUND_VAR": "first"}, clear=False):
+            env1 = beets_subprocess_env()
+        with patch.dict(os.environ, {"LATE_BOUND_VAR": "second"}, clear=False):
+            env2 = beets_subprocess_env()
+        self.assertEqual(env1["LATE_BOUND_VAR"], "first")
+        self.assertEqual(env2["LATE_BOUND_VAR"], "second")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -15,7 +15,7 @@ from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,  # type: ignor
                          get_decision_tree, full_pipeline_decision,
                          detect_release_source)
 from lib.transitions import apply_transition  # type: ignore[import-not-found]
-from lib.util import resolve_failed_path  # type: ignore[import-not-found]
+from lib.util import beets_subprocess_env, resolve_failed_path  # type: ignore[import-not-found]
 from spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,  # type: ignore[import-not-found]
                              ALBUM_SUSPECT_PCT, MIN_CLIFF_SLICES,
                              CLIFF_THRESHOLD_DB_PER_KHZ)
@@ -630,7 +630,7 @@ def post_pipeline_ban_source(h, body: dict) -> None:
             result = _sp.run(
                 ["beet", "remove", "-d", f"mb_albumid:{mb_release_id}"],
                 capture_output=True, text=True, timeout=30,
-                env={**os.environ, "HOME": "/home/abl030"},
+                env=beets_subprocess_env(),
             )
             beets_removed = result.returncode == 0
 


### PR DESCRIPTION
## Summary
- `lib/beets.py::beets_validate` launched the harness via `sp.Popen` without an explicit `env=`. Under the systemd service (root, `HOME=/root`) the beets Discogs plugin could not resolve its config at `~/.config/beets/` and returned 0 candidates for every `--search-id <numeric_id>` → `scenario=mbid_not_found` on every Discogs validation.
- Three other subprocess sites were already hand-rolling `env={**os.environ, "HOME": "/home/abl030"}` inline (harness, import_one, ban-source). Four copies, one missing — classic parallel-code-paths bug. Extract `lib.util.beets_subprocess_env()` as the single source of truth.

## Reproduction
```
sudo HOME=/root    harness --search-id 19199203 <path>  → candidate_count: 0  ❌
sudo HOME=/home/abl030 harness --search-id 19199203 <path>  → candidate_count: 1  ✓
```

Live failures: `download_log` ids 3604, 3607, 3610, 3611, 3613, 3615, 3616 — every Discogs validation attempt for Blueline Medic - The Apology Wars (request ids 1710, 1711) between PR #100 deploy and this fix. **Independent of PR #100** — the msgspec boundary never saw a candidate to validate because the Discogs plugin wasn't returning any.

## Shape of the change
Per `.claude/rules/scope.md` (clean-as-you-go + no parallel code paths):

- **New**: `lib.util.beets_subprocess_env()` — returns `{**os.environ, "HOME": "/home/abl030"}`. Single source of truth for "env that a beets subprocess needs". Reads `os.environ` at call time (not frozen at import) so tests can patch it.
- **Migrated 5 subprocess launchers** to use the helper:
  - `lib/beets.py::beets_validate` — **the bug site**; now passes `env=beets_subprocess_env()` to Popen.
  - `harness/import_one.py` harness Popen (line 569)
  - `harness/import_one.py` `beet move` (line 1125)
  - `lib/import_dispatch.py` import_one.py launch (line 504)
  - `web/routes/pipeline.py` ban-source `beet remove` (line 630)

No new class of bug in this shape is possible — if a future caller launches a beets-touching subprocess, the inline env construction is gone and the helper is the obvious path.

## Test plan
- [x] New helper test in `tests/test_util.py::TestBeetsSubprocessEnv` — 4 tests (exists, HOME override wins over caller env, other vars inherit, not frozen at import)
- [x] New regression test in `tests/test_beets_validation.py::test_launches_harness_with_beets_subprocess_env` — inspects `sp.Popen.call_args`, asserts `env` kwarg present and `HOME == "/home/abl030"`. Fails loud if the kwarg is ever dropped again.
- [x] `nix-shell --run "bash scripts/run_tests.sh"` → 1707 tests, all pass
- [x] `pyright` clean on all 7 touched files
- [ ] Codex review — next
- [ ] Live verification on doc2 post-deploy: `pipeline-cli force-import` (or natural requeue) of request 1711 should now return `candidate_count >= 1` instead of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)