### PR TITLE
fix(release_cleanup): harden remove loop against subprocess failures (#123 PR B)

### DIFF
--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -23,12 +23,24 @@ The function below is the only way to couple the two sides. Given a
    did), clears the pipeline DB's on-disk quality fields so stale
    ``current_spectral_*`` / ``imported_path`` / ``verified_lossless``
    can't mislead downstream consumers.
+
+Issue #123 PR B: each ``sp.run`` is now wrapped in a try/except that
+catches ``TimeoutExpired``, non-zero exit codes, and any ``OSError``
+(e.g. ``beet`` missing from PATH). The loop always attempts every
+selector, and per-selector failures are surfaced via
+``ReleaseCleanupResult.selector_failures`` so the caller can tell
+partial failure from a clean run. Before this change, a
+``TimeoutExpired`` on selector 1 escaped the loop and left selector 2
+untried — *after* the ban-source caller had already committed the
+denylist row, leaving the banned copy on disk with no recovery path.
 """
 
 from __future__ import annotations
 
+import logging
 import subprocess as sp
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import Literal, TYPE_CHECKING
 
 from lib.util import beets_subprocess_env
 
@@ -37,21 +49,99 @@ if TYPE_CHECKING:
     from lib.pipeline_db import PipelineDB
 
 
+log = logging.getLogger("soularr")
+
+
+SelectorFailureReason = Literal["timeout", "nonzero_rc", "exception"]
+
+
+@dataclass(frozen=True)
+class SelectorFailure:
+    """One ``beet remove -d`` attempt that didn't cleanly exit.
+
+    ``reason`` is a coarse tag so callers (including the web UI) can
+    classify at a glance without parsing ``detail`` strings. Keep the
+    set closed — see ``SelectorFailureReason``. ``detail`` is a short
+    human-readable string for logs and debugging; do not parse it.
+    """
+    selector: str
+    reason: SelectorFailureReason
+    detail: str
+
+
+@dataclass(frozen=True)
+class ReleaseCleanupResult:
+    """Outcome of a ``remove_and_reset_release`` call.
+
+    - ``beets_removed``: the album was present before the call AND is
+      absent afterward — i.e. this call is responsible for its removal.
+      A prior out-of-band ``beet rm`` returns False here; the pipeline
+      DB is still cleared if the album is absent.
+    - ``absent_after``: beets no longer holds the album. Pipeline DB
+      clearing fires iff this is True.
+    - ``selector_failures``: one entry per selector whose ``sp.run``
+      raised or exited non-zero. An empty tuple means every selector
+      ran clean. Non-empty does NOT automatically mean the overall
+      operation failed — a Discogs-layout album can live under two
+      selectors, so failing one while the other removes the album
+      still leaves ``absent_after == True``.
+    """
+    beets_removed: bool
+    absent_after: bool
+    selector_failures: tuple[SelectorFailure, ...]
+
+
+def _run_remove_selector(selector: str) -> SelectorFailure | None:
+    """Run ``beet remove -d <selector>`` once, never raise.
+
+    Returns ``None`` on clean exit (rc=0), otherwise a
+    ``SelectorFailure``. This is the one place that touches the beets
+    subprocess; isolating it means the loop in
+    ``remove_and_reset_release`` can be trivially correct ("always
+    iterate every selector, collect any failures").
+    """
+    try:
+        proc = sp.run(
+            ["beet", "remove", "-d", selector],
+            capture_output=True, text=True, timeout=30,
+            env=beets_subprocess_env(),
+        )
+    except sp.TimeoutExpired as exc:
+        msg = f"timed out after {exc.timeout}s"
+        log.warning(
+            "release_cleanup: beet remove -d %s %s", selector, msg)
+        return SelectorFailure(
+            selector=selector, reason="timeout", detail=msg)
+    except OSError as exc:
+        msg = f"{type(exc).__name__}: {exc}"
+        log.warning(
+            "release_cleanup: beet remove -d %s raised %s",
+            selector, msg)
+        return SelectorFailure(
+            selector=selector, reason="exception", detail=msg)
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip().splitlines()
+        msg = stderr[-1] if stderr else f"rc={proc.returncode}"
+        log.warning(
+            "release_cleanup: beet remove -d %s exited %d: %s",
+            selector, proc.returncode, msg)
+        return SelectorFailure(
+            selector=selector, reason="nonzero_rc",
+            detail=f"rc={proc.returncode}: {msg}")
+
+    return None
+
+
 def remove_and_reset_release(
     beets_db: "BeetsDB",
     pipeline_db: "PipelineDB",
     release_id: str,
     request_id: int,
-) -> tuple[bool, bool]:
+) -> ReleaseCleanupResult:
     """Atomically remove a release from beets and clear pipeline ghost state.
 
-    Returns ``(beets_removed, absent_after)``:
-    - ``beets_removed``: True iff the album was present before this
-      call AND is absent afterward — i.e. THIS call removed it.
-      (An out-of-band prior removal returns False here; it still
-      clears the pipeline DB.)
-    - ``absent_after``: True iff beets no longer holds the album
-      after this call. Clearing fires iff this is True.
+    See ``ReleaseCleanupResult`` for the return contract.
 
     Preconditions: ``release_id`` is non-empty. Callers that may pass
     an empty ID must guard before invoking.
@@ -62,16 +152,19 @@ def remove_and_reset_release(
     before = beets_db.locate(release_id)
     album_was_in_beets = before.kind == "exact"
 
+    failures: list[SelectorFailure] = []
     if album_was_in_beets:
         # ``before.selectors`` is every selector the ID could live
-        # under (one for UUIDs, two for Discogs numerics). Running
-        # all of them makes the remove idempotent across layouts.
+        # under (one for UUIDs, two for Discogs numerics). We iterate
+        # EVERY selector unconditionally — catching per-selector
+        # failures in ``_run_remove_selector`` — so a timeout on one
+        # never leaves the others untried. That's the PR #123B bug:
+        # the raw loop raised out on the first ``TimeoutExpired``,
+        # after the ban-source caller had committed the denylist row.
         for selector in before.selectors:
-            sp.run(
-                ["beet", "remove", "-d", selector],
-                capture_output=True, text=True, timeout=30,
-                env=beets_subprocess_env(),
-            )
+            failure = _run_remove_selector(selector)
+            if failure is not None:
+                failures.append(failure)
 
     after = beets_db.locate(release_id)
     absent_after = after.kind != "exact"
@@ -80,4 +173,8 @@ def remove_and_reset_release(
     if absent_after:
         pipeline_db.clear_on_disk_quality_fields(request_id)
 
-    return beets_removed, absent_after
+    return ReleaseCleanupResult(
+        beets_removed=beets_removed,
+        absent_after=absent_after,
+        selector_failures=tuple(failures),
+    )

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -161,6 +161,13 @@ def remove_and_reset_release(
         # never leaves the others untried. That's the PR #123B bug:
         # the raw loop raised out on the first ``TimeoutExpired``,
         # after the ban-source caller had committed the denylist row.
+        # NB: when selector N times out, Python kills the child process
+        # before moving on. Beets uses a file-backed SQLite DB, so a
+        # killed-mid-transaction remove can leave the WAL in a state
+        # where selector N+1 briefly blocks acquiring the write lock.
+        # SQLite clears this on its own; tests mock subprocess so they
+        # can't exercise it, but if production logs show lock contention
+        # the fix is to increase the timeout or serialize retries.
         for selector in before.selectors:
             failure = _run_remove_selector(selector)
             if failure is not None:

--- a/tests/test_release_cleanup.py
+++ b/tests/test_release_cleanup.py
@@ -1,0 +1,318 @@
+"""Tests for ``lib.release_cleanup.remove_and_reset_release``.
+
+Issue #123 PR B: the function's subprocess loop had no
+``TimeoutExpired`` or ``OSError`` handling — a timeout on one selector
+raised out of the loop, leaving the second selector untried *after*
+the ban-source caller had already committed the denylist row. The
+hardening replaces the raw ``(bool, bool)`` tuple return with a typed
+``ReleaseCleanupResult`` dataclass that surfaces per-selector failures
+to the caller, and wraps each ``sp.run`` in a try/except so the loop
+always attempts every selector.
+
+The pure-function tests here use a lightweight stub ``BeetsDB`` + a
+``MagicMock`` ``PipelineDB`` — the pipeline DB surface this function
+touches is exactly one method (``clear_on_disk_quality_fields``), and
+the assertion we care about is "was it called, with what argument",
+which MagicMock makes direct. Subprocess behavior is mocked via
+``patch('lib.release_cleanup.sp.run', ...)``.
+"""
+
+from __future__ import annotations
+
+import subprocess as sp
+import unittest
+from dataclasses import dataclass
+from typing import Literal, Optional
+from unittest.mock import MagicMock, patch
+
+from lib.release_cleanup import (
+    ReleaseCleanupResult,
+    SelectorFailure,
+    remove_and_reset_release,
+)
+
+
+@dataclass
+class _StubLocation:
+    kind: Literal["exact", "absent"]
+    album_id: Optional[int]
+    selectors: tuple[str, ...]
+
+
+class _StubBeetsDB:
+    """Minimal BeetsDB double: returns scripted ``locate`` results.
+
+    ``remove_and_reset_release`` calls ``locate`` exactly twice (before
+    and after the subprocess loop). Tests enqueue the sequence and
+    assert the transitions. Production callers route through the real
+    ``BeetsDB`` which is covered elsewhere (tests/test_beets_db.py).
+    """
+
+    def __init__(self, sequence: list[_StubLocation]) -> None:
+        self._sequence = list(sequence)
+        self.calls: list[str] = []
+
+    def locate(self, release_id: str) -> _StubLocation:
+        self.calls.append(release_id)
+        return self._sequence.pop(0)
+
+
+RELEASE_UUID = "aaa0bbb0-cccc-dddd-eeee-ffffffffffff"
+DISCOGS_ID = "12856590"
+
+
+def _ok(stdout: str = "", stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=0, stdout=stdout, stderr=stderr)
+
+
+class TestReleaseCleanupResult(unittest.TestCase):
+    """The new typed return contract."""
+
+    def test_result_dataclass_fields(self) -> None:
+        """``ReleaseCleanupResult`` exposes beets_removed, absent_after,
+        selector_failures — no raw tuples allowed across the seam."""
+        r = ReleaseCleanupResult(
+            beets_removed=True,
+            absent_after=True,
+            selector_failures=(),
+        )
+        self.assertTrue(r.beets_removed)
+        self.assertTrue(r.absent_after)
+        self.assertEqual(r.selector_failures, ())
+
+    def test_result_is_frozen(self) -> None:
+        """The result is immutable — callers must construct, not mutate."""
+        r = ReleaseCleanupResult(
+            beets_removed=True, absent_after=True, selector_failures=())
+        with self.assertRaises(Exception):
+            # dataclasses.FrozenInstanceError subclasses AttributeError
+            r.beets_removed = False  # type: ignore[misc]
+
+    def test_selector_failure_dataclass_fields(self) -> None:
+        """``SelectorFailure`` records which selector, why, and detail."""
+        f = SelectorFailure(
+            selector="mb_albumid:abc",
+            reason="timeout",
+            detail="beet remove timed out after 30s",
+        )
+        self.assertEqual(f.selector, "mb_albumid:abc")
+        self.assertEqual(f.reason, "timeout")
+        self.assertEqual(f.detail, "beet remove timed out after 30s")
+
+
+class TestAllSelectorsSucceed(unittest.TestCase):
+    """Baseline: when every selector exits 0, no failures, album gone."""
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_uuid_single_selector_clean_exit(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _ok()
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, (f"mb_albumid:{RELEASE_UUID}",)),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=RELEASE_UUID, request_id=42)
+
+        self.assertIsInstance(result, ReleaseCleanupResult)
+        self.assertTrue(result.beets_removed)
+        self.assertTrue(result.absent_after)
+        self.assertEqual(result.selector_failures, ())
+        self.assertEqual(mock_run.call_count, 1)
+        # Pipeline DB clear fires on absent_after=True.
+        pdb.clear_on_disk_quality_fields.assert_called_once_with(42)
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_discogs_pair_of_selectors_both_run(
+            self, mock_run: MagicMock) -> None:
+        """Discogs numeric → two selectors; both run on the happy path."""
+        mock_run.return_value = _ok()
+        selectors = (f"discogs_albumid:{DISCOGS_ID}", f"mb_albumid:{DISCOGS_ID}")
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=DISCOGS_ID, request_id=42)
+
+        self.assertEqual(mock_run.call_count, 2,
+                         "Discogs selectors must both run on happy path.")
+        self.assertTrue(result.absent_after)
+        self.assertEqual(result.selector_failures, ())
+
+
+class TestTimeoutOnOneSelector(unittest.TestCase):
+    """The bug report: timeout on selector A must not abort the loop."""
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_timeout_on_first_selector_still_runs_second(
+            self, mock_run: MagicMock) -> None:
+        """``TimeoutExpired`` on selector 1 must not prevent selector 2.
+
+        Before the fix, ``TimeoutExpired`` escaped the loop and the
+        ban-source caller saw a 500 after the denylist row was already
+        committed. The second selector (legacy ``mb_albumid`` for a
+        Discogs-layout album) never ran, so the banned copy stayed on
+        disk.
+        """
+        selectors = (f"discogs_albumid:{DISCOGS_ID}", f"mb_albumid:{DISCOGS_ID}")
+        # Selector 1: timeout. Selector 2: clean exit.
+        mock_run.side_effect = [
+            sp.TimeoutExpired(cmd=["beet", "remove", "-d", selectors[0]],
+                              timeout=30),
+            _ok(),
+        ]
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=DISCOGS_ID, request_id=42)
+
+        self.assertEqual(
+            mock_run.call_count, 2,
+            "Timeout on selector 1 must not skip selector 2.")
+        self.assertTrue(result.absent_after,
+                        "Second selector's success still leaves album gone.")
+        self.assertEqual(len(result.selector_failures), 1)
+        self.assertEqual(result.selector_failures[0].selector, selectors[0])
+        self.assertEqual(result.selector_failures[0].reason, "timeout")
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_timeout_on_both_selectors_returns_partial_failure(
+            self, mock_run: MagicMock) -> None:
+        """All selectors time out → two failures recorded, no clear."""
+        selectors = (f"discogs_albumid:{DISCOGS_ID}", f"mb_albumid:{DISCOGS_ID}")
+        mock_run.side_effect = [
+            sp.TimeoutExpired(cmd=["beet", "remove", "-d", selectors[0]],
+                              timeout=30),
+            sp.TimeoutExpired(cmd=["beet", "remove", "-d", selectors[1]],
+                              timeout=30),
+        ]
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("exact", 1, selectors),  # still present after
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=DISCOGS_ID, request_id=42)
+
+        self.assertEqual(
+            mock_run.call_count, 2,
+            "Even after selector 1 times out, selector 2 must be attempted.")
+        self.assertFalse(result.absent_after)
+        self.assertFalse(result.beets_removed)
+        self.assertEqual(len(result.selector_failures), 2)
+        # No DB clear when album still present — conservative.
+        pdb.clear_on_disk_quality_fields.assert_not_called()
+
+
+class TestNonZeroExitCodeLoopContinues(unittest.TestCase):
+    """``beet remove`` exits non-zero → record, keep looping."""
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_nonzero_rc_on_first_still_runs_second(
+            self, mock_run: MagicMock) -> None:
+        selectors = (f"discogs_albumid:{DISCOGS_ID}", f"mb_albumid:{DISCOGS_ID}")
+        mock_run.side_effect = [
+            MagicMock(returncode=1, stdout="", stderr="permission denied"),
+            _ok(),
+        ]
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=DISCOGS_ID, request_id=42)
+
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertEqual(len(result.selector_failures), 1)
+        self.assertEqual(result.selector_failures[0].reason, "nonzero_rc")
+        # Second selector cleared it → absent_after True.
+        self.assertTrue(result.absent_after)
+
+
+class TestMissingBeetBinary(unittest.TestCase):
+    """``FileNotFoundError`` (beet not on PATH) is caught gracefully."""
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_filenotfounderror_does_not_propagate(
+            self, mock_run: MagicMock) -> None:
+        """Beet missing from PATH must not crash the ban-source handler.
+
+        The denylist row is already committed by the caller before
+        ``remove_and_reset_release`` is invoked — an uncaught exception
+        here leaves the caller's state inconsistent with a surfaced 500.
+        """
+        selectors = (f"mb_albumid:{RELEASE_UUID}",)
+        mock_run.side_effect = FileNotFoundError(
+            2, "No such file or directory", "beet")
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("exact", 1, selectors),
+        ])
+        pdb = MagicMock()
+
+        # Must not raise — the caller expects a result object it can
+        # surface to the user, not a 500.
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=RELEASE_UUID, request_id=42)
+
+        self.assertEqual(len(result.selector_failures), 1)
+        self.assertEqual(result.selector_failures[0].reason, "exception")
+        self.assertFalse(result.absent_after)
+        # Conservative: album still present by locate() so no clear.
+        pdb.clear_on_disk_quality_fields.assert_not_called()
+
+
+class TestAlreadyGoneBeforeCall(unittest.TestCase):
+    """Pre-gone: no subprocess runs, pipeline DB still cleared."""
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_no_sp_run_when_locate_already_absent(
+            self, mock_run: MagicMock) -> None:
+        beets = _StubBeetsDB([
+            _StubLocation("absent", None, ()),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=RELEASE_UUID, request_id=42)
+
+        mock_run.assert_not_called()
+        self.assertFalse(result.beets_removed)
+        self.assertTrue(result.absent_after)
+        self.assertEqual(result.selector_failures, ())
+        pdb.clear_on_disk_quality_fields.assert_called_once_with(42)
+
+
+class TestEmptyReleaseIdRejected(unittest.TestCase):
+    """Empty release_id is a caller bug — keep the ValueError contract."""
+
+    def test_empty_release_id_raises(self) -> None:
+        beets = _StubBeetsDB([])
+        pdb = MagicMock()
+        with self.assertRaises(ValueError):
+            remove_and_reset_release(
+                beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+                release_id="", request_id=42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1002,7 +1002,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
     SET_INTENT_REQUIRED_FIELDS = {
         "status", "id", "intent", "target_format", "requeued",
     }
-    BAN_SOURCE_REQUIRED_FIELDS = {"status", "username", "beets_removed"}
+    BAN_SOURCE_REQUIRED_FIELDS = {
+        "status", "username", "beets_removed", "cleanup_errors",
+    }
     FORCE_IMPORT_REQUIRED_FIELDS = {
         "status", "request_id", "artist", "album", "message",
     }
@@ -1499,7 +1501,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         attempts (e.g. permissions error, wrong column and no legacy
         fallback matched), the on-disk quality state is still accurate,
         so don't clear it. Modelled by ``locate`` returning 'exact'
-        both before and after the subprocess calls.
+        both before and after the subprocess calls. The non-zero rc
+        also surfaces in ``cleanup_errors`` so the UI can tell the
+        user the ban committed but the on-disk remove was incomplete
+        (issue #123 PR B).
         """
         self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
@@ -1510,19 +1515,26 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
             current_spectral_grade="genuine",
             verified_lossless=True,
         )
-        # Album is still there after the remove attempt (both calls exact).
+        # Album is still there after the remove attempt. Seed the
+        # selector tuple so the remove loop has something to iterate.
         self._set_locate_sequence([
-            ("exact", 1, ()),
-            ("exact", 1, ()),
+            ("exact", 1, (f"mb_albumid:{self.RELEASE_ID}",)),
+            ("exact", 1, (f"mb_albumid:{self.RELEASE_ID}",)),
         ])
 
-        status, _data = self._post("/api/pipeline/ban-source", {
+        status, data = self._post("/api/pipeline/ban-source", {
             "request_id": 1704, "username": "baduser",
             "mb_release_id": self.RELEASE_ID,
         })
 
         self.assertEqual(status, 200)
         self.mock_db.clear_on_disk_quality_fields.assert_not_called()
+        # #123 PR B: the non-zero rc surfaces as a cleanup error so the
+        # UI can distinguish "banned cleanly" from "banned but album
+        # still on disk".
+        self.assertEqual(len(data["cleanup_errors"]), 1)
+        self.assertEqual(data["cleanup_errors"][0]["reason"], "nonzero_rc")
+        self.assertFalse(data["beets_removed"])
 
     @patch("lib.release_cleanup.sp.run")
     @patch("web.routes.pipeline.apply_transition")

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -256,7 +256,19 @@ export async function banSource(requestId, username, mbid) {
     });
     const data = await r.json();
     if (data.status === 'ok') {
-      toast(`Banned ${username}, ${data.beets_removed ? 'removed from beets' : 'not in beets'}, requeued`);
+      // Issue #123 PR B: distinguish three outcomes. `cleanup_errors`
+      // non-empty means at least one beet-remove selector timed out /
+      // exited non-zero / raised — the denylist committed, but the
+      // album may still be on disk under one of the selectors. Show
+      // a warning toast so the user knows to investigate rather than
+      // reporting a clean "not in beets".
+      const errs = data.cleanup_errors || [];
+      if (errs.length > 0) {
+        const reasons = errs.map(e => e.reason).join(', ');
+        toast(`Banned ${username}, but beet remove had ${errs.length} failure(s) (${reasons}). Album may still be on disk; check journalctl.`, true);
+      } else {
+        toast(`Banned ${username}, ${data.beets_removed ? 'removed from beets' : 'not in beets'}, requeued`);
+      }
     } else {
       toast(data.error || 'Ban failed', true);
     }

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from dataclasses import asdict
 
 from web.classify import classify_log_entry, LogEntry
 from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
@@ -667,10 +668,11 @@ def post_pipeline_ban_source(h, body: dict) -> None:
             request_id=int(req_id),
         )
         beets_removed = cleanup.beets_removed
-        cleanup_errors = [
-            {"selector": f.selector, "reason": f.reason, "detail": f.detail}
-            for f in cleanup.selector_failures
-        ]
+        # ``asdict`` so future fields on ``SelectorFailure`` (e.g. a
+        # timestamp) propagate to the route response without anyone
+        # having to remember to update the literal here (issue #123
+        # PR B review feedback).
+        cleanup_errors = [asdict(f) for f in cleanup.selector_failures]
 
     req = s._db().get_request(int(req_id))
     if req:

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -649,15 +649,28 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     # (whether this handler just removed it or a prior ``beet rm``
     # did), clear the pipeline DB's on-disk quality fields in the
     # same call so nothing downstream reasons about ghost state.
+    #
+    # Issue #123 PR B: ``remove_and_reset_release`` now returns a
+    # typed result. ``selector_failures`` surfaces per-selector
+    # problems (timeout, non-zero rc, exception) so the ban-source
+    # handler can tell a user the ban succeeded but the remove was
+    # incomplete, rather than silently reporting success after a
+    # denylist-committed / album-still-on-disk split brain.
     beets_removed = False
+    cleanup_errors: list[dict[str, str]] = []
     b = s._beets_db()
     if mb_release_id and b:
-        beets_removed, _ = remove_and_reset_release(
+        cleanup = remove_and_reset_release(
             beets_db=b,
             pipeline_db=s._db(),
             release_id=mb_release_id,
             request_id=int(req_id),
         )
+        beets_removed = cleanup.beets_removed
+        cleanup_errors = [
+            {"selector": f.selector, "reason": f.reason, "detail": f.detail}
+            for f in cleanup.selector_failures
+        ]
 
     req = s._db().get_request(int(req_id))
     if req:
@@ -676,6 +689,7 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         "status": "ok",
         "username": username,
         "beets_removed": beets_removed,
+        "cleanup_errors": cleanup_errors,
     })
 
 


### PR DESCRIPTION
Closes #123 (PR B — harden remove_and_reset_release).

## The bug

\`lib/release_cleanup.py::remove_and_reset_release\`'s per-selector loop had no try/except around \`sp.run\`:

\`\`\`python
for selector in before.selectors:
    sp.run(
        [\"beet\", \"remove\", \"-d\", selector],
        capture_output=True, text=True, timeout=30,
        env=beets_subprocess_env(),
    )
\`\`\`

A \`TimeoutExpired\` on selector 1 escaped the loop. Selector 2 never ran. The caller (\`post_pipeline_ban_source\`) had already committed \`add_denylist\` on the line above — so the user saw a 500 in the web UI while the denylist persisted and the banned album stayed on disk under the second selector layout, with no recovery path.

## Fix (structural — not just the symptom)

1. **One place handles subprocess fragility**: new \`_run_remove_selector(selector)\` that invokes \`sp.run\` and returns \`SelectorFailure | None\`. Catches \`TimeoutExpired\`, \`OSError\` (covers \`FileNotFoundError\` from missing \`beet\`), and non-zero rc. Never raises. This makes the loop trivially correct: *always iterate every selector, collect failures*.

2. **Typed result**: \`ReleaseCleanupResult\` frozen dataclass replaces the \`tuple[bool, bool]\` return. Adds \`selector_failures: tuple[SelectorFailure, ...]\` so callers can tell partial failure from clean runs. \`SelectorFailure\` has \`reason: Literal[\"timeout\",\"nonzero_rc\",\"exception\"]\` + human-readable \`detail\`.

3. **UI surface**: \`/api/pipeline/ban-source\` response now includes \`cleanup_errors\` — the UI can show \"banned, but album still on disk\" distinctly from clean success. \`beets_removed\` preserved in the shape.

## Test plan

- [x] 1892 tests pass (\`nix-shell --run \"bash scripts/run_tests.sh\"\`) — 1881 existing + 11 new
- [x] pyright clean on all touched files (0 errors, 0 warnings)
- [x] New \`tests/test_release_cleanup.py\` (11 tests):
  - Happy path: UUID single selector + Discogs two-selector pair
  - **Bug repro**: timeout on selector 1 → selector 2 still attempts, ends \`absent_after=True\` via selector 2's success
  - Both selectors timeout → 2 failures recorded, no DB clear (conservative)
  - Non-zero rc on selector 1 → selector 2 still attempts
  - \`FileNotFoundError\` (beet missing from PATH) → handled gracefully, returns result not exception
  - Pre-gone path (\`locate\` absent before call) → no \`sp.run\`, still clears DB
  - Empty \`release_id\` → \`ValueError\` (preserved caller contract)
  - Dataclass frozen + field contract
- [x] \`test_ban_source_skips_clear_when_beet_remove_failed\` extended: non-zero rc now surfaces in \`cleanup_errors[0].reason == \"nonzero_rc\"\` (was silently swallowed before)
- [x] \`BAN_SOURCE_REQUIRED_FIELDS\` route contract updated to include \`cleanup_errors\` — the \`TestRouteContractAudit\` guard keeps this honest

## Non-scope

- \`harness/import_one.py:1185-1204\` has the same class of smell (subprocess \`beet move\` with partial error handling). Audit flagged it but issue #123 scopes PR B to \`remove_and_reset_release\` only. Follow-up candidate if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)