### PR TITLE
fix(import_one): harden post-import beet move (#127)

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -47,8 +47,8 @@ from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
 from lib.util import beets_subprocess_env
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
-                         AudioQualityMeasurement, ImportResult,
-                         PostflightInfo, QualityRankConfig,
+                         AudioQualityMeasurement, DisambiguationFailure,
+                         ImportResult, PostflightInfo, QualityRankConfig,
                          comparison_format_hint,
                          determine_verified_lossless,
                          import_quality_decision, transcode_detection)
@@ -705,18 +705,65 @@ def run_import(path, mb_release_id):
     return (0 if applied else 2), beets_lines, kept_duplicate
 
 
-def _run_disambiguation_move(mbid: str) -> str | None:
+def _apply_disambiguation(
+    mbid: str,
+    beets: BeetsDB,
+    album_path: str,
+    r: ImportResult,
+) -> str:
+    """Run the post-import ``beet move`` and update ImportResult/path.
+
+    Never raises. Returns the (possibly updated) album path. On clean
+    exit, sets ``r.postflight.disambiguated = True`` and re-reads the
+    path from beets DB. On any failure mode (timeout, OSError,
+    non-zero rc), records a typed ``DisambiguationFailure`` on
+    ``r.postflight.disambiguation_failure`` and returns the original
+    ``album_path`` unchanged.
+
+    Extracting this from ``main()`` makes the call-site contract
+    testable in isolation: the album-on-disk state is decoupled from
+    disambiguation success, ImportResult JSON always emits cleanly,
+    and ``r.exit_code`` / ``r.decision`` are never touched by a
+    disambiguation failure.
+    """
+    move_failure = _run_disambiguation_move(mbid)
+    if move_failure is not None:
+        # Album is already imported to beets — only the post-import
+        # path-disambiguation move did not exit cleanly. Surface the
+        # typed reason so the audit trail in download_log shows *why*
+        # without lying that disambiguation succeeded.
+        _log(f"  [DISAMBIGUATE] beet move failed "
+             f"({move_failure.reason}): {move_failure.detail}")
+        r.postflight.disambiguation_failure = move_failure
+        return album_path
+
+    pf_info_after = beets.get_album_info(mbid, _rank_cfg)
+    if pf_info_after:
+        new_path = pf_info_after.album_path
+        if new_path != album_path:
+            _log(f"  [DISAMBIGUATE] Path changed: {album_path} → {new_path}")
+            album_path = new_path
+            r.postflight.imported_path = new_path
+        else:
+            _log(f"  [DISAMBIGUATE] Path unchanged (already unique)")
+    r.postflight.disambiguated = True
+    return album_path
+
+
+def _run_disambiguation_move(mbid: str) -> DisambiguationFailure | None:
     """Run ``beet move mb_albumid:<mbid>`` once, never raise (issue #127).
 
     Mirrors ``lib/release_cleanup.py::_run_remove_selector``: one place
     owns the subprocess invocation, catches every fragile failure mode
     (``TimeoutExpired``, ``OSError`` from a missing ``beet`` binary,
-    non-zero rc), and returns a short error string the caller stores on
-    ``PostflightInfo.disambiguation_error``. Returns ``None`` on a
-    clean rc=0 exit.
+    non-zero rc), and returns a typed ``DisambiguationFailure`` (with a
+    ``Literal["timeout","nonzero_rc","exception"]`` reason tag) so the
+    caller and downstream consumers can classify failures without
+    parsing the ``detail`` string. Returns ``None`` on a clean rc=0
+    exit.
 
-    Why this is its own function: the call site fires *after* beets has
-    already imported the album to disk. An uncaught exception here
+    Why this is its own function: the call site fires *after* beets
+    has already imported the album to disk. An uncaught exception here
     would crash ``import_one.py`` before it could emit the
     ``__IMPORT_RESULT__`` sentinel — the caller would treat the import
     as failed even though the album is on disk, leaving a "semi-lie"
@@ -730,14 +777,18 @@ def _run_disambiguation_move(mbid: str) -> str | None:
             env=beets_subprocess_env(),
         )
     except subprocess.TimeoutExpired as exc:
-        return f"timeout after {exc.timeout}s"
+        return DisambiguationFailure(
+            reason="timeout", detail=f"timeout after {exc.timeout}s")
     except OSError as exc:
-        return f"{type(exc).__name__}: {exc}"
+        return DisambiguationFailure(
+            reason="exception", detail=f"{type(exc).__name__}: {exc}")
 
     if proc.returncode != 0:
         stderr = (proc.stderr or "").strip().splitlines()
         last = stderr[-1] if stderr else ""
-        return f"rc={proc.returncode}: {last}" if last else f"rc={proc.returncode}"
+        detail = (f"rc={proc.returncode}: {last}"
+                  if last else f"rc={proc.returncode}")
+        return DisambiguationFailure(reason="nonzero_rc", detail=detail)
 
     return None
 
@@ -1219,27 +1270,7 @@ def main():
     # `beet move` re-evaluates all editions and fixes the paths.
     if kept_duplicate:
         _log(f"[DISAMBIGUATE] Running beet move for album id:{pf_info.album_id}")
-        move_error = _run_disambiguation_move(mbid)
-        if move_error is None:
-            # Re-read path from beets DB — it may have changed
-            pf_info_after = beets.get_album_info(mbid, _rank_cfg)
-            if pf_info_after:
-                new_path = pf_info_after.album_path
-                if new_path != album_path:
-                    _log(f"  [DISAMBIGUATE] Path changed: {album_path} → {new_path}")
-                    album_path = new_path
-                    r.postflight.imported_path = new_path
-                else:
-                    _log(f"  [DISAMBIGUATE] Path unchanged (already unique)")
-            r.postflight.disambiguated = True
-        else:
-            # Album is already imported to beets; the post-import path
-            # disambiguation didn't run cleanly. Surface the reason on
-            # PostflightInfo so the audit trail in download_log can
-            # show *why* the move failed without silently lying that
-            # disambiguation succeeded.
-            _log(f"  [DISAMBIGUATE] beet move failed: {move_error}")
-            r.postflight.disambiguation_error = move_error
+        album_path = _apply_disambiguation(mbid, beets, album_path, r)
 
     # --- Post-import extension check ---
     # Detect .bak files (known bug: track 01 sometimes renamed to .bak during import)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -705,6 +705,43 @@ def run_import(path, mb_release_id):
     return (0 if applied else 2), beets_lines, kept_duplicate
 
 
+def _run_disambiguation_move(mbid: str) -> str | None:
+    """Run ``beet move mb_albumid:<mbid>`` once, never raise (issue #127).
+
+    Mirrors ``lib/release_cleanup.py::_run_remove_selector``: one place
+    owns the subprocess invocation, catches every fragile failure mode
+    (``TimeoutExpired``, ``OSError`` from a missing ``beet`` binary,
+    non-zero rc), and returns a short error string the caller stores on
+    ``PostflightInfo.disambiguation_error``. Returns ``None`` on a
+    clean rc=0 exit.
+
+    Why this is its own function: the call site fires *after* beets has
+    already imported the album to disk. An uncaught exception here
+    would crash ``import_one.py`` before it could emit the
+    ``__IMPORT_RESULT__`` sentinel — the caller would treat the import
+    as failed even though the album is on disk, leaving a "semi-lie"
+    that can trigger duplicate force-import attempts (the bug PR #126
+    flagged as out-of-scope follow-up to #123).
+    """
+    try:
+        proc = subprocess.run(
+            [BEET_BIN, "move", f"mb_albumid:{mbid}"],
+            capture_output=True, text=True, timeout=120,
+            env=beets_subprocess_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        return f"timeout after {exc.timeout}s"
+    except OSError as exc:
+        return f"{type(exc).__name__}: {exc}"
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip().splitlines()
+        last = stderr[-1] if stderr else ""
+        return f"rc={proc.returncode}: {last}" if last else f"rc={proc.returncode}"
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Pipeline DB updates
 # ---------------------------------------------------------------------------
@@ -1182,12 +1219,8 @@ def main():
     # `beet move` re-evaluates all editions and fixes the paths.
     if kept_duplicate:
         _log(f"[DISAMBIGUATE] Running beet move for album id:{pf_info.album_id}")
-        move_result = subprocess.run(
-            [BEET_BIN, "move", f"mb_albumid:{mbid}"],
-            capture_output=True, text=True, timeout=120,
-            env=beets_subprocess_env(),
-        )
-        if move_result.returncode == 0:
+        move_error = _run_disambiguation_move(mbid)
+        if move_error is None:
             # Re-read path from beets DB — it may have changed
             pf_info_after = beets.get_album_info(mbid, _rank_cfg)
             if pf_info_after:
@@ -1200,8 +1233,13 @@ def main():
                     _log(f"  [DISAMBIGUATE] Path unchanged (already unique)")
             r.postflight.disambiguated = True
         else:
-            _log(f"  [DISAMBIGUATE] beet move failed (rc={move_result.returncode}): "
-                 f"{move_result.stderr[:200]}")
+            # Album is already imported to beets; the post-import path
+            # disambiguation didn't run cleanly. Surface the reason on
+            # PostflightInfo so the audit trail in download_log can
+            # show *why* the move failed without silently lying that
+            # disambiguation succeeded.
+            _log(f"  [DISAMBIGUATE] beet move failed: {move_error}")
+            r.postflight.disambiguation_error = move_error
 
     # --- Post-import extension check ---
     # Detect .bak files (known bug: track 01 sometimes renamed to .bak during import)

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1306,6 +1306,23 @@ class SpectralDetail:
     existing_suspect_pct: float = 0.0
 
 
+DisambiguationFailureReason = Literal["timeout", "nonzero_rc", "exception"]
+
+
+@dataclass(frozen=True)
+class DisambiguationFailure:
+    """Why the post-import ``beet move`` did not exit cleanly (issue #127).
+
+    Mirrors ``lib/release_cleanup.py::SelectorFailure`` shape:
+    ``reason`` is a coarse Literal tag so callers (and the future web
+    UI Recents tab) can classify failures at a glance without parsing
+    ``detail`` strings; ``detail`` is a short human-readable string for
+    logs and the JSONB audit trail (do not parse it).
+    """
+    reason: DisambiguationFailureReason
+    detail: str
+
+
 @dataclass
 class PostflightInfo:
     """Beets post-import verification data."""
@@ -1315,12 +1332,26 @@ class PostflightInfo:
     bad_extensions: list[str] = field(default_factory=list)  # files with non-audio extensions
     disambiguated: bool = False  # True if beet move ran cleanly to fix %aunique paths
     # Issue #127: when ``beet move`` was attempted but did not exit cleanly
-    # (TimeoutExpired, OSError, or non-zero rc), this carries a short
-    # human-readable reason. The album was still imported to beets — only
-    # the post-import path-disambiguation move failed. ``None`` means
-    # either ``disambiguated=True`` (clean success) or that no move was
+    # (TimeoutExpired, OSError, or non-zero rc), this carries a typed
+    # failure record. The album was still imported to beets — only the
+    # post-import path-disambiguation move failed. ``None`` means either
+    # ``disambiguated=True`` (clean success) or that no move was
     # attempted (no duplicate kept).
-    disambiguation_error: Optional[str] = None
+    disambiguation_failure: Optional[DisambiguationFailure] = None
+
+
+def _postflight_from_dict(d: Optional[dict]) -> PostflightInfo:
+    """Construct PostflightInfo from a dict, handling the nested
+    ``disambiguation_failure`` (issue #127) and any other future nested
+    fields. Old rows missing the field default to ``None``.
+    """
+    if not d:
+        return PostflightInfo()
+    pf_d = dict(d)
+    df_d = pf_d.pop("disambiguation_failure", None)
+    if isinstance(df_d, dict):
+        pf_d["disambiguation_failure"] = DisambiguationFailure(**df_d)
+    return PostflightInfo(**pf_d)
 
 
 @dataclass
@@ -1404,8 +1435,7 @@ class ImportResult:
                 per_track=spectral.get("per_track", []),
                 existing_suspect_pct=spectral.get("existing_suspect_pct", 0.0),
             ),
-            postflight=(PostflightInfo(**d["postflight"])
-                        if "postflight" in d else PostflightInfo()),
+            postflight=_postflight_from_dict(d.get("postflight")),
             beets_log=d.get("beets_log", []),
             error=d.get("error"),
         )
@@ -1438,8 +1468,7 @@ class ImportResult:
                         if "conversion" in d else ConversionInfo()),
             spectral=(SpectralDetail(**d["spectral"])
                       if "spectral" in d else SpectralDetail()),
-            postflight=(PostflightInfo(**d["postflight"])
-                        if "postflight" in d else PostflightInfo()),
+            postflight=_postflight_from_dict(d.get("postflight")),
             beets_log=d.get("beets_log", []),
             error=d.get("error"),
             v0_verification_bitrate=d.get("v0_verification_bitrate"),

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1313,7 +1313,14 @@ class PostflightInfo:
     track_count: Optional[int] = None
     imported_path: Optional[str] = None
     bad_extensions: list[str] = field(default_factory=list)  # files with non-audio extensions
-    disambiguated: bool = False  # True if beet move ran to fix %aunique paths
+    disambiguated: bool = False  # True if beet move ran cleanly to fix %aunique paths
+    # Issue #127: when ``beet move`` was attempted but did not exit cleanly
+    # (TimeoutExpired, OSError, or non-zero rc), this carries a short
+    # human-readable reason. The album was still imported to beets — only
+    # the post-import path-disambiguation move failed. ``None`` means
+    # either ``disambiguated=True`` (clean success) or that no move was
+    # attempted (no duplicate kept).
+    disambiguation_error: Optional[str] = None
 
 
 @dataclass

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,7 @@ from lib.quality import (
     AudioQualityMeasurement,
     CodecRankBands,
     ConversionInfo,
+    DisambiguationFailure,
     DownloadInfo,
     ImportResult,
     PostflightInfo,
@@ -89,7 +90,7 @@ def make_import_result(
     error: str | None = None,
     imported_path: str | None = None,
     disambiguated: bool = False,
-    disambiguation_error: str | None = None,
+    disambiguation_failure: DisambiguationFailure | None = None,
     final_format: str | None = None,
 ) -> ImportResult:
     """Build an ImportResult with sensible defaults."""
@@ -120,7 +121,7 @@ def make_import_result(
         postflight=PostflightInfo(
             imported_path=imported_path,
             disambiguated=disambiguated,
-            disambiguation_error=disambiguation_error,
+            disambiguation_failure=disambiguation_failure,
         ),
         final_format=final_format,
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -89,6 +89,7 @@ def make_import_result(
     error: str | None = None,
     imported_path: str | None = None,
     disambiguated: bool = False,
+    disambiguation_error: str | None = None,
     final_format: str | None = None,
 ) -> ImportResult:
     """Build an ImportResult with sensible defaults."""
@@ -119,6 +120,7 @@ def make_import_result(
         postflight=PostflightInfo(
             imported_path=imported_path,
             disambiguated=disambiguated,
+            disambiguation_error=disambiguation_error,
         ),
         final_format=final_format,
     )

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -6,10 +6,15 @@ Covers:
 - run_import() returning kept_duplicate=False for same-MBID duplicates (replace)
 - run_import() returning kept_duplicate=False on normal imports (no duplicate)
 - beet move invocation after kept_duplicate import
+- _run_disambiguation_move() helper hardening (issue #127): subprocess
+  fragility around the post-import ``beet move`` call. The helper must
+  never raise — TimeoutExpired, OSError, and non-zero rc all surface as
+  a short error string (or None on clean exit).
 """
 
 import json
 import os
+import subprocess
 import sys
 import unittest
 from unittest.mock import patch, MagicMock, ANY
@@ -269,6 +274,108 @@ class TestDisambiguateBeetMove(unittest.TestCase):
 
         self.assertFalse(pf.disambiguated)
         self.assertEqual(pf.imported_path, "/Beets/The National/2010 - High Violet")
+
+
+class TestRunDisambiguationMoveHelper(unittest.TestCase):
+    """Direct unit tests for ``_run_disambiguation_move(mbid)`` (issue #127).
+
+    Mirrors the hardened helper pattern in
+    ``lib/release_cleanup.py::_run_remove_selector``: one place owns the
+    subprocess invocation, never raises, returns a short typed-ish error
+    description (``str | None``) the caller stores on ``PostflightInfo``.
+
+    Bug being prevented: the original inline ``subprocess.run`` had no
+    try/except. A ``TimeoutExpired`` or ``OSError`` on the post-import
+    ``beet move`` crashed import_one.py *after* beets had already
+    written the album to disk, so callers parsed no JSON sentinel and
+    treated the import as failed — a semi-lie that could trigger a
+    duplicate force-import attempt.
+    """
+
+    MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
+    @patch("harness.import_one.subprocess.run")
+    def test_clean_exit_returns_none(self, mock_run):
+        from harness import import_one
+
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = ""
+        mock_run.return_value = proc
+
+        result = import_one._run_disambiguation_move(self.MBID)
+
+        self.assertIsNone(result)
+        mock_run.assert_called_once()
+        # argv shape is the seam contract — must hit `beet move
+        # mb_albumid:<mbid>` with text capture and a 120s timeout.
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0][1:], ["move", f"mb_albumid:{self.MBID}"])
+        self.assertEqual(kwargs.get("timeout"), 120)
+        self.assertTrue(kwargs.get("capture_output"))
+        self.assertTrue(kwargs.get("text"))
+
+    @patch("harness.import_one.subprocess.run")
+    def test_timeout_returns_typed_string(self, mock_run):
+        from harness import import_one
+
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["beet", "move"], timeout=120)
+
+        result = import_one._run_disambiguation_move(self.MBID)
+
+        self.assertIsNotNone(result)
+        assert result is not None  # narrow for pyright
+        self.assertIn("timeout", result.lower())
+        self.assertIn("120", result)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_oserror_returns_typed_string(self, mock_run):
+        """FileNotFoundError (beet missing on PATH) must be caught."""
+        from harness import import_one
+
+        mock_run.side_effect = FileNotFoundError(2, "No such file", "beet")
+
+        result = import_one._run_disambiguation_move(self.MBID)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        # Reason tag should identify the exception class so the audit
+        # trail in download_log can distinguish "beet missing" from
+        # "beet timed out".
+        self.assertIn("FileNotFoundError", result)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_nonzero_rc_with_stderr_includes_last_line(self, mock_run):
+        from harness import import_one
+
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stderr = ("warning: ignored line\n"
+                       "error: could not find album with id mb_albumid:bogus\n")
+        mock_run.return_value = proc
+
+        result = import_one._run_disambiguation_move(self.MBID)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("rc=1", result)
+        self.assertIn("could not find album", result)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_nonzero_rc_with_empty_stderr_still_returns(self, mock_run):
+        from harness import import_one
+
+        proc = MagicMock()
+        proc.returncode = 2
+        proc.stderr = ""
+        mock_run.return_value = proc
+
+        result = import_one._run_disambiguation_move(self.MBID)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("rc=2", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -522,6 +522,30 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         self.assertIsNone(r.postflight.disambiguation_failure)
 
     @patch("harness.import_one.subprocess.run")
+    def test_clean_move_but_pf_info_after_none(self, mock_run):
+        """Edge case: move ran cleanly but beets DB no longer returns
+        the album (race / out-of-band deletion). Original code set
+        ``disambiguated=True`` and left ``imported_path`` unchanged.
+        Pin that behavior so a future refactor can't silently change
+        whether a partial-state album is treated as disambiguated."""
+        from harness import import_one
+
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = ""
+        mock_run.return_value = proc
+        r, beets = self._make_result_and_beets()
+        beets.get_album_info.return_value = None
+
+        new_path = import_one._apply_disambiguation(
+            self.MBID, beets, self.ORIGINAL_PATH, r)
+
+        self.assertEqual(new_path, self.ORIGINAL_PATH)
+        self.assertEqual(r.postflight.imported_path, self.ORIGINAL_PATH)
+        self.assertTrue(r.postflight.disambiguated)
+        self.assertIsNone(r.postflight.disambiguation_failure)
+
+    @patch("harness.import_one.subprocess.run")
     def test_clean_move_path_changed(self, mock_run):
         """Successful move: pf_info_after returns new path → path
         mutates and is propagated back via return value AND on

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -281,8 +281,9 @@ class TestRunDisambiguationMoveHelper(unittest.TestCase):
 
     Mirrors the hardened helper pattern in
     ``lib/release_cleanup.py::_run_remove_selector``: one place owns the
-    subprocess invocation, never raises, returns a short typed-ish error
-    description (``str | None``) the caller stores on ``PostflightInfo``.
+    subprocess invocation, never raises, returns a typed
+    ``DisambiguationFailure`` (with a ``Literal`` reason tag) the
+    caller stores on ``PostflightInfo``. Returns ``None`` on clean exit.
 
     Bug being prevented: the original inline ``subprocess.run`` had no
     try/except. A ``TimeoutExpired`` or ``OSError`` on the post-import
@@ -316,7 +317,7 @@ class TestRunDisambiguationMoveHelper(unittest.TestCase):
         self.assertTrue(kwargs.get("text"))
 
     @patch("harness.import_one.subprocess.run")
-    def test_timeout_returns_typed_string(self, mock_run):
+    def test_timeout_returns_typed_failure(self, mock_run):
         from harness import import_one
 
         mock_run.side_effect = subprocess.TimeoutExpired(
@@ -326,11 +327,12 @@ class TestRunDisambiguationMoveHelper(unittest.TestCase):
 
         self.assertIsNotNone(result)
         assert result is not None  # narrow for pyright
-        self.assertIn("timeout", result.lower())
-        self.assertIn("120", result)
+        self.assertEqual(result.reason, "timeout")
+        self.assertIn("timeout", result.detail.lower())
+        self.assertIn("120", result.detail)
 
     @patch("harness.import_one.subprocess.run")
-    def test_oserror_returns_typed_string(self, mock_run):
+    def test_oserror_returns_typed_failure(self, mock_run):
         """FileNotFoundError (beet missing on PATH) must be caught."""
         from harness import import_one
 
@@ -340,10 +342,11 @@ class TestRunDisambiguationMoveHelper(unittest.TestCase):
 
         self.assertIsNotNone(result)
         assert result is not None
-        # Reason tag should identify the exception class so the audit
-        # trail in download_log can distinguish "beet missing" from
-        # "beet timed out".
-        self.assertIn("FileNotFoundError", result)
+        # Reason tag matches SelectorFailure's "exception" class.
+        self.assertEqual(result.reason, "exception")
+        # Detail carries the exception class name so the audit trail can
+        # distinguish "beet missing" from other OSError flavors.
+        self.assertIn("FileNotFoundError", result.detail)
 
     @patch("harness.import_one.subprocess.run")
     def test_nonzero_rc_with_stderr_includes_last_line(self, mock_run):
@@ -359,8 +362,9 @@ class TestRunDisambiguationMoveHelper(unittest.TestCase):
 
         self.assertIsNotNone(result)
         assert result is not None
-        self.assertIn("rc=1", result)
-        self.assertIn("could not find album", result)
+        self.assertEqual(result.reason, "nonzero_rc")
+        self.assertIn("rc=1", result.detail)
+        self.assertIn("could not find album", result.detail)
 
     @patch("harness.import_one.subprocess.run")
     def test_nonzero_rc_with_empty_stderr_still_returns(self, mock_run):
@@ -375,7 +379,174 @@ class TestRunDisambiguationMoveHelper(unittest.TestCase):
 
         self.assertIsNotNone(result)
         assert result is not None
-        self.assertIn("rc=2", result)
+        self.assertEqual(result.reason, "nonzero_rc")
+        self.assertEqual(result.detail, "rc=2")
+
+
+class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
+    """Integration test for the ``_apply_disambiguation`` callsite contract.
+
+    The reviewer's P2 ask on PR #128: prove that the import-success
+    path is preserved when the move fails. Specifically — when the
+    underlying ``beet move`` raises ``TimeoutExpired`` (or returns
+    non-zero rc), the function:
+
+    1. Must NOT raise — the album is already on disk, the caller's
+       ``ImportResult`` exit_code/decision must be untouched.
+    2. Must record a typed ``DisambiguationFailure`` on
+       ``r.postflight.disambiguation_failure``.
+    3. Must NOT set ``r.postflight.disambiguated = True`` (lying).
+    4. Must NOT mutate ``imported_path`` (the failed move did not
+       change the path on disk).
+    5. Must round-trip cleanly through ImportResult JSON serialization
+       — proving the ``__IMPORT_RESULT__`` sentinel still emits.
+    """
+
+    MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+    ORIGINAL_PATH = "/Beets/The National/2010 - High Violet"
+
+    def _make_result_and_beets(self):
+        from lib.quality import ImportResult, PostflightInfo
+
+        r = ImportResult(
+            decision="import",
+            postflight=PostflightInfo(
+                beets_id=42, track_count=11,
+                imported_path=self.ORIGINAL_PATH))
+        beets = MagicMock()
+        return r, beets
+
+    def _assert_import_success_preserved(self, r):
+        """Properties (1)+(5): import succeeded; ImportResult JSON survives."""
+        from lib.quality import ImportResult
+
+        self.assertEqual(r.exit_code, 0)
+        self.assertEqual(r.decision, "import")
+        # JSON round-trip — proves the sentinel line will emit cleanly
+        # and downstream parse_import_result() can still consume it.
+        roundtrip = ImportResult.from_json(r.to_json())
+        self.assertEqual(roundtrip.exit_code, 0)
+        self.assertEqual(roundtrip.decision, "import")
+        self.assertFalse(roundtrip.postflight.disambiguated)
+        self.assertEqual(roundtrip.postflight.imported_path,
+                         self.ORIGINAL_PATH)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_timeout_does_not_crash_and_preserves_import(self, mock_run):
+        from harness import import_one
+
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["beet", "move"], timeout=120)
+        r, beets = self._make_result_and_beets()
+
+        # Must NOT raise.
+        new_path = import_one._apply_disambiguation(
+            self.MBID, beets, self.ORIGINAL_PATH, r)
+
+        # Property (4): path unchanged on failure.
+        self.assertEqual(new_path, self.ORIGINAL_PATH)
+        # Property (3): not lying about disambiguation.
+        self.assertFalse(r.postflight.disambiguated)
+        # Property (2): typed failure recorded with correct reason tag.
+        self.assertIsNotNone(r.postflight.disambiguation_failure)
+        assert r.postflight.disambiguation_failure is not None
+        self.assertEqual(
+            r.postflight.disambiguation_failure.reason, "timeout")
+        # beets.get_album_info MUST NOT be called when move fails —
+        # we don't trust the DB state to update the path.
+        beets.get_album_info.assert_not_called()
+        # Properties (1)+(5).
+        self._assert_import_success_preserved(r)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_nonzero_rc_does_not_crash_and_preserves_import(self, mock_run):
+        from harness import import_one
+
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stderr = "error: beets db locked\n"
+        mock_run.return_value = proc
+        r, beets = self._make_result_and_beets()
+
+        new_path = import_one._apply_disambiguation(
+            self.MBID, beets, self.ORIGINAL_PATH, r)
+
+        self.assertEqual(new_path, self.ORIGINAL_PATH)
+        self.assertFalse(r.postflight.disambiguated)
+        assert r.postflight.disambiguation_failure is not None
+        self.assertEqual(
+            r.postflight.disambiguation_failure.reason, "nonzero_rc")
+        self._assert_import_success_preserved(r)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_oserror_does_not_crash_and_preserves_import(self, mock_run):
+        from harness import import_one
+
+        mock_run.side_effect = FileNotFoundError(2, "No such file", "beet")
+        r, beets = self._make_result_and_beets()
+
+        new_path = import_one._apply_disambiguation(
+            self.MBID, beets, self.ORIGINAL_PATH, r)
+
+        self.assertEqual(new_path, self.ORIGINAL_PATH)
+        self.assertFalse(r.postflight.disambiguated)
+        assert r.postflight.disambiguation_failure is not None
+        self.assertEqual(
+            r.postflight.disambiguation_failure.reason, "exception")
+        self._assert_import_success_preserved(r)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_clean_move_path_unchanged(self, mock_run):
+        """Successful move: pf_info_after returns same path → no path
+        mutation, but disambiguated=True and failure is None."""
+        from harness import import_one
+        from lib.beets_db import AlbumInfo
+
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = ""
+        mock_run.return_value = proc
+        r, beets = self._make_result_and_beets()
+        # Same path returned — no rename happened.
+        beets.get_album_info.return_value = AlbumInfo(
+            album_id=42, track_count=11,
+            min_bitrate_kbps=245, is_cbr=False,
+            album_path=self.ORIGINAL_PATH)
+
+        new_path = import_one._apply_disambiguation(
+            self.MBID, beets, self.ORIGINAL_PATH, r)
+
+        self.assertEqual(new_path, self.ORIGINAL_PATH)
+        self.assertTrue(r.postflight.disambiguated)
+        # Property: no_failure on success.
+        self.assertIsNone(r.postflight.disambiguation_failure)
+
+    @patch("harness.import_one.subprocess.run")
+    def test_clean_move_path_changed(self, mock_run):
+        """Successful move: pf_info_after returns new path → path
+        mutates and is propagated back via return value AND on
+        r.postflight.imported_path."""
+        from harness import import_one
+        from lib.beets_db import AlbumInfo
+
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = ""
+        mock_run.return_value = proc
+        r, beets = self._make_result_and_beets()
+        renamed = self.ORIGINAL_PATH + " [expanded edition]"
+        beets.get_album_info.return_value = AlbumInfo(
+            album_id=42, track_count=11,
+            min_bitrate_kbps=245, is_cbr=False,
+            album_path=renamed)
+
+        new_path = import_one._apply_disambiguation(
+            self.MBID, beets, self.ORIGINAL_PATH, r)
+
+        self.assertEqual(new_path, renamed)
+        self.assertEqual(r.postflight.imported_path, renamed)
+        self.assertTrue(r.postflight.disambiguated)
+        self.assertIsNone(r.postflight.disambiguation_failure)
 
 
 if __name__ == "__main__":

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -75,7 +75,7 @@ class TestImportResultConstruction(unittest.TestCase):
         self.assertIsNone(p.track_count)
         self.assertIsNone(p.imported_path)
         self.assertFalse(p.disambiguated)
-        self.assertIsNone(p.disambiguation_error)
+        self.assertIsNone(p.disambiguation_failure)
 
     def test_postflight_disambiguated_roundtrip(self):
         """disambiguated field survives JSON round-trip."""
@@ -87,28 +87,58 @@ class TestImportResultConstruction(unittest.TestCase):
         j = r.to_json()
         r2 = ImportResult.from_json(j)
         self.assertTrue(r2.postflight.disambiguated)
-        self.assertIsNone(r2.postflight.disambiguation_error)
+        self.assertIsNone(r2.postflight.disambiguation_failure)
         self.assertEqual(r2.postflight.imported_path, "/Beets/Artist/Album [CAD 3X03]")
 
-    def test_postflight_disambiguation_error_roundtrip(self):
-        """disambiguation_error survives JSON round-trip (issue #127).
+    def test_postflight_disambiguation_failure_roundtrip(self):
+        """disambiguation_failure survives JSON round-trip (issue #127).
 
         When the post-import ``beet move`` fails (timeout, missing
         binary, non-zero rc), the album is still imported but the path
-        wasn't fixed. The error string lives on PostflightInfo so the
-        audit trail in download_log.import_result can show *why* the
-        move didn't run.
+        wasn't fixed. The typed failure record lives on PostflightInfo
+        so the audit trail in download_log.import_result preserves
+        both the coarse reason tag and the human-readable detail.
         """
+        from lib.quality import DisambiguationFailure
+
         r = ImportResult(
             postflight=PostflightInfo(
                 beets_id=42, track_count=11,
                 imported_path="/Beets/Artist/Album",
                 disambiguated=False,
-                disambiguation_error="timeout after 120s"))
+                disambiguation_failure=DisambiguationFailure(
+                    reason="timeout", detail="timeout after 120s")))
         j = r.to_json()
         r2 = ImportResult.from_json(j)
         self.assertFalse(r2.postflight.disambiguated)
-        self.assertEqual(r2.postflight.disambiguation_error, "timeout after 120s")
+        assert r2.postflight.disambiguation_failure is not None
+        self.assertEqual(
+            r2.postflight.disambiguation_failure.reason, "timeout")
+        self.assertEqual(
+            r2.postflight.disambiguation_failure.detail,
+            "timeout after 120s")
+
+    def test_postflight_legacy_v2_row_without_failure_field(self):
+        """Old v2 download_log rows serialized BEFORE issue #127 lack
+        the disambiguation_failure key. Deserialization must default
+        it to None — never raise."""
+        # Hand-rolled dict mimicking a pre-#127 v2 row: postflight has
+        # disambiguated but no disambiguation_failure key at all.
+        d = {
+            "version": 2,
+            "exit_code": 0,
+            "decision": "import",
+            "postflight": {
+                "beets_id": 42,
+                "track_count": 11,
+                "imported_path": "/Beets/Artist/Album",
+                "disambiguated": True,
+                # NO disambiguation_failure / disambiguation_error key
+            },
+        }
+        r = ImportResult.from_dict(d)
+        self.assertTrue(r.postflight.disambiguated)
+        self.assertIsNone(r.postflight.disambiguation_failure)
 
     def test_full_construction(self):
         r = ImportResult(

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -75,6 +75,7 @@ class TestImportResultConstruction(unittest.TestCase):
         self.assertIsNone(p.track_count)
         self.assertIsNone(p.imported_path)
         self.assertFalse(p.disambiguated)
+        self.assertIsNone(p.disambiguation_error)
 
     def test_postflight_disambiguated_roundtrip(self):
         """disambiguated field survives JSON round-trip."""
@@ -86,7 +87,28 @@ class TestImportResultConstruction(unittest.TestCase):
         j = r.to_json()
         r2 = ImportResult.from_json(j)
         self.assertTrue(r2.postflight.disambiguated)
+        self.assertIsNone(r2.postflight.disambiguation_error)
         self.assertEqual(r2.postflight.imported_path, "/Beets/Artist/Album [CAD 3X03]")
+
+    def test_postflight_disambiguation_error_roundtrip(self):
+        """disambiguation_error survives JSON round-trip (issue #127).
+
+        When the post-import ``beet move`` fails (timeout, missing
+        binary, non-zero rc), the album is still imported but the path
+        wasn't fixed. The error string lives on PostflightInfo so the
+        audit trail in download_log.import_result can show *why* the
+        move didn't run.
+        """
+        r = ImportResult(
+            postflight=PostflightInfo(
+                beets_id=42, track_count=11,
+                imported_path="/Beets/Artist/Album",
+                disambiguated=False,
+                disambiguation_error="timeout after 120s"))
+        j = r.to_json()
+        r2 = ImportResult.from_json(j)
+        self.assertFalse(r2.postflight.disambiguated)
+        self.assertEqual(r2.postflight.disambiguation_error, "timeout after 120s")
 
     def test_full_construction(self):
         r = ImportResult(


### PR DESCRIPTION
Closes #127 — the sibling of PR #126's release_cleanup hardening, explicitly out-of-scope from #123.

## The bug

`harness/import_one.py:1185-1204` ran the post-import `beet move mb_albumid:<mbid>` (used to fix `%aunique` paths after a duplicate-album import) inside a bare `subprocess.run` with no try/except. When that call failed:

- **`TimeoutExpired` uncaught**: propagates out of `main()` after beets has *already imported the album to disk*. `_emit_and_exit(r)` never fires → no `__IMPORT_RESULT__` sentinel on stdout. The dispatch caller (`dispatch_import_from_db`) parses no result and treats the import as failed. The album is on disk; a force-import retry could duplicate the import.
- **`OSError` / `FileNotFoundError`** (beet missing on PATH): same uncaught propagation, same semi-lie.
- **Non-zero rc**: handled but only logged. `disambiguated=False` on `PostflightInfo` was indistinguishable from "no move attempted".

## The fix (structural — mirrors `lib/release_cleanup.py`)

Same shape as `_run_remove_selector`: one place owns the subprocess, never raises, returns a typed-ish result the caller stores.

1. **`_run_disambiguation_move(mbid: str) -> str | None`** — module-level helper. Catches `TimeoutExpired`, `OSError`, surfaces non-zero rc with stderr's last line. Returns `None` on clean rc=0.
2. **`PostflightInfo.disambiguation_error: Optional[str]`** — three states distinguishable:
   - `disambiguated=True, error=None` → success
   - `disambiguated=False, error=None` → never attempted (no `kept_duplicate`)
   - `disambiguated=False, error=<reason>` → move ran, failed
   Round-trips through `to_json`/`from_dict` automatically.
3. **Call site collapses** to `move_error = _run_disambiguation_move(mbid)` → branch on `is None`. The path re-read (`get_album_info` after move) only fires on clean exit, same as before.

After this PR, album-on-disk state is decoupled from disambiguation success: `import_one.py` always emits `ImportResult` JSON cleanly; the audit trail in `download_log.import_result` shows *why* the move failed; the dispatch path never has to choose between "trust beets DB" and "retry the import".

## Test plan

- [x] 1898 tests pass (1893 existing + 5 new) — `nix-shell --run \"bash scripts/run_tests.sh\"`
- [x] pyright clean on all touched files (0 errors, 0 warnings)
- [x] New \`TestRunDisambiguationMoveHelper\` (5 cases in \`tests/test_disambiguation.py\`):
  - clean rc=0 → returns None, argv shape verified
  - \`TimeoutExpired\` → returns \"timeout after 120s\"
  - \`FileNotFoundError\` → returns \"FileNotFoundError: ...\"
  - non-zero rc + stderr → returns \"rc=1: <last line>\"
  - non-zero rc + empty stderr → returns \"rc=2\"
- [x] New \`test_postflight_disambiguation_error_roundtrip\` in \`tests/test_import_result.py\` — JSON round-trip preserves the field
- [x] \`test_postflight_defaults\` extended to assert the new field defaults to \`None\`
- [x] \`tests/helpers.py::make_import_result\` accepts \`disambiguation_error\` for downstream test ergonomics

## Non-scope

The structural audit flagged 6 other subprocess sites in \`harness/import_one.py\` with similar smells (ffprobe in \`_get_folder_bitrates\`/\`_is_m4a_alac\`, ffmpeg in \`convert_lossless\`, post-import ffprobe extension fix). They live at different layers and would balloon scope. The post-import ffprobe extension fix at \`harness/import_one.py:1216\` is the closest sibling — same \"after beets import\" timing — and is the strongest follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)