### PR TITLE
Never rmtree failed_imports on force/manual-import (#89)

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -14,9 +14,8 @@ import sys
 from dataclasses import dataclass
 from typing import Sequence, TYPE_CHECKING
 
-from lib.quality import (parse_import_result, DownloadInfo, ImportResult,
-                         SpectralMeasurement,
-                         ValidationResult,
+from lib.quality import (parse_import_result, DispatchAction, DownloadInfo,
+                         ImportResult, SpectralMeasurement, ValidationResult,
                          QUALITY_UPGRADE_TIERS, QUALITY_LOSSLESS,
                          dispatch_action, compute_effective_override_bitrate,
                          extract_usernames, narrow_override_on_downgrade,
@@ -44,6 +43,31 @@ logger = logging.getLogger("soularr")
 # ``auto_import``, none of which appear here — their staging dir under
 # ``/Incoming`` is always safe to remove (see issue #89).
 FORCE_MANUAL_SCENARIOS: frozenset[str] = frozenset({"force_import", "manual_import"})
+
+
+def _should_cleanup_path(scenario: str, action: "DispatchAction") -> bool:
+    """Whether ``_cleanup_staged_dir`` is safe for this dispatch outcome.
+
+    Issue #89 rules:
+
+    * Auto-import (scenario not in ``FORCE_MANUAL_SCENARIOS``) always
+      cleans its disposable ``/Incoming`` staging dir.
+    * Force/manual-import paths pass the user's ``failed_imports/…``
+      folder — cleanup is only safe on a successful import
+      (``action.mark_done=True``, meaning beets has moved the files out
+      and the source directory is now empty). On a ``downgrade`` /
+      ``transcode_downgrade`` decision (mark_done=False) the files are
+      still in the source folder, so cleanup would delete the user's
+      data.
+    * Successful force/manual import MUST clean so the wrong-matches tab
+      (``lib.pipeline_db.get_wrong_matches``) stops treating the
+      still-existing folder as an active pending entry — otherwise the
+      album would show up as re-importable even though beets already
+      has it.
+    """
+    if scenario not in FORCE_MANUAL_SCENARIOS:
+        return True
+    return action.mark_done
 
 
 @dataclass(frozen=True)
@@ -684,17 +708,19 @@ def dispatch_import_core(
                 _trigger_meelo(cfg)
                 _trigger_plex(cfg, ir.postflight.imported_path)
                 _trigger_jellyfin(cfg)
-            if action.cleanup and scenario not in FORCE_MANUAL_SCENARIOS:
-                # Issue #89: cleanup is only safe for auto-import. The auto
-                # path passes a disposable ``/Incoming`` staging directory;
-                # force/manual paths pass the user's ``failed_imports/…``
-                # folder, which is the only copy of the source. A
-                # ``downgrade`` / ``transcode_downgrade`` decision there
-                # would delete the user's data. On successful force/manual
-                # imports the beets subprocess has already moved files out,
-                # leaving an empty folder — skip that too, predictable
-                # never-delete behavior beats a clever "delete if empty"
-                # rule that still surprises on partial imports.
+            if action.cleanup and _should_cleanup_path(scenario, action):
+                # Issue #89: force/manual paths pass the user's
+                # ``failed_imports/…`` folder as ``path`` — cleanup is
+                # data loss on a ``downgrade`` / ``transcode_downgrade``
+                # decision where beets never moved the files.
+                # ``_should_cleanup_path`` only allows cleanup on force/
+                # manual when the decision actually imported (mark_done=
+                # True, i.e. beets has moved the files and the source
+                # directory is now empty), which keeps the wrong-matches
+                # tab honest and prevents duplicate re-imports of an
+                # already-imported album. Auto-import scenarios always
+                # clean — their staging dir under ``/Incoming`` is
+                # disposable by design.
                 _cleanup_staged_dir(path)
             if action.mark_done and ir.postflight.disambiguated and ir.postflight.imported_path:
                 removed = cleanup_disambiguation_orphans(ir.postflight.imported_path)

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -36,6 +36,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger("soularr")
 
 
+# Scenarios whose ``path`` is the user's source data (``failed_imports/…``),
+# NOT a disposable staging directory. Used to gate ``_cleanup_staged_dir``
+# so a ``downgrade`` / ``transcode_downgrade`` decision from the harness
+# can never delete the user's only copy of the source. Auto-import uses
+# bv_result.scenario values like ``strong_match`` / ``weak_match`` /
+# ``auto_import``, none of which appear here — their staging dir under
+# ``/Incoming`` is always safe to remove (see issue #89).
+FORCE_MANUAL_SCENARIOS: frozenset[str] = frozenset({"force_import", "manual_import"})
+
+
 @dataclass(frozen=True)
 class QualityGateState:
     """Resolved on-disk state for a quality-gate evaluation."""
@@ -674,7 +684,17 @@ def dispatch_import_core(
                 _trigger_meelo(cfg)
                 _trigger_plex(cfg, ir.postflight.imported_path)
                 _trigger_jellyfin(cfg)
-            if action.cleanup:
+            if action.cleanup and scenario not in FORCE_MANUAL_SCENARIOS:
+                # Issue #89: cleanup is only safe for auto-import. The auto
+                # path passes a disposable ``/Incoming`` staging directory;
+                # force/manual paths pass the user's ``failed_imports/…``
+                # folder, which is the only copy of the source. A
+                # ``downgrade`` / ``transcode_downgrade`` decision there
+                # would delete the user's data. On successful force/manual
+                # imports the beets subprocess has already moved files out,
+                # leaving an empty folder — skip that too, predictable
+                # never-delete behavior beats a clever "delete if empty"
+                # rule that still surprises on partial imports.
                 _cleanup_staged_dir(path)
             if action.mark_done and ir.postflight.disambiguated and ir.postflight.imported_path:
                 removed = cleanup_disambiguation_orphans(ir.postflight.imported_path)

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -199,16 +199,26 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         r = self._dispatch(force=False, ir=ir)
         r["mock_cleanup"].assert_not_called()
 
-    def test_force_import_success_still_no_cleanup(self):
-        """Issue #89: even on successful force-import, we don't rmtree the
-        source. Beets has moved the files out, leaving an empty folder;
-        the user gets to decide whether to remove it. Predictable behavior
-        (never delete) beats clever behavior (delete-if-empty-after-success)
-        because the latter still surprises users on partial imports.
+    def test_force_import_success_cleans_empty_source(self):
+        """Issue #89 (Codex round 1): on successful force-import, beets
+        has moved the files out so the source folder is empty. We MUST
+        clean it — otherwise ``get_wrong_matches()`` keeps treating the
+        still-existing path as an active pending entry, the
+        wrong-matches tab shows a ghost row, and the album can be
+        re-force-imported even though beets already has it. Cleanup on
+        mark_done=True is what makes the wrong-matches tab honest.
         """
         r = self._dispatch(force=True)  # default decision="import"
         self.assertTrue(r["result"].success)
-        r["mock_cleanup"].assert_not_called()
+        r["mock_cleanup"].assert_called_once_with(r["path"])
+
+    def test_manual_import_success_cleans_empty_source(self):
+        """Same invariant for manual-import: successful import cleans the
+        now-empty source folder so the wrong-matches tab reflects reality.
+        """
+        r = self._dispatch(force=False)
+        self.assertTrue(r["result"].success)
+        r["mock_cleanup"].assert_called_once_with(r["path"])
 
 
 class TestDispatchFromDbAdvisoryLock(unittest.TestCase):

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -66,6 +66,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
             "mock_gate": mock_gate,
             "mock_meelo": ext.meelo,
             "mock_jellyfin": ext.jellyfin,
+            "mock_cleanup": ext.cleanup,
         }
 
     # --- Success path ---
@@ -159,6 +160,55 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         r = self._dispatch()
         self.assertTrue(hasattr(r["result"], "success"))
         self.assertTrue(hasattr(r["result"], "message"))
+
+    # --- Issue #89: force/manual rejections must NOT delete source files ---
+    #
+    # Auto-import passes a disposable /Incoming staging directory — cleanup
+    # on `downgrade` / `transcode_downgrade` is correct. Force/manual pass
+    # the user's `failed_imports/…` directory, which IS the only copy of
+    # the source material. A cleanup there would delete the user's data
+    # when the harness decides against importing.
+
+    def test_force_downgrade_does_not_delete_source(self):
+        """Issue #89: downgrade decision on force-import must not rmtree
+        the failed_imports source directory."""
+        ir = make_import_result(decision="downgrade",
+                                new_min_bitrate=128, prev_min_bitrate=180)
+        r = self._dispatch(force=True, ir=ir)
+        r["mock_cleanup"].assert_not_called()
+
+    def test_manual_downgrade_does_not_delete_source(self):
+        """Issue #89: downgrade decision on manual-import must not rmtree
+        the failed_imports source directory."""
+        ir = make_import_result(decision="downgrade",
+                                new_min_bitrate=128, prev_min_bitrate=180)
+        r = self._dispatch(force=False, ir=ir)
+        r["mock_cleanup"].assert_not_called()
+
+    def test_force_transcode_downgrade_does_not_delete_source(self):
+        """Issue #89: transcode_downgrade on force-import must not rmtree."""
+        ir = make_import_result(decision="transcode_downgrade",
+                                new_min_bitrate=190, prev_min_bitrate=320)
+        r = self._dispatch(force=True, ir=ir)
+        r["mock_cleanup"].assert_not_called()
+
+    def test_manual_transcode_downgrade_does_not_delete_source(self):
+        """Issue #89: transcode_downgrade on manual-import must not rmtree."""
+        ir = make_import_result(decision="transcode_downgrade",
+                                new_min_bitrate=190, prev_min_bitrate=320)
+        r = self._dispatch(force=False, ir=ir)
+        r["mock_cleanup"].assert_not_called()
+
+    def test_force_import_success_still_no_cleanup(self):
+        """Issue #89: even on successful force-import, we don't rmtree the
+        source. Beets has moved the files out, leaving an empty folder;
+        the user gets to decide whether to remove it. Predictable behavior
+        (never delete) beats clever behavior (delete-if-empty-after-success)
+        because the latter still surprises users on partial imports.
+        """
+        r = self._dispatch(force=True)  # default decision="import"
+        self.assertTrue(r["result"].success)
+        r["mock_cleanup"].assert_not_called()
 
 
 class TestDispatchFromDbAdvisoryLock(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes #89. When the harness returned ``downgrade`` or ``transcode_downgrade`` on a force/manual import, ``dispatch_import_core`` ran ``_cleanup_staged_dir(path)`` on the user's ``failed_imports/…`` source folder — silently deleting the only copy of the album. ``download_log.validation_result.failed_path`` kept pointing at the now-empty path.

## Root cause

``dispatch_action`` sets ``cleanup=True`` for both successful imports *and* ``downgrade`` / ``transcode_downgrade`` rejections. On auto-import the ``path`` is a disposable ``/Incoming`` staging dir so the cleanup is correct. Force/manual paths pass the actual ``failed_imports/…`` directory — cleanup there is data loss on reject, and a stale directory on success lets the wrong-matches tab treat the already-imported album as re-importable (Codex round 1).

## The fix

Introduce ``FORCE_MANUAL_SCENARIOS = frozenset({"force_import", "manual_import"})`` at module scope and extract ``_should_cleanup_path(scenario, action)``:

- Auto-import always cleans (disposable ``/Incoming`` staging).
- Force/manual clean **only** when ``action.mark_done`` is True — beets has moved the files out, the source directory is empty, and leaving it behind would ghost the wrong-matches tab.
- Force/manual with ``downgrade`` / ``transcode_downgrade`` (mark_done=False) skip cleanup → no data loss on rejection.

The named constant + helper makes the invariant searchable and forces any future force-like scenario to be explicitly classified.

Pre-existing bug on main; confirmed by PR #87's adversarial audit as present before that PR.

## Known separate concern (not in this PR)

Codex flagged a second data-loss vector in ``harness/import_one.py::convert_lossless``: when no ``verified_lossless_target`` is configured, lossless sources are deleted in place *before* the quality decision. On force/manual reject of a FLAC folder, the user's FLACs are already gone regardless of what this PR does about ``_cleanup_staged_dir``. Tracked separately at #111 — requires harness changes and beets mixed-format behavior verification.

## Test plan

Six new tests in ``TestDispatchFromDbOrchestration``:

- [x] ``test_force_downgrade_does_not_delete_source``
- [x] ``test_manual_downgrade_does_not_delete_source``
- [x] ``test_force_transcode_downgrade_does_not_delete_source``
- [x] ``test_manual_transcode_downgrade_does_not_delete_source``
- [x] ``test_force_import_success_cleans_empty_source`` — wrong-matches tab honesty (Codex round 1)
- [x] ``test_manual_import_success_cleans_empty_source``
- [x] Existing auto-path guard ``TestDispatchImport.test_downgrade_rejected`` still asserts ``mock_cleanup.assert_called_once()`` — no regression on the disposable-staging path.
- [x] Full suite: 1784 tests pass, 53 skipped (pre-existing). pyright clean on ``lib/import_dispatch.py`` + ``tests/test_dispatch_from_db.py``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)