### PR TITLE
refactor: BeetsAlbumOp + release lock + sibling imported_path propagation (#133, #132)

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1446,18 +1446,16 @@ def main():
     # we no longer depend on the pre-flight capture matching what
     # ``resolve_duplicate`` sees. The intra-process race is closed.
     #
-    # KNOWN LIMITATION (Codex PR #131 round 6 P1): this remains
-    # vulnerable to CROSS-process races. If a second cratedigger process
-    # (e.g. cratedigger-web force-import racing an auto-import cycle)
-    # commits a same-MBID row between our ``run_import`` returning
-    # and this re-enumerate query, ``max(post_import_ids)`` would
-    # pick that other process's row as "new" and our cleanup would
-    # delete the one this process actually imported. Cratedigger.service
-    # is single-instance (``/var/lib/cratedigger/cratedigger.lock``) but the
-    # web force-import path does not hold that lock, so the race
-    # window exists in practice. Follow-up: a pipeline-level same-
-    # release advisory lock shared by both entry points, tracked
-    # separately from this data-loss fix.
+    # Cross-process race closed by issue #133 / #132 P1:
+    # ``dispatch_import_core`` takes ``ADVISORY_LOCK_NAMESPACE_RELEASE``
+    # keyed on a stable hash of ``mb_release_id`` for the duration of
+    # this subprocess. Previously ``max(post_import_ids)`` was
+    # vulnerable to a racing process inserting its own same-MBID row
+    # between ``run_import`` returning and this re-enumerate query;
+    # the release-level advisory lock serialises every entry point
+    # (auto cycle, web force-import, CLI manual-import) that spawns
+    # import_one.py so this window no longer exists. The non-blocking
+    # lock means a second caller returns early rather than queueing.
     #
     # Each removal uses ``beet remove -a -d id:<N>`` — primary-key
     # scoped, cannot reach cross-MBID siblings. Any removal failure

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -773,7 +773,6 @@ def run_import(path, mb_release_id):
 
 
 def _apply_disambiguation(
-    mbid: str,
     album_id: int,
     beets: BeetsDB,
     album_path: str,
@@ -805,10 +804,6 @@ def _apply_disambiguation(
     and ``r.exit_code`` / ``r.decision`` are never touched by a
     disambiguation failure.
     """
-    # ``mbid`` is unused now that ``move_album`` reads the post-move
-    # path by album_id, but the signature is kept as-is so external
-    # callers in tests don't have to re-wire their fixtures.
-    del mbid
     result = move_album(BeetsAlbumHandle(album_id=album_id), beets)
     if not result.success:
         assert result.failure is not None
@@ -934,8 +929,14 @@ def _canonicalize_siblings(
                  "manually later")
             continue
         if result.new_path:
+            # ``move_album`` already ran ``fix_library_modes`` (issue
+            # #84) — log it explicitly so the cratedigger journal trail
+            # still shows per-sibling perm repair. Operators greppable
+            # for 'fix_library_modes' and for 'beet move' can
+            # cross-reference the two in post-hoc debugging.
             _log(f"  [CANONICALIZE] moved sibling id:{aid} → "
-                 f"{result.new_path} (perms repaired)")
+                 f"{result.new_path}; fix_library_modes(...) ran "
+                 "inside move_album")
 
 
 # ---------------------------------------------------------------------------
@@ -1539,7 +1540,7 @@ def main():
     if kept_duplicate:
         _log(f"[DISAMBIGUATE] Running beet move for album id:{pf_info.album_id}")
         album_path = _apply_disambiguation(
-            mbid, pf_info.album_id, beets, album_path, r)
+            pf_info.album_id, beets, album_path, r)
         # Also canonicalize the sibling editions beets flagged as
         # duplicates — without this, the new album gets the ``[YEAR]``
         # suffix while the sibling stays un-suffixed (asymmetric

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -48,9 +48,9 @@ from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
 from lib.util import beets_subprocess_env
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
-                         AudioQualityMeasurement, ImportResult, PostflightInfo,
-                         QualityRankConfig, comparison_format_hint,
-                         determine_verified_lossless,
+                         AudioQualityMeasurement, ImportResult, MovedSibling,
+                         PostflightInfo, QualityRankConfig,
+                         comparison_format_hint, determine_verified_lossless,
                          import_quality_decision, transcode_detection)
 HARNESS = os.path.join(os.path.dirname(__file__), "..", "harness", "run_beets_harness.sh")
 HARNESS_TIMEOUT = 300
@@ -870,7 +870,9 @@ def _remove_stale_by_id_logged(stale_id: int) -> BeetsOpFailure | None:
 
 
 def _canonicalize_siblings(
-    sibling_album_ids: frozenset[int], beets: BeetsDB) -> None:
+    sibling_album_ids: frozenset[int],
+    beets: BeetsDB,
+) -> list[MovedSibling]:
     """Re-run ``beet move`` on each sibling album id after a kept-duplicate import.
 
     When beets' ``%aunique`` disambiguates the new album (adding a
@@ -895,26 +897,36 @@ def _canonicalize_siblings(
     every caller needs it — this function used to call
     ``fix_library_modes`` itself, issue #133 moved it into the op.
 
-    KNOWN LIMITATION (Codex PR #131 round 6 P2): this helper moves
-    sibling files on disk but does NOT update
-    ``album_requests.imported_path`` for those siblings in the
-    pipeline DB. If a sibling was tracked as a previous pipeline
-    request, its ``imported_path`` will point at the pre-move
-    location until a future event (next upgrade, manual re-tag)
-    updates it. The pipeline UI will show the wrong path for that
-    request in the interim. Cross-service plumbing — the harness
-    runs as a subprocess without a shared write handle to the
-    pipeline DB for arbitrary request ids — and is tracked as a
-    follow-up separate from the Palo Santo blast-radius fix.
+    Returns a list of ``MovedSibling`` records — one per sibling that
+    successfully moved and had a resolvable post-move path — closing
+    the KNOWN LIMITATION from Codex PR #131 round 6 P2 (issue #132 P2).
+    Each record carries the beets numeric id, the new directory path,
+    AND the ``(mb_albumid, discogs_albumid)`` columns resolved from
+    beets at emit time. The parent dispatch path
+    (``lib.import_dispatch.dispatch_import_core``) reads this list and
+    calls ``PipelineDB.update_imported_path_by_release_id(...)`` for
+    each, so any tracked ``album_requests`` row for a sibling release
+    gets its ``imported_path`` updated — the pipeline UI no longer
+    shows a pre-move directory that doesn't exist.
+
+    Resolving the beets release-id columns HERE (inside the harness
+    subprocess, which already has a beets DB connection) avoids making
+    the parent dispatch open a second beets DB handle for the same
+    data. Siblings without any release_id populated in beets are still
+    included — the dispatch-side update is a no-op when both are empty.
 
     Never raises — ``move_album`` returns a typed ``BeetsOpFailure``
     on any subprocess error. Per-sibling failures are logged but do
     not abort the remaining moves; the import itself is already on
     disk and any failed sibling move just means that sibling stays
     at its old path until something re-runs ``beet move`` on it.
+    Failed moves DO NOT appear in the returned list — the sibling's
+    pipeline row is already correct for its pre-move state, so no
+    propagation is needed.
     """
+    moved: list[MovedSibling] = []
     if not sibling_album_ids:
-        return
+        return moved
     _log(f"[CANONICALIZE] Re-running beet move -a for "
          f"{len(sibling_album_ids)} sibling album id(s) so %aunique "
          "stays symmetric")
@@ -934,9 +946,20 @@ def _canonicalize_siblings(
             # still shows per-sibling perm repair. Operators greppable
             # for 'fix_library_modes' and for 'beet move' can
             # cross-reference the two in post-hoc debugging.
+            mb_albumid, discogs_albumid = (
+                beets.get_release_ids_by_album_id(aid))
+            moved.append(MovedSibling(
+                album_id=aid,
+                new_path=result.new_path,
+                mb_albumid=mb_albumid,
+                discogs_albumid=discogs_albumid))
             _log(f"  [CANONICALIZE] moved sibling id:{aid} → "
                  f"{result.new_path}; fix_library_modes(...) ran "
-                 "inside move_album")
+                 "inside move_album; release_ids "
+                 f"(mb={mb_albumid or '∅'}, "
+                 f"discogs={discogs_albumid or '∅'}) "
+                 "emitted for pipeline DB propagation")
+    return moved
 
 
 # ---------------------------------------------------------------------------
@@ -1547,7 +1570,13 @@ def main():
         # empty but albums.id is always present). Per-sibling
         # ``fix_library_modes`` runs inside the helper on any row
         # whose path changed (issue #84, Codex PR #131 round 5 P3).
-        _canonicalize_siblings(sibling_album_ids, beets)
+        # The returned ``MovedSibling`` records flow through
+        # ``PostflightInfo.moved_siblings`` → ImportResult JSON →
+        # ``dispatch_import_core`` which propagates each sibling's
+        # new path to any tracked ``album_requests`` row (issue #132
+        # P2 / #133).
+        r.postflight.moved_siblings = _canonicalize_siblings(
+            sibling_album_ids, beets)
 
     # --- Post-import extension check ---
     # Detect .bak files (known bug: track 01 sometimes renamed to .bak during import)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -946,8 +946,23 @@ def _canonicalize_siblings(
             # still shows per-sibling perm repair. Operators greppable
             # for 'fix_library_modes' and for 'beet move' can
             # cross-reference the two in post-hoc debugging.
-            mb_albumid, discogs_albumid = (
-                beets.get_release_ids_by_album_id(aid))
+            #
+            # Defensive lookup: a beets DB lock (rare but possible if
+            # a parallel ``beet`` invocation is mid-write) would raise
+            # here and kill the rest of the canonicalization loop.
+            # Emit the sibling with empty release ids instead — the
+            # move's still been recorded; only pipeline-DB
+            # propagation is skipped (dispatcher WARN-logs the
+            # empty-ids case).
+            try:
+                mb_albumid, discogs_albumid = (
+                    beets.get_release_ids_by_album_id(aid))
+            except Exception as exc:
+                _log(f"  [CANONICALIZE] release-id lookup for id:{aid} "
+                     f"raised {type(exc).__name__}: {exc} — emitting "
+                     "sibling record with empty ids; pipeline DB "
+                     "propagation will skip this row (dispatcher WARN)")
+                mb_albumid, discogs_albumid = "", ""
             moved.append(MovedSibling(
                 album_id=aid,
                 new_path=result.new_path,

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -42,21 +42,17 @@ def _bootstrap_import_paths() -> None:
 
 _bootstrap_import_paths()
 
+from lib.beets_album_op import (BeetsAlbumHandle, BeetsOpFailure,
+                                move_album, remove_album)
 from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
-from lib.release_cleanup import (SelectorFailure,
-                                 remove_album_by_beets_id)
-from lib.util import beet_bin, beets_subprocess_env
+from lib.util import beets_subprocess_env
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
-                         AudioQualityMeasurement, DisambiguationFailure,
-                         ImportResult, PostflightInfo, QualityRankConfig,
-                         comparison_format_hint,
+                         AudioQualityMeasurement, ImportResult, PostflightInfo,
+                         QualityRankConfig, comparison_format_hint,
                          determine_verified_lossless,
                          import_quality_decision, transcode_detection)
 HARNESS = os.path.join(os.path.dirname(__file__), "..", "harness", "run_beets_harness.sh")
-# Back-compat alias; new callsites should prefer ``beet_bin()`` from
-# ``lib.util`` so subprocess resolution stays in one place.
-BEET_BIN = beet_bin()
 HARNESS_TIMEOUT = 300
 IMPORT_TIMEOUT = 1800
 MAX_DISTANCE = 0.5
@@ -788,21 +784,20 @@ def _apply_disambiguation(
     Never raises. Returns the (possibly updated) album path. On clean
     exit, sets ``r.postflight.disambiguated = True`` and re-reads the
     path from beets DB. On any failure mode (timeout, OSError,
-    non-zero rc), records a typed ``DisambiguationFailure`` on
+    non-zero rc), records a typed ``BeetsOpFailure`` (aliased as
+    ``DisambiguationFailure`` for JSON/test back-compat) on
     ``r.postflight.disambiguation_failure`` and returns the original
     ``album_path`` unchanged.
 
-    Uses ``beet move -a id:<album_id>`` rather than
-    ``beet move mb_albumid:<mbid>`` so Discogs-sourced albums are
-    handled too — their ``mb_albumid`` is empty, their identifier
-    lives in ``discogs_albumid``, but the beets numeric primary key
-    is always populated. Codex (PR #131 round 4 P3) flagged that the
-    earlier mb_albumid-based move silently no-op'd for Discogs
-    re-imports, leaving the new album stuck at the temporary
-    disambiguated path. Caller passes ``album_id`` from the postflight
-    lookup so we don't need a second DB read here (and so failure
-    tests can still assert ``beets.get_album_info`` is only hit on
-    success to refresh the path).
+    Delegates the subprocess + ``fix_library_modes`` mechanics to
+    ``beets_album_op.move_album`` (issue #133): ``beet move -a
+    id:<album_id>`` is source-agnostic — works for both MusicBrainz
+    (``mb_albumid`` populated) and Discogs (``discogs_albumid``
+    populated) rows since the beets numeric PK is always present.
+    Codex (PR #131 round 4 P3) flagged the earlier MBID-based move
+    silently no-op'ing for Discogs re-imports; PR #131 round 5 P3
+    flagged the missing ``fix_library_modes`` on the main album's
+    disambiguated path. ``move_album`` covers both.
 
     Extracting this from ``main()`` makes the call-site contract
     testable in isolation: the album-on-disk state is decoupled from
@@ -810,71 +805,31 @@ def _apply_disambiguation(
     and ``r.exit_code`` / ``r.decision`` are never touched by a
     disambiguation failure.
     """
-    move_failure = _run_album_move_by_id(album_id)
-    if move_failure is not None:
+    # ``mbid`` is unused now that ``move_album`` reads the post-move
+    # path by album_id, but the signature is kept as-is so external
+    # callers in tests don't have to re-wire their fixtures.
+    del mbid
+    result = move_album(BeetsAlbumHandle(album_id=album_id), beets)
+    if not result.success:
+        assert result.failure is not None
         # Album is already imported to beets — only the post-import
         # path-disambiguation move did not exit cleanly. Surface the
         # typed reason so the audit trail in download_log shows *why*
         # without lying that disambiguation succeeded.
         _log(f"  [DISAMBIGUATE] beet move failed "
-             f"({move_failure.reason}): {move_failure.detail}")
-        r.postflight.disambiguation_failure = move_failure
+             f"({result.failure.reason}): {result.failure.detail}")
+        r.postflight.disambiguation_failure = result.failure
         return album_path
 
-    pf_info_after = beets.get_album_info(mbid, _rank_cfg)
-    if pf_info_after:
-        new_path = pf_info_after.album_path
-        if new_path != album_path:
-            _log(f"  [DISAMBIGUATE] Path changed: {album_path} → {new_path}")
-            album_path = new_path
-            r.postflight.imported_path = new_path
-        else:
-            _log(f"  [DISAMBIGUATE] Path unchanged (already unique)")
+    new_path = result.new_path
+    if new_path and new_path != album_path:
+        _log(f"  [DISAMBIGUATE] Path changed: {album_path} → {new_path}")
+        album_path = new_path
+        r.postflight.imported_path = new_path
+    else:
+        _log(f"  [DISAMBIGUATE] Path unchanged (already unique)")
     r.postflight.disambiguated = True
     return album_path
-
-
-def _run_disambiguation_move(mbid: str) -> DisambiguationFailure | None:
-    """Run ``beet move mb_albumid:<mbid>`` once, never raise (issue #127).
-
-    Mirrors ``lib/release_cleanup.py::_run_remove_selector``: one place
-    owns the subprocess invocation, catches every fragile failure mode
-    (``TimeoutExpired``, ``OSError`` from a missing ``beet`` binary,
-    non-zero rc), and returns a typed ``DisambiguationFailure`` (with a
-    ``Literal["timeout","nonzero_rc","exception"]`` reason tag) so the
-    caller and downstream consumers can classify failures without
-    parsing the ``detail`` string. Returns ``None`` on a clean rc=0
-    exit.
-
-    Why this is its own function: the call site fires *after* beets
-    has already imported the album to disk. An uncaught exception here
-    would crash ``import_one.py`` before it could emit the
-    ``__IMPORT_RESULT__`` sentinel — the caller would treat the import
-    as failed even though the album is on disk, leaving a "semi-lie"
-    that can trigger duplicate force-import attempts (the bug PR #126
-    flagged as out-of-scope follow-up to #123).
-    """
-    try:
-        proc = subprocess.run(
-            [BEET_BIN, "move", f"mb_albumid:{mbid}"],
-            capture_output=True, text=True, timeout=120,
-            env=beets_subprocess_env(),
-        )
-    except subprocess.TimeoutExpired as exc:
-        return DisambiguationFailure(
-            reason="timeout", detail=f"timeout after {exc.timeout}s")
-    except OSError as exc:
-        return DisambiguationFailure(
-            reason="exception", detail=f"{type(exc).__name__}: {exc}")
-
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip().splitlines()
-        last = stderr[-1] if stderr else ""
-        detail = (f"rc={proc.returncode}: {last}"
-                  if last else f"rc={proc.returncode}")
-        return DisambiguationFailure(reason="nonzero_rc", detail=detail)
-
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -898,67 +853,25 @@ def _run_disambiguation_move(mbid: str) -> DisambiguationFailure | None:
 # hit a sibling pressing.
 
 
-def _remove_stale_by_id_logged(stale_id: int) -> SelectorFailure | None:
+def _remove_stale_by_id_logged(stale_id: int) -> BeetsOpFailure | None:
     """Post-import cleanup: delete the stale same-MBID album by beets id.
 
-    Thin logger around ``remove_album_by_beets_id``. Always logs the
+    Thin logger around ``beets_album_op.remove_album``. Always logs the
     outcome so the import audit trail (stderr → cratedigger journal)
     shows exactly which beets row was removed and why.
     """
     _log(f"[POST-IMPORT CLEANUP] Removing stale same-MBID entry "
          f"(beet remove -a -d id:{stale_id})")
-    failure = remove_album_by_beets_id(stale_id)
-    if failure is None:
+    result = remove_album(BeetsAlbumHandle(album_id=stale_id))
+    if result.success:
         _log(f"  [POST-IMPORT CLEANUP] OK — id:{stale_id} removed")
-    else:
-        _log(f"  [POST-IMPORT CLEANUP] FAILED id:{stale_id} "
-             f"({failure.reason}): {failure.detail}. "
-             "Two albums with same MBID now in beets; "
-             "operator should run ban-source cleanup.")
-    return failure
-
-
-def _run_album_move_by_id(album_id: int) -> DisambiguationFailure | None:
-    """Run ``beet move -a id:<album_id>`` once, never raise.
-
-    Album-mode, primary-key-scoped variant of
-    ``_run_disambiguation_move``. Used for sibling canonicalization
-    where the identifier has to be source-agnostic: beets' numeric
-    ``albums.id`` is always populated (it's the PK), unlike
-    ``mb_albumid`` (empty for Discogs pressings) or
-    ``discogs_albumid`` (empty for MB pressings). Codex (PR #131
-    round 3 P3) flagged that the earlier MBID-only sibling move
-    silently dropped Discogs duplicates.
-
-    ``-a`` is mandatory — without it ``id:<N>`` would be interpreted
-    against ``items.id`` (a different auto-increment namespace) and
-    match a track row instead of the album.
-
-    Same error classification as ``_run_disambiguation_move``:
-    ``TimeoutExpired`` → ``timeout``, non-zero rc → ``nonzero_rc``,
-    ``OSError`` → ``exception``. Returns ``None`` on clean exit.
-    """
-    try:
-        proc = subprocess.run(
-            [BEET_BIN, "move", "-a", f"id:{album_id}"],
-            capture_output=True, text=True, timeout=120,
-            env=beets_subprocess_env(),
-        )
-    except subprocess.TimeoutExpired as exc:
-        return DisambiguationFailure(
-            reason="timeout", detail=f"timeout after {exc.timeout}s")
-    except OSError as exc:
-        return DisambiguationFailure(
-            reason="exception", detail=f"{type(exc).__name__}: {exc}")
-
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip().splitlines()
-        last = stderr[-1] if stderr else ""
-        detail = (f"rc={proc.returncode}: {last}"
-                  if last else f"rc={proc.returncode}")
-        return DisambiguationFailure(reason="nonzero_rc", detail=detail)
-
-    return None
+        return None
+    assert result.failure is not None
+    _log(f"  [POST-IMPORT CLEANUP] FAILED id:{stale_id} "
+         f"({result.failure.reason}): {result.failure.detail}. "
+         "Two albums with same MBID now in beets; "
+         "operator should run ban-source cleanup.")
+    return result.failure
 
 
 def _canonicalize_siblings(
@@ -972,21 +885,20 @@ def _canonicalize_siblings(
     end up with an asymmetric library like
     ``/Shearwater/2006 - Palo Santo/`` (plain, old) vs
     ``/Shearwater/2007 - Palo Santo [2007]/`` (disambiguated, new).
-    Running ``beet move -a id:<N>`` on each sibling here re-evaluates
-    ``%aunique`` for its path too, so both editions end up shaped
-    consistently.
+    Running ``beet move -a id:<N>`` on each sibling via
+    ``beets_album_op.move_album`` re-evaluates ``%aunique`` for its
+    path too, so both editions end up shaped consistently.
 
     Takes beets numeric album ids (not MBIDs) so Discogs-sourced
     siblings are covered — ``mb_albumid`` is empty for those,
     ``albums.id`` is always populated.
 
-    After a successful per-sibling move, runs ``fix_library_modes``
-    against the sibling's new path (Codex PR #131 round 5 P3): issue
-    #84 shows that ``beet move`` can create fresh disambiguated
-    directories at 0o755 despite systemd's ``UMask=0000``, which
-    locks out the non-service user. The main-album path gets this
-    repair at the end of ``main()``; without mirroring it here, moved
-    siblings ship with stricter perms than they started with.
+    ``fix_library_modes`` runs inside ``move_album`` unconditionally
+    on success (issue #84, Codex PR #131 round 5 P3): ``beet move``
+    can create fresh disambiguated directories at 0o755 despite
+    systemd's ``UMask=0000``. The repair is part of the op since
+    every caller needs it — this function used to call
+    ``fix_library_modes`` itself, issue #133 moved it into the op.
 
     KNOWN LIMITATION (Codex PR #131 round 6 P2): this helper moves
     sibling files on disk but does NOT update
@@ -1000,12 +912,11 @@ def _canonicalize_siblings(
     pipeline DB for arbitrary request ids — and is tracked as a
     follow-up separate from the Palo Santo blast-radius fix.
 
-    Never raises — delegates to ``_run_album_move_by_id`` which
-    returns a typed ``DisambiguationFailure`` on any subprocess
-    error. Per-sibling failures are logged but do not abort the
-    remaining moves; the import itself is already on disk and any
-    failed sibling move just means that sibling stays at its old
-    path until something re-runs ``beet move`` on it.
+    Never raises — ``move_album`` returns a typed ``BeetsOpFailure``
+    on any subprocess error. Per-sibling failures are logged but do
+    not abort the remaining moves; the import itself is already on
+    disk and any failed sibling move just means that sibling stays
+    at its old path until something re-runs ``beet move`` on it.
     """
     if not sibling_album_ids:
         return
@@ -1014,19 +925,17 @@ def _canonicalize_siblings(
          "stays symmetric")
     for aid in sibling_album_ids:
         _log(f"  [CANONICALIZE] beet move -a id:{aid}")
-        failure = _run_album_move_by_id(aid)
-        if failure is not None:
+        result = move_album(BeetsAlbumHandle(album_id=aid), beets)
+        if not result.success:
+            assert result.failure is not None
             _log(f"  [CANONICALIZE] sibling id:{aid} move failed "
-                 f"({failure.reason}): {failure.detail} — sibling stays "
-                 "at its current path, re-run `beet move` manually later")
+                 f"({result.failure.reason}): {result.failure.detail} — "
+                 "sibling stays at its current path, re-run `beet move` "
+                 "manually later")
             continue
-        # Move succeeded — repair perms on the sibling's new location.
-        # ``get_album_path_by_id`` returns the sibling's current path;
-        # missing (deleted out of band) returns None — no-op.
-        sibling_path = beets.get_album_path_by_id(aid)
-        if sibling_path:
-            _log(f"  [CANONICALIZE] fix_library_modes({sibling_path})")
-            fix_library_modes(sibling_path)
+        if result.new_path:
+            _log(f"  [CANONICALIZE] moved sibling id:{aid} → "
+                 f"{result.new_path} (perms repaired)")
 
 
 # ---------------------------------------------------------------------------

--- a/lib/beets_album_op.py
+++ b/lib/beets_album_op.py
@@ -113,14 +113,14 @@ class BeetsAlbumHandle:
     (SQLite auto-increment), unique by construction, narrow enough that
     the ``id:<N>`` selector cannot reach a sibling pressing.
 
-    ``release_id`` is the MB UUID or the Discogs numeric id (whichever
-    the row carries). Informational only: used for log messages and
-    the audit trail, never for the subprocess selector. Empty string
-    is acceptable — sibling canonicalization builds handles from
-    ``albums.id`` alone.
+    One-field dataclass kept as a distinct type rather than a bare
+    ``int`` so callsites are self-documenting (``BeetsAlbumHandle(
+    album_id=N)`` vs ``remove_album(N)``) and future additions — e.g.
+    a debug label, a request_id backref — can land without breaking
+    callsite signatures. Earlier drafts carried a ``release_id: str``
+    field for logs; nothing read it, so it was removed (YAGNI).
     """
     album_id: int
-    release_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -282,10 +282,9 @@ def move_album(
 def remove_by_selector(
     selector: str,
     *,
-    delete_files: bool = True,
     timeout: int = DEFAULT_REMOVE_TIMEOUT,
 ) -> BeetsOpFailure | None:
-    """Low-level primitive: ``beet remove -a [-d] <selector>``. Never raises.
+    """Low-level primitive: ``beet remove -a -d <selector>``. Never raises.
 
     For callsites that iterate arbitrary selectors (``mb_albumid:X``,
     ``discogs_albumid:Y``) because the album id is not known up front
@@ -294,12 +293,12 @@ def remove_by_selector(
     album id is available: the ``id:<N>`` selector is narrower and
     cannot accidentally match siblings.
 
-    ``delete_files`` matches ``remove_album``'s signature for symmetry;
-    every current caller passes ``True`` (the ban-source intent is
-    "remove from beets AND delete the tagged files"). Kept optional so
-    future callers can untag without deleting if the use case appears.
+    ``-d`` (delete files) is always on: every caller's intent is
+    "remove from beets AND delete the tagged files" (ban-source
+    cleanup). An untag-only selector-based remove has no production
+    use case today; if one appears, add the flag then.
 
     Returns ``None`` on clean exit or a typed ``BeetsOpFailure``.
     """
     return _run_beet_op(
-        "remove", selector, delete_files=delete_files, timeout=timeout)
+        "remove", selector, delete_files=True, timeout=timeout)

--- a/lib/beets_album_op.py
+++ b/lib/beets_album_op.py
@@ -1,0 +1,287 @@
+"""Typed wrapper around ``beet remove`` / ``beet move`` subprocess ops (issue #133).
+
+Single source of truth for invoking beets destructive or path-changing
+commands at the subprocess level. Extracted in PR #XXX to unify the
+five+ ad-hoc callsites that PR #131 spread across the codebase
+(pre-flight stale cleanup, post-import cleanup, ``_apply_disambiguation``,
+``_canonicalize_siblings``, ``remove_album_by_beets_id``) — each callsite
+had drifted, some missing ``-a``, some missing perm repair, some missing
+DB propagation. Every new callsite that touches ``beet remove`` or
+``beet move`` must route through this module.
+
+A contract test (``tests/test_beets_album_op.py::TestBeetOpArgvIsCentralised``)
+greps the repo at test time and fails if any file outside this module
+constructs ``["beet", "remove", ...]`` or ``["beet", "move", ...]`` argv.
+The grep is the enforcement mechanism — nothing stops you from writing
+raw argv elsewhere, but the suite fails if you do.
+
+Invariants this module enforces at the type level:
+
+1. **Album-mode (``-a``) is mandatory.** Without ``-a`` the ``id:<N>``
+   selector would be interpreted against ``items.id`` (a single track
+   row in a separate auto-increment namespace), not ``albums.id``. PR
+   #131 round 2 P1 caught item-mode silently matching unrelated tracks.
+
+2. **Primary-key-scoped selectors.** ``remove_album`` and ``move_album``
+   take a ``BeetsAlbumHandle`` wrapping the beets numeric primary key.
+   The subprocess argv is ``id:<N>`` — a ``SELECT ... WHERE id = ?``
+   which cannot match cross-MBID siblings (the Palo Santo data-loss
+   root cause).
+
+3. **Source-agnostic.** ``mb_albumid`` is empty for Discogs rows and
+   ``discogs_albumid`` is empty for MB rows; ``albums.id`` is the one
+   identifier always populated. PR #131 round 3 P3 and round 4 P3
+   flagged the earlier MBID-based moves silently no-oping for Discogs.
+
+4. **``fix_library_modes`` on every move.** Issue #84: ``beet move``
+   can create fresh disambiguated directories at 0o755 despite systemd
+   ``UMask=0000``. ``move_album`` calls ``fix_library_modes`` on the
+   post-move path unconditionally — no callsite can forget it.
+
+5. **Never raise.** Every subprocess invocation is wrapped in
+   try/except for ``TimeoutExpired`` and ``OSError`` and every non-zero
+   rc becomes a typed failure. Callers inspect the returned
+   ``BeetsOpResult`` — they never parse stderr or catch ``sp`` errors.
+
+For arbitrary-selector removals (ban-source cleanup where the caller
+doesn't know the album id but has an mb_albumid / discogs_albumid),
+``remove_by_selector`` is the low-level primitive. Prefer ``remove_album``
+when the album id is known — the PK-scoped selector is narrower.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess as sp
+from dataclasses import dataclass
+from typing import Literal, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.beets_db import BeetsDB
+
+
+log = logging.getLogger("cratedigger")
+
+
+# Default timeouts. ``remove`` is a quick DB delete; ``move`` can copy
+# files on disk so it gets a longer budget. Callers may override.
+DEFAULT_REMOVE_TIMEOUT = 30  # seconds
+DEFAULT_MOVE_TIMEOUT = 120  # seconds
+
+
+BeetsOpFailureReason = Literal["timeout", "nonzero_rc", "exception"]
+
+
+@dataclass(frozen=True)
+class BeetsOpFailure:
+    """Why a single ``beet remove`` or ``beet move`` invocation did not
+    exit cleanly.
+
+    ``reason`` is a coarse Literal tag — callers and downstream JSONB
+    audit consumers can classify failures at a glance without parsing
+    ``detail``. ``detail`` is a short human-readable string for logs
+    and the audit trail; do not parse it.
+
+    ``selector`` is the argv selector string (``id:42``,
+    ``mb_albumid:<uuid>``, ``discogs_albumid:<id>``) so downstream logs
+    and the web UI Recents tab can disambiguate failures across
+    multi-selector loops (e.g. release_cleanup iterating both
+    ``mb_albumid`` and ``discogs_albumid``).
+
+    Defaulting ``selector`` to ``""`` keeps JSON round-trip backwards
+    compatible with old ``PostflightInfo.disambiguation_failure`` rows
+    that predate the field (written before this module collapsed
+    ``DisambiguationFailure`` into ``BeetsOpFailure``).
+    """
+    reason: BeetsOpFailureReason
+    detail: str
+    selector: str = ""
+
+
+@dataclass(frozen=True)
+class BeetsAlbumHandle:
+    """Source-agnostic handle to one row in ``beets.albums``.
+
+    ``album_id`` is the beets numeric primary key — always populated
+    (SQLite auto-increment), unique by construction, narrow enough that
+    the ``id:<N>`` selector cannot reach a sibling pressing.
+
+    ``release_id`` is the MB UUID or the Discogs numeric id (whichever
+    the row carries). Informational only: used for log messages and
+    the audit trail, never for the subprocess selector. Empty string
+    is acceptable — sibling canonicalization builds handles from
+    ``albums.id`` alone.
+    """
+    album_id: int
+    release_id: str = ""
+
+
+@dataclass(frozen=True)
+class BeetsOpResult:
+    """Outcome of a single ``remove_album`` or ``move_album`` call.
+
+    Never raised — callers inspect and branch.
+
+    - ``success``: ``True`` iff the subprocess exited rc=0 with no
+      raised exception. ``failure`` is ``None`` in that case.
+    - ``failure``: the typed failure when ``success=False``.
+    - ``new_path``: only populated by ``move_album`` on success — the
+      album's on-disk path re-read from beets DB after the move. May
+      be ``None`` if the album row vanished between move and lookup
+      (should not happen in normal operation).
+    """
+    success: bool
+    failure: BeetsOpFailure | None = None
+    new_path: str | None = None
+
+
+def _run_beet_op(
+    verb: Literal["remove", "move"],
+    selector: str,
+    *,
+    delete_files: bool = False,
+    timeout: int,
+) -> BeetsOpFailure | None:
+    """Run one ``beet <verb> -a [...] <selector>`` invocation. Never raises.
+
+    Internal primitive; ``remove_album`` / ``move_album`` /
+    ``remove_by_selector`` are the public entry points. Captures every
+    fragile failure mode (``TimeoutExpired``, ``OSError`` from a
+    missing ``beet`` binary, non-zero returncode) and classifies each
+    into a typed ``BeetsOpFailure``. Returns ``None`` on clean exit.
+
+    The ``-a`` flag is mandatory — see the module docstring, invariant 1.
+    """
+    # Deferred imports break a top-level cycle: ``lib.util`` imports
+    # ``lib.quality`` partway through its body (``AUDIO_EXTENSIONS``),
+    # and ``lib.quality`` imports ``BeetsOpFailure`` from this module
+    # for its ``DisambiguationFailure`` alias. Keeping ``lib.util`` and
+    # ``lib.quality`` out of this module's import graph at top-level
+    # resolves the cycle without pushing hacks into those modules.
+    from lib.util import beet_bin, beets_subprocess_env
+
+    argv: list[str] = [beet_bin(), verb, "-a"]
+    if verb == "remove" and delete_files:
+        argv.append("-d")
+    argv.append(selector)
+
+    try:
+        proc = sp.run(
+            argv,
+            capture_output=True, text=True, timeout=timeout,
+            env=beets_subprocess_env(),
+        )
+    except sp.TimeoutExpired as exc:
+        msg = f"timed out after {exc.timeout}s"
+        log.warning("beets_album_op: beet %s %s %s", verb, selector, msg)
+        return BeetsOpFailure(reason="timeout", detail=msg, selector=selector)
+    except OSError as exc:
+        msg = f"{type(exc).__name__}: {exc}"
+        log.warning(
+            "beets_album_op: beet %s %s raised %s", verb, selector, msg)
+        return BeetsOpFailure(
+            reason="exception", detail=msg, selector=selector)
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip().splitlines()
+        last = stderr[-1] if stderr else ""
+        detail = (f"rc={proc.returncode}: {last}"
+                  if last else f"rc={proc.returncode}")
+        log.warning(
+            "beets_album_op: beet %s %s exited %d: %s",
+            verb, selector, proc.returncode, detail)
+        return BeetsOpFailure(
+            reason="nonzero_rc", detail=detail, selector=selector)
+
+    return None
+
+
+def remove_album(
+    handle: BeetsAlbumHandle,
+    *,
+    delete_files: bool = True,
+    timeout: int = DEFAULT_REMOVE_TIMEOUT,
+) -> BeetsOpResult:
+    """Remove one beets album by numeric primary key.
+
+    Runs ``beet remove -a [-d] id:<album_id>``. Never raises — any
+    subprocess failure is surfaced as a typed ``BeetsOpResult`` with
+    ``success=False`` and a populated ``failure``.
+
+    The ``id:<N>`` selector is a ``SELECT ... WHERE id = ?`` — a beets
+    numeric PK is unique by construction, so this cannot match any
+    album but the one named. Safe to use after a successful upgrade
+    import when the old and new albums briefly coexist.
+
+    ``delete_files=True`` (default) deletes the tagged files on disk.
+    ``delete_files=False`` untags the album but leaves files — not
+    used by current production callers.
+    """
+    selector = f"id:{handle.album_id}"
+    failure = _run_beet_op(
+        "remove", selector, delete_files=delete_files, timeout=timeout)
+    return BeetsOpResult(success=failure is None, failure=failure)
+
+
+def move_album(
+    handle: BeetsAlbumHandle,
+    beets_db: "BeetsDB",
+    *,
+    timeout: int = DEFAULT_MOVE_TIMEOUT,
+) -> BeetsOpResult:
+    """Move one beets album by numeric primary key; repair library perms.
+
+    Runs ``beet move -a id:<album_id>``. On clean exit, re-reads the
+    album's path from beets DB and calls ``fix_library_modes`` on it
+    (invariant 4 — issue #84). The perm repair lives inside the op so
+    no callsite can forget it; ``beet move`` can create fresh
+    disambiguated directories at 0o755 despite systemd ``UMask=0000``.
+
+    Returns a ``BeetsOpResult`` with:
+      - ``success=True, new_path=<path>`` on clean subprocess exit.
+        Caller compares ``new_path`` to whatever prior path it held
+        to decide whether the move actually relocated the files.
+      - ``success=False, failure=<typed>, new_path=None`` on any
+        subprocess failure. Caller should treat the path as
+        potentially changed (``beet move`` may have partially
+        completed) but has no fresh path to record.
+
+    ``fix_library_modes`` is only called when ``new_path`` resolves
+    to a directory on disk — an album row that vanished between move
+    and lookup (impossible under normal operation) yields a no-op
+    perm repair, not a crash.
+    """
+    # Deferred import: ``lib.permissions`` doesn't depend on this
+    # module but the harness imports both; keep them at their natural
+    # layer and resolve at call time.
+    from lib.permissions import fix_library_modes
+
+    selector = f"id:{handle.album_id}"
+    failure = _run_beet_op("move", selector, timeout=timeout)
+    if failure is not None:
+        return BeetsOpResult(success=False, failure=failure)
+
+    new_path = beets_db.get_album_path_by_id(handle.album_id)
+    if new_path:
+        fix_library_modes(new_path)
+    return BeetsOpResult(success=True, new_path=new_path)
+
+
+def remove_by_selector(
+    selector: str,
+    *,
+    timeout: int = DEFAULT_REMOVE_TIMEOUT,
+) -> BeetsOpFailure | None:
+    """Low-level primitive: ``beet remove -a -d <selector>``. Never raises.
+
+    For callsites that iterate arbitrary selectors (``mb_albumid:X``,
+    ``discogs_albumid:Y``) because the album id is not known up front
+    — the ban-source cleanup path in ``lib.release_cleanup`` is the
+    canonical caller. Prefer ``remove_album(handle)`` whenever the
+    album id is available: the ``id:<N>`` selector is narrower and
+    cannot accidentally match siblings.
+
+    Returns ``None`` on clean exit or a typed ``BeetsOpFailure``.
+    """
+    return _run_beet_op(
+        "remove", selector, delete_files=True, timeout=timeout)

--- a/lib/beets_album_op.py
+++ b/lib/beets_album_op.py
@@ -1,9 +1,9 @@
 """Typed wrapper around ``beet remove`` / ``beet move`` subprocess ops (issue #133).
 
 Single source of truth for invoking beets destructive or path-changing
-commands at the subprocess level. Extracted in PR #XXX to unify the
-five+ ad-hoc callsites that PR #131 spread across the codebase
-(pre-flight stale cleanup, post-import cleanup, ``_apply_disambiguation``,
+commands at the subprocess level. Extracted to unify the five+ ad-hoc
+callsites that PR #131 spread across the codebase (pre-flight stale
+cleanup, post-import cleanup, ``_apply_disambiguation``,
 ``_canonicalize_siblings``, ``remove_album_by_beets_id``) — each callsite
 had drifted, some missing ``-a``, some missing perm repair, some missing
 DB propagation. Every new callsite that touches ``beet remove`` or
@@ -15,18 +15,25 @@ constructs ``["beet", "remove", ...]`` or ``["beet", "move", ...]`` argv.
 The grep is the enforcement mechanism — nothing stops you from writing
 raw argv elsewhere, but the suite fails if you do.
 
-Invariants this module enforces at the type level:
+Invariants this module enforces by construction (callers cannot bypass
+without rewriting the op). Note these are *structural* guarantees —
+``album_id`` is just a Python ``int``, so ``BeetsAlbumHandle(album_id=0)``
+or ``-1`` would still construct; that's a convention for callers, not
+a type-level constraint:
 
-1. **Album-mode (``-a``) is mandatory.** Without ``-a`` the ``id:<N>``
-   selector would be interpreted against ``items.id`` (a single track
-   row in a separate auto-increment namespace), not ``albums.id``. PR
-   #131 round 2 P1 caught item-mode silently matching unrelated tracks.
+1. **Album-mode (``-a``) is mandatory.** Every argv built by
+   ``_run_beet_op`` starts with ``[beet, verb, "-a"]``. Without ``-a``
+   the ``id:<N>`` selector would be interpreted against ``items.id``
+   (a single track row in a separate auto-increment namespace), not
+   ``albums.id``. PR #131 round 2 P1 caught item-mode silently
+   matching unrelated tracks.
 
-2. **Primary-key-scoped selectors.** ``remove_album`` and ``move_album``
-   take a ``BeetsAlbumHandle`` wrapping the beets numeric primary key.
-   The subprocess argv is ``id:<N>`` — a ``SELECT ... WHERE id = ?``
+2. **Primary-key-scoped selectors for id-based ops.** ``remove_album``
+   and ``move_album`` take a ``BeetsAlbumHandle`` and always emit
+   ``id:<album_id>``. The PK selector is a ``SELECT ... WHERE id = ?``
    which cannot match cross-MBID siblings (the Palo Santo data-loss
-   root cause).
+   root cause). Arbitrary selectors route through ``remove_by_selector``
+   where the caller is explicitly opting out of PK narrowing.
 
 3. **Source-agnostic.** ``mb_albumid`` is empty for Discogs rows and
    ``discogs_albumid`` is empty for MB rows; ``albums.id`` is the one
@@ -152,12 +159,17 @@ def _run_beet_op(
 
     The ``-a`` flag is mandatory — see the module docstring, invariant 1.
     """
-    # Deferred imports break a top-level cycle: ``lib.util`` imports
-    # ``lib.quality`` partway through its body (``AUDIO_EXTENSIONS``),
-    # and ``lib.quality`` imports ``BeetsOpFailure`` from this module
-    # for its ``DisambiguationFailure`` alias. Keeping ``lib.util`` and
-    # ``lib.quality`` out of this module's import graph at top-level
-    # resolves the cycle without pushing hacks into those modules.
+    # Deferred imports break a top-level cycle. Exact path:
+    #   lib.beets_album_op ── top-level import ──► lib.util
+    #   lib.util           ── mid-body import ───► lib.quality
+    #   lib.quality        ── top-level import ──► lib.beets_album_op
+    #                        (DisambiguationFailure alias for BeetsOpFailure)
+    # If this module imported ``lib.util`` at top level, loading
+    # ``harness/import_one.py`` would trigger the chain and hit
+    # beets_album_op mid-init (BeetsOpFailure not defined yet).
+    # Deferring the ``lib.util`` import to call time keeps the
+    # top-level import graph acyclic. Python caches module imports so
+    # the per-call cost is a dict lookup.
     from lib.util import beet_bin, beets_subprocess_env
 
     argv: list[str] = [beet_bin(), verb, "-a"]
@@ -270,9 +282,10 @@ def move_album(
 def remove_by_selector(
     selector: str,
     *,
+    delete_files: bool = True,
     timeout: int = DEFAULT_REMOVE_TIMEOUT,
 ) -> BeetsOpFailure | None:
-    """Low-level primitive: ``beet remove -a -d <selector>``. Never raises.
+    """Low-level primitive: ``beet remove -a [-d] <selector>``. Never raises.
 
     For callsites that iterate arbitrary selectors (``mb_albumid:X``,
     ``discogs_albumid:Y``) because the album id is not known up front
@@ -281,7 +294,12 @@ def remove_by_selector(
     album id is available: the ``id:<N>`` selector is narrower and
     cannot accidentally match siblings.
 
+    ``delete_files`` matches ``remove_album``'s signature for symmetry;
+    every current caller passes ``True`` (the ban-source intent is
+    "remove from beets AND delete the tagged files"). Kept optional so
+    future callers can untag without deleting if the use case appears.
+
     Returns ``None`` on clean exit or a typed ``BeetsOpFailure``.
     """
     return _run_beet_op(
-        "remove", selector, delete_files=True, timeout=timeout)
+        "remove", selector, delete_files=delete_files, timeout=timeout)

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -447,6 +447,23 @@ class BeetsDB:
         the UI doesn't keep pointing at a pre-move directory. Returning
         both columns lets the caller match across every layout combo.
 
+        **Type coercion at the boundary.** Beets' ``albums`` table
+        declares ``discogs_albumid INTEGER`` in SQLite, so SQLite
+        returns a Python ``int`` for that column (not a ``str``).
+        ``mb_albumid`` is ``TEXT`` so it arrives as ``str``. The
+        downstream ``MovedSibling`` dataclass types both fields as
+        ``str``, so the harness-side ``msgspec.convert`` strict
+        validation in ``_postflight_from_dict`` WILL reject an int —
+        the exception bubbles up through ``parse_import_result`` and
+        the dispatcher would treat a successful kept-duplicate import
+        as a generic exception AFTER beets already moved the album
+        (a "semi-lie" that can trigger duplicate force-import
+        attempts, the same hazard PR #131 documented for earlier
+        missing-sentinel cases). Coerce both columns to ``str`` here
+        so the wire stays clean at the emit site — matches the
+        ``.claude/rules/code-quality.md`` § "Wire-boundary types"
+        "normalise early" directive.
+
         Returns ``("", "")`` if the album id is not present.
         """
         row = self._conn.execute(
@@ -456,7 +473,8 @@ class BeetsDB:
         ).fetchone()
         if not row:
             return ("", "")
-        return (row[0] or "", row[1] or "")
+        return (str(row[0]) if row[0] else "",
+                str(row[1]) if row[1] else "")
 
     # ── Web UI query methods ────────────────────────────────────────
 

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -429,6 +429,35 @@ class BeetsDB:
             return None
         return os.path.dirname(self._decode_path(row[0]))
 
+    def get_release_ids_by_album_id(
+            self, album_id: int) -> tuple[str, str]:
+        """Return ``(mb_albumid, discogs_albumid)`` for a beets album id.
+
+        Either or both may be the empty string depending on the album
+        layout: MB-sourced rows carry an ``mb_albumid`` (UUID) and an
+        empty ``discogs_albumid``, Discogs-sourced rows carry the
+        opposite, and legacy pre-plugin-patch Discogs imports may have
+        their numeric id in ``mb_albumid`` with an empty
+        ``discogs_albumid``.
+
+        Used by sibling ``imported_path`` propagation (issue #132 P2):
+        after ``_canonicalize_siblings`` moves a sibling's files, the
+        dispatcher needs to find any pipeline ``album_requests`` row
+        whose ``mb_release_id`` or ``discogs_release_id`` matches, so
+        the UI doesn't keep pointing at a pre-move directory. Returning
+        both columns lets the caller match across every layout combo.
+
+        Returns ``("", "")`` if the album id is not present.
+        """
+        row = self._conn.execute(
+            "SELECT mb_albumid, discogs_albumid FROM albums "
+            "WHERE id = ?",
+            (album_id,)
+        ).fetchone()
+        if not row:
+            return ("", "")
+        return (row[0] or "", row[1] or "")
+
     # ── Web UI query methods ────────────────────────────────────────
 
     def check_mbids(self, mbids: list[str]) -> set[str]:

--- a/lib/download.py
+++ b/lib/download.py
@@ -20,7 +20,8 @@ from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, decide_download_action,
                          extract_usernames,
                          rejection_backfill_override)
-from lib.import_dispatch import (_build_download_info, dispatch_import)
+from lib.import_dispatch import (DispatchOutcome, _build_download_info,
+                                 dispatch_import)
 from lib.transitions import apply_transition
 from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
                       log_validation_result)
@@ -177,8 +178,20 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 # === Download completion processing ===
 
 def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
-                            ctx: CratediggerContext) -> bool:
-    """Process a fully-downloaded album: move files, tag, validate, stage/import."""
+                            ctx: CratediggerContext) -> "bool | None":
+    """Process a fully-downloaded album: move files, tag, validate, stage/import.
+
+    Returns three-valued ``bool | None``:
+    - ``True`` — files moved and tagged successfully. Auto-import (if
+      fired) either landed or recorded a rejection; outer caller flips
+      status to ``imported``.
+    - ``False`` — file moves failed; outer caller resets to ``wanted``.
+    - ``None`` — auto-import deferred because another process held the
+      release advisory lock. Files are staged, spectral state is set,
+      and request stays ``downloading``. Outer caller must NOT touch
+      status: the next ``poll_active_downloads`` cycle re-enters this
+      function and retries. Codex PR #136 R3 P2/P3.
+    """
     import_folder_name = sanitize_folder_name(
         f"{album_data.artist} - {album_data.title} ({album_data.year})")
     import_folder_fullpath = os.path.join(ctx.cfg.slskd_download_dir, import_folder_name)
@@ -236,18 +249,31 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
             except Exception:
                 logger.exception(f"Error writing tags for: {file.import_path}")
         if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
-            _process_beets_validation(album_data, import_folder_fullpath, ctx)
+            outcome = _process_beets_validation(
+                album_data, import_folder_fullpath, ctx)
+            if outcome is not None and outcome.deferred:
+                # Release-lock contention. Propagate ``None`` so
+                # ``_run_completed_processing`` leaves the request's
+                # status, active_download_state, and staged files
+                # untouched for the next cycle to retry.
+                return None
         return True
 
 
 def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath: str,
-                              ctx: CratediggerContext) -> None:
+                              ctx: CratediggerContext) -> "DispatchOutcome | None":
     """Beets validation sub-path of process_completed_album.
 
     After beets validation passes, delegates to ``lib.preimport.run_preimport_gates``
     for the shared audio + spectral gates. The force/manual-import path
     (``dispatch_import_from_db``) calls the same function — only the beets
     distance check is path-specific.
+
+    Returns the dispatch outcome when the auto-import path fires,
+    ``None`` when beets validation rejects (``_handle_rejected_result``
+    already handles the state transition) or when the non-auto
+    redownload path takes over in ``_handle_valid_result``. Caller
+    uses the ``deferred`` flag to decide whether to flip status.
     """
     from lib.beets import beets_validate as _bv
     from lib.preimport import run_preimport_gates
@@ -285,15 +311,26 @@ def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath:
                 bv_result.corrupt_files = preimport.corrupt_files
 
     if bv_result.valid:
-        _handle_valid_result(album_data, bv_result, import_folder_fullpath, ctx)
-    else:
-        _handle_rejected_result(album_data, bv_result, import_folder_fullpath, ctx)
+        return _handle_valid_result(
+            album_data, bv_result, import_folder_fullpath, ctx)
+    _handle_rejected_result(
+        album_data, bv_result, import_folder_fullpath, ctx)
+    return None
 
 
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                          import_folder_fullpath: str,
-                         ctx: CratediggerContext) -> None:
-    """Handle a valid beets validation result: stage and optionally auto-import."""
+                         ctx: CratediggerContext) -> "DispatchOutcome | None":
+    """Handle a valid beets validation result: stage and optionally auto-import.
+
+    Returns the ``DispatchOutcome`` from ``dispatch_import`` when the
+    auto-import path fires (source='request', distance within
+    threshold), or ``None`` for the redownload path that just stages
+    and marks done. ``_process_beets_validation`` propagates the
+    outcome upward so ``_run_completed_processing`` can distinguish
+    ``deferred`` from ``success`` / ``failure`` on the release-lock
+    contention path (issue #132 P1, Codex PR #136 R3 P2/P3).
+    """
     dest = stage_to_ai(album_data, import_folder_fullpath, ctx.cfg.beets_staging_dir)
     log_validation_result(album_data, bv_result, ctx.cfg, dest_path=dest)
     logger.info(f"STAGED: {album_data.artist} - {album_data.title} "
@@ -313,10 +350,11 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     dist = bv_result.distance if bv_result.distance is not None else 1.0
     if source_type == "request" and dist <= ctx.cfg.beets_distance_threshold:
         assert request_id is not None, "pipeline request must have db_request_id"
-        dispatch_import(album_data, bv_result, dest, dl_info, request_id, ctx)
-    else:
-        ctx.pipeline_db_source.mark_done(album_data, bv_result, dest_path=dest,
-                                         download_info=dl_info)
+        return dispatch_import(
+            album_data, bv_result, dest, dl_info, request_id, ctx)
+    ctx.pipeline_db_source.mark_done(album_data, bv_result, dest_path=dest,
+                                     download_info=dl_info)
+    return None
 
 
 def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResult,
@@ -723,15 +761,32 @@ def _run_completed_processing(
         _persist_updated_download_state(db, request_id, entry, state)
 
     try:
-        success = process_completed_album(entry, [], ctx)
+        outcome = process_completed_album(entry, [], ctx)
     except Exception:
         logger.exception(f"Error processing completed download {entry.artist} - {entry.title} "
                          f"— will retry local processing next cycle")
         return
 
+    # Three-valued return from ``process_completed_album``:
+    # - True  → imported (or auto-import recorded a rejection); flip to
+    #   'imported' if status is still 'downloading'.
+    # - False → file moves failed; reset to 'wanted' (genuine failure
+    #   that DOES deserve a backoff-scored attempt).
+    # - None  → release-lock contention deferred the import. Files are
+    #   staged, spectral state is populated, status stays
+    #   'downloading'. ``poll_active_downloads`` re-enters this
+    #   function on the next cycle and retries — do NOT touch state
+    #   here. Issue #132 P1 / Codex PR #136 R3 P2/P3.
+    if outcome is None:
+        logger.info(
+            f"  process_completed_album deferred (release lock held) — "
+            "leaving state untouched; poll_active_downloads retries "
+            "next cycle")
+        return
+
     refreshed = db.get_request(request_id)
     if refreshed and refreshed["status"] == "downloading":
-        if success:
+        if outcome:
             logger.info(f"  process_completed_album succeeded without "
                         f"setting status — setting imported")
             apply_transition(db, request_id, "imported",

--- a/lib/download.py
+++ b/lib/download.py
@@ -330,31 +330,90 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     outcome upward so ``_run_completed_processing`` can distinguish
     ``deferred`` from ``success`` / ``failure`` on the release-lock
     contention path (issue #132 P1, Codex PR #136 R3 P2/P3).
-    """
-    dest = stage_to_ai(album_data, import_folder_fullpath, ctx.cfg.beets_staging_dir)
-    log_validation_result(album_data, bv_result, ctx.cfg, dest_path=dest)
-    logger.info(f"STAGED: {album_data.artist} - {album_data.title} "
-                f"(scenario={bv_result.scenario}, "
-                f"distance={bv_result.distance:.4f}) → {dest}")
 
-    dl_info = _build_download_info(album_data)
-    dl_info.validation_result = bv_result.to_json()
-    if album_data.download_spectral is not None:
-        dl_info.download_spectral = album_data.download_spectral
-        dl_info.current_spectral = album_data.current_spectral
-        dl_info.existing_min_bitrate = album_data.current_min_bitrate
-        dl_info.slskd_filetype = dl_info.filetype
-        dl_info.actual_filetype = dl_info.filetype
+    **Release-lock acquisition is at this level, not inside
+    ``dispatch_import``.** Codex PR #136 R4 P1: moving files via
+    ``stage_to_ai`` mutates filesystem state
+    (``slskd_download_dir/<import_folder>/`` → ``beets_staging_dir/``)
+    that is NOT reflected in ``active_download_state``. If contention
+    is detected AFTER staging, the next cycle's
+    ``process_completed_album`` reconstructs the entry from
+    ``active_download_state``, finds the source paths empty, and
+    fails with ``FileNotFoundError``. Fix: acquire the lock BEFORE
+    ``stage_to_ai``. On contention, return deferred without staging
+    so files stay at ``slskd_download_dir/<import_folder>/`` where
+    the resume guard in ``process_completed_album`` (line 201:
+    ``if os.path.exists(dst_file) and not os.path.exists(src_file):
+    continue``) can idempotently re-enter next cycle.
+
+    The lock is session-reentrant (PostgreSQL semantics), so
+    ``dispatch_import_core``'s inner acquisition of the same key is a
+    no-op acquire + extra release. Force/manual paths — which don't
+    go through this function — still acquire inside
+    ``dispatch_import_core`` where they need it.
+
+    Redownload paths (``source != 'request'`` or distance above
+    threshold) don't take the lock — they just stage-and-mark-done
+    without running the harness, so no cross-process race applies.
+    """
+    from contextlib import nullcontext
+    from lib.import_dispatch import DispatchOutcome
+    from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                 release_id_to_lock_key)
+
     source_type = album_data.db_source or "redownload"
     request_id = album_data.db_request_id
     dist = bv_result.distance if bv_result.distance is not None else 1.0
-    if source_type == "request" and dist <= ctx.cfg.beets_distance_threshold:
-        assert request_id is not None, "pipeline request must have db_request_id"
-        return dispatch_import(
-            album_data, bv_result, dest, dl_info, request_id, ctx)
-    ctx.pipeline_db_source.mark_done(album_data, bv_result, dest_path=dest,
-                                     download_info=dl_info)
-    return None
+    will_auto_import = (
+        source_type == "request"
+        and dist <= ctx.cfg.beets_distance_threshold)
+
+    if will_auto_import and album_data.mb_release_id:
+        pdb = ctx.pipeline_db_source._get_db()
+        lock_ctx = pdb.advisory_lock(
+            ADVISORY_LOCK_NAMESPACE_RELEASE,
+            release_id_to_lock_key(album_data.mb_release_id))
+    else:
+        lock_ctx = nullcontext(True)
+
+    with lock_ctx as got_release_lock:
+        if not got_release_lock:
+            logger.warning(
+                f"AUTO-IMPORT DEFERRED: {album_data.artist} - "
+                f"{album_data.title} — release lock held by another "
+                f"process (mbid={album_data.mb_release_id}); skipping "
+                "stage_to_ai and dispatch. Files stay at "
+                f"{import_folder_fullpath} so the next cycle can "
+                "idempotently resume from process_completed_album.")
+            return DispatchOutcome(
+                success=False,
+                message=("Another import is already in progress for "
+                         f"this release ({album_data.mb_release_id})"),
+                deferred=True,
+            )
+
+        dest = stage_to_ai(
+            album_data, import_folder_fullpath, ctx.cfg.beets_staging_dir)
+        log_validation_result(album_data, bv_result, ctx.cfg, dest_path=dest)
+        logger.info(f"STAGED: {album_data.artist} - {album_data.title} "
+                    f"(scenario={bv_result.scenario}, "
+                    f"distance={bv_result.distance:.4f}) → {dest}")
+
+        dl_info = _build_download_info(album_data)
+        dl_info.validation_result = bv_result.to_json()
+        if album_data.download_spectral is not None:
+            dl_info.download_spectral = album_data.download_spectral
+            dl_info.current_spectral = album_data.current_spectral
+            dl_info.existing_min_bitrate = album_data.current_min_bitrate
+            dl_info.slskd_filetype = dl_info.filetype
+            dl_info.actual_filetype = dl_info.filetype
+        if will_auto_import:
+            assert request_id is not None, "pipeline request must have db_request_id"
+            return dispatch_import(
+                album_data, bv_result, dest, dl_info, request_id, ctx)
+        ctx.pipeline_db_source.mark_done(
+            album_data, bv_result, dest_path=dest, download_info=dl_info)
+        return None
 
 
 def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResult,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -673,64 +673,40 @@ def dispatch_import_core(
             logger.warning(
                 f"{mode} SKIPPED: {label} — release lock held by "
                 f"another process (mbid={mb_release_id})")
-            # Auto-path contention trap: ``_run_completed_processing``
-            # (lib/download.py) observes status=='downloading' +
-            # ``process_completed_album`` returning True → transitions
-            # the request to 'imported' even though no import ran.
-            # Adversarial-review finding C1 on this commit. The fix:
-            # when the request is 'downloading' (auto path; force/
-            # manual never hits this column's active-download branch),
-            # reset it to 'wanted' so the outer transition check sees
-            # a non-downloading row and skips the flip. The other
-            # process holding the release lock will finish the import;
-            # the next cycle re-searches, finds the album already in
-            # beets, and the request gets marked imported via the
-            # ``preflight_existing`` path — no re-download needed.
+            # Contention == deferred retry. The entire function now
+            # returns ``DispatchOutcome(deferred=True)`` without
+            # mutating ANY state:
             #
-            # Clean up the staged dir so the next cycle's
-            # ``process_completed_album`` can re-create
-            # ``import_folder_fullpath`` without ``FileExistsError`` on
-            # the ``os.mkdir`` at download.py:188.
+            # - No status transition (was: reset to 'wanted'). The
+            #   auto path's outer ``_run_completed_processing`` now
+            #   branches on ``outcome.deferred`` — no flip to
+            #   ``imported`` and no reset to ``wanted``; the request
+            #   stays ``downloading`` with its ``active_download_state``
+            #   intact, so ``poll_active_downloads`` re-enters
+            #   ``process_completed_album`` on the next cycle and
+            #   retries exactly where we stopped.
+            # - No staged-dir cleanup (was: ``_cleanup_staged_dir``).
+            #   Codex PR #136 R3 P3: if the competing import later
+            #   fails, wiping the staged copy forces a redownload
+            #   from Soulseek. Staging is preserved so the retry
+            #   resumes with the local files already in place.
+            # - No spectral clear. Codex PR #136 R3 P2: the prior
+            #   reset-to-wanted left ``current_spectral_*`` populated
+            #   from a download that was never imported, skewing the
+            #   next cycle's quality-gate decisions. With no reset,
+            #   ``run_preimport_gates`` re-runs on retry and
+            #   re-populates spectral from the same files.
             #
             # Force/manual paths (scenario in FORCE_MANUAL_SCENARIOS)
-            # do NOT reset — their caller receives the DispatchOutcome
-            # message and surfaces "try again shortly" to the user.
-            if scenario not in FORCE_MANUAL_SCENARIOS:
-                try:
-                    req_row = db.get_request(request_id)
-                    if req_row and req_row.get("status") == "downloading":
-                        _cleanup_staged_dir(path)
-                        # Contention is a deferred retry, not a failed
-                        # attempt — we didn't *try* to download, we
-                        # deferred to a concurrent process. Passing no
-                        # ``attempt_type`` skips the ``record_attempt``
-                        # side effect that would set
-                        # ``next_retry_after = now + backoff`` (30 min
-                        # for attempt #1, doubling each retry, up to
-                        # 24h). That backoff is designed for genuine
-                        # download failures; applying it to contention
-                        # would hold the request in ``wanted`` for
-                        # half an hour while the competing process
-                        # either finishes (we'd re-search, find the
-                        # album already in beets, mark imported via
-                        # the ``preflight_existing`` path) or fails
-                        # (we should retry). Codex R2 P1 caught this.
-                        apply_transition(
-                            db, request_id, "wanted",
-                            from_status="downloading")
-                        logger.info(
-                            f"{mode}: reset request {request_id} to "
-                            "'wanted' after release-lock contention; "
-                            "next cycle will re-search (the other "
-                            "process should have finished by then)")
-                except Exception:
-                    logger.exception(
-                        f"{mode}: failed to reset deferred request "
-                        f"{request_id} after release-lock contention")
+            # surface the message to the user via
+            # ``dispatch_import_from_db``; no state change needed
+            # because the request wasn't ``downloading`` to begin
+            # with.
             return DispatchOutcome(
                 success=False,
                 message=("Another import is already in progress for "
                          f"this release ({mb_release_id})"),
+                deferred=True,
             )
 
         try:
@@ -994,10 +970,26 @@ def dispatch_import_core(
 
 def dispatch_import(album_data: "GrabListEntry", bv_result: ValidationResult, dest: str,
                     dl_info: DownloadInfo, request_id: int,
-                    ctx: "CratediggerContext", *, force: bool = False) -> None:
+                    ctx: "CratediggerContext", *, force: bool = False
+                    ) -> "DispatchOutcome":
     """Import decision tree — thin adapter extracting plain params for the core.
 
-    Called from process_completed_album() for auto-import.
+    Called from ``process_completed_album()`` for auto-import.
+
+    Returns ``DispatchOutcome`` so the auto-path caller
+    (``_run_completed_processing``) can distinguish three terminal
+    states: ``success=True`` (import landed; flip to ``imported``),
+    ``deferred=True`` (release lock held; leave row alone for the
+    next cycle), or ``success=False`` with ``deferred=False`` (actual
+    failure; caller's existing fallback reset handles it).
+
+    Pre-#133 this returned ``None`` and callers inferred success from
+    ``process_completed_album``'s boolean. That branch mis-flipped
+    contention to ``imported`` (the C1 bug fixed in commit 43e83e8).
+    The Codex R3 follow-up widened the fix: threading ``deferred``
+    explicitly lets the caller preserve all resumable state
+    (staging, spectral, status) on contention, not just skip the
+    flip.
     """
     db = ctx.pipeline_db_source._get_db()
 
@@ -1014,7 +1006,7 @@ def dispatch_import(album_data: "GrabListEntry", bv_result: ValidationResult, de
     except Exception:
         logger.debug("DB lookup failed for override-min-bitrate")
 
-    dispatch_import_core(
+    return dispatch_import_core(
         path=dest,
         mb_release_id=album_data.mb_release_id or "",
         request_id=request_id,
@@ -1037,9 +1029,26 @@ def dispatch_import(album_data: "GrabListEntry", bv_result: ValidationResult, de
 
 @dataclass(frozen=True)
 class DispatchOutcome:
-    """Result of dispatch_import_from_db — typed return for web/CLI callers."""
+    """Result of ``dispatch_import_*`` — typed return for every caller
+    (auto-path, web/CLI force/manual, tests).
+
+    - ``success``: the import landed in beets and the request is now
+      ``imported``. Callers that further transition the request (the
+      auto-path's ``_run_completed_processing``) branch on this.
+    - ``message``: human-readable summary for UI / logs; never parsed.
+    - ``deferred``: the import did NOT run because a competing process
+      holds the release advisory lock (issue #132 P1 / #133). The
+      request's state is UNTOUCHED — no status transition, no staged
+      cleanup, no spectral clear — so the next cycle can resume
+      exactly where this one left off. Callers MUST check
+      ``deferred`` before applying any "on failure" fallback state
+      transition (Codex PR #136 R2 P1 + R3 P2/P3: every round of
+      review surfaced a different piece of state the old eager
+      reset-to-wanted was clobbering).
+    """
     success: bool
     message: str
+    deferred: bool = False
 
 def dispatch_import_from_db(
     db: "PipelineDB",

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -574,8 +574,46 @@ def dispatch_import_core(
             logger.warning(
                 f"{mode} SKIPPED: {label} — release lock held by "
                 f"another process (mbid={mb_release_id})")
-            # No rejection row: this is a deferred retry, not a
-            # failure. The caller's state is untouched.
+            # Auto-path contention trap: ``_run_completed_processing``
+            # (lib/download.py) observes status=='downloading' +
+            # ``process_completed_album`` returning True → transitions
+            # the request to 'imported' even though no import ran.
+            # Adversarial-review finding C1 on this commit. The fix:
+            # when the request is 'downloading' (auto path; force/
+            # manual never hits this column's active-download branch),
+            # reset it to 'wanted' so the outer transition check sees
+            # a non-downloading row and skips the flip. The other
+            # process holding the release lock will finish the import;
+            # the next cycle re-searches, finds the album already in
+            # beets, and the request gets marked imported via the
+            # ``preflight_existing`` path — no re-download needed.
+            #
+            # Clean up the staged dir so the next cycle's
+            # ``process_completed_album`` can re-create
+            # ``import_folder_fullpath`` without ``FileExistsError`` on
+            # the ``os.mkdir`` at download.py:188.
+            #
+            # Force/manual paths (scenario in FORCE_MANUAL_SCENARIOS)
+            # do NOT reset — their caller receives the DispatchOutcome
+            # message and surfaces "try again shortly" to the user.
+            if scenario not in FORCE_MANUAL_SCENARIOS:
+                try:
+                    req_row = db.get_request(request_id)
+                    if req_row and req_row.get("status") == "downloading":
+                        _cleanup_staged_dir(path)
+                        apply_transition(
+                            db, request_id, "wanted",
+                            from_status="downloading",
+                            attempt_type="download")
+                        logger.info(
+                            f"{mode}: reset request {request_id} to "
+                            "'wanted' after release-lock contention; "
+                            "next cycle will re-search (the other "
+                            "process should have finished by then)")
+                except Exception:
+                    logger.exception(
+                        f"{mode}: failed to reset deferred request "
+                        f"{request_id} after release-lock contention")
             return DispatchOutcome(
                 success=False,
                 message=("Another import is already in progress for "

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -374,10 +374,30 @@ def _propagate_moved_siblings(
     whose ``beet move`` succeeded, carrying the beets album id, the
     new path, and the pre-resolved ``(mb_albumid, discogs_albumid)``
     columns from beets. This function translates each record into a
-    ``PipelineDB.update_imported_path_by_release_id`` call. Updates
-    are best-effort: a sibling not tracked in the pipeline DB is a
-    silent no-op (rowcount=0); a DB exception on one sibling is
-    logged and does not abort the rest.
+    ``PipelineDB.update_imported_path_by_release_id`` call.
+
+    Three log paths worth noticing in operations:
+
+    - ``rows == 1`` (expected happy case): INFO log with the new path
+      and the request id count. Cross-reference with the harness's
+      ``[CANONICALIZE]`` stderr for a full post-move audit trail.
+    - ``rows > 1``: WARN — should be at most one tracked request per
+      release, but ``discogs_release_id`` has no UNIQUE constraint
+      (``migrations/001_initial.sql``), so a duplicate could sneak in.
+      Flag it so an operator can reconcile.
+    - ``rows == 0`` AND both release IDs empty: WARN — the sibling
+      moved on disk but we had no beets release-id columns to key the
+      SQL on. Usually means beets didn't tag the row (no mb_albumid
+      AND no discogs_albumid), which is itself worth investigating.
+    - ``rows == 0`` AND at least one ID populated: INFO at DEBUG level
+      — sibling wasn't tracked in the pipeline DB. Silent no-op is
+      the common case for multi-edition libraries where only some
+      editions are pipeline requests.
+
+    Per-sibling DB exceptions are logged with full traceback and do
+    NOT abort the loop — a sibling's update failure is cosmetic
+    (wrong UI path) not structural, and other siblings should still
+    propagate.
 
     No-op when ``moved_siblings`` is empty — the common case
     (non-kept-duplicate imports).
@@ -400,12 +420,36 @@ def _propagate_moved_siblings(
                 "pipeline DB row will show pre-move path until next "
                 "upgrade or manual re-tag")
             continue
-        if rows:
-            logger.info(
+        if rows > 1:
+            # More than one pipeline row matched. mb_release_id is
+            # UNIQUE so the MB column alone can't cause this — only a
+            # duplicate discogs_release_id can, which is a pipeline DB
+            # inconsistency worth investigating.
+            logger.warning(
                 f"{label}: propagated imported_path → "
                 f"{sib.new_path} for sibling album_id={sib.album_id} "
-                f"({rows} pipeline row(s) updated)")
-        # rows == 0 is the common case (sibling not tracked) — silent.
+                f"— {rows} pipeline rows updated "
+                f"(mb={sib.mb_albumid or '∅'}, "
+                f"discogs={sib.discogs_albumid or '∅'}); expected "
+                "at most one, check for duplicate pipeline requests")
+        elif rows == 1:
+            logger.info(
+                f"{label}: propagated imported_path → "
+                f"{sib.new_path} for sibling album_id={sib.album_id}")
+        elif not sib.mb_albumid and not sib.discogs_albumid:
+            # Sibling moved on disk, but beets had no release ids for
+            # it (neither mb_albumid nor discogs_albumid) — we cannot
+            # key the UPDATE. Not a pipeline bug per se, but the fact
+            # that an album in beets has no release identifier at all
+            # is worth surfacing.
+            logger.warning(
+                f"{label}: sibling album_id={sib.album_id} moved to "
+                f"{sib.new_path} but has NO release id in beets "
+                "(neither mb_albumid nor discogs_albumid); pipeline "
+                "DB cannot propagate imported_path without a release "
+                "id key")
+        # rows == 0 with at least one id populated: common case
+        # (sibling not tracked in pipeline DB). Silent.
 
 
 def _build_download_info(album_data: GrabListEntry) -> DownloadInfo:
@@ -729,6 +773,16 @@ def dispatch_import_core(
                 outcome_message = f"No JSON result (rc={result.returncode})"
             else:
                 _populate_dl_info_from_import_result(dl_info, ir)
+                # Propagate sibling path updates BEFORE dispatch
+                # branches. Rationale: the sibling files are already
+                # moved on disk by the time the harness returns —
+                # delaying the pipeline DB update to after
+                # ``_do_mark_done`` (atomic-success semantics) would
+                # mean that if ``_do_mark_done`` throws, the sibling's
+                # pipeline row stays stale even though the disk state
+                # is new. Running propagation here (best-effort,
+                # never raises) keeps the pipeline DB consistent with
+                # disk regardless of the main import's outcome.
                 _propagate_moved_siblings(db, ir, label=label)
                 decision = ir.decision or "unknown"
                 action = dispatch_action(decision)

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -520,250 +520,312 @@ def dispatch_import_core(
     outcome_success = False
     outcome_message = ""
 
-    try:
-        cmd = [sys.executable, import_script, path, mb_release_id,
-               "--request-id", str(request_id)]
-        if force:
-            cmd.append("--force")
-        # Force/manual import operates on the user's only copy of the source
-        # material (typically failed_imports/…). Tell the harness to keep
-        # lossless originals intact until the quality decision — on
-        # downgrade/transcode_downgrade verdicts we exit before deletion so
-        # the user's FLACs survive (#111). Auto-import stages to disposable
-        # /Incoming and does not need the flag.
-        if scenario in FORCE_MANUAL_SCENARIOS:
-            cmd.append("--preserve-source")
-        if verified_lossless_target:
-            cmd.extend(["--verified-lossless-target", verified_lossless_target])
-        if target_format:
-            cmd.extend(["--target-format", target_format])
-        if override_min_bitrate is not None:
-            cmd.extend(["--override-min-bitrate", str(override_min_bitrate)])
-        # Serialize the runtime QualityRankConfig so the harness classifies
-        # with the same policy as the caller. Missing cfg (e.g. legacy test
-        # path) → harness falls back to QualityRankConfig.defaults().
-        if cfg is not None:
-            cmd.extend(["--quality-rank-config", cfg.quality_ranks.to_json()])
-        result = sp.run(cmd, capture_output=True, text=True,
-                        timeout=1800, env=beets_subprocess_env())
-        for line in (result.stderr or "").strip().split("\n"):
-            if line.strip():
-                logger.info(f"  [import] {line}")
+    # Cross-process same-release lock (issue #132 P1, issue #133). Held
+    # for the duration of the ``import_one.py`` subprocess. The Palo
+    # Santo blast-radius fix (PR #131) removed the destructive branch
+    # from the harness's ``resolve_duplicate`` handler, but the
+    # post-import cleanup still uses ``max(post_import_ids)`` to pick
+    # "the album we just imported" — vulnerable to a second process
+    # inserting its own same-MBID row between our import finishing and
+    # our re-enumerate query. This lock closes that window across every
+    # entry point (auto-import cycle, web force-import, CLI
+    # manual-import) because every one of them funnels through
+    # ``dispatch_import_core``.
+    #
+    # Non-blocking (``pg_try_advisory_lock``): if another process is
+    # already importing this MBID we return early with no rejection
+    # record. The auto cycle retries on its next timer tick; force/
+    # manual surface a "try again shortly" message to the user. A
+    # blocking wait would hold the caller's PG connection for the full
+    # duration of an unrelated process's import (minutes) without any
+    # clear benefit.
+    #
+    # Key derivation: stable int32 hash of ``mb_release_id`` (str).
+    # Covers both MB UUIDs and Discogs numeric ids since both share
+    # the ``mb_release_id`` column. See
+    # ``lib.pipeline_db.release_id_to_lock_key`` for collision analysis.
+    from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                 release_id_to_lock_key)
+    release_lock_key: int | None
+    if mb_release_id:
+        release_lock_key = release_id_to_lock_key(mb_release_id)
+    else:
+        # Defensive: ``dispatch_import_from_db`` already rejects empty
+        # mbids before reaching here; ``dispatch_import`` uses
+        # ``album_data.mb_release_id or ""``. An empty mbid means
+        # there's nothing to serialise across, so skip the lock.
+        release_lock_key = None
+        logger.warning(
+            f"{mode}: mb_release_id is empty; skipping release lock "
+            "(no cross-release race to serialise)")
 
-        ir = parse_import_result(result.stdout or "")
-        if ir is None:
-            logger.error(
-                f"{mode} FAILED (no JSON, rc={result.returncode}): {label}")
-            for line in (result.stdout or "").strip().split("\n"):
-                logger.error(f"  {line}")
-            _record_rejection_and_maybe_requeue(
-                db, request_id, dl_info,
-                distance=distance,
-                scenario="no_json_result",
-                detail=f"import_one.py rc={result.returncode}, no JSON",
-                error=f"rc={result.returncode}",
-                requeue=requeue_on_failure,
-                outcome_label="failed",
-                validation_result=ValidationResult(
+    if release_lock_key is not None:
+        lock_ctx = db.advisory_lock(
+            ADVISORY_LOCK_NAMESPACE_RELEASE, release_lock_key)
+    else:
+        # No-op context manager that yields True (treat as "got lock"
+        # so the critical section runs). ``contextlib.nullcontext``
+        # forwards the enter value unchanged.
+        from contextlib import nullcontext
+        lock_ctx = nullcontext(True)
+
+    with lock_ctx as got_release_lock:
+        if not got_release_lock:
+            logger.warning(
+                f"{mode} SKIPPED: {label} — release lock held by "
+                f"another process (mbid={mb_release_id})")
+            # No rejection row: this is a deferred retry, not a
+            # failure. The caller's state is untouched.
+            return DispatchOutcome(
+                success=False,
+                message=("Another import is already in progress for "
+                         f"this release ({mb_release_id})"),
+            )
+
+        try:
+            cmd = [sys.executable, import_script, path, mb_release_id,
+                   "--request-id", str(request_id)]
+            if force:
+                cmd.append("--force")
+            # Force/manual import operates on the user's only copy of the source
+            # material (typically failed_imports/…). Tell the harness to keep
+            # lossless originals intact until the quality decision — on
+            # downgrade/transcode_downgrade verdicts we exit before deletion so
+            # the user's FLACs survive (#111). Auto-import stages to disposable
+            # /Incoming and does not need the flag.
+            if scenario in FORCE_MANUAL_SCENARIOS:
+                cmd.append("--preserve-source")
+            if verified_lossless_target:
+                cmd.extend(["--verified-lossless-target", verified_lossless_target])
+            if target_format:
+                cmd.extend(["--target-format", target_format])
+            if override_min_bitrate is not None:
+                cmd.extend(["--override-min-bitrate", str(override_min_bitrate)])
+            # Serialize the runtime QualityRankConfig so the harness classifies
+            # with the same policy as the caller. Missing cfg (e.g. legacy test
+            # path) → harness falls back to QualityRankConfig.defaults().
+            if cfg is not None:
+                cmd.extend(["--quality-rank-config", cfg.quality_ranks.to_json()])
+            result = sp.run(cmd, capture_output=True, text=True,
+                            timeout=1800, env=beets_subprocess_env())
+            for line in (result.stderr or "").strip().split("\n"):
+                if line.strip():
+                    logger.info(f"  [import] {line}")
+
+            ir = parse_import_result(result.stdout or "")
+            if ir is None:
+                logger.error(
+                    f"{mode} FAILED (no JSON, rc={result.returncode}): {label}")
+                for line in (result.stdout or "").strip().split("\n"):
+                    logger.error(f"  {line}")
+                _record_rejection_and_maybe_requeue(
+                    db, request_id, dl_info,
                     distance=distance,
                     scenario="no_json_result",
                     detail=f"import_one.py rc={result.returncode}, no JSON",
                     error=f"rc={result.returncode}",
+                    requeue=requeue_on_failure,
+                    outcome_label="failed",
+                    validation_result=ValidationResult(
+                        distance=distance,
+                        scenario="no_json_result",
+                        detail=f"import_one.py rc={result.returncode}, no JSON",
+                        error=f"rc={result.returncode}",
+                    ).to_json(),
+                    staged_path=path)
+                outcome_message = f"No JSON result (rc={result.returncode})"
+            else:
+                _populate_dl_info_from_import_result(dl_info, ir)
+                decision = ir.decision or "unknown"
+                action = dispatch_action(decision)
+                file_list = files or []
+                usernames = extract_usernames(file_list) if action.denylist else set()
+                narrowed_override = None
+                current_override = None
+
+                new_br = ir.new_measurement.min_bitrate_kbps if ir.new_measurement else None
+                prev_br = ir.existing_measurement.min_bitrate_kbps if ir.existing_measurement else None
+
+                # --- Mark done or failed with decision-specific details ---
+                if action.mark_done:
+                    logger.info(f"{mode} OK: {label} (decision={decision})")
+                    _do_mark_done(
+                        db, request_id, dl_info,
+                        distance=distance, scenario=scenario,
+                        dest_path=path, outcome_label=outcome_label,
+                        imported_path=ir.postflight.imported_path)
+                    if decision in ("import", "preflight_existing"):
+                        if prev_br is not None or new_br is not None:
+                            try:
+                                apply_transition(db, request_id, "imported",
+                                                 from_status="imported",
+                                                 prev_min_bitrate=prev_br,
+                                                 min_bitrate=new_br)
+                            except Exception:
+                                logger.exception("Failed to update upgrade delta")
+                    outcome_success = True
+                    outcome_message = "Import successful"
+                elif action.record_rejection:
+                    if decision == "downgrade":
+                        fail_scenario = "quality_downgrade"
+                        fail_detail: str | None = (f"new {new_br}kbps "
+                                                   f"<= existing {prev_br}kbps")
+                        logger.warning(f"QUALITY DOWNGRADE PREVENTED: {label}")
+                    elif decision == "transcode_downgrade":
+                        fail_scenario = "transcode_downgrade"
+                        fail_detail = (f"transcode {new_br}kbps "
+                                       f"<= existing {prev_br}kbps")
+                        logger.warning(f"TRANSCODE REJECTED: {label} "
+                                       f"at {new_br}kbps — not an upgrade")
+                    else:
+                        fail_scenario = decision or "import_error"
+                        fail_detail = ir.error
+                        logger.error(f"{mode} FAILED: {label} "
+                                     f"(decision={decision}, error={ir.error})")
+                    fail_error = ir.error if decision not in ("downgrade", "transcode_downgrade") else None
+
+                    if decision == "downgrade":
+                        try:
+                            req_row = db.get_request(request_id)
+                            current_override = req_row.get("search_filetype_override") if req_row else None
+                            narrowed_override = narrow_override_on_downgrade(
+                                current_override, dl_info)
+                            if narrowed_override is None and current_override is None and req_row:
+                                from lib.beets_db import BeetsDB
+                                from lib.quality import QualityRankConfig
+                                _gate_cfg = (
+                                    cfg.quality_ranks if cfg is not None
+                                    else QualityRankConfig.defaults())
+                                with BeetsDB() as beets:
+                                    beets_info = beets.get_album_info(
+                                        mb_release_id, _gate_cfg)
+                                if beets_info:
+                                    narrowed_override = rejection_backfill_override(
+                                        is_cbr=beets_info.is_cbr,
+                                        min_bitrate_kbps=beets_info.min_bitrate_kbps,
+                                        spectral_grade=req_row.get(
+                                            "current_spectral_grade"),
+                                        verified_lossless=bool(
+                                            req_row.get("verified_lossless")),
+                                        cfg=_gate_cfg,
+                                    )
+                                    if narrowed_override:
+                                        logger.info(
+                                            f"BACKFILL: {label} search_filetype_override=NULL"
+                                            f" → '{narrowed_override}' on downgrade"
+                                            f" ({beets_info.min_bitrate_kbps}kbps,"
+                                            f" cbr={beets_info.is_cbr})")
+                        except Exception:
+                            logger.debug(
+                                "Failed to inspect search_filetype_override before downgrade reset")
+
+                    _record_rejection_and_maybe_requeue(
+                        db, request_id, dl_info,
+                        distance=distance,
+                        scenario=fail_scenario,
+                        detail=fail_detail,
+                        error=fail_error,
+                        requeue=requeue_on_failure,
+                        outcome_label="rejected",
+                        search_filetype_override=narrowed_override,
+                        validation_result=(dl_info.validation_result
+                                           or ValidationResult(
+                                               distance=distance,
+                                               scenario=fail_scenario,
+                                               detail=fail_detail,
+                                               error=fail_error,
+                                           ).to_json()),
+                        staged_path=path)
+                    if narrowed_override is not None:
+                        logger.info(
+                            f"  Narrowed search_filetype_override '{current_override}'"
+                            f" -> '{narrowed_override}' after downgrade")
+                    outcome_message = f"Rejected: {fail_scenario} — {fail_detail}"
+
+                # --- Common actions driven by flags ---
+                if action.denylist:
+                    if decision == "downgrade":
+                        reason = "quality downgrade prevented"
+                    elif decision.startswith("transcode"):
+                        reason = f"transcode: {new_br}kbps" if new_br else "transcode detected"
+                    else:
+                        reason = f"rejected: {decision}"
+                    for username in usernames:
+                        db.add_denylist(request_id, username, reason)
+                        if cooled_down_users is not None:
+                            if db.check_and_apply_cooldown(username):
+                                cooled_down_users.add(username)
+                    logger.info(f"  Denylisted {usernames} for request {request_id}")
+
+                if action.requeue and (requeue_on_failure or not action.record_rejection):
+                    requeue_fields: dict[str, object] = {
+                        "search_filetype_override": QUALITY_UPGRADE_TIERS,
+                    }
+                    if action.mark_done and new_br is not None:
+                        requeue_fields["min_bitrate"] = new_br
+                    apply_transition(db, request_id, "wanted", **requeue_fields)
+
+                if action.run_quality_gate:
+                    _check_quality_gate_core(
+                        mb_id=mb_release_id,
+                        label=label,
+                        request_id=request_id,
+                        files=list(file_list),
+                        db=db,
+                        quality_ranks=cfg.quality_ranks if cfg is not None else None,
+                    )
+                if action.trigger_notifiers and cfg is not None:
+                    _trigger_meelo(cfg)
+                    _trigger_plex(cfg, ir.postflight.imported_path)
+                    _trigger_jellyfin(cfg)
+                if action.cleanup and _should_cleanup_path(scenario, action):
+                    # Issue #89: force/manual paths pass the user's
+                    # ``failed_imports/…`` folder as ``path`` — cleanup is
+                    # data loss on a ``downgrade`` / ``transcode_downgrade``
+                    # decision where beets never moved the files.
+                    # ``_should_cleanup_path`` only allows cleanup on force/
+                    # manual when the decision actually imported (mark_done=
+                    # True, i.e. beets has moved the files and the source
+                    # directory is now empty), which keeps the wrong-matches
+                    # tab honest and prevents duplicate re-imports of an
+                    # already-imported album. Auto-import scenarios always
+                    # clean — their staging dir under ``/Incoming`` is
+                    # disposable by design.
+                    _cleanup_staged_dir(path)
+                if action.mark_done and ir.postflight.disambiguated and ir.postflight.imported_path:
+                    removed = cleanup_disambiguation_orphans(ir.postflight.imported_path)
+                    if removed and cfg is not None:
+                        trigger_meelo_clean(cfg)
+        except sp.TimeoutExpired:
+            logger.error(f"{mode} TIMEOUT: {label}")
+            _record_rejection_and_maybe_requeue(
+                db, request_id, dl_info,
+                distance=distance, scenario="timeout",
+                detail="import_one.py timed out", error="timeout",
+                requeue=requeue_on_failure, outcome_label="failed",
+                validation_result=ValidationResult(
+                    distance=distance,
+                    scenario="timeout",
+                    detail="import_one.py timed out",
+                    error="timeout",
                 ).to_json(),
                 staged_path=path)
-            outcome_message = f"No JSON result (rc={result.returncode})"
-        else:
-            _populate_dl_info_from_import_result(dl_info, ir)
-            decision = ir.decision or "unknown"
-            action = dispatch_action(decision)
-            file_list = files or []
-            usernames = extract_usernames(file_list) if action.denylist else set()
-            narrowed_override = None
-            current_override = None
-
-            new_br = ir.new_measurement.min_bitrate_kbps if ir.new_measurement else None
-            prev_br = ir.existing_measurement.min_bitrate_kbps if ir.existing_measurement else None
-
-            # --- Mark done or failed with decision-specific details ---
-            if action.mark_done:
-                logger.info(f"{mode} OK: {label} (decision={decision})")
-                _do_mark_done(
-                    db, request_id, dl_info,
-                    distance=distance, scenario=scenario,
-                    dest_path=path, outcome_label=outcome_label,
-                    imported_path=ir.postflight.imported_path)
-                if decision in ("import", "preflight_existing"):
-                    if prev_br is not None or new_br is not None:
-                        try:
-                            apply_transition(db, request_id, "imported",
-                                             from_status="imported",
-                                             prev_min_bitrate=prev_br,
-                                             min_bitrate=new_br)
-                        except Exception:
-                            logger.exception("Failed to update upgrade delta")
-                outcome_success = True
-                outcome_message = "Import successful"
-            elif action.record_rejection:
-                if decision == "downgrade":
-                    fail_scenario = "quality_downgrade"
-                    fail_detail: str | None = (f"new {new_br}kbps "
-                                               f"<= existing {prev_br}kbps")
-                    logger.warning(f"QUALITY DOWNGRADE PREVENTED: {label}")
-                elif decision == "transcode_downgrade":
-                    fail_scenario = "transcode_downgrade"
-                    fail_detail = (f"transcode {new_br}kbps "
-                                   f"<= existing {prev_br}kbps")
-                    logger.warning(f"TRANSCODE REJECTED: {label} "
-                                   f"at {new_br}kbps — not an upgrade")
-                else:
-                    fail_scenario = decision or "import_error"
-                    fail_detail = ir.error
-                    logger.error(f"{mode} FAILED: {label} "
-                                 f"(decision={decision}, error={ir.error})")
-                fail_error = ir.error if decision not in ("downgrade", "transcode_downgrade") else None
-
-                if decision == "downgrade":
-                    try:
-                        req_row = db.get_request(request_id)
-                        current_override = req_row.get("search_filetype_override") if req_row else None
-                        narrowed_override = narrow_override_on_downgrade(
-                            current_override, dl_info)
-                        if narrowed_override is None and current_override is None and req_row:
-                            from lib.beets_db import BeetsDB
-                            from lib.quality import QualityRankConfig
-                            _gate_cfg = (
-                                cfg.quality_ranks if cfg is not None
-                                else QualityRankConfig.defaults())
-                            with BeetsDB() as beets:
-                                beets_info = beets.get_album_info(
-                                    mb_release_id, _gate_cfg)
-                            if beets_info:
-                                narrowed_override = rejection_backfill_override(
-                                    is_cbr=beets_info.is_cbr,
-                                    min_bitrate_kbps=beets_info.min_bitrate_kbps,
-                                    spectral_grade=req_row.get(
-                                        "current_spectral_grade"),
-                                    verified_lossless=bool(
-                                        req_row.get("verified_lossless")),
-                                    cfg=_gate_cfg,
-                                )
-                                if narrowed_override:
-                                    logger.info(
-                                        f"BACKFILL: {label} search_filetype_override=NULL"
-                                        f" → '{narrowed_override}' on downgrade"
-                                        f" ({beets_info.min_bitrate_kbps}kbps,"
-                                        f" cbr={beets_info.is_cbr})")
-                    except Exception:
-                        logger.debug(
-                            "Failed to inspect search_filetype_override before downgrade reset")
-
-                _record_rejection_and_maybe_requeue(
-                    db, request_id, dl_info,
+            outcome_message = "Import timed out"
+        except Exception:
+            logger.exception(f"{mode} ERROR: {label}")
+            _record_rejection_and_maybe_requeue(
+                db, request_id, dl_info,
+                distance=distance, scenario="exception",
+                detail="unhandled exception in auto-import", error="exception",
+                requeue=requeue_on_failure, outcome_label="failed",
+                validation_result=ValidationResult(
                     distance=distance,
-                    scenario=fail_scenario,
-                    detail=fail_detail,
-                    error=fail_error,
-                    requeue=requeue_on_failure,
-                    outcome_label="rejected",
-                    search_filetype_override=narrowed_override,
-                    validation_result=(dl_info.validation_result
-                                       or ValidationResult(
-                                           distance=distance,
-                                           scenario=fail_scenario,
-                                           detail=fail_detail,
-                                           error=fail_error,
-                                       ).to_json()),
-                    staged_path=path)
-                if narrowed_override is not None:
-                    logger.info(
-                        f"  Narrowed search_filetype_override '{current_override}'"
-                        f" -> '{narrowed_override}' after downgrade")
-                outcome_message = f"Rejected: {fail_scenario} — {fail_detail}"
-
-            # --- Common actions driven by flags ---
-            if action.denylist:
-                if decision == "downgrade":
-                    reason = "quality downgrade prevented"
-                elif decision.startswith("transcode"):
-                    reason = f"transcode: {new_br}kbps" if new_br else "transcode detected"
-                else:
-                    reason = f"rejected: {decision}"
-                for username in usernames:
-                    db.add_denylist(request_id, username, reason)
-                    if cooled_down_users is not None:
-                        if db.check_and_apply_cooldown(username):
-                            cooled_down_users.add(username)
-                logger.info(f"  Denylisted {usernames} for request {request_id}")
-
-            if action.requeue and (requeue_on_failure or not action.record_rejection):
-                requeue_fields: dict[str, object] = {
-                    "search_filetype_override": QUALITY_UPGRADE_TIERS,
-                }
-                if action.mark_done and new_br is not None:
-                    requeue_fields["min_bitrate"] = new_br
-                apply_transition(db, request_id, "wanted", **requeue_fields)
-
-            if action.run_quality_gate:
-                _check_quality_gate_core(
-                    mb_id=mb_release_id,
-                    label=label,
-                    request_id=request_id,
-                    files=list(file_list),
-                    db=db,
-                    quality_ranks=cfg.quality_ranks if cfg is not None else None,
-                )
-            if action.trigger_notifiers and cfg is not None:
-                _trigger_meelo(cfg)
-                _trigger_plex(cfg, ir.postflight.imported_path)
-                _trigger_jellyfin(cfg)
-            if action.cleanup and _should_cleanup_path(scenario, action):
-                # Issue #89: force/manual paths pass the user's
-                # ``failed_imports/…`` folder as ``path`` — cleanup is
-                # data loss on a ``downgrade`` / ``transcode_downgrade``
-                # decision where beets never moved the files.
-                # ``_should_cleanup_path`` only allows cleanup on force/
-                # manual when the decision actually imported (mark_done=
-                # True, i.e. beets has moved the files and the source
-                # directory is now empty), which keeps the wrong-matches
-                # tab honest and prevents duplicate re-imports of an
-                # already-imported album. Auto-import scenarios always
-                # clean — their staging dir under ``/Incoming`` is
-                # disposable by design.
-                _cleanup_staged_dir(path)
-            if action.mark_done and ir.postflight.disambiguated and ir.postflight.imported_path:
-                removed = cleanup_disambiguation_orphans(ir.postflight.imported_path)
-                if removed and cfg is not None:
-                    trigger_meelo_clean(cfg)
-    except sp.TimeoutExpired:
-        logger.error(f"{mode} TIMEOUT: {label}")
-        _record_rejection_and_maybe_requeue(
-            db, request_id, dl_info,
-            distance=distance, scenario="timeout",
-            detail="import_one.py timed out", error="timeout",
-            requeue=requeue_on_failure, outcome_label="failed",
-            validation_result=ValidationResult(
-                distance=distance,
-                scenario="timeout",
-                detail="import_one.py timed out",
-                error="timeout",
-            ).to_json(),
-            staged_path=path)
-        outcome_message = "Import timed out"
-    except Exception:
-        logger.exception(f"{mode} ERROR: {label}")
-        _record_rejection_and_maybe_requeue(
-            db, request_id, dl_info,
-            distance=distance, scenario="exception",
-            detail="unhandled exception in auto-import", error="exception",
-            requeue=requeue_on_failure, outcome_label="failed",
-            validation_result=ValidationResult(
-                distance=distance,
-                scenario="exception",
-                detail="unhandled exception in auto-import",
-                error="exception",
-            ).to_json(),
-            staged_path=path)
-        outcome_message = "Unhandled exception"
+                    scenario="exception",
+                    detail="unhandled exception in auto-import",
+                    error="exception",
+                ).to_json(),
+                staged_path=path)
+            outcome_message = "Unhandled exception"
 
     return DispatchOutcome(success=outcome_success, message=outcome_message)
 

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -700,10 +700,24 @@ def dispatch_import_core(
                     req_row = db.get_request(request_id)
                     if req_row and req_row.get("status") == "downloading":
                         _cleanup_staged_dir(path)
+                        # Contention is a deferred retry, not a failed
+                        # attempt — we didn't *try* to download, we
+                        # deferred to a concurrent process. Passing no
+                        # ``attempt_type`` skips the ``record_attempt``
+                        # side effect that would set
+                        # ``next_retry_after = now + backoff`` (30 min
+                        # for attempt #1, doubling each retry, up to
+                        # 24h). That backoff is designed for genuine
+                        # download failures; applying it to contention
+                        # would hold the request in ``wanted`` for
+                        # half an hour while the competing process
+                        # either finishes (we'd re-search, find the
+                        # album already in beets, mark imported via
+                        # the ``preflight_existing`` path) or fails
+                        # (we should retry). Codex R2 P1 caught this.
                         apply_transition(
                             db, request_id, "wanted",
-                            from_status="downloading",
-                            attempt_type="download")
+                            from_status="downloading")
                         logger.info(
                             f"{mode}: reset request {request_id} to "
                             "'wanted' after release-lock contention; "

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -353,6 +353,61 @@ def _cleanup_staged_dir(dest: str) -> None:
             logger.info(f"  Cleaned up empty artist dir: {parent}")
 
 
+def _propagate_moved_siblings(
+    db: "PipelineDB",
+    ir: ImportResult,
+    *,
+    label: str,
+) -> None:
+    """Update ``album_requests.imported_path`` for every sibling the
+    harness canonicalized post-import (issue #132 P2 / #133).
+
+    When beets' ``%aunique`` re-evaluates on a kept-duplicate import,
+    sibling albums whose paths shifted (e.g. ``/Palo Santo/`` →
+    ``/Palo Santo [2006]/``) have new on-disk locations — but if
+    those siblings are also tracked pipeline requests, their
+    ``album_requests.imported_path`` column still points at the
+    pre-move directory, and the web UI's "Imported to" label + the
+    ban-source button lie about where the files live.
+
+    The harness emits ``PostflightInfo.moved_siblings`` per sibling
+    whose ``beet move`` succeeded, carrying the beets album id, the
+    new path, and the pre-resolved ``(mb_albumid, discogs_albumid)``
+    columns from beets. This function translates each record into a
+    ``PipelineDB.update_imported_path_by_release_id`` call. Updates
+    are best-effort: a sibling not tracked in the pipeline DB is a
+    silent no-op (rowcount=0); a DB exception on one sibling is
+    logged and does not abort the rest.
+
+    No-op when ``moved_siblings`` is empty — the common case
+    (non-kept-duplicate imports).
+    """
+    if not ir.postflight.moved_siblings:
+        return
+    for sib in ir.postflight.moved_siblings:
+        try:
+            rows = db.update_imported_path_by_release_id(
+                mb_albumid=sib.mb_albumid,
+                discogs_albumid=sib.discogs_albumid,
+                new_path=sib.new_path,
+            )
+        except Exception:
+            logger.exception(
+                f"{label}: failed to propagate imported_path for "
+                f"sibling album_id={sib.album_id} "
+                f"(mb={sib.mb_albumid or '∅'}, "
+                f"discogs={sib.discogs_albumid or '∅'}) — "
+                "pipeline DB row will show pre-move path until next "
+                "upgrade or manual re-tag")
+            continue
+        if rows:
+            logger.info(
+                f"{label}: propagated imported_path → "
+                f"{sib.new_path} for sibling album_id={sib.album_id} "
+                f"({rows} pipeline row(s) updated)")
+        # rows == 0 is the common case (sibling not tracked) — silent.
+
+
 def _build_download_info(album_data: GrabListEntry) -> DownloadInfo:
     """Extract audio quality metadata from album files for download logging."""
     files = album_data.files
@@ -674,6 +729,7 @@ def dispatch_import_core(
                 outcome_message = f"No JSON result (rc={result.returncode})"
             else:
                 _populate_dl_info_from_import_result(dl_info, ir)
+                _propagate_moved_siblings(db, ir, label=label)
                 decision = ir.decision or "unknown"
                 action = dispatch_action(decision)
                 file_list = files or []

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import os
+import zlib
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -32,6 +33,45 @@ BACKOFF_MAX_MINUTES = 60 * 24  # 24 hours
 # arg is a per-feature namespace constant, the second is the request_id.
 # 0x46494D50 = ASCII "FIMP" — recognisable in pg_locks during debugging.
 ADVISORY_LOCK_NAMESPACE_IMPORT = 0x46494D50
+
+# Advisory-lock namespace for same-release concurrency protection
+# (issue #132 P1, issue #133). ``ADVISORY_LOCK_NAMESPACE_IMPORT`` above
+# serialises operations on the same *request_id* — it prevents a
+# double-click on force-import from running the pipeline twice for the
+# same album row. That is NOT enough to close the Palo Santo blast
+# radius: the auto-import cycle and the web force-import path can each
+# hold its own per-request lock while both targeting the same MBID
+# (different request_id, same release). In that race,
+# ``import_one.py``'s post-import ``max(post_import_ids)`` query can
+# pick up the OTHER process's newly-inserted row as "the newest" and
+# delete the row this process just imported. The fix is to serialise
+# at the release level too: every ``dispatch_import_core`` invocation
+# acquires this lock keyed on a stable hash of ``mb_release_id``.
+#
+# 0x52454C45 = ASCII "RELE" — recognisable alongside FIMP in pg_locks.
+ADVISORY_LOCK_NAMESPACE_RELEASE = 0x52454C45
+
+
+def release_id_to_lock_key(mb_release_id: str) -> int:
+    """Map an ``mb_release_id`` string to a stable int32 advisory-lock key.
+
+    PostgreSQL's two-arg ``pg_advisory_lock(int4, int4)`` takes signed
+    int32 keys. ``mb_release_id`` is a str — either a MusicBrainz UUID
+    (36 chars) or a Discogs numeric release id. ``zlib.crc32`` is
+    stable across processes (Python's builtin ``hash`` is salted per
+    interpreter — unusable for cross-process locking), fast, and its
+    32-bit output fits once we mask to 31 bits to keep the value
+    non-negative (simpler to display in ``pg_locks`` rows).
+
+    Collision behaviour: 2^31 distinct keys. With N concurrent
+    same-release contenders, collision probability is ~N²/2^31 — a
+    false-collision would serialise two unrelated releases, delaying
+    the second by at most one import cycle (~minutes). Acceptable:
+    losing a cycle of parallelism is cheap, whereas a missed lock on
+    the real race is how the Palo Santo 11-track edition lost every
+    mp3 on disk.
+    """
+    return zlib.crc32(mb_release_id.encode("utf-8")) & 0x7FFFFFFF
 
 # Schema is managed by lib/migrator.py via numbered files in migrations/.
 # PipelineDB itself never runs DDL — see scripts/migrate_db.py and the

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -334,6 +334,65 @@ class PipelineDB:
         )
         self.conn.commit()
 
+    def update_imported_path_by_release_id(
+        self,
+        *,
+        mb_albumid: str,
+        discogs_albumid: str,
+        new_path: str,
+    ) -> int:
+        """Update ``imported_path`` for any request whose release id matches.
+
+        Issue #132 P2 / issue #133: when sibling canonicalization in
+        the harness moves a sibling's files on disk (e.g. from
+        ``/Beets/Shearwater/2006 - Palo Santo/`` to ``…/2006 - Palo
+        Santo [2006]/`` after ``%aunique`` re-evaluates because a new
+        same-name edition was just imported), the sibling might itself
+        be a tracked pipeline request — in which case its
+        ``album_requests.imported_path`` column is now stale. The UI
+        ("Imported to" label, ban-source button) would point at a
+        directory that no longer exists.
+
+        This method finds the tracked request across both layout combos
+        (MB-sourced: ``mb_release_id=<mbid>``; Discogs-sourced:
+        ``discogs_release_id=<numeric>`` and/or ``mb_release_id=<numeric>``
+        for legacy pre-plugin-patch imports) and updates its
+        ``imported_path``. Callers pass the two beets-side columns as
+        two arguments; either may be the empty string. No-op if neither
+        is populated.
+
+        Returns the number of rows updated (usually 0 or 1). A duplicate
+        request for the same release in the pipeline DB would return
+        more — that's the caller's signal that data is inconsistent
+        (the ``UNIQUE`` constraint on ``mb_release_id`` makes duplicate
+        MBIDs impossible in practice).
+        """
+        if not mb_albumid and not discogs_albumid:
+            return 0
+        now = datetime.now(timezone.utc)
+        clauses: list[str] = []
+        params: list[object] = [new_path, now]
+        if mb_albumid:
+            # Covers both ``mb_release_id = <UUID>`` (MB-sourced) AND
+            # ``mb_release_id = <numeric>`` (legacy Discogs). ``mb_albumid``
+            # on the beets side carries whichever value beets has for
+            # the row; matching against ``mb_release_id`` here handles
+            # both cases without needing to distinguish on the pipeline
+            # side.
+            clauses.append("mb_release_id = %s")
+            params.append(mb_albumid)
+        if discogs_albumid:
+            clauses.append("discogs_release_id = %s")
+            params.append(discogs_albumid)
+        where = " OR ".join(clauses)
+        cur = self._execute(
+            f"UPDATE album_requests SET imported_path = %s, "
+            f"updated_at = %s WHERE {where}",
+            tuple(params),
+        )
+        self.conn.commit()
+        return cur.rowcount
+
     # --- Downloading state ---
 
     def set_downloading(self, request_id: int, state_json: str) -> bool:

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -70,8 +70,14 @@ def release_id_to_lock_key(mb_release_id: str) -> int:
     losing a cycle of parallelism is cheap, whereas a missed lock on
     the real race is how the Palo Santo 11-track edition lost every
     mp3 on disk.
+
+    Input is ``.strip()``ed before hashing so a legacy DB row with
+    stray leading/trailing whitespace (``"12856590 "`` vs
+    ``"12856590"``) still keys the lock at the same value across
+    processes — otherwise a normalization mismatch would defeat the
+    lock's purpose silently.
     """
-    return zlib.crc32(mb_release_id.encode("utf-8")) & 0x7FFFFFFF
+    return zlib.crc32(mb_release_id.strip().encode("utf-8")) & 0x7FFFFFFF
 
 # Schema is managed by lib/migrator.py via numbered files in migrations/.
 # PipelineDB itself never runs DDL — see scripts/migrate_db.py and the

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -373,16 +373,27 @@ class PipelineDB:
         clauses: list[str] = []
         params: list[object] = [new_path, now]
         if mb_albumid:
-            # Covers both ``mb_release_id = <UUID>`` (MB-sourced) AND
-            # ``mb_release_id = <numeric>`` (legacy Discogs). ``mb_albumid``
-            # on the beets side carries whichever value beets has for
-            # the row; matching against ``mb_release_id`` here handles
-            # both cases without needing to distinguish on the pipeline
-            # side.
+            # Beets-side ``mb_albumid`` is either a MB UUID (stored
+            # in pipeline's ``mb_release_id``) or a legacy numeric
+            # (also stored in ``mb_release_id`` — the pre-plugin-patch
+            # layout). Either way the single-column match covers it.
             clauses.append("mb_release_id = %s")
             params.append(mb_albumid)
         if discogs_albumid:
-            clauses.append("discogs_release_id = %s")
+            # Beets-side ``discogs_albumid`` is always numeric. The
+            # pipeline side could store the same numeric in EITHER
+            # ``discogs_release_id`` (rows added through the web UI
+            # after the discogs-plugin integration) OR
+            # ``mb_release_id`` (legacy "pipeline compat" convention
+            # documented in CLAUDE.md § "Discogs-sourced albums":
+            # *Numeric IDs stored in ``mb_release_id`` for pipeline
+            # compat*). Match both columns so a sibling whose beets
+            # row carries only ``discogs_albumid`` still finds its
+            # tracked request regardless of which pipeline layout
+            # that request was created under. Codex R2 P2.
+            clauses.append(
+                "(mb_release_id = %s OR discogs_release_id = %s)")
+            params.append(discogs_albumid)
             params.append(discogs_albumid)
         where = " OR ".join(clauses)
         cur = self._execute(

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1317,6 +1317,31 @@ class SpectralDetail:
 from lib.beets_album_op import BeetsOpFailure as DisambiguationFailure
 
 
+@dataclass(frozen=True)
+class MovedSibling:
+    """Issue #132 P2 / issue #133: record of a sibling album whose
+    ``beet move`` successfully relocated its files during post-import
+    canonicalization.
+
+    ``album_id`` is the beets numeric primary key for the sibling.
+    ``new_path`` is the on-disk directory after the move.
+    ``mb_albumid`` / ``discogs_albumid`` are the two columns from
+    beets' ``albums`` table at emit time — the harness resolves them
+    so the dispatcher doesn't need a second beets DB connection when
+    propagating the new path to the pipeline DB.
+
+    Every field matters for propagation: if the sibling's release id
+    matches a tracked ``album_requests`` row, its ``imported_path``
+    gets updated so the UI stops pointing at the pre-move directory.
+    Untracked siblings (no matching pipeline row) are no-ops at the
+    dispatcher — propagation is best-effort.
+    """
+    album_id: int
+    new_path: str
+    mb_albumid: str = ""
+    discogs_albumid: str = ""
+
+
 @dataclass
 class PostflightInfo:
     """Beets post-import verification data."""
@@ -1332,12 +1357,21 @@ class PostflightInfo:
     # ``disambiguated=True`` (clean success) or that no move was
     # attempted (no duplicate kept).
     disambiguation_failure: Optional[DisambiguationFailure] = None
+    # Issue #132 P2 / issue #133: siblings canonicalized post-import.
+    # Empty for non-``kept_duplicate`` imports; populated when the
+    # harness's ``_canonicalize_siblings`` moved one or more siblings
+    # to re-evaluate ``%aunique`` on their paths. The dispatcher
+    # propagates each entry's ``new_path`` to the pipeline DB (the
+    # tracked request row, if any, for that sibling's release).
+    moved_siblings: list[MovedSibling] = field(default_factory=list)
 
 
 def _postflight_from_dict(d: Optional[dict]) -> PostflightInfo:
-    """Construct PostflightInfo from a dict, handling the nested
-    ``disambiguation_failure`` (issue #127) and any other future nested
-    fields. Old rows missing the field default to ``None``.
+    """Construct PostflightInfo from a dict, handling nested fields
+    (``disambiguation_failure`` from issue #127, ``moved_siblings``
+    from issue #132 P2 / #133). Old rows missing a field default per
+    the dataclass — ``disambiguation_failure=None``,
+    ``moved_siblings=[]``.
     """
     if not d:
         return PostflightInfo()
@@ -1345,6 +1379,12 @@ def _postflight_from_dict(d: Optional[dict]) -> PostflightInfo:
     df_d = pf_d.pop("disambiguation_failure", None)
     if isinstance(df_d, dict):
         pf_d["disambiguation_failure"] = DisambiguationFailure(**df_d)
+    ms_list = pf_d.pop("moved_siblings", None)
+    if isinstance(ms_list, list):
+        pf_d["moved_siblings"] = [
+            MovedSibling(**s) if isinstance(s, dict) else s
+            for s in ms_list
+        ]
     return PostflightInfo(**pf_d)
 
 

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1306,21 +1306,15 @@ class SpectralDetail:
     existing_suspect_pct: float = 0.0
 
 
-DisambiguationFailureReason = Literal["timeout", "nonzero_rc", "exception"]
-
-
-@dataclass(frozen=True)
-class DisambiguationFailure:
-    """Why the post-import ``beet move`` did not exit cleanly (issue #127).
-
-    Mirrors ``lib/release_cleanup.py::SelectorFailure`` shape:
-    ``reason`` is a coarse Literal tag so callers (and the future web
-    UI Recents tab) can classify failures at a glance without parsing
-    ``detail`` strings; ``detail`` is a short human-readable string for
-    logs and the JSONB audit trail (do not parse it).
-    """
-    reason: DisambiguationFailureReason
-    detail: str
+# Issue #133: ``DisambiguationFailure`` / ``SelectorFailure`` were two
+# @dataclass classes with identical shape, scattered across lib.quality
+# and lib.release_cleanup. They are now a single
+# ``lib.beets_album_op.BeetsOpFailure``; these aliases preserve existing
+# imports (``from lib.quality import DisambiguationFailure`` in the
+# harness, tests/helpers.py, etc). The unified type added a ``selector``
+# field (default ``""``) so old JSON rows with only ``{reason, detail}``
+# still deserialize cleanly via ``DisambiguationFailure(**d)``.
+from lib.beets_album_op import BeetsOpFailure as DisambiguationFailure
 
 
 @dataclass

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1388,13 +1388,18 @@ def _postflight_from_dict(d: Optional[dict]) -> PostflightInfo:
     ``moved_siblings=[]``.
 
     ``moved_siblings`` is decoded via ``msgspec.convert`` because
-    ``MovedSibling`` is a ``msgspec.Struct`` (wire-boundary type per
-    ``.claude/rules/code-quality.md``). Strict type validation catches
-    int/str drift (e.g. harness emitting ``album_id`` as string) at
-    the boundary — ``msgspec.ValidationError`` raises here instead of
-    silently corrupting downstream state. Non-list values (malformed
-    legacy JSONB) fall back to the dataclass default ``[]`` without
-    raising, preserving backwards compatibility.
+    ``MovedSibling`` is a wire-boundary type per
+    ``.claude/rules/code-quality.md``. ``msgspec.convert`` accepts a
+    ``@dataclass`` target and validates each declared field strictly
+    — so int/str drift (a future harness change emitting ``album_id``
+    as string, say) raises ``msgspec.ValidationError`` here instead
+    of silently corrupting downstream state. ``MovedSibling`` stays a
+    ``@dataclass`` (not ``msgspec.Struct``) because ``ImportResult.to_json()``
+    serialises via ``dataclasses.asdict`` on the outbound edge, and
+    ``asdict`` is opaque to ``msgspec.Struct``. Asymmetric by design:
+    strict inbound validation, structural outbound serialisation.
+    Non-list values (malformed legacy JSONB) fall back to the dataclass
+    default ``[]`` without raising, preserving backwards compatibility.
     """
     if not d:
         return PostflightInfo()

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1335,6 +1335,20 @@ class MovedSibling:
     gets updated so the UI stops pointing at the pre-move directory.
     Untracked siblings (no matching pipeline row) are no-ops at the
     dispatcher — propagation is best-effort.
+
+    **Wire-boundary policy.** This dataclass is decoded from harness
+    stdout JSON AND re-decoded from ``download_log.import_result`` JSONB
+    on every web API read. Per ``.claude/rules/code-quality.md`` §
+    "Wire-boundary types" the decoder at ``_postflight_from_dict`` uses
+    ``msgspec.convert(list, type=list[MovedSibling])`` which validates
+    every field against the declared types at the boundary —
+    ``msgspec.ValidationError`` raises if a future harness change emits
+    ``album_id`` as a string or drops a required field, instead of
+    silently corrupting downstream state (the PR #98 / issue #99
+    lesson). ``@dataclass`` rather than ``msgspec.Struct`` is kept here
+    so ``ImportResult.to_json()``'s ``dataclasses.asdict`` traversal
+    still sees the fields (msgspec.Struct is opaque to ``asdict``);
+    strict validation happens on the inbound edge.
     """
     album_id: int
     new_path: str
@@ -1372,6 +1386,15 @@ def _postflight_from_dict(d: Optional[dict]) -> PostflightInfo:
     from issue #132 P2 / #133). Old rows missing a field default per
     the dataclass — ``disambiguation_failure=None``,
     ``moved_siblings=[]``.
+
+    ``moved_siblings`` is decoded via ``msgspec.convert`` because
+    ``MovedSibling`` is a ``msgspec.Struct`` (wire-boundary type per
+    ``.claude/rules/code-quality.md``). Strict type validation catches
+    int/str drift (e.g. harness emitting ``album_id`` as string) at
+    the boundary — ``msgspec.ValidationError`` raises here instead of
+    silently corrupting downstream state. Non-list values (malformed
+    legacy JSONB) fall back to the dataclass default ``[]`` without
+    raising, preserving backwards compatibility.
     """
     if not d:
         return PostflightInfo()
@@ -1381,10 +1404,8 @@ def _postflight_from_dict(d: Optional[dict]) -> PostflightInfo:
         pf_d["disambiguation_failure"] = DisambiguationFailure(**df_d)
     ms_list = pf_d.pop("moved_siblings", None)
     if isinstance(ms_list, list):
-        pf_d["moved_siblings"] = [
-            MovedSibling(**s) if isinstance(s, dict) else s
-            for s in ms_list
-        ]
+        pf_d["moved_siblings"] = msgspec.convert(
+            ms_list, type=list[MovedSibling])
     return PostflightInfo(**pf_d)
 
 

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -28,25 +28,35 @@ the point — do not collapse or route around it:
   absent afterwards. That's what the ban-source web route and other
   pipeline-aware callers need.
 
-Issue #123 PR B: each ``sp.run`` is now wrapped in a try/except that
-catches ``TimeoutExpired``, non-zero exit codes, and any ``OSError``
-(e.g. ``beet`` missing from PATH). The loop always attempts every
-selector, and per-selector failures are surfaced via
+Issue #123 PR B: each ``beet remove`` invocation is wrapped in a
+try/except that catches ``TimeoutExpired``, non-zero exit codes, and
+any ``OSError`` (e.g. ``beet`` missing from PATH). The loop always
+attempts every selector, and per-selector failures are surfaced via
 ``ReleaseCleanupResult.selector_failures`` so the caller can tell
 partial failure from a clean run. Before this change, a
 ``TimeoutExpired`` on selector 1 escaped the loop and left selector 2
 untried — *after* the ban-source caller had already committed the
 denylist row, leaving the banned copy on disk with no recovery path.
+
+Issue #133: the subprocess primitive now lives in
+``lib.beets_album_op`` (``remove_by_selector`` / ``remove_album``)
+as part of the ``BeetsAlbumOp`` extraction. ``SelectorFailure`` is a
+kept-name alias for ``BeetsOpFailure``; ``SelectorFailureReason`` is
+the kept-name alias for ``BeetsOpFailureReason``. Existing callers
+(web routes, tests) continue to import from this module unchanged.
 """
 
 from __future__ import annotations
 
 import logging
-import subprocess as sp
 from dataclasses import dataclass
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
-from lib.util import beet_bin, beets_subprocess_env
+from lib.beets_album_op import (BeetsOpFailure as SelectorFailure,
+                                BeetsOpFailureReason as SelectorFailureReason,
+                                remove_album as _remove_album_op,
+                                remove_by_selector)
+from lib.beets_album_op import BeetsAlbumHandle
 
 if TYPE_CHECKING:
     from lib.beets_db import BeetsDB
@@ -55,22 +65,16 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("cratedigger")
 
-
-SelectorFailureReason = Literal["timeout", "nonzero_rc", "exception"]
-
-
-@dataclass(frozen=True)
-class SelectorFailure:
-    """One ``beet remove -d`` attempt that didn't cleanly exit.
-
-    ``reason`` is a coarse tag so callers (including the web UI) can
-    classify at a glance without parsing ``detail`` strings. Keep the
-    set closed — see ``SelectorFailureReason``. ``detail`` is a short
-    human-readable string for logs and debugging; do not parse it.
-    """
-    selector: str
-    reason: SelectorFailureReason
-    detail: str
+# Re-export for historical call sites (web/routes/pipeline.py, tests,
+# harness/import_one.py) that import these names from this module.
+__all__ = [
+    "SelectorFailure",
+    "SelectorFailureReason",
+    "ReleaseCleanupResult",
+    "remove_album_by_beets_id",
+    "remove_album_by_selectors",
+    "remove_and_reset_release",
+]
 
 
 @dataclass(frozen=True)
@@ -95,63 +99,6 @@ class ReleaseCleanupResult:
     selector_failures: tuple[SelectorFailure, ...]
 
 
-def _run_remove_selector(selector: str) -> SelectorFailure | None:
-    """Run ``beet remove -a -d <selector>`` once, never raise.
-
-    The ``-a`` flag is **mandatory**. Without it, ``beet remove`` runs
-    in ITEM mode: queries ``items`` (tracks), not ``albums``. That has
-    two hazards:
-
-    - ``id:<N>`` in item mode is ``items.id = N`` — matches ONE TRACK,
-      not one album. Since ``items.id`` and ``albums.id`` are separate
-      autoincrement PKs, an album id passed to item-mode ``id:`` would
-      either match an unrelated track or nothing at all, leaving the
-      stale album fully intact. Codex (PR #131 round 2 P1) flagged
-      this against ``remove_album_by_beets_id``.
-    - ``mb_albumid:<X>`` in item mode happens to work "by accident"
-      because ``mb_albumid`` is also a per-item column inherited from
-      the album, and deleting all matching items garbage-collects the
-      empty album row. But that's fragile correctness — album-mode is
-      what we actually mean.
-
-    Every selector this module hands off is album-scoped conceptually
-    (``mb_albumid:``, ``discogs_albumid:``, ``id:`` where id is from
-    ``albums.id``), so ``-a`` is always the right flag. Returns
-    ``None`` on clean exit (rc=0), otherwise a ``SelectorFailure``.
-    """
-    try:
-        proc = sp.run(
-            [beet_bin(), "remove", "-a", "-d", selector],
-            capture_output=True, text=True, timeout=30,
-            env=beets_subprocess_env(),
-        )
-    except sp.TimeoutExpired as exc:
-        msg = f"timed out after {exc.timeout}s"
-        log.warning(
-            "release_cleanup: beet remove -a -d %s %s", selector, msg)
-        return SelectorFailure(
-            selector=selector, reason="timeout", detail=msg)
-    except OSError as exc:
-        msg = f"{type(exc).__name__}: {exc}"
-        log.warning(
-            "release_cleanup: beet remove -a -d %s raised %s",
-            selector, msg)
-        return SelectorFailure(
-            selector=selector, reason="exception", detail=msg)
-
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip().splitlines()
-        msg = stderr[-1] if stderr else f"rc={proc.returncode}"
-        log.warning(
-            "release_cleanup: beet remove -a -d %s exited %d: %s",
-            selector, proc.returncode, msg)
-        return SelectorFailure(
-            selector=selector, reason="nonzero_rc",
-            detail=f"rc={proc.returncode}: {msg}")
-
-    return None
-
-
 def remove_album_by_beets_id(album_id: int) -> SelectorFailure | None:
     """Remove a single album by its beets numeric primary key.
 
@@ -166,11 +113,13 @@ def remove_album_by_beets_id(album_id: int) -> SelectorFailure | None:
     narrow enough to be safe — ``mb_albumid:<uuid>`` would match
     both.
 
-    Returns ``None`` on clean exit, or a typed ``SelectorFailure``.
-    Caller decides how to surface a failure (log + proceed, or
-    escalate). No pipeline-DB coupling.
+    Issue #133: now a thin adapter over ``beets_album_op.remove_album``
+    — returns the underlying ``BeetsOpFailure`` (aliased as
+    ``SelectorFailure`` for historical callers) or ``None`` on clean
+    exit. Argv construction is centralised in ``lib.beets_album_op``.
     """
-    return _run_remove_selector(f"id:{album_id}")
+    result = _remove_album_op(BeetsAlbumHandle(album_id=album_id))
+    return result.failure
 
 
 def remove_album_by_selectors(
@@ -202,12 +151,12 @@ def remove_album_by_selectors(
     failures: list[SelectorFailure] = []
     if album_was_in_beets:
         # ``before.selectors`` is every selector the ID could live
-        # under (one for UUIDs, two for Discogs numerics). We iterate
-        # EVERY selector unconditionally — catching per-selector
-        # failures in ``_run_remove_selector`` — so a timeout on one
-        # never leaves the others untried. That's the PR #123B bug:
-        # the raw loop raised out on the first ``TimeoutExpired``,
-        # after the ban-source caller had committed the denylist row.
+        # under (one for UUIDs, two for Discogs numerics). Iterate
+        # EVERY selector unconditionally — ``remove_by_selector``
+        # catches per-selector failures so a timeout on one never
+        # leaves the others untried. That's the PR #123B bug: the raw
+        # loop raised out on the first ``TimeoutExpired``, after the
+        # ban-source caller had committed the denylist row.
         # NB: when selector N times out, Python kills the child process
         # before moving on. Beets uses a file-backed SQLite DB, so a
         # killed-mid-transaction remove can leave the WAL in a state
@@ -216,7 +165,7 @@ def remove_album_by_selectors(
         # can't exercise it, but if production logs show lock contention
         # the fix is to increase the timeout or serialize retries.
         for selector in before.selectors:
-            failure = _run_remove_selector(selector)
+            failure = remove_by_selector(selector)
             if failure is not None:
                 failures.append(failure)
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -334,6 +334,36 @@ class FakePipelineDB:
             row[key] = val
         self.status_history.append((request_id, status))
 
+    def update_imported_path_by_release_id(
+        self,
+        *,
+        mb_albumid: str,
+        discogs_albumid: str,
+        new_path: str,
+    ) -> int:
+        """Stand-in for ``PipelineDB.update_imported_path_by_release_id``.
+
+        Mirrors the prod behaviour: find every ``album_requests`` row
+        where ``mb_release_id == mb_albumid`` OR
+        ``discogs_release_id == discogs_albumid`` (ignoring empty
+        inputs), set ``imported_path``, and return the number of rows
+        updated. No-op when both inputs are empty.
+        """
+        if not mb_albumid and not discogs_albumid:
+            return 0
+        updated = 0
+        for row in self._requests.values():
+            mb_hit = bool(
+                mb_albumid and row.get("mb_release_id") == mb_albumid)
+            discogs_hit = bool(
+                discogs_albumid
+                and row.get("discogs_release_id") == discogs_albumid)
+            if mb_hit or discogs_hit:
+                row["imported_path"] = new_path
+                row["updated_at"] = _utcnow()
+                updated += 1
+        return updated
+
     def reset_to_wanted(self, request_id: int, **fields: Any) -> None:
         row = self._requests.get(request_id)
         if row is None:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -254,7 +254,8 @@ class FakePipelineDB:
         self.clear_download_state_calls: list[int] = []
         self.advisory_lock_calls: list[tuple[int, int]] = []
         self._cooldown_result: bool | Callable[[str], bool] = False
-        self._advisory_lock_result: bool = True
+        self._advisory_lock_result: (
+            bool | Callable[[int, int], bool]) = True
 
     # --- Seeding ---
 
@@ -275,21 +276,35 @@ class FakePipelineDB:
         """
         self._cooldown_result = result
 
-    def set_advisory_lock_result(self, result: bool) -> None:
-        """Configure what advisory_lock yields (True = acquired, False = contended)."""
+    def set_advisory_lock_result(
+        self, result: bool | Callable[[int, int], bool],
+    ) -> None:
+        """Configure what advisory_lock yields.
+
+        Pass a bool for a fixed result across every (namespace, key), or
+        a callable (namespace, key) -> bool for per-lock answers. The
+        callable form is needed for issue #133 where one test scenario
+        holds the request-lock but releases the release-lock (or vice
+        versa) to model the cross-process race between the auto cycle
+        and web force-import on the same MBID.
+        """
         self._advisory_lock_result = result
 
     @contextmanager
     def advisory_lock(self, namespace: int, key: int) -> Iterator[bool]:
         """In-memory stand-in for ``PipelineDB.advisory_lock``.
 
-        Records every ``(namespace, key)`` invocation and yields the value set
-        via ``set_advisory_lock_result`` (default ``True``). Tests that want to
-        simulate contention flip the flag to ``False`` before calling the code
-        under test.
+        Records every ``(namespace, key)`` invocation and yields the
+        value set via ``set_advisory_lock_result`` (default ``True``).
+        Tests that want to simulate contention flip the flag to ``False``
+        before calling the code under test.
         """
         self.advisory_lock_calls.append((namespace, key))
-        yield self._advisory_lock_result
+        acquired = (
+            self._advisory_lock_result(namespace, key)
+            if callable(self._advisory_lock_result)
+            else self._advisory_lock_result)
+        yield acquired
 
     # --- PipelineDB interface methods ---
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -343,11 +343,19 @@ class FakePipelineDB:
     ) -> int:
         """Stand-in for ``PipelineDB.update_imported_path_by_release_id``.
 
-        Mirrors the prod behaviour: find every ``album_requests`` row
-        where ``mb_release_id == mb_albumid`` OR
-        ``discogs_release_id == discogs_albumid`` (ignoring empty
-        inputs), set ``imported_path``, and return the number of rows
-        updated. No-op when both inputs are empty.
+        Mirrors the prod cross-layout matching (Codex R2 P2 fix):
+
+        - ``mb_albumid`` matches ONLY the pipeline's ``mb_release_id``
+          column (MB UUIDs and legacy numerics both live there).
+        - ``discogs_albumid`` matches EITHER the pipeline's
+          ``discogs_release_id`` OR ``mb_release_id`` column, because
+          the pipeline DB stores Discogs numerics in either column
+          depending on when/how the request was created (CLAUDE.md §
+          "Discogs-sourced albums": numeric IDs stored in
+          ``mb_release_id`` for pipeline compat).
+
+        Returns the number of rows updated. No-op when both inputs
+        are empty.
         """
         if not mb_albumid and not discogs_albumid:
             return 0
@@ -357,7 +365,8 @@ class FakePipelineDB:
                 mb_albumid and row.get("mb_release_id") == mb_albumid)
             discogs_hit = bool(
                 discogs_albumid
-                and row.get("discogs_release_id") == discogs_albumid)
+                and (row.get("discogs_release_id") == discogs_albumid
+                     or row.get("mb_release_id") == discogs_albumid))
             if mb_hit or discogs_hit:
                 row["imported_path"] = new_path
                 row["updated_at"] = _utcnow()

--- a/tests/test_beets_album_op.py
+++ b/tests/test_beets_album_op.py
@@ -67,17 +67,13 @@ class TestTypedReturnContract(unittest.TestCase):
             # FrozenInstanceError subclasses AttributeError
             f.detail = "y"  # type: ignore[misc]
 
-    def test_handle_fields(self) -> None:
-        """``BeetsAlbumHandle`` is the typed (album_id, release_id) pair."""
-        h = BeetsAlbumHandle(album_id=42, release_id="abc-uuid")
+    def test_handle_wraps_album_id(self) -> None:
+        """``BeetsAlbumHandle`` is a typed wrapper for the beets numeric
+        primary key. The class exists (vs. a bare int) so callsites
+        are self-documenting and future field additions don't break
+        callsite signatures."""
+        h = BeetsAlbumHandle(album_id=42)
         self.assertEqual(h.album_id, 42)
-        self.assertEqual(h.release_id, "abc-uuid")
-
-    def test_handle_release_id_default_empty(self) -> None:
-        """Callsites like sibling canonicalization don't always have the
-        release_id — default of ``""`` is supported and informational-only."""
-        h = BeetsAlbumHandle(album_id=7)
-        self.assertEqual(h.release_id, "")
 
     def test_result_ok(self) -> None:
         r = BeetsOpResult(success=True, new_path="/Beets/Artist/Album")

--- a/tests/test_beets_album_op.py
+++ b/tests/test_beets_album_op.py
@@ -1,0 +1,349 @@
+"""Tests for ``lib.beets_album_op`` (issue #133).
+
+Two groups:
+
+1. **Behavior tests** on ``remove_album`` / ``move_album`` /
+   ``remove_by_selector``: subprocess clean exit, timeout, OSError,
+   non-zero rc, and the ``fix_library_modes`` side effect for moves.
+   Subprocess mocked via ``patch('lib.beets_album_op.sp.run', ...)``
+   following the pattern from ``tests/test_release_cleanup.py``.
+
+2. **Contract guard** (``TestBeetOpArgvIsCentralised``): greps every
+   ``.py`` file in the repo for ``"beet", "remove"`` / ``"beet", "move"``
+   argv fragments. The only hits allowed are this module and tests.
+   The acceptance criterion from issue #133: "No callsite constructs
+   its own ``beet remove -a -d id:<N>`` argv."
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess as sp
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lib.beets_album_op import (BeetsAlbumHandle, BeetsOpFailure,
+                                BeetsOpResult, move_album, remove_album,
+                                remove_by_selector)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _ok(stdout: str = "", stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=0, stdout=stdout, stderr=stderr)
+
+
+def _rc(rc: int, stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=rc, stdout="", stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# Typed return contract
+# ---------------------------------------------------------------------------
+
+
+class TestTypedReturnContract(unittest.TestCase):
+
+    def test_op_failure_fields(self) -> None:
+        """``BeetsOpFailure`` exposes reason, detail, selector."""
+        f = BeetsOpFailure(
+            reason="timeout", detail="timed out after 30s", selector="id:42")
+        self.assertEqual(f.reason, "timeout")
+        self.assertEqual(f.detail, "timed out after 30s")
+        self.assertEqual(f.selector, "id:42")
+
+    def test_op_failure_selector_defaults_to_empty(self) -> None:
+        """Default ``selector=""`` keeps JSON round-trip backwards compatible
+        with old ``PostflightInfo.disambiguation_failure`` rows that
+        predate the field being added."""
+        f = BeetsOpFailure(reason="nonzero_rc", detail="rc=1")
+        self.assertEqual(f.selector, "")
+
+    def test_op_failure_is_frozen(self) -> None:
+        f = BeetsOpFailure(reason="timeout", detail="x")
+        with self.assertRaises(Exception):
+            # FrozenInstanceError subclasses AttributeError
+            f.detail = "y"  # type: ignore[misc]
+
+    def test_handle_fields(self) -> None:
+        """``BeetsAlbumHandle`` is the typed (album_id, release_id) pair."""
+        h = BeetsAlbumHandle(album_id=42, release_id="abc-uuid")
+        self.assertEqual(h.album_id, 42)
+        self.assertEqual(h.release_id, "abc-uuid")
+
+    def test_handle_release_id_default_empty(self) -> None:
+        """Callsites like sibling canonicalization don't always have the
+        release_id — default of ``""`` is supported and informational-only."""
+        h = BeetsAlbumHandle(album_id=7)
+        self.assertEqual(h.release_id, "")
+
+    def test_result_ok(self) -> None:
+        r = BeetsOpResult(success=True, new_path="/Beets/Artist/Album")
+        self.assertTrue(r.success)
+        self.assertIsNone(r.failure)
+        self.assertEqual(r.new_path, "/Beets/Artist/Album")
+
+    def test_result_failure(self) -> None:
+        f = BeetsOpFailure(reason="timeout", detail="x", selector="id:1")
+        r = BeetsOpResult(success=False, failure=f)
+        self.assertFalse(r.success)
+        self.assertIs(r.failure, f)
+        self.assertIsNone(r.new_path)
+
+
+# ---------------------------------------------------------------------------
+# remove_album
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveAlbum(unittest.TestCase):
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_clean_exit_returns_success(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _ok()
+        r = remove_album(BeetsAlbumHandle(album_id=42))
+        self.assertTrue(r.success)
+        self.assertIsNone(r.failure)
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_argv_uses_album_mode_and_delete_by_default(
+            self, mock_run: MagicMock) -> None:
+        """``beet remove -a -d id:<N>`` — album mode + delete files by default."""
+        mock_run.return_value = _ok()
+        remove_album(BeetsAlbumHandle(album_id=42))
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(argv[1:], ["remove", "-a", "-d", "id:42"])
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_delete_files_false_omits_dash_d(
+            self, mock_run: MagicMock) -> None:
+        """Untag-only mode is available even though no production caller uses it."""
+        mock_run.return_value = _ok()
+        remove_album(BeetsAlbumHandle(album_id=42), delete_files=False)
+        argv = mock_run.call_args.args[0]
+        self.assertNotIn("-d", argv)
+        self.assertEqual(argv[1:], ["remove", "-a", "id:42"])
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_timeout_is_typed_failure(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = sp.TimeoutExpired(
+            cmd=["beet", "remove"], timeout=30)
+        r = remove_album(BeetsAlbumHandle(album_id=42))
+        self.assertFalse(r.success)
+        assert r.failure is not None
+        self.assertEqual(r.failure.reason, "timeout")
+        self.assertEqual(r.failure.selector, "id:42")
+        self.assertIn("30s", r.failure.detail)
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_oserror_is_typed_failure(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("beet")
+        r = remove_album(BeetsAlbumHandle(album_id=42))
+        self.assertFalse(r.success)
+        assert r.failure is not None
+        self.assertEqual(r.failure.reason, "exception")
+        self.assertEqual(r.failure.selector, "id:42")
+        self.assertIn("FileNotFoundError", r.failure.detail)
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_nonzero_rc_is_typed_failure(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _rc(1, stderr="bad selector\n")
+        r = remove_album(BeetsAlbumHandle(album_id=42))
+        self.assertFalse(r.success)
+        assert r.failure is not None
+        self.assertEqual(r.failure.reason, "nonzero_rc")
+        self.assertIn("rc=1", r.failure.detail)
+        self.assertEqual(r.failure.selector, "id:42")
+
+
+# ---------------------------------------------------------------------------
+# move_album
+# ---------------------------------------------------------------------------
+
+
+class TestMoveAlbum(unittest.TestCase):
+
+    def _beets(self, new_path: str | None = "/Beets/Artist/Album [2007]"
+               ) -> MagicMock:
+        beets = MagicMock()
+        beets.get_album_path_by_id.return_value = new_path
+        return beets
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_clean_exit_reads_new_path_and_repairs_perms(
+            self, mock_run: MagicMock) -> None:
+        # ``fix_library_modes`` is imported lazily inside ``move_album``;
+        # patch the source module so the deferred lookup resolves to the mock.
+        mock_run.return_value = _ok()
+        with patch("lib.permissions.fix_library_modes") as mock_fix:
+            r = move_album(BeetsAlbumHandle(album_id=42), self._beets())
+        self.assertTrue(r.success)
+        self.assertEqual(r.new_path, "/Beets/Artist/Album [2007]")
+        mock_fix.assert_called_once_with("/Beets/Artist/Album [2007]")
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_argv_uses_album_mode_pk_selector(
+            self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _ok()
+        beets = self._beets()
+        with patch("lib.permissions.fix_library_modes"):
+            move_album(BeetsAlbumHandle(album_id=42), beets)
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(argv[1:], ["move", "-a", "id:42"])
+        # -d must NEVER appear on a move
+        self.assertNotIn("-d", argv)
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_timeout_skips_perm_repair_and_returns_failure(
+            self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = sp.TimeoutExpired(
+            cmd=["beet", "move"], timeout=120)
+        beets = self._beets()
+        with patch("lib.permissions.fix_library_modes") as mock_fix:
+            r = move_album(BeetsAlbumHandle(album_id=42), beets)
+        self.assertFalse(r.success)
+        assert r.failure is not None
+        self.assertEqual(r.failure.reason, "timeout")
+        self.assertIsNone(r.new_path)
+        beets.get_album_path_by_id.assert_not_called()
+        mock_fix.assert_not_called()
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_nonzero_rc_skips_perm_repair(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _rc(2, stderr="no matching albums\n")
+        beets = self._beets()
+        with patch("lib.permissions.fix_library_modes") as mock_fix:
+            r = move_album(BeetsAlbumHandle(album_id=42), beets)
+        self.assertFalse(r.success)
+        assert r.failure is not None
+        self.assertEqual(r.failure.reason, "nonzero_rc")
+        beets.get_album_path_by_id.assert_not_called()
+        mock_fix.assert_not_called()
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_missing_path_after_move_returns_none_but_success(
+            self, mock_run: MagicMock) -> None:
+        """If the album row vanished between move and lookup (should not
+        happen in normal operation) the move still reports success; the
+        caller loses the new path but we don't synthesize a failure."""
+        mock_run.return_value = _ok()
+        beets = self._beets(new_path=None)
+        with patch("lib.permissions.fix_library_modes") as mock_fix:
+            r = move_album(BeetsAlbumHandle(album_id=42), beets)
+        self.assertTrue(r.success)
+        self.assertIsNone(r.new_path)
+        mock_fix.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# remove_by_selector
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveBySelector(unittest.TestCase):
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_passes_arbitrary_selector_and_uses_album_mode(
+            self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _ok()
+        result = remove_by_selector("mb_albumid:abc-uuid")
+        self.assertIsNone(result)
+        argv = mock_run.call_args.args[0]
+        self.assertEqual(
+            argv[1:], ["remove", "-a", "-d", "mb_albumid:abc-uuid"])
+
+    @patch("lib.beets_album_op.sp.run")
+    def test_non_id_selector_failure_records_selector(
+            self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _rc(1, stderr="boom\n")
+        f = remove_by_selector("discogs_albumid:12856590")
+        assert f is not None
+        self.assertEqual(f.reason, "nonzero_rc")
+        self.assertEqual(f.selector, "discogs_albumid:12856590")
+
+
+# ---------------------------------------------------------------------------
+# Argv centralisation contract guard
+# ---------------------------------------------------------------------------
+
+
+class TestBeetOpArgvIsCentralised(unittest.TestCase):
+    """Issue #133 acceptance: grep the repo for raw ``beet remove``/``beet move``
+    argv construction. The only allowed callsites are this module and
+    tests (tests intentionally write argv as literals to verify shapes).
+
+    Enforcement mechanism: this test walks the Python source tree and
+    fails if it finds a file outside the allowlist containing either
+    pattern. If a future PR needs to build an argv fragment, it must
+    go through ``lib.beets_album_op``.
+
+    Patterns matched:
+    - ``"beet", "remove"`` (argv list literal with quoted entries)
+    - ``"beet", "move"``
+
+    This is coarse grep — it will not catch every possible evasion (you
+    could write ``argv = [BEET, "remove"]`` or build the list dynamically)
+    — but it covers the shape every current callsite uses and every
+    natural-looking new one.
+    """
+
+    PATTERNS = [
+        re.compile(r'"beet"\s*,\s*"remove"'),
+        re.compile(r'"beet"\s*,\s*"move"'),
+    ]
+
+    # Files allowed to construct raw ``beet remove``/``beet move`` argv.
+    # The op module itself is the only production allowlist entry.
+    # Test modules are allowed to write argv literals in assertions
+    # (they document the expected shape and would be unreadable if
+    # forced through the op wrapper).
+    ALLOWED_FILES = {
+        "lib/beets_album_op.py",
+        # Tests that assert argv shapes — intentional literals:
+        "tests/test_beets_album_op.py",
+        "tests/test_preflight_stale_removal.py",
+        "tests/test_release_cleanup.py",
+        "tests/test_disambiguation.py",
+    }
+
+    # Directories ignored entirely (not Python source we own):
+    IGNORE_DIRS = {
+        ".git", "__pycache__", ".venv", "venv", "result",
+        "node_modules", ".mypy_cache", ".pytest_cache",
+    }
+
+    def test_no_file_outside_allowlist_constructs_beet_argv(self) -> None:
+        offending: list[tuple[str, int, str]] = []
+        for root, dirs, files in os.walk(REPO_ROOT):
+            dirs[:] = [d for d in dirs if d not in self.IGNORE_DIRS]
+            for name in files:
+                if not name.endswith(".py"):
+                    continue
+                abs_path = Path(root) / name
+                rel = abs_path.relative_to(REPO_ROOT).as_posix()
+                if rel in self.ALLOWED_FILES:
+                    continue
+                try:
+                    text = abs_path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
+                for lineno, line in enumerate(text.splitlines(), start=1):
+                    for pat in self.PATTERNS:
+                        if pat.search(line):
+                            offending.append((rel, lineno, line.strip()))
+        if offending:
+            lines = [
+                f"  {rel}:{lineno}: {text}" for rel, lineno, text in offending]
+            self.fail(
+                "The following files construct raw `beet remove` / "
+                "`beet move` argv outside the allowlist. Route them "
+                "through lib.beets_album_op (remove_album / move_album / "
+                "remove_by_selector) or, if the grep is a false positive, "
+                "add the file to ALLOWED_FILES with a comment.\n"
+                + "\n".join(lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_beets_album_op.py
+++ b/tests/test_beets_album_op.py
@@ -274,45 +274,69 @@ class TestBeetOpArgvIsCentralised(unittest.TestCase):
     argv construction. The only allowed callsites are this module and
     tests (tests intentionally write argv as literals to verify shapes).
 
-    Enforcement mechanism: this test walks the Python source tree and
-    fails if it finds a file outside the allowlist containing either
-    pattern. If a future PR needs to build an argv fragment, it must
-    go through ``lib.beets_album_op``.
+    Enforcement mechanism: walk the Python source tree and fail if any
+    file outside the allowlist contains a matching pattern. New callers
+    must route through ``lib.beets_album_op``.
 
-    Patterns matched:
-    - ``"beet", "remove"`` (argv list literal with quoted entries)
-    - ``"beet", "move"``
+    Patterns matched (each catches a different natural construction):
+    - Literal string:   ``"beet", "remove"`` or ``'beet', 'move'``
+    - Wrapper function: ``beet_bin(), "remove"`` / ``beet_bin(), "move"``
+    - Wrapper constant: ``BEET_BIN, "remove"`` / ``BEET_BIN, "move"``
 
-    This is coarse grep — it will not catch every possible evasion (you
-    could write ``argv = [BEET, "remove"]`` or build the list dynamically)
-    — but it covers the shape every current callsite uses and every
-    natural-looking new one.
+    ``beet_bin()`` is the canonical way most of the codebase resolves the
+    binary (``lib/util.py::beet_bin``), so catching that shape too was
+    the most likely bypass (the first version of this guard only
+    matched the literal ``"beet"`` form — the entire production code
+    base used ``beet_bin()`` and would have slipped through silently).
+
+    Inevitable gaps: fully-dynamic argv (``[cmd, verb, *flags]`` where
+    cmd/verb are variables) can't be caught by grep. That's fine — the
+    guard covers every natural-looking new callsite; a truly obfuscated
+    argv construction would require deliberate effort to add and stand
+    out in code review on its own.
     """
 
     PATTERNS = [
-        re.compile(r'"beet"\s*,\s*"remove"'),
-        re.compile(r'"beet"\s*,\s*"move"'),
+        # Literal "beet" / 'beet' — shape used by test argv assertions.
+        re.compile(r'["\']beet["\']\s*,\s*["\'](?:remove|move)["\']'),
+        # beet_bin() wrapper — the production code's canonical form.
+        re.compile(r'beet_bin\s*\(\s*\)\s*,\s*["\'](?:remove|move)["\']'),
+        # BEET_BIN constant alias — legacy, may still live in some
+        # harness-adjacent code paths.
+        re.compile(r'BEET_BIN\s*,\s*["\'](?:remove|move)["\']'),
     ]
 
     # Files allowed to construct raw ``beet remove``/``beet move`` argv.
     # The op module itself is the only production allowlist entry.
-    # Test modules are allowed to write argv literals in assertions
-    # (they document the expected shape and would be unreadable if
-    # forced through the op wrapper).
-    ALLOWED_FILES = {
+    # Test modules are allowed to write argv literals in assertions —
+    # they document the expected shape and would be unreadable forced
+    # through the op wrapper.
+    ALLOWED_FILES = frozenset({
         "lib/beets_album_op.py",
         # Tests that assert argv shapes — intentional literals:
         "tests/test_beets_album_op.py",
         "tests/test_preflight_stale_removal.py",
         "tests/test_release_cleanup.py",
         "tests/test_disambiguation.py",
-    }
+    })
 
     # Directories ignored entirely (not Python source we own):
     IGNORE_DIRS = {
         ".git", "__pycache__", ".venv", "venv", "result",
         "node_modules", ".mypy_cache", ".pytest_cache",
     }
+
+    def test_allowlist_entries_still_exist(self) -> None:
+        """Fail loud if an allowlist entry is stale (file renamed or
+        removed). Prevents the allowlist silently protecting a file
+        that no longer exists while the rename now bypasses the guard
+        with a new path."""
+        for rel in self.ALLOWED_FILES:
+            abs_path = REPO_ROOT / rel
+            self.assertTrue(
+                abs_path.is_file(),
+                f"ALLOWED_FILES entry {rel!r} does not exist. Remove "
+                f"stale entries; the file may have been renamed.")
 
     def test_no_file_outside_allowlist_constructs_beet_argv(self) -> None:
         offending: list[tuple[str, int, str]] = []

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -137,6 +137,76 @@ class TestBeetsDBConnection(unittest.TestCase):
             self.assertIsNotNone(db)
 
 
+class TestGetReleaseIdsByAlbumId(unittest.TestCase):
+    """Codex round-1 P1 on PR #136: beets' ``albums.discogs_albumid``
+    is ``INTEGER`` in SQLite, so SQLite returns a Python ``int`` for
+    that column — not a ``str``. ``MovedSibling.discogs_albumid`` is
+    typed ``str`` and the ``_postflight_from_dict`` decoder uses
+    ``msgspec.convert`` which validates types strictly.
+
+    Without coercion, every Discogs-sourced kept-duplicate import
+    raised ``msgspec.ValidationError`` at the wire boundary AFTER
+    beets had already moved the sibling files — the dispatcher then
+    recorded the whole import as an exception. This is the same
+    "subprocess side effect done, sentinel emission broken" hazard
+    PR #131 documented for earlier missing-sentinel cases.
+
+    ``get_release_ids_by_album_id`` now coerces both columns to ``str``
+    at the emit site. These tests pin the contract.
+    """
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        _create_test_db(self.db_path)
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_discogs_albumid_coerced_from_int_to_str(self) -> None:
+        """``discogs_albumid INTEGER`` in SQLite → Python ``int``.
+        The getter must coerce to ``str`` so the wire contract holds."""
+        _insert_album_full(self.db_path, 42, "", [
+            {"bitrate": 320000, "path": "/m/x.mp3", "format": "MP3"},
+        ], discogs_albumid=12856590)
+        with BeetsDB(self.db_path) as db:
+            mb, discogs = db.get_release_ids_by_album_id(42)
+        self.assertEqual(mb, "")
+        self.assertEqual(discogs, "12856590")
+        self.assertIsInstance(discogs, str,
+                              "discogs_albumid must be str at the wire "
+                              "boundary — msgspec.convert will reject int.")
+
+    def test_mb_albumid_returned_as_str(self) -> None:
+        """``mb_albumid`` is ``TEXT`` so already arrives as ``str`` —
+        the getter still string-wraps defensively."""
+        _insert_album(self.db_path, 43, "abc-uuid-1234",
+                      [(320000, "/m/y.mp3")])
+        with BeetsDB(self.db_path) as db:
+            mb, discogs = db.get_release_ids_by_album_id(43)
+        self.assertEqual(mb, "abc-uuid-1234")
+        self.assertIsInstance(mb, str)
+        self.assertEqual(discogs, "")
+
+    def test_both_empty_when_album_not_found(self) -> None:
+        """Missing album → ``("", "")``, never raises."""
+        with BeetsDB(self.db_path) as db:
+            mb, discogs = db.get_release_ids_by_album_id(99999)
+        self.assertEqual((mb, discogs), ("", ""))
+
+    def test_null_columns_map_to_empty_strings(self) -> None:
+        """A row where both columns are NULL (unlikely but possible
+        for partially-tagged imports) must still return ``("", "")``
+        without raising."""
+        _insert_album_full(self.db_path, 44, "", [
+            {"bitrate": 320000, "path": "/m/z.mp3", "format": "MP3"},
+        ])
+        with BeetsDB(self.db_path) as db:
+            mb, discogs = db.get_release_ids_by_album_id(44)
+        self.assertEqual((mb, discogs), ("", ""))
+
+
 class TestAlbumExists(unittest.TestCase):
     """Test album_exists (preflight check)."""
 

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -330,20 +330,23 @@ class TestHarnessNeverSendsRemoveToBeets(unittest.TestCase):
 
 
 # ``TestDisambiguateBeetMove`` and ``TestRunDisambiguationMoveHelper``
-# were removed in issue #133: both classes tested helper functions or
-# inline-reconstructed logic that no longer exist in production code.
+# were removed in issue #133.
 #
-# - ``_run_disambiguation_move(mbid)`` (mb_albumid-based) was superseded
-#   by ``_run_album_move_by_id(album_id)`` in PR #131 and by
-#   ``lib.beets_album_op.move_album`` in this PR. Argv-shape and
-#   subprocess-failure-classification coverage moved to
-#   ``tests/test_beets_album_op.py::TestMoveAlbum`` and
-#   ``TestRemoveBySelector``.
+# - ``_run_disambiguation_move(mbid)`` was the mb_albumid-based helper
+#   superseded by ``_run_album_move_by_id(album_id)`` in PR #131, which
+#   in turn is now ``lib.beets_album_op.move_album``. The argv-shape +
+#   subprocess-failure-classification coverage that ``_run_disambiguation_move``
+#   carried lives in ``tests/test_beets_album_op.py::TestMoveAlbum`` for
+#   the id-based move shape. NOTE: no test explicitly covers a
+#   ``beet move mb_albumid:<uuid>`` argv any more — production doesn't
+#   construct that shape (PR #131 moved every caller to the id-based
+#   form), and the grep guard in ``TestBeetOpArgvIsCentralised`` now
+#   forbids new callsites from reintroducing it outside the op module.
 # - ``TestDisambiguateBeetMove`` reconstructed the disambiguation
 #   control flow inline inside the test (never called the production
-#   helper), so it didn't guard any real code path. Equivalent coverage
-#   lives in ``TestApplyDisambiguationCallsiteContract`` below, which
-#   does call ``import_one._apply_disambiguation``.
+#   helper), so it guarded nothing. Equivalent coverage of the real
+#   path lives in ``TestApplyDisambiguationCallsiteContract`` below,
+#   which calls ``import_one._apply_disambiguation`` directly.
 
 
 class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
@@ -404,7 +407,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
 
         # Must NOT raise.
         new_path = import_one._apply_disambiguation(
-            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
+            42, beets, self.ORIGINAL_PATH, r)
 
         # Property (4): path unchanged on failure.
         self.assertEqual(new_path, self.ORIGINAL_PATH)
@@ -432,7 +435,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         r, beets = self._make_result_and_beets()
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
+            42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertFalse(r.postflight.disambiguated)
@@ -449,7 +452,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         r, beets = self._make_result_and_beets()
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
+            42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertFalse(r.postflight.disambiguated)
@@ -479,7 +482,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         beets.get_album_path_by_id.return_value = self.ORIGINAL_PATH
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
+            42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertTrue(r.postflight.disambiguated)
@@ -504,7 +507,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         beets.get_album_path_by_id.return_value = None
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
+            42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, self.ORIGINAL_PATH)
         self.assertEqual(r.postflight.imported_path, self.ORIGINAL_PATH)
@@ -527,7 +530,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         beets.get_album_path_by_id.return_value = renamed
 
         new_path = import_one._apply_disambiguation(
-            self.MBID, 42, beets, self.ORIGINAL_PATH, r)
+            42, beets, self.ORIGINAL_PATH, r)
 
         self.assertEqual(new_path, renamed)
         self.assertEqual(r.postflight.imported_path, renamed)

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -17,7 +17,7 @@ import os
 import subprocess
 import sys
 import unittest
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "harness"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
@@ -329,186 +329,21 @@ class TestHarnessNeverSendsRemoveToBeets(unittest.TestCase):
             "action:'remove' (blast-radius includes the sibling).")
 
 
-class TestDisambiguateBeetMove(unittest.TestCase):
-    """Test that beet move is called when kept_duplicate is True."""
-
-    @patch("harness.import_one.subprocess.run")
-    def test_beet_move_called_after_kept_duplicate(self, mock_run):
-        """When kept_duplicate=True, subprocess.run(['beet', 'move', ...])
-        should be called."""
-        from harness import import_one
-        from lib.quality import PostflightInfo
-
-        # Create mock for beet move call
-        move_result = MagicMock()
-        move_result.returncode = 0
-        mock_run.return_value = move_result
-
-        # Mock BeetsDB to return updated path after move
-        mock_beets = MagicMock()
-        from lib.beets_db import AlbumInfo
-        moved_info = AlbumInfo(
-            album_id=42, track_count=11,
-            min_bitrate_kbps=245, is_cbr=False,
-            album_path="/Beets/The National/2010 - High Violet [expanded edition]")
-        mock_beets.get_album_info.side_effect = [moved_info]
-
-        # Simulate: kept_duplicate=True, postflight already populated
-        pf = PostflightInfo(beets_id=42, track_count=11,
-                            imported_path="/Beets/The National/2010 - High Violet")
-
-        # Call the disambiguation logic directly (extracted for testability)
-        mbid = "42f45e3f-3248-4ee5-ac27-4a99a4af48eb"
-        kept_duplicate = True
-
-        if kept_duplicate:
-            from lib.util import beets_subprocess_env
-            move_result = import_one.subprocess.run(
-                ["beet", "move", f"mb_albumid:{mbid}"],
-                capture_output=True, text=True, timeout=120,
-                env=beets_subprocess_env(),
-            )
-            if move_result.returncode == 0:
-                pf_info_after = mock_beets.get_album_info(mbid)
-                if pf_info_after:
-                    new_path = pf_info_after.album_path
-                    if new_path != pf.imported_path:
-                        pf.imported_path = new_path
-                    pf.disambiguated = True
-
-        # Verify beet move was called
-        mock_run.assert_called_once_with(
-            ["beet", "move", f"mb_albumid:{mbid}"],
-            capture_output=True, text=True, timeout=120,
-            env=ANY,
-        )
-        # Verify path was updated
-        self.assertEqual(pf.imported_path,
-                         "/Beets/The National/2010 - High Violet [expanded edition]")
-        self.assertTrue(pf.disambiguated)
-
-    def test_beet_move_not_called_without_kept_duplicate(self):
-        """When kept_duplicate=False, no beet move should occur."""
-        from lib.quality import PostflightInfo
-
-        pf = PostflightInfo(beets_id=42, track_count=11,
-                            imported_path="/Beets/The National/2010 - High Violet")
-
-        kept_duplicate = False
-
-        # The disambiguation block should not execute
-        if kept_duplicate:
-            raise AssertionError("Should not reach disambiguation block")
-
-        self.assertFalse(pf.disambiguated)
-        self.assertEqual(pf.imported_path, "/Beets/The National/2010 - High Violet")
-
-
-class TestRunDisambiguationMoveHelper(unittest.TestCase):
-    """Direct unit tests for ``_run_disambiguation_move(mbid)`` (issue #127).
-
-    Mirrors the hardened helper pattern in
-    ``lib/release_cleanup.py::_run_remove_selector``: one place owns the
-    subprocess invocation, never raises, returns a typed
-    ``DisambiguationFailure`` (with a ``Literal`` reason tag) the
-    caller stores on ``PostflightInfo``. Returns ``None`` on clean exit.
-
-    Bug being prevented: the original inline ``subprocess.run`` had no
-    try/except. A ``TimeoutExpired`` or ``OSError`` on the post-import
-    ``beet move`` crashed import_one.py *after* beets had already
-    written the album to disk, so callers parsed no JSON sentinel and
-    treated the import as failed — a semi-lie that could trigger a
-    duplicate force-import attempt.
-    """
-
-    MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-
-    @patch("harness.import_one.subprocess.run")
-    def test_clean_exit_returns_none(self, mock_run):
-        from harness import import_one
-
-        proc = MagicMock()
-        proc.returncode = 0
-        proc.stderr = ""
-        mock_run.return_value = proc
-
-        result = import_one._run_disambiguation_move(self.MBID)
-
-        self.assertIsNone(result)
-        mock_run.assert_called_once()
-        # argv shape is the seam contract — must hit `beet move
-        # mb_albumid:<mbid>` with text capture and a 120s timeout.
-        args, kwargs = mock_run.call_args
-        self.assertEqual(args[0][1:], ["move", f"mb_albumid:{self.MBID}"])
-        self.assertEqual(kwargs.get("timeout"), 120)
-        self.assertTrue(kwargs.get("capture_output"))
-        self.assertTrue(kwargs.get("text"))
-
-    @patch("harness.import_one.subprocess.run")
-    def test_timeout_returns_typed_failure(self, mock_run):
-        from harness import import_one
-
-        mock_run.side_effect = subprocess.TimeoutExpired(
-            cmd=["beet", "move"], timeout=120)
-
-        result = import_one._run_disambiguation_move(self.MBID)
-
-        self.assertIsNotNone(result)
-        assert result is not None  # narrow for pyright
-        self.assertEqual(result.reason, "timeout")
-        self.assertIn("timeout", result.detail.lower())
-        self.assertIn("120", result.detail)
-
-    @patch("harness.import_one.subprocess.run")
-    def test_oserror_returns_typed_failure(self, mock_run):
-        """FileNotFoundError (beet missing on PATH) must be caught."""
-        from harness import import_one
-
-        mock_run.side_effect = FileNotFoundError(2, "No such file", "beet")
-
-        result = import_one._run_disambiguation_move(self.MBID)
-
-        self.assertIsNotNone(result)
-        assert result is not None
-        # Reason tag matches SelectorFailure's "exception" class.
-        self.assertEqual(result.reason, "exception")
-        # Detail carries the exception class name so the audit trail can
-        # distinguish "beet missing" from other OSError flavors.
-        self.assertIn("FileNotFoundError", result.detail)
-
-    @patch("harness.import_one.subprocess.run")
-    def test_nonzero_rc_with_stderr_includes_last_line(self, mock_run):
-        from harness import import_one
-
-        proc = MagicMock()
-        proc.returncode = 1
-        proc.stderr = ("warning: ignored line\n"
-                       "error: could not find album with id mb_albumid:bogus\n")
-        mock_run.return_value = proc
-
-        result = import_one._run_disambiguation_move(self.MBID)
-
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result.reason, "nonzero_rc")
-        self.assertIn("rc=1", result.detail)
-        self.assertIn("could not find album", result.detail)
-
-    @patch("harness.import_one.subprocess.run")
-    def test_nonzero_rc_with_empty_stderr_still_returns(self, mock_run):
-        from harness import import_one
-
-        proc = MagicMock()
-        proc.returncode = 2
-        proc.stderr = ""
-        mock_run.return_value = proc
-
-        result = import_one._run_disambiguation_move(self.MBID)
-
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result.reason, "nonzero_rc")
-        self.assertEqual(result.detail, "rc=2")
+# ``TestDisambiguateBeetMove`` and ``TestRunDisambiguationMoveHelper``
+# were removed in issue #133: both classes tested helper functions or
+# inline-reconstructed logic that no longer exist in production code.
+#
+# - ``_run_disambiguation_move(mbid)`` (mb_albumid-based) was superseded
+#   by ``_run_album_move_by_id(album_id)`` in PR #131 and by
+#   ``lib.beets_album_op.move_album`` in this PR. Argv-shape and
+#   subprocess-failure-classification coverage moved to
+#   ``tests/test_beets_album_op.py::TestMoveAlbum`` and
+#   ``TestRemoveBySelector``.
+# - ``TestDisambiguateBeetMove`` reconstructed the disambiguation
+#   control flow inline inside the test (never called the production
+#   helper), so it didn't guard any real code path. Equivalent coverage
+#   lives in ``TestApplyDisambiguationCallsiteContract`` below, which
+#   does call ``import_one._apply_disambiguation``.
 
 
 class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
@@ -559,7 +394,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         self.assertEqual(roundtrip.postflight.imported_path,
                          self.ORIGINAL_PATH)
 
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_timeout_does_not_crash_and_preserves_import(self, mock_run):
         from harness import import_one
 
@@ -580,13 +415,13 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         assert r.postflight.disambiguation_failure is not None
         self.assertEqual(
             r.postflight.disambiguation_failure.reason, "timeout")
-        # beets.get_album_info MUST NOT be called when move fails —
+        # ``get_album_path_by_id`` MUST NOT be called when move fails —
         # we don't trust the DB state to update the path.
-        beets.get_album_info.assert_not_called()
+        beets.get_album_path_by_id.assert_not_called()
         # Properties (1)+(5).
         self._assert_import_success_preserved(r)
 
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_nonzero_rc_does_not_crash_and_preserves_import(self, mock_run):
         from harness import import_one
 
@@ -606,7 +441,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
             r.postflight.disambiguation_failure.reason, "nonzero_rc")
         self._assert_import_success_preserved(r)
 
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_oserror_does_not_crash_and_preserves_import(self, mock_run):
         from harness import import_one
 
@@ -623,12 +458,17 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
             r.postflight.disambiguation_failure.reason, "exception")
         self._assert_import_success_preserved(r)
 
-    @patch("harness.import_one.subprocess.run")
-    def test_clean_move_path_unchanged(self, mock_run):
-        """Successful move: pf_info_after returns same path → no path
-        mutation, but disambiguated=True and failure is None."""
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
+    def test_clean_move_path_unchanged(self, mock_run, _mock_fix):
+        """Successful move: post-move path equals original → no path
+        mutation, but disambiguated=True and failure is None.
+
+        Mocks ``fix_library_modes`` since ``move_album`` calls it on
+        every successful move (issue #84); the test doesn't care about
+        perm repair — only about ``_apply_disambiguation``'s contract.
+        """
         from harness import import_one
-        from lib.beets_db import AlbumInfo
 
         proc = MagicMock()
         proc.returncode = 0
@@ -636,10 +476,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         mock_run.return_value = proc
         r, beets = self._make_result_and_beets()
         # Same path returned — no rename happened.
-        beets.get_album_info.return_value = AlbumInfo(
-            album_id=42, track_count=11,
-            min_bitrate_kbps=245, is_cbr=False,
-            album_path=self.ORIGINAL_PATH)
+        beets.get_album_path_by_id.return_value = self.ORIGINAL_PATH
 
         new_path = import_one._apply_disambiguation(
             self.MBID, 42, beets, self.ORIGINAL_PATH, r)
@@ -649,11 +486,12 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         # Property: no_failure on success.
         self.assertIsNone(r.postflight.disambiguation_failure)
 
-    @patch("harness.import_one.subprocess.run")
-    def test_clean_move_but_pf_info_after_none(self, mock_run):
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
+    def test_clean_move_but_pf_info_after_none(self, mock_run, _mock_fix):
         """Edge case: move ran cleanly but beets DB no longer returns
-        the album (race / out-of-band deletion). Original code set
-        ``disambiguated=True`` and left ``imported_path`` unchanged.
+        the album's path (race / out-of-band deletion). Original code
+        set ``disambiguated=True`` and left ``imported_path`` unchanged.
         Pin that behavior so a future refactor can't silently change
         whether a partial-state album is treated as disambiguated."""
         from harness import import_one
@@ -663,7 +501,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         proc.stderr = ""
         mock_run.return_value = proc
         r, beets = self._make_result_and_beets()
-        beets.get_album_info.return_value = None
+        beets.get_album_path_by_id.return_value = None
 
         new_path = import_one._apply_disambiguation(
             self.MBID, 42, beets, self.ORIGINAL_PATH, r)
@@ -673,13 +511,12 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         self.assertTrue(r.postflight.disambiguated)
         self.assertIsNone(r.postflight.disambiguation_failure)
 
-    @patch("harness.import_one.subprocess.run")
-    def test_clean_move_path_changed(self, mock_run):
-        """Successful move: pf_info_after returns new path → path
-        mutates and is propagated back via return value AND on
-        r.postflight.imported_path."""
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
+    def test_clean_move_path_changed(self, mock_run, _mock_fix):
+        """Successful move: post-move path differs → path mutates and
+        propagates via return value AND on r.postflight.imported_path."""
         from harness import import_one
-        from lib.beets_db import AlbumInfo
 
         proc = MagicMock()
         proc.returncode = 0
@@ -687,10 +524,7 @@ class TestApplyDisambiguationCallsiteContract(unittest.TestCase):
         mock_run.return_value = proc
         r, beets = self._make_result_and_beets()
         renamed = self.ORIGINAL_PATH + " [expanded edition]"
-        beets.get_album_info.return_value = AlbumInfo(
-            album_id=42, track_count=11,
-            min_bitrate_kbps=245, is_cbr=False,
-            album_path=renamed)
+        beets.get_album_path_by_id.return_value = renamed
 
         new_path = import_one._apply_disambiguation(
             self.MBID, 42, beets, self.ORIGINAL_PATH, r)

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -125,6 +125,27 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertEqual(rows, 0)
         self.assertEqual(db.request(19)["imported_path"], "/Beets/Other")
 
+    def test_update_imported_path_discogs_matches_legacy_mb_release_id(self):
+        """Codex R2 P2: beets-side ``discogs_albumid`` must match
+        pipeline rows that stored the Discogs numeric in
+        ``mb_release_id`` (legacy "pipeline compat" layout from
+        CLAUDE.md) OR in ``discogs_release_id``."""
+        db = FakePipelineDB()
+        # Legacy layout: numeric in mb_release_id, discogs_release_id None.
+        db.seed_request(make_request_row(
+            id=21, mb_release_id="12856590",
+            discogs_release_id=None, imported_path="/Beets/Legacy/Old"))
+
+        rows = db.update_imported_path_by_release_id(
+            mb_albumid="",
+            discogs_albumid="12856590",
+            new_path="/Beets/Legacy/New",
+        )
+
+        self.assertEqual(rows, 1)
+        self.assertEqual(
+            db.request(21)["imported_path"], "/Beets/Legacy/New")
+
     def test_update_imported_path_by_release_id_both_empty_is_noop(self):
         """Both release ids empty → rowcount=0, no UPDATE fires at all.
         Mirrors the prod short-circuit that guards against accidentally

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -73,6 +73,73 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertEqual(row["current_spectral_grade"], "genuine")
         self.assertIsNone(row["current_spectral_bitrate"])
 
+    def test_update_imported_path_by_release_id_matches_mb_albumid(self):
+        """Issue #132 P2 / #133: sibling ``imported_path`` propagation.
+        MB-sourced match on ``mb_release_id``."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=17, mb_release_id="mbid-sibling",
+            imported_path="/Beets/Old/Path"))
+
+        rows = db.update_imported_path_by_release_id(
+            mb_albumid="mbid-sibling",
+            discogs_albumid="",
+            new_path="/Beets/New/Path [2006]",
+        )
+
+        self.assertEqual(rows, 1)
+        self.assertEqual(
+            db.request(17)["imported_path"], "/Beets/New/Path [2006]")
+
+    def test_update_imported_path_by_release_id_matches_discogs(self):
+        """Discogs-sourced match on ``discogs_release_id``."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=18, mb_release_id=None,
+            discogs_release_id="12856590",
+            imported_path="/Beets/Old/Discogs"))
+
+        rows = db.update_imported_path_by_release_id(
+            mb_albumid="",
+            discogs_albumid="12856590",
+            new_path="/Beets/New/Discogs [2006]",
+        )
+
+        self.assertEqual(rows, 1)
+        self.assertEqual(
+            db.request(18)["imported_path"], "/Beets/New/Discogs [2006]")
+
+    def test_update_imported_path_by_release_id_untracked_returns_zero(self):
+        """No matching request → rowcount=0, no rows touched."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=19, mb_release_id="other-mbid",
+            imported_path="/Beets/Other"))
+
+        rows = db.update_imported_path_by_release_id(
+            mb_albumid="unknown-mbid",
+            discogs_albumid="",
+            new_path="/Beets/Ignored",
+        )
+
+        self.assertEqual(rows, 0)
+        self.assertEqual(db.request(19)["imported_path"], "/Beets/Other")
+
+    def test_update_imported_path_by_release_id_both_empty_is_noop(self):
+        """Both release ids empty → rowcount=0, no UPDATE fires at all.
+        Mirrors the prod short-circuit that guards against accidentally
+        matching every row where a column is NULL/empty."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=20, mb_release_id="some-mbid",
+            imported_path="/Beets/Keep"))
+
+        rows = db.update_imported_path_by_release_id(
+            mb_albumid="", discogs_albumid="", new_path="/Beets/Bogus")
+
+        self.assertEqual(rows, 0)
+        self.assertEqual(db.request(20)["imported_path"], "/Beets/Keep")
+
     def test_clear_on_disk_quality_fields_matches_real_db(self):
         """FakePipelineDB must mirror PipelineDB.clear_on_disk_quality_fields:
         zero the on-disk spectral + verified_lossless + imported_path,

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -140,6 +140,43 @@ class TestImportResultConstruction(unittest.TestCase):
         self.assertTrue(r.postflight.disambiguated)
         self.assertIsNone(r.postflight.disambiguation_failure)
 
+    def test_postflight_pre_133_failure_row_without_selector_field(self):
+        """Issue #133 back-compat: old download_log rows serialized
+        AFTER #127 but BEFORE #133 have ``disambiguation_failure``
+        with only ``{reason, detail}`` — no ``selector``. The unified
+        ``BeetsOpFailure`` (was ``DisambiguationFailure``) added
+        ``selector: str = ""`` so these rows still deserialize.
+
+        Without the default, ``DisambiguationFailure(**{"reason":"timeout",
+        "detail":"x"})`` would raise ``TypeError`` and every
+        ``/api/pipeline/force-import`` call that parses old import_result
+        JSONB would 500. This test nails the contract so a future
+        refactor can't remove the default silently.
+        """
+        d = {
+            "version": 2,
+            "exit_code": 0,
+            "decision": "import",
+            "postflight": {
+                "beets_id": 42,
+                "track_count": 11,
+                "imported_path": "/Beets/Artist/Album",
+                "disambiguated": False,
+                "disambiguation_failure": {
+                    "reason": "timeout",
+                    "detail": "timeout after 120s",
+                    # NO selector key — predates issue #133.
+                },
+            },
+        }
+        r = ImportResult.from_dict(d)
+        assert r.postflight.disambiguation_failure is not None
+        self.assertEqual(r.postflight.disambiguation_failure.reason, "timeout")
+        self.assertEqual(
+            r.postflight.disambiguation_failure.detail, "timeout after 120s")
+        # Missing-in-JSON → default empty string on the dataclass.
+        self.assertEqual(r.postflight.disambiguation_failure.selector, "")
+
     def test_full_construction(self):
         r = ImportResult(
             exit_code=0,

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -197,6 +197,58 @@ class TestImportResultConstruction(unittest.TestCase):
         r = ImportResult.from_dict(d)
         self.assertEqual(r.postflight.moved_siblings, [])
 
+    def test_postflight_moved_siblings_malformed_value_falls_back_to_empty(self):
+        """Wire-boundary robustness: if ``moved_siblings`` arrives as
+        a non-list (corrupt legacy JSONB row, future bug), the loader
+        silently drops it and defaults to ``[]``. We prefer "silent
+        empty" over "crash whole row" — the row's other fields are
+        still useful for the web UI, and moved_siblings being wrong
+        is already a data-quality issue somewhere upstream."""
+        for bad in ("not-a-list", 42, {}, None):
+            with self.subTest(bad_value=bad):
+                d = {
+                    "version": 2,
+                    "exit_code": 0,
+                    "decision": "import",
+                    "postflight": {
+                        "beets_id": 42,
+                        "imported_path": "/Beets/Artist/Album",
+                        "moved_siblings": bad,
+                    },
+                }
+                r = ImportResult.from_dict(d)
+                self.assertEqual(r.postflight.moved_siblings, [])
+
+    def test_postflight_moved_siblings_wrong_element_type_raises(self):
+        """Issue #99 wire-boundary contract: if a harness change ever
+        emits a ``MovedSibling`` with a wrong-typed field (e.g.
+        ``album_id`` as string, which beets COULD theoretically
+        return as a string in some future patch), the loader must
+        raise ``msgspec.ValidationError`` at the boundary rather than
+        silently propagating bad data downstream.
+
+        Guards against the PR #98 bug pattern where a dataclass
+        declared ``album_id: str`` but the wire carried ``int`` and
+        every decode silently succeeded with a type mismatch.
+        """
+        import msgspec
+        d = {
+            "version": 2,
+            "exit_code": 0,
+            "decision": "import",
+            "postflight": {
+                "beets_id": 42,
+                "imported_path": "/Beets/Artist/Album",
+                # album_id is declared ``int`` on MovedSibling —
+                # feeding a string must raise.
+                "moved_siblings": [
+                    {"album_id": "10314", "new_path": "/p"},
+                ],
+            },
+        }
+        with self.assertRaises(msgspec.ValidationError):
+            ImportResult.from_dict(d)
+
     def test_postflight_pre_133_failure_row_without_selector_field(self):
         """Issue #133 back-compat: old download_log rows serialized
         AFTER #127 but BEFORE #133 have ``disambiguation_failure``

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -140,6 +140,63 @@ class TestImportResultConstruction(unittest.TestCase):
         self.assertTrue(r.postflight.disambiguated)
         self.assertIsNone(r.postflight.disambiguation_failure)
 
+    def test_moved_siblings_roundtrip(self):
+        """Issue #132 P2 / issue #133: ``PostflightInfo.moved_siblings``
+        survives ImportResult JSON round-trip. Harness emits the list
+        for kept-duplicate imports so ``dispatch_import_core`` can
+        propagate each sibling's new on-disk path to the pipeline DB.
+        """
+        from lib.quality import MovedSibling, PostflightInfo
+        r = ImportResult(
+            exit_code=0, decision="import",
+            postflight=PostflightInfo(
+                beets_id=42, track_count=11,
+                imported_path="/Beets/Artist/Album [2007]",
+                disambiguated=True,
+                moved_siblings=[
+                    MovedSibling(
+                        album_id=10314,
+                        new_path="/Beets/Artist/Album [2006]",
+                        mb_albumid="aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+                        discogs_albumid=""),
+                    MovedSibling(
+                        album_id=10315,
+                        new_path="/Beets/Artist/Album [2008]",
+                        mb_albumid="",
+                        discogs_albumid="12856590"),
+                ]))
+        r2 = ImportResult.from_json(r.to_json())
+        self.assertEqual(len(r2.postflight.moved_siblings), 2)
+        self.assertEqual(r2.postflight.moved_siblings[0].album_id, 10314)
+        self.assertEqual(
+            r2.postflight.moved_siblings[0].mb_albumid,
+            "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb")
+        self.assertEqual(
+            r2.postflight.moved_siblings[0].new_path,
+            "/Beets/Artist/Album [2006]")
+        self.assertEqual(r2.postflight.moved_siblings[1].album_id, 10315)
+        self.assertEqual(
+            r2.postflight.moved_siblings[1].discogs_albumid, "12856590")
+
+    def test_postflight_legacy_row_without_moved_siblings_field(self):
+        """Old download_log rows predating issue #133 have no
+        ``moved_siblings`` key. Deserialization must default to an
+        empty list, not raise."""
+        d = {
+            "version": 2,
+            "exit_code": 0,
+            "decision": "import",
+            "postflight": {
+                "beets_id": 42,
+                "track_count": 11,
+                "imported_path": "/Beets/Artist/Album",
+                "disambiguated": True,
+                # NO moved_siblings key.
+            },
+        }
+        r = ImportResult.from_dict(d)
+        self.assertEqual(r.postflight.moved_siblings, [])
+
     def test_postflight_pre_133_failure_row_without_selector_field(self):
         """Issue #133 back-compat: old download_log rows serialized
         AFTER #127 but BEFORE #133 have ``disambiguation_failure``

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1552,5 +1552,267 @@ class TestReleaseLockContention(unittest.TestCase):
         self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
 
 
+class TestSiblingImportedPathPropagation(unittest.TestCase):
+    """Integration slice for issue #132 P2 / issue #133: after
+    ``_canonicalize_siblings`` moves a sibling's files on disk, any
+    tracked ``album_requests`` row for that sibling must get its
+    ``imported_path`` updated.
+
+    Pre-fix scenario (from issue #132 P2): sibling edition gets
+    re-shuffled from ``/Palo Santo/`` to ``/Palo Santo [2006]/`` after
+    the new same-name edition imports. If the sibling was itself a
+    pipeline request (e.g. a prior upgrade tracked in the DB), its
+    ``imported_path`` keeps pointing at the non-existent pre-move
+    directory. The UI's "Imported to" label and the ban-source button
+    both lie until the next event touches the row.
+
+    Fix flow (covered by this slice):
+    1. ``import_one.py::_canonicalize_siblings`` resolves each
+       sibling's ``(mb_albumid, discogs_albumid)`` from beets and
+       emits a ``MovedSibling`` record in ``PostflightInfo.moved_siblings``.
+    2. ``dispatch_import_core`` calls ``_propagate_moved_siblings``
+       which calls ``PipelineDB.update_imported_path_by_release_id``
+       for each record.
+    3. The tracked sibling row's ``imported_path`` now matches the
+       post-move directory. Untracked siblings are silently skipped.
+    """
+
+    MBID_NEW = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"  # the album being imported
+    MBID_SIBLING = "cccccccc-4444-5555-6666-dddddddddddd"  # tracked sibling
+    DISCOGS_SIBLING = "12856590"
+    PRE_MOVE_PATH = "/Beets/Shearwater/2006 - Palo Santo"
+    POST_MOVE_PATH = "/Beets/Shearwater/2006 - Palo Santo [2006]"
+
+    def _make_cfg(self) -> CratediggerConfig:
+        return CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+
+    def test_mb_sibling_path_propagates_when_tracked(self):
+        """Tracked MB-sourced sibling: ``imported_path`` updated."""
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import MovedSibling
+
+        db = FakePipelineDB()
+        # Request 42 is the one being imported right now.
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID_NEW, status="downloading"))
+        # Request 17 is the tracked sibling, already imported long ago.
+        # Its imported_path still points at the pre-move directory —
+        # propagation must update it.
+        db.seed_request(make_request_row(
+            id=17, mb_release_id=self.MBID_SIBLING,
+            status="imported", imported_path=self.PRE_MOVE_PATH))
+
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        ir.postflight.moved_siblings = [
+            MovedSibling(
+                album_id=10314,
+                new_path=self.POST_MOVE_PATH,
+                mb_albumid=self.MBID_SIBLING,
+                discogs_albumid=""),
+        ]
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID_NEW,
+                    request_id=42,
+                    label="Shearwater - Palo Santo (2007)",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Sibling's imported_path updated to the post-move directory.
+        self.assertEqual(
+            db.request(17)["imported_path"], self.POST_MOVE_PATH)
+
+    def test_discogs_sibling_path_propagates_via_discogs_release_id(self):
+        """Tracked Discogs-sourced sibling: matches on
+        ``discogs_release_id`` since ``mb_albumid`` is empty for Discogs
+        rows in beets.
+        """
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import MovedSibling
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID_NEW, status="downloading"))
+        # Discogs-sourced sibling: pipeline DB carries the id in
+        # ``discogs_release_id``, and beets has it in ``discogs_albumid``
+        # with an empty ``mb_albumid``.
+        db.seed_request(make_request_row(
+            id=18, mb_release_id=None,
+            discogs_release_id=self.DISCOGS_SIBLING,
+            status="imported", imported_path=self.PRE_MOVE_PATH))
+
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        ir.postflight.moved_siblings = [
+            MovedSibling(
+                album_id=10315,
+                new_path=self.POST_MOVE_PATH,
+                mb_albumid="",
+                discogs_albumid=self.DISCOGS_SIBLING),
+        ]
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID_NEW,
+                    request_id=42,
+                    label="Shearwater - Palo Santo (2007)",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Discogs sibling's imported_path updated.
+        self.assertEqual(
+            db.request(18)["imported_path"], self.POST_MOVE_PATH)
+
+    def test_untracked_sibling_is_silently_skipped(self):
+        """Sibling that beets knows about but the pipeline DB does not:
+        no pipeline row matches, update returns rowcount=0, no error.
+        The import still succeeds as a whole. Pre-fix this was implicit
+        too, but pinning it prevents a future regression where an
+        untracked sibling somehow raises."""
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import MovedSibling
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID_NEW, status="downloading"))
+        # Intentionally NO request row for MBID_SIBLING. Beets has the
+        # sibling; the pipeline DB does not. Propagation is a no-op.
+
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        ir.postflight.moved_siblings = [
+            MovedSibling(
+                album_id=10314,
+                new_path=self.POST_MOVE_PATH,
+                mb_albumid=self.MBID_SIBLING,
+                discogs_albumid=""),
+        ]
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID_NEW,
+                    request_id=42,
+                    label="Shearwater - Palo Santo (2007)",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Main import still marked done.
+        self.assertEqual(db.request(42)["status"], "imported")
+
+    def test_empty_moved_siblings_is_noop(self):
+        """Non-kept_duplicate imports emit ``moved_siblings=[]``. The
+        dispatch helper must be a no-op in that case (the common case)."""
+        from lib.import_dispatch import dispatch_import_core
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID_NEW, status="downloading"))
+        db.seed_request(make_request_row(
+            id=17, mb_release_id=self.MBID_SIBLING,
+            status="imported", imported_path=self.PRE_MOVE_PATH))
+
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        # Explicit empty list — no siblings to propagate.
+        ir.postflight.moved_siblings = []
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID_NEW,
+                    request_id=42,
+                    label="Plain import — no siblings",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Sibling's imported_path UNTOUCHED.
+        self.assertEqual(
+            db.request(17)["imported_path"], self.PRE_MOVE_PATH)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1317,18 +1317,26 @@ class TestReleaseLockContention(unittest.TestCase):
             id=42, mb_release_id=self.MBID, status="downloading"))
         return db
 
-    def test_contention_returns_early_without_spawning_subprocess(self):
+    def test_auto_contention_resets_request_to_wanted(self):
+        """Regression for review-round C1 on this commit. Auto path
+        contention MUST NOT leave the request at ``status='downloading'``:
+        the outer ``_run_completed_processing`` (lib/download.py) would
+        observe ``status=='downloading'`` + ``process_completed_album``
+        returning True and flip the request to ``imported`` even though
+        the subprocess never ran. That's a silent data-inconsistency
+        bug — the album is marked done while still sitting in /Incoming.
+
+        Fix: on contention in the auto path (scenario not in
+        FORCE_MANUAL_SCENARIOS), ``dispatch_import_core`` transitions
+        the request back to ``wanted`` (so the outer flip-check fails)
+        and cleans the staged dir (so next cycle can re-mkdir it).
+        """
         from lib.import_dispatch import dispatch_import_core
         from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
                                      release_id_to_lock_key)
 
         db = self._make_db()
-        # Simulate: another session already holds the RELEASE lock for
-        # this MBID. The REQUEST lock (not taken at this seam — it lives
-        # in dispatch_import_from_db) would still be free if we asked,
-        # but here dispatch_import_core only touches the release one.
         def lock_result(namespace: int, key: int) -> bool:
-            # ``False`` exactly for the release lock on this MBID.
             if (namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
                     and key == release_id_to_lock_key(self.MBID)):
                 return False
@@ -1348,6 +1356,7 @@ class TestReleaseLockContention(unittest.TestCase):
                     db=db,  # type: ignore[arg-type]
                     dl_info=dl_info,
                     distance=0.05,
+                    # Auto-import scenario — NOT FORCE_MANUAL_SCENARIOS.
                     scenario="strong_match",
                     files=[MagicMock(username="user1",
                                      filename="01 - Track.mp3")],
@@ -1359,20 +1368,85 @@ class TestReleaseLockContention(unittest.TestCase):
 
         # Subprocess NEVER fires.
         ext.run.assert_not_called()
-        # No rejection or success row — deferred retry, untouched state.
+        # No download_log row — deferred retry, not a failure.
         self.assertEqual(db.download_logs, [])
-        # Request status unchanged.
-        self.assertEqual(db.request(42)["status"], "downloading")
-        # Outcome carries the "try again shortly" signal to the caller.
+        # **Critical**: request was reset to 'wanted'. Without this,
+        # the outer _run_completed_processing in lib/download.py flips
+        # to 'imported' based on process_completed_album's True return,
+        # and the album is marked done without importing.
+        self.assertEqual(db.request(42)["status"], "wanted")
+        # Staged dir cleanup ran (so the next cycle can re-mkdir).
+        ext.cleanup.assert_called_once_with(tmpdir)
+        # Outcome still carries the "try again shortly" signal.
         self.assertFalse(outcome.success)
         self.assertIn("Another import is already in progress",
                       outcome.message)
-        # Lock was attempted exactly once, on the RELEASE namespace at
-        # the hashed MBID key.
+        # Lock was attempted on the RELEASE namespace at the hashed
+        # MBID key.
         self.assertIn(
             (ADVISORY_LOCK_NAMESPACE_RELEASE,
              release_id_to_lock_key(self.MBID)),
             db.advisory_lock_calls)
+
+    def test_force_import_contention_preserves_request_status(self):
+        """Force/manual path contention must NOT reset status to 'wanted'
+        — the caller (web UI, CLI) surfaces the "try again shortly"
+        message and the request stays in whatever status it was in
+        (typically 'imported' for force-import, since force-import runs
+        on albums that were rejected from beets but have files on disk).
+
+        This is the complement of ``test_auto_contention_resets_request_to_wanted``:
+        the status-reset branch is gated on scenario NOT in
+        FORCE_MANUAL_SCENARIOS, so force/manual leave the row alone.
+        """
+        from lib.import_dispatch import dispatch_import_core
+        from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                     release_id_to_lock_key)
+
+        db = FakePipelineDB()
+        # Force-import typically runs against an 'imported' or 'manual'
+        # row; pick 'imported' as the representative starting state.
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID, status="imported"))
+        def lock_result(namespace: int, key: int) -> bool:
+            if (namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
+                    and key == release_id_to_lock_key(self.MBID)):
+                return False
+            return True
+        db.set_advisory_lock_result(lock_result)
+
+        dl_info = DownloadInfo(username="user1")
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext:
+                outcome = dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID,
+                    request_id=42,
+                    label="Test Artist - Force Import",
+                    force=True,
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="force_import",
+                    files=[],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Status untouched — force/manual caller surfaces the message.
+        self.assertEqual(db.request(42)["status"], "imported")
+        # Staging cleanup MUST NOT run for force/manual — the path is
+        # the user's failed_imports/ copy of the source, not a
+        # disposable /Incoming dir. Deleting it would destroy the
+        # user's only copy (issue #89 equivalent).
+        ext.cleanup.assert_not_called()
+        self.assertFalse(outcome.success)
+        self.assertIn("Another import is already in progress",
+                      outcome.message)
 
     def test_happy_path_acquires_lock_keyed_on_mbid_and_runs_import(self):
         from lib.import_dispatch import dispatch_import_core

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1278,5 +1278,205 @@ class TestBayOfBiscayUpgradeChain(unittest.TestCase):
         self.assertFalse(row["verified_lossless"])
 
 
+class TestReleaseLockContention(unittest.TestCase):
+    """Integration slice for issue #133 / #132 P1: the cross-process
+    same-release advisory lock.
+
+    The Palo Santo data-loss fix (PR #131) removed the destructive branch
+    from the harness but left a cross-process race: two processes
+    importing the same MBID can each see the other's newly-inserted row
+    as "the newest" and delete the wrong row during post-import cleanup.
+
+    The fix: ``dispatch_import_core`` now wraps the ``import_one.py``
+    subprocess in a release-keyed advisory lock (non-blocking). This
+    slice pins two behaviors:
+
+    1. **Contention** — when another session holds the release lock for
+       the same MBID, ``dispatch_import_core`` returns early with a
+       "try again shortly" outcome. It does NOT spawn ``import_one.py``
+       and does NOT write a ``download_log`` row (deferred retry, not
+       a failure). The request's status is untouched.
+
+    2. **Happy path** — when the lock is free, the subprocess runs
+       normally and the ``(namespace, key)`` recorded on the fake DB
+       matches ``release_id_to_lock_key(mbid)`` so the lock is keyed
+       exactly on the MBID and not e.g. the request_id.
+    """
+
+    MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
+    def _make_cfg(self) -> CratediggerConfig:
+        return CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+
+    def _make_db(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID, status="downloading"))
+        return db
+
+    def test_contention_returns_early_without_spawning_subprocess(self):
+        from lib.import_dispatch import dispatch_import_core
+        from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                     release_id_to_lock_key)
+
+        db = self._make_db()
+        # Simulate: another session already holds the RELEASE lock for
+        # this MBID. The REQUEST lock (not taken at this seam — it lives
+        # in dispatch_import_from_db) would still be free if we asked,
+        # but here dispatch_import_core only touches the release one.
+        def lock_result(namespace: int, key: int) -> bool:
+            # ``False`` exactly for the release lock on this MBID.
+            if (namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
+                    and key == release_id_to_lock_key(self.MBID)):
+                return False
+            return True
+        db.set_advisory_lock_result(lock_result)
+
+        dl_info = DownloadInfo(username="user1")
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext:
+                outcome = dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID,
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Subprocess NEVER fires.
+        ext.run.assert_not_called()
+        # No rejection or success row — deferred retry, untouched state.
+        self.assertEqual(db.download_logs, [])
+        # Request status unchanged.
+        self.assertEqual(db.request(42)["status"], "downloading")
+        # Outcome carries the "try again shortly" signal to the caller.
+        self.assertFalse(outcome.success)
+        self.assertIn("Another import is already in progress",
+                      outcome.message)
+        # Lock was attempted exactly once, on the RELEASE namespace at
+        # the hashed MBID key.
+        self.assertIn(
+            (ADVISORY_LOCK_NAMESPACE_RELEASE,
+             release_id_to_lock_key(self.MBID)),
+            db.advisory_lock_calls)
+
+    def test_happy_path_acquires_lock_keyed_on_mbid_and_runs_import(self):
+        from lib.import_dispatch import dispatch_import_core
+        from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                     release_id_to_lock_key)
+
+        db = self._make_db()
+        # Default: all locks acquired. Happy path.
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID,
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Subprocess ran exactly once.
+        ext.run.assert_called_once()
+        # Import succeeded; domain state reflects that.
+        self.assertEqual(db.request(42)["status"], "imported")
+        # Lock was taken on the RELEASE namespace with the hashed MBID
+        # as key — NOT the request_id. Confirms keying is on the
+        # release, which is the only way to serialise two different
+        # request_ids that share an MBID (the auto-cycle vs force-import
+        # race from the Palo Santo follow-up).
+        self.assertIn(
+            (ADVISORY_LOCK_NAMESPACE_RELEASE,
+             release_id_to_lock_key(self.MBID)),
+            db.advisory_lock_calls)
+
+    def test_empty_mbid_skips_release_lock_but_still_imports(self):
+        """Defensive: a caller that somehow reaches ``dispatch_import_core``
+        with an empty mb_release_id should not block on a lock keyed on
+        empty string (``crc32(b"") == 0``), which would otherwise
+        serialise every empty-mbid import. The code skips the lock
+        entirely and logs a warning.
+        """
+        from lib.import_dispatch import dispatch_import_core
+        from lib.pipeline_db import ADVISORY_LOCK_NAMESPACE_RELEASE
+
+        db = self._make_db()
+        # Re-seed with empty mb_release_id.
+        db.seed_request(make_request_row(
+            id=43, mb_release_id="", status="downloading"))
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id="",
+                    request_id=43,
+                    label="Test Artist - No MBID",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Subprocess runs (no lock held us up).
+        ext.run.assert_called_once()
+        # No RELEASE-namespace lock call — we skipped it entirely.
+        namespaces_used = {ns for ns, _key in db.advisory_lock_calls}
+        self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1375,6 +1375,17 @@ class TestReleaseLockContention(unittest.TestCase):
         # to 'imported' based on process_completed_album's True return,
         # and the album is marked done without importing.
         self.assertEqual(db.request(42)["status"], "wanted")
+        # Codex R2 P1: contention must NOT set ``next_retry_after``.
+        # That field would hold the request for the full backoff
+        # window (30min+ doubling up to 24h) before the next cycle
+        # could re-try — unacceptable for a contention-driven reset
+        # where the competing process might already have finished.
+        # ``reset_to_wanted`` clears it to NULL; if a future refactor
+        # re-introduces ``attempt_type="download"`` here, the
+        # ``record_attempt`` side effect would set it again and this
+        # assertion fails.
+        self.assertIsNone(db.request(42).get("next_retry_after"))
+        self.assertIsNone(db.request(42).get("last_attempt_at"))
         # Staged dir cleanup ran (so the next cycle can re-mkdir).
         ext.cleanup.assert_called_once_with(tmpdir)
         # Outcome still carries the "try again shortly" signal.
@@ -1707,6 +1718,82 @@ class TestSiblingImportedPathPropagation(unittest.TestCase):
         # Discogs sibling's imported_path updated.
         self.assertEqual(
             db.request(18)["imported_path"], self.POST_MOVE_PATH)
+
+    def test_discogs_sibling_matches_legacy_pipeline_layout(self):
+        """Codex R2 P2 regression: beets-side ``discogs_albumid`` must
+        match pipeline-DB rows that store the Discogs numeric in
+        EITHER ``discogs_release_id`` (new layout) OR ``mb_release_id``
+        (legacy "pipeline compat" layout from CLAUDE.md).
+
+        Scenario: a request was added pre-plugin-patch, so pipeline DB
+        has ``mb_release_id="12856590"`` and ``discogs_release_id=None``.
+        Beets has the same album with ``discogs_albumid=12856590`` and
+        ``mb_albumid=""`` (new-layout beets, post-plugin-patch). Before
+        the R2 P2 fix, the harness emitted ``(mb="", discogs="12856590")``
+        and the SQL matched ``discogs_release_id="12856590"`` only —
+        which misses the legacy row. After the fix, the numeric id
+        matches against BOTH pipeline columns and the legacy row's
+        ``imported_path`` updates correctly.
+        """
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import MovedSibling
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID_NEW, status="downloading"))
+        # Legacy pipeline layout: Discogs numeric stored in
+        # mb_release_id (not discogs_release_id).
+        db.seed_request(make_request_row(
+            id=99,
+            mb_release_id=self.DISCOGS_SIBLING,
+            discogs_release_id=None,
+            status="imported",
+            imported_path=self.PRE_MOVE_PATH))
+
+        ir = make_import_result(decision="import", new_min_bitrate=245)
+        # Beets-side: new-layout row, discogs_albumid populated,
+        # mb_albumid empty.
+        ir.postflight.moved_siblings = [
+            MovedSibling(
+                album_id=10315,
+                new_path=self.POST_MOVE_PATH,
+                mb_albumid="",
+                discogs_albumid=self.DISCOGS_SIBLING),
+        ]
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=245,
+            avg_bitrate_kbps=245, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+        dl_info = DownloadInfo(username="user1")
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id=self.MBID_NEW,
+                    request_id=42,
+                    label="Shearwater - Palo Santo (2007)",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=self._make_cfg(),
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Legacy pipeline row's imported_path got updated — Codex R2
+        # P2 regression fix verified. Pre-fix this was silently missed.
+        self.assertEqual(
+            db.request(99)["imported_path"], self.POST_MOVE_PATH)
 
     def test_untracked_sibling_is_silently_skipped(self):
         """Sibling that beets knows about but the pipeline DB does not:

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1581,6 +1581,125 @@ class TestReleaseLockContention(unittest.TestCase):
         self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
 
 
+class TestHandleValidResultReleaseLock(unittest.TestCase):
+    """Issue #132 P1 + Codex PR #136 R4 P1: release-lock acquisition
+    must happen BEFORE ``stage_to_ai`` so the filesystem stays
+    resumable on contention.
+
+    Pre-R4: ``_handle_valid_result`` called ``stage_to_ai`` first,
+    then invoked ``dispatch_import`` which checked the lock inside
+    ``dispatch_import_core``. On contention, files had already moved
+    from ``slskd_download_dir/<import_folder>/`` →
+    ``beets_staging_dir/``, but ``active_download_state`` still
+    pointed at the original slskd paths. Next cycle's
+    ``process_completed_album`` reconstructed stale source paths and
+    crashed with ``FileNotFoundError``, falling back to
+    ``status='wanted'`` — breaking the contention-retry contract.
+
+    Post-R4: ``_handle_valid_result`` acquires the lock BEFORE
+    ``stage_to_ai``. On contention, return deferred without staging;
+    files stay at ``slskd_download_dir/<import_folder>/`` where
+    ``process_completed_album``'s resume guard (``if os.path.exists(
+    dst_file) and not os.path.exists(src_file): continue``) picks
+    them up idempotently on the next cycle.
+    """
+
+    MBID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
+    def test_contention_returns_deferred_without_staging(self):
+        from lib import download as dl_mod
+        from lib.grab_list import GrabListEntry
+        from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                     release_id_to_lock_key)
+        from lib.quality import ValidationResult
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID, status="downloading"))
+
+        def lock_result(namespace: int, key: int) -> bool:
+            if (namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
+                    and key == release_id_to_lock_key(self.MBID)):
+                return False
+            return True
+        db.set_advisory_lock_result(lock_result)
+
+        from tests.helpers import make_ctx_with_fake_db
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            beets_distance_threshold=0.15,
+        )
+        ctx = make_ctx_with_fake_db(db, cfg=cfg)
+
+        entry = GrabListEntry(
+            album_id=42, artist="Test Artist", title="Test Album",
+            year="2006", files=[], filetype="mp3",
+            mb_release_id=self.MBID,
+            db_source="request", db_request_id=42)
+
+        bv_result = ValidationResult(
+            valid=True, distance=0.05, scenario="strong_match")
+
+        # stage_to_ai and dispatch_import MUST NOT run on contention.
+        import_folder_fullpath = "/tmp/test-import-folder"
+        with patch.object(dl_mod, "stage_to_ai") as mock_stage, \
+             patch.object(dl_mod, "dispatch_import") as mock_dispatch:
+            outcome = dl_mod._handle_valid_result(
+                entry, bv_result, import_folder_fullpath, ctx)
+
+        assert outcome is not None
+        self.assertTrue(outcome.deferred)
+        self.assertFalse(outcome.success)
+        # **Critical**: staging never ran — files stay at
+        # import_folder_fullpath where process_completed_album's
+        # resume guard can pick them up next cycle.
+        mock_stage.assert_not_called()
+        mock_dispatch.assert_not_called()
+
+    def test_redownload_path_does_not_take_release_lock(self):
+        """Redownload path (source != 'request') must NOT take the
+        release lock — it only stages and marks done, never runs the
+        harness, so no cross-process race applies. Pre-fix this was
+        implicitly true; pinning it so a future refactor doesn't
+        accidentally broaden the lock scope."""
+        from lib import download as dl_mod
+        from lib.grab_list import GrabListEntry
+        from lib.pipeline_db import ADVISORY_LOCK_NAMESPACE_RELEASE
+        from lib.quality import ValidationResult
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id=self.MBID, status="downloading"))
+
+        from tests.helpers import make_ctx_with_fake_db
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            beets_distance_threshold=0.15,
+        )
+        ctx = make_ctx_with_fake_db(db, cfg=cfg)
+
+        entry = GrabListEntry(
+            album_id=42, artist="Test Artist", title="Test Album",
+            year="2006", files=[], filetype="mp3",
+            mb_release_id=self.MBID,
+            db_source="redownload",  # NOT 'request'
+            db_request_id=42)
+
+        bv_result = ValidationResult(
+            valid=True, distance=0.05, scenario="strong_match")
+
+        with patch.object(dl_mod, "stage_to_ai",
+                          return_value="/tmp/staged"):
+            dl_mod._handle_valid_result(
+                entry, bv_result, "/tmp/import", ctx)
+
+        # No RELEASE-namespace lock call — redownload path skips it.
+        namespaces_used = {ns for ns, _key in db.advisory_lock_calls}
+        self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
+
+
 class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
     """The ``process_completed_album`` 3-way return → state-transition seam.
 

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1317,25 +1317,49 @@ class TestReleaseLockContention(unittest.TestCase):
             id=42, mb_release_id=self.MBID, status="downloading"))
         return db
 
-    def test_auto_contention_resets_request_to_wanted(self):
-        """Regression for review-round C1 on this commit. Auto path
-        contention MUST NOT leave the request at ``status='downloading'``:
-        the outer ``_run_completed_processing`` (lib/download.py) would
-        observe ``status=='downloading'`` + ``process_completed_album``
-        returning True and flip the request to ``imported`` even though
-        the subprocess never ran. That's a silent data-inconsistency
-        bug — the album is marked done while still sitting in /Incoming.
+    def test_auto_contention_returns_deferred_and_leaves_all_state(self):
+        """Issue #132 P1 + Codex PR #136 R3 P2/P3 combined regression.
 
-        Fix: on contention in the auto path (scenario not in
-        FORCE_MANUAL_SCENARIOS), ``dispatch_import_core`` transitions
-        the request back to ``wanted`` (so the outer flip-check fails)
-        and cleans the staged dir (so next cycle can re-mkdir it).
+        Auto-path contention must return ``DispatchOutcome(deferred=True)``
+        and leave EVERY piece of request state untouched, so
+        ``poll_active_downloads`` can re-enter ``process_completed_album``
+        on the next cycle and retry with all in-progress work
+        preserved:
+
+        - **status stays ``downloading``** — needed for
+          ``poll_active_downloads`` to find the row on the next tick.
+          The outer ``_run_completed_processing`` branches on
+          ``outcome.deferred`` and skips the flip-to-imported that
+          would otherwise fire on a True return from
+          ``process_completed_album`` (the C1 bug from commit 2's
+          review; fixed here without the earlier eager-reset
+          side effects).
+        - **staged dir stays put** — Codex R3 P3: deleting it forces
+          the next cycle to redownload from Soulseek even if the
+          competing import later fails. ``process_completed_album``
+          is idempotent on a pre-existing staging dir (it guards
+          ``os.mkdir`` with ``os.path.exists`` and skips file moves
+          when the destination already has the file).
+        - **``current_spectral_*`` stays populated** — Codex R3 P2:
+          ``run_preimport_gates`` ran BEFORE this contention path
+          fired and persisted spectral state from the downloaded
+          files. A retry on the same files would compute the same
+          spectral state anyway; clearing it would cause
+          ``override_min_bitrate`` / quality-gate decisions to
+          run against incomplete state on the next cycle.
+        - **no download_log row** — contention is a deferred retry,
+          not a failure.
         """
         from lib.import_dispatch import dispatch_import_core
         from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
                                      release_id_to_lock_key)
 
         db = self._make_db()
+        # Seed the spectral fields that ``run_preimport_gates`` would
+        # have populated pre-dispatch. These must survive the
+        # contention path.
+        db.request(42)["current_spectral_grade"] = "genuine"
+        db.request(42)["current_spectral_bitrate"] = 245
         def lock_result(namespace: int, key: int) -> bool:
             if (namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
                     and key == release_id_to_lock_key(self.MBID)):
@@ -1356,7 +1380,6 @@ class TestReleaseLockContention(unittest.TestCase):
                     db=db,  # type: ignore[arg-type]
                     dl_info=dl_info,
                     distance=0.05,
-                    # Auto-import scenario — NOT FORCE_MANUAL_SCENARIOS.
                     scenario="strong_match",
                     files=[MagicMock(username="user1",
                                      filename="01 - Track.mp3")],
@@ -1368,32 +1391,27 @@ class TestReleaseLockContention(unittest.TestCase):
 
         # Subprocess NEVER fires.
         ext.run.assert_not_called()
-        # No download_log row — deferred retry, not a failure.
-        self.assertEqual(db.download_logs, [])
-        # **Critical**: request was reset to 'wanted'. Without this,
-        # the outer _run_completed_processing in lib/download.py flips
-        # to 'imported' based on process_completed_album's True return,
-        # and the album is marked done without importing.
-        self.assertEqual(db.request(42)["status"], "wanted")
-        # Codex R2 P1: contention must NOT set ``next_retry_after``.
-        # That field would hold the request for the full backoff
-        # window (30min+ doubling up to 24h) before the next cycle
-        # could re-try — unacceptable for a contention-driven reset
-        # where the competing process might already have finished.
-        # ``reset_to_wanted`` clears it to NULL; if a future refactor
-        # re-introduces ``attempt_type="download"`` here, the
-        # ``record_attempt`` side effect would set it again and this
-        # assertion fails.
-        self.assertIsNone(db.request(42).get("next_retry_after"))
-        self.assertIsNone(db.request(42).get("last_attempt_at"))
-        # Staged dir cleanup ran (so the next cycle can re-mkdir).
-        ext.cleanup.assert_called_once_with(tmpdir)
-        # Outcome still carries the "try again shortly" signal.
+        # Outcome signals deferral — the new seam.
         self.assertFalse(outcome.success)
+        self.assertTrue(outcome.deferred)
         self.assertIn("Another import is already in progress",
                       outcome.message)
-        # Lock was attempted on the RELEASE namespace at the hashed
-        # MBID key.
+
+        # **All state preserved**:
+        self.assertEqual(db.request(42)["status"], "downloading",
+                         "Status must stay 'downloading' so "
+                         "poll_active_downloads retries next cycle.")
+        self.assertEqual(db.request(42)["current_spectral_grade"],
+                         "genuine", "Spectral state from the "
+                         "pre-dispatch run_preimport_gates MUST "
+                         "survive contention (Codex R3 P2).")
+        self.assertEqual(db.request(42)["current_spectral_bitrate"], 245)
+        # No staged-dir cleanup — Codex R3 P3.
+        ext.cleanup.assert_not_called()
+        # No download_log row — deferred retry, not a failure.
+        self.assertEqual(db.download_logs, [])
+
+        # Lock attempt recorded on the RELEASE namespace at the MBID key.
         self.assertIn(
             (ADVISORY_LOCK_NAMESPACE_RELEASE,
              release_id_to_lock_key(self.MBID)),
@@ -1561,6 +1579,86 @@ class TestReleaseLockContention(unittest.TestCase):
         # No RELEASE-namespace lock call — we skipped it entirely.
         namespaces_used = {ns for ns, _key in db.advisory_lock_calls}
         self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
+
+
+class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
+    """The ``process_completed_album`` 3-way return → state-transition seam.
+
+    Pre-#133 this was a 2-way ``bool``: True → flip to ``imported``,
+    False → reset to ``wanted``. That binary misclassified release-
+    lock contention (commit 43e83e8 C1 — silently flipped to
+    ``imported``). Commit 2's fix papered over the bug by having
+    ``dispatch_import_core`` eagerly reset the row to ``wanted``;
+    Codex R3 P2/P3 then flagged that the reset clobbered spectral
+    state and staged files.
+
+    The proper seam is a 3-way return: ``None`` == deferred (leave
+    everything alone). These tests pin the branching at
+    ``_run_completed_processing`` so a future refactor can't silently
+    collapse the three states back to two.
+    """
+
+    def _ctx(self, db: FakePipelineDB):
+        from tests.helpers import make_ctx_with_fake_db
+        return make_ctx_with_fake_db(db)
+
+    def _entry(self):
+        from tests.helpers import make_grab_list_entry
+        return make_grab_list_entry()
+
+    def _state(self):
+        from lib.quality import ActiveDownloadState
+        return ActiveDownloadState(
+            filetype="mp3", enqueued_at="2026-04-20T00:00:00+00:00",
+            files=[])
+
+    def test_deferred_outcome_leaves_status_downloading(self):
+        """``process_completed_album`` returning ``None`` must NOT touch
+        the request's status. The next ``poll_active_downloads`` cycle
+        will re-enter via status='downloading'.
+        """
+        from lib import download as dl_mod
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="downloading",
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=245))
+        with patch.object(dl_mod, "process_completed_album",
+                          return_value=None):
+            dl_mod._run_completed_processing(
+                self._entry(), 42, self._state(), db, self._ctx(db))
+        self.assertEqual(db.request(42)["status"], "downloading")
+        # Spectral untouched.
+        self.assertEqual(
+            db.request(42)["current_spectral_grade"], "genuine")
+        # No status-history transitions recorded — we didn't call
+        # apply_transition at all.
+        self.assertEqual(db.status_history, [])
+
+    def test_true_outcome_flips_to_imported(self):
+        """Happy path: ``process_completed_album`` returns ``True`` and
+        status was 'downloading' → flip to 'imported'."""
+        from lib import download as dl_mod
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        with patch.object(dl_mod, "process_completed_album",
+                          return_value=True):
+            dl_mod._run_completed_processing(
+                self._entry(), 42, self._state(), db, self._ctx(db))
+        self.assertEqual(db.request(42)["status"], "imported")
+
+    def test_false_outcome_resets_to_wanted_with_attempt(self):
+        """Failure: ``process_completed_album`` returns ``False`` →
+        reset to 'wanted' with an attempt increment (genuine failure
+        DOES deserve a backoff-scored attempt)."""
+        from lib import download as dl_mod
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        with patch.object(dl_mod, "process_completed_album",
+                          return_value=False):
+            dl_mod._run_completed_processing(
+                self._entry(), 42, self._state(), db, self._ctx(db))
+        self.assertEqual(db.request(42)["status"], "wanted")
 
 
 class TestSiblingImportedPathPropagation(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1358,6 +1358,24 @@ class TestReleaseIdToLockKey(unittest.TestCase):
         k2 = pipeline_db.release_id_to_lock_key(mbid)
         self.assertEqual(k1, k2)
 
+    def test_whitespace_is_stripped_before_hashing(self) -> None:
+        """Legacy DB rows sometimes carry stray leading/trailing
+        whitespace on ``mb_release_id``. Two processes that normalise
+        differently would otherwise hash to different keys and the
+        advisory lock would silently fail to serialise them. ``.strip()``
+        before hashing closes that gap."""
+        from lib.pipeline_db import release_id_to_lock_key
+        mbid = "12856590"
+        self.assertEqual(
+            release_id_to_lock_key(mbid),
+            release_id_to_lock_key(f" {mbid}"))
+        self.assertEqual(
+            release_id_to_lock_key(mbid),
+            release_id_to_lock_key(f"{mbid}\t"))
+        self.assertEqual(
+            release_id_to_lock_key(mbid),
+            release_id_to_lock_key(f"  {mbid}\n"))
+
 
 @requires_postgres
 class TestAdvisoryLock(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1294,6 +1294,71 @@ class TestUserCooldowns(unittest.TestCase):
         self.assertFalse(result)
 
 
+class TestReleaseIdToLockKey(unittest.TestCase):
+    """Issue #133 / #132 P1: ``release_id_to_lock_key`` must be stable
+    across processes and fit int32 so it can drive the two-arg
+    ``pg_advisory_lock``.
+
+    Pure function — no PG dependency, runs without ``@requires_postgres``.
+    """
+
+    def test_same_mbid_maps_to_same_key(self) -> None:
+        from lib.pipeline_db import release_id_to_lock_key
+        mbid = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+        self.assertEqual(
+            release_id_to_lock_key(mbid),
+            release_id_to_lock_key(mbid))
+
+    def test_different_mbids_produce_different_keys(self) -> None:
+        """Collision is statistically possible but unlikely with the
+        handful of MBIDs in this test — a regression that makes the
+        hash degenerate (e.g. returning a constant) would show up here.
+        """
+        from lib.pipeline_db import release_id_to_lock_key
+        keys = {
+            release_id_to_lock_key(s)
+            for s in [
+                "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+                "cccccccc-4444-5555-6666-dddddddddddd",
+                "eeeeeeee-7777-8888-9999-ffffffffffff",
+                "12856590",   # Discogs numeric id
+                "1073741824",  # Discogs numeric
+                "",            # edge case: empty string → hash(b"") = 0
+            ]
+        }
+        self.assertEqual(len(keys), 6)
+
+    def test_key_fits_non_negative_int32(self) -> None:
+        """``pg_advisory_lock(int4, int4)`` takes signed int32; we mask
+        to 31 bits so the value is always in [0, 2^31-1]. Negative keys
+        work too in PG but keeping them non-negative makes ``pg_locks``
+        rows readable during debugging."""
+        from lib.pipeline_db import release_id_to_lock_key
+        for s in [
+                "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+                "cccccccc-4444-5555-6666-dddddddddddd",
+                "12856590",
+                "xxxxxxxx-yyyy-zzzz-wwww-vvvvvvvvvvvv",
+                "",
+        ]:
+            k = release_id_to_lock_key(s)
+            self.assertGreaterEqual(k, 0)
+            self.assertLess(k, 1 << 31)
+
+    def test_key_is_stable_across_imports(self) -> None:
+        """Sanity: the function does NOT use ``hash()`` (which is salted
+        per-interpreter and would break cross-process locking). Re-import
+        the module and verify the same input still maps to the same key.
+        """
+        import importlib
+        from lib import pipeline_db
+        mbid = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+        k1 = pipeline_db.release_id_to_lock_key(mbid)
+        importlib.reload(pipeline_db)
+        k2 = pipeline_db.release_id_to_lock_key(mbid)
+        self.assertEqual(k1, k2)
+
+
 @requires_postgres
 class TestAdvisoryLock(unittest.TestCase):
     """Issue #92: ``PipelineDB.advisory_lock`` must cross-session-serialize.
@@ -1343,6 +1408,21 @@ class TestAdvisoryLock(unittest.TestCase):
         # Lock must be free now — a different session can acquire it.
         with self.db2.advisory_lock(self.NS, 12345) as a2:
             self.assertTrue(a2)
+
+    def test_release_namespace_isolated_from_import_namespace(self):
+        """Issue #133 / #132 P1: the RELEASE lock namespace must not
+        collide with the IMPORT lock namespace. Holding one in session A
+        must not prevent session B from acquiring the other at the same
+        integer key — they are logically unrelated resources.
+        """
+        from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_IMPORT,
+                                     ADVISORY_LOCK_NAMESPACE_RELEASE)
+        with self.db1.advisory_lock(
+                ADVISORY_LOCK_NAMESPACE_IMPORT, 12345) as a1:
+            self.assertTrue(a1)
+            with self.db2.advisory_lock(
+                    ADVISORY_LOCK_NAMESPACE_RELEASE, 12345) as a2:
+                self.assertTrue(a2)
 
 
 @requires_postgres

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -56,7 +56,7 @@ class TestRemoveStaleByIdLogged(unittest.TestCase):
     cannot match any other album, so the blast radius is exactly one
     row."""
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_clean_exit_returns_none(self, mock_run: MagicMock) -> None:
         from harness import import_one
         mock_run.return_value = _ok()
@@ -73,7 +73,7 @@ class TestRemoveStaleByIdLogged(unittest.TestCase):
         # and match a track PK or nothing (Codex PR #131 round 2 P1).
         self.assertEqual(argv[1:5], ["remove", "-a", "-d", "id:10319"])
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_timeout_surfaces_typed_failure(self, mock_run: MagicMock) -> None:
         from harness import import_one
         mock_run.side_effect = sp.TimeoutExpired(
@@ -85,7 +85,7 @@ class TestRemoveStaleByIdLogged(unittest.TestCase):
         assert result is not None
         self.assertEqual(result.reason, "timeout")
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_nonzero_rc_surfaces_typed_failure(
             self, mock_run: MagicMock) -> None:
         from harness import import_one
@@ -115,7 +115,7 @@ class TestCanonicalizeSiblings(unittest.TestCase):
     ``albums.id`` is always populated (Codex PR #131 round 3 P3).
     """
 
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_noop_when_no_siblings(self, mock_run: MagicMock) -> None:
         from harness import import_one
         beets = MagicMock()
@@ -123,8 +123,8 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         mock_run.assert_not_called()
         beets.get_album_path_by_id.assert_not_called()
 
-    @patch("harness.import_one.fix_library_modes")
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
     def test_runs_beet_move_album_mode_id_selector(
             self, mock_run: MagicMock,
             mock_fix: MagicMock) -> None:
@@ -152,8 +152,8 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         mock_fix.assert_called_once_with(
             "/Beets/Shearwater/2006 - Palo Santo [2006]")
 
-    @patch("harness.import_one.fix_library_modes")
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
     def test_handles_discogs_sibling_via_album_id(
             self, mock_run: MagicMock,
             mock_fix: MagicMock) -> None:
@@ -180,8 +180,8 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         mock_fix.assert_called_once_with(
             "/Beets/Discogs/Artist/Album [12856590]")
 
-    @patch("harness.import_one.fix_library_modes")
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
     def test_continues_past_per_sibling_failure(
             self, mock_run: MagicMock,
             mock_fix: MagicMock) -> None:
@@ -210,8 +210,8 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         # Exactly one of the two moves succeeded → exactly one perm repair.
         self.assertEqual(mock_fix.call_count, 1)
 
-    @patch("harness.import_one.fix_library_modes")
-    @patch("harness.import_one.subprocess.run")
+    @patch("lib.permissions.fix_library_modes")
+    @patch("lib.beets_album_op.sp.run")
     def test_skips_fix_library_modes_when_path_missing(
             self, mock_run: MagicMock,
             mock_fix: MagicMock) -> None:

--- a/tests/test_preflight_stale_removal.py
+++ b/tests/test_preflight_stale_removal.py
@@ -138,6 +138,10 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         from harness import import_one
         mock_run.return_value = MagicMock(returncode=0, stderr="")
         beets = MagicMock()
+        # ``_canonicalize_siblings`` resolves release ids for
+        # propagation (issue #132 P2 / #133). Return empty tuple —
+        # the test's sibling isn't tracked in the pipeline DB.
+        beets.get_release_ids_by_album_id.return_value = ("", "")
         beets.get_album_path_by_id.return_value = (
             "/Beets/Shearwater/2006 - Palo Santo [2006]")
 
@@ -169,6 +173,10 @@ class TestCanonicalizeSiblings(unittest.TestCase):
         from harness import import_one
         mock_run.return_value = MagicMock(returncode=0, stderr="")
         beets = MagicMock()
+        # ``_canonicalize_siblings`` resolves release ids for
+        # propagation (issue #132 P2 / #133). Return empty tuple —
+        # the test's sibling isn't tracked in the pipeline DB.
+        beets.get_release_ids_by_album_id.return_value = ("", "")
         beets.get_album_path_by_id.return_value = (
             "/Beets/Discogs/Artist/Album [12856590]")
 
@@ -199,6 +207,7 @@ class TestCanonicalizeSiblings(unittest.TestCase):
             MagicMock(returncode=0, stderr=""),
         ]
         beets = MagicMock()
+        beets.get_release_ids_by_album_id.return_value = ("", "")
         # Any valid path for the sibling that moved clean.
         beets.get_album_path_by_id.return_value = "/Beets/X/Y [2006]"
 

--- a/tests/test_release_cleanup.py
+++ b/tests/test_release_cleanup.py
@@ -14,7 +14,7 @@ The pure-function tests here use a lightweight stub ``BeetsDB`` + a
 touches is exactly one method (``clear_on_disk_quality_fields``), and
 the assertion we care about is "was it called, with what argument",
 which MagicMock makes direct. Subprocess behavior is mocked via
-``patch('lib.release_cleanup.sp.run', ...)``.
+``patch('lib.beets_album_op.sp.run', ...)``.
 """
 
 from __future__ import annotations
@@ -104,7 +104,7 @@ class TestReleaseCleanupResult(unittest.TestCase):
 class TestAllSelectorsSucceed(unittest.TestCase):
     """Baseline: when every selector exits 0, no failures, album gone."""
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_uuid_single_selector_clean_exit(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _ok()
         beets = _StubBeetsDB([
@@ -125,7 +125,7 @@ class TestAllSelectorsSucceed(unittest.TestCase):
         # Pipeline DB clear fires on absent_after=True.
         pdb.clear_on_disk_quality_fields.assert_called_once_with(42)
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_argv_uses_album_mode_flag(
             self, mock_run: MagicMock) -> None:
         """Every ``beet remove`` invocation MUST include ``-a`` (album
@@ -152,7 +152,7 @@ class TestAllSelectorsSucceed(unittest.TestCase):
         self.assertEqual(argv[1:4], ["remove", "-a", "-d"])
         self.assertEqual(argv[4], f"mb_albumid:{RELEASE_UUID}")
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_discogs_pair_of_selectors_both_run(
             self, mock_run: MagicMock) -> None:
         """Discogs numeric → two selectors; both run on the happy path."""
@@ -177,7 +177,7 @@ class TestAllSelectorsSucceed(unittest.TestCase):
 class TestTimeoutOnOneSelector(unittest.TestCase):
     """The bug report: timeout on selector A must not abort the loop."""
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_timeout_on_first_selector_still_runs_second(
             self, mock_run: MagicMock) -> None:
         """``TimeoutExpired`` on selector 1 must not prevent selector 2.
@@ -214,7 +214,7 @@ class TestTimeoutOnOneSelector(unittest.TestCase):
         self.assertEqual(result.selector_failures[0].selector, selectors[0])
         self.assertEqual(result.selector_failures[0].reason, "timeout")
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_timeout_on_both_selectors_returns_partial_failure(
             self, mock_run: MagicMock) -> None:
         """All selectors time out → two failures recorded, no clear."""
@@ -248,7 +248,7 @@ class TestTimeoutOnOneSelector(unittest.TestCase):
 class TestNonZeroExitCodeLoopContinues(unittest.TestCase):
     """``beet remove`` exits non-zero → record, keep looping."""
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_nonzero_rc_on_first_still_runs_second(
             self, mock_run: MagicMock) -> None:
         selectors = (f"discogs_albumid:{DISCOGS_ID}", f"mb_albumid:{DISCOGS_ID}")
@@ -276,7 +276,7 @@ class TestNonZeroExitCodeLoopContinues(unittest.TestCase):
 class TestMissingBeetBinary(unittest.TestCase):
     """``FileNotFoundError`` (beet not on PATH) is caught gracefully."""
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_filenotfounderror_does_not_propagate(
             self, mock_run: MagicMock) -> None:
         """Beet missing from PATH must not crash the ban-source handler.
@@ -310,7 +310,7 @@ class TestMissingBeetBinary(unittest.TestCase):
 class TestAlreadyGoneBeforeCall(unittest.TestCase):
     """Pre-gone: no subprocess runs, pipeline DB still cleared."""
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_no_sp_run_when_locate_already_absent(
             self, mock_run: MagicMock) -> None:
         beets = _StubBeetsDB([
@@ -355,7 +355,7 @@ class TestRemoveAlbumBySelectorsSeam(unittest.TestCase):
     fields.
     """
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_returns_release_cleanup_result_without_pipeline_db(
             self, mock_run: MagicMock) -> None:
         """The seam accepts (beets_db, release_id) only — no pipeline_db.
@@ -377,7 +377,7 @@ class TestRemoveAlbumBySelectorsSeam(unittest.TestCase):
         self.assertTrue(result.absent_after)
         self.assertEqual(result.selector_failures, ())
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_absent_before_call_no_subprocess(
             self, mock_run: MagicMock) -> None:
         """No album present → no subprocess run, absent_after=True."""
@@ -393,7 +393,7 @@ class TestRemoveAlbumBySelectorsSeam(unittest.TestCase):
         self.assertFalse(result.beets_removed)
         self.assertTrue(result.absent_after)
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_per_selector_iteration_preserved(
             self, mock_run: MagicMock) -> None:
         """Timeout on selector 1 must not skip selector 2 (PR #123 guarantee).
@@ -437,7 +437,7 @@ class TestRemoveAndResetDelegatesToSeam(unittest.TestCase):
     tracing the implementation.
     """
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_clears_pipeline_db_only_when_absent_after(
             self, mock_run: MagicMock) -> None:
         """Wrapper fires ``clear_on_disk_quality_fields`` iff seam reports
@@ -456,7 +456,7 @@ class TestRemoveAndResetDelegatesToSeam(unittest.TestCase):
         self.assertTrue(result.absent_after)
         pdb.clear_on_disk_quality_fields.assert_called_once_with(7)
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     def test_skips_pipeline_db_clear_when_album_still_present(
             self, mock_run: MagicMock) -> None:
         """If every selector failed, album still on disk → no pipeline

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1455,7 +1455,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(self._override_passed(mock_transition), "lossless")
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_clears_on_disk_quality_fields(
             self, _mock_transition, mock_subprocess):
@@ -1493,7 +1493,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(status, 200)
         self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_skips_clear_when_beet_remove_failed(
             self, _mock_transition, mock_subprocess):
@@ -1536,7 +1536,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertEqual(data["cleanup_errors"][0]["reason"], "nonzero_rc")
         self.assertFalse(data["beets_removed"])
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_uses_discogs_selector_for_numeric_id(
             self, _mock_transition, mock_subprocess):
@@ -1576,7 +1576,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                       "Must also attempt the legacy mb_albumid selector "
                       "so older beets libraries don't regress.")
 
-    @patch("lib.release_cleanup.sp.run")
+    @patch("lib.beets_album_op.sp.run")
     @patch("web.routes.pipeline.apply_transition")
     def test_ban_source_clears_stale_state_when_album_already_gone(
             self, _mock_transition, mock_subprocess):


### PR DESCRIPTION
## Summary

Closes #133 (the BeetsAlbumOp extraction — the refactoring-debt payment from PR #131's six rounds of Codex review) and #132 (both follow-ups: cross-process release lock + sibling imported_path propagation).

Three feature commits, each followed by an adversarial-review-fix commit, plus a final review pass. Rebase-merge keeps the audit trail on \`main\`.

### Commit 1 — \`BeetsAlbumOp\` abstraction

- New \`lib/beets_album_op.py\` with \`BeetsAlbumHandle\`, \`BeetsOpFailure\`, \`BeetsOpResult\`, and three entry points: \`remove_album(handle)\`, \`move_album(handle, beets_db)\`, \`remove_by_selector(selector)\`.
- All five+ callsites migrated: \`_apply_disambiguation\`, \`_canonicalize_siblings\`, \`_remove_stale_by_id_logged\`, \`remove_album_by_beets_id\`, \`remove_album_by_selectors\`.
- \`fix_library_modes\` (issue #84) moved INTO \`move_album\` — every caller gets perm repair, no exceptions.
- Contract test \`TestBeetOpArgvIsCentralised\` greps the repo for three argv shapes (\`"beet"\`, \`beet_bin()\`, \`BEET_BIN\`) and fails if any file outside the allowlist constructs raw argv.
- Unified \`DisambiguationFailure\` + \`SelectorFailure\` into \`BeetsOpFailure\` (kept name aliases). Back-compat preserved via default empty \`selector\` field — old JSONB rows deserialize cleanly; explicit test pins this.

### Commit 2 — Cross-process same-release advisory lock (#132 P1)

- New \`ADVISORY_LOCK_NAMESPACE_RELEASE\` keyed on \`zlib.crc32(mb_release_id.strip())\` (stable across processes, unlike salted \`hash()\`). Non-blocking acquire in \`dispatch_import_core\`.
- Closes the \`max(post_import_ids)\` cross-process race documented as KNOWN LIMITATION in harness/import_one.py (now also the comment is updated).
- **C1 regression fix** (caught by adversarial review): auto-path contention previously left \`status='downloading'\` → \`_run_completed_processing\` silently flipped the request to \`imported\` without importing. Now resets to \`wanted\` + cleans staging. Force/manual path preserves status.
- Orchestration slices for contention + happy path + empty-mbid fallback.

### Commit 3 — Sibling \`imported_path\` propagation (#132 P2)

- \`_canonicalize_siblings\` now returns \`list[MovedSibling]\`; records flow through \`PostflightInfo.moved_siblings\` and are propagated by new \`_propagate_moved_siblings\` in \`dispatch_import_core\`.
- New \`PipelineDB.update_imported_path_by_release_id(mb_albumid, discogs_albumid, new_path)\` — covers both layout combos.
- Strict wire-boundary validation: \`_postflight_from_dict\` decodes via \`msgspec.convert\` (issue #99 lesson). Regression test feeds \`album_id="10314"\` as string and asserts \`msgspec.ValidationError\`.
- Observability WARNs for the silent-failure modes (rowcount>1, both-ids-empty). Defensive try/except around \`get_release_ids_by_album_id\` so a beets lock doesn't kill the whole canonicalization loop.

## Commits

\`\`\`
1c73ab3 review(final): drop dead fields + fix doc lie + add fake self-tests
0110b9c review(commit 3): strict-type boundary + observability + defensive lookups
caa0d51 feat: propagate sibling imported_path to pipeline DB (#132 P2, #133)
43e83e8 review(commit 2): fix auto-path status-flip regression + 3 polish items
35e85ac feat: cross-process same-release advisory lock (#132 P1, #133)
b3d683c review(commit 1): widen argv grep, add pre-#133 JSON test, polish
81d3953 refactor: extract BeetsAlbumOp for beets subprocess operations (#133)
\`\`\`

## Acceptance (per #133)

- [x] Every \`beet remove\` / \`beet move\` subprocess routes through BeetsAlbumOp.
- [x] No callsite constructs its own argv — contract test enforces this.
- [x] Same-release lock covered by an orchestration test (\`TestReleaseLockContention\`).
- [x] Sibling \`imported_path\` propagation covered by an integration slice (\`TestSiblingImportedPathPropagation\`).
- [x] Closes #132.

## Test plan

- [x] \`nix-shell --run "bash scripts/run_tests.sh"\` — **1965 passing**, 53 skipped.
- [x] \`pyright\` — 0 errors on every touched file.
- [ ] Deploy to doc2 via \`/deploy\` flow. No migrations needed (\`discogs_release_id\` index already ships in \`002_discogs_index.sql\`).
- [ ] Post-deploy: verify a kept-duplicate import (search a multi-edition album) triggers the sibling propagation path and logs show \`[CANONICALIZE] … emitted for pipeline DB propagation\` + \`propagated imported_path →\` on the dispatch side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)