### PR TITLE
fix(download): resolve slskd collision-renamed files on disk (#144)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -71,7 +71,9 @@ def resolve_slskd_local_path(file: "DownloadFile",
     Returns the full path, or ``None`` if the file cannot be located.
     Tries the exact expected path first, then falls back to matching the
     ``_<ticks>`` collision-rename variants. When multiple collision variants
-    exist, prefers the one whose byte size matches ``file.size``.
+    exist, prefers the one whose byte size matches ``file.size``, else
+    picks deterministically and logs a warning so ambiguous cases are
+    visible in journald.
     """
     folder = slskd_local_folder(file.file_dir, slskd_download_dir)
     expected_name = file.filename.split("\\")[-1]
@@ -90,14 +92,32 @@ def resolve_slskd_local_path(file: "DownloadFile",
             matches.append(candidate)
     if not matches:
         return None
-    if len(matches) > 1 and file.size:
-        for candidate in matches:
-            try:
-                if os.path.getsize(candidate) == file.size:
-                    return candidate
-            except OSError:
-                continue
-    return sorted(matches)[0]
+    if len(matches) == 1:
+        logger.info(f"slskd collision-renamed file resolved: {expected_name} → "
+                    f"{os.path.basename(matches[0])}")
+        return matches[0]
+    if file.size:
+        size_matches = [c for c in matches
+                        if _safe_getsize(c) == file.size]
+        if len(size_matches) == 1:
+            logger.info(f"slskd collision-renamed file resolved by size: "
+                        f"{expected_name} → {os.path.basename(size_matches[0])} "
+                        f"(chose 1 of {len(matches)} candidates by size={file.size})")
+            return size_matches[0]
+    chosen = sorted(matches)[0]
+    logger.warning(f"AMBIGUOUS slskd collision resolution for {expected_name} in {folder}: "
+                   f"{len(matches)} candidates, no unique size match, picked "
+                   f"{os.path.basename(chosen)} deterministically. "
+                   f"Target size={file.size}, candidates="
+                   f"{[(os.path.basename(c), _safe_getsize(c)) for c in matches]}")
+    return chosen
+
+
+def _safe_getsize(path: str) -> int | None:
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return None
 
 
 # === slskd transfer helpers ===
@@ -256,7 +276,10 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
     import_folder_fullpath = os.path.join(ctx.cfg.slskd_download_dir, import_folder_name)
     rm_dirs: list[str] = []
     moved_files_history: list[tuple[str, str]] = []
-    if not os.path.exists(import_folder_fullpath):
+    if os.path.exists(import_folder_fullpath):
+        logger.info(f"Staging folder {import_folder_fullpath} already exists — "
+                    f"resuming or reusing prior attempt")
+    else:
         os.mkdir(import_folder_fullpath)
     for file in album_data.files:
         src_folder = slskd_local_folder(file.file_dir, ctx.cfg.slskd_download_dir)
@@ -274,6 +297,7 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
         file.import_path = dst_file
         if os.path.exists(dst_file) and not os.path.exists(src_file):
             # Resume safely after a crash that already moved this file.
+            logger.info(f"Already-moved file detected: {dst_file} (src gone, skipping)")
             continue
         try:
             shutil.move(src_file, dst_file)

--- a/lib/download.py
+++ b/lib/download.py
@@ -6,8 +6,10 @@ instead of reading module-level globals.
 
 from __future__ import annotations
 
+import glob
 import logging
 import os
+import re
 import shutil
 import time
 from datetime import datetime, timezone
@@ -41,6 +43,63 @@ def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
     return analyze_album(folder, trim_seconds=trim_seconds)
 
 
+# === slskd on-disk path resolution ===
+#
+# slskd's default placement rule: a remote share path like
+#   @@user\Share\Artist\Album\CD1\17 - Track.mp3
+# gets saved to
+#   {download_root}/CD1/17 - Track.mp3
+# i.e. the trailing component of the remote folder becomes the on-disk
+# folder name. On filename collision — the same folder name (e.g. "CD1")
+# often appears across unrelated downloads — slskd appends a .NET Ticks
+# suffix before the extension:
+#   17 - Track_639123086573912108.mp3
+# See issue #144 for the regression this locked down.
+
+_TICKS_SUFFIX = re.compile(r"^(?P<base>.+)_(?P<ticks>\d{17,20})$")
+
+
+def slskd_local_folder(file_dir: str, slskd_download_dir: str) -> str:
+    """Return the on-disk folder slskd places this file_dir's downloads into."""
+    return os.path.join(slskd_download_dir, file_dir.split("\\")[-1])
+
+
+def resolve_slskd_local_path(file: "DownloadFile",
+                             slskd_download_dir: str) -> str | None:
+    """Resolve the actual on-disk path of a downloaded slskd file.
+
+    Returns the full path, or ``None`` if the file cannot be located.
+    Tries the exact expected path first, then falls back to matching the
+    ``_<ticks>`` collision-rename variants. When multiple collision variants
+    exist, prefers the one whose byte size matches ``file.size``.
+    """
+    folder = slskd_local_folder(file.file_dir, slskd_download_dir)
+    expected_name = file.filename.split("\\")[-1]
+    expected_path = os.path.join(folder, expected_name)
+    if os.path.isfile(expected_path):
+        return expected_path
+
+    base, ext = os.path.splitext(expected_name)
+    # Collision candidates only — filter by strict `_<17-20 digit ticks><ext>`
+    # shape so we never match a different file that happens to share a prefix.
+    pattern = os.path.join(folder, f"{glob.escape(base)}_*{ext}")
+    matches: list[str] = []
+    for candidate in glob.iglob(pattern):
+        stem = os.path.splitext(os.path.basename(candidate))[0]
+        if _TICKS_SUFFIX.fullmatch(stem):
+            matches.append(candidate)
+    if not matches:
+        return None
+    if len(matches) > 1 and file.size:
+        for candidate in matches:
+            try:
+                if os.path.getsize(candidate) == file.size:
+                    return candidate
+            except OSError:
+                continue
+    return sorted(matches)[0]
+
+
 # === slskd transfer helpers ===
 
 def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> None:
@@ -53,7 +112,7 @@ def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> None:
         except Exception:
             logger.warning(f"Failed to cancel download {file.filename} for {file.username}",
                            exc_info=True)
-        delete_dir = os.path.join(ctx.cfg.slskd_download_dir, file.file_dir.split("\\")[-1])
+        delete_dir = slskd_local_folder(file.file_dir, ctx.cfg.slskd_download_dir)
         if os.path.isdir(delete_dir):
             shutil.rmtree(delete_dir)
 
@@ -200,12 +259,15 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
     if not os.path.exists(import_folder_fullpath):
         os.mkdir(import_folder_fullpath)
     for file in album_data.files:
-        file_folder = file.file_dir.split("\\")[-1]
-        filename = file.filename.split("\\")[-1]
-        src_folder = os.path.join(ctx.cfg.slskd_download_dir, file_folder)
+        src_folder = slskd_local_folder(file.file_dir, ctx.cfg.slskd_download_dir)
         if src_folder not in rm_dirs:
             rm_dirs.append(src_folder)
-        src_file = os.path.join(src_folder, filename)
+        # Destination filename keeps the remote basename (no ticks suffix,
+        # even if slskd appended one on the source).
+        filename = file.filename.split("\\")[-1]
+        resolved_src = resolve_slskd_local_path(file, ctx.cfg.slskd_download_dir)
+        src_file = resolved_src if resolved_src is not None \
+            else os.path.join(src_folder, filename)
         if file.disk_no is not None and file.disk_count is not None and file.disk_count > 1:
             filename = f"Disk {file.disk_no} - {filename}"
         dst_file = os.path.join(import_folder_fullpath, filename)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -782,6 +782,153 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             self.assertFalse(result)
 
 
+class TestResolveSlskdLocalPath(unittest.TestCase):
+    """Pure tests for the slskd on-disk path resolution helper.
+
+    slskd places files at ``{download_root}/{last_remote_folder}/{filename}``.
+    On filename collision with an existing file, slskd appends a `_<ticks>`
+    suffix before the extension (the `_<18-19-digit-integer>` pattern seen on
+    disk). The resolver must find the file in both cases. Regression guard
+    for issue #144.
+    """
+
+    def test_returns_expected_path_when_file_exists(self):
+        from lib.download import resolve_slskd_local_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            folder = os.path.join(tmpdir, "CD1")
+            os.makedirs(folder)
+            fname = "17.- The Crystals - Da Doo Ron Ron.mp3"
+            src = os.path.join(folder, fname)
+            with open(src, "w") as fp:
+                fp.write("x")
+            f = make_download_file(
+                filename=f"@@ctvhz\\Shared Music\\Phil Spector\\CD1\\{fname}",
+                file_dir="@@ctvhz\\Shared Music\\Phil Spector\\CD1",
+                size=1,
+            )
+            self.assertEqual(resolve_slskd_local_path(f, tmpdir), src)
+
+    def test_finds_collision_renamed_file(self):
+        """slskd renames colliding filenames as ``<base>_<ticks><ext>``.
+
+        When the plain filename is absent, the resolver must match the
+        ticks-suffixed variant. Reproduces the #144 crash scenario — file
+        ``17.- ...Da Doo Ron Ron.mp3`` landed on disk as
+        ``17.- ...Da Doo Ron Ron_639123086573912108.mp3``.
+        """
+        from lib.download import resolve_slskd_local_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            folder = os.path.join(tmpdir, "CD1")
+            os.makedirs(folder)
+            base = "17.- The Crystals - Da Doo Ron Ron"
+            suffixed = os.path.join(folder, f"{base}_639123086573912108.mp3")
+            with open(suffixed, "w") as fp:
+                fp.write("x" * 2048)
+            f = make_download_file(
+                filename=f"@@ctvhz\\CD1\\{base}.mp3",
+                file_dir="@@ctvhz\\CD1",
+                size=2048,
+            )
+            self.assertEqual(resolve_slskd_local_path(f, tmpdir), suffixed)
+
+    def test_prefers_size_match_when_multiple_collision_candidates(self):
+        """Size tiebreak disambiguates when multiple collision-suffixed
+        variants exist (multiple users uploading same-named files to the
+        same on-disk folder — frequent with generic ``CD1`` folders)."""
+        from lib.download import resolve_slskd_local_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            folder = os.path.join(tmpdir, "CD1")
+            os.makedirs(folder)
+            base = "01 - Track"
+            wrong = os.path.join(folder, f"{base}_639000000000000001.mp3")
+            right = os.path.join(folder, f"{base}_639000000000000002.mp3")
+            with open(wrong, "w") as fp:
+                fp.write("x" * 100)
+            with open(right, "w") as fp:
+                fp.write("x" * 5555)
+            f = make_download_file(
+                filename=f"user\\CD1\\{base}.mp3",
+                file_dir="user\\CD1",
+                size=5555,
+            )
+            self.assertEqual(resolve_slskd_local_path(f, tmpdir), right)
+
+    def test_returns_none_when_file_missing(self):
+        from lib.download import resolve_slskd_local_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "CD1"))
+            f = make_download_file(
+                filename="user\\CD1\\nope.mp3",
+                file_dir="user\\CD1",
+                size=1,
+            )
+            self.assertIsNone(resolve_slskd_local_path(f, tmpdir))
+
+    def test_does_not_match_partial_base_prefix(self):
+        """Globbing must not match ``01 - Track Two.mp3`` when looking for
+        ``01 - Track.mp3`` — the collision suffix is ``_<digits>``, not a
+        free-form extension of the basename."""
+        from lib.download import resolve_slskd_local_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            folder = os.path.join(tmpdir, "CD1")
+            os.makedirs(folder)
+            with open(os.path.join(folder, "01 - Track Two.mp3"), "w") as fp:
+                fp.write("x")
+            f = make_download_file(
+                filename="user\\CD1\\01 - Track.mp3",
+                file_dir="user\\CD1",
+                size=1,
+            )
+            self.assertIsNone(resolve_slskd_local_path(f, tmpdir))
+
+
+class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
+    """Integration: ``process_completed_album`` must handle slskd's collision
+    rename. Directly reproduces the issue #144 crash — file landed on disk
+    with ``_<ticks>`` appended; the move must still succeed."""
+
+    @patch("lib.download.music_tag")
+    def test_moves_collision_renamed_files(self, mock_mt):
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            folder = os.path.join(tmpdir, "CD1")
+            os.makedirs(folder)
+            base = "17.- The Crystals - Da Doo Ron Ron"
+            src_suffixed = os.path.join(folder, f"{base}_639123086573912108.mp3")
+            with open(src_suffixed, "w") as fp:
+                fp.write("fake audio")
+
+            files = [make_download_file(
+                filename=f"@@ctvhz\\Phil Spector\\CD1\\{base}.mp3",
+                file_dir="@@ctvhz\\Phil Spector\\CD1",
+                size=len("fake audio"),
+            )]
+            album = make_grab_list_entry(files=files, mb_release_id="",
+                                          artist="Phil Spector", title="Back to Mono",
+                                          year="1991")
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = tmpdir
+            cfg.beets_validation_enabled = False
+            mock_mt.load_file.return_value = MagicMock()
+            result = process_completed_album(album, [], ctx)
+            self.assertTrue(result)
+            # Source should be gone; destination should exist.
+            self.assertFalse(os.path.exists(src_suffixed))
+            import_folder = os.path.join(
+                tmpdir, "Phil Spector - Back to Mono (1991)")
+            moved = os.listdir(import_folder)
+            self.assertEqual(len(moved), 1)
+            # Destination keeps the clean (non-suffixed) basename.
+            self.assertEqual(moved[0], f"{base}.mp3")
+
+
 class TestPollActiveDownloads(unittest.TestCase):
     """Test poll_active_downloads() — core polling function."""
 


### PR DESCRIPTION
## Summary

- Fixes #144. `process_completed_album()` crashed with `FileNotFoundError` whenever slskd had saved a downloaded file with a `_<ticks>` collision suffix (common for multi-disc downloads that share a generic trailing folder name like `CD1`).
- Adds `slskd_local_folder` to centralize the folder-basename derivation and `resolve_slskd_local_path` to try the expected path first, then fall back to ticks variants, preferring `file.size` as a tiebreaker.
- Adds observability logs at the decision points so ambiguous/rare paths are visible in journald if they ever fire — without building a state machine for hypotheticals.

## Test plan

- [x] Pure tests for the resolver: exact match, collision variant match, size tiebreak, returns None when missing, rejects false-positive prefix matches.
- [x] Integration test on `process_completed_album` reproducing the #144 crash — file on disk only as `<name>_639…<ext>`, move still succeeds and dest keeps the clean basename.
- [x] `Ran 2033 tests — OK (skipped=53)`; pyright clean.

## Observability added

- `INFO`: collision variant resolved (single candidate or size-picked).
- `WARNING`: ambiguous collision (>1 candidate, no unique size match) — dumps candidate names and sizes.
- `INFO`: staging folder already existed on entry (reused/resumed).
- `INFO`: already-moved file detected (resume path).

## Scope

Keeping this focused on the actual bug. Codex raised several adjacent edge cases during review (ambiguous-same-size duplicates, stale cross-request staging folders, tag-write-changed-sizes on retry) — all real but rare, all pre-existing behaviors not introduced by this PR. The logs above make them visible if they ever bite; if they do, file as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)