### PR TITLE
rename: soularr → cratedigger (code + upstream module)

### DIFF
--- a/.claude/agents/playwright.md
+++ b/.claude/agents/playwright.md
@@ -1,6 +1,6 @@
 ---
 name: playwright
-description: Drive a real browser to test the soularr web UI at music.ablz.au. Use for debugging the browse tab (MusicBrainz + Discogs sources), library view, recents/validation log, decisions simulator, and the add-to-pipeline flow. Especially useful for the Discogs pathway — search, artist discography, master pressings, release detail, and verifying external links.
+description: Drive a real browser to test the cratedigger web UI at music.ablz.au. Use for debugging the browse tab (MusicBrainz + Discogs sources), library view, recents/validation log, decisions simulator, and the add-to-pipeline flow. Especially useful for the Discogs pathway — search, artist discography, master pressings, release detail, and verifying external links.
 mcpServers:
   - playwright:
       type: stdio
@@ -29,9 +29,9 @@ Common workflow:
 - `browser_console_messages` / `browser_network_requests` — diagnose broken panels / API failures
 - `browser_close` — tear down
 
-## Primary Target: music.ablz.au (soularr web UI)
+## Primary Target: music.ablz.au (cratedigger web UI)
 
-A single-page app for browsing MusicBrainz and Discogs, viewing the beets library, and adding releases to the pipeline. Served on doc2 by `soularr-web.service`. Architecture details in `docs/webui-primer.md`; the Discogs mirror it calls into is documented in `docs/discogs-mirror.md`.
+A single-page app for browsing MusicBrainz and Discogs, viewing the beets library, and adding releases to the pipeline. Served on doc2 by `cratedigger-web.service`. Architecture details in `docs/webui-primer.md`; the Discogs mirror it calls into is documented in `docs/discogs-mirror.md`.
 
 **Always use `https://music.ablz.au`** (HTTPS; plain HTTP will time out). Cloudflare-tunnelled — LAN presence or Cloudflare Access may be required. If you hit an auth wall, report it and stop; don't guess credentials.
 

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -6,17 +6,17 @@ Run pyright + full test suite + type safety grep gate. Use this before committin
 
 1. Run pyright on all key files:
 ```bash
-pyright lib/quality.py lib/beets.py lib/beets_db.py lib/pipeline_db.py lib/import_dispatch.py lib/download.py harness/import_one.py harness/beets_harness.py album_source.py soularr.py scripts/pipeline_cli.py web/routes/pipeline.py web/routes/imports.py web/routes/library.py web/routes/browse.py tests/test_validation_result.py tests/test_import_result.py tests/test_quality_decisions.py tests/test_beets_db.py tests/test_pipeline_db.py tests/test_album_source.py tests/test_import_dispatch.py tests/test_web_server.py
+pyright lib/quality.py lib/beets.py lib/beets_db.py lib/pipeline_db.py lib/import_dispatch.py lib/download.py harness/import_one.py harness/beets_harness.py album_source.py cratedigger.py scripts/pipeline_cli.py web/routes/pipeline.py web/routes/imports.py web/routes/library.py web/routes/browse.py tests/test_validation_result.py tests/test_import_result.py tests/test_quality_decisions.py tests/test_beets_db.py tests/test_pipeline_db.py tests/test_album_source.py tests/test_import_dispatch.py tests/test_web_server.py
 ```
 
 Must be **0 errors**. Do not proceed if there are new errors (psycopg2/slskd_api "could not be resolved" warnings are OK — they're C extensions).
 
 2. Dict access grep gate — catch missed dict→attribute conversions on typed objects:
 ```bash
-grep -rn 'album\["\|album\['"'"'' --include='*.py' soularr.py lib/download.py album_source.py
+grep -rn 'album\["\|album\['"'"'' --include='*.py' cratedigger.py lib/download.py album_source.py
 ```
 
-Must return **0 matches**. `album` in soularr.py/download.py is a typed `AlbumRecord` dataclass. Note: `req["field"]` is fine — `get_request()` returns `dict[str, Any]`. `release["field"]` in web routes is fine — those are raw MusicBrainz API dicts.
+Must return **0 matches**. `album` in cratedigger.py/download.py is a typed `AlbumRecord` dataclass. Note: `req["field"]` is fine — `get_request()` returns `dict[str, Any]`. `release["field"]` in web routes is fine — those are raw MusicBrainz API dicts.
 
 3. Run full test suite:
 ```bash
@@ -25,8 +25,8 @@ nix-shell --run "bash scripts/run_tests.sh"
 
 4. Check results:
 ```bash
-grep -E "^Ran |^OK|^FAILED" /tmp/soularr-test-output.txt
-grep "^FAIL:\|^ERROR:" /tmp/soularr-test-output.txt
+grep -E "^Ran |^OK|^FAILED" /tmp/cratedigger-test-output.txt
+grep "^FAIL:\|^ERROR:" /tmp/cratedigger-test-output.txt
 ```
 
 Must show `OK`. slskd live test skips (Docker not running) are acceptable. The `test_calls_refresh_endpoint` error is a known pre-existing issue.

--- a/.claude/commands/debug-download.md
+++ b/.claude/commands/debug-download.md
@@ -10,7 +10,7 @@ Query full audit trail for a download_log entry. Pass the download_log ID or an 
 
 1. Find the row:
 ```bash
-ssh doc2 "psql -h 192.168.100.11 -U soularr soularr -c \"
+ssh doc2 "psql -h 192.168.100.11 -U cratedigger cratedigger -c \"
 SELECT dl.id, ar.artist_name, ar.album_title, dl.outcome, dl.beets_scenario,
        dl.import_result IS NOT NULL as has_ir,
        dl.validation_result IS NOT NULL as has_vr,
@@ -24,7 +24,7 @@ ORDER BY dl.id DESC LIMIT 5;
 
 2. Import decision (if has_ir):
 ```bash
-ssh doc2 "psql -h 192.168.100.11 -U soularr soularr -c \"
+ssh doc2 "psql -h 192.168.100.11 -U cratedigger cratedigger -c \"
 SELECT import_result->>'decision' as decision,
        import_result->'quality'->>'new_min_bitrate' as new_br,
        import_result->'quality'->>'prev_min_bitrate' as prev_br,
@@ -41,7 +41,7 @@ FROM download_log WHERE id = <ID>;
 
 3. Per-track spectral (if has per_track):
 ```bash
-ssh doc2 "psql -h 192.168.100.11 -U soularr soularr -c \"
+ssh doc2 "psql -h 192.168.100.11 -U cratedigger cratedigger -c \"
 SELECT t->>'grade' as grade, t->>'hf_deficit_db' as hf_deficit,
        t->>'cliff_detected' as cliff, t->>'estimated_bitrate_kbps' as est_br
 FROM download_log, jsonb_array_elements(import_result->'spectral'->'per_track') AS t
@@ -51,7 +51,7 @@ WHERE id = <ID>;
 
 4. Validation detail (if has_vr):
 ```bash
-ssh doc2 "psql -h 192.168.100.11 -U soularr soularr -c \"
+ssh doc2 "psql -h 192.168.100.11 -U cratedigger cratedigger -c \"
 SELECT validation_result->>'scenario' as scenario,
        validation_result->>'distance' as distance,
        validation_result->>'recommendation' as rec,
@@ -66,7 +66,7 @@ FROM download_log WHERE id = <ID>;
 
 5. Track mapping (if has_vr with mapping):
 ```bash
-ssh doc2 "psql -h 192.168.100.11 -U soularr soularr -c \"
+ssh doc2 "psql -h 192.168.100.11 -U cratedigger cratedigger -c \"
 SELECT m->'item'->>'title' as local_title,
        m->'track'->>'title' as mb_title,
        m->'item'->>'path' as local_file

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -11,11 +11,11 @@ git add <files> && git commit -m "<message>" && git push
 
 2. Update flake input on doc1 and push:
 ```bash
-ssh doc1 'cd ~/nixosconfig && nix flake update soularr-src && git add flake.lock && git commit -m "soularr: <description>" && git push'
+ssh doc1 'cd ~/nixosconfig && nix flake update cratedigger-src && git add flake.lock && git commit -m "cratedigger: <description>" && git push'
 # NOTE: If already on doc1 (hostname = proxmox-vm), run the inner command directly without ssh
 ```
 
-3. Rebuild doc2 (this also runs `soularr-db-migrate.service` automatically):
+3. Rebuild doc2 (this also runs `cratedigger-db-migrate.service` automatically):
 ```bash
 ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
 ```
@@ -27,13 +27,13 @@ ssh doc2 'grep "<something unique>" /nix/store/*/lib/quality.py 2>/dev/null | he
 
 5. Verify the migration unit succeeded (especially when `migrations/` changed):
 ```bash
-ssh doc2 'sudo systemctl status soularr-db-migrate.service --no-pager | head -10'
+ssh doc2 'sudo systemctl status cratedigger-db-migrate.service --no-pager | head -10'
 ssh doc2 'pipeline-cli query "SELECT version, name, applied_at FROM schema_migrations ORDER BY version DESC LIMIT 5"'
 ```
 
 ## Database migrations
 
-Schema is managed by versioned files in `migrations/NNN_name.sql`. The `soularr-db-migrate.service` oneshot unit runs the migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch` because `restartIfChanged = true`. `soularr.service` and `soularr-web.service` both `requires` it, so a failed migration blocks the app from starting.
+Schema is managed by versioned files in `migrations/NNN_name.sql`. The `cratedigger-db-migrate.service` oneshot unit runs the migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch` because `restartIfChanged = true`. `cratedigger.service` and `cratedigger-web.service` both `requires` it, so a failed migration blocks the app from starting.
 
 To add a schema change:
 1. Create the next-numbered file: `migrations/NNN_describe_change.sql`
@@ -43,17 +43,17 @@ To add a schema change:
 
 For destructive changes, backup first:
 ```bash
-ssh doc2 'pg_dump -h 192.168.100.11 -U soularr soularr' > /tmp/soularr_backup_$(date +%Y%m%d_%H%M%S).sql
+ssh doc2 'pg_dump -h 192.168.100.11 -U cratedigger cratedigger' > /tmp/cratedigger_backup_$(date +%Y%m%d_%H%M%S).sql
 ```
 
 To run the migrator manually (e.g. after editing `migrations/` and pulling the flake on doc2 without a full rebuild):
 ```bash
-ssh doc2 'sudo systemctl restart soularr-db-migrate.service'
-ssh doc2 'sudo journalctl -u soularr-db-migrate.service -n 30'
+ssh doc2 'sudo systemctl restart cratedigger-db-migrate.service'
+ssh doc2 'sudo journalctl -u cratedigger-db-migrate.service -n 30'
 ```
 
 ## IMPORTANT
-- `restartIfChanged = false` on `soularr.service` — deploys don't restart soularr itself. The 5-min timer picks up new code on next cycle.
-- `restartIfChanged = true` on `soularr-db-migrate.service` — deploys DO re-run the migrator. Fast no-op if nothing changed.
-- To force a run: `ssh doc2 'sudo systemctl start soularr --no-block'` (don't block — it's a oneshot)
+- `restartIfChanged = false` on `cratedigger.service` — deploys don't restart cratedigger itself. The 5-min timer picks up new code on next cycle.
+- `restartIfChanged = true` on `cratedigger-db-migrate.service` — deploys DO re-run the migrator. Fast no-op if nothing changed.
+- To force a run: `ssh doc2 'sudo systemctl start cratedigger --no-block'` (don't block — it's a oneshot)
 - Flake updates MUST happen on doc1 (has git push credentials). NEVER from doc2 or Windows.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -12,7 +12,7 @@
 Any type whose **input comes from outside our Python code** (harness stdout, an HTTP response, a JSONB blob coming back from the DB, a subprocess's stdout) must be a `msgspec.Struct` so the deserializer validates the typed contract at the boundary. Pyright does not see inside `dict.get()` — only runtime validation catches int-vs-str drift, mis-typed fields, or missing required data. This is the lesson of issue #99 / PR #98 (every Discogs validation silently logged `mbid_not_found` because a dataclass said `str` but the wire carried `int`).
 
 - **Use `msgspec.Struct`** for: harness/subprocess JSON messages, external API responses, DB JSONB rows we read back and type-check, any other "decode this blob into a typed object" site.
-- **Keep `@dataclass`** for: types we construct entirely from our own typed Python code (`ImportResult`, `QualityRankConfig`, `SoularrConfig`, `ActiveDownloadState` when we're the only writer). Their inputs are already typed — the strict boundary buys nothing.
+- **Keep `@dataclass`** for: types we construct entirely from our own typed Python code (`ImportResult`, `QualityRankConfig`, `CratediggerConfig`, `ActiveDownloadState` when we're the only writer). Their inputs are already typed — the strict boundary buys nothing.
 - **Decode at exactly one site.** The wire boundary is the one place the untyped blob becomes a typed object. After that, every downstream consumer works with the Struct directly — no defensive coercion, no `dict.get()`, no re-validation. If you find yourself writing a `_coerce_x` helper on the consumer side, the boundary is in the wrong place.
 - **Strict ≠ coerce.** Declare fields as the type you want (`str`, not `str | int`). `msgspec.ValidationError` at the boundary is the detector. Do not use `strict=False` to silently coerce away real type drift.
 - **Normalise early if the external source is untidy.** Harness-side `_id_str` in `harness/beets_harness.py` coerces int IDs to str *before* emitting — so the wire is always clean, and the downstream Struct validation never trips in the happy path. Keep normalisation at the source, not at the consumer.
@@ -23,7 +23,7 @@ Any type whose **input comes from outside our Python code** (harness stdout, an 
 - Write tests FIRST (RED), then implement (GREEN)
 - Every new function, dataclass, and decision branch needs test coverage
 - Use `nix-shell --run "bash scripts/run_tests.sh"` for full suite
-- Read `/tmp/soularr-test-output.txt` instead of re-running the 2-minute suite
+- Read `/tmp/cratedigger-test-output.txt` instead of re-running the 2-minute suite
 - For single modules during dev: `nix-shell --run "python3 -m unittest tests.<module> -v"`
 
 ## API Contract Tests
@@ -43,7 +43,7 @@ Any type whose **input comes from outside our Python code** (harness stdout, an 
 
 ## Decision Logic
 - All quality/import decisions must be pure functions in `lib/quality.py`
-- No decision logic inline in soularr.py — call the pure function, branch on result
+- No decision logic inline in cratedigger.py — call the pure function, branch on result
 - Every pure function must have direct unit tests (not just tested through integration)
 
 ## Pipeline Decision Debugging — Simulator-First TDD
@@ -83,7 +83,7 @@ Any type whose **input comes from outside our Python code** (harness stdout, an 
 
 ## No Parallel Code Paths
 - Never create a second function that calls the same subprocess (import_one.py, beets_harness.py, etc.). If a new entry point needs the pipeline, write an adapter that constructs the existing function's inputs and delegates. If the interface makes this painful, fix the interface — don't route around it.
-- Never construct `SoularrConfig` with positional/keyword args for a subset of fields. Always use `SoularrConfig.from_ini()` with the runtime config file. Partial configs silently diverge when new config fields are added.
+- Never construct `CratediggerConfig` with positional/keyword args for a subset of fields. Always use `CratediggerConfig.from_ini()` with the runtime config file. Partial configs silently diverge when new config fields are added.
 - Before adding a new function that "does roughly what X does but simpler," check if X can be called with an adapter. The adapter may be ugly — that's a signal to improve X's interface, not to duplicate X.
 
 ## New Work Checklist (read this first)
@@ -130,7 +130,7 @@ Four categories of tests. Each has different rules for what's acceptable. **All 
 - Mocking is allowed for external edges (subprocess, meelo, plex), but the assertion target must be domain state.
 - **Use `FakePipelineDB` from `tests/fakes.py` for stateful collaborators instead of MagicMock.** It records request rows, download_logs, denylist entries, cooldowns, status history, spectral state updates. See `tests/test_fakes.py` for the full API.
 - **Use `FakeSlskdAPI` from `tests/fakes.py` for slskd interactions.** Stateful `transfers` and `users` fakes with `add_transfer()`, `queue_download_snapshots()`, `set_directory()`, `set_directory_error()`, configurable errors, and call recording.
-- Use `make_ctx_with_fake_db(fake_db)` from `tests/helpers.py` to wire `FakePipelineDB` into a `SoularrContext`.
+- Use `make_ctx_with_fake_db(fake_db)` from `tests/helpers.py` to wire `FakePipelineDB` into a `CratediggerContext`.
 - Use builders from `tests/helpers.py` — never hand-roll 20-field dicts.
 
 ### 4. Integration slice tests
@@ -155,7 +155,7 @@ Always use these instead of inventing parallel scaffolding:
 - `make_download_file(...)` — real `DownloadFile` (not MagicMock)
 - `make_grab_list_entry(...)` — real `GrabListEntry`
 - `make_spectral_context(...)` — `SpectralContext`
-- `make_ctx_with_fake_db(fake_db)` — `SoularrContext` wired to a fake
+- `make_ctx_with_fake_db(fake_db)` — `CratediggerContext` wired to a fake
 - `patch_dispatch_externals()` — context manager for the 6 dispatch external patches
 
 **`tests/fakes.py`** — stateful fakes:

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -1,20 +1,20 @@
 # Deployment Rules
 
-- All code deploys via Nix flake: push soularr → `nix flake update soularr-src` on doc1 → `nixos-rebuild switch` doc2
-- The NixOS module lives in this repo at `nix/module.nix` (exposed as `nixosModules.default`). The downstream wrapper at `~/nixosconfig/modules/nixos/services/soularr.nix` imports it via `inputs.soularr-src.nixosModules.default`.
+- All code deploys via Nix flake: push cratedigger → `nix flake update cratedigger-src` on doc1 → `nixos-rebuild switch` doc2
+- The NixOS module lives in this repo at `nix/module.nix` (exposed as `nixosModules.default`). The downstream wrapper at `~/nixosconfig/modules/nixos/services/cratedigger.nix` imports it via `inputs.cratedigger-src.nixosModules.default`.
 - Flake updates MUST happen on doc1 (has git push credentials). NEVER from doc2.
-- `restartIfChanged = false` on the soularr service — deploys don't restart it. The 5-min timer picks up new code on the next cycle. `soularr-web` and `soularr-db-migrate` use the systemd default and DO restart on switch.
-- Always verify deployed code: `ssh doc2 'grep "<unique string>" /nix/store/*/lib/quality.py 2>/dev/null'`. For module changes: `ssh doc2 'cat /etc/systemd/system/soularr.service'` or check the rendered `/var/lib/soularr/config.ini`.
+- `restartIfChanged = false` on the cratedigger service — deploys don't restart it. The 5-min timer picks up new code on the next cycle. `cratedigger-web` and `cratedigger-db-migrate` use the systemd default and DO restart on switch.
+- Always verify deployed code: `ssh doc2 'grep "<unique string>" /nix/store/*/lib/quality.py 2>/dev/null'`. For module changes: `ssh doc2 'cat /etc/systemd/system/cratedigger.service'` or check the rendered `/var/lib/cratedigger/config.ini`.
 - Before deploying changes to `nix/module.nix`, run the VM check: `nix build .#checks.x86_64-linux.moduleVm`.
 - Use the `/deploy` command for the full sequence.
 
 ## Database migrations
 
-- Schema lives in `migrations/NNN_name.sql`. The deploy unit `soularr-db-migrate.service` (oneshot, `restartIfChanged = true`) runs them automatically on every `nixos-rebuild switch`, BEFORE `soularr.service` and `soularr-web.service` start. Both services `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
+- Schema lives in `migrations/NNN_name.sql`. The deploy unit `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs them automatically on every `nixos-rebuild switch`, BEFORE `cratedigger.service` and `cratedigger-web.service` start. Both services `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
 - To add a schema change: drop a new numbered SQL file in `migrations/`. The next deploy applies it. No manual psql, no out-of-band steps. See `.claude/rules/pipeline-db.md` for the full workflow.
-- Backup before any destructive migration: `ssh doc2 'pg_dump -h 192.168.100.11 -U soularr soularr' > /tmp/soularr_backup_$(date +%Y%m%d_%H%M%S).sql`
+- Backup before any destructive migration: `ssh doc2 'pg_dump -h 192.168.100.11 -U cratedigger cratedigger' > /tmp/cratedigger_backup_$(date +%Y%m%d_%H%M%S).sql`
 - After deploy, verify the migration ran: `ssh doc2 'pipeline-cli query "SELECT * FROM schema_migrations ORDER BY version DESC LIMIT 5"'`
-- If a migration fails, check `ssh doc2 'sudo journalctl -u soularr-db-migrate.service'` for the error.
+- If a migration fails, check `ssh doc2 'sudo journalctl -u cratedigger-db-migrate.service'` for the error.
 
 ## Post-Deploy Reflection
 - After deploying non-trivial changes, spawn an Opus agent to assess: did we make the code better? Did we finish what we intended? Are there loose ends or untested paths?

--- a/.claude/rules/pipeline-db.md
+++ b/.claude/rules/pipeline-db.md
@@ -9,7 +9,7 @@ paths:
 
 # Pipeline DB Rules (PostgreSQL)
 
-- Connection: `postgresql://soularr@192.168.100.11:5432/soularr`
+- Connection: `postgresql://cratedigger@192.168.100.11:5432/cratedigger`
 - **MUST use `autocommit=True`** in `PipelineDB` — prevents idle-in-transaction deadlocks
 - 4 statuses: wanted, downloading, imported, manual
 - JSONB columns: use for structured audit data (`import_result`, `validation_result`)
@@ -17,7 +17,7 @@ paths:
 ## Schema migrations are versioned files, NOT runtime DDL
 
 - Schema lives in `migrations/NNN_name.sql`. Files are applied in version order by `lib/migrator.py` and tracked in the `schema_migrations` table.
-- The deploy systemd unit `soularr-db-migrate.service` runs the migrator on every `nixos-rebuild switch` (`restartIfChanged = true`). `soularr.service` and `soularr-web.service` both `requires` it, so they cannot start against an un-migrated DB.
+- The deploy systemd unit `cratedigger-db-migrate.service` runs the migrator on every `nixos-rebuild switch` (`restartIfChanged = true`). `cratedigger.service` and `cratedigger-web.service` both `requires` it, so they cannot start against an un-migrated DB.
 - `PipelineDB.__init__` does NOT run DDL. There is no `run_migrations` kwarg, no `init_schema()` method. Construct it against an already-migrated DB.
 - Tests get the schema applied once at session start in `tests/conftest.py` via `apply_migrations(TEST_DSN)`. Test setup helpers just `TRUNCATE` between tests.
 
@@ -27,7 +27,7 @@ paths:
 2. Write the change as plain SQL. Each file runs in its own transaction. **Do not** wrap statements in `IF NOT EXISTS` / `EXCEPTION WHEN duplicate_column` guards — versioned migrations only run once per DB, so guards just hide bugs.
 3. The file is the contract. Once shipped, never edit it. To fix a mistake, add a new migration.
 4. Run `nix-shell --run "python3 -m unittest tests.test_migrator -v"` to confirm the file parses and applies cleanly against the ephemeral PG.
-5. Backup before deploying anything destructive: `ssh doc2 'pg_dump -h 192.168.100.11 -U soularr soularr' > /tmp/soularr_backup_$(date +%Y%m%d_%H%M%S).sql`
+5. Backup before deploying anything destructive: `ssh doc2 'pg_dump -h 192.168.100.11 -U cratedigger cratedigger' > /tmp/cratedigger_backup_$(date +%Y%m%d_%H%M%S).sql`
 
 ## What NOT to do
 

--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -13,4 +13,4 @@ paths:
 - Redis cache: MB data 24h TTL, beets/pipeline 5min TTL, explicit invalidation on POST mutations
 - Static JS served at `/js/*.js` — `node --check` validates syntax in CI
 - The web UI reads download_log JSONB columns (import_result, validation_result) — use the typed field names from the dataclasses, not arbitrary strings
-- After changes: `ssh doc2 'sudo systemctl restart soularr-web'`
+- After changes: `ssh doc2 'sudo systemctl restart cratedigger-web'`

--- a/.codex/skills/cratedigger-pr-review-fix/SKILL.md
+++ b/.codex/skills/cratedigger-pr-review-fix/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: soularr-pr-review-fix
-description: Review, fix, verify, and publish GitHub pull requests for the Soularr repository. Use when working in this repo and the user asks to review a PR, inspect the current PR branch, address findings, push the fixes to the PR branch, and leave a concise PR comment summarizing the changes and verification.
+name: cratedigger-pr-review-fix
+description: Review, fix, verify, and publish GitHub pull requests for the Cratedigger repository. Use when working in this repo and the user asks to review a PR, inspect the current PR branch, address findings, push the fixes to the PR branch, and leave a concise PR comment summarizing the changes and verification.
 ---
 
-# Soularr PR Review Fix
+# Cratedigger PR Review Fix
 
 ## Overview
 
-Run the full Soularr PR workflow end-to-end: load repo context, inspect the PR with GitHub plus the local checkout, review for bugs and regressions, implement fixes on the PR branch, verify with repo-required checks, push, and comment on the PR.
+Run the full Cratedigger PR workflow end-to-end: load repo context, inspect the PR with GitHub plus the local checkout, review for bugs and regressions, implement fixes on the PR branch, verify with repo-required checks, push, and comment on the PR.
 
 Prefer GitHub connector data for PR metadata, patch text, and comments. Prefer local `git` and the checked-out repo for file context, edits, tests, and pushing.
 
@@ -67,7 +67,7 @@ If the user asked for a review-only pass, stop after findings. If the user asked
 4. Keep one logical change per commit.
 5. When fixing a bug, also fix the structural cause if the repo rules make that the correct scope.
 
-For Soularr specifically:
+For Cratedigger specifically:
 
 - use typed dataclasses, not dict bridges
 - keep decision logic in `lib/quality.py` when the behavior is a pure decision
@@ -89,7 +89,7 @@ Use the full suite when the change is broad, cross-cutting, or risky:
 nix-shell --run "bash scripts/run_tests.sh"
 ```
 
-If you use the full suite, read `/tmp/soularr-test-output.txt` instead of rerunning just to inspect output.
+If you use the full suite, read `/tmp/cratedigger-test-output.txt` instead of rerunning just to inspect output.
 
 Do not claim verification you did not run.
 

--- a/.codex/skills/cratedigger-pr-review-fix/agents/openai.yaml
+++ b/.codex/skills/cratedigger-pr-review-fix/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cratedigger PR Review"
+  short_description: "Review a Cratedigger PR, fix it, and publish"
+  default_prompt: "Use $cratedigger-pr-review-fix to review PR 44 in this repo, fix the issues, push the branch, and leave a PR comment."

--- a/.codex/skills/soularr-pr-review-fix/agents/openai.yaml
+++ b/.codex/skills/soularr-pr-review-fix/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Soularr PR Review"
-  short_description: "Review a Soularr PR, fix it, and publish"
-  default_prompt: "Use $soularr-pr-review-fix to review PR 44 in this repo, fix the issues, push the branch, and leave a PR comment."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # **Windows laptop SSH access**: There is no native SSH key on Windows. A NixOS WSL2 instance has the SSH key via sops-nix at `/run/secrets/ssh_key_abl030`. To get SSH access to doc1/doc2, run: `mkdir -p ~/.ssh && wsl -d NixOS -- bash -c 'cat /run/secrets/ssh_key_abl030' > ~/.ssh/id_doc2 && chmod 600 ~/.ssh/id_doc2` then SSH with `ssh -i ~/.ssh/id_doc2 abl030@doc2` or `ssh -i ~/.ssh/id_doc2 abl030@proxmox-vm`. The key works for both machines. You may need `-o StrictHostKeyChecking=no` on first use.
 
-# **The pipeline DB is PostgreSQL (migrated from SQLite on 2026-03-25). It runs in an nspawn container on doc2 (192.168.100.11:5432). Access via `pipeline-cli` on doc2's PATH, or from doc1 via `ssh doc2 'pipeline-cli ...'`. Data lives at `/mnt/virtio/soularr/postgres` for portability. 4 statuses: wanted, downloading, imported, manual.**
+# **The pipeline DB is PostgreSQL (migrated from SQLite on 2026-03-25). It runs in an nspawn container on doc2 (192.168.100.11:5432). Access via `pipeline-cli` on doc2's PATH, or from doc1 via `ssh doc2 'pipeline-cli ...'`. Data lives at `/mnt/virtio/cratedigger/postgres` for portability. 4 statuses: wanted, downloading, imported, manual.**
 
 # **NIXOSCONFIG CHANGES MUST BE MADE ON DOC1. The nixosconfig repo lives at `~/nixosconfig` on doc1. All edits, commits, and pushes MUST happen there — doc1 has the git push credentials. NEVER try to edit nixosconfig from doc2 or Windows. SSH to doc1 first, make the change, commit, push, then deploy to doc2.**
 
@@ -12,17 +12,17 @@
 
 A quality-obsessed music acquisition pipeline. Searches Soulseek via slskd, validates downloads against MusicBrainz via beets, auto-imports with spectral quality verification, or stages for manual review. Includes a web UI at `music.ablz.au` for browsing MusicBrainz and adding album requests.
 
-Originally inspired by [mrusse/soularr](https://github.com/mrusse/soularr) ([Ko-Fi](https://ko-fi.com/mrusse)). Has since diverged into its own project — the pipeline DB is the sole source of truth, and the web UI at `music.ablz.au` is the album picker. Internal code still uses "soularr" naming in many places (class names, logger, systemd service, DB name).
+Originally inspired by [mrusse/soularr](https://github.com/mrusse/soularr) ([Ko-Fi](https://ko-fi.com/mrusse)). Has since diverged into its own project — the pipeline DB is the sole source of truth, and the web UI at `music.ablz.au` is the album picker.
 
 ## Web UI (music.ablz.au)
 
-A single-page web app for browsing the local MusicBrainz mirror and Discogs mirror, viewing your beets library, and adding releases to the pipeline. Runs on doc2 as `soularr-web` systemd service. No build step — stdlib `http.server`, vanilla JS, single HTML file. For full details on architecture, API endpoints, frontend features, and deployment, read `docs/webui-primer.md`.
+A single-page web app for browsing the local MusicBrainz mirror and Discogs mirror, viewing your beets library, and adding releases to the pipeline. Runs on doc2 as `cratedigger-web` systemd service. No build step — stdlib `http.server`, vanilla JS, single HTML file. For full details on architecture, API endpoints, frontend features, and deployment, read `docs/webui-primer.md`.
 
 The browse tab has an MB/Discogs source toggle. When Discogs is selected, search, artist discography, master pressings, and release detail all hit the local Discogs mirror at `discogs.ablz.au`. Discogs releases can be added to the pipeline and flow through the same search → download → validate → import pipeline as MusicBrainz releases. External links are source-aware (musicbrainz.org vs discogs.com).
 
 ## Meelo
 
-Meelo is the self-hosted music server that scans the beets library and serves a browseable catalogue with playback. After soularr auto-imports an album to beets, it triggers a Meelo scanner rescan so the new album appears in the UI immediately. Meelo runs on doc1 (proxmox-vm) as podman containers. For full details on architecture, API access, troubleshooting, and the scanner/refresh workflow, read `docs/meelo-primer.md`.
+Meelo is the self-hosted music server that scans the beets library and serves a browseable catalogue with playback. After cratedigger auto-imports an album to beets, it triggers a Meelo scanner rescan so the new album appears in the UI immediately. Meelo runs on doc1 (proxmox-vm) as podman containers. For full details on architecture, API access, troubleshooting, and the scanner/refresh workflow, read `docs/meelo-primer.md`.
 
 ## Beets
 
@@ -37,7 +37,7 @@ Beets' Discogs plugin is patched (Nix `substituteInPlace` in `beets.nix`) to use
 ## Repository Structure
 
 ```
-soularr.py              — Search, match, enqueue logic + main(). Thin wrappers delegate
+cratedigger.py              — Search, match, enqueue logic + main(). Thin wrappers delegate
                            to lib/ modules for download processing and utilities.
 album_source.py         — AlbumRecord, DatabaseSource abstraction
 web/
@@ -48,8 +48,8 @@ web/
 lib/
   beets.py              — Beets validation (dry-run import via harness, returns ValidationResult)
   beets_db.py           — BeetsDB: read-only beets SQLite queries (AlbumInfo dataclass)
-  config.py             — SoularrConfig dataclass (typed config from config.ini)
-  context.py            — SoularrContext dataclass (replaces module globals for extracted functions).
+  config.py             — CratediggerConfig dataclass (typed config from config.ini)
+  context.py            — CratediggerContext dataclass (replaces module globals for extracted functions).
                            Includes cooled_down_users cache populated at cycle start.
   download.py           — Async download polling, completion processing, slskd
                            transfer helpers. All functions accept ctx. Delegates
@@ -93,7 +93,7 @@ lib/
                            Dispatch functions:
                            - dispatch_action() → DispatchAction (mark_done/failed/denylist/requeue flags)
                            - compute_effective_override_bitrate(), extract_usernames()
-                           - verify_filetype() (slskd file matching, moved from soularr.py)
+                           - verify_filetype() (slskd file matching, moved from cratedigger.py)
                            Import result types:
                            - ImportResult, ConversionInfo, SpectralDetail, PostflightInfo
                            - AudioQualityMeasurement (on ImportResult as new_measurement/existing_measurement)
@@ -136,9 +136,9 @@ scripts/
   pipeline_cli.py       — CLI: list, add, status, retry, cancel, show, quality, query,
                            force-import, manual-import, set-intent, repair-spectral
   migrate_db.py         — CLI entry point for the schema migrator. Runs by the
-                           soularr-db-migrate.service systemd unit on every nixos-rebuild.
+                           cratedigger-db-migrate.service systemd unit on every nixos-rebuild.
   populate_tracks.py    — Populate tracks from MusicBrainz API
-  run_tests.sh          — Test runner: saves output to /tmp/soularr-test-output.txt
+  run_tests.sh          — Test runner: saves output to /tmp/cratedigger-test-output.txt
 tests/                  — Test suite (1400+ tests). Run: nix-shell --run "bash scripts/run_tests.sh"
   fakes.py              — FakePipelineDB (full PipelineDB stand-in: requests, download_logs,
                            denylist, cooldowns, status_history, spectral state, attempt counters,
@@ -158,7 +158,7 @@ tests/                  — Test suite (1400+ tests). Run: nix-shell --run "bash
                            TestRouteContractAudit guard that introspects Handler._FUNC_*_ROUTES
                            and fails if any route is unclassified — enforces contract coverage
                            at test time, not at review time.
-test_soularr.py         — Legacy verify_filetype tests (imports from lib/quality)
+test_cratedigger.py         — Legacy verify_filetype tests (imports from lib/quality)
 nix/                    — Nix-native distribution (PR series 2026-04-19)
   slskd-api.nix         — slskd-api PyPI build (single source of truth — was duplicated
                            between shell.nix and the downstream module before)
@@ -171,11 +171,11 @@ nix/                    — Nix-native distribution (PR series 2026-04-19)
                            Generic, paths-as-options, no sops/homelab assumptions.
                            Owns: configTemplate, preStartScript, slskdHealthCheck,
                            qualityRanksSection, all systemd unit definitions, and
-                           the full options surface (services.soularr.*).
+                           the full options surface (services.cratedigger.*).
   tests/module-vm.nix   — NixOS VM check (nix flake check #moduleVm). Boots the
                            module against an ephemeral postgres and asserts:
                            migrator runs, config.ini renders, pipeline-cli works,
-                           soularr-web responds 200. Catches breakage in the option
+                           cratedigger-web responds 200. Catches breakage in the option
                            surface, prestart, systemd graph, wrapper PYTHONPATH.
 flake.nix               — Outputs: packages.slskd-api, devShells.default,
                            nixosModules.default, checks.moduleVm
@@ -190,40 +190,40 @@ flake.nix               — Outputs: packages.slskd-api, devShells.default,
 ## Infrastructure
 
 - **doc1** (`192.168.1.29`): Runs beets (Home Manager), this repo lives at `/home/abl030/soularr`
-- **doc2** (`192.168.1.35`): Runs Soularr (systemd oneshot, 5-min timer), MusicBrainz mirror (`:5200`), slskd (`:5030`)
+- **doc2** (`192.168.1.35`): Runs Cratedigger (systemd oneshot, 5-min timer), MusicBrainz mirror (`:5200`), slskd (`:5030`)
 - **Shared storage**: `/mnt/virtio` (virtiofs) — beets DB, pipeline DB, music library all accessible from both machines
-- **Nix deployment**: Soularr is a flake input (`soularr-src`) in `~/nixosconfig/flake.nix`. The downstream wrapper at `~/nixosconfig/modules/nixos/services/soularr.nix` imports `inputs.soularr-src.nixosModules.default` for the upstream module and layers on sops + nspawn DB + redis + localProxy. All scripts deploy from the Nix store via `${inputs.soularr-src}/...` paths set up by the upstream module's `cfg.src` (default `../.`).
+- **Nix deployment**: Cratedigger is a flake input (`cratedigger-src`) in `~/nixosconfig/flake.nix`. The downstream wrapper at `~/nixosconfig/modules/nixos/services/cratedigger.nix` imports `inputs.cratedigger-src.nixosModules.default` for the upstream module and layers on sops + nspawn DB + redis + localProxy. All scripts deploy from the Nix store via `${inputs.cratedigger-src}/...` paths set up by the upstream module's `cfg.src` (default `../.`).
 
 ### Key Paths
 
 | Path | Machine | Purpose |
 |------|---------|---------|
-| `192.168.100.11:5432/soularr` | doc2 nspawn | Pipeline DB (PostgreSQL, source of truth) |
-| `/mnt/virtio/soularr/postgres` | Shared | PostgreSQL data dir (portable) |
+| `192.168.100.11:5432/cratedigger` | doc2 nspawn | Pipeline DB (PostgreSQL, source of truth) |
+| `/mnt/virtio/cratedigger/postgres` | Shared | PostgreSQL data dir (portable) |
 | `/mnt/virtio/Music/beets-library.db` | Shared | Beets library DB |
 | `/mnt/virtio/Music/Beets` | Shared | Beets library (tagged files) |
 | `/mnt/virtio/Music/Incoming` | Shared | Staging area for validated downloads |
 | `/mnt/virtio/Music/Re-download` | Shared | READMEs for redownload targets |
 | `/mnt/virtio/music/slskd` | doc2 | slskd download directory |
-| `/var/lib/soularr` | doc2 | Soularr runtime state (config.ini, lock file, denylists) |
+| `/var/lib/cratedigger` | doc2 | Cratedigger runtime state (config.ini, lock file, denylists) |
 
 ### Accessing doc2
 
 ```bash
 ssh doc2
-sudo journalctl -u soularr -f                        # tail logs
-sudo journalctl -u soularr --since "5 min ago"        # recent logs
-sudo systemctl is-active soularr                       # check if running
-sudo systemctl start soularr --no-block                # trigger run (oneshot — without --no-block it blocks until the entire run completes)
-sudo cat /var/lib/soularr/config.ini                   # view generated config
+sudo journalctl -u cratedigger -f                        # tail logs
+sudo journalctl -u cratedigger --since "5 min ago"        # recent logs
+sudo systemctl is-active cratedigger                       # check if running
+sudo systemctl start cratedigger --no-block                # trigger run (oneshot — without --no-block it blocks until the entire run completes)
+sudo cat /var/lib/cratedigger/config.ini                   # view generated config
 ```
 
-**IMPORTANT for Claude Code**: `systemctl start soularr` blocks until the oneshot service finishes (minutes). Always use `--no-block` when starting via SSH from a Bash tool call. To start + tail logs:
+**IMPORTANT for Claude Code**: `systemctl start cratedigger` blocks until the oneshot service finishes (minutes). Always use `--no-block` when starting via SSH from a Bash tool call. To start + tail logs:
 ```bash
 # Step 1: start (returns immediately)
-ssh doc2 'sudo systemctl start soularr --no-block'
+ssh doc2 'sudo systemctl start cratedigger --no-block'
 # Step 2: tail logs (separate command, use run_in_background or timeout)
-ssh doc2 'sudo journalctl -u soularr -f --since "5 sec ago"'
+ssh doc2 'sudo journalctl -u cratedigger -f --since "5 sec ago"'
 ```
 Never use `&` inside SSH quotes to background systemctl — SSH keeps the connection open waiting for all child processes regardless.
 
@@ -245,7 +245,7 @@ Web UI (music.ablz.au)               CLI
     │ (check previous downloads)  │ (search new)
     ▼                             ▼
 ┌──────────────────────────────────────────────┐
-│  Soularr (soularr.py + lib/download.py)      │
+│  Cratedigger (cratedigger.py + lib/download.py)      │
 │  Phase 1: poll → Phase 2: search + enqueue   │
 └──────────────────┬───────────────────────────┘
                    │
@@ -378,7 +378,7 @@ Quality comparison is now **rank-based**, not raw-bitrate-based. Every measureme
 - **FLAC > any lossy** (LOSSLESS > TRANSPARENT)
 - **Unverifiable CBR 320** → TRANSPARENT but still `requeue_lossless` via the `is_cbr && !verified_lossless` branch
 
-Every numeric threshold lives in `QualityRankConfig` (one dataclass) and can be retuned via Nix options at `services.soularr.qualityRanks.*` on the upstream module (`nix/module.nix` in this repo), which render into `[Quality Ranks]` in `/var/lib/soularr/config.ini` on every `nixos-rebuild`. The default `mp3_vbr.excellent=210` preserves the legacy 210kbps gate threshold for bare-codec measurements. **To retune: see `README.md` § "Tuning the quality rank model"** — every option documented with defaults, meaning, and when to retune, plus the three collection fields (`mp3_vbr_levels`, `lossless_codecs`, `mixed_format_precedence`) that are NOT Nix-exposed but live on the same dataclass. Full rationale in `docs/quality-ranks.md`; default drift caught by `TestQualityRankConfigDefaults` pin tests (#67). **The search filter (`[Search Settings] allowed_filetypes`) is deliberately permissive**: high-quality preferred tiers lead, bare-codec fallback tiers at the end (`aac, opus, ogg, mp3, wav`) catch anything the rank model understands so the rank model is the authoritative quality decision (not the search filter). README § "The search filter is deliberately permissive" has the full design.
+Every numeric threshold lives in `QualityRankConfig` (one dataclass) and can be retuned via Nix options at `services.cratedigger.qualityRanks.*` on the upstream module (`nix/module.nix` in this repo), which render into `[Quality Ranks]` in `/var/lib/cratedigger/config.ini` on every `nixos-rebuild`. The default `mp3_vbr.excellent=210` preserves the legacy 210kbps gate threshold for bare-codec measurements. **To retune: see `README.md` § "Tuning the quality rank model"** — every option documented with defaults, meaning, and when to retune, plus the three collection fields (`mp3_vbr_levels`, `lossless_codecs`, `mixed_format_precedence`) that are NOT Nix-exposed but live on the same dataclass. Full rationale in `docs/quality-ranks.md`; default drift caught by `TestQualityRankConfigDefaults` pin tests (#67). **The search filter (`[Search Settings] allowed_filetypes`) is deliberately permissive**: high-quality preferred tiers lead, bare-codec fallback tiers at the end (`aac, opus, ogg, mp3, wav`) catch anything the rank model understands so the rank model is the authoritative quality decision (not the search filter). README § "The search filter is deliberately permissive" has the full design.
 
 **Key rule**: the `verified_lossless=True` bypass is now **tier-gated**. It imports on verdict `"better"` or `"equivalent"` but blocks on `"worse"`. This prevents a deliberately-too-low `verified_lossless_target` (Opus 64) from replacing a good existing album.
 
@@ -417,7 +417,7 @@ Lo-fi V0 at 207kbps now passes the gate via the `"mp3 v0"` label contract (`cfg.
 2. Import directly, quality gate classifies the measurement into a `QualityRank` (mp3_vbr band table) and accepts if the rank is at or above `cfg.quality_ranks.gate_min_rank` (default `EXCELLENT` ≈ 210kbps)
 
 **MP3 CBR downloads** (320, 256, etc.):
-1. Spectral check runs in `process_completed_album()` (soularr.py) — detects upsampled garbage via cliff detection
+1. Spectral check runs in `process_completed_album()` (cratedigger.py) — detects upsampled garbage via cliff detection
 2. If spectral says SUSPECT → reject, denylist user
 3. If spectral says genuine or marginal → import (something is better than nothing)
 4. Quality gate: even when CBR rank is TRANSPARENT, the `is_cbr && !verified_lossless && rank < LOSSLESS` branch fires → re-queues with `search_filetype_override="lossless"` to find a verifiable lossless source
@@ -521,7 +521,7 @@ CREATE TABLE user_cooldowns (
 1. **Trigger**: `_timeout_album()` (download.py) and `reject_and_requeue()` (album_source.py) call `db.check_and_apply_cooldown(username)` after logging the outcome
 2. **Decision**: `check_and_apply_cooldown()` queries `download_log` for last N outcomes, delegates to `should_cooldown()` pure function
 3. **Storage**: If triggered, upserts `user_cooldowns` with `cooldown_until = NOW() + 3 days`
-4. **Cache**: `ctx.cooled_down_users` populated at cycle start in `soularr.py main()`, shared with Phase 1 thread. Updated in real-time when new cooldowns are applied mid-cycle.
+4. **Cache**: `ctx.cooled_down_users` populated at cycle start in `cratedigger.py main()`, shared with Phase 1 thread. Updated in real-time when new cooldowns are applied mid-cycle.
 5. **Enforcement**: `try_enqueue()` and `try_multi_enqueue()` in `lib/enqueue.py` skip users in `ctx.cooled_down_users` before checking the per-request denylist
 
 ### Re-cooldown behavior
@@ -541,7 +541,7 @@ pipeline-cli query "SELECT * FROM user_cooldowns ORDER BY cooldown_until DESC"
 pipeline-cli query "SELECT soulseek_username, COUNT(*) FROM download_log WHERE outcome = 'timeout' GROUP BY soulseek_username ORDER BY count DESC LIMIT 10"
 
 # Manually seed cooldowns for all users with 5+ consecutive failures
-psql -h 192.168.100.11 -U soularr soularr -c "INSERT INTO user_cooldowns ..."
+psql -h 192.168.100.11 -U cratedigger cratedigger -c "INSERT INTO user_cooldowns ..."
 ```
 
 ## Deploying Changes
@@ -554,21 +554,21 @@ Flake input changes MUST be done on doc1 and pushed from there. Doc2 has no git 
 git add <files> && git commit -m "description" && git push
 
 # 2. Update Nix flake input (MUST be on doc1 — it has git push access)
-ssh doc1 'cd ~/nixosconfig && nix flake update soularr-src && git add flake.lock && git commit -m "soularr: description" && git push'
+ssh doc1 'cd ~/nixosconfig && nix flake update cratedigger-src && git add flake.lock && git commit -m "cratedigger: description" && git push'
 
-# 3. Deploy to doc2 — runs soularr-db-migrate.service AND restarts soularr-web automatically
+# 3. Deploy to doc2 — runs cratedigger-db-migrate.service AND restarts cratedigger-web automatically
 ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
 ```
 
 **From doc1 directly:**
 ```bash
 cd ~/nixosconfig
-nix flake update soularr-src
-git add flake.lock && git commit -m "soularr: description" && git push
+nix flake update cratedigger-src
+git add flake.lock && git commit -m "cratedigger: description" && git push
 ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
 ```
 
-**IMPORTANT**: `restartIfChanged = false` on `soularr.service` — deploys don't restart Soularr itself. The 5-min timer picks up new code on the next cycle, or manually start. `soularr-web` and `soularr-db-migrate` use the systemd default (restart on change) so they pick up the new code immediately at switch time.
+**IMPORTANT**: `restartIfChanged = false` on `cratedigger.service` — deploys don't restart Cratedigger itself. The 5-min timer picks up new code on the next cycle, or manually start. `cratedigger-web` and `cratedigger-db-migrate` use the systemd default (restart on change) so they pick up the new code immediately at switch time.
 
 ### Validating before deploy
 
@@ -582,7 +582,7 @@ This catches: option surface breakage, prestart sed-substitution bugs, systemd d
 
 ## Database Migrations
 
-Schema changes go through versioned migration files. The deploy unit `soularr-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE `soularr.service` and `soularr-web.service` start. Both services `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
+Schema changes go through versioned migration files. The deploy unit `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE `cratedigger.service` and `cratedigger-web.service` start. Both services `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
 
 **Layout:**
 - `migrations/NNN_name.sql` — versioned, append-only. Each file runs in its own transaction, exactly once per DB.
@@ -597,13 +597,13 @@ Schema changes go through versioned migration files. The deploy unit `soularr-db
 
 **Verifying after deploy:**
 ```bash
-ssh doc2 'sudo systemctl status soularr-db-migrate.service --no-pager | head -10'
+ssh doc2 'sudo systemctl status cratedigger-db-migrate.service --no-pager | head -10'
 ssh doc2 'pipeline-cli query "SELECT version, name, applied_at FROM schema_migrations ORDER BY version DESC LIMIT 5"'
 ```
 
-**If a migration fails:** `ssh doc2 'sudo journalctl -u soularr-db-migrate.service -n 50'`. The unit must be in `active (exited)` state for soularr/soularr-web to start.
+**If a migration fails:** `ssh doc2 'sudo journalctl -u cratedigger-db-migrate.service -n 50'`. The unit must be in `active (exited)` state for cratedigger/cratedigger-web to start.
 
-**For destructive changes**, backup first: `ssh doc2 'pg_dump -h 192.168.100.11 -U soularr soularr' > /tmp/soularr_backup_$(date +%Y%m%d_%H%M%S).sql`
+**For destructive changes**, backup first: `ssh doc2 'pg_dump -h 192.168.100.11 -U cratedigger cratedigger' > /tmp/cratedigger_backup_$(date +%Y%m%d_%H%M%S).sql`
 
 **Never** edit a migration file that has already shipped. Frozen history. To fix a mistake, add a new migration that corrects it.
 
@@ -613,12 +613,12 @@ ssh doc2 'pipeline-cli query "SELECT version, name, applied_at FROM schema_migra
 
 The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosModules.default` in `flake.nix`. It's generic and homelab-agnostic: every secret is a `*File` path, the DB is a `dsn` string, no sops/nspawn/reverse-proxy assumptions.
 
-`~/nixosconfig/modules/nixos/services/soularr.nix` is a thin homelab wrapper (~150 lines) that imports the upstream module and adds:
-- sops-nix per-key secret materialization (`soularr-secrets-split` oneshot — see "Sops + per-key secrets" below)
+`~/nixosconfig/modules/nixos/services/cratedigger.nix` is a thin homelab wrapper (~150 lines) that imports the upstream module and adds:
+- sops-nix per-key secret materialization (`cratedigger-secrets-split` oneshot — see "Sops + per-key secrets" below)
 - the nspawn PostgreSQL container for the pipeline DB
 - the redis instance for the web UI cache
 - the `homelab.localProxy.hosts` entry for `music.ablz.au`
-- systemd `after`/`wants`/`restartTriggers` splicing in `container@soularr-db.service`
+- systemd `after`/`wants`/`restartTriggers` splicing in `container@cratedigger-db.service`
 
 Key options on the upstream module (full set in `nix/module.nix`):
 
@@ -626,8 +626,8 @@ Key options on the upstream module (full set in `nix/module.nix`):
 |---|---|---|
 | `enable` | `false` | Master switch |
 | `user` / `group` | `"root"` | Service identity. Default root because slskd downloads + beets need broad fs access. |
-| `src` | `../.` | Path to soularr source tree. Defaults to this flake's repo root. |
-| `stateDir` | `/var/lib/soularr` | Runtime state (config.ini, lock file). |
+| `src` | `../.` | Path to cratedigger source tree. Defaults to this flake's repo root. |
+| `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |
 | `slskd.hostUrl` | `http://localhost:5030` | slskd HTTP base URL. |
@@ -645,35 +645,35 @@ Key options on the upstream module (full set in `nix/module.nix`):
 
 The module:
 1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, slskd-api)
-2. Wraps `soularr.py` / `pipeline_cli.py` / `migrate_db.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH
-3. Renders `/var/lib/soularr/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path
-4. Pre-start: health-check slskd → render config.ini → start `soularr.py`
+2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH
+3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path
+4. Pre-start: health-check slskd → render config.ini → start `cratedigger.py`
 
 Systemd units:
-- `soularr-db-migrate.service` — oneshot, `restartIfChanged = true`, `RemainAfterExit = true`. Runs the schema migrator on every `nixos-rebuild switch`. Both `soularr.service` and `soularr-web.service` `requires` it, so the app cannot start against an un-migrated DB.
-- `soularr.service` — oneshot pipeline run. `restartIfChanged = false` (5-min timer picks up new code).
-- `soularr.timer` — fires every 5 minutes (configurable via `timer.onUnitActiveSec`).
-- `soularr-web.service` — long-running web UI for music.ablz.au.
+- `cratedigger-db-migrate.service` — oneshot, `restartIfChanged = true`, `RemainAfterExit = true`. Runs the schema migrator on every `nixos-rebuild switch`. Both `cratedigger.service` and `cratedigger-web.service` `requires` it, so the app cannot start against an un-migrated DB.
+- `cratedigger.service` — oneshot pipeline run. `restartIfChanged = false` (5-min timer picks up new code).
+- `cratedigger.timer` — fires every 5 minutes (configurable via `timer.onUnitActiveSec`).
+- `cratedigger-web.service` — long-running web UI for music.ablz.au.
 
 ### Sops + per-key secrets
 
-sops-nix's `key = "..."` does NOT actually extract a single value from a multi-key dotenv file (it writes the whole `KEY=VALUE` envfile regardless — verified empirically; same gotcha is documented in `~/nixosconfig/modules/nixos/services/alerting.nix` for the gotify token). The upstream module wants raw values per file, so the homelab wrapper materializes them via a `soularr-secrets-split` oneshot at boot:
+sops-nix's `key = "..."` does NOT actually extract a single value from a multi-key dotenv file (it writes the whole `KEY=VALUE` envfile regardless — verified empirically; same gotcha is documented in `~/nixosconfig/modules/nixos/services/alerting.nix` for the gotify token). The upstream module wants raw values per file, so the homelab wrapper materializes them via a `cratedigger-secrets-split` oneshot at boot:
 
 ```nix
-systemd.services.soularr-secrets-split = {
-  before = ["soularr.service" "soularr-web.service" "soularr-db-migrate.service"];
-  serviceConfig.ExecStart = pkgs.writeShellScript "soularr-secrets-split" ''
+systemd.services.cratedigger-secrets-split = {
+  before = ["cratedigger.service" "cratedigger-web.service" "cratedigger-db-migrate.service"];
+  serviceConfig.ExecStart = pkgs.writeShellScript "cratedigger-secrets-split" ''
     set -euo pipefail
-    install -d -m 0700 /run/soularr-secrets
+    install -d -m 0700 /run/cratedigger-secrets
     for key in SOULARR_SLSKD_API_KEY MEELO_USERNAME MEELO_PASSWORD PLEX_TOKEN JELLYFIN_TOKEN; do
       grep -m1 "^$key=" "${config.sops.secrets."soularr/env".path}" \
-        | cut -d= -f2- | tr -d '\n' > "/run/soularr-secrets/$key"
-      chmod 0400 "/run/soularr-secrets/$key"
+        | cut -d= -f2- | tr -d '\n' > "/run/cratedigger-secrets/$key"
+      chmod 0400 "/run/cratedigger-secrets/$key"
     done
   '';
 };
-services.soularr.slskd.apiKeyFile = "/run/soularr-secrets/SOULARR_SLSKD_API_KEY";
-services.soularr.notifiers.meelo.usernameFile = "/run/soularr-secrets/MEELO_USERNAME";
+services.cratedigger.slskd.apiKeyFile = "/run/cratedigger-secrets/SOULARR_SLSKD_API_KEY";
+services.cratedigger.notifiers.meelo.usernameFile = "/run/cratedigger-secrets/MEELO_USERNAME";
 # ... etc
 ```
 
@@ -682,7 +682,7 @@ If you don't use sops or have one key per encrypted file, skip the splitter and 
 ### Flake outputs
 
 ```
-github:abl030/soularr
+github:abl030/cratedigger
 ├── nixosModules.default              ← upstream NixOS module
 ├── packages.<system>.slskd-api        ← slskd-api PyPI build (not in nixpkgs)
 ├── devShells.<system>.default         ← test/dev environment
@@ -695,15 +695,15 @@ Build the VM check: `nix build .#checks.x86_64-linux.moduleVm`.
 
 **ALWAYS use `nix-shell --run` to run tests and Python commands.** The dev shell (`shell.nix`) provides psycopg2, sox, ffmpeg, music-tag, slskd-api — without it, tests will fail with missing imports. Never run `python3` directly outside `nix-shell`.
 
-**Use the test runner script** — it saves output to `/tmp/soularr-test-output.txt` so you can grep failures without re-running the full 2-minute suite:
+**Use the test runner script** — it saves output to `/tmp/cratedigger-test-output.txt` so you can grep failures without re-running the full 2-minute suite:
 
 ```bash
 nix-shell --run "bash scripts/run_tests.sh"           # full suite (~2 min), saves output
-grep "^FAIL\|^ERROR" /tmp/soularr-test-output.txt     # check for failures after the fact
-grep "^Ran " /tmp/soularr-test-output.txt              # quick pass/fail count
+grep "^FAIL\|^ERROR" /tmp/cratedigger-test-output.txt     # check for failures after the fact
+grep "^Ran " /tmp/cratedigger-test-output.txt              # quick pass/fail count
 ```
 
-**NEVER re-run the full suite just to grep output differently.** Read `/tmp/soularr-test-output.txt` instead.
+**NEVER re-run the full suite just to grep output differently.** Read `/tmp/cratedigger-test-output.txt` instead.
 
 For single test modules during development:
 ```bash
@@ -851,4 +851,4 @@ curl -s "http://192.168.1.35:5200/ws/2/release-group/RGID?inc=releases&fmt=json"
 ## Secrets
 
 - slskd API key: sops-managed, injected into config.ini at runtime
-- Discogs token: `~/.config/beets/secrets.yaml` on doc1 (not used by Soularr directly)
+- Discogs token: `~/.config/beets/secrets.yaml` on doc1 (not used by Cratedigger directly)

--- a/README.md
+++ b/README.md
@@ -72,19 +72,19 @@ Add it to your flake:
 
 ```nix
 {
-  inputs.cratedigger.url = "github:abl030/soularr";
+  inputs.cratedigger.url = "github:abl030/cratedigger";
   outputs = { self, nixpkgs, cratedigger, ... }: {
     nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
       modules = [
         cratedigger.nixosModules.default
         ({ config, ... }: {
-          services.soularr = {
+          services.cratedigger = {
             enable = true;
             slskd = {
               apiKeyFile = "/run/secrets/slskd-api-key";   # raw key, one line
               downloadDir = "/var/lib/slskd/downloads";
             };
-            pipelineDb.dsn = "postgresql://soularr@localhost/soularr";
+            pipelineDb.dsn = "postgresql://cratedigger@localhost/cratedigger";
             beetsValidation = {
               enable = true;
               stagingDir = "/srv/music/Incoming";
@@ -102,17 +102,17 @@ Add it to your flake:
 }
 ```
 
-You provide: PostgreSQL (the module just takes a DSN), slskd, redis if you want web caching, and a secrets backend that materializes `*File` paths the module reads. The module defaults to running as root because slskd downloads land outside any service-user home and beets needs broad filesystem access; override `services.soularr.user` once you've set up the surrounding permissions.
+You provide: PostgreSQL (the module just takes a DSN), slskd, redis if you want web caching, and a secrets backend that materializes `*File` paths the module reads. The module defaults to running as root because slskd downloads land outside any service-user home and beets needs broad filesystem access; override `services.cratedigger.user` once you've set up the surrounding permissions.
 
 Try it without committing:
 
 ```bash
-nix develop github:abl030/soularr        # dev shell with deps
-nix run github:abl030/soularr#slskd-api  # build the slskd-api package
-nix flake check github:abl030/soularr    # boot the VM check
+nix develop github:abl030/cratedigger        # dev shell with deps
+nix run github:abl030/cratedigger#slskd-api  # build the slskd-api package
+nix flake check github:abl030/cratedigger    # boot the VM check
 ```
 
-For homelab consumers (sops-nix, nspawn DB containers, reverse proxies), see `~/nixosconfig/modules/nixos/services/soularr.nix` for a worked example wrapping this module.
+For homelab consumers (sops-nix, nspawn DB containers, reverse proxies), see `~/nixosconfig/modules/nixos/services/cratedigger.nix` for a worked example wrapping this module.
 
 ## Quality decision pipeline
 
@@ -127,13 +127,13 @@ All quality decisions are pure functions in `lib/quality.py` with full unit test
 
 ## Tuning the quality rank model
 
-Every threshold, enum, and per-codec band in the rank model is tunable via Nix options on the deployment side. The runtime parses them from `[Quality Ranks]` in `/var/lib/soularr/config.ini`, which is regenerated on every `nixos-rebuild switch` from the Nix module. Full rationale and per-band justification lives in [`docs/quality-ranks.md`](docs/quality-ranks.md); this section is the tuning reference.
+Every threshold, enum, and per-codec band in the rank model is tunable via Nix options on the deployment side. The runtime parses them from `[Quality Ranks]` in `/var/lib/cratedigger/config.ini`, which is regenerated on every `nixos-rebuild switch` from the Nix module. Full rationale and per-band justification lives in [`docs/quality-ranks.md`](docs/quality-ranks.md); this section is the tuning reference.
 
 ### Where to tune
 
-All options live under `services.soularr.qualityRanks.*` and are declared by the upstream NixOS module at [`nix/module.nix`](nix/module.nix) in this repo. Set them anywhere in your NixOS config that imports `cratedigger.nixosModules.default` — typically a host config or a homelab wrapper. The `[Quality Ranks]` section of `config.ini` is regenerated from these options on every `nixos-rebuild switch`; Soularr picks up the new values on its next 5-min timer fire.
+All options live under `services.cratedigger.qualityRanks.*` and are declared by the upstream NixOS module at [`nix/module.nix`](nix/module.nix) in this repo. Set them anywhere in your NixOS config that imports `cratedigger.nixosModules.default` — typically a host config or a homelab wrapper. The `[Quality Ranks]` section of `config.ini` is regenerated from these options on every `nixos-rebuild switch`; Cratedigger picks up the new values on its next 5-min timer fire.
 
-**Source of truth**: `QualityRankConfig.defaults()` in `lib/quality.py`, pinned by `TestQualityRankConfigDefaults` in `tests/test_quality_decisions.py`. The Nix options mirror those defaults for declarative visibility -- you should be able to open `soularr.nix` and read your current policy without grepping Python. Drift between Python and Nix is caught at soularr test time: bump a default in either repo, the pin test fails and reminds you to update the other.
+**Source of truth**: `QualityRankConfig.defaults()` in `lib/quality.py`, pinned by `TestQualityRankConfigDefaults` in `tests/test_quality_decisions.py`. The Nix options mirror those defaults for declarative visibility -- you should be able to open `cratedigger.nix` and read your current policy without grepping Python. Drift between Python and Nix is caught at cratedigger test time: bump a default in either repo, the pin test fails and reminds you to update the other.
 
 ### Nix-exposed options
 
@@ -183,8 +183,8 @@ Three fields are part of the rank model but are NOT surfaced as Nix options beca
 The exact deploy flow depends on where you set the options. For a host config that imports `cratedigger.nixosModules.default` directly:
 
 ```bash
-$EDITOR hosts/<your-host>/configuration.nix   # tweak services.soularr.qualityRanks.*
-git commit -am "soularr: retune <what>" && git push
+$EDITOR hosts/<your-host>/configuration.nix   # tweak services.cratedigger.qualityRanks.*
+git commit -am "cratedigger: retune <what>" && git push
 sudo nixos-rebuild switch --flake .
 ```
 
@@ -193,22 +193,22 @@ For the abl030 homelab (this project's reference deployment):
 ```bash
 # On doc1 — has git push credentials for nixosconfig
 cd ~/nixosconfig
-$EDITOR hosts/doc2/configuration.nix          # tweak services.soularr.qualityRanks.*
-git commit -am "soularr: retune <what>" && git push
+$EDITOR hosts/doc2/configuration.nix          # tweak services.cratedigger.qualityRanks.*
+git commit -am "cratedigger: retune <what>" && git push
 ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
 ```
 
 ### How to verify the new config is live
 
-1. **Read the generated file** -- `ssh doc2 'sudo cat /var/lib/soularr/config.ini | grep -A 30 "\[Quality Ranks\]"'`. The section should show the exact values from your Nix edit.
+1. **Read the generated file** -- `ssh doc2 'sudo cat /var/lib/cratedigger/config.ini | grep -A 30 "\[Quality Ranks\]"'`. The section should show the exact values from your Nix edit.
 
-2. **Check the runtime picks them up** -- `ssh doc2 'pipeline-cli quality <any_request_id>'`. The output prints the active `gate_min_rank`, `bitrate_metric`, and thresholds the simulator is using. Mismatch means Soularr hasn't restarted since the rebuild (it's a 5-min timer) -- wait a cycle or `sudo systemctl start soularr --no-block`.
+2. **Check the runtime picks them up** -- `ssh doc2 'pipeline-cli quality <any_request_id>'`. The output prints the active `gate_min_rank`, `bitrate_metric`, and thresholds the simulator is using. Mismatch means Cratedigger hasn't restarted since the rebuild (it's a 5-min timer) -- wait a cycle or `sudo systemctl start cratedigger --no-block`.
 
 3. **Visual confirmation** -- open the [Decisions tab at music.ablz.au](https://music.ablz.au). The top of the tab renders three pills (**Gate min rank** / **Bitrate metric** / **Within-rank tolerance**) pulled from the same `_runtime_rank_config()` snapshot. If your tuning is live, the pills show the new values (#68). The transcode stage rule threshold also reflects `bands.mp3Vbr.excellent` live, since `get_decision_tree()` threads `cfg` through (#75).
 
 ### The search filter is deliberately permissive
 
-The `[Search Settings] allowed_filetypes` list in `config.ini` (exposed as `services.soularr.searchSettings.allowedFiletypes` on the upstream module) is a **priority-ordered preference list**, not a quality gate. It decides which codecs Soularr prefers when multiple options exist for the same album and drives peer selection within each tier; it does NOT decide whether a file is "good enough". That call belongs to the rank model.
+The `[Search Settings] allowed_filetypes` list in `config.ini` (exposed as `services.cratedigger.searchSettings.allowedFiletypes` on the upstream module) is a **priority-ordered preference list**, not a quality gate. It decides which codecs Cratedigger prefers when multiple options exist for the same album and drives peer selection within each tier; it does NOT decide whether a file is "good enough". That call belongs to the rank model.
 
 **Current production list** (top-to-bottom priority):
 
@@ -216,7 +216,7 @@ The `[Search Settings] allowed_filetypes` list in `config.ini` (exposed as `serv
 mp3 v0,mp3 320,flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,aac,opus,ogg,mp3,wav
 ```
 
-**How it actually works** (in `soularr.py:_build_search_cache` → `lib/enqueue.py:_try_filetype`):
+**How it actually works** (in `cratedigger.py:_build_search_cache` → `lib/enqueue.py:_try_filetype`):
 
 1. slskd returns every peer that has a file matching the raw text query "artist album". No filetype restriction on the wire — the codec preference is applied locally.
 2. `_build_search_cache()` walks each file and buckets it into the **first tier it matches**. Files that match zero tiers are dropped.
@@ -241,7 +241,7 @@ mp3 v0,mp3 320,flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,aac,opus
 - **Remove a bare-codec fallback tier** if you want the search filter to enforce a codec floor. E.g. removing `opus` means Opus 128 is invisible again, matching the pre-2026-04-11 behavior.
 - **Add format/bitrate-specific tiers** if you want to promote or demote specific subsets. E.g. inserting `opus 128+` between `alac` and the bare-codec fallbacks would prefer Opus 128 before falling through to AAC/OGG.
 
-**Exposed as `services.soularr.searchSettings.allowedFiletypes`** (a `listOf str`). Set it on the host config that imports the upstream module to override the default list above.
+**Exposed as `services.cratedigger.searchSettings.allowedFiletypes`** (a `listOf str`). Set it on the host config that imports the upstream module to override the default list above.
 
 ### Where the docs live
 
@@ -323,7 +323,7 @@ curl -s "http://192.168.1.35:5200/ws/2/release/<MBID>?inc=recordings+media&fmt=j
 After verifying a FLAC download is genuine (via spectral analysis + V0 conversion), the pipeline can convert to a configurable target format instead of keeping V0. Set via the upstream module:
 
 ```nix
-services.soularr.beetsValidation.verifiedLosslessTarget = "opus 128";
+services.cratedigger.beetsValidation.verifiedLosslessTarget = "opus 128";
 ```
 
 This renders into `[Beets Validation] verified_lossless_target = opus 128` in the runtime `config.ini`.
@@ -349,7 +349,7 @@ After a successful auto-import, Cratedigger fires a best-effort library-refresh 
 Configure via the upstream module:
 
 ```nix
-services.soularr.notifiers = {
+services.cratedigger.notifiers = {
   meelo = {
     enable = true;
     url = "https://meelo.example.com";
@@ -376,7 +376,7 @@ The module renders the `[Meelo]` / `[Plex]` / `[Jellyfin]` sections of `config.i
 ## Running tests
 
 ```bash
-nix-shell --run "bash scripts/run_tests.sh"    # full suite, saves to /tmp/soularr-test-output.txt
+nix-shell --run "bash scripts/run_tests.sh"    # full suite, saves to /tmp/cratedigger-test-output.txt
 nix-shell --run "python3 -m unittest tests.<module> -v"  # single module
 ```
 
@@ -393,18 +393,18 @@ Shared infrastructure lives in `tests/fakes.py` (stateful fakes) and `tests/help
 
 Deployed via NixOS. The upstream module at [`nix/module.nix`](nix/module.nix) builds a Python environment with dependencies and registers four systemd units:
 
-- `soularr-db-migrate.service` — oneshot, runs the schema migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch`. `restartIfChanged = true` + `RemainAfterExit = true` so it always re-evaluates when the unit derivation changes but doesn't re-run between cycles.
-- `soularr.service` — oneshot pipeline run, triggered by `soularr.timer`. Runs healthcheck → prestart (renders `config.ini`) → `soularr.py`. `restartIfChanged = false` so deploys don't restart it mid-cycle; the next timer fire picks up the new code.
-- `soularr.timer` — fires every 5 minutes by default (`services.soularr.timer.onUnitActiveSec`).
-- `soularr-web.service` — long-running web UI bound to `services.soularr.web.port` (default 8085).
+- `cratedigger-db-migrate.service` — oneshot, runs the schema migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch`. `restartIfChanged = true` + `RemainAfterExit = true` so it always re-evaluates when the unit derivation changes but doesn't re-run between cycles.
+- `cratedigger.service` — oneshot pipeline run, triggered by `cratedigger.timer`. Runs healthcheck → prestart (renders `config.ini`) → `cratedigger.py`. `restartIfChanged = false` so deploys don't restart it mid-cycle; the next timer fire picks up the new code.
+- `cratedigger.timer` — fires every 5 minutes by default (`services.cratedigger.timer.onUnitActiveSec`).
+- `cratedigger-web.service` — long-running web UI bound to `services.cratedigger.web.port` (default 8085).
 
-`soularr.service` and `soularr-web.service` both `requires` the migrate unit, so the app cannot start against an un-migrated DB.
+`cratedigger.service` and `cratedigger-web.service` both `requires` the migrate unit, so the app cannot start against an un-migrated DB.
 
 To deploy a new revision:
 
 ```bash
-# 1. Push your soularr changes
-cd /path/to/soularr && git push
+# 1. Push your cratedigger changes
+cd /path/to/cratedigger && git push
 
 # 2. Update the flake input on the consumer side
 cd /path/to/your-nixos-config
@@ -415,11 +415,11 @@ git commit -am "cratedigger: bump" && git push
 sudo nixos-rebuild switch --flake .       # or via --flake github:user/repo#host
 ```
 
-`restartIfChanged = false` on `soularr.service` means the deploy completes without restarting an in-flight cycle; the next 5-min timer fire runs the new code.
+`restartIfChanged = false` on `cratedigger.service` means the deploy completes without restarting an in-flight cycle; the next 5-min timer fire runs the new code.
 
 ### Schema migrations
 
-Schema lives in `migrations/NNN_name.sql`, applied by a tiny custom migrator (`lib/migrator.py`) that tracks applied versions in a `schema_migrations` table. The deploy systemd unit `soularr-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE the app services start. `soularr.service` and `soularr-web.service` both `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
+Schema lives in `migrations/NNN_name.sql`, applied by a tiny custom migrator (`lib/migrator.py`) that tracks applied versions in a `schema_migrations` table. The deploy systemd unit `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE the app services start. `cratedigger.service` and `cratedigger-web.service` both `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
 
 To add a schema change:
 

--- a/TODO-audio-quality.md
+++ b/TODO-audio-quality.md
@@ -15,7 +15,7 @@ Created 2026-04-03. Tracks the AudioFileSpec refactoring and planned extensions.
 ### ALAC/m4a fix
 - `.m4a` files now match `alac` config (was broken: `"m4a" != "alac"`)
 - `album_track_num()`, `album_match()`, `download_filter()` all use `spec.extension`
-- `SoularrConfig.allowed_specs` property added
+- `CratediggerConfig.allowed_specs` property added
 
 ### Consolidated AUDIO_EXTENSIONS
 - Replaced 8 duplicate `_AUDIO_EXTS` sets across the codebase with imports from `lib/quality.py`

--- a/TODO-type-safety.md
+++ b/TODO-type-safety.md
@@ -16,7 +16,7 @@ This applies to every remaining untyped boundary below.
 
 ### 1. ~~`AlbumRecord.from_db_row()` returns `dict`~~ ✅ DONE
 
-Replaced with typed `AlbumRecord`, `ReleaseRecord`, `MediaRecord` dataclasses. All ~50 access sites in soularr.py and lib/download.py updated. `_get_request_id()` deleted. Tests fixed to use real constructors.
+Replaced with typed `AlbumRecord`, `ReleaseRecord`, `MediaRecord` dataclasses. All ~50 access sites in cratedigger.py and lib/download.py updated. `_get_request_id()` deleted. Tests fixed to use real constructors.
 
 ### 2. `PipelineDB.get_request()` returns `dict[str, Any]` — INTENTIONALLY LEFT AS DICT
 
@@ -32,5 +32,5 @@ Audited all tests. Fixed `test_download.py` (2 tests passing dicts → `AlbumRec
 
 ### 5. ~~Stale comments~~ ✅ DONE
 
-- Fixed "bridge during migration" → removed from soularr.py
+- Fixed "bridge during migration" → removed from cratedigger.py
 - Fixed "Lidarr bridge" → clarified as legacy columns in pipeline_db.py

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 # TODO
 
-No outstanding items. Track issues at https://github.com/abl030/soularr/issues
+No outstanding items. Track issues at https://github.com/abl030/cratedigger/issues

--- a/album_source.py
+++ b/album_source.py
@@ -1,6 +1,6 @@
 """Album source — Pipeline DB as the source of wanted albums.
 
-Provides the interface soularr.py uses to get wanted albums, fetch tracks,
+Provides the interface cratedigger.py uses to get wanted albums, fetch tracks,
 and report completion. AlbumRecord is a typed dataclass returned by from_db_row().
 """
 
@@ -12,7 +12,7 @@ import os
 import urllib.request
 from dataclasses import dataclass
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 from lib.quality import detect_release_source
@@ -306,7 +306,7 @@ class DatabaseSource:
         try:
             url = f"{MB_API_BASE}/release/{mb_id}?inc=recordings&fmt=json"
             req = urllib.request.Request(url)
-            req.add_header("User-Agent", "soularr-db/1.0")
+            req.add_header("User-Agent", "cratedigger-db/1.0")
             with urllib.request.urlopen(req, timeout=15) as resp:
                 data = json.loads(resp.read())
         except Exception:
@@ -337,7 +337,7 @@ class DatabaseSource:
         try:
             url = f"{DISCOGS_API_BASE}/api/releases/{discogs_id}"
             req = urllib.request.Request(url)
-            req.add_header("User-Agent", "soularr-db/1.0")
+            req.add_header("User-Agent", "cratedigger-db/1.0")
             with urllib.request.urlopen(req, timeout=15) as resp:
                 data = json.loads(resp.read())
         except Exception:

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -13,8 +13,8 @@ import slskd_api
 
 if TYPE_CHECKING:
     from album_source import DatabaseSource
-    from lib.config import SoularrConfig
-    from lib.context import SoularrContext
+    from lib.config import CratediggerConfig
+    from lib.context import CratediggerContext
 
 
 class TrackRecord(TypedDict):
@@ -42,12 +42,12 @@ class SlskdDirectory(TypedDict):
     files: list[SlskdFile]
 
 
-# === Typed Config (populated in main() via SoularrConfig.from_ini()) ===
-cfg: SoularrConfig = None  # type: ignore[assignment]  # Set in main()
+# === Typed Config (populated in main() via CratediggerConfig.from_ini()) ===
+cfg: CratediggerConfig = None  # type: ignore[assignment]  # Set in main()
 
 # === API Clients & Logging ===
 slskd: slskd_api.SlskdClient = None  # type: ignore[assignment]  # Set in main()
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 # === API client instances (set in main()) ===
 pipeline_db_source: "DatabaseSource" = None  # type: ignore[assignment]  # Set in main()
@@ -55,7 +55,7 @@ pipeline_db_source: "DatabaseSource" = None  # type: ignore[assignment]  # Set i
 # === Runtime context (populated in main()) ===
 # Module-level reference for thin wrappers that can't receive ctx as a parameter.
 # All matching/search functions receive ctx explicitly.
-_module_ctx: Any = None  # SoularrContext — set in main()
+_module_ctx: Any = None  # CratediggerContext — set in main()
 
 from lib.browse import (
     _browse_directories,
@@ -84,7 +84,7 @@ from lib.matching import (
 )
 
 
-def filter_list(albums: Sequence[Any], filter_cfg: SoularrConfig) -> list[Any] | None:
+def filter_list(albums: Sequence[Any], filter_cfg: CratediggerConfig) -> list[Any] | None:
     """Filter albums against the title blacklist. Returns None if nothing passes."""
     result = []
     for album in albums:
@@ -525,7 +525,7 @@ from lib.download import (cancel_and_delete as _cancel_and_delete_impl,
 
 
 def _make_ctx():
-    """Return the module-level SoularrContext (created in main())."""
+    """Return the module-level CratediggerContext (created in main())."""
     return _module_ctx
 
 
@@ -556,7 +556,7 @@ def main():
     from lib.permissions import reset_umask
     reset_umask()
 
-    parser = argparse.ArgumentParser(description="Soularr music download pipeline")
+    parser = argparse.ArgumentParser(description="Cratedigger music download pipeline")
     parser.add_argument("-c", "--config-dir", default=os.getcwd(),
                         help="Config directory (default: cwd)")
     parser.add_argument("-v", "--var-dir", default=os.getcwd(),
@@ -565,11 +565,11 @@ def main():
                         help="Disable lock file creation")
     args = parser.parse_args()
 
-    lock_file_path = os.path.join(args.var_dir, ".soularr.lock")
+    lock_file_path = os.path.join(args.var_dir, ".cratedigger.lock")
     config_file_path = os.path.join(args.config_dir, "config.ini")
 
     if not args.no_lock_file and os.path.exists(lock_file_path):
-        logger.info("Soularr instance is already running.")
+        logger.info("Cratedigger instance is already running.")
         sys.exit(1)
 
     try:
@@ -585,14 +585,14 @@ def main():
             logger.error(
                 f"Config file not found at {config_file_path}. "
                 "Pass --config-dir to specify its location. "
-                "Under the upstream NixOS module, /var/lib/soularr/config.ini "
+                "Under the upstream NixOS module, /var/lib/cratedigger/config.ini "
                 "is rendered by preStartScript at boot."
             )
             sys.exit(1)
 
         # --- Parse config into typed dataclass ---
-        from lib.config import SoularrConfig
-        cfg = SoularrConfig.from_ini(config, config_dir=args.config_dir, var_dir=args.var_dir)
+        from lib.config import CratediggerConfig
+        cfg = CratediggerConfig.from_ini(config, config_dir=args.config_dir, var_dir=args.var_dir)
 
         setup_logging(config)
 
@@ -636,8 +636,8 @@ def main():
         slskd = slskd_api.SlskdClient(host=cfg.slskd_host_url, api_key=cfg.resolved_slskd_api_key(), url_base=cfg.slskd_url_base)
 
         # Build context with fresh caches for this cycle
-        from lib.context import SoularrContext
-        _module_ctx = SoularrContext(cfg=cfg, slskd=slskd, pipeline_db_source=pipeline_db_source)
+        from lib.context import CratediggerContext
+        _module_ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=pipeline_db_source)
 
         # Load persisted caches from previous runs
         from lib.cache import load_caches
@@ -667,7 +667,7 @@ def main():
         def _run_phase1():
             """Run Phase 1 in a background thread with its own DB connection."""
             phase1_source = DatabaseSource(cfg.pipeline_db_dsn)
-            phase1_ctx = SoularrContext(
+            phase1_ctx = CratediggerContext(
                 cfg=cfg,
                 slskd=slskd,
                 pipeline_db_source=phase1_source,
@@ -698,7 +698,7 @@ def main():
                 except Exception:
                     logger.exception("Fatal error in search phase!")
                 if failed == 0:
-                    logger.info("Soularr finished. Exiting...")
+                    logger.info("Cratedigger finished. Exiting...")
                 else:
                     logger.info(f"{failed}: releases failed to find a match in the search results and are still wanted.")
             else:
@@ -715,7 +715,7 @@ def main():
         slskd.transfers.remove_completed_downloads()
 
         elapsed = time.time() - cycle_start
-        logger.info(f"Soularr cycle complete in {elapsed:.1f}s")
+        logger.info(f"Cratedigger cycle complete in {elapsed:.1f}s")
 
     finally:
         # Save caches for next run

--- a/docs/async-downloads-plan.md
+++ b/docs/async-downloads-plan.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Replace the blocking `monitor_downloads()` loop with a poll-based approach. Each 5-minute soularr run will:
+Replace the blocking `monitor_downloads()` loop with a poll-based approach. Each 5-minute cratedigger run will:
 
 1. Poll slskd for status of albums currently downloading (from previous runs)
 2. Process any completions/timeouts
@@ -381,7 +381,7 @@ def _timeout_album(
     entry: GrabListEntry,
     request_id: int,
     reason: str,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> None:
     """Handle download timeout: cancel, log, reset to wanted.
 
@@ -411,7 +411,7 @@ def _timeout_album(
     _reset_to_wanted(db, request_id)
 
 
-def poll_active_downloads(ctx: SoularrContext) -> None:
+def poll_active_downloads(ctx: CratediggerContext) -> None:
     """Poll slskd for status of all downloading albums.
 
     For each album with status='downloading':
@@ -659,7 +659,7 @@ prevents stale state from accumulating.
 
 ### Commit 7: Build ActiveDownloadState from GrabListEntry at enqueue time
 
-**Files**: `lib/download.py`, `soularr.py`
+**Files**: `lib/download.py`, `cratedigger.py`
 
 **Tests first** (RED): `tests/test_download.py`
 - `test_build_active_download_state`: GrabListEntry → ActiveDownloadState with correct fields
@@ -696,7 +696,7 @@ def build_active_download_state(entry: GrabListEntry) -> ActiveDownloadState:
 
 ### Commit 8: Refactor `grab_most_wanted()` — enqueue-only, no blocking monitor
 
-**Files**: `lib/download.py`, `soularr.py`
+**Files**: `lib/download.py`, `cratedigger.py`
 
 This is the core behavior change. `grab_most_wanted()` currently calls `search_and_queue()` then blocks in `monitor_downloads()`. The new version calls `search_and_queue()`, persists download state to DB, and returns immediately.
 
@@ -713,7 +713,7 @@ Replace the body of `grab_most_wanted()` in `lib/download.py`:
 ```python
 def grab_most_wanted(albums: list[Any],
                      search_and_queue: Callable[..., tuple[dict, list, list]],
-                     ctx: SoularrContext) -> int:
+                     ctx: CratediggerContext) -> int:
     """Search, enqueue, persist download state, return immediately.
 
     Does NOT block waiting for downloads. Download monitoring happens
@@ -762,7 +762,7 @@ def grab_most_wanted(albums: list[Any],
 
 ### Commit 9: Refactor `main()` — new flow with poll-first
 
-**Files**: `soularr.py`
+**Files**: `cratedigger.py`
 
 **Tests**: No new unit tests — this is orchestration. Verify via integration test / manual run.
 
@@ -804,7 +804,7 @@ Replace the relevant section of `main()` (lines ~1136-1162):
                     os.remove(lock_file_path)
                 sys.exit(0)
             if failed == 0:
-                logger.info("Soularr finished. Exiting...")
+                logger.info("Cratedigger finished. Exiting...")
             else:
                 logger.info(f"{failed}: releases failed to find a match.")
         else:
@@ -820,7 +820,7 @@ Replace the relevant section of `main()` (lines ~1136-1162):
 - `remove_completed_downloads()` always runs at the end (not conditional on failed count)
 - `_make_ctx()` called once — currently it's called inside `grab_most_wanted()` wrapper, which rebuilds it each time. Now we build it once at the top.
 
-**Wait — `_make_ctx()` issue**: The wrapper functions in soularr.py (`cancel_and_delete`, `slskd_do_enqueue`, `grab_most_wanted`) each call `_make_ctx()`. The search functions called by `search_and_queue` use module globals directly (not ctx). So the poll phase needs a ctx but the search phase uses globals. This is fine — we build ctx once for the poll, and the existing wrappers build it again for the search/enqueue phase. No change needed to the wrapper pattern.
+**Wait — `_make_ctx()` issue**: The wrapper functions in cratedigger.py (`cancel_and_delete`, `slskd_do_enqueue`, `grab_most_wanted`) each call `_make_ctx()`. The search functions called by `search_and_queue` use module globals directly (not ctx). So the poll phase needs a ctx but the search phase uses globals. This is fine — we build ctx once for the poll, and the existing wrappers build it again for the search/enqueue phase. No change needed to the wrapper pattern.
 
 Actually, we need to make sure `pipeline_db_source` is initialized before calling `_poll_impl`. Looking at the current flow:
 
@@ -843,16 +843,16 @@ The order is already correct: `pipeline_db_source` is set before `slskd`, and we
 - `monitor_downloads()` (lines 402-466)
 - `_handle_download_problems()` (lines 468-557)
 
-Also remove the import of `monitor_downloads` in `soularr.py` if it exists. Check:
+Also remove the import of `monitor_downloads` in `cratedigger.py` if it exists. Check:
 
 ```python
-# soularr.py line 1002-1004
+# cratedigger.py line 1002-1004
 from lib.download import (cancel_and_delete as _cancel_and_delete_impl,
                           slskd_do_enqueue as _slskd_do_enqueue_impl,
                           grab_most_wanted as _grab_most_wanted_impl)
 ```
 
-`monitor_downloads` is not imported into soularr.py — it's only called from within `grab_most_wanted` in download.py. After commit 7, it's dead code.
+`monitor_downloads` is not imported into cratedigger.py — it's only called from within `grab_most_wanted` in download.py. After commit 7, it's dead code.
 
 **Tests**: Verify existing tests still pass. Some tests in `test_download.py` or `test_integration.py` may test `monitor_downloads` directly — these should be removed or updated to test `poll_active_downloads` instead.
 
@@ -912,7 +912,7 @@ Transfer IDs are ephemeral. We persist filenames in `ActiveDownloadState` and re
 
 ## What's Deferred
 
-1. **Orphan file reconciliation**: If soularr crashes after enqueue but before DB write, slskd has downloads nobody tracks. These accumulate silently. Could add a reconciliation step later.
+1. **Orphan file reconciliation**: If cratedigger crashes after enqueue but before DB write, slskd has downloads nobody tracks. These accumulate silently. Could add a reconciliation step later.
 
 2. **Per-file retry persistence across runs**: Retry counters reset to 0 each run because `GrabListEntry` is reconstructed from DB with `retry=None`. A file that errors on run N gets retry=1, but on run N+1 the counter resets — so a file could retry up to 5 times per run, indefinitely across runs. The absolute timeout (stalled_timeout) is the only protection. Cross-run retry tracking would need JSONB state updates on each poll, adding complexity.
 
@@ -942,21 +942,21 @@ Transfer IDs are ephemeral. We persist filenames in `ActiveDownloadState` and re
 3. **Verify**: 
    ```bash
    # Check schema
-   ssh doc2 'psql -h 192.168.100.11 -U soularr soularr -c "
+   ssh doc2 'psql -h 192.168.100.11 -U cratedigger cratedigger -c "
      SELECT column_name, data_type FROM information_schema.columns 
      WHERE table_name = '\''album_requests'\'' AND column_name = '\''active_download_state'\''
    "'
 
    # Watch first run with new code
-   ssh doc2 'sudo systemctl start soularr --no-block'
-   ssh doc2 'sudo journalctl -u soularr -f --since "5 sec ago"'
+   ssh doc2 'sudo systemctl start cratedigger --no-block'
+   ssh doc2 'sudo journalctl -u cratedigger -f --since "5 sec ago"'
 
    # Verify downloading albums exist after search phase
    ssh doc2 'pipeline-cli list downloading'
 
    # Verify completions processed on next run
    # (wait for timer or start manually)
-   ssh doc2 'sudo journalctl -u soularr --since "5 min ago" | grep -i "poll\|complete\|timeout"'
+   ssh doc2 'sudo journalctl -u cratedigger --since "5 min ago" | grep -i "poll\|complete\|timeout"'
    ```
 
 ---

--- a/docs/audio-classification-research.md
+++ b/docs/audio-classification-research.md
@@ -1,6 +1,6 @@
 # Toward a Trustworthy Audio Classification System
 
-This document captures the April 12-13, 2026 research pass on Soularr's
+This document captures the April 12-13, 2026 research pass on Cratedigger's
 audio classification system: what the current classifier does, what the
 corpus work found, where the current rules are weak, and what existing prior
 art already exists outside this repo.
@@ -18,12 +18,12 @@ This write-up is only about the audio classification component:
 
 - detecting bad MP3 / fake-lossless / lossy-origin audio
 - deciding when a download should be auto-rejected, auto-imported, or staged
-- evaluating whether Soularr's current detector is too trigger-happy
+- evaluating whether Cratedigger's current detector is too trigger-happy
 
-It is not about the wider Soularr pipeline, web UI, or beets integration
+It is not about the wider Cratedigger pipeline, web UI, or beets integration
 except where those systems affect classifier inputs or policy decisions.
 
-## Current Soularr Classifier
+## Current Cratedigger Classifier
 
 The current detector lives primarily in:
 
@@ -73,7 +73,7 @@ For MP3 imports, Stage 1 is a pre-import spectral gate:
 - if the new download looks no better than what already exists, it can be
   hard-rejected as `spectral_reject`
 
-This is important because Soularr is not currently trying to solve
+This is important because Cratedigger is not currently trying to solve
 "classification in the abstract." It is solving "should this download replace
 what I already have?"
 
@@ -352,12 +352,12 @@ Important traits:
 - based on published research
 - explicitly warns that it is useful but not perfect
 
-For Soularr, this makes it a good shadow-mode baseline detector even if it
+For Cratedigger, this makes it a good shadow-mode baseline detector even if it
 turns out to be awkward to embed directly.
 
 #### 2. `audiocheckr`
 
-This is the closest conceptual overlap with what Soularr needs as a headless
+This is the closest conceptual overlap with what Cratedigger needs as a headless
 CLI / library-style system.
 
 Two ideas from it stand out as immediately relevant:
@@ -372,7 +372,7 @@ That maps directly to the biggest weakness observed locally:
 
 The licensing note matters:
 
-- Soularr is GPL-3.0
+- Cratedigger is GPL-3.0
 - `audiocheckr` is AGPL-3.0
 - borrowing concepts is fine
 - vendoring code should be a deliberate licensing decision, not an accidental
@@ -381,7 +381,7 @@ The licensing note matters:
 #### 3. `AudioAuditor`
 
 This project matters less as a dependency and more as proof that heuristic
-cutoff-based systems can be built out much further than Soularr currently has.
+cutoff-based systems can be built out much further than Cratedigger currently has.
 
 Useful ideas:
 
@@ -405,7 +405,7 @@ In other words:
 
 The right target is not "one magic model that never makes mistakes."
 
-A trustworthy classifier in Soularr should mean:
+A trustworthy classifier in Cratedigger should mean:
 
 1. We understand what kinds of bad files it catches.
 2. We understand what kinds of bad files it misses.
@@ -431,12 +431,12 @@ It should become the long-term foundation for classifier work:
 
 ### 2. Add external detectors in shadow mode before trusting them in policy
 
-The safest next step is not "replace Soularr's classifier."
+The safest next step is not "replace Cratedigger's classifier."
 
 It is:
 
 - run an external detector in shadow mode
-- record agreement / disagreement against Soularr's current detector
+- record agreement / disagreement against Cratedigger's current detector
 - inspect the disagreement set manually
 
 The best candidate for this is `vamp-lossy-encoding-detector`.
@@ -451,7 +451,7 @@ If the integration friction is acceptable, it should be used as:
 The single biggest idea worth stealing from prior art is profile-aware
 sensitivity.
 
-Soularr should likely distinguish between at least:
+Cratedigger should likely distinguish between at least:
 
 - standard modern pop / rock / electronic
 - ambient / drone / noise
@@ -503,7 +503,7 @@ The second is not.
 ### High priority
 
 - add a shadow backend for `vamp-lossy-encoding-detector`
-- extend `scripts/spectral_corpus.py` to compare Soularr vs. external detectors
+- extend `scripts/spectral_corpus.py` to compare Cratedigger vs. external detectors
 - record disagreement sets in machine-readable output
 - keep building a labeled edge corpus from:
   - failed imports
@@ -529,7 +529,7 @@ The second is not.
 
 The main conclusions from this chat and research pass are:
 
-1. The current Soularr audio classifier is useful, but narrow.
+1. The current Cratedigger audio classifier is useful, but narrow.
 2. It catches obvious transcodes better than subtle modern lossy-origin files.
 3. Soulseek really does contain a lot of bad high-bitrate files.
 4. The current raw reject counts overstate the number of distinct bad cases.

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -1,6 +1,6 @@
-# Beets Primer for Soularr
+# Beets Primer for Cratedigger
 
-This document describes how beets is set up, configured, and used in the music pipeline. It's written for the Soularr fork's Claude context — if you're modifying anything that touches beets imports, validation, or the harness, read this first.
+This document describes how beets is set up, configured, and used in the music pipeline. It's written for the Cratedigger fork's Claude context — if you're modifying anything that touches beets imports, validation, or the harness, read this first.
 
 ## What is Beets?
 
@@ -13,7 +13,7 @@ Beets is the canonical source of truth for the tagged music library at `/Beets`.
 - **Lyrics** — fetching synced lyrics from a local LRCLIB mirror
 - **Library DB** — SQLite database tracking every album and track
 
-When Soularr downloads an album and it passes validation, beets is what actually imports it into the library.
+When Cratedigger downloads an album and it passes validation, beets is what actually imports it into the library.
 
 ## Version & Installation
 
@@ -126,7 +126,7 @@ fetchart:
 | `/mnt/virtio/Music/beets-library.db` | SQLite database — the DB source of truth |
 | `/mnt/virtio/Music/beets-import.log` | Import log |
 | `/mnt/virtio/Music/AI` | Staging area — raw copies from `/Me`, pre-import |
-| `/mnt/virtio/Music/Incoming` | Re-download staging — Soularr-validated downloads awaiting conversion and import |
+| `/mnt/virtio/Music/Incoming` | Re-download staging — Cratedigger-validated downloads awaiting conversion and import |
 | `/mnt/virtio/Music/Re-download` | Re-download queue — each album has a README.md explaining why |
 
 ### File Organization
@@ -161,7 +161,7 @@ Some legacy imports are m4a, ogg, opus, wma, or even ape — these came from the
 
 ## The Beets Harness
 
-The harness (`harness/beets_harness.py`) is a custom `ImportSession` subclass that replaces beets' interactive terminal prompts with a JSON protocol over stdin/stdout. This is how Soularr (and all automated imports) communicate with beets.
+The harness (`harness/beets_harness.py`) is a custom `ImportSession` subclass that replaces beets' interactive terminal prompts with a JSON protocol over stdin/stdout. This is how Cratedigger (and all automated imports) communicate with beets.
 
 ### Why the Harness Exists
 
@@ -247,7 +247,7 @@ Added 2026-03-24 to fix the "silent import" problem. Previously, a successful im
 
 ## import_one.py
 
-The one-shot import script used by Soularr for auto-importing `source='request'` albums. Lives at `harness/import_one.py`.
+The one-shot import script used by Cratedigger for auto-importing `source='request'` albums. Lives at `harness/import_one.py`.
 
 ### Flow
 
@@ -472,7 +472,7 @@ Beets has a built-in `badfiles` plugin that provides:
 - `beet bad [QUERY]` — on-demand file corruption check
 - `check_on_import: yes` — validate files before importing (interactive prompt: abort/skip/continue)
 
-Currently NOT enabled. The `check_on_import` option triggers interactive prompts that break the JSON harness. See GitHub issue #2 for the plan to integrate audio validation into Soularr's post-download pipeline instead.
+Currently NOT enabled. The `check_on_import` option triggers interactive prompts that break the JSON harness. See GitHub issue #2 for the plan to integrate audio validation into Cratedigger's post-download pipeline instead.
 
 ## Deploying Beets Config Changes
 
@@ -497,7 +497,7 @@ beet ls -a | head -5                 # Quick smoke test
 
 ## Deploying to doc2
 
-doc2 runs Soularr but needs access to beets via the harness. The harness shell wrapper (`run_beets_harness.sh`) bootstraps from doc1's Nix beets environment. Since both machines share `/mnt/virtio`, the harness files are accessible from doc2 without copying.
+doc2 runs Cratedigger but needs access to beets via the harness. The harness shell wrapper (`run_beets_harness.sh`) bootstraps from doc1's Nix beets environment. Since both machines share `/mnt/virtio`, the harness files are accessible from doc2 without copying.
 
 **NEVER cross-build from doc1** (`--target-host doc2` is slow). Always:
 ```bash

--- a/docs/code-improvement-ideas.md
+++ b/docs/code-improvement-ideas.md
@@ -4,12 +4,12 @@ Notes from the async-downloads implementation (2026-04-03). These are structural
 
 ## 1. TestConfig factory instead of MagicMock
 
-**Problem**: Tests create `SoularrConfig` via `MagicMock()`, which means pyright can't check attribute names. About 10 pyright "errors" across test files are `Cannot assign to attribute "stalled_timeout" for class "SoularrConfig"`. Real type errors are invisible in this noise.
+**Problem**: Tests create `CratediggerConfig` via `MagicMock()`, which means pyright can't check attribute names. About 10 pyright "errors" across test files are `Cannot assign to attribute "stalled_timeout" for class "CratediggerConfig"`. Real type errors are invisible in this noise.
 
-**Fix**: Create a `TestConfig` factory that returns a real `SoularrConfig` with test defaults:
+**Fix**: Create a `TestConfig` factory that returns a real `CratediggerConfig` with test defaults:
 
 ```python
-def make_test_config(**overrides) -> SoularrConfig:
+def make_test_config(**overrides) -> CratediggerConfig:
     defaults = {
         "slskd_download_dir": "/tmp/test_downloads",
         "stalled_timeout": 300,
@@ -18,7 +18,7 @@ def make_test_config(**overrides) -> SoularrConfig:
         ...
     }
     defaults.update(overrides)
-    return SoularrConfig(**defaults)
+    return CratediggerConfig(**defaults)
 ```
 
 Tests get `ctx.cfg.stalled_timeout = 600` → `make_test_config(stalled_timeout=600)`. Pyright catches typos at write time. The mock noise vanishes.
@@ -57,11 +57,11 @@ class CompletionResult:
 
 Or simpler: have `process_completed_album` always set status, even in the no-beets path. The safety net in `poll_active_downloads` becomes dead code.
 
-## 4. Extract soularr.py globals into a proper entry point
+## 4. Extract cratedigger.py globals into a proper entry point
 
-**Problem**: `soularr.py` uses module-level globals (`slskd`, `cfg`, `pipeline_db_source`, `search_cache`, `folder_cache`, `broken_user`) and thin closure wrappers (`_make_ctx()`, `cancel_and_delete()`, `grab_most_wanted()`) to bridge between the global state and `lib/` functions that take `SoularrContext`. Adding `poll_active_downloads` to `main()` required understanding which globals were initialized at which point.
+**Problem**: `cratedigger.py` uses module-level globals (`slskd`, `cfg`, `pipeline_db_source`, `search_cache`, `folder_cache`, `broken_user`) and thin closure wrappers (`_make_ctx()`, `cancel_and_delete()`, `grab_most_wanted()`) to bridge between the global state and `lib/` functions that take `CratediggerContext`. Adding `poll_active_downloads` to `main()` required understanding which globals were initialized at which point.
 
-**Fix**: Build `SoularrContext` once at the top of `main()` after all initialization is complete. Thread it through explicitly. Kill the closure wrappers. The search caches could live on `SoularrContext` or a new `SearchState` dataclass.
+**Fix**: Build `CratediggerContext` once at the top of `main()` after all initialization is complete. Thread it through explicitly. Kill the closure wrappers. The search caches could live on `CratediggerContext` or a new `SearchState` dataclass.
 
 This would also make integration testing the full `main()` flow possible — currently you can't test `main()` without mocking module globals.
 
@@ -90,6 +90,6 @@ This catches CHECK constraint issues, column migration bugs, and status visibili
 
 ## 7. `failed_grab` parameter is vestigial
 
-**Problem**: `process_completed_album` accepts `failed_grab: list[Any]` but never reads it. Every caller passes `[]`. It's been dead since the function was extracted from `soularr.py`.
+**Problem**: `process_completed_album` accepts `failed_grab: list[Any]` but never reads it. Every caller passes `[]`. It's been dead since the function was extracted from `cratedigger.py`.
 
 **Fix**: Remove the parameter. Update the 3 callers. One-line diff per caller.

--- a/docs/debug-runs.md
+++ b/docs/debug-runs.md
@@ -2,7 +2,7 @@
 
 ## Run 1 (14:21-14:28, PID 1654705, old code — no spectral CBR 320 check yet)
 
-First run with spectral check in import_one.py (FLAC path) and quality gate spectral awareness. CBR 320 spectral check in soularr.py was deployed mid-run so didn't apply.
+First run with spectral check in import_one.py (FLAC path) and quality gate spectral awareness. CBR 320 spectral check in cratedigger.py was deployed mid-run so didn't apply.
 
 ### Results:
 | Album | Source | Type | Spectral New | Spectral Existing | Outcome |
@@ -17,7 +17,7 @@ First run with spectral check in import_one.py (FLAC path) and quality gate spec
 
 ### Bugs found:
 1. **BUG: FLAC→V0 downgrade blocked by fake CBR 320 on disk** — Aquarium Drunkard: genuine FLAC→V0 at 227kbps blocked because beets says existing is 320kbps, but that 320 is upsampled garbage. `import_one.py` reads beets directly, doesn't know pipeline DB set `min_bitrate=0`.
-   - **Fix**: Add `--override-min-bitrate` arg to import_one.py, soularr.py passes pipeline DB `min_bitrate` value
+   - **Fix**: Add `--override-min-bitrate` arg to import_one.py, cratedigger.py passes pipeline DB `min_bitrate` value
    - **Status**: Fixed and deployed (commit d3e50ff)
 
 ### Cleanup:
@@ -28,7 +28,7 @@ First run with spectral check in import_one.py (FLAC path) and quality gate spec
 
 ## Run 2 (14:29-15:00, PID 1674348, CBR 320 spectral check deployed but --override fix ran on OLD Nix store)
 
-Mountain Goats only (non-MG deferred). Had CBR 320 spectral check in soularr.py but import_one.py was still old code (no --override-min-bitrate) because soularr was started before the deploy finished.
+Mountain Goats only (non-MG deferred). Had CBR 320 spectral check in cratedigger.py but import_one.py was still old code (no --override-min-bitrate) because cratedigger was started before the deploy finished.
 
 ### Results:
 | Album | Source | Type | Spectral New | Spectral Existing | Outcome |
@@ -48,8 +48,8 @@ Mountain Goats only (non-MG deferred). Had CBR 320 spectral check in soularr.py 
    - **Fix**: Only set album `estimated_bitrate` when album grade is `suspect` or `likely_transcode`
    - **Status**: Fixed and deployed (commit 0d888b4)
 
-3. **BUG: --override-min-bitrate not applied** — Aquarium Drunkard still blocked because soularr process loaded old Nix store code before deploy completed
-   - **Root cause**: Operational — started soularr before deploy finished
+3. **BUG: --override-min-bitrate not applied** — Aquarium Drunkard still blocked because cratedigger process loaded old Nix store code before deploy completed
+   - **Root cause**: Operational — started cratedigger before deploy finished
    - **Fix**: No code change needed, just need fresh process after deploy
    - **Status**: Next run will use correct code
 
@@ -89,7 +89,7 @@ Mountain Goats only. Both fixes deployed:
 
 1. **VBR MP3 downloads skip spectral check** — VBR bitrate IS the quality signal. A V0 file at 240kbps from genuine lossless can't be faked. Only CBR 320 and FLAC need spectral verification.
 
-2. **CBR 320 spectral check runs in soularr.py, not import_one.py** — Because CBR 320 downloads don't go through FLAC→V0 conversion, they need spectral checking at the soularr level before staging/import.
+2. **CBR 320 spectral check runs in cratedigger.py, not import_one.py** — Because CBR 320 downloads don't go through FLAC→V0 conversion, they need spectral checking at the cratedigger level before staging/import.
 
 3. **FLAC spectral check runs in import_one.py** — Informational alongside the V0 conversion. The V0 bitrate is still the primary gate for FLACs. Spectral on existing beets files reveals the "truth" about what's on disk for comparison.
 

--- a/docs/discogs-mirror.md
+++ b/docs/discogs-mirror.md
@@ -2,7 +2,7 @@
 
 ## What It Is
 
-A self-hosted mirror of the Discogs music database, serving a JSON API at `https://discogs.ablz.au`. Built in Rust, imports monthly CC0 XML dumps (~19M releases) into PostgreSQL, provides full-text search and entity lookups. Intended as the Discogs counterpart to the MusicBrainz mirror for release disambiguation in soularr-web.
+A self-hosted mirror of the Discogs music database, serving a JSON API at `https://discogs.ablz.au`. Built in Rust, imports monthly CC0 XML dumps (~19M releases) into PostgreSQL, provides full-text search and entity lookups. Intended as the Discogs counterpart to the MusicBrainz mirror for release disambiguation in cratedigger-web.
 
 - **Source repo**: https://github.com/abl030/discogs-api
 - **Live API**: https://discogs.ablz.au

--- a/docs/meelo-primer.md
+++ b/docs/meelo-primer.md
@@ -638,7 +638,7 @@ Beets (canonical tagger)
   → writes tagged files to /mnt/virtio/Music/Beets/
   → Meelo scans /mnt/virtio/Music/ (all subdirs: Beets, AI, Live, etc.)
 
-Lidarr + Soularr + slskd (download pipeline on doc2)
+Lidarr + Cratedigger + slskd (download pipeline on doc2)
   → downloads and validates music
   → beets imports to /Beets
   → Meelo picks up new files on next scan

--- a/docs/parallel-search.md
+++ b/docs/parallel-search.md
@@ -1,6 +1,6 @@
 # Parallel Soulseek Searches
 
-Soularr can overlap Soulseek searches to cut cycle time significantly.
+Cratedigger can overlap Soulseek searches to cut cycle time significantly.
 
 ## Problem
 
@@ -111,7 +111,7 @@ Note: the benchmark currently fires concurrent `search_text()` calls, which work
 | File | Role |
 |------|------|
 | `lib/search.py` | `SearchResult` dataclass |
-| `soularr.py` | `_submit_search()`, `_collect_search_results()`, `_search_and_queue_parallel()` |
+| `cratedigger.py` | `_submit_search()`, `_collect_search_results()`, `_search_and_queue_parallel()` |
 | `lib/config.py` | `parallel_searches` config field |
 | `scripts/bench_parallel_search.py` | Concurrency sweep benchmark |
 | `tests/test_slskd_live.py` | `TestParallelSearchTiming` live tests |

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -204,7 +204,7 @@ It now tier-gates the bypass:
 - `verified_lossless=True` + verdict `"worse"` → **downgrade** (blocked).
 
 This prevents a deliberately-too-low `verified_lossless_target` (Opus 64,
-Opus 48) from replacing a good existing album. The soularr process also logs
+Opus 48) from replacing a good existing album. The cratedigger process also logs
 a warning at startup when `verified_lossless_target` classifies below
 `gate_min_rank`, so operators see the contradiction before it bites.
 
@@ -284,8 +284,8 @@ Validation:
 - All codec strings are lowercased on parse — `FLAC,Alac,WAV` is identical
   to `flac,alac,wav`.
 
-Reload by restarting `soularr-web` (the web simulator reads this file on
-every request) and waiting for the next `soularr.timer` fire (5 min).
+Reload by restarting `cratedigger-web` (the web simulator reads this file on
+every request) and waiting for the next `cratedigger.timer` fire (5 min).
 
 ## Diagnostic tooling
 

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -187,7 +187,7 @@ Albums that were downloaded as FLAC, converted to V0 at or above the `cfg.mp3_vb
 
 ## TODO
 
-- [ ] Integrate spectral gradient check into pipeline (import_one.py or soularr.py)
+- [ ] Integrate spectral gradient check into pipeline (import_one.py or cratedigger.py)
 - [ ] Add spectral quality score to pipeline DB (new column) and web UI display
 - [ ] Run spectral check on CBR 320 MP3 downloads post-download
 - [ ] Run spectral check on FLACs pre-conversion to catch transcodes early

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -2,7 +2,7 @@
 
 ## What It Is
 
-A single-page web app for browsing MusicBrainz and adding album releases to the Soularr pipeline. Replaces Lidarr as the album picker. Served at `https://music.ablz.au`.
+A single-page web app for browsing MusicBrainz and adding album releases to the Cratedigger pipeline. Replaces Lidarr as the album picker. Served at `https://music.ablz.au`.
 
 ## Architecture
 
@@ -17,8 +17,8 @@ Browser → https://music.ablz.au
 ```
 
 - **No build step, no npm, no framework** — stdlib `http.server`, vanilla JS, single HTML file
-- Runs on doc2 as `soularr-web` systemd service
-- Python env shared with soularr (psycopg2, requests, etc.)
+- Runs on doc2 as `cratedigger-web` systemd service
+- Python env shared with cratedigger (psycopg2, requests, etc.)
 
 ## Files
 
@@ -69,7 +69,7 @@ Browser → https://music.ablz.au
 The upstream module declares the web options at `nix/module.nix` in this repo:
 
 ```nix
-services.soularr.web = {
+services.cratedigger.web = {
   enable = mkOption { type = types.bool; default = false; };
   port = mkOption { type = types.port; default = 8085; };
   beetsDb = mkOption { type = types.str; description = "Path to beets-library.db (read-only)"; };
@@ -80,27 +80,27 @@ services.soularr.web = {
 };
 ```
 
-Enabled in this homelab via `~/nixosconfig/hosts/doc2/configuration.nix` (and the wrapper at `~/nixosconfig/modules/nixos/services/soularr.nix` provides the redis instance + reverse proxy entry):
+Enabled in this homelab via `~/nixosconfig/hosts/doc2/configuration.nix` (and the wrapper at `~/nixosconfig/modules/nixos/services/cratedigger.nix` provides the redis instance + reverse proxy entry):
 
 ```nix
 # in hosts/doc2/configuration.nix — picks up the wrapper's defaults
-homelab.services.soularr.enable = true;
-# the wrapper sets services.soularr.web.enable = true; on its own
+homelab.services.cratedigger.enable = true;
+# the wrapper sets services.cratedigger.web.enable = true; on its own
 ```
 
 What this creates on doc2:
-- `soularr-web.service` — simple type, restart on failure, ExecStart wraps `web/server.py` with the python env from `nix/package.nix`
-- `services.redis.servers.soularr` — provided by the homelab wrapper (not the upstream module)
+- `cratedigger-web.service` — simple type, restart on failure, ExecStart wraps `web/server.py` with the python env from `nix/package.nix`
+- `services.redis.servers.cratedigger` — provided by the homelab wrapper (not the upstream module)
 - `music.ablz.au` nginx reverse proxy via `homelab.localProxy.hosts` (homelab wrapper)
 - Cloudflare DNS + ACME cert auto-provisioned
 
 ## Deployment
 
-Code changes in `web/` deploy via the normal soularr flake update:
+Code changes in `web/` deploy via the normal cratedigger flake update:
 
 ```bash
 cd ~/soularr && git add web/ && git commit -m "..." && git push
-cd ~/nixosconfig && nix flake update soularr-src && nix fmt
+cd ~/nixosconfig && nix flake update cratedigger-src && nix fmt
 git add flake.lock && git commit -m "..." && git push
 ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Cratedigger / Soularr — quality-obsessed music acquisition pipeline";
+  description = "Cratedigger — quality-obsessed music acquisition pipeline";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -32,11 +32,11 @@
       checks = forLinux ({ pkgs, system }: {
         # Boots a NixOS VM with the upstream module enabled against an
         # ephemeral postgres + a stubbed slskd. Verifies: migrator runs,
-        # config.ini is rendered correctly, soularr-web responds.
+        # config.ini is rendered correctly, cratedigger-web responds.
         moduleVm = import ./nix/tests/module-vm.nix {
           inherit pkgs system;
-          soularrModule = ./nix/module.nix;
-          soularrSrc = ./.;
+          cratediggerModule = ./nix/module.nix;
+          cratediggerSrc = ./.;
         };
       });
     };

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -902,7 +902,7 @@ def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
     """Post-import cleanup: delete the stale same-MBID album by beets id.
 
     Thin logger around ``remove_album_by_beets_id``. Always logs the
-    outcome so the import audit trail (stderr → soularr journal)
+    outcome so the import audit trail (stderr → cratedigger journal)
     shows exactly which beets row was removed and why.
     """
     _log(f"[POST-IMPORT CLEANUP] Removing stale same-MBID entry "
@@ -1037,7 +1037,7 @@ def update_pipeline_db(request_id, status, imported_path=None, distance=None, sc
     """Update pipeline DB status. Best-effort — failures logged but don't block."""
     try:
         from lib.pipeline_db import PipelineDB
-        dsn = os.environ.get("PIPELINE_DB_DSN", "postgresql://soularr@localhost/soularr")
+        dsn = os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger")
         db = PipelineDB(dsn)
         extra = {}
         if imported_path:
@@ -1537,13 +1537,13 @@ def main():
     # ``resolve_duplicate`` sees. The intra-process race is closed.
     #
     # KNOWN LIMITATION (Codex PR #131 round 6 P1): this remains
-    # vulnerable to CROSS-process races. If a second soularr process
-    # (e.g. soularr-web force-import racing an auto-import cycle)
+    # vulnerable to CROSS-process races. If a second cratedigger process
+    # (e.g. cratedigger-web force-import racing an auto-import cycle)
     # commits a same-MBID row between our ``run_import`` returning
     # and this re-enumerate query, ``max(post_import_ids)`` would
     # pick that other process's row as "new" and our cleanup would
-    # delete the one this process actually imported. Soularr.service
-    # is single-instance (``/var/lib/soularr/soularr.lock``) but the
+    # delete the one this process actually imported. Cratedigger.service
+    # is single-instance (``/var/lib/cratedigger/cratedigger.lock``) but the
     # web force-import path does not hold that lock, so the race
     # window exists in practice. Follow-up: a pipeline-level same-
     # release advisory lock shared by both entry points, tracked

--- a/lib/beets.py
+++ b/lib/beets.py
@@ -13,7 +13,7 @@ import msgspec
 from lib.quality import ValidationResult, ChooseMatchMessage
 from lib.util import beets_subprocess_env
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 def beets_validate(harness_path, album_path, mb_release_id, distance_threshold=0.15):

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -1,7 +1,7 @@
 """Beets library database queries.
 
 Read-only access to the beets SQLite DB. Centralizes all scattered
-sqlite3.connect() calls from soularr.py and import_one.py.
+sqlite3.connect() calls from cratedigger.py and import_one.py.
 
 Usage:
     with BeetsDB() as db:

--- a/lib/browse.py
+++ b/lib/browse.py
@@ -1,4 +1,4 @@
-"""Directory browsing and file filtering helpers for Soularr."""
+"""Directory browsing and file filtering helpers for Cratedigger."""
 
 from __future__ import annotations
 
@@ -6,17 +6,17 @@ import logging
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lib.config import SoularrConfig
-    from soularr import SlskdDirectory
+    from lib.config import CratediggerConfig
+    from cratedigger import SlskdDirectory
 
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 def download_filter(
     allowed_filetype: str,
     directory: SlskdDirectory,
-    download_cfg: SoularrConfig,
+    download_cfg: CratediggerConfig,
 ) -> SlskdDirectory:
     """Return a filtered directory listing without mutating the input."""
     logging.debug("download_filtering")

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -1,4 +1,4 @@
-"""Persist runtime caches across soularr runs.
+"""Persist runtime caches across cratedigger runs.
 
 Atomic save/load of folder_cache, user_upload_speed, search_dir_audio_count
 to a JSON file in var_dir. Per-entry TTL: each entry is stamped when fetched,
@@ -15,11 +15,11 @@ from datetime import datetime, timezone
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lib.context import SoularrContext
+    from lib.context import CratediggerContext
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
-CACHE_FILENAME = "soularr_cache.json"
+CACHE_FILENAME = "cratedigger_cache.json"
 FOLDER_CACHE_TTL_SECONDS = 86400  # 24 hours
 
 
@@ -27,7 +27,7 @@ def cache_path(var_dir: str) -> str:
     return os.path.join(var_dir, CACHE_FILENAME)
 
 
-def save_caches(ctx: SoularrContext, var_dir: str) -> None:
+def save_caches(ctx: CratediggerContext, var_dir: str) -> None:
     """Save persistable caches to disk. Atomic write (tmp + rename).
 
     Each entry is wrapped with its fetch timestamp for per-entry TTL eviction.
@@ -79,7 +79,7 @@ def save_caches(ctx: SoularrContext, var_dir: str) -> None:
         logger.warning("Failed to save caches", exc_info=True)
 
 
-def load_caches(ctx: SoularrContext, var_dir: str) -> None:
+def load_caches(ctx: CratediggerContext, var_dir: str) -> None:
     """Load persisted caches into ctx. Evicts entries older than TTL."""
     path = cache_path(var_dir)
     if not os.path.exists(path):

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,6 +1,6 @@
-"""Soularr configuration dataclass.
+"""Cratedigger configuration dataclass.
 
-Replaces the 50+ module-level globals in soularr.py with a single
+Replaces the 50+ module-level globals in cratedigger.py with a single
 frozen dataclass. Constructed once from config.ini via from_ini().
 """
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 # --- Secret file reader (issue #117) ---
 #
 # Secrets (slskd API key, notifier credentials) must NOT sit plaintext in the
-# rendered /var/lib/soularr/config.ini. Instead, the config stores a *_file path
+# rendered /var/lib/cratedigger/config.ini. Instead, the config stores a *_file path
 # pointing at an out-of-band secret (sops-nix, agenix, raw file, etc.) and the
 # Python pipeline reads it on demand here. The in-process cache avoids
 # re-reading on every notifier call while still picking up rotations across
@@ -55,7 +55,7 @@ def invalidate_secret_cache() -> None:
 
 
 @dataclass(frozen=True)
-class SoularrConfig:
+class CratediggerConfig:
     """All configuration values, read-only after initialization."""
 
     # --- Slskd ---
@@ -113,7 +113,7 @@ class SoularrConfig:
 
     # --- Pipeline DB ---
     pipeline_db_enabled: bool = False
-    pipeline_db_dsn: str = "postgresql://soularr@localhost/soularr"
+    pipeline_db_dsn: str = "postgresql://cratedigger@localhost/cratedigger"
 
     # --- Meelo ---
     meelo_url: Optional[str] = None
@@ -184,10 +184,10 @@ class SoularrConfig:
 
     @classmethod
     def from_ini(cls, config: configparser.RawConfigParser,
-                 config_dir: str = ".", var_dir: str = ".") -> "SoularrConfig":
-        """Parse a ConfigParser into a SoularrConfig.
+                 config_dir: str = ".", var_dir: str = ".") -> "CratediggerConfig":
+        """Parse a ConfigParser into a CratediggerConfig.
 
-        Reproduces the exact same parsing logic as main() in soularr.py.
+        Reproduces the exact same parsing logic as main() in cratedigger.py.
         """
         def get(section, key, fallback=""):
             return config.get(section, key, fallback=fallback)
@@ -272,7 +272,7 @@ class SoularrConfig:
             quality_ranks=QualityRankConfig.from_ini(config),
             # Pipeline DB
             pipeline_db_enabled=getbool("Pipeline DB", "enabled", False),
-            pipeline_db_dsn=get("Pipeline DB", "dsn", "postgresql://soularr@localhost/soularr"),
+            pipeline_db_dsn=get("Pipeline DB", "dsn", "postgresql://cratedigger@localhost/cratedigger"),
             # Meelo
             meelo_url=get("Meelo", "url") or None,
             meelo_username=get("Meelo", "username") or None,
@@ -292,27 +292,27 @@ class SoularrConfig:
             jellyfin_library_id=get("Jellyfin", "library_id") or None,
             # Paths
             var_dir=var_dir,
-            lock_file_path=os.path.join(var_dir, ".soularr.lock"),
+            lock_file_path=os.path.join(var_dir, ".cratedigger.lock"),
             config_file_path=os.path.join(config_dir, "config.ini"),
         )
 
 
-DEFAULT_RUNTIME_CONFIG_PATH = "/var/lib/soularr/config.ini"
+DEFAULT_RUNTIME_CONFIG_PATH = "/var/lib/cratedigger/config.ini"
 
 
 def _runtime_config_path(config_path: str | None = None) -> str:
     """Resolve the active runtime config.ini path."""
-    return config_path or os.environ.get("SOULARR_RUNTIME_CONFIG") or DEFAULT_RUNTIME_CONFIG_PATH
+    return config_path or os.environ.get("CRATEDIGGER_RUNTIME_CONFIG") or DEFAULT_RUNTIME_CONFIG_PATH
 
 
-def read_runtime_config(config_path: str | None = None) -> SoularrConfig:
-    """Read the active runtime config.ini into a full SoularrConfig.
+def read_runtime_config(config_path: str | None = None) -> CratediggerConfig:
+    """Read the active runtime config.ini into a full CratediggerConfig.
 
     Manual-import, force-import, the CLI, and web simulator all need the same
-    runtime config the main soularr process reads.
+    runtime config the main cratedigger process reads.
 
     Missing config (file does not exist) is a soft failure — return a default
-    SoularrConfig so callers degrade safely. This covers test environments and
+    CratediggerConfig so callers degrade safely. This covers test environments and
     the very first deploy before the prestart has rendered the file.
 
     Unreadable config (file exists but PermissionError) raises loudly. This
@@ -325,23 +325,23 @@ def read_runtime_config(config_path: str | None = None) -> SoularrConfig:
     """
     path = _runtime_config_path(config_path)
     if not path or not os.path.exists(path):
-        return SoularrConfig()
+        return CratediggerConfig()
 
     parser = configparser.RawConfigParser()
     try:
         parser.read(path)
     except configparser.Error:
-        return SoularrConfig()
+        return CratediggerConfig()
     except PermissionError as exc:
         raise PermissionError(
             f"Cannot read {path} — check file mode / group ownership. "
-            "On the upstream NixOS module, set services.soularr.configMode "
-            "(default 0600) and services.soularr.configGroup so the calling "
+            "On the upstream NixOS module, set services.cratedigger.configMode "
+            "(default 0600) and services.cratedigger.configGroup so the calling "
             "user can read it. See issue #117."
         ) from exc
 
     runtime_dir = os.path.dirname(path)
-    return SoularrConfig.from_ini(
+    return CratediggerConfig.from_ini(
         parser,
         config_dir=runtime_dir,
         var_dir=runtime_dir,
@@ -356,7 +356,7 @@ def read_runtime_rank_config(config_path: str | None = None) -> QualityRankConfi
 def read_verified_lossless_target(config_path: str | None = None) -> str:
     """Read verified_lossless_target from the runtime config file.
 
-    Manual-import and force-import run outside the main soularr process, so they
+    Manual-import and force-import run outside the main cratedigger process, so they
     need a small helper to discover the same runtime setting. Callers may pass an
     explicit path, otherwise the standard doc2 runtime config is used.
     """

--- a/lib/context.py
+++ b/lib/context.py
@@ -1,7 +1,7 @@
-"""SoularrContext — runtime state container for the pipeline engine.
+"""CratediggerContext — runtime state container for the pipeline engine.
 
-Replaces module-level globals in soularr.py. Functions extracted to
-lib/download.py, lib/import_dispatch.py, etc. receive a SoularrContext
+Replaces module-level globals in cratedigger.py. Functions extracted to
+lib/download.py, lib/import_dispatch.py, etc. receive a CratediggerContext
 as their first parameter instead of reading globals.
 """
 
@@ -12,15 +12,15 @@ from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from album_source import DatabaseSource
-    from lib.config import SoularrConfig
+    from lib.config import CratediggerConfig
 
 
 @dataclass
-class SoularrContext:
+class CratediggerContext:
     """All runtime state needed by the pipeline engine."""
 
     # --- Core dependencies (set once in main()) ---
-    cfg: SoularrConfig
+    cfg: CratediggerConfig
     slskd: Any  # slskd_api.SlskdClient — Any to avoid import
     pipeline_db_source: DatabaseSource
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -1,6 +1,6 @@
 """Download processing — monitoring, completion, and orchestration.
 
-Extracted from soularr.py. All functions receive a SoularrContext
+Extracted from cratedigger.py. All functions receive a CratediggerContext
 instead of reading module-level globals.
 """
 
@@ -26,10 +26,10 @@ from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
                       log_validation_result)
 
 if TYPE_CHECKING:
-    from lib.context import SoularrContext
+    from lib.context import CratediggerContext
     from lib.quality import ValidationResult
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 MAX_FILE_RETRIES = 5
 
 
@@ -42,7 +42,7 @@ def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
 
 # === slskd transfer helpers ===
 
-def cancel_and_delete(files: list[Any], ctx: SoularrContext) -> None:
+def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> None:
     """Cancel downloads and remove their directories."""
     for file in files:
         if not file.id:
@@ -57,7 +57,7 @@ def cancel_and_delete(files: list[Any], ctx: SoularrContext) -> None:
             shutil.rmtree(delete_dir)
 
 
-def slskd_download_status(downloads: list[Any], ctx: SoularrContext,
+def slskd_download_status(downloads: list[Any], ctx: CratediggerContext,
                           *, snapshot: list[dict[str, Any]] | None = None) -> bool:
     """Get status of each download file from slskd API.
 
@@ -85,7 +85,7 @@ def slskd_download_status(downloads: list[Any], ctx: SoularrContext,
 
 
 def slskd_do_enqueue(username: str, files: list[dict[str, Any]],
-                     file_dir: str, ctx: SoularrContext) -> list[DownloadFile] | None:
+                     file_dir: str, ctx: CratediggerContext) -> list[DownloadFile] | None:
     """Enqueue files for download via slskd. Returns DownloadFile list or None."""
     try:
         enqueue = ctx.slskd.transfers.enqueue(username=username, files=files)
@@ -177,7 +177,7 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 # === Download completion processing ===
 
 def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
-                            ctx: SoularrContext) -> bool:
+                            ctx: CratediggerContext) -> bool:
     """Process a fully-downloaded album: move files, tag, validate, stage/import."""
     import_folder_name = sanitize_folder_name(
         f"{album_data.artist} - {album_data.title} ({album_data.year})")
@@ -241,7 +241,7 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
 
 
 def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath: str,
-                              ctx: SoularrContext) -> None:
+                              ctx: CratediggerContext) -> None:
     """Beets validation sub-path of process_completed_album.
 
     After beets validation passes, delegates to ``lib.preimport.run_preimport_gates``
@@ -292,7 +292,7 @@ def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath:
 
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                          import_folder_fullpath: str,
-                         ctx: SoularrContext) -> None:
+                         ctx: CratediggerContext) -> None:
     """Handle a valid beets validation result: stage and optionally auto-import."""
     dest = stage_to_ai(album_data, import_folder_fullpath, ctx.cfg.beets_staging_dir)
     log_validation_result(album_data, bv_result, ctx.cfg, dest_path=dest)
@@ -321,7 +321,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
 
 def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResult,
                             import_folder_fullpath: str,
-                            ctx: SoularrContext) -> None:
+                            ctx: CratediggerContext) -> None:
     """Handle a rejected beets validation result."""
     failed_dest = move_failed_import(import_folder_fullpath, scenario=bv_result.scenario)
     bv_result.failed_path = failed_dest
@@ -356,7 +356,7 @@ def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResu
 
 
 def _compute_rejection_backfill(album_data: GrabListEntry,
-                                ctx: SoularrContext) -> str | None:
+                                ctx: CratediggerContext) -> str | None:
     """Check if search_filetype_override should be backfilled on rejection.
 
     Only fires when search_filetype_override is currently NULL and the on-disk state
@@ -618,7 +618,7 @@ def _timeout_album(
     entry: GrabListEntry,
     request_id: int,
     reason: str,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> None:
     """Handle download timeout: cancel, log, reset to wanted."""
     cancel_and_delete(entry.files, ctx)
@@ -715,7 +715,7 @@ def _run_completed_processing(
     request_id: int,
     state: ActiveDownloadState,
     db: Any,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> None:
     """Run or resume local post-download processing for a completed album."""
     if state.processing_started_at is None:
@@ -744,7 +744,7 @@ def _run_completed_processing(
                              attempt_type="download")
 
 
-def poll_active_downloads(ctx: SoularrContext) -> None:
+def poll_active_downloads(ctx: CratediggerContext) -> None:
     """Poll slskd for status of all downloading albums.
 
     For each album with status='downloading':
@@ -918,7 +918,7 @@ def poll_active_downloads(ctx: SoularrContext) -> None:
 
 def grab_most_wanted(albums: list[Any],
                      search_and_queue: Callable[..., tuple[dict, list, list]],
-                     ctx: SoularrContext) -> int:
+                     ctx: CratediggerContext) -> int:
     """Search, enqueue, persist download state, return immediately.
 
     Does NOT block waiting for downloads. Download monitoring happens

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -1,4 +1,4 @@
-"""Release selection and enqueue helpers extracted from soularr.py."""
+"""Release selection and enqueue helpers extracted from cratedigger.py."""
 
 from __future__ import annotations
 
@@ -12,12 +12,12 @@ from lib.grab_list import GrabListEntry
 from lib.matching import check_for_match, get_album_by_id
 
 if TYPE_CHECKING:
-    from soularr import SlskdDirectory, TrackRecord
-    from lib.config import SoularrConfig
-    from lib.context import SoularrContext
+    from cratedigger import SlskdDirectory, TrackRecord
+    from lib.config import CratediggerConfig
+    from lib.context import CratediggerContext
 
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 @dataclass(frozen=True)
@@ -61,7 +61,7 @@ def release_trackcount_mode(releases: list[Any]) -> Any:
 def choose_release(
     artist_name: str,
     releases: list[Any],
-    release_cfg: SoularrConfig,
+    release_cfg: CratediggerConfig,
 ) -> Any:
     """Choose the best release candidate to try first."""
     most_common_trackcount = release_trackcount_mode(releases)
@@ -127,7 +127,7 @@ def choose_release(
     return releases[0]
 
 
-def _get_denied_users(album_id: int, ctx: SoularrContext) -> set[str]:
+def _get_denied_users(album_id: int, ctx: CratediggerContext) -> set[str]:
     """Get denied users from the pipeline DB source_denylist."""
     request_id = abs(album_id)
     if request_id in ctx.denied_users_cache:
@@ -172,7 +172,7 @@ def _prefixed_directory_files(
     ]
 
 
-def get_album_tracks(album: Any, ctx: SoularrContext) -> list[TrackRecord]:
+def get_album_tracks(album: Any, ctx: CratediggerContext) -> list[TrackRecord]:
     """Get tracks for an album from the pipeline DB source."""
     return cast("list[TrackRecord]", ctx.pipeline_db_source.get_tracks(album))
 
@@ -181,7 +181,7 @@ def try_enqueue(
     all_tracks: Sequence[TrackRecord],
     results: dict[str, dict[str, list[str]]],
     allowed_filetype: str,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> EnqueueAttempt:
     """Single album match and enqueue."""
     album_id = all_tracks[0]["albumId"]
@@ -248,7 +248,7 @@ def try_multi_enqueue(
     all_tracks: Sequence[TrackRecord],
     results: dict[str, dict[str, list[str]]],
     allowed_filetype: str,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> EnqueueAttempt:
     """Locate and enqueue a multi-disc album."""
     split_release: list[dict[str, Any]] = []
@@ -347,7 +347,7 @@ def _try_filetype(
     results: dict[str, dict[str, list[str]]],
     allowed_filetype: str,
     grab_list: dict[int, GrabListEntry],
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> FindDownloadResult:
     """Try to match and enqueue an album at a specific filetype quality."""
     album_id = album.id
@@ -413,7 +413,7 @@ def _try_filetype(
 def find_download(
     album: Any,
     grab_list: dict[int, GrabListEntry],
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> FindDownloadResult:
     """Walk search results and enqueue the best matching download."""
     album_id = album.id

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -1,6 +1,6 @@
 """Import dispatch — auto-import decision tree.
 
-Extracted from soularr.py process_completed_album(). Contains the logic
+Extracted from cratedigger.py process_completed_album(). Contains the logic
 that runs import_one.py and dispatches on the ImportResult decision.
 """
 
@@ -26,13 +26,13 @@ from lib.util import (beets_subprocess_env, cleanup_disambiguation_orphans,
 from lib.preimport import inspect_local_files, run_preimport_gates
 
 if TYPE_CHECKING:
-    from lib.config import SoularrConfig
-    from lib.context import SoularrContext
+    from lib.config import CratediggerConfig
+    from lib.context import CratediggerContext
     from lib.grab_list import GrabListEntry
     from lib.pipeline_db import PipelineDB
     from lib.quality import AudioQualityMeasurement, QualityRankConfig
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 # Scenarios whose ``path`` is the user's source data (``failed_imports/…``),
@@ -490,7 +490,7 @@ def dispatch_import_core(
     distance: float = 0.0,
     scenario: str = "auto_import",
     files: Sequence[object] | None = None,
-    cfg: "SoularrConfig | None" = None,
+    cfg: "CratediggerConfig | None" = None,
     outcome_label: str = "success",
     requeue_on_failure: bool = True,
     cooled_down_users: set[str] | None = None,
@@ -770,7 +770,7 @@ def dispatch_import_core(
 
 def dispatch_import(album_data: "GrabListEntry", bv_result: ValidationResult, dest: str,
                     dl_info: DownloadInfo, request_id: int,
-                    ctx: "SoularrContext", *, force: bool = False) -> None:
+                    ctx: "CratediggerContext", *, force: bool = False) -> None:
     """Import decision tree — thin adapter extracting plain params for the core.
 
     Called from process_completed_album() for auto-import.

--- a/lib/import_service.py
+++ b/lib/import_service.py
@@ -12,7 +12,7 @@ import logging
 
 from lib.quality import ImportResult
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 def _apply_request_spectral_fields(

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -1,4 +1,4 @@
-"""Matching helpers extracted from soularr.py."""
+"""Matching helpers extracted from cratedigger.py."""
 
 from __future__ import annotations
 
@@ -11,15 +11,15 @@ from lib.browse import _browse_directories, rank_candidate_dirs
 from lib.util import _track_titles_cross_check
 
 if TYPE_CHECKING:
-    from lib.config import SoularrConfig
-    from lib.context import SoularrContext
-    from soularr import SlskdDirectory, SlskdFile, TrackRecord
+    from lib.config import CratediggerConfig
+    from lib.context import CratediggerContext
+    from cratedigger import SlskdDirectory, SlskdFile, TrackRecord
 
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
-def get_album_by_id(album_id: int, ctx: SoularrContext) -> Any:
+def get_album_by_id(album_id: int, ctx: CratediggerContext) -> Any:
     """Get album data by ID from the context cache."""
     if album_id in ctx.current_album_cache:
         return ctx.current_album_cache[album_id]
@@ -31,7 +31,7 @@ def album_match(
     slskd_tracks: Sequence[SlskdFile],
     username: str,
     filetype: str,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> bool:
     """Check whether the browsed directory matches the expected album."""
     match_cfg = ctx.cfg
@@ -132,7 +132,7 @@ def check_ratio(
 
 def album_track_num(
     directory: SlskdDirectory,
-    match_cfg: SoularrConfig,
+    match_cfg: CratediggerConfig,
 ) -> dict[str, Any]:
     """Count matching audio tracks and infer a consistent filetype."""
     from lib.quality import AUDIO_EXTENSIONS as _all_audio_exts
@@ -173,7 +173,7 @@ def check_for_match(
     allowed_filetype: str,
     file_dirs: list[str],
     username: str,
-    ctx: SoularrContext,
+    ctx: CratediggerContext,
 ) -> tuple[bool, Any, str]:
     """Check candidate directories for an album match."""
     logger.debug(f"Current broken users {ctx.broken_user}")

--- a/lib/migrator.py
+++ b/lib/migrator.py
@@ -12,7 +12,7 @@ Migration filename format: ``NNN_short_name.sql``, e.g.::
 Adding a schema change is a single PR step:
 
     1. Create the next-numbered ``.sql`` file in ``migrations/``.
-    2. The deploy systemd unit (``soularr-db-migrate.service``) will run it
+    2. The deploy systemd unit (``cratedigger-db-migrate.service``) will run it
        on the next ``nixos-rebuild switch`` via :func:`apply_migrations`.
 
 The migrator never edits or re-runs an applied migration. If you need to

--- a/lib/permissions.py
+++ b/lib/permissions.py
@@ -32,7 +32,7 @@ LIBRARY_DIR_MODE = 0o777
 def reset_umask() -> None:
     """Set the process umask to 0, matching the systemd unit's UMask=0000.
 
-    Call this at every pipeline entry point (soularr.py main(), import_one.py
+    Call this at every pipeline entry point (cratedigger.py main(), import_one.py
     main(), beets_harness.py main()) so subprocesses further down the chain
     inherit it. Do NOT call this at module-import time — the umask is
     process-wide and would leak into any code that imports the module.

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -6,7 +6,7 @@ connect over the network — no more SQLite file locking issues on virtiofs.
 
 Usage:
     from lib.pipeline_db import PipelineDB
-    db = PipelineDB("postgresql://soularr@192.168.1.35/soularr")
+    db = PipelineDB("postgresql://cratedigger@192.168.1.35/cratedigger")
     db.add_request(mb_release_id="...", artist_name="...", album_title="...", source="redownload")
 """
 
@@ -21,7 +21,7 @@ import psycopg2.extras
 
 from lib.quality import CooldownConfig, SpectralMeasurement, should_cooldown
 
-DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN", "postgresql://soularr@localhost/soularr")
+DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger")
 
 # Exponential backoff: base_minutes * 2^(attempts-1), capped at max
 BACKOFF_BASE_MINUTES = 30
@@ -35,7 +35,7 @@ ADVISORY_LOCK_NAMESPACE_IMPORT = 0x46494D50
 
 # Schema is managed by lib/migrator.py via numbered files in migrations/.
 # PipelineDB itself never runs DDL — see scripts/migrate_db.py and the
-# soularr-db-migrate.service systemd unit (Nix module).
+# cratedigger-db-migrate.service systemd unit (Nix module).
 
 
 @dataclass(frozen=True)
@@ -61,7 +61,7 @@ class PipelineDB:
 
     Schema migrations are NOT this class's responsibility. They live in
     ``migrations/*.sql`` and are applied by ``lib.migrator.apply_migrations``,
-    which the deploy systemd unit ``soularr-db-migrate.service`` runs on every
+    which the deploy systemd unit ``cratedigger-db-migrate.service`` runs on every
     ``nixos-rebuild switch``. Construct this class against an already-migrated
     database.
     """

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -28,10 +28,10 @@ from lib.quality import (SPECTRAL_TRANSCODE_GRADES, SpectralMeasurement,
 from lib.util import repair_mp3_headers, validate_audio
 
 if TYPE_CHECKING:
-    from lib.config import SoularrConfig
+    from lib.config import CratediggerConfig
     from lib.pipeline_db import PipelineDB
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 # Lazy import proxy — keeps sox out of import-time deps.
@@ -196,7 +196,7 @@ def _needs_spectral_check(
 
 def _analyze_existing(
     mb_release_id: str,
-    cfg: "SoularrConfig",
+    cfg: "CratediggerConfig",
 ) -> tuple[int | None, SpectralMeasurement | None]:
     """Look up existing beets album and spectral-analyze its files.
 
@@ -286,7 +286,7 @@ def run_preimport_gates(
     download_filetype: str,
     download_min_bitrate_bps: int | None,
     download_is_vbr: bool | None,
-    cfg: "SoularrConfig",
+    cfg: "CratediggerConfig",
     db: "PipelineDB | None" = None,
     request_id: int | None = None,
     usernames: set[str] | None = None,
@@ -320,7 +320,7 @@ def run_preimport_gates(
             files, in bps (or kbps if < 1000). Normalized internally.
         download_is_vbr: True when any file in the download reports VBR.
             Spectral check is skipped for VBR MP3s.
-        cfg: Runtime SoularrConfig (for ``audio_check_mode`` and
+        cfg: Runtime CratediggerConfig (for ``audio_check_mode`` and
             ``quality_ranks``).
         db: Pipeline DB — pass to enable denylist + spectral state side effects.
         request_id: Required when ``db`` is supplied.

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1,7 +1,7 @@
 """Quality decision logic for the download pipeline.
 
 Pure functions — no database, no filesystem, no external dependencies.
-Used by soularr.py and import_one.py, tested directly against real audio fixtures.
+Used by cratedigger.py and import_one.py, tested directly against real audio fixtures.
 """
 
 import configparser
@@ -370,7 +370,7 @@ class ValidationResult:
     Accumulated through the validation pipeline:
     1. beets_validate() populates candidates, distance, scenario
     2. Audio integrity check may set scenario=audio_corrupt + corrupt_files
-    3. soularr.py populates source info (username, folder, failed_path, denylisted)
+    3. cratedigger.py populates source info (username, folder, failed_path, denylisted)
 
     Stored in download_log.validation_result (JSONB) for complete auditability.
     """
@@ -387,7 +387,7 @@ class ValidationResult:
     local_track_count: Optional[int] = None
     recommendation: Optional[str] = None        # beets confidence: "strong", "medium", "none"
     path: Optional[str] = None                  # album path being validated
-    # Source info (populated by soularr.py)
+    # Source info (populated by cratedigger.py)
     soulseek_username: Optional[str] = None
     download_folder: Optional[str] = None
     failed_path: Optional[str] = None
@@ -551,7 +551,7 @@ class ActiveDownloadState:
 class DownloadInfo:
     """Audio quality metadata extracted from downloaded files.
 
-    Replaces the untyped dl_info dict that was passed through soularr.py,
+    Replaces the untyped dl_info dict that was passed through cratedigger.py,
     album_source.py, and pipeline_db.py. Every field that ends up in
     download_log has a typed slot here.
     """
@@ -1359,7 +1359,7 @@ class ImportResult:
     """Structured result emitted by import_one.py as JSON.
 
     Carries every piece of data that crosses the subprocess boundary
-    from import_one.py back to soularr.py. Stored in download_log.import_result
+    from import_one.py back to cratedigger.py. Stored in download_log.import_result
     for complete auditability.
 
     new_measurement / existing_measurement carry the coherent quality state
@@ -1769,7 +1769,7 @@ def is_verified_lossless(was_converted: bool, original_filetype: Optional[str],
 
 
 # ---------------------------------------------------------------------------
-# Post-import quality gate (runs after successful import in soularr.py)
+# Post-import quality gate (runs after successful import in cratedigger.py)
 # ---------------------------------------------------------------------------
 
 def gate_rank(

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from lib.pipeline_db import PipelineDB
 
 
-log = logging.getLogger("soularr")
+log = logging.getLogger("cratedigger")
 
 
 SelectorFailureReason = Literal["timeout", "nonzero_rc", "exception"]

--- a/lib/transitions.py
+++ b/lib/transitions.py
@@ -16,7 +16,7 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from lib.pipeline_db import PipelineDB
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 @dataclass(frozen=True)

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,4 +1,4 @@
-"""Utility functions for the Soularr pipeline.
+"""Utility functions for the Cratedigger pipeline.
 
 Pure utilities with no dependency on module-level globals.
 Functions that need config receive it as a parameter.
@@ -19,11 +19,11 @@ from datetime import datetime
 from typing import Any, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lib.config import SoularrConfig
+    from lib.config import CratediggerConfig
     from lib.grab_list import GrabListEntry
     from lib.quality import ValidationResult
 
-logger = logging.getLogger("soularr")
+logger = logging.getLogger("cratedigger")
 
 
 @dataclass
@@ -63,7 +63,7 @@ def beets_subprocess_env() -> dict[str, str]:
     and import_one.py). Single source of truth for the HOME override.
 
     Beets resolves its config from `$HOME/.config/beets/config.yaml`. The
-    soularr systemd service runs as root with HOME=/root; the Nix Home
+    cratedigger systemd service runs as root with HOME=/root; the Nix Home
     Manager beets config (including the Discogs plugin token and the patched
     base URL for the local Discogs mirror) lives at /home/abl030/.config/.
     Without the override, the Discogs plugin silently returns 0 candidates
@@ -412,7 +412,7 @@ def _meelo_scanner_post(url: str, jwt: str, path: str) -> None:
         resp.read()
 
 
-def trigger_meelo_scan(cfg: SoularrConfig) -> None:
+def trigger_meelo_scan(cfg: CratediggerConfig) -> None:
     """Trigger a Meelo library scan after import. Best-effort — failures don't block."""
     if not cfg.meelo_url:
         return
@@ -428,7 +428,7 @@ def trigger_meelo_scan(cfg: SoularrConfig) -> None:
         logger.warning(f"MEELO: scan trigger failed: {e}")
 
 
-def trigger_meelo_clean(cfg: SoularrConfig) -> None:
+def trigger_meelo_clean(cfg: CratediggerConfig) -> None:
     """Trigger a Meelo library clean to remove orphaned entries. Best-effort."""
     if not cfg.meelo_url:
         return
@@ -447,7 +447,7 @@ def trigger_meelo_clean(cfg: SoularrConfig) -> None:
 # === Plex integration ===
 
 
-def trigger_plex_scan(cfg: SoularrConfig, imported_path: str | None = None) -> None:
+def trigger_plex_scan(cfg: CratediggerConfig, imported_path: str | None = None) -> None:
     """Trigger a Plex library scan after import. Best-effort — failures don't block.
 
     If imported_path is provided, does a targeted partial scan of just that folder.
@@ -490,7 +490,7 @@ def trigger_plex_scan(cfg: SoularrConfig, imported_path: str | None = None) -> N
 # === Jellyfin integration ===
 
 
-def trigger_jellyfin_scan(cfg: SoularrConfig) -> None:
+def trigger_jellyfin_scan(cfg: CratediggerConfig) -> None:
     """Trigger a Jellyfin library scan after import. Best-effort — failures don't block.
 
     If jellyfin_library_id is set, refreshes just that library item.
@@ -526,7 +526,7 @@ def trigger_jellyfin_scan(cfg: SoularrConfig) -> None:
 # === Validation logging ===
 
 def log_validation_result(album_data: GrabListEntry, result: ValidationResult,
-                          cfg: SoularrConfig,
+                          cfg: CratediggerConfig,
                           dest_path: str | None = None) -> None:
     """Append beets validation result to tracking JSONL."""
     entry = {

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -17,11 +17,11 @@
 
 -- Idle-in-transaction safety net: kill anything sitting on a transaction
 -- for more than 60 seconds. Wrapped in a DO block so it does not abort the
--- migration when the soularr role does not exist (ephemeral test DBs) or
+-- migration when the cratedigger role does not exist (ephemeral test DBs) or
 -- the migrating user lacks ALTER ROLE privilege.
 DO $$
 BEGIN
-    ALTER ROLE soularr SET idle_in_transaction_session_timeout = '60s';
+    ALTER ROLE cratedigger SET idle_in_transaction_session_timeout = '60s';
 EXCEPTION
     WHEN undefined_object THEN NULL;
     WHEN insufficient_privilege THEN NULL;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,12 +1,12 @@
-# Upstream NixOS module for Soularr / Cratedigger.
+# Upstream NixOS module for Cratedigger.
 #
 # Generic, paths-as-options, no sops/homelab/nspawn assumptions. Downstream
 # wrappers (e.g. ~/nixosconfig) layer their secrets backend, DB host, and
 # reverse-proxy on top via standard NixOS option merging.
 #
-# Identity defaults to root because slskd downloads land outside the soularr
+# Identity defaults to root because slskd downloads land outside the cratedigger
 # user's home and beets needs broad filesystem access. Override with
-# `services.soularr.user` / `services.soularr.group` if you're hardened.
+# `services.cratedigger.user` / `services.cratedigger.group` if you're hardened.
 {
   config,
   lib,
@@ -15,7 +15,7 @@
 }: let
   inherit (lib) mkOption mkEnableOption mkIf optionalString types concatStringsSep;
 
-  cfg = config.services.soularr;
+  cfg = config.services.cratedigger;
   src = cfg.src;
 
   # Same python env the dev shell uses — single source of truth.
@@ -36,9 +36,9 @@
   ];
 
   # CLI wrappers — the only place PYTHONPATH is set.
-  soularrPkg = pkgs.writeShellScriptBin "soularr" ''
+  cratediggerPkg = pkgs.writeShellScriptBin "cratedigger" ''
     export PATH="${runtimePath}:$PATH"
-    exec ${pythonEnv}/bin/python ${src}/soularr.py "$@"
+    exec ${pythonEnv}/bin/python ${src}/cratedigger.py "$@"
   '';
 
   pipelineCli = pkgs.writeShellScriptBin "pipeline-cli" ''
@@ -55,7 +55,7 @@
       --migrations-dir "${src}/migrations" "$@"
   '';
 
-  webPkg = pkgs.writeShellScriptBin "soularr-web" ''
+  webPkg = pkgs.writeShellScriptBin "cratedigger-web" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:${src}/lib:${src}/web:''${PYTHONPATH:-}"
     exec ${pythonEnv}/bin/python ${src}/web/server.py \
@@ -89,11 +89,11 @@
       ${bandSection "aac" qr.bands.aac}
     '';
 
-  # Issue #117: secrets live at the *File paths referenced here. The soularr
-  # Python code reads them on demand via SoularrConfig.resolved_*() accessors,
+  # Issue #117: secrets live at the *File paths referenced here. The cratedigger
+  # Python code reads them on demand via CratediggerConfig.resolved_*() accessors,
   # so nothing sensitive is ever embedded in config.ini and the file can be
   # world-readable (see absence of chmod/chgrp in preStartScript).
-  configTemplate = pkgs.writeText "soularr-config.ini" ''
+  configTemplate = pkgs.writeText "cratedigger-config.ini" ''
     [Slskd]
     api_key_file = ${cfg.slskd.apiKeyFile}
     host_url = ${cfg.slskd.hostUrl}
@@ -170,17 +170,17 @@
   # no chmod dance, no sed substitution, and no group-ownership hack. The
   # secrets themselves still need to be readable by cfg.user at whatever paths
   # slskd.apiKeyFile / notifiers.*.{username,password,token}File point to.
-  preStartScript = pkgs.writeShellScript "soularr-prestart" ''
+  preStartScript = pkgs.writeShellScript "cratedigger-prestart" ''
     set -euo pipefail
     config_dir="${cfg.stateDir}"
     mkdir -p "$config_dir"
     ${pkgs.coreutils}/bin/install -m 0644 ${configTemplate} "$config_dir/config.ini"
-    rm -f "$config_dir/.soularr.lock"
+    rm -f "$config_dir/.cratedigger.lock"
   '';
 
   # Optional health check for a stuck slskd reconnect loop. Generic — the
   # restart command is configurable so non-systemd slskd setups still work.
-  slskdHealthCheck = pkgs.writeShellScript "soularr-slskd-healthcheck" ''
+  slskdHealthCheck = pkgs.writeShellScript "cratedigger-slskd-healthcheck" ''
     set -euo pipefail
     api_key=$(${pkgs.coreutils}/bin/cat "${cfg.slskd.apiKeyFile}")
     status=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $api_key" "${cfg.slskd.hostUrl}/api/v0/server" 2>/dev/null || echo '{}')
@@ -189,21 +189,21 @@
     if [ "$connected" = "true" ] && [ "$logged_in" = "true" ]; then
       exit 0
     fi
-    echo "soularr: slskd not connected (connected=$connected, loggedIn=$logged_in)" >&2
+    echo "cratedigger: slskd not connected (connected=$connected, loggedIn=$logged_in)" >&2
     ${optionalString (cfg.healthCheck.onFailureCommand != "") ''
-      echo "soularr: running onFailureCommand to recover slskd..." >&2
+      echo "cratedigger: running onFailureCommand to recover slskd..." >&2
       ${cfg.healthCheck.onFailureCommand}
       for i in $(${pkgs.coreutils}/bin/seq 1 12); do
         ${pkgs.coreutils}/bin/sleep 5
         status=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $api_key" "${cfg.slskd.hostUrl}/api/v0/server" 2>/dev/null || echo '{}')
         logged_in=$(echo "$status" | ${pkgs.jq}/bin/jq -r '.isLoggedIn // false')
         if [ "$logged_in" = "true" ]; then
-          echo "soularr: slskd reconnected after recovery" >&2
+          echo "cratedigger: slskd reconnected after recovery" >&2
           exit 0
         fi
       done
     ''}
-    echo "soularr: slskd unhealthy, skipping run" >&2
+    echo "cratedigger: slskd unhealthy, skipping run" >&2
     exit 1
   '';
 
@@ -231,23 +231,23 @@
     };
   };
 in {
-  options.services.soularr = {
-    enable = mkEnableOption "Soularr — Soulseek download pipeline";
+  options.services.cratedigger = {
+    enable = mkEnableOption "Cratedigger — Soulseek download pipeline";
 
     src = mkOption {
       type = types.path;
       default = ../.;
       defaultText = lib.literalExpression "../.";
-      description = "Path to the soularr source tree. Defaults to this flake's repo root.";
+      description = "Path to the cratedigger source tree. Defaults to this flake's repo root.";
     };
 
     user = mkOption {
       type = types.str;
       default = "root";
       description = ''
-        UNIX user to run soularr as. Defaults to root because slskd downloads
+        UNIX user to run cratedigger as. Defaults to root because slskd downloads
         and the beets library typically live outside any service-user home and
-        soularr needs broad read/write access. Override only if you've set up
+        cratedigger needs broad read/write access. Override only if you've set up
         the surrounding permissions (slskd group membership, beets DB
         ownership, /Incoming write access, etc.) for an unprivileged user.
       '';
@@ -256,12 +256,12 @@ in {
     group = mkOption {
       type = types.str;
       default = "root";
-      description = "UNIX group to run soularr as. See `user` for context.";
+      description = "UNIX group to run cratedigger as. See `user` for context.";
     };
 
     stateDir = mkOption {
       type = types.str;
-      default = "/var/lib/soularr";
+      default = "/var/lib/cratedigger";
       description = "Runtime state directory (config.ini, lock file).";
     };
 
@@ -269,7 +269,7 @@ in {
       enable = mkOption {
         type = types.bool;
         default = true;
-        description = "Run soularr periodically via systemd timer.";
+        description = "Run cratedigger periodically via systemd timer.";
       };
       onBootSec = mkOption {
         type = types.str;
@@ -288,7 +288,7 @@ in {
         type = types.path;
         description = ''
           Path to a file containing the slskd API key (raw, no envvar prefix).
-          Must be readable by services.soularr.user. Use sops/agenix or any
+          Must be readable by services.cratedigger.user. Use sops/agenix or any
           out-of-band mechanism — the module just reads the file at runtime.
 
           Since issue #117 this path is written directly into config.ini and
@@ -337,7 +337,7 @@ in {
       };
       dsn = mkOption {
         type = types.str;
-        example = "postgresql://soularr@localhost/soularr";
+        example = "postgresql://cratedigger@localhost/cratedigger";
         description = "PostgreSQL connection string for the pipeline DB.";
       };
     };
@@ -403,8 +403,8 @@ in {
 
     # Notifier credential *File options follow the same contract as
     # slskd.apiKeyFile (issue #117): paths written into config.ini, read on
-    # demand by SoularrConfig.resolved_*(). They must be readable by
-    # services.soularr.user. If the operator also triggers imports via
+    # demand by CratediggerConfig.resolved_*(). They must be readable by
+    # services.cratedigger.user. If the operator also triggers imports via
     # pipeline-cli from a non-root shell, the same files must be readable
     # by that user too, otherwise notifier scans silently no-op after
     # CLI-triggered imports (the import itself still succeeds).
@@ -473,7 +473,7 @@ in {
         example = "systemctl restart slskd.service";
         description = ''
           Shell command to run when the health check fails. Empty = log and skip
-          the run. The command is invoked as root (or services.soularr.user) and
+          the run. The command is invoked as root (or services.cratedigger.user) and
           retries are attempted for up to a minute after it returns.
         '';
       };
@@ -597,15 +597,15 @@ in {
     assertions = [
       {
         assertion = !cfg.notifiers.meelo.enable || (cfg.notifiers.meelo.usernameFile != null && cfg.notifiers.meelo.passwordFile != null && cfg.notifiers.meelo.url != "");
-        message = "services.soularr.notifiers.meelo: enable requires url, usernameFile, and passwordFile";
+        message = "services.cratedigger.notifiers.meelo: enable requires url, usernameFile, and passwordFile";
       }
       {
         assertion = !cfg.notifiers.plex.enable || (cfg.notifiers.plex.tokenFile != null && cfg.notifiers.plex.url != "");
-        message = "services.soularr.notifiers.plex: enable requires url and tokenFile";
+        message = "services.cratedigger.notifiers.plex: enable requires url and tokenFile";
       }
       {
         assertion = !cfg.notifiers.jellyfin.enable || (cfg.notifiers.jellyfin.tokenFile != null && cfg.notifiers.jellyfin.url != "");
-        message = "services.soularr.notifiers.jellyfin: enable requires url and tokenFile";
+        message = "services.cratedigger.notifiers.jellyfin: enable requires url and tokenFile";
       }
     ];
 
@@ -615,7 +615,7 @@ in {
       ${cfg.user} = {
         isSystemUser = true;
         group = cfg.group;
-        description = "Soularr service user";
+        description = "Cratedigger service user";
       };
     };
     users.groups = mkIf (cfg.group != "root") {
@@ -631,11 +631,11 @@ in {
       "d ${cfg.stateDir} 0755 ${cfg.user} ${cfg.group} -"
     ];
 
-    # Schema migrator. RemainAfterExit=true so soularr / soularr-web can
+    # Schema migrator. RemainAfterExit=true so cratedigger / cratedigger-web can
     # require us without re-running on every cycle. Idempotent — fast no-op
     # when schema is already current.
-    systemd.services.soularr-db-migrate = {
-      description = "Apply Soularr pipeline DB schema migrations";
+    systemd.services.cratedigger-db-migrate = {
+      description = "Apply Cratedigger pipeline DB schema migrations";
       wantedBy = ["multi-user.target"];
       restartIfChanged = true;
       serviceConfig = {
@@ -648,16 +648,16 @@ in {
       };
     };
 
-    systemd.services.soularr = {
-      description = "Soularr — Soulseek download pipeline";
-      after = ["soularr-db-migrate.service"];
-      requires = ["soularr-db-migrate.service"];
+    systemd.services.cratedigger = {
+      description = "Cratedigger — Soulseek download pipeline";
+      after = ["cratedigger-db-migrate.service"];
+      requires = ["cratedigger-db-migrate.service"];
       restartIfChanged = false;
       # Deliberately exclude pythonEnv: it ships a `beet` binary (because
       # `pkgs.beets` is in pythonEnv for the dev shell + tests), and putting
       # it on PATH shadows whatever `beet` the consumer has provisioned for
       # the harness wrapper to find. The python interpreter is invoked via
-      # absolute path inside soularrPkg / pipelineCli, so it doesn't need
+      # absolute path inside cratediggerPkg / pipelineCli, so it doesn't need
       # to be on PATH. The harness wrapper at harness/run_beets_harness.sh
       # uses `command -v beet` to find a beets installation that already
       # has the consumer's plugins/config (e.g. home-manager).
@@ -669,13 +669,13 @@ in {
         UMask = "0000";
         ExecStartPre = lib.optional cfg.healthCheck.enable slskdHealthCheck ++ [preStartScript];
         Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
-        ExecStart = "${soularrPkg}/bin/soularr";
+        ExecStart = "${cratediggerPkg}/bin/cratedigger";
         WorkingDirectory = cfg.stateDir;
       };
     };
 
-    systemd.timers.soularr = mkIf cfg.timer.enable {
-      description = "Soularr periodic run timer";
+    systemd.timers.cratedigger = mkIf cfg.timer.enable {
+      description = "Cratedigger periodic run timer";
       wantedBy = ["timers.target"];
       timerConfig = {
         OnBootSec = cfg.timer.onBootSec;
@@ -684,16 +684,16 @@ in {
       };
     };
 
-    systemd.services.soularr-web = mkIf cfg.web.enable {
-      description = "Soularr web UI";
-      after = ["soularr-db-migrate.service"];
-      requires = ["soularr-db-migrate.service"];
+    systemd.services.cratedigger-web = mkIf cfg.web.enable {
+      description = "Cratedigger web UI";
+      after = ["cratedigger-db-migrate.service"];
+      requires = ["cratedigger-db-migrate.service"];
       wantedBy = ["multi-user.target"];
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = "${webPkg}/bin/soularr-web";
+        ExecStart = "${webPkg}/bin/cratedigger-web";
         Restart = "on-failure";
         RestartSec = 5;
         Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,7 +3,7 @@
 let
   slskd-api = pkgs.callPackage ./slskd-api.nix { };
 
-  # Production python deps. Deliberately does NOT include beets — soularr
+  # Production python deps. Deliberately does NOT include beets — cratedigger
   # invokes beets out-of-process via harness/run_beets_harness.sh, which
   # uses whatever `beet` the deployment environment provides (so the
   # consumer's plugins + MB host config + library DB all just work).

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -19,6 +19,6 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    echo "soularr dev shell — run: python3 -m unittest discover tests -v"
+    echo "cratedigger dev shell — run: python3 -m unittest discover tests -v"
   '';
 }

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -1,32 +1,32 @@
-# NixOS VM test for the upstream soularr module.
+# NixOS VM test for the upstream cratedigger module.
 #
 # Boots a single VM that runs:
-#   - PostgreSQL with a `soularr` user/db (the module's expected backend)
-#   - The soularr module enabled with web ON, no slskd, fake API key file
+#   - PostgreSQL with a `cratedigger` user/db (the module's expected backend)
+#   - The cratedigger module enabled with web ON, no slskd, fake API key file
 #
 # Verifies:
-#   - soularr-db-migrate.service runs to active (exited)
+#   - cratedigger-db-migrate.service runs to active (exited)
 #   - schema_migrations table is populated
-#   - /var/lib/soularr/config.ini exists with the API key substituted
+#   - /var/lib/cratedigger/config.ini exists with the API key substituted
 #   - pipeline-cli is on PATH and connects to the DB
-#   - soularr-web responds on its port
+#   - cratedigger-web responds on its port
 #
 # Does NOT exercise: slskd interaction, real downloads, beets — those need
 # heavyweight fixtures that belong in the python test suite.
-{ pkgs, system, soularrModule, soularrSrc }:
+{ pkgs, system, cratediggerModule, cratediggerSrc }:
 
 pkgs.testers.nixosTest {
-  name = "soularr-module-vm";
+  name = "cratedigger-module-vm";
 
   nodes.machine = { config, lib, pkgs, ... }: {
-    imports = [ soularrModule ];
+    imports = [ cratediggerModule ];
 
     services.postgresql = {
       enable = true;
-      ensureDatabases = [ "soularr" ];
+      ensureDatabases = [ "cratedigger" ];
       ensureUsers = [
         {
-          name = "soularr";
+          name = "cratedigger";
           ensureDBOwnership = true;
         }
       ];
@@ -38,33 +38,33 @@ pkgs.testers.nixosTest {
     };
 
     # Fake slskd API key — never actually called because healthCheck is off.
-    environment.etc."soularr/slskd-api-key" = {
+    environment.etc."cratedigger/slskd-api-key" = {
       text = "test-api-key-do-not-use\n";
       mode = "0400";
     };
 
-    # Stub beets library DB so soularr-web can open it read-only.
-    environment.etc."soularr/beets.db" = {
+    # Stub beets library DB so cratedigger-web can open it read-only.
+    environment.etc."cratedigger/beets.db" = {
       text = "";
       mode = "0644";
     };
 
-    services.soularr = {
+    services.cratedigger = {
       enable = true;
-      src = soularrSrc;
+      src = cratediggerSrc;
       slskd = {
-        apiKeyFile = "/etc/soularr/slskd-api-key";
-        downloadDir = "/var/lib/soularr-downloads";
+        apiKeyFile = "/etc/cratedigger/slskd-api-key";
+        downloadDir = "/var/lib/cratedigger-downloads";
       };
-      pipelineDb.dsn = "postgresql://soularr@localhost/soularr";
+      pipelineDb.dsn = "postgresql://cratedigger@localhost/cratedigger";
       beetsValidation = {
         enable = false;
-        stagingDir = "/var/lib/soularr-staging";
-        trackingFile = "/var/lib/soularr-staging/tracking.jsonl";
+        stagingDir = "/var/lib/cratedigger-staging";
+        trackingFile = "/var/lib/cratedigger-staging/tracking.jsonl";
       };
       web = {
         enable = true;
-        beetsDb = "/etc/soularr/beets.db";
+        beetsDb = "/etc/cratedigger/beets.db";
         redis.host = "127.0.0.1";
       };
       timer.enable = false;
@@ -79,12 +79,12 @@ pkgs.testers.nixosTest {
     };
 
     # Order our migrate unit after postgres comes up.
-    systemd.services.soularr-db-migrate = {
+    systemd.services.cratedigger-db-migrate = {
       after = [ "postgresql.service" ];
       requires = [ "postgresql.service" ];
     };
-    systemd.services.soularr-web.after = [ "postgresql.service" "redis.service" ];
-    systemd.services.soularr-web.wants = [ "postgresql.service" "redis.service" ];
+    systemd.services.cratedigger-web.after = [ "postgresql.service" "redis.service" ];
+    systemd.services.cratedigger-web.wants = [ "postgresql.service" "redis.service" ];
 
     # Speed up the VM
     virtualisation.memorySize = 2048;
@@ -93,39 +93,39 @@ pkgs.testers.nixosTest {
   testScript = ''
     machine.start()
     machine.wait_for_unit("postgresql.service")
-    machine.wait_for_unit("soularr-db-migrate.service")
+    machine.wait_for_unit("cratedigger-db-migrate.service")
 
     # The migrator is a oneshot with RemainAfterExit=true — confirm it landed
     # in active (exited), not failed.
-    state = machine.succeed("systemctl is-active soularr-db-migrate.service").strip()
+    state = machine.succeed("systemctl is-active cratedigger-db-migrate.service").strip()
     assert state == "active", f"migrator unit not active: {state}"
 
     # Migrations recorded
-    out = machine.succeed("sudo -u postgres psql soularr -At -c 'SELECT version FROM schema_migrations ORDER BY version'")
+    out = machine.succeed("sudo -u postgres psql cratedigger -At -c 'SELECT version FROM schema_migrations ORDER BY version'")
     versions = [v.strip() for v in out.strip().split() if v.strip()]
     assert "1" in versions, f"baseline migration missing, got {versions}"
     assert "2" in versions, f"002 migration missing, got {versions}"
 
     # config.ini rendered with api_key_file pointing at the out-of-band secret,
-    # not the plaintext key itself (issue #117). The soularr ExecStart will
+    # not the plaintext key itself (issue #117). The cratedigger ExecStart will
     # fail because there's no real slskd, but ExecStartPre (preStartScript)
     # runs first and writes the config — that's all we need to assert here.
-    machine.succeed("systemctl start soularr.service || true")
-    machine.succeed("test -f /var/lib/soularr/config.ini")
-    machine.succeed("grep -q 'api_key_file = /etc/soularr/slskd-api-key' /var/lib/soularr/config.ini")
+    machine.succeed("systemctl start cratedigger.service || true")
+    machine.succeed("test -f /var/lib/cratedigger/config.ini")
+    machine.succeed("grep -q 'api_key_file = /etc/cratedigger/slskd-api-key' /var/lib/cratedigger/config.ini")
     # The secret itself must NEVER appear in config.ini — that's the whole fix.
-    machine.fail("grep -q 'test-api-key-do-not-use' /var/lib/soularr/config.ini")
+    machine.fail("grep -q 'test-api-key-do-not-use' /var/lib/cratedigger/config.ini")
     # config.ini is now world-readable since it contains no secrets.
-    mode = machine.succeed("stat -c %a /var/lib/soularr/config.ini").strip()
+    mode = machine.succeed("stat -c %a /var/lib/cratedigger/config.ini").strip()
     assert mode == "644", f"config.ini should be 0644, got {mode}"
-    machine.succeed("grep -q 'enabled = False' /var/lib/soularr/config.ini")  # beets disabled
-    machine.succeed("grep -q '\\[Quality Ranks\\]' /var/lib/soularr/config.ini")
+    machine.succeed("grep -q 'enabled = False' /var/lib/cratedigger/config.ini")  # beets disabled
+    machine.succeed("grep -q '\\[Quality Ranks\\]' /var/lib/cratedigger/config.ini")
 
     # pipeline-cli on PATH and connects
     machine.succeed("pipeline-cli list wanted")
 
     # Web UI listens
-    machine.wait_for_unit("soularr-web.service")
+    machine.wait_for_unit("cratedigger-web.service")
     machine.wait_for_open_port(8085)
     machine.succeed("curl -sf http://127.0.0.1:8085/ > /dev/null")
   '';

--- a/scripts/bench_parallel_search.py
+++ b/scripts/bench_parallel_search.py
@@ -30,7 +30,7 @@ import slskd_api
 
 
 # Diverse queries: mix of popular (guaranteed results) and less common artists.
-# All use the wildcarded-first-char format that soularr uses in production.
+# All use the wildcarded-first-char format that cratedigger uses in production.
 QUERIES = [
     "*eatles abbey road",
     "*ink *loyd dark side moon",
@@ -66,7 +66,7 @@ def run_single_search(client: slskd_api.SlskdClient, query: str,
         return SingleSearchResult(query=query, result_count=0,
                                   elapsed_s=time.time() - t0, error=str(e))
 
-    # Wait for completion (same pattern as soularr.py)
+    # Wait for completion (same pattern as cratedigger.py)
     time.sleep(5)
     deadline = time.time() + (search_timeout / 1000) + 10
     while time.time() < deadline:

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 if [ $# -eq 0 ]; then
-    nix-shell --run "pyright soularr.py lib/*.py album_source.py"
+    nix-shell --run "pyright cratedigger.py lib/*.py album_source.py"
 else
     nix-shell --run "pyright $*"
 fi

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -8,7 +8,7 @@ recorded in the ``schema_migrations`` table.
 Idempotent: running it on an already-up-to-date database is a no-op.
 
 Usage:
-    migrate_db.py --dsn postgresql://soularr@host/db
+    migrate_db.py --dsn postgresql://cratedigger@host/db
     PIPELINE_DB_DSN=... migrate_db.py
     migrate_db.py --migrations-dir /path/to/migrations
 """
@@ -26,7 +26,7 @@ from lib.migrator import DEFAULT_MIGRATIONS_DIR, apply_migrations
 
 DEFAULT_DSN = os.environ.get(
     "PIPELINE_DB_DSN",
-    "postgresql://soularr@192.168.100.11:5432/soularr",
+    "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
 )
 
 

--- a/scripts/migrate_to_postgres.py
+++ b/scripts/migrate_to_postgres.py
@@ -5,8 +5,8 @@ Reads all data from the SQLite database and inserts it into PostgreSQL.
 All non-imported/non-manual statuses are mapped to 'wanted'.
 
 Usage:
-    python3 scripts/migrate_to_postgres.py /mnt/virtio/Music/pipeline.db postgresql://soularr@localhost/soularr
-    python3 scripts/migrate_to_postgres.py /mnt/virtio/Music/pipeline.db postgresql://soularr@localhost/soularr --dry-run
+    python3 scripts/migrate_to_postgres.py /mnt/virtio/Music/pipeline.db postgresql://cratedigger@localhost/cratedigger
+    python3 scripts/migrate_to_postgres.py /mnt/virtio/Music/pipeline.db postgresql://cratedigger@localhost/cratedigger --dry-run
 """
 
 import argparse

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -24,7 +24,7 @@ from lib.transitions import apply_transition
 
 DEFAULT_DSN = os.environ.get(
     "PIPELINE_DB_DSN",
-    "postgresql://soularr@192.168.100.11:5432/soularr",
+    "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
 )
 
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 # Usage: nix-shell --run "bash scripts/run_tests.sh"
 set -euo pipefail
 
-OUT="/tmp/soularr-test-output.txt"
+OUT="/tmp/cratedigger-test-output.txt"
 
 # JS syntax check
 echo "=== JS syntax check ==="

--- a/tests/ephemeral_pg.py
+++ b/tests/ephemeral_pg.py
@@ -53,7 +53,7 @@ class EphemeralPostgres:
                 "nix-shell -p postgresql python3Packages.psycopg2"
             )
 
-        self.tmpdir = tempfile.mkdtemp(prefix="soularr_test_pg_")
+        self.tmpdir = tempfile.mkdtemp(prefix="cratedigger_test_pg_")
         self.port = _find_free_port()
         datadir = os.path.join(self.tmpdir, "data")
         logfile = os.path.join(self.tmpdir, "pg.log")
@@ -94,10 +94,10 @@ class EphemeralPostgres:
             host="127.0.0.1", port=self.port, dbname="postgres", user=os.getenv("USER", "root")
         )
         conn.autocommit = True
-        conn.cursor().execute("CREATE DATABASE soularr_test")
+        conn.cursor().execute("CREATE DATABASE cratedigger_test")
         conn.close()
 
-        self.dsn = f"postgresql://{os.getenv('USER', 'root')}@127.0.0.1:{self.port}/soularr_test"
+        self.dsn = f"postgresql://{os.getenv('USER', 'root')}@127.0.0.1:{self.port}/cratedigger_test"
         self._started = True
 
         # Register cleanup in case stop() is never called

--- a/tests/ephemeral_slskd.py
+++ b/tests/ephemeral_slskd.py
@@ -72,10 +72,10 @@ class EphemeralSlskd:
 
         username = creds["username"]
         password = creds["password"]
-        self.api_key = creds.get("api_key", "soularr-test-key")
+        self.api_key = creds.get("api_key", "cratedigger-test-key")
 
         self.port = _find_free_port()
-        self._tmpdir = tempfile.mkdtemp(prefix="soularr_test_slskd_")
+        self._tmpdir = tempfile.mkdtemp(prefix="cratedigger_test_slskd_")
         self.download_dir = os.path.join(self._tmpdir, "downloads")
         os.makedirs(self.download_dir)
 
@@ -89,13 +89,13 @@ class EphemeralSlskd:
             f.write(f"""soulseek:
   username: {username}
   password: {password}
-  description: soularr integration test
+  description: cratedigger integration test
 web:
   port: 5030
   authentication:
     disabled: false
     api_keys:
-      soularr_test:
+      cratedigger_test:
         key: {self.api_key}
         role: administrator
         cidr: 0.0.0.0/0,::/0

--- a/tests/fixtures/test_config.ini
+++ b/tests/fixtures/test_config.ini
@@ -47,7 +47,7 @@ tracking_file = /mnt/virtio/Music/Re-download/beets-validated.jsonl
 
 [Pipeline DB]
 enabled = True
-dsn = postgresql://soularr@192.168.100.11:5432/soularr
+dsn = postgresql://cratedigger@192.168.100.11:5432/cratedigger
 
 [Meelo]
 url = http://192.168.1.29:5001

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -291,15 +291,15 @@ def make_ctx_with_fake_db(
     cfg: Any = None,
     slskd: Any = None,
 ) -> Any:
-    """Build a SoularrContext wired to a FakePipelineDB.
+    """Build a CratediggerContext wired to a FakePipelineDB.
 
     The fake is wired via pipeline_db_source._get_db() so production code
     that calls ctx.pipeline_db_source._get_db() gets the fake.
     """
-    from lib.context import SoularrContext
+    from lib.context import CratediggerContext
     mock_source = MagicMock()
     mock_source._get_db.return_value = fake_db
-    return SoularrContext(
+    return CratediggerContext(
         cfg=cfg if cfg is not None else MagicMock(),
         slskd=slskd if slskd is not None else MagicMock(),
         pipeline_db_source=mock_source,

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -1,6 +1,6 @@
-"""Tests for beets validation pipeline in soularr.
+"""Tests for beets validation pipeline in cratedigger.
 
-Since soularr.py has heavy external dependencies (slskd_api, music_tag),
+Since cratedigger.py has heavy external dependencies (slskd_api, music_tag),
 we mock at the module level before importing, or test via subprocess simulation.
 """
 
@@ -14,16 +14,16 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 
-# Mock heavy dependencies before importing soularr
+# Mock heavy dependencies before importing cratedigger
 sys.modules["requests"] = MagicMock()
 sys.modules["music_tag"] = MagicMock()
 sys.modules["slskd_api"] = MagicMock()
 sys.modules["slskd_api.apis"] = MagicMock()
 sys.modules["slskd_api.apis.users"] = MagicMock()
 
-# Now import soularr and lib modules
+# Now import cratedigger and lib modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import soularr
+import cratedigger
 from lib.beets import beets_validate
 from lib.grab_list import GrabListEntry
 from lib.quality import ValidationResult
@@ -165,7 +165,7 @@ class TestBeetsValidate(unittest.TestCase):
     @patch("lib.beets.sp.Popen")
     def test_launches_harness_with_beets_subprocess_env(self, mock_popen):
         """Regression guard: the harness subprocess MUST receive the beets
-        env (HOME override). When soularr runs as the systemd service (root,
+        env (HOME override). When cratedigger runs as the systemd service (root,
         HOME=/root) without this, beets' Discogs plugin can't find its
         config at `~/.config/beets/` and returns 0 candidates for every
         --search-id — scenario=mbid_not_found on every Discogs validation.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,15 +8,15 @@ import unittest
 
 from unittest.mock import MagicMock
 
-from lib.context import SoularrContext
+from lib.context import CratediggerContext
 
 
-def _make_ctx() -> SoularrContext:
-    """Build a minimal SoularrContext for cache tests."""
+def _make_ctx() -> CratediggerContext:
+    """Build a minimal CratediggerContext for cache tests."""
     cfg = MagicMock()
     slskd = MagicMock()
     pipeline_db_source = MagicMock()
-    return SoularrContext(cfg=cfg, slskd=slskd, pipeline_db_source=pipeline_db_source)
+    return CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=pipeline_db_source)
 
 
 class TestCachePersistence(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for SoularrConfig — verify from_ini() matches old global parsing."""
+"""Tests for CratediggerConfig — verify from_ini() matches old global parsing."""
 
 import configparser
 import os
@@ -10,7 +10,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.config import (
-    SoularrConfig,
+    CratediggerConfig,
     invalidate_secret_cache,
     read_runtime_config,
     read_runtime_rank_config,
@@ -23,7 +23,7 @@ TEST_CONFIG = os.path.join(FIXTURES_DIR, "test_config.ini")
 
 
 def load_test_config():
-    """Load the test config.ini the same way soularr.py does (RawConfigParser)."""
+    """Load the test config.ini the same way cratedigger.py does (RawConfigParser)."""
     config = configparser.RawConfigParser()
     config.read(TEST_CONFIG)
     return config
@@ -35,7 +35,7 @@ class TestConfigFromIni(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         ini = load_test_config()
-        cls.cfg = SoularrConfig.from_ini(ini, config_dir="/etc/soularr", var_dir="/var/lib/soularr")
+        cls.cfg = CratediggerConfig.from_ini(ini, config_dir="/etc/cratedigger", var_dir="/var/lib/cratedigger")
 
     # --- Slskd ---
     def test_slskd_api_key(self):
@@ -98,10 +98,10 @@ class TestConfigFromIni(unittest.TestCase):
 
     def test_browse_parallelism_capped_at_8(self):
         """Values > 8 should be clamped to 8."""
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         ini = configparser.ConfigParser()
         ini.read_string("[Search Settings]\nbrowse_parallelism = 20\n")
-        cfg = SoularrConfig.from_ini(ini)
+        cfg = CratediggerConfig.from_ini(ini)
         self.assertEqual(cfg.browse_parallelism, 8)
 
     # --- Release ---
@@ -164,7 +164,7 @@ class TestConfigFromIni(unittest.TestCase):
 
     def test_pipeline_db_dsn(self):
         self.assertEqual(self.cfg.pipeline_db_dsn,
-                         "postgresql://soularr@192.168.100.11:5432/soularr")
+                         "postgresql://cratedigger@192.168.100.11:5432/cratedigger")
 
     # --- Meelo ---
     def test_meelo_url(self):
@@ -188,10 +188,10 @@ class TestConfigFromIni(unittest.TestCase):
 
     # --- Paths ---
     def test_lock_file_path(self):
-        self.assertEqual(self.cfg.lock_file_path, "/var/lib/soularr/.soularr.lock")
+        self.assertEqual(self.cfg.lock_file_path, "/var/lib/cratedigger/.cratedigger.lock")
 
     def test_config_file_path(self):
-        self.assertEqual(self.cfg.config_file_path, "/etc/soularr/config.ini")
+        self.assertEqual(self.cfg.config_file_path, "/etc/cratedigger/config.ini")
 
 
 
@@ -200,7 +200,7 @@ class TestConfigFrozen(unittest.TestCase):
 
     def test_cannot_mutate(self):
         ini = load_test_config()
-        cfg = SoularrConfig.from_ini(ini)
+        cfg = CratediggerConfig.from_ini(ini)
         with self.assertRaises(AttributeError):
             cfg.page_size = 99  # type: ignore[misc]  # intentional: testing frozen dataclass  # type: ignore[misc]
 
@@ -214,7 +214,7 @@ class TestConfigDefaults(unittest.TestCase):
         for section in ["Slskd", "Search Settings", "Release Settings",
                         "Download Settings", "Beets Validation", "Pipeline DB", "Meelo", "Plex"]:
             config.add_section(section)
-        cfg = SoularrConfig.from_ini(config)
+        cfg = CratediggerConfig.from_ini(config)
         self.assertEqual(cfg.page_size, 10)
         self.assertEqual(cfg.stalled_timeout, 3600)
         self.assertAlmostEqual(cfg.beets_distance_threshold, 0.15)
@@ -230,7 +230,7 @@ class TestConfigDefaults(unittest.TestCase):
                         "Download Settings", "Beets Validation", "Pipeline DB", "Meelo", "Plex"]:
             config.add_section(section)
         config.set("Search Settings", "allowed_filetypes", "flac")
-        cfg = SoularrConfig.from_ini(config)
+        cfg = CratediggerConfig.from_ini(config)
         self.assertEqual(cfg.allowed_filetypes, ("flac",))
 
     def test_verified_lossless_target_default_empty(self):
@@ -238,7 +238,7 @@ class TestConfigDefaults(unittest.TestCase):
         for section in ["Slskd", "Search Settings", "Release Settings",
                         "Download Settings", "Beets Validation", "Pipeline DB", "Meelo", "Plex"]:
             config.add_section(section)
-        cfg = SoularrConfig.from_ini(config)
+        cfg = CratediggerConfig.from_ini(config)
         self.assertEqual(cfg.verified_lossless_target, "")
 
     def test_verified_lossless_target_set(self):
@@ -247,14 +247,14 @@ class TestConfigDefaults(unittest.TestCase):
                         "Download Settings", "Beets Validation", "Pipeline DB", "Meelo", "Plex"]:
             config.add_section(section)
         config.set("Beets Validation", "verified_lossless_target", "opus 128")
-        cfg = SoularrConfig.from_ini(config)
+        cfg = CratediggerConfig.from_ini(config)
         self.assertEqual(cfg.verified_lossless_target, "opus 128")
 
 
 class TestReadVerifiedLosslessTarget(unittest.TestCase):
     def test_missing_file_returns_empty(self):
         self.assertEqual(
-            read_verified_lossless_target("/nonexistent/soularr-config.ini"), ""
+            read_verified_lossless_target("/nonexistent/cratedigger-config.ini"), ""
         )
 
     def test_reads_runtime_value_from_config_file(self):
@@ -370,7 +370,7 @@ class TestReadSecretFile(unittest.TestCase):
 
 
 class TestSecretFileFields(unittest.TestCase):
-    """from_ini() reads *_file keys from the INI into SoularrConfig."""
+    """from_ini() reads *_file keys from the INI into CratediggerConfig."""
 
     def setUp(self):
         invalidate_secret_cache()
@@ -389,7 +389,7 @@ class TestSecretFileFields(unittest.TestCase):
             "[Jellyfin]\n"
             "token_file = /run/secrets/jellyfin-token\n"
         )
-        cfg = SoularrConfig.from_ini(config)
+        cfg = CratediggerConfig.from_ini(config)
         self.assertEqual(cfg.slskd_api_key_file, "/run/secrets/slskd-key")
         self.assertEqual(cfg.meelo_username_file, "/run/secrets/meelo-user")
         self.assertEqual(cfg.meelo_password_file, "/run/secrets/meelo-pass")
@@ -397,7 +397,7 @@ class TestSecretFileFields(unittest.TestCase):
         self.assertEqual(cfg.jellyfin_token_file, "/run/secrets/jellyfin-token")
 
     def test_file_paths_default_to_empty(self):
-        cfg = SoularrConfig.from_ini(configparser.RawConfigParser())
+        cfg = CratediggerConfig.from_ini(configparser.RawConfigParser())
         self.assertEqual(cfg.slskd_api_key_file, "")
         self.assertEqual(cfg.meelo_username_file, "")
         self.assertEqual(cfg.meelo_password_file, "")
@@ -427,21 +427,21 @@ class TestResolvedSecrets(unittest.TestCase):
 
     def test_slskd_api_key_resolves_file_over_direct(self):
         path = self._write_secret("from-file\n")
-        cfg = SoularrConfig(slskd_api_key="from-direct", slskd_api_key_file=path)
+        cfg = CratediggerConfig(slskd_api_key="from-direct", slskd_api_key_file=path)
         self.assertEqual(cfg.resolved_slskd_api_key(), "from-file")
 
     def test_slskd_api_key_falls_back_to_direct_when_no_file(self):
-        cfg = SoularrConfig(slskd_api_key="from-direct")
+        cfg = CratediggerConfig(slskd_api_key="from-direct")
         self.assertEqual(cfg.resolved_slskd_api_key(), "from-direct")
 
     def test_slskd_api_key_empty_when_neither_set(self):
-        cfg = SoularrConfig()
+        cfg = CratediggerConfig()
         self.assertEqual(cfg.resolved_slskd_api_key(), "")
 
     def test_meelo_credentials_resolve_from_files(self):
         user_path = self._write_secret("meelo-user")
         pass_path = self._write_secret("meelo-pass")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             meelo_username_file=user_path,
             meelo_password_file=pass_path,
         )
@@ -450,25 +450,25 @@ class TestResolvedSecrets(unittest.TestCase):
 
     def test_plex_token_resolves_from_file(self):
         path = self._write_secret("plex-live-token\n")
-        cfg = SoularrConfig(plex_url="http://plex", plex_token_file=path)
+        cfg = CratediggerConfig(plex_url="http://plex", plex_token_file=path)
         self.assertEqual(cfg.resolved_plex_token(), "plex-live-token")
 
     def test_jellyfin_token_resolves_from_file(self):
         path = self._write_secret("jellyfin-live-token\n")
-        cfg = SoularrConfig(jellyfin_url="http://jellyfin", jellyfin_token_file=path)
+        cfg = CratediggerConfig(jellyfin_url="http://jellyfin", jellyfin_token_file=path)
         self.assertEqual(cfg.resolved_jellyfin_token(), "jellyfin-live-token")
 
     def test_notifier_resolvers_none_when_unset(self):
-        cfg = SoularrConfig()
+        cfg = CratediggerConfig()
         self.assertIsNone(cfg.resolved_meelo_username())
         self.assertIsNone(cfg.resolved_meelo_password())
         self.assertIsNone(cfg.resolved_plex_token())
         self.assertIsNone(cfg.resolved_jellyfin_token())
 
     def test_legacy_plaintext_field_still_resolves(self):
-        """Direct fields on SoularrConfig keep working so tests and old deployments
+        """Direct fields on CratediggerConfig keep working so tests and old deployments
         that haven't switched to *_file paths continue to function."""
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             meelo_url="http://meelo",
             meelo_username="legacy-user",
             meelo_password="legacy-pass",
@@ -507,7 +507,7 @@ class TestMainCLIParsing(unittest.TestCase):
     """Test the CLI argument parsing and config loading path in main()."""
 
     def setUp(self):
-        # soularr.main() calls reset_umask() (sets umask to 0 for the pipeline's
+        # cratedigger.main() calls reset_umask() (sets umask to 0 for the pipeline's
         # subprocess chain, GH #84). Restore the prior umask so later tests in
         # the same process keep their expected default.
         self._saved_umask = os.umask(0o022)
@@ -532,31 +532,31 @@ class TestMainCLIParsing(unittest.TestCase):
         return path
 
     def _run_main_until_config_parse(self, argv: list[str], callback) -> None:
-        import soularr
+        import cratedigger
 
-        soularr.cfg = None
-        soularr.pipeline_db_source = None
-        soularr._module_ctx = None
+        cratedigger.cfg = None
+        cratedigger.pipeline_db_source = None
+        cratedigger._module_ctx = None
 
         def fake_from_ini(config, config_dir=".", var_dir="."):
             callback(config, config_dir, var_dir)
             raise self._StopMain()
 
         with patch.object(sys, "argv", argv), \
-             patch("lib.config.SoularrConfig.from_ini", side_effect=fake_from_ini):
+             patch("lib.config.CratediggerConfig.from_ini", side_effect=fake_from_ini):
             with self.assertRaises(self._StopMain):
-                soularr.main()
+                cratedigger.main()
 
     def test_missing_config_exits_with_error(self):
         """main() exits 1 when config.ini doesn't exist at --config-dir."""
-        import soularr
+        import cratedigger
 
         with tempfile.TemporaryDirectory() as d:
             with patch.object(sys, "argv", [
-                "soularr", "--config-dir", d, "--var-dir", d, "--no-lock-file"
+                "cratedigger", "--config-dir", d, "--var-dir", d, "--no-lock-file"
             ]):
                 with self.assertRaises(SystemExit) as cm:
-                    soularr.main()
+                    cratedigger.main()
             self.assertEqual(cm.exception.code, 1)
 
     def test_config_dir_resolves_config_path(self):
@@ -571,15 +571,15 @@ class TestMainCLIParsing(unittest.TestCase):
                 self.assertEqual(config.get("Slskd", "api_key"), "from-config-dir")
 
             self._run_main_until_config_parse(
-                ["soularr", "--config-dir", d, "--var-dir", d, "--no-lock-file"],
+                ["cratedigger", "--config-dir", d, "--var-dir", d, "--no-lock-file"],
                 assert_from_ini,
             )
 
     def test_lock_file_created_in_var_dir(self):
-        """Lock file path is var_dir/.soularr.lock."""
+        """Lock file path is var_dir/.cratedigger.lock."""
         with tempfile.TemporaryDirectory() as config_dir, tempfile.TemporaryDirectory() as var_dir:
             self._write_minimal_config(config_dir)
-            lock_path = os.path.join(var_dir, ".soularr.lock")
+            lock_path = os.path.join(var_dir, ".cratedigger.lock")
 
             def assert_from_ini(config, actual_config_dir, actual_var_dir):
                 self.assertEqual(actual_config_dir, config_dir)
@@ -587,7 +587,7 @@ class TestMainCLIParsing(unittest.TestCase):
                 self.assertTrue(os.path.exists(lock_path))
 
             self._run_main_until_config_parse(
-                ["soularr", "--config-dir", config_dir, "--var-dir", var_dir],
+                ["cratedigger", "--config-dir", config_dir, "--var-dir", var_dir],
                 assert_from_ini,
             )
 
@@ -595,7 +595,7 @@ class TestMainCLIParsing(unittest.TestCase):
         """--no-lock-file sets the flag to True."""
         with tempfile.TemporaryDirectory() as d:
             self._write_minimal_config(d)
-            lock_path = os.path.join(d, ".soularr.lock")
+            lock_path = os.path.join(d, ".cratedigger.lock")
 
             def assert_from_ini(config, config_dir, var_dir):
                 self.assertEqual(config_dir, d)
@@ -603,7 +603,7 @@ class TestMainCLIParsing(unittest.TestCase):
                 self.assertFalse(os.path.exists(lock_path))
 
             self._run_main_until_config_parse(
-                ["soularr", "--config-dir", d, "--var-dir", d, "--no-lock-file"],
+                ["cratedigger", "--config-dir", d, "--var-dir", d, "--no-lock-file"],
                 assert_from_ini,
             )
 
@@ -617,9 +617,9 @@ class TestMainCLIParsing(unittest.TestCase):
                 self.assertEqual(var_dir, cwd)
                 self.assertEqual(config.get("Slskd", "api_key"), "from-default-cwd")
 
-            with patch("soularr.os.getcwd", return_value=cwd):
+            with patch("cratedigger.os.getcwd", return_value=cwd):
                 self._run_main_until_config_parse(
-                    ["soularr", "--no-lock-file"],
+                    ["cratedigger", "--no-lock-file"],
                     assert_from_ini,
                 )
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,19 +1,19 @@
-"""Tests for lib/context.py — SoularrContext dataclass."""
+"""Tests for lib/context.py — CratediggerContext dataclass."""
 
 import unittest
 from unittest.mock import MagicMock
 
 
-class TestSoularrContext(unittest.TestCase):
-    """Test SoularrContext construction and cache isolation."""
+class TestCratediggerContext(unittest.TestCase):
+    """Test CratediggerContext construction and cache isolation."""
 
     def test_context_construction(self):
-        from lib.context import SoularrContext
+        from lib.context import CratediggerContext
         mock_cfg = MagicMock()
         mock_slskd = MagicMock()
         mock_db_source = MagicMock()
 
-        ctx = SoularrContext(
+        ctx = CratediggerContext(
             cfg=mock_cfg,
             slskd=mock_slskd,
             pipeline_db_source=mock_db_source,
@@ -30,17 +30,17 @@ class TestSoularrContext(unittest.TestCase):
         self.assertEqual(len(ctx.broken_user), 0)
 
     def test_context_cache_isolation(self):
-        from lib.context import SoularrContext
+        from lib.context import CratediggerContext
         mock_cfg = MagicMock()
         mock_slskd = MagicMock()
         mock_db_source = MagicMock()
 
-        ctx1 = SoularrContext(
+        ctx1 = CratediggerContext(
             cfg=mock_cfg,
             slskd=mock_slskd,
             pipeline_db_source=mock_db_source,
         )
-        ctx2 = SoularrContext(
+        ctx2 = CratediggerContext(
             cfg=mock_cfg,
             slskd=mock_slskd,
             pipeline_db_source=mock_db_source,

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -4,9 +4,9 @@ import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
-from lib.context import SoularrContext
+from lib.context import CratediggerContext
 from lib.quality import CooldownConfig, should_cooldown
-from soularr import TrackRecord
+from cratedigger import TrackRecord
 from tests.fakes import FakePipelineDB
 from tests.helpers import (
     make_ctx_with_fake_db,
@@ -73,14 +73,14 @@ class TestEnqueueCooldownFiltering(unittest.TestCase):
     """Cooled-down users should be skipped during enqueue with distinct log messages."""
 
     def _make_ctx(self, cooled_down_users: set[str] | None = None,
-                  denied_users: list[str] | None = None) -> SoularrContext:
+                  denied_users: list[str] | None = None) -> CratediggerContext:
         source = MagicMock()
         db = MagicMock()
         db.get_denylisted_users.return_value = [
             {"username": u} for u in (denied_users or [])
         ]
         source._get_db.return_value = db
-        ctx = SoularrContext(
+        ctx = CratediggerContext(
             cfg=MagicMock(),
             slskd=MagicMock(),
             pipeline_db_source=source,
@@ -138,7 +138,7 @@ class TestEnqueueCooldownFiltering(unittest.TestCase):
         ]
         results = {"deaduser": {"flac": ["Music\\Album"]}}
 
-        with self.assertLogs("soularr", level=logging.INFO) as cm:
+        with self.assertLogs("cratedigger", level=logging.INFO) as cm:
             try_enqueue(tracks, results, "flac", ctx)
 
         cooldown_msgs = [m for m in cm.output if "cooldown" in m.lower()]

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from lib.config import SoularrConfig
+from lib.config import CratediggerConfig
 from lib.quality import DownloadInfo
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
@@ -38,7 +38,7 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
         )
         db.seed_request(req)
 
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
             verified_lossless_target=verified_lossless_target,
@@ -183,7 +183,7 @@ class TestDispatchCoreSeams(unittest.TestCase):
         ir = kwargs.pop("ir", make_import_result())
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
         )

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from lib.config import SoularrConfig
+from lib.config import CratediggerConfig
 from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
 from tests.fakes import FakePipelineDB
 
@@ -44,7 +44,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
                  patch("lib.import_dispatch._check_quality_gate_core") as mock_gate, \
                  patch("lib.import_dispatch.parse_import_result", return_value=ir), \
                  patch("lib.config.read_runtime_config",
-                       return_value=SoularrConfig(
+                       return_value=CratediggerConfig(
                            beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
                            pipeline_db_enabled=True,
                        )):
@@ -260,7 +260,7 @@ class TestDispatchFromDbAdvisoryLock(unittest.TestCase):
                  patch("lib.import_dispatch._check_quality_gate_core"), \
                  patch("lib.import_dispatch.parse_import_result", return_value=ir), \
                  patch("lib.config.read_runtime_config",
-                       return_value=SoularrConfig(
+                       return_value=CratediggerConfig(
                            beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
                            pipeline_db_enabled=True,
                        )):
@@ -308,7 +308,7 @@ class TestDispatchFromDbAdvisoryLock(unittest.TestCase):
             with patch("lib.import_dispatch.run_preimport_gates") as mock_gates, \
                  patch("lib.import_dispatch.inspect_local_files") as mock_inspect, \
                  patch("lib.config.read_runtime_config",
-                       return_value=SoularrConfig(
+                       return_value=CratediggerConfig(
                            beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
                            pipeline_db_enabled=True,
                        )):
@@ -337,7 +337,7 @@ class TestDispatchFromDbRuntimeConfigSeam(unittest.TestCase):
             album_title="Album",
         ))
 
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
             pipeline_db_enabled=True,
         )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -61,8 +61,8 @@ def _make_transfer_mock(filename="01 - Track.mp3", username="user1",
 
 
 def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None):
-    """Build a mock SoularrContext."""
-    from lib.context import SoularrContext
+    """Build a mock CratediggerContext."""
+    from lib.context import CratediggerContext
     if cfg is None:
         cfg = MagicMock()
         cfg.slskd_download_dir = "/tmp/test_downloads"
@@ -81,7 +81,7 @@ def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None):
         slskd = MagicMock()
     if pipeline_db_source is None:
         pipeline_db_source = MagicMock()
-    return SoularrContext(cfg=cfg, slskd=slskd,
+    return CratediggerContext(cfg=cfg, slskd=slskd,
                           pipeline_db_source=pipeline_db_source)
 
 
@@ -212,7 +212,7 @@ class TestCancelAndDelete(unittest.TestCase):
         slskd.transfers.cancel_download_error = Exception("network error")
         ctx = _make_ctx(slskd=slskd)
         f = make_download_file()
-        with self.assertLogs("soularr", level="WARNING") as logs, \
+        with self.assertLogs("cratedigger", level="WARNING") as logs, \
              patch("os.path.isdir", return_value=False):
             cancel_and_delete([f], ctx)  # should not raise
         self.assertIn("Failed to cancel download", "\n".join(logs.output))
@@ -1255,7 +1255,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         }])
         slskd.transfers.enqueue_result = False
 
-        with self.assertLogs("soularr", level="WARNING") as logs:
+        with self.assertLogs("cratedigger", level="WARNING") as logs:
             poll_active_downloads(ctx)
 
         # Should NOT process — 7 files vanished (errored), album not complete
@@ -1675,7 +1675,7 @@ class TestComputeRejectionBackfillCfgThreading(unittest.TestCase):
             search_filetype_override=None,
         ))
 
-        # Real SoularrConfig is heavy; a SimpleNamespace with quality_ranks
+        # Real CratediggerConfig is heavy; a SimpleNamespace with quality_ranks
         # is enough — _compute_rejection_backfill only reads ctx.cfg.quality_ranks.
         from types import SimpleNamespace
         cfg = SimpleNamespace(

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from lib.beets_db import AlbumInfo
-from lib.config import SoularrConfig
+from lib.config import CratediggerConfig
 from tests.fakes import FakePipelineDB
 from tests.helpers import (
     make_import_result,
@@ -167,7 +167,7 @@ class TestForceImportRunsSpectralGate(unittest.TestCase):
             album_path="/Beets/Luce",
         )
 
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
             audio_check_mode="normal",
@@ -329,7 +329,7 @@ class TestForceImportRunsAudioCheck(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/Test")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
             audio_check_mode="normal",
@@ -398,7 +398,7 @@ class TestForceImportStillSkipsBeetsDistance(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/Test")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
             audio_check_mode="normal",
@@ -602,7 +602,7 @@ class TestForceImportSplitsMultiUserSources(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=96,
             avg_bitrate_kbps=96, format="MP3", is_cbr=True,
             album_path="/Beets/Luce")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True, audio_check_mode="normal",
         )
@@ -666,7 +666,7 @@ class TestPreimportRejectionPreservesCorruptFiles(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/Test")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, pipeline_db_enabled=True,
             audio_check_mode="normal",
         )
@@ -735,7 +735,7 @@ class TestForceImportDoesNotCorruptSpectralStateOnFailure(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=192,
             avg_bitrate_kbps=192, format="MP3", is_cbr=True,
             album_path="/Beets/NonexistentPath")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, pipeline_db_enabled=True,
             audio_check_mode="normal",
         )
@@ -787,7 +787,7 @@ class TestAutoPathPreservesSpectralPropagation(unittest.TestCase):
     """
 
     def test_auto_path_propagates_download_spectral(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -799,7 +799,7 @@ class TestAutoPathPreservesSpectralPropagation(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=256,
             avg_bitrate_kbps=256, format="MP3", is_cbr=True,
             album_path="/Beets/NonexistentPath")
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch("lib.preimport.spectral_analyze",
                    return_value=_analyze_result("suspect", 192, 80.0, 5)), \
@@ -912,7 +912,7 @@ class TestForceImportRepairsBeforeInspection(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/Test")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, pipeline_db_enabled=True,
             audio_check_mode="normal")
 
@@ -980,7 +980,7 @@ class TestPreimportFallsBackToPersistedSpectral(unittest.TestCase):
     """
 
     def test_stored_spectral_used_when_beets_lookup_empty(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -998,7 +998,7 @@ class TestPreimportFallsBackToPersistedSpectral(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/NonexistentPath")
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch("lib.preimport.spectral_analyze",
                    return_value=_analyze_result(
@@ -1036,10 +1036,10 @@ class TestPreimportRepairsEvenWhenAudioCheckOff(unittest.TestCase):
     def test_repair_runs_with_audio_check_off(self):
         import os
         from unittest.mock import patch
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
         tmpdir = tempfile.mkdtemp()
         try:
             with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
@@ -1075,7 +1075,7 @@ class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
     """
 
     def test_genuine_stored_spectral_ignored(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -1091,7 +1091,7 @@ class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/NonexistentPath")
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         # Download is a suspect 192kbps transcode. If the fallback used the
         # stored grade=genuine/bitrate=96 verbatim, 192 > 96 would wrongly
@@ -1135,12 +1135,12 @@ class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
         """is_vbr=None → filesystem inspection fills it in → spectral runs."""
         import os
         from unittest.mock import patch
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates, LocalFileInspection
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -1185,12 +1185,12 @@ class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
         """
         import os
         from unittest.mock import patch
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates, LocalFileInspection
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -1247,12 +1247,12 @@ class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
         """
         import os
         from unittest.mock import patch
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates, LocalFileInspection
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -1296,12 +1296,12 @@ class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
         """
         import os
         from unittest.mock import patch
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates, LocalFileInspection
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -1348,12 +1348,12 @@ class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
         upload through the gate is cheap and safe.
         """
         from unittest.mock import patch
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates, LocalFileInspection
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch("lib.preimport.inspect_local_files",
                    return_value=LocalFileInspection(
@@ -1388,7 +1388,7 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
     """
 
     def test_no_beets_album_means_no_fallback(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -1400,7 +1400,7 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
             current_spectral_grade="likely_transcode",
             current_spectral_bitrate=128,
         ))
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         # BeetsDB returns None → album not in beets.
         def _mock_beets_db_no_album():
@@ -1474,7 +1474,7 @@ class TestGateRejectionWritesRejectedOutcome(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/Test")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, pipeline_db_enabled=True,
             audio_check_mode="normal")
 
@@ -1541,7 +1541,7 @@ class TestForceImportRejectsNestedLayout(unittest.TestCase):
             album_id=1, track_count=10, min_bitrate_kbps=320,
             avg_bitrate_kbps=320, format="MP3", is_cbr=True,
             album_path="/Beets/Test")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, pipeline_db_enabled=True,
             audio_check_mode="off")
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -13,7 +13,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from lib.config import SoularrConfig
+from lib.config import CratediggerConfig
 from lib.quality import (DownloadInfo, ImportResult, ConversionInfo,
                          AudioQualityMeasurement,
                          QUALITY_UPGRADE_TIERS, QUALITY_FLAC_ONLY)
@@ -38,7 +38,7 @@ def _make_album_data(artist="Test Artist", title="Test Album",
 
 
 def _make_ctx():
-    """Build a mock SoularrContext."""
+    """Build a mock CratediggerContext."""
     ctx = MagicMock()
     ctx.cfg.beets_harness_path = "/nix/store/fake/harness/run_beets_harness.sh"
     ctx.cfg.beets_distance_threshold = 0.15
@@ -172,7 +172,7 @@ class TestDispatchImport(unittest.TestCase):
             id=42, status="downloading",
             **(request_overrides or {}),
         ))
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
         )
@@ -431,9 +431,9 @@ class TestDispatchRankConfigArgv(unittest.TestCase):
 
     def test_default_cfg_serializes_to_argv(self):
         """Default QualityRankConfig → argv contains the round-trip JSON."""
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.quality import QualityRankConfig
-        cfg = SoularrConfig(beets_harness_path=_HARNESS)
+        cfg = CratediggerConfig(beets_harness_path=_HARNESS)
         cmd = self._run_dispatch_capture_cmd(cfg)
         raw = self._extract_rank_config_json(cmd)
         self.assertIsNotNone(raw)
@@ -444,7 +444,7 @@ class TestDispatchRankConfigArgv(unittest.TestCase):
 
     def test_custom_cfg_serializes_to_argv(self):
         """Custom gate_min_rank + metric survive the argv round-trip."""
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.quality import (QualityRank, QualityRankConfig,
                                  RankBitrateMetric)
         custom_ranks = QualityRankConfig(
@@ -452,7 +452,7 @@ class TestDispatchRankConfigArgv(unittest.TestCase):
             gate_min_rank=QualityRank.GOOD,
             within_rank_tolerance_kbps=15,
         )
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, quality_ranks=custom_ranks)
         cmd = self._run_dispatch_capture_cmd(cfg)
         raw = self._extract_rank_config_json(cmd)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,9 +15,9 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch, PropertyMock
 
 if TYPE_CHECKING:
-    from lib.config import SoularrConfig
+    from lib.config import CratediggerConfig
 
-# Mock heavy deps before importing soularr
+# Mock heavy deps before importing cratedigger
 sys.modules["music_tag"] = MagicMock()
 sys.modules["slskd_api"] = MagicMock()
 sys.modules["slskd_api.apis"] = MagicMock()
@@ -25,20 +25,20 @@ sys.modules["slskd_api.apis.users"] = MagicMock()
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-import soularr
+import cratedigger
 from lib import enqueue as enqueue_module
 from lib.grab_list import DownloadFile
 from lib.download import (cancel_and_delete, slskd_download_status,
                           slskd_do_enqueue, downloads_all_done)
 from lib.import_dispatch import _build_download_info
-from lib.context import SoularrContext
+from lib.context import CratediggerContext
 from tests.fakes import FakeSlskdAPI
 from tests.helpers import make_download_file, make_grab_list_entry
 
 
 def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None, **cache_overrides):
-    """Build a test SoularrContext."""
-    return SoularrContext(
+    """Build a test CratediggerContext."""
+    return CratediggerContext(
         cfg=cfg or MagicMock(),
         slskd=slskd or MagicMock(),
         pipeline_db_source=pipeline_db_source or MagicMock(),
@@ -55,14 +55,14 @@ def _make_matching_cfg(
     use_extension_whitelist: bool = False,
     extensions_whitelist: tuple[str, ...] = (),
     **extra,
-) -> "SoularrConfig":
-    """Build a SoularrConfig with matching-friendly defaults.
+) -> "CratediggerConfig":
+    """Build a CratediggerConfig with matching-friendly defaults.
 
     Uses the real frozen dataclass so tests break immediately when new
     required fields are added, rather than silently passing via MagicMock.
     """
-    from lib.config import SoularrConfig
-    return SoularrConfig(
+    from lib.config import CratediggerConfig
+    return CratediggerConfig(
         allowed_filetypes=allowed_filetypes,
         minimum_match_ratio=minimum_match_ratio,
         ignored_users=ignored_users,
@@ -137,12 +137,12 @@ def make_search_result(username, files, upload_speed=1048576):
     }
 
 
-def make_tracks(*track_defs: tuple[int, str, int]) -> list["soularr.TrackRecord"]:
+def make_tracks(*track_defs: tuple[int, str, int]) -> list["cratedigger.TrackRecord"]:
     """Build a list of TrackRecord dicts from (albumId, title, mediumNumber) tuples."""
     return [{"albumId": a, "title": t, "mediumNumber": m} for a, t, m in track_defs]  # type: ignore[misc]
 
 
-def make_directory(dir_path: str, files: list[dict[str, object]]) -> "soularr.SlskdDirectory":
+def make_directory(dir_path: str, files: list[dict[str, object]]) -> "cratedigger.SlskdDirectory":
     """Build a directory dict as slskd.users.directory() returns it."""
     return {
         "directory": dir_path,
@@ -171,7 +171,7 @@ class TestBuildSearchCache(unittest.TestCase):
             {"filename": "Music\\Album\\01.flac", "size": 100},
             {"filename": "Music\\Album\\02.flac", "size": 100},
         ])]
-        entries, speeds, counts = soularr._build_search_cache(results, self._specs("flac"))
+        entries, speeds, counts = cratedigger._build_search_cache(results, self._specs("flac"))
         self.assertIn("user1", entries)
         self.assertIn("flac", entries["user1"])
         self.assertEqual(entries["user1"]["flac"], ["Music\\Album"])
@@ -187,7 +187,7 @@ class TestBuildSearchCache(unittest.TestCase):
                 {"filename": "B\\01.flac", "size": 100},
             ], upload_speed=5000),
         ]
-        _, speeds, _ = soularr._build_search_cache(results, self._specs("flac"))
+        _, speeds, _ = cratedigger._build_search_cache(results, self._specs("flac"))
         self.assertEqual(speeds["user1"], 5000)
 
     def test_multiple_filetypes(self):
@@ -198,7 +198,7 @@ class TestBuildSearchCache(unittest.TestCase):
             {"filename": "A\\01.mp3", "size": 50, "bitRate": 245,
              "sampleRate": 44100, "bitDepth": 0, "isVariableBitRate": True},
         ])]
-        entries, _, _ = soularr._build_search_cache(
+        entries, _, _ = cratedigger._build_search_cache(
             results, self._specs("flac", "mp3 v0")
         )
         self.assertIn("flac", entries["user1"])
@@ -209,13 +209,13 @@ class TestBuildSearchCache(unittest.TestCase):
         results = [make_search_result("user1", [
             {"filename": "A\\cover.jpg", "size": 50},
         ])]
-        entries, _, counts = soularr._build_search_cache(results, self._specs("flac"))
+        entries, _, counts = cratedigger._build_search_cache(results, self._specs("flac"))
         # User entry created but no filetypes
         self.assertEqual(entries.get("user1", {}), {})
 
     def test_empty_results(self):
         """Empty search results should return empty dicts."""
-        entries, speeds, counts = soularr._build_search_cache([], self._specs("flac"))
+        entries, speeds, counts = cratedigger._build_search_cache([], self._specs("flac"))
         self.assertEqual(entries, {})
         self.assertEqual(speeds, {})
         self.assertEqual(counts, {})
@@ -227,7 +227,7 @@ class TestBuildSearchCache(unittest.TestCase):
             {"filename": "A\\02.flac", "size": 100},
             {"filename": "A\\03.flac", "size": 100},
         ])]
-        entries, _, counts = soularr._build_search_cache(results, self._specs("flac"))
+        entries, _, counts = cratedigger._build_search_cache(results, self._specs("flac"))
         self.assertEqual(entries["user1"]["flac"], ["A"])
         self.assertEqual(counts["user1"]["A"], 3)
 
@@ -238,28 +238,28 @@ class TestGetUserDirs(unittest.TestCase):
     def test_specific_filetype(self):
         """Should return dirs for the exact filetype requested."""
         results = {"flac": ["Dir1", "Dir2"], "mp3 v0": ["Dir3"]}
-        self.assertEqual(soularr._get_user_dirs(results, "flac"), ["Dir1", "Dir2"])
+        self.assertEqual(cratedigger._get_user_dirs(results, "flac"), ["Dir1", "Dir2"])
 
     def test_missing_filetype_returns_none(self):
         """Should return None when the user has no dirs for that filetype."""
         results = {"flac": ["Dir1"]}
-        self.assertIsNone(soularr._get_user_dirs(results, "mp3 v0"))
+        self.assertIsNone(cratedigger._get_user_dirs(results, "mp3 v0"))
 
     def test_catch_all_merges_all(self):
         """Catch-all '*' should merge dirs from all filetypes, deduped."""
         results = {"flac": ["Dir1", "Dir2"], "mp3 v0": ["Dir2", "Dir3"]}
-        dirs = soularr._get_user_dirs(results, "*")
+        dirs = cratedigger._get_user_dirs(results, "*")
         self.assertEqual(dirs, ["Dir1", "Dir2", "Dir3"])
 
     def test_catch_all_empty_returns_none(self):
         """Catch-all with no dirs should return None."""
         results = {"flac": [], "mp3 v0": []}
-        self.assertIsNone(soularr._get_user_dirs(results, "*"))
+        self.assertIsNone(cratedigger._get_user_dirs(results, "*"))
 
     def test_catch_all_single_filetype(self):
         """Catch-all with one filetype should return those dirs."""
         results = {"flac": ["Dir1"]}
-        self.assertEqual(soularr._get_user_dirs(results, "*"), ["Dir1"])
+        self.assertEqual(cratedigger._get_user_dirs(results, "*"), ["Dir1"])
 
 
 class TestRawDictBoundary(unittest.TestCase):
@@ -293,24 +293,24 @@ class TestRawDictBoundary(unittest.TestCase):
 
     def test_album_track_num_with_raw_dicts(self):
         """album_track_num receives raw directory dicts."""
-        orig_cfg = soularr.cfg
-        soularr.cfg = _make_matching_cfg(allowed_filetypes=("flac", "mp3"))
+        orig_cfg = cratedigger.cfg
+        cratedigger.cfg = _make_matching_cfg(allowed_filetypes=("flac", "mp3"))
         try:
             directory = make_directory("Music\\Album", [
                 {"filename": "01 - Track.flac", "size": 100},
                 {"filename": "02 - Track.flac", "size": 100},
                 {"filename": "cover.jpg", "size": 50},
             ])
-            result = soularr.album_track_num(directory, soularr.cfg)
+            result = cratedigger.album_track_num(directory, cratedigger.cfg)
             self.assertEqual(result["count"], 2)
             self.assertEqual(result["filetype"], "flac")
         finally:
-            soularr.cfg = orig_cfg
+            cratedigger.cfg = orig_cfg
 
     def test_download_filter_with_raw_dicts(self):
         """download_filter returns a new dict without mutating the input."""
-        orig_cfg = soularr.cfg
-        soularr.cfg = _make_matching_cfg(
+        orig_cfg = cratedigger.cfg
+        cratedigger.cfg = _make_matching_cfg(
             download_filtering=True,
             use_extension_whitelist=True,
             extensions_whitelist=("jpg", "txt"),
@@ -321,7 +321,7 @@ class TestRawDictBoundary(unittest.TestCase):
                 {"filename": "cover.jpg", "size": 50},
                 {"filename": "info.nfo", "size": 10},
             ])
-            filtered = soularr.download_filter("flac", directory, soularr.cfg)
+            filtered = cratedigger.download_filter("flac", directory, cratedigger.cfg)
             filenames = [f["filename"] for f in filtered["files"]]
             self.assertIn("01 - Track.flac", filenames)
             self.assertIn("cover.jpg", filenames)
@@ -329,23 +329,23 @@ class TestRawDictBoundary(unittest.TestCase):
             # Original should be unchanged
             self.assertEqual(len(directory["files"]), 3)
         finally:
-            soularr.cfg = orig_cfg
+            cratedigger.cfg = orig_cfg
 
 
 class TestContextDependencyPropagation(unittest.TestCase):
     """Verify matching/enqueue helpers use ctx dependencies, not module globals."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        self._orig_pdb = soularr.pipeline_db_source
+        self._orig_cfg = cratedigger.cfg
+        self._orig_pdb = cratedigger.pipeline_db_source
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
-        soularr.pipeline_db_source = self._orig_pdb
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.pipeline_db_source = self._orig_pdb
 
     def test_check_for_match_uses_ctx_cfg(self):
         """Matching should read config from ctx, not the module-level cfg."""
-        soularr.cfg = _make_matching_cfg(
+        cratedigger.cfg = _make_matching_cfg(
             allowed_filetypes=("mp3",),
             minimum_match_ratio=0.99,
             ignored_users=("user1",),
@@ -363,7 +363,7 @@ class TestContextDependencyPropagation(unittest.TestCase):
         }
         ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
-        found, _, _ = soularr.check_for_match(
+        found, _, _ = cratedigger.check_for_match(
             make_tracks((1, "Track One", 1)),
             "flac",
             ["Music\\Album"],
@@ -385,9 +385,9 @@ class TestContextDependencyPropagation(unittest.TestCase):
         global_db = MagicMock()
         global_db.get_denylisted_users.return_value = [{"username": "wrong"}]
         global_source._get_db.return_value = global_db
-        soularr.pipeline_db_source = global_source
+        cratedigger.pipeline_db_source = global_source
 
-        denied = soularr._get_denied_users(12, ctx)
+        denied = cratedigger._get_denied_users(12, ctx)
 
         self.assertEqual(denied, {"baduser"})
         ctx_source._get_db.assert_called_once()
@@ -403,9 +403,9 @@ class TestContextDependencyPropagation(unittest.TestCase):
 
         global_source = MagicMock()
         global_source.get_tracks.return_value = []
-        soularr.pipeline_db_source = global_source
+        cratedigger.pipeline_db_source = global_source
 
-        tracks = soularr.get_album_tracks(album, ctx)
+        tracks = cratedigger.get_album_tracks(album, ctx)
 
         self.assertEqual(tracks, expected_tracks)
         ctx_source.get_tracks.assert_called_once_with(album)
@@ -668,12 +668,12 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
     """Verify try_multi_enqueue works without deepcopy on results."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        self._orig_slskd = soularr.slskd
-        self._orig_pdb = soularr.pipeline_db_source
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+        self._orig_pdb = cratedigger.pipeline_db_source
 
         mock_cfg = _make_matching_cfg()
-        soularr.cfg = mock_cfg
+        cratedigger.cfg = mock_cfg
 
         slskd = FakeSlskdAPI()
         slskd.users.set_directory("user1", "Music\\Disc1", [
@@ -682,18 +682,18 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
             ])
         ])
         self.slskd = slskd
-        soularr.slskd = slskd
+        cratedigger.slskd = slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
-        soularr.pipeline_db_source = mock_pdb
+        cratedigger.pipeline_db_source = mock_pdb
 
         self.ctx = _make_ctx(cfg=mock_cfg, slskd=slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
-        soularr.slskd = self._orig_slskd
-        soularr.pipeline_db_source = self._orig_pdb
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+        cratedigger.pipeline_db_source = self._orig_pdb
 
     def test_results_dict_not_mutated(self):
         """try_multi_enqueue should not mutate the results dict."""
@@ -743,7 +743,7 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
                 (True, dir2, "Music\\Disc2"),
             ],
         ), patch("time.sleep"):
-            soularr.try_multi_enqueue(release, tracks, results, "flac", self.ctx)
+            cratedigger.try_multi_enqueue(release, tracks, results, "flac", self.ctx)
 
         self.assertEqual(results, original_results)
 
@@ -789,7 +789,7 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
                 (True, dir2, "Music\\Disc2"),
             ],
         ), patch("time.sleep"):
-            attempt = soularr.try_multi_enqueue(
+            attempt = cratedigger.try_multi_enqueue(
                 release, tracks, results, "flac", self.ctx
             )
 
@@ -814,30 +814,30 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
     """Verify successful matches do not corrupt cached directory data."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        self._orig_slskd = soularr.slskd
-        self._orig_pdb = soularr.pipeline_db_source
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+        self._orig_pdb = cratedigger.pipeline_db_source
 
         mock_cfg = _make_matching_cfg(
             download_filtering=True,
             use_extension_whitelist=True,
             extensions_whitelist=("jpg",),
         )
-        soularr.cfg = mock_cfg
+        cratedigger.cfg = mock_cfg
 
         slskd = FakeSlskdAPI()
-        soularr.slskd = slskd
+        cratedigger.slskd = slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
-        soularr.pipeline_db_source = mock_pdb
+        cratedigger.pipeline_db_source = mock_pdb
 
         self.ctx = _make_ctx(cfg=mock_cfg, slskd=slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
-        soularr.slskd = self._orig_slskd
-        soularr.pipeline_db_source = self._orig_pdb
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+        cratedigger.pipeline_db_source = self._orig_pdb
 
     def test_folder_cache_not_corrupted_after_download_filter(self):
         """download_filter returns a new dict — folder_cache should be intact."""
@@ -855,13 +855,13 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
 
         # First call: match with 1 track, 1 audio file
         tracks = make_tracks((1, "Track One", 1))
-        found, directory, file_dir = soularr.check_for_match(
+        found, directory, file_dir = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Album"], "testuser", self.ctx
         )
         self.assertTrue(found)
 
         # Mutate the returned directory via download_filter (as try_enqueue does)
-        soularr.download_filter("flac", directory, self.ctx.cfg)
+        cratedigger.download_filter("flac", directory, self.ctx.cfg)
 
         # folder_cache should still have ALL 3 files (including .nfo)
         cached = self.ctx.folder_cache["testuser"]["Music\\Album"]
@@ -883,16 +883,16 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
         tracks = make_tracks((1, "Track One", 1))
 
         # First match
-        found1, dir1, _ = soularr.check_for_match(
+        found1, dir1, _ = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Album"], "testuser", self.ctx
         )
         self.assertTrue(found1)
 
         # Mutate it
-        soularr.download_filter("flac", dir1, self.ctx.cfg)
+        cratedigger.download_filter("flac", dir1, self.ctx.cfg)
 
         # Second match on the same cached dir should still succeed
-        found2, dir2, _ = soularr.check_for_match(
+        found2, dir2, _ = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Album"], "testuser", self.ctx
         )
         self.assertTrue(found2)
@@ -913,7 +913,7 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
             "deepcopy",
             side_effect=AssertionError("deepcopy should not be used"),
         ):
-            found, directory, file_dir = soularr.check_for_match(
+            found, directory, file_dir = cratedigger.check_for_match(
                 make_tracks((1, "Track One", 1)),
                 "flac",
                 ["Music\\Album"],
@@ -930,15 +930,15 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
     """Verify try_enqueue prefixes file paths without mutating the source directory."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        soularr.cfg = _make_matching_cfg()
+        self._orig_cfg = cratedigger.cfg
+        cratedigger.cfg = _make_matching_cfg()
         source = MagicMock()
         db = MagicMock()
         db.get_denylisted_users.return_value = []
         source._get_db.return_value = db
         self.slskd = FakeSlskdAPI()
         self.ctx = _make_ctx(
-            cfg=soularr.cfg,
+            cfg=cratedigger.cfg,
             slskd=self.slskd,
             pipeline_db_source=source,
         )
@@ -946,7 +946,7 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
         self.ctx.user_upload_speed["user1"] = 10
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
+        cratedigger.cfg = self._orig_cfg
 
     def test_try_enqueue_builds_prefixed_file_copies(self):
         directory = make_directory("Music\\Album", [
@@ -967,7 +967,7 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
             "check_for_match",
             return_value=(True, directory, "Music\\Album"),
         ), patch("time.sleep"):
-            attempt = soularr.try_enqueue(
+            attempt = cratedigger.try_enqueue(
                 make_tracks((1, "Track One", 1)),
                 results,
                 "flac",
@@ -989,12 +989,12 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
     """Search logging should preserve telemetry semantics across failures."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        soularr.cfg = MagicMock()
-        soularr.cfg.parallel_searches = 1
+        self._orig_cfg = cratedigger.cfg
+        cratedigger.cfg = MagicMock()
+        cratedigger.cfg.parallel_searches = 1
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
+        cratedigger.cfg = self._orig_cfg
 
     def test_log_search_result_preserves_unknown_result_count(self):
         db = MagicMock()
@@ -1005,7 +1005,7 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
 
         from lib.search import SearchResult
 
-        soularr._log_search_result(
+        cratedigger._log_search_result(
             album,
             SearchResult(album_id=1, success=False, query="Artist Album", outcome="error"),
             ctx,
@@ -1033,7 +1033,7 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
             result_count=7,
             elapsed_s=1.5,
         )
-        soularr._apply_find_download_result(
+        cratedigger._apply_find_download_result(
             album,
             result,
             enqueue_module.FindDownloadResult(outcome="enqueue_failed"),
@@ -1050,7 +1050,7 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
         source._get_db.return_value = db
         slskd = FakeSlskdAPI()
         slskd.transfers.enqueue_result = False
-        ctx = _make_ctx(cfg=soularr.cfg, slskd=slskd, pipeline_db_source=source)
+        ctx = _make_ctx(cfg=cratedigger.cfg, slskd=slskd, pipeline_db_source=source)
         ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         ctx.user_upload_speed["user1"] = 10
 
@@ -1064,7 +1064,7 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
             "check_for_match",
             return_value=(True, directory, "Music\\Album"),
         ):
-            attempt = soularr.try_enqueue(
+            attempt = cratedigger.try_enqueue(
                 make_tracks((1, "Track One", 1)),
                 results,
                 "flac",
@@ -1084,26 +1084,26 @@ class TestNegativeMatchCache(unittest.TestCase):
     """Verify negative match cache prevents re-evaluating known mismatches."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        self._orig_slskd = soularr.slskd
-        self._orig_pdb = soularr.pipeline_db_source
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+        self._orig_pdb = cratedigger.pipeline_db_source
 
         mock_cfg = _make_matching_cfg()
-        soularr.cfg = mock_cfg
+        cratedigger.cfg = mock_cfg
 
         slskd = FakeSlskdAPI()
-        soularr.slskd = slskd
+        cratedigger.slskd = slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
-        soularr.pipeline_db_source = mock_pdb
+        cratedigger.pipeline_db_source = mock_pdb
 
         self.ctx = _make_ctx(cfg=mock_cfg, slskd=slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
-        soularr.slskd = self._orig_slskd
-        soularr.pipeline_db_source = self._orig_pdb
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+        cratedigger.pipeline_db_source = self._orig_pdb
 
     def test_same_dir_same_track_count_skipped(self):
         """A dir that failed matching should be skipped on retry with same track count."""
@@ -1120,7 +1120,7 @@ class TestNegativeMatchCache(unittest.TestCase):
         )
 
         # First call — misses (1 file vs 3 tracks)
-        found1, _, _ = soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        found1, _, _ = cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
         self.assertFalse(found1)
 
         # Negative cache should contain (user1, Music\Album, 3, flac)
@@ -1128,7 +1128,7 @@ class TestNegativeMatchCache(unittest.TestCase):
 
         # Second call with same track count — should skip (no album_track_num re-eval)
         # We verify by checking that the negative cache hit prevents redundant work
-        found2, _, _ = soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        found2, _, _ = cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
         self.assertFalse(found2)
 
     def test_same_dir_different_filetype_not_skipped(self):
@@ -1143,7 +1143,7 @@ class TestNegativeMatchCache(unittest.TestCase):
         tracks = make_tracks((1, "Track One", 1))
 
         # Fails for "flac" (file is .mp3, album_track_num won't count it as flac)
-        soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
         self.assertIn(("user1", "Music\\Album", 1, "flac"), self.ctx.negative_matches)
 
         # Should NOT be skipped for "*" (different filetype key)
@@ -1163,11 +1163,11 @@ class TestNegativeMatchCache(unittest.TestCase):
             (1, "Track Two", 1),
             (1, "Track Three", 1),
         )
-        soularr.check_for_match(tracks_3, "flac", ["Music\\Album"], "user1", self.ctx)
+        cratedigger.check_for_match(tracks_3, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # Now try with 1 track — should NOT be skipped (different track count)
         tracks_1 = make_tracks((1, "Track One", 1))
-        found, _, _ = soularr.check_for_match(tracks_1, "flac", ["Music\\Album"], "user1", self.ctx)
+        found, _, _ = cratedigger.check_for_match(tracks_1, "flac", ["Music\\Album"], "user1", self.ctx)
         self.assertTrue(found)  # 1 file matches 1 track
 
 
@@ -1175,26 +1175,26 @@ class TestSearchResultPreFiltering(unittest.TestCase):
     """Verify directories with wrong audio file count are skipped before browsing."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        self._orig_slskd = soularr.slskd
-        self._orig_pdb = soularr.pipeline_db_source
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+        self._orig_pdb = cratedigger.pipeline_db_source
 
         mock_cfg = _make_matching_cfg()
-        soularr.cfg = mock_cfg
+        cratedigger.cfg = mock_cfg
 
         self.slskd = FakeSlskdAPI()
-        soularr.slskd = self.slskd
+        cratedigger.slskd = self.slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
-        soularr.pipeline_db_source = mock_pdb
+        cratedigger.pipeline_db_source = mock_pdb
 
         self.ctx = _make_ctx(cfg=mock_cfg, slskd=self.slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
-        soularr.slskd = self._orig_slskd
-        soularr.pipeline_db_source = self._orig_pdb
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+        cratedigger.pipeline_db_source = self._orig_pdb
 
     def test_dir_with_wrong_count_skipped_before_browse(self):
         """Directory with 3 audio files should be skipped when we need 12 tracks."""
@@ -1204,8 +1204,8 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         }
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
-        tracks: list[soularr.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
-        soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        tracks: list[cratedigger.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
+        cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # Should NOT have called slskd.users.directory — skipped before browse
         self.assertEqual(self.slskd.users.directory_calls, [])
@@ -1223,8 +1223,8 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         ])
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
-        tracks: list[soularr.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
-        soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        tracks: list[cratedigger.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
+        cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # SHOULD have browsed — count is close enough
         self.assertEqual(
@@ -1240,8 +1240,8 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         ])
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
-        tracks: list[soularr.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
-        soularr.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        tracks: list[cratedigger.TrackRecord] = [{"albumId": 1, "title": f"Track {i}", "mediumNumber": 1} for i in range(12)]  # type: ignore[misc]
+        cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
 
         # Should browse — no metadata to pre-filter
         self.assertEqual(
@@ -1259,7 +1259,7 @@ class TestRankCandidateDirs(unittest.TestCase):
             "Music\\Artist\\The Album Name",
             "Music\\Other\\Random",
         ]
-        ranked = soularr.rank_candidate_dirs(dirs, "The Album Name", "Artist")
+        ranked = cratedigger.rank_candidate_dirs(dirs, "The Album Name", "Artist")
         self.assertEqual(ranked[0], "Music\\Artist\\The Album Name")
 
     def test_artist_name_in_path_promoted(self):
@@ -1267,7 +1267,7 @@ class TestRankCandidateDirs(unittest.TestCase):
             "Music\\Other\\Album",
             "Music\\Artist\\Album",
         ]
-        ranked = soularr.rank_candidate_dirs(dirs, "Album", "Artist")
+        ranked = cratedigger.rank_candidate_dirs(dirs, "Album", "Artist")
         self.assertEqual(ranked[0], "Music\\Artist\\Album")
 
     def test_penalty_keywords_demoted(self):
@@ -1276,7 +1276,7 @@ class TestRankCandidateDirs(unittest.TestCase):
             "Music\\Artist\\The Real Album",
             "Music\\Artist\\Greatest Hits",
         ]
-        ranked = soularr.rank_candidate_dirs(dirs, "The Real Album", "Artist")
+        ranked = cratedigger.rank_candidate_dirs(dirs, "The Real Album", "Artist")
         self.assertEqual(ranked[0], "Music\\Artist\\The Real Album")
         # Best Of and Greatest Hits should be last
         penalty_dirs = ranked[1:]
@@ -1290,7 +1290,7 @@ class TestRankCandidateDirs(unittest.TestCase):
             "Music\\Artist\\Discography\\Album",
             "Music\\Artist\\Album",
         ]
-        ranked = soularr.rank_candidate_dirs(dirs, "Album", "Artist")
+        ranked = cratedigger.rank_candidate_dirs(dirs, "Album", "Artist")
         self.assertEqual(ranked[0], "Music\\Artist\\Album")
 
     def test_case_insensitive(self):
@@ -1298,13 +1298,13 @@ class TestRankCandidateDirs(unittest.TestCase):
             "music\\other\\random",
             "MUSIC\\ARTIST\\THE ALBUM",
         ]
-        ranked = soularr.rank_candidate_dirs(dirs, "The Album", "Artist")
+        ranked = cratedigger.rank_candidate_dirs(dirs, "The Album", "Artist")
         self.assertEqual(ranked[0], "MUSIC\\ARTIST\\THE ALBUM")
 
     def test_preserves_order_for_equal_scores(self):
         """Dirs with equal scores should preserve original order."""
         dirs = ["Music\\Dir1", "Music\\Dir2", "Music\\Dir3"]
-        ranked = soularr.rank_candidate_dirs(dirs, "Unrelated", "Nobody")
+        ranked = cratedigger.rank_candidate_dirs(dirs, "Unrelated", "Nobody")
         self.assertEqual(ranked, dirs)
 
 
@@ -1312,26 +1312,26 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
     """Verify parallel directory browsing populates folder_cache correctly."""
 
     def setUp(self):
-        self._orig_cfg = soularr.cfg
-        self._orig_slskd = soularr.slskd
-        self._orig_pdb = soularr.pipeline_db_source
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+        self._orig_pdb = cratedigger.pipeline_db_source
 
         mock_cfg = _make_matching_cfg()
-        soularr.cfg = mock_cfg
+        cratedigger.cfg = mock_cfg
 
         self.slskd = FakeSlskdAPI()
-        soularr.slskd = self.slskd
+        cratedigger.slskd = self.slskd
 
         mock_pdb = MagicMock()
         mock_pdb.get_denied_users.return_value = []
-        soularr.pipeline_db_source = mock_pdb
+        cratedigger.pipeline_db_source = mock_pdb
 
         self.ctx = _make_ctx(cfg=mock_cfg, slskd=self.slskd, pipeline_db_source=mock_pdb)
 
     def tearDown(self):
-        soularr.cfg = self._orig_cfg
-        soularr.slskd = self._orig_slskd
-        soularr.pipeline_db_source = self._orig_pdb
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+        cratedigger.pipeline_db_source = self._orig_pdb
 
     def test_parallel_browse_populates_cache(self):
         """_browse_directories should populate folder_cache for all dirs."""
@@ -1343,7 +1343,7 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
                 ])
             ])
 
-        results = soularr._browse_directories(
+        results = cratedigger._browse_directories(
             dirs_to_browse, "user1", self.slskd, max_workers=2
         )
 
@@ -1372,7 +1372,7 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
             Exception("Peer offline"),
         )
 
-        results = soularr._browse_directories(
+        results = cratedigger._browse_directories(
             dirs_to_browse, "user1", self.slskd, max_workers=2
         )
 
@@ -1394,7 +1394,7 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         tracks = make_tracks((1, "Track One", 1))
 
-        found, _, _ = soularr.check_for_match(
+        found, _, _ = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Dir1", "Music\\Dir2"], "user1", self.ctx
         )
         self.assertFalse(found)

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from lib.beets_db import AlbumInfo
-from lib.config import SoularrConfig
+from lib.config import CratediggerConfig
 from lib.quality import (
     IMPORT_RESULT_SENTINEL,
     QUALITY_LOSSLESS,
@@ -72,7 +72,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         ))
 
         if cfg is None:
-            cfg = SoularrConfig(
+            cfg = CratediggerConfig(
                 beets_harness_path=_HARNESS,
                 pipeline_db_enabled=True,
             )
@@ -236,7 +236,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
             avg_bitrate_kbps=180, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
-        custom_cfg = SoularrConfig(
+        custom_cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
             quality_ranks=QualityRankConfig(gate_min_rank=QualityRank.GOOD),
@@ -279,7 +279,7 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
             median_bitrate_kbps=245,
             format="MP3", is_cbr=False, album_path="/Beets/Test")
 
-        custom_cfg = SoularrConfig(
+        custom_cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
             quality_ranks=QualityRankConfig(
@@ -454,7 +454,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
     """
 
     def test_suspect_download_updates_current_spectral_and_denylists(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -468,7 +468,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             is_cbr=True,
             album_path="/Beets/Test",
         )
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch(
             "lib.preimport.spectral_analyze",
@@ -488,7 +488,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             ],
         ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
              patch("os.path.isdir", return_value=True):
-            with self.assertLogs("soularr", level="WARNING") as logs:
+            with self.assertLogs("cratedigger", level="WARNING") as logs:
                 result = run_preimport_gates(
                     path="/tmp/download",
                     mb_release_id="mbid-123",
@@ -535,7 +535,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
         import_no_exist. The key invariant: the reject reason must NOT
         read ``spectral {x}kbps <= existing {x}kbps`` with equal numbers.
         """
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -550,7 +550,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             is_cbr=True,
             album_path="/Beets/Test",
         )
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch(
             "lib.preimport.spectral_analyze",
@@ -592,7 +592,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
         against 320kbps (a real comparison) and the detail string reflects
         that — not the self-compare "128 <= 128" the old code produced.
         """
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -606,7 +606,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             is_cbr=True,
             album_path="/Beets/Test",
         )
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch(
             "lib.preimport.spectral_analyze",
@@ -647,7 +647,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
 
         With the fix: decision sees 280 vs container 256 → import_upgrade.
         """
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
@@ -661,7 +661,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             is_cbr=True,
             album_path="/Beets/Test",
         )
-        cfg = SoularrConfig(audio_check_mode="off")
+        cfg = CratediggerConfig(audio_check_mode="off")
 
         with patch(
             "lib.preimport.spectral_analyze",
@@ -705,7 +705,7 @@ class TestDispatchNoJsonResult(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
 
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
         )
@@ -756,7 +756,7 @@ class TestForceImportSlice(unittest.TestCase):
             avg_bitrate_kbps=320, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
         )
@@ -812,7 +812,7 @@ class TestForceImportSlice(unittest.TestCase):
             avg_bitrate_kbps=320, format="MP3",
             is_cbr=False, album_path="/Beets/Test")
 
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS, pipeline_db_enabled=True)
 
         tmpdir = tempfile.mkdtemp()
@@ -1076,7 +1076,7 @@ class TestBayOfBiscayUpgradeChain(unittest.TestCase):
             id=42, status="downloading",
             **(request_overrides or {}),
         ))
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
         )

--- a/tests/test_js_release_actions.mjs
+++ b/tests/test_js_release_actions.mjs
@@ -93,7 +93,7 @@ clearStore();
 {
   // User report: "downloading" pressing showed Remove request greyed
   // out. The backend's /api/pipeline/delete handles any status, so
-  // there's no reason to disable. Soularr's next poll cycle drops
+  // there's no reason to disable. Cratedigger's next poll cycle drops
   // any orphan slskd transfer when the row is gone.
   const html = renderActionToolbar({
     id: 'rel-5', in_library: false,

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -87,7 +87,7 @@ class TestDiscoverMigrations(unittest.TestCase):
 
     def test_missing_directory_raises(self):
         with self.assertRaises(FileNotFoundError):
-            discover_migrations("/tmp/this-path-does-not-exist-soularr")
+            discover_migrations("/tmp/this-path-does-not-exist-cratedigger")
 
     def test_default_migrations_dir_resolves(self):
         """Sanity: the package-level DEFAULT_MIGRATIONS_DIR points at migrations/."""

--- a/tests/test_no_dual_load.py
+++ b/tests/test_no_dual_load.py
@@ -103,12 +103,12 @@ class TestNoDualLoad(unittest.TestCase):
             "contains the repo root, and every import uses its prefixed form."
         )
 
-    def test_soularr_main_no_dual_load(self):
-        """Booting soularr.py must not load any module twice."""
+    def test_cratedigger_main_no_dual_load(self):
+        """Booting cratedigger.py must not load any module twice."""
         bootstrap = (
             "import sys, os\n"
             "sys.path.insert(0, os.path.abspath('.'))\n"
-            "import soularr  # noqa: F401\n"
+            "import cratedigger  # noqa: F401\n"
         )
         modules = _run_entrypoint_and_dump_modules(bootstrap)
         offenders = _dual_loaded(modules)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -70,7 +70,7 @@ class TestFixLibraryModes(unittest.TestCase):
                                  f"{p}: file mode must not be modified")
 
     def test_nonexistent_path_is_noop(self):
-        fix_library_modes("/tmp/soularr-does-not-exist-xyz")
+        fix_library_modes("/tmp/cratedigger-does-not-exist-xyz")
 
     def test_file_path_is_noop(self):
         """Passing a file path should not chmod anything — the helper is

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -568,7 +568,7 @@ class TestCmdRepairSpectral(unittest.TestCase):
 
             args = MagicMock(dry_run=False)
             stdout = io.StringIO()
-            with patch.dict(os.environ, {"SOULARR_RUNTIME_CONFIG": cfg_path}), \
+            with patch.dict(os.environ, {"CRATEDIGGER_RUNTIME_CONFIG": cfg_path}), \
                  patch("lib.beets_db.BeetsDB", return_value=mock_beets), \
                  redirect_stdout(stdout):
                 pipeline_cli.cmd_repair_spectral(db, args)

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1,7 +1,7 @@
 """Tests for lib/pipeline_db.py — Pipeline DB module (PostgreSQL).
 
 Requires a PostgreSQL server. Set TEST_DB_DSN env var to run, e.g.:
-    TEST_DB_DSN=postgresql://soularr@localhost/soularr_test python3 -m unittest tests.test_pipeline_db -v
+    TEST_DB_DSN=postgresql://cratedigger@localhost/cratedigger_test python3 -m unittest tests.test_pipeline_db -v
 
 Tests create/drop tables in the target database — use a dedicated test DB.
 """

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -8,7 +8,7 @@ classification.
 
 Fixture generation: tests/fixtures/generate_fixtures.sh
 
-The quality gate decision tree (from soularr.py _check_quality_gate):
+The quality gate decision tree (from cratedigger.py _check_quality_gate):
 
   1. verified_lossless=TRUE + any bitrate  → ACCEPT
   2. gate_bitrate < 210kbps                → REQUEUE_UPGRADE
@@ -232,7 +232,7 @@ def load_or_analyze_all():
 
 
 def _call_quality_gate(min_bitrate, is_cbr, verified_lossless, spectral_bitrate=None):
-    """Wrapper: call the real quality_gate_decision() from soularr.py
+    """Wrapper: call the real quality_gate_decision() from cratedigger.py
     and convert its string return to a QualityDecision enum for test assertions."""
     from lib.quality import AudioQualityMeasurement
     m = AudioQualityMeasurement(min_bitrate_kbps=min_bitrate, is_cbr=is_cbr,
@@ -597,7 +597,7 @@ class TestLiveBugReproductions(unittest.TestCase):
         grade=="suspect", missing "likely_transcode". Also, spectral said
         new=160 <= existing=160, so it should have been rejected.
 
-        Root cause: soularr.py line 1426 checked `== "suspect"` not
+        Root cause: cratedigger.py line 1426 checked `== "suspect"` not
         `in ("suspect", "likely_transcode")`.
         """
         r = full_pipeline_decision(

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -2495,7 +2495,7 @@ class TestQualityRankConfigDefaults(unittest.TestCase):
     """Lock the default policy values so changes are explicit.
 
     **These values are mirrored in the upstream NixOS module at**
-    ``nix/module.nix`` → ``services.soularr.qualityRanks.*`` (see README
+    ``nix/module.nix`` → ``services.cratedigger.qualityRanks.*`` (see README
     § "Tuning the quality rank model" for the deployment surface and
     issue #67 for the rationale). If you change a default here, you
     MUST also update the Nix defaults, otherwise a fresh

--- a/tests/test_slskd_live.py
+++ b/tests/test_slskd_live.py
@@ -4,7 +4,7 @@ Tier 1: Search + enqueue shape validation (~30s) — runs if slskd available.
 Tier 2: Full download pipeline (~2-5min) — runs if SLSKD_TEST_FULL=1.
 
 These tests validate that real slskd API responses match the dict shapes
-soularr.py expects. They caught three production crashes from dict/DownloadFile
+cratedigger.py expects. They caught three production crashes from dict/DownloadFile
 boundary mismatches on 2026-03-29.
 
 Requires: tests/.slskd-creds.json + docker (auto-started by conftest.py).
@@ -125,10 +125,10 @@ class TestSlskdSearchShapes(unittest.TestCase):
         """verify_filetype() works with actual slskd file dicts — no AttributeError."""
         # Mock cfg to avoid global state issues
         from unittest.mock import MagicMock
-        import soularr
+        import cratedigger
         from lib.quality import verify_filetype
-        orig_cfg = soularr.cfg
-        soularr.cfg = MagicMock()
+        orig_cfg = cratedigger.cfg
+        cratedigger.cfg = MagicMock()
         try:
             for r in self.results[:3]:
                 for f in r.get("files", [])[:3]:
@@ -138,7 +138,7 @@ class TestSlskdSearchShapes(unittest.TestCase):
                     except (KeyError, ValueError):
                         pass  # Wrong type is fine — crashing is not
         finally:
-            soularr.cfg = orig_cfg
+            cratedigger.cfg = orig_cfg
 
 
 @unittest.skipUnless(SLSKD_HOST, "slskd not available — no creds or docker")

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -201,7 +201,7 @@ class TestApplyTransition(unittest.TestCase):
         """When set_downloading returns False, transition logs a warning."""
         db = self._make_db("wanted")
         db.set_downloading.return_value = False
-        with self.assertLogs("soularr", level="WARNING") as cm:
+        with self.assertLogs("cratedigger", level="WARNING") as cm:
             apply_transition(db, 1, "downloading", from_status="wanted",
                              state_json='{"filetype":"flac"}')
         self.assertTrue(any("status guard" in msg for msg in cm.output))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-"""Tests for lib/util.py — pure utility functions extracted from soularr.py."""
+"""Tests for lib/util.py — pure utility functions extracted from cratedigger.py."""
 
 import json
 import os
@@ -596,7 +596,7 @@ class TestNotifiersReadSecretsFromFiles(unittest.TestCase):
     """Issue #117: notifier functions must read secrets from *_file paths so
     the rendered config.ini never embeds plaintext credentials.
 
-    These tests use a real SoularrConfig (not MagicMock) so the resolver
+    These tests use a real CratediggerConfig (not MagicMock) so the resolver
     methods actually run and the file-reading path is exercised end to end.
     """
 
@@ -616,11 +616,11 @@ class TestNotifiersReadSecretsFromFiles(unittest.TestCase):
     @patch("lib.util._meelo_scanner_post")
     @patch("lib.util._meelo_jwt_login", return_value="tok")
     def test_meelo_scan_reads_credentials_from_files(self, mock_login, mock_post):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.util import trigger_meelo_scan
         user_path = self._write("meelo-user", "live-user\n")
         pass_path = self._write("meelo-pass", "live-pass\n")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             meelo_url="http://meelo:5001",
             meelo_username_file=user_path,
             meelo_password_file=pass_path,
@@ -632,11 +632,11 @@ class TestNotifiersReadSecretsFromFiles(unittest.TestCase):
     @patch("lib.util._meelo_scanner_post")
     @patch("lib.util._meelo_jwt_login", return_value="tok")
     def test_meelo_clean_reads_credentials_from_files(self, mock_login, mock_post):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.util import trigger_meelo_clean
         user_path = self._write("meelo-user", "live-user\n")
         pass_path = self._write("meelo-pass", "live-pass\n")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             meelo_url="http://meelo:5001",
             meelo_username_file=user_path,
             meelo_password_file=pass_path,
@@ -646,10 +646,10 @@ class TestNotifiersReadSecretsFromFiles(unittest.TestCase):
 
     @patch("lib.util.urllib.request.urlopen")
     def test_plex_scan_reads_token_from_file(self, mock_urlopen):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.util import trigger_plex_scan
         token_path = self._write("plex-token", "plex-live-tok\n")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             plex_url="http://plex:32400",
             plex_token_file=token_path,
             plex_library_section_id="3",
@@ -666,10 +666,10 @@ class TestNotifiersReadSecretsFromFiles(unittest.TestCase):
 
     @patch("lib.util.urllib.request.urlopen")
     def test_jellyfin_scan_reads_token_from_file(self, mock_urlopen):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.util import trigger_jellyfin_scan
         token_path = self._write("jf-token", "jellyfin-live-tok\n")
-        cfg = SoularrConfig(
+        cfg = CratediggerConfig(
             jellyfin_url="http://jellyfin:8096",
             jellyfin_token_file=token_path,
         )
@@ -683,23 +683,23 @@ class TestNotifiersReadSecretsFromFiles(unittest.TestCase):
         self.assertEqual(req.get_header("X-emby-token"), "jellyfin-live-tok")
 
     def test_plex_scan_skipped_when_token_file_empty_and_no_direct_token(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.util import trigger_plex_scan
-        cfg = SoularrConfig(plex_url="http://plex:32400")
+        cfg = CratediggerConfig(plex_url="http://plex:32400")
         # Should not raise, should just skip — no token available.
         trigger_plex_scan(cfg, "/path")
 
     def test_jellyfin_scan_skipped_when_token_file_empty(self):
-        from lib.config import SoularrConfig
+        from lib.config import CratediggerConfig
         from lib.util import trigger_jellyfin_scan
-        cfg = SoularrConfig(jellyfin_url="http://jellyfin:8096")
+        cfg = CratediggerConfig(jellyfin_url="http://jellyfin:8096")
         trigger_jellyfin_scan(cfg)
 
 
 class TestBeetsSubprocessEnv(unittest.TestCase):
     """beets_subprocess_env() is the single source of truth for the env dict
     used by every subprocess that invokes beets (directly or via the harness
-    / import_one.py). Beets reads `~/.config/beets/config.yaml`; when soularr
+    / import_one.py). Beets reads `~/.config/beets/config.yaml`; when cratedigger
     runs as the systemd service (root, HOME=/root), the Nix Home Manager
     beets config isn't there and the Discogs plugin returns 0 candidates for
     every --search-id. See live failures in download_log for Blueline Medic.
@@ -722,7 +722,7 @@ class TestBeetsSubprocessEnv(unittest.TestCase):
         """Non-HOME vars pass through unchanged — PATH, PYTHONPATH etc. must
         still reach the subprocess."""
         from lib.util import beets_subprocess_env
-        sentinel = "SOULARR_TEST_SENTINEL_VAR_XYZ"
+        sentinel = "CRATEDIGGER_TEST_SENTINEL_VAR_XYZ"
         with patch.dict(os.environ, {sentinel: "present"}, clear=False):
             env = beets_subprocess_env()
         self.assertEqual(env.get(sentinel), "present")

--- a/tests/test_validation_result.py
+++ b/tests/test_validation_result.py
@@ -377,7 +377,7 @@ class TestValidationResultConstruction(unittest.TestCase):
         self.assertIsNotNone(vr.failed_path)
 
     def test_source_info(self) -> None:
-        """Source info populated by soularr.py after beets_validate returns."""
+        """Source info populated by cratedigger.py after beets_validate returns."""
         vr = ValidationResult(
             valid=False, scenario="high_distance",
             soulseek_username="baduser123",

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -156,7 +156,7 @@ class TestMetaNamespace(_CacheTestBase):
 class TestStartupFlushLeavesMetaAlone(unittest.TestCase):
     """Server startup flushes legacy `web:*` routing cache but MUST NOT
     touch the pure `meta:*` metadata namespace. Flushing it on every
-    `systemctl restart soularr-web` would defeat the 24h cache —
+    `systemctl restart cratedigger-web` would defeat the 24h cache —
     Codex review on PR #104.
     """
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -927,8 +927,8 @@ class TestPipelineRouteDirectEquivalence(_WebServerCase):
         from lib.config import read_runtime_rank_config
 
         # The route reads the runtime cfg via `_runtime_rank_config()`.
-        # In the test env there's no /var/lib/soularr/config.ini, so it
-        # falls back to SoularrConfig() defaults. Read it once here so
+        # In the test env there's no /var/lib/cratedigger/config.ini, so it
+        # falls back to CratediggerConfig() defaults. Read it once here so
         # both sides use identical cfg.
         cfg = read_runtime_rank_config()
 
@@ -3068,7 +3068,7 @@ class TestReleaseEndpointReflectsPipelineWrite(_CachedServerCase):
         first = self._call_release_detail()
         self.assertEqual(first["pipeline_status"], "wanted")
 
-        # Simulate soularr pipeline flipping status outside the web UI.
+        # Simulate cratedigger pipeline flipping status outside the web UI.
         # No POST to /api/cache/invalidate, no web-UI cache-group flush —
         # this is the exact sequence that produced the stale-badge bug.
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(

--- a/web/cache.py
+++ b/web/cache.py
@@ -1,4 +1,4 @@
-"""Redis cache layer for the Soularr web UI.
+"""Redis cache layer for the Cratedigger web UI.
 
 Two separate namespaces:
 
@@ -13,7 +13,7 @@ Two separate namespaces:
   group, discogs master/release, beets, pipeline, library/artist,
   disambiguate, …) MUST NOT be cached here — that baked
   `pipeline_status` / `in_library` into the payload and leaked stale
-  badges when soularr-the-pipeline updated Postgres outside the web
+  badges when cratedigger-the-pipeline updated Postgres outside the web
   UI's POST invalidation paths. See issue #101.
 
 All operations fail-safe — Redis being down means cache miss, never

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -19,7 +19,7 @@ import urllib.request
 from web import cache as _cache
 
 DISCOGS_API_BASE = "https://discogs.ablz.au"
-USER_AGENT = "soularr-web/1.0"
+USER_AGENT = "cratedigger-web/1.0"
 
 
 def _get(url: str) -> dict:

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -19,7 +19,7 @@
  * Acquire decision tree (highest priority first):
  *   1. pipeline_status in ('wanted', 'downloading') → "Remove request"
  *      enabled. Backend's /api/pipeline/delete handles any status —
- *      it removes the row and soularr's next poll cycle ignores the
+ *      it removes the row and cratedigger's next poll cycle ignores the
  *      orphaned slskd transfer. User's mental model: "if it's in the
  *      pipeline, I can remove it".
  *   2. in_library OR pipeline_status === 'imported' → "Upgrade" enabled
@@ -83,7 +83,7 @@ export function renderActionToolbar(item, opts = {}) {
   let acquireBtn;
   if ((pStatus === 'wanted' || pStatus === 'downloading') && pId) {
     // Cancellable. Backend deletes the row regardless of status; if a
-    // download is in flight, soularr's next poll ignores the orphan
+    // download is in flight, cratedigger's next poll ignores the orphan
     // slskd transfer. Covers fresh add-requests, queued upgrades, and
     // mid-download cancels.
     acquireBtn = `<button class="btn" style="${baseStyle}background:#5a2a2a;color:#f88;" onclick="event.stopPropagation(); window.disambRemove(${pId}, this)">Remove request</button>`;

--- a/web/mb.py
+++ b/web/mb.py
@@ -22,7 +22,7 @@ import urllib.error
 from web import cache as _cache
 
 MB_API_BASE = "http://192.168.1.35:5200/ws/2"
-USER_AGENT = "soularr-web/1.0"
+USER_AGENT = "cratedigger-web/1.0"
 
 
 def _get(url):

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -166,7 +166,7 @@ def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
 
 def _runtime_rank_config():
     """Load the runtime QualityRankConfig from the same config.ini the main
-    soularr process reads, so web simulator matches production dispatch."""
+    cratedigger process reads, so web simulator matches production dispatch."""
     from lib.config import read_runtime_rank_config  # type: ignore[import-not-found]
 
     return read_runtime_rank_config()

--- a/web/server.py
+++ b/web/server.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Soularr Web UI — album request manager at music.ablz.au.
+"""Cratedigger Web UI — album request manager at music.ablz.au.
 
 Browse MusicBrainz, add releases to the pipeline DB, view status.
 
 Usage:
-    python3 web/server.py --port 8085 --dsn postgresql://soularr@192.168.100.11/soularr
+    python3 web/server.py --port 8085 --dsn postgresql://cratedigger@192.168.100.11/cratedigger
 """
 
 import argparse
@@ -23,7 +23,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
     level=logging.INFO,
 )
-log = logging.getLogger("soularr-web")
+log = logging.getLogger("cratedigger-web")
 
 # Ensure repo root is importable when run as __main__ so `from lib.X` /
 # `from web.X` resolve without relying on PYTHONPATH.
@@ -156,7 +156,7 @@ def _rank_cfg():
 
     Falls back to defaults if the ini can't be read (e.g. tests / first-
     boot). The cache is module-scoped — a deploy restart picks up any
-    [Quality Ranks] changes via the soularr-web service restart that
+    [Quality Ranks] changes via the cratedigger-web service restart that
     deploy.md guarantees.
     """
     global _rank_cfg_cache
@@ -177,7 +177,7 @@ def compute_library_rank(format_str: str | None, bitrate_kbps: int | None) -> st
     the import gate uses, so what you see in the badge matches what the
     pipeline's quality decisions act on. Returns lowercase rank name
     ('lossless', 'transparent', 'excellent', 'good', 'acceptable',
-    'poor', 'unknown'). Treats MP3 as VBR — soularr's pipeline only
+    'poor', 'unknown'). Treats MP3 as VBR — cratedigger's pipeline only
     produces VBR-V0 MP3, and for the bitrate buckets the badge cares
     about the VBR-vs-CBR distinction barely matters at the display level.
     """
@@ -272,7 +272,7 @@ class Handler(BaseHTTPRequestHandler):
     # Routing-level response cache was removed by issue #101 — it used to
     # cache the full HTTP response under `web:<url>`, which baked in
     # per-request overlay state (pipeline_status, in_library, …) and
-    # leaked stale badges for up to 5 min after soularr-the-pipeline
+    # leaked stale badges for up to 5 min after cratedigger-the-pipeline
     # wrote to Postgres outside the web UI's POST paths.
     #
     # The pure MB/Discogs metadata that this cache used to cover is now
@@ -282,7 +282,7 @@ class Handler(BaseHTTPRequestHandler):
     # lookups that no longer need caching.
     #
     # `cache.invalidate_groups()` is still callable for backwards
-    # compatibility with soularr's main loop POSTing to
+    # compatibility with cratedigger's main loop POSTing to
     # /api/cache/invalidate, but it's a no-op for any fresh deploy
     # (no `web:` keys exist).
 
@@ -324,7 +324,7 @@ class Handler(BaseHTTPRequestHandler):
 
         try:
             # Cache invalidation endpoint — kept for backwards compat with
-            # soularr's main-loop POST at end of every cycle. Post-#101
+            # cratedigger's main-loop POST at end of every cycle. Post-#101
             # there's nothing to invalidate at the `web:` namespace, so
             # this is a best-effort no-op.
             if path == "/api/cache/invalidate":
@@ -363,9 +363,9 @@ class Handler(BaseHTTPRequestHandler):
 def main():
     global db, beets_db_path, _beets
 
-    parser = argparse.ArgumentParser(description="Soularr Web UI")
+    parser = argparse.ArgumentParser(description="Cratedigger Web UI")
     parser.add_argument("--port", type=int, default=8085)
-    parser.add_argument("--dsn", default=os.environ.get("PIPELINE_DB_DSN", "postgresql://soularr@localhost/soularr"))
+    parser.add_argument("--dsn", default=os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger"))
     parser.add_argument("--beets-db", default="/mnt/virtio/Music/beets-library.db")
     parser.add_argument("--mb-api", default=None, help="MusicBrainz API base URL")
     parser.add_argument("--redis-host", default=None, help="Redis host for caching (optional)")
@@ -396,7 +396,7 @@ def main():
         _beets = BeetsDB(beets_db_path)
 
     server = HTTPServer(("0.0.0.0", args.port), Handler)
-    print(f"Soularr Web UI listening on http://0.0.0.0:{args.port}")
+    print(f"Cratedigger Web UI listening on http://0.0.0.0:{args.port}")
     print(f"  Pipeline DB: {args.dsn}")
     print(f"  Beets DB: {beets_db_path}")
     print(f"  MB API: {mb_api.MB_API_BASE}")


### PR DESCRIPTION
## Summary

Finalises the project rename. 97 files, 802 substitutions.

- Python entrypoint `soularr.py` → `cratedigger.py`
- All internal symbols: `SoularrConfig` → `CratediggerConfig`, `SoularrContext` → `CratediggerContext`, loggers, cache filenames
- Upstream NixOS module: `services.soularr.*` → `services.cratedigger.*`; systemd units renamed (`cratedigger.service`, `cratedigger-web.service`, `cratedigger-db-migrate.service`)
- Docs, tests, `.claude/` rules/commands/agents, `.codex/skills/*`
- Repo already renamed on GitHub to `abl030/cratedigger`; About blurb + homepage updated.

## Preserved (stay on "soularr")

- `mrusse/soularr` upstream attribution — origin story
- `/home/abl030/soularr` working dir + `-home-abl030-soularr` memory dir — renamed between sessions (issue #134 phase 8)
- `SOULARR_SLSKD_API_KEY`, `soularr/env` sops labels — not worth rotating encrypted state over a cosmetic rename

## ⚠️ Deploy order

**Do not `nix flake update cratedigger-src` against this branch without simultaneously landing the nixosconfig wrapper rename** — the live wrapper (`~/nixosconfig/modules/nixos/services/soularr.nix`) still references `\${inputs.soularr-src}/soularr.py`, which this PR renames. Merge after phases 3+4 are staged, in a single doc2 maintenance window.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 1928 tests pass
- [x] `pyright cratedigger.py lib/ harness/ web/ tests/` — 0 errors
- [x] `nix build .#checks.x86_64-linux.moduleVm` — VM test passes
- [ ] Phase 3 wrapper PR in nixosconfig ready
- [ ] Phase 4 doc2 maintenance window (backup → rename DB/user → rename state dir → rename nspawn machine → rebuild)

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)