### PR TITLE
refactor: tighten shared DB infrastructure (#140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ lib/
                            Schema is NOT this class's responsibility — see lib/migrator.py.
                            Search logging: log_search(), get_search_history(), get_search_history_batch()
                            User cooldowns: add_cooldown(), get_cooled_down_users(), check_and_apply_cooldown()
+                           Advisory locks: advisory_lock() + ADVISORY_LOCK_NAMESPACE_{IMPORT,RELEASE}.
+                           Namespaces, keys, ordering, contention semantics: docs/advisory-locks.md.
                            RequestSpectralStateUpdate (typed spectral state writes)
   migrator.py           — Versioned SQL migrator. discover_migrations() parses
                            migrations/NNN_name.sql files; apply_migrations() runs unapplied

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -1,0 +1,232 @@
+# PostgreSQL Advisory Locks
+
+Cratedigger uses PostgreSQL advisory locks to serialise pipeline
+operations that must not run concurrently across different DB sessions
+(the auto cycle on the systemd timer, the web UI's force-import path,
+CLI force/manual invocations). Every lock in this codebase is
+**non-blocking** (`pg_try_advisory_lock`), **session-scoped** (held until
+release or session close), and **reentrant within a session** (a second
+acquire of the same `(namespace, key)` in the same session always
+returns true).
+
+This doc is the single source of truth for namespaces, keys, ordering,
+and reentrancy. Add a new lock only after reading the rules below and
+updating both the **namespace table** and the **call-site index**.
+
+## Why advisory locks
+
+We do not use row-level locks because the thing we're serialising on —
+"don't let two processes import the same release at the same time" —
+spans multiple statements across multiple tables (`album_requests`,
+`download_log`, beets' own SQLite DB, and filesystem state in
+`/Incoming` and `/Beets`). A row lock on `album_requests` would only
+cover the row-level updates; the subprocess calls to `import_one.py`
+run outside the transaction envelope.
+
+Advisory locks are:
+
+- Cheap (two `pg_locks` entries, no table rows touched)
+- Orthogonal to row locks (don't interfere with autocommit writes)
+- Easy to name (int4 pairs — we use ASCII-recognisable values so
+  `pg_locks` is debuggable at a glance)
+- Easy to scope (we pick per-request vs per-release based on the
+  invariant we're protecting)
+
+## Namespaces
+
+All namespace constants live in `lib/pipeline_db.py`. The key space is
+PostgreSQL's two-arg `pg_advisory_lock(int4, int4)` — first arg is the
+namespace, second is the per-lock key.
+
+| Namespace | Constant | Hex | ASCII | Key | Scope |
+|---|---|---|---|---|---|
+| Per-request import | `ADVISORY_LOCK_NAMESPACE_IMPORT` | `0x46494D50` | "FIMP" | `request_id` | Force/manual-import double-click protection |
+| Per-release pipeline | `ADVISORY_LOCK_NAMESPACE_RELEASE` | `0x52454C45` | "RELE" | `release_id_to_lock_key(mb_release_id)` | Cross-process same-MBID serialisation |
+
+The ASCII-visible hex lets `pg_locks` rows be interpreted at a glance
+during debugging:
+
+```sql
+SELECT classid, objid FROM pg_locks WHERE locktype = 'advisory';
+-- classid=0x46494D50 → force/manual-import lock
+-- classid=0x52454C45 → release-level lock
+```
+
+### IMPORT — per-request lock
+
+**Why**: Issue #92. A double-click on the force-import button in the
+web UI could fire two HTTP POSTs that each launched the full pipeline
+on the same `request_id`, writing duplicate `download_log` rows and
+running `import_one.py` twice against the same files. The second caller
+would crash or produce bogus state.
+
+**Scope**: Only held by `dispatch_import_from_db` — the sole entry
+point for force/manual imports. The auto-import path does not acquire
+this lock because it has no concurrent-duplicate vector (the systemd
+timer only fires one pipeline at a time, and the RELEASE lock already
+covers cross-timer-cycle races).
+
+**Key**: The raw `request_id` (int4 auto-increment on
+`album_requests.id` — fits trivially in an int4 lock key).
+
+### RELEASE — per-MBID lock
+
+**Why**: Issue #132 P1 / issue #133. The Palo Santo incident. Two
+processes (the auto cycle and a web force-import, or two racing
+force-import clicks on sibling requests for the same MBID) each held
+their own per-request lock while targeting the same MusicBrainz
+release. The harness's post-import `max(post_import_ids)` query then
+picked up the *other* process's newly-inserted beets row as "the album
+we just imported" and `beet remove -d`-ed it. Eleven FLAC tracks of
+Shearwater's *Palo Santo* 11-track edition disappeared from disk.
+
+**Scope**: Held for the duration of every `import_one.py` subprocess
+— that is, in every path that runs the harness. `dispatch_import_core`
+is the funnel; both the auto path and the force/manual path go through
+it.
+
+**Key**: `release_id_to_lock_key(mb_release_id)` — a 31-bit
+`zlib.crc32` mask of the (`.strip()`-normalised) release id string.
+Covers both MB UUIDs and Discogs numeric IDs since both share the
+`mb_release_id` column. See the docstring on `release_id_to_lock_key`
+in `lib/pipeline_db.py` for the collision analysis (probability
+~N²/2^31; false collision delays an unrelated release by one cycle).
+
+## Acquisition order
+
+Force/manual paths hold both locks at once. **IMPORT is outer, RELEASE
+is inner.** Always. A reverse nesting would risk a cross-process
+deadlock if two flows acquire in opposite order, but because RELEASE is
+taken by the same session further down the call graph and no other
+call site acquires both locks, in practice there is only one ordering
+to follow and it's the one in the code:
+
+```
+FORCE/MANUAL (dispatch_import_from_db)
+  └─ acquire IMPORT(request_id)                                ← outer
+      └─ _dispatch_import_from_db_locked
+          └─ dispatch_import_core
+              └─ acquire RELEASE(release_id_to_lock_key(mbid)) ← inner
+                  └─ import_one.py subprocess
+```
+
+The auto path only holds RELEASE, and acquires it at
+`_handle_valid_result` *before* `stage_to_ai` runs (Codex PR #136 R4
+P1 — see below). `dispatch_import_core`'s inner acquisition of the
+same key is a no-op reentrant acquire:
+
+```
+AUTO (_handle_valid_result in lib/download.py)
+  └─ acquire RELEASE(release_id_to_lock_key(mbid))             ← outer
+      └─ stage_to_ai                                           ← moves files
+      └─ dispatch_import
+          └─ dispatch_import_core
+              └─ acquire RELEASE(...)                          ← reentrant no-op
+                  └─ import_one.py subprocess
+```
+
+**Why RELEASE outer at `_handle_valid_result`, not at
+`dispatch_import_core`?** Codex PR #136 R4 P1: `stage_to_ai` mutates
+filesystem state (`slskd_download_dir/<import_folder>/` →
+`beets_staging_dir/`) that is NOT reflected in the pipeline DB's
+`active_download_state` column. If contention is detected AFTER
+staging, the next cycle's `process_completed_album` reconstructs the
+entry from `active_download_state`, finds the source paths empty, and
+fails with `FileNotFoundError`. Acquiring the RELEASE lock BEFORE
+`stage_to_ai` keeps the original files in place on contention, so the
+resume guard (`if os.path.exists(dst_file) and not
+os.path.exists(src_file): continue`) can idempotently re-enter next
+cycle.
+
+## Contention behaviour
+
+All acquires are non-blocking via `pg_try_advisory_lock`. On
+contention:
+
+- **IMPORT contention** (force/manual): log `SKIPPED: request N —
+  another import is already in progress` and return a
+  `DispatchOutcome(success=False, message=...)` so the UI surfaces a
+  "try again shortly" toast. The second caller writes nothing.
+- **RELEASE contention** (auto): log `AUTO-IMPORT DEFERRED` and return
+  `DispatchOutcome(deferred=True)`. `_run_completed_processing`
+  branches on `deferred` and preserves the `downloading` status with
+  its `active_download_state` intact — the next cycle idempotently
+  re-enters `process_completed_album` and retries exactly where we
+  stopped. Codex PR #136 R3 P2/P3.
+- **RELEASE contention** (force/manual): log `FORCE-IMPORT SKIPPED` /
+  `MANUAL-IMPORT SKIPPED`, return `DispatchOutcome(success=False,
+  deferred=False)`, no state mutated. Same UI message as IMPORT
+  contention.
+
+Blocking acquires (`pg_advisory_lock`) are never used — they would
+pin the caller's PG connection for the full duration of an unrelated
+process's import (minutes) with no clear benefit.
+
+## Reentrancy
+
+PostgreSQL advisory locks are reentrant *within a session*. Acquiring
+`(namespace, key)` twice from the same session returns true both
+times; two releases are needed. Two *different* sessions never both
+hold the same lock — the second caller's `pg_try_advisory_lock`
+returns false.
+
+Cratedigger exploits this in the auto path: `_handle_valid_result`
+acquires RELEASE, `dispatch_import_core` acquires it again
+(reentrantly), the inner release is a no-op, the outer release is the
+real one. The design keeps `dispatch_import_core`'s lock scope correct
+for the force/manual path (where it IS the first acquisition) without
+double-gating the auto path.
+
+The pipeline runs on a single `PipelineDB` instance per process —
+every call through `advisory_lock()` uses the same connection. If a
+future change introduces a second `PipelineDB` instance in the same
+process, cross-instance reentrancy no longer applies; revisit the
+ordering rules.
+
+## Call-site index
+
+| Path | File | Function | Namespace | Key expression |
+|---|---|---|---|---|
+| Auto-import outer | `lib/download.py` | `_handle_valid_result` | RELEASE | `release_id_to_lock_key(album_data.mb_release_id)` |
+| Auto + force/manual inner | `lib/import_dispatch.py` | `dispatch_import_core` | RELEASE | `release_id_to_lock_key(mb_release_id)` |
+| Force/manual outer | `lib/import_dispatch.py` | `dispatch_import_from_db` | IMPORT | `request_id` |
+
+Every acquire site carries a comment linking back here. Line numbers
+are intentionally omitted — grep for `advisory_lock(` to find them.
+`git log -S 'advisory_lock(' -- lib/` is the archaeology path.
+
+## Extending
+
+To add a new lock:
+
+1. Pick a namespace constant with an ASCII-recognisable hex value (make
+   `pg_locks` debuggable). Define it in `lib/pipeline_db.py` next to
+   the existing `ADVISORY_LOCK_NAMESPACE_*` constants.
+2. Decide key derivation. Natural-int keys (request_id) are trivial.
+   String keys need a stable hash — use `zlib.crc32(...) & 0x7FFFFFFF`
+   and follow the collision analysis pattern in
+   `release_id_to_lock_key`.
+3. If the new lock can be held concurrently with IMPORT or RELEASE,
+   decide the ordering and document it here. Add a deadlock analysis
+   in the commit message.
+4. Add a row to the **Namespaces** and **Call-site index** tables in
+   this doc.
+5. Every acquire site must carry a comment referencing this doc
+   (`See docs/advisory-locks.md.`).
+6. Add a test in `tests/test_pipeline_db.py`'s `TestAdvisoryLock`
+   class exercising the new namespace. `FakePipelineDB` already
+   covers the contract side via `advisory_lock_calls` and
+   `set_advisory_lock_result`.
+
+## Test coverage
+
+- `tests/test_pipeline_db.py::TestAdvisoryLock` — real PG semantics:
+  same-key blocking across sessions, different-key no-contention,
+  cross-namespace same-key isolation, reentrancy within a session.
+- `tests/test_integration_slices.py` — release-lock contention on
+  the auto path (`TestReleaseLockContentionDefers...`) and the
+  force/manual path.
+- `tests/test_dispatch_from_db.py` — IMPORT-lock double-acquisition
+  short-circuits.
+- `tests/test_fakes.py` — `FakePipelineDB.advisory_lock` records calls
+  and lets tests flip acquisition results per-`(namespace, key)`.

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -113,7 +113,8 @@ FORCE/MANUAL (dispatch_import_from_db)
 The auto path only holds RELEASE, and acquires it at
 `_handle_valid_result` *before* `stage_to_ai` runs (Codex PR #136 R4
 P1 — see below). `dispatch_import_core`'s inner acquisition of the
-same key is a no-op reentrant acquire:
+same key — reached via `dispatch_import` (the auto-path orchestration
+wrapper in `lib/import_dispatch.py`) — is a no-op reentrant acquire:
 
 ```
 AUTO (_handle_valid_result in lib/download.py)
@@ -177,11 +178,19 @@ real one. The design keeps `dispatch_import_core`'s lock scope correct
 for the force/manual path (where it IS the first acquisition) without
 double-gating the auto path.
 
-The pipeline runs on a single `PipelineDB` instance per process —
-every call through `advisory_lock()` uses the same connection. If a
-future change introduces a second `PipelineDB` instance in the same
-process, cross-instance reentrancy no longer applies; revisit the
-ordering rules.
+**Scope**: reentrancy is per-session, not per-process. A single
+Cratedigger process does hold multiple `PipelineDB` instances in
+practice — the auto pipeline has `phase1_source` and `phase2_source`
+each owning their own session, `album_source.py` lazily opens another,
+and the web server opens yet one more. Every `advisory_lock()` call
+must go through the same `PipelineDB` instance as its matching outer
+acquire for the reentrant no-op to apply. The auto path and the
+force/manual path both thread the same
+`ctx.pipeline_db_source._get_db()` / `db` reference from the outer
+acquire down into `dispatch_import_core`, so they stay within one
+session. If a future change opens a fresh `PipelineDB` for the inner
+acquire, the second `pg_try_advisory_lock` comes from a different
+session and returns False — revisit the ordering rules.
 
 ## Call-site index
 
@@ -209,24 +218,45 @@ To add a new lock:
 3. If the new lock can be held concurrently with IMPORT or RELEASE,
    decide the ordering and document it here. Add a deadlock analysis
    in the commit message.
-4. Add a row to the **Namespaces** and **Call-site index** tables in
+4. Audit every `PipelineDB(...)` construction site the acquire can
+   reach. Advisory locks are **session-scoped**; if the caller runs
+   through a different `PipelineDB` instance than its matching outer
+   acquire, the inner `pg_try_advisory_lock` comes from a different
+   session and returns False. The auto path's reentrant no-op works
+   only because the same `ctx.pipeline_db_source` flows through the
+   whole chain; a new lock that spans web + CLI + auto needs a
+   design-level decision.
+5. Add a row to the **Namespaces** and **Call-site index** tables in
    this doc.
-5. Every acquire site must carry a comment referencing this doc
+6. Every acquire site must carry a comment referencing this doc
    (`See docs/advisory-locks.md.`).
-6. Add a test in `tests/test_pipeline_db.py`'s `TestAdvisoryLock`
+7. Add a test in `tests/test_pipeline_db.py`'s `TestAdvisoryLock`
    class exercising the new namespace. `FakePipelineDB` already
    covers the contract side via `advisory_lock_calls` and
-   `set_advisory_lock_result`.
+   `set_advisory_lock_result` (the fake records calls regardless of
+   namespace — no fake update needed unless the new namespace
+   requires per-key deterministic behaviour in some slice test, in
+   which case extend `set_advisory_lock_result`'s callable form).
+8. Verify on-host before calling it shipped. Unit tests prove the
+   semantics; the cross-process story (race with the 5-minute timer,
+   race with a web force-import) only manifests in a running
+   pipeline. Watch `pg_locks` during a deliberate race if you are
+   unsure. `nix build .#checks.x86_64-linux.moduleVm` does NOT
+   exercise cross-process lock behaviour — it's a smoke test for
+   module wiring only.
 
 ## Test coverage
 
 - `tests/test_pipeline_db.py::TestAdvisoryLock` — real PG semantics:
   same-key blocking across sessions, different-key no-contention,
-  cross-namespace same-key isolation, reentrancy within a session.
-- `tests/test_integration_slices.py` — release-lock contention on
-  the auto path (`TestReleaseLockContentionDefers...`) and the
-  force/manual path.
+  cross-namespace same-key isolation, exception-safe release,
+  same-session reentrancy.
+- `tests/test_integration_slices.py::TestReleaseLockContention`
+  and `::TestHandleValidResultReleaseLock` — release-lock contention
+  on the auto path at `_handle_valid_result` and the
+  `dispatch_import_core` inner site.
 - `tests/test_dispatch_from_db.py` — IMPORT-lock double-acquisition
-  short-circuits.
+  short-circuits without writing a `download_log` row, running a
+  subprocess, transitioning status, or firing cooldowns (fast-fail).
 - `tests/test_fakes.py` — `FakePipelineDB.advisory_lock` records calls
   and lets tests flip acquisition results per-`(namespace, key)`.

--- a/lib/download.py
+++ b/lib/download.py
@@ -329,35 +329,20 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     and marks done. ``_process_beets_validation`` propagates the
     outcome upward so ``_run_completed_processing`` can distinguish
     ``deferred`` from ``success`` / ``failure`` on the release-lock
-    contention path (issue #132 P1, Codex PR #136 R3 P2/P3).
+    contention path.
 
-    **Release-lock acquisition is at this level, not inside
-    ``dispatch_import``.** Codex PR #136 R4 P1: moving files via
-    ``stage_to_ai`` mutates filesystem state
-    (``slskd_download_dir/<import_folder>/`` → ``beets_staging_dir/``)
-    that is NOT reflected in ``active_download_state``. If contention
-    is detected AFTER staging, the next cycle's
-    ``process_completed_album`` reconstructs the entry from
-    ``active_download_state``, finds the source paths empty, and
-    fails with ``FileNotFoundError``. Fix: acquire the lock BEFORE
-    ``stage_to_ai``. On contention, return deferred without staging
-    so files stay at ``slskd_download_dir/<import_folder>/`` where
-    the resume guard in ``process_completed_album`` (line 201:
-    ``if os.path.exists(dst_file) and not os.path.exists(src_file):
-    continue``) can idempotently re-enter next cycle.
+    This function acquires the RELEASE advisory lock outer for the
+    auto-import path *before* ``stage_to_ai`` runs, so contention
+    leaves files in their slskd-download location and the next
+    cycle's resume guard in ``process_completed_album`` can
+    idempotently re-enter. Redownload paths don't take the lock —
+    they stage-and-mark-done without running the harness, so no
+    cross-process race applies.
 
-    The lock is session-reentrant (PostgreSQL semantics), so
-    ``dispatch_import_core``'s inner acquisition of the same key is a
-    no-op acquire + extra release. Force/manual paths — which don't
-    go through this function — still acquire inside
-    ``dispatch_import_core`` where they need it.
-
-    Redownload paths (``source != 'request'`` or distance above
-    threshold) don't take the lock — they just stage-and-mark-done
-    without running the harness, so no cross-process race applies.
-
-    See ``docs/advisory-locks.md`` for the namespace table, key
-    derivation, ordering rules, and the call-site index.
+    See ``docs/advisory-locks.md`` for namespaces, keys, ordering,
+    and contention behaviour (including the ``stage_to_ai`` rationale
+    for acquiring at this level rather than inside
+    ``dispatch_import_core``).
     """
     from contextlib import nullcontext
     from lib.import_dispatch import DispatchOutcome

--- a/lib/download.py
+++ b/lib/download.py
@@ -355,6 +355,9 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     Redownload paths (``source != 'request'`` or distance above
     threshold) don't take the lock — they just stage-and-mark-done
     without running the harness, so no cross-process race applies.
+
+    See ``docs/advisory-locks.md`` for the namespace table, key
+    derivation, ordering rules, and the call-site index.
     """
     from contextlib import nullcontext
     from lib.import_dispatch import DispatchOutcome

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -619,30 +619,16 @@ def dispatch_import_core(
     outcome_success = False
     outcome_message = ""
 
-    # Cross-process same-release lock (issue #132 P1, issue #133). Held
-    # for the duration of the ``import_one.py`` subprocess. The Palo
-    # Santo blast-radius fix (PR #131) removed the destructive branch
-    # from the harness's ``resolve_duplicate`` handler, but the
-    # post-import cleanup still uses ``max(post_import_ids)`` to pick
-    # "the album we just imported" — vulnerable to a second process
-    # inserting its own same-MBID row between our import finishing and
-    # our re-enumerate query. This lock closes that window across every
-    # entry point (auto-import cycle, web force-import, CLI
-    # manual-import) because every one of them funnels through
-    # ``dispatch_import_core``.
-    #
-    # Non-blocking (``pg_try_advisory_lock``): if another process is
-    # already importing this MBID we return early with no rejection
-    # record. The auto cycle retries on its next timer tick; force/
-    # manual surface a "try again shortly" message to the user. A
-    # blocking wait would hold the caller's PG connection for the full
-    # duration of an unrelated process's import (minutes) without any
-    # clear benefit.
-    #
-    # Key derivation: stable int32 hash of ``mb_release_id`` (str).
-    # Covers both MB UUIDs and Discogs numeric ids since both share
-    # the ``mb_release_id`` column. See
-    # ``lib.pipeline_db.release_id_to_lock_key`` for collision analysis.
+    # Acquire the RELEASE (per-MBID) advisory lock for the duration of
+    # the ``import_one.py`` subprocess. This is the funnel every path
+    # goes through (auto, force, manual), so the lock here closes the
+    # Palo Santo window (issues #132 P1 / #133) for every entry point.
+    # Auto path: ``_handle_valid_result`` has already acquired RELEASE
+    # outer — this acquisition is a session-reentrant no-op. Force/
+    # manual path: this is the first RELEASE acquisition, nested inside
+    # the IMPORT lock held by ``dispatch_import_from_db``.
+    # See ``docs/advisory-locks.md`` for the full rationale, the
+    # ordering rules, and the call-site index.
     from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
                                  release_id_to_lock_key)
     release_lock_key: int | None
@@ -1067,11 +1053,15 @@ def dispatch_import_from_db(
     All other quality checks (downgrade prevention, quality gate, meelo scan,
     denylist) run identically to auto-import.
 
-    Concurrency (issue #92): a per-``request_id`` advisory lock is taken up
-    front. Two concurrent force/manual imports on the same request (double-
-    click in the UI, racing CLI invocations) would otherwise each run the
-    full pipeline and write duplicate ``download_log`` rows. The second
-    caller fast-fails without side effects.
+    Concurrency (issue #92): a per-``request_id`` advisory lock (IMPORT
+    namespace) is taken up front. Two concurrent force/manual imports
+    on the same request (double-click in the UI, racing CLI
+    invocations) would otherwise each run the full pipeline and write
+    duplicate ``download_log`` rows. The second caller fast-fails
+    without side effects. ``dispatch_import_core`` below will acquire
+    the RELEASE lock as the inner nested acquisition. See
+    ``docs/advisory-locks.md`` for namespaces, ordering, and the
+    call-site index.
 
     Args:
         db: PipelineDB instance

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -28,27 +28,20 @@ DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localh
 BACKOFF_BASE_MINUTES = 30
 BACKOFF_MAX_MINUTES = 60 * 24  # 24 hours
 
-# Advisory-lock namespace for force/manual-import concurrency protection
-# (issue #92). The two-arg pg_advisory_lock takes (int4, int4); the first
-# arg is a per-feature namespace constant, the second is the request_id.
-# 0x46494D50 = ASCII "FIMP" — recognisable in pg_locks during debugging.
+# Advisory-lock namespaces. Every lock in this codebase is
+# session-scoped, non-blocking (``pg_try_advisory_lock``), and
+# session-reentrant. See ``docs/advisory-locks.md`` for the canonical
+# rules covering namespace values, key derivation, ordering, and call
+# sites. Every acquire site links back there.
+
+# Per-request lock — force/manual-import double-click protection
+# (issue #92). Key = ``request_id``. ``0x46494D50`` = ASCII "FIMP",
+# recognisable in ``pg_locks`` during debugging.
 ADVISORY_LOCK_NAMESPACE_IMPORT = 0x46494D50
 
-# Advisory-lock namespace for same-release concurrency protection
-# (issue #132 P1, issue #133). ``ADVISORY_LOCK_NAMESPACE_IMPORT`` above
-# serialises operations on the same *request_id* — it prevents a
-# double-click on force-import from running the pipeline twice for the
-# same album row. That is NOT enough to close the Palo Santo blast
-# radius: the auto-import cycle and the web force-import path can each
-# hold its own per-request lock while both targeting the same MBID
-# (different request_id, same release). In that race,
-# ``import_one.py``'s post-import ``max(post_import_ids)`` query can
-# pick up the OTHER process's newly-inserted row as "the newest" and
-# delete the row this process just imported. The fix is to serialise
-# at the release level too: every ``dispatch_import_core`` invocation
-# acquires this lock keyed on a stable hash of ``mb_release_id``.
-#
-# 0x52454C45 = ASCII "RELE" — recognisable alongside FIMP in pg_locks.
+# Per-release lock — Palo Santo protection (issue #132 P1, issue #133).
+# Key = ``release_id_to_lock_key(mb_release_id)``. ``0x52454C45`` =
+# ASCII "RELE", recognisable alongside FIMP in ``pg_locks``.
 ADVISORY_LOCK_NAMESPACE_RELEASE = 0x52454C45
 
 
@@ -159,6 +152,9 @@ class PipelineDB:
         single session, so this only protects against inter-session races;
         the web server (single-threaded ``HTTPServer``) already serialises
         within its own session.
+
+        See ``docs/advisory-locks.md`` for namespaces, keys, ordering,
+        and call-site index.
         """
         self._ensure_conn()
         with self.conn.cursor() as cur:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -33,8 +33,12 @@ class DownloadLogRow:
     beets_detail: str | None = None
     staged_path: str | None = None
     error_message: str | None = None
-    validation_result: str | None = None
-    import_result: str | None = None
+    validation_result: Any = None
+    import_result: Any = None
+    # Auto-assigned monotonic id matching PostgreSQL serial behaviour.
+    id: int = 0
+    # Auto-populated timestamp matching download_log.created_at.
+    created_at: datetime = field(default_factory=_utcnow)
     # Catch-all for less commonly asserted fields
     extra: dict[str, Any] = field(default_factory=dict)
 
@@ -45,6 +49,27 @@ class DenylistEntry:
     request_id: int
     username: str
     reason: str | None = None
+
+
+@dataclass
+class SearchLogRow:
+    """One row in search_log, captured by FakePipelineDB.log_search."""
+    request_id: int
+    query: str | None = None
+    result_count: int | None = None
+    elapsed_s: float | None = None
+    outcome: str = "error"
+    id: int = 0
+    created_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass
+class UserCooldownRow:
+    """One row in user_cooldowns, captured by FakePipelineDB.add_cooldown."""
+    username: str
+    cooldown_until: datetime
+    reason: str | None = None
+    created_at: datetime = field(default_factory=_utcnow)
 
 
 @dataclass
@@ -245,7 +270,10 @@ class FakePipelineDB:
 
     def __init__(self) -> None:
         self._requests: dict[int, dict[str, Any]] = {}
+        self._tracks: dict[int, list[dict[str, Any]]] = {}
         self.download_logs: list[DownloadLogRow] = []
+        self.search_logs: list[SearchLogRow] = []
+        self.user_cooldowns: dict[str, UserCooldownRow] = {}
         self.denylist: list[DenylistEntry] = []
         self.cooldowns_applied: list[str] = []
         self.recorded_attempts: list[tuple[int, str]] = []
@@ -253,6 +281,10 @@ class FakePipelineDB:
         self.update_download_state_calls: list[tuple[int, str]] = []
         self.clear_download_state_calls: list[int] = []
         self.advisory_lock_calls: list[tuple[int, int]] = []
+        self.closed = False
+        self._next_request_id = 0
+        self._next_download_log_id = 0
+        self._next_search_log_id = 0
         self._cooldown_result: bool | Callable[[str], bool] = False
         self._advisory_lock_result: (
             bool | Callable[[int, int], bool]) = True
@@ -263,6 +295,8 @@ class FakePipelineDB:
         """Add a request row to the fake DB. Must include 'id'."""
         rid = row["id"]
         self._requests[rid] = copy.deepcopy(row)
+        if rid > self._next_request_id:
+            self._next_request_id = rid
 
     def request(self, request_id: int) -> dict[str, Any]:
         """Get a request row (for test assertions). Raises KeyError if missing."""
@@ -431,10 +465,23 @@ class FakePipelineDB:
             "staged_path", "error_message", "validation_result",
             "import_result",
         }
-        entry_kwargs = {k: kwargs.get(k) for k in named}
         extra = {k: v for k, v in kwargs.items() if k not in named}
+        self._next_download_log_id += 1
         self.download_logs.append(DownloadLogRow(
-            request_id=request_id, **entry_kwargs, extra=extra))
+            request_id=request_id,
+            outcome=kwargs.get("outcome"),
+            soulseek_username=kwargs.get("soulseek_username"),
+            filetype=kwargs.get("filetype"),
+            beets_distance=kwargs.get("beets_distance"),
+            beets_scenario=kwargs.get("beets_scenario"),
+            beets_detail=kwargs.get("beets_detail"),
+            staged_path=kwargs.get("staged_path"),
+            error_message=kwargs.get("error_message"),
+            validation_result=kwargs.get("validation_result"),
+            import_result=kwargs.get("import_result"),
+            id=self._next_download_log_id,
+            extra=extra,
+        ))
 
     def add_denylist(self, request_id: int, username: str,
                      reason: str | None = None) -> None:
@@ -495,6 +542,377 @@ class FakePipelineDB:
         if row:
             row.update(fields)
             row["updated_at"] = _utcnow()
+
+    # --- Session lifecycle ---
+
+    def close(self) -> None:
+        """Record that the fake connection was closed. No-op otherwise."""
+        self.closed = True
+
+    # --- album_requests write + query ---
+
+    def add_request(self, artist_name: str, album_title: str, source: str,
+                    mb_release_id: str | None = None,
+                    mb_release_group_id: str | None = None,
+                    mb_artist_id: str | None = None,
+                    discogs_release_id: str | None = None,
+                    year: int | None = None, country: str | None = None,
+                    format: str | None = None,
+                    source_path: str | None = None,
+                    reasoning: str | None = None,
+                    status: str = "wanted") -> int:
+        self._next_request_id += 1
+        rid = self._next_request_id
+        now = _utcnow()
+        self._requests[rid] = {
+            "id": rid,
+            "artist_name": artist_name,
+            "album_title": album_title,
+            "source": source,
+            "mb_release_id": mb_release_id,
+            "mb_release_group_id": mb_release_group_id,
+            "mb_artist_id": mb_artist_id,
+            "discogs_release_id": discogs_release_id,
+            "year": year,
+            "country": country,
+            "format": format,
+            "source_path": source_path,
+            "reasoning": reasoning,
+            "status": status,
+            "created_at": now,
+            "updated_at": now,
+        }
+        return rid
+
+    def delete_request(self, request_id: int) -> None:
+        self._requests.pop(request_id, None)
+        self._tracks.pop(request_id, None)
+
+    def get_wanted(self, limit: int | None = None) -> list[dict[str, Any]]:
+        """Return wanted requests past their retry gate, new ones first."""
+        now = _utcnow()
+        eligible = [
+            r for r in self._requests.values()
+            if r.get("status") == "wanted"
+            and (r.get("next_retry_after") is None
+                 or r["next_retry_after"] <= now)
+        ]
+        # Mirrors the real ORDER BY: search_attempts=0 first, then
+        # random — the fake uses insertion order for determinism.
+        eligible.sort(
+            key=lambda r: 0 if (r.get("search_attempts") or 0) == 0 else 1)
+        if limit is not None:
+            eligible = eligible[:int(limit)]
+        return [copy.deepcopy(r) for r in eligible]
+
+    def get_log(self, limit: int = 50,
+                outcome_filter: str | None = None,
+                ) -> list[dict[str, object]]:
+        imported = {"success", "force_import"}
+        rejected = {"rejected", "failed", "timeout"}
+        rows: list[dict[str, object]] = []
+        # Newest-first to match the real ORDER BY dl.created_at DESC.
+        for entry in reversed(self.download_logs):
+            if outcome_filter == "imported" and entry.outcome not in imported:
+                continue
+            if outcome_filter == "rejected" and entry.outcome not in rejected:
+                continue
+            req = self._requests.get(entry.request_id, {})
+            joined: dict[str, object] = {
+                "id": entry.id,
+                "request_id": entry.request_id,
+                "outcome": entry.outcome,
+                "soulseek_username": entry.soulseek_username,
+                "filetype": entry.filetype,
+                "beets_distance": entry.beets_distance,
+                "beets_scenario": entry.beets_scenario,
+                "beets_detail": entry.beets_detail,
+                "staged_path": entry.staged_path,
+                "error_message": entry.error_message,
+                "validation_result": entry.validation_result,
+                "import_result": entry.import_result,
+                "created_at": entry.created_at,
+                # Joined request columns.
+                "album_title": req.get("album_title"),
+                "artist_name": req.get("artist_name"),
+                "mb_release_id": req.get("mb_release_id"),
+                "year": req.get("year"),
+                "country": req.get("country"),
+                "request_status": req.get("status"),
+                "request_min_bitrate": req.get("min_bitrate"),
+                "prev_min_bitrate": req.get("prev_min_bitrate"),
+                "search_filetype_override": req.get(
+                    "search_filetype_override"),
+                "source": req.get("source"),
+            }
+            rows.append(joined)
+            if len(rows) >= limit:
+                break
+        return rows
+
+    def get_by_status(self, status: str) -> list[dict[str, Any]]:
+        return [
+            copy.deepcopy(r) for r in sorted(
+                (r for r in self._requests.values()
+                 if r.get("status") == status),
+                key=lambda r: r.get("created_at") or _utcnow())
+        ]
+
+    def get_recent(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Return requests that have at least one download_log row."""
+        with_history = {row.request_id for row in self.download_logs}
+        rows = [
+            r for r in self._requests.values() if r["id"] in with_history]
+        rows.sort(
+            key=lambda r: r.get("updated_at") or _utcnow(), reverse=True)
+        return [copy.deepcopy(r) for r in rows[:limit]]
+
+    def count_by_status(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for r in self._requests.values():
+            status = r.get("status") or ""
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    # --- Track management ---
+
+    def set_tracks(self, request_id: int,
+                   tracks: list[dict[str, Any]]) -> None:
+        self._tracks[request_id] = [
+            {
+                "disc_number": t.get("disc_number", 1),
+                "track_number": t["track_number"],
+                "title": t["title"],
+                "length_seconds": t.get("length_seconds"),
+            }
+            for t in tracks
+        ]
+
+    def get_tracks(self, request_id: int) -> list[dict[str, Any]]:
+        rows = list(self._tracks.get(request_id, []))
+        rows.sort(key=lambda t: (t["disc_number"], t["track_number"]))
+        return [copy.deepcopy(t) for t in rows]
+
+    def get_track_counts(self,
+                         request_ids: list[int]) -> dict[int, int]:
+        return {
+            rid: len(self._tracks[rid])
+            for rid in request_ids
+            if rid in self._tracks and self._tracks[rid]
+        }
+
+    # --- Download history queries ---
+
+    def get_download_log_entry(self,
+                               log_id: int) -> dict[str, Any] | None:
+        for entry in self.download_logs:
+            if entry.id == log_id:
+                return self._download_log_to_dict(entry)
+        return None
+
+    def get_download_history(self,
+                             request_id: int) -> list[dict[str, Any]]:
+        return [
+            self._download_log_to_dict(e)
+            for e in reversed(self.download_logs)
+            if e.request_id == request_id
+        ]
+
+    def get_download_history_batch(
+        self, request_ids: list[int],
+    ) -> dict[int, list[dict[str, Any]]]:
+        wanted = set(request_ids)
+        result: dict[int, list[dict[str, Any]]] = {}
+        for entry in reversed(self.download_logs):
+            if entry.request_id not in wanted:
+                continue
+            result.setdefault(entry.request_id, []).append(
+                self._download_log_to_dict(entry))
+        return result
+
+    def _download_log_to_dict(self,
+                              entry: DownloadLogRow) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            "id": entry.id,
+            "request_id": entry.request_id,
+            "outcome": entry.outcome,
+            "soulseek_username": entry.soulseek_username,
+            "filetype": entry.filetype,
+            "beets_distance": entry.beets_distance,
+            "beets_scenario": entry.beets_scenario,
+            "beets_detail": entry.beets_detail,
+            "staged_path": entry.staged_path,
+            "error_message": entry.error_message,
+            "validation_result": entry.validation_result,
+            "import_result": entry.import_result,
+            "created_at": entry.created_at,
+        }
+        row.update(entry.extra)
+        return row
+
+    # --- Wrong-match review queue ---
+
+    def get_wrong_matches(self) -> list[dict[str, object]]:
+        """Rejected downloads whose ``validation_result.failed_path`` is set.
+
+        Mirrors the real ``DISTINCT ON (request_id, failed_path)`` —
+        collapse to newest per ``(request_id, failed_path)``, then sort
+        newest-first within each request.
+        """
+        skip_scenarios = {"audio_corrupt", "spectral_reject"}
+        collapsed: dict[tuple[int, str], DownloadLogRow] = {}
+        for entry in self.download_logs:
+            if entry.outcome != "rejected":
+                continue
+            vr = self._validation_result_dict(entry.validation_result)
+            failed_path = vr.get("failed_path") if vr else None
+            if not failed_path:
+                continue
+            if vr and vr.get("scenario") in skip_scenarios:
+                continue
+            key = (entry.request_id, str(failed_path))
+            prev = collapsed.get(key)
+            if prev is None or entry.id > prev.id:
+                collapsed[key] = entry
+        rows: list[dict[str, object]] = []
+        for entry in collapsed.values():
+            req = self._requests.get(entry.request_id, {})
+            rows.append({
+                "download_log_id": entry.id,
+                "request_id": entry.request_id,
+                "artist_name": req.get("artist_name"),
+                "album_title": req.get("album_title"),
+                "mb_release_id": req.get("mb_release_id"),
+                "soulseek_username": entry.soulseek_username,
+                "validation_result": entry.validation_result,
+                "request_status": req.get("status"),
+                "request_min_bitrate": req.get("min_bitrate"),
+                "request_verified_lossless": req.get("verified_lossless"),
+                "request_current_spectral_grade": req.get(
+                    "current_spectral_grade"),
+                "request_current_spectral_bitrate": req.get(
+                    "current_spectral_bitrate"),
+                "request_imported_path": req.get("imported_path"),
+            })
+        rows.sort(key=lambda r: (
+            r["request_id"], -int(r["download_log_id"])))  # type: ignore[arg-type, operator]
+        return rows
+
+    def clear_wrong_match_path(self, log_id: int) -> bool:
+        """Strip ``failed_path`` from a download_log row's validation_result.
+
+        Returns True when the entry was found and carried a failed_path.
+        """
+        for entry in self.download_logs:
+            if entry.id != log_id:
+                continue
+            vr = self._validation_result_dict(entry.validation_result)
+            if not vr or "failed_path" not in vr:
+                return False
+            new_vr = {k: v for k, v in vr.items() if k != "failed_path"}
+            if isinstance(entry.validation_result, str):
+                entry.validation_result = json.dumps(new_vr)
+            else:
+                entry.validation_result = new_vr
+            return True
+        return False
+
+    @staticmethod
+    def _validation_result_dict(vr: Any) -> dict[str, Any] | None:
+        if isinstance(vr, dict):
+            return vr
+        if isinstance(vr, str):
+            try:
+                parsed = json.loads(vr)
+            except (json.JSONDecodeError, ValueError):
+                return None
+            return parsed if isinstance(parsed, dict) else None
+        return None
+
+    # --- Search log ---
+
+    def log_search(self, request_id: int, query: str | None = None,
+                   result_count: int | None = None,
+                   elapsed_s: float | None = None,
+                   outcome: str = "error") -> None:
+        self._next_search_log_id += 1
+        self.search_logs.append(SearchLogRow(
+            request_id=request_id,
+            query=query,
+            result_count=result_count,
+            elapsed_s=elapsed_s,
+            outcome=outcome,
+            id=self._next_search_log_id,
+        ))
+
+    def get_search_history(self,
+                           request_id: int) -> list[dict[str, object]]:
+        return [
+            self._search_log_to_dict(e)
+            for e in reversed(self.search_logs)
+            if e.request_id == request_id
+        ]
+
+    def get_search_history_batch(
+        self, request_ids: list[int],
+    ) -> dict[int, list[dict[str, object]]]:
+        wanted = set(request_ids)
+        result: dict[int, list[dict[str, object]]] = {}
+        for entry in reversed(self.search_logs):
+            if entry.request_id not in wanted:
+                continue
+            result.setdefault(entry.request_id, []).append(
+                self._search_log_to_dict(entry))
+        return result
+
+    @staticmethod
+    def _search_log_to_dict(entry: SearchLogRow) -> dict[str, object]:
+        return {
+            "id": entry.id,
+            "request_id": entry.request_id,
+            "query": entry.query,
+            "result_count": entry.result_count,
+            "elapsed_s": entry.elapsed_s,
+            "outcome": entry.outcome,
+            "created_at": entry.created_at,
+        }
+
+    # --- User cooldowns ---
+
+    def add_cooldown(self, username: str, cooldown_until: datetime,
+                     reason: str | None = None) -> None:
+        """Upsert a cooldown keyed by username."""
+        existing = self.user_cooldowns.get(username)
+        created_at = existing.created_at if existing is not None else _utcnow()
+        self.user_cooldowns[username] = UserCooldownRow(
+            username=username,
+            cooldown_until=cooldown_until,
+            reason=reason,
+            created_at=created_at,
+        )
+
+    def get_cooled_down_users(self) -> list[str]:
+        now = _utcnow()
+        return [
+            c.username for c in self.user_cooldowns.values()
+            if c.cooldown_until > now
+        ]
+
+    def get_user_cooldowns(self) -> list[dict[str, Any]]:
+        rows = sorted(
+            self.user_cooldowns.values(),
+            key=lambda c: c.cooldown_until,
+            reverse=True,
+        )
+        return [
+            {
+                "username": c.username,
+                "cooldown_until": c.cooldown_until,
+                "reason": c.reason,
+                "created_at": c.created_at,
+            }
+            for c in rows
+        ]
 
     def assert_log(self, test: Any, index: int, **expected: Any) -> None:
         """Assert fields on a download_log entry at the given index.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -637,24 +637,52 @@ class FakePipelineDB:
                     source_path: str | None = None,
                     reasoning: str | None = None,
                     status: str = "wanted") -> int:
+        """Insert an album_requests row.
+
+        Seeds the full ``album_requests`` column set (matching
+        ``make_request_row`` in ``tests/helpers.py``) so fake-backed
+        tests that then read DB-defaulted fields like ``beets_distance``
+        or ``*_attempts`` see the same NULL/0 defaults production
+        callers get from PostgreSQL. Codex R7.
+        """
         self._next_request_id += 1
         rid = self._next_request_id
         now = _utcnow()
         self._requests[rid] = {
             "id": rid,
-            "artist_name": artist_name,
-            "album_title": album_title,
-            "source": source,
             "mb_release_id": mb_release_id,
             "mb_release_group_id": mb_release_group_id,
             "mb_artist_id": mb_artist_id,
             "discogs_release_id": discogs_release_id,
+            "artist_name": artist_name,
+            "album_title": album_title,
             "year": year,
             "country": country,
             "format": format,
+            "source": source,
             "source_path": source_path,
             "reasoning": reasoning,
             "status": status,
+            "search_attempts": 0,
+            "download_attempts": 0,
+            "validation_attempts": 0,
+            "last_attempt_at": None,
+            "next_retry_after": None,
+            "beets_distance": None,
+            "beets_scenario": None,
+            "imported_path": None,
+            "search_filetype_override": None,
+            "target_format": None,
+            "min_bitrate": None,
+            "prev_min_bitrate": None,
+            "lidarr_album_id": None,
+            "lidarr_artist_id": None,
+            "last_download_spectral_bitrate": None,
+            "last_download_spectral_grade": None,
+            "verified_lossless": False,
+            "current_spectral_grade": None,
+            "current_spectral_bitrate": None,
+            "active_download_state": None,
             "created_at": now,
             "updated_at": now,
         }

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -21,6 +21,33 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _as_datetime(value: Any) -> datetime:
+    """Normalise a timestamp-ish value to an aware ``datetime``.
+
+    ``make_request_row`` seeds ISO-string ``created_at``/``updated_at``
+    columns while ``FakePipelineDB.add_request`` stores datetimes.
+    Sorting with a mixed key would raise ``TypeError``; this helper
+    collapses both shapes to a comparable datetime (aware, UTC) and
+    uses ``_EPOCH`` as the sentinel for missing values so ordering
+    stays deterministic.
+    """
+    if value is None:
+        return _EPOCH
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return _EPOCH
+        return parsed if parsed.tzinfo else parsed.replace(
+            tzinfo=timezone.utc)
+    return _EPOCH
+
+
 @dataclass
 class DownloadLogRow:
     """One row in download_log, captured by FakePipelineDB.log_download."""
@@ -634,8 +661,22 @@ class FakePipelineDB:
         return rid
 
     def delete_request(self, request_id: int) -> None:
+        """Delete a request and cascade to child tables.
+
+        Real ``album_requests`` has ``ON DELETE CASCADE`` foreign keys
+        from ``album_tracks``, ``download_log``, ``search_log``, and
+        ``source_denylist`` (see ``migrations/001_initial.sql``). Mirror
+        that here so fake-backed tests cannot observe an impossible
+        post-delete state where child rows survive their parent.
+        """
         self._requests.pop(request_id, None)
         self._tracks.pop(request_id, None)
+        self.download_logs = [
+            e for e in self.download_logs if e.request_id != request_id]
+        self.search_logs = [
+            e for e in self.search_logs if e.request_id != request_id]
+        self.denylist = [
+            e for e in self.denylist if e.request_id != request_id]
 
     def get_wanted(self, limit: int | None = None) -> list[dict[str, Any]]:
         """Return wanted requests past their retry gate, new ones first.
@@ -673,20 +714,14 @@ class FakePipelineDB:
             if outcome_filter == "rejected" and entry.outcome not in rejected:
                 continue
             req = self._requests.get(entry.request_id, {})
-            joined: dict[str, object] = {
-                "id": entry.id,
-                "request_id": entry.request_id,
-                "outcome": entry.outcome,
-                "soulseek_username": entry.soulseek_username,
-                "filetype": entry.filetype,
-                "beets_distance": entry.beets_distance,
-                "beets_scenario": entry.beets_scenario,
-                "beets_detail": entry.beets_detail,
-                "staged_path": entry.staged_path,
-                "error_message": entry.error_message,
-                "validation_result": entry.validation_result,
-                "import_result": entry.import_result,
-                "created_at": entry.created_at,
+            # Real SQL is ``SELECT dl.*, ar.album_title, …`` — every
+            # download_log column must appear, including the auxiliary
+            # fields ``log_download`` parks in ``entry.extra``
+            # (bitrate, actual_filetype, spectral_grade, final_format,
+            # etc.). Dropping them here would silently mis-classify rows
+            # in callers that feed ``get_log`` into LogEntry.from_row.
+            joined: dict[str, object] = self._download_log_to_dict(entry)
+            joined.update({
                 # Joined request columns.
                 "album_title": req.get("album_title"),
                 "artist_name": req.get("artist_name"),
@@ -699,7 +734,7 @@ class FakePipelineDB:
                 "search_filetype_override": req.get(
                     "search_filetype_override"),
                 "source": req.get("source"),
-            }
+            })
             rows.append(joined)
             if len(rows) >= limit:
                 break
@@ -710,7 +745,7 @@ class FakePipelineDB:
             copy.deepcopy(r) for r in sorted(
                 (r for r in self._requests.values()
                  if r.get("status") == status),
-                key=lambda r: r.get("created_at") or _utcnow())
+                key=lambda r: _as_datetime(r.get("created_at")))
         ]
 
     def get_recent(self, limit: int = 20) -> list[dict[str, Any]]:
@@ -718,14 +753,13 @@ class FakePipelineDB:
         with_history = {row.request_id for row in self.download_logs}
         rows = [
             r for r in self._requests.values() if r["id"] in with_history]
-        # Use a sentinel for missing ``updated_at`` so Python's stable
-        # sort is deterministic (computing ``_utcnow()`` per key call
-        # would produce a fresh timestamp each comparison and make
-        # ordering non-deterministic when multiple rows share the
-        # sentinel).
-        epoch = datetime.min.replace(tzinfo=timezone.utc)
+        # ``_as_datetime`` normalises ISO strings (from ``make_request_row``)
+        # and datetimes (from ``add_request``) to one representation so
+        # Python's stable sort does not raise ``TypeError`` on mixed inputs,
+        # and uses a fixed epoch sentinel for missing ``updated_at`` so
+        # ordering stays deterministic.
         rows.sort(
-            key=lambda r: r.get("updated_at") or epoch, reverse=True)
+            key=lambda r: _as_datetime(r.get("updated_at")), reverse=True)
         return [copy.deepcopy(r) for r in rows[:limit]]
 
     def count_by_status(self) -> dict[str | None, int]:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -458,29 +458,78 @@ class FakePipelineDB:
                 row["active_download_state"] = state_json
             row["updated_at"] = _utcnow()
 
-    def log_download(self, request_id: int, **kwargs: Any) -> None:
-        named = {
-            "outcome", "soulseek_username", "filetype",
-            "beets_distance", "beets_scenario", "beets_detail",
-            "staged_path", "error_message", "validation_result",
-            "import_result",
-        }
-        extra = {k: v for k, v in kwargs.items() if k not in named}
+    def log_download(self, request_id: int,
+                     soulseek_username: str | None = None,
+                     filetype: str | None = None,
+                     download_path: str | None = None,
+                     beets_distance: float | None = None,
+                     beets_scenario: str | None = None,
+                     beets_detail: str | None = None,
+                     valid: bool | None = None,
+                     outcome: str | None = None,
+                     staged_path: str | None = None,
+                     error_message: str | None = None,
+                     bitrate: int | None = None,
+                     sample_rate: int | None = None,
+                     bit_depth: int | None = None,
+                     is_vbr: bool | None = None,
+                     was_converted: bool | None = None,
+                     original_filetype: str | None = None,
+                     slskd_filetype: str | None = None,
+                     slskd_bitrate: int | None = None,
+                     actual_filetype: str | None = None,
+                     actual_min_bitrate: int | None = None,
+                     spectral_grade: str | None = None,
+                     spectral_bitrate: int | None = None,
+                     existing_min_bitrate: int | None = None,
+                     existing_spectral_bitrate: int | None = None,
+                     import_result: Any = None,
+                     validation_result: Any = None,
+                     final_format: str | None = None,
+                     **extra: Any) -> None:
+        """Record a download_log row.
+
+        Every parameter name matches ``PipelineDB.log_download`` exactly
+        — the contract test in ``test_fakes.py`` enforces this. Only
+        the 11 "first-class" fields land on ``DownloadLogRow``; the
+        remaining named fields plus any test-only ``**extra`` merge into
+        ``.extra`` so ``assert_log`` can still introspect them.
+        """
         self._next_download_log_id += 1
+        auxiliary: dict[str, Any] = {
+            "download_path": download_path,
+            "valid": valid,
+            "bitrate": bitrate,
+            "sample_rate": sample_rate,
+            "bit_depth": bit_depth,
+            "is_vbr": is_vbr,
+            "was_converted": was_converted,
+            "original_filetype": original_filetype,
+            "slskd_filetype": slskd_filetype,
+            "slskd_bitrate": slskd_bitrate,
+            "actual_filetype": actual_filetype,
+            "actual_min_bitrate": actual_min_bitrate,
+            "spectral_grade": spectral_grade,
+            "spectral_bitrate": spectral_bitrate,
+            "existing_min_bitrate": existing_min_bitrate,
+            "existing_spectral_bitrate": existing_spectral_bitrate,
+            "final_format": final_format,
+        }
+        auxiliary.update(extra)
         self.download_logs.append(DownloadLogRow(
             request_id=request_id,
-            outcome=kwargs.get("outcome"),
-            soulseek_username=kwargs.get("soulseek_username"),
-            filetype=kwargs.get("filetype"),
-            beets_distance=kwargs.get("beets_distance"),
-            beets_scenario=kwargs.get("beets_scenario"),
-            beets_detail=kwargs.get("beets_detail"),
-            staged_path=kwargs.get("staged_path"),
-            error_message=kwargs.get("error_message"),
-            validation_result=kwargs.get("validation_result"),
-            import_result=kwargs.get("import_result"),
+            outcome=outcome,
+            soulseek_username=soulseek_username,
+            filetype=filetype,
+            beets_distance=beets_distance,
+            beets_scenario=beets_scenario,
+            beets_detail=beets_detail,
+            staged_path=staged_path,
+            error_message=error_message,
+            validation_result=validation_result,
+            import_result=import_result,
             id=self._next_download_log_id,
-            extra=extra,
+            extra=auxiliary,
         ))
 
     def add_denylist(self, request_id: int, username: str,
@@ -589,7 +638,15 @@ class FakePipelineDB:
         self._tracks.pop(request_id, None)
 
     def get_wanted(self, limit: int | None = None) -> list[dict[str, Any]]:
-        """Return wanted requests past their retry gate, new ones first."""
+        """Return wanted requests past their retry gate, new ones first.
+
+        Mirrors the real ORDER BY (``search_attempts=0`` ahead of the
+        rest) but breaks ties in insertion order rather than with
+        ``RANDOM()`` so tests are deterministic. Callers that care
+        about specific rows within a priority bucket should assert on
+        set membership rather than list order — the real DB randomises
+        ties every cycle.
+        """
         now = _utcnow()
         eligible = [
             r for r in self._requests.values()
@@ -597,8 +654,6 @@ class FakePipelineDB:
             and (r.get("next_retry_after") is None
                  or r["next_retry_after"] <= now)
         ]
-        # Mirrors the real ORDER BY: search_attempts=0 first, then
-        # random — the fake uses insertion order for determinism.
         eligible.sort(
             key=lambda r: 0 if (r.get("search_attempts") or 0) == 0 else 1)
         if limit is not None:
@@ -663,14 +718,20 @@ class FakePipelineDB:
         with_history = {row.request_id for row in self.download_logs}
         rows = [
             r for r in self._requests.values() if r["id"] in with_history]
+        # Use a sentinel for missing ``updated_at`` so Python's stable
+        # sort is deterministic (computing ``_utcnow()`` per key call
+        # would produce a fresh timestamp each comparison and make
+        # ordering non-deterministic when multiple rows share the
+        # sentinel).
+        epoch = datetime.min.replace(tzinfo=timezone.utc)
         rows.sort(
-            key=lambda r: r.get("updated_at") or _utcnow(), reverse=True)
+            key=lambda r: r.get("updated_at") or epoch, reverse=True)
         return [copy.deepcopy(r) for r in rows[:limit]]
 
-    def count_by_status(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
+    def count_by_status(self) -> dict[str | None, int]:
+        counts: dict[str | None, int] = {}
         for r in self._requests.values():
-            status = r.get("status") or ""
+            status = r.get("status")
             counts[status] = counts.get(status, 0) + 1
         return counts
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -801,6 +801,7 @@ def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
         mismatches.extend(_diff_positional_layout(name, real_sig, fake_sig))
         mismatches.extend(_diff_named_params(name, real_sig, fake_sig))
         mismatches.extend(_diff_variadic(name, real_sig, fake_sig))
+        mismatches.extend(_diff_fake_extras(name, real_sig, fake_sig))
     return mismatches
 
 
@@ -889,6 +890,41 @@ def _diff_named_params(
                 f"{method}({pname}): real has a default but fake "
                 "requires this param (production calls that omit it "
                 "would crash against the fake)")
+    return out
+
+
+def _diff_fake_extras(
+    method: str,
+    real_sig: inspect.Signature,
+    fake_sig: inspect.Signature,
+) -> list[str]:
+    """Fake params absent from real must have defaults.
+
+    A fake that adds a required keyword-only parameter
+    (e.g. ``def m(self, request_id, *, new_required):``) has no match
+    in ``_diff_named_params`` — that helper walks only real params.
+    Every production call that omits the new kwarg works against real
+    but raises ``TypeError`` against the fake. Codex R5.
+
+    Optional extras (with defaults) are fine — they represent
+    test-only bookkeeping the fake may accept.
+    """
+    out: list[str] = []
+    real_names = {p.name for p in real_sig.parameters.values()}
+    for fp in fake_sig.parameters.values():
+        if fp.name == "self":
+            continue
+        if fp.kind in (inspect.Parameter.VAR_POSITIONAL,
+                       inspect.Parameter.VAR_KEYWORD):
+            continue
+        if fp.name in real_names:
+            continue
+        # Fake-only parameter. Required → crashes real-valid callers.
+        if fp.default is inspect.Parameter.empty:
+            out.append(
+                f"{method}({fp.name}): fake requires a parameter not "
+                "on real — production calls that omit it would crash "
+                "against the fake (give it a default, or remove it)")
     return out
 
 
@@ -1050,3 +1086,33 @@ class TestPipelineDBFakeContractInternals(unittest.TestCase):
             any("extra positional parameters" in m for m in diff),
             f"Expected drift for fake with extra positional, got: "
             f"{diff}")
+
+    def test_fake_with_required_keyword_only_not_on_real_is_caught(self):
+        """Codex R5: a fake that adds a required keyword-only
+        parameter real doesn't have would crash any production-valid
+        call that omits it."""
+        class Real:
+            def m(self, request_id: int) -> None:
+                ...
+        class Fake:
+            def m(self, request_id: int, *, new_required: str) -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("new_required" in m and "not on real" in m
+                for m in diff),
+            f"Expected drift for required fake-only kwarg, got: "
+            f"{diff}")
+
+    def test_fake_with_optional_keyword_only_not_on_real_is_allowed(self):
+        """Optional fake-only params (for test-only bookkeeping) are
+        permitted — real-valid callers never pass them, so they don't
+        affect call compatibility."""
+        class Real:
+            def m(self, request_id: int) -> None:
+                ...
+        class Fake:
+            def m(self, request_id: int, *,
+                  test_only: bool = False) -> None:
+                ...
+        self.assertEqual(_diff_signatures(Real, Fake), [])

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -409,6 +409,26 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         rid = db.add_request("X", "Y", source="request")
         self.assertEqual(rid, 43)
 
+    def test_sort_mixes_seeded_iso_strings_and_added_datetimes(self):
+        """``make_request_row`` seeds ISO strings, ``add_request``
+        stores datetimes — the fake must normalise them so sorts
+        don't raise ``TypeError`` on mixed input (codex R2)."""
+        db = FakePipelineDB()
+        # Seeded: ISO string timestamps.
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        # Added: datetime timestamps.
+        db.add_request("Artist", "Album", source="request")
+        # Both of these would crash on ``str < datetime`` without
+        # normalisation.
+        rows = db.get_by_status("wanted")
+        self.assertEqual(len(rows), 2)
+        # Populate download history for both then ensure ``get_recent``
+        # also sorts through the mixed shapes without raising.
+        db.log_download(1, outcome="success")
+        db.log_download(2, outcome="success")
+        recent = db.get_recent()
+        self.assertEqual({r["id"] for r in recent}, {1, 2})
+
     def test_delete_request_removes_row_and_tracks(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))
@@ -416,6 +436,27 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         db.delete_request(1)
         self.assertNotIn(1, db._requests)  # type: ignore[attr-defined]
         self.assertEqual(db.get_tracks(1), [])
+
+    def test_delete_request_cascades_to_child_tables(self):
+        """Real SQL has ``ON DELETE CASCADE`` from album_requests to
+        download_log, search_log, and source_denylist. The fake must
+        prune those too so tests cannot observe an impossible state
+        where orphaned child rows survive their parent (codex R2)."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.seed_request(make_request_row(id=2))
+        db.log_download(1, outcome="success")
+        db.log_download(2, outcome="success")
+        db.log_search(1, outcome="found")
+        db.log_search(2, outcome="no_match")
+        db.add_denylist(1, "badguy")
+        db.add_denylist(2, "other")
+
+        db.delete_request(1)
+
+        self.assertEqual([e.request_id for e in db.download_logs], [2])
+        self.assertEqual([e.request_id for e in db.search_logs], [2])
+        self.assertEqual([e.request_id for e in db.denylist], [2])
 
     def test_get_wanted_prioritizes_new_and_respects_limit(self):
         db = FakePipelineDB()
@@ -467,6 +508,24 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
                          ["rejected", "failed"])
         # Joined request columns present.
         self.assertEqual(all_rows[0]["album_title"], "Album A")
+
+    def test_get_log_surfaces_auxiliary_columns(self):
+        """Real ``get_log`` returns ``dl.*`` — every ``log_download``
+        column must be present, including fields parked in
+        ``entry.extra`` (bitrate, spectral_grade, final_format, etc.)
+        Codex R2: callers that feed these rows into LogEntry.from_row
+        would otherwise classify incomplete data (codex R2)."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.log_download(
+            1, outcome="success",
+            bitrate=256, spectral_grade="genuine",
+            final_format="mp3 v0", actual_min_bitrate=245)
+        rows = db.get_log()
+        self.assertEqual(rows[0]["bitrate"], 256)
+        self.assertEqual(rows[0]["spectral_grade"], "genuine")
+        self.assertEqual(rows[0]["final_format"], "mp3 v0")
+        self.assertEqual(rows[0]["actual_min_bitrate"], 245)
 
     def test_get_by_status_sorts_by_created_at(self):
         db = FakePipelineDB()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1,9 +1,11 @@
 """Tests for lightweight fakes and shared builders."""
 
+import inspect
 import unittest
+from datetime import datetime, timedelta, timezone
 
 from lib.grab_list import DownloadFile, GrabListEntry
-from lib.pipeline_db import RequestSpectralStateUpdate
+from lib.pipeline_db import PipelineDB, RequestSpectralStateUpdate
 from lib.quality import SpectralContext, SpectralMeasurement, ValidationResult
 from tests.fakes import FakePipelineDB, FakeSlskdAPI
 from tests.helpers import (
@@ -373,3 +375,334 @@ class TestFakePipelineDBDiscogs(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1, discogs_release_id="12345"))
         self.assertIsNone(db.get_request_by_discogs_release_id("99999"))
+
+
+class TestFakePipelineDBNewStubs(unittest.TestCase):
+    """Self-tests for fake methods retroactively added under issue #140.
+
+    These cover behaviour that tests relying on the fake may start
+    exercising. Matches the rule in ``.claude/rules/code-quality.md``:
+    "every new PipelineDB method needs an equivalent stub on
+    FakePipelineDB with a self-test in tests/test_fakes.py."
+    """
+
+    def test_close_marks_flag(self):
+        db = FakePipelineDB()
+        self.assertFalse(db.closed)
+        db.close()
+        self.assertTrue(db.closed)
+
+    def test_add_request_assigns_monotonic_id(self):
+        db = FakePipelineDB()
+        rid1 = db.add_request("Artist A", "Album A", source="request")
+        rid2 = db.add_request("Artist B", "Album B", source="request")
+        self.assertEqual((rid1, rid2), (1, 2))
+        self.assertEqual(db.request(rid1)["artist_name"], "Artist A")
+        self.assertEqual(db.request(rid2)["status"], "wanted")
+
+    def test_add_request_coexists_with_seeded_ids(self):
+        """Seeded ids must advance the auto-increment cursor so
+        ``add_request`` cannot collide."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42))
+        rid = db.add_request("X", "Y", source="request")
+        self.assertEqual(rid, 43)
+
+    def test_delete_request_removes_row_and_tracks(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.set_tracks(1, [{"track_number": 1, "title": "T"}])
+        db.delete_request(1)
+        self.assertNotIn(1, db._requests)  # type: ignore[attr-defined]
+        self.assertEqual(db.get_tracks(1), [])
+
+    def test_get_wanted_prioritizes_new_and_respects_limit(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted",
+                                          search_attempts=0))
+        db.seed_request(make_request_row(id=2, status="wanted",
+                                          search_attempts=5))
+        db.seed_request(make_request_row(id=3, status="imported"))
+        rows = db.get_wanted()
+        self.assertEqual([r["id"] for r in rows], [1, 2])
+        self.assertEqual(
+            [r["id"] for r in db.get_wanted(limit=1)], [1])
+
+    def test_get_wanted_skips_albums_inside_retry_window(self):
+        db = FakePipelineDB()
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        db.seed_request(make_request_row(
+            id=1, status="wanted", next_retry_after=future))
+        db.seed_request(make_request_row(id=2, status="wanted"))
+        rows = db.get_wanted()
+        self.assertEqual([r["id"] for r in rows], [2])
+
+    def test_get_log_filters_and_orders_newest_first(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, album_title="Album A"))
+        db.log_download(1, outcome="success")
+        db.log_download(1, outcome="failed")
+        db.log_download(1, outcome="rejected")
+        all_rows = db.get_log()
+        self.assertEqual([r["outcome"] for r in all_rows],
+                         ["rejected", "failed", "success"])
+        imported = db.get_log(outcome_filter="imported")
+        self.assertEqual([r["outcome"] for r in imported], ["success"])
+        rejected = db.get_log(outcome_filter="rejected")
+        self.assertEqual([r["outcome"] for r in rejected],
+                         ["rejected", "failed"])
+        # Joined request columns present.
+        self.assertEqual(all_rows[0]["album_title"], "Album A")
+
+    def test_get_by_status_sorts_by_created_at(self):
+        db = FakePipelineDB()
+        now = datetime.now(timezone.utc)
+        db.seed_request(make_request_row(
+            id=1, status="wanted", created_at=now + timedelta(seconds=2)))
+        db.seed_request(make_request_row(
+            id=2, status="wanted", created_at=now))
+        rows = db.get_by_status("wanted")
+        self.assertEqual([r["id"] for r in rows], [2, 1])
+
+    def test_get_recent_requires_download_history(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.seed_request(make_request_row(id=2))
+        db.log_download(1, outcome="success")
+        rows = db.get_recent()
+        self.assertEqual([r["id"] for r in rows], [1])
+
+    def test_count_by_status(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        db.seed_request(make_request_row(id=2, status="wanted"))
+        db.seed_request(make_request_row(id=3, status="imported"))
+        self.assertEqual(
+            db.count_by_status(), {"wanted": 2, "imported": 1})
+
+    def test_tracks_round_trip_and_count(self):
+        db = FakePipelineDB()
+        db.set_tracks(1, [
+            {"track_number": 2, "title": "Second"},
+            {"track_number": 1, "title": "First"},
+        ])
+        rows = db.get_tracks(1)
+        self.assertEqual([t["track_number"] for t in rows], [1, 2])
+        self.assertEqual(db.get_track_counts([1, 99]), {1: 2})
+
+    def test_download_log_history_and_lookup_by_id(self):
+        db = FakePipelineDB()
+        db.log_download(1, outcome="success")
+        db.log_download(1, outcome="failed")
+        db.log_download(2, outcome="rejected")
+
+        history_1 = db.get_download_history(1)
+        self.assertEqual([r["outcome"] for r in history_1],
+                         ["failed", "success"])
+        batch = db.get_download_history_batch([1, 2])
+        self.assertEqual({k: [r["outcome"] for r in v]
+                          for k, v in batch.items()},
+                         {1: ["failed", "success"], 2: ["rejected"]})
+
+        first_id = db.download_logs[0].id
+        entry = db.get_download_log_entry(first_id)
+        assert entry is not None
+        self.assertEqual(entry["outcome"], "success")
+        self.assertIsNone(db.get_download_log_entry(99999))
+
+    def test_get_wrong_matches_collapses_per_request_and_path(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, artist_name="A", album_title="B"))
+        # Two rejections on the same (request, failed_path) — keep newest.
+        db.log_download(1, outcome="rejected",
+                        validation_result={"failed_path": "/p1"})
+        db.log_download(1, outcome="rejected",
+                        validation_result={"failed_path": "/p1"})
+        # Different path — separate row.
+        db.log_download(1, outcome="rejected",
+                        validation_result={"failed_path": "/p2"})
+        # Scenario filtered out.
+        db.log_download(1, outcome="rejected", validation_result={
+            "failed_path": "/p3", "scenario": "audio_corrupt"})
+        # Non-rejected — ignored.
+        db.log_download(1, outcome="success",
+                        validation_result={"failed_path": "/p4"})
+
+        rows = db.get_wrong_matches()
+        paths = sorted([
+            (r["validation_result"] or {}).get("failed_path")  # type: ignore[union-attr]
+            for r in rows])
+        self.assertEqual(paths, ["/p1", "/p2"])
+
+    def test_clear_wrong_match_path_strips_key(self):
+        db = FakePipelineDB()
+        db.log_download(1, outcome="rejected",
+                        validation_result={"failed_path": "/p1",
+                                           "scenario": "wrong_match"})
+        log_id = db.download_logs[0].id
+        self.assertTrue(db.clear_wrong_match_path(log_id))
+        vr = db.download_logs[0].validation_result
+        assert isinstance(vr, dict)
+        self.assertNotIn("failed_path", vr)
+        self.assertEqual(vr["scenario"], "wrong_match")
+        # Second call returns False (already stripped).
+        self.assertFalse(db.clear_wrong_match_path(log_id))
+
+    def test_clear_wrong_match_path_handles_json_string(self):
+        """Real ``validation_result`` is JSONB — fakes also accept JSON
+        strings so tests can pass either shape."""
+        import json as _json
+        db = FakePipelineDB()
+        db.log_download(1, outcome="rejected",
+                        validation_result=_json.dumps(
+                            {"failed_path": "/p", "x": 1}))
+        self.assertTrue(
+            db.clear_wrong_match_path(db.download_logs[0].id))
+        stored = _json.loads(db.download_logs[0].validation_result)  # type: ignore[arg-type]
+        self.assertNotIn("failed_path", stored)
+
+    def test_search_log_history_and_batch(self):
+        db = FakePipelineDB()
+        db.log_search(1, query="a b", outcome="found", result_count=10,
+                      elapsed_s=0.5)
+        db.log_search(1, query="c d", outcome="no_match")
+        db.log_search(2, query="e f", outcome="error")
+
+        history_1 = db.get_search_history(1)
+        self.assertEqual([r["outcome"] for r in history_1],
+                         ["no_match", "found"])
+        batch = db.get_search_history_batch([1, 2])
+        self.assertEqual(
+            {k: [r["outcome"] for r in v] for k, v in batch.items()},
+            {1: ["no_match", "found"], 2: ["error"]})
+
+    def test_user_cooldowns_upsert_and_filter(self):
+        db = FakePipelineDB()
+        now = datetime.now(timezone.utc)
+        db.add_cooldown("alice", now + timedelta(days=3), reason="x")
+        db.add_cooldown("bob", now - timedelta(days=1), reason="expired")
+        # Upsert — second call on alice replaces cooldown_until/reason.
+        db.add_cooldown("alice", now + timedelta(days=7), reason="y")
+
+        active = db.get_cooled_down_users()
+        self.assertEqual(active, ["alice"])
+
+        rows = db.get_user_cooldowns()
+        # Newest cooldown_until first.
+        self.assertEqual([r["username"] for r in rows], ["alice", "bob"])
+        self.assertEqual(rows[0]["reason"], "y")
+
+
+def _public_methods(cls: type) -> set[str]:
+    """Return the set of non-underscore method names defined on ``cls``."""
+    return {
+        name for name, obj in vars(cls).items()
+        if callable(obj) and not name.startswith("_")
+    }
+
+
+class TestPipelineDBFakeContract(unittest.TestCase):
+    """Enforce FakePipelineDB stays in lockstep with PipelineDB.
+
+    Models ``TestRouteContractAudit`` (tests/test_web_server.py): the
+    convention in ``.claude/rules/code-quality.md`` — "every new
+    PipelineDB method must have a matching stub on FakePipelineDB with
+    a self-test in tests/test_fakes.py" — is enforced at test time, not
+    at review time.
+
+    Silent drift was possible before this test existed. In PR #136
+    ``update_imported_path_by_release_id`` only got its direct self-test
+    after the final-review agent flagged it; any orchestration test
+    that tried to call the method via a fake that lacked it would have
+    crashed with ``AttributeError``. A new kwarg on a real method would
+    be silently swallowed if the fake accepted ``**kwargs``.
+    """
+
+    def test_fake_exposes_every_public_method_of_real(self) -> None:
+        """Every non-underscore method on ``PipelineDB`` must exist on
+        ``FakePipelineDB``."""
+        real = _public_methods(PipelineDB)
+        fake = _public_methods(FakePipelineDB)
+        missing = real - fake
+        self.assertEqual(
+            missing, set(),
+            f"FakePipelineDB is missing stubs for: {sorted(missing)}. "
+            "See .claude/rules/code-quality.md 'New PipelineDB method' "
+            "in the new-work checklist.",
+        )
+
+    def test_fake_signatures_compatible_with_real(self) -> None:
+        """For every shared method, each named parameter on the real
+        method must exist (or be accepted via ``**kwargs``) on the fake,
+        with a compatible kind.
+
+        This catches the "real added a new kwarg; fake silently
+        ignored it" drift. Return types and type annotations are not
+        checked — the fake is free to use ``Any`` for brevity.
+        """
+        real_methods = _public_methods(PipelineDB)
+        fake_methods = _public_methods(FakePipelineDB)
+        shared = real_methods & fake_methods
+
+        mismatches: list[str] = []
+        for name in sorted(shared):
+            real_sig = inspect.signature(getattr(PipelineDB, name))
+            fake_sig = inspect.signature(getattr(FakePipelineDB, name))
+
+            fake_params = fake_sig.parameters
+            fake_accepts_kwargs = any(
+                p.kind == inspect.Parameter.VAR_KEYWORD
+                for p in fake_params.values()
+            )
+            fake_accepts_varargs = any(
+                p.kind == inspect.Parameter.VAR_POSITIONAL
+                for p in fake_params.values()
+            )
+
+            for pname, param in real_sig.parameters.items():
+                if pname == "self":
+                    continue
+                if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                    if not fake_accepts_varargs:
+                        mismatches.append(
+                            f"{name}: real has *{pname} but fake does "
+                            "not accept variable positional args")
+                    continue
+                if param.kind == inspect.Parameter.VAR_KEYWORD:
+                    if not fake_accepts_kwargs:
+                        mismatches.append(
+                            f"{name}: real has **{pname} but fake does "
+                            "not accept variable keyword args")
+                    continue
+                # Regular named parameter (positional-or-keyword or
+                # keyword-only).
+                if pname in fake_params:
+                    fp = fake_params[pname]
+                    # Allowed kind transitions: same kind, or
+                    # real=positional-or-keyword → fake=keyword-only
+                    # (fake is stricter but still callable via keyword).
+                    allowed = (
+                        fp.kind == param.kind
+                        or (param.kind
+                            == inspect.Parameter.POSITIONAL_OR_KEYWORD
+                            and fp.kind
+                            == inspect.Parameter.KEYWORD_ONLY)
+                    )
+                    if not allowed:
+                        mismatches.append(
+                            f"{name}({pname}): kind mismatch — "
+                            f"real={param.kind.name}, "
+                            f"fake={fp.kind.name}")
+                elif not fake_accepts_kwargs:
+                    mismatches.append(
+                        f"{name}: param '{pname}' present on real but "
+                        "missing on fake and no **kwargs")
+
+        self.assertEqual(
+            mismatches, [],
+            "FakePipelineDB signatures drifted from PipelineDB. "
+            "Update the fake so every real parameter is either named "
+            "explicitly or absorbed by **kwargs. Mismatches:\n  "
+            + "\n  ".join(mismatches),
+        )

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -806,25 +806,24 @@ def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
                     "**kwargs does not count)")
                 continue
             fp = fake_params[pname]
-            # Allowed kind transitions: same kind, or
-            # real=positional-or-keyword → fake=keyword-only
-            # (fake is stricter but still callable via keyword).
-            allowed = (
-                fp.kind == param.kind
-                or (param.kind
-                    == inspect.Parameter.POSITIONAL_OR_KEYWORD
-                    and fp.kind
-                    == inspect.Parameter.KEYWORD_ONLY)
-            )
-            if not allowed:
+            # Kind must match exactly. A fake that narrows
+            # positional-or-keyword to keyword-only breaks any caller
+            # passing it positionally (``add_request("Artist",
+            # "Album", source="request")``) — fake-backed tests would
+            # raise ``TypeError`` while this contract stayed green
+            # (codex R3).
+            if fp.kind != param.kind:
                 mismatches.append(
                     f"{name}({pname}): kind mismatch — "
                     f"real={param.kind.name}, "
                     f"fake={fp.kind.name}")
                 continue
-            # Requiredness: a real param without default must have
-            # no default on the fake either — otherwise the fake
-            # silently makes the arg optional.
+            # Requiredness drift in both directions:
+            # - real required → fake optional: silently makes the arg
+            #   optional on the fake so callers can omit it.
+            # - real optional → fake required: production calls that
+            #   omit the arg work against real but raise ``TypeError``
+            #   against the fake. Codex R3.
             real_required = param.default is inspect.Parameter.empty
             fake_required = fp.default is inspect.Parameter.empty
             if real_required and not fake_required:
@@ -832,6 +831,11 @@ def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
                     f"{name}({pname}): real requires this param but "
                     "fake gives it a default (silently makes it "
                     "optional)")
+            elif fake_required and not real_required:
+                mismatches.append(
+                    f"{name}({pname}): real has a default but fake "
+                    "requires this param (production calls that omit "
+                    "it would crash against the fake)")
     return mismatches
 
 
@@ -900,3 +904,33 @@ class TestPipelineDBFakeContractInternals(unittest.TestCase):
         self.assertTrue(
             any("**extra" in m for m in diff),
             f"Expected drift when fake drops **kwargs, got: {diff}")
+
+    def test_positional_or_keyword_narrowed_to_keyword_only_is_caught(self):
+        """Codex R3: a fake that narrows pos-or-keyword to keyword-only
+        would break every caller using positional args — must fail the
+        contract so fake-backed tests cannot silently green."""
+        class Real:
+            def m(self, artist_name: str, album_title: str) -> None:
+                ...
+        class Fake:
+            def m(self, *, artist_name: str, album_title: str) -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("kind mismatch" in m for m in diff),
+            f"Expected drift for narrowed kind, got: {diff}")
+
+    def test_optional_becoming_required_on_fake_is_caught(self):
+        """Codex R3: a fake that drops a default would force production
+        callers to pass the arg — production calls that omit it would
+        work against real but crash the fake."""
+        class Real:
+            def m(self, flag: bool = False) -> None:
+                ...
+        class Fake:
+            def m(self, flag: bool) -> None:  # no default
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("fake requires this param" in m for m in diff),
+            f"Expected drift for tightened requiredness, got: {diff}")

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -727,6 +727,37 @@ class TestPipelineDBFakeContract(unittest.TestCase):
             "in the new-work checklist.",
         )
 
+    def test_fake_only_methods_stay_on_the_allowlist(self) -> None:
+        """Methods on ``FakePipelineDB`` that don't mirror ``PipelineDB``
+        must be intentional test helpers on an explicit allowlist.
+
+        Catches typos in new stub names
+        (``update_importred_path_by_release_id`` would pass the
+        ``real - fake`` check because the method isn't on real, but
+        the sigcheck never exercises it). Without this inverse
+        enforcement, a typo'd stub would compile and tests against it
+        would crash with ``AttributeError`` — the exact silent-drift
+        vector this contract is meant to prevent.
+        """
+        allowed_fake_only = {
+            "seed_request",
+            "request",
+            "assert_log",
+            "set_advisory_lock_result",
+            "set_cooldown_result",
+        }
+        real = _public_methods(PipelineDB)
+        fake = _public_methods(FakePipelineDB)
+        unexpected = fake - real - allowed_fake_only
+        self.assertEqual(
+            unexpected, set(),
+            f"FakePipelineDB has methods not on PipelineDB and not on "
+            f"the allowlist: {sorted(unexpected)}. If these are "
+            "intentional test helpers, add them to "
+            "``allowed_fake_only``. If they're typo'd stubs meant to "
+            "mirror a real method, rename them.",
+        )
+
     def test_fake_signatures_compatible_with_real(self) -> None:
         """For every shared method, each named parameter on the real
         method must be declared by name on the fake with a compatible
@@ -801,7 +832,7 @@ def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
         mismatches.extend(_diff_positional_layout(name, real_sig, fake_sig))
         mismatches.extend(_diff_named_params(name, real_sig, fake_sig))
         mismatches.extend(_diff_variadic(name, real_sig, fake_sig))
-        mismatches.extend(_diff_fake_extras(name, real_sig, fake_sig))
+        mismatches.extend(_diff_fake_only_required(name, real_sig, fake_sig))
     return mismatches
 
 
@@ -893,7 +924,7 @@ def _diff_named_params(
     return out
 
 
-def _diff_fake_extras(
+def _diff_fake_only_required(
     method: str,
     real_sig: inspect.Signature,
     fake_sig: inspect.Signature,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -755,12 +755,39 @@ class TestPipelineDBFakeContract(unittest.TestCase):
         )
 
 
+_POSITIONAL_KINDS = (
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+)
+
+
 def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
     """Return a list of signature drift messages between two classes.
 
-    Extracted so ``TestPipelineDBFakeContractInternals`` can directly
-    exercise the drift detector against synthetic classes without
-    mutating the real fake.
+    The invariant the reviewers kept circling: the fake must be
+    substitutable for the real in every production-valid call pattern.
+    Checks, in order, what a caller could observe:
+
+    1. Positional layout must match exactly. Any reorder, insertion,
+       or rename at a positional slot would bind ``add_request("A",
+       "B", "request")`` to the wrong parameter on the fake (codex R4).
+    2. Every named real parameter must be declared by name on the
+       fake. ``**kwargs`` absorption is NOT sufficient — a fake that
+       absorbs a renamed kwarg silently reproduces the drift this
+       contract is meant to prevent (round 1).
+    3. Kinds must match exactly. Narrowing positional-or-keyword to
+       keyword-only breaks positional callers (codex R3).
+    4. Requiredness drift in both directions: real required → fake
+       optional lets the fake accept calls real would reject; real
+       optional → fake required crashes calls real would handle
+       (codex R3).
+    5. ``*args`` / ``**kwargs`` on real require equivalents on fake
+       so variadic callers don't silently lose arguments.
+
+    The fake may add trailing keyword-only parameters with defaults
+    (for test-only bookkeeping) and absorb test-only extras with
+    ``**kwargs`` — those are not visible to any real-valid caller so
+    they do not need to be mirrored back onto real.
     """
     real_methods = _public_methods(real_cls)
     fake_methods = _public_methods(fake_cls)
@@ -771,72 +798,125 @@ def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
         real_sig = inspect.signature(getattr(real_cls, name))
         fake_sig = inspect.signature(getattr(fake_cls, name))
 
-        fake_params = fake_sig.parameters
-        fake_accepts_varargs = any(
-            p.kind == inspect.Parameter.VAR_POSITIONAL
-            for p in fake_params.values()
-        )
-        fake_accepts_kwargs = any(
-            p.kind == inspect.Parameter.VAR_KEYWORD
-            for p in fake_params.values()
-        )
-
-        for pname, param in real_sig.parameters.items():
-            if pname == "self":
-                continue
-            if param.kind == inspect.Parameter.VAR_POSITIONAL:
-                if not fake_accepts_varargs:
-                    mismatches.append(
-                        f"{name}: real has *{pname} but fake does "
-                        "not accept variable positional args")
-                continue
-            if param.kind == inspect.Parameter.VAR_KEYWORD:
-                if not fake_accepts_kwargs:
-                    mismatches.append(
-                        f"{name}: real has **{pname} but fake does "
-                        "not accept variable keyword args")
-                continue
-            # Regular named parameter (positional-or-keyword or
-            # keyword-only). MUST be declared on the fake —
-            # **kwargs absorption is not sufficient.
-            if pname not in fake_params:
-                mismatches.append(
-                    f"{name}: param '{pname}' present on real but "
-                    "not declared on fake (declare it explicitly — "
-                    "**kwargs does not count)")
-                continue
-            fp = fake_params[pname]
-            # Kind must match exactly. A fake that narrows
-            # positional-or-keyword to keyword-only breaks any caller
-            # passing it positionally (``add_request("Artist",
-            # "Album", source="request")``) — fake-backed tests would
-            # raise ``TypeError`` while this contract stayed green
-            # (codex R3).
-            if fp.kind != param.kind:
-                mismatches.append(
-                    f"{name}({pname}): kind mismatch — "
-                    f"real={param.kind.name}, "
-                    f"fake={fp.kind.name}")
-                continue
-            # Requiredness drift in both directions:
-            # - real required → fake optional: silently makes the arg
-            #   optional on the fake so callers can omit it.
-            # - real optional → fake required: production calls that
-            #   omit the arg work against real but raise ``TypeError``
-            #   against the fake. Codex R3.
-            real_required = param.default is inspect.Parameter.empty
-            fake_required = fp.default is inspect.Parameter.empty
-            if real_required and not fake_required:
-                mismatches.append(
-                    f"{name}({pname}): real requires this param but "
-                    "fake gives it a default (silently makes it "
-                    "optional)")
-            elif fake_required and not real_required:
-                mismatches.append(
-                    f"{name}({pname}): real has a default but fake "
-                    "requires this param (production calls that omit "
-                    "it would crash against the fake)")
+        mismatches.extend(_diff_positional_layout(name, real_sig, fake_sig))
+        mismatches.extend(_diff_named_params(name, real_sig, fake_sig))
+        mismatches.extend(_diff_variadic(name, real_sig, fake_sig))
     return mismatches
+
+
+def _positional_params(
+    sig: inspect.Signature,
+) -> list[inspect.Parameter]:
+    return [
+        p for p in sig.parameters.values()
+        if p.name != "self" and p.kind in _POSITIONAL_KINDS
+    ]
+
+
+def _diff_positional_layout(
+    method: str,
+    real_sig: inspect.Signature,
+    fake_sig: inspect.Signature,
+) -> list[str]:
+    """Positional slots must match real exactly — no reorder, no extras.
+
+    Python binds positional args by index; a fake that adds
+    ``add_request(album_title, artist_name, source)`` would satisfy the
+    name-matching check while binding ``add_request("Artist", "Album",
+    "request")`` to the wrong parameters (codex R4).
+    """
+    out: list[str] = []
+    real_pos = _positional_params(real_sig)
+    fake_pos = _positional_params(fake_sig)
+
+    for i, rp in enumerate(real_pos):
+        if i >= len(fake_pos):
+            out.append(
+                f"{method}: positional slot {i} ('{rp.name}') "
+                "present on real but missing from fake's positional "
+                "sequence")
+            continue
+        fp = fake_pos[i]
+        if fp.name != rp.name:
+            out.append(
+                f"{method}: positional slot {i} — real='{rp.name}', "
+                f"fake='{fp.name}' (reorder, rename, or inserted "
+                "parameter would break positional callers)")
+    if len(fake_pos) > len(real_pos):
+        extras = [fp.name for fp in fake_pos[len(real_pos):]]
+        out.append(
+            f"{method}: fake has extra positional parameters beyond "
+            f"real: {extras} (a positional call on real would bind "
+            "nothing to these slots on the fake)")
+    return out
+
+
+def _diff_named_params(
+    method: str,
+    real_sig: inspect.Signature,
+    fake_sig: inspect.Signature,
+) -> list[str]:
+    """Every named real param must be declared on the fake with a
+    compatible kind and requiredness."""
+    out: list[str] = []
+    fake_params = fake_sig.parameters
+    for pname, param in real_sig.parameters.items():
+        if pname == "self":
+            continue
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL,
+                          inspect.Parameter.VAR_KEYWORD):
+            continue
+        if pname not in fake_params:
+            out.append(
+                f"{method}: param '{pname}' present on real but "
+                "not declared on fake (declare it explicitly — "
+                "**kwargs does not count)")
+            continue
+        fp = fake_params[pname]
+        if fp.kind != param.kind:
+            out.append(
+                f"{method}({pname}): kind mismatch — "
+                f"real={param.kind.name}, fake={fp.kind.name}")
+            continue
+        real_required = param.default is inspect.Parameter.empty
+        fake_required = fp.default is inspect.Parameter.empty
+        if real_required and not fake_required:
+            out.append(
+                f"{method}({pname}): real requires this param but "
+                "fake gives it a default (silently makes it optional)")
+        elif fake_required and not real_required:
+            out.append(
+                f"{method}({pname}): real has a default but fake "
+                "requires this param (production calls that omit it "
+                "would crash against the fake)")
+    return out
+
+
+def _diff_variadic(
+    method: str,
+    real_sig: inspect.Signature,
+    fake_sig: inspect.Signature,
+) -> list[str]:
+    """``*args`` / ``**kwargs`` on real require equivalents on fake."""
+    out: list[str] = []
+    fake_accepts_varargs = any(
+        p.kind == inspect.Parameter.VAR_POSITIONAL
+        for p in fake_sig.parameters.values())
+    fake_accepts_kwargs = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD
+        for p in fake_sig.parameters.values())
+    for param in real_sig.parameters.values():
+        if (param.kind == inspect.Parameter.VAR_POSITIONAL
+                and not fake_accepts_varargs):
+            out.append(
+                f"{method}: real has *{param.name} but fake does "
+                "not accept variable positional args")
+        elif (param.kind == inspect.Parameter.VAR_KEYWORD
+                and not fake_accepts_kwargs):
+            out.append(
+                f"{method}: real has **{param.name} but fake does "
+                "not accept variable keyword args")
+    return out
 
 
 class TestPipelineDBFakeContractInternals(unittest.TestCase):
@@ -934,3 +1014,39 @@ class TestPipelineDBFakeContractInternals(unittest.TestCase):
         self.assertTrue(
             any("fake requires this param" in m for m in diff),
             f"Expected drift for tightened requiredness, got: {diff}")
+
+    def test_positional_reorder_is_caught(self):
+        """Codex R4: a fake that swaps positional parameter order
+        would bind positional args to the wrong params. Name-matching
+        alone cannot catch this — the positional layout must be
+        checked by index."""
+        class Real:
+            def m(self, artist_name: str, album_title: str,
+                  source: str) -> None:
+                ...
+        class Fake:
+            def m(self, album_title: str, artist_name: str,
+                  source: str) -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("positional slot" in m for m in diff),
+            f"Expected drift for reordered positional params, got: "
+            f"{diff}")
+
+    def test_fake_with_extra_positional_param_is_caught(self):
+        """Codex R4: a fake that adds an extra positional parameter
+        beyond real breaks positional callers — real's call pattern
+        would leave that slot unbound on the fake."""
+        class Real:
+            def m(self, artist_name: str, album_title: str) -> None:
+                ...
+        class Fake:
+            def m(self, artist_name: str, album_title: str,
+                  new_required: str) -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("extra positional parameters" in m for m in diff),
+            f"Expected drift for fake with extra positional, got: "
+            f"{diff}")

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -401,6 +401,31 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         self.assertEqual(db.request(rid1)["artist_name"], "Artist A")
         self.assertEqual(db.request(rid2)["status"], "wanted")
 
+    def test_add_request_seeds_full_row_shape(self):
+        """Codex R7: rows must carry the DB-defaulted columns
+        production readers index directly (``beets_distance``,
+        ``imported_path``, ``*_attempts``, spectral + verified_lossless)
+        so fake-backed tests don't raise ``KeyError`` where Postgres
+        would return NULL/0."""
+        db = FakePipelineDB()
+        rid = db.add_request("X", "Y", source="request")
+        row = db.request(rid)
+        for key in (
+            "beets_distance", "beets_scenario", "imported_path",
+            "search_attempts", "download_attempts", "validation_attempts",
+            "last_download_spectral_grade", "current_spectral_grade",
+            "verified_lossless", "min_bitrate", "prev_min_bitrate",
+            "search_filetype_override", "target_format",
+            "active_download_state",
+        ):
+            self.assertIn(key, row,
+                          f"add_request row missing '{key}' — "
+                          "production readers index it directly")
+        self.assertEqual(row["search_attempts"], 0)
+        self.assertEqual(row["download_attempts"], 0)
+        self.assertEqual(row["validation_attempts"], 0)
+        self.assertFalse(row["verified_lossless"])
+
     def test_add_request_coexists_with_seeded_ids(self):
         """Seeded ids must advance the auto-increment cursor so
         ``add_request`` cannot collide."""

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -3,6 +3,7 @@
 import inspect
 import unittest
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.pipeline_db import PipelineDB, RequestSpectralStateUpdate
@@ -437,6 +438,19 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         rows = db.get_wanted()
         self.assertEqual([r["id"] for r in rows], [2])
 
+    def test_get_wanted_tie_break_is_set_not_order(self):
+        """Within a priority bucket the real DB randomises order —
+        callers must assert on set membership, not list position."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", search_attempts=0))
+        db.seed_request(make_request_row(
+            id=2, status="wanted", search_attempts=0))
+        db.seed_request(make_request_row(
+            id=3, status="wanted", search_attempts=0))
+        rows = db.get_wanted()
+        self.assertEqual({r["id"] for r in rows}, {1, 2, 3})
+
     def test_get_log_filters_and_orders_newest_first(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1, album_title="Album A"))
@@ -472,6 +486,20 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         rows = db.get_recent()
         self.assertEqual([r["id"] for r in rows], [1])
 
+    def test_get_recent_deterministic_with_missing_updated_at(self):
+        """Sort key must not call ``_utcnow()`` per comparison —
+        multiple rows with no ``updated_at`` must fall into a stable
+        insertion order so tests cannot flake."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, updated_at=None))
+        db.seed_request(make_request_row(id=2, updated_at=None))
+        db.seed_request(make_request_row(id=3, updated_at=None))
+        db.log_download(1, outcome="success")
+        db.log_download(2, outcome="success")
+        db.log_download(3, outcome="success")
+        rows = db.get_recent()
+        self.assertEqual({r["id"] for r in rows}, {1, 2, 3})
+
     def test_count_by_status(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1, status="wanted"))
@@ -479,6 +507,14 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         db.seed_request(make_request_row(id=3, status="imported"))
         self.assertEqual(
             db.count_by_status(), {"wanted": 2, "imported": 1})
+
+    def test_count_by_status_preserves_none_bucket(self):
+        """Real SQL ``GROUP BY status`` keeps NULL as its own key; the
+        fake must not collapse it to an empty string."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status=None))
+        db.seed_request(make_request_row(id=2, status="wanted"))
+        self.assertEqual(db.count_by_status(), {None: 1, "wanted": 1})
 
     def test_tracks_round_trip_and_count(self):
         db = FakePipelineDB()
@@ -634,75 +670,174 @@ class TestPipelineDBFakeContract(unittest.TestCase):
 
     def test_fake_signatures_compatible_with_real(self) -> None:
         """For every shared method, each named parameter on the real
-        method must exist (or be accepted via ``**kwargs``) on the fake,
-        with a compatible kind.
+        method must be declared by name on the fake with a compatible
+        kind and no stricter requiredness.
 
-        This catches the "real added a new kwarg; fake silently
-        ignored it" drift. Return types and type annotations are not
-        checked — the fake is free to use ``Any`` for brevity.
+        This catches "real added a new kwarg; fake silently ignored it"
+        drift. Crucially, a bare ``**kwargs`` on the fake is NOT allowed
+        to absorb a named real parameter — otherwise a fake that
+        accepts ``**kwargs`` would pass this check for any real
+        signature, reproducing the exact silent-drift failure mode the
+        contract is meant to prevent.
+
+        ``**kwargs`` on the fake may still absorb test-only extras and
+        matches the real's own ``**kwargs`` when present. Return types
+        and type annotations are not checked — the fake is free to use
+        ``Any`` for brevity.
         """
-        real_methods = _public_methods(PipelineDB)
-        fake_methods = _public_methods(FakePipelineDB)
-        shared = real_methods & fake_methods
-
-        mismatches: list[str] = []
-        for name in sorted(shared):
-            real_sig = inspect.signature(getattr(PipelineDB, name))
-            fake_sig = inspect.signature(getattr(FakePipelineDB, name))
-
-            fake_params = fake_sig.parameters
-            fake_accepts_kwargs = any(
-                p.kind == inspect.Parameter.VAR_KEYWORD
-                for p in fake_params.values()
-            )
-            fake_accepts_varargs = any(
-                p.kind == inspect.Parameter.VAR_POSITIONAL
-                for p in fake_params.values()
-            )
-
-            for pname, param in real_sig.parameters.items():
-                if pname == "self":
-                    continue
-                if param.kind == inspect.Parameter.VAR_POSITIONAL:
-                    if not fake_accepts_varargs:
-                        mismatches.append(
-                            f"{name}: real has *{pname} but fake does "
-                            "not accept variable positional args")
-                    continue
-                if param.kind == inspect.Parameter.VAR_KEYWORD:
-                    if not fake_accepts_kwargs:
-                        mismatches.append(
-                            f"{name}: real has **{pname} but fake does "
-                            "not accept variable keyword args")
-                    continue
-                # Regular named parameter (positional-or-keyword or
-                # keyword-only).
-                if pname in fake_params:
-                    fp = fake_params[pname]
-                    # Allowed kind transitions: same kind, or
-                    # real=positional-or-keyword → fake=keyword-only
-                    # (fake is stricter but still callable via keyword).
-                    allowed = (
-                        fp.kind == param.kind
-                        or (param.kind
-                            == inspect.Parameter.POSITIONAL_OR_KEYWORD
-                            and fp.kind
-                            == inspect.Parameter.KEYWORD_ONLY)
-                    )
-                    if not allowed:
-                        mismatches.append(
-                            f"{name}({pname}): kind mismatch — "
-                            f"real={param.kind.name}, "
-                            f"fake={fp.kind.name}")
-                elif not fake_accepts_kwargs:
-                    mismatches.append(
-                        f"{name}: param '{pname}' present on real but "
-                        "missing on fake and no **kwargs")
-
+        mismatches = _diff_signatures(PipelineDB, FakePipelineDB)
         self.assertEqual(
             mismatches, [],
             "FakePipelineDB signatures drifted from PipelineDB. "
-            "Update the fake so every real parameter is either named "
-            "explicitly or absorbed by **kwargs. Mismatches:\n  "
+            "Every real parameter must be named explicitly on the fake "
+            "(bare **kwargs does NOT satisfy the contract). "
+            "Mismatches:\n  "
             + "\n  ".join(mismatches),
         )
+
+
+def _diff_signatures(real_cls: type, fake_cls: type) -> list[str]:
+    """Return a list of signature drift messages between two classes.
+
+    Extracted so ``TestPipelineDBFakeContractInternals`` can directly
+    exercise the drift detector against synthetic classes without
+    mutating the real fake.
+    """
+    real_methods = _public_methods(real_cls)
+    fake_methods = _public_methods(fake_cls)
+    shared = real_methods & fake_methods
+
+    mismatches: list[str] = []
+    for name in sorted(shared):
+        real_sig = inspect.signature(getattr(real_cls, name))
+        fake_sig = inspect.signature(getattr(fake_cls, name))
+
+        fake_params = fake_sig.parameters
+        fake_accepts_varargs = any(
+            p.kind == inspect.Parameter.VAR_POSITIONAL
+            for p in fake_params.values()
+        )
+        fake_accepts_kwargs = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD
+            for p in fake_params.values()
+        )
+
+        for pname, param in real_sig.parameters.items():
+            if pname == "self":
+                continue
+            if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                if not fake_accepts_varargs:
+                    mismatches.append(
+                        f"{name}: real has *{pname} but fake does "
+                        "not accept variable positional args")
+                continue
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                if not fake_accepts_kwargs:
+                    mismatches.append(
+                        f"{name}: real has **{pname} but fake does "
+                        "not accept variable keyword args")
+                continue
+            # Regular named parameter (positional-or-keyword or
+            # keyword-only). MUST be declared on the fake —
+            # **kwargs absorption is not sufficient.
+            if pname not in fake_params:
+                mismatches.append(
+                    f"{name}: param '{pname}' present on real but "
+                    "not declared on fake (declare it explicitly — "
+                    "**kwargs does not count)")
+                continue
+            fp = fake_params[pname]
+            # Allowed kind transitions: same kind, or
+            # real=positional-or-keyword → fake=keyword-only
+            # (fake is stricter but still callable via keyword).
+            allowed = (
+                fp.kind == param.kind
+                or (param.kind
+                    == inspect.Parameter.POSITIONAL_OR_KEYWORD
+                    and fp.kind
+                    == inspect.Parameter.KEYWORD_ONLY)
+            )
+            if not allowed:
+                mismatches.append(
+                    f"{name}({pname}): kind mismatch — "
+                    f"real={param.kind.name}, "
+                    f"fake={fp.kind.name}")
+                continue
+            # Requiredness: a real param without default must have
+            # no default on the fake either — otherwise the fake
+            # silently makes the arg optional.
+            real_required = param.default is inspect.Parameter.empty
+            fake_required = fp.default is inspect.Parameter.empty
+            if real_required and not fake_required:
+                mismatches.append(
+                    f"{name}({pname}): real requires this param but "
+                    "fake gives it a default (silently makes it "
+                    "optional)")
+    return mismatches
+
+
+class TestPipelineDBFakeContractInternals(unittest.TestCase):
+    """Regression tests for the drift detector itself.
+
+    The detector must fail when real and fake disagree, otherwise the
+    outer contract test is a silent no-op. Exercise the drift cases
+    directly.
+    """
+
+    def test_kwargs_does_not_absorb_named_param(self):
+        """Bare **kwargs on fake must NOT satisfy a named real param."""
+        class Real:
+            def m(self, request_id: int, flag: bool = False) -> None:
+                ...
+        class Fake:
+            def m(self, request_id: int, **kwargs: Any) -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("'flag'" in m for m in diff),
+            f"Expected drift for named param 'flag', got: {diff}")
+
+    def test_renamed_param_is_caught(self):
+        class Real:
+            def m(self, spectral_grade: str | None = None) -> None:
+                ...
+        class Fake:
+            def m(self, grade: str | None = None) -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("'spectral_grade'" in m for m in diff),
+            f"Expected drift for renamed param, got: {diff}")
+
+    def test_required_becoming_optional_is_caught(self):
+        class Real:
+            def m(self, release_id: str) -> None:
+                ...
+        class Fake:
+            def m(self, release_id: str = "") -> None:
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("release_id" in m and "optional" in m for m in diff),
+            f"Expected requiredness drift, got: {diff}")
+
+    def test_clean_signature_yields_no_diff(self):
+        class Real:
+            def m(self, request_id: int, flag: bool = False) -> None:
+                ...
+        class Fake:
+            def m(self, request_id: int, flag: bool = False) -> None:
+                ...
+        self.assertEqual(_diff_signatures(Real, Fake), [])
+
+    def test_star_kwargs_on_real_still_requires_fake_kwargs(self):
+        class Real:
+            def m(self, **extra: Any) -> None:
+                ...
+        class Fake:
+            def m(self) -> None:  # no **kwargs
+                ...
+        diff = _diff_signatures(Real, Fake)
+        self.assertTrue(
+            any("**extra" in m for m in diff),
+            f"Expected drift when fake drops **kwargs, got: {diff}")

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1442,6 +1442,34 @@ class TestAdvisoryLock(unittest.TestCase):
                     ADVISORY_LOCK_NAMESPACE_RELEASE, 12345) as a2:
                 self.assertTrue(a2)
 
+    def test_reentrant_within_same_session(self):
+        """``docs/advisory-locks.md`` depends on within-session
+        reentrancy: the auto path's outer ``_handle_valid_result``
+        acquire and ``dispatch_import_core``'s inner acquire on the
+        same key both succeed because they share a session.
+
+        Two acquires from the same session both return True; the inner
+        release must be a no-op (the outer context still prevents a
+        second session from acquiring). Only after the outer context
+        releases does a second session succeed.
+        """
+        with self.db1.advisory_lock(self.NS, 12345) as outer:
+            self.assertTrue(outer)
+            with self.db1.advisory_lock(self.NS, 12345) as inner:
+                self.assertTrue(inner)
+                # Inner release happens on __exit__; outer still holds.
+                # Second session must still be locked out.
+                with self.db2.advisory_lock(self.NS, 12345) as other:
+                    self.assertFalse(other)
+            # Back in the outer context after the inner release — the
+            # second session must STILL be blocked (outer still holds).
+            with self.db2.advisory_lock(self.NS, 12345) as other:
+                self.assertFalse(other)
+        # After the outer context releases, the second session can
+        # finally acquire.
+        with self.db2.advisory_lock(self.NS, 12345) as other:
+            self.assertTrue(other)
+
 
 @requires_postgres
 class TestGetWrongMatches(unittest.TestCase):


### PR DESCRIPTION
Closes #140.

## Summary

Two small refactors on shared DB infrastructure, bundled per the issue's scope:

- **P1** — `TestPipelineDBFakeContract` enforces `.claude/rules/code-quality.md`'s "every `PipelineDB` method needs a `FakePipelineDB` stub" convention at test time. Retroactively fills 22 missing stubs (with self-tests for each) and adds a comprehensive signature-drift detector covering positional layout, named params, requiredness in both directions, `*args`/`**kwargs`, fake-only required params, and fake-only method typos.
- **P2** — `docs/advisory-locks.md` is the canonical reference for the two PostgreSQL advisory locks (IMPORT, RELEASE). Covers namespaces, keys, reentrancy (scoped to session, not process), ordering, contention behaviour, the Palo Santo incident, a call-site index, and an extending checklist. Every acquire site links back; the CLAUDE.md `pipeline_db.py` bullet points at the doc.

## Acceptance check

- [x] `TestPipelineDBFakeContract` fails if a new public method is added to `PipelineDB` without a matching fake.
- [x] `FakePipelineDB.advisory_lock`, `update_imported_path_by_release_id`, and every other post-#136 method pass the contract.
- [x] `docs/advisory-locks.md` exists; linked from every acquire site.
- [x] Full suite green (2015 tests, 53 skipped).

## Review trail

Audit trail of all review rounds (in-process adversarial + codex). Rebase merge preserves every fix commit on main.

**P1 commit** (`24d0fff`):
- **P1 R1** (`80b4483`) — in-process adversarial found: `**kwargs` absorbing named params on fake, tie-break ordering lie in `get_wanted`, null-status collapse in `count_by_status`, `get_recent` sort non-determinism.
- **P1 R2** (`e319ce6`) — codex found: `delete_request` cascade (real has `ON DELETE CASCADE`), `get_log` dropping `extra` auxiliary columns, mixed ISO-string/datetime sort crash.
- **P1 R3** (`9ec38b3`) — codex found: kind-narrowing drift (pos-or-kw → keyword-only), reverse requiredness drift (real-optional → fake-required).

**P2 commit** (`5ca1330`):
- **P2 R1** (`c26c1e8`) — in-process adversarial found: false "one PipelineDB per process" claim, claimed-but-missing reentrancy test, wrong test class name in coverage map; added CLAUDE.md pointer.
- **P2 R2** (`4152910`) — codex found: `_diff_signatures` missing positional-layout check (reorder, inserted positional); this triggered the stop-and-refactor rule and split the walker into four purpose-named helpers so the invariant is comprehensive.
- **P2 R3** (`9b16c7f`) — codex found: `_diff_fake_only_required` helper still missed fake-only required kwargs (fake extras); added and tested.

**Final holistic** (`e099932`, `c1e723b`):
- Stale duplicated docstring block in `_handle_valid_result` (26 lines of content the doc now owns, with a wrong line-number reference); trimmed.
- Helper misnamed `_diff_fake_extras` → `_diff_fake_only_required`.
- Inverse contract: fake-only methods (typos) now caught via allowlist.
- Codex final: `add_request` was seeding a partial row shape; now mirrors the full `album_requests` column set so DB-defaulted readers work.

**Convergence**: codex's last pass returned no findings.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 2015 tests green
- [x] `nix-shell --run "pyright tests/fakes.py tests/test_fakes.py"` — 0 errors
- [ ] `ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'` — post-merge deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)