### PR TITLE
fix(web): split MB/Discogs metadata cache from pipeline overlay (#101)

### DIFF
--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -153,6 +153,44 @@ class TestMetaNamespace(_CacheTestBase):
             "no-op cache must call fetch every time (never cache-hit)")
 
 
+class TestMemoizeMetaFresh(_CacheTestBase):
+    """`fresh=True` is the bypass used by POST handlers that persist
+    metadata into the pipeline DB. A 24h stale cache read on an add /
+    upgrade path would silently bake yesterday's title / tracks into
+    `album_requests`. Flagged by Codex review on issue #101.
+    """
+
+    def test_fresh_skips_cache_read_and_repopulates(self) -> None:
+        calls: list[int] = []
+
+        def _fetch_v1() -> dict:
+            calls.append(1)
+            return {"title": "Old Title"}
+
+        def _fetch_v2() -> dict:
+            calls.append(2)
+            return {"title": "Corrected Title"}
+
+        # Warm the cache via a normal GET-style call.
+        first = self.cache.memoize_meta("mb:release:abc", _fetch_v1)
+        self.assertEqual(first, {"title": "Old Title"})
+        self.assertEqual(calls, [1])
+
+        # fresh=True MUST bypass the read and re-fetch.
+        second = self.cache.memoize_meta("mb:release:abc", _fetch_v2,
+                                         fresh=True)
+        self.assertEqual(second, {"title": "Corrected Title"},
+                         "fresh=True must ignore the cached value")
+        self.assertEqual(calls, [1, 2])
+
+        # And it must have repopulated the cache — a subsequent GET
+        # without fresh= sees the fresh value. Warms the cache on writes.
+        third = self.cache.memoize_meta("mb:release:abc", _fetch_v2)
+        self.assertEqual(third, {"title": "Corrected Title"})
+        self.assertEqual(calls, [1, 2],
+                         "cache must have been repopulated by fresh=True")
+
+
 class TestMetaIsolatedFromGroupInvalidation(_CacheTestBase):
     """Core guarantee for issue #101: MB/Discogs metadata cache must
     survive pipeline-state / library-state invalidation events.

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -153,6 +153,56 @@ class TestMetaNamespace(_CacheTestBase):
             "no-op cache must call fetch every time (never cache-hit)")
 
 
+class TestStartupFlushLeavesMetaAlone(unittest.TestCase):
+    """Server startup flushes legacy `web:*` routing cache but MUST NOT
+    touch the pure `meta:*` metadata namespace. Flushing it on every
+    `systemctl restart soularr-web` would defeat the 24h cache —
+    Codex review on PR #104.
+    """
+
+    def test_main_does_not_invalidate_meta_pattern(self) -> None:
+        """Source-level regression guard. `main()` in web/server.py
+        must not call `cache.invalidate_pattern('meta:*')`. If a future
+        change wants to flush metadata, do it per-key via a version
+        prefix bump, not a blanket startup wipe."""
+        import ast
+        import os
+
+        server_py = os.path.join(
+            os.path.dirname(__file__), "..", "web", "server.py")
+        with open(server_py) as f:
+            tree = ast.parse(f.read())
+
+        main_fn = next(
+            (n for n in ast.walk(tree)
+             if isinstance(n, ast.FunctionDef) and n.name == "main"),
+            None,
+        )
+        self.assertIsNotNone(main_fn,
+                             "couldn't locate main() in web/server.py")
+        assert main_fn is not None  # narrow for pyright
+
+        for node in ast.walk(main_fn):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            is_invalidate = (
+                isinstance(fn, ast.Attribute)
+                and fn.attr == "invalidate_pattern"
+            )
+            if not is_invalidate:
+                continue
+            if not node.args:
+                continue
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                self.assertNotEqual(
+                    arg.value, "meta:*",
+                    "main() must not flush meta:* on startup — that "
+                    "defeats the 24h MB/Discogs metadata cache on every "
+                    "restart. See Codex review on PR #104.")
+
+
 class TestMemoizeMetaFresh(_CacheTestBase):
     """`fresh=True` is the bypass used by POST handlers that persist
     metadata into the pipeline DB. A 24h stale cache read on an add /

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -1,0 +1,223 @@
+"""Tests for the web metadata cache — the `meta:` namespace.
+
+The `meta:` namespace caches PURE MusicBrainz / Discogs metadata only.
+It is deliberately separate from the old routing-level `web:` namespace
+which baked per-user overlay state (`pipeline_status`, `in_library`,
+`library_rank`, ...) into the cached payload. See issue #101.
+
+These tests pin two properties:
+  1. `meta_get` / `meta_set` / `memoize_meta` round-trip correctly and
+     no-op when Redis is unavailable.
+  2. Group invalidations for `pipeline` / `library` / `mb` / `discogs`
+     do NOT touch `meta:` keys. MB/Discogs metadata is effectively
+     immutable on our daily-sync'd mirrors, so pipeline-state changes
+     must not flush the expensive metadata cache.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import unittest
+from typing import Any
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "web"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class FakeRedis:
+    """Minimal Redis stub: in-memory store with TTL tracking and SCAN."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[str, float | None]] = {}
+
+    def ping(self) -> bool:
+        return True
+
+    def get(self, key: str) -> str | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        value, expires = entry
+        if expires is not None and time.time() > expires:
+            self._store.pop(key, None)
+            return None
+        return value
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        self._store[key] = (value, time.time() + ttl)
+
+    def delete(self, *keys: str) -> int:
+        n = 0
+        for k in keys:
+            if k in self._store:
+                self._store.pop(k, None)
+                n += 1
+        return n
+
+    def scan(self, cursor: int = 0, match: str | None = None,
+             count: int = 100) -> tuple[int, list[str]]:
+        import fnmatch
+        pattern = match or "*"
+        keys = [k for k in self._store if fnmatch.fnmatch(k, pattern)]
+        return 0, keys
+
+
+class _CacheTestBase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        import web.cache as cache
+        self.cache = cache
+        self.fake = FakeRedis()
+        self._saved = cache._redis
+        cache._redis = self.fake
+
+    def tearDown(self) -> None:
+        self.cache._redis = self._saved
+
+
+class TestMetaNamespace(_CacheTestBase):
+    """meta_get / meta_set / memoize_meta round-trip."""
+
+    def test_meta_set_then_get_returns_value(self) -> None:
+        self.cache.meta_set("mb:release:abc", {"id": "abc", "title": "Foo"})
+        self.assertEqual(
+            self.cache.meta_get("mb:release:abc"),
+            {"id": "abc", "title": "Foo"},
+        )
+
+    def test_meta_get_returns_none_on_miss(self) -> None:
+        self.assertIsNone(self.cache.meta_get("mb:release:missing"))
+
+    def test_meta_namespace_is_prefixed(self) -> None:
+        """meta_set must store under meta: so it doesn't collide with
+        the old web:* routing cache namespace."""
+        self.cache.meta_set("mb:release:abc", {"x": 1})
+        self.assertIn("meta:mb:release:abc", self.fake._store)
+        self.assertNotIn("mb:release:abc", self.fake._store)
+        self.assertNotIn("web:mb:release:abc", self.fake._store)
+
+    def test_memoize_meta_calls_fetch_on_miss_only(self) -> None:
+        calls: list[str] = []
+
+        def _fetch() -> dict[str, Any]:
+            calls.append("fetch")
+            return {"id": "abc"}
+
+        first = self.cache.memoize_meta("mb:release:abc", _fetch)
+        second = self.cache.memoize_meta("mb:release:abc", _fetch)
+        self.assertEqual(first, {"id": "abc"})
+        self.assertEqual(second, {"id": "abc"})
+        self.assertEqual(calls, ["fetch"],
+                         "fetch must only run on the first call")
+
+    def test_memoize_meta_honours_ttl(self) -> None:
+        """TTL=1 means a second call after > 1s re-fetches."""
+        calls: list[str] = []
+
+        def _fetch() -> dict[str, Any]:
+            calls.append("fetch")
+            return {"n": len(calls)}
+
+        self.cache.memoize_meta("mb:release:abc", _fetch, ttl=1)
+        # Advance fake-redis clock
+        self.fake._store["meta:mb:release:abc"] = (
+            self.fake._store["meta:mb:release:abc"][0],
+            time.time() - 1,
+        )
+        second = self.cache.memoize_meta("mb:release:abc", _fetch, ttl=1)
+        self.assertEqual(len(calls), 2,
+                         "expired entry must trigger a second fetch")
+        self.assertEqual(second, {"n": 2})
+
+    def test_meta_ops_noop_when_redis_absent(self) -> None:
+        """With _redis=None (CLI / no Redis), meta helpers degrade cleanly."""
+        self.cache._redis = None
+        self.cache.meta_set("mb:release:abc", {"x": 1})
+        self.assertIsNone(self.cache.meta_get("mb:release:abc"))
+
+        calls: list[str] = []
+
+        def _fetch() -> dict[str, Any]:
+            calls.append("fetch")
+            return {"ok": True}
+
+        first = self.cache.memoize_meta("mb:release:abc", _fetch)
+        second = self.cache.memoize_meta("mb:release:abc", _fetch)
+        self.assertEqual(first, {"ok": True})
+        self.assertEqual(second, {"ok": True})
+        self.assertEqual(
+            len(calls), 2,
+            "no-op cache must call fetch every time (never cache-hit)")
+
+
+class TestMetaIsolatedFromGroupInvalidation(_CacheTestBase):
+    """Core guarantee for issue #101: MB/Discogs metadata cache must
+    survive pipeline-state / library-state invalidation events.
+
+    Before the fix, /api/release/<id> etc. cached the baked overlay
+    under web:*. A pipeline POST called invalidate_groups("pipeline",
+    "library", "mb", "discogs") and dropped the entire entry. After
+    the fix the overlay isn't cached — only pure metadata is — and
+    group invalidations must NOT reach into the meta: namespace.
+    """
+
+    def _seed(self) -> None:
+        # meta: entries we must PRESERVE across group invalidations
+        self.cache.meta_set("mb:release:abc", {"id": "abc"})
+        self.cache.meta_set("mb:release-group:rg-1", {"id": "rg-1"})
+        self.cache.meta_set("discogs:release:99", {"id": 99})
+        self.cache.meta_set("discogs:master:44", {"id": 44})
+        # web: entries we SHOULD drop on invalidation (legacy routing cache)
+        self.fake._store["web:/api/release/abc"] = ("{}", None)
+        self.fake._store["web:/api/pipeline/status"] = ("{}", None)
+        self.fake._store["web:/api/beets/search?q=x"] = ("{}", None)
+
+    def _assert_meta_intact(self) -> None:
+        self.assertEqual(self.cache.meta_get("mb:release:abc"), {"id": "abc"})
+        self.assertEqual(self.cache.meta_get("mb:release-group:rg-1"), {"id": "rg-1"})
+        self.assertEqual(self.cache.meta_get("discogs:release:99"), {"id": 99})
+        self.assertEqual(self.cache.meta_get("discogs:master:44"), {"id": 44})
+
+    def test_invalidate_pipeline_group_leaves_meta_intact(self) -> None:
+        self._seed()
+        self.cache.invalidate_groups("pipeline")
+        self._assert_meta_intact()
+
+    def test_invalidate_library_group_leaves_meta_intact(self) -> None:
+        self._seed()
+        self.cache.invalidate_groups("library")
+        self._assert_meta_intact()
+
+    def test_invalidate_mb_group_leaves_meta_intact(self) -> None:
+        """Legacy `mb` group wiped web:/api/release* etc. The `meta:`
+        namespace for MB metadata must NOT be affected — it's the
+        expensive pure-metadata cache we want to keep warm across
+        unrelated pipeline writes."""
+        self._seed()
+        self.cache.invalidate_groups("mb")
+        self._assert_meta_intact()
+
+    def test_invalidate_discogs_group_leaves_meta_intact(self) -> None:
+        self._seed()
+        self.cache.invalidate_groups("discogs")
+        self._assert_meta_intact()
+
+    def test_invalidate_all_four_groups_leaves_meta_intact(self) -> None:
+        self._seed()
+        self.cache.invalidate_groups("pipeline", "library", "mb", "discogs")
+        self._assert_meta_intact()
+
+    def test_invalidate_web_pattern_leaves_meta_intact(self) -> None:
+        """server.py does `invalidate_pattern('web:*')` on startup to
+        flush stale routing-cache responses. That MUST NOT reach into
+        meta:, or every deploy would dump 24h of MB/Discogs cache."""
+        self._seed()
+        self.cache.invalidate_pattern("web:*")
+        self._assert_meta_intact()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2190,5 +2190,159 @@ class TestLibraryArtistContract(unittest.TestCase):
                 f"Album '{album.get('album')}' missing fields: {missing}")
 
 
+class TestOverlayNotBakedIntoRoutingCache(_WebServerCase):
+    """Issue #101: endpoints that enrich MB/Discogs metadata with per-user
+    pipeline/library overlay state MUST NOT be cached at the routing level.
+
+    Pre-fix, /api/release/<id> and friends were cached under web:<url> at
+    TTL_LIBRARY=300s. A pipeline-side UPDATE (e.g. status wanted→downloading)
+    bypasses the web UI's POST-invalidation paths, so a second GET in the
+    300s window returned a stale pipeline_status baked into the cached
+    payload.
+
+    Fix: drop every overlay-baking endpoint from Handler._CACHE_TTLS and
+    move pure MB/Discogs metadata into a separate meta: namespace at the
+    API helper layer (web/mb.py, web/discogs.py). Local DB lookups
+    (check_pipeline, check_beets_library) run on every request — cheap.
+    """
+
+    # The exact endpoint prefixes proven to bake overlay state — every
+    # single one of these was confirmed by the Explore audit to mutate
+    # the response with at least one of: pipeline_status, pipeline_id,
+    # in_library, library_rank, library_format, library_min_bitrate,
+    # beets_album_id, beets_tracks, upgrade_queued, in_beets, library_status.
+    FORBIDDEN_ROUTING_CACHE_PREFIXES = (
+        "/api/release-group",
+        "/api/release",
+        "/api/discogs/master",
+        "/api/discogs/release",
+        "/api/discogs/artist",
+        "/api/artist",              # /api/artist/<id> + /api/artist/<id>/disambiguate + /api/artist/compare
+        "/api/library",             # /api/library/artist
+        "/api/beets",               # /api/beets/search + /api/beets/album + /api/beets/recent
+        "/api/pipeline/recent",
+        "/api/pipeline/all",
+        "/api/pipeline/log",
+        "/api/pipeline/status",
+    )
+
+    def test_forbidden_prefixes_are_not_in_routing_cache_ttls(self) -> None:
+        """Handler._CACHE_TTLS must not contain any overlay-baking prefix."""
+        import web.server as srv
+        ttls: dict[str, int] = getattr(srv.Handler, "_CACHE_TTLS", {})
+        leaked = set(ttls) & set(self.FORBIDDEN_ROUTING_CACHE_PREFIXES)
+        self.assertFalse(
+            leaked,
+            f"Overlay-baking prefixes must not be in _CACHE_TTLS — "
+            f"they would bake per-user pipeline/library state into Redis "
+            f"and leak stale badges when the pipeline writes to Postgres "
+            f"outside the web UI's POST paths. Offenders: {sorted(leaked)}")
+
+
+class _CachedServerCase(_WebServerCase):
+    """Shared harness: _WebServerCase but with a FakeRedis wired up so we
+    can observe routing-cache behaviour in isolation. Pre-fix this would
+    exhibit the stale-badge bug; post-fix it proves the overlay recomputes."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        import web.cache as cache
+        from tests.test_web_cache import FakeRedis
+        cls._cache = cache
+        cls._saved_redis = cache._redis
+        cache._redis = FakeRedis()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._cache._redis = cls._saved_redis
+        super().tearDownClass()
+
+
+class TestReleaseEndpointReflectsPipelineWrite(_CachedServerCase):
+    """Regression test for issue #101.
+
+    The bug: /api/release/<id> cached the full response including
+    pipeline_status. When the pipeline wrote status='downloading'
+    directly to Postgres (outside the web UI's POST invalidation
+    paths), a second GET within 300s returned the stale 'wanted'
+    status. Badges lagged by up to 5 minutes.
+
+    Post-fix: the overlay is recomputed on every request, so external
+    DB writes show up immediately.
+    """
+
+    RELEASE_ID = "c6cd62c4-da2a-4a89-a219-adba66d6c7d4"
+
+    def setUp(self) -> None:
+        # Clear any state left behind by a previous test that shares the
+        # FakeRedis instance, so each scenario starts cold. `_redis` is
+        # typed `object | None` on the module; narrow to FakeRedis here.
+        from tests.test_web_cache import FakeRedis
+        fake = self._cache._redis
+        assert isinstance(fake, FakeRedis)
+        fake._store.clear()
+
+    def _call_release_detail(self) -> dict:
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value=set()):
+            mock_mb.get_release.return_value = {
+                "id": self.RELEASE_ID,
+                "title": "Test Album",
+                "tracks": [],
+            }
+            _status, data = self._get(f"/api/release/{self.RELEASE_ID}")
+            return data
+
+    def test_release_reflects_external_status_write(self) -> None:
+        """Pipeline writes status='downloading' directly to Postgres
+        between two GETs. The second GET must see 'downloading'."""
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=42, status="wanted", mb_release_id=self.RELEASE_ID,
+        )
+        first = self._call_release_detail()
+        self.assertEqual(first["pipeline_status"], "wanted")
+
+        # Simulate soularr pipeline flipping status outside the web UI.
+        # No POST to /api/cache/invalidate, no web-UI cache-group flush —
+        # this is the exact sequence that produced the stale-badge bug.
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=42, status="downloading", mb_release_id=self.RELEASE_ID,
+        )
+        second = self._call_release_detail()
+        self.assertEqual(
+            second["pipeline_status"], "downloading",
+            "Second GET must see the fresh DB state, not a baked-in "
+            "pipeline_status from a cached response. If this fails, the "
+            "routing-level cache is still capturing the overlay.")
+
+    def test_release_reflects_external_library_state_flip(self) -> None:
+        """Same bug for the in_library flag. After an album is imported
+        the 'in_library' flag flips true in beets; a second GET within
+        the cache window must reflect that without an explicit flush."""
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=42, status="imported", mb_release_id=self.RELEASE_ID,
+        )
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value=set()):
+            mock_mb.get_release.return_value = {
+                "id": self.RELEASE_ID, "title": "T", "tracks": [],
+            }
+            _s, first = self._get(f"/api/release/{self.RELEASE_ID}")
+        self.assertFalse(first["in_library"])
+
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library",
+                      return_value={self.RELEASE_ID}):
+            mock_mb.get_release.return_value = {
+                "id": self.RELEASE_ID, "title": "T", "tracks": [],
+            }
+            _s, second = self._get(f"/api/release/{self.RELEASE_ID}")
+        self.assertTrue(
+            second["in_library"],
+            "Second GET must recompute the overlay against current beets "
+            "state instead of returning a cached in_library=False.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1078,7 +1078,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         )
 
         self.assertEqual(status, 200)
-        mock_dg_get.assert_called_once_with(12856590)
+        mock_dg_get.assert_called_once_with(12856590, fresh=True)
         mock_mb_get.assert_not_called()
         # Confirm Discogs ID is mirrored into both columns for pipeline-compat
         add_kwargs = self.mock_db.add_request.call_args.kwargs
@@ -1138,6 +1138,96 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.DELETE_REQUIRED_FIELDS,
                                 "pipeline delete response")
+
+    # -- fresh=True seam (Codex review on issue #101) ----------------
+
+    @patch("routes.pipeline.mb_api.get_release")
+    def test_pipeline_add_mb_fetches_release_fresh(self, mock_get_release):
+        """POST /api/pipeline/add (MusicBrainz) MUST bypass the 24h meta
+        cache — the fetched metadata is persisted into `album_requests`
+        and `request_tracks`. A stale cached payload from an earlier
+        browse would silently bake pre-correction artist / title / tracks
+        into the pipeline DB.
+        """
+        mock_get_release.return_value = {
+            "release_group_id": "rg-1",
+            "artist_id": "artist-1",
+            "artist_name": "Test Artist",
+            "title": "Test Album",
+            "year": 2024,
+            "country": "US",
+            "tracks": [{"title": "Track"}],
+        }
+
+        status, _data = self._post("/api/pipeline/add",
+                                   {"mb_release_id": "abc-123"})
+
+        self.assertEqual(status, 200)
+        mock_get_release.assert_called_once_with("abc-123", fresh=True)
+
+    @patch("routes.pipeline.discogs_api.get_release")
+    def test_pipeline_add_discogs_fetches_release_fresh(self, mock_get_release):
+        """POST /api/pipeline/add (Discogs) MUST bypass the 24h meta cache."""
+        self.mock_db.get_request_by_discogs_release_id.return_value = None
+        mock_get_release.return_value = {
+            "artist_id": "3840",
+            "artist_name": "Radiohead",
+            "title": "OK Computer",
+            "year": 1997,
+            "country": "Europe",
+            "tracks": [{"title": "Airbag"}],
+        }
+
+        status, _data = self._post("/api/pipeline/add",
+                                   {"discogs_release_id": "83182"})
+
+        self.assertEqual(status, 200)
+        mock_get_release.assert_called_once_with(83182, fresh=True)
+
+    @patch("routes.pipeline.apply_transition")
+    @patch("routes.pipeline.mb_api.get_release")
+    def test_pipeline_upgrade_new_mb_fetches_release_fresh(
+            self, mock_get_release, _mock_transition):
+        """POST /api/pipeline/upgrade creating a brand-new MB request
+        MUST bypass the meta cache — same rationale as add."""
+        self.mock_db.get_request_by_mb_release_id.return_value = None
+        self.mock_db.get_request_by_discogs_release_id.return_value = None
+        self.mock_db.add_request.return_value = 999
+        mock_get_release.return_value = {
+            "artist_id": "a-1", "artist_name": "A", "title": "T",
+            "year": 2024, "country": "US", "tracks": [],
+        }
+
+        status, _data = self._post(
+            "/api/pipeline/upgrade",
+            {"mb_release_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+        )
+
+        self.assertEqual(status, 200)
+        mock_get_release.assert_called_once_with(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", fresh=True)
+
+    @patch("routes.pipeline.apply_transition")
+    @patch("routes.pipeline.discogs_api.get_release")
+    def test_pipeline_upgrade_new_discogs_fetches_release_fresh(
+            self, mock_get_release, _mock_transition):
+        """POST /api/pipeline/upgrade creating a brand-new Discogs request
+        MUST bypass the meta cache — same rationale as add."""
+        self.mock_db.get_request_by_mb_release_id.return_value = None
+        self.mock_db.get_request_by_discogs_release_id.return_value = None
+        self.mock_db.add_request.return_value = 999
+        mock_get_release.return_value = {
+            "id": "12856590", "title": "New.Old.Rare",
+            "artist_name": "Blueline Medic", "artist_id": "3640",
+            "year": 2010, "country": "Australia", "tracks": [],
+        }
+
+        status, _data = self._post(
+            "/api/pipeline/upgrade", {"mb_release_id": "12856590"},
+        )
+
+        self.assertEqual(status, 200)
+        mock_get_release.assert_called_once_with(12856590, fresh=True)
 
 
 class TestUserRequeueOverridePreservation(_WebServerCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2434,5 +2434,255 @@ class TestReleaseEndpointReflectsPipelineWrite(_CachedServerCase):
             "state instead of returning a cached in_library=False.")
 
 
+class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
+    """Issue #101 Codex round 3 — the `/api/artist/<id>/disambiguate`
+    and `/api/artist/compare` endpoints run expensive pure analysis on
+    top of MB metadata (`filter_non_live` + `analyse_artist_releases`,
+    `merge_discographies`). After the response-cache removal, naïvely
+    running that analysis on every request regresses warm-load latency
+    from ~5ms (full response cached) to ~50-300ms (analysis re-runs).
+
+    Fix: cache the pre-overlay skeleton separately under `meta:`. It's
+    a pure function of pure-metadata inputs — safe. Overlay (live DB
+    state) still runs on every request.
+
+    These tests pin the split: skeleton is cached across calls, and
+    the overlay reflects live DB state even when the skeleton is warm.
+    """
+
+    ARTIST_ID = "664c3e0e-42d8-48c1-b209-1efca19c0325"
+    RELEASE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    RG_ID = "11111111-1111-1111-1111-111111111111"
+
+    _RAW_RELEASES = [
+        {
+            "id": RELEASE_ID,
+            "title": "Album",
+            "date": "2020-01-01",
+            "country": "US",
+            "status": "Official",
+            "release-group": {
+                "id": RG_ID,
+                "title": "Album",
+                "primary-type": "Album",
+                "secondary-types": [],
+            },
+            "media": [{
+                "position": 1, "format": "CD", "track-count": 1,
+                "tracks": [{
+                    "position": 1, "number": "1", "title": "Track",
+                    "recording": {"id": "rec-1", "title": "Track"},
+                }],
+            }],
+        },
+    ]
+
+    def setUp(self) -> None:
+        from tests.test_web_cache import FakeRedis
+        fake = self._cache._redis
+        assert isinstance(fake, FakeRedis)
+        fake._store.clear()
+
+    # -- Disambiguate ------------------------------------------------
+
+    def test_disambiguate_skeleton_cached_in_meta_namespace(self) -> None:
+        """First GET computes the skeleton; second GET reuses it. We
+        assert the skeleton ended up under `meta:` and the pure-
+        analysis fetch is only issued once across both requests."""
+        from tests.test_web_cache import FakeRedis
+        fake = self._cache._redis
+        assert isinstance(fake, FakeRedis)
+
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}):
+            mock_mb.get_artist_releases_with_recordings.return_value = \
+                self._RAW_RELEASES
+            mock_mb.get_artist_name.return_value = "Test Artist"
+
+            s1, _ = self._get(f"/api/artist/{self.ARTIST_ID}/disambiguate")
+            s2, _ = self._get(f"/api/artist/{self.ARTIST_ID}/disambiguate")
+
+            self.assertEqual(s1, 200)
+            self.assertEqual(s2, 200)
+            # The pure MB fetch helper was called once — either this is
+            # the first call (skeleton miss) or the route's own meta-
+            # cached skeleton short-circuited to avoid re-calling it.
+            self.assertEqual(
+                mock_mb.get_artist_releases_with_recordings.call_count, 1,
+                "skeleton caching must reuse the analysis across calls "
+                "— the expensive pure-python analysis should NOT re-run "
+                "on warm loads")
+
+        # Skeleton key is in the meta: namespace — not web:, so it
+        # survives pipeline/library group invalidations.
+        meta_keys = [k for k in fake._store
+                     if k.startswith("meta:") and self.ARTIST_ID in k]
+        self.assertTrue(
+            meta_keys,
+            f"expected a meta: key for artist {self.ARTIST_ID}, got: "
+            f"{sorted(fake._store.keys())}")
+
+    def test_disambiguate_overlay_reflects_live_state_across_skeleton_cache(
+            self) -> None:
+        """Skeleton cache is warm; change live DB state; next GET must
+        still reflect the new pipeline_status via overlay."""
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline",
+                      return_value={self.RELEASE_ID: {"id": 42, "status": "wanted"}}):
+            mock_mb.get_artist_releases_with_recordings.return_value = \
+                self._RAW_RELEASES
+            mock_mb.get_artist_name.return_value = "Test Artist"
+            _s, first = self._get(
+                f"/api/artist/{self.ARTIST_ID}/disambiguate")
+
+        self.assertEqual(
+            first["release_groups"][0]["pressings"][0]["pipeline_status"],
+            "wanted")
+
+        # External DB write — status flips to 'downloading'. No POST
+        # invalidation (same bug class as the release-detail test).
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline",
+                      return_value={self.RELEASE_ID: {"id": 42, "status": "downloading"}}):
+            mock_mb.get_artist_releases_with_recordings.return_value = \
+                self._RAW_RELEASES
+            mock_mb.get_artist_name.return_value = "Test Artist"
+            _s, second = self._get(
+                f"/api/artist/{self.ARTIST_ID}/disambiguate")
+
+        self.assertEqual(
+            second["release_groups"][0]["pressings"][0]["pipeline_status"],
+            "downloading",
+            "Even with the skeleton cached in meta:, the overlay must "
+            "recompute against current DB state — otherwise the skeleton "
+            "cache reintroduces the stale-badge bug.")
+        # RG-level pipeline_status must also flip.
+        self.assertEqual(
+            second["release_groups"][0]["pipeline_status"], "downloading")
+
+    def test_disambiguate_overlay_reflects_library_flip(self) -> None:
+        """Same guarantee for in_library — beets state flips, overlay must
+        see it without invalidating the skeleton cache."""
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}):
+            mock_mb.get_artist_releases_with_recordings.return_value = \
+                self._RAW_RELEASES
+            mock_mb.get_artist_name.return_value = "Test Artist"
+            _s, first = self._get(
+                f"/api/artist/{self.ARTIST_ID}/disambiguate")
+        self.assertFalse(
+            first["release_groups"][0]["pressings"][0]["in_library"])
+
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library",
+                      return_value={self.RELEASE_ID}), \
+                patch("web.server.check_pipeline", return_value={}):
+            mock_mb.get_artist_releases_with_recordings.return_value = \
+                self._RAW_RELEASES
+            mock_mb.get_artist_name.return_value = "Test Artist"
+            _s, second = self._get(
+                f"/api/artist/{self.ARTIST_ID}/disambiguate")
+        self.assertTrue(
+            second["release_groups"][0]["pressings"][0]["in_library"])
+        self.assertEqual(
+            second["release_groups"][0]["library_status"], "in_library")
+
+    # -- Compare -----------------------------------------------------
+
+    def test_compare_skeleton_cached_in_meta_namespace(self) -> None:
+        """merge_discographies is pure — its output is cacheable."""
+        from tests.test_web_cache import FakeRedis
+        fake = self._cache._redis
+        assert isinstance(fake, FakeRedis)
+
+        mb_rg = {
+            "id": self.RG_ID, "title": "OK Computer", "type": "Album",
+            "secondary_types": [], "first_release_date": "1997",
+            "artist_credit": "Radiohead", "primary_artist_id": self.ARTIST_ID,
+        }
+        discogs_rg = {
+            "id": "21491", "title": "OK Computer", "type": "Album",
+            "secondary_types": [], "first_release_date": "1997",
+            "artist_credit": "Radiohead", "primary_artist_id": "3840",
+        }
+
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("routes.browse.discogs_api") as mock_dg, \
+                patch("web.server.get_library_artist", return_value=[]):
+            mock_mb.search_artists.return_value = [
+                {"id": self.ARTIST_ID, "name": "Radiohead"}]
+            mock_mb.get_artist_release_groups.return_value = [mb_rg]
+            mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+            mock_dg.search_artists.return_value = [
+                {"id": "3840", "name": "Radiohead"}]
+            mock_dg.get_artist_releases.return_value = [discogs_rg]
+
+            s1, _ = self._get("/api/artist/compare?name=Radiohead")
+            s2, _ = self._get("/api/artist/compare?name=Radiohead")
+            self.assertEqual(s1, 200)
+            self.assertEqual(s2, 200)
+            # Pure MB/Discogs discography fetches are called once across
+            # both requests — their outputs went into the skeleton cache.
+            self.assertEqual(mock_mb.get_artist_release_groups.call_count, 1)
+            self.assertEqual(mock_dg.get_artist_releases.call_count, 1)
+
+        meta_keys = [k for k in fake._store if k.startswith("meta:")
+                     and "compare" in k]
+        self.assertTrue(
+            meta_keys,
+            "expected a compare skeleton under meta:, got: "
+            f"{sorted(fake._store.keys())}")
+
+    def test_compare_overlay_reflects_library_flip(self) -> None:
+        """Even with the compare skeleton cached, annotate_in_library
+        must run on every request so badges flip with beets state."""
+        mb_rg = {
+            "id": self.RG_ID, "title": "OK Computer", "type": "Album",
+            "secondary_types": [], "first_release_date": "1997",
+            "artist_credit": "Radiohead", "primary_artist_id": self.ARTIST_ID,
+        }
+        discogs_rg = {
+            "id": "21491", "title": "OK Computer", "type": "Album",
+            "secondary_types": [], "first_release_date": "1997",
+            "artist_credit": "Radiohead", "primary_artist_id": "3840",
+        }
+
+        def _run(lib_albums: list[dict]) -> dict:
+            with patch("web.server.mb_api") as mock_mb, \
+                    patch("routes.browse.discogs_api") as mock_dg, \
+                    patch("web.server.get_library_artist",
+                          return_value=lib_albums):
+                mock_mb.search_artists.return_value = [
+                    {"id": self.ARTIST_ID, "name": "Radiohead"}]
+                mock_mb.get_artist_release_groups.return_value = [mb_rg]
+                mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+                mock_dg.search_artists.return_value = [
+                    {"id": "3840", "name": "Radiohead"}]
+                mock_dg.get_artist_releases.return_value = [discogs_rg]
+                _s, data = self._get("/api/artist/compare?name=Radiohead")
+                return data
+
+        first = _run([])
+        self.assertFalse(first["both"][0]["mb"].get("in_library"))
+
+        # Library flips — beets now holds this album.
+        lib_album = {
+            "mb_albumid": self.RELEASE_ID,
+            "mb_releasegroupid": self.RG_ID,
+            "album": "OK Computer",
+            "formats": "MP3",
+            "min_bitrate": 320000,
+        }
+        second = _run([lib_album])
+        self.assertTrue(
+            second["both"][0]["mb"].get("in_library"),
+            "Compare overlay must run per-request — a warm skeleton "
+            "cache must not mask a library-state change.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1559,8 +1559,10 @@ class TestBrowseRouteContracts(_WebServerCase):
             mock_mb.search_artists.return_value = [{"id": self.ARTIST_ID, "name": "Radiohead"}]
             mock_mb.get_artist_release_groups.return_value = [mb_rg]
             mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+            mock_mb.get_artist_name.return_value = "Radiohead"
             mock_dg.search_artists.return_value = [{"id": "3840", "name": "Radiohead"}]
             mock_dg.get_artist_releases.return_value = [discogs_rg]
+            mock_dg.get_artist_name.return_value = "Radiohead"
             status, data = self._get("/api/artist/compare?name=Radiohead")
 
         self.assertEqual(status, 200)
@@ -1598,8 +1600,10 @@ class TestBrowseRouteContracts(_WebServerCase):
             mock_mb.search_artists.return_value = [{"id": self.ARTIST_ID, "name": "Artist"}]
             mock_mb.get_artist_release_groups.return_value = [official_rg, bootleg_rg]
             mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+            mock_mb.get_artist_name.return_value = "Artist"
             mock_dg.search_artists.return_value = []
             mock_dg.get_artist_releases.return_value = []
+            mock_dg.get_artist_name.return_value = ""
             status, data = self._get("/api/artist/compare?name=Artist")
 
         self.assertEqual(status, 200)
@@ -2617,9 +2621,11 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
                 {"id": self.ARTIST_ID, "name": "Radiohead"}]
             mock_mb.get_artist_release_groups.return_value = [mb_rg]
             mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+            mock_mb.get_artist_name.return_value = "Radiohead"
             mock_dg.search_artists.return_value = [
                 {"id": "3840", "name": "Radiohead"}]
             mock_dg.get_artist_releases.return_value = [discogs_rg]
+            mock_dg.get_artist_name.return_value = "Radiohead"
 
             s1, _ = self._get("/api/artist/compare?name=Radiohead")
             s2, _ = self._get("/api/artist/compare?name=Radiohead")
@@ -2636,6 +2642,72 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
             meta_keys,
             "expected a compare skeleton under meta:, got: "
             f"{sorted(fake._store.keys())}")
+
+    def test_compare_artist_names_are_canonical_not_user_supplied(self) -> None:
+        """Codex round 4: previously the compare skeleton cached
+        user-supplied artist names inside the response body, so the
+        first request's `name=` query param won for 24h. Canonical
+        names from the MB/Discogs API must be used instead.
+        """
+        mb_rg = {
+            "id": self.RG_ID, "title": "OK Computer", "type": "Album",
+            "secondary_types": [], "first_release_date": "1997",
+            "artist_credit": "Radiohead", "primary_artist_id": self.ARTIST_ID,
+        }
+        discogs_rg = {
+            "id": "21491", "title": "OK Computer", "type": "Album",
+            "secondary_types": [], "first_release_date": "1997",
+            "artist_credit": "Radiohead", "primary_artist_id": "3840",
+        }
+
+        # First request — misspelled name. Skeleton gets cached.
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("routes.browse.discogs_api") as mock_dg, \
+                patch("web.server.get_library_artist", return_value=[]):
+            mock_mb.search_artists.return_value = [
+                {"id": self.ARTIST_ID, "name": "Radiohead"}]
+            mock_mb.get_artist_release_groups.return_value = [mb_rg]
+            mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+            mock_mb.get_artist_name.return_value = "Radiohead"
+            mock_dg.search_artists.return_value = [
+                {"id": "3840", "name": "Radiohead"}]
+            mock_dg.get_artist_releases.return_value = [discogs_rg]
+            mock_dg.get_artist_name.return_value = "Radiohead"
+            _s, first = self._get(
+                "/api/artist/compare?name=Radiohea&"
+                f"mbid={self.ARTIST_ID}&discogs_id=3840")
+
+        # mb_artist name must be canonical from MB, not the typo.
+        self.assertEqual(
+            (first["mb_artist"] or {}).get("name"), "Radiohead",
+            "mb_artist.name must be the canonical name from MB, not "
+            "the user-supplied ?name= query param — otherwise a typo "
+            "on the first request poisons the 24h skeleton cache.")
+
+        # Second request — different (correct) name. Must STILL return
+        # the canonical Radiohead, and the skeleton cache must have been
+        # reused (no re-fetch of the release-group metadata).
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("routes.browse.discogs_api") as mock_dg, \
+                patch("web.server.get_library_artist", return_value=[]):
+            mock_mb.search_artists.return_value = [
+                {"id": self.ARTIST_ID, "name": "Radiohead"}]
+            mock_mb.get_artist_release_groups.return_value = [mb_rg]
+            mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+            mock_mb.get_artist_name.return_value = "Radiohead"
+            mock_dg.search_artists.return_value = [
+                {"id": "3840", "name": "Radiohead"}]
+            mock_dg.get_artist_releases.return_value = [discogs_rg]
+            mock_dg.get_artist_name.return_value = "Radiohead"
+            _s, second = self._get(
+                "/api/artist/compare?name=Radiohead&"
+                f"mbid={self.ARTIST_ID}&discogs_id=3840")
+            # Expensive metadata fetch was served from cache (skeleton
+            # still reusable despite different ?name=).
+            self.assertEqual(mock_mb.get_artist_release_groups.call_count, 0)
+
+        self.assertEqual(
+            (second["mb_artist"] or {}).get("name"), "Radiohead")
 
     def test_compare_overlay_reflects_library_flip(self) -> None:
         """Even with the compare skeleton cached, annotate_in_library
@@ -2660,9 +2732,11 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
                     {"id": self.ARTIST_ID, "name": "Radiohead"}]
                 mock_mb.get_artist_release_groups.return_value = [mb_rg]
                 mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
+                mock_mb.get_artist_name.return_value = "Radiohead"
                 mock_dg.search_artists.return_value = [
                     {"id": "3840", "name": "Radiohead"}]
                 mock_dg.get_artist_releases.return_value = [discogs_rg]
+                mock_dg.get_artist_name.return_value = "Radiohead"
                 _s, data = self._get("/api/artist/compare?name=Radiohead")
                 return data
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2615,7 +2615,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
         }
 
         with patch("web.server.mb_api") as mock_mb, \
-                patch("routes.browse.discogs_api") as mock_dg, \
+                patch("web.routes.browse.discogs_api") as mock_dg, \
                 patch("web.server.get_library_artist", return_value=[]):
             mock_mb.search_artists.return_value = [
                 {"id": self.ARTIST_ID, "name": "Radiohead"}]
@@ -2662,7 +2662,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
 
         # First request — misspelled name. Skeleton gets cached.
         with patch("web.server.mb_api") as mock_mb, \
-                patch("routes.browse.discogs_api") as mock_dg, \
+                patch("web.routes.browse.discogs_api") as mock_dg, \
                 patch("web.server.get_library_artist", return_value=[]):
             mock_mb.search_artists.return_value = [
                 {"id": self.ARTIST_ID, "name": "Radiohead"}]
@@ -2688,7 +2688,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
         # the canonical Radiohead, and the skeleton cache must have been
         # reused (no re-fetch of the release-group metadata).
         with patch("web.server.mb_api") as mock_mb, \
-                patch("routes.browse.discogs_api") as mock_dg, \
+                patch("web.routes.browse.discogs_api") as mock_dg, \
                 patch("web.server.get_library_artist", return_value=[]):
             mock_mb.search_artists.return_value = [
                 {"id": self.ARTIST_ID, "name": "Radiohead"}]
@@ -2725,7 +2725,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
 
         def _run(lib_albums: list[dict]) -> dict:
             with patch("web.server.mb_api") as mock_mb, \
-                    patch("routes.browse.discogs_api") as mock_dg, \
+                    patch("web.routes.browse.discogs_api") as mock_dg, \
                     patch("web.server.get_library_artist",
                           return_value=lib_albums):
                 mock_mb.search_artists.return_value = [

--- a/web/cache.py
+++ b/web/cache.py
@@ -128,15 +128,23 @@ def meta_set(key: str, value: Any, ttl: int = TTL_MB) -> None:
         pass
 
 
-def memoize_meta(key: str, fetch_fn: Callable[[], Any], ttl: int = TTL_MB) -> Any:
+def memoize_meta(key: str, fetch_fn: Callable[[], Any], ttl: int = TTL_MB,
+                 *, fresh: bool = False) -> Any:
     """Return cached `meta:<key>` or call `fetch_fn()` and cache the result.
 
     With Redis absent (CLI context, tests), degrades to pass-through —
     every call runs `fetch_fn()` and nothing is cached.
+
+    `fresh=True` skips the cache read and re-fetches live, then repopulates
+    the cache with the fresh result. Use this on write paths (e.g. POST
+    handlers that persist metadata into Postgres) where a 24h-old snapshot
+    would silently bake stale artist/title/track data into the pipeline
+    DB. Every `fresh=True` call still warms the cache for subsequent GETs.
     """
-    cached = meta_get(key)
-    if cached is not None:
-        return cached
+    if not fresh:
+        cached = meta_get(key)
+        if cached is not None:
+            return cached
     result = fetch_fn()
     meta_set(key, result, ttl)
     return result

--- a/web/cache.py
+++ b/web/cache.py
@@ -1,8 +1,23 @@
 """Redis cache layer for the Soularr web UI.
 
-All operations are fail-safe — Redis being down means cache miss, never an error.
-MB data cached 24h (mirror syncs daily at 3am). Beets/pipeline data cached 5min
-with explicit invalidation on mutations.
+Two separate namespaces:
+
+- `meta:<key>` — PURE MusicBrainz / Discogs metadata. 24h TTL (mirrors
+  sync daily). Populated via `memoize_meta()` inside `web/mb.py` and
+  `web/discogs.py`. **Never** invalidated by pipeline / library
+  writes — MB/Discogs metadata doesn't care about pipeline state.
+
+- `web:<url>` — legacy routing-level cache for whole HTTP responses.
+  Only used today for the pure-search endpoints (`/api/search`,
+  `/api/discogs/search`). Overlay-baking endpoints (release, release-
+  group, discogs master/release, beets, pipeline, library/artist,
+  disambiguate, …) MUST NOT be cached here — that baked
+  `pipeline_status` / `in_library` into the payload and leaked stale
+  badges when soularr-the-pipeline updated Postgres outside the web
+  UI's POST invalidation paths. See issue #101.
+
+All operations fail-safe — Redis being down means cache miss, never
+an error.
 """
 
 from __future__ import annotations
@@ -10,15 +25,25 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from typing import Any, Callable
 
 log = logging.getLogger(__name__)
 
 # TTL constants (seconds)
-TTL_MB = 86400       # 24h — MB mirror data, effectively static
-TTL_LIBRARY = 300    # 5min — beets/pipeline data, also invalidated on mutation
+TTL_MB = 86400       # 24h — MB/Discogs mirror data, effectively static
+TTL_LIBRARY = 300    # 5min — legacy routing cache (now only for search)
 
-# Group → pattern mapping for bulk invalidation
-# Keys are stored as "web:<url_path>", so patterns match on URL prefixes
+# Key prefix for the pure-metadata namespace. Kept as a module constant
+# so `meta_get` / `meta_set` / `memoize_meta` all agree, and callers /
+# tests can assert on the final key shape.
+_META_PREFIX = "meta:"
+
+# Group → pattern mapping for bulk invalidation of routing-level responses.
+# Pattern scope is deliberately limited to `web:` keys — the `meta:`
+# namespace (pure MB/Discogs metadata) is NEVER invalidated by pipeline
+# state changes because the metadata didn't change. A pipeline write
+# only makes a cached overlay response stale; the metadata underneath
+# is still correct.
 _GROUP_PATTERNS: dict[str, list[str]] = {
     "pipeline": ["web:/api/pipeline*"],
     "library": ["web:/api/beets*", "web:/api/library*"],
@@ -41,6 +66,9 @@ def init(host: str, port: int = 6379) -> None:
     except Exception as e:
         log.warning("Redis unavailable (%s), running without cache", e)
         _redis = None
+
+
+# ── Routing-level cache (legacy `web:` namespace) ─────────────────────
 
 
 def cache_get(key: str) -> dict | list | None:
@@ -66,6 +94,57 @@ def cache_set(key: str, value: dict | list, ttl: int = TTL_MB) -> None:
         pass
 
 
+# ── Pure-metadata cache (`meta:` namespace) ──────────────────────────
+#
+# These helpers prefix the key with `meta:` so the patterns in
+# `_GROUP_PATTERNS` (all scoped to `web:`) cannot reach them. That is
+# the whole point — an album transitioning wanted→downloading in
+# Postgres MUST NOT flush the MB mirror lookup for that album's release
+# group. Only the routing-cache responses under `web:` are overlay-
+# baked and need group invalidation.
+
+
+def meta_get(key: str) -> Any:
+    """Get from the pure metadata cache. Key is prefixed with `meta:`."""
+    if _redis is None:
+        return None
+    try:
+        raw = _redis.get(f"{_META_PREFIX}{key}")  # type: ignore[union-attr]
+        if raw is None:
+            return None
+        return json.loads(raw)
+    except Exception:
+        return None
+
+
+def meta_set(key: str, value: Any, ttl: int = TTL_MB) -> None:
+    """Set in the pure metadata cache. Key is prefixed with `meta:`."""
+    if _redis is None:
+        return
+    try:
+        _redis.setex(  # type: ignore[union-attr]
+            f"{_META_PREFIX}{key}", ttl, json.dumps(value))
+    except Exception:
+        pass
+
+
+def memoize_meta(key: str, fetch_fn: Callable[[], Any], ttl: int = TTL_MB) -> Any:
+    """Return cached `meta:<key>` or call `fetch_fn()` and cache the result.
+
+    With Redis absent (CLI context, tests), degrades to pass-through —
+    every call runs `fetch_fn()` and nothing is cached.
+    """
+    cached = meta_get(key)
+    if cached is not None:
+        return cached
+    result = fetch_fn()
+    meta_set(key, result, ttl)
+    return result
+
+
+# ── Invalidation ──────────────────────────────────────────────────────
+
+
 def invalidate(key: str) -> None:
     """Delete a single cache key."""
     if _redis is None:
@@ -77,13 +156,19 @@ def invalidate(key: str) -> None:
 
 
 def invalidate_pattern(pattern: str) -> None:
-    """Delete all keys matching a glob pattern (e.g. 'library:*')."""
+    """Delete all keys matching a glob pattern (e.g. 'library:*').
+
+    Callers should use the `web:` or `meta:` prefix explicitly. Patterns
+    without a prefix are allowed but discouraged — they can match across
+    namespaces.
+    """
     if _redis is None:
         return
     try:
         cursor = 0
         while True:
-            cursor, keys = _redis.scan(cursor=cursor, match=pattern, count=100)  # type: ignore[union-attr]
+            cursor, keys = _redis.scan(  # type: ignore[union-attr]
+                cursor=cursor, match=pattern, count=100)
             if keys:
                 _redis.delete(*keys)  # type: ignore[union-attr]
             if cursor == 0:
@@ -93,7 +178,11 @@ def invalidate_pattern(pattern: str) -> None:
 
 
 def invalidate_groups(*groups: str) -> None:
-    """Invalidate all keys in named groups (e.g. 'pipeline', 'library')."""
+    """Invalidate all routing-cache keys in named groups.
+
+    Scope is the `web:` namespace only — `_GROUP_PATTERNS` patterns are
+    all `web:/api/...`. The `meta:` namespace is out of reach by design.
+    """
     for group in groups:
         patterns = _GROUP_PATTERNS.get(group, [])
         for pattern in patterns:

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -16,7 +16,7 @@ import re
 import urllib.parse
 import urllib.request
 
-from web import cache as _cache  # type: ignore[import-not-found]
+from web import cache as _cache
 
 DISCOGS_API_BASE = "https://discogs.ablz.au"
 USER_AGENT = "soularr-web/1.0"

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -3,12 +3,20 @@
 All queries hit the local Discogs mirror at DISCOGS_API_BASE.
 Response shapes are normalized to match what the frontend expects,
 mirroring web/mb.py where possible.
+
+Pure-metadata responses are memoized via `cache.memoize_meta()` at
+24h TTL. See web/mb.py and web/cache.py for rationale — the cache
+layer sits at the API helper level, not at the HTTP routing level,
+so that per-user pipeline / library overlay state is never baked
+into Redis (issue #101).
 """
 
 import json
 import re
 import urllib.parse
 import urllib.request
+
+from web import cache as _cache  # type: ignore[import-not-found]
 
 DISCOGS_API_BASE = "https://discogs.ablz.au"
 USER_AGENT = "soularr-web/1.0"
@@ -94,32 +102,35 @@ def search_releases(query: str) -> list[dict]:
     master-level metadata (master_title, master_first_released, primary_type, score)
     that the mirror provides on each search hit.
     """
-    q = urllib.parse.quote(query)
-    data = _get(f"{DISCOGS_API_BASE}/api/search?title={q}&per_page=25")
-    seen_master: set[int] = set()
-    results = []
-    for r in data.get("results", []):
-        master_id = r.get("master_id")
-        artists = r.get("artists", [])
-        if master_id and master_id in seen_master:
-            continue
-        if master_id:
-            seen_master.add(master_id)
-        title = r.get("master_title") or r.get("title", "") if master_id else r.get("title", "")
-        first_released = r.get("master_first_released") or r.get("released", "") if master_id else r.get("released", "")
-        results.append({
-            "id": str(master_id) if master_id else str(r["id"]),
-            "title": title,
-            "primary_type": r.get("primary_type", ""),
-            "first_release_date": first_released,
-            "artist_id": str(_primary_artist_id(artists) or ""),
-            "artist_name": _primary_artist_name(artists),
-            "artist_disambiguation": "",
-            "score": int(r.get("score", 0) * 100),
-            "is_master": bool(master_id),
-            "discogs_release_id": str(r["id"]),
-        })
-    return results
+    def _fetch() -> list[dict]:
+        q = urllib.parse.quote(query)
+        data = _get(f"{DISCOGS_API_BASE}/api/search?title={q}&per_page=25")
+        seen_master: set[int] = set()
+        results = []
+        for r in data.get("results", []):
+            master_id = r.get("master_id")
+            artists = r.get("artists", [])
+            if master_id and master_id in seen_master:
+                continue
+            if master_id:
+                seen_master.add(master_id)
+            title = r.get("master_title") or r.get("title", "") if master_id else r.get("title", "")
+            first_released = r.get("master_first_released") or r.get("released", "") if master_id else r.get("released", "")
+            results.append({
+                "id": str(master_id) if master_id else str(r["id"]),
+                "title": title,
+                "primary_type": r.get("primary_type", ""),
+                "first_release_date": first_released,
+                "artist_id": str(_primary_artist_id(artists) or ""),
+                "artist_name": _primary_artist_name(artists),
+                "artist_disambiguation": "",
+                "score": int(r.get("score", 0) * 100),
+                "is_master": bool(master_id),
+                "discogs_release_id": str(r["id"]),
+            })
+        return results
+
+    return _cache.memoize_meta(f"discogs:search:releases:{query}", _fetch)
 
 
 def search_artists(query: str) -> list[dict]:
@@ -128,17 +139,20 @@ def search_artists(query: str) -> list[dict]:
     Uses /api/artists?name=, which is a real ts_rank artist-name search —
     parity with MB's /ws/2/artist?query=.
     """
-    q = urllib.parse.quote(query)
-    data = _get(f"{DISCOGS_API_BASE}/api/artists?name={q}&per_page=20")
-    return [
-        {
-            "id": str(r["id"]),
-            "name": r.get("name", ""),
-            "disambiguation": "",
-            "score": int(r.get("score", 0) * 100),
-        }
-        for r in data.get("results", [])
-    ]
+    def _fetch() -> list[dict]:
+        q = urllib.parse.quote(query)
+        data = _get(f"{DISCOGS_API_BASE}/api/artists?name={q}&per_page=20")
+        return [
+            {
+                "id": str(r["id"]),
+                "name": r.get("name", ""),
+                "disambiguation": "",
+                "score": int(r.get("score", 0) * 100),
+            }
+            for r in data.get("results", [])
+        ]
+
+    return _cache.memoize_meta(f"discogs:search:artists:{query}", _fetch)
 
 
 def get_artist_releases(artist_id: int) -> list[dict]:
@@ -149,115 +163,127 @@ def get_artist_releases(artist_id: int) -> list[dict]:
     id "release-<n>" and is_masterless=True; we strip the prefix so the bare
     release ID is usable for downstream lookups.
     """
-    entries: list[dict] = []
-    page = 1
-    while True:
-        data = _get(
-            f"{DISCOGS_API_BASE}/api/artists/{artist_id}/masters?per_page=100&page={page}"
-        )
-        results = data.get("results", [])
-        if not results:
-            break
-        for r in results:
-            raw_id = r.get("id")
-            is_masterless = bool(r.get("is_masterless"))
-            if is_masterless and isinstance(raw_id, str) and raw_id.startswith("release-"):
-                bare_id = raw_id[len("release-"):]
-                entry = {
-                    "id": bare_id,
-                    "title": r.get("title", ""),
-                    "type": r.get("type", ""),
-                    "secondary_types": [],
-                    "first_release_date": r.get("first_release_date", ""),
-                    "artist_credit": r.get("artist_credit", ""),
-                    "primary_artist_id": str(r.get("primary_artist_id") or ""),
-                    "is_masterless": True,
-                    "discogs_release_id": bare_id,
-                }
-            else:
-                entry = {
-                    "id": str(raw_id),
-                    "title": r.get("title", ""),
-                    "type": r.get("type", ""),
-                    "secondary_types": [],
-                    "first_release_date": r.get("first_release_date", ""),
-                    "artist_credit": r.get("artist_credit", ""),
-                    "primary_artist_id": str(r.get("primary_artist_id") or ""),
-                }
-            entries.append(entry)
-        total = data.get("total", 0)
-        if page * data.get("per_page", 100) >= total:
-            break
-        if len(entries) >= 500:
-            break
-        page += 1
-    return entries
+    def _fetch() -> list[dict]:
+        entries: list[dict] = []
+        page = 1
+        while True:
+            data = _get(
+                f"{DISCOGS_API_BASE}/api/artists/{artist_id}/masters?per_page=100&page={page}"
+            )
+            results = data.get("results", [])
+            if not results:
+                break
+            for r in results:
+                raw_id = r.get("id")
+                is_masterless = bool(r.get("is_masterless"))
+                if is_masterless and isinstance(raw_id, str) and raw_id.startswith("release-"):
+                    bare_id = raw_id[len("release-"):]
+                    entry = {
+                        "id": bare_id,
+                        "title": r.get("title", ""),
+                        "type": r.get("type", ""),
+                        "secondary_types": [],
+                        "first_release_date": r.get("first_release_date", ""),
+                        "artist_credit": r.get("artist_credit", ""),
+                        "primary_artist_id": str(r.get("primary_artist_id") or ""),
+                        "is_masterless": True,
+                        "discogs_release_id": bare_id,
+                    }
+                else:
+                    entry = {
+                        "id": str(raw_id),
+                        "title": r.get("title", ""),
+                        "type": r.get("type", ""),
+                        "secondary_types": [],
+                        "first_release_date": r.get("first_release_date", ""),
+                        "artist_credit": r.get("artist_credit", ""),
+                        "primary_artist_id": str(r.get("primary_artist_id") or ""),
+                    }
+                entries.append(entry)
+            total = data.get("total", 0)
+            if page * data.get("per_page", 100) >= total:
+                break
+            if len(entries) >= 500:
+                break
+            page += 1
+        return entries
+
+    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases", _fetch)
 
 
 def get_master_releases(master_id: int) -> dict:
     """Get all releases (pressings) for a master. Mirrors mb.get_release_group_releases()."""
-    data = _get(f"{DISCOGS_API_BASE}/api/masters/{master_id}")
-    releases = []
-    for r in data.get("releases", []):
-        formats = r.get("formats", [])
-        format_names = [f.get("name", "?") for f in formats]
-        releases.append({
-            "id": str(r["id"]),
-            "title": r.get("title", data.get("title", "")),
-            "date": r.get("released", ""),
-            "country": r.get("country", ""),
-            "status": "Official",
-            "track_count": r.get("track_count", 0),
-            "format": ", ".join(format_names) if format_names else "?",
-            "media_count": len(formats),
-            "labels": r.get("labels", []),
-        })
-    return {
-        "title": data.get("title", ""),
-        "type": data.get("primary_type", ""),
-        "first_release_date": data.get("first_release_date", ""),
-        "artist_credit": data.get("artist_credit", ""),
-        "primary_artist_id": str(data.get("primary_artist_id") or ""),
-        "releases": releases,
-    }
+    def _fetch() -> dict:
+        data = _get(f"{DISCOGS_API_BASE}/api/masters/{master_id}")
+        releases = []
+        for r in data.get("releases", []):
+            formats = r.get("formats", [])
+            format_names = [f.get("name", "?") for f in formats]
+            releases.append({
+                "id": str(r["id"]),
+                "title": r.get("title", data.get("title", "")),
+                "date": r.get("released", ""),
+                "country": r.get("country", ""),
+                "status": "Official",
+                "track_count": r.get("track_count", 0),
+                "format": ", ".join(format_names) if format_names else "?",
+                "media_count": len(formats),
+                "labels": r.get("labels", []),
+            })
+        return {
+            "title": data.get("title", ""),
+            "type": data.get("primary_type", ""),
+            "first_release_date": data.get("first_release_date", ""),
+            "artist_credit": data.get("artist_credit", ""),
+            "primary_artist_id": str(data.get("primary_artist_id") or ""),
+            "releases": releases,
+        }
+
+    return _cache.memoize_meta(f"discogs:master:{master_id}", _fetch)
 
 
 def get_release(release_id: int) -> dict:
     """Get full release details with tracks. Mirrors mb.get_release()."""
-    data = _get(f"{DISCOGS_API_BASE}/api/releases/{release_id}")
-    artists = data.get("artists", [])
-    artist_name = _primary_artist_name(artists)
-    artist_id = _primary_artist_id(artists)
+    def _fetch() -> dict:
+        data = _get(f"{DISCOGS_API_BASE}/api/releases/{release_id}")
+        artists = data.get("artists", [])
+        artist_name = _primary_artist_name(artists)
+        artist_id = _primary_artist_id(artists)
 
-    tracks = []
-    for track in data.get("tracks", []):
-        disc, track_num = _parse_position(track.get("position", ""))
-        tracks.append({
-            "disc_number": disc,
-            "track_number": track_num,
-            "title": track.get("title", ""),
-            "length_seconds": _parse_duration(track.get("duration", "")),
-        })
+        tracks = []
+        for track in data.get("tracks", []):
+            disc, track_num = _parse_position(track.get("position", ""))
+            tracks.append({
+                "disc_number": disc,
+                "track_number": track_num,
+                "title": track.get("title", ""),
+                "length_seconds": _parse_duration(track.get("duration", "")),
+            })
 
-    year = _parse_year(data.get("released", ""))
+        year = _parse_year(data.get("released", ""))
 
-    return {
-        "id": str(data["id"]),
-        "title": data.get("title", ""),
-        "artist_name": artist_name,
-        "artist_id": str(artist_id) if artist_id else None,
-        "release_group_id": str(data.get("master_id", "")) if data.get("master_id") else None,
-        "date": data.get("released", ""),
-        "year": year,
-        "country": data.get("country", ""),
-        "status": "Official",
-        "tracks": tracks,
-        "labels": data.get("labels", []),
-        "formats": data.get("formats", []),
-    }
+        return {
+            "id": str(data["id"]),
+            "title": data.get("title", ""),
+            "artist_name": artist_name,
+            "artist_id": str(artist_id) if artist_id else None,
+            "release_group_id": str(data.get("master_id", "")) if data.get("master_id") else None,
+            "date": data.get("released", ""),
+            "year": year,
+            "country": data.get("country", ""),
+            "status": "Official",
+            "tracks": tracks,
+            "labels": data.get("labels", []),
+            "formats": data.get("formats", []),
+        }
+
+    return _cache.memoize_meta(f"discogs:release:{release_id}", _fetch)
 
 
 def get_artist_name(artist_id: int) -> str:
     """Look up an artist's name by Discogs ID."""
-    data = _get(f"{DISCOGS_API_BASE}/api/artists/{artist_id}")
-    return data.get("name", "")
+    def _fetch() -> str:
+        data = _get(f"{DISCOGS_API_BASE}/api/artists/{artist_id}")
+        return data.get("name", "")
+
+    return _cache.memoize_meta(f"discogs:artist:{artist_id}:name", _fetch)

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -242,8 +242,14 @@ def get_master_releases(master_id: int) -> dict:
     return _cache.memoize_meta(f"discogs:master:{master_id}", _fetch)
 
 
-def get_release(release_id: int) -> dict:
-    """Get full release details with tracks. Mirrors mb.get_release()."""
+def get_release(release_id: int, *, fresh: bool = False) -> dict:
+    """Get full release details with tracks. Mirrors mb.get_release().
+
+    `fresh=True` bypasses the cache. Used by POST handlers in
+    `web/routes/pipeline.py` that persist this metadata into the
+    pipeline DB — a 24h cache hit would silently write stale
+    artist/title/track data into `album_requests` / `request_tracks`.
+    """
     def _fetch() -> dict:
         data = _get(f"{DISCOGS_API_BASE}/api/releases/{release_id}")
         artists = data.get("artists", [])
@@ -277,7 +283,8 @@ def get_release(release_id: int) -> dict:
             "formats": data.get("formats", []),
         }
 
-    return _cache.memoize_meta(f"discogs:release:{release_id}", _fetch)
+    return _cache.memoize_meta(
+        f"discogs:release:{release_id}", _fetch, fresh=fresh)
 
 
 def get_artist_name(artist_id: int) -> str:

--- a/web/mb.py
+++ b/web/mb.py
@@ -1,11 +1,27 @@
 """MusicBrainz API helpers — shared between pipeline_cli and web server.
 
-All queries hit the local MB mirror at MB_API_BASE.
+All queries hit the local MB mirror at MB_API_BASE. The pure-metadata
+responses are memoized via `cache.memoize_meta()` at 24h TTL so the
+web UI can render multiple cards per page without hammering the mirror.
+
+The cache layer intentionally sits here — not at the HTTP routing
+level — because route handlers enrich each response with per-user
+pipeline/library overlay state (`pipeline_status`, `in_library`, …).
+Caching the post-overlay response baked that state into Redis and
+leaked stale badges when the pipeline updated Postgres outside the
+web UI's POST invalidation paths. See issue #101.
 """
 
 import json
+import urllib.parse
 import urllib.request
 import urllib.error
+
+# Disambiguate from lib/cache.py (per-user folder cache). Use the
+# `web.` package-qualified path so pyright resolves to web/cache.py,
+# and so there's no ambiguity with `lib/cache.py` (which pyright sees
+# via `extraPaths: ["lib", ...]` in pyrightconfig.json).
+from web import cache as _cache  # type: ignore[import-not-found]
 
 MB_API_BASE = "http://192.168.1.35:5200/ws/2"
 USER_AGENT = "soularr-web/1.0"
@@ -33,191 +49,217 @@ def search_release_groups(query):
     Uses /release search (not /release-group) because the local MB mirror's
     search index only covers releases.
     """
-    q = urllib.parse.quote(query)
-    data = _get(f"{MB_API_BASE}/release?query={q}&fmt=json&limit=25")
-    seen_rg: set[str] = set()
-    results = []
-    for r in data.get("releases", []):
-        rg = r.get("release-group", {})
-        rg_id = rg.get("id", "")
-        if not rg_id or rg_id in seen_rg:
-            continue
-        seen_rg.add(rg_id)
-        artist_credit = r.get("artist-credit", [{}])
-        artist = artist_credit[0].get("artist", {}) if artist_credit else {}
-        results.append({
-            "id": rg_id,
-            "title": rg.get("title", r.get("title", "")),
-            "primary_type": rg.get("primary-type", ""),
-            "first_release_date": rg.get("first-release-date", r.get("date", "")),
-            "artist_id": artist.get("id", ""),
-            "artist_name": artist.get("name", ""),
-            "artist_disambiguation": artist.get("disambiguation", ""),
-            "score": r.get("score", 0),
-        })
-    return results
+    def _fetch() -> list[dict]:
+        q = urllib.parse.quote(query)
+        data = _get(f"{MB_API_BASE}/release?query={q}&fmt=json&limit=25")
+        seen_rg: set[str] = set()
+        results = []
+        for r in data.get("releases", []):
+            rg = r.get("release-group", {})
+            rg_id = rg.get("id", "")
+            if not rg_id or rg_id in seen_rg:
+                continue
+            seen_rg.add(rg_id)
+            artist_credit = r.get("artist-credit", [{}])
+            artist = artist_credit[0].get("artist", {}) if artist_credit else {}
+            results.append({
+                "id": rg_id,
+                "title": rg.get("title", r.get("title", "")),
+                "primary_type": rg.get("primary-type", ""),
+                "first_release_date": rg.get("first-release-date", r.get("date", "")),
+                "artist_id": artist.get("id", ""),
+                "artist_name": artist.get("name", ""),
+                "artist_disambiguation": artist.get("disambiguation", ""),
+                "score": r.get("score", 0),
+            })
+        return results
+
+    return _cache.memoize_meta(f"mb:search:release_groups:{query}", _fetch)
 
 
 def search_artists(query):
     """Search for artists by name. Returns list of {id, name, disambiguation, score}."""
-    q = urllib.parse.quote(query)
-    data = _get(f"{MB_API_BASE}/artist?query={q}&fmt=json&limit=20")
-    return [
-        {
-            "id": a["id"],
-            "name": a.get("name", ""),
-            "disambiguation": a.get("disambiguation", ""),
-            "score": a.get("score", 0),
-        }
-        for a in data.get("artists", [])
-    ]
+    def _fetch() -> list[dict]:
+        q = urllib.parse.quote(query)
+        data = _get(f"{MB_API_BASE}/artist?query={q}&fmt=json&limit=20")
+        return [
+            {
+                "id": a["id"],
+                "name": a.get("name", ""),
+                "disambiguation": a.get("disambiguation", ""),
+                "score": a.get("score", 0),
+            }
+            for a in data.get("artists", [])
+        ]
+
+    return _cache.memoize_meta(f"mb:search:artists:{query}", _fetch)
 
 
 def get_artist_release_groups(artist_mbid):
     """Get all release groups for an artist. Returns list of {id, title, type, first_release_date}."""
-    results = []
-    offset = 0
-    while True:
-        data = _get(
-            f"{MB_API_BASE}/release-group?artist={artist_mbid}"
-            f"&inc=artist-credits&fmt=json&limit=100&offset={offset}"
-        )
-        for rg in data.get("release-groups", []):
-            ac = rg.get("artist-credit", [])
-            credit_name = " / ".join(a.get("name", "?") for a in ac) if ac else ""
-            # Extract primary artist ID from credit for reliable own-work detection
-            primary_artist_id = ac[0].get("artist", {}).get("id") if ac else None
-            results.append({
-                "id": rg["id"],
-                "title": rg.get("title", ""),
-                "type": rg.get("primary-type", ""),
-                "secondary_types": rg.get("secondary-types", []),
-                "first_release_date": rg.get("first-release-date", ""),
-                "artist_credit": credit_name,
-                "primary_artist_id": primary_artist_id,
-            })
-        total = data.get("release-group-count", 0)
-        offset += 100
-        if offset >= total:
-            break
-    return results
+    def _fetch() -> list[dict]:
+        results = []
+        offset = 0
+        while True:
+            data = _get(
+                f"{MB_API_BASE}/release-group?artist={artist_mbid}"
+                f"&inc=artist-credits&fmt=json&limit=100&offset={offset}"
+            )
+            for rg in data.get("release-groups", []):
+                ac = rg.get("artist-credit", [])
+                credit_name = " / ".join(a.get("name", "?") for a in ac) if ac else ""
+                # Extract primary artist ID from credit for reliable own-work detection
+                primary_artist_id = ac[0].get("artist", {}).get("id") if ac else None
+                results.append({
+                    "id": rg["id"],
+                    "title": rg.get("title", ""),
+                    "type": rg.get("primary-type", ""),
+                    "secondary_types": rg.get("secondary-types", []),
+                    "first_release_date": rg.get("first-release-date", ""),
+                    "artist_credit": credit_name,
+                    "primary_artist_id": primary_artist_id,
+                })
+            total = data.get("release-group-count", 0)
+            offset += 100
+            if offset >= total:
+                break
+        return results
+
+    return _cache.memoize_meta(f"mb:artist:{artist_mbid}:release_groups", _fetch)
 
 
 def get_official_release_group_ids(artist_mbid):
     """Get the set of release group IDs that have at least one official release."""
-    rg_ids = set()
-    offset = 0
-    while True:
-        data = _get(
-            f"{MB_API_BASE}/release?artist={artist_mbid}"
-            f"&status=official&inc=release-groups&fmt=json&limit=100&offset={offset}"
-        )
-        for r in data.get("releases", []):
-            rg_id = r.get("release-group", {}).get("id")
-            if rg_id:
-                rg_ids.add(rg_id)
-        total = data.get("release-count", 0)
-        offset += 100
-        if offset >= total:
-            break
-    return rg_ids
+    # JSON cannot serialize a set, so we cache the sorted list and
+    # rebuild the set on the caller's side. Callers use `x in` which
+    # works on either, but set semantics are preserved here for clarity.
+    def _fetch() -> list[str]:
+        rg_ids: set[str] = set()
+        offset = 0
+        while True:
+            data = _get(
+                f"{MB_API_BASE}/release?artist={artist_mbid}"
+                f"&status=official&inc=release-groups&fmt=json&limit=100&offset={offset}"
+            )
+            for r in data.get("releases", []):
+                rg_id = r.get("release-group", {}).get("id")
+                if rg_id:
+                    rg_ids.add(rg_id)
+            total = data.get("release-count", 0)
+            offset += 100
+            if offset >= total:
+                break
+        return sorted(rg_ids)
+
+    cached = _cache.memoize_meta(
+        f"mb:artist:{artist_mbid}:official_rg_ids", _fetch)
+    return set(cached)
 
 
 def get_release_group_releases(rg_mbid):
     """Get all releases for a release group. Returns list of release summaries."""
-    # First get the release group metadata
-    rg_data = _get(f"{MB_API_BASE}/release-group/{rg_mbid}?fmt=json")
+    def _fetch() -> dict:
+        # First get the release group metadata
+        rg_data = _get(f"{MB_API_BASE}/release-group/{rg_mbid}?fmt=json")
 
-    # Then browse all releases (paginated — the lookup endpoint caps at 25)
-    releases = []
-    offset = 0
-    while True:
-        data = _get(
-            f"{MB_API_BASE}/release?release-group={rg_mbid}"
-            f"&inc=media&fmt=json&limit=100&offset={offset}"
-        )
-        for r in data.get("releases", []):
-            track_count = sum(m.get("track-count", 0) for m in r.get("media", []))
-            formats = [(m.get("format") or "?") for m in r.get("media", [])]
-            releases.append({
-                "id": r["id"],
-                "title": r.get("title", ""),
-                "date": r.get("date", ""),
-                "country": r.get("country", ""),
-                "status": r.get("status", ""),
-                "track_count": track_count,
-                "format": ", ".join(formats) if formats else "?",
-                "media_count": len(r.get("media", [])),
-            })
-        total = data.get("release-count", 0)
-        offset += 100
-        if offset >= total:
-            break
+        # Then browse all releases (paginated — the lookup endpoint caps at 25)
+        releases = []
+        offset = 0
+        while True:
+            data = _get(
+                f"{MB_API_BASE}/release?release-group={rg_mbid}"
+                f"&inc=media&fmt=json&limit=100&offset={offset}"
+            )
+            for r in data.get("releases", []):
+                track_count = sum(m.get("track-count", 0) for m in r.get("media", []))
+                formats = [(m.get("format") or "?") for m in r.get("media", [])]
+                releases.append({
+                    "id": r["id"],
+                    "title": r.get("title", ""),
+                    "date": r.get("date", ""),
+                    "country": r.get("country", ""),
+                    "status": r.get("status", ""),
+                    "track_count": track_count,
+                    "format": ", ".join(formats) if formats else "?",
+                    "media_count": len(r.get("media", [])),
+                })
+            total = data.get("release-count", 0)
+            offset += 100
+            if offset >= total:
+                break
 
-    return {
-        "title": rg_data.get("title", ""),
-        "type": rg_data.get("primary-type", ""),
-        "releases": releases,
-    }
+        return {
+            "title": rg_data.get("title", ""),
+            "type": rg_data.get("primary-type", ""),
+            "releases": releases,
+        }
+
+    return _cache.memoize_meta(f"mb:release-group:{rg_mbid}:releases", _fetch)
 
 
 def get_release(release_mbid):
     """Get full release details with tracks."""
-    data = _get(
-        f"{MB_API_BASE}/release/{release_mbid}"
-        f"?inc=recordings+artist-credits+media&fmt=json"
-    )
-    artist_credit = data.get("artist-credit", [{}])
-    artist_name = artist_credit[0].get("name", "Unknown") if artist_credit else "Unknown"
-    artist_id = (artist_credit[0].get("artist", {}).get("id") if artist_credit else None)
-    rg_id = (data.get("release-group") or {}).get("id")
+    def _fetch() -> dict:
+        data = _get(
+            f"{MB_API_BASE}/release/{release_mbid}"
+            f"?inc=recordings+artist-credits+media&fmt=json"
+        )
+        artist_credit = data.get("artist-credit", [{}])
+        artist_name = artist_credit[0].get("name", "Unknown") if artist_credit else "Unknown"
+        artist_id = (artist_credit[0].get("artist", {}).get("id") if artist_credit else None)
+        rg_id = (data.get("release-group") or {}).get("id")
 
-    tracks = []
-    for medium in data.get("media", []):
-        disc = medium.get("position", 1)
-        if "pregap" in medium:
-            pg = medium["pregap"]
-            length_ms = pg.get("length") or (pg.get("recording") or {}).get("length")
-            tracks.append({
-                "disc_number": disc,
-                "track_number": 0,
-                "title": pg.get("title", ""),
-                "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
-            })
-        for track in medium.get("tracks", []):
-            length_ms = track.get("length") or (track.get("recording") or {}).get("length")
-            tracks.append({
-                "disc_number": disc,
-                "track_number": track.get("position", track.get("number", 0)),
-                "title": track.get("title", ""),
-                "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
-            })
+        tracks = []
+        for medium in data.get("media", []):
+            disc = medium.get("position", 1)
+            if "pregap" in medium:
+                pg = medium["pregap"]
+                length_ms = pg.get("length") or (pg.get("recording") or {}).get("length")
+                tracks.append({
+                    "disc_number": disc,
+                    "track_number": 0,
+                    "title": pg.get("title", ""),
+                    "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
+                })
+            for track in medium.get("tracks", []):
+                length_ms = track.get("length") or (track.get("recording") or {}).get("length")
+                tracks.append({
+                    "disc_number": disc,
+                    "track_number": track.get("position", track.get("number", 0)),
+                    "title": track.get("title", ""),
+                    "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
+                })
 
-    year = None
-    if data.get("date"):
-        try:
-            year = int(data["date"][:4])
-        except (ValueError, IndexError):
-            pass
+        year = None
+        if data.get("date"):
+            try:
+                year = int(data["date"][:4])
+            except (ValueError, IndexError):
+                pass
 
-    return {
-        "id": data["id"],
-        "title": data.get("title", ""),
-        "artist_name": artist_name,
-        "artist_id": artist_id,
-        "release_group_id": rg_id,
-        "date": data.get("date", ""),
-        "year": year,
-        "country": data.get("country", ""),
-        "status": data.get("status", ""),
-        "tracks": tracks,
-    }
+        return {
+            "id": data["id"],
+            "title": data.get("title", ""),
+            "artist_name": artist_name,
+            "artist_id": artist_id,
+            "release_group_id": rg_id,
+            "date": data.get("date", ""),
+            "year": year,
+            "country": data.get("country", ""),
+            "status": data.get("status", ""),
+            "tracks": tracks,
+        }
+
+    return _cache.memoize_meta(f"mb:release:{release_mbid}", _fetch)
 
 
 def get_artist_name(artist_mbid):
     """Look up an artist's name by MBID."""
-    data = _get(f"{MB_API_BASE}/artist/{artist_mbid}?fmt=json")
-    return data.get("name", "")
+    def _fetch() -> str:
+        data = _get(f"{MB_API_BASE}/artist/{artist_mbid}?fmt=json")
+        return data.get("name", "")
+
+    return _cache.memoize_meta(f"mb:artist:{artist_mbid}:name", _fetch)
 
 
 def get_artist_releases_with_recordings(artist_mbid):
@@ -225,21 +267,21 @@ def get_artist_releases_with_recordings(artist_mbid):
 
     Returns raw MB release dicts with media[].tracks[].recording and release-group fields.
     """
-    releases = []
-    offset = 0
-    while True:
-        data = _get(
-            f"{MB_API_BASE}/release?artist={artist_mbid}"
-            f"&inc=recordings+media+release-groups&fmt=json&limit=100&offset={offset}"
-        )
-        page = data.get("releases", [])
-        releases.extend(page)
-        total = data.get("release-count", 0)
-        offset += len(page)
-        if not page or offset >= total:
-            break
-    return releases
+    def _fetch() -> list[dict]:
+        releases = []
+        offset = 0
+        while True:
+            data = _get(
+                f"{MB_API_BASE}/release?artist={artist_mbid}"
+                f"&inc=recordings+media+release-groups&fmt=json&limit=100&offset={offset}"
+            )
+            page = data.get("releases", [])
+            releases.extend(page)
+            total = data.get("release-count", 0)
+            offset += len(page)
+            if not page or offset >= total:
+                break
+        return releases
 
-
-# Keep urllib.parse available for the quote() call above
-import urllib.parse  # noqa: E402
+    return _cache.memoize_meta(
+        f"mb:artist:{artist_mbid}:releases_with_recordings", _fetch)

--- a/web/mb.py
+++ b/web/mb.py
@@ -197,8 +197,14 @@ def get_release_group_releases(rg_mbid):
     return _cache.memoize_meta(f"mb:release-group:{rg_mbid}:releases", _fetch)
 
 
-def get_release(release_mbid):
-    """Get full release details with tracks."""
+def get_release(release_mbid, *, fresh: bool = False):
+    """Get full release details with tracks.
+
+    `fresh=True` bypasses the cache. Used by POST handlers in
+    `web/routes/pipeline.py` that persist this metadata into the
+    pipeline DB — a 24h cache hit would silently write stale
+    artist/title/track data into `album_requests` / `request_tracks`.
+    """
     def _fetch() -> dict:
         data = _get(
             f"{MB_API_BASE}/release/{release_mbid}"
@@ -250,7 +256,8 @@ def get_release(release_mbid):
             "tracks": tracks,
         }
 
-    return _cache.memoize_meta(f"mb:release:{release_mbid}", _fetch)
+    return _cache.memoize_meta(
+        f"mb:release:{release_mbid}", _fetch, fresh=fresh)
 
 
 def get_artist_name(artist_mbid):

--- a/web/mb.py
+++ b/web/mb.py
@@ -17,11 +17,9 @@ import urllib.parse
 import urllib.request
 import urllib.error
 
-# Disambiguate from lib/cache.py (per-user folder cache). Use the
-# `web.` package-qualified path so pyright resolves to web/cache.py,
-# and so there's no ambiguity with `lib/cache.py` (which pyright sees
-# via `extraPaths: ["lib", ...]` in pyrightconfig.json).
-from web import cache as _cache  # type: ignore[import-not-found]
+# Use the `web.` package-qualified path to avoid any collision with
+# lib/cache.py (a different module — the per-user folder cache).
+from web import cache as _cache
 
 MB_API_BASE = "http://192.168.1.35:5200/ws/2"
 USER_AGENT = "soularr-web/1.0"

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -6,9 +6,11 @@ Both are enriched with library/pipeline status via check_beets_library() and che
 """
 from __future__ import annotations
 
+import copy
 import re
 from typing import TYPE_CHECKING
 
+from web import cache as _cache
 from web import discogs as discogs_api
 from lib.artist_compare import annotate_in_library, merge_discographies
 
@@ -92,9 +94,17 @@ def get_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]], artist_i
     h._json({"release_groups": rgs})  # type: ignore[attr-defined]
 
 
-def get_artist_disambiguate(h: BaseHTTPRequestHandler, params: dict[str, list[str]], artist_id: str) -> None:
+def _build_disambiguate_skeleton(artist_id: str) -> dict:
+    """Pure-metadata skeleton of the disambiguate response (no overlay).
+
+    Runs the expensive `analyse_artist_releases` pass on cached MB
+    metadata and returns a JSON-serializable dict. Callers cache this
+    under `meta:` and then layer pipeline / library state on top per-
+    request. The analysis is a pure function of pure-metadata inputs,
+    so its output is semantically part of the metadata cache.
+    """
     srv = _server()
-    from lib.artist_releases import (
+    from lib.artist_releases import (  # local to avoid heavy import at route-load
         filter_non_live,
         analyse_artist_releases,
     )
@@ -103,102 +113,120 @@ def get_artist_disambiguate(h: BaseHTTPRequestHandler, params: dict[str, list[st
     filtered = filter_non_live(raw_releases)
     rg_infos = analyse_artist_releases(filtered)
 
-    # Cross-reference library and pipeline status using all release IDs
-    all_mbids: list[str] = []
+    rgs_skeleton: list[dict] = []
     for rg in rg_infos:
-        all_mbids.extend(rg.release_ids)
-    in_library = srv.check_beets_library(all_mbids) if all_mbids else set()
-    in_pipeline = srv.check_pipeline(all_mbids) if all_mbids else {}
-
-    rgs_json: list[dict] = []
-    for rg in rg_infos:
-        # A release group is "in library" if ANY pressing is
-        lib_status = "in_library" if any(rid in in_library for rid in rg.release_ids) else None
-        # Pipeline status: find the first pressing that's in the pipeline
-        pip_status: str | None = None
-        pip_id: int | None = None
-        for rid in rg.release_ids:
-            pip = in_pipeline.get(rid)
-            if pip:
-                pip_status = pip["status"]
-                pip_id = pip["id"]
-                break
-
-        # Look up beets album IDs + on-disk quality for in-library pressings
-        lib_mbids = [p.release_id for p in rg.pressings if p.release_id in in_library]
-        b = srv._beets_db()
-        beets_ids = b.get_album_ids_by_mbids(lib_mbids) if lib_mbids and b else {}
-        quality = b.check_mbids_detail(lib_mbids) if lib_mbids and b else {}
-
-        # RG-level quality: pick the first in-library pressing's quality
-        # so the disambiguate row badge shows on-disk format/rank too.
-        rg_quality = None
-        for rid in rg.release_ids:
-            if rid in quality:
-                rg_quality = quality[rid]
-                break
-
-        pressings_json = []
-        for p in rg.pressings:
-            p_lib = p.release_id in in_library
-            p_pip = in_pipeline.get(p.release_id)
-            pq = quality.get(p.release_id) or {}
-            entry = {
-                "release_id": p.release_id,
-                "title": p.title,
-                "date": p.date,
-                "format": p.format,
-                "track_count": p.track_count,
-                "country": p.country,
-                "recording_ids": p.recording_ids,
-                "in_library": p_lib,
-                "beets_album_id": beets_ids.get(p.release_id),
-                "pipeline_status": p_pip["status"] if p_pip else None,
-                "pipeline_id": p_pip["id"] if p_pip else None,
-            }
-            if pq:
-                entry["library_format"] = pq.get("beets_format") or ""
-                entry["library_min_bitrate"] = pq.get("beets_bitrate") or 0
-                entry["library_rank"] = srv.compute_library_rank(
-                    entry["library_format"], entry["library_min_bitrate"])
-            pressings_json.append(entry)
-
-        rg_dict = {
+        rgs_skeleton.append({
             "release_group_id": rg.release_group_id,
             "title": rg.title,
             "primary_type": rg.primary_type,
             "first_date": rg.first_date,
-            "release_ids": rg.release_ids,
-            "pressings": pressings_json,
+            "release_ids": list(rg.release_ids),
+            "pressings": [
+                {
+                    "release_id": p.release_id,
+                    "title": p.title,
+                    "date": p.date,
+                    "format": p.format,
+                    "track_count": p.track_count,
+                    "country": p.country,
+                    "recording_ids": list(p.recording_ids),
+                }
+                for p in rg.pressings
+            ],
             "track_count": rg.track_count,
             "unique_track_count": rg.unique_track_count,
             "covered_by": rg.covered_by,
-            "library_status": lib_status,
-            "pipeline_status": pip_status,
-            "pipeline_id": pip_id,
             "tracks": [
                 {
                     "recording_id": t.recording_id,
                     "title": t.title,
                     "unique": t.unique,
-                    "also_on": t.also_on,
+                    "also_on": list(t.also_on),
                 }
                 for t in rg.tracks
             ],
-        }
-        if rg_quality:
-            rg_dict["library_format"] = rg_quality.get("beets_format") or ""
-            rg_dict["library_min_bitrate"] = rg_quality.get("beets_bitrate") or 0
-            rg_dict["library_rank"] = srv.compute_library_rank(
-                rg_dict["library_format"], rg_dict["library_min_bitrate"])
-        rgs_json.append(rg_dict)
+        })
 
-    artist_name = srv.mb_api.get_artist_name(artist_id)
-    h._json({  # type: ignore[attr-defined]
+    return {
         "artist_id": artist_id,
-        "artist_name": artist_name,
-        "release_groups": rgs_json,
-    })
+        "artist_name": srv.mb_api.get_artist_name(artist_id),
+        "release_groups": rgs_skeleton,
+    }
+
+
+def _overlay_disambiguate(skeleton: dict) -> dict:
+    """Apply per-request pipeline / library overlay to the cached
+    skeleton. Returns a new dict — does NOT mutate the cached value."""
+    srv = _server()
+    response = copy.deepcopy(skeleton)
+    b = srv._beets_db()
+
+    all_mbids: list[str] = []
+    for rg in response["release_groups"]:
+        all_mbids.extend(rg["release_ids"])
+    in_library = srv.check_beets_library(all_mbids) if all_mbids else set()
+    in_pipeline = srv.check_pipeline(all_mbids) if all_mbids else {}
+
+    for rg in response["release_groups"]:
+        rg["library_status"] = (
+            "in_library"
+            if any(rid in in_library for rid in rg["release_ids"])
+            else None
+        )
+        rg_pip_status: str | None = None
+        rg_pip_id: int | None = None
+        for rid in rg["release_ids"]:
+            pip = in_pipeline.get(rid)
+            if pip:
+                rg_pip_status = pip["status"]
+                rg_pip_id = pip["id"]
+                break
+        rg["pipeline_status"] = rg_pip_status
+        rg["pipeline_id"] = rg_pip_id
+
+        lib_mbids = [p["release_id"] for p in rg["pressings"]
+                     if p["release_id"] in in_library]
+        beets_ids = b.get_album_ids_by_mbids(lib_mbids) if lib_mbids and b else {}
+        quality = b.check_mbids_detail(lib_mbids) if lib_mbids and b else {}
+
+        rg_quality = None
+        for rid in rg["release_ids"]:
+            if rid in quality:
+                rg_quality = quality[rid]
+                break
+
+        for p in rg["pressings"]:
+            rid = p["release_id"]
+            p["in_library"] = rid in in_library
+            p["beets_album_id"] = beets_ids.get(rid)
+            p_pip = in_pipeline.get(rid)
+            p["pipeline_status"] = p_pip["status"] if p_pip else None
+            p["pipeline_id"] = p_pip["id"] if p_pip else None
+            pq = quality.get(rid) or {}
+            if pq:
+                p["library_format"] = pq.get("beets_format") or ""
+                p["library_min_bitrate"] = pq.get("beets_bitrate") or 0
+                p["library_rank"] = srv.compute_library_rank(
+                    p["library_format"], p["library_min_bitrate"])
+
+        if rg_quality:
+            rg["library_format"] = rg_quality.get("beets_format") or ""
+            rg["library_min_bitrate"] = rg_quality.get("beets_bitrate") or 0
+            rg["library_rank"] = srv.compute_library_rank(
+                rg["library_format"], rg["library_min_bitrate"])
+
+    return response
+
+
+def get_artist_disambiguate(h: BaseHTTPRequestHandler, params: dict[str, list[str]], artist_id: str) -> None:
+    # Cache the pure-metadata skeleton (analyse_artist_releases output
+    # serialized to JSON-safe dicts) under meta:. Overlay runs per
+    # request — see issue #101 Codex round 3 for why the split matters.
+    skeleton = _cache.memoize_meta(
+        f"mb:artist:{artist_id}:disambiguate",
+        lambda: _build_disambiguate_skeleton(artist_id),
+    )
+    h._json(_overlay_disambiguate(skeleton))  # type: ignore[attr-defined]
 
 
 def get_release_group(h: BaseHTTPRequestHandler, params: dict[str, list[str]], rg_id: str) -> None:
@@ -344,24 +372,12 @@ def get_discogs_release(h: BaseHTTPRequestHandler, params: dict[str, list[str]],
     h._json(data)  # type: ignore[attr-defined]
 
 
-def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) -> None:
-    """Side-by-side discography from both MB and Discogs for one artist.
-
-    Resolves both source artist IDs from the supplied name (and optional
-    explicit IDs to skip the lookup), fetches each source's discography,
-    and fuzzy-merges by title+year via lib.artist_compare.merge_discographies.
-
-    Returns three buckets so the UI can show what each source uniquely
-    contributes plus the matched-on-both core catalog.
-    """
+def _resolve_compare_artists(name: str, mbid: str, discogs_id: str) -> tuple[
+        str, str, dict | None, dict | None]:
+    """Resolve MB / Discogs artist IDs from the supplied name when not
+    passed explicitly. Returns the final (mbid, discogs_id, mb_artist,
+    discogs_artist) tuple. Pure-metadata: runs only memoized searches."""
     srv = _server()
-    name = params.get("name", [""])[0].strip()
-    if not name:
-        h._error("Missing parameter 'name'")  # type: ignore[attr-defined]
-        return
-    mbid = params.get("mbid", [""])[0].strip()
-    discogs_id = params.get("discogs_id", [""])[0].strip()
-
     mb_artist: dict | None = None
     discogs_artist: dict | None = None
 
@@ -391,13 +407,23 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     else:
         discogs_artist = {"id": discogs_id, "name": name}
 
+    return mbid, discogs_id, mb_artist, discogs_artist
+
+
+def _build_compare_skeleton(mbid: str, discogs_id: str,
+                            mb_artist: dict | None,
+                            discogs_artist: dict | None) -> dict:
+    """Pure-metadata compare skeleton — no in_library overlay.
+
+    Resolves both discographies from the cached API helpers, stamps
+    has_official bootleg flags, and runs merge_discographies (pure
+    fuzzy title+year join). Safe to cache under `meta:` — its output
+    depends only on (mbid, discogs_id) and pure-metadata inputs.
+    """
+    srv = _server()
     mb_groups: list[dict] = []
     if mbid:
         mb_groups = srv.mb_api.get_artist_release_groups(mbid)
-        # Mark bootleg status on MB rows so the frontend can split them
-        # into a Bootleg-only collapsible section like the Discography
-        # sub-tab. Discogs has no official/bootleg concept in the CC0
-        # dump, so Discogs-only rows are always treated as official.
         official_rg_ids = srv.mb_api.get_official_release_group_ids(mbid)
         for rg in mb_groups:
             rg["has_official"] = rg["id"] in official_rg_ids
@@ -406,21 +432,83 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     if discogs_id:
         discogs_groups = discogs_api.get_artist_releases(int(discogs_id))
 
-    # Row-level in-library badge — same as Discography sub-tab. Beets
-    # query is keyed by name with mbid for the UUID-match fast path.
-    if name:
-        lib = srv.get_library_artist(name, mbid)
-        annotate_in_library(mb_groups, discogs_groups, lib, rank_fn=srv.compute_library_rank)
-
     merged = merge_discographies(mb_groups, discogs_groups)
-
-    h._json({  # type: ignore[attr-defined]
+    return {
         "mb_artist": mb_artist,
         "discogs_artist": discogs_artist,
         "both": merged.both,
         "mb_only": merged.mb_only,
         "discogs_only": merged.discogs_only,
-    })
+    }
+
+
+def _overlay_compare(skeleton: dict, name: str, mbid: str) -> dict:
+    """Apply per-request `in_library` overlay to a cached compare
+    skeleton. Returns a new dict — does not mutate the cached value.
+
+    annotate_in_library mutates row dicts in place. We deep-copy the
+    skeleton first so the cached dict stays clean for the next request.
+    """
+    srv = _server()
+    response = copy.deepcopy(skeleton)
+    if not name:
+        return response
+
+    lib = srv.get_library_artist(name, mbid)
+
+    # Reconstruct flat mb_groups / discogs_groups lists that reference
+    # the dict instances inside the three buckets, so annotate_in_library
+    # mutates them in place (the 'both' bucket holds pairs, not flat rows).
+    mb_groups: list[dict] = []
+    discogs_groups: list[dict] = []
+    for pair in response["both"]:
+        if isinstance(pair.get("mb"), dict):
+            mb_groups.append(pair["mb"])
+        if isinstance(pair.get("discogs"), dict):
+            discogs_groups.append(pair["discogs"])
+    mb_groups.extend(response["mb_only"])
+    discogs_groups.extend(response["discogs_only"])
+
+    annotate_in_library(mb_groups, discogs_groups, lib,
+                        rank_fn=srv.compute_library_rank)
+    return response
+
+
+def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) -> None:
+    """Side-by-side discography from both MB and Discogs for one artist.
+
+    Resolves both source artist IDs from the supplied name (and optional
+    explicit IDs to skip the lookup), fetches each source's discography,
+    and fuzzy-merges by title+year via lib.artist_compare.merge_discographies.
+
+    Returns three buckets so the UI can show what each source uniquely
+    contributes plus the matched-on-both core catalog.
+
+    Pure-metadata skeleton (both discographies + merge output) is cached
+    under `meta:` — the expensive merge doesn't re-run on warm loads.
+    The `in_library` overlay runs per-request on a deep-copied skeleton.
+    """
+    name = params.get("name", [""])[0].strip()
+    if not name:
+        h._error("Missing parameter 'name'")  # type: ignore[attr-defined]
+        return
+    mbid = params.get("mbid", [""])[0].strip()
+    discogs_id = params.get("discogs_id", [""])[0].strip()
+
+    mbid, discogs_id, mb_artist, discogs_artist = _resolve_compare_artists(
+        name, mbid, discogs_id)
+
+    # Skeleton key is the resolved (mbid, discogs_id) pair — deterministic
+    # even when the user searches by a name variant. mb_artist /
+    # discogs_artist names are keyed into the skeleton so cached lookups
+    # carry their display name through.
+    cache_key = f"artist:compare:{mbid or 'none'}:{discogs_id or 'none'}"
+    skeleton = _cache.memoize_meta(
+        cache_key,
+        lambda: _build_compare_skeleton(
+            mbid, discogs_id, mb_artist, discogs_artist),
+    )
+    h._json(_overlay_compare(skeleton, name, mbid))  # type: ignore[attr-defined]
 
 
 # ── Route tables ─────────────────────────────────────────────────────

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -372,53 +372,47 @@ def get_discogs_release(h: BaseHTTPRequestHandler, params: dict[str, list[str]],
     h._json(data)  # type: ignore[attr-defined]
 
 
-def _resolve_compare_artists(name: str, mbid: str, discogs_id: str) -> tuple[
-        str, str, dict | None, dict | None]:
-    """Resolve MB / Discogs artist IDs from the supplied name when not
-    passed explicitly. Returns the final (mbid, discogs_id, mb_artist,
-    discogs_artist) tuple. Pure-metadata: runs only memoized searches."""
+def _resolve_compare_artist_ids(name: str, mbid: str,
+                                discogs_id: str) -> tuple[str, str]:
+    """Resolve MB / Discogs artist IDs from `name` when not passed
+    explicitly. Returns the (mbid, discogs_id) pair. Display names
+    are resolved separately from the canonical APIs — keeping them
+    out of the cache key means a `?name=` typo doesn't produce a
+    different cache entry for the same underlying artist pair."""
     srv = _server()
-    mb_artist: dict | None = None
-    discogs_artist: dict | None = None
-
     if not mbid:
         hits = srv.mb_api.search_artists(name)
         for a in hits:
             if (a.get("name") or "").lower() == name.lower():
                 mbid = a["id"]
-                mb_artist = {"id": a["id"], "name": a["name"]}
                 break
         if not mbid and hits:
             mbid = hits[0]["id"]
-            mb_artist = {"id": hits[0]["id"], "name": hits[0]["name"]}
-    else:
-        mb_artist = {"id": mbid, "name": name}
 
     if not discogs_id:
         hits = discogs_api.search_artists(name)
         for a in hits:
             if (a.get("name") or "").lower() == name.lower():
                 discogs_id = a["id"]
-                discogs_artist = {"id": a["id"], "name": a["name"]}
                 break
         if not discogs_id and hits:
             discogs_id = hits[0]["id"]
-            discogs_artist = {"id": hits[0]["id"], "name": hits[0]["name"]}
-    else:
-        discogs_artist = {"id": discogs_id, "name": name}
 
-    return mbid, discogs_id, mb_artist, discogs_artist
+    return mbid, discogs_id
 
 
-def _build_compare_skeleton(mbid: str, discogs_id: str,
-                            mb_artist: dict | None,
-                            discogs_artist: dict | None) -> dict:
-    """Pure-metadata compare skeleton — no in_library overlay.
+def _build_compare_skeleton(mbid: str, discogs_id: str) -> dict:
+    """Pure-metadata compare skeleton — no in_library overlay and
+    deliberately no artist labels either.
 
-    Resolves both discographies from the cached API helpers, stamps
-    has_official bootleg flags, and runs merge_discographies (pure
-    fuzzy title+year join). Safe to cache under `meta:` — its output
-    depends only on (mbid, discogs_id) and pure-metadata inputs.
+    Display names (`mb_artist`, `discogs_artist`) are resolved from the
+    canonical MB / Discogs helpers in `_canonical_artist_labels()`,
+    outside this cached value. Codex round 4 on PR #104 flagged that
+    baking the request's `?name=` into the cache meant a typo on the
+    first request served for the next 24h.
+
+    Safe to cache under `meta:` — the output depends only on the
+    resolved `(mbid, discogs_id)` pair and pure-metadata inputs.
     """
     srv = _server()
     mb_groups: list[dict] = []
@@ -434,12 +428,32 @@ def _build_compare_skeleton(mbid: str, discogs_id: str,
 
     merged = merge_discographies(mb_groups, discogs_groups)
     return {
-        "mb_artist": mb_artist,
-        "discogs_artist": discogs_artist,
         "both": merged.both,
         "mb_only": merged.mb_only,
         "discogs_only": merged.discogs_only,
     }
+
+
+def _canonical_artist_labels(mbid: str, discogs_id: str) -> tuple[
+        dict | None, dict | None]:
+    """Resolve `{id, name}` for each source from the canonical API
+    helpers. Names come back from `mb_api.get_artist_name` /
+    `discogs_api.get_artist_name`, which are themselves memoized in
+    `meta:`, so this is cheap — and it guarantees the display name is
+    the same across requests regardless of whatever `?name=` spelling
+    a given client happened to use.
+    """
+    srv = _server()
+    mb_artist: dict | None = None
+    if mbid:
+        mb_artist = {"id": mbid, "name": srv.mb_api.get_artist_name(mbid) or ""}
+    discogs_artist: dict | None = None
+    if discogs_id:
+        discogs_artist = {
+            "id": discogs_id,
+            "name": discogs_api.get_artist_name(int(discogs_id)) or "",
+        }
+    return mb_artist, discogs_artist
 
 
 def _overlay_compare(skeleton: dict, name: str, mbid: str) -> dict:
@@ -495,20 +509,20 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     mbid = params.get("mbid", [""])[0].strip()
     discogs_id = params.get("discogs_id", [""])[0].strip()
 
-    mbid, discogs_id, mb_artist, discogs_artist = _resolve_compare_artists(
-        name, mbid, discogs_id)
+    mbid, discogs_id = _resolve_compare_artist_ids(name, mbid, discogs_id)
 
-    # Skeleton key is the resolved (mbid, discogs_id) pair — deterministic
-    # even when the user searches by a name variant. mb_artist /
-    # discogs_artist names are keyed into the skeleton so cached lookups
-    # carry their display name through.
+    # Skeleton key is the resolved (mbid, discogs_id) pair — display
+    # names are stamped on outside the cache from the canonical APIs.
     cache_key = f"artist:compare:{mbid or 'none'}:{discogs_id or 'none'}"
     skeleton = _cache.memoize_meta(
         cache_key,
-        lambda: _build_compare_skeleton(
-            mbid, discogs_id, mb_artist, discogs_artist),
+        lambda: _build_compare_skeleton(mbid, discogs_id),
     )
-    h._json(_overlay_compare(skeleton, name, mbid))  # type: ignore[attr-defined]
+    response = _overlay_compare(skeleton, name, mbid)
+    mb_artist, discogs_artist = _canonical_artist_labels(mbid, discogs_id)
+    response["mb_artist"] = mb_artist
+    response["discogs_artist"] = discogs_artist
+    h._json(response)  # type: ignore[attr-defined]
 
 
 # ── Route tables ─────────────────────────────────────────────────────

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -303,7 +303,11 @@ def post_pipeline_add(h, body: dict) -> None:
             })
             return
 
-        release = discogs_api.get_release(int(discogs_id))
+        # Bypass the 24h meta cache — this write path persists artist /
+        # title / tracks into `album_requests`. A stale cached snapshot
+        # would silently bake yesterday's pre-correction metadata into
+        # the pipeline DB (Codex review, issue #101).
+        release = discogs_api.get_release(int(discogs_id), fresh=True)
 
         req_id = s._db().add_request(
             mb_release_id=discogs_id,
@@ -338,7 +342,10 @@ def post_pipeline_add(h, body: dict) -> None:
         })
         return
 
-    release = mb_api.get_release(mbid)
+    # Bypass the 24h meta cache — same reason as the Discogs branch
+    # above. Writing stale metadata into the pipeline DB is worse than
+    # an extra MB mirror round trip on add.
+    release = mb_api.get_release(mbid, fresh=True)
 
     req_id = s._db().add_request(
         mb_release_id=mbid,
@@ -445,8 +452,12 @@ def post_pipeline_upgrade(h, body: dict) -> None:
     else:
         # Brand-new request — no prior override to preserve.
         quality = QUALITY_UPGRADE_TIERS
+        # Bypass the 24h meta cache — both branches persist metadata
+        # into the pipeline DB (artist / title / tracks). Stale cache
+        # reads would silently bake pre-correction data from an earlier
+        # browse. Cheap extra mirror hit on a write path.
         if source == "discogs":
-            release = discogs_api.get_release(int(mbid))
+            release = discogs_api.get_release(int(mbid), fresh=True)
             req_id = s._db().add_request(
                 mb_release_id=mbid,
                 discogs_release_id=mbid,
@@ -458,7 +469,7 @@ def post_pipeline_upgrade(h, body: dict) -> None:
                 source="request",
             )
         else:
-            release = mb_api.get_release(mbid)
+            release = mb_api.get_release(mbid, fresh=True)
             req_id = s._db().add_request(
                 mb_release_id=mbid,
                 mb_artist_id=release.get("artist_id"),

--- a/web/server.py
+++ b/web/server.py
@@ -246,11 +246,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(body)
-        # Capture for routing-level cache (set by do_GET)
-        key = getattr(self, "_cache_capture_key", None)
-        ttl = getattr(self, "_cache_capture_ttl", None)
-        if status == 200 and key is not None and ttl is not None:
-            cache.cache_set(key, data, ttl)
 
     def _html(self, path):
         html_path = os.path.join(os.path.dirname(__file__), path)
@@ -280,72 +275,27 @@ class Handler(BaseHTTPRequestHandler):
     def _error(self, msg, status=400):
         self._json({"error": msg}, status)
 
-    # Routes that should be cached, mapped to their TTL.
-    # Prefix-matched: "/api/artist" matches "/api/artist/<id>" etc.
-    # Order matters: first matching prefix wins (see _cache_ttl_for_path).
-    # Specific paths that bake pipeline_status + in_library into the payload
-    # MUST come before their broader prefix so they get the short TTL.
-    # Soularr's pipeline-side status transitions (downloading -> imported,
-    # quality-gate re-queue -> wanted) happen outside the web UI's POST
-    # invalidation paths, so a long TTL leaves stale badges in the UI for
-    # hours. TTL_LIBRARY caps the staleness at 5min. See issue tracker for
-    # the architectural fix (split MB metadata cache from pipeline overlay).
-    _CACHE_TTLS: dict[str, int] = {
-        "/api/search": cache.TTL_MB,
-        "/api/artist": cache.TTL_MB,
-        "/api/release-group": cache.TTL_LIBRARY,
-        "/api/release": cache.TTL_LIBRARY,
-        "/api/discogs/master": cache.TTL_LIBRARY,
-        "/api/discogs/release": cache.TTL_LIBRARY,
-        "/api/discogs": cache.TTL_MB,
-        "/api/library": cache.TTL_LIBRARY,
-        "/api/beets": cache.TTL_LIBRARY,
-        "/api/pipeline/status": cache.TTL_LIBRARY,
-        "/api/pipeline/all": cache.TTL_LIBRARY,
-        "/api/pipeline/recent": cache.TTL_LIBRARY,
-        "/api/pipeline/log": cache.TTL_LIBRARY,
-    }
-
-    # POST routes and which cache groups they invalidate.
-    _POST_INVALIDATIONS: dict[str, tuple[str, ...]] = {
-        "/api/pipeline/add": ("pipeline", "mb", "discogs"),
-        "/api/pipeline/update": ("pipeline", "mb", "discogs"),
-        "/api/pipeline/upgrade": ("pipeline", "library", "mb", "discogs"),
-        "/api/pipeline/set-quality": ("pipeline",),
-        "/api/pipeline/set-intent": ("pipeline",),
-        "/api/pipeline/ban-source": ("pipeline", "library", "mb", "discogs"),
-        "/api/pipeline/force-import": ("pipeline", "library", "mb", "discogs"),
-        "/api/pipeline/delete": ("pipeline", "mb", "discogs"),
-        "/api/beets/delete": ("library", "mb", "discogs"),
-        "/api/manual-import/import": ("pipeline", "library", "mb", "discogs"),
-        "/api/wrong-matches/delete": ("pipeline",),
-    }
-
-    def _cache_ttl_for_path(self, path: str) -> int | None:
-        """Return TTL if this path should be cached, None otherwise."""
-        for prefix, ttl in self._CACHE_TTLS.items():
-            if path == prefix or path.startswith(prefix + "/"):
-                return ttl
-        return None
+    # Routing-level response cache was removed by issue #101 — it used to
+    # cache the full HTTP response under `web:<url>`, which baked in
+    # per-request overlay state (pipeline_status, in_library, …) and
+    # leaked stale badges for up to 5 min after soularr-the-pipeline
+    # wrote to Postgres outside the web UI's POST paths.
+    #
+    # The pure MB/Discogs metadata that this cache used to cover is now
+    # memoized one layer down, inside web/mb.py and web/discogs.py, at
+    # the `meta:` namespace (24h TTL). Local-DB overlays (check_pipeline,
+    # check_beets_library) run on every request — cheap single-SQL
+    # lookups that no longer need caching.
+    #
+    # `cache.invalidate_groups()` is still callable for backwards
+    # compatibility with soularr's main loop POSTing to
+    # /api/cache/invalidate, but it's a no-op for any fresh deploy
+    # (no `web:` keys exist).
 
     def do_GET(self):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/") or "/"
         params = parse_qs(parsed.query)
-
-        # Cache check: use full URL (path + query) as key
-        cache_key = f"web:{path}"
-        if parsed.query:
-            cache_key += f"?{parsed.query}"
-        ttl = self._cache_ttl_for_path(path)
-        if ttl is not None:
-            cached = cache.cache_get(cache_key)
-            if cached is not None:
-                self._json(cached)
-                return
-            # Set up capture so _json() stores the response
-            self._cache_capture_key = cache_key
-            self._cache_capture_ttl = ttl
 
         try:
             # Serve static JS modules
@@ -373,16 +323,16 @@ class Handler(BaseHTTPRequestHandler):
             log.exception("GET %s failed", path)
             _try_reconnect_db()
             self._error(str(e), 500)
-        finally:
-            self._cache_capture_key = None
-            self._cache_capture_ttl = None
 
     def do_POST(self):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/")
 
         try:
-            # Cache invalidation endpoint (for soularr main loop)
+            # Cache invalidation endpoint — kept for backwards compat with
+            # soularr's main-loop POST at end of every cycle. Post-#101
+            # there's nothing to invalidate at the `web:` namespace, so
+            # this is a best-effort no-op.
             if path == "/api/cache/invalidate":
                 length = int(self.headers.get("Content-Length", 0))
                 body = json.loads(self.rfile.read(length)) if length else {}
@@ -396,10 +346,6 @@ class Handler(BaseHTTPRequestHandler):
                 length = int(self.headers.get("Content-Length", 0))
                 body = json.loads(self.rfile.read(length)) if length else {}
                 fn(self, body)  # type: ignore[operator]
-                # Invalidate cache groups after successful mutation
-                groups = self._POST_INVALIDATIONS.get(path)
-                if groups:
-                    cache.invalidate_groups(*groups)
                 return
             self._error("Not found", 404)
         except Exception as e:
@@ -434,10 +380,14 @@ def main():
 
     if args.redis_host:
         cache.init(args.redis_host, args.redis_port)
-        # Flush stale web:* keys so backend changes (e.g. updated discogs.py
-        # normalizer) take effect immediately on restart instead of being
-        # masked by 24h-TTL MB/discogs entries.
+        # Flush any lingering keys from previous cache generations so backend
+        # changes (e.g. an updated discogs.py normalizer) take effect
+        # immediately on restart instead of being masked by stale entries.
+        # Covers both the legacy `web:*` routing namespace (removed in #101
+        # but may still exist on in-place upgrades) and the `meta:*`
+        # pure-metadata namespace that wraps mb/discogs helper outputs.
         cache.invalidate_pattern("web:*")
+        cache.invalidate_pattern("meta:*")
 
     if args.mb_api:
         mb_api.MB_API_BASE = args.mb_api

--- a/web/server.py
+++ b/web/server.py
@@ -380,14 +380,16 @@ def main():
 
     if args.redis_host:
         cache.init(args.redis_host, args.redis_port)
-        # Flush any lingering keys from previous cache generations so backend
-        # changes (e.g. an updated discogs.py normalizer) take effect
-        # immediately on restart instead of being masked by stale entries.
-        # Covers both the legacy `web:*` routing namespace (removed in #101
-        # but may still exist on in-place upgrades) and the `meta:*`
-        # pure-metadata namespace that wraps mb/discogs helper outputs.
+        # Flush only the legacy `web:*` routing namespace on startup. It
+        # was removed in #101 but may still hold stale overlay-baked
+        # responses on in-place upgrades.
+        #
+        # Do NOT flush `meta:*` here — it's the 24h pure-metadata cache
+        # that should survive routine restarts (Codex review). If a
+        # helper-shape change needs to invalidate cached metadata (rare
+        # — e.g. a discogs.py normalizer tweak), bump the cache key
+        # prefix in the helper or flush `meta:*` manually during deploy.
         cache.invalidate_pattern("web:*")
-        cache.invalidate_pattern("meta:*")
 
     if args.mb_api:
         mb_api.MB_API_BASE = args.mb_api


### PR DESCRIPTION
Closes #101.

## Summary
- Remove routing-level HTTP response cache — it baked per-user overlay state (`pipeline_status`, `in_library`, `library_rank`, `beets_album_id`, `upgrade_queued`, ...) into Redis and leaked stale badges when soularr-the-pipeline wrote to Postgres outside the web UI's POST invalidation paths.
- Add a pure-metadata cache namespace (`meta:`) in `web/cache.py`. `memoize_meta()` wraps external fetches at TTL_MB 24h and is deliberately isolated from the `pipeline` / `library` / `mb` / `discogs` group invalidation patterns — MB/Discogs metadata is effectively immutable on our daily-sync'd mirrors and must survive pipeline writes.
- Wrap every external fetch in `web/mb.py` (`search_*`, `get_artist_release_groups`, `get_official_release_group_ids`, `get_release_group_releases`, `get_release`, `get_artist_name`, `get_artist_releases_with_recordings`) and `web/discogs.py` (`search_*`, `get_artist_releases`, `get_master_releases`, `get_release`, `get_artist_name`) with `memoize_meta`.
- Local DB overlays (`check_pipeline`, `check_beets_library`, `check_beets_library_detail`) now run on every request — single-SQL lookups that never needed caching. Matches the user ask: "just the mb/discogs metadata cached but the local db lookups native to the app can be redone."
- Keep `/api/cache/invalidate` as a backwards-compat no-op so soularr's main-loop POST at the end of every cycle still works.
- Startup now flushes `web:*` AND `meta:*` so deploys of backend shape changes (e.g. a normalizer tweak) take effect immediately.

## Structural change
The routing-cache bug class was caused by mixing pure external metadata (infrequent, cacheable) with per-request overlay state (hot, DB-backed) in one response-level cache. Splitting them eliminates the class entirely: the only thing still cached is the expensive MB/Discogs roundtrip; everything that depends on live DB state is always fresh. No more invalidation plumbing needed for response-level overlays.

## Test plan
- [x] `tests/test_web_cache.py` — new unit tests for `meta_get` / `meta_set` / `memoize_meta` round-trip, namespace isolation, TTL expiry, no-op when Redis absent, and the core guarantee: `invalidate_groups(pipeline, library, mb, discogs)` and `invalidate_pattern('web:*')` never touch `meta:` keys.
- [x] `tests/test_web_server.py::TestOverlayNotBakedIntoRoutingCache` — asserts `_CACHE_TTLS` doesn't contain any of the 11 overlay-baking prefixes the Explore audit surfaced.
- [x] `tests/test_web_server.py::TestReleaseEndpointReflectsPipelineWrite` — live HTTP with FakeRedis: GET → external DB status flip → GET returns fresh state, for both `pipeline_status` and `in_library`. Pre-fix this failed with stale values.
- [x] Full suite: 1722 tests OK on doc1 dev shell.
- [x] pyright clean on `web/cache.py`, `web/mb.py`, `web/discogs.py`, `web/server.py`, `tests/test_web_cache.py`, `tests/test_web_server.py`.
- [ ] Deploy → verify music.ablz.au still renders release-group / release / discogs-master / discogs-release pages and badges flip within seconds of a pipeline state change.