### PR TITLE
feat(web): show last successful import (not latest attempt) on wrong-matches groups

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2128,8 +2128,9 @@ class TestWrongMatchesContract(unittest.TestCase):
         "status", "min_bitrate", "format", "verified_lossless",
         "current_spectral_grade", "current_spectral_bitrate",
         "quality_label", "quality_rank",
-        # Most-recent download_log row for the expanded view.
-        "latest_download",
+        # Summary of the last successful import for the request — tells the
+        # user what's actually on disk, not the most recent attempt.
+        "latest_import",
     }
     ENTRY_REQUIRED_FIELDS = {
         "download_log_id", "soulseek_username", "failed_path", "files_exist",
@@ -2285,21 +2286,28 @@ class TestWrongMatchesContract(unittest.TestCase):
         # a 'not on disk' badge from `status` and absent label.
         self.assertTrue(group["quality_label"] is None or isinstance(group["quality_label"], str))
 
-    def test_group_includes_latest_download(self):
-        """latest_download surfaces the newest download_log row for the request.
+    def test_group_latest_import_picks_most_recent_success(self):
+        """latest_import shows the last successful import, not the newest attempt.
 
-        This tells the user whether the release is still being actively retried
-        or has already been imported elsewhere.
+        A rejection that happened after a successful import doesn't change what
+        beets has — the earlier success is still what's on disk.
         """
         row = self._row(42, 100, "testuser", "/fi/Test")
         self.mock_db.get_wrong_matches.return_value = [row]
         self.mock_db.get_download_history_batch.return_value = {
             100: [
+                # Newest = rejected (a later force-import attempt that failed).
                 {"id": 999, "outcome": "rejected",
                  "created_at": "2026-04-19T09:00:00+00:00",
                  "soulseek_username": "newestuser",
                  "actual_filetype": "mp3", "actual_min_bitrate": 192,
                  "beets_scenario": "high_distance"},
+                # Then an older force_import — this is what's actually on disk.
+                {"id": 900, "outcome": "force_import",
+                 "created_at": "2026-04-10T09:00:00+00:00",
+                 "soulseek_username": "forceuser",
+                 "actual_filetype": "mp3", "actual_min_bitrate": 207,
+                 "beets_scenario": "force_import"},
                 {"id": 800, "outcome": "success",
                  "created_at": "2026-03-10T12:00:00+00:00",
                  "soulseek_username": "olderuser",
@@ -2308,20 +2316,40 @@ class TestWrongMatchesContract(unittest.TestCase):
         }
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
-        latest = group["latest_download"]
+        latest = group["latest_import"]
         self.assertIsNotNone(latest)
-        self.assertEqual(latest["id"], 999)
-        self.assertEqual(latest["outcome"], "rejected")
-        self.assertEqual(latest["soulseek_username"], "newestuser")
+        self.assertEqual(latest["id"], 900,
+                         "Must pick the most recent success/force/manual import, "
+                         "not the newest rejection.")
+        self.assertEqual(latest["outcome"], "force_import")
+        self.assertEqual(latest["soulseek_username"], "forceuser")
 
-    def test_group_latest_download_none_when_batch_empty(self):
-        """Edge case: if the history batch has no entry for a request, latest_download is None."""
+    def test_group_latest_import_none_when_never_imported(self):
+        """Release that has only rejections → latest_import is None."""
+        row = self._row(42, 100, "testuser", "/fi/Test")
+        self.mock_db.get_wrong_matches.return_value = [row]
+        self.mock_db.get_download_history_batch.return_value = {
+            100: [
+                {"id": 999, "outcome": "rejected",
+                 "created_at": "2026-04-19T09:00:00+00:00",
+                 "soulseek_username": "u1"},
+                {"id": 998, "outcome": "timeout",
+                 "created_at": "2026-04-18T09:00:00+00:00",
+                 "soulseek_username": "u2"},
+            ],
+        }
+        status, data = self._get("/api/wrong-matches")
+        group = data["groups"][0]
+        self.assertIsNone(group["latest_import"])
+
+    def test_group_latest_import_none_when_batch_empty(self):
+        """Edge case: no history rows at all → latest_import is None."""
         row = self._row(42, 100, "testuser", "/fi/Test")
         self.mock_db.get_wrong_matches.return_value = [row]
         self.mock_db.get_download_history_batch.return_value = {}
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
-        self.assertIsNone(group["latest_download"])
+        self.assertIsNone(group["latest_import"])
 
     def test_group_dropped_when_no_entries_have_existing_files(self):
         """If every entry's files are gone, the group is excluded from the UI."""

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -136,22 +136,20 @@ function fmtTs(iso) {
 }
 
 /**
- * Render the "Latest activity" header inside an expanded group so the user
- * can see at a glance whether the release is still being actively retried
- * or has already seen a recent success.
+ * Render the "Last import" header inside an expanded group. Shows the most
+ * recent success/force_import/manual_import for the release — i.e. what's
+ * actually on disk — not the newest attempt. A later rejection doesn't
+ * change what beets has.
  * @param {any} d
  * @returns {string}
  */
-function renderLatestDownload(d) {
-  if (!d) return '<div style="color:#555;font-size:0.78em;padding:4px 8px;">No download history.</div>';
-  const outcomeColor = d.outcome === 'success' || d.outcome === 'force_import' || d.outcome === 'manual_import'
-    ? '#6d6'
-    : d.outcome === 'rejected' || d.outcome === 'failed' ? '#f88' : '#da6';
+function renderLatestImport(d) {
+  if (!d) return '<div style="color:#555;font-size:0.78em;padding:4px 8px;">No successful import on disk.</div>';
   const fmtBr = d.actual_filetype ? `${String(d.actual_filetype).toUpperCase()}${d.actual_min_bitrate ? ' ' + d.actual_min_bitrate + 'k' : ''}` : '';
   return `
-    <div style="background:#161616;border-left:3px solid ${outcomeColor};padding:6px 10px;margin:0 0 8px 0;font-size:0.78em;">
+    <div style="background:#161616;border-left:3px solid #6d6;padding:6px 10px;margin:0 0 8px 0;font-size:0.78em;">
       <div style="color:#aaa;">
-        <span style="color:${outcomeColor};font-weight:600;">Latest: ${esc(d.outcome || '?')}</span>
+        <span style="color:#6d6;font-weight:600;">Last import: ${esc(d.outcome || '?')}</span>
         <span style="color:#666;margin-left:8px;">${esc(fmtTs(d.created_at))}</span>
       </div>
       <div style="color:#888;margin-top:2px;">
@@ -195,7 +193,7 @@ function renderGroup(g) {
     </div>`;
 
   const entries = (g.entries || []).map((/** @type {any} */ e) => renderEntry(e)).join('');
-  const latest = renderLatestDownload(g.latest_download);
+  const latest = renderLatestImport(g.latest_import);
 
   // Group-level bulk actions: currently just "Delete All" so the user can
   // clear an entire release's failed_imports without clicking each candidate.

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -184,30 +184,46 @@ def _quality_summary(row: dict[str, object],
     }
 
 
-def _latest_download_summary(row: dict[str, object]) -> dict[str, object] | None:
-    """Compact summary for the expanded view's 'Latest activity' row.
+_IMPORT_SUCCESS_OUTCOMES = ("success", "force_import", "manual_import")
 
-    The DB gives us ``download_log`` rows newest-first per request; we only
-    surface the metadata that fits in a one-line header — id, outcome,
-    timestamp, user, and the actual format/bitrate on disk.
+
+def _latest_import_summary(rows: list[dict[str, object]]
+                           ) -> dict[str, object] | None:
+    """Summary of the last successful import for a request.
+
+    The expanded-group header describes what's currently on disk, not the most
+    recent attempt. A rejection that happened after a successful import
+    doesn't change what beets has — the earlier success is still the
+    authoritative picture. Scan the newest-first history for the first
+    success/force_import/manual_import row and surface its metadata.
+
+    Returns ``None`` when the release has never been successfully imported.
     """
-    if not row:
+    if not rows:
         return None
     from datetime import datetime
-    created_raw = row.get("created_at")
+    picked: dict[str, object] | None = None
+    for row in rows:
+        outcome = row.get("outcome")
+        if isinstance(outcome, str) and outcome in _IMPORT_SUCCESS_OUTCOMES:
+            picked = row
+            break
+    if picked is None:
+        return None
+    created_raw = picked.get("created_at")
     created: str | None = None
     if isinstance(created_raw, datetime):
         created = created_raw.isoformat()
     elif isinstance(created_raw, str):
         created = created_raw
     return {
-        "id": row.get("id"),
-        "outcome": row.get("outcome"),
+        "id": picked.get("id"),
+        "outcome": picked.get("outcome"),
         "created_at": created,
-        "soulseek_username": row.get("soulseek_username"),
-        "actual_filetype": row.get("actual_filetype"),
-        "actual_min_bitrate": row.get("actual_min_bitrate"),
-        "beets_scenario": row.get("beets_scenario"),
+        "soulseek_username": picked.get("soulseek_username"),
+        "actual_filetype": picked.get("actual_filetype"),
+        "actual_min_bitrate": picked.get("actual_min_bitrate"),
+        "beets_scenario": picked.get("beets_scenario"),
     }
 
 
@@ -258,7 +274,7 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
                 "in_library": _is_in_beets(row, beets_info),
                 "pending_count": 0,
                 "entries": [],
-                "latest_download": None,  # filled in after the loop
+                "latest_import": None,  # filled in after the loop
                 **_quality_summary(row, beets_info),
             }
             groups[request_id] = group
@@ -281,16 +297,15 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
         })
         group["pending_count"] = len(entries_list)
 
-    # Enrich each group with the most-recent download_log row for the request.
-    # Reuses the existing batch helper — returns newest-first per request, so
-    # the head of each list is the latest.
+    # Enrich each group with a summary of the last successful import for the
+    # request. Reuses the existing batch helper — returns newest-first per
+    # request — and filters for success/force_import/manual_import so the
+    # header describes what's on disk rather than the latest attempt.
     if order:
         history = pdb.get_download_history_batch(order)
         for rid in order:
             rows_for_req = history.get(rid) or []
-            if rows_for_req:
-                groups[rid]["latest_download"] = _latest_download_summary(
-                    rows_for_req[0])
+            groups[rid]["latest_import"] = _latest_import_summary(rows_for_req)
 
     h._json({"groups": [groups[rid] for rid in order]})
 


### PR DESCRIPTION
## Summary

The expanded-group header on the wrong-matches tab previously rendered the newest `download_log` row regardless of outcome — so a group whose last activity was a rejection would display "Latest: rejected" even though an earlier successful import already put the album on disk. Misleading: what's on disk is what matters.

Renamed the contract field `latest_download` → `latest_import` and filtered the history for the first success / force_import / manual_import row. Returns `None` when the release has never been successfully imported, rendering as "No successful import on disk." in the UI.

## Test plan

- [x] `test_group_latest_import_picks_most_recent_success` — later rejection in history must not mask an earlier `force_import`
- [x] `test_group_latest_import_none_when_never_imported` — all-failures history → None
- [x] `test_group_latest_import_none_when_batch_empty` — empty batch → None
- [x] Full suite: 1820 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)