### PR TITLE
[codex] Make library the SSOT for beets and requests

### DIFF
--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -758,4 +758,5 @@ class BeetsDB:
             "added": r[10], "mb_releasegroupid": r[11],
             "release_group_title": r[12], "min_bitrate": r[13],
             "source": source,
+            "discogs_albumid": str(r[14]) if r[14] is not None else None,
         }

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -550,6 +550,8 @@ class PipelineDB:
                 FROM album_requests
                 WHERE mb_artist_id = %s
                    OR (artist_name ILIKE %s ESCAPE '\\'
+                       -- Hyphen-free ids (e.g. legacy numerics / Discogs ids)
+                       -- deliberately fall back to the artist-name match.
                        AND (mb_artist_id IS NULL OR mb_artist_id = ''
                             OR mb_artist_id NOT LIKE '%%-%%'))
                 ORDER BY year, album_title

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -28,6 +28,11 @@ DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localh
 BACKOFF_BASE_MINUTES = 30
 BACKOFF_MAX_MINUTES = 60 * 24  # 24 hours
 
+
+def _escape_like_pattern(value: str) -> str:
+    """Escape SQL LIKE wildcards for ``... LIKE %s ESCAPE '\'``."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
 # Advisory-lock namespaces. Every lock in this codebase is
 # session-scoped, non-blocking (``pg_try_advisory_lock``), and
 # session-reentrant. See ``docs/advisory-locks.md`` for the canonical
@@ -523,6 +528,45 @@ class PipelineDB:
             "SELECT status, COUNT(*) as cnt FROM album_requests GROUP BY status"
         )
         return {r["status"]: r["cnt"] for r in cur.fetchall()}
+
+    def list_requests_by_artist(
+        self,
+        artist_name: str,
+        mb_artist_id: str = "",
+    ) -> list[dict[str, Any]]:
+        """List request rows for one artist, including legacy name fallbacks.
+
+        ``/api/library/artist`` is the SSOT view for albums already in
+        beets and albums still wanted in beets. Prefer exact
+        ``mb_artist_id`` matches when available, but keep the legacy
+        name fallback for older pipeline rows that predate artist-id
+        population or store a non-MB value there.
+        """
+        name_pattern = f"%{_escape_like_pattern(artist_name.strip())}%"
+        if mb_artist_id:
+            cur = self._execute(
+                """
+                SELECT *
+                FROM album_requests
+                WHERE mb_artist_id = %s
+                   OR (artist_name ILIKE %s ESCAPE '\\'
+                       AND (mb_artist_id IS NULL OR mb_artist_id = ''
+                            OR mb_artist_id NOT LIKE '%%-%%'))
+                ORDER BY year, album_title
+                """,
+                (mb_artist_id, name_pattern),
+            )
+        else:
+            cur = self._execute(
+                """
+                SELECT *
+                FROM album_requests
+                WHERE artist_name ILIKE %s ESCAPE '\\'
+                ORDER BY year, album_title
+                """,
+                (name_pattern,),
+            )
+        return [dict(r) for r in cur.fetchall()]
 
     # --- Track management ---
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -542,6 +542,8 @@ class PipelineDB:
         name fallback for older pipeline rows that predate artist-id
         population or store a non-MB value there.
         """
+        # Pair with `ESCAPE '\'` below so literal `%` / `_` in artist names
+        # do not expand into wildcard matches on PostgreSQL.
         name_pattern = f"%{_escape_like_pattern(artist_name.strip())}%"
         if mb_artist_id:
             cur = self._execute(

--- a/scripts/cleanup_ghost_imported.py
+++ b/scripts/cleanup_ghost_imported.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Find and optionally purge ghost imported pipeline rows.
+
+A ghost imported row is ``album_requests.status='imported'`` but the
+exact release ID is absent from the beets library. This script uses the
+same exact-ID seam as the web UI (`BeetsDB.locate`) and can either print
+the rows (`--dry-run`, default) or delete them from the pipeline DB
+(`--apply`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lib.beets_db import BeetsDB
+from lib.pipeline_db import PipelineDB
+
+DEFAULT_DSN = os.environ.get(
+    "PIPELINE_DB_DSN",
+    "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
+)
+
+
+def _row_release_id(row: dict[str, Any]) -> str:
+    return str(row.get("mb_release_id") or row.get("discogs_release_id") or "").strip()
+
+
+def classify_imported_rows(
+    rows: list[dict[str, Any]],
+    beets: BeetsDB,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split imported rows into ghosts and manual-review rows."""
+    ghosts: list[dict[str, Any]] = []
+    manual_review: list[dict[str, Any]] = []
+    for row in rows:
+        release_id = _row_release_id(row)
+        if not release_id:
+            manual_review.append(row)
+            continue
+        if beets.locate(release_id).kind == "absent":
+            ghosts.append(row)
+    return ghosts, manual_review
+
+
+def _print_rows(label: str, rows: list[dict[str, Any]]) -> None:
+    print(f"{label}: {len(rows)}")
+    for row in rows:
+        release_id = _row_release_id(row)
+        imported_path = row.get("imported_path") or ""
+        print(
+            f"{row['id']}\t{row['artist_name']} - {row['album_title']}\t"
+            f"{release_id}\t{imported_path}"
+        )
+
+
+def cmd_scan(db: PipelineDB, beets: BeetsDB) -> int:
+    rows = db.get_by_status("imported")
+    ghosts, manual_review = classify_imported_rows(rows, beets)
+    _print_rows("ghost imported rows", ghosts)
+    if manual_review:
+        print()
+        _print_rows("manual review needed (no release id)", manual_review)
+    return 0
+
+
+def cmd_apply(db: PipelineDB, beets: BeetsDB) -> int:
+    rows = db.get_by_status("imported")
+    ghosts, manual_review = classify_imported_rows(rows, beets)
+    for row in ghosts:
+        db.delete_request(int(row["id"]))
+        print(f"deleted {row['id']}: {row['artist_name']} - {row['album_title']}")
+    print(f"\ndeleted {len(ghosts)} ghost imported rows")
+    if manual_review:
+        print()
+        _print_rows("manual review needed (no release id)", manual_review)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn", default=DEFAULT_DSN,
+                        help="PostgreSQL DSN for the pipeline DB")
+    parser.add_argument("--beets-db", default="/mnt/virtio/Music/beets-library.db",
+                        help="Path to beets-library.db")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true",
+                      help="Print ghost rows without deleting them (default)")
+    mode.add_argument("--apply", action="store_true",
+                      help="Delete matching ghost imported rows")
+    args = parser.parse_args()
+
+    db = PipelineDB(args.dsn)
+    try:
+        with BeetsDB(args.beets_db) as beets:
+            if args.apply:
+                return cmd_apply(db, beets)
+            return cmd_scan(db, beets)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -797,6 +797,44 @@ class FakePipelineDB:
             counts[status] = counts.get(status, 0) + 1
         return counts
 
+    def list_requests_by_artist(
+        self,
+        artist_name: str,
+        mb_artist_id: str = "",
+    ) -> list[dict[str, Any]]:
+        needle = artist_name.lower()
+
+        def _legacy_name_match(row: dict[str, Any]) -> bool:
+            artist = str(row.get("artist_name") or "").lower()
+            artist_id = row.get("mb_artist_id")
+            artist_id_str = str(artist_id or "")
+            return (
+                needle in artist
+                and (
+                    artist_id is None
+                    or artist_id_str == ""
+                    or "-" not in artist_id_str
+                )
+            )
+
+        rows: list[dict[str, Any]] = []
+        for row in self._requests.values():
+            if mb_artist_id:
+                if row.get("mb_artist_id") == mb_artist_id or _legacy_name_match(row):
+                    rows.append(copy.deepcopy(row))
+            else:
+                if needle in str(row.get("artist_name") or "").lower():
+                    rows.append(copy.deepcopy(row))
+
+        def _sort_key(row: dict[str, Any]) -> tuple[bool, int, str]:
+            year = row.get("year")
+            year_num = int(year) if isinstance(year, int) else 0
+            title = str(row.get("album_title") or "")
+            return (year is not None, year_num, title)
+
+        rows.sort(key=_sort_key)
+        return rows
+
     # --- Track management ---
 
     def set_tracks(self, request_id: int,

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -1386,6 +1386,7 @@ class TestAlbumRowSource(unittest.TestCase):
         discogs = [a for a in albums if a["album"] == "Discogs Album"]
         self.assertEqual(len(discogs), 1)
         self.assertEqual(discogs[0]["source"], "discogs")
+        self.assertEqual(discogs[0]["discogs_albumid"], "67890")
 
 
 if __name__ == "__main__":

--- a/tests/test_cleanup_ghost_imported.py
+++ b/tests/test_cleanup_ghost_imported.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for scripts/cleanup_ghost_imported.py."""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lib.beets_db import BeetsDB
+from scripts.cleanup_ghost_imported import classify_imported_rows
+
+
+def _make_beets_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE albums (id INTEGER PRIMARY KEY, mb_albumid TEXT, discogs_albumid INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestCleanupGhostImported(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "beets.db")
+        _make_beets_db(self.db_path)
+
+    def tearDown(self) -> None:
+        try:
+            os.remove(self.db_path)
+        except FileNotFoundError:
+            pass
+        os.rmdir(self.tmpdir)
+
+    def test_classify_imported_rows_detects_missing_mb_and_discogs_releases(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO albums (id, mb_albumid) VALUES (1, ?)",
+            ("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",),
+        )
+        conn.execute(
+            "INSERT INTO albums (id, discogs_albumid) VALUES (2, ?)",
+            (12856590,),
+        )
+        conn.commit()
+        conn.close()
+
+        rows = [
+            {
+                "id": 1,
+                "mb_release_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "discogs_release_id": None,
+                "artist_name": "Present MB",
+                "album_title": "Keep",
+            },
+            {
+                "id": 2,
+                "mb_release_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "discogs_release_id": None,
+                "artist_name": "Missing MB",
+                "album_title": "Ghost",
+            },
+            {
+                "id": 3,
+                "mb_release_id": None,
+                "discogs_release_id": "12856590",
+                "artist_name": "Present Discogs",
+                "album_title": "Keep Too",
+            },
+            {
+                "id": 4,
+                "mb_release_id": None,
+                "discogs_release_id": "5555555",
+                "artist_name": "Missing Discogs",
+                "album_title": "Ghost Too",
+            },
+        ]
+
+        with BeetsDB(self.db_path) as beets:
+            ghosts, manual_review = classify_imported_rows(rows, beets)
+
+        self.assertEqual([row["id"] for row in ghosts], [2, 4])
+        self.assertEqual(manual_review, [])
+
+    def test_classify_imported_rows_flags_missing_release_ids_for_manual_review(self):
+        rows = [
+            {
+                "id": 7,
+                "mb_release_id": None,
+                "discogs_release_id": None,
+                "artist_name": "Unknown",
+                "album_title": "Needs Review",
+            }
+        ]
+
+        with BeetsDB(self.db_path) as beets:
+            ghosts, manual_review = classify_imported_rows(rows, beets)
+
+        self.assertEqual(ghosts, [])
+        self.assertEqual([row["id"] for row in manual_review], [7])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -209,6 +209,56 @@ class TestFakePipelineDB(unittest.TestCase):
         ids = {r["id"] for r in rows}
         self.assertEqual(ids, {1, 3})
 
+    def test_list_requests_by_artist_prefers_mb_artist_id_and_legacy_fallback(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1,
+            artist_name="Test Artist",
+            album_title="Exact MBID",
+            mb_artist_id="artist-1234-uuid",
+        ))
+        db.seed_request(make_request_row(
+            id=2,
+            artist_name="Test Artist",
+            album_title="Legacy Name Match",
+            mb_artist_id=None,
+        ))
+        db.seed_request(make_request_row(
+            id=3,
+            artist_name="Test Artist",
+            album_title="Other MBID",
+            mb_artist_id="other-artist-uuid",
+        ))
+
+        rows = db.list_requests_by_artist("Test Artist", "artist-1234-uuid")
+
+        self.assertEqual([row["id"] for row in rows], [1, 2])
+
+    def test_list_requests_by_artist_name_only_matches_substring(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1,
+            artist_name="The National",
+            album_title="Boxer",
+            year=2007,
+        ))
+        db.seed_request(make_request_row(
+            id=2,
+            artist_name="The National",
+            album_title="Sleep Well Beast",
+            year=2017,
+        ))
+        db.seed_request(make_request_row(
+            id=3,
+            artist_name="Nation of Language",
+            album_title="Introduction, Presence",
+            year=2020,
+        ))
+
+        rows = db.list_requests_by_artist("The National")
+
+        self.assertEqual([row["id"] for row in rows], [1, 2])
+
     def test_assert_log_passes(self):
         db = FakePipelineDB()
         db.log_download(42, outcome="success", soulseek_username="user1")

--- a/tests/test_js_library.mjs
+++ b/tests/test_js_library.mjs
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for web/js/library.js pure helpers.
+ * Run with: node tests/test_js_library.mjs
+ */
+
+import { buildDeleteConfirmHtml } from '../web/js/library.js';
+
+let passed = 0;
+let failed = 0;
+
+function assertContains(haystack, needle, msg) {
+  if (haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} — '${needle}' not in output`);
+  }
+}
+
+function assertExcludes(haystack, needle, msg) {
+  if (!haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} — unexpectedly found '${needle}'`);
+  }
+}
+
+console.log('buildDeleteConfirmHtml() escapes user-visible text and JS args');
+{
+  const html = buildDeleteConfirmHtml(
+    42,
+    'Mum & Dad',
+    "Kid A's <special>",
+    10,
+    1712,
+    "rel-10'oops",
+  );
+  assertContains(html, 'Mum &amp; Dad - Kid A&#39;s &lt;special&gt;', 'artist/album escaped in overlay body');
+  assertContains(html, 'window.executeBeetsDeletion(42, this, 1712, &quot;rel-10&#39;oops&quot;)', 'release id encoded as JS string arg');
+  assertContains(html, 'matching pipeline request/history', 'pipeline note rendered when release id provided');
+}
+
+console.log('buildDeleteConfirmHtml() omits pipeline note without release id');
+{
+  const html = buildDeleteConfirmHtml(7, 'Bodyjar', 'Plastic Skies', 12, null, '');
+  assertContains(html, 'window.executeBeetsDeletion(7, this, null, &quot;&quot;)', 'empty release id still encoded safely');
+  assertExcludes(html, 'matching pipeline request/history', 'no pipeline note without release id');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/test_js_release_actions.mjs
+++ b/tests/test_js_release_actions.mjs
@@ -4,7 +4,7 @@
  */
 
 import { pipelineStore } from '../web/js/state.js';
-import { renderActionToolbar } from '../web/js/release_actions.js';
+import { renderActionToolbar, renderRemoveFromBeetsButton } from '../web/js/release_actions.js';
 
 let passed = 0;
 let failed = 0;
@@ -144,6 +144,27 @@ clearStore();
   assertContains(html, '&quot;rel-10&#39;oops&quot;', 'release id encoded as JS string arg');
   assertContains(html, '&quot;Some of the 12th Man&#39;s Greatest Hits&quot;', 'album encoded as JS string arg');
   assertContains(html, 'window.confirmDeleteBeets(77', 'delete handler still rendered');
+}
+
+console.log('Remove from beets helper — shared renderer supports detail view styling');
+clearStore();
+{
+  const html = renderRemoveFromBeetsButton({
+    id: "rel-11'oops",
+    in_library: true,
+    beets_album_id: 88,
+    pipeline_id: 900,
+    artist: 'Mum & Dad',
+    album: "Kid A's <special>",
+    track_count: 10,
+  }, {
+    className: 'p-btn delete-beets',
+    label: 'Delete from beets',
+    stopPropagation: true,
+  });
+  assertContains(html, 'class="p-btn delete-beets"', 'custom class supported');
+  assertContains(html, 'event.stopPropagation(); window.confirmDeleteBeets(88', 'stopPropagation wiring supported');
+  assertContains(html, '&quot;Kid A&#39;s &lt;special&gt;&quot;', 'album encoded safely');
 }
 
 console.log('Acquire button — manual review → disabled Add request');

--- a/tests/test_js_release_actions.mjs
+++ b/tests/test_js_release_actions.mjs
@@ -36,7 +36,7 @@ clearStore();
 {
   const html = renderActionToolbar({ id: 'rel-1', in_library: false });
   assertContains(html, '>Add request</button>', 'shows Add request label');
-  assertContains(html, "window.addRelease('rel-1'", 'Add wired up');
+  assertContains(html, 'window.addRelease(&quot;rel-1&quot;', 'Add wired up');
   assertExcludes(html, '>Upgrade</button>', 'no Upgrade in this state');
   assertExcludes(html, '>Remove request</button>', 'no Remove request in this state');
   assertContains(html, '>Remove from beets</button>', 'Remove from beets always rendered');
@@ -51,13 +51,13 @@ clearStore();
     artist: 'Bodyjar', album: 'Plastic Skies', track_count: 12,
   });
   assertContains(html, '>Upgrade</button>', 'shows Upgrade label');
-  assertContains(html, "window.upgradeAlbum('rel-2'", 'Upgrade wired up');
+  assertContains(html, 'window.upgradeAlbum(&quot;rel-2&quot;', 'Upgrade wired up');
   assertExcludes(html, '>Add request</button>', 'no Add request');
   assertExcludes(html, '>Remove request</button>', 'no Remove request');
   assertContains(html, 'window.confirmDeleteBeets(42', 'Remove from beets enabled');
-  assertContains(html, ", null, 'rel-2')", 'release id passed to delete confirm');
-  assertContains(html, "'Bodyjar'", 'artist passed to delete confirm');
-  assertContains(html, "'Plastic Skies'", 'album passed to delete confirm');
+  assertContains(html, ', null, &quot;rel-2&quot;)', 'release id passed to delete confirm');
+  assertContains(html, '&quot;Bodyjar&quot;', 'artist passed to delete confirm');
+  assertContains(html, '&quot;Plastic Skies&quot;', 'album passed to delete confirm');
 }
 
 console.log('Acquire button — in library + wanted → Remove request (the user-reported bug)');
@@ -75,7 +75,7 @@ clearStore();
   assertExcludes(html, '>Upgrade</button>', 'no Upgrade — wanted wins');
   // Remove from beets still independent
   assertContains(html, 'window.confirmDeleteBeets(42', 'Remove from beets still enabled');
-  assertContains(html, ", 1712, 'rel-3')", 'pipeline context passed to delete confirm');
+  assertContains(html, ', 1712, &quot;rel-3&quot;)', 'pipeline context passed to delete confirm');
 }
 
 console.log('Acquire button — not in library + wanted → Remove request');
@@ -128,6 +128,22 @@ pipelineStore.set('rel-7', { status: 'wanted', id: 500 });
     pipeline_status: null, pipeline_id: null,
   });
   assertContains(html, 'window.disambRemove(500', 'pipelineStore overrides backend');
+}
+
+console.log('Remove from beets — apostrophes stay JS-safe inside onclick');
+clearStore();
+{
+  const html = renderActionToolbar({
+    id: "rel-10'oops",
+    in_library: true,
+    beets_album_id: 77,
+    artist: 'The 12th Man',
+    album: "Some of the 12th Man's Greatest Hits",
+    track_count: 14,
+  });
+  assertContains(html, '&quot;rel-10&#39;oops&quot;', 'release id encoded as JS string arg');
+  assertContains(html, '&quot;Some of the 12th Man&#39;s Greatest Hits&quot;', 'album encoded as JS string arg');
+  assertContains(html, 'window.confirmDeleteBeets(77', 'delete handler still rendered');
 }
 
 console.log('Acquire button — manual review → disabled Add request');

--- a/tests/test_js_release_actions.mjs
+++ b/tests/test_js_release_actions.mjs
@@ -55,6 +55,7 @@ clearStore();
   assertExcludes(html, '>Add request</button>', 'no Add request');
   assertExcludes(html, '>Remove request</button>', 'no Remove request');
   assertContains(html, 'window.confirmDeleteBeets(42', 'Remove from beets enabled');
+  assertContains(html, ", null, 'rel-2')", 'release id passed to delete confirm');
   assertContains(html, "'Bodyjar'", 'artist passed to delete confirm');
   assertContains(html, "'Plastic Skies'", 'album passed to delete confirm');
 }
@@ -74,6 +75,7 @@ clearStore();
   assertExcludes(html, '>Upgrade</button>', 'no Upgrade — wanted wins');
   // Remove from beets still independent
   assertContains(html, 'window.confirmDeleteBeets(42', 'Remove from beets still enabled');
+  assertContains(html, ", 1712, 'rel-3')", 'pipeline context passed to delete confirm');
 }
 
 console.log('Acquire button — not in library + wanted → Remove request');

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_util.mjs
  */
 
-import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
+import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
 
 let passed = 0;
 let failed = 0;
@@ -101,6 +101,11 @@ assertEqual(overrideToIntent('lossless'), 'lossless', '"lossless" → lossless')
 assertEqual(overrideToIntent('flac'), 'lossless', '"flac" (backward compat) → lossless');
 assertEqual(overrideToIntent('flac,mp3 v0,mp3 320'), 'default', 'CSV → default');
 assertEqual(overrideToIntent('unknown'), 'default', 'unknown → default');
+
+// --- jsArg tests ---
+console.log('jsArg()');
+assertEqual(jsArg("Kid A's"), '&quot;Kid A&#39;s&quot;', 'encodes apostrophes inside JS string literal');
+assertEqual(jsArg(null), '&quot;&quot;', 'null becomes empty string literal');
 
 // --- detectSource tests ---
 console.log('detectSource()');

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1896,6 +1896,96 @@ class TestBrowseRouteContracts(_WebServerCase):
         self.assertEqual(data["albums"][0]["pipeline_id"], 42)
         self.assertTrue(data["albums"][0]["in_library"])
 
+    def test_library_artist_route_dedups_discogs_pipeline_row_when_beets_row_has_same_discogs_id(self):
+        import web.server as srv
+
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=55,
+            mb_release_id=None,
+            discogs_release_id="12856590",
+            mb_artist_id=None,
+            artist_name="Test Artist",
+            album_title="Discogs Import",
+            source="request",
+            status="wanted",
+        ))
+        beets_album = {
+            "id": 8,
+            "album": "Discogs Import",
+            "artist": "Test Artist",
+            "year": 2001,
+            "mb_albumid": None,
+            "discogs_albumid": "12856590",
+            "track_count": 10,
+            "mb_releasegroupid": None,
+            "release_group_title": "Discogs Import",
+            "added": 1773651902.0,
+            "formats": "MP3",
+            "min_bitrate": 320000,
+            "type": "album",
+            "label": "Test Label",
+            "country": "AU",
+            "source": "discogs",
+        }
+
+        with patch.object(srv, "db", fake_db), \
+                patch("web.server.get_library_artist", return_value=[beets_album]):
+            status, data = self._get(
+                f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(len(data["albums"]), 1)
+        self.assertEqual(data["albums"][0]["id"], 8)
+        self.assertEqual(data["albums"][0]["mb_albumid"], "12856590")
+        self.assertEqual(data["albums"][0]["pipeline_id"], 55)
+        self.assertTrue(data["albums"][0]["in_library"])
+
+    def test_library_artist_route_sorts_merged_rows_after_dedup(self):
+        import web.server as srv
+
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=50,
+            mb_release_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            mb_release_group_id="22222222-2222-2222-2222-222222222222",
+            mb_artist_id=self.ARTIST_ID,
+            artist_name="Test Artist",
+            album_title="Older Request",
+            year=1997,
+            status="wanted",
+        ))
+        beets_album = {
+            "id": 9,
+            "album": "Later Library Album",
+            "artist": "Test Artist",
+            "year": 2005,
+            "mb_albumid": self.RELEASE_ID,
+            "track_count": 11,
+            "mb_releasegroupid": self.RG_ID,
+            "release_group_title": "Later Library Album",
+            "added": 1773651903.0,
+            "formats": "MP3",
+            "min_bitrate": 320000,
+            "type": "album",
+            "label": "Test Label",
+            "country": "US",
+            "source": "musicbrainz",
+        }
+
+        with patch.object(srv, "db", fake_db), \
+                patch("web.server.get_library_artist", return_value=[beets_album]):
+            status, data = self._get(
+                f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual([row["album"] for row in data["albums"]], [
+            "Older Request",
+            "Later Library Album",
+        ])
+
     def test_artist_compare_contract(self):
         """Compare endpoint returns mb_artist, discogs_artist, and three buckets."""
         mb_rg = {
@@ -2326,6 +2416,23 @@ class TestBeetsRouteContracts(_WebServerCase):
             "bitdepth": 16,
         }
 
+    def _configure_beets_delete_mock(
+        self,
+        mock_beets_cls: MagicMock,
+        *,
+        delete_side_effect: object | None = None,
+    ) -> None:
+        beets = mock_beets_cls.return_value.__enter__.return_value
+        beets.get_album_detail.return_value = {"id": 7}
+        if delete_side_effect is not None:
+            mock_beets_cls.delete_album.side_effect = delete_side_effect
+            return
+        mock_beets_cls.delete_album.return_value = (
+            "Test Album",
+            "Test Artist",
+            ["/music/Test Artist/Test Album/01 Track.mp3"],
+        )
+
     def test_beets_search_contract(self):
         self.beets.search_albums.return_value = [self._album()]
         with patch("web.server.check_pipeline", return_value={}):
@@ -2363,20 +2470,16 @@ class TestBeetsRouteContracts(_WebServerCase):
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
     @patch("web.routes.library.os.path.exists", return_value=True)
-    @patch("lib.beets_db.BeetsDB.delete_album")
+    @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_contract(
         self,
-        mock_delete,
+        mock_beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
     ):
         self._srv.beets_db_path = "/tmp/beets.db"
-        mock_delete.return_value = (
-            "Test Album",
-            "Test Artist",
-            ["/music/Test Artist/Test Album/01 Track.mp3"],
-        )
+        self._configure_beets_delete_mock(mock_beets_cls)
 
         status, data = self._post("/api/beets/delete", {"id": 7, "confirm": "DELETE"})
 
@@ -2387,10 +2490,10 @@ class TestBeetsRouteContracts(_WebServerCase):
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
     @patch("web.routes.library.os.path.exists", return_value=True)
-    @patch("lib.beets_db.BeetsDB.delete_album")
+    @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_explicit_pipeline_request(
         self,
-        mock_delete,
+        mock_beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -2402,11 +2505,7 @@ class TestBeetsRouteContracts(_WebServerCase):
         fake_db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        mock_delete.return_value = (
-            "Test Album",
-            "Test Artist",
-            ["/music/Test Artist/Test Album/01 Track.mp3"],
-        )
+        self._configure_beets_delete_mock(mock_beets_cls)
 
         with patch.object(srv, "db", fake_db):
             status, data = self._post("/api/beets/delete", {
@@ -2425,10 +2524,10 @@ class TestBeetsRouteContracts(_WebServerCase):
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
     @patch("web.routes.library.os.path.exists", return_value=True)
-    @patch("lib.beets_db.BeetsDB.delete_album")
+    @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_pipeline_request_by_release_id_fallback(
         self,
-        mock_delete,
+        mock_beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -2440,11 +2539,7 @@ class TestBeetsRouteContracts(_WebServerCase):
         fake_db.seed_request(make_request_row(
             id=99, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        mock_delete.return_value = (
-            "Test Album",
-            "Test Artist",
-            ["/music/Test Artist/Test Album/01 Track.mp3"],
-        )
+        self._configure_beets_delete_mock(mock_beets_cls)
 
         with patch.object(srv, "db", fake_db):
             status, data = self._post("/api/beets/delete", {
@@ -2462,10 +2557,10 @@ class TestBeetsRouteContracts(_WebServerCase):
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
     @patch("web.routes.library.os.path.exists", return_value=True)
-    @patch("lib.beets_db.BeetsDB.delete_album")
+    @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_without_purge_pipeline_leaves_request_intact(
         self,
-        mock_delete,
+        mock_beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -2477,11 +2572,7 @@ class TestBeetsRouteContracts(_WebServerCase):
         fake_db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        mock_delete.return_value = (
-            "Test Album",
-            "Test Artist",
-            ["/music/Test Artist/Test Album/01 Track.mp3"],
-        )
+        self._configure_beets_delete_mock(mock_beets_cls)
 
         with patch.object(srv, "db", fake_db):
             status, data = self._post("/api/beets/delete", {
@@ -2497,10 +2588,10 @@ class TestBeetsRouteContracts(_WebServerCase):
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
     @patch("web.routes.library.os.path.exists", return_value=True)
-    @patch("lib.beets_db.BeetsDB.delete_album")
+    @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purge_with_no_pipeline_context_is_noop(
         self,
-        mock_delete,
+        mock_beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -2509,11 +2600,7 @@ class TestBeetsRouteContracts(_WebServerCase):
 
         self._srv.beets_db_path = "/tmp/beets.db"
         fake_db = FakePipelineDB()
-        mock_delete.return_value = (
-            "Test Album",
-            "Test Artist",
-            ["/music/Test Artist/Test Album/01 Track.mp3"],
-        )
+        self._configure_beets_delete_mock(mock_beets_cls)
 
         with patch.object(srv, "db", fake_db):
             status, data = self._post("/api/beets/delete", {
@@ -2529,10 +2616,10 @@ class TestBeetsRouteContracts(_WebServerCase):
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
     @patch("web.routes.library.os.path.exists", return_value=True)
-    @patch("lib.beets_db.BeetsDB.delete_album")
+    @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_discogs_request_by_numeric_release_id_fallback(
         self,
-        mock_delete,
+        mock_beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -2547,11 +2634,7 @@ class TestBeetsRouteContracts(_WebServerCase):
             discogs_release_id="12856590",
             status="imported",
         ))
-        mock_delete.return_value = (
-            "Test Album",
-            "Test Artist",
-            ["/music/Test Artist/Test Album/01 Track.mp3"],
-        )
+        self._configure_beets_delete_mock(mock_beets_cls)
 
         with patch.object(srv, "db", fake_db):
             status, data = self._post("/api/beets/delete", {
@@ -2565,6 +2648,40 @@ class TestBeetsRouteContracts(_WebServerCase):
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 77)
         self.assertIsNone(fake_db.get_request(77))
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB")
+    def test_beets_delete_pipeline_failure_aborts_before_beets_delete(
+        self,
+        mock_beets_cls,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        import web.server as srv
+
+        self._srv.beets_db_path = "/tmp/beets.db"
+        self._configure_beets_delete_mock(mock_beets_cls)
+        failing_db = MagicMock()
+        failing_db.get_request.return_value = make_request_row(
+            id=42, status="imported", mb_release_id=self.RELEASE_ID,
+        )
+        failing_db.delete_request.side_effect = RuntimeError("boom")
+
+        with patch.object(srv, "db", failing_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+                "purge_pipeline": True,
+                "pipeline_id": 42,
+                "release_id": self.RELEASE_ID,
+            })
+
+        self.assertEqual(status, 500)
+        self.assertIn("error", data)
+        mock_beets_cls.delete_album.assert_not_called()
 
 
 class TestApplyPipelineBitrateOverride(unittest.TestCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 from lib.manual_import import FolderInfo, FolderMatch, ImportRequest
+from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
 _MOCK_PIPELINE_REQUEST = make_request_row(
@@ -175,6 +176,7 @@ def _make_server():
     mock_db.get_wrong_matches.return_value = [copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)]
     mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
     mock_db.clear_wrong_match_path.return_value = True
+    mock_db.list_requests_by_artist.return_value = []
 
     srv.db = mock_db
     srv.beets_db_path = None  # No beets DB in tests
@@ -1811,35 +1813,34 @@ class TestBrowseRouteContracts(_WebServerCase):
                                 "library artist album")
 
     def test_library_artist_route_includes_pipeline_only_requests(self):
-        from datetime import datetime, timezone
+        import web.server as srv
 
-        row = {
-            "id": 42,
-            "mb_release_id": self.RELEASE_ID,
-            "mb_release_group_id": self.RG_ID,
-            "artist_name": "Test Artist",
-            "album_title": "Wanted Album",
-            "year": 2024,
-            "country": "US",
-            "format": "CD",
-            "source": "request",
-            "status": "wanted",
-            "created_at": datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc),
-            "min_bitrate": 320,
-            "search_filetype_override": "flac",
-            "target_format": None,
-        }
-        orig_execute = self.mock_db._execute.return_value
-        self.mock_db._execute.return_value = MagicMock(
-            fetchall=MagicMock(return_value=[row]))
-        self.mock_db.get_track_counts.return_value = {42: 10}
-        try:
-            with patch("web.server.get_library_artist", return_value=[]):
-                status, data = self._get(
-                    f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
-                )
-        finally:
-            self.mock_db._execute.return_value = orig_execute
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=42,
+            mb_release_id=self.RELEASE_ID,
+            mb_release_group_id=self.RG_ID,
+            mb_artist_id=self.ARTIST_ID,
+            artist_name="Test Artist",
+            album_title="Wanted Album",
+            year=2024,
+            country="US",
+            format="CD",
+            source="request",
+            status="wanted",
+            min_bitrate=320,
+            search_filetype_override="flac",
+        ))
+        fake_db.set_tracks(42, [
+            {"track_number": i + 1, "title": f"Track {i + 1}"}
+            for i in range(10)
+        ])
+
+        with patch.object(srv, "db", fake_db), \
+                patch("web.server.get_library_artist", return_value=[]):
+            status, data = self._get(
+                f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
+            )
 
         self.assertEqual(status, 200)
         self.assertEqual(len(data["albums"]), 1)
@@ -1848,6 +1849,52 @@ class TestBrowseRouteContracts(_WebServerCase):
         self.assertEqual(data["albums"][0]["pipeline_status"], "wanted")
         self.assertEqual(data["albums"][0]["pipeline_id"], 42)
         self.assertIsNone(data["albums"][0]["beets_album_id"])
+
+    def test_library_artist_route_dedups_pipeline_row_when_beets_row_has_same_release_id(self):
+        import web.server as srv
+
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=42,
+            mb_release_id=self.RELEASE_ID,
+            mb_release_group_id=self.RG_ID,
+            mb_artist_id=self.ARTIST_ID,
+            artist_name="Test Artist",
+            album_title="Duplicate Pipeline Row",
+            status="wanted",
+        ))
+        beets_album = {
+            "id": 7,
+            "album": "Test Album",
+            "artist": "Test Artist",
+            "year": 2024,
+            "mb_albumid": self.RELEASE_ID,
+            "track_count": 10,
+            "mb_releasegroupid": self.RG_ID,
+            "release_group_title": "Test Album",
+            "added": 1773651901.0,
+            "formats": "MP3",
+            "min_bitrate": 320000,
+            "type": "album",
+            "label": "Test Label",
+            "country": "US",
+            "source": "musicbrainz",
+        }
+
+        with patch.object(srv, "db", fake_db), \
+                patch("web.server.get_library_artist", return_value=[beets_album]), \
+                patch("web.server.check_pipeline", return_value={
+                    self.RELEASE_ID: {"id": 42, "status": "wanted"},
+                }):
+            status, data = self._get(
+                f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(len(data["albums"]), 1)
+        self.assertEqual(data["albums"][0]["id"], 7)
+        self.assertEqual(data["albums"][0]["pipeline_id"], 42)
+        self.assertTrue(data["albums"][0]["in_library"])
 
     def test_artist_compare_contract(self):
         """Compare endpoint returns mb_artist, discogs_artist, and three buckets."""
@@ -2221,7 +2268,10 @@ class TestBeetsRouteContracts(_WebServerCase):
         "disc", "track", "title", "length", "format", "bitrate",
         "samplerate", "bitdepth",
     }
-    DELETE_REQUIRED_FIELDS = {"status", "id", "album", "artist", "deleted_files"}
+    DELETE_REQUIRED_FIELDS = {
+        "status", "id", "album", "artist", "deleted_files",
+        "pipeline_deleted", "pipeline_id",
+    }
 
     RELEASE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
     RG_ID = "11111111-1111-1111-1111-111111111111"
@@ -2345,29 +2395,32 @@ class TestBeetsRouteContracts(_WebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
+        import web.server as srv
+
         self._srv.beets_db_path = "/tmp/beets.db"
-        self.mock_db.delete_request.reset_mock()
-        self.mock_db.get_request.return_value = make_request_row(
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
-        )
+        ))
         mock_delete.return_value = (
             "Test Album",
             "Test Artist",
             ["/music/Test Artist/Test Album/01 Track.mp3"],
         )
 
-        status, data = self._post("/api/beets/delete", {
-            "id": 7,
-            "confirm": "DELETE",
-            "purge_pipeline": True,
-            "pipeline_id": 42,
-            "release_id": self.RELEASE_ID,
-        })
+        with patch.object(srv, "db", fake_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+                "purge_pipeline": True,
+                "pipeline_id": 42,
+                "release_id": self.RELEASE_ID,
+            })
 
         self.assertEqual(status, 200)
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 42)
-        self.mock_db.delete_request.assert_called_once_with(42)
+        self.assertIsNone(fake_db.get_request(42))
 
     @patch("web.routes.library.os.path.isdir", return_value=False)
     @patch("web.routes.library.os.path.isfile", return_value=False)
@@ -2380,29 +2433,138 @@ class TestBeetsRouteContracts(_WebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
+        import web.server as srv
+
         self._srv.beets_db_path = "/tmp/beets.db"
-        self.mock_db.delete_request.reset_mock()
-        self.mock_db.get_request.return_value = None
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
             id=99, status="imported", mb_release_id=self.RELEASE_ID,
-        )
+        ))
         mock_delete.return_value = (
             "Test Album",
             "Test Artist",
             ["/music/Test Artist/Test Album/01 Track.mp3"],
         )
 
-        status, data = self._post("/api/beets/delete", {
-            "id": 7,
-            "confirm": "DELETE",
-            "purge_pipeline": True,
-            "release_id": self.RELEASE_ID,
-        })
+        with patch.object(srv, "db", fake_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+                "purge_pipeline": True,
+                "release_id": self.RELEASE_ID,
+            })
 
         self.assertEqual(status, 200)
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 99)
-        self.mock_db.delete_request.assert_called_once_with(99)
+        self.assertIsNone(fake_db.get_request(99))
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB.delete_album")
+    def test_beets_delete_without_purge_pipeline_leaves_request_intact(
+        self,
+        mock_delete,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        import web.server as srv
+
+        self._srv.beets_db_path = "/tmp/beets.db"
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=42, status="imported", mb_release_id=self.RELEASE_ID,
+        ))
+        mock_delete.return_value = (
+            "Test Album",
+            "Test Artist",
+            ["/music/Test Artist/Test Album/01 Track.mp3"],
+        )
+
+        with patch.object(srv, "db", fake_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+            })
+
+        self.assertEqual(status, 200)
+        self.assertFalse(data["pipeline_deleted"])
+        self.assertIsNone(data["pipeline_id"])
+        self.assertIsNotNone(fake_db.get_request(42))
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB.delete_album")
+    def test_beets_delete_purge_with_no_pipeline_context_is_noop(
+        self,
+        mock_delete,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        import web.server as srv
+
+        self._srv.beets_db_path = "/tmp/beets.db"
+        fake_db = FakePipelineDB()
+        mock_delete.return_value = (
+            "Test Album",
+            "Test Artist",
+            ["/music/Test Artist/Test Album/01 Track.mp3"],
+        )
+
+        with patch.object(srv, "db", fake_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+                "purge_pipeline": True,
+            })
+
+        self.assertEqual(status, 200)
+        self.assertFalse(data["pipeline_deleted"])
+        self.assertIsNone(data["pipeline_id"])
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB.delete_album")
+    def test_beets_delete_purges_discogs_request_by_numeric_release_id_fallback(
+        self,
+        mock_delete,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        import web.server as srv
+
+        self._srv.beets_db_path = "/tmp/beets.db"
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=77,
+            mb_release_id=None,
+            discogs_release_id="12856590",
+            status="imported",
+        ))
+        mock_delete.return_value = (
+            "Test Album",
+            "Test Artist",
+            ["/music/Test Artist/Test Album/01 Track.mp3"],
+        )
+
+        with patch.object(srv, "db", fake_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+                "purge_pipeline": True,
+                "release_id": "12856590",
+            })
+
+        self.assertEqual(status, 200)
+        self.assertTrue(data["pipeline_deleted"])
+        self.assertEqual(data["pipeline_id"], 77)
+        self.assertIsNone(fake_db.get_request(77))
 
 
 class TestApplyPipelineBitrateOverride(unittest.TestCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1715,6 +1715,8 @@ class TestBrowseRouteContracts(_WebServerCase):
         "id", "album", "artist", "year", "mb_albumid", "track_count",
         "mb_releasegroupid", "release_group_title", "added", "formats",
         "min_bitrate", "type", "label", "country", "source",
+        "in_library", "beets_album_id", "pipeline_status", "pipeline_id",
+        "upgrade_queued", "library_rank",
     }
     RELEASE_GROUP_REQUIRED_FIELDS = {
         "id", "title", "country", "date", "format", "track_count", "status",
@@ -1797,7 +1799,8 @@ class TestBrowseRouteContracts(_WebServerCase):
             "country": "US",
             "source": "musicbrainz",
         }
-        with patch("web.server.get_library_artist", return_value=[album]):
+        with patch("web.server.get_library_artist", return_value=[album]), \
+                patch("web.server.check_pipeline", return_value={}):
             status, data = self._get(
                 f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
             )
@@ -1806,6 +1809,45 @@ class TestBrowseRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, {"albums"}, "library artist response")
         _assert_required_fields(self, data["albums"][0], self.LIBRARY_ALBUM_REQUIRED_FIELDS,
                                 "library artist album")
+
+    def test_library_artist_route_includes_pipeline_only_requests(self):
+        from datetime import datetime, timezone
+
+        row = {
+            "id": 42,
+            "mb_release_id": self.RELEASE_ID,
+            "mb_release_group_id": self.RG_ID,
+            "artist_name": "Test Artist",
+            "album_title": "Wanted Album",
+            "year": 2024,
+            "country": "US",
+            "format": "CD",
+            "source": "request",
+            "status": "wanted",
+            "created_at": datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc),
+            "min_bitrate": 320,
+            "search_filetype_override": "flac",
+            "target_format": None,
+        }
+        orig_execute = self.mock_db._execute.return_value
+        self.mock_db._execute.return_value = MagicMock(
+            fetchall=MagicMock(return_value=[row]))
+        self.mock_db.get_track_counts.return_value = {42: 10}
+        try:
+            with patch("web.server.get_library_artist", return_value=[]):
+                status, data = self._get(
+                    f"/api/library/artist?name=Test%20Artist&mbid={self.ARTIST_ID}"
+                )
+        finally:
+            self.mock_db._execute.return_value = orig_execute
+
+        self.assertEqual(status, 200)
+        self.assertEqual(len(data["albums"]), 1)
+        self.assertEqual(data["albums"][0]["album"], "Wanted Album")
+        self.assertFalse(data["albums"][0]["in_library"])
+        self.assertEqual(data["albums"][0]["pipeline_status"], "wanted")
+        self.assertEqual(data["albums"][0]["pipeline_id"], 42)
+        self.assertIsNone(data["albums"][0]["beets_album_id"])
 
     def test_artist_compare_contract(self):
         """Compare endpoint returns mb_artist, discogs_artist, and three buckets."""
@@ -2291,6 +2333,76 @@ class TestBeetsRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.DELETE_REQUIRED_FIELDS,
                                 "beets delete response")
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB.delete_album")
+    def test_beets_delete_purges_explicit_pipeline_request(
+        self,
+        mock_delete,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        self._srv.beets_db_path = "/tmp/beets.db"
+        self.mock_db.delete_request.reset_mock()
+        self.mock_db.get_request.return_value = make_request_row(
+            id=42, status="imported", mb_release_id=self.RELEASE_ID,
+        )
+        mock_delete.return_value = (
+            "Test Album",
+            "Test Artist",
+            ["/music/Test Artist/Test Album/01 Track.mp3"],
+        )
+
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "pipeline_id": 42,
+            "release_id": self.RELEASE_ID,
+        })
+
+        self.assertEqual(status, 200)
+        self.assertTrue(data["pipeline_deleted"])
+        self.assertEqual(data["pipeline_id"], 42)
+        self.mock_db.delete_request.assert_called_once_with(42)
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB.delete_album")
+    def test_beets_delete_purges_pipeline_request_by_release_id_fallback(
+        self,
+        mock_delete,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        self._srv.beets_db_path = "/tmp/beets.db"
+        self.mock_db.delete_request.reset_mock()
+        self.mock_db.get_request.return_value = None
+        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+            id=99, status="imported", mb_release_id=self.RELEASE_ID,
+        )
+        mock_delete.return_value = (
+            "Test Album",
+            "Test Artist",
+            ["/music/Test Artist/Test Album/01 Track.mp3"],
+        )
+
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "release_id": self.RELEASE_ID,
+        })
+
+        self.assertEqual(status, 200)
+        self.assertTrue(data["pipeline_deleted"])
+        self.assertEqual(data["pipeline_id"], 99)
+        self.mock_db.delete_request.assert_called_once_with(99)
 
 
 class TestApplyPipelineBitrateOverride(unittest.TestCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1844,11 +1844,14 @@ class TestBrowseRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         self.assertEqual(len(data["albums"]), 1)
+        _assert_required_fields(self, data["albums"][0], self.LIBRARY_ALBUM_REQUIRED_FIELDS,
+                                "pipeline-only library artist album")
         self.assertEqual(data["albums"][0]["album"], "Wanted Album")
         self.assertFalse(data["albums"][0]["in_library"])
         self.assertEqual(data["albums"][0]["pipeline_status"], "wanted")
         self.assertEqual(data["albums"][0]["pipeline_id"], 42)
         self.assertIsNone(data["albums"][0]["beets_album_id"])
+        self.assertIsNone(data["albums"][0]["library_rank"])
 
     def test_library_artist_route_dedups_pipeline_row_when_beets_row_has_same_release_id(self):
         import web.server as srv
@@ -2682,6 +2685,42 @@ class TestBeetsRouteContracts(_WebServerCase):
         self.assertEqual(status, 500)
         self.assertIn("error", data)
         mock_beets_cls.delete_album.assert_not_called()
+
+    @patch("web.routes.library.os.path.isdir", return_value=False)
+    @patch("web.routes.library.os.path.isfile", return_value=False)
+    @patch("web.routes.library.os.path.exists", return_value=True)
+    @patch("lib.beets_db.BeetsDB")
+    def test_beets_delete_failure_after_pipeline_purge_returns_targeted_error(
+        self,
+        mock_beets_cls,
+        _mock_exists,
+        _mock_isfile,
+        _mock_isdir,
+    ):
+        import web.server as srv
+
+        self._srv.beets_db_path = "/tmp/beets.db"
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=42, status="imported", mb_release_id=self.RELEASE_ID,
+        ))
+        self._configure_beets_delete_mock(
+            mock_beets_cls,
+            delete_side_effect=OSError("boom"),
+        )
+
+        with patch.object(srv, "db", fake_db):
+            status, data = self._post("/api/beets/delete", {
+                "id": 7,
+                "confirm": "DELETE",
+                "purge_pipeline": True,
+                "pipeline_id": 42,
+                "release_id": self.RELEASE_ID,
+            })
+
+        self.assertEqual(status, 500)
+        self.assertIn("Pipeline request was removed", data["error"])
+        self.assertIsNone(fake_db.get_request(42))
 
 
 class TestApplyPipelineBitrateOverride(unittest.TestCase):

--- a/web/js/analysis.js
+++ b/web/js/analysis.js
@@ -226,8 +226,9 @@ export async function disambRemove(pipelineId, btn) {
  * @param {number} beetsId
  * @param {number|null} pipelineId
  * @param {HTMLButtonElement} btn
+ * @param {string} [releaseId]
  */
-export async function disambDeleteFromLibrary(beetsId, pipelineId, btn) {
+export async function disambDeleteFromLibrary(beetsId, pipelineId, btn, releaseId = '') {
   if (!confirm(`Delete album #${beetsId} from beets library and pipeline? This removes files from disk.`)) return;
   btn.disabled = true;
   btn.textContent = '...';
@@ -235,23 +236,25 @@ export async function disambDeleteFromLibrary(beetsId, pipelineId, btn) {
     const r = await fetch(`${API}/api/beets/delete`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({id: beetsId, confirm: 'DELETE'}),
+      body: JSON.stringify({
+        id: beetsId,
+        confirm: 'DELETE',
+        purge_pipeline: true,
+        pipeline_id: pipelineId,
+        release_id: releaseId,
+      }),
     });
     const data = await r.json();
     if (data.status === 'ok') {
-      // Also delete from pipeline if there's a pipeline entry
-      if (pipelineId) {
-        await fetch(`${API}/api/pipeline/delete`, {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({id: pipelineId}),
-        });
+      if (data.pipeline_deleted && releaseId) {
+        updatePipelineStatus(releaseId, null, null);
       }
       btn.textContent = 'Deleted';
       btn.style.background = '#333';
       btn.style.color = '#666';
       invalidateBrowseArtist();
-      toast(`Deleted: ${data.artist} - ${data.album} (${data.deleted_files} files)`);
+      const pipelineMsg = data.pipeline_deleted ? ', request removed' : '';
+      toast(`Deleted: ${data.artist} - ${data.album} (${data.deleted_files} files${pipelineMsg})`);
     } else {
       btn.textContent = 'Error';
       toast(data.error || 'Delete failed', true);

--- a/web/js/analysis.js
+++ b/web/js/analysis.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { state, API, toast, updatePipelineStatus, pipelineStore } from './state.js';
+import { state, API, toast, updatePipelineStatus } from './state.js';
 import { esc } from './util.js';
 import { renderTypedSections } from './grouping.js';
 import { renderActionToolbar } from './release_actions.js';
@@ -218,49 +218,5 @@ export async function disambRemove(pipelineId, btn) {
   } catch (e) {
     btn.textContent = 'Error';
     toast('Remove failed', true);
-  }
-}
-
-/**
- * Delete an album from the beets library and optionally the pipeline.
- * @param {number} beetsId
- * @param {number|null} pipelineId
- * @param {HTMLButtonElement} btn
- * @param {string} [releaseId]
- */
-export async function disambDeleteFromLibrary(beetsId, pipelineId, btn, releaseId = '') {
-  if (!confirm(`Delete album #${beetsId} from beets library and pipeline? This removes files from disk.`)) return;
-  btn.disabled = true;
-  btn.textContent = '...';
-  try {
-    const r = await fetch(`${API}/api/beets/delete`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({
-        id: beetsId,
-        confirm: 'DELETE',
-        purge_pipeline: true,
-        pipeline_id: pipelineId,
-        release_id: releaseId,
-      }),
-    });
-    const data = await r.json();
-    if (data.status === 'ok') {
-      if (data.pipeline_deleted && releaseId) {
-        updatePipelineStatus(releaseId, null, null);
-      }
-      btn.textContent = 'Deleted';
-      btn.style.background = '#333';
-      btn.style.color = '#666';
-      invalidateBrowseArtist();
-      const pipelineMsg = data.pipeline_deleted ? ', request removed' : '';
-      toast(`Deleted: ${data.artist} - ${data.album} (${data.deleted_files} files${pipelineMsg})`);
-    } else {
-      btn.textContent = 'Error';
-      toast(data.error || 'Delete failed', true);
-    }
-  } catch (e) {
-    btn.textContent = 'Error';
-    toast('Delete failed', true);
   }
 }

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -2,7 +2,7 @@
 import { API, state, toast, updatePipelineStatus } from './state.js';
 import { esc, jsArg, qualityLabel, overrideToIntent, externalReleaseUrl, sourceLabel } from './util.js';
 import { renderTypedSections } from './grouping.js';
-import { renderActionToolbar } from './release_actions.js';
+import { renderActionToolbar, renderRemoveFromBeetsButton } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
 import { renderDownloadHistoryItem } from './history.js';
 
@@ -268,7 +268,19 @@ export async function toggleLibDetail(id) {
         html += `<button class="p-btn upgrade-btn" onclick="event.stopPropagation(); window.upgradeAlbum('${data.mb_albumid}', this)">Upgrade${brLabel}</button>`;
       }
     }
-    html += `<button class="p-btn delete-beets" onclick="event.stopPropagation(); window.confirmDeleteBeets(${id}, ${jsArg(data.artist || '')}, ${jsArg(data.album || '')}, ${data.tracks ? data.tracks.length : 0}, ${data.pipeline_id ?? 'null'}, ${jsArg(data.mb_albumid || '')})">Delete from beets</button>`;
+    html += renderRemoveFromBeetsButton({
+      id: data.mb_albumid || '',
+      in_library: true,
+      beets_album_id: id,
+      pipeline_id: data.pipeline_id || null,
+      artist: data.artist || '',
+      album: data.album || '',
+      track_count: data.tracks ? data.tracks.length : 0,
+    }, {
+      className: 'p-btn delete-beets',
+      label: 'Delete from beets',
+      stopPropagation: true,
+    });
     html += '</div>';
     el.innerHTML = html;
   } catch (e) { el.innerHTML = '<div class="loading" style="padding:8px;">Failed to load</div>'; }

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { API, state, toast, updatePipelineStatus } from './state.js';
-import { esc, qualityLabel, overrideToIntent, externalReleaseUrl, sourceLabel } from './util.js';
+import { esc, jsArg, qualityLabel, overrideToIntent, externalReleaseUrl, sourceLabel } from './util.js';
 import { renderTypedSections } from './grouping.js';
 import { renderActionToolbar } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
@@ -91,7 +91,7 @@ export function renderLibraryResults(albums, targetEl) {
       const added = a.added ? new Date(a.added * 1000 + 8 * 3600000).toISOString().slice(0, 10) : '?';
       const mbid = a.mb_albumid || '';
       const inLibrary = a.in_library !== false;
-      const beetsAlbumId = a.beets_album_id || (inLibrary ? a.id : null);
+      const beetsAlbumId = a.beets_album_id ?? null;
       const pipelineId = a.pipeline_id || null;
       const detailId = inLibrary
         ? `lib-${beetsAlbumId}`
@@ -268,7 +268,7 @@ export async function toggleLibDetail(id) {
         html += `<button class="p-btn upgrade-btn" onclick="event.stopPropagation(); window.upgradeAlbum('${data.mb_albumid}', this)">Upgrade${brLabel}</button>`;
       }
     }
-    html += `<button class="p-btn delete-beets" onclick="event.stopPropagation(); window.confirmDeleteBeets(${id}, '${esc(data.artist)}', '${esc(data.album)}', ${data.tracks ? data.tracks.length : 0}, ${data.pipeline_id ?? 'null'}, '${esc(data.mb_albumid || '')}')">Delete from beets</button>`;
+    html += `<button class="p-btn delete-beets" onclick="event.stopPropagation(); window.confirmDeleteBeets(${id}, ${jsArg(data.artist || '')}, ${jsArg(data.album || '')}, ${data.tracks ? data.tracks.length : 0}, ${data.pipeline_id ?? 'null'}, ${jsArg(data.mb_albumid || '')})">Delete from beets</button>`;
     html += '</div>';
     el.innerHTML = html;
   } catch (e) { el.innerHTML = '<div class="loading" style="padding:8px;">Failed to load</div>'; }
@@ -400,6 +400,33 @@ export async function setIntent(pipelineId, intent) {
 }
 
 /**
+ * Build the confirmation overlay HTML for deleting an album from beets.
+ * @param {number} id
+ * @param {string} artist
+ * @param {string} album
+ * @param {number} trackCount
+ * @param {number|null} [pipelineId]
+ * @param {string} [releaseId]
+ */
+export function buildDeleteConfirmHtml(id, artist, album, trackCount, pipelineId = null, releaseId = '') {
+  const parsedTrackCount = Number(trackCount);
+  const safeTrackCount = Number.isFinite(parsedTrackCount) ? parsedTrackCount : 0;
+  const pipelineNote = releaseId
+    ? '<br>This also removes any matching pipeline request/history so the release is forgotten.'
+    : '';
+  return `
+    <div class="confirm-box">
+      <h3>Delete from beets?</h3>
+      <p>${esc(artist)} - ${esc(album)}<br>${safeTrackCount} tracks will be permanently deleted from disk.${pipelineNote}</p>
+      <div class="actions">
+        <button class="p-btn" onclick="this.closest('.confirm-overlay').remove()">Cancel</button>
+        <button class="p-btn delete-beets" id="confirm-delete-btn" onclick="window.executeBeetsDeletion(${id}, this, ${pipelineId ?? 'null'}, ${jsArg(releaseId)})">Yes, delete permanently</button>
+      </div>
+    </div>
+  `;
+}
+
+/**
  * Show a confirmation overlay for deleting an album from beets.
  * @param {number} id
  * @param {string} artist
@@ -411,19 +438,9 @@ export async function setIntent(pipelineId, intent) {
 export function confirmDeleteBeets(id, artist, album, trackCount, pipelineId = null, releaseId = '') {
   const overlay = document.createElement('div');
   overlay.className = 'confirm-overlay';
-  const pipelineNote = releaseId
-    ? '<br>This also removes any matching pipeline request/history so the release is forgotten.'
-    : '';
-  overlay.innerHTML = `
-    <div class="confirm-box">
-      <h3>Delete from beets?</h3>
-      <p>${artist} - ${album}<br>${trackCount} tracks will be permanently deleted from disk.${pipelineNote}</p>
-      <div class="actions">
-        <button class="p-btn" onclick="this.closest('.confirm-overlay').remove()">Cancel</button>
-        <button class="p-btn delete-beets" id="confirm-delete-btn" onclick="window.executeBeetsDeletion(${id}, this, ${pipelineId ?? 'null'}, '${releaseId}')">Yes, delete permanently</button>
-      </div>
-    </div>
-  `;
+  overlay.innerHTML = buildDeleteConfirmHtml(
+    id, artist, album, trackCount, pipelineId, releaseId,
+  );
   document.body.appendChild(overlay);
   overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
 }

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -1,10 +1,39 @@
 // @ts-check
-import { API, toast, updatePipelineStatus } from './state.js';
+import { API, state, toast, updatePipelineStatus } from './state.js';
 import { esc, qualityLabel, overrideToIntent, externalReleaseUrl, sourceLabel } from './util.js';
 import { renderTypedSections } from './grouping.js';
 import { renderActionToolbar } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
 import { renderDownloadHistoryItem } from './history.js';
+
+
+function refreshAfterBeetsDeletion(albumId) {
+  if (state.browseArtist) {
+    delete state.browseCache[state.browseArtist.id];
+  }
+
+  const browseArtist = document.getElementById('browse-artist');
+  if (browseArtist && browseArtist.style.display !== 'none' && state.browseArtist) {
+    window.switchSubView?.(state.browseSubView || 'discography');
+    return;
+  }
+
+  const activeTab = document.querySelector('.tab.active')?.textContent?.trim();
+  if (activeTab === 'Recents') {
+    window.loadRecents?.();
+    return;
+  }
+  if (activeTab === 'Pipeline') {
+    window.loadPipeline?.();
+    return;
+  }
+
+  const detail = document.getElementById('lib-' + albumId);
+  if (detail) {
+    detail.previousElementSibling?.remove();
+    detail.remove();
+  }
+}
 
 /**
  * Render library results into a target element (thin wrapper).
@@ -61,33 +90,38 @@ export function renderLibraryResults(albums, targetEl) {
     function renderAlbum(a) {
       const added = a.added ? new Date(a.added * 1000 + 8 * 3600000).toISOString().slice(0, 10) : '?';
       const mbid = a.mb_albumid || '';
-      // Library row is always in_library by definition. beets_album_id is
-      // the row's beets DB id. Pipeline state comes from the route's
-      // _enrich step (pipeline_status / pipeline_id / upgrade_queued).
+      const inLibrary = a.in_library !== false;
+      const beetsAlbumId = a.beets_album_id || (inLibrary ? a.id : null);
+      const pipelineId = a.pipeline_id || null;
+      const detailId = inLibrary
+        ? `lib-${beetsAlbumId}`
+        : `lib-pipeline-${pipelineId || a.id}`;
+      const detailToggle = inLibrary && beetsAlbumId
+        ? `window.toggleLibDetail(${beetsAlbumId})`
+        : `window.toggleDetail('${detailId}', ${pipelineId || a.id})`;
+
       const toolbar = mbid ? renderActionToolbar({
         id: mbid,
-        in_library: true,
-        beets_album_id: a.id,
+        in_library: inLibrary,
+        beets_album_id: beetsAlbumId,
         pipeline_status: a.pipeline_status || null,
-        pipeline_id: a.pipeline_id || null,
+        pipeline_id: pipelineId,
         upgrade_queued: !!a.upgrade_queued,
         artist: a.artist || '',
         album: a.album || '',
         track_count: a.track_count || 0,
       }, { size: 'small' }) : '';
-      // Library rows are by definition in_library, so the unified
-      // renderer always emits the quality-aware badge — same code path
-      // discography/compare/analysis use.
+
       const badges = renderStatusBadges({
         id: a.mb_albumid,
-        in_library: true,
+        in_library: inLibrary,
         library_format: a.formats,
         library_min_bitrate: a.min_bitrate ? Math.round(a.min_bitrate / 1000) : 0,
         library_rank: a.library_rank,
         pipeline_status: a.pipeline_status,
       });
       return `
-        <div class="lib-item" onclick="window.toggleLibDetail(${a.id})">
+        <div class="lib-item" onclick="${detailToggle}">
           <div class="p-top">
             <div>
               <div class="p-title">${esc(a.album)}${badges}</div>
@@ -104,7 +138,7 @@ export function renderLibraryResults(albums, targetEl) {
             <span>added ${added}</span>
           </div>
         </div>
-        <div class="lib-detail" id="lib-${a.id}"></div>
+        <div class="lib-detail" id="${detailId}"></div>
       `;
     }
 
@@ -234,7 +268,7 @@ export async function toggleLibDetail(id) {
         html += `<button class="p-btn upgrade-btn" onclick="event.stopPropagation(); window.upgradeAlbum('${data.mb_albumid}', this)">Upgrade${brLabel}</button>`;
       }
     }
-    html += `<button class="p-btn delete-beets" onclick="event.stopPropagation(); window.confirmDeleteBeets(${id}, '${esc(data.artist)}', '${esc(data.album)}', ${data.tracks ? data.tracks.length : 0})">Delete from beets</button>`;
+    html += `<button class="p-btn delete-beets" onclick="event.stopPropagation(); window.confirmDeleteBeets(${id}, '${esc(data.artist)}', '${esc(data.album)}', ${data.tracks ? data.tracks.length : 0}, ${data.pipeline_id ?? 'null'}, '${esc(data.mb_albumid || '')}')">Delete from beets</button>`;
     html += '</div>';
     el.innerHTML = html;
   } catch (e) { el.innerHTML = '<div class="loading" style="padding:8px;">Failed to load</div>'; }
@@ -371,17 +405,22 @@ export async function setIntent(pipelineId, intent) {
  * @param {string} artist
  * @param {string} album
  * @param {number} trackCount
+ * @param {number|null} [pipelineId]
+ * @param {string} [releaseId]
  */
-export function confirmDeleteBeets(id, artist, album, trackCount) {
+export function confirmDeleteBeets(id, artist, album, trackCount, pipelineId = null, releaseId = '') {
   const overlay = document.createElement('div');
   overlay.className = 'confirm-overlay';
+  const pipelineNote = releaseId
+    ? '<br>This also removes any matching pipeline request/history so the release is forgotten.'
+    : '';
   overlay.innerHTML = `
     <div class="confirm-box">
       <h3>Delete from beets?</h3>
-      <p>${artist} - ${album}<br>${trackCount} tracks will be permanently deleted from disk.</p>
+      <p>${artist} - ${album}<br>${trackCount} tracks will be permanently deleted from disk.${pipelineNote}</p>
       <div class="actions">
         <button class="p-btn" onclick="this.closest('.confirm-overlay').remove()">Cancel</button>
-        <button class="p-btn delete-beets" id="confirm-delete-btn" onclick="window.executeBeetsDeletion(${id}, this)">Yes, delete permanently</button>
+        <button class="p-btn delete-beets" id="confirm-delete-btn" onclick="window.executeBeetsDeletion(${id}, this, ${pipelineId ?? 'null'}, '${releaseId}')">Yes, delete permanently</button>
       </div>
     </div>
   `;
@@ -393,23 +432,33 @@ export function confirmDeleteBeets(id, artist, album, trackCount) {
  * Execute the beets deletion after confirmation.
  * @param {number} id
  * @param {HTMLButtonElement} btn
+ * @param {number|null} [pipelineId]
+ * @param {string} [releaseId]
  */
-export async function executeBeetsDeletion(id, btn) {
+export async function executeBeetsDeletion(id, btn, pipelineId = null, releaseId = '') {
   btn.disabled = true;
   btn.textContent = 'Deleting...';
   try {
     const r = await fetch(`${API}/api/beets/delete`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({id, confirm: 'DELETE'}),
+      body: JSON.stringify({
+        id,
+        confirm: 'DELETE',
+        purge_pipeline: true,
+        pipeline_id: pipelineId,
+        release_id: releaseId,
+      }),
     });
     const data = await r.json();
     document.querySelector('.confirm-overlay')?.remove();
     if (data.status === 'ok') {
-      toast(`Deleted: ${data.artist} - ${data.album} (${data.deleted_files} files)`);
-      // Remove the item from the DOM
-      const detail = document.getElementById('lib-' + id);
-      if (detail) { detail.previousElementSibling?.remove(); detail.remove(); }
+      if (data.pipeline_deleted && releaseId) {
+        updatePipelineStatus(releaseId, null, null);
+      }
+      const pipelineMsg = data.pipeline_deleted ? ', request removed' : '';
+      toast(`Deleted: ${data.artist} - ${data.album} (${data.deleted_files} files${pipelineMsg})`);
+      refreshAfterBeetsDeletion(id);
     } else {
       toast(data.error || 'Delete failed', true);
     }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -12,7 +12,7 @@ import { loadRecents, setRecentsFilter, renderRecentsItems } from './recents.js'
 import { loadPipeline, setFilter, renderPipeline, toggleDetail, deleteRequest, updateStatus } from './pipeline.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
-import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove, disambDeleteFromLibrary } from './analysis.js';
+import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
 import { loadManualImport, runManualImport } from './manual.js';
 import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup } from './wrong-matches.js';
 import { toast } from './state.js';
@@ -98,7 +98,6 @@ Object.assign(window, {
   renderDisambiguateInto,
   toggleDisambRGTracks,
   disambRemove,
-  disambDeleteFromLibrary,
   loadManualImport,
   runManualImport,
   showManualSub,

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -40,6 +40,16 @@ import { esc } from './util.js';
 import { pipelineStore } from './state.js';
 
 /**
+ * Encode a JS string literal for embedding inside a double-quoted HTML attribute.
+ * Returns HTML-escaped JSON, e.g. `&quot;Kid A&quot;`.
+ * @param {string|null|undefined} value
+ * @returns {string}
+ */
+function jsArg(value) {
+  return esc(JSON.stringify(String(value ?? '')));
+}
+
+/**
  * @typedef {Object} ActionItem
  * @property {string} id - Release ID (MB UUID or numeric Discogs)
  * @property {boolean} [in_library]
@@ -75,9 +85,9 @@ export function renderActionToolbar(item, opts = {}) {
     : 'padding:4px 10px;font-size:0.78em;';
   const baseStyle = `${sizeStyle}white-space:nowrap;`;
 
-  const escId = esc(item.id);
-  const artist = esc(item.artist || '');
-  const album = esc(item.album || '');
+  const idArg = jsArg(item.id);
+  const artistArg = jsArg(item.artist || '');
+  const albumArg = jsArg(item.album || '');
   const trackCount = item.track_count || 0;
 
   // Acquire — single context-aware button. See module header for the
@@ -91,9 +101,9 @@ export function renderActionToolbar(item, opts = {}) {
     // mid-download cancels.
     acquireBtn = `<button class="btn" style="${baseStyle}background:#5a2a2a;color:#f88;" onclick="event.stopPropagation(); window.disambRemove(${pId}, this)">Remove request</button>`;
   } else if (inLibrary || pStatus === 'imported') {
-    acquireBtn = `<button class="btn btn-add" style="${baseStyle}" onclick="event.stopPropagation(); window.upgradeAlbum('${escId}', this)">Upgrade</button>`;
+    acquireBtn = `<button class="btn btn-add" style="${baseStyle}" onclick="event.stopPropagation(); window.upgradeAlbum(${idArg}, this)">Upgrade</button>`;
   } else if (!inLibrary && !pStatus) {
-    acquireBtn = `<button class="btn btn-add" style="${baseStyle}" onclick="event.stopPropagation(); window.addRelease('${escId}', this)">Add request</button>`;
+    acquireBtn = `<button class="btn btn-add" style="${baseStyle}" onclick="event.stopPropagation(); window.addRelease(${idArg}, this)">Add request</button>`;
   } else {
     // Manual review or other terminal/unknown state — no live action.
     acquireBtn = `<button class="btn btn-add" style="${baseStyle}" disabled>Add request</button>`;
@@ -101,7 +111,7 @@ export function renderActionToolbar(item, opts = {}) {
 
   // Remove from beets — greyed out when not in library
   const removeBeetsBtn = canRemoveBeets
-    ? `<button class="btn" style="${baseStyle}background:#3a2a2a;color:#f88;" onclick="event.stopPropagation(); window.confirmDeleteBeets(${beetsId}, '${artist}', '${album}', ${trackCount}, ${pId ?? 'null'}, '${escId}')">Remove from beets</button>`
+    ? `<button class="btn" style="${baseStyle}background:#3a2a2a;color:#f88;" onclick="event.stopPropagation(); window.confirmDeleteBeets(${beetsId}, ${artistArg}, ${albumArg}, ${trackCount}, ${pId ?? 'null'}, ${idArg})">Remove from beets</button>`
     : `<button class="btn" style="${baseStyle}" disabled>Remove from beets</button>`;
 
   return `<span class="action-toolbar" style="display:inline-flex;gap:4px;flex-wrap:wrap;">${acquireBtn}${removeBeetsBtn}</span>`;

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -14,7 +14,10 @@
  *                       other states' affordances are unreachable so
  *                       showing them as separate greyed buttons just
  *                       added noise.
- *   [Remove from beets] enabled when in library and beets album id known
+ *   [Remove from beets] enabled when in library and beets album id known.
+ *                       When clicked, the backend also purges the matching
+ *                       pipeline request/history so the release goes back to
+ *                       a clean "not requested" state.
  *
  * Acquire decision tree (highest priority first):
  *   1. pipeline_status in ('wanted', 'downloading') → "Remove request"
@@ -98,7 +101,7 @@ export function renderActionToolbar(item, opts = {}) {
 
   // Remove from beets — greyed out when not in library
   const removeBeetsBtn = canRemoveBeets
-    ? `<button class="btn" style="${baseStyle}background:#3a2a2a;color:#f88;" onclick="event.stopPropagation(); window.confirmDeleteBeets(${beetsId}, '${artist}', '${album}', ${trackCount})">Remove from beets</button>`
+    ? `<button class="btn" style="${baseStyle}background:#3a2a2a;color:#f88;" onclick="event.stopPropagation(); window.confirmDeleteBeets(${beetsId}, '${artist}', '${album}', ${trackCount}, ${pId ?? 'null'}, '${escId}')">Remove from beets</button>`
     : `<button class="btn" style="${baseStyle}" disabled>Remove from beets</button>`;
 
   return `<span class="action-toolbar" style="display:inline-flex;gap:4px;flex-wrap:wrap;">${acquireBtn}${removeBeetsBtn}</span>`;

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -53,6 +53,40 @@ import { pipelineStore } from './state.js';
  */
 
 /**
+ * Render the shared delete-from-beets button for browse-tab surfaces.
+ *
+ * @param {ActionItem} item
+ * @param {Object} [opts]
+ * @param {string} [opts.className]
+ * @param {string} [opts.enabledStyle]
+ * @param {string} [opts.disabledStyle]
+ * @param {string} [opts.label]
+ * @param {boolean} [opts.stopPropagation]
+ * @returns {string}
+ */
+export function renderRemoveFromBeetsButton(item, opts = {}) {
+  const stored = pipelineStore.get(item.id);
+  const pId = stored ? stored.id : (item.pipeline_id || null);
+  const inLibrary = !!item.in_library;
+  const beetsId = item.beets_album_id || null;
+  const canRemoveBeets = inLibrary && !!beetsId;
+  const className = opts.className || 'btn';
+  const label = opts.label || 'Remove from beets';
+  const stopPropagation = opts.stopPropagation ? 'event.stopPropagation(); ' : '';
+
+  const enabledStyle = opts.enabledStyle ? ` style="${opts.enabledStyle}"` : '';
+  const disabledStyle = opts.disabledStyle ? ` style="${opts.disabledStyle}"` : '';
+
+  const artistArg = jsArg(item.artist || '');
+  const albumArg = jsArg(item.album || '');
+  const trackCount = item.track_count || 0;
+
+  return canRemoveBeets
+    ? `<button class="${className}"${enabledStyle} onclick="${stopPropagation}window.confirmDeleteBeets(${beetsId}, ${artistArg}, ${albumArg}, ${trackCount}, ${pId ?? 'null'}, ${jsArg(item.id)})">${label}</button>`
+    : `<button class="${className}"${disabledStyle} disabled>${label}</button>`;
+}
+
+/**
  * Render the toolbar HTML for one row.
  *
  * @param {ActionItem} item
@@ -67,8 +101,6 @@ export function renderActionToolbar(item, opts = {}) {
   const pStatus = stored ? stored.status : (item.pipeline_status || null);
   const pId = stored ? stored.id : (item.pipeline_id || null);
   const inLibrary = !!item.in_library;
-  const beetsId = item.beets_album_id || null;
-  const canRemoveBeets = inLibrary && !!beetsId;
 
   const sizeStyle = opts.size === 'small'
     ? 'padding:2px 8px;font-size:0.7em;'
@@ -76,9 +108,6 @@ export function renderActionToolbar(item, opts = {}) {
   const baseStyle = `${sizeStyle}white-space:nowrap;`;
 
   const idArg = jsArg(item.id);
-  const artistArg = jsArg(item.artist || '');
-  const albumArg = jsArg(item.album || '');
-  const trackCount = item.track_count || 0;
 
   // Acquire — single context-aware button. See module header for the
   // full priority order. The key invariant: at most one of Add/Upgrade/
@@ -99,10 +128,12 @@ export function renderActionToolbar(item, opts = {}) {
     acquireBtn = `<button class="btn btn-add" style="${baseStyle}" disabled>Add request</button>`;
   }
 
-  // Remove from beets — greyed out when not in library
-  const removeBeetsBtn = canRemoveBeets
-    ? `<button class="btn" style="${baseStyle}background:#3a2a2a;color:#f88;" onclick="event.stopPropagation(); window.confirmDeleteBeets(${beetsId}, ${artistArg}, ${albumArg}, ${trackCount}, ${pId ?? 'null'}, ${idArg})">Remove from beets</button>`
-    : `<button class="btn" style="${baseStyle}" disabled>Remove from beets</button>`;
+  const removeBeetsBtn = renderRemoveFromBeetsButton(item, {
+    className: 'btn',
+    enabledStyle: `${baseStyle}background:#3a2a2a;color:#f88;`,
+    disabledStyle: baseStyle,
+    stopPropagation: true,
+  });
 
   return `<span class="action-toolbar" style="display:inline-flex;gap:4px;flex-wrap:wrap;">${acquireBtn}${removeBeetsBtn}</span>`;
 }

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -36,18 +36,8 @@
  * just decides who gets clicked.
  */
 
-import { esc } from './util.js';
+import { jsArg } from './util.js';
 import { pipelineStore } from './state.js';
-
-/**
- * Encode a JS string literal for embedding inside a double-quoted HTML attribute.
- * Returns HTML-escaped JSON, e.g. `&quot;Kid A&quot;`.
- * @param {string|null|undefined} value
- * @returns {string}
- */
-function jsArg(value) {
-  return esc(JSON.stringify(String(value ?? '')));
-}
 
 /**
  * @typedef {Object} ActionItem

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -105,6 +105,16 @@ export function esc(s) {
 }
 
 /**
+ * Encode a JS string literal for embedding inside a double-quoted HTML attribute.
+ * Returns HTML-escaped JSON, e.g. `&quot;Kid A&quot;`.
+ * @param {string|null|undefined} value
+ * @returns {string}
+ */
+export function jsArg(value) {
+  return esc(JSON.stringify(String(value ?? '')));
+}
+
+/**
  * Detect whether a release ID is MusicBrainz (UUID) or Discogs (numeric).
  * @param {string|null|undefined} id
  * @returns {'musicbrainz'|'discogs'|'unknown'}

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from web import cache as _cache
 from web import discogs as discogs_api
 from lib.artist_compare import annotate_in_library, merge_discographies
+from lib.quality import detect_release_source
 
 if TYPE_CHECKING:
     from http.server import BaseHTTPRequestHandler
@@ -28,6 +29,44 @@ def _server():
     """
     from web import server
     return server
+
+
+def _release_identity(
+    release_id: object | None,
+    discogs_release_id: object | None = None,
+) -> tuple[str, str] | None:
+    """Stable identity for a row keyed by exact release, MB or Discogs."""
+    rid = str(release_id or "").strip()
+    if rid:
+        source = detect_release_source(rid)
+        if source == "musicbrainz":
+            return ("mb", rid)
+        if source == "discogs":
+            return ("discogs", rid)
+    discogs_id = str(discogs_release_id or "").strip()
+    if discogs_id:
+        return ("discogs", discogs_id)
+    return None
+
+
+def _library_album_sort_key(row: dict[str, object]) -> tuple[bool, int, str, str, int, int]:
+    """Deterministic chronological-ish ordering for merged library rows."""
+    year = row.get("year")
+    year_num = year if isinstance(year, int) else 0
+    album = str(row.get("album") or "")
+    country = str(row.get("country") or "")
+    beets_album_id = row.get("beets_album_id")
+    pipeline_id = row.get("pipeline_id")
+    beets_key = beets_album_id if isinstance(beets_album_id, int) else -1
+    pipeline_key = pipeline_id if isinstance(pipeline_id, int) else -1
+    return (
+        year is None,
+        year_num,
+        album.casefold(),
+        country.casefold(),
+        beets_key,
+        pipeline_key,
+    )
 
 
 def get_search(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) -> None:
@@ -53,18 +92,30 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
         h._error("Missing parameter 'name'")  # type: ignore[attr-defined]
         return
 
-    def _pipeline_album_rows() -> list[dict[str, object]]:
-        if not srv.db:
-            return []
+    pipeline_rows = srv._db().list_requests_by_artist(name, mbid) if srv.db else []
+    track_counts = (
+        srv._db().get_track_counts([int(r["id"]) for r in pipeline_rows])
+        if pipeline_rows and srv.db else {}
+    )
+    pipeline_by_identity: dict[tuple[str, str], dict[str, object]] = {}
+    for row in pipeline_rows:
+        identity = _release_identity(
+            row.get("mb_release_id"),
+            row.get("discogs_release_id"),
+        )
+        if identity is None:
+            continue
+        pipeline_by_identity[identity] = row
 
-        db = srv._db()
-        rows = db.list_requests_by_artist(name, mbid)
-        track_counts = db.get_track_counts([int(r["id"]) for r in rows]) if rows else {}
+    def _pipeline_album_rows() -> list[dict[str, object]]:
         result: list[dict[str, object]] = []
-        for row in rows:
+        for row in pipeline_rows:
             created_at = row.get("created_at")
             added = created_at.timestamp() if isinstance(created_at, datetime) else 0.0
             min_br = row.get("min_bitrate")
+            release_id = str(
+                row.get("mb_release_id") or row.get("discogs_release_id") or ""
+            ).strip()
             result.append({
                 "id": int(row["id"]),
                 "beets_album_id": None,
@@ -72,7 +123,7 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
                 "album": row["album_title"],
                 "artist": row["artist_name"],
                 "year": row.get("year"),
-                "mb_albumid": row.get("mb_release_id"),
+                "mb_albumid": release_id or None,
                 "track_count": track_counts.get(int(row["id"]), 0),
                 "mb_releasegroupid": row.get("mb_release_group_id"),
                 "release_group_title": row["album_title"],
@@ -89,9 +140,6 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
                     row["status"] == "wanted"
                     and bool(row.get("search_filetype_override") or row.get("target_format"))
                 ),
-                # Keep the payload shape uniform with in-library rows.
-                # badges.js ignores library_rank unless in_library=true.
-                "library_rank": "unknown",
             })
         return result
 
@@ -100,14 +148,15 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     # standardised action toolbar (Acquire / Remove from beets) shows
     # accurate per-row state. Also compute library_rank so the unified
     # badge renderer can colour the in-library badge by codec-aware tier.
-    mbids = [str(a["mb_albumid"]) for a in albums if a.get("mb_albumid")]
-    in_pipeline = srv.check_pipeline(mbids) if mbids else {}
-    seen_release_ids: set[str] = set()
+    seen_release_ids: set[tuple[str, str]] = set()
     for a in albums:
+        if not a.get("mb_albumid") and a.get("discogs_albumid"):
+            a["mb_albumid"] = a["discogs_albumid"]
         a["in_library"] = True
         a["beets_album_id"] = a["id"]
         a["upgrade_queued"] = False
-        pi = in_pipeline.get(str(a.get("mb_albumid", "")))
+        identity = _release_identity(a.get("mb_albumid"), a.get("discogs_albumid"))
+        pi = pipeline_by_identity.get(identity) if identity else None
         if pi:
             a["pipeline_status"] = pi["status"]
             a["pipeline_id"] = pi["id"]
@@ -123,16 +172,17 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
         br_bps = br_raw if isinstance(br_raw, int) else 0
         kbps = br_bps // 1000
         a["library_rank"] = srv.compute_library_rank(fmt, kbps)
-        rid = str(a.get("mb_albumid") or "")
-        if rid:
-            seen_release_ids.add(rid)
+        if identity:
+            seen_release_ids.add(identity)
+        a.pop("discogs_albumid", None)
 
     for req in _pipeline_album_rows():
-        rid = str(req.get("mb_albumid") or "")
-        if rid and rid in seen_release_ids:
+        identity = _release_identity(req.get("mb_albumid"))
+        if identity and identity in seen_release_ids:
             continue
         albums.append(req)
 
+    albums.sort(key=_library_album_sort_key)
     h._json({"albums": albums})  # type: ignore[attr-defined]
 
 

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -113,6 +113,9 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
             created_at = row.get("created_at")
             added = created_at.timestamp() if isinstance(created_at, datetime) else 0.0
             min_br = row.get("min_bitrate")
+            # Frontend keys every library row by `mb_albumid`, then routes MB
+            # UUIDs vs numeric Discogs IDs via detectSource(). Pipeline rows do
+            # not have a second canonical release-id slot, so overload it here.
             release_id = str(
                 row.get("mb_release_id") or row.get("discogs_release_id") or ""
             ).strip()
@@ -125,6 +128,8 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
                 "year": row.get("year"),
                 "mb_albumid": release_id or None,
                 "track_count": track_counts.get(int(row["id"]), 0),
+                # Pipeline rows do not carry RG titles; mirror the album title
+                # so the library subview can render a stable group heading.
                 "mb_releasegroupid": row.get("mb_release_group_id"),
                 "release_group_title": row["album_title"],
                 "added": added,
@@ -134,6 +139,10 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
                 "label": "",
                 "country": row.get("country"),
                 "source": row.get("source"),
+                # Keep the row shape uniform with beets-backed entries; badges
+                # ignore this when `in_library` is false, but the route contract
+                # expects every album row to carry the same keys.
+                "library_rank": None,
                 "pipeline_status": row["status"],
                 "pipeline_id": int(row["id"]),
                 "upgrade_queued": (
@@ -150,6 +159,9 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     # badge renderer can colour the in-library badge by codec-aware tier.
     seen_release_ids: set[tuple[str, str]] = set()
     for a in albums:
+        # Beets rows also overload `mb_albumid` with numeric Discogs IDs when
+        # the library lacks an MB UUID so the frontend can use one release-id
+        # field and still disambiguate by source.
         if not a.get("mb_albumid") and a.get("discogs_albumid"):
             a["mb_albumid"] = a["discogs_albumid"]
         a["in_library"] = True

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -51,6 +51,77 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     if not name:
         h._error("Missing parameter 'name'")  # type: ignore[attr-defined]
         return
+
+    def _pipeline_album_rows() -> list[dict[str, object]]:
+        if not srv.db:
+            return []
+
+        db = srv._db()
+        if mbid:
+            cur = db._execute(
+                """
+                SELECT id, mb_release_id, mb_release_group_id,
+                       artist_name, album_title, year, country, format,
+                       source, status, created_at, min_bitrate,
+                       search_filetype_override, target_format
+                FROM album_requests
+                WHERE mb_artist_id = %s
+                   OR (artist_name ILIKE %s
+                       AND (mb_artist_id IS NULL OR mb_artist_id = ''
+                            OR mb_artist_id NOT LIKE '%%-%%'))
+                ORDER BY year, album_title
+                """,
+                (mbid, f"%{name}%"),
+            )
+        else:
+            cur = db._execute(
+                """
+                SELECT id, mb_release_id, mb_release_group_id,
+                       artist_name, album_title, year, country, format,
+                       source, status, created_at, min_bitrate,
+                       search_filetype_override, target_format
+                FROM album_requests
+                WHERE artist_name ILIKE %s
+                ORDER BY year, album_title
+                """,
+                (f"%{name}%",),
+            )
+
+        rows = [dict(r) for r in cur.fetchall()]
+        track_counts = db.get_track_counts([int(r["id"]) for r in rows]) if rows else {}
+        result: list[dict[str, object]] = []
+        for row in rows:
+            created_at = row.get("created_at")
+            added = created_at.timestamp() if hasattr(created_at, "timestamp") else 0.0
+            min_br = row.get("min_bitrate")
+            result.append({
+                "id": int(row["id"]),
+                "beets_album_id": None,
+                "in_library": False,
+                "album": row["album_title"],
+                "artist": row["artist_name"],
+                "year": row.get("year"),
+                "mb_albumid": row.get("mb_release_id"),
+                "track_count": track_counts.get(int(row["id"]), 0),
+                "mb_releasegroupid": row.get("mb_release_group_id"),
+                "release_group_title": row["album_title"],
+                "added": added,
+                "formats": row.get("format") or "",
+                "min_bitrate": (int(min_br) * 1000) if isinstance(min_br, int) else None,
+                "type": "album",
+                "label": "",
+                "country": row.get("country"),
+                "source": row.get("source"),
+                "pipeline_status": row["status"],
+                "pipeline_id": int(row["id"]),
+                "upgrade_queued": (
+                    row["status"] == "wanted"
+                    and bool(row.get("search_filetype_override") or row.get("target_format"))
+                ),
+                "library_rank": "unknown",
+            })
+        return result
+
     albums = srv.get_library_artist(name, mbid)
     # Enrich with pipeline_status / pipeline_id / upgrade_queued so the
     # standardised action toolbar (Acquire / Remove from beets) shows
@@ -58,7 +129,11 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     # badge renderer can colour the in-library badge by codec-aware tier.
     mbids = [str(a["mb_albumid"]) for a in albums if a.get("mb_albumid")]
     in_pipeline = srv.check_pipeline(mbids) if mbids else {}
+    seen_release_ids: set[str] = set()
     for a in albums:
+        a["in_library"] = True
+        a["beets_album_id"] = a["id"]
+        a["upgrade_queued"] = False
         pi = in_pipeline.get(str(a.get("mb_albumid", "")))
         if pi:
             a["pipeline_status"] = pi["status"]
@@ -75,6 +150,16 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
         br_bps = br_raw if isinstance(br_raw, int) else 0
         kbps = br_bps // 1000
         a["library_rank"] = srv.compute_library_rank(fmt, kbps)
+        rid = str(a.get("mb_albumid") or "")
+        if rid:
+            seen_release_ids.add(rid)
+
+    for req in _pipeline_album_rows():
+        rid = str(req.get("mb_albumid") or "")
+        if rid and rid in seen_release_ids:
+            continue
+        albums.append(req)
+
     h._json({"albums": albums})  # type: ignore[attr-defined]
 
 

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import re
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from web import cache as _cache
@@ -57,42 +58,12 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
             return []
 
         db = srv._db()
-        if mbid:
-            cur = db._execute(
-                """
-                SELECT id, mb_release_id, mb_release_group_id,
-                       artist_name, album_title, year, country, format,
-                       source, status, created_at, min_bitrate,
-                       search_filetype_override, target_format
-                FROM album_requests
-                WHERE mb_artist_id = %s
-                   OR (artist_name ILIKE %s
-                       AND (mb_artist_id IS NULL OR mb_artist_id = ''
-                            OR mb_artist_id NOT LIKE '%%-%%'))
-                ORDER BY year, album_title
-                """,
-                (mbid, f"%{name}%"),
-            )
-        else:
-            cur = db._execute(
-                """
-                SELECT id, mb_release_id, mb_release_group_id,
-                       artist_name, album_title, year, country, format,
-                       source, status, created_at, min_bitrate,
-                       search_filetype_override, target_format
-                FROM album_requests
-                WHERE artist_name ILIKE %s
-                ORDER BY year, album_title
-                """,
-                (f"%{name}%",),
-            )
-
-        rows = [dict(r) for r in cur.fetchall()]
+        rows = db.list_requests_by_artist(name, mbid)
         track_counts = db.get_track_counts([int(r["id"]) for r in rows]) if rows else {}
         result: list[dict[str, object]] = []
         for row in rows:
             created_at = row.get("created_at")
-            added = created_at.timestamp() if hasattr(created_at, "timestamp") else 0.0
+            added = created_at.timestamp() if isinstance(created_at, datetime) else 0.0
             min_br = row.get("min_bitrate")
             result.append({
                 "id": int(row["id"]),
@@ -118,6 +89,8 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
                     row["status"] == "wanted"
                     and bool(row.get("search_filetype_override") or row.get("target_format"))
                 ),
+                # Keep the payload shape uniform with in-library rows.
+                # badges.js ignores library_rank unless in_library=true.
                 "library_rank": "unknown",
             })
         return result

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -140,6 +140,8 @@ def post_beets_delete(h, body: dict) -> None:
 
     deleted_pipeline_id = None
     if purge_pipeline:
+        # Purge the pipeline row before the destructive beets delete so a
+        # failing DB write cannot recreate the original ghost-imported bug.
         req = _find_pipeline_request_for_release(
             int(pipeline_id) if pipeline_id is not None else None,
             release_id,
@@ -157,23 +159,45 @@ def post_beets_delete(h, body: dict) -> None:
             deleted_pipeline_id = int(req["id"])
 
     try:
-        album_name, artist_name, file_paths = BeetsDB.delete_album(srv.beets_db_path, int(album_id))
+        album_name, artist_name, file_paths = BeetsDB.delete_album(
+            srv.beets_db_path,
+            int(album_id),
+        )
+        album_dir = os.path.dirname(file_paths[0]) if file_paths else None
+        # Delete individual files from disk (safe — won't destroy shared directories)
+        deleted_files = 0
+        for path in file_paths:
+            if os.path.isfile(path):
+                os.remove(path)
+                deleted_files += 1
+        # Remove directory only if now empty (other albums may share it)
+        if album_dir and os.path.isdir(album_dir):
+            try:
+                os.rmdir(album_dir)
+            except OSError:
+                pass  # not empty — other albums' files still there
     except ValueError:
         h._error("Album not found", 404)
         return
-    album_dir = os.path.dirname(file_paths[0]) if file_paths else None
-    # Delete individual files from disk (safe — won't destroy shared directories)
-    deleted_files = 0
-    for path in file_paths:
-        if os.path.isfile(path):
-            os.remove(path)
-            deleted_files += 1
-    # Remove directory only if now empty (other albums may share it)
-    if album_dir and os.path.isdir(album_dir):
-        try:
-            os.rmdir(album_dir)
-        except OSError:
-            pass  # not empty — other albums' files still there
+    except Exception:
+        if deleted_pipeline_id is not None:
+            # Deliberate failure mode split: at this point the pipeline row is
+            # already gone, so callers need a more specific error than a
+            # generic 500 to understand the partial-success state.
+            log.exception(
+                "Beets delete failed after purging pipeline request %s for album %s",
+                deleted_pipeline_id,
+                album_id,
+            )
+            h._error(
+                "Pipeline request was removed, but delete from beets failed; "
+                "check logs and disk state",
+                500,
+            )
+            return
+        log.exception("Beets delete failed for album %s", album_id)
+        h._error("Delete from beets failed", 500)
+        return
 
     h._json({
         "status": "ok", "id": album_id,

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -9,6 +9,42 @@ def _server():
     return server
 
 
+def _find_pipeline_request_for_release(
+    pipeline_id: int | None,
+    release_id: str,
+) -> dict | None:
+    """Resolve the pipeline request the UI wants purged, if any.
+
+    Prefer the explicit ``pipeline_id`` from the frontend when present;
+    fall back to the release ID so stale/missing row overlays do not turn
+    the delete into a ghost imported row again.
+    """
+    srv = _server()
+    if not srv.db:
+        return None
+
+    db = srv._db()
+    if pipeline_id is not None:
+        req = db.get_request(int(pipeline_id))
+        if req:
+            return req
+
+    release_id = release_id.strip()
+    if not release_id:
+        return None
+
+    req = db.get_request_by_mb_release_id(release_id)
+    if req:
+        return req
+
+    if release_id.isdigit():
+        req = db.get_request_by_discogs_release_id(release_id)
+        if req:
+            return req
+
+    return None
+
+
 def get_beets_search(h, params: dict[str, list[str]]) -> None:
     q = params.get("q", [""])[0].strip()
     if not q or len(q) < 2:
@@ -76,6 +112,9 @@ def get_beets_recent(h, params: dict[str, list[str]]) -> None:
 def post_beets_delete(h, body: dict) -> None:
     album_id = body.get("id")
     confirm = body.get("confirm")
+    purge_pipeline = bool(body.get("purge_pipeline"))
+    pipeline_id = body.get("pipeline_id")
+    release_id = str(body.get("release_id") or "").strip()
     if not album_id:
         h._error("Missing id")
         return
@@ -105,10 +144,23 @@ def post_beets_delete(h, body: dict) -> None:
             os.rmdir(album_dir)
         except OSError:
             pass  # not empty — other albums' files still there
+
+    deleted_pipeline_id = None
+    if purge_pipeline:
+        req = _find_pipeline_request_for_release(
+            int(pipeline_id) if pipeline_id is not None else None,
+            release_id,
+        )
+        if req:
+            srv._db().delete_request(int(req["id"]))
+            deleted_pipeline_id = int(req["id"])
+
     h._json({
         "status": "ok", "id": album_id,
         "album": album_name, "artist": artist_name,
         "deleted_files": deleted_files,
+        "pipeline_deleted": deleted_pipeline_id is not None,
+        "pipeline_id": deleted_pipeline_id,
     })
 
 

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -1,7 +1,10 @@
 """Beets library route handlers — search, album detail, recent, delete."""
 
+import logging
 import os
 import re
+
+log = logging.getLogger("cratedigger-web")
 
 
 def _server():
@@ -127,6 +130,33 @@ def post_beets_delete(h, body: dict) -> None:
         return
     from lib.beets_db import BeetsDB
     try:
+        with BeetsDB(srv.beets_db_path) as beets:
+            if not beets.get_album_detail(int(album_id)):
+                h._error("Album not found", 404)
+                return
+    except FileNotFoundError:
+        h._error("Beets DB not available")
+        return
+
+    deleted_pipeline_id = None
+    if purge_pipeline:
+        req = _find_pipeline_request_for_release(
+            int(pipeline_id) if pipeline_id is not None else None,
+            release_id,
+        )
+        if req:
+            try:
+                srv._db().delete_request(int(req["id"]))
+            except Exception:
+                log.exception(
+                    "Failed to purge pipeline request %s before beets delete",
+                    req.get("id"),
+                )
+                h._error("Failed to purge pipeline request", 500)
+                return
+            deleted_pipeline_id = int(req["id"])
+
+    try:
         album_name, artist_name, file_paths = BeetsDB.delete_album(srv.beets_db_path, int(album_id))
     except ValueError:
         h._error("Album not found", 404)
@@ -144,16 +174,6 @@ def post_beets_delete(h, body: dict) -> None:
             os.rmdir(album_dir)
         except OSError:
             pass  # not empty — other albums' files still there
-
-    deleted_pipeline_id = None
-    if purge_pipeline:
-        req = _find_pipeline_request_for_release(
-            int(pipeline_id) if pipeline_id is not None else None,
-            release_id,
-        )
-        if req:
-            srv._db().delete_request(int(req["id"]))
-            deleted_pipeline_id = int(req["id"])
 
     h._json({
         "status": "ok", "id": album_id,


### PR DESCRIPTION
## What changed
- make `/api/library/artist` the SSOT view for library management: it now merges beets rows with pipeline-only requests, dedups on exact release identity for both MusicBrainz and Discogs rows, and sorts the merged result once for a stable chronological view
- route the shared delete-from-beets action through `/api/beets/delete` with pipeline context so deleting from the UI also removes the matching pipeline request/history
- purge the pipeline request before the destructive beets delete, so a pipeline-side failure no longer recreates the exact ghost `imported` state this PR fixes
- move ghost-import cleanup into `scripts/cleanup_ghost_imported.py` instead of an inline heredoc in the PR description

## Why
Deleting a release from beets removed the album from the beets DB and disk, but left the `album_requests` row behind at `status='imported'`. That produced a ghost imported state in the UI: the release no longer appeared in the library, but browse rows still showed `imported` and offered `Upgrade` instead of `Add request`.

Separately, the library subview only rendered beets rows, so requests that were not yet on disk had to be managed somewhere else. This change makes that view the SSOT for both owned albums and wanted/requested releases.

## Impact
- deleting from beets now behaves like the pipeline never had that release
- the library subview shows both on-disk albums and pipeline-only requests
- MB and Discogs rows dedup correctly when the same release exists in both beets and the pipeline
- ghost imported cleanup is now a reviewed repo script instead of manual shell quoting

## Validation
- `node tests/test_js_release_actions.mjs`
- `nix-shell --run "python3 -m unittest tests.test_web_server.TestBrowseRouteContracts tests.test_web_server.TestBeetsRouteContracts tests.test_fakes.TestFakePipelineDB tests.test_fakes.TestPipelineDBFakeContract tests.test_beets_db tests.test_cleanup_ghost_imported -v"`
- `nix-shell --run "pyright lib/pipeline_db.py lib/beets_db.py web/routes/browse.py web/routes/library.py scripts/cleanup_ghost_imported.py tests/test_beets_db.py tests/test_cleanup_ghost_imported.py tests/fakes.py tests/test_fakes.py tests/test_web_server.py"`

## Manual Ops
Run from this repo checkout (defaults assume the shared beets DB path and the doc2 pipeline DB DSN):

Dry run:
```bash
nix-shell --run "python3 scripts/cleanup_ghost_imported.py --dry-run"
```

Apply purge:
```bash
nix-shell --run "python3 scripts/cleanup_ghost_imported.py --apply"
```

Override paths/DSN if needed:
```bash
nix-shell --run "python3 scripts/cleanup_ghost_imported.py --dry-run --dsn postgresql://cratedigger@192.168.100.11:5432/cratedigger --beets-db /mnt/virtio/Music/beets-library.db"
```
