### PR TITLE
refactor(imports): unify on prefixed imports, drop lib/ from PYTHONPATH (#95)

### DIFF
--- a/album_source.py
+++ b/album_source.py
@@ -150,11 +150,7 @@ class DatabaseSource:
 
     def _get_db(self):
         if self._db is None:
-            import sys
-            lib_dir = os.path.join(os.path.dirname(__file__), "lib")
-            if lib_dir not in sys.path:
-                sys.path.insert(0, lib_dir)
-            from pipeline_db import PipelineDB
+            from lib.pipeline_db import PipelineDB
             self._db = PipelineDB(self.dsn)
         return self._db
 

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -33,14 +33,12 @@ from dataclasses import dataclass
 from typing import NoReturn
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-LIB_DIR = os.path.join(ROOT_DIR, "lib")
 
 
 def _bootstrap_import_paths() -> None:
-    """Ensure standalone harness runs can import both lib.* and top-level modules."""
-    for path in (ROOT_DIR, LIB_DIR):
-        if path not in sys.path:
-            sys.path.insert(0, path)
+    """Ensure standalone harness runs can import lib.* via the repo root."""
+    if ROOT_DIR not in sys.path:
+        sys.path.insert(0, ROOT_DIR)
 
 
 _bootstrap_import_paths()
@@ -1169,7 +1167,7 @@ def main():
             os.rename(item_path, new_path)
             # Update beets DB (writable connection for this fix)
             import sqlite3 as _sqlite3
-            from beets_db import DEFAULT_BEETS_DB
+            from lib.beets_db import DEFAULT_BEETS_DB
             with _sqlite3.connect(DEFAULT_BEETS_DB) as fix_conn:
                 fix_conn.execute("UPDATE items SET path = ? WHERE id = ?",
                                  (new_path.encode(), item_id))

--- a/lib/beets.py
+++ b/lib/beets.py
@@ -8,18 +8,10 @@ import json
 import logging
 import subprocess as sp
 
-import os
-import sys
-
 import msgspec
 
-# Ensure lib/ is importable whether called from project root or lib/
-_lib_dir = os.path.dirname(os.path.abspath(__file__))
-if _lib_dir not in sys.path:
-    sys.path.insert(0, _lib_dir)
-
-from quality import ValidationResult, ChooseMatchMessage
-from util import beets_subprocess_env
+from lib.quality import ValidationResult, ChooseMatchMessage
+from lib.util import beets_subprocess_env
 
 logger = logging.getLogger("soularr")
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-import sys
 import time
 from datetime import datetime, timezone
 from typing import Any, Callable, TYPE_CHECKING
@@ -37,10 +36,7 @@ MAX_FILE_RETRIES = 5
 # Lazy import for spectral analysis — avoids hard dep on sox at import time
 def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
     """Proxy to spectral_check.analyze_album (lazy import)."""
-    lib_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "lib")
-    if lib_dir not in sys.path:
-        sys.path.insert(0, lib_dir)
-    from spectral_check import analyze_album
+    from lib.spectral_check import analyze_album
     return analyze_album(folder, trim_seconds=trim_seconds)
 
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -5,7 +5,7 @@ Connects to PostgreSQL via a DSN (connection string). Both doc1 and doc2
 connect over the network — no more SQLite file locking issues on virtiofs.
 
 Usage:
-    from pipeline_db import PipelineDB
+    from lib.pipeline_db import PipelineDB
     db = PipelineDB("postgresql://soularr@192.168.1.35/soularr")
     db.add_request(mb_release_id="...", artist_name="...", album_title="...", source="redownload")
 """

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -44,10 +43,7 @@ def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
     use this proxy (not the one in lib.download) so patches on
     ``lib.preimport.spectral_analyze`` take effect.
     """
-    lib_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "lib")
-    if lib_dir not in sys.path:
-        sys.path.insert(0, lib_dir)
-    from spectral_check import analyze_album
+    from lib.spectral_check import analyze_album
     return analyze_album(folder, trim_seconds=trim_seconds)
 
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
-  "extraPaths": ["lib", "harness", "scripts"],
+  "extraPaths": ["."],
   "pythonVersion": "3.13",
   "reportMissingImports": "error"
 }

--- a/scripts/migrate_to_postgres.py
+++ b/scripts/migrate_to_postgres.py
@@ -14,8 +14,8 @@ import sqlite3
 import sys
 import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-from pipeline_db import PipelineDB
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from lib.pipeline_db import PipelineDB
 
 
 STATUS_MAP = {

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -33,26 +33,25 @@ from decimal import Decimal
 
 import psycopg2
 
-REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, REPO_ROOT)
-sys.path.insert(0, os.path.join(REPO_ROOT, "lib"))
-sys.path.insert(0, os.path.join(REPO_ROOT, "web"))
-from pipeline_db import PipelineDB, DEFAULT_DSN
-from util import resolve_failed_path as _shared_resolve_failed_path
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+from lib.pipeline_db import PipelineDB, DEFAULT_DSN
+from lib.util import resolve_failed_path as _shared_resolve_failed_path
 
 MB_API = "http://192.168.1.35:5200/ws/2"
 
 
 def _load_runtime_rank_config():
     """Load the runtime QualityRankConfig from the active config.ini."""
-    from config import read_runtime_rank_config
+    from lib.config import read_runtime_rank_config
 
     return read_runtime_rank_config()
 
 
 def _load_runtime_verified_lossless_target() -> str:
     """Load the runtime verified_lossless_target from the active config.ini."""
-    from config import read_verified_lossless_target
+    from lib.config import read_verified_lossless_target
 
     return read_verified_lossless_target()
 
@@ -71,7 +70,7 @@ def _quality_preview_target_label(
 
 def _load_beets_album_info(mb_release_id, rank_cfg):
     """Best-effort Beets album lookup for current quality metadata."""
-    from beets_db import BeetsDB
+    from lib.beets_db import BeetsDB
 
     if not mb_release_id:
         return None
@@ -144,7 +143,7 @@ def cmd_list(db, args):
 
 
 def cmd_add(db, args):
-    from quality import detect_release_source
+    from lib.quality import detect_release_source
     release_id = args.mbid
     source = args.source
     id_source = detect_release_source(release_id)
@@ -591,10 +590,10 @@ def cmd_show(db, args):
 
 def cmd_quality(db, args):
     """Show quality state and simulate decisions for common download scenarios."""
-    from quality import (full_pipeline_decision, quality_gate_decision,
-                         AudioQualityMeasurement, gate_rank,
-                         rejection_backfill_override,
-                         search_tiers, compute_effective_override_bitrate)
+    from lib.quality import (full_pipeline_decision, quality_gate_decision,
+                             AudioQualityMeasurement, gate_rank,
+                             rejection_backfill_override,
+                             search_tiers, compute_effective_override_bitrate)
 
     rank_cfg = _load_runtime_rank_config()
 
@@ -951,7 +950,7 @@ def cmd_repair_spectral(db, args):
     causing the quality gate to requeue indefinitely (issue #18).
     """
     from lib.import_dispatch import load_quality_gate_state
-    from quality import quality_gate_decision
+    from lib.quality import quality_gate_decision
 
     rank_cfg = _load_runtime_rank_config()
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -204,7 +204,7 @@ def _cmd_add_discogs(db, discogs_id, source):
 
     print(f"  Fetching Discogs release {discogs_id}...")
     try:
-        import discogs as discogs_api  # type: ignore[import-not-found]
+        from web import discogs as discogs_api
         release = discogs_api.get_release(int(discogs_id))
     except Exception as e:
         print(f"  Failed to fetch release from Discogs API: {e}")

--- a/scripts/populate_tracks.py
+++ b/scripts/populate_tracks.py
@@ -11,10 +11,11 @@ import sys
 import os
 import time
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-sys.path.insert(0, os.path.dirname(__file__))
-from pipeline_db import PipelineDB
-from pipeline_cli import fetch_mb_release, tracks_from_mb_release
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+from lib.pipeline_db import PipelineDB
+from scripts.pipeline_cli import fetch_mb_release, tracks_from_mb_release
 
 DB_PATH = "/mnt/virtio/Music/pipeline.db"
 RATE_LIMIT_SECONDS = 0.1  # 100ms between requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,10 @@ import os
 import shutil
 import sys
 
-# Make this available to all test modules
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+# Put repo root on sys.path so `from lib.X import Y` and `from scripts.X import Y`
+# resolve. Do NOT add lib/ or scripts/ directly — that would reintroduce the
+# issue #95 dual-load footgun (module reachable as both `quality` and `lib.quality`).
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Try to start ephemeral PostgreSQL if tools are available
 _pg = None

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -94,7 +94,7 @@ class TestAlbumRecordFromDbRow(unittest.TestCase):
 class TestDatabaseSource(unittest.TestCase):
     def _make_source(self):
         """Create a DatabaseSource with test PostgreSQL DB."""
-        from pipeline_db import PipelineDB
+        from lib.pipeline_db import PipelineDB
         db = PipelineDB(TEST_DSN)
         for table in ["source_denylist", "download_log", "album_tracks", "album_requests"]:
             db._execute(f"TRUNCATE {table} CASCADE")

--- a/tests/test_conversion_e2e.py
+++ b/tests/test_conversion_e2e.py
@@ -77,7 +77,7 @@ class TestConversionSpec(unittest.TestCase):
     """Test ConversionSpec dataclass and V0_SPEC constant."""
 
     def test_v0_spec_values(self):
-        from import_one import V0_SPEC
+        from harness.import_one import V0_SPEC
         self.assertEqual(V0_SPEC.codec, "libmp3lame")
         self.assertEqual(V0_SPEC.codec_args, ("-q:a", "0"))
         self.assertEqual(V0_SPEC.extension, "mp3")
@@ -85,7 +85,7 @@ class TestConversionSpec(unittest.TestCase):
         self.assertIn("-id3v2_version", V0_SPEC.metadata_args)
 
     def test_frozen(self):
-        from import_one import V0_SPEC
+        from harness.import_one import V0_SPEC
         with self.assertRaises(AttributeError):
             V0_SPEC.codec = "other"  # type: ignore[misc]
 
@@ -94,7 +94,7 @@ class TestParseVerifiedLosslessTarget(unittest.TestCase):
     """Test parsing target format strings into ConversionSpec."""
 
     def _parse(self, spec):
-        from import_one import parse_verified_lossless_target
+        from harness.import_one import parse_verified_lossless_target
         return parse_verified_lossless_target(spec)
 
     # --- Opus ---
@@ -319,20 +319,20 @@ class TestLosslessTierMatching(unittest.TestCase):
 
 class TestFlacSpec(unittest.TestCase):
     def test_flac_spec_values(self):
-        from import_one import FLAC_SPEC
+        from harness.import_one import FLAC_SPEC
         self.assertEqual(FLAC_SPEC.codec, "flac")
         self.assertEqual(FLAC_SPEC.codec_args, ())
         self.assertEqual(FLAC_SPEC.extension, "flac")
 
     def test_conversion_target_lossless(self):
         """target_format='lossless' should return 'lossless' (keep on disk)."""
-        from import_one import conversion_target
+        from harness.import_one import conversion_target
         self.assertEqual(
             conversion_target("lossless", True, "opus 128"), "lossless")
 
     def test_conversion_target_flac_backward_compat(self):
         """target_format='flac' still works (backward compat with old DB rows)."""
-        from import_one import conversion_target
+        from harness.import_one import conversion_target
         self.assertEqual(
             conversion_target("flac", True, "opus 128"), "lossless")
 
@@ -363,7 +363,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_v0_conversion_genuine(self):
         """Genuine FLAC → V0: only .mp3 files on disk, bitrate > 210."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
@@ -382,7 +382,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_v0_conversion_transcode(self):
         """Transcode FLAC → V0: .mp3 on disk, bitrate < 210."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=12000)
@@ -396,7 +396,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_v0_keep_source(self):
         """keep_source=True preserves FLAC alongside MP3."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
@@ -407,7 +407,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_opus_128_conversion(self):
         """FLAC → Opus 128: only .opus files on disk."""
-        from import_one import convert_lossless, parse_verified_lossless_target
+        from harness.import_one import convert_lossless, parse_verified_lossless_target
         spec = parse_verified_lossless_target("opus 128")
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
@@ -421,7 +421,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_mp3_v2_conversion(self):
         """FLAC → MP3 V2: .mp3 files, bitrate lower than V0."""
-        from import_one import convert_lossless, parse_verified_lossless_target
+        from harness.import_one import convert_lossless, parse_verified_lossless_target
         spec = parse_verified_lossless_target("mp3 v2")
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
@@ -434,7 +434,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_aac_128_conversion(self):
         """FLAC → AAC 128: .m4a files on disk."""
-        from import_one import convert_lossless, parse_verified_lossless_target
+        from harness.import_one import convert_lossless, parse_verified_lossless_target
         spec = parse_verified_lossless_target("aac 128")
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
@@ -447,7 +447,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_aac_target_handles_alac_same_extension_collision(self):
         """ALAC .m4a → AAC .m4a should replace the source, not skip it."""
-        from import_one import (
+        from harness.import_one import (
             V0_SPEC,
             _remove_files_by_ext,
             _remove_lossless_files,
@@ -480,7 +480,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_wav_to_flac_normalization(self):
         """WAV → FLAC via FLAC_SPEC: .flac files on disk, WAV removed."""
-        from import_one import convert_lossless, FLAC_SPEC
+        from harness.import_one import convert_lossless, FLAC_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             os.makedirs(album)
@@ -499,7 +499,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_alac_to_flac_normalization(self):
         """ALAC .m4a → FLAC via FLAC_SPEC: .flac on disk, .m4a removed."""
-        from import_one import convert_lossless, FLAC_SPEC
+        from harness.import_one import convert_lossless, FLAC_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             os.makedirs(album)
@@ -524,7 +524,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         This is harmless — the normalization path in import_one.py main()
         only calls FLAC_SPEC for non-FLAC sources (ALAC/WAV).
         """
-        from import_one import convert_lossless, FLAC_SPEC
+        from harness.import_one import convert_lossless, FLAC_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=1, cutoff_hz=15500)
@@ -535,7 +535,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_no_lossless_files_noop(self):
         """Directory with only MP3s → no conversion."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as d:
             # Create a fake mp3
             with open(os.path.join(d, "track.mp3"), "w") as f:
@@ -547,7 +547,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
 
     def test_dry_run_no_output(self):
         """Dry run should not create output files."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=1, cutoff_hz=15500)
@@ -572,7 +572,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
 
     def test_genuine_flac_default_is_verified_lossless(self):
         """Genuine FLAC → V0 → bitrate > 210 → verified lossless."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         from lib.quality import (determine_verified_lossless,
                                  transcode_detection)
         with tempfile.TemporaryDirectory() as d:
@@ -599,7 +599,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
 
     def test_transcode_flac_not_verified(self):
         """Transcode FLAC → V0 → bitrate < 210 → NOT verified lossless."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         from lib.quality import (determine_verified_lossless,
                                  transcode_detection)
         with tempfile.TemporaryDirectory() as d:
@@ -624,7 +624,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
 
     def test_genuine_flac_with_target_converts_twice(self):
         """Genuine FLAC → V0 (verify) → Opus 128 (final): only .opus on disk."""
-        from import_one import (convert_lossless, V0_SPEC,
+        from harness.import_one import (convert_lossless, V0_SPEC,
                                 parse_verified_lossless_target)
         from lib.quality import (determine_verified_lossless,
                                  transcode_detection)
@@ -670,7 +670,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
 
     def test_transcode_flac_with_target_skips_second_conversion(self):
         """Transcode FLAC + target configured → keep V0, skip target conversion."""
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         from lib.quality import (determine_verified_lossless,
                                  transcode_detection)
         with tempfile.TemporaryDirectory() as d:
@@ -714,7 +714,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
         conversion, convert_lossless() would skip all files (output exists)
         and leave zero audio files after cleanup.
         """
-        from import_one import (convert_lossless, V0_SPEC,
+        from harness.import_one import (convert_lossless, V0_SPEC,
                                 parse_verified_lossless_target,
                                 _remove_files_by_ext, _remove_lossless_files)
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -47,12 +47,12 @@ OTHER_MBID = "cccccccc-4444-5555-6666-dddddddddddd"
 class TestRunImportKeptDuplicate(unittest.TestCase):
     """Test that run_import correctly reports kept_duplicate."""
 
-    @patch("import_one.select.select")
-    @patch("import_one.subprocess.Popen")
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
     def test_keep_different_edition_sets_kept_duplicate(self, mock_popen, mock_select):
         """When resolve_duplicate has a different MBID and we say keep,
         kept_duplicate should be True."""
-        import import_one
+        from harness import import_one
 
         messages = [
             {"type": "resolve_duplicate", "duplicate_mbids": [OTHER_MBID]},
@@ -72,12 +72,12 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertTrue(kept_duplicate)
 
-    @patch("import_one.select.select")
-    @patch("import_one.subprocess.Popen")
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
     def test_replace_same_mbid_not_kept_duplicate(self, mock_popen, mock_select):
         """When resolve_duplicate has the same MBID (stale entry), we say
         remove — kept_duplicate should be False."""
-        import import_one
+        from harness import import_one
 
         messages = [
             {"type": "resolve_duplicate", "duplicate_mbids": [TARGET_MBID]},
@@ -96,11 +96,11 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertFalse(kept_duplicate)
 
-    @patch("import_one.select.select")
-    @patch("import_one.subprocess.Popen")
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
     def test_no_duplicate_not_kept(self, mock_popen, mock_select):
         """Normal import without duplicate resolution — kept_duplicate False."""
-        import import_one
+        from harness import import_one
 
         messages = [
             {"type": "choose_match", "candidates": [
@@ -118,14 +118,14 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertFalse(kept_duplicate)
 
-    @patch("import_one.os.killpg")
-    @patch("import_one.os.getpgid", return_value=12345)
-    @patch("import_one.select.select")
-    @patch("import_one.subprocess.Popen")
+    @patch("harness.import_one.os.killpg")
+    @patch("harness.import_one.os.getpgid", return_value=12345)
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
     def test_timeout_returns_false_kept_duplicate(self, mock_popen, mock_select,
                                                   mock_getpgid, mock_killpg):
         """On timeout, kept_duplicate should be False."""
-        import import_one
+        from harness import import_one
 
         proc = MagicMock()
         proc.pid = 12345
@@ -145,11 +145,11 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertFalse(kept_duplicate)
 
-    @patch("import_one.select.select")
-    @patch("import_one.subprocess.Popen")
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
     def test_skip_returns_false_kept_duplicate(self, mock_popen, mock_select):
         """When MBID not found in candidates (skip), kept_duplicate False."""
-        import import_one
+        from harness import import_one
 
         messages = [
             {"type": "choose_match", "candidates": [
@@ -167,11 +167,11 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         self.assertEqual(rc, 4)
         self.assertFalse(kept_duplicate)
 
-    @patch("import_one.select.select")
-    @patch("import_one.subprocess.Popen")
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
     def test_harness_nonzero_after_apply_returns_error(self, mock_popen, mock_select):
         """A harness crash after applying a candidate must still fail run_import."""
-        import import_one
+        from harness import import_one
 
         messages = [
             {"type": "choose_match", "candidates": [
@@ -199,12 +199,12 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
 class TestDisambiguateBeetMove(unittest.TestCase):
     """Test that beet move is called when kept_duplicate is True."""
 
-    @patch("import_one.subprocess.run")
+    @patch("harness.import_one.subprocess.run")
     def test_beet_move_called_after_kept_duplicate(self, mock_run):
         """When kept_duplicate=True, subprocess.run(['beet', 'move', ...])
         should be called."""
-        import import_one
-        from quality import PostflightInfo
+        from harness import import_one
+        from lib.quality import PostflightInfo
 
         # Create mock for beet move call
         move_result = MagicMock()
@@ -213,7 +213,7 @@ class TestDisambiguateBeetMove(unittest.TestCase):
 
         # Mock BeetsDB to return updated path after move
         mock_beets = MagicMock()
-        from beets_db import AlbumInfo
+        from lib.beets_db import AlbumInfo
         moved_info = AlbumInfo(
             album_id=42, track_count=11,
             min_bitrate_kbps=245, is_cbr=False,
@@ -256,7 +256,7 @@ class TestDisambiguateBeetMove(unittest.TestCase):
 
     def test_beet_move_not_called_without_kept_duplicate(self):
         """When kept_duplicate=False, no beet move should occur."""
-        from quality import PostflightInfo
+        from lib.quality import PostflightInfo
 
         pf = PostflightInfo(beets_id=42, track_count=11,
                             imported_path="/Beets/The National/2010 - High Violet")

--- a/tests/test_force_import.py
+++ b/tests/test_force_import.py
@@ -25,7 +25,7 @@ TEST_DSN = os.environ.get("TEST_DB_DSN")
 
 
 def make_db():
-    from pipeline_db import PipelineDB
+    from lib.pipeline_db import PipelineDB
     db = PipelineDB(TEST_DSN)
     for table in ["source_denylist", "download_log", "album_tracks", "album_requests"]:
         db._execute(f"TRUNCATE {table} CASCADE")
@@ -49,7 +49,7 @@ class TestImportOneForceFlag(unittest.TestCase):
 
     def test_force_flag_sets_max_distance_999(self) -> None:
         """--force must set MAX_DISTANCE=999 in the real main() entry point."""
-        import import_one
+        from harness import import_one
 
         class _StopAfterForce(Exception):
             pass
@@ -59,8 +59,8 @@ class TestImportOneForceFlag(unittest.TestCase):
             with patch.object(
                 sys, "argv",
                 ["import_one.py", "/tmp/staged-album", "mbid-123", "--force"],
-            ), patch("import_one._log"), patch(
-                "import_one.BeetsDB", side_effect=_StopAfterForce
+            ), patch("harness.import_one._log"), patch(
+                "harness.import_one.BeetsDB", side_effect=_StopAfterForce
             ):
                 with self.assertRaises(_StopAfterForce):
                     import_one.main()
@@ -71,7 +71,7 @@ class TestImportOneForceFlag(unittest.TestCase):
 
     def test_default_main_keeps_max_distance(self) -> None:
         """Without --force, main() must leave MAX_DISTANCE at the default."""
-        import import_one
+        from harness import import_one
 
         class _StopBeforeWork(Exception):
             pass
@@ -81,8 +81,8 @@ class TestImportOneForceFlag(unittest.TestCase):
             with patch.object(
                 sys, "argv",
                 ["import_one.py", "/tmp/staged-album", "mbid-123"],
-            ), patch("import_one._log"), patch(
-                "import_one.BeetsDB", side_effect=_StopBeforeWork
+            ), patch("harness.import_one._log"), patch(
+                "harness.import_one.BeetsDB", side_effect=_StopBeforeWork
             ):
                 with self.assertRaises(_StopBeforeWork):
                     import_one.main()
@@ -168,14 +168,14 @@ class TestCmdForceImport(unittest.TestCase):
 
     def test_force_import_missing_log_entry(self) -> None:
         """force-import with non-existent download_log_id should print error."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         args = MagicMock(download_log_id=99999, dsn=TEST_DSN)
         # Should not raise, just print error
         pipeline_cli.cmd_force_import(self.db, args)
 
     def test_force_import_no_failed_path(self) -> None:
         """force-import on log entry without failed_path should print error."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         req_id = self.db.add_request(
             mb_release_id="test-mbid-3",
             artist_name="Test",
@@ -193,7 +193,7 @@ class TestCmdForceImport(unittest.TestCase):
 
     def test_force_import_files_missing(self) -> None:
         """force-import when failed_path doesn't exist should print error."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         req_id = self.db.add_request(
             mb_release_id="test-mbid-4",
             artist_name="Test",
@@ -218,7 +218,7 @@ class TestCmdForceImport(unittest.TestCase):
 
     def test_force_import_no_mbid(self) -> None:
         """force-import when album_request has no mb_release_id should error."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         req_id = self.db.add_request(
             mb_release_id=None,
             discogs_release_id="12345",
@@ -249,7 +249,7 @@ class TestCmdForceImport(unittest.TestCase):
 class TestResolveFailedPath(unittest.TestCase):
     def test_absolute_path_exists(self) -> None:
         """Absolute path that exists should be returned as-is."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         import tempfile
         with tempfile.TemporaryDirectory() as d:
             result = pipeline_cli._resolve_failed_path(d)
@@ -257,13 +257,13 @@ class TestResolveFailedPath(unittest.TestCase):
 
     def test_nonexistent_path_returns_none(self) -> None:
         """Path that doesn't exist anywhere should return None."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         result = pipeline_cli._resolve_failed_path("/nonexistent/path/xyz")
         self.assertIsNone(result)
 
     def test_relative_path_resolved(self) -> None:
         """Relative path should be resolved against SLSKD_DOWNLOAD_DIRS."""
-        import pipeline_cli
+        from scripts import pipeline_cli
         import tempfile
         with tempfile.TemporaryDirectory() as base:
             # Create a subdir to simulate failed_imports/Album

--- a/tests/test_harness_serialization.py
+++ b/tests/test_harness_serialization.py
@@ -42,8 +42,8 @@ for name, mock in _beets_mocks.items():
 setattr(sys.modules["beets.importer.session"], "ImportSession",
         type("ImportSession", (object,), {}))
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "harness"))
-import beets_harness  # noqa: E402
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from harness import beets_harness  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -12,7 +12,6 @@ import sys
 import unittest
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-LIB_DIR = os.path.join(ROOT_DIR, "lib")
 HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
 
 sys.path.insert(0, ROOT_DIR)
@@ -20,32 +19,36 @@ sys.path.insert(0, HARNESS_DIR)
 
 
 class TestImportBootstrap(unittest.TestCase):
-    """Standalone harness imports should bootstrap the repo root."""
+    """Standalone harness imports should bootstrap the repo root so lib.* resolves.
 
-    def test_harness_only_import_bootstraps_lib_package(self):
-        module_names = ["import_one", "lib", "lib.beets_db", "lib.quality", "lib.spectral_check"]
-        saved_modules = {name: sys.modules.get(name) for name in module_names}
-        saved_path = list(sys.path)
-        try:
-            for name in module_names:
-                sys.modules.pop(name, None)
-            sys.path[:] = [p for p in sys.path if p not in (ROOT_DIR, LIB_DIR, HARNESS_DIR)]
-            sys.path.insert(0, HARNESS_DIR)
+    The bootstrap deliberately does NOT add ``lib/`` to sys.path — doing so
+    would reintroduce the issue #95 dual-load footgun where a module is
+    reachable under both ``quality`` and ``lib.quality``.
+    """
 
-            import_one = importlib.import_module("import_one")
+    def test_standalone_invocation_resolves_lib_imports(self):
+        """Running `python harness/import_one.py` directly must resolve lib.*.
 
-            self.assertEqual(import_one.ROOT_DIR, ROOT_DIR)
-            self.assertIn(ROOT_DIR, sys.path)
-            self.assertIn(LIB_DIR, sys.path)
-            spectral_check = importlib.import_module("lib.spectral_check")
-            self.assertTrue(callable(spectral_check.analyze_album))
-        finally:
-            sys.path[:] = saved_path
-            for name in module_names:
-                sys.modules.pop(name, None)
-            for name, module in saved_modules.items():
-                if module is not None:
-                    sys.modules[name] = module
+        Python puts the script's directory (``harness/``) first on sys.path,
+        not the repo root. ``_bootstrap_import_paths()`` inserts the repo
+        root so ``from lib.X import Y`` resolves even without PYTHONPATH.
+        """
+        proc = subprocess.run(
+            [sys.executable, "-c",
+             "import sys, os\n"
+             f"sys.path.insert(0, {HARNESS_DIR!r})\n"
+             "import import_one\n"
+             "assert 'lib.quality' in sys.modules\n"
+             "assert 'lib.beets_db' in sys.modules\n"
+             f"assert {ROOT_DIR!r} in sys.path\n"
+             "print('OK')\n"],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(
+            proc.returncode, 0,
+            f"Standalone import_one import failed:\nstdout:{proc.stdout}\nstderr:{proc.stderr}"
+        )
+        self.assertIn("OK", proc.stdout)
 
 
 # ============================================================================
@@ -56,17 +59,17 @@ class TestStageResult(unittest.TestCase):
     """Test the StageResult dataclass."""
 
     def test_terminal_when_set(self):
-        from import_one import StageResult
+        from harness.import_one import StageResult
         r = StageResult(decision="path_missing", exit_code=3, terminal=True)
         self.assertTrue(r.is_terminal)
 
     def test_not_terminal_when_continue(self):
-        from import_one import StageResult
+        from harness.import_one import StageResult
         r = StageResult()
         self.assertFalse(r.is_terminal)
 
     def test_default_values(self):
-        from import_one import StageResult
+        from harness.import_one import StageResult
         r = StageResult()
         self.assertEqual(r.decision, "continue")
         self.assertEqual(r.exit_code, 0)
@@ -82,25 +85,25 @@ class TestPreflightDecision(unittest.TestCase):
     """Test the preflight stage decision logic (pure)."""
 
     def test_already_in_beets_no_path(self):
-        from import_one import preflight_decision
+        from harness.import_one import preflight_decision
         r = preflight_decision(already_in_beets=True, path_exists=False)
         self.assertEqual(r.decision, "preflight_existing")
         self.assertEqual(r.exit_code, 0)
 
     def test_not_in_beets_no_path(self):
-        from import_one import preflight_decision
+        from harness.import_one import preflight_decision
         r = preflight_decision(already_in_beets=False, path_exists=False)
         self.assertEqual(r.decision, "path_missing")
         self.assertEqual(r.exit_code, 3)
 
     def test_path_exists_continue(self):
-        from import_one import preflight_decision
+        from harness.import_one import preflight_decision
         r = preflight_decision(already_in_beets=True, path_exists=True)
         self.assertEqual(r.decision, "continue")
         self.assertFalse(r.is_terminal)
 
     def test_not_in_beets_path_exists(self):
-        from import_one import preflight_decision
+        from harness.import_one import preflight_decision
         r = preflight_decision(already_in_beets=False, path_exists=True)
         self.assertEqual(r.decision, "continue")
         self.assertFalse(r.is_terminal)
@@ -114,20 +117,20 @@ class TestConversionDecision(unittest.TestCase):
     """Test post-conversion decision (pure)."""
 
     def test_failed_conversion(self):
-        from import_one import conversion_decision
+        from harness.import_one import conversion_decision
         r = conversion_decision(converted=3, failed=1)
         self.assertEqual(r.decision, "conversion_failed")
         self.assertEqual(r.exit_code, 1)
         self.assertTrue(r.is_terminal)
 
     def test_successful_conversion(self):
-        from import_one import conversion_decision
+        from harness.import_one import conversion_decision
         r = conversion_decision(converted=3, failed=0)
         self.assertEqual(r.decision, "continue")
         self.assertFalse(r.is_terminal)
 
     def test_no_flacs(self):
-        from import_one import conversion_decision
+        from harness.import_one import conversion_decision
         r = conversion_decision(converted=0, failed=0)
         self.assertEqual(r.decision, "continue")
         self.assertFalse(r.is_terminal)
@@ -144,8 +147,8 @@ class TestQualityDecisionStage(unittest.TestCase):
     """
 
     def test_downgrade_exit_5(self):
-        from import_one import quality_decision_stage
-        from quality import AudioQualityMeasurement
+        from harness.import_one import quality_decision_stage
+        from lib.quality import AudioQualityMeasurement
         new = AudioQualityMeasurement(min_bitrate_kbps=192)
         existing = AudioQualityMeasurement(min_bitrate_kbps=320)
         r = quality_decision_stage(new, existing, is_transcode=False)
@@ -154,8 +157,8 @@ class TestQualityDecisionStage(unittest.TestCase):
         self.assertTrue(r.is_terminal)
 
     def test_transcode_downgrade_exit_6(self):
-        from import_one import quality_decision_stage
-        from quality import AudioQualityMeasurement
+        from harness.import_one import quality_decision_stage
+        from lib.quality import AudioQualityMeasurement
         new = AudioQualityMeasurement(min_bitrate_kbps=128)
         existing = AudioQualityMeasurement(min_bitrate_kbps=192)
         r = quality_decision_stage(new, existing, is_transcode=True)
@@ -164,8 +167,8 @@ class TestQualityDecisionStage(unittest.TestCase):
         self.assertTrue(r.is_terminal)
 
     def test_import_continues(self):
-        from import_one import quality_decision_stage
-        from quality import AudioQualityMeasurement
+        from harness.import_one import quality_decision_stage
+        from lib.quality import AudioQualityMeasurement
         new = AudioQualityMeasurement(min_bitrate_kbps=245, verified_lossless=True)
         existing = AudioQualityMeasurement(min_bitrate_kbps=192)
         r = quality_decision_stage(new, existing, is_transcode=False)
@@ -174,8 +177,8 @@ class TestQualityDecisionStage(unittest.TestCase):
         self.assertFalse(r.is_terminal)
 
     def test_transcode_upgrade_continues(self):
-        from import_one import quality_decision_stage
-        from quality import AudioQualityMeasurement
+        from harness.import_one import quality_decision_stage
+        from lib.quality import AudioQualityMeasurement
         new = AudioQualityMeasurement(min_bitrate_kbps=245)
         existing = AudioQualityMeasurement(min_bitrate_kbps=128)
         r = quality_decision_stage(new, existing, is_transcode=True)
@@ -184,8 +187,8 @@ class TestQualityDecisionStage(unittest.TestCase):
         self.assertFalse(r.is_terminal)
 
     def test_first_import_no_existing(self):
-        from import_one import quality_decision_stage
-        from quality import AudioQualityMeasurement
+        from harness.import_one import quality_decision_stage
+        from lib.quality import AudioQualityMeasurement
         new = AudioQualityMeasurement(min_bitrate_kbps=245, verified_lossless=True)
         r = quality_decision_stage(new, None, is_transcode=False)
         self.assertEqual(r.decision, "import")
@@ -194,8 +197,8 @@ class TestQualityDecisionStage(unittest.TestCase):
     def test_override_used_for_comparison(self):
         """Override bitrate should be used instead of existing when provided.
         Caller constructs existing with override bitrate already resolved."""
-        from import_one import quality_decision_stage
-        from quality import AudioQualityMeasurement
+        from harness.import_one import quality_decision_stage
+        from lib.quality import AudioQualityMeasurement
         # existing beets=320 but override=128 (spectral detected fake 320)
         # Caller resolves: existing gets 128. new=245 > 128, so upgrade.
         new = AudioQualityMeasurement(min_bitrate_kbps=245, verified_lossless=True)
@@ -215,7 +218,7 @@ class TestExistingMeasurementBuilder(unittest.TestCase):
         drive median too, otherwise a future MEDIAN-policy deployment would
         silently outvote the override and compare against the original median.
         """
-        from import_one import build_existing_measurement
+        from harness.import_one import build_existing_measurement
         from lib.beets_db import AlbumInfo
 
         info = AlbumInfo(
@@ -253,11 +256,11 @@ class TestFinalExitDecision(unittest.TestCase):
     """Test the final exit code after successful import."""
 
     def test_transcode_exit_6(self):
-        from import_one import final_exit_decision
+        from harness.import_one import final_exit_decision
         self.assertEqual(final_exit_decision(is_transcode=True), 6)
 
     def test_normal_exit_0(self):
-        from import_one import final_exit_decision
+        from harness.import_one import final_exit_decision
         self.assertEqual(final_exit_decision(is_transcode=False), 0)
 
 
@@ -273,7 +276,7 @@ class TestConversionTarget(unittest.TestCase):
     """Test conversion_target: what should lossless files become on disk?"""
 
     def _target(self, target_format=None, verified=False, vl_target=None):
-        from import_one import conversion_target
+        from harness.import_one import conversion_target
         return conversion_target(target_format, verified, vl_target)
 
     def test_default_is_none(self):
@@ -305,15 +308,15 @@ class TestShouldRunTargetConversion(unittest.TestCase):
     """Second conversion pass should skip the keep-lossless sentinel."""
 
     def test_none_skips_target_conversion(self):
-        from import_one import should_run_target_conversion
+        from harness.import_one import should_run_target_conversion
         self.assertFalse(should_run_target_conversion(None))
 
     def test_lossless_sentinel_skips_target_conversion(self):
-        from import_one import should_run_target_conversion
+        from harness.import_one import should_run_target_conversion
         self.assertFalse(should_run_target_conversion("lossless"))
 
     def test_real_target_runs_second_pass(self):
-        from import_one import should_run_target_conversion
+        from harness.import_one import should_run_target_conversion
         self.assertTrue(should_run_target_conversion("opus 128"))
 
 
@@ -325,22 +328,22 @@ class TestTargetCleanupDecision(unittest.TestCase):
     """When a target was configured but skipped (transcode), source files must be cleaned up."""
 
     def test_target_skipped_needs_cleanup(self):
-        from import_one import target_cleanup_decision
+        from harness.import_one import target_cleanup_decision
         self.assertTrue(target_cleanup_decision(
             target_achieved=False, target_was_configured=True, sources_kept=5))
 
     def test_no_target_configured_no_cleanup(self):
-        from import_one import target_cleanup_decision
+        from harness.import_one import target_cleanup_decision
         self.assertFalse(target_cleanup_decision(
             target_achieved=False, target_was_configured=False, sources_kept=5))
 
     def test_target_achieved_no_cleanup(self):
-        from import_one import target_cleanup_decision
+        from harness.import_one import target_cleanup_decision
         self.assertFalse(target_cleanup_decision(
             target_achieved=True, target_was_configured=True, sources_kept=5))
 
     def test_no_sources_no_cleanup(self):
-        from import_one import target_cleanup_decision
+        from harness.import_one import target_cleanup_decision
         self.assertFalse(target_cleanup_decision(
             target_achieved=False, target_was_configured=True, sources_kept=0))
 
@@ -353,7 +356,7 @@ class TestConvertLosslessKeepSource(unittest.TestCase):
     def test_keep_source_preserves_flac(self):
         """With keep_source=True, FLAC files should remain after V0 conversion."""
         import tempfile
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as tmpdir:
             flac_path = os.path.join(tmpdir, "track01.flac")
             subprocess.run(
@@ -372,7 +375,7 @@ class TestConvertLosslessKeepSource(unittest.TestCase):
     def test_default_removes_flac(self):
         """Default behavior (keep_source=False) removes FLAC after conversion."""
         import tempfile
-        from import_one import convert_lossless, V0_SPEC
+        from harness.import_one import convert_lossless, V0_SPEC
         with tempfile.TemporaryDirectory() as tmpdir:
             flac_path = os.path.join(tmpdir, "track01.flac")
             subprocess.run(
@@ -399,25 +402,25 @@ class TestFindTargetCandidate(unittest.TestCase):
 
     def test_int_album_id_matches_str_target(self):
         """Discogs candidate with int album_id matches str DB mb_release_id."""
-        from import_one import _find_target_candidate
+        from harness.import_one import _find_target_candidate
         cands = [{"album_id": 2085134, "distance": 0.05}]
         self.assertEqual(_find_target_candidate(cands, "2085134"), 0)
 
     def test_str_album_id_matches_str_target(self):
         """MusicBrainz UUID path still works."""
-        from import_one import _find_target_candidate
+        from harness.import_one import _find_target_candidate
         uuid = "f100b6b0-6daa-4c9b-b33a-3e14c564cf58"
         cands = [{"album_id": uuid, "distance": 0.02}]
         self.assertEqual(_find_target_candidate(cands, uuid), 0)
 
     def test_no_match_returns_none(self):
-        from import_one import _find_target_candidate
+        from harness.import_one import _find_target_candidate
         cands = [{"album_id": 999999}, {"album_id": "other-uuid"}]
         self.assertIsNone(_find_target_candidate(cands, "2085134"))
 
     def test_picks_first_match_when_multiple(self):
         """Stable ordering: first match wins."""
-        from import_one import _find_target_candidate
+        from harness.import_one import _find_target_candidate
         cands = [
             {"album_id": "wrong"},
             {"album_id": 2085134},      # int, target match
@@ -426,7 +429,7 @@ class TestFindTargetCandidate(unittest.TestCase):
         self.assertEqual(_find_target_candidate(cands, "2085134"), 1)
 
     def test_empty_candidates_returns_none(self):
-        from import_one import _find_target_candidate
+        from harness.import_one import _find_target_candidate
         self.assertIsNone(_find_target_candidate([], "2085134"))
 
 

--- a/tests/test_no_dual_load.py
+++ b/tests/test_no_dual_load.py
@@ -1,0 +1,136 @@
+"""Regression test for issue #95 — ensure no module loads under two names.
+
+When ``lib/`` (or ``web/``, ``harness/``, ``scripts/``) is on ``PYTHONPATH``
+alongside the repo root, Python will load the same file twice — once as
+``lib.quality`` and once as ``quality`` — producing two distinct class
+objects. Enum identity checks (``is``), isinstance, and pickle round-trips
+all silently break across that boundary. PR #94 hit this in production
+for ``RankBitrateMetric.AVG``.
+
+This test boots the web server's entrypoint in a subprocess, dumps
+``sys.modules``, and fails if any module name appears both bare and
+prefixed. Running as a subprocess (not ``importlib.import_module`` in-
+process) catches wrapper / entrypoint misconfigurations that only
+manifest when the process starts from ``web/server.py``.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+# Modules that live under a package directory and whose bare name would
+# collide with the prefixed name if the package dir were on PYTHONPATH.
+# Each entry is (package, module_file_stem).
+PACKAGE_MODULES: list[tuple[str, str]] = []
+for pkg in ("lib", "web", "harness", "scripts"):
+    pkg_dir = os.path.join(REPO_ROOT, pkg)
+    if not os.path.isdir(pkg_dir):
+        continue
+    for entry in os.listdir(pkg_dir):
+        if entry.endswith(".py") and entry != "__init__.py":
+            PACKAGE_MODULES.append((pkg, entry[:-3]))
+
+
+def _run_entrypoint_and_dump_modules(bootstrap_code: str) -> set[str]:
+    """Run ``bootstrap_code`` in a fresh Python and return loaded module names.
+
+    Uses a clean subprocess with PYTHONPATH set to only the repo root, so
+    the test mirrors production's single-canonical-path invariant.
+    """
+    script = bootstrap_code + (
+        "\nimport json, sys\n"
+        "print('__MODULES_BEGIN__')\n"
+        "print(json.dumps(sorted(sys.modules)))\n"
+        "print('__MODULES_END__')\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_ROOT
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"Bootstrap failed (rc={proc.returncode}):\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    begin = proc.stdout.find("__MODULES_BEGIN__")
+    end = proc.stdout.find("__MODULES_END__")
+    if begin < 0 or end < 0:
+        raise AssertionError(f"Missing sentinels in output:\n{proc.stdout}")
+    payload = proc.stdout[begin:end].split("\n", 1)[1].strip()
+    return set(json.loads(payload))
+
+
+def _dual_loaded(modules: set[str]) -> list[tuple[str, str]]:
+    """Return list of (bare, prefixed) pairs that both appear in modules."""
+    offenders = []
+    for pkg, stem in PACKAGE_MODULES:
+        prefixed = f"{pkg}.{stem}"
+        if stem in modules and prefixed in modules:
+            offenders.append((stem, prefixed))
+    return offenders
+
+
+class TestNoDualLoad(unittest.TestCase):
+    """Guard against the PYTHONPATH footgun from issue #95."""
+
+    def test_web_server_no_dual_load(self):
+        """Booting web/server.py must not load any module twice."""
+        # Stubs: server.main() parses argv and connects to PG. We only want
+        # the import graph, so short-circuit at ``main``.
+        bootstrap = (
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.abspath('.'))\n"
+            # Stub out the Handler.serve_forever loop — import only.
+            "import web.server\n"
+        )
+        modules = _run_entrypoint_and_dump_modules(bootstrap)
+        offenders = _dual_loaded(modules)
+        self.assertEqual(
+            offenders, [],
+            f"Modules loaded under both bare and prefixed names: {offenders}. "
+            "This is the issue #95 footgun — two copies of the same class "
+            "object will compare unequal with `is`. Ensure PYTHONPATH only "
+            "contains the repo root, and every import uses its prefixed form."
+        )
+
+    def test_soularr_main_no_dual_load(self):
+        """Booting soularr.py must not load any module twice."""
+        bootstrap = (
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.abspath('.'))\n"
+            "import soularr  # noqa: F401\n"
+        )
+        modules = _run_entrypoint_and_dump_modules(bootstrap)
+        offenders = _dual_loaded(modules)
+        self.assertEqual(
+            offenders, [],
+            f"Modules loaded under both bare and prefixed names: {offenders}."
+        )
+
+    def test_pipeline_cli_no_dual_load(self):
+        """Importing scripts.pipeline_cli must not dual-load anything."""
+        bootstrap = (
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.abspath('.'))\n"
+            "import scripts.pipeline_cli  # noqa: F401\n"
+        )
+        modules = _run_entrypoint_and_dump_modules(bootstrap)
+        offenders = _dual_loaded(modules)
+        self.assertEqual(
+            offenders, [],
+            f"Modules loaded under both bare and prefixed names: {offenders}."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -13,11 +13,8 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.dirname(__file__))
 import conftest  # noqa: F401
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-_scripts_dir = os.path.join(os.path.dirname(__file__), "..", "scripts")
-sys.path.insert(0, os.path.abspath(_scripts_dir))
-import pipeline_cli
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from scripts import pipeline_cli
 from tests.helpers import make_request_row
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
@@ -44,7 +41,7 @@ SAMPLE_MB_RELEASE = {
 
 
 def make_db():
-    from pipeline_db import PipelineDB
+    from lib.pipeline_db import PipelineDB
     db = PipelineDB(TEST_DSN)
     for table in ["source_denylist", "download_log", "album_tracks", "album_requests"]:
         db._execute(f"TRUNCATE {table} CASCADE")
@@ -60,7 +57,7 @@ class TestCmdAdd(unittest.TestCase):
     def tearDown(self):
         self.db.close()
 
-    @patch("pipeline_cli.fetch_mb_release")
+    @patch("scripts.pipeline_cli.fetch_mb_release")
     def test_add_with_mbid(self, mock_fetch):
         mock_fetch.return_value = SAMPLE_MB_RELEASE
         args = MagicMock(mbid="44438bf9-26d9-4460-9b4f-1a1b015e37a1", source="request")
@@ -76,7 +73,7 @@ class TestCmdAdd(unittest.TestCase):
         tracks = self.db.get_tracks(req["id"])
         self.assertEqual(len(tracks), 3)
 
-    @patch("pipeline_cli.fetch_mb_release")
+    @patch("scripts.pipeline_cli.fetch_mb_release")
     def test_add_duplicate_skipped(self, mock_fetch):
         self.db.add_request(
             mb_release_id="44438bf9-26d9-4460-9b4f-1a1b015e37a1",
@@ -155,7 +152,7 @@ class TestTracksFromMbRelease(unittest.TestCase):
 
 class TestCmdForceImport(unittest.TestCase):
     @patch("builtins.print")
-    @patch("pipeline_cli._resolve_failed_path", return_value="/tmp/Test Album")
+    @patch("scripts.pipeline_cli._resolve_failed_path", return_value="/tmp/Test Album")
     def test_force_import_passes_source_username_to_dispatch(self, _mock_resolve, _mock_print):
         from lib.import_dispatch import DispatchOutcome
 
@@ -185,7 +182,7 @@ class TestCmdForceImport(unittest.TestCase):
 
 class TestCmdManualImport(unittest.TestCase):
     @patch("builtins.print")
-    @patch("pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
+    @patch("scripts.pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
     def test_failed_manual_import_prints_error(self, _mock_resolve, _mock_print):
         from lib.import_dispatch import DispatchOutcome
         db = MagicMock()
@@ -207,7 +204,7 @@ class TestCmdManualImport(unittest.TestCase):
         _mock_print.assert_any_call("  [FAIL] Rejected: quality_downgrade — new 192kbps <= existing 320kbps")
 
     @patch("builtins.print")
-    @patch("pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
+    @patch("scripts.pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
     def test_manual_import_calls_dispatch_from_db(self, _mock_resolve, _mock_print):
         from lib.import_dispatch import DispatchOutcome
         db = MagicMock()
@@ -228,7 +225,7 @@ class TestCmdManualImport(unittest.TestCase):
         )
 
     @patch("builtins.print")
-    @patch("pipeline_cli._resolve_failed_path",
+    @patch("scripts.pipeline_cli._resolve_failed_path",
            return_value="/mnt/virtio/music/slskd/failed_imports/Foo - Bar")
     def test_manual_import_resolves_relative_path(self, _mock_resolve, _mock_print):
         """Manual-import must resolve relative paths the same way force-import
@@ -255,7 +252,7 @@ class TestCmdManualImport(unittest.TestCase):
         )
 
     @patch("builtins.print")
-    @patch("pipeline_cli._resolve_failed_path", return_value=None)
+    @patch("scripts.pipeline_cli._resolve_failed_path", return_value=None)
     def test_manual_import_aborts_when_path_cannot_be_resolved(
         self, _mock_resolve, mock_print
     ):
@@ -620,13 +617,13 @@ class TestCmdQuality(unittest.TestCase):
             }
 
         stdout = io.StringIO()
-        with patch("pipeline_cli._load_runtime_rank_config",
+        with patch("scripts.pipeline_cli._load_runtime_rank_config",
                    return_value=QualityRankConfig.defaults()), \
-             patch("pipeline_cli._load_runtime_verified_lossless_target",
+             patch("scripts.pipeline_cli._load_runtime_verified_lossless_target",
                    return_value=runtime_target or ""), \
-             patch("pipeline_cli._load_beets_album_info",
+             patch("scripts.pipeline_cli._load_beets_album_info",
                    return_value=beets_info), \
-             patch("quality.full_pipeline_decision",
+             patch("lib.quality.full_pipeline_decision",
                    side_effect=fake_full_pipeline_decision), \
              redirect_stdout(stdout):
             pipeline_cli.cmd_quality(db, MagicMock(id=request_row["id"]))
@@ -722,13 +719,13 @@ class TestCmdQuality(unittest.TestCase):
         db = MagicMock()
         db.get_request.return_value = request_row
         stdout = io.StringIO()
-        with patch("pipeline_cli._load_runtime_rank_config",
+        with patch("scripts.pipeline_cli._load_runtime_rank_config",
                    return_value=QualityRankConfig.defaults()), \
-             patch("pipeline_cli._load_runtime_verified_lossless_target",
+             patch("scripts.pipeline_cli._load_runtime_verified_lossless_target",
                    return_value=""), \
-             patch("pipeline_cli._load_beets_album_info",
+             patch("scripts.pipeline_cli._load_beets_album_info",
                    return_value=beets_info), \
-             patch("quality.full_pipeline_decision",
+             patch("lib.quality.full_pipeline_decision",
                    side_effect=fake_full_pipeline_decision), \
              redirect_stdout(stdout):
             pipeline_cli.cmd_quality(db, MagicMock(id=9))

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -33,7 +33,7 @@ def make_db():
     Schema is migrated once in conftest.py at session start. This helper
     just truncates all tables for an isolated test slate.
     """
-    import pipeline_db
+    from lib import pipeline_db
     db = pipeline_db.PipelineDB(TEST_DSN)
     for table in ["user_cooldowns", "source_denylist", "search_log", "download_log", "album_tracks", "album_requests"]:
         db._execute(f"TRUNCATE {table} CASCADE")
@@ -784,7 +784,7 @@ class TestSpectralColumns(unittest.TestCase):
         self.assertIsNone(req["current_spectral_bitrate"])
 
     def test_update_spectral_state_updates_both_pairs(self):
-        import pipeline_db
+        from lib import pipeline_db
         from lib.quality import SpectralMeasurement
 
         self.db.update_spectral_state(
@@ -805,7 +805,7 @@ class TestSpectralColumns(unittest.TestCase):
         self.assertEqual(req["current_spectral_bitrate"], 245)
 
     def test_update_spectral_state_on_disk_only_clears_nulls(self):
-        import pipeline_db
+        from lib import pipeline_db
         from lib.quality import SpectralMeasurement
 
         self.db.update_status(

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -29,9 +29,8 @@ from typing import Optional
 
 # Add project root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 
-from spectral_check import analyze_album, AlbumResult
+from lib.spectral_check import analyze_album, AlbumResult
 from lib.quality import (quality_gate_decision, full_pipeline_decision,
                          spectral_import_decision, import_quality_decision,
                          transcode_detection, QUALITY_MIN_BITRATE_KBPS)

--- a/tests/test_spectral_check.py
+++ b/tests/test_spectral_check.py
@@ -15,7 +15,7 @@ class TestParseRmsFromStat(unittest.TestCase):
     """Test parsing RMS amplitude from sox stat stderr output."""
 
     def test_parse_valid_output(self):
-        from spectral_check import parse_rms_from_stat
+        from lib.spectral_check import parse_rms_from_stat
         stderr = (
             "Samples read:          12658176\n"
             "Length (seconds):    143.516735\n"
@@ -27,18 +27,18 @@ class TestParseRmsFromStat(unittest.TestCase):
         self.assertAlmostEqual(result, 0.170998, places=6)
 
     def test_parse_very_small_rms(self):
-        from spectral_check import parse_rms_from_stat
+        from lib.spectral_check import parse_rms_from_stat
         stderr = "RMS     amplitude:     0.000003\n"
         result = parse_rms_from_stat(stderr)
         assert result is not None
         self.assertAlmostEqual(result, 0.000003, places=9)
 
     def test_parse_missing_rms_returns_none(self):
-        from spectral_check import parse_rms_from_stat
+        from lib.spectral_check import parse_rms_from_stat
         self.assertIsNone(parse_rms_from_stat("no rms here\n"))
 
     def test_parse_empty_string(self):
-        from spectral_check import parse_rms_from_stat
+        from lib.spectral_check import parse_rms_from_stat
         self.assertIsNone(parse_rms_from_stat(""))
 
 
@@ -46,26 +46,26 @@ class TestRmsToDb(unittest.TestCase):
     """Test RMS to dB conversion."""
 
     def test_positive_rms(self):
-        from spectral_check import rms_to_db
+        from lib.spectral_check import rms_to_db
         # 20 * log10(0.01) ≈ -40
         self.assertAlmostEqual(rms_to_db(0.01), -40.0, places=1)
 
     def test_unity_rms(self):
-        from spectral_check import rms_to_db
+        from lib.spectral_check import rms_to_db
         self.assertAlmostEqual(rms_to_db(1.0), 0.0, places=1)
 
     def test_very_small_rms(self):
-        from spectral_check import rms_to_db
+        from lib.spectral_check import rms_to_db
         result = rms_to_db(0.0000001)
         self.assertLess(result, -100)
 
     def test_zero_rms_returns_floor(self):
-        from spectral_check import rms_to_db
+        from lib.spectral_check import rms_to_db
         result = rms_to_db(0.0)
         self.assertEqual(result, -140.0)
 
     def test_negative_rms_returns_floor(self):
-        from spectral_check import rms_to_db
+        from lib.spectral_check import rms_to_db
         result = rms_to_db(-0.5)
         self.assertEqual(result, -140.0)
 
@@ -74,14 +74,14 @@ class TestGradientCalculation(unittest.TestCase):
     """Test spectral gradient (cliff) detection."""
 
     def test_flat_spectrum_no_cliff(self):
-        from spectral_check import detect_cliff
+        from lib.spectral_check import detect_cliff
         # All slices at roughly the same dB level
         slices = [{"freq": 12000 + i * 500, "db": -50.0} for i in range(16)]
         result = detect_cliff(slices, threshold_db_per_khz=-12, min_slices=2, slice_width_hz=500)
         self.assertIsNone(result)
 
     def test_steep_dropoff_detects_cliff(self):
-        from spectral_check import detect_cliff
+        from lib.spectral_check import detect_cliff
         # Normal until 16kHz, then cliff
         slices = []
         for i in range(16):
@@ -98,7 +98,7 @@ class TestGradientCalculation(unittest.TestCase):
         self.assertLessEqual(result, 16500)
 
     def test_single_steep_slice_no_cliff(self):
-        from spectral_check import detect_cliff
+        from lib.spectral_check import detect_cliff
         # One steep drop, then recovery — not a cliff
         slices = [{"freq": 12000 + i * 500, "db": -50.0} for i in range(16)]
         slices[5]["db"] = -70.0  # single spike
@@ -107,7 +107,7 @@ class TestGradientCalculation(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_gradual_rolloff_no_cliff(self):
-        from spectral_check import detect_cliff
+        from lib.spectral_check import detect_cliff
         # Smooth rolloff at -5 dB/kHz (natural, not a cliff)
         slices = [{"freq": 12000 + i * 500, "db": -50.0 - i * 2.5} for i in range(16)]
         result = detect_cliff(slices, threshold_db_per_khz=-12, min_slices=2, slice_width_hz=500)
@@ -118,32 +118,32 @@ class TestEstimateOriginalBitrate(unittest.TestCase):
     """Test bitrate estimation from cliff frequency."""
 
     def test_cliff_at_16khz_is_128(self):
-        from spectral_check import estimate_bitrate_from_cliff
+        from lib.spectral_check import estimate_bitrate_from_cliff
         result = estimate_bitrate_from_cliff(16000)
         self.assertEqual(result, 128)
 
     def test_cliff_at_17khz_is_128(self):
-        from spectral_check import estimate_bitrate_from_cliff
+        from lib.spectral_check import estimate_bitrate_from_cliff
         result = estimate_bitrate_from_cliff(17000)
         self.assertEqual(result, 128)
 
     def test_cliff_at_15khz_is_96(self):
-        from spectral_check import estimate_bitrate_from_cliff
+        from lib.spectral_check import estimate_bitrate_from_cliff
         result = estimate_bitrate_from_cliff(15000)
         self.assertEqual(result, 96)
 
     def test_cliff_at_18khz_is_192(self):
-        from spectral_check import estimate_bitrate_from_cliff
+        from lib.spectral_check import estimate_bitrate_from_cliff
         result = estimate_bitrate_from_cliff(18500)
         self.assertEqual(result, 192)
 
     def test_cliff_at_19khz_is_256(self):
-        from spectral_check import estimate_bitrate_from_cliff
+        from lib.spectral_check import estimate_bitrate_from_cliff
         result = estimate_bitrate_from_cliff(19500)
         self.assertEqual(result, 256)
 
     def test_no_cliff_returns_none(self):
-        from spectral_check import estimate_bitrate_from_cliff
+        from lib.spectral_check import estimate_bitrate_from_cliff
         self.assertIsNone(estimate_bitrate_from_cliff(None))
 
 
@@ -151,35 +151,35 @@ class TestClassifyTrack(unittest.TestCase):
     """Test per-track classification logic."""
 
     def test_genuine(self):
-        from spectral_check import classify_track
+        from lib.spectral_check import classify_track
         result = classify_track(hf_deficit_db=35.0, cliff_freq_hz=None)
         self.assertEqual(result.grade, "genuine")
         self.assertFalse(result.cliff_detected)
 
     def test_suspect_cliff(self):
-        from spectral_check import classify_track
+        from lib.spectral_check import classify_track
         result = classify_track(hf_deficit_db=45.0, cliff_freq_hz=16000)
         self.assertEqual(result.grade, "suspect")
         self.assertTrue(result.cliff_detected)
         self.assertEqual(result.estimated_bitrate_kbps, 128)
 
     def test_suspect_hf_deficit(self):
-        from spectral_check import classify_track
+        from lib.spectral_check import classify_track
         result = classify_track(hf_deficit_db=65.0, cliff_freq_hz=None)
         self.assertEqual(result.grade, "suspect")
 
     def test_marginal(self):
-        from spectral_check import classify_track
+        from lib.spectral_check import classify_track
         result = classify_track(hf_deficit_db=50.0, cliff_freq_hz=None)
         self.assertEqual(result.grade, "marginal")
 
     def test_marginal_boundary_40(self):
-        from spectral_check import classify_track
+        from lib.spectral_check import classify_track
         result = classify_track(hf_deficit_db=40.0, cliff_freq_hz=None)
         self.assertEqual(result.grade, "marginal")
 
     def test_genuine_boundary_39(self):
-        from spectral_check import classify_track
+        from lib.spectral_check import classify_track
         result = classify_track(hf_deficit_db=39.9, cliff_freq_hz=None)
         self.assertEqual(result.grade, "genuine")
 
@@ -188,14 +188,14 @@ class TestClassifyAlbum(unittest.TestCase):
     """Test album-level classification from track results."""
 
     def test_all_genuine(self):
-        from spectral_check import classify_album, TrackResult
+        from lib.spectral_check import classify_album, TrackResult
         tracks = [TrackResult("genuine", 35.0, False, None, None)] * 10
         grade, pct = classify_album(tracks)
         self.assertEqual(grade, "genuine")
         self.assertEqual(pct, 0.0)
 
     def test_majority_suspect(self):
-        from spectral_check import classify_album, TrackResult
+        from lib.spectral_check import classify_album, TrackResult
         tracks = ([TrackResult("suspect", 70.0, True, 16000, 128)] * 7 +
                   [TrackResult("genuine", 35.0, False, None, None)] * 3)
         grade, pct = classify_album(tracks)
@@ -203,7 +203,7 @@ class TestClassifyAlbum(unittest.TestCase):
         self.assertEqual(pct, 70.0)
 
     def test_below_threshold(self):
-        from spectral_check import classify_album, TrackResult
+        from lib.spectral_check import classify_album, TrackResult
         tracks = ([TrackResult("suspect", 70.0, True, 16000, 128)] * 4 +
                   [TrackResult("genuine", 35.0, False, None, None)] * 6)
         grade, pct = classify_album(tracks)
@@ -211,7 +211,7 @@ class TestClassifyAlbum(unittest.TestCase):
         self.assertEqual(pct, 40.0)
 
     def test_empty_tracks(self):
-        from spectral_check import classify_album
+        from lib.spectral_check import classify_album
         grade, pct = classify_album([])
         self.assertEqual(grade, "genuine")
 
@@ -222,9 +222,9 @@ class TestAnalyzeTrackMocked(unittest.TestCase):
     def _make_sox_output(self, rms):
         return "", "RMS     amplitude:     %.6f\n" % rms
 
-    @patch("spectral_check.subprocess.run")
+    @patch("lib.spectral_check.subprocess.run")
     def test_calls_sox_with_correct_args(self, mock_run):
-        from spectral_check import analyze_track
+        from lib.spectral_check import analyze_track
         mock_run.return_value = MagicMock(
             stderr="RMS     amplitude:     0.100000\n",
             returncode=0
@@ -238,9 +238,9 @@ class TestAnalyzeTrackMocked(unittest.TestCase):
         self.assertIn("trim", first_call_args)
         self.assertIn("30", first_call_args)
 
-    @patch("spectral_check.subprocess.run")
+    @patch("lib.spectral_check.subprocess.run")
     def test_genuine_profile(self, mock_run):
-        from spectral_check import analyze_track
+        from lib.spectral_check import analyze_track
         # Simulate genuine file: ref=0.1, all slices gradually decreasing
         def side_effect(cmd, **kwargs):
             sinc_arg = [a for a in cmd if "-" in a and a[0].isdigit()]
@@ -254,17 +254,17 @@ class TestAnalyzeTrackMocked(unittest.TestCase):
         self.assertEqual(result.grade, "genuine")
         self.assertFalse(result.cliff_detected)
 
-    @patch("spectral_check.subprocess.run")
+    @patch("lib.spectral_check.subprocess.run")
     def test_sox_not_found(self, mock_run):
-        from spectral_check import analyze_track
+        from lib.spectral_check import analyze_track
         mock_run.side_effect = FileNotFoundError("sox not found")
         result = analyze_track("/fake/path.mp3")
         self.assertEqual(result.grade, "error")
 
-    @patch("spectral_check.subprocess.run")
+    @patch("lib.spectral_check.subprocess.run")
     def test_sox_timeout(self, mock_run):
         import subprocess
-        from spectral_check import analyze_track
+        from lib.spectral_check import analyze_track
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="sox", timeout=60)
         result = analyze_track("/fake/path.mp3")
         self.assertEqual(result.grade, "error")
@@ -289,25 +289,25 @@ class TestSpectralIntegration(unittest.TestCase):
     """Integration tests with real sox and generated audio fixtures."""
 
     def test_genuine_flac_all_genres(self):
-        from spectral_check import analyze_album
+        from lib.spectral_check import analyze_album
         result = analyze_album(_fixture("01_genuine_flac"))
         self.assertEqual(result.grade, "genuine",
                          f"Genuine FLACs flagged as {result.grade} ({result.suspect_pct:.0f}% suspect)")
 
     def test_genuine_v0_all_genres(self):
-        from spectral_check import analyze_album
+        from lib.spectral_check import analyze_album
         result = analyze_album(_fixture("02_genuine_v0"))
         self.assertEqual(result.grade, "genuine",
                          f"Genuine V0s flagged as {result.grade} ({result.suspect_pct:.0f}% suspect)")
 
     def test_genuine_320_all_genres(self):
-        from spectral_check import analyze_album
+        from lib.spectral_check import analyze_album
         result = analyze_album(_fixture("04_cbr_320"))
         self.assertEqual(result.grade, "genuine",
                          f"Genuine 320s flagged as {result.grade} ({result.suspect_pct:.0f}% suspect)")
 
     def test_transcode_128_flac_detected(self):
-        from spectral_check import analyze_album
+        from lib.spectral_check import analyze_album
         result = analyze_album(_fixture("09_fake_flac_128"))
         self.assertIn(result.grade, ("suspect", "likely_transcode"),
                       f"128→FLAC transcodes not detected: {result.grade} ({result.suspect_pct:.0f}%)")
@@ -318,13 +318,13 @@ class TestSpectralIntegration(unittest.TestCase):
                 self.assertLessEqual(t.estimated_bitrate_kbps, 160)
 
     def test_transcode_192_flac_detected(self):
-        from spectral_check import analyze_album
+        from lib.spectral_check import analyze_album
         result = analyze_album(_fixture("11_fake_flac_192"))
         self.assertIn(result.grade, ("suspect", "likely_transcode"),
                       f"192→FLAC transcodes not detected: {result.grade} ({result.suspect_pct:.0f}%)")
 
     def test_album_grade_has_estimated_bitrate(self):
-        from spectral_check import analyze_album
+        from lib.spectral_check import analyze_album
         result = analyze_album(_fixture("09_fake_flac_128"))
         self.assertIsNotNone(result.estimated_bitrate_kbps,
                              "Album-level estimated bitrate should be set for transcodes")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -348,7 +348,7 @@ class TestServerEndpoints(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(data["intent"], "lossless")
 
-    @patch("routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
+    @patch("web.routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
     @patch("lib.import_dispatch.dispatch_import_from_db")
     def test_post_force_import_passes_source_username(self, mock_dispatch, _mock_resolve):
         self.mock_db.get_download_log_entry.return_value = {
@@ -734,7 +734,7 @@ class TestPipelineRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SIMULATE_REQUIRED_FIELDS,
                                 "pipeline simulate response")
 
-    @patch("routes.pipeline.full_pipeline_decision")
+    @patch("web.routes.pipeline.full_pipeline_decision")
     def test_pipeline_simulate_threads_target_format(self, mock_simulate):
         mock_simulate.return_value = {
             "stage0_spectral_gate": "skipped_flac",
@@ -971,7 +971,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.mock_db.add_request.return_value = 501
         self.mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
 
-    @patch("routes.pipeline.mb_api.get_release")
+    @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_add_contract(self, mock_get_release):
         mock_get_release.return_value = {
             "release_group_id": "rg-1",
@@ -1001,7 +1001,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.EXISTS_REQUIRED_FIELDS,
                                 "pipeline add exists response")
 
-    @patch("routes.pipeline.discogs_api.get_release")
+    @patch("web.routes.pipeline.discogs_api.get_release")
     def test_pipeline_add_discogs_contract(self, mock_get_release):
         self.mock_db.get_request_by_discogs_release_id.return_value = None
         mock_get_release.return_value = {
@@ -1035,7 +1035,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.EXISTS_REQUIRED_FIELDS,
                                 "pipeline add discogs exists response")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_pipeline_update_contract(self, _mock_transition):
         status, data = self._post("/api/pipeline/update", {"id": 100, "status": "manual"})
 
@@ -1043,7 +1043,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPDATE_REQUIRED_FIELDS,
                                 "pipeline update response")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_pipeline_upgrade_contract(self, _mock_transition):
         self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
 
@@ -1053,9 +1053,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response")
 
-    @patch("routes.pipeline.apply_transition")
-    @patch("routes.pipeline.discogs_api.get_release")
-    @patch("routes.pipeline.mb_api.get_release")
+    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.discogs_api.get_release")
+    @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_upgrade_discogs_new_request_uses_discogs_api(
         self, mock_mb_get, mock_dg_get, _mock_transition,
     ):
@@ -1087,7 +1087,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response (discogs)")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_pipeline_set_quality_contract(self, _mock_transition):
         self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
 
@@ -1110,7 +1110,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_INTENT_REQUIRED_FIELDS,
                                 "pipeline set-intent response")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_pipeline_ban_source_contract(self, _mock_transition):
         status, data = self._post(
             "/api/pipeline/ban-source",
@@ -1121,7 +1121,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.BAN_SOURCE_REQUIRED_FIELDS,
                                 "pipeline ban-source response")
 
-    @patch("routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
+    @patch("web.routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
     @patch("lib.import_dispatch.dispatch_import_from_db")
     def test_pipeline_force_import_contract(self, mock_dispatch, _mock_resolve):
         mock_dispatch.return_value = MagicMock(success=True, message="Import successful")
@@ -1177,7 +1177,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
 
     # -- Upgrade --------------------------------------------------------
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_upgrade_preserves_stricter_override(self, mock_transition):
         """Upgrade on an imported album with override='lossless' must keep it."""
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
@@ -1191,7 +1191,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(self._override_passed(mock_transition), "lossless")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_upgrade_preserves_narrowed_override(self, mock_transition):
         """Upgrade must preserve a post-downgrade-narrow like 'lossless,mp3 v0'."""
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
@@ -1205,7 +1205,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(self._override_passed(mock_transition), "lossless,mp3 v0")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_upgrade_falls_back_to_full_tiers_when_no_override(self, mock_transition):
         """Upgrade on an imported album with no override falls back to the full ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
@@ -1224,7 +1224,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
 
     # -- Update (status → wanted) ---------------------------------------
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_update_to_wanted_preserves_stricter_override(self, mock_transition):
         """Flipping an imported album back to wanted must preserve 'lossless'."""
         self.mock_db.get_request.return_value = make_request_row(
@@ -1239,7 +1239,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(self._override_passed(mock_transition), "lossless")
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_update_to_wanted_falls_back_to_full_tiers_when_no_override(
             self, mock_transition):
         """Flipping imported→wanted with no override uses the full upgrade ladder."""
@@ -1260,7 +1260,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
 
     # -- Ban source (regression pin) ------------------------------------
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_preserves_stricter_override(self, mock_transition):
         """Pin: ban_source already preserves override. Guard against future regression."""
         self.mock_db.get_request.return_value = make_request_row(
@@ -1289,8 +1289,8 @@ class TestManualImportRouteContracts(_WebServerCase):
         self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
         self.mock_db.get_by_status.side_effect = None
 
-    @patch("routes.imports.match_folders_to_requests")
-    @patch("routes.imports.scan_complete_folder")
+    @patch("web.routes.imports.match_folders_to_requests")
+    @patch("web.routes.imports.scan_complete_folder")
     def test_manual_import_scan_contract(self, mock_scan, mock_match):
         folder = FolderInfo(
             name="Test Artist - Test Album",
@@ -1465,7 +1465,7 @@ class TestBrowseRouteContracts(_WebServerCase):
         # server.py loads routes via `from routes import browse` (sys.path hack),
         # so the canonical module is `routes.browse`, not `web.routes.browse`.
         with patch("web.server.mb_api") as mock_mb, \
-                patch("routes.browse.discogs_api") as mock_dg:
+                patch("web.routes.browse.discogs_api") as mock_dg:
             mock_mb.search_artists.return_value = [{"id": self.ARTIST_ID, "name": "Radiohead"}]
             mock_mb.get_artist_release_groups.return_value = [mb_rg]
             mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
@@ -1504,7 +1504,7 @@ class TestBrowseRouteContracts(_WebServerCase):
             "artist_credit": "Artist", "primary_artist_id": self.ARTIST_ID,
         }
         with patch("web.server.mb_api") as mock_mb, \
-                patch("routes.browse.discogs_api") as mock_dg:
+                patch("web.routes.browse.discogs_api") as mock_dg:
             mock_mb.search_artists.return_value = [{"id": self.ARTIST_ID, "name": "Artist"}]
             mock_mb.get_artist_release_groups.return_value = [official_rg, bootleg_rg]
             mock_mb.get_official_release_group_ids.return_value = {self.RG_ID}
@@ -1899,9 +1899,9 @@ class TestBeetsRouteContracts(_WebServerCase):
         _assert_required_fields(self, data["tracks"][0], self.TRACK_REQUIRED_FIELDS,
                                 "beets album track")
 
-    @patch("routes.library.os.path.isdir", return_value=False)
-    @patch("routes.library.os.path.isfile", return_value=False)
-    @patch("routes.library.os.path.exists", return_value=True)
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
     @patch("lib.beets_db.BeetsDB.delete_album")
     def test_beets_delete_contract(
         self,
@@ -2040,7 +2040,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(data["status"], "ok")
 
-    @patch("routes.imports.resolve_failed_path", return_value="/mnt/virtio/music/slskd/failed_imports/Test")
+    @patch("web.routes.imports.resolve_failed_path", return_value="/mnt/virtio/music/slskd/failed_imports/Test")
     def test_relative_failed_path_uses_resolved_path(self, _mock_resolve):
         row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
         row["validation_result"]["failed_path"] = "failed_imports/Test"
@@ -2053,8 +2053,8 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertTrue(entry["files_exist"])
         self.assertEqual(entry["failed_path"], "/mnt/virtio/music/slskd/failed_imports/Test")
 
-    @patch("routes.imports.shutil.rmtree")
-    @patch("routes.imports.resolve_failed_path", return_value="/mnt/virtio/music/slskd/failed_imports/Test")
+    @patch("web.routes.imports.shutil.rmtree")
+    @patch("web.routes.imports.resolve_failed_path", return_value="/mnt/virtio/music/slskd/failed_imports/Test")
     def test_delete_relative_failed_path_removes_resolved_directory(self, _mock_resolve, mock_rmtree):
         entry = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
         entry["validation_result"]["failed_path"] = "failed_imports/Test"

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -6,17 +6,11 @@ Both are enriched with library/pipeline status via check_beets_library() and che
 """
 from __future__ import annotations
 
-import os
 import re
-import sys
 from typing import TYPE_CHECKING
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
-
-import mb as mb_api  # noqa: E402
-import discogs as discogs_api  # noqa: E402
-from lib.artist_compare import annotate_in_library, merge_discographies  # noqa: E402
+from web import discogs as discogs_api
+from lib.artist_compare import annotate_in_library, merge_discographies
 
 if TYPE_CHECKING:
     from http.server import BaseHTTPRequestHandler
@@ -29,7 +23,7 @@ def _server():
     check_beets_library(), check_pipeline() goes through this so that
     test mocks on web.server.* are respected.
     """
-    from web import server  # type: ignore[import-not-found]
+    from web import server
     return server
 
 

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -1,23 +1,18 @@
 """Manual import route handlers — scan, import, wrong matches."""
 
 import json
-import os
 import shutil
-import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-
-from lib.manual_import import (  # type: ignore[import-not-found]
+from lib.manual_import import (
     scan_complete_folder,
     match_folders_to_requests,
     ImportRequest,
 )
-from lib.util import resolve_failed_path  # type: ignore[import-not-found]
+from lib.util import resolve_failed_path
 
 
 def _server():
-    from web import server  # type: ignore[import-not-found]
+    from web import server
     return server
 
 

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -50,7 +50,7 @@ def get_beets_album(h, params: dict[str, list[str]], album_id_str: str) -> None:
             result["upgrade_queued"] = (
                 req["status"] == "wanted" and bool(req.get("search_filetype_override") or req.get("target_format"))
             )
-            from classify import classify_log_entry as _clf, LogEntry as _LE
+            from web.classify import classify_log_entry as _clf, LogEntry as _LE
             dh = []
             for h_entry in history:
                 he = _LE.from_row(h_entry)

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -1,13 +1,11 @@
 """Beets library route handlers — search, album detail, recent, delete."""
 
-import os, re, sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+import os
+import re
 
 
 def _server():
-    from web import server  # type: ignore[import-not-found]
+    from web import server
     return server
 
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1,31 +1,26 @@
 """Pipeline API route handlers, extracted from server.py."""
 
 import json
-import os
 import re
-import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-
-from classify import classify_log_entry, LogEntry  # type: ignore[import-not-found]
-from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,  # type: ignore[import-not-found]
+from web.classify import classify_log_entry, LogEntry
+from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
                          resolve_user_requeue_override,
                          should_clear_lossless_search_override,
                          get_decision_tree, full_pipeline_decision,
                          detect_release_source)
-from lib.transitions import apply_transition  # type: ignore[import-not-found]
-from lib.util import beets_subprocess_env, resolve_failed_path  # type: ignore[import-not-found]
-from spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,  # type: ignore[import-not-found]
-                             ALBUM_SUSPECT_PCT, MIN_CLIFF_SLICES,
-                             CLIFF_THRESHOLD_DB_PER_KHZ)
-import mb as mb_api  # type: ignore[import-not-found]
-import discogs as discogs_api  # type: ignore[import-not-found]
+from lib.transitions import apply_transition
+from lib.util import beets_subprocess_env, resolve_failed_path
+from lib.spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,
+                                ALBUM_SUSPECT_PCT, MIN_CLIFF_SLICES,
+                                CLIFF_THRESHOLD_DB_PER_KHZ)
+from web import mb as mb_api
+from web import discogs as discogs_api
 
 
 def _server():
     """Deferred import to avoid circular deps."""
-    from web import server  # type: ignore[import-not-found]
+    from web import server
     return server
 
 

--- a/web/server.py
+++ b/web/server.py
@@ -25,22 +25,23 @@ logging.basicConfig(
 )
 log = logging.getLogger("soularr-web")
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-sys.path.insert(0, os.path.dirname(__file__))
+# Ensure repo root is importable when run as __main__ so `from lib.X` /
+# `from web.X` resolve without relying on PYTHONPATH.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Ensure this module is importable as 'web.server' even when run as __main__,
 # so route modules can `from web import server` and get the same instance.
 if __name__ == "__main__" or "web.server" not in sys.modules:
     sys.modules["web.server"] = sys.modules[__name__]
 
-import web.cache as cache
-import mb as mb_api
-from beets_db import BeetsDB
-from pipeline_db import PipelineDB
-from routes import browse as _browse_routes  # type: ignore[import-untyped]
-from routes import library as _library_routes  # type: ignore[import-untyped]
-from routes import imports as _imports_routes  # type: ignore[import-untyped]
-from routes import pipeline as _pipeline_routes  # type: ignore[import-untyped]
+from web import cache as cache
+from web import mb as mb_api
+from lib.beets_db import BeetsDB
+from lib.pipeline_db import PipelineDB
+from web.routes import browse as _browse_routes
+from web.routes import library as _library_routes
+from web.routes import imports as _imports_routes
+from web.routes import pipeline as _pipeline_routes
 
 _db_dsn = None
 


### PR DESCRIPTION
## Summary

Closes #95.

Every module under `lib/`, `web/`, `harness/`, and `scripts/` used to be reachable under two names — once via the package path (`lib.quality`) and once via the PYTHONPATH shortcut (`quality`). A single process that imported both names loaded the module **twice** with distinct class objects, so `RankBitrateMetric.AVG from quality` was not the same object as `RankBitrateMetric.AVG from lib.quality` even though they compared equal by value. PR #94 hit this in production: `_selected_bitrate` used `cfg.bitrate_metric is RankBitrateMetric.AVG`, which compared `False` across the module boundary, silently broke the AVG rank policy for VBR albums, and was only caught by the post-deploy probe.

The hotfix on main (commits `13ca54b`, `bed9742`) consolidated **one caller** and added an `is`-on-enum lint. This PR removes the footgun structurally.

## What changed

- **Codemod every bare import** under production code to its prefixed form:
  - `from quality import X` → `from lib.quality import X`
  - `from util import X` → `from lib.util import X`
  - `from spectral_check import X` → `from lib.spectral_check import X`
  - `from pipeline_db import X` → `from lib.pipeline_db import X`
  - `from beets_db import X` → `from lib.beets_db import X`
  - `import mb as mb_api` → `from web import mb as mb_api`
  - `import discogs as discogs_api` → `from web import discogs as discogs_api`
  - `from classify import X` → `from web.classify import X`
  - `from pipeline_cli import X` → `from scripts.pipeline_cli import X`
- **Drop the per-subdir `sys.path.insert` bootstraps** in `web/server.py`, `web/routes/*.py`, `album_source.py`, `lib/beets.py`, `lib/download.py`, `lib/preimport.py`, `scripts/*.py`. A single repo-root entry is sufficient for the prefixed form to resolve.
- **`harness/import_one.py`** keeps its own `ROOT_DIR` bootstrap so standalone invocations (`python harness/import_one.py …`) still resolve `lib.*`, but `LIB_DIR` is no longer added.
- **Nix wrapper** (`nixosconfig/modules/nixos/services/soularr.nix`): drop `lib/harness/scripts/web` from `PYTHONPATH` on all three wrappers (`pipeline-cli`, `pipeline-migrate`, `soularr-web`). Only the repo root stays. *Must deploy together with this change.*
- **`pyrightconfig.json`**: `extraPaths` shrinks from `[lib, harness, scripts]` to `[.]` so the LSP sees the same single canonical path production does.

## Regression guard

`tests/test_no_dual_load.py` boots each entrypoint (`web/server.py`, `soularr.py`, `scripts.pipeline_cli`) in a subprocess with `PYTHONPATH` pinned to the repo root only, dumps `sys.modules`, and fails if any module appears under both its bare and prefixed name. This encodes the lesson of issue #95 at test time: any future addition that reintroduces the dual-load path will fail CI.

I also verified the test catches the original bug: before the refactor, setting `PYTHONPATH=".:./lib"` and importing both `lib.quality` and `quality` shows both in `sys.modules`. Post-refactor, the production entrypoints only load each module once.

## Test updates

Tests that used bare imports (`test_pipeline_cli`, `test_force_import`, `test_disambiguation`, `test_spectral_check`, `test_import_one_stages`, …) are updated to use the prefixed form, and their `@patch("routes.pipeline.X")` / `@patch("import_one.X")` / `@patch("quality.X")` targets are rewritten to `@patch("web.routes.pipeline.X")` / `@patch("harness.import_one.X")` / `@patch("lib.quality.X")` so the mocks hit the same module the code actually imports from. (A bunch of those patches had been relying on the dual-load — the mock was attached to one copy while the code read from the other.)

## Companion nixosconfig change

The Nix wrapper change lives in `nixosconfig`, not this repo. Both must land together for the deploy to work. I have the edit locally on doc1; will commit + push + deploy together once this PR is approved and merged.

## Test plan

- [x] Full test suite: 1711 tests pass (0 failures, 0 errors, 53 skipped)
- [x] pyright: 12 errors (identical to baseline — all pre-existing, none in code this PR touched)
- [x] `tests/test_no_dual_load.py` passes: `web.server`, `soularr`, `scripts.pipeline_cli` entrypoints load each module exactly once
- [x] Manually verified the test *catches* the regression by dual-loading `quality` + `lib.quality` under the old PYTHONPATH shape
- [ ] Deploy and monitor logs for any import-time regressions (handled post-merge per `.claude/rules/deploy.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)