### PR TITLE
fix(harness): pre-flight same-MBID removal to close data-loss hole

### DIFF
--- a/harness/beets_harness.py
+++ b/harness/beets_harness.py
@@ -276,11 +276,28 @@ class HarnessImportSession(ImportSession):
             return Action.SKIP
 
     def resolve_duplicate(self, task: ImportTask, found_duplicates):
-        """Ask controller how to handle duplicates."""
+        """Ask controller how to handle duplicates.
+
+        Emits two parallel arrays, one entry per duplicate (same index):
+
+        - ``duplicate_mbids``: ``mb_albumid`` for each duplicate.
+          Empty string for Discogs-sourced pressings (their identifier
+          lives in ``discogs_albumid``, and ``mb_albumid`` is empty).
+          Used by the controller to detect same-MBID staleness.
+        - ``duplicate_album_ids``: ``albums.id`` for each duplicate.
+          The beets numeric primary key is unambiguous across MB and
+          Discogs — always present, always unique. Used by the
+          controller for post-import sibling canonicalization via
+          ``beet move -a id:<N>`` (Codex PR #131 round 3 P3: Discogs
+          sibling ids were being dropped because the old payload
+          only carried mb_albumid).
+        """
         dup_mbids = []
+        dup_album_ids = []
         for dup in found_duplicates:
             mbid = getattr(dup, "mb_albumid", None) or ""
             dup_mbids.append(mbid)
+            dup_album_ids.append(getattr(dup, "id", None))
         msg = {
             "type": "resolve_duplicate",
             "path": _path_str(task.paths[0]) if task.paths else "",
@@ -288,6 +305,7 @@ class HarnessImportSession(ImportSession):
             "cur_album": task.cur_album or "",
             "duplicate_count": len(found_duplicates),
             "duplicate_mbids": dup_mbids,
+            "duplicate_album_ids": dup_album_ids,
         }
         _send(msg)
 

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -882,13 +882,20 @@ def _capture_stale_beets_id(
     the new album imports, both briefly coexist; we then remove the
     captured id. If the album isn't in beets at all, returns None and
     the caller simply skips the post-import cleanup.
+
+    Uses ``BeetsDB.locate()`` rather than ``get_album_info()`` because
+    ``get_album_info()`` returns ``None`` for albums with no readable
+    track/bitrate rows — and "partial stale import with broken items"
+    is exactly the pathology this cleanup exists to handle (Codex PR
+    #131 round 2 P2). ``locate()`` only queries ``albums`` so the
+    presence check and id capture don't depend on item-level data.
     """
     if not mbid:
         return None
-    info = beets.get_album_info(mbid, _rank_cfg)
-    if info is None:
+    location = beets.locate(mbid)
+    if location.kind != "exact" or location.album_id is None:
         return None
-    return info.album_id
+    return location.album_id
 
 
 def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
@@ -1426,15 +1433,32 @@ def main():
     # captured above), there are now TWO rows with the target MBID —
     # the stale one and the fresh import (beets' ``%aunique`` placed
     # the new album at a disambiguated path, so both coexist on disk).
-    # Remove the stale one by its exact numeric primary key. ``id:<N>``
-    # cannot match any other row.
+    # Remove the stale one by its exact album-mode numeric primary
+    # key. ``beet remove -a -d id:<N>`` runs in album mode and matches
+    # ``albums.id = N`` exactly — cannot match any other row.
     #
-    # Why this runs BEFORE ``get_album_info`` below: with two rows
-    # sharing the MBID, ``get_album_info``'s ``LIMIT 1`` lookup is
-    # undefined. Removing the stale first makes the subsequent
-    # lookup unambiguous.
+    # Codex (PR #131 round 2 P3): treat any cleanup failure as
+    # ``import_failed``. The new album IS on disk at this point, but
+    # leaving the stale row in beets silently leads to a split-brain
+    # library where subsequent upgrades may capture the wrong id or
+    # reason about the stale row's paths/bitrates. Failing explicitly
+    # surfaces the problem so the operator's ban-source cleanup can
+    # run before the request is considered complete.
     if stale_beets_id is not None:
-        _remove_stale_by_id_logged(stale_beets_id)
+        failure = _remove_stale_by_id_logged(stale_beets_id)
+        if failure is not None:
+            r.exit_code = 2
+            r.decision = "import_failed"
+            r.error = (f"Stale beets album id:{stale_beets_id} "
+                       f"(mbid={mbid}) could not be removed: "
+                       f"{failure.reason}: {failure.detail}. The new "
+                       "album is on disk but two same-MBID rows now "
+                       "exist in beets. Operator must clean up via "
+                       "ban-source before the request can be marked "
+                       "complete.")
+            _log(f"[ERROR] {r.error}")
+            beets.close()
+            _emit_and_exit(r)
 
     # --- Post-flight verification ---
     pf_info = beets.get_album_info(mbid, _rank_cfg)
@@ -1446,18 +1470,16 @@ def main():
         beets.close()
         _emit_and_exit(r)
 
-    # If the stale removal failed, two rows may still exist and
-    # ``pf_info`` may have picked the STALE one (it's got an older,
-    # lower id and beets' lookup is LIMIT-1 with no ORDER BY). Bail
-    # out loudly rather than let the pipeline run a quality decision
-    # against the wrong album — the new album IS in beets, but the
-    # postflight info is unreliable until someone cleans up.
+    # Extra guard: if pf_info still resolves to the stale id, something
+    # is seriously wrong (cleanup claimed success but beets still holds
+    # the row). Fail loudly rather than quality-gate against the stale.
     if stale_beets_id is not None and pf_info.album_id == stale_beets_id:
         r.exit_code = 2
         r.decision = "import_failed"
-        r.error = (f"Post-flight picked stale beets_id={stale_beets_id} "
-                   f"for mbid={mbid}; stale removal failed and two rows "
-                   "still exist. Operator must clean up via ban-source.")
+        r.error = (f"Post-flight resolved to stale beets_id={stale_beets_id} "
+                   f"for mbid={mbid} despite cleanup reporting success — "
+                   "beets DB is in an inconsistent state. Operator must "
+                   "clean up via ban-source.")
         _log(f"[ERROR] {r.error}")
         beets.close()
         _emit_and_exit(r)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -778,6 +778,7 @@ def run_import(path, mb_release_id):
 
 def _apply_disambiguation(
     mbid: str,
+    album_id: int,
     beets: BeetsDB,
     album_path: str,
     r: ImportResult,
@@ -791,13 +792,25 @@ def _apply_disambiguation(
     ``r.postflight.disambiguation_failure`` and returns the original
     ``album_path`` unchanged.
 
+    Uses ``beet move -a id:<album_id>`` rather than
+    ``beet move mb_albumid:<mbid>`` so Discogs-sourced albums are
+    handled too — their ``mb_albumid`` is empty, their identifier
+    lives in ``discogs_albumid``, but the beets numeric primary key
+    is always populated. Codex (PR #131 round 4 P3) flagged that the
+    earlier mb_albumid-based move silently no-op'd for Discogs
+    re-imports, leaving the new album stuck at the temporary
+    disambiguated path. Caller passes ``album_id`` from the postflight
+    lookup so we don't need a second DB read here (and so failure
+    tests can still assert ``beets.get_album_info`` is only hit on
+    success to refresh the path).
+
     Extracting this from ``main()`` makes the call-site contract
     testable in isolation: the album-on-disk state is decoupled from
     disambiguation success, ImportResult JSON always emits cleanly,
     and ``r.exit_code`` / ``r.decision`` are never touched by a
     disambiguation failure.
     """
-    move_failure = _run_disambiguation_move(mbid)
+    move_failure = _run_album_move_by_id(album_id)
     if move_failure is not None:
         # Album is already imported to beets — only the post-import
         # path-disambiguation move did not exit cleanly. Surface the
@@ -1094,6 +1107,41 @@ def main():
     r.already_in_beets = already_in_beets
     if already_in_beets:
         _log(f"[PRE-FLIGHT] Already in beets: {mbid} — checking if new files are better")
+
+    # --- Enumerate stale same-MBID rows + fail-fast on split-brain ---
+    #
+    # Runs BEFORE any destructive pre-import work (Codex PR #131 round
+    # 4 P2). If we bail with ``import_failed`` because beets already
+    # has more than one same-MBID row, the staged download must still
+    # be intact so the operator can re-run the pipeline after cleanup.
+    # Later stages — spectral analysis, ``convert_lossless``,
+    # ``_remove_lossless_files`` — mutate ``args.path`` in place, so a
+    # guard placed after them would leave operators without the
+    # original files to retry with.
+    #
+    # ``locate()`` uses ``LIMIT 1`` and would miss siblings in the
+    # split-brain case (Codex PR #131 round 3 P2). The enumerate
+    # helper scans every ``albums.id`` matching the release id across
+    # both layouts (mb_albumid + discogs_albumid).
+    stale_ids: list[int] = (
+        beets.get_all_album_ids_for_release(mbid)
+        if already_in_beets else [])
+    if len(stale_ids) > 1:
+        r.exit_code = 2
+        r.decision = "import_failed"
+        r.error = (f"Beets already has {len(stale_ids)} rows for "
+                   f"mbid={mbid} before import: {stale_ids}. "
+                   "Cannot safely run an upgrade against a split-brain "
+                   "state — operator must reduce to at most one row "
+                   "(e.g. via ban-source cleanup) before retrying. "
+                   "Staged download is untouched.")
+        _log(f"[ERROR] {r.error}")
+        beets.close()
+        _emit_and_exit(r)
+    stale_beets_id: int | None = stale_ids[0] if stale_ids else None
+    if stale_beets_id is not None:
+        _log(f"[PRE-FLIGHT] Captured stale beets id:{stale_beets_id} for "
+             f"post-import cleanup (will remove after upgrade lands)")
 
     # --- Path check (pure decision) ---
     pf = preflight_decision(already_in_beets, os.path.isdir(args.path))
@@ -1427,52 +1475,25 @@ def main():
         _log(f"  [CLEANUP] Removed lossless originals "
              f"(target skipped or preserve-source approved)")
 
-    # --- Capture stale beets id BEFORE the import ---
-    #
-    # The 2026-04-20 Palo Santo data-loss event trained us off the
-    # mid-import "remove" path entirely (see run_import). Instead we
-    # capture the stale row's beets numeric id here and remove it
-    # AFTER the import succeeds, by its exact primary-key selector
-    # ``id:<N>`` — the narrowest possible scope (cannot match siblings
-    # by construction — SQLite autoincrement PKs are unique).
-    #
-    # Codex (PR #131 round 1 P1) flagged the alternative design where
-    # pre-flight deleted the stale row before ``run_import``: if the
-    # harness times out / crashes / rejects the candidate, we're left
-    # with no album at all. Capture-then-import-then-remove preserves
-    # the invariant that the existing copy survives until the
-    # replacement is confirmed on disk.
-    #
-    # Codex (PR #131 round 3 P2): ``locate()`` only returns a single
-    # id via LIMIT 1. If beets somehow has MULTIPLE same-MBID rows
-    # before this import (prior cleanup timeout, manual duplicate
-    # insertion, etc.), capturing just one and removing just that
-    # one leaves the others intact — silent split-brain after a
-    # "successful" import. Enumerate all matches and fail-fast if
-    # count > 1 so the operator is forced to clean up first.
-    stale_ids: list[int] = (
-        beets.get_all_album_ids_for_release(mbid)
-        if already_in_beets else [])
-    if len(stale_ids) > 1:
-        r.exit_code = 2
-        r.decision = "import_failed"
-        r.error = (f"Beets already has {len(stale_ids)} rows for "
-                   f"mbid={mbid} before import: {stale_ids}. "
-                   "Cannot safely run an upgrade against a split-brain "
-                   "state — operator must reduce to at most one row "
-                   "(e.g. via ban-source cleanup) before retrying.")
-        _log(f"[ERROR] {r.error}")
-        beets.close()
-        _emit_and_exit(r)
-    stale_beets_id: int | None = stale_ids[0] if stale_ids else None
-    if stale_beets_id is not None:
-        _log(f"[PRE-FLIGHT] Captured stale beets id:{stale_beets_id} for "
-             f"post-import cleanup (will remove after upgrade lands)")
-
     # --- Import ---
+    #
+    # ``stale_beets_id`` and ``stale_ids`` were captured/validated
+    # earlier in main() — before any destructive pre-import work on
+    # the staged download — so the bail-out for split-brain has
+    # already happened (Codex PR #131 round 4 P2).
     _log(f"[IMPORT] {args.path} → beets (mbid={mbid})")
     rc, beets_lines, kept_duplicate, sibling_album_ids = run_import(
         args.path, mbid)
+
+    # Exclude the stale row's album id from sibling canonicalization
+    # — it will be removed by ``_remove_stale_by_id_logged`` below,
+    # so re-running ``beet move`` on it wastes a subprocess call and
+    # more importantly covers the Discogs re-import case (Codex PR
+    # #131 round 4 P3) where ``run_import``'s inner filter — keyed by
+    # ``mb_albumid`` — cannot detect that an empty-mbid Discogs row
+    # is actually the same release.
+    if stale_beets_id is not None:
+        sibling_album_ids = sibling_album_ids - frozenset([stale_beets_id])
     r.beets_log = beets_lines
 
     if rc != 0:
@@ -1554,7 +1575,8 @@ def main():
     # `beet move` re-evaluates all editions and fixes the paths.
     if kept_duplicate:
         _log(f"[DISAMBIGUATE] Running beet move for album id:{pf_info.album_id}")
-        album_path = _apply_disambiguation(mbid, beets, album_path, r)
+        album_path = _apply_disambiguation(
+            mbid, pf_info.album_id, beets, album_path, r)
         # Also canonicalize the sibling editions beets flagged as
         # duplicates — without this, the new album gets the ``[YEAR]``
         # suffix while the sibling stays un-suffixed (asymmetric

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -988,6 +988,18 @@ def _canonicalize_siblings(
     repair at the end of ``main()``; without mirroring it here, moved
     siblings ship with stricter perms than they started with.
 
+    KNOWN LIMITATION (Codex PR #131 round 6 P2): this helper moves
+    sibling files on disk but does NOT update
+    ``album_requests.imported_path`` for those siblings in the
+    pipeline DB. If a sibling was tracked as a previous pipeline
+    request, its ``imported_path`` will point at the pre-move
+    location until a future event (next upgrade, manual re-tag)
+    updates it. The pipeline UI will show the wrong path for that
+    request in the interim. Cross-service plumbing — the harness
+    runs as a subprocess without a shared write handle to the
+    pipeline DB for arbitrary request ids — and is tracked as a
+    follow-up separate from the Palo Santo blast-radius fix.
+
     Never raises — delegates to ``_run_album_move_by_id`` which
     returns a typed ``DisambiguationFailure`` on any subprocess
     error. Per-sibling failures are logged but do not abort the
@@ -1522,7 +1534,20 @@ def main():
     # This supersedes the round-3/4 ``stale_beets_id`` approach: by
     # deriving the set-to-remove from the post-import state directly,
     # we no longer depend on the pre-flight capture matching what
-    # ``resolve_duplicate`` sees. The race is closed.
+    # ``resolve_duplicate`` sees. The intra-process race is closed.
+    #
+    # KNOWN LIMITATION (Codex PR #131 round 6 P1): this remains
+    # vulnerable to CROSS-process races. If a second soularr process
+    # (e.g. soularr-web force-import racing an auto-import cycle)
+    # commits a same-MBID row between our ``run_import`` returning
+    # and this re-enumerate query, ``max(post_import_ids)`` would
+    # pick that other process's row as "new" and our cleanup would
+    # delete the one this process actually imported. Soularr.service
+    # is single-instance (``/var/lib/soularr/soularr.lock``) but the
+    # web force-import path does not hold that lock, so the race
+    # window exists in practice. Follow-up: a pipeline-level same-
+    # release advisory lock shared by both entry points, tracked
+    # separately from this data-loss fix.
     #
     # Each removal uses ``beet remove -a -d id:<N>`` — primary-key
     # scoped, cannot reach cross-MBID siblings. Any removal failure

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -587,7 +587,7 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
 def run_import(path, mb_release_id):
     """Drive the beets harness to import one album.
 
-    Returns (exit_code, beets_lines, kept_duplicate, sibling_mbids).
+    Returns (exit_code, beets_lines, kept_duplicate, sibling_album_ids).
 
     - ``kept_duplicate`` is True whenever beets asked us to resolve a
       duplicate during this import — we ALWAYS answer "keep" now
@@ -595,13 +595,15 @@ def run_import(path, mb_release_id):
       flag is really "post-import beet move needed". Triggers the
       ``%aunique`` re-evaluation via ``_apply_disambiguation`` in
       main().
-    - ``sibling_mbids`` is every non-target MBID we saw in
-      ``resolve_duplicate`` callbacks. These are different-edition
-      pressings beets flagged as duplicates; after the new album is
-      in beets, main() re-runs ``beet move`` on each so ``%aunique``
-      re-evaluates their paths too — otherwise one edition gets the
-      ``[YEAR]`` suffix and the other stays unsuffixed, which looks
-      asymmetric in Plex/Meelo.
+    - ``sibling_album_ids`` is the set of beets numeric album ids
+      (``albums.id``) for every non-same-MBID duplicate beets flagged.
+      Keyed by the beets primary key, not ``mb_albumid``, because
+      Discogs-sourced pressings have empty ``mb_albumid`` — Codex
+      (PR #131 round 3 P3) flagged that the earlier MBID-based set
+      silently dropped Discogs siblings, leaving asymmetric folder
+      layouts that this feature was meant to fix. After the new
+      album is in beets, main() runs ``beet move -a id:<N>`` on each
+      so ``%aunique`` re-evaluates their paths too.
     """
     cmd = [HARNESS, "--noincremental", "--search-id", mb_release_id, path]
     print(f"  [HARNESS] {' '.join(cmd)}", file=sys.stderr)
@@ -617,7 +619,7 @@ def run_import(path, mb_release_id):
 
     applied = False
     kept_duplicate = False
-    sibling_mbids: set[str] = set()
+    sibling_album_ids: set[int] = set()
     timeout = HARNESS_TIMEOUT
 
     try:
@@ -688,12 +690,24 @@ def run_import(path, mb_release_id):
                 # ``beet move mb_albumid:<target>`` re-runs ``%aunique`` to
                 # fix the new album's path.
                 dup_mbids = msg.get("duplicate_mbids", [])
+                dup_album_ids = msg.get("duplicate_album_ids", [])
                 proc.stdin.write(json.dumps({"action": "keep"}) + "\n")
                 proc.stdin.flush()
                 kept_duplicate = True
-                for dm in dup_mbids:
-                    if dm and dm != mb_release_id:
-                        sibling_mbids.add(dm)
+                # Collect sibling beets numeric album ids. Paired
+                # index-wise with dup_mbids: skip entries whose MBID
+                # matches our target (those are stale same-MBID rows,
+                # handled by post-import cleanup via id:<N>). Keep
+                # everything else — including Discogs siblings whose
+                # ``mb_albumid`` is empty but whose beets ``album_id``
+                # is always present.
+                for idx, aid in enumerate(dup_album_ids):
+                    if not isinstance(aid, int):
+                        continue
+                    dm = dup_mbids[idx] if idx < len(dup_mbids) else ""
+                    if dm and dm == mb_release_id:
+                        continue  # stale same-MBID — post-import cleanup handles
+                    sibling_album_ids.add(aid)
                 if mb_release_id in dup_mbids:
                     # Rare: happens when an operator ran an upgrade
                     # without going through dispatch (or a race allowed
@@ -723,7 +737,7 @@ def run_import(path, mb_release_id):
                           file=sys.stderr)
                     if proc.poll() is None:
                         proc.wait()
-                    return 4, [], False, frozenset()
+                    return 4, [], False, frozenset([])
 
                 cand = candidates[matched_idx]
                 dist = cand.get("distance", 1.0)
@@ -734,7 +748,7 @@ def run_import(path, mb_release_id):
                     print(f"  [REJECT] distance={dist:.4f} > {MAX_DISTANCE}", file=sys.stderr)
                     if proc.poll() is None:
                         proc.wait()
-                    return 2, [], False, frozenset()
+                    return 2, [], False, frozenset([])
 
                 proc.stdin.write(json.dumps({"action": "apply", "candidate_index": matched_idx}) + "\n")
                 proc.stdin.flush()
@@ -756,10 +770,10 @@ def run_import(path, mb_release_id):
                 beets_lines.append(line.strip())
 
     if proc_rc not in (None, 0):
-        return 2, beets_lines, kept_duplicate, frozenset(sibling_mbids)
+        return 2, beets_lines, kept_duplicate, frozenset(sibling_album_ids)
 
     return ((0 if applied else 2), beets_lines, kept_duplicate,
-            frozenset(sibling_mbids))
+            frozenset(sibling_album_ids))
 
 
 def _apply_disambiguation(
@@ -871,33 +885,6 @@ def _run_disambiguation_move(mbid: str) -> DisambiguationFailure | None:
 # hit a sibling pressing.
 
 
-def _capture_stale_beets_id(
-    mbid: str, beets: BeetsDB) -> int | None:
-    """Return the beets numeric id of the stale same-MBID album, or None.
-
-    Called pre-import, before any destructive action. If the album is
-    already present exactly once (true by construction — beets enforces
-    unique insertion at import time, so there's at most one row with a
-    given MBID before our import starts), we remember its id. After
-    the new album imports, both briefly coexist; we then remove the
-    captured id. If the album isn't in beets at all, returns None and
-    the caller simply skips the post-import cleanup.
-
-    Uses ``BeetsDB.locate()`` rather than ``get_album_info()`` because
-    ``get_album_info()`` returns ``None`` for albums with no readable
-    track/bitrate rows — and "partial stale import with broken items"
-    is exactly the pathology this cleanup exists to handle (Codex PR
-    #131 round 2 P2). ``locate()`` only queries ``albums`` so the
-    presence check and id capture don't depend on item-level data.
-    """
-    if not mbid:
-        return None
-    location = beets.locate(mbid)
-    if location.kind != "exact" or location.album_id is None:
-        return None
-    return location.album_id
-
-
 def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
     """Post-import cleanup: delete the stale same-MBID album by beets id.
 
@@ -906,7 +893,7 @@ def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
     shows exactly which beets row was removed and why.
     """
     _log(f"[POST-IMPORT CLEANUP] Removing stale same-MBID entry "
-         f"(beet remove -d id:{stale_id})")
+         f"(beet remove -a -d id:{stale_id})")
     failure = remove_album_by_beets_id(stale_id)
     if failure is None:
         _log(f"  [POST-IMPORT CLEANUP] OK — id:{stale_id} removed")
@@ -918,8 +905,51 @@ def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
     return failure
 
 
-def _canonicalize_siblings(sibling_mbids: frozenset[str]) -> None:
-    """Re-run ``beet move`` on each sibling MBID after a kept-duplicate import.
+def _run_album_move_by_id(album_id: int) -> DisambiguationFailure | None:
+    """Run ``beet move -a id:<album_id>`` once, never raise.
+
+    Album-mode, primary-key-scoped variant of
+    ``_run_disambiguation_move``. Used for sibling canonicalization
+    where the identifier has to be source-agnostic: beets' numeric
+    ``albums.id`` is always populated (it's the PK), unlike
+    ``mb_albumid`` (empty for Discogs pressings) or
+    ``discogs_albumid`` (empty for MB pressings). Codex (PR #131
+    round 3 P3) flagged that the earlier MBID-only sibling move
+    silently dropped Discogs duplicates.
+
+    ``-a`` is mandatory — without it ``id:<N>`` would be interpreted
+    against ``items.id`` (a different auto-increment namespace) and
+    match a track row instead of the album.
+
+    Same error classification as ``_run_disambiguation_move``:
+    ``TimeoutExpired`` → ``timeout``, non-zero rc → ``nonzero_rc``,
+    ``OSError`` → ``exception``. Returns ``None`` on clean exit.
+    """
+    try:
+        proc = subprocess.run(
+            [BEET_BIN, "move", "-a", f"id:{album_id}"],
+            capture_output=True, text=True, timeout=120,
+            env=beets_subprocess_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        return DisambiguationFailure(
+            reason="timeout", detail=f"timeout after {exc.timeout}s")
+    except OSError as exc:
+        return DisambiguationFailure(
+            reason="exception", detail=f"{type(exc).__name__}: {exc}")
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip().splitlines()
+        last = stderr[-1] if stderr else ""
+        detail = (f"rc={proc.returncode}: {last}"
+                  if last else f"rc={proc.returncode}")
+        return DisambiguationFailure(reason="nonzero_rc", detail=detail)
+
+    return None
+
+
+def _canonicalize_siblings(sibling_album_ids: frozenset[int]) -> None:
+    """Re-run ``beet move`` on each sibling album id after a kept-duplicate import.
 
     When beets' ``%aunique`` disambiguates the new album (adding a
     ``[YEAR]`` suffix because a different-edition sibling exists), the
@@ -928,26 +958,31 @@ def _canonicalize_siblings(sibling_mbids: frozenset[str]) -> None:
     end up with an asymmetric library like
     ``/Shearwater/2006 - Palo Santo/`` (plain, old) vs
     ``/Shearwater/2007 - Palo Santo [2007]/`` (disambiguated, new).
-    Running ``beet move mb_albumid:<sibling>`` on each sibling here
-    re-evaluates ``%aunique`` for its path too, so both editions end
-    up shaped consistently.
+    Running ``beet move -a id:<N>`` on each sibling here re-evaluates
+    ``%aunique`` for its path too, so both editions end up shaped
+    consistently.
 
-    Never raises — delegates to ``_run_disambiguation_move`` which
+    Takes beets numeric album ids (not MBIDs) so Discogs-sourced
+    siblings are covered — ``mb_albumid`` is empty for those,
+    ``albums.id`` is always populated.
+
+    Never raises — delegates to ``_run_album_move_by_id`` which
     returns a typed ``DisambiguationFailure`` on any subprocess
     error. Per-sibling failures are logged but do not abort the
     remaining moves; the import itself is already on disk and any
     failed sibling move just means that sibling stays at its old
     path until something re-runs ``beet move`` on it.
     """
-    if not sibling_mbids:
+    if not sibling_album_ids:
         return
-    _log(f"[CANONICALIZE] Re-running beet move for "
-         f"{len(sibling_mbids)} sibling MBID(s) so %aunique stays symmetric")
-    for sibling in sibling_mbids:
-        _log(f"  [CANONICALIZE] beet move mb_albumid:{sibling}")
-        failure = _run_disambiguation_move(sibling)
+    _log(f"[CANONICALIZE] Re-running beet move -a for "
+         f"{len(sibling_album_ids)} sibling album id(s) so %aunique "
+         "stays symmetric")
+    for aid in sibling_album_ids:
+        _log(f"  [CANONICALIZE] beet move -a id:{aid}")
+        failure = _run_album_move_by_id(aid)
         if failure is not None:
-            _log(f"  [CANONICALIZE] sibling {sibling} move failed "
+            _log(f"  [CANONICALIZE] sibling id:{aid} move failed "
                  f"({failure.reason}): {failure.detail} — sibling stays "
                  "at its current path, re-run `beet move` manually later")
 
@@ -1407,15 +1442,36 @@ def main():
     # with no album at all. Capture-then-import-then-remove preserves
     # the invariant that the existing copy survives until the
     # replacement is confirmed on disk.
-    stale_beets_id = (_capture_stale_beets_id(mbid, beets)
-                      if already_in_beets else None)
+    #
+    # Codex (PR #131 round 3 P2): ``locate()`` only returns a single
+    # id via LIMIT 1. If beets somehow has MULTIPLE same-MBID rows
+    # before this import (prior cleanup timeout, manual duplicate
+    # insertion, etc.), capturing just one and removing just that
+    # one leaves the others intact — silent split-brain after a
+    # "successful" import. Enumerate all matches and fail-fast if
+    # count > 1 so the operator is forced to clean up first.
+    stale_ids: list[int] = (
+        beets.get_all_album_ids_for_release(mbid)
+        if already_in_beets else [])
+    if len(stale_ids) > 1:
+        r.exit_code = 2
+        r.decision = "import_failed"
+        r.error = (f"Beets already has {len(stale_ids)} rows for "
+                   f"mbid={mbid} before import: {stale_ids}. "
+                   "Cannot safely run an upgrade against a split-brain "
+                   "state — operator must reduce to at most one row "
+                   "(e.g. via ban-source cleanup) before retrying.")
+        _log(f"[ERROR] {r.error}")
+        beets.close()
+        _emit_and_exit(r)
+    stale_beets_id: int | None = stale_ids[0] if stale_ids else None
     if stale_beets_id is not None:
         _log(f"[PRE-FLIGHT] Captured stale beets id:{stale_beets_id} for "
              f"post-import cleanup (will remove after upgrade lands)")
 
     # --- Import ---
     _log(f"[IMPORT] {args.path} → beets (mbid={mbid})")
-    rc, beets_lines, kept_duplicate, sibling_mbids = run_import(
+    rc, beets_lines, kept_duplicate, sibling_album_ids = run_import(
         args.path, mbid)
     r.beets_log = beets_lines
 
@@ -1502,8 +1558,10 @@ def main():
         # Also canonicalize the sibling editions beets flagged as
         # duplicates — without this, the new album gets the ``[YEAR]``
         # suffix while the sibling stays un-suffixed (asymmetric
-        # folder layout in Plex/Meelo).
-        _canonicalize_siblings(sibling_mbids)
+        # folder layout in Plex/Meelo). Takes beets numeric album ids
+        # so Discogs siblings are covered too (their mb_albumid is
+        # empty but albums.id is always present).
+        _canonicalize_siblings(sibling_album_ids)
 
     # --- Post-import extension check ---
     # Detect .bak files (known bug: track 01 sometimes renamed to .bak during import)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -25,7 +25,6 @@ import json
 import os
 import select
 import signal
-import shutil
 import statistics
 import subprocess
 import sys
@@ -45,9 +44,9 @@ _bootstrap_import_paths()
 
 from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
-from lib.release_cleanup import (ReleaseCleanupResult,
-                                 remove_album_by_selectors)
-from lib.util import beets_subprocess_env
+from lib.release_cleanup import (SelectorFailure,
+                                 remove_album_by_beets_id)
+from lib.util import beet_bin, beets_subprocess_env
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, DisambiguationFailure,
                          ImportResult, PostflightInfo, QualityRankConfig,
@@ -55,8 +54,9 @@ from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          determine_verified_lossless,
                          import_quality_decision, transcode_detection)
 HARNESS = os.path.join(os.path.dirname(__file__), "..", "harness", "run_beets_harness.sh")
-BEET_BIN = (shutil.which("beet")
-            or "/etc/profiles/per-user/abl030/bin/beet")
+# Back-compat alias; new callsites should prefer ``beet_bin()`` from
+# ``lib.util`` so subprocess resolution stays in one place.
+BEET_BIN = beet_bin()
 HARNESS_TIMEOUT = 300
 IMPORT_TIMEOUT = 1800
 MAX_DISTANCE = 0.5
@@ -587,9 +587,21 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
 def run_import(path, mb_release_id):
     """Drive the beets harness to import one album.
 
-    Returns (exit_code, beets_lines, kept_duplicate) where kept_duplicate
-    is True if we told beets to keep a different edition during duplicate
-    resolution (triggers post-import `beet move` for %aunique disambiguation).
+    Returns (exit_code, beets_lines, kept_duplicate, sibling_mbids).
+
+    - ``kept_duplicate`` is True whenever beets asked us to resolve a
+      duplicate during this import — we ALWAYS answer "keep" now
+      (never "remove", which has cross-MBID blast radius), so the
+      flag is really "post-import beet move needed". Triggers the
+      ``%aunique`` re-evaluation via ``_apply_disambiguation`` in
+      main().
+    - ``sibling_mbids`` is every non-target MBID we saw in
+      ``resolve_duplicate`` callbacks. These are different-edition
+      pressings beets flagged as duplicates; after the new album is
+      in beets, main() re-runs ``beet move`` on each so ``%aunique``
+      re-evaluates their paths too — otherwise one edition gets the
+      ``[YEAR]`` suffix and the other stays unsuffixed, which looks
+      asymmetric in Plex/Meelo.
     """
     cmd = [HARNESS, "--noincremental", "--search-id", mb_release_id, path]
     print(f"  [HARNESS] {' '.join(cmd)}", file=sys.stderr)
@@ -605,6 +617,7 @@ def run_import(path, mb_release_id):
 
     applied = False
     kept_duplicate = False
+    sibling_mbids: set[str] = set()
     timeout = HARNESS_TIMEOUT
 
     try:
@@ -614,7 +627,7 @@ def run_import(path, mb_release_id):
                 print(f"  [TIMEOUT] No output for {timeout}s", file=sys.stderr)
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
                 proc.wait()
-                return 2, [], False
+                return 2, [], False, frozenset()
 
             line = proc.stdout.readline()
             if not line:
@@ -655,31 +668,42 @@ def run_import(path, mb_release_id):
                 # 157b51f8...) lost every mp3 on disk when the 19-track 2007
                 # reissue (mb=168d7fea...) re-imported.
                 #
-                # Structural fix: the destructive branch is gone. Stale
-                # same-MBID entries are handled by pre-flight via
-                # ``_preflight_remove_stale_mbid`` (a targeted
-                # ``beet remove -d mb_albumid:<mbid>`` that can only match
-                # that one album). By the time this harness starts, the
-                # stale entry is already absent — any duplicates still
-                # visible here are different-MBID siblings we MUST keep.
+                # Structural fix: the destructive branch is unrepresentable
+                # from here. If a stale same-MBID album exists, main()
+                # removes it AFTER the new album is successfully in beets,
+                # using the numeric primary-key selector ``id:<stale>``
+                # which cannot match any other row. At this callsite we
+                # unconditionally answer "keep" — preserving every album
+                # beets flagged, including legitimate different-MBID
+                # siblings we must not touch.
+                #
+                # Sibling MBIDs (non-target hits) are collected so main()
+                # can re-run ``beet move`` on each after the import —
+                # otherwise ``%aunique`` disambiguates only the new album,
+                # leaving the sibling at an un-suffixed path (ugly, and
+                # music scanners see two differently-shaped folders for
+                # the same album name).
                 #
                 # ``kept_duplicate = True`` unconditionally so post-import
                 # ``beet move mb_albumid:<target>`` re-runs ``%aunique`` to
-                # fix the new album's path (beets doesn't fully disambiguate
-                # at import time when the disambiguator field starts empty).
+                # fix the new album's path.
                 dup_mbids = msg.get("duplicate_mbids", [])
                 proc.stdin.write(json.dumps({"action": "keep"}) + "\n")
                 proc.stdin.flush()
                 kept_duplicate = True
+                for dm in dup_mbids:
+                    if dm and dm != mb_release_id:
+                        sibling_mbids.add(dm)
                 if mb_release_id in dup_mbids:
-                    # Should be rare: pre-flight failed to remove the stale
-                    # entry, or a race allowed it back. Log loudly so the
-                    # audit trail shows why beets has two albums with the
-                    # same MBID; operator can run the ban-source cleanup.
+                    # Rare: happens when an operator ran an upgrade
+                    # without going through dispatch (or a race allowed
+                    # two rows with the same MBID briefly). main() will
+                    # remove the stale entry by its exact beets numeric
+                    # id after the import finishes.
                     print(
-                        f"  [DUP] Same MBID in library despite pre-flight "
-                        f"(existing: {dup_mbids}); keeping both — pre-flight "
-                        "targeted remove must have failed",
+                        f"  [DUP] Same MBID in library "
+                        f"(existing: {dup_mbids}); keeping both — "
+                        "main() will remove stale by beets id post-import",
                         file=sys.stderr)
                 else:
                     print(
@@ -699,7 +723,7 @@ def run_import(path, mb_release_id):
                           file=sys.stderr)
                     if proc.poll() is None:
                         proc.wait()
-                    return 4, [], False
+                    return 4, [], False, frozenset()
 
                 cand = candidates[matched_idx]
                 dist = cand.get("distance", 1.0)
@@ -710,7 +734,7 @@ def run_import(path, mb_release_id):
                     print(f"  [REJECT] distance={dist:.4f} > {MAX_DISTANCE}", file=sys.stderr)
                     if proc.poll() is None:
                         proc.wait()
-                    return 2, [], False
+                    return 2, [], False, frozenset()
 
                 proc.stdin.write(json.dumps({"action": "apply", "candidate_index": matched_idx}) + "\n")
                 proc.stdin.flush()
@@ -732,9 +756,10 @@ def run_import(path, mb_release_id):
                 beets_lines.append(line.strip())
 
     if proc_rc not in (None, 0):
-        return 2, beets_lines, kept_duplicate
+        return 2, beets_lines, kept_duplicate, frozenset(sibling_mbids)
 
-    return (0 if applied else 2), beets_lines, kept_duplicate
+    return ((0 if applied else 2), beets_lines, kept_duplicate,
+            frozenset(sibling_mbids))
 
 
 def _apply_disambiguation(
@@ -826,38 +851,98 @@ def _run_disambiguation_move(mbid: str) -> DisambiguationFailure | None:
 
 
 # ---------------------------------------------------------------------------
-# Pre-flight same-MBID stale removal
+# Same-MBID stale-entry handling — POST-import, by beets numeric id
 # ---------------------------------------------------------------------------
+#
+# The 2026-04-20 Palo Santo event trained us off two things at once:
+#
+# 1. Never answer "remove" to beets' resolve_duplicate (cross-MBID blast
+#    radius — see run_import).
+# 2. Never destroy the existing copy BEFORE the replacement is in beets.
+#    Codex (PR #131 round 1 P1) flagged this: a pre-flight remove that
+#    is followed by a harness timeout leaves the request with no files
+#    at all.
+#
+# The safe shape: capture the stale row's beets id BEFORE the import
+# (no destructive action), let the import land the new album at a
+# disambiguated path via ``%aunique``, THEN remove the stale row by its
+# primary key. The ``id:<N>`` selector is a ``SELECT ... WHERE id = ?``
+# — unique by SQLite auto-increment, so it is physically impossible to
+# hit a sibling pressing.
 
-def _preflight_remove_stale_mbid(
-    mbid: str, beets: BeetsDB) -> ReleaseCleanupResult | None:
-    """Targeted removal of a stale same-MBID album before the beets import.
 
-    This is the structural fix for the Palo Santo data-loss bug (2026-
-    04-20). Beets' own ``find_duplicates()`` drags in cross-MBID
-    sibling pressings and its ``remove_duplicates()`` deletes every
-    item in every match — so asking the interactive harness to
-    "remove" a stale same-MBID entry destroys the siblings too. The
-    primitive here delegates to
-    ``lib.release_cleanup.remove_album_by_selectors`` which can only
-    target the exact MBID via ``beet remove -d mb_albumid:<mbid>``.
+def _capture_stale_beets_id(
+    mbid: str, beets: BeetsDB) -> int | None:
+    """Return the beets numeric id of the stale same-MBID album, or None.
 
-    Returns:
-    - ``None`` if the album isn't in beets (nothing to remove) or if
-      ``mbid`` is empty. Caller proceeds straight to the import.
-    - ``ReleaseCleanupResult`` otherwise. Callers that care about
-      partial failure (``absent_after=False``) can bail out of the
-      import rather than run into the cross-MBID blast radius path.
-
-    Does NOT touch the pipeline DB — harness subprocess has no
-    PipelineDB handle. The pipeline-side clear happens in
-    ``dispatch_import`` / the web layer on the parent side.
+    Called pre-import, before any destructive action. If the album is
+    already present exactly once (true by construction — beets enforces
+    unique insertion at import time, so there's at most one row with a
+    given MBID before our import starts), we remember its id. After
+    the new album imports, both briefly coexist; we then remove the
+    captured id. If the album isn't in beets at all, returns None and
+    the caller simply skips the post-import cleanup.
     """
     if not mbid:
         return None
-    if not beets.album_exists(mbid):
+    info = beets.get_album_info(mbid, _rank_cfg)
+    if info is None:
         return None
-    return remove_album_by_selectors(beets_db=beets, release_id=mbid)
+    return info.album_id
+
+
+def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
+    """Post-import cleanup: delete the stale same-MBID album by beets id.
+
+    Thin logger around ``remove_album_by_beets_id``. Always logs the
+    outcome so the import audit trail (stderr → soularr journal)
+    shows exactly which beets row was removed and why.
+    """
+    _log(f"[POST-IMPORT CLEANUP] Removing stale same-MBID entry "
+         f"(beet remove -d id:{stale_id})")
+    failure = remove_album_by_beets_id(stale_id)
+    if failure is None:
+        _log(f"  [POST-IMPORT CLEANUP] OK — id:{stale_id} removed")
+    else:
+        _log(f"  [POST-IMPORT CLEANUP] FAILED id:{stale_id} "
+             f"({failure.reason}): {failure.detail}. "
+             "Two albums with same MBID now in beets; "
+             "operator should run ban-source cleanup.")
+    return failure
+
+
+def _canonicalize_siblings(sibling_mbids: frozenset[str]) -> None:
+    """Re-run ``beet move`` on each sibling MBID after a kept-duplicate import.
+
+    When beets' ``%aunique`` disambiguates the new album (adding a
+    ``[YEAR]`` suffix because a different-edition sibling exists), the
+    sibling album's path is NOT automatically re-evaluated — it stays
+    at whatever path it was originally imported under. Left alone, you
+    end up with an asymmetric library like
+    ``/Shearwater/2006 - Palo Santo/`` (plain, old) vs
+    ``/Shearwater/2007 - Palo Santo [2007]/`` (disambiguated, new).
+    Running ``beet move mb_albumid:<sibling>`` on each sibling here
+    re-evaluates ``%aunique`` for its path too, so both editions end
+    up shaped consistently.
+
+    Never raises — delegates to ``_run_disambiguation_move`` which
+    returns a typed ``DisambiguationFailure`` on any subprocess
+    error. Per-sibling failures are logged but do not abort the
+    remaining moves; the import itself is already on disk and any
+    failed sibling move just means that sibling stays at its old
+    path until something re-runs ``beet move`` on it.
+    """
+    if not sibling_mbids:
+        return
+    _log(f"[CANONICALIZE] Re-running beet move for "
+         f"{len(sibling_mbids)} sibling MBID(s) so %aunique stays symmetric")
+    for sibling in sibling_mbids:
+        _log(f"  [CANONICALIZE] beet move mb_albumid:{sibling}")
+        failure = _run_disambiguation_move(sibling)
+        if failure is not None:
+            _log(f"  [CANONICALIZE] sibling {sibling} move failed "
+                 f"({failure.reason}): {failure.detail} — sibling stays "
+                 "at its current path, re-run `beet move` manually later")
 
 
 # ---------------------------------------------------------------------------
@@ -1300,38 +1385,31 @@ def main():
         _log(f"  [CLEANUP] Removed lossless originals "
              f"(target skipped or preserve-source approved)")
 
-    # --- Pre-flight: remove stale same-MBID album BEFORE running the
-    # beets interactive import. This is the structural fix for the Palo
-    # Santo data-loss bug (2026-04-20): beets' ``find_duplicates()``
-    # drags cross-MBID sibling pressings into the resolve_duplicate
-    # callback, so if we asked the harness to answer "remove" for the
-    # same-MBID case, beets' ``remove_duplicates()`` would delete every
-    # item in every match — siblings included. The fix scopes the
-    # removal to exactly one MBID via ``beet remove -d mb_albumid:...``
-    # which is selector-scoped and cannot reach siblings. By the time
-    # ``run_import`` starts, the stale entry is absent, and the only
-    # duplicates ``find_duplicates()`` might still see are legitimate
-    # different-MBID editions we want to keep.
-    if already_in_beets:
-        cleanup = _preflight_remove_stale_mbid(mbid, beets)
-        if cleanup is not None:
-            if cleanup.absent_after:
-                _log(f"  [PRE-FLIGHT] Removed stale same-MBID entry "
-                     f"(beet remove -d mb_albumid:{mbid})")
-            else:
-                # Targeted remove failed (timeout/error). Log every
-                # selector failure so the audit trail says what went
-                # wrong. Proceed anyway — the "keep" duplicate response
-                # is still safe (no data loss), it just means beets ends
-                # up with two albums at the same MBID until someone runs
-                # the ban-source cleanup.
-                for f in cleanup.selector_failures:
-                    _log(f"  [PRE-FLIGHT] {f.selector} failed ({f.reason}): "
-                         f"{f.detail}")
+    # --- Capture stale beets id BEFORE the import ---
+    #
+    # The 2026-04-20 Palo Santo data-loss event trained us off the
+    # mid-import "remove" path entirely (see run_import). Instead we
+    # capture the stale row's beets numeric id here and remove it
+    # AFTER the import succeeds, by its exact primary-key selector
+    # ``id:<N>`` — the narrowest possible scope (cannot match siblings
+    # by construction — SQLite autoincrement PKs are unique).
+    #
+    # Codex (PR #131 round 1 P1) flagged the alternative design where
+    # pre-flight deleted the stale row before ``run_import``: if the
+    # harness times out / crashes / rejects the candidate, we're left
+    # with no album at all. Capture-then-import-then-remove preserves
+    # the invariant that the existing copy survives until the
+    # replacement is confirmed on disk.
+    stale_beets_id = (_capture_stale_beets_id(mbid, beets)
+                      if already_in_beets else None)
+    if stale_beets_id is not None:
+        _log(f"[PRE-FLIGHT] Captured stale beets id:{stale_beets_id} for "
+             f"post-import cleanup (will remove after upgrade lands)")
 
     # --- Import ---
     _log(f"[IMPORT] {args.path} → beets (mbid={mbid})")
-    rc, beets_lines, kept_duplicate = run_import(args.path, mbid)
+    rc, beets_lines, kept_duplicate, sibling_mbids = run_import(
+        args.path, mbid)
     r.beets_log = beets_lines
 
     if rc != 0:
@@ -1342,12 +1420,44 @@ def main():
         _log(f"[ERROR] Import failed (rc={rc})")
         _emit_and_exit(r)
 
+    # --- Post-import cleanup: remove stale same-MBID row by beets id ---
+    #
+    # If the album was already in beets when we started (stale_beets_id
+    # captured above), there are now TWO rows with the target MBID —
+    # the stale one and the fresh import (beets' ``%aunique`` placed
+    # the new album at a disambiguated path, so both coexist on disk).
+    # Remove the stale one by its exact numeric primary key. ``id:<N>``
+    # cannot match any other row.
+    #
+    # Why this runs BEFORE ``get_album_info`` below: with two rows
+    # sharing the MBID, ``get_album_info``'s ``LIMIT 1`` lookup is
+    # undefined. Removing the stale first makes the subsequent
+    # lookup unambiguous.
+    if stale_beets_id is not None:
+        _remove_stale_by_id_logged(stale_beets_id)
+
     # --- Post-flight verification ---
     pf_info = beets.get_album_info(mbid, _rank_cfg)
     if not pf_info:
         r.exit_code = 2
         r.decision = "import_failed"
         r.error = f"Post-flight: MBID {mbid} NOT in beets DB after import"
+        _log(f"[ERROR] {r.error}")
+        beets.close()
+        _emit_and_exit(r)
+
+    # If the stale removal failed, two rows may still exist and
+    # ``pf_info`` may have picked the STALE one (it's got an older,
+    # lower id and beets' lookup is LIMIT-1 with no ORDER BY). Bail
+    # out loudly rather than let the pipeline run a quality decision
+    # against the wrong album — the new album IS in beets, but the
+    # postflight info is unreliable until someone cleans up.
+    if stale_beets_id is not None and pf_info.album_id == stale_beets_id:
+        r.exit_code = 2
+        r.decision = "import_failed"
+        r.error = (f"Post-flight picked stale beets_id={stale_beets_id} "
+                   f"for mbid={mbid}; stale removal failed and two rows "
+                   "still exist. Operator must clean up via ban-source.")
         _log(f"[ERROR] {r.error}")
         beets.close()
         _emit_and_exit(r)
@@ -1367,6 +1477,11 @@ def main():
     if kept_duplicate:
         _log(f"[DISAMBIGUATE] Running beet move for album id:{pf_info.album_id}")
         album_path = _apply_disambiguation(mbid, beets, album_path, r)
+        # Also canonicalize the sibling editions beets flagged as
+        # duplicates — without this, the new album gets the ``[YEAR]``
+        # suffix while the sibling stays un-suffixed (asymmetric
+        # folder layout in Plex/Meelo).
+        _canonicalize_siblings(sibling_mbids)
 
     # --- Post-import extension check ---
     # Detect .bak files (known bug: track 01 sometimes renamed to .bak during import)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -961,7 +961,8 @@ def _run_album_move_by_id(album_id: int) -> DisambiguationFailure | None:
     return None
 
 
-def _canonicalize_siblings(sibling_album_ids: frozenset[int]) -> None:
+def _canonicalize_siblings(
+    sibling_album_ids: frozenset[int], beets: BeetsDB) -> None:
     """Re-run ``beet move`` on each sibling album id after a kept-duplicate import.
 
     When beets' ``%aunique`` disambiguates the new album (adding a
@@ -978,6 +979,14 @@ def _canonicalize_siblings(sibling_album_ids: frozenset[int]) -> None:
     Takes beets numeric album ids (not MBIDs) so Discogs-sourced
     siblings are covered — ``mb_albumid`` is empty for those,
     ``albums.id`` is always populated.
+
+    After a successful per-sibling move, runs ``fix_library_modes``
+    against the sibling's new path (Codex PR #131 round 5 P3): issue
+    #84 shows that ``beet move`` can create fresh disambiguated
+    directories at 0o755 despite systemd's ``UMask=0000``, which
+    locks out the non-service user. The main-album path gets this
+    repair at the end of ``main()``; without mirroring it here, moved
+    siblings ship with stricter perms than they started with.
 
     Never raises — delegates to ``_run_album_move_by_id`` which
     returns a typed ``DisambiguationFailure`` on any subprocess
@@ -998,6 +1007,14 @@ def _canonicalize_siblings(sibling_album_ids: frozenset[int]) -> None:
             _log(f"  [CANONICALIZE] sibling id:{aid} move failed "
                  f"({failure.reason}): {failure.detail} — sibling stays "
                  "at its current path, re-run `beet move` manually later")
+            continue
+        # Move succeeded — repair perms on the sibling's new location.
+        # ``get_album_path_by_id`` returns the sibling's current path;
+        # missing (deleted out of band) returns None — no-op.
+        sibling_path = beets.get_album_path_by_id(aid)
+        if sibling_path:
+            _log(f"  [CANONICALIZE] fix_library_modes({sibling_path})")
+            fix_library_modes(sibling_path)
 
 
 # ---------------------------------------------------------------------------
@@ -1477,23 +1494,12 @@ def main():
 
     # --- Import ---
     #
-    # ``stale_beets_id`` and ``stale_ids`` were captured/validated
-    # earlier in main() — before any destructive pre-import work on
-    # the staged download — so the bail-out for split-brain has
-    # already happened (Codex PR #131 round 4 P2).
+    # ``stale_ids`` was validated earlier in main() — split-brain
+    # fail-fast already happened before any destructive pre-import
+    # work (Codex PR #131 round 4 P2). Here we just run the import.
     _log(f"[IMPORT] {args.path} → beets (mbid={mbid})")
     rc, beets_lines, kept_duplicate, sibling_album_ids = run_import(
         args.path, mbid)
-
-    # Exclude the stale row's album id from sibling canonicalization
-    # — it will be removed by ``_remove_stale_by_id_logged`` below,
-    # so re-running ``beet move`` on it wastes a subprocess call and
-    # more importantly covers the Discogs re-import case (Codex PR
-    # #131 round 4 P3) where ``run_import``'s inner filter — keyed by
-    # ``mb_albumid`` — cannot detect that an empty-mbid Discogs row
-    # is actually the same release.
-    if stale_beets_id is not None:
-        sibling_album_ids = sibling_album_ids - frozenset([stale_beets_id])
     r.beets_log = beets_lines
 
     if rc != 0:
@@ -1504,38 +1510,60 @@ def main():
         _log(f"[ERROR] Import failed (rc={rc})")
         _emit_and_exit(r)
 
-    # --- Post-import cleanup: remove stale same-MBID row by beets id ---
+    # --- Post-import cleanup: remove EVERY same-MBID row except the new one ---
     #
-    # If the album was already in beets when we started (stale_beets_id
-    # captured above), there are now TWO rows with the target MBID —
-    # the stale one and the fresh import (beets' ``%aunique`` placed
-    # the new album at a disambiguated path, so both coexist on disk).
-    # Remove the stale one by its exact album-mode numeric primary
-    # key. ``beet remove -a -d id:<N>`` runs in album mode and matches
-    # ``albums.id = N`` exactly — cannot match any other row.
+    # Beets' ``album.id`` is SQLite AUTOINCREMENT — the row we just
+    # imported has the highest id of every same-MBID row. Any other
+    # same-MBID rows are stale (whether they existed at pre-flight
+    # enumerate, or were inserted by a racing process between that
+    # check and ``resolve_duplicate`` firing — Codex PR #131 round 5
+    # P2). Enumerate again, remove everything but the newest.
     #
-    # Codex (PR #131 round 2 P3): treat any cleanup failure as
-    # ``import_failed``. The new album IS on disk at this point, but
-    # leaving the stale row in beets silently leads to a split-brain
-    # library where subsequent upgrades may capture the wrong id or
-    # reason about the stale row's paths/bitrates. Failing explicitly
-    # surfaces the problem so the operator's ban-source cleanup can
-    # run before the request is considered complete.
-    if stale_beets_id is not None:
-        failure = _remove_stale_by_id_logged(stale_beets_id)
+    # This supersedes the round-3/4 ``stale_beets_id`` approach: by
+    # deriving the set-to-remove from the post-import state directly,
+    # we no longer depend on the pre-flight capture matching what
+    # ``resolve_duplicate`` sees. The race is closed.
+    #
+    # Each removal uses ``beet remove -a -d id:<N>`` — primary-key
+    # scoped, cannot reach cross-MBID siblings. Any removal failure
+    # is an ``import_failed`` (same as round-2 P3 contract): the new
+    # album is on disk but leaving stale rows corrupts future upgrade
+    # captures. Operator must run ban-source before the request can
+    # be marked complete.
+    post_import_ids = beets.get_all_album_ids_for_release(mbid)
+    if not post_import_ids:
+        r.exit_code = 2
+        r.decision = "import_failed"
+        r.error = (f"Post-import: MBID {mbid} NOT in beets DB after "
+                   "import — the harness reported success but no row "
+                   "survives.")
+        _log(f"[ERROR] {r.error}")
+        beets.close()
+        _emit_and_exit(r)
+    new_album_id = max(post_import_ids)  # highest id = freshest row
+    stale_to_remove = [aid for aid in post_import_ids
+                       if aid != new_album_id]
+    for aid in stale_to_remove:
+        failure = _remove_stale_by_id_logged(aid)
         if failure is not None:
             r.exit_code = 2
             r.decision = "import_failed"
-            r.error = (f"Stale beets album id:{stale_beets_id} "
+            r.error = (f"Stale beets album id:{aid} "
                        f"(mbid={mbid}) could not be removed: "
                        f"{failure.reason}: {failure.detail}. The new "
-                       "album is on disk but two same-MBID rows now "
-                       "exist in beets. Operator must clean up via "
-                       "ban-source before the request can be marked "
-                       "complete.")
+                       "album is on disk but multiple same-MBID rows "
+                       "still exist in beets. Operator must clean up "
+                       "via ban-source before the request can be "
+                       "marked complete.")
             _log(f"[ERROR] {r.error}")
             beets.close()
             _emit_and_exit(r)
+
+    # Sibling canonicalization should never try to move a row we just
+    # removed. Post-import cleanup above covered the Discogs re-import
+    # case (where ``run_import``'s inner filter couldn't see that an
+    # empty-mbid row matched our target).
+    sibling_album_ids = sibling_album_ids - frozenset(stale_to_remove)
 
     # --- Post-flight verification ---
     pf_info = beets.get_album_info(mbid, _rank_cfg)
@@ -1547,16 +1575,17 @@ def main():
         beets.close()
         _emit_and_exit(r)
 
-    # Extra guard: if pf_info still resolves to the stale id, something
-    # is seriously wrong (cleanup claimed success but beets still holds
-    # the row). Fail loudly rather than quality-gate against the stale.
-    if stale_beets_id is not None and pf_info.album_id == stale_beets_id:
+    # Extra guard: pf_info must resolve to the new album id. After the
+    # cleanup loop above there should be exactly one same-MBID row —
+    # if ``get_album_info``'s LIMIT 1 pulled something else, beets is
+    # in an inconsistent state.
+    if pf_info.album_id != new_album_id:
         r.exit_code = 2
         r.decision = "import_failed"
-        r.error = (f"Post-flight resolved to stale beets_id={stale_beets_id} "
-                   f"for mbid={mbid} despite cleanup reporting success — "
-                   "beets DB is in an inconsistent state. Operator must "
-                   "clean up via ban-source.")
+        r.error = (f"Post-flight resolved to beets_id={pf_info.album_id} "
+                   f"but new album id was {new_album_id}; cleanup left "
+                   "beets in an inconsistent state. Operator must clean "
+                   "up via ban-source.")
         _log(f"[ERROR] {r.error}")
         beets.close()
         _emit_and_exit(r)
@@ -1582,8 +1611,10 @@ def main():
         # suffix while the sibling stays un-suffixed (asymmetric
         # folder layout in Plex/Meelo). Takes beets numeric album ids
         # so Discogs siblings are covered too (their mb_albumid is
-        # empty but albums.id is always present).
-        _canonicalize_siblings(sibling_album_ids)
+        # empty but albums.id is always present). Per-sibling
+        # ``fix_library_modes`` runs inside the helper on any row
+        # whose path changed (issue #84, Codex PR #131 round 5 P3).
+        _canonicalize_siblings(sibling_album_ids, beets)
 
     # --- Post-import extension check ---
     # Detect .bak files (known bug: track 01 sometimes renamed to .bak during import)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -45,6 +45,8 @@ _bootstrap_import_paths()
 
 from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
+from lib.release_cleanup import (ReleaseCleanupResult,
+                                 remove_album_by_selectors)
 from lib.util import beets_subprocess_env
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, DisambiguationFailure,
@@ -639,21 +641,51 @@ def run_import(path, mb_release_id):
                 proc.stdin.flush()
 
             elif msg_type == "resolve_duplicate":
+                # Always answer "keep". Never "remove".
+                #
+                # Live 2026-04-20 data-loss event (Shearwater "Palo Santo"):
+                # beets' ``find_duplicates()`` returned a cross-MBID sibling
+                # pressing even with ``duplicate_keys: [albumartist, album,
+                # mb_albumid]`` in config. The old "same-MBID → remove" branch
+                # then called beets' ``task.should_remove_duplicates = True``,
+                # which iterates ``duplicate_items()`` and calls
+                # ``util.remove(item.path)`` on every item in every found
+                # duplicate — blast radius is whatever find_duplicates chose,
+                # not what we asked for. The 11-track 2006 sibling (mb=
+                # 157b51f8...) lost every mp3 on disk when the 19-track 2007
+                # reissue (mb=168d7fea...) re-imported.
+                #
+                # Structural fix: the destructive branch is gone. Stale
+                # same-MBID entries are handled by pre-flight via
+                # ``_preflight_remove_stale_mbid`` (a targeted
+                # ``beet remove -d mb_albumid:<mbid>`` that can only match
+                # that one album). By the time this harness starts, the
+                # stale entry is already absent — any duplicates still
+                # visible here are different-MBID siblings we MUST keep.
+                #
+                # ``kept_duplicate = True`` unconditionally so post-import
+                # ``beet move mb_albumid:<target>`` re-runs ``%aunique`` to
+                # fix the new album's path (beets doesn't fully disambiguate
+                # at import time when the disambiguator field starts empty).
                 dup_mbids = msg.get("duplicate_mbids", [])
+                proc.stdin.write(json.dumps({"action": "keep"}) + "\n")
+                proc.stdin.flush()
+                kept_duplicate = True
                 if mb_release_id in dup_mbids:
-                    # Same MBID already in DB — stale/partial entry, replace it.
-                    proc.stdin.write(json.dumps({"action": "remove"}) + "\n")
-                    proc.stdin.flush()
-                    print(f"  [DUP] Same MBID in library, removing stale entry", file=sys.stderr)
+                    # Should be rare: pre-flight failed to remove the stale
+                    # entry, or a race allowed it back. Log loudly so the
+                    # audit trail shows why beets has two albums with the
+                    # same MBID; operator can run the ban-source cleanup.
+                    print(
+                        f"  [DUP] Same MBID in library despite pre-flight "
+                        f"(existing: {dup_mbids}); keeping both — pre-flight "
+                        "targeted remove must have failed",
+                        file=sys.stderr)
                 else:
-                    # Different edition of same album — keep both.
-                    # NOTE: beets %aunique{} does NOT fully disambiguate at
-                    # import time (the new album gets "" if its disambiguator
-                    # field is empty). We run `beet move` post-import to fix.
-                    proc.stdin.write(json.dumps({"action": "keep"}) + "\n")
-                    proc.stdin.flush()
-                    kept_duplicate = True
-                    print(f"  [DUP] Different edition (existing: {dup_mbids}), keeping both", file=sys.stderr)
+                    print(
+                        f"  [DUP] Different edition (existing: {dup_mbids}), "
+                        "keeping both",
+                        file=sys.stderr)
 
             elif msg_type in ("choose_match", "choose_item"):
                 candidates = msg.get("candidates", [])
@@ -791,6 +823,41 @@ def _run_disambiguation_move(mbid: str) -> DisambiguationFailure | None:
         return DisambiguationFailure(reason="nonzero_rc", detail=detail)
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight same-MBID stale removal
+# ---------------------------------------------------------------------------
+
+def _preflight_remove_stale_mbid(
+    mbid: str, beets: BeetsDB) -> ReleaseCleanupResult | None:
+    """Targeted removal of a stale same-MBID album before the beets import.
+
+    This is the structural fix for the Palo Santo data-loss bug (2026-
+    04-20). Beets' own ``find_duplicates()`` drags in cross-MBID
+    sibling pressings and its ``remove_duplicates()`` deletes every
+    item in every match — so asking the interactive harness to
+    "remove" a stale same-MBID entry destroys the siblings too. The
+    primitive here delegates to
+    ``lib.release_cleanup.remove_album_by_selectors`` which can only
+    target the exact MBID via ``beet remove -d mb_albumid:<mbid>``.
+
+    Returns:
+    - ``None`` if the album isn't in beets (nothing to remove) or if
+      ``mbid`` is empty. Caller proceeds straight to the import.
+    - ``ReleaseCleanupResult`` otherwise. Callers that care about
+      partial failure (``absent_after=False``) can bail out of the
+      import rather than run into the cross-MBID blast radius path.
+
+    Does NOT touch the pipeline DB — harness subprocess has no
+    PipelineDB handle. The pipeline-side clear happens in
+    ``dispatch_import`` / the web layer on the parent side.
+    """
+    if not mbid:
+        return None
+    if not beets.album_exists(mbid):
+        return None
+    return remove_album_by_selectors(beets_db=beets, release_id=mbid)
 
 
 # ---------------------------------------------------------------------------
@@ -1232,6 +1299,35 @@ def main():
         _remove_lossless_files(args.path)
         _log(f"  [CLEANUP] Removed lossless originals "
              f"(target skipped or preserve-source approved)")
+
+    # --- Pre-flight: remove stale same-MBID album BEFORE running the
+    # beets interactive import. This is the structural fix for the Palo
+    # Santo data-loss bug (2026-04-20): beets' ``find_duplicates()``
+    # drags cross-MBID sibling pressings into the resolve_duplicate
+    # callback, so if we asked the harness to answer "remove" for the
+    # same-MBID case, beets' ``remove_duplicates()`` would delete every
+    # item in every match — siblings included. The fix scopes the
+    # removal to exactly one MBID via ``beet remove -d mb_albumid:...``
+    # which is selector-scoped and cannot reach siblings. By the time
+    # ``run_import`` starts, the stale entry is absent, and the only
+    # duplicates ``find_duplicates()`` might still see are legitimate
+    # different-MBID editions we want to keep.
+    if already_in_beets:
+        cleanup = _preflight_remove_stale_mbid(mbid, beets)
+        if cleanup is not None:
+            if cleanup.absent_after:
+                _log(f"  [PRE-FLIGHT] Removed stale same-MBID entry "
+                     f"(beet remove -d mb_albumid:{mbid})")
+            else:
+                # Targeted remove failed (timeout/error). Log every
+                # selector failure so the audit trail says what went
+                # wrong. Proceed anyway — the "keep" duplicate response
+                # is still safe (no data loss), it just means beets ends
+                # up with two albums at the same MBID until someone runs
+                # the ban-source cleanup.
+                for f in cleanup.selector_failures:
+                    _log(f"  [PRE-FLIGHT] {f.selector} failed ({f.reason}): "
+                         f"{f.detail}")
 
     # --- Import ---
     _log(f"[IMPORT] {args.path} → beets (mbid={mbid})")

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -197,6 +197,48 @@ class BeetsDB:
 
         return ReleaseLocation(kind="absent", album_id=None, selectors=())
 
+    def get_all_album_ids_for_release(self, release_id: str) -> list[int]:
+        """Return every album id whose mb/discogs id matches ``release_id``.
+
+        Unlike ``locate()`` (which returns a single id via ``LIMIT 1``),
+        this enumerates *every* row — needed so post-import stale
+        cleanup can detect the split-brain "multiple same-MBID rows
+        already exist" state and fail-fast rather than delete just
+        one while the others survive (Codex PR #131 round 3 P2).
+
+        Same dispatch as ``locate()``:
+        - Numeric ID → match on ``discogs_albumid`` OR ``mb_albumid``
+          (dual Discogs layout).
+        - UUID → match on ``mb_albumid`` only.
+        - Empty → ``[]``.
+
+        Returns an empty list if the release is absent.
+        """
+        if not release_id:
+            return []
+        source = detect_release_source(release_id)
+        numeric: int | None = None
+        if source == "discogs":
+            try:
+                numeric = int(release_id)
+            except ValueError:
+                numeric = None
+
+        if numeric is not None:
+            rows = self._conn.execute(
+                "SELECT id FROM albums "
+                "WHERE discogs_albumid = ? OR mb_albumid = ? "
+                "ORDER BY id",
+                (numeric, release_id),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT id FROM albums WHERE mb_albumid = ? "
+                "ORDER BY id",
+                (release_id,),
+            ).fetchall()
+        return [int(r[0]) for r in rows]
+
     def _batch_lookup_album_ids(
         self, release_ids: list[str]
     ) -> dict[str, int]:

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -409,6 +409,18 @@ class BeetsDB:
         album_id = self._lookup_album_id(mb_release_id)
         if album_id is None:
             return None
+        return self.get_album_path_by_id(album_id)
+
+    def get_album_path_by_id(self, album_id: int) -> Optional[str]:
+        """Get an album's directory by beets numeric id. Returns None if not found.
+
+        Used for post-move path lookups where the caller has the
+        album's PK but not its MBID — sibling canonicalization in
+        ``harness/import_one.py::_canonicalize_siblings`` uses this
+        to resolve each sibling's new path so ``fix_library_modes``
+        can repair permissions on any freshly-created disambiguated
+        directory (issue #84, Codex PR #131 round 5 P3).
+        """
         row = self._conn.execute(
             "SELECT path FROM items WHERE album_id = ? LIMIT 1",
             (album_id,)

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -96,30 +96,45 @@ class ReleaseCleanupResult:
 
 
 def _run_remove_selector(selector: str) -> SelectorFailure | None:
-    """Run ``beet remove -d <selector>`` once, never raise.
+    """Run ``beet remove -a -d <selector>`` once, never raise.
 
-    Returns ``None`` on clean exit (rc=0), otherwise a
-    ``SelectorFailure``. This is the one place that touches the beets
-    subprocess; isolating it means the loop in
-    ``remove_and_reset_release`` can be trivially correct ("always
-    iterate every selector, collect any failures").
+    The ``-a`` flag is **mandatory**. Without it, ``beet remove`` runs
+    in ITEM mode: queries ``items`` (tracks), not ``albums``. That has
+    two hazards:
+
+    - ``id:<N>`` in item mode is ``items.id = N`` — matches ONE TRACK,
+      not one album. Since ``items.id`` and ``albums.id`` are separate
+      autoincrement PKs, an album id passed to item-mode ``id:`` would
+      either match an unrelated track or nothing at all, leaving the
+      stale album fully intact. Codex (PR #131 round 2 P1) flagged
+      this against ``remove_album_by_beets_id``.
+    - ``mb_albumid:<X>`` in item mode happens to work "by accident"
+      because ``mb_albumid`` is also a per-item column inherited from
+      the album, and deleting all matching items garbage-collects the
+      empty album row. But that's fragile correctness — album-mode is
+      what we actually mean.
+
+    Every selector this module hands off is album-scoped conceptually
+    (``mb_albumid:``, ``discogs_albumid:``, ``id:`` where id is from
+    ``albums.id``), so ``-a`` is always the right flag. Returns
+    ``None`` on clean exit (rc=0), otherwise a ``SelectorFailure``.
     """
     try:
         proc = sp.run(
-            [beet_bin(), "remove", "-d", selector],
+            [beet_bin(), "remove", "-a", "-d", selector],
             capture_output=True, text=True, timeout=30,
             env=beets_subprocess_env(),
         )
     except sp.TimeoutExpired as exc:
         msg = f"timed out after {exc.timeout}s"
         log.warning(
-            "release_cleanup: beet remove -d %s %s", selector, msg)
+            "release_cleanup: beet remove -a -d %s %s", selector, msg)
         return SelectorFailure(
             selector=selector, reason="timeout", detail=msg)
     except OSError as exc:
         msg = f"{type(exc).__name__}: {exc}"
         log.warning(
-            "release_cleanup: beet remove -d %s raised %s",
+            "release_cleanup: beet remove -a -d %s raised %s",
             selector, msg)
         return SelectorFailure(
             selector=selector, reason="exception", detail=msg)
@@ -128,7 +143,7 @@ def _run_remove_selector(selector: str) -> SelectorFailure | None:
         stderr = (proc.stderr or "").strip().splitlines()
         msg = stderr[-1] if stderr else f"rc={proc.returncode}"
         log.warning(
-            "release_cleanup: beet remove -d %s exited %d: %s",
+            "release_cleanup: beet remove -a -d %s exited %d: %s",
             selector, proc.returncode, msg)
         return SelectorFailure(
             selector=selector, reason="nonzero_rc",

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -8,21 +8,25 @@ Every Codex round on PR #119 surfaced one of those steps being skipped
 missed a legacy Discogs album, a cleared-but-not-removed race in the
 'already gone' path.
 
-The function below is the only way to couple the two sides. Given a
-``release_id`` (UUID or Discogs numeric) it:
+The module exposes two entry points and the layering between them is
+the point — do not collapse or route around it:
 
-1. Calls ``BeetsDB.locate(release_id)`` to enumerate every selector
-   the ID could live under (one for UUIDs, two for Discogs numerics
-   covering the new + legacy layouts).
-2. If the album is exact-present, runs ``beet remove -d`` for EVERY
-   selector. Hitting a selector that doesn't hold the album is a
-   harmless no-op; skipping the one that does would silently leave
-   the banned copy on disk.
-3. Re-queries ``locate`` to confirm the album is absent.
-4. If absent (whether this call removed it or a prior ``beet rm``
-   did), clears the pipeline DB's on-disk quality fields so stale
-   ``current_spectral_*`` / ``imported_path`` / ``verified_lossless``
-   can't mislead downstream consumers.
+- ``remove_album_by_selectors(beets_db, release_id)`` is the pure
+  beets-only primitive. Given a ``release_id`` it locates the album,
+  iterates every selector, collects per-selector failures, and
+  re-queries to confirm absence. No pipeline DB coupling. Callable
+  from the harness (which runs as a subprocess with no PipelineDB
+  handle) — this is what the pre-flight same-MBID removal in
+  ``harness/import_one.py`` uses to avoid the cross-MBID blast
+  radius of beets' ``task.should_remove_duplicates = True`` path.
+
+- ``remove_and_reset_release(beets_db, pipeline_db, release_id,
+  request_id)`` wraps the primitive and adds one extra step:
+  clearing ``current_spectral_*`` / ``imported_path`` /
+  ``verified_lossless`` via
+  ``PipelineDB.clear_on_disk_quality_fields`` iff the album is
+  absent afterwards. That's what the ban-source web route and other
+  pipeline-aware callers need.
 
 Issue #123 PR B: each ``sp.run`` is now wrapped in a try/except that
 catches ``TimeoutExpired``, non-zero exit codes, and any ``OSError``
@@ -133,15 +137,22 @@ def _run_remove_selector(selector: str) -> SelectorFailure | None:
     return None
 
 
-def remove_and_reset_release(
+def remove_album_by_selectors(
     beets_db: "BeetsDB",
-    pipeline_db: "PipelineDB",
     release_id: str,
-    request_id: int,
 ) -> ReleaseCleanupResult:
-    """Atomically remove a release from beets and clear pipeline ghost state.
+    """Remove a release from beets via its canonical selectors.
 
-    See ``ReleaseCleanupResult`` for the return contract.
+    Pure beets-only primitive — does NOT touch the pipeline DB. See
+    ``ReleaseCleanupResult`` for the return contract.
+
+    Called from:
+    - ``remove_and_reset_release`` (this module) which wraps this and
+      adds pipeline-side ``clear_on_disk_quality_fields``
+    - ``harness/import_one.py`` pre-flight, where a stale same-MBID
+      entry must be removed before the beets interactive import
+      starts — without touching cross-MBID sibling pressings that
+      beets' own ``remove_duplicates()`` would have destroyed
 
     Preconditions: ``release_id`` is non-empty. Callers that may pass
     an empty ID must guard before invoking.
@@ -177,11 +188,38 @@ def remove_and_reset_release(
     absent_after = after.kind != "exact"
     beets_removed = album_was_in_beets and absent_after
 
-    if absent_after:
-        pipeline_db.clear_on_disk_quality_fields(request_id)
-
     return ReleaseCleanupResult(
         beets_removed=beets_removed,
         absent_after=absent_after,
         selector_failures=tuple(failures),
     )
+
+
+def remove_and_reset_release(
+    beets_db: "BeetsDB",
+    pipeline_db: "PipelineDB",
+    release_id: str,
+    request_id: int,
+) -> ReleaseCleanupResult:
+    """Atomically remove a release from beets and clear pipeline ghost state.
+
+    Thin wrapper around ``remove_album_by_selectors`` that adds the
+    pipeline-DB cleanup: iff the album is absent afterwards, clear
+    stale ``current_spectral_*`` / ``imported_path`` /
+    ``verified_lossless`` so downstream consumers don't reason about
+    ghost state left behind by the removed album.
+
+    See ``ReleaseCleanupResult`` for the return contract.
+
+    Preconditions: ``release_id`` is non-empty. Callers that may pass
+    an empty ID must guard before invoking.
+    """
+    if not release_id:
+        raise ValueError("release_id must be non-empty")
+
+    result = remove_album_by_selectors(beets_db, release_id)
+
+    if result.absent_after:
+        pipeline_db.clear_on_disk_quality_fields(request_id)
+
+    return result

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -46,7 +46,7 @@ import subprocess as sp
 from dataclasses import dataclass
 from typing import Literal, TYPE_CHECKING
 
-from lib.util import beets_subprocess_env
+from lib.util import beet_bin, beets_subprocess_env
 
 if TYPE_CHECKING:
     from lib.beets_db import BeetsDB
@@ -106,7 +106,7 @@ def _run_remove_selector(selector: str) -> SelectorFailure | None:
     """
     try:
         proc = sp.run(
-            ["beet", "remove", "-d", selector],
+            [beet_bin(), "remove", "-d", selector],
             capture_output=True, text=True, timeout=30,
             env=beets_subprocess_env(),
         )
@@ -135,6 +135,27 @@ def _run_remove_selector(selector: str) -> SelectorFailure | None:
             detail=f"rc={proc.returncode}: {msg}")
 
     return None
+
+
+def remove_album_by_beets_id(album_id: int) -> SelectorFailure | None:
+    """Remove a single album by its beets numeric primary key.
+
+    Narrower than ``remove_album_by_selectors``: the ``id:<N>``
+    selector is a ``SELECT ... WHERE id = ?`` — a beets numeric PK
+    is unique by construction, so this cannot match any album but
+    the one. Used by the harness to remove a stale same-MBID entry
+    AFTER a successful upgrade import: during the import both the
+    old and new albums briefly coexist (new is imported to a
+    disambiguated path via ``%aunique``), so we can't scope the
+    removal by MBID. Matching by beets id is the only selector
+    narrow enough to be safe — ``mb_albumid:<uuid>`` would match
+    both.
+
+    Returns ``None`` on clean exit, or a typed ``SelectorFailure``.
+    Caller decides how to surface a failure (log + proceed, or
+    escalate). No pipeline-DB coupling.
+    """
+    return _run_remove_selector(f"id:{album_id}")
 
 
 def remove_album_by_selectors(

--- a/lib/util.py
+++ b/lib/util.py
@@ -36,6 +36,28 @@ class AudioValidationResult:
 
 # === Subprocess env for beets ===
 
+
+def beet_bin() -> str:
+    """Locate the ``beet`` executable, preferring PATH.
+
+    Single source of truth for "where does ``beet`` live" across every
+    subprocess callsite (harness disambiguation move, release_cleanup
+    remove, force-import, etc). Before this helper, ``release_cleanup``
+    used the literal ``"beet"`` and relied on parent PATH resolution
+    while ``harness/import_one.py`` had its own ``shutil.which("beet")
+    or <hardcoded path>`` fallback — Codex (PR #131 round 1 P3) flagged
+    the inconsistency after the pre-flight removal path started
+    routing through ``release_cleanup`` from the harness, where the
+    systemd-narrowed PATH (coreutils/findutils/grep/sed only) does not
+    include ``/etc/profiles/per-user/abl030/bin``.
+
+    Resolved at CALL time (not import time) so tests that patch
+    ``shutil.which`` see the patched value.
+    """
+    return (shutil.which("beet")
+            or "/etc/profiles/per-user/abl030/bin/beet")
+
+
 def beets_subprocess_env() -> dict[str, str]:
     """Env for subprocesses that invoke beets (directly or via the harness
     and import_one.py). Single source of truth for the HOME override.

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -306,6 +306,72 @@ class TestLocate(unittest.TestCase):
         self.assertIsNone(loc.album_id)
         self.assertEqual(loc.selectors, ())
 
+    def test_enumerate_all_same_mbid_single_row(self) -> None:
+        """One album → single-element list. The common case.
+
+        Pins the contract used by ``import_one.main`` pre-import: if
+        the release is present exactly once, ``stale_ids = [id]`` and
+        post-import cleanup removes that id by PK.
+        """
+        with BeetsDB(self.db_path) as db:
+            ids = db.get_all_album_ids_for_release(
+                "aaa0bbb0-cccc-dddd-eeee-ffffffffffff")
+        self.assertEqual(ids, [1])
+
+    def test_enumerate_all_same_mbid_multi_row_split_brain(self) -> None:
+        """Two rows with same MBID → both ids returned.
+
+        Regression guard for Codex PR #131 round 3 P2: the earlier
+        ``locate()``-based capture picked up just one row via LIMIT 1,
+        so cleanup deleted the first but left the second behind.
+        ``main`` now enumerates and fails fast if len > 1 — operator
+        must reduce to one row before re-running.
+        """
+        # Insert a second row with the same MBID as album 1.
+        _insert_album_full(self.db_path, 99,
+                           "aaa0bbb0-cccc-dddd-eeee-ffffffffffff", [
+                               {"bitrate": 192000, "path": "/m/dup/01.mp3",
+                                "format": "MP3", "samplerate": 44100,
+                                "bitdepth": 0},
+                           ], album="OK Computer",
+                           albumartist="Radiohead")
+        with BeetsDB(self.db_path) as db:
+            ids = db.get_all_album_ids_for_release(
+                "aaa0bbb0-cccc-dddd-eeee-ffffffffffff")
+        self.assertEqual(sorted(ids), [1, 99])
+
+    def test_enumerate_all_same_mbid_absent(self) -> None:
+        """No match → empty list, not None."""
+        with BeetsDB(self.db_path) as db:
+            ids = db.get_all_album_ids_for_release("zzz-not-present")
+        self.assertEqual(ids, [])
+
+    def test_enumerate_all_same_mbid_discogs_dual_layout(self) -> None:
+        """Discogs numeric → both new-layout and legacy rows returned.
+
+        The enumeration must cover both columns for the same reason
+        ``locate()``'s selector tuple does: a library that has some
+        rows in ``discogs_albumid`` and some in ``mb_albumid`` (mid-
+        migration) is a valid state, and cleanup needs to see every
+        row or silently leaves one behind.
+        """
+        # Insert another Discogs row under the legacy mb_albumid column
+        # with the same numeric id as album 2 (which is under
+        # discogs_albumid).
+        _insert_album_full(self.db_path, 98, "12856590", [
+            {"bitrate": 320000, "path": "/m/disc_legacy/01.mp3",
+             "format": "MP3", "samplerate": 44100, "bitdepth": 0},
+        ], album="New Ritual (legacy press)", albumartist="DICE")
+        with BeetsDB(self.db_path) as db:
+            ids = db.get_all_album_ids_for_release("12856590")
+        self.assertEqual(sorted(ids), [2, 98])
+
+    def test_enumerate_all_same_mbid_empty_release_id(self) -> None:
+        """Empty release_id short-circuits to ``[]`` (caller safety)."""
+        with BeetsDB(self.db_path) as db:
+            ids = db.get_all_album_ids_for_release("")
+        self.assertEqual(ids, [])
+
     def test_locate_rejects_artist_album_kwargs(self) -> None:
         """``locate`` takes only a release_id — no fuzzy escape hatch.
 

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -71,7 +71,7 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         # select.select always says stdout is ready
         mock_select.return_value = ([99], [], [])
 
-        rc, beets_lines, kept_duplicate = import_one.run_import(
+        rc, beets_lines, kept_duplicate, sibling_mbids = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 0)
@@ -106,7 +106,7 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         mock_popen.return_value = proc
         mock_select.return_value = ([99], [], [])
 
-        rc, beets_lines, kept_duplicate = import_one.run_import(
+        rc, beets_lines, kept_duplicate, sibling_mbids = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 0)
@@ -138,7 +138,7 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         mock_popen.return_value = proc
         mock_select.return_value = ([99], [], [])
 
-        rc, beets_lines, kept_duplicate = import_one.run_import(
+        rc, beets_lines, kept_duplicate, sibling_mbids = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 0)
@@ -165,7 +165,7 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         # select returns empty = timeout
         mock_select.return_value = ([], [], [])
 
-        rc, beets_lines, kept_duplicate = import_one.run_import(
+        rc, beets_lines, kept_duplicate, sibling_mbids = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 2)
@@ -187,7 +187,7 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         mock_popen.return_value = proc
         mock_select.return_value = ([99], [], [])
 
-        rc, beets_lines, kept_duplicate = import_one.run_import(
+        rc, beets_lines, kept_duplicate, sibling_mbids = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 4)
@@ -214,7 +214,7 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         mock_popen.return_value = proc
         mock_select.return_value = ([99], [], [])
 
-        rc, beets_lines, kept_duplicate = import_one.run_import(
+        rc, beets_lines, kept_duplicate, sibling_mbids = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 2)
@@ -313,7 +313,7 @@ class TestHarnessNeverSendsRemoveToBeets(unittest.TestCase):
         mock_popen.return_value = proc
         mock_select.return_value = ([99], [], [])
 
-        rc, _, kept_duplicate = import_one.run_import(
+        rc, _, kept_duplicate, _siblings = import_one.run_import(
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 0)

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -569,7 +569,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
 
         # Must NOT raise.
         new_path = import_one._apply_disambiguation(
-            self.MBID, beets, self.ORIGINAL_PATH, r)
+            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
 
         # Property (4): path unchanged on failure.
         self.assertEqual(new_path, self.ORIGINAL_PATH)
@@ -597,7 +597,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         r, beets = self._make_result_and_beets()
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, beets, self.ORIGINAL_PATH, r)
+            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertFalse(r.postflight.disambiguated)
@@ -614,7 +614,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         r, beets = self._make_result_and_beets()
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, beets, self.ORIGINAL_PATH, r)
+            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertFalse(r.postflight.disambiguated)
@@ -642,7 +642,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
             album_path=self.ORIGINAL_PATH)
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, beets, self.ORIGINAL_PATH, r)
+            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertTrue(r.postflight.disambiguated)
@@ -666,7 +666,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         beets.get_album_info.return_value = None
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, beets, self.ORIGINAL_PATH, r)
+            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertEqual(r.postflight.imported_path, self.ORIGINAL_PATH)
@@ -693,7 +693,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
             album_path=renamed)
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, beets, self.ORIGINAL_PATH, r)
+            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, renamed)
         self.assertEqual(r.postflight.imported_path, renamed)

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -79,9 +79,20 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
 
     @patch("harness.import_one.select.select")
     @patch("harness.import_one.subprocess.Popen")
-    def test_replace_same_mbid_not_kept_duplicate(self, mock_popen, mock_select):
-        """When resolve_duplicate has the same MBID (stale entry), we say
-        remove — kept_duplicate should be False."""
+    def test_same_mbid_still_keeps_never_removes(self, mock_popen, mock_select):
+        """Same-MBID in dup_mbids must NOT trigger a 'remove' response.
+
+        Regression guard for the Palo Santo data-loss bug (this PR): when
+        beets' ``find_duplicates()`` returns both the same-MBID stale
+        entry AND a cross-MBID sibling pressing, answering ``"remove"``
+        causes beets' ``remove_duplicates()`` to wipe every item in
+        every found duplicate — including the cross-MBID sibling's files
+        on disk. The harness must never send ``"remove"``; stale same-
+        MBID removal happens in pre-flight via targeted
+        ``beet remove -d mb_albumid:<mbid>`` before this subprocess
+        starts. ``kept_duplicate`` stays True so post-import
+        disambiguation re-runs ``beet move`` to fix %aunique paths.
+        """
         from harness import import_one
 
         messages = [
@@ -99,7 +110,17 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
             "/tmp/test", TARGET_MBID)
 
         self.assertEqual(rc, 0)
-        self.assertFalse(kept_duplicate)
+        self.assertTrue(kept_duplicate,
+                        "Any resolve_duplicate firing must set kept_duplicate "
+                        "True so post-import beet move re-runs.")
+        # No stdin payload may carry action:"remove" — the destructive
+        # branch is gone entirely.
+        writes = "".join(
+            call.args[0] for call in proc.stdin.write.call_args_list)
+        self.assertNotIn('"remove"', writes,
+                         "Harness must never answer action:'remove' to "
+                         "resolve_duplicate — beets' remove_duplicates() has "
+                         "cross-MBID blast radius.")
 
     @patch("harness.import_one.select.select")
     @patch("harness.import_one.subprocess.Popen")
@@ -199,6 +220,113 @@ class TestRunImportKeptDuplicate(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertFalse(kept_duplicate)
         self.assertIn("readonly database", "\n".join(beets_lines))
+
+
+class TestHarnessNeverSendsRemoveToBeets(unittest.TestCase):
+    """Invariant: ``run_import`` must NEVER answer ``action: "remove"``.
+
+    Beets' ``remove_duplicates()`` (``beets/importer/tasks.py``) deletes
+    every item in every album returned by ``find_duplicates()`` — the
+    call cannot be scoped to one MBID from the harness side. In live
+    production (2026-04-20), ``find_duplicates()`` returned a cross-
+    MBID sibling pressing even with ``duplicate_keys: [albumartist,
+    album, mb_albumid]`` configured, so answering "remove" destroyed
+    the sibling's files on disk. The structural fix is to make the
+    "remove" branch *unrepresentable*: the only answer to
+    ``resolve_duplicate`` is ``"keep"`` (sibling preservation). Stale
+    same-MBID removal happens in pre-flight via a targeted
+    ``beet remove -d mb_albumid:<mbid>`` that only matches that one
+    album.
+
+    Every sub-test asserts the same thing — ``"remove"`` never crosses
+    the wire — under different dup_mbids shapes so a future accidental
+    re-introduction of the branch fails here first.
+    """
+
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
+    def test_same_mbid_only(self, mock_popen, mock_select):
+        from harness import import_one
+
+        messages = [
+            {"type": "resolve_duplicate", "duplicate_mbids": [TARGET_MBID]},
+            {"type": "choose_match", "candidates": [
+                {"album_id": TARGET_MBID, "distance": 0.05,
+                 "artist": "X", "album": "Y"}]},
+        ]
+        proc = _make_harness_proc(messages)
+        mock_popen.return_value = proc
+        mock_select.return_value = ([99], [], [])
+
+        import_one.run_import("/tmp/test", TARGET_MBID)
+
+        writes = "".join(
+            call.args[0] for call in proc.stdin.write.call_args_list)
+        self.assertNotIn('"remove"', writes)
+
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
+    def test_different_mbid_only(self, mock_popen, mock_select):
+        from harness import import_one
+
+        messages = [
+            {"type": "resolve_duplicate", "duplicate_mbids": [OTHER_MBID]},
+            {"type": "choose_match", "candidates": [
+                {"album_id": TARGET_MBID, "distance": 0.05,
+                 "artist": "X", "album": "Y"}]},
+        ]
+        proc = _make_harness_proc(messages)
+        mock_popen.return_value = proc
+        mock_select.return_value = ([99], [], [])
+
+        import_one.run_import("/tmp/test", TARGET_MBID)
+
+        writes = "".join(
+            call.args[0] for call in proc.stdin.write.call_args_list)
+        self.assertNotIn('"remove"', writes)
+
+    @patch("harness.import_one.select.select")
+    @patch("harness.import_one.subprocess.Popen")
+    def test_palo_santo_mixed_dup_mbids_preserves_sibling(
+            self, mock_popen, mock_select):
+        """Live-log reproduction: dup_mbids contains BOTH the target MBID
+        AND a sibling pressing's MBID. Before the fix this took the
+        ``"remove"`` branch and beets wiped both albums' files on disk.
+        After the fix the harness answers ``"keep"`` so beets imports
+        the new album alongside; targeted pre-flight removal (run
+        separately upstream of ``run_import``) handles the stale
+        same-MBID entry without touching the sibling.
+        """
+        from harness import import_one
+
+        messages = [
+            # The 2026-04-20 live event: both the incoming 19-track
+            # (target) MBID and the 11-track sibling's MBID showed up
+            # as duplicates.
+            {"type": "resolve_duplicate",
+             "duplicate_mbids": [TARGET_MBID, OTHER_MBID]},
+            {"type": "choose_match", "candidates": [
+                {"album_id": TARGET_MBID, "distance": 0.05,
+                 "artist": "X", "album": "Y"}]},
+        ]
+        proc = _make_harness_proc(messages)
+        mock_popen.return_value = proc
+        mock_select.return_value = ([99], [], [])
+
+        rc, _, kept_duplicate = import_one.run_import(
+            "/tmp/test", TARGET_MBID)
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(
+            kept_duplicate,
+            "Even in the mixed case, kept_duplicate must be True — "
+            "post-import beet move still needs to re-run %aunique.")
+        writes = "".join(
+            call.args[0] for call in proc.stdin.write.call_args_list)
+        self.assertNotIn(
+            '"remove"', writes,
+            "The Palo Santo bug: mixed dup_mbids must NEVER trigger "
+            "action:'remove' (blast-radius includes the sibling).")
 
 
 class TestDisambiguateBeetMove(unittest.TestCase):

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -1,26 +1,34 @@
-"""Tests for pre-flight same-MBID removal in import_one.py.
+"""Tests for same-MBID stale-entry handling in import_one.py.
 
 Bug being locked in (live 2026-04-20): when an upgrade re-import runs
-against an album already in beets, the stale same-MBID entry must be
-removed via a *targeted* ``beet remove -d mb_albumid:<mbid>`` BEFORE
-the beets import harness starts — not mid-import via beets' own
-``remove_duplicates()``, which has cross-MBID blast radius and wiped
-the 11-track Palo Santo sibling in production.
+against an album already in beets, we must remove the stale same-MBID
+row with a selector that CANNOT reach sibling pressings. The narrowest
+such selector is the beets numeric primary key (``id:<N>``).
 
-The seam these tests pin: ``_preflight_remove_stale_mbid(mbid, beets)``
-in ``harness/import_one.py``. It delegates to
-``lib.release_cleanup.remove_album_by_selectors`` (the pure-beets
-primitive — no PipelineDB coupling, because the harness subprocess has
-no PipelineDB on hand).
+Round 2 design (post PR #131 Codex P1): the stale removal runs AFTER
+the new album is successfully in beets, not before. A pre-flight
+remove could leave the user with no files at all if the harness times
+out / crashes. The capture-then-import-then-remove shape keeps the
+existing copy alive until the replacement is confirmed.
 
-Contract:
-- If the album IS in beets → returns a non-None ReleaseCleanupResult
-  with absent_after reflecting whether removal succeeded. Subprocess
-  ran at least once.
-- If the album is NOT in beets → returns None (no work to do). No
-  subprocess runs.
-- Empty mbid → returns None (preflight is opt-in; callers that
-  already know the album isn't present shouldn't need to gate).
+Seams pinned here:
+
+- ``_capture_stale_beets_id(mbid, beets)``
+  Pre-import, no destruction: returns the stale row's beets id (if
+  present) or None. Caller stashes it until post-import cleanup.
+
+- ``_remove_stale_by_id_logged(stale_id)``
+  Post-import, destructive: runs ``beet remove -d id:<N>`` via
+  ``lib.release_cleanup.remove_album_by_beets_id``. ``id:<N>`` is a
+  SQLite primary-key selector — it cannot match any other row, by
+  construction. Logs the outcome so the import audit trail shows
+  exactly which beets row was removed.
+
+- ``_canonicalize_siblings(sibling_mbids)``
+  Post-import, non-destructive: re-runs ``beet move`` on each
+  different-edition sibling so ``%aunique`` re-evaluates their paths
+  too. Keeps folder layout symmetric when two pressings of the same
+  album name co-exist.
 """
 
 from __future__ import annotations
@@ -38,6 +46,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 TARGET_MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+SIBLING_MBID = "cccccccc-4444-5555-6666-dddddddddddd"
 
 
 @dataclass
@@ -48,113 +57,162 @@ class _StubLocation:
 
 
 class _StubBeetsDB:
-    """Minimal BeetsDB double. Same shape as tests/test_release_cleanup.py."""
+    """Minimal BeetsDB double for capture-only pre-flight tests.
 
-    def __init__(self, sequence: list[_StubLocation]) -> None:
-        self._sequence = list(sequence)
-        self.locate_calls: list[str] = []
+    ``_capture_stale_beets_id`` calls ``get_album_info`` to extract the
+    stale row's beets id. Shape: return an ``AlbumInfo`` with the id we
+    want to see captured, or None for the "not in beets" path.
+    """
 
-    def locate(self, release_id: str) -> _StubLocation:
-        self.locate_calls.append(release_id)
-        return self._sequence.pop(0)
+    def __init__(self, album_info: object | None) -> None:
+        self._album_info = album_info
 
-    def album_exists(self, mbid: str) -> bool:
-        """Harness pre-flight uses album_exists for the initial check.
-
-        The stub mirrors locate() — one entry consumed per call.
-        """
-        return self._sequence[0].kind == "exact" if self._sequence else False
+    def get_album_info(self, mbid: str, cfg: object) -> object | None:
+        return self._album_info
 
 
 def _ok() -> MagicMock:
     return MagicMock(returncode=0, stdout="", stderr="")
 
 
-class TestPreflightRemoveStaleMBID(unittest.TestCase):
-    """The pre-flight helper is the seam that makes the Palo Santo fix work.
+class TestCaptureStaleBeetsId(unittest.TestCase):
+    """Pre-import capture is non-destructive — it only reads.
 
-    By the time ``run_import`` starts, the stale same-MBID album must
-    already be gone — otherwise beets' ``find_duplicates()`` drags it
-    into the resolve_duplicate callback and we're back to answering
-    ``"keep"`` on a dup list that may include cross-MBID siblings.
-    (Keep is safe, but cleaner to not even have the stale entry
-    present.)
+    The PR #131 round-1 regression was that the remove ran before the
+    import, so a crashed import left the user with no album at all.
+    This helper replaces that path: it just reads the stale id, caller
+    stores it, and the destructive step runs post-import.
     """
 
-    @patch("lib.release_cleanup.sp.run")
-    def test_removes_when_album_in_beets(self, mock_run: MagicMock) -> None:
-        """Album present → targeted beet remove runs, result returned."""
+    def test_returns_beets_id_when_album_present(self) -> None:
         from harness import import_one
-        mock_run.return_value = _ok()
-        beets = _StubBeetsDB([
-            _StubLocation("exact", 1, (f"mb_albumid:{TARGET_MBID}",)),
-            _StubLocation("absent", None, ()),
-        ])
+        from lib.beets_db import AlbumInfo
 
-        result = import_one._preflight_remove_stale_mbid(
+        beets = _StubBeetsDB(AlbumInfo(
+            album_id=10319, track_count=19,
+            min_bitrate_kbps=320, is_cbr=True,
+            album_path="/Beets/Shearwater/2007 - Palo Santo"))
+
+        result = import_one._capture_stale_beets_id(
             TARGET_MBID, beets)  # type: ignore[arg-type]
 
-        self.assertIsNotNone(result)
-        assert result is not None  # narrow for pyright
-        self.assertTrue(result.beets_removed)
-        self.assertTrue(result.absent_after)
-        # The subprocess MUST use an MBID-scoped selector.
-        mock_run.assert_called_once()
-        argv = mock_run.call_args.args[0]
-        self.assertEqual(argv[0:3], ["beet", "remove", "-d"])
-        self.assertEqual(argv[3], f"mb_albumid:{TARGET_MBID}")
+        self.assertEqual(result, 10319)
 
-    @patch("lib.release_cleanup.sp.run")
-    def test_no_op_when_album_absent(self, mock_run: MagicMock) -> None:
-        """Album not in beets → returns None, no subprocess, no churn."""
+    def test_returns_none_when_absent(self) -> None:
         from harness import import_one
-        beets = _StubBeetsDB([
-            _StubLocation("absent", None, ()),
-        ])
+        beets = _StubBeetsDB(None)
 
-        result = import_one._preflight_remove_stale_mbid(
+        result = import_one._capture_stale_beets_id(
             TARGET_MBID, beets)  # type: ignore[arg-type]
 
         self.assertIsNone(result)
-        mock_run.assert_not_called()
 
-    @patch("lib.release_cleanup.sp.run")
-    def test_empty_mbid_returns_none(self, mock_run: MagicMock) -> None:
-        """Empty MBID is a no-op (caller guards)."""
+    def test_returns_none_for_empty_mbid(self) -> None:
         from harness import import_one
-        beets = _StubBeetsDB([])
+        beets = _StubBeetsDB(None)
 
-        result = import_one._preflight_remove_stale_mbid(
+        result = import_one._capture_stale_beets_id(
             "", beets)  # type: ignore[arg-type]
 
         self.assertIsNone(result)
-        mock_run.assert_not_called()
+
+
+class TestRemoveStaleByIdLogged(unittest.TestCase):
+    """Post-import cleanup: ``beet remove -d id:<N>`` via the release_cleanup
+    primitive. The ``id:<N>`` selector is the beets numeric PK — it
+    cannot match any other album, so the blast radius is exactly one
+    row."""
 
     @patch("lib.release_cleanup.sp.run")
-    def test_surfaces_partial_failure(self, mock_run: MagicMock) -> None:
-        """Timeout leaves the album on disk → result reflects it.
+    def test_clean_exit_returns_none(self, mock_run: MagicMock) -> None:
+        from harness import import_one
+        mock_run.return_value = _ok()
 
-        Caller (main) must be able to see absent_after=False and decide
-        whether to abort the import rather than blunder on into a
-        beets ``remove_duplicates`` → data-loss scenario.
-        """
+        result = import_one._remove_stale_by_id_logged(10319)
+
+        self.assertIsNone(result)
+        mock_run.assert_called_once()
+        argv = mock_run.call_args.args[0]
+        # Selector must be id:<int> — primary-key scope, NEVER mb_albumid
+        # (which can match multiple rows and would hit siblings).
+        self.assertEqual(argv[1:4], ["remove", "-d", "id:10319"])
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_timeout_surfaces_typed_failure(self, mock_run: MagicMock) -> None:
         from harness import import_one
         mock_run.side_effect = sp.TimeoutExpired(
-            cmd=["beet", "remove", "-d", f"mb_albumid:{TARGET_MBID}"],
-            timeout=30)
-        beets = _StubBeetsDB([
-            _StubLocation("exact", 1, (f"mb_albumid:{TARGET_MBID}",)),
-            _StubLocation("exact", 1, (f"mb_albumid:{TARGET_MBID}",)),
-        ])
+            cmd=["beet", "remove", "-d", "id:10319"], timeout=30)
 
-        result = import_one._preflight_remove_stale_mbid(
-            TARGET_MBID, beets)  # type: ignore[arg-type]
+        result = import_one._remove_stale_by_id_logged(10319)
 
         self.assertIsNotNone(result)
         assert result is not None
-        self.assertFalse(result.absent_after)
-        self.assertEqual(len(result.selector_failures), 1)
-        self.assertEqual(result.selector_failures[0].reason, "timeout")
+        self.assertEqual(result.reason, "timeout")
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_nonzero_rc_surfaces_typed_failure(
+            self, mock_run: MagicMock) -> None:
+        from harness import import_one
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="some error")
+
+        result = import_one._remove_stale_by_id_logged(10319)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.reason, "nonzero_rc")
+
+
+class TestCanonicalizeSiblings(unittest.TestCase):
+    """Re-running ``beet move`` on sibling MBIDs keeps folder layout symmetric.
+
+    When ``%aunique`` disambiguates an incoming album because a
+    different-edition sibling already exists, only the new album gets
+    its path re-evaluated at import time. The sibling stays at the
+    path it had when it was originally imported — often with no
+    suffix because it was alone back then. ``beet move
+    mb_albumid:<sibling>`` re-evaluates ``%aunique`` for the sibling
+    too, so both editions end up shaped the same way.
+    """
+
+    @patch("harness.import_one.subprocess.run")
+    def test_noop_when_no_siblings(self, mock_run: MagicMock) -> None:
+        from harness import import_one
+        import_one._canonicalize_siblings(frozenset())
+        mock_run.assert_not_called()
+
+    @patch("harness.import_one.subprocess.run")
+    def test_runs_beet_move_for_each_sibling(
+            self, mock_run: MagicMock) -> None:
+        from harness import import_one
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        import_one._canonicalize_siblings(frozenset([SIBLING_MBID]))
+
+        mock_run.assert_called_once()
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(argv[1:], ["move", f"mb_albumid:{SIBLING_MBID}"])
+
+    @patch("harness.import_one.subprocess.run")
+    def test_continues_past_per_sibling_failure(
+            self, mock_run: MagicMock) -> None:
+        """Timeout on sibling 1 must not stop sibling 2 moving.
+
+        Import is already on disk — per-sibling failures only affect
+        that sibling's cosmetic path. Keep going.
+        """
+        from harness import import_one
+        other = "dddddddd-7777-8888-9999-eeeeeeeeeeee"
+        # Sibling 1 times out, sibling 2 exits clean.
+        mock_run.side_effect = [
+            sp.TimeoutExpired(cmd=["beet", "move"], timeout=120),
+            MagicMock(returncode=0, stderr=""),
+        ]
+
+        import_one._canonicalize_siblings(
+            frozenset([SIBLING_MBID, other]))
+
+        self.assertEqual(mock_run.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -118,12 +118,16 @@ class TestCanonicalizeSiblings(unittest.TestCase):
     @patch("harness.import_one.subprocess.run")
     def test_noop_when_no_siblings(self, mock_run: MagicMock) -> None:
         from harness import import_one
-        import_one._canonicalize_siblings(frozenset([]))
+        beets = MagicMock()
+        import_one._canonicalize_siblings(frozenset([]), beets)
         mock_run.assert_not_called()
+        beets.get_album_path_by_id.assert_not_called()
 
+    @patch("harness.import_one.fix_library_modes")
     @patch("harness.import_one.subprocess.run")
     def test_runs_beet_move_album_mode_id_selector(
-            self, mock_run: MagicMock) -> None:
+            self, mock_run: MagicMock,
+            mock_fix: MagicMock) -> None:
         """Each sibling move MUST use ``beet move -a id:<N>``.
 
         ``-a`` puts beets in album mode so ``id:<N>`` matches
@@ -133,16 +137,26 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         """
         from harness import import_one
         mock_run.return_value = MagicMock(returncode=0, stderr="")
+        beets = MagicMock()
+        beets.get_album_path_by_id.return_value = (
+            "/Beets/Shearwater/2006 - Palo Santo [2006]")
 
-        import_one._canonicalize_siblings(frozenset([10314]))
+        import_one._canonicalize_siblings(frozenset([10314]), beets)
 
         mock_run.assert_called_once()
         argv = mock_run.call_args.args[0]
         self.assertEqual(argv[1:], ["move", "-a", "id:10314"])
+        # P3 round 5: post-move perm repair on the sibling's new
+        # path — issue #84 ``beet move`` can create fresh
+        # disambiguated dirs at 0o755 even with UMask=0000.
+        mock_fix.assert_called_once_with(
+            "/Beets/Shearwater/2006 - Palo Santo [2006]")
 
+    @patch("harness.import_one.fix_library_modes")
     @patch("harness.import_one.subprocess.run")
     def test_handles_discogs_sibling_via_album_id(
-            self, mock_run: MagicMock) -> None:
+            self, mock_run: MagicMock,
+            mock_fix: MagicMock) -> None:
         """Regression for Codex PR #131 round 3 P3.
 
         Pre-fix, siblings were identified by ``mb_albumid`` — empty
@@ -154,20 +168,29 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         """
         from harness import import_one
         mock_run.return_value = MagicMock(returncode=0, stderr="")
+        beets = MagicMock()
+        beets.get_album_path_by_id.return_value = (
+            "/Beets/Discogs/Artist/Album [12856590]")
 
-        import_one._canonicalize_siblings(frozenset([12856590]))
+        import_one._canonicalize_siblings(frozenset([12856590]), beets)
 
         mock_run.assert_called_once()
         argv = mock_run.call_args.args[0]
         self.assertEqual(argv[1:], ["move", "-a", "id:12856590"])
+        mock_fix.assert_called_once_with(
+            "/Beets/Discogs/Artist/Album [12856590]")
 
+    @patch("harness.import_one.fix_library_modes")
     @patch("harness.import_one.subprocess.run")
     def test_continues_past_per_sibling_failure(
-            self, mock_run: MagicMock) -> None:
+            self, mock_run: MagicMock,
+            mock_fix: MagicMock) -> None:
         """Timeout on sibling 1 must not stop sibling 2 moving.
 
         Import is already on disk — per-sibling failures only affect
-        that sibling's cosmetic path. Keep going.
+        that sibling's cosmetic path. Keep going. ``fix_library_modes``
+        only runs on the sibling that moved cleanly — we don't repair
+        perms for a failed move (the sibling's path didn't change).
         """
         from harness import import_one
         # Sibling 1 times out, sibling 2 exits clean.
@@ -175,10 +198,34 @@ class TestCanonicalizeSiblings(unittest.TestCase):
             sp.TimeoutExpired(cmd=["beet", "move"], timeout=120),
             MagicMock(returncode=0, stderr=""),
         ]
+        beets = MagicMock()
+        # Any valid path for the sibling that moved clean.
+        beets.get_album_path_by_id.return_value = "/Beets/X/Y [2006]"
 
-        import_one._canonicalize_siblings(frozenset([10314, 10315]))
+        # frozenset ordering isn't deterministic; test by asserting
+        # counts, not which specific id got which outcome.
+        import_one._canonicalize_siblings(frozenset([10314, 10315]), beets)
 
         self.assertEqual(mock_run.call_count, 2)
+        # Exactly one of the two moves succeeded → exactly one perm repair.
+        self.assertEqual(mock_fix.call_count, 1)
+
+    @patch("harness.import_one.fix_library_modes")
+    @patch("harness.import_one.subprocess.run")
+    def test_skips_fix_library_modes_when_path_missing(
+            self, mock_run: MagicMock,
+            mock_fix: MagicMock) -> None:
+        """If the sibling was deleted out-of-band between move and
+        path lookup, ``get_album_path_by_id`` returns None — the
+        perm repair call is skipped (no path to chmod)."""
+        from harness import import_one
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        beets = MagicMock()
+        beets.get_album_path_by_id.return_value = None
+
+        import_one._canonicalize_siblings(frozenset([10314]), beets)
+
+        mock_fix.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -37,8 +37,6 @@ import os
 import subprocess as sp
 import sys
 import unittest
-from dataclasses import dataclass
-from typing import Literal, Optional
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "harness"))
@@ -46,97 +44,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 TARGET_MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-SIBLING_MBID = "cccccccc-4444-5555-6666-dddddddddddd"
-
-
-@dataclass
-class _StubLocation:
-    kind: Literal["exact", "absent"]
-    album_id: Optional[int]
-    selectors: tuple[str, ...]
-
-
-class _StubBeetsDB:
-    """Minimal BeetsDB double for capture-only pre-flight tests.
-
-    ``_capture_stale_beets_id`` calls ``locate(mbid)`` to extract the
-    stale row's beets id — deliberately NOT ``get_album_info``, which
-    would skip the capture for partial stale imports (corrupted items,
-    zero-bitrate tracks, etc.). Codex (PR #131 round 2 P2) flagged
-    that: the whole point of cleanup is to handle the broken-import
-    case, so the capture must not depend on track readability.
-    """
-
-    def __init__(self, location: _StubLocation | None) -> None:
-        self._location = location or _StubLocation("absent", None, ())
-
-    def locate(self, release_id: str) -> _StubLocation:
-        return self._location
 
 
 def _ok() -> MagicMock:
     return MagicMock(returncode=0, stdout="", stderr="")
-
-
-class TestCaptureStaleBeetsId(unittest.TestCase):
-    """Pre-import capture is non-destructive — it only reads.
-
-    The PR #131 round-1 regression was that the remove ran before the
-    import, so a crashed import left the user with no album at all.
-    This helper replaces that path: it just reads the stale id, caller
-    stores it, and the destructive step runs post-import.
-    """
-
-    def test_returns_beets_id_when_album_present(self) -> None:
-        from harness import import_one
-
-        beets = _StubBeetsDB(_StubLocation(
-            "exact", 10319, (f"mb_albumid:{TARGET_MBID}",)))
-
-        result = import_one._capture_stale_beets_id(
-            TARGET_MBID, beets)  # type: ignore[arg-type]
-
-        self.assertEqual(result, 10319)
-
-    def test_returns_beets_id_for_partial_import_with_broken_items(self) -> None:
-        """Codex PR #131 round 2 P2: a stale album with zero-bitrate items
-        (corrupted, unreadable, partially downloaded) would return None
-        from ``get_album_info`` but is exactly the case cleanup exists
-        for. ``locate()`` doesn't touch items, so the capture still
-        fires and post-import cleanup can run.
-        """
-        from harness import import_one
-
-        # Simulate a partial stale album: locate() finds it, any
-        # attempt to read its track data would return None — but we
-        # never go there now.
-        beets = _StubBeetsDB(_StubLocation(
-            "exact", 10319, (f"mb_albumid:{TARGET_MBID}",)))
-
-        result = import_one._capture_stale_beets_id(
-            TARGET_MBID, beets)  # type: ignore[arg-type]
-
-        self.assertEqual(result, 10319,
-                         "locate()-based capture must work even when "
-                         "the stale album has no readable track data.")
-
-    def test_returns_none_when_absent(self) -> None:
-        from harness import import_one
-        beets = _StubBeetsDB(_StubLocation("absent", None, ()))
-
-        result = import_one._capture_stale_beets_id(
-            TARGET_MBID, beets)  # type: ignore[arg-type]
-
-        self.assertIsNone(result)
-
-    def test_returns_none_for_empty_mbid(self) -> None:
-        from harness import import_one
-        beets = _StubBeetsDB(None)
-
-        result = import_one._capture_stale_beets_id(
-            "", beets)  # type: ignore[arg-type]
-
-        self.assertIsNone(result)
 
 
 class TestRemoveStaleByIdLogged(unittest.TestCase):
@@ -189,34 +100,66 @@ class TestRemoveStaleByIdLogged(unittest.TestCase):
 
 
 class TestCanonicalizeSiblings(unittest.TestCase):
-    """Re-running ``beet move`` on sibling MBIDs keeps folder layout symmetric.
+    """Re-running ``beet move`` on sibling albums keeps folder layout symmetric.
 
     When ``%aunique`` disambiguates an incoming album because a
     different-edition sibling already exists, only the new album gets
     its path re-evaluated at import time. The sibling stays at the
     path it had when it was originally imported — often with no
-    suffix because it was alone back then. ``beet move
-    mb_albumid:<sibling>`` re-evaluates ``%aunique`` for the sibling
-    too, so both editions end up shaped the same way.
+    suffix because it was alone back then. ``beet move -a id:<N>`` on
+    each sibling re-evaluates ``%aunique`` for its path too, so both
+    editions end up shaped the same way.
+
+    Keyed by beets numeric album id (not MBID) so Discogs-sourced
+    siblings are covered: their ``mb_albumid`` is empty but
+    ``albums.id`` is always populated (Codex PR #131 round 3 P3).
     """
 
     @patch("harness.import_one.subprocess.run")
     def test_noop_when_no_siblings(self, mock_run: MagicMock) -> None:
         from harness import import_one
-        import_one._canonicalize_siblings(frozenset())
+        import_one._canonicalize_siblings(frozenset([]))
         mock_run.assert_not_called()
 
     @patch("harness.import_one.subprocess.run")
-    def test_runs_beet_move_for_each_sibling(
+    def test_runs_beet_move_album_mode_id_selector(
             self, mock_run: MagicMock) -> None:
+        """Each sibling move MUST use ``beet move -a id:<N>``.
+
+        ``-a`` puts beets in album mode so ``id:<N>`` matches
+        ``albums.id`` (unique PK). Without it, ``id:<N>`` would hit
+        ``items.id`` (a separate auto-increment namespace) and move
+        a single track instead of the sibling album.
+        """
         from harness import import_one
         mock_run.return_value = MagicMock(returncode=0, stderr="")
 
-        import_one._canonicalize_siblings(frozenset([SIBLING_MBID]))
+        import_one._canonicalize_siblings(frozenset([10314]))
 
         mock_run.assert_called_once()
         argv = mock_run.call_args.args[0]
-        self.assertEqual(argv[1:], ["move", f"mb_albumid:{SIBLING_MBID}"])
+        self.assertEqual(argv[1:], ["move", "-a", "id:10314"])
+
+    @patch("harness.import_one.subprocess.run")
+    def test_handles_discogs_sibling_via_album_id(
+            self, mock_run: MagicMock) -> None:
+        """Regression for Codex PR #131 round 3 P3.
+
+        Pre-fix, siblings were identified by ``mb_albumid`` — empty
+        string for Discogs-sourced pressings, so they silently got
+        dropped by the ``if dm`` filter in run_import. Switching the
+        collection to ``album_ids`` (PK, always populated) covers
+        both sources. The set here carries only an integer — no MBID
+        needed — to prove the helper no longer requires it.
+        """
+        from harness import import_one
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        import_one._canonicalize_siblings(frozenset([12856590]))
+
+        mock_run.assert_called_once()
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(argv[1:], ["move", "-a", "id:12856590"])
 
     @patch("harness.import_one.subprocess.run")
     def test_continues_past_per_sibling_failure(
@@ -227,15 +170,13 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         that sibling's cosmetic path. Keep going.
         """
         from harness import import_one
-        other = "dddddddd-7777-8888-9999-eeeeeeeeeeee"
         # Sibling 1 times out, sibling 2 exits clean.
         mock_run.side_effect = [
             sp.TimeoutExpired(cmd=["beet", "move"], timeout=120),
             MagicMock(returncode=0, stderr=""),
         ]
 
-        import_one._canonicalize_siblings(
-            frozenset([SIBLING_MBID, other]))
+        import_one._canonicalize_siblings(frozenset([10314, 10315]))
 
         self.assertEqual(mock_run.call_count, 2)
 

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -59,16 +59,19 @@ class _StubLocation:
 class _StubBeetsDB:
     """Minimal BeetsDB double for capture-only pre-flight tests.
 
-    ``_capture_stale_beets_id`` calls ``get_album_info`` to extract the
-    stale row's beets id. Shape: return an ``AlbumInfo`` with the id we
-    want to see captured, or None for the "not in beets" path.
+    ``_capture_stale_beets_id`` calls ``locate(mbid)`` to extract the
+    stale row's beets id — deliberately NOT ``get_album_info``, which
+    would skip the capture for partial stale imports (corrupted items,
+    zero-bitrate tracks, etc.). Codex (PR #131 round 2 P2) flagged
+    that: the whole point of cleanup is to handle the broken-import
+    case, so the capture must not depend on track readability.
     """
 
-    def __init__(self, album_info: object | None) -> None:
-        self._album_info = album_info
+    def __init__(self, location: _StubLocation | None) -> None:
+        self._location = location or _StubLocation("absent", None, ())
 
-    def get_album_info(self, mbid: str, cfg: object) -> object | None:
-        return self._album_info
+    def locate(self, release_id: str) -> _StubLocation:
+        return self._location
 
 
 def _ok() -> MagicMock:
@@ -86,21 +89,40 @@ class TestCaptureStaleBeetsId(unittest.TestCase):
 
     def test_returns_beets_id_when_album_present(self) -> None:
         from harness import import_one
-        from lib.beets_db import AlbumInfo
 
-        beets = _StubBeetsDB(AlbumInfo(
-            album_id=10319, track_count=19,
-            min_bitrate_kbps=320, is_cbr=True,
-            album_path="/Beets/Shearwater/2007 - Palo Santo"))
+        beets = _StubBeetsDB(_StubLocation(
+            "exact", 10319, (f"mb_albumid:{TARGET_MBID}",)))
 
         result = import_one._capture_stale_beets_id(
             TARGET_MBID, beets)  # type: ignore[arg-type]
 
         self.assertEqual(result, 10319)
 
+    def test_returns_beets_id_for_partial_import_with_broken_items(self) -> None:
+        """Codex PR #131 round 2 P2: a stale album with zero-bitrate items
+        (corrupted, unreadable, partially downloaded) would return None
+        from ``get_album_info`` but is exactly the case cleanup exists
+        for. ``locate()`` doesn't touch items, so the capture still
+        fires and post-import cleanup can run.
+        """
+        from harness import import_one
+
+        # Simulate a partial stale album: locate() finds it, any
+        # attempt to read its track data would return None — but we
+        # never go there now.
+        beets = _StubBeetsDB(_StubLocation(
+            "exact", 10319, (f"mb_albumid:{TARGET_MBID}",)))
+
+        result = import_one._capture_stale_beets_id(
+            TARGET_MBID, beets)  # type: ignore[arg-type]
+
+        self.assertEqual(result, 10319,
+                         "locate()-based capture must work even when "
+                         "the stale album has no readable track data.")
+
     def test_returns_none_when_absent(self) -> None:
         from harness import import_one
-        beets = _StubBeetsDB(None)
+        beets = _StubBeetsDB(_StubLocation("absent", None, ()))
 
         result = import_one._capture_stale_beets_id(
             TARGET_MBID, beets)  # type: ignore[arg-type]
@@ -133,9 +155,12 @@ class TestRemoveStaleByIdLogged(unittest.TestCase):
         self.assertIsNone(result)
         mock_run.assert_called_once()
         argv = mock_run.call_args.args[0]
-        # Selector must be id:<int> — primary-key scope, NEVER mb_albumid
-        # (which can match multiple rows and would hit siblings).
-        self.assertEqual(argv[1:4], ["remove", "-d", "id:10319"])
+        # Selector must be ``-a -d id:<int>`` — album mode (``-a``),
+        # delete files (``-d``), primary-key scope (``id:<N>`` against
+        # ``albums.id``, unique by SQLite auto-increment). Without
+        # ``-a`` the selector would be interpreted against ``items``
+        # and match a track PK or nothing (Codex PR #131 round 2 P1).
+        self.assertEqual(argv[1:5], ["remove", "-a", "-d", "id:10319"])
 
     @patch("lib.release_cleanup.sp.run")
     def test_timeout_surfaces_typed_failure(self, mock_run: MagicMock) -> None:

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -1,0 +1,161 @@
+"""Tests for pre-flight same-MBID removal in import_one.py.
+
+Bug being locked in (live 2026-04-20): when an upgrade re-import runs
+against an album already in beets, the stale same-MBID entry must be
+removed via a *targeted* ``beet remove -d mb_albumid:<mbid>`` BEFORE
+the beets import harness starts — not mid-import via beets' own
+``remove_duplicates()``, which has cross-MBID blast radius and wiped
+the 11-track Palo Santo sibling in production.
+
+The seam these tests pin: ``_preflight_remove_stale_mbid(mbid, beets)``
+in ``harness/import_one.py``. It delegates to
+``lib.release_cleanup.remove_album_by_selectors`` (the pure-beets
+primitive — no PipelineDB coupling, because the harness subprocess has
+no PipelineDB on hand).
+
+Contract:
+- If the album IS in beets → returns a non-None ReleaseCleanupResult
+  with absent_after reflecting whether removal succeeded. Subprocess
+  ran at least once.
+- If the album is NOT in beets → returns None (no work to do). No
+  subprocess runs.
+- Empty mbid → returns None (preflight is opt-in; callers that
+  already know the album isn't present shouldn't need to gate).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess as sp
+import sys
+import unittest
+from dataclasses import dataclass
+from typing import Literal, Optional
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "harness"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+TARGET_MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
+
+@dataclass
+class _StubLocation:
+    kind: Literal["exact", "absent"]
+    album_id: Optional[int]
+    selectors: tuple[str, ...]
+
+
+class _StubBeetsDB:
+    """Minimal BeetsDB double. Same shape as tests/test_release_cleanup.py."""
+
+    def __init__(self, sequence: list[_StubLocation]) -> None:
+        self._sequence = list(sequence)
+        self.locate_calls: list[str] = []
+
+    def locate(self, release_id: str) -> _StubLocation:
+        self.locate_calls.append(release_id)
+        return self._sequence.pop(0)
+
+    def album_exists(self, mbid: str) -> bool:
+        """Harness pre-flight uses album_exists for the initial check.
+
+        The stub mirrors locate() — one entry consumed per call.
+        """
+        return self._sequence[0].kind == "exact" if self._sequence else False
+
+
+def _ok() -> MagicMock:
+    return MagicMock(returncode=0, stdout="", stderr="")
+
+
+class TestPreflightRemoveStaleMBID(unittest.TestCase):
+    """The pre-flight helper is the seam that makes the Palo Santo fix work.
+
+    By the time ``run_import`` starts, the stale same-MBID album must
+    already be gone — otherwise beets' ``find_duplicates()`` drags it
+    into the resolve_duplicate callback and we're back to answering
+    ``"keep"`` on a dup list that may include cross-MBID siblings.
+    (Keep is safe, but cleaner to not even have the stale entry
+    present.)
+    """
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_removes_when_album_in_beets(self, mock_run: MagicMock) -> None:
+        """Album present → targeted beet remove runs, result returned."""
+        from harness import import_one
+        mock_run.return_value = _ok()
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, (f"mb_albumid:{TARGET_MBID}",)),
+            _StubLocation("absent", None, ()),
+        ])
+
+        result = import_one._preflight_remove_stale_mbid(
+            TARGET_MBID, beets)  # type: ignore[arg-type]
+
+        self.assertIsNotNone(result)
+        assert result is not None  # narrow for pyright
+        self.assertTrue(result.beets_removed)
+        self.assertTrue(result.absent_after)
+        # The subprocess MUST use an MBID-scoped selector.
+        mock_run.assert_called_once()
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(argv[0:3], ["beet", "remove", "-d"])
+        self.assertEqual(argv[3], f"mb_albumid:{TARGET_MBID}")
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_no_op_when_album_absent(self, mock_run: MagicMock) -> None:
+        """Album not in beets → returns None, no subprocess, no churn."""
+        from harness import import_one
+        beets = _StubBeetsDB([
+            _StubLocation("absent", None, ()),
+        ])
+
+        result = import_one._preflight_remove_stale_mbid(
+            TARGET_MBID, beets)  # type: ignore[arg-type]
+
+        self.assertIsNone(result)
+        mock_run.assert_not_called()
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_empty_mbid_returns_none(self, mock_run: MagicMock) -> None:
+        """Empty MBID is a no-op (caller guards)."""
+        from harness import import_one
+        beets = _StubBeetsDB([])
+
+        result = import_one._preflight_remove_stale_mbid(
+            "", beets)  # type: ignore[arg-type]
+
+        self.assertIsNone(result)
+        mock_run.assert_not_called()
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_surfaces_partial_failure(self, mock_run: MagicMock) -> None:
+        """Timeout leaves the album on disk → result reflects it.
+
+        Caller (main) must be able to see absent_after=False and decide
+        whether to abort the import rather than blunder on into a
+        beets ``remove_duplicates`` → data-loss scenario.
+        """
+        from harness import import_one
+        mock_run.side_effect = sp.TimeoutExpired(
+            cmd=["beet", "remove", "-d", f"mb_albumid:{TARGET_MBID}"],
+            timeout=30)
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, (f"mb_albumid:{TARGET_MBID}",)),
+            _StubLocation("exact", 1, (f"mb_albumid:{TARGET_MBID}",)),
+        ])
+
+        result = import_one._preflight_remove_stale_mbid(
+            TARGET_MBID, beets)  # type: ignore[arg-type]
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertFalse(result.absent_after)
+        self.assertEqual(len(result.selector_failures), 1)
+        self.assertEqual(result.selector_failures[0].reason, "timeout")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_cleanup.py
+++ b/tests/test_release_cleanup.py
@@ -126,6 +126,33 @@ class TestAllSelectorsSucceed(unittest.TestCase):
         pdb.clear_on_disk_quality_fields.assert_called_once_with(42)
 
     @patch("lib.release_cleanup.sp.run")
+    def test_argv_uses_album_mode_flag(
+            self, mock_run: MagicMock) -> None:
+        """Every ``beet remove`` invocation MUST include ``-a`` (album
+        mode). Without it, ``id:<N>`` is interpreted against
+        ``items.id`` and the stale album survives (Codex PR #131
+        round 2 P1). The ``-a`` flag is also required for
+        ``remove_album_by_beets_id`` which this module exposes.
+        Re-asserted here as a contract test so a future refactor that
+        drops ``-a`` fails at test time, not in production.
+        """
+        mock_run.return_value = _ok()
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, (f"mb_albumid:{RELEASE_UUID}",)),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=RELEASE_UUID, request_id=42)
+
+        argv = mock_run.call_args.args[0]
+        # Shape: [beet_binary, "remove", "-a", "-d", selector]
+        self.assertEqual(argv[1:4], ["remove", "-a", "-d"])
+        self.assertEqual(argv[4], f"mb_albumid:{RELEASE_UUID}")
+
+    @patch("lib.release_cleanup.sp.run")
     def test_discogs_pair_of_selectors_both_run(
             self, mock_run: MagicMock) -> None:
         """Discogs numeric → two selectors; both run on the happy path."""

--- a/tests/test_release_cleanup.py
+++ b/tests/test_release_cleanup.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock, patch
 from lib.release_cleanup import (
     ReleaseCleanupResult,
     SelectorFailure,
+    remove_album_by_selectors,
     remove_and_reset_release,
 )
 
@@ -312,6 +313,144 @@ class TestEmptyReleaseIdRejected(unittest.TestCase):
             remove_and_reset_release(
                 beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
                 release_id="", request_id=42)
+
+
+class TestRemoveAlbumBySelectorsSeam(unittest.TestCase):
+    """``remove_album_by_selectors`` is the pure-beets primitive.
+
+    The harness import_one.py needs to pre-remove a stale same-MBID
+    album BEFORE running the beets import so beets' ``find_duplicates``
+    doesn't drag in cross-MBID siblings (the Palo Santo data-loss bug).
+    The harness has no PipelineDB on hand — it runs as a subprocess from
+    beets's own Python env — so the primitive can't couple to pipeline
+    state. ``remove_and_reset_release`` continues to wrap it for the
+    ban-source route which does need to clear pipeline-side quality
+    fields.
+    """
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_returns_release_cleanup_result_without_pipeline_db(
+            self, mock_run: MagicMock) -> None:
+        """The seam accepts (beets_db, release_id) only — no pipeline_db.
+
+        Pinned via signature: if a future refactor re-adds a pipeline_db
+        parameter, this test fails at import time and forces a review.
+        """
+        mock_run.return_value = _ok()
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, (f"mb_albumid:{RELEASE_UUID}",)),
+            _StubLocation("absent", None, ()),
+        ])
+
+        result = remove_album_by_selectors(
+            beets_db=beets, release_id=RELEASE_UUID)  # type: ignore[arg-type]
+
+        self.assertIsInstance(result, ReleaseCleanupResult)
+        self.assertTrue(result.beets_removed)
+        self.assertTrue(result.absent_after)
+        self.assertEqual(result.selector_failures, ())
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_absent_before_call_no_subprocess(
+            self, mock_run: MagicMock) -> None:
+        """No album present → no subprocess run, absent_after=True."""
+        beets = _StubBeetsDB([
+            _StubLocation("absent", None, ()),
+            _StubLocation("absent", None, ()),
+        ])
+
+        result = remove_album_by_selectors(
+            beets_db=beets, release_id=RELEASE_UUID)  # type: ignore[arg-type]
+
+        mock_run.assert_not_called()
+        self.assertFalse(result.beets_removed)
+        self.assertTrue(result.absent_after)
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_per_selector_iteration_preserved(
+            self, mock_run: MagicMock) -> None:
+        """Timeout on selector 1 must not skip selector 2 (PR #123 guarantee).
+
+        The same hardened loop semantics apply to the pure primitive —
+        re-run the regression guard so the extraction doesn't drop it.
+        """
+        selectors = (f"discogs_albumid:{DISCOGS_ID}", f"mb_albumid:{DISCOGS_ID}")
+        mock_run.side_effect = [
+            sp.TimeoutExpired(cmd=["beet", "remove", "-d", selectors[0]],
+                              timeout=30),
+            _ok(),
+        ]
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("absent", None, ()),
+        ])
+
+        result = remove_album_by_selectors(
+            beets_db=beets, release_id=DISCOGS_ID)  # type: ignore[arg-type]
+
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertTrue(result.absent_after)
+        self.assertEqual(len(result.selector_failures), 1)
+        self.assertEqual(result.selector_failures[0].reason, "timeout")
+
+    def test_empty_release_id_raises(self) -> None:
+        """Empty ID is a caller bug — same ValueError contract as the wrapper."""
+        beets = _StubBeetsDB([])
+        with self.assertRaises(ValueError):
+            remove_album_by_selectors(
+                beets_db=beets, release_id="")  # type: ignore[arg-type]
+
+
+class TestRemoveAndResetDelegatesToSeam(unittest.TestCase):
+    """``remove_and_reset_release`` is now a wrapper around the pure seam.
+
+    This class pins the composition: wrapper = seam + pipeline-DB clear.
+    Keeps the "no parallel code paths" rule (code-quality.md §) visible —
+    a future reviewer reading just these tests can see the split without
+    tracing the implementation.
+    """
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_clears_pipeline_db_only_when_absent_after(
+            self, mock_run: MagicMock) -> None:
+        """Wrapper fires ``clear_on_disk_quality_fields`` iff seam reports
+        absent_after=True. The seam itself must not touch pipeline_db."""
+        mock_run.return_value = _ok()
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, (f"mb_albumid:{RELEASE_UUID}",)),
+            _StubLocation("absent", None, ()),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=RELEASE_UUID, request_id=7)
+
+        self.assertTrue(result.absent_after)
+        pdb.clear_on_disk_quality_fields.assert_called_once_with(7)
+
+    @patch("lib.release_cleanup.sp.run")
+    def test_skips_pipeline_db_clear_when_album_still_present(
+            self, mock_run: MagicMock) -> None:
+        """If every selector failed, album still on disk → no pipeline
+        DB clear. Wrapper must not lie about cleanup success."""
+        selectors = (f"mb_albumid:{RELEASE_UUID}",)
+        mock_run.side_effect = [
+            sp.TimeoutExpired(cmd=["beet", "remove", "-d", selectors[0]],
+                              timeout=30),
+        ]
+        beets = _StubBeetsDB([
+            _StubLocation("exact", 1, selectors),
+            _StubLocation("exact", 1, selectors),
+        ])
+        pdb = MagicMock()
+
+        result = remove_and_reset_release(
+            beets_db=beets, pipeline_db=pdb,  # type: ignore[arg-type]
+            release_id=RELEASE_UUID, request_id=7)
+
+        self.assertFalse(result.absent_after)
+        pdb.clear_on_disk_quality_fields.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Live 2026-04-20 bug: Shearwater "Palo Santo" 11-track 2006 edition was deleted from disk (every mp3) when the 19-track 2007 reissue re-imported as an upgrade. Total data loss on a deliberately-curated sibling pressing (see [CLAUDE.md § curated music collection rule](../blob/main/CLAUDE.md)).

**Root cause** — blast-radius interaction between beets and the harness:
1. Beets' `find_duplicates()` returned a cross-MBID sibling in `dup_mbids` even with `duplicate_keys: [albumartist, album, mb_albumid]` configured.
2. `harness/import_one.py` answered `action: "remove"` whenever the target MBID appeared anywhere in that list, triggering `task.should_remove_duplicates = True` in beets. That path iterates `duplicate_items(lib)` and `util.remove(item.path)` on every item of every match — it cannot be scoped to one MBID from the harness side.

**Structural fix** — make the destructive answer unrepresentable, and scope every beets subprocess op to exactly one row:

- `harness/import_one.py::run_import` always answers `"keep"`. The `"remove"` branch is gone.
- Pre-flight: enumerate every same-MBID row via `BeetsDB.get_all_album_ids_for_release`, fail-fast if `> 1` (split-brain). Runs BEFORE any destructive conversion.
- Post-import: derive the new album from the post-import re-enumerate (highest `albums.id` is the fresh import), remove every other same-MBID row via `beet remove -a -d id:<N>` (primary-key scoped — cannot reach siblings). Any failure → `import_failed`.
- `_apply_disambiguation` now uses `beet move -a id:<N>` (source-agnostic — works for Discogs `discogs_albumid` rows too).
- Sibling canonicalization: harness emits beets `album.id` for each duplicate; `_canonicalize_siblings` runs `beet move -a id:<N>` per sibling and mirrors `fix_library_modes` perm repair (issue #84 coverage).
- `lib/release_cleanup.py` extracted into a pure `remove_album_by_selectors` primitive + a `remove_album_by_beets_id` helper; every subprocess uses `-a` album mode.
- `lib/util.py::beet_bin()` is the single source of truth for `beet` binary location (unified across `release_cleanup`, `import_one`, and future callers).

## Codex review

Six rounds of code review; each surfaced distinct correctness leaves, all fixed or documented:

- **R1** (3 findings): pre-flight deletion was too early → moved to post-import; BEET_BIN inconsistency → unified; cleanup errors ignored → fail import.
- **R2** (3 findings): item-mode selector destroyed wrong rows → `-a` mandatory; `get_album_info` capture depended on readable tracks → switched to `locate()`; cleanup failure silently passed → treat as `import_failed`.
- **R3** (2 findings): `locate()` LIMIT 1 missed split-brain → enumerate all; Discogs siblings dropped (empty `mb_albumid`) → emit `duplicate_album_ids` from harness.
- **R4** (2 findings): split-brain guard ran after conversion → moved ahead of destructive work; `_apply_disambiguation` failed for Discogs → use `-a id:<N>` selector.
- **R5** (2 findings): intra-process race in stale capture → derive survivor from post-import state; sibling perm repair missing → call `fix_library_modes` post-move.
- **R6** (2 findings): `max()` vulnerable to cross-process race, sibling path not propagated to pipeline DB → documented as known limitations with follow-up scope; both require plumbing larger than this blast-radius fix. See code comments + commit `ed27212` for details.

## Test plan

- [x] `TestHarnessNeverSendsRemoveToBeets` — invariant guard (grep `proc.stdin.write` for `"remove"` across every dup_mbids shape)
- [x] `TestRemoveAlbumBySelectorsSeam` / `TestRemoveAndResetDelegatesToSeam` — pin the `-a` flag + pipeline_db separation
- [x] `TestRemoveStaleByIdLogged` — `beet remove -a -d id:<N>` shape
- [x] `TestCanonicalizeSiblings` — source-agnostic sibling moves + `fix_library_modes` coverage
- [x] `BeetsDB.get_all_album_ids_for_release` — 5 tests covering single row / split-brain multi / Discogs dual layout / empty / absent
- [x] Full suite: **1928 passing, 53 skipped**
- [x] `pyright` 0 errors on every touched file

## Follow-ups (tracked separately)

- Re-queue request 1739 so the 11-track edition re-downloads (live repair).
- Cross-process same-release advisory lock shared by soularr.service and soularr-web (Codex R6 P1).
- Pipeline DB `imported_path` propagation for moved siblings (Codex R6 P2).
- Root-cause why beets' `find_duplicates()` returns cross-MBID siblings when `duplicate_keys` includes `mb_albumid` — this PR removes the blast radius regardless, but the upstream duplicate-detection contract is still worth investigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)