### PR TITLE
Fix spectral decision self-comparing on stale beets path (#90)

### DIFF
--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -465,19 +465,22 @@ def run_preimport_gates(
             logger.debug("failed to read persisted spectral state",
                          exc_info=True)
 
-    # --- Persist spectral state to DB (if wired) ---
-    if db is not None and request_id is not None:
-        written = _persist_spectral_state(
-            db=db, request_id=request_id,
-            download_spectral=result.download_spectral,
-            existing_spectral=result.existing_spectral,
-            existing_min_bitrate=result.existing_min_bitrate,
-            label=label,
-            propagate_download_to_existing=propagate_download_to_existing,
-        )
-        result.existing_spectral = written
-
     # --- Spectral decision ---
+    #
+    # Issue #90: the decision MUST run BEFORE _persist_spectral_state
+    # propagates the download's spectral into ``result.existing_spectral``.
+    # When BeetsDB returns an album (``existing_min_bitrate`` populated) but
+    # the on-disk album_path is stale — so ``existing_spectral`` stayed None
+    # — the propagation helper adopts the download's spectral as "the
+    # current on-disk state". If we then read ``result.existing_spectral``
+    # for the decision, we compare the download against a copy of itself
+    # and every suspect-grade download rejects at ``new <= existing`` when
+    # new == existing by construction.
+    #
+    # Snapshot the value spectral_import_decision will see here, keep the
+    # propagation logic intact, and persist AFTER the decision so the DB
+    # still carries the download's spectral forward for the NEXT run's
+    # decision (which is what the propagation is actually for).
     existing_cliff_bitrate = (
         result.existing_spectral.bitrate_kbps
         if result.existing_spectral is not None else None
@@ -519,5 +522,21 @@ def run_preimport_gates(
         logger.info(
             f"SPECTRAL: {label} suspect at {dl_cliff_bitrate}kbps "
             f"but no existing album, importing")
+
+    # --- Persist spectral state to DB (if wired) ---
+    # Runs AFTER the decision so the propagation (download → existing) can't
+    # poison the comparison above. The written value still flows back into
+    # ``result.existing_spectral`` for downstream logging — callers read this
+    # field to populate DownloadInfo.current_spectral and validation logs.
+    if db is not None and request_id is not None:
+        written = _persist_spectral_state(
+            db=db, request_id=request_id,
+            download_spectral=result.download_spectral,
+            existing_spectral=result.existing_spectral,
+            existing_min_bitrate=result.existing_min_bitrate,
+            label=label,
+            propagate_download_to_existing=propagate_download_to_existing,
+        )
+        result.existing_spectral = written
 
     return result

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -512,6 +512,187 @@ class TestSpectralPropagationSlice(unittest.TestCase):
         self.assertIn("spectral: 128kbps <= existing 320kbps",
                       db.denylist[0].reason or "")
 
+    def test_stale_album_path_does_not_self_compare(self):
+        """Issue #90: when BeetsDB returns an album whose on-disk path has
+        gone stale (``os.path.isdir`` returns False), propagation must not
+        mutate ``existing_spectral`` *before* ``spectral_import_decision``
+        runs — otherwise the download is compared against itself and
+        legitimate suspect-grade downloads get rejected by their own
+        spectral estimate.
+
+        Setup: beets says the album exists (min_bitrate=320) but
+        isdir(album_path) is False. Download is suspect at 128kbps.
+
+        With the bug: propagation writes download's 128kbps into
+        existing_spectral, then decision sees new=128 vs existing=128 →
+        reject (self-compare).
+
+        Correct behavior: decision compares download's 128 against the
+        container's 320 (fallback via existing_min_bitrate) → reject with a
+        legitimate comparison; OR if existing_min_bitrate also isn't
+        trustworthy (e.g. caller treats stale path as no-existing),
+        import_no_exist. The key invariant: the reject reason must NOT
+        read ``spectral {x}kbps <= existing {x}kbps`` with equal numbers.
+        """
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        # Album metadata present in beets...
+        beets_info = AlbumInfo(
+            album_id=1,
+            track_count=10,
+            min_bitrate_kbps=320,
+            avg_bitrate_kbps=320,
+            format="MP3",
+            is_cbr=True,
+            album_path="/Beets/Test",
+        )
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch(
+            "lib.preimport.spectral_analyze",
+            return_value=SimpleNamespace(
+                grade="suspect",
+                estimated_bitrate_kbps=128,
+                suspect_pct=90.0,
+                tracks=[],
+            ),
+        ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+             patch("os.path.isdir", return_value=False):
+            result = run_preimport_gates(
+                path="/tmp/download",
+                mb_release_id="mbid-123",
+                label="Test Artist - Test Album",
+                download_filetype="mp3",
+                download_min_bitrate_bps=320_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames={"user1"},
+                propagate_download_to_existing=True,
+            )
+
+        # The self-compare bug — if any reject fires, it must not read as
+        # "spectral X <= existing X" with equal numbers. A legitimate reject
+        # against the container bitrate (320) is allowed.
+        if not result.valid:
+            self.assertNotEqual(result.detail,
+                                "spectral 128kbps <= existing 128kbps",
+                                "self-compare bug: download compared against "
+                                "a propagated copy of its own spectral")
+
+    def test_stale_album_path_rejects_against_container_bitrate(self):
+        """Issue #90 regression guard: when beets path is stale, the spectral
+        decision must fall back to the container's min_bitrate (320), not
+        the download's own spectral. So a suspect 128kbps download rejects
+        against 320kbps (a real comparison) and the detail string reflects
+        that — not the self-compare "128 <= 128" the old code produced.
+        """
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        beets_info = AlbumInfo(
+            album_id=1,
+            track_count=10,
+            min_bitrate_kbps=320,
+            avg_bitrate_kbps=320,
+            format="MP3",
+            is_cbr=True,
+            album_path="/Beets/Test",
+        )
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch(
+            "lib.preimport.spectral_analyze",
+            return_value=SimpleNamespace(
+                grade="suspect",
+                estimated_bitrate_kbps=128,
+                suspect_pct=90.0,
+                tracks=[],
+            ),
+        ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+             patch("os.path.isdir", return_value=False):
+            result = run_preimport_gates(
+                path="/tmp/download",
+                mb_release_id="mbid-123",
+                label="Test Artist - Test Album",
+                download_filetype="mp3",
+                download_min_bitrate_bps=320_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames={"user1"},
+                propagate_download_to_existing=True,
+            )
+
+        self.assertFalse(result.valid, "suspect 128 < container 320 should reject")
+        self.assertEqual(result.scenario, "spectral_reject")
+        self.assertEqual(result.detail, "spectral 128kbps <= existing 320kbps",
+                         "reject must compare against stale container's 320kbps, "
+                         "not a propagated copy of the download's 128kbps")
+
+    def test_stale_album_path_imports_when_download_beats_container(self):
+        """Issue #90 correctness: suspect download above the container
+        bitrate must import (import_upgrade) instead of self-rejecting.
+
+        Without the fix: propagation writes 280 into existing_spectral,
+        decision sees 280 <= 280 → reject. A legitimate upgrade blocked.
+
+        With the fix: decision sees 280 vs container 256 → import_upgrade.
+        """
+        from lib.config import SoularrConfig
+        from lib.preimport import run_preimport_gates
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        beets_info = AlbumInfo(
+            album_id=1,
+            track_count=10,
+            min_bitrate_kbps=256,
+            avg_bitrate_kbps=256,
+            format="MP3",
+            is_cbr=True,
+            album_path="/Beets/Test",
+        )
+        cfg = SoularrConfig(audio_check_mode="off")
+
+        with patch(
+            "lib.preimport.spectral_analyze",
+            return_value=SimpleNamespace(
+                grade="suspect",
+                estimated_bitrate_kbps=280,
+                suspect_pct=90.0,
+                tracks=[],
+            ),
+        ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
+             patch("os.path.isdir", return_value=False):
+            result = run_preimport_gates(
+                path="/tmp/download",
+                mb_release_id="mbid-123",
+                label="Test Artist - Test Album",
+                download_filetype="mp3",
+                download_min_bitrate_bps=280_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames={"user1"},
+                propagate_download_to_existing=True,
+            )
+
+        self.assertTrue(result.valid,
+                        "suspect 280 > container 256 should import (upgrade)")
+        # Propagation still persisted the download's spectral for future runs.
+        row = db.request(42)
+        self.assertEqual(row["current_spectral_grade"], "suspect")
+        self.assertEqual(row["current_spectral_bitrate"], 280)
+
 
 class TestDispatchNoJsonResult(unittest.TestCase):
     """Integration slice: sp.run returns no sentinel -> record rejection."""


### PR DESCRIPTION
## Summary

Closes #90. Moves the `_persist_spectral_state` call in `run_preimport_gates` to **after** the `spectral_import_decision` call. Before the fix, propagation writing the download's own spectral into `result.existing_spectral` caused the decision to compare the download against itself when BeetsDB returned a stale `album_path`.

## Repro

Preconditions (all required, hence why it stayed latent):

- Album is in beets (`existing_info.min_bitrate_kbps` populated).
- `os.path.isdir(existing_info.album_path)` is False (moved/deleted/permission loss without beets cleanup).
- Download is MP3/CBR with a `suspect` or `likely_transcode` grade.

With the bug: `_persist_spectral_state` propagates `download_spectral` → `result.existing_spectral`; `spectral_import_decision` then sees `new_q == existing_q`, hits `new_q <= existing_q` → reject, with a self-referential detail string like `spectral 128kbps <= existing 128kbps`.

## The fix

One structural change: run the decision first, persist second. The invariant is now explicit in comments next to both blocks — `spectral_import_decision` must only see `existing_spectral` values that came from BeetsDB's own analysis or the persisted-state fallback, never from a helper whose inputs include the current download. The DB write (and its future-decision-facing propagation) still happens, just on the correct side of the decision boundary.

Pre-existing bug on main, confirmed by PR #87's adversarial audit. Independent structural subagent review (`/fix-bug` step 2) confirmed the same primary finding and suggested this exact fix.

## Test plan

Three new tests in `TestSpectralPropagationSlice`:

- [x] `test_stale_album_path_does_not_self_compare` — reject detail must never read `spectral X <= existing X` with equal numbers (generic anti-regression against the self-compare pattern).
- [x] `test_stale_album_path_rejects_against_container_bitrate` — suspect 128 vs stale container 320 must reject as `128 <= 320`, not `128 <= 128`.
- [x] `test_stale_album_path_imports_when_download_beats_container` — suspect 280 vs stale container 256 must import (import_upgrade); the bug would falsely reject with `280 <= 280`.
- [x] Existing `test_suspect_download_updates_current_spectral_and_denylists` (flat/on-disk scenario) still passes — persist runs after decision but before return, so caller-visible state is unchanged in every non-bugged scenario.
- [x] Full suite: 1778 tests pass, 53 skipped (pre-existing). `pyright lib/preimport.py tests/test_integration_slices.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)