### PR TITLE
fix(beets_db): delete fuzzy artist+album match path (#123)

### DIFF
--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ReleaseLocation:
-    """Single seam for 'is this release on disk?' — see issue #121.
+    """Single seam for 'is this release on disk?' — see issues #121 / #123.
 
     The pipeline DB packs two ID kinds into one column (``mb_release_id``):
     MusicBrainz UUIDs and Discogs numeric strings. Beets stores them in
@@ -36,20 +36,22 @@ class ReleaseLocation:
 
     - ``kind="exact"``: beets holds the specific pressing keyed by
       ``release_id``. Quality / cleanup decisions may rely on this.
-    - ``kind="fuzzy"``: no ID hit, but artist+album name fuzzy-matched
-      something. Used ONLY for the user-facing 'in library' badge.
-      Never attribute quality or trigger removes off a fuzzy hit —
-      multiple pressings share titles, so we'd act on the wrong one.
     - ``kind="absent"``: nothing matches. ``album_id is None`` and
       ``selectors == ()``.
+
+    Issue #123 collapsed the older 3-state Literal (``exact`` / ``fuzzy``
+    / ``absent``) down to 2. The fuzzy artist+album fallback conflated
+    identity with presence — a sibling pressing title-match would
+    silently attribute another release's quality fields to the badge.
+    'In library' now means exact-ID match, period.
 
     ``selectors`` is the set of ``beet remove -d`` queries the ID
     could live under. Iterating every selector turns a selector-
     skipped remove into a harmless no-op instead of silently leaving
-    the banned copy on disk — see ``BeetsDB.remove_selectors`` /
+    the banned copy on disk — see
     ``web/routes/pipeline.py::post_pipeline_ban_source``.
     """
-    kind: Literal["exact", "fuzzy", "absent"]
+    kind: Literal["exact", "absent"]
     album_id: int | None
     selectors: tuple[str, ...]
 
@@ -135,12 +137,7 @@ class BeetsDB:
             return raw.decode("utf-8", errors="replace")
         return str(raw)
 
-    def locate(
-        self,
-        release_id: str,
-        artist: Optional[str] = None,
-        album: Optional[str] = None,
-    ) -> ReleaseLocation:
+    def locate(self, release_id: str) -> ReleaseLocation:
         """Resolve a pipeline ``mb_release_id`` to a ``ReleaseLocation``.
 
         Single seam for 'is this release on disk?' (issue #121).
@@ -153,10 +150,13 @@ class BeetsDB:
           ``beet remove -d`` tries every layout.
         - UUID shape: check ``mb_albumid`` only. Selector is the
           single ``mb_albumid:<uuid>`` query.
-        - When the ID misses AND the caller supplied artist+album,
-          fall back to a fuzzy ``LIKE`` match. Fuzzy hits expose
-          ``kind="fuzzy"`` and EMPTY selectors — callers must not
-          turn a fuzzy hit into a ``beet remove -d``.
+        - Miss on both paths → ``kind="absent"``.
+
+        Issue #123: the artist/album fuzzy fallback was removed. It
+        conflated identity with presence and silently attributed stale
+        quality fields from sibling pressings to the badge. The honest
+        UI for a legacy untagged album is 'not in library' — re-tag it
+        or add the release to the pipeline.
         """
         source = detect_release_source(release_id)
         numeric: int | None = None
@@ -195,27 +195,7 @@ class BeetsDB:
             return ReleaseLocation(
                 kind="exact", album_id=album_id, selectors=selectors)
 
-        # Fuzzy fallback — only when the caller supplies artist+album.
-        # Returns the first match so the UI can still show 'in library',
-        # but no selectors (we can't identify a specific pressing).
-        if artist and album:
-            fuzzy_id = self._fuzzy_album_id(artist, album)
-            if fuzzy_id is not None:
-                return ReleaseLocation(
-                    kind="fuzzy", album_id=fuzzy_id, selectors=())
-
         return ReleaseLocation(kind="absent", album_id=None, selectors=())
-
-    def _fuzzy_album_id(self, artist: str, album: str) -> Optional[int]:
-        """Internal: first album whose artist+album fuzzily matches."""
-        row = self._conn.execute(
-            "SELECT id FROM albums "
-            "WHERE albumartist LIKE ? COLLATE NOCASE "
-            "  AND album LIKE ? COLLATE NOCASE "
-            "LIMIT 1",
-            (f"%{artist}%", f"%{album}%"),
-        ).fetchone()
-        return row[0] if row else None
 
     def _batch_lookup_album_ids(
         self, release_ids: list[str]
@@ -233,10 +213,6 @@ class BeetsDB:
         stay in sync without either falling into an N+1 pattern — the
         paired-consistency concern Codex round 1 + round 2 kept circling
         (issue #121).
-
-        Fuzzy fallback is NOT applied here — batch callers never want
-        fuzzy hits for 'in library' quality or album-id uses. For the
-        single-ID fuzzy case, use ``locate(id, artist, album)``.
         """
         if not release_ids:
             return {}
@@ -291,7 +267,7 @@ class BeetsDB:
         """Legacy thin wrapper — kept for internal callers only.
 
         New code should call ``locate()`` and inspect ``.album_id``.
-        Returns the exact-match album id (no fuzzy fallback) or None.
+        Returns the exact-match album id or None.
         """
         loc = self.locate(release_id)
         return loc.album_id if loc.kind == "exact" else None
@@ -299,9 +275,10 @@ class BeetsDB:
     def album_exists(self, release_id: str) -> bool:
         """Check if a release is already in the beets library.
 
-        Exact ID match only — no fuzzy fallback. For the 'in library'
-        badge with fuzzy fallback, use ``locate(id, artist, album)``
-        and check ``loc.kind in ("exact", "fuzzy")``.
+        Exact ID match. Issue #123 collapsed the 'in library' signal
+        to this single predicate — the fuzzy artist+album fallback was
+        deleted because it attributed sibling pressings' quality to
+        the badge.
         """
         return self.locate(release_id).kind == "exact"
 
@@ -642,21 +619,6 @@ class BeetsDB:
             return album_row[0], album_row[1], file_paths
         finally:
             conn.close()
-
-    def find_by_artist_album(self, artist: str, album: str) -> Optional[int]:
-        """Find track count by artist+album name. Returns None if not found."""
-        row = self._conn.execute(
-            "SELECT a.id FROM albums a "
-            "WHERE a.albumartist LIKE ? COLLATE NOCASE AND a.album LIKE ? COLLATE NOCASE "
-            "LIMIT 1",
-            (f"%{artist}%", f"%{album}%"),
-        ).fetchone()
-        if not row:
-            return None
-        count = self._conn.execute(
-            "SELECT COUNT(*) FROM items WHERE album_id = ?", (row[0],)
-        ).fetchone()
-        return count[0] if count else None
 
     def get_avg_bitrate_kbps(self, mb_release_id: str) -> Optional[int]:
         """Get average track bitrate (kbps) for a release. None if not found.

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -208,10 +208,14 @@ class TestLocate(unittest.TestCase):
       the column that actually holds the album.
     - Discogs numeric in legacy ``albums.mb_albumid`` (pre-plugin-patch
       libraries) → ``kind="exact"`` with the same selector pair.
-    - No ID match but artist/album fuzzy-matches → ``kind="fuzzy"``.
-      Used only for the in-library badge, never for quality or cleanup.
     - Nothing matches → ``kind="absent"`` with ``selectors=()`` and
       ``album_id=None``.
+
+    Issue #123 sharpened the seam: the fuzzy ``kind="fuzzy"`` fallback was
+    deleted because it silently attributed quality to sibling pressings
+    (the PR #119 marathon). After this change, 'is this release on disk?'
+    is answered solely by exact-ID match and ``locate()`` takes only a
+    ``release_id`` argument — no artist/album fallback.
     """
 
     def setUp(self) -> None:
@@ -282,54 +286,66 @@ class TestLocate(unittest.TestCase):
         self.assertIsNone(loc.album_id)
         self.assertEqual(loc.selectors, ())
 
-    def test_locate_fuzzy_matches_artist_album(self) -> None:
-        """No ID match but artist/album fuzzy-matches → kind='fuzzy'.
+    def test_locate_untagged_album_is_absent(self) -> None:
+        """Legacy untagged albums resolve to absent, not a fuzzy ghost hit.
 
-        Legacy manual imports (Discogs-style metadata with neither
-        ``mb_albumid`` nor ``discogs_albumid`` populated) still want
-        to show as 'in library' for the UI badge. They must NOT leak
-        into quality-or-cleanup code paths — those pin on ``exact``.
+        Issue #123: the old fuzzy fallback claimed the album was 'in
+        library' when artist+album matched an untagged row. That leaked
+        a sibling pressing's quality into the UI (see the PR #119
+        marathon). After the refactor, the honest answer is ``absent``
+        — the user can re-tag their library or add the release to the
+        pipeline.
         """
-        # Insert an album with no ID at all
         _insert_album_full(self.db_path, 4, "", [
             {"bitrate": 320000, "path": "/m/u/01.mp3", "format": "MP3",
              "samplerate": 44100, "bitdepth": 0},
         ], album="Untagged", albumartist="Some Artist")
         with BeetsDB(self.db_path) as db:
-            loc = db.locate("no-id-at-all",
-                            artist="Some Artist", album="Untagged")
-        self.assertEqual(loc.kind, "fuzzy")
-        self.assertEqual(loc.album_id, 4)
-        # Fuzzy hits don't produce selectors — `beet remove -d` should
-        # never target a fuzzy hit because it might delete a different
-        # pressing that happens to share the title.
-        self.assertEqual(loc.selectors, ())
-
-    def test_locate_no_fuzzy_when_artist_album_missing(self) -> None:
-        """Without artist/album args, we don't fuzzy-match.
-
-        The auto-import path (``album_exists`` at preflight) never
-        passes artist/album — it must get ``absent`` when the ID isn't
-        in beets, not a random fuzzy hit.
-        """
-        with BeetsDB(self.db_path) as db:
             loc = db.locate("no-id-at-all")
         self.assertEqual(loc.kind, "absent")
+        self.assertIsNone(loc.album_id)
+        self.assertEqual(loc.selectors, ())
 
-    def test_locate_exact_beats_fuzzy(self) -> None:
-        """When an exact ID matches, fuzzy never fires."""
+    def test_locate_rejects_artist_album_kwargs(self) -> None:
+        """``locate`` takes only a release_id — no fuzzy escape hatch.
+
+        Issue #123: the old signature accepted optional artist/album
+        kwargs to drive the fuzzy fallback. Removing the fallback means
+        the kwargs are dead weight that would invite future callers to
+        re-introduce the bug. Passing them now is a TypeError.
+        """
+        # Cast to Any so the test's runtime TypeError assertion is the
+        # guard — without the cast, pyright statically rejects the call
+        # (which is also desired, just not what this runtime test is
+        # proving).
+        from typing import Any
         with BeetsDB(self.db_path) as db:
-            loc = db.locate("aaa0bbb0-cccc-dddd-eeee-ffffffffffff",
-                            artist="Different Artist", album="Different Album")
-        self.assertEqual(loc.kind, "exact")
-        self.assertEqual(loc.album_id, 1)
+            locate_any: Any = db.locate
+            with self.assertRaises(TypeError):
+                locate_any("no-id-at-all",
+                           artist="Some Artist",
+                           album="Untagged")
 
     def test_locate_numeric_but_not_in_either_column(self) -> None:
-        """Numeric ID with no exact hit and no fuzzy → absent."""
+        """Numeric ID with no exact hit → absent."""
         with BeetsDB(self.db_path) as db:
             loc = db.locate("99999999")
         self.assertEqual(loc.kind, "absent")
         self.assertEqual(loc.selectors, ())
+
+    def test_release_location_kind_literal_is_exact_or_absent(self) -> None:
+        """``ReleaseLocation.kind`` is narrowed to 2 states (issue #123).
+
+        Pyright enforces the Literal at static time; this runtime guard
+        asserts the ``__args__`` of the annotation so a future
+        well-meaning contributor can't re-add ``"fuzzy"`` as a valid
+        value without tripping the test suite.
+        """
+        from typing import get_args, get_type_hints
+        from lib.beets_db import ReleaseLocation
+        hints = get_type_hints(ReleaseLocation)
+        kind_args = get_args(hints["kind"])
+        self.assertEqual(set(kind_args), {"exact", "absent"})
 
 
 class TestCheckMbidsDiscogsAware(unittest.TestCase):
@@ -1037,28 +1053,30 @@ class TestGetAlbumsByArtist(unittest.TestCase):
         self.assertEqual(len(results), 0)
 
 
-class TestFindByArtistAlbum(unittest.TestCase):
-    """Test find_by_artist_album — track count for artist+album match."""
+class TestFuzzyMethodsRemoved(unittest.TestCase):
+    """Issue #123: ``find_by_artist_album`` / ``_fuzzy_album_id`` deleted.
 
-    def setUp(self) -> None:
-        self.tmpdir = tempfile.mkdtemp()
-        self.db_path = os.path.join(self.tmpdir, "test.db")
-        _create_test_db(self.db_path)
-        _insert_album(self.db_path, 1, "aaa-111", [
-            (320000, "/m/a/01.mp3"),
-            (320000, "/m/a/02.mp3"),
-            (320000, "/m/a/03.mp3"),
-        ], album="OK Computer", albumartist="Radiohead")
+    The fuzzy presence path conflated identity (which pressing?) with
+    presence (is anything by this artist here?) and silently attributed
+    quality to sibling pressings. These methods were the last entry
+    points into that path. Guard against accidental reintroduction.
+    """
 
-    def test_returns_track_count(self) -> None:
-        with BeetsDB(self.db_path) as db:
-            count = db.find_by_artist_album("Radiohead", "OK Computer")
-        self.assertEqual(count, 3)
+    def test_find_by_artist_album_no_longer_exists(self) -> None:
+        from lib.beets_db import BeetsDB
+        self.assertFalse(
+            hasattr(BeetsDB, "find_by_artist_album"),
+            "find_by_artist_album was deleted in issue #123 "
+            "— fuzzy presence checks must not return.",
+        )
 
-    def test_returns_none_for_no_match(self) -> None:
-        with BeetsDB(self.db_path) as db:
-            count = db.find_by_artist_album("Nonexistent", "Nonexistent")
-        self.assertIsNone(count)
+    def test_fuzzy_album_id_no_longer_exists(self) -> None:
+        from lib.beets_db import BeetsDB
+        self.assertFalse(
+            hasattr(BeetsDB, "_fuzzy_album_id"),
+            "_fuzzy_album_id was deleted in issue #123 "
+            "— fuzzy LIKE query must not return.",
+        )
 
 
 class TestGetAvgBitrateKbps(unittest.TestCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -714,6 +714,38 @@ class TestPipelineRouteContracts(_WebServerCase):
         _assert_required_fields(self, data["recent"][0], self.RECENT_REQUIRED_FIELDS,
                                 "pipeline recent item")
 
+    @patch("web.server.check_beets_by_artist_album",
+           create=True, return_value=12)
+    @patch("web.server.check_beets_library_detail", return_value={})
+    def test_pipeline_recent_in_beets_false_when_mbid_not_in_beets(
+            self, _mock_detail, _mock_fuzzy):
+        """No exact MBID hit → ``in_beets`` False, no fuzzy fallback.
+
+        Issue #123: ``get_pipeline_recent`` previously fell back to
+        ``check_beets_by_artist_album`` when the MBID missed the batch
+        lookup. That fuzzy LIKE match could return a track count for
+        an unrelated pressing by the same artist. After deleting the
+        fuzzy path, the recents row honestly reports ``in_beets=False``
+        and ``beets_tracks=0`` when the exact ID is not in beets —
+        even if a shim would have returned 12 tracks (mocked here with
+        ``create=True`` so the test is RED against the current code).
+        """
+        row = make_request_row(
+            id=303, status="imported", album_title="Recent Album",
+            mb_release_id="no-such-id-in-beets")
+        self.mock_db.get_recent.return_value = [row]
+        self.mock_db.get_track_counts.return_value = {303: 8}
+        self.mock_db.get_download_history_batch.return_value = {}
+
+        status, data = self._get("/api/pipeline/recent")
+        self.assertEqual(status, 200)
+        item = data["recent"][0]
+        self.assertFalse(
+            item["in_beets"],
+            "Issue #123: no exact ID match → in_beets False "
+            "(artist/album fuzzy fallback was deleted).")
+        self.assertEqual(item["beets_tracks"], 0)
+
     def test_pipeline_constants_contract(self):
         status, data = self._get("/api/pipeline/constants")
 
@@ -2535,21 +2567,26 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertFalse(group["verified_lossless"],
                          "verified_lossless must read False when nothing is on disk.")
 
-    @patch("web.server.check_beets_by_artist_album", return_value=12)
+    @patch("web.server.check_beets_by_artist_album",
+           create=True, return_value=12)
     @patch("web.server.check_beets_library_detail", return_value={})
-    def test_group_shows_badge_but_blanks_quality_when_fuzzy_only(
+    def test_group_in_library_false_when_mbid_not_in_beets(
             self, _mock_detail, _mock_fuzzy):
-        """Fuzzy match → in-library badge, but on-disk quality stays blank.
+        """No exact MBID hit → ``in_library`` is False, quality blanks.
 
-        Issue #121: a fuzzy artist+album hit does NOT identify a specific
-        pressing — multiple pressings of 'OK Computer' will all match
-        'Radiohead' + 'OK Computer'. Attributing the pipeline DB's
-        ``min_bitrate`` / ``verified_lossless`` / ``current_spectral_*``
-        to 'whatever fuzzy happened to match' mislabels sibling pressings.
+        Issue #123: the old behavior was a fuzzy artist+album fallback
+        that turned on the badge for a sibling pressing match. That
+        conflated identity and presence and silently attributed stale
+        pipeline DB quality fields to whatever row fuzzy happened to
+        catch. After deleting the fuzzy path, 'in library' means
+        'beets holds this exact release ID' and nothing else.
 
-        The badge stays on (the UI still tells the user 'something by
-        this artist exists'), but the quality strip goes silent because
-        we can't honestly claim which pressing's quality we're reporting.
+        The fuzzy shim is mocked with ``create=True`` so the test is
+        RED against the current code (which would call it and flip the
+        badge on) and GREEN after the deletion (the call site vanishes,
+        so the mock sits unused). If a user has an untagged legacy copy
+        of the album, the honest UI answer is 'not in library' — re-tag
+        it or add it to the pipeline.
         """
         row = self._row(42, 100, "testuser", "/fi/Test",
                          mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
@@ -2563,31 +2600,29 @@ class TestWrongMatchesContract(unittest.TestCase):
         status, data = self._get("/api/wrong-matches")
         self.assertEqual(status, 200)
         group = data["groups"][0]
-        self.assertTrue(group["in_library"],
-                        "Fuzzy match still drives the in-library badge.")
-        self.assertIsNone(group["min_bitrate"],
-                          "Fuzzy-only: must not claim a bitrate for an "
-                          "unknown pressing.")
-        self.assertFalse(group["verified_lossless"],
-                         "Fuzzy-only: verified_lossless must read False.")
+        self.assertFalse(
+            group["in_library"],
+            "Issue #123: no exact ID match → in_library False "
+            "(fuzzy fallback was deleted).")
+        self.assertIsNone(group["min_bitrate"])
+        self.assertFalse(group["verified_lossless"])
         self.assertIsNone(group["current_spectral_grade"])
         self.assertIsNone(group["quality_label"])
         self.assertIsNone(group["quality_rank"])
 
-    @patch("web.server.check_beets_by_artist_album", return_value=12)
+    @patch("web.server.check_beets_by_artist_album",
+           create=True, return_value=12)
     @patch("web.server.check_beets_library_detail", return_value={})
-    def test_group_blanks_quality_for_mbidless_request_via_fuzzy(
+    def test_group_in_library_false_for_mbidless_request(
             self, _mock_detail, _mock_fuzzy):
-        """No MBID → locate cannot produce an exact hit, so quality blanks.
+        """Request with no MBID → always ``in_library`` False (issue #123).
 
-        Same rule as the fuzzy-with-MBID case: the badge reflects the
-        fuzzy signal so the user still sees 'something exists', but
-        the quality strip stays honest about how much we actually
-        know. An adversarial review (issue #123 follow-up) showed the
-        MBID-less case is just as vulnerable to misidentification —
-        ``LIKE %artist%`` can match unrelated rows when artist/album
-        names contain wildcard chars, and legacy imports with missing
-        tags can collide with sibling pressings by the same artist.
+        A request that never had an MBID (edge case — shouldn't happen
+        in current flows but persists in old rows) cannot pattern-match
+        anything exact. After fuzzy deletion, the only honest answer
+        is 'not in library' — even if a fuzzy artist+album shim would
+        have returned a match (mocked here with ``create=True`` so the
+        test is RED against the current code).
         """
         row = self._row(42, 100, "testuser", "/fi/Test", mb_release_id=None)
         row["request_status"] = "imported"
@@ -2599,7 +2634,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         status, data = self._get("/api/wrong-matches")
         self.assertEqual(status, 200)
         group = data["groups"][0]
-        self.assertTrue(group["in_library"])
+        self.assertFalse(group["in_library"])
         self.assertIsNone(group["min_bitrate"])
         self.assertFalse(group["verified_lossless"])
         self.assertIsNone(group["current_spectral_grade"])
@@ -3380,6 +3415,23 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
             second["both"][0]["mb"].get("in_library"),
             "Compare overlay must run per-request — a warm skeleton "
             "cache must not mask a library-state change.")
+
+
+class TestFuzzyShimRemoved(unittest.TestCase):
+    """Issue #123: ``web.server.check_beets_by_artist_album`` deleted.
+
+    Guard against accidental reintroduction — the shim was the only
+    path from the web layer into the fuzzy fallback, so deleting it
+    completes the closure.
+    """
+
+    def test_check_beets_by_artist_album_no_longer_exposed(self) -> None:
+        from web import server
+        self.assertFalse(
+            hasattr(server, "check_beets_by_artist_album"),
+            "check_beets_by_artist_album was deleted in issue #123 "
+            "— the fuzzy artist+album shim must not return.",
+        )
 
 
 if __name__ == "__main__":

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -94,26 +94,23 @@ function renderQualityBadges(g) {
   // nothing on disk, so checking status alone would swallow the signal
   // and leave the badge strip empty.
   //
-  // Issue #121: the backend splits the signal — `in_library`
-  // reflects both exact and fuzzy hits (for the badge), while the
-  // quality strip (`quality_label`, `min_bitrate`,
-  // `current_spectral_grade`, `format`) is populated ONLY on an
-  // exact ID match. A fuzzy substring hit can match the wrong
-  // pressing, so we can't honestly attribute quality to it; the
-  // in_library=true + no-quality case is normal for fuzzy hits
-  // (and still safe for the 'not on disk' badge guard below).
-  // `format` stays in the guard because it's the fallback badge
-  // text below when bitrate is null (e.g. FLAC with no bitrate
-  // metadata), so its presence means an on-disk badge will render.
+  // Issues #121 / #123: the backend gates `in_library` and the
+  // quality fields (`quality_label`, `min_bitrate`,
+  // `current_spectral_grade`, `format`) on exact-ID match — no
+  // fuzzy fallback. When `in_library=true` the quality fields will
+  // be populated; when false they'll be null. `format` stays in the
+  // guard because it's the fallback badge text when bitrate is null
+  // (e.g. FLAC with no bitrate metadata).
   const hasOnDiskQuality = g.quality_label || g.min_bitrate
     || g.current_spectral_grade || g.format;
   if (!hasOnDiskQuality && !g.in_library) {
     return '<span class="badge" style="background:#3a2a2a;color:#f88;">nothing on disk</span>';
   }
   if (!hasOnDiskQuality) {
-    // Fuzzy library hit without indexed quality data — defer to
-    // the separate 'in library' badge rendered on the group card;
-    // we can't honestly assert more than that.
+    // Defensive: in_library=true should imply quality fields are
+    // set post-#123, but keep the empty-string return so a partial
+    // dataset (e.g. beets row exists but items table is empty)
+    // doesn't break the UI.
     return '';
   }
 

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -31,31 +31,21 @@ def _row_presence(
 ) -> str:
     """Answer 'is this release on disk?' for a wrong-matches row.
 
-    Returns one of ``'exact'`` / ``'fuzzy'`` / ``'absent'`` — the same
-    vocabulary as ``BeetsDB.ReleaseLocation.kind`` (issue #121). The
-    ``beets_info`` dict is the batched exact-hit lookup the caller has
-    already performed (via ``check_beets_library_detail`` →
-    ``BeetsDB.check_mbids_detail``); presence there is proof of an
-    exact ID match. When the ID misses, we fall back to the fuzzy
-    artist+album check, which carries a weaker badge-only guarantee.
+    Returns ``'exact'`` if the pipeline row's ``mb_release_id`` appears
+    in the batched exact-hit lookup (via ``check_beets_library_detail``
+    → ``BeetsDB.check_mbids_detail``), otherwise ``'absent'``. Matches
+    the vocabulary of ``BeetsDB.ReleaseLocation.kind`` (issues #121 /
+    #123).
 
-    Two callers of the result:
-    - ``in_library`` badge: any non-absent value shows the badge.
-    - ``_quality_summary``: only ``'exact'`` unlocks on-disk fields,
-      because fuzzy can match the wrong pressing (artist+album
-      ``LIKE`` matches sibling pressings, manual imports with
-      different tags, or — unescaped ``_`` / ``%`` in the name —
-      completely unrelated rows).
+    Issue #123 deleted the fuzzy artist+album fallback that used to
+    return ``'fuzzy'``. It conflated identity with presence and
+    silently attributed stale quality fields from sibling pressings
+    to the badge. 'In library' now means exact-ID match, period.
     """
     mbid = row.get("mb_release_id")
     if isinstance(mbid, str) and mbid and mbid in beets_info:
         return "exact"
-    artist = row.get("artist_name")
-    album = row.get("album_title")
-    if not isinstance(artist, str) or not isinstance(album, str):
-        return "absent"
-    fuzzy = _server().check_beets_by_artist_album(artist, album)
-    return "fuzzy" if fuzzy is not None else "absent"
+    return "absent"
 
 
 def _target_candidate(vr: dict[str, object]) -> dict[str, object] | None:
@@ -164,13 +154,11 @@ def _quality_summary(row: dict[str, object],
     (those never live in beets). We combine them so the user can see at a
     glance whether force-importing is worthwhile.
 
-    On-disk quality is reported only when ``presence == "exact"`` — a
-    fuzzy artist/album hit does NOT identify a specific pressing
-    (multiple pressings share titles), so attributing the pipeline DB's
-    quality fields to 'whatever fuzzy happened to match' would mislabel
-    sibling pressings. Fuzzy and absent both blank the quality strip;
-    the ``in_library`` badge is rendered separately and still picks up
-    fuzzy hits. See issue #121.
+    On-disk quality is reported only when ``presence == "exact"`` (issues
+    #121 / #123). The fuzzy artist+album fallback was deleted — 'in
+    library' now means exact-ID match, so ``presence != "exact"`` and
+    ``"absent"`` are synonymous here (kept as a string to preserve the
+    ``ReleaseLocation.kind`` vocabulary for the read side).
     """
     status = str(row.get("request_status") or "wanted")
     if presence != "exact":
@@ -306,16 +294,13 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
         assert isinstance(request_id, int)
         group = groups.get(request_id)
         if group is None:
-            # Single seam for 'is this release on disk?' (issue #121).
-            # ``_row_presence`` returns the same vocabulary
-            # (exact / fuzzy / absent) as ``BeetsDB.locate``. The badge
-            # turns on for both exact and fuzzy — users still see
-            # 'something by this artist exists'. The quality strip
-            # blanks unless ``presence == "exact"`` so we never claim
-            # the quality of a specific pressing from a fuzzy hit
-            # (which can match sibling pressings with the same title).
+            # Single seam for 'is this release on disk?' (issues #121 /
+            # #123). ``_row_presence`` now returns just ``"exact"`` or
+            # ``"absent"`` — the badge and the quality strip both gate
+            # on exact-ID match, with no fuzzy escape hatch. Untagged
+            # legacy copies honestly read 'not in library' now.
             presence = _row_presence(row, beets_info)
-            in_library = presence != "absent"
+            in_library = presence == "exact"
             group = {
                 "request_id": request_id,
                 "artist": row["artist_name"],

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -113,15 +113,14 @@ def get_pipeline_recent(h, params: dict[str, list[str]]) -> None:
                 if bi.get(k):
                     item[k] = bi[k]
         else:
-            fallback = s.check_beets_by_artist_album(
-                r.get("artist_name", ""), r.get("album_title", "")
-            )
-            if fallback is not None:
-                item["in_beets"] = True
-                item["beets_tracks"] = fallback
-            else:
-                item["in_beets"] = False
-                item["beets_tracks"] = 0
+            # Issue #123: artist+album fuzzy fallback deleted. Legacy
+            # rows with an untagged beets copy now honestly read as
+            # 'not in library' — fuzzy LIKE matches could return a
+            # track count for an unrelated sibling pressing by the
+            # same artist, which misled the UI's 'already on disk'
+            # signal.
+            item["in_beets"] = False
+            item["beets_tracks"] = 0
         history = history_batch.get(r["id"], [])
         success = next((dl for dl in history if dl.get("outcome") == "success"), None)
         if success:

--- a/web/server.py
+++ b/web/server.py
@@ -103,12 +103,6 @@ def check_beets_library_detail(mbids: list[str] | list[object]) -> dict[str, dic
     return b.check_mbids_detail([str(m) for m in mbids]) if b else {}
 
 
-def check_beets_by_artist_album(artist: str, album: str) -> int | None:
-    """Fuzzy check: is there an album by this artist in beets? Returns track count or None."""
-    b = _beets_db()
-    return b.find_by_artist_album(artist, album) if b else None
-
-
 def get_library_artist(artist_name, mb_artist_id=None):
     """Get albums by an artist from the beets library."""
     b = _beets_db()


### PR DESCRIPTION
Closes #123 (PR A — delete fuzzy).

## Summary

PR #122 closed #121 by extracting `BeetsDB.locate()` as the single "is this release on disk?" seam. Issue #123 observed that the only reason the seam still had a fuzzy escape hatch was backwards compatibility with legacy untagged libraries — and that fallback is exactly what caused the PR #119 marathon (DICE/Reality: sibling pressing title-matched, another release's quality fields got attributed to the badge).

This PR collapses the invariant so the class of bug can't recur.

### Deleted (structural fix, not just symptom)

- `ReleaseLocation.kind`: narrowed from `Literal["exact","fuzzy","absent"]` → `Literal["exact","absent"]`
- `BeetsDB.locate()`: dropped the `artist`/`album` kwargs — single-ID exact lookup
- `BeetsDB.find_by_artist_album` — deleted
- `BeetsDB._fuzzy_album_id` — deleted
- `web.server.check_beets_by_artist_album` — deleted
- `web.routes.imports._row_presence`: fuzzy branch deleted; collapsed to two lines
- `web.routes.pipeline.get_pipeline_recent`: fuzzy fallback deleted; untagged beets copies now honestly report `in_beets=False`
- `web/js/wrong-matches.js`: comment block updated — `in_library=true` now implies quality fields are populated

### Behavior change (visible)

If your beets library has albums with no `mb_albumid` / `discogs_albumid` tag, the web UI now shows them as "not in library" even when an artist+album substring match would previously have picked them up. Re-tag the album (or add the release to the pipeline) to restore the badge.

### Stays

- `remove_and_reset_release`: already gated on `kind == "exact"`. Works unchanged.
- `get_pipeline_recent`: numeric fallback path deleted but shape unchanged.

### Follow-up (out of scope, per issue #123)

- **PR B**: harden `remove_and_reset_release` error handling (try/except around `sp.run`, surface partial-failure). Separate focused PR.

## Test plan

- [x] 1881 tests pass (full suite via `nix-shell --run "bash scripts/run_tests.sh"`)
- [x] `pyright` clean on all 7 touched files (0 errors, 0 warnings)
- [x] `node --check` clean on all JS files
- [x] 6 new RED→GREEN contract tests exercising: 2-variant Literal guard, deleted symbols stay gone (hasattr guards), `locate()` rejects artist/album kwargs, `/api/wrong-matches` returns `in_library=False` when MBID misses even when the fuzzy shim is mocked to return a hit (tests use `create=True` so they're RED against the current code, GREEN after), `/api/pipeline/recent` returns `in_beets=False` when MBID misses.
- [x] Old fuzzy-specific tests replaced with the new contract tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)