### PR TITLE
fix(web): render recents cards from point-in-time bitrate, not current album state

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -294,6 +294,7 @@ def _populate_dl_info_from_import_result(dl_info: DownloadInfo,
     if new_m:
         if new_m.min_bitrate_kbps is not None:
             dl_info.bitrate = new_m.min_bitrate_kbps * 1000
+            dl_info.actual_min_bitrate = new_m.min_bitrate_kbps
         dl_info.download_spectral = SpectralMeasurement.from_parts(
             new_m.spectral_grade, new_m.spectral_bitrate_kbps)
         dl_info.verified_lossless_override = new_m.verified_lossless

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -90,6 +90,40 @@ class TestPopulateDlInfoFromImportResult(unittest.TestCase):
         self.assertEqual(dl.slskd_filetype, "mp3")
         self.assertEqual(dl.actual_filetype, "mp3")
 
+    def test_populates_actual_min_bitrate_from_new_measurement(self):
+        """Point-in-time min bitrate must land in dl.actual_min_bitrate so the
+        download_log column is non-NULL. Recents UI relies on this column to
+        render per-row 'upgrade X to Y' verdicts — when NULL the UI silently
+        falls through to album_requests.min_bitrate (current state), painting
+        every historical row with the latest value.
+        Live reproducer: request 1055, rows 3628/3631 both have NULL column
+        despite JSONB carrying 119 and 162.
+        """
+        from lib.import_dispatch import _populate_dl_info_from_import_result
+        dl = DownloadInfo(filetype="mp3")
+        ir = make_import_result(was_converted=False, new_min_bitrate=119)
+        _populate_dl_info_from_import_result(dl, ir)
+        self.assertEqual(dl.actual_min_bitrate, 119)
+
+    def test_populates_actual_min_bitrate_for_flac_conversion(self):
+        """Same guarantee for the FLAC→V0 conversion path — the V0 min bitrate
+        is the point-in-time value and must land on the column."""
+        from lib.import_dispatch import _populate_dl_info_from_import_result
+        dl = DownloadInfo(filetype="flac")
+        ir = make_import_result(was_converted=True, original_filetype="flac",
+                                target_filetype="mp3", new_min_bitrate=245)
+        _populate_dl_info_from_import_result(dl, ir)
+        self.assertEqual(dl.actual_min_bitrate, 245)
+
+    def test_leaves_actual_min_bitrate_none_when_measurement_missing(self):
+        """If there's no new_measurement in the ImportResult, we don't
+        fabricate a value — NULL is the honest signal for consumers."""
+        from lib.import_dispatch import _populate_dl_info_from_import_result
+        dl = DownloadInfo(filetype="mp3")
+        ir = ImportResult(decision="import_failed", new_measurement=None)
+        _populate_dl_info_from_import_result(dl, ir)
+        self.assertIsNone(dl.actual_min_bitrate)
+
 
 class TestCleanupStagedDir(unittest.TestCase):
 

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -787,5 +787,245 @@ class TestVerdictSpectralFallback(unittest.TestCase):
         self.assertIn("nexus15", result.summary)
 
 
+# ============================================================================
+# Point-in-time bitrate — per-row verdicts must NOT use current album state
+# ============================================================================
+
+class TestPerRowBitrateIsPointInTime(unittest.TestCase):
+    """Every per-row display (verdict, summary, downloaded_label) must resolve
+    the 'downloaded' bitrate from this row's state at the time of that
+    download — never from album_requests.min_bitrate (which the recents query
+    JOINs in as request_min_bitrate and which reflects the album's *current*
+    state at query time).
+
+    Live reproducer: request 1055 (Velella Velella - Bay of Biscay), two
+    successive download_log rows:
+      - row 3628 (brandlos, earlier): imported 119kbps → UI should say '128→119'
+      - row 3631 (Ceezles, later):    imported 162kbps → UI should say '119→162'
+    Both rows have download_log.actual_min_bitrate = NULL, but the JSONB
+    carries the correct new_measurement.min_bitrate_kbps. The old code fell
+    through to request_min_bitrate (=162, the current album state), so both
+    rows painted '→162' as the 'to' value — inventing a fake self-upgrade
+    for the older row.
+    """
+
+    def _brandlos_row(self):
+        """Earlier of two successive upgrades — column NULL, JSONB has 119.
+        Must display as '128 → 119', not '128 → 162'."""
+        return _entry(
+            outcome="success",
+            existing_min_bitrate=128,
+            actual_min_bitrate=None,          # pre-fix rows have NULL
+            bitrate=119000,                   # container bitrate (legacy signal)
+            request_min_bitrate=162,          # current album state via JOIN
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "new_measurement": {
+                    "min_bitrate_kbps": 119,
+                    "avg_bitrate_kbps": 179,
+                    "median_bitrate_kbps": 181,
+                    "format": "MP3",
+                    "is_cbr": False,
+                    "verified_lossless": False,
+                    "spectral_grade": "likely_transcode",
+                    "spectral_bitrate_kbps": 160,
+                },
+                "existing_measurement": {
+                    "min_bitrate_kbps": 128,
+                    "spectral_grade": "genuine",
+                },
+            },
+        )
+
+    # ---- _upgrade_verdict (line 193) ----
+
+    def test_upgrade_verdict_uses_point_in_time_bitrate(self):
+        """The headline bug: two successive upgrades both show current album
+        state as the 'to' bitrate. Must use this row's new_measurement."""
+        result = classify_log_entry(self._brandlos_row())
+        self.assertIn("119", result.verdict,
+                      f"verdict must contain 119 (this download), got: {result.verdict!r}")
+        self.assertNotIn("162", result.verdict,
+                         f"verdict must NOT contain 162 (current album state): {result.verdict!r}")
+
+    def test_upgrade_verdict_reads_from_import_result_when_column_null(self):
+        """Historical rows with NULL actual_min_bitrate must render correctly
+        from the JSONB — no retroactive reindex needed."""
+        result = classify_log_entry(self._brandlos_row())
+        self.assertIn("128", result.verdict)  # existing
+        self.assertIn("119", result.verdict)  # new, from JSONB
+        self.assertTrue(result.verdict.startswith("Upgrade:"),
+                        f"expected 'Upgrade:' prefix, got: {result.verdict!r}")
+
+    # ---- _build_summary (line 404) for the Upgraded branch ----
+
+    def test_upgrade_summary_uses_point_in_time_bitrate(self):
+        """The collapsed-card summary inherits the verdict for upgrades, so it
+        must also be point-in-time (not current album state)."""
+        entry = self._brandlos_row()
+        entry.soulseek_username = "brandlos"
+        result = classify_log_entry(entry)
+        self.assertIn("119", result.summary)
+        self.assertNotIn("162", result.summary)
+        self.assertIn("brandlos", result.summary)
+
+    # ---- _build_summary (line 404) for the Imported branch ----
+
+    def test_imported_summary_uses_point_in_time_bitrate(self):
+        """New-import rows (existing_min_bitrate=None) still share the same
+        or-chain bug. If a request later gets upgraded, the 'Imported' summary
+        for the historical row must not inherit the newer state."""
+        entry = _entry(
+            outcome="success",
+            existing_min_bitrate=None,         # first import
+            actual_min_bitrate=None,           # column NULL
+            bitrate=128000,
+            request_min_bitrate=320,           # album got upgraded later
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "new_measurement": {"min_bitrate_kbps": 128},
+                "existing_measurement": None,
+            },
+        )
+        result = classify_log_entry(entry)
+        self.assertEqual(result.badge, "Imported")
+        self.assertIn("128", result.summary)
+        self.assertNotIn("320", result.summary)
+
+    # ---- _new_import_verdict (line 312) ----
+
+    def test_new_import_verdict_uses_point_in_time_bitrate(self):
+        """Same or-chain in _new_import_verdict."""
+        entry = _entry(
+            outcome="success",
+            existing_min_bitrate=None,
+            actual_min_bitrate=None,
+            bitrate=128000,
+            request_min_bitrate=320,
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "new_measurement": {"min_bitrate_kbps": 128},
+            },
+        )
+        result = classify_log_entry(entry)
+        self.assertIn("128", result.verdict)
+        self.assertNotIn("320", result.verdict)
+
+    # ---- _classify_search_filetype_override (line 300-301) ----
+
+    def test_search_filetype_override_uses_point_in_time_bitrate(self):
+        """The 'Replaced unverified CBR with X' label must reflect this row's
+        bitrate tier, not the album's current state. Point-in-time 243kbps
+        renders as 'V0'; leaked current-state 350kbps would render as '320'."""
+        entry = _entry(
+            outcome="success",
+            search_filetype_override="flac",
+            existing_min_bitrate=320,
+            actual_min_bitrate=None,
+            bitrate=243000,
+            request_min_bitrate=350,           # aliases to '320' tier
+            actual_filetype="mp3",
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "new_measurement": {"min_bitrate_kbps": 243},
+            },
+        )
+        result = classify_log_entry(entry)
+        self.assertEqual(result.badge, "Upgraded")
+        self.assertIn("V0", result.verdict,
+                      f"expected V0 tier (from 243kbps), got: {result.verdict!r}")
+        self.assertNotIn("320", result.verdict,
+                         f"verdict leaked current-state 320 tier: {result.verdict!r}")
+
+    # ---- _build_downloaded_label (line 432-434) ----
+
+    def test_downloaded_label_uses_point_in_time_bitrate(self):
+        """downloaded_label builds from actual_min_bitrate or bitrate//1000;
+        it already avoids request_min_bitrate. But for retroactive
+        correctness (NULL column rows), the JSONB should be consulted first."""
+        entry = _entry(
+            outcome="success",
+            actual_min_bitrate=None,
+            bitrate=119000,
+            request_min_bitrate=162,
+            actual_filetype="mp3",
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "new_measurement": {"min_bitrate_kbps": 119},
+            },
+        )
+        result = classify_log_entry(entry)
+        # The label must reflect this row's download, not current state.
+        self.assertIn("119", result.downloaded_label)
+        self.assertNotIn("162", result.downloaded_label)
+
+    # ---- Parametrized guard: current album state never leaks into a per-row
+    # display regardless of which render path runs. ----
+
+    def test_current_album_state_never_leaks_into_per_row_display(self):
+        """Invariant: when actual_min_bitrate is NULL and JSONB has a valid
+        new_measurement, no per-row string (verdict, summary, downloaded_label)
+        contains the request_min_bitrate value. Guards against adding a new
+        display call site that copies the old or-chain.
+
+        ALIEN must be in the range quality_label renders literally (<170kbps,
+        otherwise it would be aliased to a tier name like 'V0' or '320' and
+        hide the leak). Point-in-time values are chosen in a different
+        tier range so the bug is unambiguous.
+        """
+        ALIEN = 157          # <170 → renders as 'MP3 157k', stays literal
+        POINT_IN_TIME = 245  # ≥220 → renders as 'MP3 V0', no digit overlap
+        scenarios = [
+            ("upgrade",
+             _entry(outcome="success",
+                    existing_min_bitrate=128,
+                    actual_min_bitrate=None, bitrate=POINT_IN_TIME * 1000,
+                    request_min_bitrate=ALIEN,
+                    import_result={
+                        "version": 2, "decision": "import",
+                        "new_measurement": {"min_bitrate_kbps": POINT_IN_TIME},
+                        "existing_measurement": {"min_bitrate_kbps": 128},
+                    })),
+            ("new_import",
+             _entry(outcome="success",
+                    existing_min_bitrate=None,
+                    actual_min_bitrate=None, bitrate=POINT_IN_TIME * 1000,
+                    request_min_bitrate=ALIEN,
+                    import_result={
+                        "version": 2, "decision": "import",
+                        "new_measurement": {"min_bitrate_kbps": POINT_IN_TIME},
+                    })),
+            ("search_filetype_override",
+             _entry(outcome="success",
+                    search_filetype_override="flac",
+                    existing_min_bitrate=320,
+                    actual_min_bitrate=None, bitrate=POINT_IN_TIME * 1000,
+                    request_min_bitrate=ALIEN,
+                    import_result={
+                        "version": 2, "decision": "import",
+                        "new_measurement": {"min_bitrate_kbps": POINT_IN_TIME},
+                    })),
+        ]
+        alien = str(ALIEN)
+        for desc, entry in scenarios:
+            with self.subTest(desc=desc):
+                result = classify_log_entry(entry)
+                self.assertNotIn(
+                    alien, result.verdict,
+                    f"{desc}: verdict leaked current album state: {result.verdict!r}")
+                self.assertNotIn(
+                    alien, result.summary,
+                    f"{desc}: summary leaked current album state: {result.summary!r}")
+                self.assertNotIn(
+                    alien, result.downloaded_label,
+                    f"{desc}: downloaded_label leaked current album state: "
+                    f"{result.downloaded_label!r}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/classify.py
+++ b/web/classify.py
@@ -190,7 +190,7 @@ def _classify(entry: LogEntry) -> tuple[str, str, str, str]:
                 return _classify_search_filetype_override(entry, is_verified_lossless)
             verdict = _upgrade_verdict(
                 entry.existing_min_bitrate,
-                entry.actual_min_bitrate or entry.request_min_bitrate,
+                _downloaded_min_bitrate_kbps(entry),
                 entry.was_converted, entry.original_filetype,
                 is_verified_lossless,
                 actual_filetype=entry.actual_filetype)
@@ -220,15 +220,39 @@ def _parse_import_result(entry: LogEntry) -> ImportResult | None:
         return None
 
 
-def _real_bitrate_kbps(entry: LogEntry) -> int | None:
-    """Best available actual file bitrate in kbps, excluding spectral.
+def _downloaded_min_bitrate_kbps(entry: LogEntry) -> int | None:
+    """The min bitrate of the file that was downloaded for THIS log row.
 
-    spectral_bitrate is a cliff estimate ("what was the original source?"),
-    not the file's actual bitrate. It must never appear in non-spectral
-    verdicts. This matches the chain in _build_downloaded_label.
+    Point-in-time — reflects this download's state, not the album's current
+    state. Callers MUST NOT fall back to ``entry.request_min_bitrate`` for
+    per-row displays: request_min_bitrate is ``album_requests.min_bitrate``
+    at query time (the album's current state), so after a subsequent upgrade
+    it no longer matches what this row imported. Using it to paint the 'to'
+    bitrate in an older Recents card invents a fake self-upgrade (see live
+    reproducer request 1055: brandlos's 119k import was painted as 162k
+    because that's Ceezles's later upgrade).
+
+    Priority chain:
+        1. ``entry.actual_min_bitrate`` — denormalized column, populated by
+           ``_populate_dl_info_from_import_result`` on the auto-import path
+           since the ``actual_min_bitrate`` fix.
+        2. ``ir.new_measurement.min_bitrate_kbps`` — authoritative JSONB,
+           present on every row. Fixes historical rows (pre-column-fix)
+           retroactively without a backfill migration.
+        3. ``entry.bitrate`` (bps) — legacy container bitrate, last resort.
+
+    ``spectral_bitrate`` is a cliff estimate ("what was the original source?"),
+    not the file's actual bitrate. It must never appear here.
     """
-    return (entry.actual_min_bitrate
-            or (entry.bitrate // 1000 if entry.bitrate else None))
+    if entry.actual_min_bitrate:
+        return entry.actual_min_bitrate
+    ir = _parse_import_result(entry)
+    if ir is not None and ir.new_measurement is not None:
+        if ir.new_measurement.min_bitrate_kbps is not None:
+            return ir.new_measurement.min_bitrate_kbps
+    if entry.bitrate:
+        return entry.bitrate // 1000
+    return None
 
 
 def _comparison_verdict(
@@ -280,7 +304,7 @@ def _quality_verdict_from_import_result(entry: LogEntry) -> str | None:
 
 def _classify_transcode(entry: LogEntry) -> tuple[str, str, str, str]:
     """Classify a transcode_upgrade or transcode_first success."""
-    br = _real_bitrate_kbps(entry)
+    br = _downloaded_min_bitrate_kbps(entry)
     br_str = f"{br}kbps" if br else "unknown bitrate"
     if entry.beets_scenario == "transcode_upgrade":
         ex = entry.existing_min_bitrate or entry.existing_spectral_bitrate
@@ -297,8 +321,7 @@ def _classify_search_filetype_override(
 ) -> tuple[str, str, str, str]:
     """Classify a search_filetype_override upgrade (replacing unverified CBR)."""
     fmt = entry.actual_filetype or entry.filetype or "mp3"
-    cur_label = quality_label(fmt, entry.actual_min_bitrate
-                              or entry.request_min_bitrate or 0)
+    cur_label = quality_label(fmt, _downloaded_min_bitrate_kbps(entry) or 0)
     parts = [f"Replaced unverified CBR with {cur_label}"]
     if entry.was_converted and entry.original_filetype:
         parts.append(f"from {entry.original_filetype.upper()}")
@@ -309,7 +332,7 @@ def _classify_search_filetype_override(
 
 def _new_import_verdict(entry: LogEntry, is_verified_lossless: bool) -> str:
     """Build verdict for a new import (nothing on disk before)."""
-    br = entry.actual_min_bitrate or entry.request_min_bitrate
+    br = _downloaded_min_bitrate_kbps(entry)
     fmt = entry.actual_filetype or entry.filetype or "mp3"
     label = quality_label(fmt, br or 0)
     parts = [label]
@@ -340,7 +363,7 @@ def _rejection_verdict(entry: LogEntry) -> str:
         if ir_verdict is not None:
             return ir_verdict
         # Fallback: use real file bitrate, not spectral
-        new_kbps = _real_bitrate_kbps(entry)
+        new_kbps = _downloaded_min_bitrate_kbps(entry)
         old_kbps = entry.existing_min_bitrate or entry.existing_spectral_bitrate
         if scenario == "transcode_downgrade":
             return _comparison_verdict(new_kbps, old_kbps, prefix="Transcode at")
@@ -401,7 +424,7 @@ def _build_summary(entry: LogEntry, badge: str, verdict: str) -> str:
 
     if badge == "Imported":
         # Show format label for new imports
-        br = entry.actual_min_bitrate or entry.request_min_bitrate
+        br = _downloaded_min_bitrate_kbps(entry)
         fmt = entry.actual_filetype or entry.filetype or "mp3"
         label = quality_label(fmt, br or 0)
         if entry.was_converted and entry.original_filetype:
@@ -429,9 +452,7 @@ def _build_downloaded_label(entry: LogEntry) -> str:
     if not fmt:
         return ""
 
-    br_kbps = (entry.actual_min_bitrate
-               or (entry.bitrate // 1000 if entry.bitrate else None)
-               or 0)
+    br_kbps = _downloaded_min_bitrate_kbps(entry) or 0
 
     if entry.was_converted and entry.original_filetype:
         conv_label = quality_label(fmt, br_kbps)


### PR DESCRIPTION
## Summary

Two compounding UI/telemetry bugs made the Recents tab paint every historical download_log row with the album's *current* min_bitrate instead of the bitrate imported at the time of that specific download. Live reproducer: request 1055 (Velella Velella - Bay of Biscay) — brandlos's 119k import was rendered as "Upgrade: 128k to 162k" because the album had since been upgraded to 162k by a later Ceezles download.

- **Bug 1 (backend telemetry)**: \`_populate_dl_info_from_import_result\` copied \`new_measurement.min_bitrate_kbps\` into \`dl_info.bitrate\` but never into \`dl_info.actual_min_bitrate\`. Every auto-imported row had the column NULL.
- **Bug 2 (UI fallback)**: Five display sites in \`web/classify.py\` fell back to \`entry.request_min_bitrate\` when the column was NULL — but \`request_min_bitrate\` is \`album_requests.min_bitrate\` via JOIN, the album's current state at query time. Every auto-imported row hit this fallback and painted the latest value onto older rows.

## Fix (structural, per scope.md)

- Extract \`_downloaded_min_bitrate_kbps(entry)\` in classify.py as the single source of truth for per-row bitrate. Chain: column → import_result JSONB \`new_measurement\` → \`entry.bitrate\`. **Never** falls back to \`request_min_bitrate\`.
- Route all five display sites (\`_upgrade_verdict\`, \`_classify_search_filetype_override\`, \`_new_import_verdict\`, \`_build_summary\` Imported branch, \`_build_downloaded_label\`) through the helper. Rerouted \`_real_bitrate_kbps\` callers too so every bitrate resolver in the module uses the same function.
- Populate \`dl_info.actual_min_bitrate\` in \`_populate_dl_info_from_import_result\`. JSONB fallback in the helper fixes historical rows retroactively — no backfill migration needed.

## Test plan

- [x] \`TestPopulateDlInfoFromImportResult\` gains coverage for the column being populated on both no-conversion and FLAC→V0 paths, plus a guard that missing \`new_measurement\` leaves the column honestly NULL
- [x] New \`TestPerRowBitrateIsPointInTime\` class in \`test_web_recents.py\` reproduces the live request-1055 scenario exactly (column NULL, JSONB carries 119, \`request_min_bitrate\`=162) across all five display sites
- [x] subTest-driven invariant guard fails if any future display path leaks current album state into per-row output
- [x] Full suite: 1749 tests pass
- [x] Pyright clean on touched files
- [ ] Deploy and verify in live UI that request 1055's brandlos card now reads "Upgrade: 128k to 119k"

🤖 Generated with [Claude Code](https://claude.com/claude-code)