### PR TITLE
fix(web): hide ghost on-disk quality on wrong-matches card + clear fields on ban-source

### DIFF
--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -220,30 +220,75 @@ class BeetsDB:
         return {r[0] for r in rows}
 
     def check_mbids_detail(self, mbids: list[str]) -> dict[str, dict[str, object]]:
-        """Batch lookup: MBID → {beets_tracks, beets_format, beets_bitrate, beets_samplerate, beets_bitdepth}."""
+        """Batch lookup: release ID → {beets_tracks, beets_format, beets_bitrate, beets_samplerate, beets_bitdepth}.
+
+        Accepts both MusicBrainz UUIDs (matched against ``albums.mb_albumid``)
+        and Discogs numeric IDs (matched against ``albums.discogs_albumid``,
+        which beets stores as an INTEGER). The pipeline DB packs both kinds
+        of identifier into the ``mb_release_id`` column for compatibility,
+        so consumers must be able to round-trip either one back to the
+        right beets column.
+        """
         if not mbids:
             return {}
-        ph = ",".join("?" for _ in mbids)
-        rows = self._conn.execute(
-            f"SELECT a.mb_albumid, "
-            f"  (SELECT COUNT(*) FROM items WHERE album_id = a.id) AS track_count, "
-            f"  (SELECT GROUP_CONCAT(DISTINCT i.format) FROM items i WHERE i.album_id = a.id) AS formats, "
-            f"  (SELECT MIN(i.bitrate) FROM items i WHERE i.album_id = a.id) AS min_bitrate, "
-            f"  (SELECT MIN(i.samplerate) FROM items i WHERE i.album_id = a.id) AS samplerate, "
-            f"  (SELECT MAX(i.bitdepth) FROM items i WHERE i.album_id = a.id) AS bitdepth "
-            f"FROM albums a WHERE a.mb_albumid IN ({ph})", mbids
-        ).fetchall()
+
+        # Split by ID shape: UUID → mb_albumid (TEXT), numeric → discogs_albumid (INTEGER).
+        # Anything else falls through to mb_albumid too — it's the catch-all
+        # TEXT column, and old/synthetic non-UUID strings (manual fixtures,
+        # tests) still round-trip that way.
+        from lib.quality import detect_release_source
+        mb_ids: list[str] = []
+        discogs_ids: list[int] = []
+        for raw in mbids:
+            source = detect_release_source(raw)
+            if source == "discogs":
+                try:
+                    discogs_ids.append(int(raw))
+                except ValueError:
+                    continue
+            else:
+                mb_ids.append(raw)
+
         result: dict[str, dict[str, object]] = {}
-        for r in rows:
-            if r[0] is None:
-                continue
-            result[r[0]] = {
-                "beets_tracks": r[1],
-                "beets_format": r[2],
-                "beets_bitrate": int(r[3] / 1000) if r[3] else None,
-                "beets_samplerate": r[4],
-                "beets_bitdepth": r[5],
-            }
+
+        def _add_rows(rows: list[tuple[object, ...]]) -> None:
+            for r in rows:
+                if r[0] is None:
+                    continue
+                bitrate = r[3]
+                kbps = int(bitrate / 1000) if isinstance(bitrate, (int, float)) else None
+                result[str(r[0])] = {
+                    "beets_tracks": r[1],
+                    "beets_format": r[2],
+                    "beets_bitrate": kbps,
+                    "beets_samplerate": r[4],
+                    "beets_bitdepth": r[5],
+                }
+
+        detail_cols = (
+            "  (SELECT COUNT(*) FROM items WHERE album_id = a.id) AS track_count, "
+            "  (SELECT GROUP_CONCAT(DISTINCT i.format) FROM items i WHERE i.album_id = a.id) AS formats, "
+            "  (SELECT MIN(i.bitrate) FROM items i WHERE i.album_id = a.id) AS min_bitrate, "
+            "  (SELECT MIN(i.samplerate) FROM items i WHERE i.album_id = a.id) AS samplerate, "
+            "  (SELECT MAX(i.bitdepth) FROM items i WHERE i.album_id = a.id) AS bitdepth "
+        )
+
+        if mb_ids:
+            ph = ",".join("?" for _ in mb_ids)
+            _add_rows(self._conn.execute(
+                f"SELECT a.mb_albumid, {detail_cols}"
+                f"FROM albums a WHERE a.mb_albumid IN ({ph})",
+                mb_ids,
+            ).fetchall())
+
+        if discogs_ids:
+            ph = ",".join("?" for _ in discogs_ids)
+            _add_rows(self._conn.execute(
+                f"SELECT a.discogs_albumid, {detail_cols}"
+                f"FROM albums a WHERE a.discogs_albumid IN ({ph})",
+                discogs_ids,
+            ).fetchall())
+
         return result
 
     def search_albums(self, query: str, limit: int = 100) -> list[dict[str, object]]:

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -106,13 +106,17 @@ class BeetsDB:
     def album_exists(self, release_id: str) -> bool:
         """Check if a release is already in the beets library.
 
-        Dispatches by identifier shape so Discogs requests (numeric IDs
-        stored in ``albums.discogs_albumid``, INTEGER) round-trip as
-        reliably as MusicBrainz ones (UUIDs in ``albums.mb_albumid``,
-        TEXT). The pipeline DB packs both kinds into the same
-        ``mb_release_id`` column for compatibility, and downstream
-        callers like ban-source's ``beet remove -d`` depend on this
-        method returning the right answer for both.
+        Dispatches by identifier shape so Discogs requests round-trip as
+        reliably as MusicBrainz ones. Two things complicate the lookup:
+
+        - MusicBrainz UUIDs live in ``albums.mb_albumid`` (TEXT).
+        - Discogs releases live either in ``albums.discogs_albumid``
+          (INTEGER, newer imports) OR in ``albums.mb_albumid`` (TEXT)
+          for legacy libraries imported before the discogs plugin
+          started populating ``discogs_albumid``. ``artist_compare.py``
+          and the webui-primer both acknowledge this duality, so for a
+          numeric ID we have to check both columns or legacy Discogs
+          albums read as "not in beets".
         """
         from lib.quality import detect_release_source
         if detect_release_source(release_id) == "discogs":
@@ -121,8 +125,10 @@ class BeetsDB:
             except ValueError:
                 return False
             row = self._conn.execute(
-                "SELECT 1 FROM albums WHERE discogs_albumid = ?",
-                (numeric,),
+                "SELECT 1 FROM albums "
+                "WHERE discogs_albumid = ? OR mb_albumid = ? "
+                "LIMIT 1",
+                (numeric, release_id),
             ).fetchone()
         else:
             row = self._conn.execute(
@@ -253,10 +259,18 @@ class BeetsDB:
         if not mbids:
             return {}
 
-        # Split by ID shape: UUID → mb_albumid (TEXT), numeric → discogs_albumid (INTEGER).
-        # Anything else falls through to mb_albumid too — it's the catch-all
-        # TEXT column, and old/synthetic non-UUID strings (manual fixtures,
-        # tests) still round-trip that way.
+        # Split by ID shape so each id queries the columns it could possibly
+        # live in:
+        # - UUIDs → ``mb_albumid`` only (UUID format can't land in
+        #   ``discogs_albumid``, which is INTEGER).
+        # - Numerics → both ``discogs_albumid`` (newer imports) and
+        #   ``mb_albumid`` (legacy Discogs imports that predate
+        #   ``discogs_albumid`` being populated). Skipping ``mb_albumid``
+        #   for numerics would silently drop real on-disk matches for
+        #   older libraries — see lib/artist_compare.py and
+        #   docs/webui-primer.md for the duality contract.
+        # - Anything else falls through to ``mb_albumid`` (synthetic
+        #   fixture strings, manual edits).
         from lib.quality import detect_release_source
         mb_ids: list[str] = []
         discogs_ids: list[int] = []
@@ -267,6 +281,9 @@ class BeetsDB:
                     discogs_ids.append(int(raw))
                 except ValueError:
                     continue
+                # Also check mb_albumid as the TEXT value; covers legacy
+                # Discogs imports that stored the numeric ID there.
+                mb_ids.append(raw)
             else:
                 mb_ids.append(raw)
 

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -103,11 +103,11 @@ class BeetsDB:
             return raw.decode("utf-8", errors="replace")
         return str(raw)
 
-    def album_exists(self, release_id: str) -> bool:
-        """Check if a release is already in the beets library.
+    def _lookup_album_id(self, release_id: str) -> Optional[int]:
+        """Resolve a pipeline ``mb_release_id`` back to ``albums.id``.
 
-        Dispatches by identifier shape so Discogs requests round-trip as
-        reliably as MusicBrainz ones. Two things complicate the lookup:
+        Centralises the shape-aware dispatch that every album lookup in
+        this class needs. Two things complicate the mapping:
 
         - MusicBrainz UUIDs live in ``albums.mb_albumid`` (TEXT).
         - Discogs releases live either in ``albums.discogs_albumid``
@@ -116,26 +116,39 @@ class BeetsDB:
           started populating ``discogs_albumid``. ``artist_compare.py``
           and the webui-primer both acknowledge this duality, so for a
           numeric ID we have to check both columns or legacy Discogs
-          albums read as "not in beets".
+          albums read as "not in beets" — and then postflight lookups
+          like ``get_album_info`` / ``get_album_path`` also miss them,
+          breaking the import quality pipeline for those releases.
+
+        Returns the resolved ``albums.id`` or ``None`` if no row matches.
         """
         from lib.quality import detect_release_source
         if detect_release_source(release_id) == "discogs":
             try:
                 numeric = int(release_id)
             except ValueError:
-                return False
+                return None
             row = self._conn.execute(
-                "SELECT 1 FROM albums "
+                "SELECT id FROM albums "
                 "WHERE discogs_albumid = ? OR mb_albumid = ? "
                 "LIMIT 1",
                 (numeric, release_id),
             ).fetchone()
         else:
             row = self._conn.execute(
-                "SELECT 1 FROM albums WHERE mb_albumid = ?",
+                "SELECT id FROM albums WHERE mb_albumid = ?",
                 (release_id,),
             ).fetchone()
-        return row is not None
+        return row[0] if row else None
+
+    def album_exists(self, release_id: str) -> bool:
+        """Check if a release is already in the beets library.
+
+        Thin wrapper over ``_lookup_album_id``. See that helper for the
+        full ID-shape contract (MusicBrainz UUID → ``mb_albumid``,
+        Discogs numeric → ``discogs_albumid`` OR legacy ``mb_albumid``).
+        """
+        return self._lookup_album_id(release_id) is not None
 
     def get_album_info(
         self,
@@ -144,19 +157,16 @@ class BeetsDB:
     ) -> Optional[AlbumInfo]:
         """Get full album info for quality gate / postflight verification.
 
-        Returns None if the MBID isn't in beets or has no tracks.
+        Returns None if the release isn't in beets or has no tracks.
 
         Mixed-format albums (rare: manually merged albums with tracks in
         multiple codecs) are reduced to a single canonical format using
         ``cfg.mixed_format_precedence`` — the worst codec in that tuple wins
         so the rank stays conservative.
         """
-        album_row = self._conn.execute(
-            "SELECT id FROM albums WHERE mb_albumid = ?", (mb_release_id,)
-        ).fetchone()
-        if not album_row:
+        album_id = self._lookup_album_id(mb_release_id)
+        if album_id is None:
             return None
-        album_id: int = album_row[0]
 
         # Get bitrate + format stats (exclude 0-bitrate tracks)
         rows = self._conn.execute(
@@ -198,15 +208,13 @@ class BeetsDB:
         )
 
     def get_min_bitrate(self, mb_release_id: str) -> Optional[int]:
-        """Get min track bitrate (kbps) for an MBID. Returns None if not found."""
-        album_row = self._conn.execute(
-            "SELECT id FROM albums WHERE mb_albumid = ?", (mb_release_id,)
-        ).fetchone()
-        if not album_row:
+        """Get min track bitrate (kbps) for a release. Returns None if not found."""
+        album_id = self._lookup_album_id(mb_release_id)
+        if album_id is None:
             return None
         br_row = self._conn.execute(
             "SELECT MIN(bitrate) FROM items WHERE album_id = ? AND bitrate > 0",
-            (album_row[0],)
+            (album_id,)
         ).fetchone()
         if not br_row or not br_row[0]:
             return None
@@ -214,21 +222,22 @@ class BeetsDB:
 
     def get_item_paths(self, mb_release_id: str) -> list[tuple[int, str]]:
         """Get all (item_id, path) pairs for an album. Returns empty list if not found."""
-        album_row = self._conn.execute(
-            "SELECT id FROM albums WHERE mb_albumid = ?", (mb_release_id,)
-        ).fetchone()
-        if not album_row:
+        album_id = self._lookup_album_id(mb_release_id)
+        if album_id is None:
             return []
         rows = self._conn.execute(
-            "SELECT id, path FROM items WHERE album_id = ?", (album_row[0],)
+            "SELECT id, path FROM items WHERE album_id = ?", (album_id,)
         ).fetchall()
         return [(r[0], self._decode_path(r[1])) for r in rows]
 
     def get_album_path(self, mb_release_id: str) -> Optional[str]:
         """Get the directory path for an album's tracks. Returns None if not found."""
+        album_id = self._lookup_album_id(mb_release_id)
+        if album_id is None:
+            return None
         row = self._conn.execute(
-            "SELECT (SELECT path FROM items WHERE album_id = a.id LIMIT 1) "
-            "FROM albums a WHERE a.mb_albumid = ?", (mb_release_id,)
+            "SELECT path FROM items WHERE album_id = ? LIMIT 1",
+            (album_id,)
         ).fetchone()
         if not row or not row[0]:
             return None

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -103,11 +103,32 @@ class BeetsDB:
             return raw.decode("utf-8", errors="replace")
         return str(raw)
 
-    def album_exists(self, mb_release_id: str) -> bool:
-        """Check if an MBID is already in the beets library."""
-        row = self._conn.execute(
-            "SELECT 1 FROM albums WHERE mb_albumid = ?", (mb_release_id,)
-        ).fetchone()
+    def album_exists(self, release_id: str) -> bool:
+        """Check if a release is already in the beets library.
+
+        Dispatches by identifier shape so Discogs requests (numeric IDs
+        stored in ``albums.discogs_albumid``, INTEGER) round-trip as
+        reliably as MusicBrainz ones (UUIDs in ``albums.mb_albumid``,
+        TEXT). The pipeline DB packs both kinds into the same
+        ``mb_release_id`` column for compatibility, and downstream
+        callers like ban-source's ``beet remove -d`` depend on this
+        method returning the right answer for both.
+        """
+        from lib.quality import detect_release_source
+        if detect_release_source(release_id) == "discogs":
+            try:
+                numeric = int(release_id)
+            except ValueError:
+                return False
+            row = self._conn.execute(
+                "SELECT 1 FROM albums WHERE discogs_albumid = ?",
+                (numeric,),
+            ).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT 1 FROM albums WHERE mb_albumid = ?",
+                (release_id,),
+            ).fetchone()
         return row is not None
 
     def get_album_info(

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -221,6 +221,33 @@ class PipelineDB:
         """Write spectral state pairs together, including explicit NULLs."""
         self.update_request_fields(request_id, **update.as_update_fields())
 
+    def clear_on_disk_quality_fields(self, request_id: int) -> None:
+        """Zero fields that describe files currently on disk in beets.
+
+        Call this whenever an album leaves the beets library — ban-source
+        followed by ``beet remove -d``, a manual ``beet rm``, etc. The
+        fields cleared describe on-disk state: ``verified_lossless`` (set
+        only after a genuine FLAC→V0 chain) and ``current_spectral_*``
+        (spectral grade of files currently in beets).
+
+        ``min_bitrate`` and ``prev_min_bitrate`` are preserved deliberately
+        — they still act as a conservative baseline for the next quality-
+        gate comparison. ``last_download_spectral_*`` is also preserved:
+        that's an audit field describing the most recent download attempt,
+        independent of whether the result made it onto disk.
+        """
+        now = datetime.now(timezone.utc)
+        self._execute(
+            """UPDATE album_requests SET
+                   verified_lossless = FALSE,
+                   current_spectral_grade = NULL,
+                   current_spectral_bitrate = NULL,
+                   updated_at = %s
+               WHERE id = %s""",
+            (now, request_id),
+        )
+        self.conn.commit()
+
     def reset_to_wanted(self, request_id: int, **fields: Any) -> None:
         """Reset to wanted, clearing retry counters.
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -226,9 +226,15 @@ class PipelineDB:
 
         Call this whenever an album leaves the beets library — ban-source
         followed by ``beet remove -d``, a manual ``beet rm``, etc. The
-        fields cleared describe on-disk state: ``verified_lossless`` (set
-        only after a genuine FLAC→V0 chain) and ``current_spectral_*``
-        (spectral grade of files currently in beets).
+        fields cleared describe on-disk state:
+
+        - ``verified_lossless`` (set only after a genuine FLAC→V0 chain)
+        - ``current_spectral_*`` (spectral grade of files currently in
+          beets)
+        - ``imported_path`` (beets filesystem path for the release, shown
+          directly by the web UI — leaving it populated after a remove
+          means the pipeline tab still claims the album is imported at a
+          path that has just been deleted)
 
         ``min_bitrate`` and ``prev_min_bitrate`` are preserved deliberately
         — they still act as a conservative baseline for the next quality-
@@ -242,6 +248,7 @@ class PipelineDB:
                    verified_lossless = FALSE,
                    current_spectral_grade = NULL,
                    current_spectral_bitrate = NULL,
+                   imported_path = NULL,
                    updated_at = %s
                WHERE id = %s""",
             (now, request_id),

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -429,6 +429,7 @@ class FakePipelineDB:
         row["verified_lossless"] = False
         row["current_spectral_grade"] = None
         row["current_spectral_bitrate"] = None
+        row["imported_path"] = None
         row["updated_at"] = _utcnow()
 
     def get_downloading(self) -> list[dict[str, Any]]:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -422,6 +422,15 @@ class FakePipelineDB:
             row.update(fields)
             row["updated_at"] = _utcnow()
 
+    def clear_on_disk_quality_fields(self, request_id: int) -> None:
+        row = self._requests.get(request_id)
+        if row is None:
+            return
+        row["verified_lossless"] = False
+        row["current_spectral_grade"] = None
+        row["current_spectral_bitrate"] = None
+        row["updated_at"] = _utcnow()
+
     def get_downloading(self) -> list[dict[str, Any]]:
         return [copy.deepcopy(r) for r in self._requests.values()
                 if r.get("status") == "downloading"]

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -155,6 +155,24 @@ class TestAlbumExists(unittest.TestCase):
         with BeetsDB(self.db_path) as db:
             self.assertFalse(db.album_exists("xyz-999"))
 
+    def test_discogs_id_matches_discogs_albumid(self) -> None:
+        """Discogs-backed requests pack a numeric ID into ``mb_release_id``
+        that beets actually stores in ``albums.discogs_albumid``. The
+        existence check must dispatch on ID shape, otherwise a
+        Discogs-imported album reads as 'not in beets' and ban-source
+        skips the ``beet remove -d`` altogether.
+        """
+        _insert_album_full(self.db_path, 99, "", [
+            {"bitrate": 1411000, "path": "/m/disc/01.flac", "format": "FLAC",
+             "samplerate": 44100, "bitdepth": 16},
+        ], discogs_albumid=12856590)
+
+        with BeetsDB(self.db_path) as db:
+            self.assertTrue(db.album_exists("12856590"),
+                            "Discogs numeric ID must resolve via discogs_albumid.")
+            self.assertFalse(db.album_exists("999"),
+                             "Unmatched numeric ID must return False.")
+
 
 class TestGetAlbumInfo(unittest.TestCase):
     """Test get_album_info (postflight verify + quality gate data)."""

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -34,7 +34,7 @@ def _create_test_db(path: str) -> None:
             release_group_title TEXT,
             format TEXT,
             artpath BLOB,
-            discogs_albumid TEXT,
+            discogs_albumid INTEGER,
             mb_albumartistid TEXT,
             mb_albumartistids TEXT
         );
@@ -503,6 +503,43 @@ class TestCheckMbidsDetail(unittest.TestCase):
         with BeetsDB(self.db_path) as db:
             detail = db.check_mbids_detail(["zzz-999"])
         self.assertEqual(detail, {})
+
+    def test_discogs_numeric_id_matches_discogs_albumid(self) -> None:
+        """Discogs-sourced releases are stored in beets under
+        ``albums.discogs_albumid`` (INTEGER), not ``mb_albumid``. The
+        pipeline DB packs both kinds of identifier into ``mb_release_id``
+        — a UUID for MusicBrainz, a numeric string for Discogs — so the
+        detail lookup must round-trip the numeric string back to the
+        right beets column. Without this, Discogs wrong-matches lose
+        their quality summary and regress to "nothing on disk".
+        """
+        _insert_album_full(self.db_path, 10, "", [
+            {"bitrate": 1411000, "path": "/m/disc/01.flac", "format": "FLAC",
+             "samplerate": 44100, "bitdepth": 16},
+        ], discogs_albumid=12856590)
+
+        with BeetsDB(self.db_path) as db:
+            detail = db.check_mbids_detail(["12856590"])
+
+        self.assertIn("12856590", detail)
+        self.assertEqual(detail["12856590"]["beets_tracks"], 1)
+        self.assertEqual(detail["12856590"]["beets_format"], "FLAC")
+
+    def test_mixed_mbid_and_discogs_ids(self) -> None:
+        """A single batch can contain both UUID and numeric IDs — e.g.
+        the web UI renders a grid that contains both sources at once.
+        """
+        _insert_album_full(self.db_path, 11, "", [
+            {"bitrate": 320000, "path": "/m/disc/01.mp3", "format": "MP3",
+             "samplerate": 44100, "bitdepth": 0},
+        ], discogs_albumid=99)
+
+        with BeetsDB(self.db_path) as db:
+            detail = db.check_mbids_detail(["aaa-111", "99"])
+
+        self.assertIn("aaa-111", detail)
+        self.assertIn("99", detail)
+        self.assertEqual(detail["99"]["beets_format"], "MP3")
 
 
 class TestSearchAlbums(unittest.TestCase):

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -192,6 +192,59 @@ class TestAlbumExists(unittest.TestCase):
                             "Legacy numeric mb_albumid must still resolve.")
 
 
+class TestPostflightLookupsSupportDiscogs(unittest.TestCase):
+    """Regression guard: ``album_exists`` understands Discogs IDs, so the
+    postflight lookups called during import (``get_album_info``,
+    ``get_min_bitrate``, ``get_album_path``, ``get_item_paths``) must
+    agree — otherwise ``import_dispatch`` sees a preflight hit with an
+    empty postflight, marks the import successful against vanished
+    metadata, and persists a stale ``imported_path``.
+    """
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        _create_test_db(self.db_path)
+        # New-layout Discogs entry (numeric in discogs_albumid).
+        _insert_album_full(self.db_path, 1, "", [
+            {"bitrate": 320000, "path": "/m/disc/01.mp3", "format": "MP3",
+             "samplerate": 44100, "bitdepth": 0},
+            {"bitrate": 256000, "path": "/m/disc/02.mp3", "format": "MP3",
+             "samplerate": 44100, "bitdepth": 0},
+        ], discogs_albumid=12856590)
+        # Legacy-layout Discogs entry (numeric in mb_albumid).
+        _insert_album_full(self.db_path, 2, "5555555", [
+            {"bitrate": 1411000, "path": "/m/legacy/01.flac", "format": "FLAC",
+             "samplerate": 44100, "bitdepth": 16},
+        ])
+
+    def test_get_min_bitrate_resolves_discogs(self) -> None:
+        with BeetsDB(self.db_path) as db:
+            self.assertEqual(db.get_min_bitrate("12856590"), 256)
+            self.assertEqual(db.get_min_bitrate("5555555"), 1411)
+
+    def test_get_album_path_resolves_discogs(self) -> None:
+        with BeetsDB(self.db_path) as db:
+            self.assertEqual(db.get_album_path("12856590"), "/m/disc")
+            self.assertEqual(db.get_album_path("5555555"), "/m/legacy")
+
+    def test_get_item_paths_resolves_discogs(self) -> None:
+        with BeetsDB(self.db_path) as db:
+            paths = db.get_item_paths("12856590")
+        self.assertEqual(len(paths), 2)
+        self.assertTrue(all(p.startswith("/m/disc/") for _, p in paths))
+
+    def test_get_album_info_resolves_discogs(self) -> None:
+        from lib.quality import QualityRankConfig
+        cfg = QualityRankConfig.defaults()
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("12856590", cfg)
+        self.assertIsNotNone(info)
+        assert info is not None
+        self.assertEqual(info.track_count, 2)
+        self.assertEqual(info.min_bitrate_kbps, 256)
+
+
 class TestGetAlbumInfo(unittest.TestCase):
     """Test get_album_info (postflight verify + quality gate data)."""
 

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -173,6 +173,24 @@ class TestAlbumExists(unittest.TestCase):
             self.assertFalse(db.album_exists("999"),
                              "Unmatched numeric ID must return False.")
 
+    def test_discogs_id_matches_legacy_mb_albumid(self) -> None:
+        """Legacy beets libraries (imported before the Discogs plugin started
+        populating ``discogs_albumid``) stored Discogs numeric IDs as
+        TEXT in ``mb_albumid``. ``lib/artist_compare.py`` and the
+        webui-primer explicitly document this duality, so the existence
+        check must fall back to ``mb_albumid`` for numeric IDs too —
+        otherwise ban-source / status-reset skip ``beet remove`` for
+        those albums and the Discogs copy lingers forever.
+        """
+        _insert_album_full(self.db_path, 88, "5555555", [
+            {"bitrate": 1411000, "path": "/m/legacy/01.flac", "format": "FLAC",
+             "samplerate": 44100, "bitdepth": 16},
+        ])
+
+        with BeetsDB(self.db_path) as db:
+            self.assertTrue(db.album_exists("5555555"),
+                            "Legacy numeric mb_albumid must still resolve.")
+
 
 class TestGetAlbumInfo(unittest.TestCase):
     """Test get_album_info (postflight verify + quality gate data)."""
@@ -558,6 +576,25 @@ class TestCheckMbidsDetail(unittest.TestCase):
         self.assertIn("aaa-111", detail)
         self.assertIn("99", detail)
         self.assertEqual(detail["99"]["beets_format"], "MP3")
+
+    def test_legacy_discogs_numeric_in_mb_albumid(self) -> None:
+        """Legacy Discogs imports stored the numeric ID as TEXT in
+        ``mb_albumid``; ``check_mbids_detail`` must still return those
+        rows so the web UI doesn't blank real quality data (and then
+        render "different edition on disk" for a release that's
+        actually the exact pressing on disk).
+        """
+        _insert_album_full(self.db_path, 12, "5555555", [
+            {"bitrate": 1411000, "path": "/m/legacy/01.flac", "format": "FLAC",
+             "samplerate": 44100, "bitdepth": 16},
+        ])
+
+        with BeetsDB(self.db_path) as db:
+            detail = db.check_mbids_detail(["5555555"])
+
+        self.assertIn("5555555", detail)
+        self.assertEqual(detail["5555555"]["beets_format"], "FLAC")
+        self.assertEqual(detail["5555555"]["beets_bitdepth"], 16)
 
 
 class TestSearchAlbums(unittest.TestCase):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -73,6 +73,34 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertEqual(row["current_spectral_grade"], "genuine")
         self.assertIsNone(row["current_spectral_bitrate"])
 
+    def test_clear_on_disk_quality_fields_matches_real_db(self):
+        """FakePipelineDB must mirror PipelineDB.clear_on_disk_quality_fields:
+        zero the on-disk spectral + verified_lossless, preserve min_bitrate
+        and last_download_spectral_* (those aren't on-disk state).
+        """
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            min_bitrate=320,
+            verified_lossless=True,
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=160,
+            last_download_spectral_grade="suspect",
+            last_download_spectral_bitrate=192,
+        ))
+
+        db.clear_on_disk_quality_fields(42)
+
+        row = db.request(42)
+        self.assertFalse(row["verified_lossless"])
+        self.assertIsNone(row["current_spectral_grade"])
+        self.assertIsNone(row["current_spectral_bitrate"])
+        # min_bitrate preserved as baseline for next gate.
+        self.assertEqual(row["min_bitrate"], 320)
+        # Recent download's spectral is an audit trail, not on-disk state.
+        self.assertEqual(row["last_download_spectral_grade"], "suspect")
+        self.assertEqual(row["last_download_spectral_bitrate"], 192)
+
     def test_get_downloading(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1, status="downloading"))

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -75,8 +75,9 @@ class TestFakePipelineDB(unittest.TestCase):
 
     def test_clear_on_disk_quality_fields_matches_real_db(self):
         """FakePipelineDB must mirror PipelineDB.clear_on_disk_quality_fields:
-        zero the on-disk spectral + verified_lossless, preserve min_bitrate
-        and last_download_spectral_* (those aren't on-disk state).
+        zero the on-disk spectral + verified_lossless + imported_path,
+        preserve min_bitrate and last_download_spectral_* (those aren't
+        on-disk state).
         """
         db = FakePipelineDB()
         db.seed_request(make_request_row(
@@ -87,6 +88,7 @@ class TestFakePipelineDB(unittest.TestCase):
             current_spectral_bitrate=160,
             last_download_spectral_grade="suspect",
             last_download_spectral_bitrate=192,
+            imported_path="/mnt/virtio/Music/Beets/Stale/Path",
         ))
 
         db.clear_on_disk_quality_fields(42)
@@ -95,6 +97,10 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertFalse(row["verified_lossless"])
         self.assertIsNone(row["current_spectral_grade"])
         self.assertIsNone(row["current_spectral_bitrate"])
+        self.assertIsNone(row["imported_path"],
+                          "imported_path must clear — the web UI renders it "
+                          "directly and a stale path after beet rm is worse "
+                          "than no path at all.")
         # min_bitrate preserved as baseline for next gate.
         self.assertEqual(row["min_bitrate"], 320)
         # Recent download's spectral is an audit trail, not on-disk state.

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -651,6 +651,90 @@ class TestResetToWanted(unittest.TestCase):
 
 
 @requires_postgres
+class TestClearOnDiskQualityFields(unittest.TestCase):
+    """``clear_on_disk_quality_fields`` is the write-side half of the
+    "beets is the source of truth" invariant: once an album leaves beets
+    (ban-source, manual ``beet rm``), every ``album_requests`` field that
+    describes on-disk state must be cleared. Preserves ``min_bitrate`` as
+    a conservative baseline for the next quality-gate comparison, and
+    leaves ``last_download_spectral_*`` alone (that's a download-attempt
+    audit field, not on-disk state).
+    """
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def _make_request(self, suffix: str = "") -> int:
+        req_id = self.db.add_request(
+            mb_release_id=f"clear-od-{suffix}-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        self.db.update_status(req_id, "imported")
+        return req_id
+
+    def test_clears_spectral_and_verified_lossless(self):
+        req_id = self._make_request("basic")
+        self.db.update_request_fields(
+            req_id,
+            verified_lossless=True,
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=160,
+        )
+
+        self.db.clear_on_disk_quality_fields(req_id)
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertFalse(req["verified_lossless"])
+        self.assertIsNone(req["current_spectral_grade"])
+        self.assertIsNone(req["current_spectral_bitrate"])
+
+    def test_preserves_min_bitrate(self):
+        """min_bitrate is a baseline for the NEXT gate, not on-disk state."""
+        req_id = self._make_request("preserve-min")
+        self.db.update_request_fields(req_id, min_bitrate=320)
+
+        self.db.clear_on_disk_quality_fields(req_id)
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["min_bitrate"], 320)
+
+    def test_preserves_last_download_spectral(self):
+        """last_download_* tracks the latest download attempt, not on-disk state."""
+        req_id = self._make_request("preserve-ld")
+        self.db.update_request_fields(
+            req_id,
+            last_download_spectral_grade="suspect",
+            last_download_spectral_bitrate=192,
+        )
+
+        self.db.clear_on_disk_quality_fields(req_id)
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["last_download_spectral_grade"], "suspect")
+        self.assertEqual(req["last_download_spectral_bitrate"], 192)
+
+    def test_idempotent_when_fields_already_clear(self):
+        req_id = self._make_request("idempotent")
+
+        self.db.clear_on_disk_quality_fields(req_id)
+        self.db.clear_on_disk_quality_fields(req_id)
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertFalse(req["verified_lossless"])
+        self.assertIsNone(req["current_spectral_grade"])
+        self.assertIsNone(req["current_spectral_bitrate"])
+
+
+@requires_postgres
 class TestApplyTransitionDB(unittest.TestCase):
     """DB-backed contract tests for apply_transition preserve semantics."""
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -694,6 +694,24 @@ class TestClearOnDiskQualityFields(unittest.TestCase):
         self.assertIsNone(req["current_spectral_grade"])
         self.assertIsNone(req["current_spectral_bitrate"])
 
+    def test_clears_imported_path(self):
+        """After ``beet remove -d`` the on-disk path is stale — the pipeline
+        tab renders ``imported_path`` directly, so leaving it populated
+        would claim the album is imported at a directory that has just
+        been deleted.
+        """
+        req_id = self._make_request("path")
+        self.db.update_request_fields(
+            req_id,
+            imported_path="/mnt/virtio/Music/Beets/Stale/Path",
+        )
+
+        self.db.clear_on_disk_quality_fields(req_id)
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertIsNone(req["imported_path"])
+
     def test_preserves_min_bitrate(self):
         """min_bitrate is a baseline for the NEXT gate, not on-disk state."""
         req_id = self._make_request("preserve-min")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1437,6 +1437,37 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.mock_db.clear_on_disk_quality_fields.assert_not_called()
 
+    @patch("subprocess.run")
+    @patch("web.routes.pipeline.apply_transition")
+    def test_ban_source_uses_discogs_selector_for_numeric_id(
+            self, _mock_transition, mock_subprocess):
+        """Discogs-backed requests carry a numeric ID. ``beet remove -d``
+        must target ``discogs_albumid:`` for those, otherwise it runs a
+        no-op ``mb_albumid:12345`` query while the Discogs copy stays on
+        disk — the source gets denylisted but the library never loses
+        the album and the pipeline clean-up branch never fires.
+        """
+        self.mock_db.clear_on_disk_quality_fields.reset_mock()
+        mock_subprocess.return_value = MagicMock(
+            returncode=0, stdout="", stderr="")
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id="12856590",
+            min_bitrate=320,
+        )
+        self._beets.album_exists.return_value = True
+
+        status, _data = self._post("/api/pipeline/ban-source", {
+            "request_id": 1704, "username": "baduser",
+            "mb_release_id": "12856590",
+        })
+
+        self.assertEqual(status, 200)
+        called_argv = mock_subprocess.call_args.args[0]
+        self.assertIn("discogs_albumid:12856590", called_argv,
+                      "Discogs numeric ID must use the discogs_albumid "
+                      "beets selector, not mb_albumid.")
+        self.assertNotIn("mb_albumid:12856590", called_argv)
+
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_skips_clear_when_mbid_missing(self, _mock_transition):
         """Without ``mb_release_id`` we never query beets and never run

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1476,6 +1476,42 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                       "Must also attempt the legacy mb_albumid selector "
                       "so older beets libraries don't regress.")
 
+    @patch("subprocess.run")
+    @patch("web.routes.pipeline.apply_transition")
+    def test_ban_source_clears_stale_state_when_album_already_gone(
+            self, _mock_transition, mock_subprocess):
+        """Ghost state can pre-date the handler: a user runs
+        ``beet rm mb_albumid:X`` manually, then days later bans the
+        source. ``album_exists`` returns False before ban-source even
+        starts, so no ``beet remove`` runs — but the pipeline DB still
+        carries the old ``current_spectral_*`` / ``imported_path``.
+        The handler must still clear those fields so ``dispatch_import``
+        doesn't keep deriving ``--override-min-bitrate`` from phantom
+        baselines on the next import attempt.
+        """
+        self.mock_db.clear_on_disk_quality_fields.reset_mock()
+        mock_subprocess.return_value = MagicMock(
+            returncode=0, stdout="", stderr="")
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id=self.RELEASE_ID,
+            min_bitrate=320,
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=160,
+            imported_path="/mnt/virtio/Music/Beets/Stale/Path",
+        )
+        # Album was already gone when ban-source ran (earlier beet rm).
+        self._beets.album_exists.return_value = False
+
+        status, _data = self._post("/api/pipeline/ban-source", {
+            "request_id": 1704, "username": "baduser",
+            "mb_release_id": self.RELEASE_ID,
+        })
+
+        self.assertEqual(status, 200)
+        self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
+        # No remove ran — the handler had nothing to remove.
+        mock_subprocess.assert_not_called()
+
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_skips_clear_when_mbid_missing(self, _mock_transition):
         """Without ``mb_release_id`` we never query beets and never run

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2239,7 +2239,7 @@ class TestWrongMatchesContract(unittest.TestCase):
     def _row(self, download_log_id: int, request_id: int, username: str,
              failed_path: str, artist: str = "Test Artist",
              album: str = "Test Album",
-             mb_release_id: str = "abc-123",
+             mb_release_id: str | None = "abc-123",
              scenario: str = "high_distance") -> dict:
         row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
         row["download_log_id"] = download_log_id
@@ -2434,6 +2434,32 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertFalse(group["verified_lossless"])
         self.assertIsNone(group["quality_label"])
         self.assertIsNone(group["quality_rank"])
+
+    @patch("web.server.check_beets_by_artist_album", return_value=12)
+    @patch("web.server.check_beets_library_detail", return_value={})
+    def test_group_shows_quality_for_mbidless_request_via_fuzzy(
+            self, _mock_detail, _mock_fuzzy):
+        """Requests with no MBID can't be pinpointed to a specific pressing,
+        so fuzzy presence IS the best on-disk signal we have. The quality
+        summary must fall back to the fuzzy result and keep reporting the
+        pipeline DB's quality fields — blanking them would mislabel a real
+        on-disk album as absent and invite duplicate force-imports.
+        """
+        row = self._row(42, 100, "testuser", "/fi/Test", mb_release_id=None)
+        row["request_status"] = "imported"
+        row["request_min_bitrate"] = 245
+        row["request_verified_lossless"] = True
+        row["request_current_spectral_grade"] = "genuine"
+        self.mock_db.get_wrong_matches.return_value = [row]
+
+        status, data = self._get("/api/wrong-matches")
+        self.assertEqual(status, 200)
+        group = data["groups"][0]
+        self.assertTrue(group["in_library"])
+        # MBID absent + fuzzy present → trust the DB's on-disk quality.
+        self.assertEqual(group["min_bitrate"], 245)
+        self.assertTrue(group["verified_lossless"])
+        self.assertEqual(group["current_spectral_grade"], "genuine")
 
     def test_group_latest_import_picks_most_recent_success(self):
         """latest_import shows the last successful import, not the newest attempt.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2440,20 +2440,27 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertFalse(group["verified_lossless"],
                          "verified_lossless must read False when nothing is on disk.")
 
-    @patch("web.server.check_beets_by_artist_album", return_value=20)
+    @patch("web.server.check_beets_by_artist_album", return_value=12)
     @patch("web.server.check_beets_library_detail", return_value={})
-    def test_group_hides_stale_quality_when_only_fuzzy_match(
+    def test_group_shows_quality_when_fuzzy_match_only(
             self, _mock_detail, _mock_fuzzy):
-        """Multiple pressings of the same album are kept intentionally, so a
-        fuzzy artist/album match in beets does NOT mean *this* exact MB
-        release is on disk. The quality summary describes the specific
-        pressing — if the exact MBID isn't in beets, the fields must still
-        be zeroed even when ``in_library`` reads True from the fallback.
+        """Legacy / untagged beets entries still have their files on disk
+        — only the MBID tag is missing. ``_is_in_beets`` falls back to
+        a fuzzy artist/album lookup for that case, and the quality
+        summary must honour the same signal: blanking the pipeline DB's
+        real ``min_bitrate`` / ``verified_lossless`` would mislabel a
+        genuinely on-disk album as absent and push users toward
+        unnecessary force-imports.
+
+        The original multi-pressing concern is handled on the write
+        side — ``post_pipeline_ban_source`` clears on-disk quality
+        fields after a successful ``beet remove``, so a sibling
+        pressing can't leak ghost data through the fuzzy fallback.
         """
         row = self._row(42, 100, "testuser", "/fi/Test",
                          mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-        row["request_status"] = "wanted"
-        row["request_min_bitrate"] = 320
+        row["request_status"] = "imported"
+        row["request_min_bitrate"] = 245
         row["request_verified_lossless"] = True
         row["request_current_spectral_grade"] = "genuine"
         row["request_current_spectral_bitrate"] = None
@@ -2462,17 +2469,10 @@ class TestWrongMatchesContract(unittest.TestCase):
         status, data = self._get("/api/wrong-matches")
         self.assertEqual(status, 200)
         group = data["groups"][0]
-        # Fuzzy fallback finds *some* edition → in_library badge is correct.
         self.assertTrue(group["in_library"])
-        # …but this exact pressing isn't on disk, so the quality summary
-        # must blank out every on-disk field. Otherwise the removed
-        # pressing's ghost quality leaks through despite the edge case.
-        self.assertIsNone(group["min_bitrate"])
-        self.assertIsNone(group["current_spectral_grade"])
-        self.assertIsNone(group["current_spectral_bitrate"])
-        self.assertFalse(group["verified_lossless"])
-        self.assertIsNone(group["quality_label"])
-        self.assertIsNone(group["quality_rank"])
+        self.assertEqual(group["min_bitrate"], 245)
+        self.assertTrue(group["verified_lossless"])
+        self.assertEqual(group["current_spectral_grade"], "genuine")
 
     @patch("web.server.check_beets_by_artist_album", return_value=12)
     @patch("web.server.check_beets_library_detail", return_value={})

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1437,6 +1437,29 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.mock_db.clear_on_disk_quality_fields.assert_not_called()
 
+    @patch("web.routes.pipeline.apply_transition")
+    def test_ban_source_skips_clear_when_mbid_missing(self, _mock_transition):
+        """Without ``mb_release_id`` we never query beets and never run
+        ``beet remove``, so there's no positive evidence the album is gone.
+        Clearing the on-disk quality fields anyway would erase state for
+        albums that are still in the library.
+        """
+        self.mock_db.clear_on_disk_quality_fields.reset_mock()
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported",
+            min_bitrate=320,
+            current_spectral_grade="genuine",
+            verified_lossless=True,
+        )
+
+        status, _data = self._post("/api/pipeline/ban-source", {
+            "request_id": 1704, "username": "baduser",
+            # No mb_release_id.
+        })
+
+        self.assertEqual(status, 200)
+        self.mock_db.clear_on_disk_quality_fields.assert_not_called()
+
 
 class TestManualImportRouteContracts(_WebServerCase):
     """Contract tests for manual import routes."""
@@ -2377,6 +2400,40 @@ class TestWrongMatchesContract(unittest.TestCase):
                           "current_spectral_bitrate must not leak from stale DB.")
         self.assertFalse(group["verified_lossless"],
                          "verified_lossless must read False when nothing is on disk.")
+
+    @patch("web.server.check_beets_by_artist_album", return_value=20)
+    @patch("web.server.check_beets_library_detail", return_value={})
+    def test_group_hides_stale_quality_when_only_fuzzy_match(
+            self, _mock_detail, _mock_fuzzy):
+        """Multiple pressings of the same album are kept intentionally, so a
+        fuzzy artist/album match in beets does NOT mean *this* exact MB
+        release is on disk. The quality summary describes the specific
+        pressing — if the exact MBID isn't in beets, the fields must still
+        be zeroed even when ``in_library`` reads True from the fallback.
+        """
+        row = self._row(42, 100, "testuser", "/fi/Test",
+                         mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        row["request_status"] = "wanted"
+        row["request_min_bitrate"] = 320
+        row["request_verified_lossless"] = True
+        row["request_current_spectral_grade"] = "genuine"
+        row["request_current_spectral_bitrate"] = None
+        self.mock_db.get_wrong_matches.return_value = [row]
+
+        status, data = self._get("/api/wrong-matches")
+        self.assertEqual(status, 200)
+        group = data["groups"][0]
+        # Fuzzy fallback finds *some* edition → in_library badge is correct.
+        self.assertTrue(group["in_library"])
+        # …but this exact pressing isn't on disk, so the quality summary
+        # must blank out every on-disk field. Otherwise the removed
+        # pressing's ghost quality leaks through despite the edge case.
+        self.assertIsNone(group["min_bitrate"])
+        self.assertIsNone(group["current_spectral_grade"])
+        self.assertIsNone(group["current_spectral_bitrate"])
+        self.assertFalse(group["verified_lossless"])
+        self.assertIsNone(group["quality_label"])
+        self.assertIsNone(group["quality_rank"])
 
     def test_group_latest_import_picks_most_recent_success(self):
         """latest_import shows the last successful import, not the newest attempt.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1401,7 +1401,8 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
             current_spectral_bitrate=160,
             verified_lossless=False,
         )
-        self._beets.album_exists.return_value = True
+        # First call: was present. Second call (after remove): gone.
+        self._beets.album_exists.side_effect = [True, False]
 
         status, _data = self._post("/api/pipeline/ban-source", {
             "request_id": 1704, "username": "baduser",
@@ -1415,8 +1416,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_skips_clear_when_beet_remove_failed(
             self, _mock_transition, mock_subprocess):
-        """Conservative: if beets still holds the album (remove failed),
-        the on-disk quality state is still accurate, so don't clear it.
+        """Conservative: if beets still holds the album after the remove
+        attempts (e.g. permissions error, wrong column and no legacy
+        fallback matched), the on-disk quality state is still accurate,
+        so don't clear it. Modelled by ``album_exists`` returning True
+        both before and after the subprocess calls.
         """
         self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
@@ -1427,6 +1431,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
             current_spectral_grade="genuine",
             verified_lossless=True,
         )
+        # Album is still there after the remove attempt.
         self._beets.album_exists.return_value = True
 
         status, _data = self._post("/api/pipeline/ban-source", {
@@ -1442,10 +1447,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     def test_ban_source_uses_discogs_selector_for_numeric_id(
             self, _mock_transition, mock_subprocess):
         """Discogs-backed requests carry a numeric ID. ``beet remove -d``
-        must target ``discogs_albumid:`` for those, otherwise it runs a
-        no-op ``mb_albumid:12345`` query while the Discogs copy stays on
-        disk — the source gets denylisted but the library never loses
-        the album and the pipeline clean-up branch never fires.
+        must try ``discogs_albumid:<id>`` (the new layout) AND
+        ``mb_albumid:<id>`` (the legacy layout documented in
+        artist_compare.py / webui-primer.md), otherwise one of the two
+        layouts goes unremoved and the banned copy stays on disk.
         """
         self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
@@ -1454,7 +1459,8 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
             id=1704, status="imported", mb_release_id="12856590",
             min_bitrate=320,
         )
-        self._beets.album_exists.return_value = True
+        # Was there; after both removes, gone.
+        self._beets.album_exists.side_effect = [True, False]
 
         status, _data = self._post("/api/pipeline/ban-source", {
             "request_id": 1704, "username": "baduser",
@@ -1462,11 +1468,13 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         })
 
         self.assertEqual(status, 200)
-        called_argv = mock_subprocess.call_args.args[0]
-        self.assertIn("discogs_albumid:12856590", called_argv,
-                      "Discogs numeric ID must use the discogs_albumid "
-                      "beets selector, not mb_albumid.")
-        self.assertNotIn("mb_albumid:12856590", called_argv)
+        argvs = [call.args[0] for call in mock_subprocess.call_args_list]
+        flattened = [token for argv in argvs for token in argv]
+        self.assertIn("discogs_albumid:12856590", flattened,
+                      "Must attempt the new-layout selector.")
+        self.assertIn("mb_albumid:12856590", flattened,
+                      "Must also attempt the legacy mb_albumid selector "
+                      "so older beets libraries don't regress.")
 
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_skips_clear_when_mbid_missing(self, _mock_transition):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1378,6 +1378,65 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(self._override_passed(mock_transition), "lossless")
 
+    @patch("subprocess.run")
+    @patch("web.routes.pipeline.apply_transition")
+    def test_ban_source_clears_on_disk_quality_fields(
+            self, _mock_transition, mock_subprocess):
+        """After ``beet remove -d``, pipeline DB must forget on-disk quality.
+
+        ``current_spectral_*`` and ``verified_lossless`` describe files that
+        live in beets. Once the ban flow wipes those files, leaving the
+        fields populated misleads every downstream consumer (wrong-matches
+        UI shows ghost quality, library views, quality gate uses stale
+        baselines). The write-side invariant: remove-from-beets implies
+        clear-on-disk-quality.
+        """
+        self.mock_db.clear_on_disk_quality_fields.reset_mock()
+        mock_subprocess.return_value = MagicMock(
+            returncode=0, stdout="", stderr="")
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id=self.RELEASE_ID,
+            min_bitrate=320,
+            current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=160,
+            verified_lossless=False,
+        )
+        self._beets.album_exists.return_value = True
+
+        status, _data = self._post("/api/pipeline/ban-source", {
+            "request_id": 1704, "username": "baduser",
+            "mb_release_id": self.RELEASE_ID,
+        })
+
+        self.assertEqual(status, 200)
+        self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
+
+    @patch("subprocess.run")
+    @patch("web.routes.pipeline.apply_transition")
+    def test_ban_source_skips_clear_when_beet_remove_failed(
+            self, _mock_transition, mock_subprocess):
+        """Conservative: if beets still holds the album (remove failed),
+        the on-disk quality state is still accurate, so don't clear it.
+        """
+        self.mock_db.clear_on_disk_quality_fields.reset_mock()
+        mock_subprocess.return_value = MagicMock(
+            returncode=1, stdout="", stderr="beet failed")
+        self.mock_db.get_request.return_value = make_request_row(
+            id=1704, status="imported", mb_release_id=self.RELEASE_ID,
+            min_bitrate=320,
+            current_spectral_grade="genuine",
+            verified_lossless=True,
+        )
+        self._beets.album_exists.return_value = True
+
+        status, _data = self._post("/api/pipeline/ban-source", {
+            "request_id": 1704, "username": "baduser",
+            "mb_release_id": self.RELEASE_ID,
+        })
+
+        self.assertEqual(status, 200)
+        self.mock_db.clear_on_disk_quality_fields.assert_not_called()
+
 
 class TestManualImportRouteContracts(_WebServerCase):
     """Contract tests for manual import routes."""
@@ -2285,6 +2344,39 @@ class TestWrongMatchesContract(unittest.TestCase):
         # No on-disk state → label and rank may be None; the frontend can render
         # a 'not on disk' badge from `status` and absent label.
         self.assertTrue(group["quality_label"] is None or isinstance(group["quality_label"], str))
+
+    def test_group_hides_stale_quality_when_not_in_beets(self):
+        """Pipeline DB can hold stale on-disk fields after beet remove.
+
+        After a ban-source path, ``album_requests`` rows can keep the
+        ``min_bitrate`` / ``current_spectral_*`` values from a prior import
+        even though ``beet remove -d`` has wiped the files. The wrong-matches
+        card must not surface those ghost fields — otherwise the user sees
+        "320k likely_transcode" for a release with nothing on disk and
+        force-imports based on false quality data.
+        """
+        row = self._row(42, 100, "testuser", "/fi/Test")
+        row["request_status"] = "wanted"
+        row["request_min_bitrate"] = 320                  # stale
+        row["request_verified_lossless"] = False
+        row["request_current_spectral_grade"] = "likely_transcode"  # stale
+        row["request_current_spectral_bitrate"] = 160                # stale
+        self.mock_db.get_wrong_matches.return_value = [row]
+        # No beets mock — _is_in_beets returns False, so every on-disk
+        # field in the response should reflect "nothing on disk".
+        status, data = self._get("/api/wrong-matches")
+        self.assertEqual(status, 200)
+        group = data["groups"][0]
+        self.assertFalse(group["in_library"],
+                         "Precondition: test requires album absent from beets.")
+        self.assertIsNone(group["min_bitrate"],
+                          "min_bitrate must not leak from stale DB when not in beets.")
+        self.assertIsNone(group["current_spectral_grade"],
+                          "current_spectral_grade must not leak from stale DB.")
+        self.assertIsNone(group["current_spectral_bitrate"],
+                          "current_spectral_bitrate must not leak from stale DB.")
+        self.assertFalse(group["verified_lossless"],
+                         "verified_lossless must read False when nothing is on disk.")
 
     def test_group_latest_import_picks_most_recent_success(self):
         """latest_import shows the last successful import, not the newest attempt.

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -92,14 +92,29 @@ function renderQualityBadges(g) {
   // Drive the 'nothing on disk' badge off data, not the DB status.
   // A row left at status='imported' after a manual beet rm still has
   // nothing on disk, so checking status alone would swallow the signal
-  // and leave the badge strip empty. If the backend zeroed every quality
-  // field for this release, there is nothing on disk worth describing.
-  // Include `format` — it's the fallback badge text below when
-  // bitrate is null (e.g. FLAC with no bitrate metadata), so its
-  // presence means an on-disk badge would render and this early
-  // return must not pre-empt it.
-  if (!g.quality_label && !g.min_bitrate && !g.current_spectral_grade && !g.format) {
+  // and leave the badge strip empty.
+  //
+  // But only when the library is genuinely empty for this album —
+  // `g.in_library` can be true via the fuzzy artist/album fallback
+  // while every quality field is blank because this *exact pressing*
+  // isn't on disk (multi-pressing case). In that scenario the user
+  // already sees the green "in library" badge; pairing it with a red
+  // "nothing on disk" would be self-contradictory and push them
+  // toward unnecessary reimports.
+  //
+  // `format` stays in the guard because it's the fallback badge text
+  // below when bitrate is null (e.g. FLAC with no bitrate metadata),
+  // so its presence means an on-disk badge will render.
+  const hasOnDiskQuality = g.quality_label || g.min_bitrate
+    || g.current_spectral_grade || g.format;
+  if (!hasOnDiskQuality && !g.in_library) {
     return '<span class="badge" style="background:#3a2a2a;color:#f88;">nothing on disk</span>';
+  }
+  if (!hasOnDiskQuality) {
+    // Fuzzy library hit, exact pressing missing — signal the
+    // ambiguity without the red alarm that implies the album
+    // is entirely absent.
+    return '<span class="badge" style="background:#2a2a3a;color:#9bf;">different edition on disk</span>';
   }
 
   const parts = [];

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -94,7 +94,11 @@ function renderQualityBadges(g) {
   // nothing on disk, so checking status alone would swallow the signal
   // and leave the badge strip empty. If the backend zeroed every quality
   // field for this release, there is nothing on disk worth describing.
-  if (!g.quality_label && !g.min_bitrate && !g.current_spectral_grade) {
+  // Include `format` — it's the fallback badge text below when
+  // bitrate is null (e.g. FLAC with no bitrate metadata), so its
+  // presence means an on-disk badge would render and this early
+  // return must not pre-empt it.
+  if (!g.quality_label && !g.min_bitrate && !g.current_spectral_grade && !g.format) {
     return '<span class="badge" style="background:#3a2a2a;color:#f88;">nothing on disk</span>';
   }
 

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -94,27 +94,26 @@ function renderQualityBadges(g) {
   // nothing on disk, so checking status alone would swallow the signal
   // and leave the badge strip empty.
   //
-  // But only when the library is genuinely empty for this album —
-  // `g.in_library` can be true via the fuzzy artist/album fallback
-  // while every quality field is blank because this *exact pressing*
-  // isn't on disk (multi-pressing case). In that scenario the user
-  // already sees the green "in library" badge; pairing it with a red
-  // "nothing on disk" would be self-contradictory and push them
-  // toward unnecessary reimports.
-  //
-  // `format` stays in the guard because it's the fallback badge text
-  // below when bitrate is null (e.g. FLAC with no bitrate metadata),
-  // so its presence means an on-disk badge will render.
+  // The backend now uses the same fuzzy-or-exact `_is_in_beets`
+  // check to both populate `in_library` and to blank the quality
+  // fields, so they move together: fields populated ⇔ library hit.
+  // The remaining in_library=true + no-quality case is a fuzzy
+  // substring collision where beets has nothing actually indexed for
+  // this release — stay silent rather than speculating on a
+  // "different edition" claim the data doesn't support. `format`
+  // stays in the guard because it's the fallback badge text below
+  // when bitrate is null (e.g. FLAC with no bitrate metadata), so
+  // its presence means an on-disk badge will render.
   const hasOnDiskQuality = g.quality_label || g.min_bitrate
     || g.current_spectral_grade || g.format;
   if (!hasOnDiskQuality && !g.in_library) {
     return '<span class="badge" style="background:#3a2a2a;color:#f88;">nothing on disk</span>';
   }
   if (!hasOnDiskQuality) {
-    // Fuzzy library hit, exact pressing missing — signal the
-    // ambiguity without the red alarm that implies the album
-    // is entirely absent.
-    return '<span class="badge" style="background:#2a2a3a;color:#9bf;">different edition on disk</span>';
+    // Fuzzy library hit without indexed quality data — defer to
+    // the separate 'in library' badge rendered on the group card;
+    // we can't honestly assert more than that.
+    return '';
   }
 
   const parts = [];

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -89,8 +89,12 @@ function rankColor(rank) {
  * @returns {string}
  */
 function renderQualityBadges(g) {
-  // Nothing in the library yet — tell the user force-import is a fresh add.
-  if (g.status !== 'imported' && !g.quality_label && !g.min_bitrate) {
+  // Drive the 'nothing on disk' badge off data, not the DB status.
+  // A row left at status='imported' after a manual beet rm still has
+  // nothing on disk, so checking status alone would swallow the signal
+  // and leave the badge strip empty. If the backend zeroed every quality
+  // field for this release, there is nothing on disk worth describing.
+  if (!g.quality_label && !g.min_bitrate && !g.current_spectral_grade) {
     return '<span class="badge" style="background:#3a2a2a;color:#f88;">nothing on disk</span>';
   }
 

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -137,7 +137,7 @@ def post_manual_import(h, body: dict) -> None:
 
 def _quality_summary(row: dict[str, object],
                      beets_info: dict[str, dict[str, object]],
-                     in_beets: bool,
+                     exact_release_on_disk: bool,
                      ) -> dict[str, object]:
     """Describe the album's current on-disk quality for a group header.
 
@@ -146,16 +146,18 @@ def _quality_summary(row: dict[str, object],
     (those never live in beets). We combine them so the user can see at a
     glance whether force-importing is worthwhile.
 
-    When the album is NOT in beets (``in_beets=False``), every on-disk field
-    is zeroed out regardless of what the pipeline DB still holds — a prior
-    import that was later removed via ban-source or a manual ``beet rm``
-    leaves stale values behind that the write-side now clears, but old rows
-    may still carry them. Surfacing those ghosts would mislabel an empty
-    slot as "320k likely_transcode" and invite force-importing against
-    false quality data.
+    When THIS exact MB release isn't in beets (``exact_release_on_disk=False``),
+    every on-disk field is zeroed out regardless of what the pipeline DB
+    still holds — a prior import that was later removed via ban-source or a
+    manual ``beet rm`` leaves stale values behind that the write-side now
+    clears, but old rows may still carry them. Multiple pressings of the
+    same album are intentionally preserved in this library (CLAUDE.md), so
+    "some edition exists" is NOT sufficient — the quality summary
+    describes *this* release specifically, so we require an exact MBID
+    match in ``beets_info``.
     """
     status = str(row.get("request_status") or "wanted")
-    if not in_beets:
+    if not exact_release_on_disk:
         return {
             "status": status,
             "min_bitrate": None,
@@ -288,17 +290,25 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
         assert isinstance(request_id, int)
         group = groups.get(request_id)
         if group is None:
-            in_beets = _is_in_beets(row, beets_info)
+            # Two different beets-presence questions: `in_library` is the
+            # fuzzy "does any edition of this album exist?" that drives the
+            # user-facing badge, while the quality summary needs the strict
+            # "is *this exact* MB release on disk?" — multiple pressings
+            # are intentionally kept, and quality fields describe the
+            # specific pressing.
+            mbid = row.get("mb_release_id")
+            exact_on_disk = (isinstance(mbid, str) and mbid
+                             and mbid in beets_info)
             group = {
                 "request_id": request_id,
                 "artist": row["artist_name"],
                 "album": row["album_title"],
-                "mb_release_id": row.get("mb_release_id"),
-                "in_library": in_beets,
+                "mb_release_id": mbid,
+                "in_library": _is_in_beets(row, beets_info),
                 "pending_count": 0,
                 "entries": [],
                 "latest_import": None,  # filled in after the loop
-                **_quality_summary(row, beets_info, in_beets),
+                **_quality_summary(row, beets_info, bool(exact_on_disk)),
             }
             groups[request_id] = group
             order.append(request_id)

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -290,25 +290,36 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
         assert isinstance(request_id, int)
         group = groups.get(request_id)
         if group is None:
-            # Two different beets-presence questions: `in_library` is the
-            # fuzzy "does any edition of this album exist?" that drives the
-            # user-facing badge, while the quality summary needs the strict
-            # "is *this exact* MB release on disk?" — multiple pressings
-            # are intentionally kept, and quality fields describe the
-            # specific pressing.
+            # Two beets-presence questions with different precision:
+            #
+            # - ``in_library`` drives the user-facing badge. Fuzzy
+            #   "does any edition exist?" is the right answer — it
+            #   warns the user that some copy is already around even
+            #   if this specific pressing isn't.
+            # - ``has_on_disk_state`` gates the quality summary.
+            #   Multiple pressings are intentionally kept, so when
+            #   the request has an MBID we must match it exactly,
+            #   otherwise a sibling pressing's presence would let
+            #   stale quality fields from a removed pressing leak
+            #   through. When the request has NO MBID (manual add /
+            #   no-MB-release requests) we can't distinguish pressings
+            #   anyway, so the fuzzy fallback is the best signal.
             mbid = row.get("mb_release_id")
-            exact_on_disk = (isinstance(mbid, str) and mbid
-                             and mbid in beets_info)
+            in_library = _is_in_beets(row, beets_info)
+            if isinstance(mbid, str) and mbid:
+                has_on_disk_state = mbid in beets_info
+            else:
+                has_on_disk_state = in_library
             group = {
                 "request_id": request_id,
                 "artist": row["artist_name"],
                 "album": row["album_title"],
                 "mb_release_id": mbid,
-                "in_library": _is_in_beets(row, beets_info),
+                "in_library": in_library,
                 "pending_count": 0,
                 "entries": [],
                 "latest_import": None,  # filled in after the loop
-                **_quality_summary(row, beets_info, bool(exact_on_disk)),
+                **_quality_summary(row, beets_info, has_on_disk_state),
             }
             groups[request_id] = group
             order.append(request_id)

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -136,7 +136,8 @@ def post_manual_import(h, body: dict) -> None:
 
 
 def _quality_summary(row: dict[str, object],
-                     beets_info: dict[str, dict[str, object]]
+                     beets_info: dict[str, dict[str, object]],
+                     in_beets: bool,
                      ) -> dict[str, object]:
     """Describe the album's current on-disk quality for a group header.
 
@@ -144,7 +145,28 @@ def _quality_summary(row: dict[str, object],
     imported; the pipeline DB carries the spectral + verified-lossless signal
     (those never live in beets). We combine them so the user can see at a
     glance whether force-importing is worthwhile.
+
+    When the album is NOT in beets (``in_beets=False``), every on-disk field
+    is zeroed out regardless of what the pipeline DB still holds — a prior
+    import that was later removed via ban-source or a manual ``beet rm``
+    leaves stale values behind that the write-side now clears, but old rows
+    may still carry them. Surfacing those ghosts would mislabel an empty
+    slot as "320k likely_transcode" and invite force-importing against
+    false quality data.
     """
+    status = str(row.get("request_status") or "wanted")
+    if not in_beets:
+        return {
+            "status": status,
+            "min_bitrate": None,
+            "format": None,
+            "verified_lossless": False,
+            "current_spectral_grade": None,
+            "current_spectral_bitrate": None,
+            "quality_label": None,
+            "quality_rank": None,
+        }
+
     srv = _server()
     mbid = row.get("mb_release_id")
     detail = beets_info.get(mbid) if isinstance(mbid, str) and mbid else None
@@ -173,7 +195,7 @@ def _quality_summary(row: dict[str, object],
         rank = srv.compute_library_rank(fmt, beets_kbps)
 
     return {
-        "status": str(row.get("request_status") or "wanted"),
+        "status": status,
         "min_bitrate": db_kbps if db_kbps is not None else beets_kbps,
         "format": fmt,
         "verified_lossless": bool(row.get("request_verified_lossless") or False),
@@ -266,16 +288,17 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
         assert isinstance(request_id, int)
         group = groups.get(request_id)
         if group is None:
+            in_beets = _is_in_beets(row, beets_info)
             group = {
                 "request_id": request_id,
                 "artist": row["artist_name"],
                 "album": row["album_title"],
                 "mb_release_id": row.get("mb_release_id"),
-                "in_library": _is_in_beets(row, beets_info),
+                "in_library": in_beets,
                 "pending_count": 0,
                 "entries": [],
                 "latest_import": None,  # filled in after the loop
-                **_quality_summary(row, beets_info),
+                **_quality_summary(row, beets_info, in_beets),
             }
             groups[request_id] = group
             order.append(request_id)

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -137,7 +137,7 @@ def post_manual_import(h, body: dict) -> None:
 
 def _quality_summary(row: dict[str, object],
                      beets_info: dict[str, dict[str, object]],
-                     exact_release_on_disk: bool,
+                     album_on_disk: bool,
                      ) -> dict[str, object]:
     """Describe the album's current on-disk quality for a group header.
 
@@ -146,18 +146,17 @@ def _quality_summary(row: dict[str, object],
     (those never live in beets). We combine them so the user can see at a
     glance whether force-importing is worthwhile.
 
-    When THIS exact MB release isn't in beets (``exact_release_on_disk=False``),
-    every on-disk field is zeroed out regardless of what the pipeline DB
-    still holds — a prior import that was later removed via ban-source or a
-    manual ``beet rm`` leaves stale values behind that the write-side now
-    clears, but old rows may still carry them. Multiple pressings of the
-    same album are intentionally preserved in this library (CLAUDE.md), so
-    "some edition exists" is NOT sufficient — the quality summary
-    describes *this* release specifically, so we require an exact MBID
-    match in ``beets_info``.
+    When the album isn't on disk (``album_on_disk=False``), every on-disk
+    field is zeroed out regardless of what the pipeline DB still holds —
+    that's the belt-and-braces for any path that removed files without
+    clearing the quality fields (the ban-source path now clears them on
+    the write side, but older rows or out-of-band ``beet rm`` invocations
+    can still leave ghosts). The caller computes ``album_on_disk`` with
+    the same ``_is_in_beets`` fuzzy-or-exact logic that drives the
+    ``in_library`` badge, so the two are consistent.
     """
     status = str(row.get("request_status") or "wanted")
-    if not exact_release_on_disk:
+    if not album_on_disk:
         return {
             "status": status,
             "min_bitrate": None,
@@ -290,36 +289,32 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
         assert isinstance(request_id, int)
         group = groups.get(request_id)
         if group is None:
-            # Two beets-presence questions with different precision:
+            # ``_is_in_beets`` is authoritative for "files on disk for
+            # this request": exact MBID match when beets has the tag,
+            # fuzzy artist/album fallback when it doesn't. That second
+            # path covers legacy entries (Discogs imports stored in
+            # ``mb_albumid``, manual imports with the tag unset) where
+            # the album really is on disk but the MBID lookup misses.
             #
-            # - ``in_library`` drives the user-facing badge. Fuzzy
-            #   "does any edition exist?" is the right answer — it
-            #   warns the user that some copy is already around even
-            #   if this specific pressing isn't.
-            # - ``has_on_disk_state`` gates the quality summary.
-            #   Multiple pressings are intentionally kept, so when
-            #   the request has an MBID we must match it exactly,
-            #   otherwise a sibling pressing's presence would let
-            #   stale quality fields from a removed pressing leak
-            #   through. When the request has NO MBID (manual add /
-            #   no-MB-release requests) we can't distinguish pressings
-            #   anyway, so the fuzzy fallback is the best signal.
-            mbid = row.get("mb_release_id")
+            # The original multi-pressing concern that motivated a
+            # strict MBID-only check is now handled on the write side:
+            # ``post_pipeline_ban_source`` clears on-disk quality
+            # fields after a successful ``beet remove -d``, so a
+            # sibling pressing's presence can't surface ghost quality
+            # from the removed one. The invariant is now:
+            # on-disk fields are populated ⇔ files exist, maintained
+            # by the cleanup path on the writer side.
             in_library = _is_in_beets(row, beets_info)
-            if isinstance(mbid, str) and mbid:
-                has_on_disk_state = mbid in beets_info
-            else:
-                has_on_disk_state = in_library
             group = {
                 "request_id": request_id,
                 "artist": row["artist_name"],
                 "album": row["album_title"],
-                "mb_release_id": mbid,
+                "mb_release_id": row.get("mb_release_id"),
                 "in_library": in_library,
                 "pending_count": 0,
                 "entries": [],
                 "latest_import": None,  # filled in after the loop
-                **_quality_summary(row, beets_info, has_on_disk_state),
+                **_quality_summary(row, beets_info, in_library),
             }
             groups[request_id] = group
             order.append(request_id)

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -671,17 +671,15 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         # Once the files have left beets, the pipeline DB's on-disk
         # quality fields (verified_lossless, current_spectral_*) are no
         # longer accurate. Clear them so wrong-matches / library views /
-        # the quality gate don't reason about phantom state. Only clear
-        # when we have POSITIVE evidence: either we just removed the
-        # album, or we queried beets with a real mbid and it confirmed
-        # the album wasn't there. Skip when the remove attempt failed
-        # — the album may still be on disk. Skip when the caller omitted
-        # mb_release_id — we never checked, so we can't claim the album
-        # is gone.
-        beets_confirmed_absent = (
-            bool(mb_release_id) and b is not None and not album_was_in_beets
-        )
-        if beets_removed or beets_confirmed_absent:
+        # the quality gate don't reason about phantom state. Trust only
+        # the ``beet remove -d`` exit code as positive evidence — an
+        # ``album_exists()`` miss alone isn't enough, because beets
+        # entries can legitimately be on disk with the ``mb_albumid``
+        # tag unset (manual imports, legacy entries). The display-side
+        # guard in ``_quality_summary`` is the belt-and-braces that keeps
+        # wrong-matches honest even if the DB still carries ghost values
+        # from some other code path.
+        if beets_removed:
             s._db().clear_on_disk_quality_fields(int(req_id))
 
     h._json({

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -647,9 +647,17 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     if mb_release_id and b:
         album_was_in_beets = b.album_exists(mb_release_id)
         if album_was_in_beets:
+            # Discogs releases live under ``discogs_albumid`` in beets;
+            # MusicBrainz releases under ``mb_albumid``. Feed ``beet remove``
+            # the right selector so a Discogs ban-source actually targets
+            # the imported album instead of silently no-op-ing.
+            from lib.quality import detect_release_source
+            selector = ("discogs_albumid"
+                        if detect_release_source(mb_release_id) == "discogs"
+                        else "mb_albumid")
             import subprocess as _sp
             result = _sp.run(
-                ["beet", "remove", "-d", f"mb_albumid:{mb_release_id}"],
+                ["beet", "remove", "-d", f"{selector}:{mb_release_id}"],
                 capture_output=True, text=True, timeout=30,
                 env=beets_subprocess_env(),
             )

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -647,21 +647,32 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     if mb_release_id and b:
         album_was_in_beets = b.album_exists(mb_release_id)
         if album_was_in_beets:
-            # Discogs releases live under ``discogs_albumid`` in beets;
-            # MusicBrainz releases under ``mb_albumid``. Feed ``beet remove``
-            # the right selector so a Discogs ban-source actually targets
-            # the imported album instead of silently no-op-ing.
+            # Feed ``beet remove`` every selector this ID could live
+            # under. MusicBrainz releases are always in ``mb_albumid``.
+            # Discogs releases are in ``discogs_albumid`` on new-style
+            # libraries but can also be in ``mb_albumid`` on legacy
+            # libraries that predate the Discogs plugin populating
+            # ``discogs_albumid`` — ``BeetsDB.album_exists()`` confirms
+            # presence for either layout, so ban-source must match.
+            # Hitting a selector that doesn't hold the album is a
+            # harmless no-op, but skipping the selector that does would
+            # silently leave the banned copy on disk.
             from lib.quality import detect_release_source
-            selector = ("discogs_albumid"
-                        if detect_release_source(mb_release_id) == "discogs"
-                        else "mb_albumid")
+            if detect_release_source(mb_release_id) == "discogs":
+                selectors = ["discogs_albumid", "mb_albumid"]
+            else:
+                selectors = ["mb_albumid"]
             import subprocess as _sp
-            result = _sp.run(
-                ["beet", "remove", "-d", f"{selector}:{mb_release_id}"],
-                capture_output=True, text=True, timeout=30,
-                env=beets_subprocess_env(),
-            )
-            beets_removed = result.returncode == 0
+            for selector in selectors:
+                _sp.run(
+                    ["beet", "remove", "-d", f"{selector}:{mb_release_id}"],
+                    capture_output=True, text=True, timeout=30,
+                    env=beets_subprocess_env(),
+                )
+            # Confirm removal by re-querying — ``beet remove``'s return
+            # code is 0 even when nothing matched, so it can't tell us
+            # whether the right selector actually fired.
+            beets_removed = not b.album_exists(mb_release_id)
 
     req = s._db().get_request(int(req_id))
     if req:

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -642,10 +642,11 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     s._db().add_denylist(int(req_id), username, "manually banned via web UI")
 
     beets_removed = False
+    album_was_in_beets = False
     b = s._beets_db()
     if mb_release_id and b:
-        album_in_beets = b.album_exists(mb_release_id)
-        if album_in_beets:
+        album_was_in_beets = b.album_exists(mb_release_id)
+        if album_was_in_beets:
             import subprocess as _sp
             result = _sp.run(
                 ["beet", "remove", "-d", f"mb_albumid:{mb_release_id}"],
@@ -666,6 +667,18 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         if min_br is not None:
             ban_kwargs["min_bitrate"] = min_br
         apply_transition(s._db(), int(req_id), "wanted", **ban_kwargs)
+
+        # Once the files have left beets, the pipeline DB's on-disk
+        # quality fields (verified_lossless, current_spectral_*) are no
+        # longer accurate. Clear them so wrong-matches / library views /
+        # the quality gate don't reason about phantom state. Only clear
+        # when we have positive evidence: either we just removed the
+        # album, or beets confirmed it was never there and any lingering
+        # fields are already ghosts. Skip when the remove attempt failed
+        # — the album may still be on disk and the existing state is
+        # still correct.
+        if beets_removed or (b is not None and not album_was_in_beets):
+            s._db().clear_on_disk_quality_fields(int(req_id))
 
     h._json({
         "status": "ok",

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -672,12 +672,16 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         # quality fields (verified_lossless, current_spectral_*) are no
         # longer accurate. Clear them so wrong-matches / library views /
         # the quality gate don't reason about phantom state. Only clear
-        # when we have positive evidence: either we just removed the
-        # album, or beets confirmed it was never there and any lingering
-        # fields are already ghosts. Skip when the remove attempt failed
-        # — the album may still be on disk and the existing state is
-        # still correct.
-        if beets_removed or (b is not None and not album_was_in_beets):
+        # when we have POSITIVE evidence: either we just removed the
+        # album, or we queried beets with a real mbid and it confirmed
+        # the album wasn't there. Skip when the remove attempt failed
+        # — the album may still be on disk. Skip when the caller omitted
+        # mb_release_id — we never checked, so we can't claim the album
+        # is gone.
+        beets_confirmed_absent = (
+            bool(mb_release_id) and b is not None and not album_was_in_beets
+        )
+        if beets_removed or beets_confirmed_absent:
             s._db().clear_on_disk_quality_fields(int(req_id))
 
     h._json({

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -642,7 +642,7 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     s._db().add_denylist(int(req_id), username, "manually banned via web UI")
 
     beets_removed = False
-    album_was_in_beets = False
+    album_absent_after = False
     b = s._beets_db()
     if mb_release_id and b:
         album_was_in_beets = b.album_exists(mb_release_id)
@@ -669,10 +669,16 @@ def post_pipeline_ban_source(h, body: dict) -> None:
                     capture_output=True, text=True, timeout=30,
                     env=beets_subprocess_env(),
                 )
-            # Confirm removal by re-querying — ``beet remove``'s return
-            # code is 0 even when nothing matched, so it can't tell us
-            # whether the right selector actually fired.
-            beets_removed = not b.album_exists(mb_release_id)
+        # Confirm the current state regardless of whether we ran a
+        # remove. ``album_absent_after=True`` means the album is not
+        # currently in beets — from any path, including a manual
+        # ``beet rm`` that ran long before this request arrived. That
+        # is the trigger for clearing stale on-disk quality fields;
+        # ``beets_removed`` is reserved for the narrower question of
+        # whether *this* handler was the one that removed it (it feeds
+        # the API response and the toast message).
+        album_absent_after = not b.album_exists(mb_release_id)
+        beets_removed = album_was_in_beets and album_absent_after
 
     req = s._db().get_request(int(req_id))
     if req:
@@ -687,18 +693,16 @@ def post_pipeline_ban_source(h, body: dict) -> None:
             ban_kwargs["min_bitrate"] = min_br
         apply_transition(s._db(), int(req_id), "wanted", **ban_kwargs)
 
-        # Once the files have left beets, the pipeline DB's on-disk
-        # quality fields (verified_lossless, current_spectral_*) are no
-        # longer accurate. Clear them so wrong-matches / library views /
-        # the quality gate don't reason about phantom state. Trust only
-        # the ``beet remove -d`` exit code as positive evidence — an
-        # ``album_exists()`` miss alone isn't enough, because beets
-        # entries can legitimately be on disk with the ``mb_albumid``
-        # tag unset (manual imports, legacy entries). The display-side
-        # guard in ``_quality_summary`` is the belt-and-braces that keeps
-        # wrong-matches honest even if the DB still carries ghost values
-        # from some other code path.
-        if beets_removed:
+        # Once the files have left beets — whether just now or earlier
+        # via an out-of-band ``beet rm`` — the pipeline DB's on-disk
+        # quality fields (verified_lossless, current_spectral_*,
+        # imported_path) are stale. Clear them so wrong-matches /
+        # library views / quality gate don't reason about phantom state
+        # and so ``dispatch_import`` doesn't feed ``--override-min-bitrate``
+        # a ghost baseline on the next import attempt. The display-side
+        # guard in ``_quality_summary`` is the belt-and-braces for any
+        # path that skips this route entirely.
+        if album_absent_after:
             s._db().clear_on_disk_quality_fields(int(req_id))
 
     h._json({


### PR DESCRIPTION
## Summary

- **Read-side guard** in `web/routes/imports.py::_quality_summary`: zero every on-disk field (`min_bitrate`, `current_spectral_*`, `verified_lossless`, `quality_label`, `quality_rank`) when the album isn't in beets, regardless of what the pipeline DB still holds.
- **Write-side clear** in `lib/pipeline_db.py`: new `clear_on_disk_quality_fields(request_id)` zeroes `verified_lossless` + `current_spectral_*` atomically. Called by `post_pipeline_ban_source` after a successful `beet remove -d` or when beets confirmed the album was never there. Preserves `min_bitrate` (baseline for the next gate) and `last_download_spectral_*` (audit trail).

## Repro

Request 286 — **DICE — Reality** (`mbid=129bebd8-a7b9-4099-b0bc-545b704e7a95`). Force-imported 2026-04-14, later removed from beets, status reverted to `wanted`, but the DB still carried `min_bitrate=320, current_spectral_grade=likely_transcode, current_spectral_bitrate=160`. The wrong-matches card read:

```
DICE — Reality    4 candidates wanted
320k likely_transcode (160k)
Last import: force_import 2026-04-14 19:59
```

…despite nothing being on disk.

## Why both fixes?

Ban-source isn't the only path that can delete an album from beets (manual `beet rm`, orphan cleanup, disk failure). The read-side guard makes the wrong-matches UI correct for every such path. The write-side clear fixes the known leaking writer so the DB stays consistent with reality for every other consumer (library tab, quality gate baselines, CLI `show`).

## Test plan

- [x] `TestWrongMatchesContract.test_group_hides_stale_quality_when_not_in_beets` — seeds the DICE/Reality state, asserts `min_bitrate/current_spectral_*/verified_lossless` all come back as `None/False` when `in_library=False`.
- [x] `TestUserRequeueOverridePreservation.test_ban_source_clears_on_disk_quality_fields` — pins the DB call after a successful `beet remove`.
- [x] `TestUserRequeueOverridePreservation.test_ban_source_skips_clear_when_beet_remove_failed` — conservative path guard.
- [x] `TestClearOnDiskQualityFields` — DB-backed contract: clears spectral + verified_lossless, preserves min_bitrate + last_download_spectral_*, idempotent.
- [x] `test_clear_on_disk_quality_fields_matches_real_db` — FakePipelineDB parity.
- [x] Full suite: `Ran 1848 tests in 14.809s  OK (skipped=53)`
- [x] `pyright lib/pipeline_db.py web/routes/pipeline.py web/routes/imports.py tests/fakes.py` → `0 errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)