### PR TITLE
[codex] Refactor staged album current-path ownership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Originally inspired by [mrusse/soularr](https://github.com/mrusse/soularr) ([Ko-
 | `/mnt/virtio/cratedigger/postgres` | shared | PostgreSQL data dir |
 | `/mnt/virtio/Music/beets-library.db` | shared | Beets library DB |
 | `/mnt/virtio/Music/Beets` | shared | Beets library (tagged files) |
-| `/mnt/virtio/Music/Incoming` | shared | Staging area for validated downloads |
+| `/mnt/virtio/Music/Incoming` | shared | Staging root for validated downloads (`auto-import/` for request imports, `post-validation/` for manual redownload review) |
 | `/mnt/virtio/Music/Re-download` | shared | READMEs for redownload targets |
 | `/mnt/virtio/music/slskd` | doc2 | slskd download directory |
 | `/var/lib/cratedigger` | doc2 | Runtime state (config.ini, lock, denylists) |
@@ -125,12 +125,12 @@ Web UI (music.ablz.au)               CLI
       /Beets/       (cleanup /Incoming on success)
 ```
 
-**All validated downloads stage to `/Incoming` first.** For `source=request`, `import_one.py` auto-imports from `/Incoming` to `/Beets` and cleans up. For `source=redownload`, files stay in `/Incoming` for manual review. Don't assume files in `/Incoming` are redownloads — they may be mid-import.
+**All validated downloads stage under `/Incoming` first.** Request auto-imports stage under `/Incoming/auto-import`, while redownload/manual-review paths stage under `/Incoming/post-validation`. Don't assume a path under `/Incoming` is a redownload — request imports can be mid-move or mid-import there too.
 
 ### Two-track pipeline
 
-- **Requests** (`source='request'`) — user-added via CLI or web UI. Auto-imported to beets if validation passes at distance ≤ 0.15. Converts FLAC→V0 (or target format), imports, cleans up `/Incoming`.
-- **Redownloads** (`source='redownload'`) — replacing bad source material. Always staged to `/Incoming` for manual review, never auto-imported.
+- **Requests** (`source='request'`) — user-added via CLI or web UI. Auto-imported to beets if validation passes at distance ≤ 0.15. Converts FLAC→V0 (or target format), imports from `/Incoming/auto-import`, and cleans up.
+- **Redownloads** (`source='redownload'`) — replacing bad source material. Always staged to `/Incoming/post-validation` for manual review, never auto-imported.
 
 Schema fields, JSONB audit blobs, search_log outcomes, and the force-import flow live in `docs/pipeline-db-schema.md`.
 

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -142,12 +142,15 @@ album. On contention, files stay where `process_completed_album`
 expects them and the next cycle simply re-enters with the same
 `current_path`.
 
-If the process dies after moving into `beets_staging_dir` but before the
-import path updates pipeline state, the next poll cycle logs
-`POST-MOVE RESUME BLOCKED` and leaves the row in `downloading`.
-Automatic retry is intentionally disabled there to avoid replaying an
-already-started import. Operator recovery should inspect the staged path
-and either finish the import manually or reset the request explicitly.
+If the process dies after moving into `beets_staging_dir`, the next poll
+cycle only blocks when validation proves the retry is on the
+auto-import path. That is the branch where an import subprocess may
+already have started, so automatic retry stays disabled there to avoid
+duplicate import. Redownload / non-auto staging retries still re-enter
+normally because `StagedAlbum.move_to(...)` is idempotent when the album
+is already at the staged destination. For blocked auto-import rows,
+operator recovery should inspect the staged path and either finish the
+import manually or reset the request explicitly.
 
 To list candidate blocked rows, query for `status='downloading'` entries
 whose persisted `current_path` already points at your staging root:

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -116,7 +116,7 @@ FORCE/MANUAL (dispatch_import_from_db)
 ```
 
 The auto path only holds RELEASE, and acquires it at
-`_handle_valid_result` *before* `stage_to_ai` runs (Codex PR #136 R4
+`_handle_valid_result` *before* `StagedAlbum.move_to(...)` runs (Codex PR #136 R4
 P1 — see below). `_handle_valid_result` now calls
 `dispatch_import_core` directly; its inner acquisition of the same
 RELEASE key is therefore just a no-op reentrant acquire against the
@@ -125,24 +125,22 @@ outer lock already held by the auto path:
 ```
 AUTO (_handle_valid_result in lib/download.py)
   └─ acquire RELEASE(release_id_to_lock_key(mbid))             ← outer
-      └─ stage_to_ai                                           ← moves files
+      └─ staged_album.move_to(...)                             ← moves files + current_path
       └─ dispatch_import_core
           └─ acquire RELEASE(...)                              ← reentrant no-op
               └─ import_one.py subprocess
 ```
 
 **Why RELEASE outer at `_handle_valid_result`, not at
-`dispatch_import_core`?** Codex PR #136 R4 P1: `stage_to_ai` mutates
-filesystem state (`slskd_download_dir/<import_folder>/` →
-`beets_staging_dir/`) that is NOT reflected in the pipeline DB's
-`active_download_state` column. If contention is detected AFTER
-staging, the next cycle's `process_completed_album` reconstructs the
-entry from `active_download_state`, finds the source paths empty, and
-fails with `FileNotFoundError`. Acquiring the RELEASE lock BEFORE
-`stage_to_ai` keeps the original files in place on contention, so the
-resume guard (`if os.path.exists(dst_file) and not
-os.path.exists(src_file): continue`) can idempotently re-enter next
-cycle.
+`dispatch_import_core`?** The staged move now mutates both filesystem
+state (`slskd_download_dir/<import_folder>/` → `beets_staging_dir/`)
+and `active_download_state.current_path`. Resume is safe even after a
+completed move, but acquiring RELEASE first still keeps contention as a
+true no-op: no directory churn, no extra JSONB write, and no
+cross-process ambiguity about which local path currently owns the
+album. On contention, files stay where `process_completed_album`
+expects them and the next cycle simply re-enters with the same
+`current_path`.
 
 ## Contention behaviour
 

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -149,6 +149,21 @@ Automatic retry is intentionally disabled there to avoid replaying an
 already-started import. Operator recovery should inspect the staged path
 and either finish the import manually or reset the request explicitly.
 
+To list candidate blocked rows, query for `status='downloading'` entries
+whose persisted `current_path` already points at your staging root:
+
+```bash
+pipeline-cli query "
+SELECT id,
+       artist_name,
+       album_title,
+       active_download_state->>'current_path' AS current_path
+FROM album_requests
+WHERE status = 'downloading'
+  AND active_download_state->>'current_path' LIKE '<beets_staging_dir>%';
+"
+```
+
 ## Contention behaviour
 
 All acquires are non-blocking via `pg_try_advisory_lock`. On

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -142,6 +142,13 @@ album. On contention, files stay where `process_completed_album`
 expects them and the next cycle simply re-enters with the same
 `current_path`.
 
+If the process dies after moving into `beets_staging_dir` but before the
+import path updates pipeline state, the next poll cycle logs
+`POST-MOVE RESUME BLOCKED` and leaves the row in `downloading`.
+Automatic retry is intentionally disabled there to avoid replaying an
+already-started import. Operator recovery should inspect the staged path
+and either finish the import manually or reset the request explicitly.
+
 ## Contention behaviour
 
 All acquires are non-blocking via `pg_try_advisory_lock`. On

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -133,22 +133,26 @@ AUTO (_handle_valid_result in lib/download.py)
 
 **Why RELEASE outer at `_handle_valid_result`, not at
 `dispatch_import_core`?** The staged move now mutates both filesystem
-state (`slskd_download_dir/<import_folder>/` → `beets_staging_dir/`)
-and `active_download_state.current_path`. Resume is safe even after a
-completed move, but acquiring RELEASE first still keeps contention as a
-true no-op: no directory churn, no extra JSONB write, and no
-cross-process ambiguity about which local path currently owns the
+state (`slskd_download_dir/<import_folder>/` →
+`beets_staging_dir/<mode>/<artist>/<album> [request-N]`) and
+`active_download_state.current_path`. The staged path is request-scoped
+and branch-scoped (`auto-import/` vs `post-validation/`) so crash
+recovery can tell whether a row may already have launched an import
+subprocess, and two same-name editions can never collide on the same
+persisted `current_path`. Acquiring RELEASE first still keeps
+contention as a true no-op: no directory churn, no extra JSONB write,
+and no cross-process ambiguity about which local path currently owns the
 album. On contention, files stay where `process_completed_album`
 expects them and the next cycle simply re-enters with the same
 `current_path`.
 
-If the process dies after moving into `beets_staging_dir`, the next poll
-cycle only blocks when validation proves the retry is on the
-auto-import path. That is the branch where an import subprocess may
-already have started, so automatic retry stays disabled there to avoid
-duplicate import. Redownload / non-auto staging retries still re-enter
-normally because `StagedAlbum.move_to(...)` is idempotent when the album
-is already at the staged destination. For blocked auto-import rows,
+If the process dies after moving into `beets_staging_dir`, the persisted
+staging root tells the next poll whether the row is on the
+`auto-import/` or `post-validation/` branch. `auto-import/` retries are
+blocked for manual recovery because an import subprocess may already
+have started; `post-validation/` retries re-enter normally because
+`StagedAlbum.move_to(...)` is idempotent when the album is already at
+the staged destination. For blocked auto-import rows,
 operator recovery should inspect the staged path and either finish the
 import manually or reset the request explicitly.
 

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -126,7 +126,7 @@ fetchart:
 | `/mnt/virtio/Music/beets-library.db` | SQLite database — the DB source of truth |
 | `/mnt/virtio/Music/beets-import.log` | Import log |
 | `/mnt/virtio/Music/AI` | Staging area — raw copies from `/Me`, pre-import |
-| `/mnt/virtio/Music/Incoming` | Re-download staging — Cratedigger-validated downloads awaiting conversion and import |
+| `/mnt/virtio/Music/Incoming` | Processing staging root — `/Incoming/auto-import` for request auto-imports, `/Incoming/post-validation` for redownload/manual-review staging |
 | `/mnt/virtio/Music/Re-download` | Re-download queue — each album has a README.md explaining why |
 
 ### File Organization

--- a/lib/download.py
+++ b/lib/download.py
@@ -433,6 +433,14 @@ def _path_is_within(path: str, root: str) -> bool:
     except ValueError:
         return False
 
+
+def _directory_has_entries(path: str) -> bool:
+    """Return True when ``path`` exists and contains at least one entry."""
+    if not os.path.isdir(path):
+        return False
+    with os.scandir(path) as entries:
+        return any(True for _ in entries)
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -450,7 +458,8 @@ def _materialize_processing_dir(
                 "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
                 "current_path=%s already lives under beets staging. "
                 "Automatic retry is disabled to avoid duplicate import; "
-                "manual recovery is required.",
+                "manual recovery is required. See "
+                "docs/advisory-locks.md.",
                 album_data.db_request_id,
                 album_data.artist,
                 album_data.title,
@@ -1330,17 +1339,30 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             state = ActiveDownloadState.from_json(raw_state)
         fallback_current_path = None
         if state.current_path is None and state.processing_started_at is not None:
-            fallback_current_path = _canonical_import_folder_path_from_metadata(
+            canonical_fallback = _canonical_import_folder_path_from_metadata(
                 artist=row["artist_name"],
                 title=row["album_title"],
                 year=str(row["year"] or ""),
                 slskd_download_dir=ctx.cfg.slskd_download_dir,
             )
+            staged_fallback = stage_to_ai_path(
+                artist=row["artist_name"],
+                title=row["album_title"],
+                staging_dir=ctx.cfg.beets_staging_dir,
+            )
+            if (not _directory_has_entries(canonical_fallback)
+                    and os.path.isdir(staged_fallback)):
+                fallback_current_path = staged_fallback
+            else:
+                fallback_current_path = canonical_fallback
+            state.current_path = fallback_current_path
         entry = reconstruct_grab_list_entry(
             row,
             state,
             fallback_current_path=fallback_current_path,
         )
+        if fallback_current_path is not None:
+            _persist_updated_download_state(db, request_id, entry, state)
 
         if state.processing_started_at is not None:
             _run_completed_processing(entry, request_id, state, db, ctx)

--- a/lib/download.py
+++ b/lib/download.py
@@ -18,7 +18,7 @@ import music_tag
 
 from lib.download_recovery import (
     classify_processing_path,
-    resolve_missing_current_path,
+    reconcile_processing_current_path,
 )
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.processing_paths import (
@@ -1404,8 +1404,9 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             state = ActiveDownloadState.from_dict(raw_state)
         else:
             state = ActiveDownloadState.from_json(raw_state)
-        if state.current_path is None and state.processing_started_at is not None:
-            recovery_decision = resolve_missing_current_path(
+        if state.processing_started_at is not None:
+            recovery_decision = reconcile_processing_current_path(
+                current_path=state.current_path,
                 artist=row["artist_name"],
                 title=row["album_title"],
                 year=str(row["year"] or ""),
@@ -1432,19 +1433,26 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             if recovery_decision.blocked_reason == "legacy_shared_only":
                 logger.error(
                     "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
-                    "current_path is missing, canonical_path=%s has no files, "
+                    "persisted current_path=%s could not be resumed, "
+                    "canonical_path=%s has no files, "
                     "and staged_path=%s is ambiguous across editions. "
                     "Manual recovery is required.",
                     request_id,
                     row["artist_name"],
                     row["album_title"],
+                    state.current_path,
                     recovery_decision.canonical_path,
                     recovery_decision.legacy_shared_path,
                 )
                 continue
             assert recovery_decision.selected_location is not None
-            state.current_path = recovery_decision.selected_location.path
-            db.update_download_state_current_path(request_id, state.current_path)
+            selected_path = recovery_decision.selected_location.path
+            if selected_path != state.current_path:
+                state.current_path = selected_path
+                db.update_download_state_current_path(
+                    request_id,
+                    state.current_path,
+                )
         entry = reconstruct_grab_list_entry(row, state)
 
         if state.processing_started_at is not None:

--- a/lib/download.py
+++ b/lib/download.py
@@ -495,15 +495,22 @@ def _materialize_processing_dir(
                 ", ".join(missing_paths),
             )
             return False
-        if current_path_location.blocks_post_move_retry:
+        if current_path_location.blocks_auto_import_dispatch:
+            detail = (
+                "already lives at the request-scoped auto-import staged "
+                "path. Automatic retry is disabled to avoid duplicate "
+                "import; manual recovery is required."
+            )
+            if current_path_location.kind == "legacy_shared_staged":
+                detail = (
+                    "already lives at the legacy shared staged path. "
+                    "Automatic retry is disabled because the path is "
+                    "ambiguous across editions; manual recovery is required."
+                )
             _log_post_move_resume_blocked(
                 album_data,
                 current_path=staged_album.current_path,
-                detail=(
-                    "already lives at the request-scoped auto-import staged "
-                    "path. Automatic retry is disabled to avoid duplicate "
-                    "import; manual recovery is required."
-                ),
+                detail=detail,
             )
             return None
         album_data.import_folder = staged_album.current_path
@@ -1135,8 +1142,6 @@ def rederive_transfer_ids(
 def reconstruct_grab_list_entry(
     request: dict[str, Any],
     state: ActiveDownloadState,
-    *,
-    fallback_current_path: str | None = None,
 ) -> GrabListEntry:
     """Rebuild GrabListEntry from a DB row + persisted download state.
 
@@ -1170,7 +1175,7 @@ def reconstruct_grab_list_entry(
         db_source=request.get("source"),
         db_search_filetype_override=request.get("search_filetype_override"),
         db_target_format=request.get("target_format"),
-        import_folder=state.current_path or fallback_current_path,
+        import_folder=state.current_path,
     )
 
 
@@ -1399,7 +1404,6 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             state = ActiveDownloadState.from_dict(raw_state)
         else:
             state = ActiveDownloadState.from_json(raw_state)
-        fallback_current_path = None
         if state.current_path is None and state.processing_started_at is not None:
             recovery_decision = resolve_missing_current_path(
                 artist=row["artist_name"],
@@ -1439,15 +1443,9 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                 )
                 continue
             assert recovery_decision.selected_location is not None
-            fallback_current_path = recovery_decision.selected_location.path
-            state.current_path = fallback_current_path
-        entry = reconstruct_grab_list_entry(
-            row,
-            state,
-            fallback_current_path=fallback_current_path,
-        )
-        if fallback_current_path is not None:
-            db.update_download_state_current_path(request_id, fallback_current_path)
+            state.current_path = recovery_decision.selected_location.path
+            db.update_download_state_current_path(request_id, state.current_path)
+        entry = reconstruct_grab_list_entry(row, state)
 
         if state.processing_started_at is not None:
             _run_completed_processing(entry, request_id, state, db, ctx)

--- a/lib/download.py
+++ b/lib/download.py
@@ -424,8 +424,8 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 
 def _path_is_within(path: str, root: str) -> bool:
     """Return True when ``path`` is located under ``root``."""
-    abs_path = os.path.abspath(path)
-    abs_root = os.path.abspath(root)
+    abs_path = os.path.realpath(path)
+    abs_root = os.path.realpath(root)
     try:
         return os.path.commonpath([abs_path, abs_root]) == abs_root
     except ValueError:
@@ -445,9 +445,13 @@ def _materialize_processing_dir(
     if os.path.abspath(staged_album.current_path) != os.path.abspath(canonical_path):
         if _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir):
             logger.error(
-                "Current staged path already lives under beets staging: %s. "
-                "Refusing automatic retry from a post-move path; manual "
-                "recovery is required to avoid duplicate import.",
+                "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
+                "current_path=%s already lives under beets staging. "
+                "Automatic retry is disabled to avoid duplicate import; "
+                "manual recovery is required.",
+                album_data.db_request_id,
+                album_data.artist,
+                album_data.title,
                 staged_album.current_path,
             )
             return None

--- a/lib/download.py
+++ b/lib/download.py
@@ -441,6 +441,24 @@ def _directory_has_entries(path: str) -> bool:
     with os.scandir(path) as entries:
         return any(True for _ in entries)
 
+
+def _log_post_move_resume_blocked(
+    album_data: GrabListEntry,
+    *,
+    current_path: str,
+    detail: str,
+) -> None:
+    logger.error(
+        "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
+        "current_path=%s %s See docs/advisory-locks.md.",
+        album_data.db_request_id,
+        album_data.artist,
+        album_data.title,
+        current_path,
+        detail,
+    )
+
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -453,7 +471,23 @@ def _materialize_processing_dir(
           if ctx.pipeline_db_source is not None else None)
 
     if os.path.realpath(staged_album.current_path) != os.path.realpath(canonical_path):
+        is_staged_retry = _path_is_within(
+            staged_album.current_path,
+            ctx.cfg.beets_staging_dir,
+        )
         if not os.path.isdir(staged_album.current_path):
+            if is_staged_retry:
+                _log_post_move_resume_blocked(
+                    album_data,
+                    current_path=staged_album.current_path,
+                    detail=(
+                        "is already under beets staging but the directory is "
+                        "missing. Automatic retry is disabled because import "
+                        "may already have consumed the files; manual recovery "
+                        "is required."
+                    ),
+                )
+                return None
             logger.error(f"Current staged path missing: {staged_album.current_path}")
             return False
         staged_album.bind_import_paths(album_data.files)
@@ -464,6 +498,19 @@ def _materialize_processing_dir(
             if not os.path.isfile(import_path):
                 missing_paths.append(import_path)
         if missing_paths:
+            if is_staged_retry:
+                _log_post_move_resume_blocked(
+                    album_data,
+                    current_path=staged_album.current_path,
+                    detail=(
+                        "is already under beets staging but tracked files are "
+                        f"missing ({', '.join(missing_paths)}). Automatic "
+                        "retry is disabled because import may already have "
+                        "partially consumed the album; manual recovery is "
+                        "required."
+                    ),
+                )
+                return None
             logger.error(
                 "Current staged path is missing tracked files: %s",
                 ", ".join(missing_paths),
@@ -717,16 +764,14 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
         will_auto_import
         and _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir)
     ):
-        logger.error(
-            "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
-            "current_path=%s already lives under beets staging on the "
-            "auto-import path. Automatic retry is disabled to avoid "
-            "duplicate import; manual recovery is required. See "
-            "docs/advisory-locks.md.",
-            request_id,
-            album_data.artist,
-            album_data.title,
-            staged_album.current_path,
+        _log_post_move_resume_blocked(
+            album_data,
+            current_path=staged_album.current_path,
+            detail=(
+                "already lives under beets staging on the auto-import path. "
+                "Automatic retry is disabled to avoid duplicate import; "
+                "manual recovery is required."
+            ),
         )
         return DispatchOutcome(
             success=False,
@@ -1363,9 +1408,19 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             )
             if (not _directory_has_entries(canonical_fallback)
                     and os.path.isdir(staged_fallback)):
-                fallback_current_path = staged_fallback
-            else:
-                fallback_current_path = canonical_fallback
+                logger.error(
+                    "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
+                    "current_path is missing, canonical_path=%s has no files, "
+                    "and staged_path=%s is ambiguous across editions. "
+                    "Manual recovery is required.",
+                    request_id,
+                    row["artist_name"],
+                    row["album_title"],
+                    canonical_fallback,
+                    staged_fallback,
+                )
+                continue
+            fallback_current_path = canonical_fallback
             state.current_path = fallback_current_path
         entry = reconstruct_grab_list_entry(
             row,

--- a/lib/download.py
+++ b/lib/download.py
@@ -26,7 +26,8 @@ from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
                                  _record_rejection_and_maybe_requeue,
                                  dispatch_import_core, finalize_request)
-from lib.staged_album import StagedAlbum, stage_to_ai_path
+from lib.staged_album import (StagedAlbum, stage_to_ai_path,
+                              stage_to_ai_root)
 from lib.transitions import apply_transition
 from lib.util import (sanitize_folder_name, move_failed_import,
                       log_validation_result)
@@ -459,6 +460,13 @@ def _log_post_move_resume_blocked(
     )
 
 
+def _is_auto_import_staged_path(path: str, staging_dir: str) -> bool:
+    return _path_is_within(
+        path,
+        stage_to_ai_root(staging_dir=staging_dir, auto_import=True),
+    )
+
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -471,23 +479,22 @@ def _materialize_processing_dir(
           if ctx.pipeline_db_source is not None else None)
 
     if os.path.realpath(staged_album.current_path) != os.path.realpath(canonical_path):
-        is_staged_retry = _path_is_within(
+        is_auto_import_staged_retry = _is_auto_import_staged_path(
             staged_album.current_path,
             ctx.cfg.beets_staging_dir,
         )
+        if is_auto_import_staged_retry:
+            _log_post_move_resume_blocked(
+                album_data,
+                current_path=staged_album.current_path,
+                detail=(
+                    "already lives under the auto-import staging root. "
+                    "Automatic retry is disabled to avoid duplicate import; "
+                    "manual recovery is required."
+                ),
+            )
+            return None
         if not os.path.isdir(staged_album.current_path):
-            if is_staged_retry:
-                _log_post_move_resume_blocked(
-                    album_data,
-                    current_path=staged_album.current_path,
-                    detail=(
-                        "is already under beets staging but the directory is "
-                        "missing. Automatic retry is disabled because import "
-                        "may already have consumed the files; manual recovery "
-                        "is required."
-                    ),
-                )
-                return None
             logger.error(f"Current staged path missing: {staged_album.current_path}")
             return False
         staged_album.bind_import_paths(album_data.files)
@@ -498,19 +505,6 @@ def _materialize_processing_dir(
             if not os.path.isfile(import_path):
                 missing_paths.append(import_path)
         if missing_paths:
-            if is_staged_retry:
-                _log_post_move_resume_blocked(
-                    album_data,
-                    current_path=staged_album.current_path,
-                    detail=(
-                        "is already under beets staging but tracked files are "
-                        f"missing ({', '.join(missing_paths)}). Automatic "
-                        "retry is disabled because import may already have "
-                        "partially consumed the album; manual recovery is "
-                        "required."
-                    ),
-                )
-                return None
             logger.error(
                 "Current staged path is missing tracked files: %s",
                 ", ".join(missing_paths),
@@ -813,6 +807,8 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                 artist=album_data.artist,
                 title=album_data.title,
                 staging_dir=ctx.cfg.beets_staging_dir,
+                request_id=request_id,
+                auto_import=will_auto_import,
             ),
             db=db,
         )

--- a/lib/download.py
+++ b/lib/download.py
@@ -424,6 +424,8 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 
 def _path_is_within(path: str, root: str) -> bool:
     """Return True when ``path`` is located under ``root``."""
+    if not root:
+        return False
     abs_path = os.path.realpath(path)
     abs_root = os.path.realpath(root)
     try:
@@ -442,7 +444,7 @@ def _materialize_processing_dir(
     db = (ctx.pipeline_db_source._get_db()
           if ctx.pipeline_db_source is not None else None)
 
-    if os.path.abspath(staged_album.current_path) != os.path.abspath(canonical_path):
+    if os.path.realpath(staged_album.current_path) != os.path.realpath(canonical_path):
         if _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir):
             logger.error(
                 "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
@@ -472,7 +474,6 @@ def _materialize_processing_dir(
             )
             return False
         album_data.import_folder = staged_album.current_path
-        staged_album.persist_current_path(db)
         return True
 
     rm_dirs: list[str] = []
@@ -1242,9 +1243,6 @@ def _run_completed_processing(
     #   contention and guarded post-move staged paths where auto-retry
     #   would risk duplicate import. Do NOT touch state here.
     if outcome is None:
-        logger.info(
-            "  process_completed_album left state untouched; "
-            "poll_active_downloads will retry or await manual recovery")
         return
 
     refreshed = db.get_request(request_id)

--- a/lib/download.py
+++ b/lib/download.py
@@ -21,7 +21,11 @@ from lib.download_recovery import (
     resolve_missing_current_path,
 )
 from lib.grab_list import GrabListEntry, DownloadFile
-from lib.processing_paths import canonical_processing_path, directory_has_entries
+from lib.processing_paths import (
+    canonical_processing_path,
+    directory_has_entries,
+    stage_to_ai_path,
+)
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, ValidationResult,
                          decide_download_action,
@@ -31,8 +35,7 @@ from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
                                  _record_rejection_and_maybe_requeue,
                                  dispatch_import_core, finalize_request)
-from lib.staged_album import (StagedAlbum, stage_to_ai_path,
-                              stage_to_ai_root)
+from lib.staged_album import StagedAlbum
 from lib.transitions import apply_transition
 from lib.util import move_failed_import, log_validation_result
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -1310,6 +1310,11 @@ def _run_completed_processing(
 ) -> None:
     """Run or resume local post-download processing for a completed album."""
     if state.processing_started_at is None:
+        if entry.import_folder is None:
+            entry.import_folder = _canonical_import_folder_path(
+                entry,
+                ctx.cfg.slskd_download_dir,
+            )
         state.processing_started_at = datetime.now(timezone.utc).isoformat()
         _persist_updated_download_state(db, request_id, entry, state)
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -467,6 +467,23 @@ def _is_auto_import_staged_path(path: str, staging_dir: str) -> bool:
     )
 
 
+def _is_legacy_shared_staged_path(
+    path: str,
+    *,
+    artist: str,
+    title: str,
+    staging_dir: str,
+) -> bool:
+    return _path_is_within(
+        path,
+        stage_to_ai_path(
+            artist=artist,
+            title=title,
+            staging_dir=staging_dir,
+        ),
+    )
+
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -780,7 +797,18 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
 
     if (
         will_auto_import
-        and _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir)
+        and (
+            _is_auto_import_staged_path(
+                staged_album.current_path,
+                ctx.cfg.beets_staging_dir,
+            )
+            or _is_legacy_shared_staged_path(
+                staged_album.current_path,
+                artist=album_data.artist,
+                title=album_data.title,
+                staging_dir=ctx.cfg.beets_staging_dir,
+            )
+        )
     ):
         _log_post_move_resume_blocked(
             album_data,

--- a/lib/download.py
+++ b/lib/download.py
@@ -772,6 +772,7 @@ def build_active_download_state(
     enqueued_at: str | None = None,
     last_progress_at: str | None = None,
     processing_started_at: str | None = None,
+    current_path: str | None = None,
 ) -> ActiveDownloadState:
     """Build an ActiveDownloadState from a GrabListEntry.
 
@@ -799,6 +800,7 @@ def build_active_download_state(
         last_progress_at=last_progress_at or enqueued_at_value,
         files=files,
         processing_started_at=processing_started_at,
+        current_path=current_path or entry.import_folder,
     )
 
 
@@ -976,6 +978,7 @@ def reconstruct_grab_list_entry(
         db_source=request.get("source"),
         db_search_filetype_override=request.get("search_filetype_override"),
         db_target_format=request.get("target_format"),
+        import_folder=state.current_path,
     )
 
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -438,11 +438,12 @@ def _materialize_processing_dir(
             logger.error(f"Current staged path missing: {staged_album.current_path}")
             return False
         staged_album.bind_import_paths(album_data.files)
-        missing_paths = [
-            file.import_path
-            for file in album_data.files
-            if file.import_path is not None and not os.path.isfile(file.import_path)
-        ]
+        missing_paths: list[str] = []
+        for file in album_data.files:
+            import_path = file.import_path
+            assert import_path is not None
+            if not os.path.isfile(import_path):
+                missing_paths.append(import_path)
         if missing_paths:
             logger.error(
                 "Current staged path is missing tracked files: %s",
@@ -611,7 +612,7 @@ def _process_beets_validation(album_data: GrabListEntry,
         return _handle_valid_result(
             album_data, bv_result, staged_album, ctx)
     _handle_rejected_result(
-        album_data, bv_result, current_path, ctx)
+        album_data, bv_result, staged_album, ctx)
     return None
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                          staged_album: StagedAlbum,
@@ -627,16 +628,17 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     contention path.
 
     This function acquires the RELEASE advisory lock outer for the
-    auto-import path *before* the staged move runs, so contention
-    leaves files in their slskd-download location and the next
-    cycle's resume guard in ``process_completed_album`` can
-    idempotently re-enter. Redownload paths don't take the lock —
-    they stage-and-mark-done without running the harness, so no
-    cross-process race applies.
+    auto-import path *before* ``StagedAlbum.move_to`` runs, so
+    contention is a true no-op: files stay at their current local
+    processing path, ``active_download_state.current_path`` stays
+    unchanged, and the next cycle can idempotently re-enter without
+    any extra filesystem churn. Redownload paths don't take the lock
+    — they just move into staging and mark done, so no cross-process
+    race applies.
 
     See ``docs/advisory-locks.md`` for namespaces, keys, ordering,
-    and contention behaviour (including the staged-move rationale
-    for acquiring at this level rather than inside
+    and contention behaviour (including the staged-move rationale for
+    acquiring at this level rather than inside
     ``dispatch_import_core``).
     """
     from contextlib import nullcontext
@@ -707,7 +709,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                 f"AUTO-IMPORT DEFERRED: {album_data.artist} - "
                 f"{album_data.title} — release lock held by another "
                 f"process (mbid={album_data.mb_release_id}); skipping "
-                "the staged move and dispatch. Files stay at "
+                "staged move and dispatch. Files stay at "
                 f"{staged_album.current_path} so the next cycle can "
                 "idempotently resume from process_completed_album.")
             return DispatchOutcome(
@@ -780,10 +782,15 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
 
 
 def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResult,
-                            import_folder_fullpath: str,
+                            staged_album: StagedAlbum,
                             ctx: CratediggerContext) -> None:
     """Handle a rejected beets validation result."""
-    failed_dest = move_failed_import(import_folder_fullpath, scenario=bv_result.scenario)
+    failed_dest = move_failed_import(
+        staged_album.current_path,
+        scenario=bv_result.scenario,
+    )
+    if failed_dest is not None:
+        staged_album.current_path = failed_dest
     bv_result.failed_path = failed_dest
     log_validation_result(album_data, bv_result, ctx.cfg)
     usernames = set(f.username for f in album_data.files)
@@ -893,7 +900,11 @@ def build_active_download_state(
         last_progress_at=last_progress_at or enqueued_at_value,
         files=files,
         processing_started_at=processing_started_at,
-        current_path=current_path or entry.import_folder,
+        current_path=(
+            current_path
+            if current_path is not None
+            else entry.import_folder
+        ),
     )
 
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -26,8 +26,9 @@ from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
                                  _record_rejection_and_maybe_requeue,
                                  dispatch_import_core, finalize_request)
+from lib.staged_album import StagedAlbum
 from lib.transitions import apply_transition
-from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
+from lib.util import (sanitize_folder_name, move_failed_import,
                       log_validation_result)
 
 if TYPE_CHECKING:
@@ -260,6 +261,38 @@ def _safe_getsize(path: str) -> int | None:
         return None
 
 
+def _canonical_import_folder_path_from_metadata(
+    *,
+    artist: str,
+    title: str,
+    year: str,
+    slskd_download_dir: str,
+) -> str:
+    """Return the canonical local processing directory for a completed album."""
+    import_folder_name = sanitize_folder_name(
+        f"{artist} - {title} ({year})")
+    return os.path.join(slskd_download_dir, import_folder_name)
+
+
+def _canonical_import_folder_path(
+    album_data: GrabListEntry,
+    slskd_download_dir: str,
+) -> str:
+    return _canonical_import_folder_path_from_metadata(
+        artist=album_data.artist,
+        title=album_data.title,
+        year=album_data.year,
+        slskd_download_dir=slskd_download_dir,
+    )
+
+
+def _stage_to_ai_path(album_data: GrabListEntry, staging_dir: str) -> str:
+    """Return the beets staging destination for a validated album."""
+    artist_dir = sanitize_folder_name(album_data.artist)
+    album_dir = sanitize_folder_name(album_data.title)
+    return os.path.join(staging_dir, artist_dir, album_dir)
+
+
 # === slskd transfer helpers ===
 
 def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> None:
@@ -396,31 +429,34 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 
 # === Download completion processing ===
 
-def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
-                            ctx: CratediggerContext) -> "bool | None":
-    """Process a fully-downloaded album: move files, tag, validate, stage/import.
+def _materialize_processing_dir(
+    album_data: GrabListEntry,
+    staged_album: StagedAlbum,
+    ctx: CratediggerContext,
+) -> bool:
+    """Ensure ``staged_album.current_path`` holds the album's local files."""
+    canonical_path = _canonical_import_folder_path(
+        album_data, ctx.cfg.slskd_download_dir)
+    db = (ctx.pipeline_db_source._get_db()
+          if ctx.pipeline_db_source is not None else None)
 
-    Returns three-valued ``bool | None``:
-    - ``True`` — files moved and tagged successfully. Auto-import (if
-      fired) either landed or recorded a rejection; outer caller flips
-      status to ``imported``.
-    - ``False`` — file moves failed; outer caller resets to ``wanted``.
-    - ``None`` — auto-import deferred because another process held the
-      release advisory lock. Files are staged, spectral state is set,
-      and request stays ``downloading``. Outer caller must NOT touch
-      status: the next ``poll_active_downloads`` cycle re-enters this
-      function and retries. Codex PR #136 R3 P2/P3.
-    """
-    import_folder_name = sanitize_folder_name(
-        f"{album_data.artist} - {album_data.title} ({album_data.year})")
-    import_folder_fullpath = os.path.join(ctx.cfg.slskd_download_dir, import_folder_name)
+    if os.path.abspath(staged_album.current_path) != os.path.abspath(canonical_path):
+        if not os.path.isdir(staged_album.current_path):
+            logger.error(f"Current staged path missing: {staged_album.current_path}")
+            return False
+        staged_album.bind_import_paths(album_data.files)
+        album_data.import_folder = staged_album.current_path
+        staged_album.persist_current_path(db)
+        return True
+
     rm_dirs: list[str] = []
     moved_files_history: list[tuple[str, str]] = []
-    if os.path.exists(import_folder_fullpath):
-        logger.info(f"Staging folder {import_folder_fullpath} already exists — "
+    if os.path.exists(canonical_path):
+        logger.info(f"Staging folder {canonical_path} already exists — "
                     f"resuming or reusing prior attempt")
     else:
-        os.mkdir(import_folder_fullpath)
+        os.mkdir(canonical_path)
+
     for file in album_data.files:
         # Destination filename keeps the remote basename (no ticks suffix,
         # even if slskd appended one on the source).
@@ -433,9 +469,7 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
         src_folder = os.path.dirname(src_file)
         if src_folder not in rm_dirs:
             rm_dirs.append(src_folder)
-        if file.disk_no is not None and file.disk_count is not None and file.disk_count > 1:
-            filename = f"Disk {file.disk_no} - {filename}"
-        dst_file = os.path.join(import_folder_fullpath, filename)
+        dst_file = staged_album.import_path_for(file)
         file.import_path = dst_file
         if os.path.exists(dst_file) and not os.path.exists(src_file):
             # Resume safely after a crash that already moved this file.
@@ -452,85 +486,131 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
                 except Exception:
                     logger.exception(f"Critical failure during rollback: could not move {dst} back to {src}")
             try:
-                os.rmdir(import_folder_fullpath)
+                os.rmdir(canonical_path)
             except OSError:
-                logger.warning(f"Could not remove temp import directory {import_folder_fullpath}")
+                logger.warning(f"Could not remove temp import directory {canonical_path}")
             return False
-    else:  # Only runs if all files are successfully moved
-        for rm_dir in rm_dirs:
-            if rm_dir != import_folder_fullpath:
-                try:
-                    os.rmdir(rm_dir)
-                except OSError:
-                    logger.warning(f"Skipping removal of {rm_dir} because it's not empty.")
-        logger.info(f"Processing completed download: {album_data.artist} - {album_data.title}")
-        for file in album_data.files:
-            try:
-                song = music_tag.load_file(file.import_path)
-                assert song is not None
-                if file.disk_no is not None:
-                    song["discnumber"] = file.disk_no
-                    song["totaldiscs"] = file.disk_count
-                song["albumartist"] = album_data.artist
-                song["album"] = album_data.title
-                song.save()
-            except Exception:
-                logger.exception(f"Error writing tags for: {file.import_path}")
-        if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
-            from lib.beets import beets_validate as _bv
-            from lib.preimport import run_preimport_gates
 
-            bv_result = _bv(ctx.cfg.beets_harness_path, import_folder_fullpath,
-                            album_data.mb_release_id, ctx.cfg.beets_distance_threshold)
-            usernames_pre = set(f.username for f in album_data.files if f.username)
-            bv_result.soulseek_username = (
-                ", ".join(sorted(usernames_pre)) if usernames_pre else None
-            )
-            bv_result.download_folder = import_folder_fullpath
+    for rm_dir in rm_dirs:
+        if os.path.abspath(rm_dir) == os.path.abspath(canonical_path):
+            continue
+        try:
+            os.rmdir(rm_dir)
+        except OSError:
+            logger.warning(f"Skipping removal of {rm_dir} because it's not empty.")
 
-            if bv_result.valid:
-                dl_pre = _build_download_info(album_data)
-                db = (ctx.pipeline_db_source._get_db()
-                      if ctx.pipeline_db_source is not None else None)
-                preimport = run_preimport_gates(
-                    path=import_folder_fullpath,
-                    mb_release_id=album_data.mb_release_id or "",
-                    label=f"{album_data.artist} - {album_data.title}",
-                    download_filetype=dl_pre.filetype or "",
-                    download_min_bitrate_bps=dl_pre.bitrate,
-                    download_is_vbr=dl_pre.is_vbr,
-                    cfg=ctx.cfg,
-                    db=db,
-                    request_id=album_data.db_request_id,
-                    usernames=usernames_pre,
-                )
-                album_data.download_spectral = preimport.download_spectral
-                album_data.current_spectral = preimport.existing_spectral
-                album_data.current_min_bitrate = preimport.existing_min_bitrate
-                if not preimport.valid:
-                    bv_result.valid = False
-                    bv_result.scenario = preimport.scenario
-                    bv_result.detail = preimport.detail
-                    if preimport.corrupt_files:
-                        bv_result.corrupt_files = preimport.corrupt_files
-
-            if bv_result.valid:
-                outcome = _handle_valid_result(
-                    album_data, bv_result, import_folder_fullpath, ctx)
-                if outcome is not None and outcome.deferred:
-                    # Release-lock contention. Propagate ``None`` so
-                    # ``_run_completed_processing`` leaves the request's
-                    # status, active_download_state, and staged files
-                    # untouched for the next cycle to retry.
-                    return None
-            else:
-                _handle_rejected_result(
-                    album_data, bv_result, import_folder_fullpath, ctx)
-        return True
+    album_data.import_folder = staged_album.current_path
+    staged_album.persist_current_path(db)
+    return True
 
 
+def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
+                            ctx: CratediggerContext) -> "bool | None":
+    """Process a fully-downloaded album: move files, tag, validate, stage/import.
+
+    Returns three-valued ``bool | None``:
+    - ``True`` — files moved and tagged successfully. Auto-import (if
+      fired) either landed or recorded a rejection; outer caller flips
+      status to ``imported``.
+    - ``False`` — file moves failed; outer caller resets to ``wanted``.
+    - ``None`` — auto-import deferred because another process held the
+      release advisory lock. Files are staged, spectral state is set,
+      and request stays ``downloading``. Outer caller must NOT touch
+      status: the next ``poll_active_downloads`` cycle re-enters this
+      function and retries. Codex PR #136 R3 P2/P3.
+    """
+    staged_album = StagedAlbum.from_entry(
+        album_data,
+        default_path=_canonical_import_folder_path(
+            album_data, ctx.cfg.slskd_download_dir),
+    )
+    if not _materialize_processing_dir(album_data, staged_album, ctx):
+        return False
+
+    logger.info(f"Processing completed download: {album_data.artist} - {album_data.title}")
+    for file in album_data.files:
+        try:
+            song = music_tag.load_file(file.import_path)
+            assert song is not None
+            if file.disk_no is not None:
+                song["discnumber"] = file.disk_no
+                song["totaldiscs"] = file.disk_count
+            song["albumartist"] = album_data.artist
+            song["album"] = album_data.title
+            song.save()
+        except Exception:
+            logger.exception(f"Error writing tags for: {file.import_path}")
+    if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
+        outcome = _process_beets_validation(
+            album_data, staged_album, ctx)
+        if outcome is not None and outcome.deferred:
+            # Release-lock contention. Propagate ``None`` so
+            # ``_run_completed_processing`` leaves the request's
+            # status, active_download_state, and staged files
+            # untouched for the next cycle to retry.
+            return None
+    return True
+
+
+def _process_beets_validation(album_data: GrabListEntry,
+                              staged_album: StagedAlbum,
+                              ctx: CratediggerContext) -> "DispatchOutcome | None":
+    """Beets validation sub-path of process_completed_album.
+
+    After beets validation passes, delegates to ``lib.preimport.run_preimport_gates``
+    for the shared audio + spectral gates. The force/manual-import path
+    (``dispatch_import_from_db``) calls the same function — only the beets
+    distance check is path-specific.
+
+    Returns the dispatch outcome when the auto-import path fires,
+    ``None`` when beets validation rejects (``_handle_rejected_result``
+    already handles the state transition) or when the non-auto
+    redownload path takes over in ``_handle_valid_result``. Caller
+    uses the ``deferred`` flag to decide whether to flip status.
+    """
+    from lib.beets import beets_validate as _bv
+    from lib.preimport import run_preimport_gates
+    current_path = staged_album.current_path
+    bv_result = _bv(ctx.cfg.beets_harness_path, current_path,
+                    album_data.mb_release_id, ctx.cfg.beets_distance_threshold)
+    usernames_pre = set(f.username for f in album_data.files if f.username)
+    bv_result.soulseek_username = ", ".join(sorted(usernames_pre)) if usernames_pre else None
+    bv_result.download_folder = current_path
+
+    if bv_result.valid:
+        dl_pre = _build_download_info(album_data)
+        db = (ctx.pipeline_db_source._get_db()
+              if ctx.pipeline_db_source is not None else None)
+        preimport = run_preimport_gates(
+            path=current_path,
+            mb_release_id=album_data.mb_release_id or "",
+            label=f"{album_data.artist} - {album_data.title}",
+            download_filetype=dl_pre.filetype or "",
+            download_min_bitrate_bps=dl_pre.bitrate,
+            download_is_vbr=dl_pre.is_vbr,
+            cfg=ctx.cfg,
+            db=db,
+            request_id=album_data.db_request_id,
+            usernames=usernames_pre,
+        )
+        album_data.download_spectral = preimport.download_spectral
+        album_data.current_spectral = preimport.existing_spectral
+        album_data.current_min_bitrate = preimport.existing_min_bitrate
+        if not preimport.valid:
+            bv_result.valid = False
+            bv_result.scenario = preimport.scenario
+            bv_result.detail = preimport.detail
+            if preimport.corrupt_files:
+                bv_result.corrupt_files = preimport.corrupt_files
+
+    if bv_result.valid:
+        return _handle_valid_result(
+            album_data, bv_result, staged_album, ctx)
+    _handle_rejected_result(
+        album_data, bv_result, current_path, ctx)
+    return None
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
-                         import_folder_fullpath: str,
+                         staged_album: StagedAlbum,
                          ctx: CratediggerContext) -> "DispatchOutcome | None":
     """Handle a valid beets validation result: stage and optionally auto-import.
 
@@ -543,7 +623,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     contention path.
 
     This function acquires the RELEASE advisory lock outer for the
-    auto-import path *before* ``stage_to_ai`` runs, so contention
+    auto-import path *before* the staged move runs, so contention
     leaves files in their slskd-download location and the next
     cycle's resume guard in ``process_completed_album`` can
     idempotently re-enter. Redownload paths don't take the lock —
@@ -551,7 +631,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     cross-process race applies.
 
     See ``docs/advisory-locks.md`` for namespaces, keys, ordering,
-    and contention behaviour (including the ``stage_to_ai`` rationale
+    and contention behaviour (including the staged-move rationale
     for acquiring at this level rather than inside
     ``dispatch_import_core``).
     """
@@ -575,7 +655,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
             error="missing_mbid",
         )
         failed_result.failed_path = move_failed_import(
-            import_folder_fullpath,
+            staged_album.current_path,
             scenario=failed_result.scenario,
         )
         logger.error(
@@ -623,8 +703,8 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                 f"AUTO-IMPORT DEFERRED: {album_data.artist} - "
                 f"{album_data.title} — release lock held by another "
                 f"process (mbid={album_data.mb_release_id}); skipping "
-                "stage_to_ai and dispatch. Files stay at "
-                f"{import_folder_fullpath} so the next cycle can "
+                "the staged move and dispatch. Files stay at "
+                f"{staged_album.current_path} so the next cycle can "
                 "idempotently resume from process_completed_album.")
             return DispatchOutcome(
                 success=False,
@@ -633,8 +713,13 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                 deferred=True,
             )
 
-        dest = stage_to_ai(
-            album_data, import_folder_fullpath, ctx.cfg.beets_staging_dir)
+        db = (ctx.pipeline_db_source._get_db()
+              if ctx.pipeline_db_source is not None else None)
+        dest = staged_album.move_to(
+            _stage_to_ai_path(album_data, ctx.cfg.beets_staging_dir),
+            db=db,
+        )
+        album_data.import_folder = dest
         log_validation_result(album_data, bv_result, ctx.cfg, dest_path=dest)
         logger.info(f"STAGED: {album_data.artist} - {album_data.title} "
                     f"(scenario={bv_result.scenario}, "
@@ -945,6 +1030,8 @@ def rederive_transfer_ids(
 def reconstruct_grab_list_entry(
     request: dict[str, Any],
     state: ActiveDownloadState,
+    *,
+    fallback_current_path: str | None = None,
 ) -> GrabListEntry:
     """Rebuild GrabListEntry from a DB row + persisted download state.
 
@@ -978,7 +1065,7 @@ def reconstruct_grab_list_entry(
         db_source=request.get("source"),
         db_search_filetype_override=request.get("search_filetype_override"),
         db_target_format=request.get("target_format"),
-        import_folder=state.current_path,
+        import_folder=state.current_path or fallback_current_path,
     )
 
 
@@ -1040,6 +1127,7 @@ def _persist_updated_download_state(
             enqueued_at=state.enqueued_at,
             last_progress_at=state.last_progress_at,
             processing_started_at=state.processing_started_at,
+            current_path=state.current_path or entry.import_folder,
         ).to_json(),
     )
 
@@ -1207,7 +1295,19 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             state = ActiveDownloadState.from_dict(raw_state)
         else:
             state = ActiveDownloadState.from_json(raw_state)
-        entry = reconstruct_grab_list_entry(row, state)
+        fallback_current_path = None
+        if state.current_path is None and state.processing_started_at is not None:
+            fallback_current_path = _canonical_import_folder_path_from_metadata(
+                artist=row["artist_name"],
+                title=row["album_title"],
+                year=str(row["year"] or ""),
+                slskd_download_dir=ctx.cfg.slskd_download_dir,
+            )
+        entry = reconstruct_grab_list_entry(
+            row,
+            state,
+            fallback_current_path=fallback_current_path,
+        )
 
         if state.processing_started_at is not None:
             _run_completed_processing(entry, request_id, state, db, ctx)

--- a/lib/download.py
+++ b/lib/download.py
@@ -1482,6 +1482,8 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             for label, candidate in request_scoped_staged_candidates:
                 if _directory_has_entries(candidate):
                     populated_candidates.append((label, candidate))
+            if _directory_has_entries(staged_fallback):
+                populated_candidates.append(("legacy-shared", staged_fallback))
 
             if len(populated_candidates) > 1:
                 rendered_candidates = ", ".join(
@@ -1498,20 +1500,21 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                 )
                 continue
             if len(populated_candidates) == 1:
-                fallback_current_path = populated_candidates[0][1]
-            elif _directory_has_entries(staged_fallback):
-                logger.error(
-                    "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
-                    "current_path is missing, canonical_path=%s has no files, "
-                    "and staged_path=%s is ambiguous across editions. "
-                    "Manual recovery is required.",
-                    request_id,
-                    row["artist_name"],
-                    row["album_title"],
-                    canonical_fallback,
-                    staged_fallback,
-                )
-                continue
+                candidate_label, candidate_path = populated_candidates[0]
+                if candidate_label == "legacy-shared":
+                    logger.error(
+                        "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
+                        "current_path is missing, canonical_path=%s has no files, "
+                        "and staged_path=%s is ambiguous across editions. "
+                        "Manual recovery is required.",
+                        request_id,
+                        row["artist_name"],
+                        row["album_title"],
+                        canonical_fallback,
+                        staged_fallback,
+                    )
+                    continue
+                fallback_current_path = candidate_path
             else:
                 fallback_current_path = canonical_fallback
             state.current_path = fallback_current_path

--- a/lib/download.py
+++ b/lib/download.py
@@ -17,11 +17,11 @@ from typing import Any, Callable, TYPE_CHECKING
 import music_tag
 
 from lib.download_recovery import (
-    canonical_processing_path,
     classify_processing_path,
     resolve_missing_current_path,
 )
 from lib.grab_list import GrabListEntry, DownloadFile
+from lib.processing_paths import canonical_processing_path, directory_has_entries
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, ValidationResult,
                          decide_download_action,
@@ -266,27 +266,11 @@ def _safe_getsize(path: str) -> int | None:
         return None
 
 
-def _canonical_import_folder_path_from_metadata(
-    *,
-    artist: str,
-    title: str,
-    year: str,
-    slskd_download_dir: str,
-) -> str:
-    """Return the canonical local processing directory for a completed album."""
-    return canonical_processing_path(
-        artist=artist,
-        title=title,
-        year=year,
-        slskd_download_dir=slskd_download_dir,
-    )
-
-
 def _canonical_import_folder_path(
     album_data: GrabListEntry,
     slskd_download_dir: str,
 ) -> str:
-    return _canonical_import_folder_path_from_metadata(
+    return canonical_processing_path(
         artist=album_data.artist,
         title=album_data.title,
         year=album_data.year,
@@ -429,15 +413,6 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 
 
 # === Download completion processing ===
-
-def _directory_has_entries(path: str) -> bool:
-    """Return True when ``path`` exists and contains at least one entry."""
-    if not os.path.isdir(path):
-        return False
-    with os.scandir(path) as entries:
-        return any(True for _ in entries)
-
-
 def _log_post_move_resume_blocked(
     album_data: GrabListEntry,
     *,
@@ -453,6 +428,8 @@ def _log_post_move_resume_blocked(
         current_path,
         detail,
     )
+
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -1428,7 +1405,7 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                 request_id=request_id,
                 staging_dir=ctx.cfg.beets_staging_dir,
                 slskd_download_dir=ctx.cfg.slskd_download_dir,
-                has_entries=_directory_has_entries,
+                has_entries=directory_has_entries,
             )
             if recovery_decision.blocked_reason == "multiple_populated_paths":
                 rendered_candidates = ", ".join(
@@ -1467,7 +1444,7 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             fallback_current_path=fallback_current_path,
         )
         if fallback_current_path is not None:
-            _persist_updated_download_state(db, request_id, entry, state)
+            db.update_download_state_current_path(request_id, fallback_current_path)
 
         if state.processing_started_at is not None:
             _run_completed_processing(entry, request_id, state, db, ctx)

--- a/lib/download.py
+++ b/lib/download.py
@@ -453,19 +453,6 @@ def _materialize_processing_dir(
           if ctx.pipeline_db_source is not None else None)
 
     if os.path.realpath(staged_album.current_path) != os.path.realpath(canonical_path):
-        if _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir):
-            logger.error(
-                "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
-                "current_path=%s already lives under beets staging. "
-                "Automatic retry is disabled to avoid duplicate import; "
-                "manual recovery is required. See "
-                "docs/advisory-locks.md.",
-                album_data.db_request_id,
-                album_data.artist,
-                album_data.title,
-                staged_album.current_path,
-            )
-            return None
         if not os.path.isdir(staged_album.current_path):
             logger.error(f"Current staged path missing: {staged_album.current_path}")
             return False
@@ -726,7 +713,31 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     will_auto_import = wants_auto_import
     pdb = None
 
-    if will_auto_import:
+    if (
+        will_auto_import
+        and _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir)
+    ):
+        logger.error(
+            "POST-MOVE RESUME BLOCKED: request_id=%s %s - %s "
+            "current_path=%s already lives under beets staging on the "
+            "auto-import path. Automatic retry is disabled to avoid "
+            "duplicate import; manual recovery is required. See "
+            "docs/advisory-locks.md.",
+            request_id,
+            album_data.artist,
+            album_data.title,
+            staged_album.current_path,
+        )
+        return DispatchOutcome(
+            success=False,
+            message=(
+                "Auto-import may already have started for this staged "
+                f"album ({album_data.mb_release_id})"
+            ),
+            deferred=True,
+        )
+
+    if will_auto_import and album_data.mb_release_id:
         pdb = ctx.pipeline_db_source._get_db()
         lock_ctx = pdb.advisory_lock(
             ADVISORY_LOCK_NAMESPACE_RELEASE,

--- a/lib/download.py
+++ b/lib/download.py
@@ -1397,13 +1397,57 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                 year=str(row["year"] or ""),
                 slskd_download_dir=ctx.cfg.slskd_download_dir,
             )
+            request_scoped_staged_candidates = [
+                (
+                    "auto-import",
+                    stage_to_ai_path(
+                        artist=row["artist_name"],
+                        title=row["album_title"],
+                        staging_dir=ctx.cfg.beets_staging_dir,
+                        request_id=request_id,
+                        auto_import=True,
+                    ),
+                ),
+                (
+                    "post-validation",
+                    stage_to_ai_path(
+                        artist=row["artist_name"],
+                        title=row["album_title"],
+                        staging_dir=ctx.cfg.beets_staging_dir,
+                        request_id=request_id,
+                        auto_import=False,
+                    ),
+                ),
+            ]
             staged_fallback = stage_to_ai_path(
                 artist=row["artist_name"],
                 title=row["album_title"],
                 staging_dir=ctx.cfg.beets_staging_dir,
             )
-            if (not _directory_has_entries(canonical_fallback)
-                    and os.path.isdir(staged_fallback)):
+            populated_candidates: list[tuple[str, str]] = []
+            if _directory_has_entries(canonical_fallback):
+                populated_candidates.append(("canonical", canonical_fallback))
+            for label, candidate in request_scoped_staged_candidates:
+                if _directory_has_entries(candidate):
+                    populated_candidates.append((label, candidate))
+
+            if len(populated_candidates) > 1:
+                rendered_candidates = ", ".join(
+                    f"{label}={path}" for label, path in populated_candidates
+                )
+                logger.error(
+                    "MID-PROCESS RESUME BLOCKED: request_id=%s %s - %s "
+                    "found multiple populated recovery paths (%s). "
+                    "Manual recovery is required.",
+                    request_id,
+                    row["artist_name"],
+                    row["album_title"],
+                    rendered_candidates,
+                )
+                continue
+            if len(populated_candidates) == 1:
+                fallback_current_path = populated_candidates[0][1]
+            elif _directory_has_entries(staged_fallback):
                 logger.error(
                     "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
                     "current_path is missing, canonical_path=%s has no files, "
@@ -1416,7 +1460,8 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                     staged_fallback,
                 )
                 continue
-            fallback_current_path = canonical_fallback
+            else:
+                fallback_current_path = canonical_fallback
             state.current_path = fallback_current_path
         entry = reconstruct_grab_list_entry(
             row,

--- a/lib/download.py
+++ b/lib/download.py
@@ -422,11 +422,20 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 
 # === Download completion processing ===
 
+def _path_is_within(path: str, root: str) -> bool:
+    """Return True when ``path`` is located under ``root``."""
+    abs_path = os.path.abspath(path)
+    abs_root = os.path.abspath(root)
+    try:
+        return os.path.commonpath([abs_path, abs_root]) == abs_root
+    except ValueError:
+        return False
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
     ctx: CratediggerContext,
-) -> bool:
+) -> bool | None:
     """Ensure ``staged_album.current_path`` holds the album's local files."""
     canonical_path = _canonical_import_folder_path(
         album_data, ctx.cfg.slskd_download_dir)
@@ -434,6 +443,14 @@ def _materialize_processing_dir(
           if ctx.pipeline_db_source is not None else None)
 
     if os.path.abspath(staged_album.current_path) != os.path.abspath(canonical_path):
+        if _path_is_within(staged_album.current_path, ctx.cfg.beets_staging_dir):
+            logger.error(
+                "Current staged path already lives under beets staging: %s. "
+                "Refusing automatic retry from a post-move path; manual "
+                "recovery is required to avoid duplicate import.",
+                staged_album.current_path,
+            )
+            return None
         if not os.path.isdir(staged_album.current_path):
             logger.error(f"Current staged path missing: {staged_album.current_path}")
             return False
@@ -518,19 +535,19 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
       fired) either landed or recorded a rejection; outer caller flips
       status to ``imported``.
     - ``False`` — file moves failed; outer caller resets to ``wanted``.
-    - ``None`` — auto-import deferred because another process held the
-      release advisory lock. Files are staged, spectral state is set,
-      and request stays ``downloading``. Outer caller must NOT touch
-      status: the next ``poll_active_downloads`` cycle re-enters this
-      function and retries. Codex PR #136 R3 P2/P3.
+    - ``None`` — processing left the row untouched. This covers both
+      release-lock contention and post-move staged paths that must not
+      be auto-retried because they already live under
+      ``beets_staging_dir``. Outer caller must NOT touch status.
     """
     staged_album = StagedAlbum.from_entry(
         album_data,
         default_path=_canonical_import_folder_path(
             album_data, ctx.cfg.slskd_download_dir),
     )
-    if not _materialize_processing_dir(album_data, staged_album, ctx):
-        return False
+    materialized = _materialize_processing_dir(album_data, staged_album, ctx)
+    if materialized is not True:
+        return materialized
 
     logger.info(f"Processing completed download: {album_data.artist} - {album_data.title}")
     for file in album_data.files:
@@ -789,8 +806,6 @@ def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResu
         staged_album.current_path,
         scenario=bv_result.scenario,
     )
-    if failed_dest is not None:
-        staged_album.current_path = failed_dest
     bv_result.failed_path = failed_dest
     log_validation_result(album_data, bv_result, ctx.cfg)
     usernames = set(f.username for f in album_data.files)
@@ -1219,16 +1234,13 @@ def _run_completed_processing(
     #   'imported' if status is still 'downloading'.
     # - False → file moves failed; reset to 'wanted' (genuine failure
     #   that DOES deserve a backoff-scored attempt).
-    # - None  → release-lock contention deferred the import. Files are
-    #   staged, spectral state is populated, status stays
-    #   'downloading'. ``poll_active_downloads`` re-enters this
-    #   function on the next cycle and retries — do NOT touch state
-    #   here. Issue #132 P1 / Codex PR #136 R3 P2/P3.
+    # - None  → leave the row untouched. This covers both release-lock
+    #   contention and guarded post-move staged paths where auto-retry
+    #   would risk duplicate import. Do NOT touch state here.
     if outcome is None:
         logger.info(
-            f"  process_completed_album deferred (release lock held) — "
-            "leaving state untouched; poll_active_downloads retries "
-            "next cycle")
+            "  process_completed_album left state untouched; "
+            "poll_active_downloads will retry or await manual recovery")
         return
 
     refreshed = db.get_request(request_id)

--- a/lib/download.py
+++ b/lib/download.py
@@ -483,6 +483,46 @@ def _materialize_processing_dir(
             staged_album.current_path,
             ctx.cfg.beets_staging_dir,
         )
+        if not os.path.isdir(staged_album.current_path):
+            if is_auto_import_staged_retry:
+                _log_post_move_resume_blocked(
+                    album_data,
+                    current_path=staged_album.current_path,
+                    detail=(
+                        "already lives under the auto-import staging root but "
+                        "the directory is missing. Automatic retry is disabled "
+                        "because beets may already have consumed the staged "
+                        "folder; manual recovery is required."
+                    ),
+                )
+                return None
+            logger.error(f"Current staged path missing: {staged_album.current_path}")
+            return False
+        staged_album.bind_import_paths(album_data.files)
+        missing_paths: list[str] = []
+        for file in album_data.files:
+            import_path = file.import_path
+            assert import_path is not None
+            if not os.path.isfile(import_path):
+                missing_paths.append(import_path)
+        if missing_paths:
+            if is_auto_import_staged_retry:
+                _log_post_move_resume_blocked(
+                    album_data,
+                    current_path=staged_album.current_path,
+                    detail=(
+                        "already lives under the auto-import staging root but "
+                        f"tracked files are missing ({', '.join(missing_paths)}). "
+                        "Automatic retry is disabled because import may "
+                        "already have started; manual recovery is required."
+                    ),
+                )
+                return None
+            logger.error(
+                "Current staged path is missing tracked files: %s",
+                ", ".join(missing_paths),
+            )
+            return False
         if is_auto_import_staged_retry:
             _log_post_move_resume_blocked(
                 album_data,
@@ -494,22 +534,6 @@ def _materialize_processing_dir(
                 ),
             )
             return None
-        if not os.path.isdir(staged_album.current_path):
-            logger.error(f"Current staged path missing: {staged_album.current_path}")
-            return False
-        staged_album.bind_import_paths(album_data.files)
-        missing_paths: list[str] = []
-        for file in album_data.files:
-            import_path = file.import_path
-            assert import_path is not None
-            if not os.path.isfile(import_path):
-                missing_paths.append(import_path)
-        if missing_paths:
-            logger.error(
-                "Current staged path is missing tracked files: %s",
-                ", ".join(missing_paths),
-            )
-            return False
         album_data.import_folder = staged_album.current_path
         return True
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -16,6 +16,11 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import music_tag
 
+from lib.download_recovery import (
+    canonical_processing_path,
+    classify_processing_path,
+    resolve_missing_current_path,
+)
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, ValidationResult,
@@ -29,8 +34,7 @@ from lib.import_dispatch import (DispatchOutcome, _build_download_info,
 from lib.staged_album import (StagedAlbum, stage_to_ai_path,
                               stage_to_ai_root)
 from lib.transitions import apply_transition
-from lib.util import (sanitize_folder_name, move_failed_import,
-                      log_validation_result)
+from lib.util import move_failed_import, log_validation_result
 
 if TYPE_CHECKING:
     from lib.context import CratediggerContext
@@ -270,9 +274,12 @@ def _canonical_import_folder_path_from_metadata(
     slskd_download_dir: str,
 ) -> str:
     """Return the canonical local processing directory for a completed album."""
-    import_folder_name = sanitize_folder_name(
-        f"{artist} - {title} ({year})")
-    return os.path.join(slskd_download_dir, import_folder_name)
+    return canonical_processing_path(
+        artist=artist,
+        title=title,
+        year=year,
+        slskd_download_dir=slskd_download_dir,
+    )
 
 
 def _canonical_import_folder_path(
@@ -423,18 +430,6 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 
 # === Download completion processing ===
 
-def _path_is_within(path: str, root: str) -> bool:
-    """Return True when ``path`` is located under ``root``."""
-    if not root:
-        return False
-    abs_path = os.path.realpath(path)
-    abs_root = os.path.realpath(root)
-    try:
-        return os.path.commonpath([abs_path, abs_root]) == abs_root
-    except ValueError:
-        return False
-
-
 def _directory_has_entries(path: str) -> bool:
     """Return True when ``path`` exists and contains at least one entry."""
     if not os.path.isdir(path):
@@ -458,32 +453,6 @@ def _log_post_move_resume_blocked(
         current_path,
         detail,
     )
-
-
-def _is_auto_import_staged_path(path: str, staging_dir: str) -> bool:
-    return _path_is_within(
-        path,
-        stage_to_ai_root(staging_dir=staging_dir, auto_import=True),
-    )
-
-
-def _is_legacy_shared_staged_path(
-    path: str,
-    *,
-    artist: str,
-    title: str,
-    staging_dir: str,
-) -> bool:
-    return _path_is_within(
-        path,
-        stage_to_ai_path(
-            artist=artist,
-            title=title,
-            staging_dir=staging_dir,
-        ),
-    )
-
-
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -494,22 +463,28 @@ def _materialize_processing_dir(
         album_data, ctx.cfg.slskd_download_dir)
     db = (ctx.pipeline_db_source._get_db()
           if ctx.pipeline_db_source is not None else None)
+    current_path_location = classify_processing_path(
+        current_path=staged_album.current_path,
+        artist=album_data.artist,
+        title=album_data.title,
+        year=album_data.year,
+        request_id=album_data.db_request_id or 0,
+        staging_dir=ctx.cfg.beets_staging_dir,
+        slskd_download_dir=ctx.cfg.slskd_download_dir,
+    )
 
-    if os.path.realpath(staged_album.current_path) != os.path.realpath(canonical_path):
-        is_auto_import_staged_retry = _is_auto_import_staged_path(
-            staged_album.current_path,
-            ctx.cfg.beets_staging_dir,
-        )
+    if current_path_location.kind != "canonical":
         if not os.path.isdir(staged_album.current_path):
-            if is_auto_import_staged_retry:
+            if current_path_location.blocks_post_move_retry:
                 _log_post_move_resume_blocked(
                     album_data,
                     current_path=staged_album.current_path,
                     detail=(
-                        "already lives under the auto-import staging root but "
-                        "the directory is missing. Automatic retry is disabled "
-                        "because beets may already have consumed the staged "
-                        "folder; manual recovery is required."
+                        "already lives at the request-scoped auto-import "
+                        "staged path but the directory is missing. "
+                        "Automatic retry is disabled because beets may "
+                        "already have consumed the staged folder; manual "
+                        "recovery is required."
                     ),
                 )
                 return None
@@ -523,13 +498,13 @@ def _materialize_processing_dir(
             if not os.path.isfile(import_path):
                 missing_paths.append(import_path)
         if missing_paths:
-            if is_auto_import_staged_retry:
+            if current_path_location.blocks_post_move_retry:
                 _log_post_move_resume_blocked(
                     album_data,
                     current_path=staged_album.current_path,
                     detail=(
-                        "already lives under the auto-import staging root but "
-                        f"tracked files are missing ({', '.join(missing_paths)}). "
+                        "already lives at the request-scoped auto-import "
+                        f"staged path but tracked files are missing ({', '.join(missing_paths)}). "
                         "Automatic retry is disabled because import may "
                         "already have started; manual recovery is required."
                     ),
@@ -540,14 +515,14 @@ def _materialize_processing_dir(
                 ", ".join(missing_paths),
             )
             return False
-        if is_auto_import_staged_retry:
+        if current_path_location.blocks_post_move_retry:
             _log_post_move_resume_blocked(
                 album_data,
                 current_path=staged_album.current_path,
                 detail=(
-                    "already lives under the auto-import staging root. "
-                    "Automatic retry is disabled to avoid duplicate import; "
-                    "manual recovery is required."
+                    "already lives at the request-scoped auto-import staged "
+                    "path. Automatic retry is disabled to avoid duplicate "
+                    "import; manual recovery is required."
                 ),
             )
             return None
@@ -751,6 +726,15 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     wants_auto_import = (
         source_type == "request"
         and dist <= ctx.cfg.beets_distance_threshold)
+    current_path_location = classify_processing_path(
+        current_path=staged_album.current_path,
+        artist=album_data.artist,
+        title=album_data.title,
+        year=album_data.year,
+        request_id=request_id or 0,
+        staging_dir=ctx.cfg.beets_staging_dir,
+        slskd_download_dir=ctx.cfg.slskd_download_dir,
+    )
 
     if wants_auto_import and not album_data.mb_release_id:
         detail = "Request auto-import requires a MusicBrainz release ID"
@@ -797,24 +781,13 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
 
     if (
         will_auto_import
-        and (
-            _is_auto_import_staged_path(
-                staged_album.current_path,
-                ctx.cfg.beets_staging_dir,
-            )
-            or _is_legacy_shared_staged_path(
-                staged_album.current_path,
-                artist=album_data.artist,
-                title=album_data.title,
-                staging_dir=ctx.cfg.beets_staging_dir,
-            )
-        )
+        and current_path_location.blocks_auto_import_dispatch
     ):
         _log_post_move_resume_blocked(
             album_data,
             current_path=staged_album.current_path,
             detail=(
-                "already lives under beets staging on the auto-import path. "
+                f"already lives at the {current_path_location.display_name}. "
                 "Automatic retry is disabled to avoid duplicate import; "
                 "manual recovery is required."
             ),
@@ -1443,51 +1416,19 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             state = ActiveDownloadState.from_json(raw_state)
         fallback_current_path = None
         if state.current_path is None and state.processing_started_at is not None:
-            canonical_fallback = _canonical_import_folder_path_from_metadata(
+            recovery_decision = resolve_missing_current_path(
                 artist=row["artist_name"],
                 title=row["album_title"],
                 year=str(row["year"] or ""),
-                slskd_download_dir=ctx.cfg.slskd_download_dir,
-            )
-            request_scoped_staged_candidates = [
-                (
-                    "auto-import",
-                    stage_to_ai_path(
-                        artist=row["artist_name"],
-                        title=row["album_title"],
-                        staging_dir=ctx.cfg.beets_staging_dir,
-                        request_id=request_id,
-                        auto_import=True,
-                    ),
-                ),
-                (
-                    "post-validation",
-                    stage_to_ai_path(
-                        artist=row["artist_name"],
-                        title=row["album_title"],
-                        staging_dir=ctx.cfg.beets_staging_dir,
-                        request_id=request_id,
-                        auto_import=False,
-                    ),
-                ),
-            ]
-            staged_fallback = stage_to_ai_path(
-                artist=row["artist_name"],
-                title=row["album_title"],
+                request_id=request_id,
                 staging_dir=ctx.cfg.beets_staging_dir,
+                slskd_download_dir=ctx.cfg.slskd_download_dir,
+                has_entries=_directory_has_entries,
             )
-            populated_candidates: list[tuple[str, str]] = []
-            if _directory_has_entries(canonical_fallback):
-                populated_candidates.append(("canonical", canonical_fallback))
-            for label, candidate in request_scoped_staged_candidates:
-                if _directory_has_entries(candidate):
-                    populated_candidates.append((label, candidate))
-            if _directory_has_entries(staged_fallback):
-                populated_candidates.append(("legacy-shared", staged_fallback))
-
-            if len(populated_candidates) > 1:
+            if recovery_decision.blocked_reason == "multiple_populated_paths":
                 rendered_candidates = ", ".join(
-                    f"{label}={path}" for label, path in populated_candidates
+                    f"{location.short_label}={location.path}"
+                    for location in recovery_decision.populated_locations
                 )
                 logger.error(
                     "MID-PROCESS RESUME BLOCKED: request_id=%s %s - %s "
@@ -1499,24 +1440,21 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                     rendered_candidates,
                 )
                 continue
-            if len(populated_candidates) == 1:
-                candidate_label, candidate_path = populated_candidates[0]
-                if candidate_label == "legacy-shared":
-                    logger.error(
-                        "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
-                        "current_path is missing, canonical_path=%s has no files, "
-                        "and staged_path=%s is ambiguous across editions. "
-                        "Manual recovery is required.",
-                        request_id,
-                        row["artist_name"],
-                        row["album_title"],
-                        canonical_fallback,
-                        staged_fallback,
-                    )
-                    continue
-                fallback_current_path = candidate_path
-            else:
-                fallback_current_path = canonical_fallback
+            if recovery_decision.blocked_reason == "legacy_shared_only":
+                logger.error(
+                    "LEGACY STAGED RESUME BLOCKED: request_id=%s %s - %s "
+                    "current_path is missing, canonical_path=%s has no files, "
+                    "and staged_path=%s is ambiguous across editions. "
+                    "Manual recovery is required.",
+                    request_id,
+                    row["artist_name"],
+                    row["album_title"],
+                    recovery_decision.canonical_path,
+                    recovery_decision.legacy_shared_path,
+                )
+                continue
+            assert recovery_decision.selected_location is not None
+            fallback_current_path = recovery_decision.selected_location.path
             state.current_path = fallback_current_path
         entry = reconstruct_grab_list_entry(
             row,

--- a/lib/download.py
+++ b/lib/download.py
@@ -26,7 +26,7 @@ from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
                                  _record_rejection_and_maybe_requeue,
                                  dispatch_import_core, finalize_request)
-from lib.staged_album import StagedAlbum
+from lib.staged_album import StagedAlbum, stage_to_ai_path
 from lib.transitions import apply_transition
 from lib.util import (sanitize_folder_name, move_failed_import,
                       log_validation_result)
@@ -286,13 +286,6 @@ def _canonical_import_folder_path(
     )
 
 
-def _stage_to_ai_path(album_data: GrabListEntry, staging_dir: str) -> str:
-    """Return the beets staging destination for a validated album."""
-    artist_dir = sanitize_folder_name(album_data.artist)
-    album_dir = sanitize_folder_name(album_data.title)
-    return os.path.join(staging_dir, artist_dir, album_dir)
-
-
 # === slskd transfer helpers ===
 
 def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> None:
@@ -445,6 +438,17 @@ def _materialize_processing_dir(
             logger.error(f"Current staged path missing: {staged_album.current_path}")
             return False
         staged_album.bind_import_paths(album_data.files)
+        missing_paths = [
+            file.import_path
+            for file in album_data.files
+            if file.import_path is not None and not os.path.isfile(file.import_path)
+        ]
+        if missing_paths:
+            logger.error(
+                "Current staged path is missing tracked files: %s",
+                ", ".join(missing_paths),
+            )
+            return False
         album_data.import_folder = staged_album.current_path
         staged_album.persist_current_path(db)
         return True
@@ -716,7 +720,11 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
         db = (ctx.pipeline_db_source._get_db()
               if ctx.pipeline_db_source is not None else None)
         dest = staged_album.move_to(
-            _stage_to_ai_path(album_data, ctx.cfg.beets_staging_dir),
+            stage_to_ai_path(
+                artist=album_data.artist,
+                title=album_data.title,
+                staging_dir=ctx.cfg.beets_staging_dir,
+            ),
             db=db,
         )
         album_data.import_folder = dest
@@ -1127,7 +1135,7 @@ def _persist_updated_download_state(
             enqueued_at=state.enqueued_at,
             last_progress_at=state.last_progress_at,
             processing_started_at=state.processing_started_at,
-            current_path=state.current_path or entry.import_folder,
+            current_path=entry.import_folder,
         ).to_json(),
     )
 

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -398,9 +398,9 @@ def find_blocked_processing_path_issues(
     db_rows: list[dict[str, object]],
     active_transfers: set[tuple[str, str]],
     *,
-    existing_local_paths: set[str],
     staging_dir: str,
     slskd_download_dir: str,
+    has_entries: Callable[[str], bool],
 ) -> list[BlockedRecoveryIssue]:
     """Find persisted processing paths that block automatic resume."""
     issues: list[BlockedRecoveryIssue] = []
@@ -414,8 +414,6 @@ def find_blocked_processing_path_issues(
             continue
         current_path = state.get("current_path")
         if not isinstance(current_path, str) or not current_path:
-            continue
-        if current_path not in existing_local_paths:
             continue
         files = state.get("files")
         if not isinstance(files, list) or not files:
@@ -434,7 +432,7 @@ def find_blocked_processing_path_issues(
         request_id = row.get("id")
         if not isinstance(request_id, int) or isinstance(request_id, bool):
             continue
-        location = classify_processing_path(
+        recovery_decision = reconcile_processing_current_path(
             current_path=current_path,
             artist=str(row.get("artist_name") or ""),
             title=str(row.get("album_title") or ""),
@@ -442,11 +440,45 @@ def find_blocked_processing_path_issues(
             request_id=request_id,
             staging_dir=staging_dir,
             slskd_download_dir=slskd_download_dir,
+            has_entries=has_entries,
         )
-        # Request-scoped auto-import staged paths are expected while the
-        # import subprocess is still running. Only the legacy shared
-        # staged path is unambiguously blocked from automatic resume.
-        if location.kind != "legacy_shared_staged":
+        if recovery_decision.blocked_reason == "multiple_populated_paths":
+            rendered_candidates = ", ".join(
+                f"{location.short_label}={location.path}"
+                for location in recovery_decision.populated_locations
+            )
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "multiple populated local recovery paths block automatic "
+                    f"resume: {rendered_candidates}"
+                ),
+            ))
+            continue
+        if recovery_decision.blocked_reason == "legacy_shared_only":
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "ambiguous legacy shared staged path blocks automatic "
+                    f"resume: {recovery_decision.legacy_shared_path}"
+                ),
+            ))
+            continue
+
+        assert recovery_decision.selected_location is not None
+        location = recovery_decision.selected_location
+        if location.path != current_path:
+            continue
+        if not has_entries(current_path):
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "persisted processing path missing after local "
+                    f"processing: {current_path}"
+                ),
+            ))
+            continue
+        if not location.blocks_auto_import_dispatch:
             continue
         issues.append(BlockedRecoveryIssue(
             request_id=request_id,

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -7,7 +7,7 @@ import os
 from typing import Callable, Literal
 
 from lib.processing_paths import (
-    canonical_processing_path as shared_canonical_processing_path,
+    canonical_processing_path,
     normalize_processing_path,
     stage_to_ai_path,
 )
@@ -89,24 +89,6 @@ class BlockedRecoveryIssue:
 
     request_id: int
     detail: str
-
-
-def canonical_processing_path(
-    *,
-    artist: str,
-    title: str,
-    year: str,
-    slskd_download_dir: str,
-) -> str:
-    """Return the canonical local processing directory for a completed album."""
-    return shared_canonical_processing_path(
-        artist=artist,
-        title=title,
-        year=year,
-        slskd_download_dir=slskd_download_dir,
-    )
-
-
 def classify_processing_path(
     *,
     current_path: str,

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -1,0 +1,262 @@
+"""Typed recovery seam for active download processing paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Callable, Literal
+
+ProcessingPathKind = Literal[
+    "canonical",
+    "request_scoped_auto_import_staged",
+    "request_scoped_post_validation_staged",
+    "legacy_shared_staged",
+    "external",
+]
+
+BlockedRecoveryReason = Literal[
+    "multiple_populated_paths",
+    "legacy_shared_only",
+]
+
+
+@dataclass(frozen=True)
+class ProcessingPathLocation:
+    """Classified local processing path for one active download."""
+
+    path: str
+    kind: ProcessingPathKind
+
+    @property
+    def display_name(self) -> str:
+        if self.kind == "canonical":
+            return "canonical processing path"
+        if self.kind == "request_scoped_auto_import_staged":
+            return "request-scoped auto-import staged path"
+        if self.kind == "request_scoped_post_validation_staged":
+            return "request-scoped post-validation staged path"
+        if self.kind == "legacy_shared_staged":
+            return "legacy shared staged path"
+        return "processing path"
+
+    @property
+    def short_label(self) -> str:
+        if self.kind == "canonical":
+            return "canonical"
+        if self.kind == "request_scoped_auto_import_staged":
+            return "auto-import"
+        if self.kind == "request_scoped_post_validation_staged":
+            return "post-validation"
+        if self.kind == "legacy_shared_staged":
+            return "legacy-shared"
+        return "external"
+
+    @property
+    def blocks_post_move_retry(self) -> bool:
+        return self.kind == "request_scoped_auto_import_staged"
+
+    @property
+    def blocks_auto_import_dispatch(self) -> bool:
+        return self.kind in (
+            "request_scoped_auto_import_staged",
+            "legacy_shared_staged",
+        )
+
+
+@dataclass(frozen=True)
+class ResumeRecoveryDecision:
+    """Result of probing local recovery candidates for a missing current_path."""
+
+    canonical_path: str
+    legacy_shared_path: str
+    populated_locations: tuple[ProcessingPathLocation, ...]
+    selected_location: ProcessingPathLocation | None = None
+    blocked_reason: BlockedRecoveryReason | None = None
+
+
+def canonical_processing_path(
+    *,
+    artist: str,
+    title: str,
+    year: str,
+    slskd_download_dir: str,
+) -> str:
+    """Return the canonical local processing directory for a completed album."""
+    from lib.util import sanitize_folder_name
+
+    import_folder_name = sanitize_folder_name(f"{artist} - {title} ({year})")
+    return os.path.join(slskd_download_dir, import_folder_name)
+
+
+def classify_processing_path(
+    *,
+    current_path: str,
+    artist: str,
+    title: str,
+    year: str,
+    request_id: int,
+    staging_dir: str,
+    slskd_download_dir: str,
+) -> ProcessingPathLocation:
+    """Classify a persisted current_path against the active download seam."""
+    canonical_path = canonical_processing_path(
+        artist=artist,
+        title=title,
+        year=year,
+        slskd_download_dir=slskd_download_dir,
+    )
+    if os.path.realpath(current_path) == os.path.realpath(canonical_path):
+        return ProcessingPathLocation(path=current_path, kind="canonical")
+
+    request_scoped_auto_import = _stage_to_ai_path(
+        artist=artist,
+        title=title,
+        staging_dir=staging_dir,
+        request_id=request_id,
+        auto_import=True,
+    )
+    if _path_is_within(current_path, request_scoped_auto_import):
+        return ProcessingPathLocation(
+            path=current_path,
+            kind="request_scoped_auto_import_staged",
+        )
+
+    request_scoped_post_validation = _stage_to_ai_path(
+        artist=artist,
+        title=title,
+        staging_dir=staging_dir,
+        request_id=request_id,
+        auto_import=False,
+    )
+    if _path_is_within(current_path, request_scoped_post_validation):
+        return ProcessingPathLocation(
+            path=current_path,
+            kind="request_scoped_post_validation_staged",
+        )
+
+    legacy_shared_path = _stage_to_ai_path(
+        artist=artist,
+        title=title,
+        staging_dir=staging_dir,
+    )
+    if _path_is_within(current_path, legacy_shared_path):
+        return ProcessingPathLocation(
+            path=current_path,
+            kind="legacy_shared_staged",
+        )
+
+    return ProcessingPathLocation(path=current_path, kind="external")
+
+
+def resolve_missing_current_path(
+    *,
+    artist: str,
+    title: str,
+    year: str,
+    request_id: int,
+    staging_dir: str,
+    slskd_download_dir: str,
+    has_entries: Callable[[str], bool],
+) -> ResumeRecoveryDecision:
+    """Resolve a missing current_path by probing the known recovery locations."""
+    canonical_path = canonical_processing_path(
+        artist=artist,
+        title=title,
+        year=year,
+        slskd_download_dir=slskd_download_dir,
+    )
+    candidates = (
+        ProcessingPathLocation(path=canonical_path, kind="canonical"),
+        ProcessingPathLocation(
+            path=_stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+                request_id=request_id,
+                auto_import=True,
+            ),
+            kind="request_scoped_auto_import_staged",
+        ),
+        ProcessingPathLocation(
+            path=_stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+                request_id=request_id,
+                auto_import=False,
+            ),
+            kind="request_scoped_post_validation_staged",
+        ),
+        ProcessingPathLocation(
+            path=_stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+            ),
+            kind="legacy_shared_staged",
+        ),
+    )
+    populated_locations = tuple(
+        candidate
+        for candidate in candidates
+        if has_entries(candidate.path)
+    )
+    if len(populated_locations) > 1:
+        return ResumeRecoveryDecision(
+            canonical_path=canonical_path,
+            legacy_shared_path=candidates[-1].path,
+            populated_locations=populated_locations,
+            blocked_reason="multiple_populated_paths",
+        )
+    if len(populated_locations) == 1:
+        selected_location = populated_locations[0]
+        if selected_location.kind == "legacy_shared_staged":
+            return ResumeRecoveryDecision(
+                canonical_path=canonical_path,
+                legacy_shared_path=selected_location.path,
+                populated_locations=populated_locations,
+                blocked_reason="legacy_shared_only",
+            )
+        return ResumeRecoveryDecision(
+            canonical_path=canonical_path,
+            legacy_shared_path=candidates[-1].path,
+            populated_locations=populated_locations,
+            selected_location=selected_location,
+        )
+    return ResumeRecoveryDecision(
+        canonical_path=canonical_path,
+        legacy_shared_path=candidates[-1].path,
+        populated_locations=(),
+        selected_location=candidates[0],
+    )
+
+
+def _path_is_within(path: str, root: str) -> bool:
+    """Return True when ``path`` is located under ``root``."""
+    if not root:
+        return False
+    abs_path = os.path.realpath(path)
+    abs_root = os.path.realpath(root)
+    try:
+        return os.path.commonpath([abs_path, abs_root]) == abs_root
+    except ValueError:
+        return False
+
+
+def _stage_to_ai_path(
+    *,
+    artist: str,
+    title: str,
+    staging_dir: str,
+    request_id: int | None = None,
+    auto_import: bool | None = None,
+) -> str:
+    from lib.staged_album import stage_to_ai_path
+
+    return stage_to_ai_path(
+        artist=artist,
+        title=title,
+        staging_dir=staging_dir,
+        request_id=request_id,
+        auto_import=auto_import,
+    )

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -305,6 +305,67 @@ def find_blocked_recovery_issues(
     return issues
 
 
+def find_blocked_processing_path_issues(
+    db_rows: list[dict[str, object]],
+    active_transfers: set[tuple[str, str]],
+    *,
+    existing_local_paths: set[str],
+    staging_dir: str,
+    slskd_download_dir: str,
+) -> list[BlockedRecoveryIssue]:
+    """Find persisted processing paths that block automatic resume."""
+    issues: list[BlockedRecoveryIssue] = []
+    for row in db_rows:
+        if row.get("status") != "downloading":
+            continue
+        state = row.get("active_download_state")
+        if not isinstance(state, dict):
+            continue
+        if state.get("processing_started_at") is None:
+            continue
+        current_path = state.get("current_path")
+        if not isinstance(current_path, str) or not current_path:
+            continue
+        if current_path not in existing_local_paths:
+            continue
+        files = state.get("files")
+        if not isinstance(files, list) or not files:
+            continue
+        has_active = any(
+            (
+                str(file_state.get("username") or ""),
+                str(file_state.get("filename") or ""),
+            ) in active_transfers
+            for file_state in files
+            if isinstance(file_state, dict)
+        )
+        if has_active:
+            continue
+
+        request_id = row.get("id")
+        if not isinstance(request_id, int) or isinstance(request_id, bool):
+            continue
+        location = classify_processing_path(
+            current_path=current_path,
+            artist=str(row.get("artist_name") or ""),
+            title=str(row.get("album_title") or ""),
+            year=str(row.get("year") or ""),
+            request_id=request_id,
+            staging_dir=staging_dir,
+            slskd_download_dir=slskd_download_dir,
+        )
+        if not location.blocks_auto_import_dispatch:
+            continue
+        issues.append(BlockedRecoveryIssue(
+            request_id=request_id,
+            detail=(
+                f"persisted {location.display_name} blocks automatic resume: "
+                f"{location.path}"
+            ),
+        ))
+    return issues
+
+
 def _path_is_within(path: str, root: str) -> bool:
     """Return True when ``path`` is located under ``root``."""
     if not root:

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -89,6 +89,98 @@ class BlockedRecoveryIssue:
 
     request_id: int
     detail: str
+
+
+def _recovery_candidates(
+    *,
+    artist: str,
+    title: str,
+    year: str,
+    request_id: int,
+    staging_dir: str,
+    slskd_download_dir: str,
+) -> tuple[ProcessingPathLocation, ...]:
+    canonical_path = canonical_processing_path(
+        artist=artist,
+        title=title,
+        year=year,
+        slskd_download_dir=slskd_download_dir,
+    )
+    return (
+        ProcessingPathLocation(path=canonical_path, kind="canonical"),
+        ProcessingPathLocation(
+            path=stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+                request_id=request_id,
+                auto_import=True,
+            ),
+            kind="request_scoped_auto_import_staged",
+        ),
+        ProcessingPathLocation(
+            path=stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+                request_id=request_id,
+                auto_import=False,
+            ),
+            kind="request_scoped_post_validation_staged",
+        ),
+        ProcessingPathLocation(
+            path=stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+            ),
+            kind="legacy_shared_staged",
+        ),
+    )
+
+
+def _resolve_recovery_candidates(
+    candidates: tuple[ProcessingPathLocation, ...],
+    *,
+    has_entries: Callable[[str], bool],
+) -> ResumeRecoveryDecision:
+    populated_locations = tuple(
+        candidate
+        for candidate in candidates
+        if has_entries(candidate.path)
+    )
+    canonical_path = candidates[0].path
+    legacy_shared_path = candidates[-1].path
+    if len(populated_locations) > 1:
+        return ResumeRecoveryDecision(
+            canonical_path=canonical_path,
+            legacy_shared_path=legacy_shared_path,
+            populated_locations=populated_locations,
+            blocked_reason="multiple_populated_paths",
+        )
+    if len(populated_locations) == 1:
+        selected_location = populated_locations[0]
+        if selected_location.kind == "legacy_shared_staged":
+            return ResumeRecoveryDecision(
+                canonical_path=canonical_path,
+                legacy_shared_path=selected_location.path,
+                populated_locations=populated_locations,
+                blocked_reason="legacy_shared_only",
+            )
+        return ResumeRecoveryDecision(
+            canonical_path=canonical_path,
+            legacy_shared_path=legacy_shared_path,
+            populated_locations=populated_locations,
+            selected_location=selected_location,
+        )
+    return ResumeRecoveryDecision(
+        canonical_path=canonical_path,
+        legacy_shared_path=legacy_shared_path,
+        populated_locations=(),
+        selected_location=candidates[0],
+    )
+
+
 def classify_processing_path(
     *,
     current_path: str,
@@ -162,75 +254,72 @@ def resolve_missing_current_path(
     has_entries: Callable[[str], bool],
 ) -> ResumeRecoveryDecision:
     """Resolve a missing current_path by probing the known recovery locations."""
-    canonical_path = canonical_processing_path(
+    candidates = _recovery_candidates(
         artist=artist,
         title=title,
         year=year,
+        request_id=request_id,
+        staging_dir=staging_dir,
         slskd_download_dir=slskd_download_dir,
     )
-    candidates = (
-        ProcessingPathLocation(path=canonical_path, kind="canonical"),
-        ProcessingPathLocation(
-            path=stage_to_ai_path(
-                artist=artist,
-                title=title,
-                staging_dir=staging_dir,
-                request_id=request_id,
-                auto_import=True,
-            ),
-            kind="request_scoped_auto_import_staged",
-        ),
-        ProcessingPathLocation(
-            path=stage_to_ai_path(
-                artist=artist,
-                title=title,
-                staging_dir=staging_dir,
-                request_id=request_id,
-                auto_import=False,
-            ),
-            kind="request_scoped_post_validation_staged",
-        ),
-        ProcessingPathLocation(
-            path=stage_to_ai_path(
-                artist=artist,
-                title=title,
-                staging_dir=staging_dir,
-            ),
-            kind="legacy_shared_staged",
-        ),
+    return _resolve_recovery_candidates(
+        candidates,
+        has_entries=has_entries,
     )
-    populated_locations = tuple(
-        candidate
-        for candidate in candidates
-        if has_entries(candidate.path)
+
+
+def reconcile_processing_current_path(
+    *,
+    current_path: str | None,
+    artist: str,
+    title: str,
+    year: str,
+    request_id: int,
+    staging_dir: str,
+    slskd_download_dir: str,
+    has_entries: Callable[[str], bool],
+) -> ResumeRecoveryDecision:
+    """Resolve the best local path for a row already in local processing.
+
+    If the persisted ``current_path`` is missing, this is the ordinary
+    mid-process recovery path. If it still points at the canonical
+    processing dir but that dir no longer holds the album, probe the
+    staged candidates before the poll loop re-materializes a stale
+    canonical path and strands the moved files.
+    """
+    candidates = _recovery_candidates(
+        artist=artist,
+        title=title,
+        year=year,
+        request_id=request_id,
+        staging_dir=staging_dir,
+        slskd_download_dir=slskd_download_dir,
     )
-    if len(populated_locations) > 1:
-        return ResumeRecoveryDecision(
-            canonical_path=canonical_path,
-            legacy_shared_path=candidates[-1].path,
-            populated_locations=populated_locations,
-            blocked_reason="multiple_populated_paths",
+    if current_path is None:
+        return _resolve_recovery_candidates(
+            candidates,
+            has_entries=has_entries,
         )
-    if len(populated_locations) == 1:
-        selected_location = populated_locations[0]
-        if selected_location.kind == "legacy_shared_staged":
-            return ResumeRecoveryDecision(
-                canonical_path=canonical_path,
-                legacy_shared_path=selected_location.path,
-                populated_locations=populated_locations,
-                blocked_reason="legacy_shared_only",
-            )
+
+    current_location = classify_processing_path(
+        current_path=current_path,
+        artist=artist,
+        title=title,
+        year=year,
+        request_id=request_id,
+        staging_dir=staging_dir,
+        slskd_download_dir=slskd_download_dir,
+    )
+    if current_location.kind != "canonical" or has_entries(current_location.path):
         return ResumeRecoveryDecision(
-            canonical_path=canonical_path,
+            canonical_path=candidates[0].path,
             legacy_shared_path=candidates[-1].path,
-            populated_locations=populated_locations,
-            selected_location=selected_location,
+            populated_locations=(),
+            selected_location=current_location,
         )
-    return ResumeRecoveryDecision(
-        canonical_path=canonical_path,
-        legacy_shared_path=candidates[-1].path,
-        populated_locations=(),
-        selected_location=candidates[0],
+    return _resolve_recovery_candidates(
+        candidates,
+        has_entries=has_entries,
     )
 
 
@@ -354,7 +443,10 @@ def find_blocked_processing_path_issues(
             staging_dir=staging_dir,
             slskd_download_dir=slskd_download_dir,
         )
-        if not location.blocks_auto_import_dispatch:
+        # Request-scoped auto-import staged paths are expected while the
+        # import subprocess is still running. Only the legacy shared
+        # staged path is unambiguously blocked from automatic resume.
+        if location.kind != "legacy_shared_staged":
             continue
         issues.append(BlockedRecoveryIssue(
             request_id=request_id,

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
+import re
 from typing import Callable, Literal
+
+AUTO_IMPORT_STAGING_SUBDIR = "auto-import"
+POST_VALIDATION_STAGING_SUBDIR = "post-validation"
 
 ProcessingPathKind = Literal[
     "canonical",
@@ -57,6 +61,9 @@ class ProcessingPathLocation:
 
     @property
     def blocks_auto_import_dispatch(self) -> bool:
+        # ``legacy_shared_staged`` should be unreachable in the normal
+        # recovery flow, but keep the dispatch guard as defense-in-depth
+        # for manually edited rows or future bypass paths.
         return self.kind in (
             "request_scoped_auto_import_staged",
             "legacy_shared_staged",
@@ -74,6 +81,14 @@ class ResumeRecoveryDecision:
     blocked_reason: BlockedRecoveryReason | None = None
 
 
+@dataclass(frozen=True)
+class BlockedRecoveryIssue:
+    """Blocked local recovery state for a row with no persisted current_path."""
+
+    request_id: int
+    detail: str
+
+
 def canonical_processing_path(
     *,
     artist: str,
@@ -82,9 +97,7 @@ def canonical_processing_path(
     slskd_download_dir: str,
 ) -> str:
     """Return the canonical local processing directory for a completed album."""
-    from lib.util import sanitize_folder_name
-
-    import_folder_name = sanitize_folder_name(f"{artist} - {title} ({year})")
+    import_folder_name = _sanitize_folder_name(f"{artist} - {title} ({year})")
     return os.path.join(slskd_download_dir, import_folder_name)
 
 
@@ -231,12 +244,85 @@ def resolve_missing_current_path(
     )
 
 
+def find_blocked_recovery_issues(
+    db_rows: list[dict[str, object]],
+    active_transfers: set[tuple[str, str]],
+    *,
+    staging_dir: str,
+    slskd_download_dir: str,
+    has_entries: Callable[[str], bool],
+) -> list[BlockedRecoveryIssue]:
+    """Find rows whose mid-processing recovery is blocked by ambiguity."""
+    issues: list[BlockedRecoveryIssue] = []
+    for row in db_rows:
+        if row.get("status") != "downloading":
+            continue
+        state = row.get("active_download_state")
+        if not isinstance(state, dict):
+            continue
+        if state.get("processing_started_at") is None:
+            continue
+        if state.get("current_path") is not None:
+            continue
+        files = state.get("files")
+        if not isinstance(files, list) or not files:
+            continue
+        has_active = any(
+            (
+                str(file_state.get("username") or ""),
+                str(file_state.get("filename") or ""),
+            ) in active_transfers
+            for file_state in files
+            if isinstance(file_state, dict)
+        )
+        if has_active:
+            continue
+
+        request_id = row.get("id")
+        if not isinstance(request_id, int) or isinstance(request_id, bool):
+            continue
+        recovery_decision = resolve_missing_current_path(
+            artist=str(row.get("artist_name") or ""),
+            title=str(row.get("album_title") or ""),
+            year=str(row.get("year") or ""),
+            request_id=request_id,
+            staging_dir=staging_dir,
+            slskd_download_dir=slskd_download_dir,
+            has_entries=has_entries,
+        )
+        if recovery_decision.blocked_reason == "multiple_populated_paths":
+            rendered_candidates = ", ".join(
+                f"{location.short_label}={location.path}"
+                for location in recovery_decision.populated_locations
+            )
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "multiple populated local recovery paths block automatic "
+                    f"resume: {rendered_candidates}"
+                ),
+            ))
+            continue
+        if recovery_decision.blocked_reason == "legacy_shared_only":
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "ambiguous legacy shared staged path blocks automatic "
+                    f"resume: {recovery_decision.legacy_shared_path}"
+                ),
+            ))
+            continue
+        if recovery_decision.populated_locations:
+            continue
+    return issues
+
+
 def _path_is_within(path: str, root: str) -> bool:
     """Return True when ``path`` is located under ``root``."""
     if not root:
         return False
-    abs_path = os.path.realpath(path)
-    abs_root = os.path.realpath(root)
+    abs_path = os.path.abspath(os.path.normpath(path))
+    abs_root = os.path.abspath(os.path.normpath(root))
     try:
         return os.path.commonpath([abs_path, abs_root]) == abs_root
     except ValueError:
@@ -251,12 +337,31 @@ def _stage_to_ai_path(
     request_id: int | None = None,
     auto_import: bool | None = None,
 ) -> str:
-    from lib.staged_album import stage_to_ai_path
-
-    return stage_to_ai_path(
-        artist=artist,
-        title=title,
-        staging_dir=staging_dir,
-        request_id=request_id,
-        auto_import=auto_import,
+    artist_dir = _sanitize_folder_name(artist)
+    album_dir = _sanitize_folder_name(title)
+    if request_id is not None:
+        album_dir = f"{album_dir} [request-{request_id}]"
+    return os.path.join(
+        _stage_to_ai_root(staging_dir=staging_dir, auto_import=auto_import),
+        artist_dir,
+        album_dir,
     )
+
+
+def _stage_to_ai_root(
+    *,
+    staging_dir: str,
+    auto_import: bool | None = None,
+) -> str:
+    if auto_import is None:
+        return staging_dir
+    subdir = (
+        AUTO_IMPORT_STAGING_SUBDIR
+        if auto_import
+        else POST_VALIDATION_STAGING_SUBDIR
+    )
+    return os.path.join(staging_dir, subdir)
+
+
+def _sanitize_folder_name(folder_name: str) -> str:
+    return re.sub(r'[<>:."/\\|?*]', "", folder_name).strip()

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
-import re
 from typing import Callable, Literal
 
-AUTO_IMPORT_STAGING_SUBDIR = "auto-import"
-POST_VALIDATION_STAGING_SUBDIR = "post-validation"
+from lib.processing_paths import (
+    canonical_processing_path as shared_canonical_processing_path,
+    normalize_processing_path,
+    stage_to_ai_path,
+)
 
 ProcessingPathKind = Literal[
     "canonical",
@@ -97,8 +99,12 @@ def canonical_processing_path(
     slskd_download_dir: str,
 ) -> str:
     """Return the canonical local processing directory for a completed album."""
-    import_folder_name = _sanitize_folder_name(f"{artist} - {title} ({year})")
-    return os.path.join(slskd_download_dir, import_folder_name)
+    return shared_canonical_processing_path(
+        artist=artist,
+        title=title,
+        year=year,
+        slskd_download_dir=slskd_download_dir,
+    )
 
 
 def classify_processing_path(
@@ -118,10 +124,12 @@ def classify_processing_path(
         year=year,
         slskd_download_dir=slskd_download_dir,
     )
-    if os.path.realpath(current_path) == os.path.realpath(canonical_path):
+    if normalize_processing_path(current_path) == normalize_processing_path(
+        canonical_path,
+    ):
         return ProcessingPathLocation(path=current_path, kind="canonical")
 
-    request_scoped_auto_import = _stage_to_ai_path(
+    request_scoped_auto_import = stage_to_ai_path(
         artist=artist,
         title=title,
         staging_dir=staging_dir,
@@ -134,7 +142,7 @@ def classify_processing_path(
             kind="request_scoped_auto_import_staged",
         )
 
-    request_scoped_post_validation = _stage_to_ai_path(
+    request_scoped_post_validation = stage_to_ai_path(
         artist=artist,
         title=title,
         staging_dir=staging_dir,
@@ -147,7 +155,7 @@ def classify_processing_path(
             kind="request_scoped_post_validation_staged",
         )
 
-    legacy_shared_path = _stage_to_ai_path(
+    legacy_shared_path = stage_to_ai_path(
         artist=artist,
         title=title,
         staging_dir=staging_dir,
@@ -181,7 +189,7 @@ def resolve_missing_current_path(
     candidates = (
         ProcessingPathLocation(path=canonical_path, kind="canonical"),
         ProcessingPathLocation(
-            path=_stage_to_ai_path(
+            path=stage_to_ai_path(
                 artist=artist,
                 title=title,
                 staging_dir=staging_dir,
@@ -191,7 +199,7 @@ def resolve_missing_current_path(
             kind="request_scoped_auto_import_staged",
         ),
         ProcessingPathLocation(
-            path=_stage_to_ai_path(
+            path=stage_to_ai_path(
                 artist=artist,
                 title=title,
                 staging_dir=staging_dir,
@@ -201,7 +209,7 @@ def resolve_missing_current_path(
             kind="request_scoped_post_validation_staged",
         ),
         ProcessingPathLocation(
-            path=_stage_to_ai_path(
+            path=stage_to_ai_path(
                 artist=artist,
                 title=title,
                 staging_dir=staging_dir,
@@ -321,47 +329,9 @@ def _path_is_within(path: str, root: str) -> bool:
     """Return True when ``path`` is located under ``root``."""
     if not root:
         return False
-    abs_path = os.path.abspath(os.path.normpath(path))
-    abs_root = os.path.abspath(os.path.normpath(root))
+    abs_path = normalize_processing_path(path)
+    abs_root = normalize_processing_path(root)
     try:
         return os.path.commonpath([abs_path, abs_root]) == abs_root
     except ValueError:
         return False
-
-
-def _stage_to_ai_path(
-    *,
-    artist: str,
-    title: str,
-    staging_dir: str,
-    request_id: int | None = None,
-    auto_import: bool | None = None,
-) -> str:
-    artist_dir = _sanitize_folder_name(artist)
-    album_dir = _sanitize_folder_name(title)
-    if request_id is not None:
-        album_dir = f"{album_dir} [request-{request_id}]"
-    return os.path.join(
-        _stage_to_ai_root(staging_dir=staging_dir, auto_import=auto_import),
-        artist_dir,
-        album_dir,
-    )
-
-
-def _stage_to_ai_root(
-    *,
-    staging_dir: str,
-    auto_import: bool | None = None,
-) -> str:
-    if auto_import is None:
-        return staging_dir
-    subdir = (
-        AUTO_IMPORT_STAGING_SUBDIR
-        if auto_import
-        else POST_VALIDATION_STAGING_SUBDIR
-    )
-    return os.path.join(staging_dir, subdir)
-
-
-def _sanitize_folder_name(folder_name: str) -> str:
-    return re.sub(r'[<>:."/\\|?*]', "", folder_name).strip()

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -302,8 +302,6 @@ def find_blocked_recovery_issues(
                 ),
             ))
             continue
-        if recovery_decision.populated_locations:
-            continue
     return issues
 
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -484,6 +484,7 @@ class PipelineDB:
                 updated_at = %s
             WHERE id = %s
               AND status = 'downloading'
+              AND active_download_state IS NOT NULL
         """, (current_path, now, request_id))
         self.conn.commit()
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -466,6 +466,26 @@ class PipelineDB:
         """, (state_json, now, request_id))
         self.conn.commit()
 
+    def update_download_state_current_path(
+        self,
+        request_id: int,
+        current_path: str | None,
+    ) -> None:
+        """Rewrite only ``active_download_state.current_path`` in JSONB."""
+        now = datetime.now(timezone.utc)
+        self._execute("""
+            UPDATE album_requests
+            SET active_download_state = jsonb_set(
+                    COALESCE(active_download_state, '{}'::jsonb),
+                    '{current_path}',
+                    to_jsonb(%s::text),
+                    true
+                ),
+                updated_at = %s
+            WHERE id = %s
+        """, (current_path, now, request_id))
+        self.conn.commit()
+
     def get_downloading(self) -> list[dict[str, Any]]:
         """Get all albums currently being downloaded."""
         cur = self._execute(

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -471,7 +471,7 @@ class PipelineDB:
         request_id: int,
         current_path: str | None,
     ) -> None:
-        """Rewrite only ``active_download_state.current_path`` in JSONB."""
+        """Rewrite only ``active_download_state.current_path`` on downloading rows."""
         now = datetime.now(timezone.utc)
         self._execute("""
             UPDATE album_requests
@@ -483,6 +483,7 @@ class PipelineDB:
                 ),
                 updated_at = %s
             WHERE id = %s
+              AND status = 'downloading'
         """, (current_path, now, request_id))
         self.conn.commit()
 

--- a/lib/processing_paths.py
+++ b/lib/processing_paths.py
@@ -1,0 +1,77 @@
+"""Shared path helpers for active download processing and staging."""
+
+from __future__ import annotations
+
+import os
+import re
+
+AUTO_IMPORT_STAGING_SUBDIR = "auto-import"
+POST_VALIDATION_STAGING_SUBDIR = "post-validation"
+
+
+def sanitize_processing_folder_name(folder_name: str) -> str:
+    """Sanitize a filesystem path component for local processing paths."""
+    return re.sub(r'[<>:."/\\|?*]', "", folder_name).strip()
+
+
+def normalize_processing_path(path: str) -> str:
+    """Return a normalized absolute path without resolving symlinks."""
+    return os.path.abspath(os.path.normpath(path))
+
+
+def canonical_processing_path(
+    *,
+    artist: str,
+    title: str,
+    year: str,
+    slskd_download_dir: str,
+) -> str:
+    """Return the canonical local processing directory for a completed album."""
+    import_folder_name = sanitize_processing_folder_name(
+        f"{artist} - {title} ({year})",
+    )
+    return os.path.join(slskd_download_dir, import_folder_name)
+
+
+def stage_to_ai_root(
+    *,
+    staging_dir: str,
+    auto_import: bool | None = None,
+) -> str:
+    """Return the root staging directory for a given validation branch."""
+    if auto_import is None:
+        return staging_dir
+    subdir = (
+        AUTO_IMPORT_STAGING_SUBDIR
+        if auto_import
+        else POST_VALIDATION_STAGING_SUBDIR
+    )
+    return os.path.join(staging_dir, subdir)
+
+
+def stage_to_ai_path(
+    *,
+    artist: str,
+    title: str,
+    staging_dir: str,
+    request_id: int | None = None,
+    auto_import: bool | None = None,
+) -> str:
+    """Return the beets staging destination for an album."""
+    artist_dir = sanitize_processing_folder_name(artist)
+    album_dir = sanitize_processing_folder_name(title)
+    if request_id is not None:
+        album_dir = f"{album_dir} [request-{request_id}]"
+    return os.path.join(
+        stage_to_ai_root(staging_dir=staging_dir, auto_import=auto_import),
+        artist_dir,
+        album_dir,
+    )
+
+
+def directory_has_entries(path: str) -> bool:
+    """Return True when ``path`` exists and contains at least one entry."""
+    if not os.path.isdir(path):
+        return False
+    with os.scandir(path) as entries:
+        return any(True for _ in entries)

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -3041,7 +3041,7 @@ def full_pipeline_decision(
 class OrphanInfo:
     """A detected inconsistency in pipeline DB state."""
     request_id: int
-    issue_type: str  # "corrupt_downloading" | "orphaned_download" | "blocked_post_move"
+    issue_type: str  # "corrupt_downloading" | "orphaned_download" | "blocked_post_move" | "blocked_recovery"
     detail: str
 
 
@@ -3167,11 +3167,11 @@ def suggest_repair(issue: OrphanInfo) -> RepairAction:
             request_id=issue.request_id,
             action="reset_to_wanted",
             detail="Reset downloading row to wanted (transfers gone)")
-    if issue.issue_type == "blocked_post_move":
+    if issue.issue_type in ("blocked_post_move", "blocked_recovery"):
         return RepairAction(
             request_id=issue.request_id,
             action="manual_review",
-            detail="Inspect blocked post-move row and finish or reset it explicitly",
+            detail="Inspect blocked local-processing row and finish or reset it explicitly",
         )
     else:
         return RepairAction(

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -3039,7 +3039,7 @@ def full_pipeline_decision(
 class OrphanInfo:
     """A detected inconsistency in pipeline DB state."""
     request_id: int
-    issue_type: str  # "corrupt_downloading", "orphaned_download"
+    issue_type: str  # "corrupt_downloading" | "orphaned_download" | "blocked_post_move"
     detail: str
 
 
@@ -3054,15 +3054,21 @@ class RepairAction:
 def find_orphaned_downloads(
     db_rows: list[dict[str, Any]],
     active_transfers: set[tuple[str, str]],
+    *,
+    existing_local_paths: set[str] | None = None,
 ) -> list[OrphanInfo]:
     """Detect downloading rows whose slskd transfers no longer exist. Pure — no I/O.
 
     Args:
         db_rows: album_requests rows (must include status, active_download_state).
         active_transfers: set of (username, filename) tuples from slskd API.
+        existing_local_paths: optional set of persisted ``current_path`` values
+            that still exist on disk, supplied by the caller when local
+            filesystem visibility is available.
 
     Returns OrphanInfo for each downloading row where NONE of its files
-    appear in active_transfers.
+    appear in active_transfers, plus ``blocked_post_move`` when a row is
+    already in local processing but its persisted ``current_path`` is gone.
     """
     issues: list[OrphanInfo] = []
     for row in db_rows:
@@ -3071,13 +3077,6 @@ def find_orphaned_downloads(
         state = row.get("active_download_state")
         if not state:
             continue  # corrupt_downloading — handled by find_inconsistencies
-        if (
-            state.get("processing_started_at") is not None
-            and state.get("current_path")
-        ):
-            # Local processing continues after slskd has finished, so
-            # transferless rows in this phase are not orphaned downloads.
-            continue
         files = state.get("files", [])
         if not files:
             continue
@@ -3085,6 +3084,24 @@ def find_orphaned_downloads(
             (f.get("username"), f.get("filename")) in active_transfers
             for f in files
         )
+        current_path = state.get("current_path")
+        if (
+            state.get("processing_started_at") is not None
+            and current_path
+        ):
+            if (
+                not has_active
+                and existing_local_paths is not None
+                and current_path not in existing_local_paths
+            ):
+                issues.append(OrphanInfo(
+                    request_id=row["id"],
+                    issue_type="blocked_post_move",
+                    detail=f"persisted current_path missing after local processing: {current_path}",
+                ))
+            # Local processing continues after slskd has finished, so
+            # transferless rows in this phase are not ordinary orphans.
+            continue
         if not has_active:
             usernames = sorted(set(f.get("username", "?") for f in files))
             issues.append(OrphanInfo(
@@ -3128,6 +3145,12 @@ def suggest_repair(issue: OrphanInfo) -> RepairAction:
             request_id=issue.request_id,
             action="reset_to_wanted",
             detail="Reset downloading row to wanted (transfers gone)")
+    if issue.issue_type == "blocked_post_move":
+        return RepairAction(
+            request_id=issue.request_id,
+            action="manual_review",
+            detail="Inspect blocked post-move row and finish or reset it explicitly",
+        )
     else:
         return RepairAction(
             request_id=issue.request_id,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -3071,6 +3071,10 @@ def find_orphaned_downloads(
         state = row.get("active_download_state")
         if not state:
             continue  # corrupt_downloading — handled by find_inconsistencies
+        if state.get("processing_started_at") is not None:
+            # Local processing continues after slskd has finished, so
+            # transferless rows in this phase are not orphaned downloads.
+            continue
         files = state.get("files", [])
         if not files:
             continue

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -13,6 +13,8 @@ from typing import Any, Literal, Optional
 
 import msgspec
 
+from lib.download_recovery import classify_processing_path
+
 QUALITY_UPGRADE_TIERS = "lossless,mp3 v0,mp3 320"
 QUALITY_LOSSLESS = "lossless"
 
@@ -3056,6 +3058,8 @@ def find_orphaned_downloads(
     active_transfers: set[tuple[str, str]],
     *,
     existing_local_paths: set[str] | None = None,
+    staging_dir: str | None = None,
+    slskd_download_dir: str | None = None,
 ) -> list[OrphanInfo]:
     """Detect downloading rows whose slskd transfers no longer exist. Pure — no I/O.
 
@@ -3065,6 +3069,10 @@ def find_orphaned_downloads(
         existing_local_paths: optional set of persisted ``current_path`` values
             that still exist on disk, supplied by the caller when local
             filesystem visibility is available.
+        staging_dir: optional staging root for classifying persisted
+            ``current_path`` values in repair output.
+        slskd_download_dir: optional download root for classifying persisted
+            ``current_path`` values in repair output.
 
     Returns OrphanInfo for each downloading row where NONE of its files
     appear in active_transfers, plus ``blocked_post_move`` when a row is
@@ -3094,10 +3102,24 @@ def find_orphaned_downloads(
                 and existing_local_paths is not None
                 and current_path not in existing_local_paths
             ):
+                path_detail = "processing path"
+                if staging_dir and slskd_download_dir:
+                    path_detail = classify_processing_path(
+                        current_path=current_path,
+                        artist=str(row.get("artist_name") or ""),
+                        title=str(row.get("album_title") or ""),
+                        year=str(row.get("year") or ""),
+                        request_id=int(row["id"]),
+                        staging_dir=staging_dir,
+                        slskd_download_dir=slskd_download_dir,
+                    ).display_name
                 issues.append(OrphanInfo(
                     request_id=row["id"],
                     issue_type="blocked_post_move",
-                    detail=f"persisted current_path missing after local processing: {current_path}",
+                    detail=(
+                        f"persisted {path_detail} missing after local processing: "
+                        f"{current_path}"
+                    ),
                 ))
             # Local processing continues after slskd has finished, so
             # transferless rows in this phase are not ordinary orphans.

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -3077,6 +3077,9 @@ def find_orphaned_downloads(
     Returns OrphanInfo for each downloading row where NONE of its files
     appear in active_transfers, plus ``blocked_post_move`` when a row is
     already in local processing but its persisted ``current_path`` is gone.
+    Rows with ``processing_started_at`` set are treated as local-processing
+    rows even when ``current_path`` is missing; caller-side blocked recovery
+    detection owns that ambiguity.
     """
     issues: list[OrphanInfo] = []
     for row in db_rows:
@@ -3093,12 +3096,10 @@ def find_orphaned_downloads(
             for f in files
         )
         current_path = state.get("current_path")
-        if (
-            state.get("processing_started_at") is not None
-            and current_path
-        ):
+        if state.get("processing_started_at") is not None:
             if (
-                not has_active
+                current_path
+                and not has_active
                 and existing_local_paths is not None
                 and current_path not in existing_local_paths
             ):

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -500,6 +500,7 @@ class ActiveDownloadState:
     files: list[ActiveDownloadFileState]
     last_progress_at: str | None = None
     processing_started_at: str | None = None
+    current_path: str | None = None
 
     def to_json(self) -> str:
         data: dict[str, object] = {
@@ -511,6 +512,8 @@ class ActiveDownloadState:
             data["last_progress_at"] = self.last_progress_at
         if self.processing_started_at is not None:
             data["processing_started_at"] = self.processing_started_at
+        if self.current_path is not None:
+            data["current_path"] = self.current_path
         return json.dumps(data)
 
     @staticmethod
@@ -529,6 +532,11 @@ class ActiveDownloadState:
             processing_started_at=(
                 str(d["processing_started_at"])
                 if d.get("processing_started_at") is not None
+                else None
+            ),
+            current_path=(
+                str(d["current_path"])
+                if d.get("current_path") is not None
                 else None
             ),
         )

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -3071,7 +3071,10 @@ def find_orphaned_downloads(
         state = row.get("active_download_state")
         if not state:
             continue  # corrupt_downloading — handled by find_inconsistencies
-        if state.get("processing_started_at") is not None:
+        if (
+            state.get("processing_started_at") is not None
+            and state.get("current_path")
+        ):
             # Local processing continues after slskd has finished, so
             # transferless rows in this phase are not orphaned downloads.
             continue

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -13,8 +13,6 @@ from typing import Any, Literal, Optional
 
 import msgspec
 
-from lib.download_recovery import classify_processing_path
-
 QUALITY_UPGRADE_TIERS = "lossless,mp3 v0,mp3 320"
 QUALITY_LOSSLESS = "lossless"
 
@@ -3057,22 +3055,17 @@ def find_orphaned_downloads(
     db_rows: list[dict[str, Any]],
     active_transfers: set[tuple[str, str]],
     *,
-    existing_local_paths: set[str] | None = None,
-    staging_dir: str | None = None,
-    slskd_download_dir: str | None = None,
+    existing_local_paths: set[str] | None,
 ) -> list[OrphanInfo]:
     """Detect downloading rows whose slskd transfers no longer exist. Pure — no I/O.
 
     Args:
         db_rows: album_requests rows (must include status, active_download_state).
         active_transfers: set of (username, filename) tuples from slskd API.
-        existing_local_paths: optional set of persisted ``current_path`` values
-            that still exist on disk, supplied by the caller when local
-            filesystem visibility is available.
-        staging_dir: optional staging root for classifying persisted
-            ``current_path`` values in repair output.
-        slskd_download_dir: optional download root for classifying persisted
-            ``current_path`` values in repair output.
+        existing_local_paths: set of persisted ``current_path`` values that
+            still exist on disk, supplied by the caller when local filesystem
+            visibility is available. Pass ``None`` when the caller cannot
+            inspect local processing paths.
 
     Returns OrphanInfo for each downloading row where NONE of its files
     appear in active_transfers, plus ``blocked_post_move`` when a row is
@@ -3103,22 +3096,12 @@ def find_orphaned_downloads(
                 and existing_local_paths is not None
                 and current_path not in existing_local_paths
             ):
-                path_detail = "processing path"
-                if staging_dir and slskd_download_dir:
-                    path_detail = classify_processing_path(
-                        current_path=current_path,
-                        artist=str(row.get("artist_name") or ""),
-                        title=str(row.get("album_title") or ""),
-                        year=str(row.get("year") or ""),
-                        request_id=int(row["id"]),
-                        staging_dir=staging_dir,
-                        slskd_download_dir=slskd_download_dir,
-                    ).display_name
                 issues.append(OrphanInfo(
                     request_id=row["id"],
                     issue_type="blocked_post_move",
                     detail=(
-                        f"persisted {path_detail} missing after local processing: "
+                        "persisted processing path missing after local "
+                        "processing: "
                         f"{current_path}"
                     ),
                 ))

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -82,17 +82,28 @@ class StagedAlbum:
         source = os.path.abspath(self.current_path)
         target = os.path.abspath(dest)
 
-        if source != target:
-            os.makedirs(target, exist_ok=True)
+        if source == target:
+            self.current_path = target
+            self.persist_current_path(db)
+            return self.current_path
+
+        moved_entries: list[tuple[str, str]] = []
+        os.makedirs(target, exist_ok=True)
+        try:
             for entry in os.listdir(source):
-                shutil.move(
-                    os.path.join(source, entry),
-                    os.path.join(target, entry),
-                )
+                source_entry = os.path.join(source, entry)
+                target_entry = os.path.join(target, entry)
+                shutil.move(source_entry, target_entry)
+                moved_entries.append((source_entry, target_entry))
             shutil.rmtree(source, ignore_errors=True)
             self.current_path = target
-        else:
-            self.current_path = target
-
-        self.persist_current_path(db)
-        return self.current_path
+            self.persist_current_path(db)
+            return self.current_path
+        except Exception:
+            if moved_entries:
+                os.makedirs(source, exist_ok=True)
+                for source_entry, target_entry in reversed(moved_entries):
+                    if os.path.exists(target_entry):
+                        shutil.move(target_entry, source_entry)
+            self.current_path = source
+            raise

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -8,16 +8,13 @@ import os
 import shutil
 from typing import Protocol, TYPE_CHECKING
 
-from lib.util import sanitize_folder_name
+from lib.processing_paths import stage_to_ai_path, stage_to_ai_root
 
 if TYPE_CHECKING:
     from lib.grab_list import DownloadFile, GrabListEntry
 
 
 logger = logging.getLogger("cratedigger")
-
-AUTO_IMPORT_STAGING_SUBDIR = "auto-import"
-POST_VALIDATION_STAGING_SUBDIR = "post-validation"
 
 
 class SupportsCurrentPathUpdate(Protocol):
@@ -37,42 +34,6 @@ def staged_filename(file: "DownloadFile") -> str:
     if file.disk_no is not None and file.disk_count is not None and file.disk_count > 1:
         return f"Disk {file.disk_no} - {filename}"
     return filename
-
-
-def stage_to_ai_root(
-    *,
-    staging_dir: str,
-    auto_import: bool | None = None,
-) -> str:
-    """Return the root staging directory for a given validation branch."""
-    if auto_import is None:
-        return staging_dir
-    subdir = (
-        AUTO_IMPORT_STAGING_SUBDIR
-        if auto_import
-        else POST_VALIDATION_STAGING_SUBDIR
-    )
-    return os.path.join(staging_dir, subdir)
-
-
-def stage_to_ai_path(
-    *,
-    artist: str,
-    title: str,
-    staging_dir: str,
-    request_id: int | None = None,
-    auto_import: bool | None = None,
-) -> str:
-    """Return the beets staging destination for an album."""
-    artist_dir = sanitize_folder_name(artist)
-    album_dir = sanitize_folder_name(title)
-    if request_id is not None:
-        album_dir = f"{album_dir} [request-{request_id}]"
-    return os.path.join(
-        stage_to_ai_root(staging_dir=staging_dir, auto_import=auto_import),
-        artist_dir,
-        album_dir,
-    )
 
 
 @dataclass

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("cratedigger")
 
+AUTO_IMPORT_STAGING_SUBDIR = "auto-import"
+POST_VALIDATION_STAGING_SUBDIR = "post-validation"
+
 
 class SupportsCurrentPathUpdate(Protocol):
     """Minimal DB seam for persisting ``active_download_state.current_path``."""
@@ -36,11 +39,40 @@ def staged_filename(file: "DownloadFile") -> str:
     return filename
 
 
-def stage_to_ai_path(*, artist: str, title: str, staging_dir: str) -> str:
+def stage_to_ai_root(
+    *,
+    staging_dir: str,
+    auto_import: bool | None = None,
+) -> str:
+    """Return the root staging directory for a given validation branch."""
+    if auto_import is None:
+        return staging_dir
+    subdir = (
+        AUTO_IMPORT_STAGING_SUBDIR
+        if auto_import
+        else POST_VALIDATION_STAGING_SUBDIR
+    )
+    return os.path.join(staging_dir, subdir)
+
+
+def stage_to_ai_path(
+    *,
+    artist: str,
+    title: str,
+    staging_dir: str,
+    request_id: int | None = None,
+    auto_import: bool | None = None,
+) -> str:
     """Return the beets staging destination for an album."""
     artist_dir = sanitize_folder_name(artist)
     album_dir = sanitize_folder_name(title)
-    return os.path.join(staging_dir, artist_dir, album_dir)
+    if request_id is not None:
+        album_dir = f"{album_dir} [request-{request_id}]"
+    return os.path.join(
+        stage_to_ai_root(staging_dir=staging_dir, auto_import=auto_import),
+        artist_dir,
+        album_dir,
+    )
 
 
 @dataclass

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -91,9 +91,9 @@ class StagedAlbum:
                 target_entry = os.path.join(target, entry)
                 shutil.move(source_entry, target_entry)
                 moved_entries.append((source_entry, target_entry))
-            shutil.rmtree(source, ignore_errors=True)
             self.current_path = target
             self.persist_current_path(db)
+            shutil.rmtree(source, ignore_errors=True)
             return self.current_path
         except Exception:
             if moved_entries:

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -28,7 +28,7 @@ class SupportsCurrentPathUpdate(Protocol):
 
 def staged_filename(file: "DownloadFile") -> str:
     """Return the local filename used once a track is under album staging."""
-    filename = file.filename.split("\\")[-1]
+    filename = file.filename.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
     if file.disk_no is not None and file.disk_count is not None and file.disk_count > 1:
         return f"Disk {file.disk_no} - {filename}"
     return filename

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -8,8 +8,6 @@ import os
 import shutil
 from typing import Protocol, TYPE_CHECKING
 
-from lib.processing_paths import stage_to_ai_path, stage_to_ai_root
-
 if TYPE_CHECKING:
     from lib.grab_list import DownloadFile, GrabListEntry
 

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -81,6 +81,7 @@ class StagedAlbum:
         """Move album contents into ``dest`` and persist the new location."""
         source = os.path.abspath(self.current_path)
         target = os.path.abspath(dest)
+        target_preexisted = os.path.isdir(target)
 
         if source == target:
             self.current_path = target
@@ -88,8 +89,8 @@ class StagedAlbum:
             return self.current_path
 
         moved_entries: list[tuple[str, str]] = []
-        os.makedirs(target, exist_ok=True)
         try:
+            os.makedirs(target, exist_ok=True)
             for entry in os.listdir(source):
                 source_entry = os.path.join(source, entry)
                 target_entry = os.path.join(target, entry)
@@ -105,5 +106,7 @@ class StagedAlbum:
                 for source_entry, target_entry in reversed(moved_entries):
                     if os.path.exists(target_entry):
                         shutil.move(target_entry, source_entry)
+            elif not target_preexisted and os.path.isdir(target) and not os.listdir(target):
+                shutil.rmtree(target, ignore_errors=True)
             self.current_path = source
             raise

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -1,0 +1,89 @@
+"""Typed ownership of a staged album's current filesystem location."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import shutil
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.grab_list import DownloadFile, GrabListEntry
+
+
+class SupportsCurrentPathUpdate(Protocol):
+    """Minimal DB seam for persisting ``active_download_state.current_path``."""
+
+    def update_download_state_current_path(
+        self,
+        request_id: int,
+        current_path: str | None,
+    ) -> None:
+        ...
+
+
+def staged_filename(file: "DownloadFile") -> str:
+    """Return the local filename used once a track is under album staging."""
+    filename = file.filename.split("\\")[-1]
+    if file.disk_no is not None and file.disk_count is not None and file.disk_count > 1:
+        return f"Disk {file.disk_no} - {filename}"
+    return filename
+
+
+@dataclass
+class StagedAlbum:
+    """Album directory whose current location is owned explicitly."""
+
+    current_path: str
+    request_id: int | None = None
+
+    @classmethod
+    def from_entry(
+        cls,
+        entry: "GrabListEntry",
+        *,
+        default_path: str,
+    ) -> "StagedAlbum":
+        return cls(
+            current_path=entry.import_folder or default_path,
+            request_id=entry.db_request_id,
+        )
+
+    def import_path_for(self, file: "DownloadFile") -> str:
+        return os.path.join(self.current_path, staged_filename(file))
+
+    def bind_import_paths(self, files: list["DownloadFile"]) -> None:
+        for file in files:
+            file.import_path = self.import_path_for(file)
+
+    def persist_current_path(
+        self,
+        db: SupportsCurrentPathUpdate | None,
+    ) -> None:
+        if self.request_id is None or db is None:
+            return
+        db.update_download_state_current_path(self.request_id, self.current_path)
+
+    def move_to(
+        self,
+        dest: str,
+        db: SupportsCurrentPathUpdate | None = None,
+    ) -> str:
+        """Move album contents into ``dest`` and persist the new location."""
+        source = os.path.abspath(self.current_path)
+        target = os.path.abspath(dest)
+
+        if source != target:
+            os.makedirs(target, exist_ok=True)
+            for entry in os.listdir(source):
+                shutil.move(
+                    os.path.join(source, entry),
+                    os.path.join(target, entry),
+                )
+            shutil.rmtree(source, ignore_errors=True)
+            self.current_path = target
+        else:
+            self.current_path = target
+
+        self.persist_current_path(db)
+        return self.current_path

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -30,6 +30,15 @@ def staged_filename(file: "DownloadFile") -> str:
     return filename
 
 
+def stage_to_ai_path(*, artist: str, title: str, staging_dir: str) -> str:
+    """Return the beets staging destination for an album."""
+    from lib.util import sanitize_folder_name
+
+    artist_dir = sanitize_folder_name(artist)
+    album_dir = sanitize_folder_name(title)
+    return os.path.join(staging_dir, artist_dir, album_dir)
+
+
 @dataclass
 class StagedAlbum:
     """Album directory whose current location is owned explicitly."""

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -7,6 +7,8 @@ import os
 import shutil
 from typing import Protocol, TYPE_CHECKING
 
+from lib.util import sanitize_folder_name
+
 if TYPE_CHECKING:
     from lib.grab_list import DownloadFile, GrabListEntry
 
@@ -32,8 +34,6 @@ def staged_filename(file: "DownloadFile") -> str:
 
 def stage_to_ai_path(*, artist: str, title: str, staging_dir: str) -> str:
     """Return the beets staging destination for an album."""
-    from lib.util import sanitize_folder_name
-
     artist_dir = sanitize_folder_name(artist)
     album_dir = sanitize_folder_name(title)
     return os.path.join(staging_dir, artist_dir, album_dir)

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 import os
 import shutil
 from typing import Protocol, TYPE_CHECKING
@@ -11,6 +12,9 @@ from lib.util import sanitize_folder_name
 
 if TYPE_CHECKING:
     from lib.grab_list import DownloadFile, GrabListEntry
+
+
+logger = logging.getLogger("cratedigger")
 
 
 class SupportsCurrentPathUpdate(Protocol):
@@ -105,7 +109,14 @@ class StagedAlbum:
                 os.makedirs(source, exist_ok=True)
                 for source_entry, target_entry in reversed(moved_entries):
                     if os.path.exists(target_entry):
-                        shutil.move(target_entry, source_entry)
+                        try:
+                            shutil.move(target_entry, source_entry)
+                        except Exception:
+                            logger.exception(
+                                "Failed to roll back staged move %s -> %s",
+                                target_entry,
+                                source_entry,
+                            )
             elif not target_preexisted and os.path.isdir(target) and not os.listdir(target):
                 shutil.rmtree(target, ignore_errors=True)
             self.current_path = source

--- a/lib/util.py
+++ b/lib/util.py
@@ -154,18 +154,13 @@ def resolve_failed_path(
 
 def stage_to_ai(album_data: GrabListEntry, source_path: str, staging_dir: str) -> str:
     """Move validated files from slskd download area to staging/{Artist}/{Album}/."""
+    from lib.staged_album import StagedAlbum
+
     artist_dir = sanitize_folder_name(album_data.artist)
     album_dir = sanitize_folder_name(album_data.title)
     dest = os.path.join(staging_dir, artist_dir, album_dir)
-    os.makedirs(dest, exist_ok=True)
-
-    for f in os.listdir(source_path):
-        src = os.path.join(source_path, f)
-        dst = os.path.join(dest, f)
-        shutil.move(src, dst)
-
-    shutil.rmtree(source_path, ignore_errors=True)
-    return dest
+    staged_album = StagedAlbum(current_path=source_path)
+    return staged_album.move_to(dest)
 
 
 # === Audio validation ===

--- a/lib/util.py
+++ b/lib/util.py
@@ -151,18 +151,6 @@ def resolve_failed_path(
 
     return None
 
-
-def stage_to_ai(album_data: GrabListEntry, source_path: str, staging_dir: str) -> str:
-    """Move validated files from slskd download area to staging/{Artist}/{Album}/."""
-    from lib.staged_album import StagedAlbum
-
-    artist_dir = sanitize_folder_name(album_data.artist)
-    album_dir = sanitize_folder_name(album_data.title)
-    dest = os.path.join(staging_dir, artist_dir, album_dir)
-    staged_album = StagedAlbum(current_path=source_path)
-    return staged_album.move_to(dest)
-
-
 # === Audio validation ===
 
 def repair_mp3_headers(folder_path: str) -> None:

--- a/lib/util.py
+++ b/lib/util.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Sequence, TYPE_CHECKING
 
+from lib.processing_paths import sanitize_processing_folder_name
+
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
     from lib.grab_list import GrabListEntry
@@ -86,8 +88,7 @@ def beets_subprocess_env() -> dict[str, str]:
 # === Filesystem utilities ===
 
 def sanitize_folder_name(folder_name: str) -> str:
-    valid_characters = re.sub(r'[<>:."/\\|?*]', "", folder_name)
-    return valid_characters.strip()
+    return sanitize_processing_folder_name(folder_name)
 
 
 _BAD_FILE_SCENARIOS = frozenset({"audio_corrupt", "spectral_reject"})

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -18,15 +18,14 @@ from typing import Any
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from lib.import_dispatch import transition_request as _transition_request
 from lib.config import read_runtime_config
 from lib.download_recovery import (find_blocked_processing_path_issues,
                                    find_blocked_recovery_issues)
+from lib.import_dispatch import transition_request
 from lib.pipeline_db import PipelineDB
 from lib.processing_paths import directory_has_entries
 from lib.quality import (OrphanInfo, find_inconsistencies,
                          find_orphaned_downloads, suggest_repair)
-from lib.transitions import apply_transition
 
 DEFAULT_DSN = os.environ.get(
     "PIPELINE_DB_DSN",
@@ -60,18 +59,10 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
         try:
             cfg = read_runtime_config()
             active = _get_slskd_active_transfers(slskd_host, slskd_key)
-            existing_local_paths = {
-                current_path
-                for row in rows
-                for state in [row.get("active_download_state")]
-                if isinstance(state, dict)
-                for current_path in [state.get("current_path")]
-                if isinstance(current_path, str) and os.path.exists(current_path)
-            }
             orphans = find_orphaned_downloads(
                 rows,
                 active,
-                existing_local_paths=existing_local_paths,
+                existing_local_paths=None,
             )
             blocked_processing_path_issues = [
                 OrphanInfo(
@@ -82,9 +73,9 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                 for issue in find_blocked_processing_path_issues(
                     rows,
                     active,
-                    existing_local_paths=existing_local_paths,
                     staging_dir=cfg.beets_staging_dir,
                     slskd_download_dir=cfg.slskd_download_dir,
+                    has_entries=directory_has_entries,
                 )
             ]
             blocked_recovery_issues = [
@@ -149,7 +140,7 @@ def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
     for issue in issues:
         repair = suggest_repair(issue)
         if repair.action == "reset_to_wanted":
-            _transition_request(
+            transition_request(
                 db,
                 issue.request_id,
                 "wanted",
@@ -169,6 +160,8 @@ def _get_all_rows(db: PipelineDB) -> list:
         "FROM album_requests ORDER BY id"
     )
     return [dict(r) for r in cur.fetchall()]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Pipeline repair tool")
     parser.add_argument("--dsn", default=DEFAULT_DSN)

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -22,6 +22,7 @@ from lib.import_dispatch import transition_request as _transition_request
 from lib.config import read_runtime_config
 from lib.download_recovery import find_blocked_recovery_issues
 from lib.pipeline_db import PipelineDB
+from lib.processing_paths import directory_has_entries
 from lib.quality import (OrphanInfo, find_inconsistencies,
                          find_orphaned_downloads, suggest_repair)
 from lib.transitions import apply_transition
@@ -84,7 +85,7 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     active,
                     staging_dir=cfg.beets_staging_dir,
                     slskd_download_dir=cfg.slskd_download_dir,
-                    has_entries=_directory_has_entries,
+                    has_entries=directory_has_entries,
                 )
             ]
             issues.extend(orphans)
@@ -154,15 +155,6 @@ def _get_all_rows(db: PipelineDB) -> list:
         "FROM album_requests ORDER BY id"
     )
     return [dict(r) for r in cur.fetchall()]
-
-
-def _directory_has_entries(path: str) -> bool:
-    if not os.path.isdir(path):
-        return False
-    with os.scandir(path) as entries:
-        return any(True for _ in entries)
-
-
 def main():
     parser = argparse.ArgumentParser(description="Pipeline repair tool")
     parser.add_argument("--dsn", default=DEFAULT_DSN)

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -71,8 +71,6 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                 rows,
                 active,
                 existing_local_paths=existing_local_paths,
-                staging_dir=cfg.beets_staging_dir,
-                slskd_download_dir=cfg.slskd_download_dir,
             )
             blocked_recovery_issues = [
                 OrphanInfo(

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -19,6 +19,7 @@ from typing import Any
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.import_dispatch import transition_request as _transition_request
+from lib.config import read_runtime_config
 from lib.pipeline_db import PipelineDB
 from lib.quality import find_inconsistencies, find_orphaned_downloads, suggest_repair
 
@@ -49,6 +50,7 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     slskd_key: str | None) -> list:
     """Collect all issues: DB inconsistencies + optional orphaned downloads."""
     rows = _get_all_rows(db)
+    cfg = read_runtime_config()
     issues = find_inconsistencies(rows)
     if slskd_host and slskd_key:
         try:
@@ -65,6 +67,8 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                 rows,
                 active,
                 existing_local_paths=existing_local_paths,
+                staging_dir=cfg.beets_staging_dir,
+                slskd_download_dir=cfg.slskd_download_dir,
             )
             issues.extend(orphans)
             if not orphans:
@@ -127,7 +131,8 @@ def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
 def _get_all_rows(db: PipelineDB) -> list:
     """Fetch all album_requests rows for inspection."""
     cur = db._execute(
-        "SELECT id, status, active_download_state, imported_path "
+        "SELECT id, status, artist_name, album_title, year, "
+        "active_download_state, imported_path "
         "FROM album_requests ORDER BY id"
     )
     return [dict(r) for r in cur.fetchall()]

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -53,7 +53,19 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
     if slskd_host and slskd_key:
         try:
             active = _get_slskd_active_transfers(slskd_host, slskd_key)
-            orphans = find_orphaned_downloads(rows, active)
+            existing_local_paths = {
+                current_path
+                for row in rows
+                for current_path in [
+                    (row.get("active_download_state") or {}).get("current_path"),
+                ]
+                if current_path and os.path.exists(current_path)
+            }
+            orphans = find_orphaned_downloads(
+                rows,
+                active,
+                existing_local_paths=existing_local_paths,
+            )
             issues.extend(orphans)
             if not orphans:
                 print(f"  slskd: checked {len(active)} active transfers, no orphans.")

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -20,8 +20,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.import_dispatch import transition_request as _transition_request
 from lib.config import read_runtime_config
+from lib.download_recovery import find_blocked_recovery_issues
 from lib.pipeline_db import PipelineDB
-from lib.quality import find_inconsistencies, find_orphaned_downloads, suggest_repair
+from lib.quality import (OrphanInfo, find_inconsistencies,
+                         find_orphaned_downloads, suggest_repair)
+from lib.transitions import apply_transition
 
 DEFAULT_DSN = os.environ.get(
     "PIPELINE_DB_DSN",
@@ -50,10 +53,10 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     slskd_key: str | None) -> list:
     """Collect all issues: DB inconsistencies + optional orphaned downloads."""
     rows = _get_all_rows(db)
-    cfg = read_runtime_config()
     issues = find_inconsistencies(rows)
     if slskd_host and slskd_key:
         try:
+            cfg = read_runtime_config()
             active = _get_slskd_active_transfers(slskd_host, slskd_key)
             existing_local_paths = {
                 current_path
@@ -70,8 +73,23 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                 staging_dir=cfg.beets_staging_dir,
                 slskd_download_dir=cfg.slskd_download_dir,
             )
+            blocked_recovery_issues = [
+                OrphanInfo(
+                    request_id=issue.request_id,
+                    issue_type="blocked_recovery",
+                    detail=issue.detail,
+                )
+                for issue in find_blocked_recovery_issues(
+                    rows,
+                    active,
+                    staging_dir=cfg.beets_staging_dir,
+                    slskd_download_dir=cfg.slskd_download_dir,
+                    has_entries=_directory_has_entries,
+                )
+            ]
             issues.extend(orphans)
-            if not orphans:
+            issues.extend(blocked_recovery_issues)
+            if not orphans and not blocked_recovery_issues:
                 print(f"  slskd: checked {len(active)} active transfers, no orphans.")
         except Exception as e:
             print(f"  slskd: could not check orphans: {e}")
@@ -136,6 +154,13 @@ def _get_all_rows(db: PipelineDB) -> list:
         "FROM album_requests ORDER BY id"
     )
     return [dict(r) for r in cur.fetchall()]
+
+
+def _directory_has_entries(path: str) -> bool:
+    if not os.path.isdir(path):
+        return False
+    with os.scandir(path) as entries:
+        return any(True for _ in entries)
 
 
 def main():

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -20,7 +20,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.import_dispatch import transition_request as _transition_request
 from lib.config import read_runtime_config
-from lib.download_recovery import find_blocked_recovery_issues
+from lib.download_recovery import (find_blocked_processing_path_issues,
+                                   find_blocked_recovery_issues)
 from lib.pipeline_db import PipelineDB
 from lib.processing_paths import directory_has_entries
 from lib.quality import (OrphanInfo, find_inconsistencies,
@@ -62,16 +63,30 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
             existing_local_paths = {
                 current_path
                 for row in rows
-                for current_path in [
-                    (row.get("active_download_state") or {}).get("current_path"),
-                ]
-                if current_path and os.path.exists(current_path)
+                for state in [row.get("active_download_state")]
+                if isinstance(state, dict)
+                for current_path in [state.get("current_path")]
+                if isinstance(current_path, str) and os.path.exists(current_path)
             }
             orphans = find_orphaned_downloads(
                 rows,
                 active,
                 existing_local_paths=existing_local_paths,
             )
+            blocked_processing_path_issues = [
+                OrphanInfo(
+                    request_id=issue.request_id,
+                    issue_type="blocked_post_move",
+                    detail=issue.detail,
+                )
+                for issue in find_blocked_processing_path_issues(
+                    rows,
+                    active,
+                    existing_local_paths=existing_local_paths,
+                    staging_dir=cfg.beets_staging_dir,
+                    slskd_download_dir=cfg.slskd_download_dir,
+                )
+            ]
             blocked_recovery_issues = [
                 OrphanInfo(
                     request_id=issue.request_id,
@@ -87,8 +102,9 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                 )
             ]
             issues.extend(orphans)
+            issues.extend(blocked_processing_path_issues)
             issues.extend(blocked_recovery_issues)
-            if not orphans and not blocked_recovery_issues:
+            if not orphans and not blocked_processing_path_issues and not blocked_recovery_issues:
                 print(f"  slskd: checked {len(active)} active transfers, no orphans.")
         except Exception as e:
             print(f"  slskd: could not check orphans: {e}")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -502,6 +502,25 @@ class FakePipelineDB:
                 row["active_download_state"] = state_json
             row["updated_at"] = _utcnow()
 
+    def update_download_state_current_path(
+        self,
+        request_id: int,
+        current_path: str | None,
+    ) -> None:
+        row = self._requests.get(request_id)
+        if row:
+            state = row.get("active_download_state")
+            if isinstance(state, str):
+                try:
+                    state = json.loads(state)
+                except json.JSONDecodeError:
+                    state = {}
+            if not isinstance(state, dict):
+                state = {}
+            state["current_path"] = current_path
+            row["active_download_state"] = state
+            row["updated_at"] = _utcnow()
+
     def log_download(self, request_id: int,
                      soulseek_username: str | None = None,
                      filetype: str | None = None,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -512,7 +512,11 @@ class FakePipelineDB:
             (request_id, current_path),
         )
         row = self._requests.get(request_id)
-        if row and row.get("status") == "downloading":
+        if (
+            row
+            and row.get("status") == "downloading"
+            and row.get("active_download_state") is not None
+        ):
             state = row.get("active_download_state")
             if isinstance(state, str):
                 try:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -306,6 +306,7 @@ class FakePipelineDB:
         self.recorded_attempts: list[tuple[int, str]] = []
         self.status_history: list[tuple[int, str]] = []
         self.update_download_state_calls: list[tuple[int, str]] = []
+        self.update_download_state_current_path_calls: list[tuple[int, str | None]] = []
         self.clear_download_state_calls: list[int] = []
         self.advisory_lock_calls: list[tuple[int, int]] = []
         self.closed = False
@@ -507,6 +508,9 @@ class FakePipelineDB:
         request_id: int,
         current_path: str | None,
     ) -> None:
+        self.update_download_state_current_path_calls.append(
+            (request_id, current_path),
+        )
         row = self._requests.get(request_id)
         if row:
             state = row.get("active_download_state")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -512,7 +512,7 @@ class FakePipelineDB:
             (request_id, current_path),
         )
         row = self._requests.get(request_id)
-        if row:
+        if row and row.get("status") == "downloading":
             state = row.get("active_download_state")
             if isinstance(state, str):
                 try:

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -27,7 +27,8 @@ import cratedigger
 from lib.beets import beets_validate
 from lib.grab_list import GrabListEntry
 from lib.quality import ValidationResult
-from lib.util import stage_to_ai, log_validation_result, sanitize_folder_name
+from lib.staged_album import StagedAlbum, stage_to_ai_path
+from lib.util import log_validation_result, sanitize_folder_name
 
 
 def make_choose_match_msg(mb_release_id, distance, extra_candidates=None):
@@ -441,8 +442,8 @@ def _make_album_data(**overrides):
     return GrabListEntry(**defaults)  # type: ignore[arg-type]
 
 
-class TestStageToAi(unittest.TestCase):
-    """Test stage_to_ai() function."""
+class TestStagedAlbumMoveTo(unittest.TestCase):
+    """Test staging-path construction plus directory move semantics."""
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -461,7 +462,13 @@ class TestStageToAi(unittest.TestCase):
             open(os.path.join(source, name), "w").close()
 
         album_data = _make_album_data(artist="Test Artist", title="Test Album")
-        dest = stage_to_ai(album_data, source, staging)
+        dest = stage_to_ai_path(
+            artist=album_data.artist,
+            title=album_data.title,
+            staging_dir=staging,
+        )
+        staged_album = StagedAlbum(current_path=source)
+        staged_album.move_to(dest)
 
         self.assertEqual(dest, os.path.join(staging, "Test Artist", "Test Album"))
         self.assertTrue(os.path.exists(os.path.join(dest, "01 - Track.flac")))
@@ -477,7 +484,12 @@ class TestStageToAi(unittest.TestCase):
         open(os.path.join(source, "track.flac"), "w").close()
 
         album_data = _make_album_data(artist="Artist", title="Album")
-        stage_to_ai(album_data, source, staging)
+        dest = stage_to_ai_path(
+            artist=album_data.artist,
+            title=album_data.title,
+            staging_dir=staging,
+        )
+        StagedAlbum(current_path=source).move_to(dest)
 
         self.assertFalse(os.path.exists(source))
 
@@ -490,7 +502,12 @@ class TestStageToAi(unittest.TestCase):
         open(os.path.join(source, "track.flac"), "w").close()
 
         album_data = _make_album_data(artist='Test: "Artist"', title="Album/Title?")
-        dest = stage_to_ai(album_data, source, staging)
+        dest = stage_to_ai_path(
+            artist=album_data.artist,
+            title=album_data.title,
+            staging_dir=staging,
+        )
+        StagedAlbum(current_path=source).move_to(dest)
 
         # sanitize_folder_name removes <>:"/\|?*
         self.assertNotIn(":", os.path.basename(os.path.dirname(dest)))

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -575,7 +575,7 @@ class TestLogValidationResult(unittest.TestCase):
 
 
 class TestSanitizeFolderName(unittest.TestCase):
-    """Verify sanitize_folder_name works correctly for stage_to_ai."""
+    """Verify sanitize_folder_name works correctly for staged album paths."""
 
     def test_removes_special_chars(self):
         self.assertEqual(sanitize_folder_name('Test: "Artist"'), 'Test Artist')

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -26,8 +26,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import cratedigger
 from lib.beets import beets_validate
 from lib.grab_list import GrabListEntry
+from lib.processing_paths import stage_to_ai_path
 from lib.quality import ValidationResult
-from lib.staged_album import StagedAlbum, stage_to_ai_path
+from lib.staged_album import StagedAlbum
 from lib.util import log_validation_result, sanitize_folder_name
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2197,6 +2197,60 @@ class TestPollActiveDownloads(unittest.TestCase):
             )
             self.assertEqual(fake_db.status_history, [])
 
+    @patch("lib.download.process_completed_album")
+    def test_poll_stale_canonical_current_path_uses_request_scoped_staging_fallback(
+        self,
+        mock_process,
+    ):
+        """A stale canonical current_path must recover to the staged location."""
+        from lib.download import poll_active_downloads
+        from lib.processing_paths import canonical_processing_path, stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            staging_root = os.path.join(tmpdir, "staging")
+            canonical_path = canonical_processing_path(
+                artist="Test Artist",
+                title="Test Album",
+                year="2020",
+                slskd_download_dir=downloads_root,
+            )
+            staged_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=True,
+            )
+            os.makedirs(staged_path)
+            with open(os.path.join(staged_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": canonical_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = downloads_root
+            cfg.beets_staging_dir = staging_root
+
+            mock_process.return_value = None
+            poll_active_downloads(ctx)
+
+            entry = mock_process.call_args[0][0]
+            self.assertEqual(entry.import_folder, staged_path)
+            self.assertEqual(
+                fake_db.request(1)["active_download_state"]["current_path"],
+                staged_path,
+            )
+
     def test_poll_legacy_processing_row_blocks_on_ambiguous_staged_dir(self):
         """Legacy rows must not guess a shared staged dir as current_path."""
         from lib.download import poll_active_downloads

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -819,6 +819,46 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             self.assertEqual(files[0].import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
+    @patch("lib.download.music_tag")
+    def test_resumes_multi_disc_from_persisted_current_path(self, mock_mt):
+        """Resume must preserve the staged multi-disc filenames on disk."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resumed_path = os.path.join(tmpdir, "staging", "Artist", "Album")
+            os.makedirs(resumed_path)
+            resumed_file = os.path.join(resumed_path, "Disk 2 - 01 - Track.flac")
+            with open(resumed_file, "w") as f:
+                f.write("fake audio")
+
+            file = make_download_file(
+                filename="user1\\CD2\\01 - Track.flac",
+                file_dir="user1\\CD2",
+                size=len("fake audio"),
+            )
+            file.disk_no = 2
+            file.disk_count = 2
+            album = make_grab_list_entry(
+                files=[file],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_validation_enabled = False
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertTrue(result)
+            self.assertEqual(file.import_path, resumed_file)
+            self.assertTrue(os.path.exists(resumed_file))
+
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""
         from lib.download import process_completed_album

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2178,6 +2178,45 @@ class TestPollActiveDownloads(unittest.TestCase):
                 "\n".join(logs.output),
             )
 
+    def test_poll_legacy_processing_row_blocks_when_canonical_and_legacy_stage_both_exist(self):
+        """Split legacy state must not pick one side and requeue the other."""
+        from lib.download import poll_active_downloads
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            canonical_path = os.path.join(
+                tmpdir, "downloads", "Test Artist - Test Album (2020)")
+            os.makedirs(canonical_path)
+            with open(os.path.join(canonical_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+
+            staging_root = os.path.join(tmpdir, "staging")
+            staged_path = os.path.join(staging_root, "Test Artist", "Test Album")
+            os.makedirs(staged_path)
+            with open(os.path.join(staged_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertIsNone(fake_db.request(1)["active_download_state"].get("current_path"))
+            self.assertEqual(fake_db.update_download_state_calls, [])
+            self.assertIn("MID-PROCESS RESUME BLOCKED", "\n".join(logs.output))
+
     def test_poll_missing_persisted_current_path_resets_to_wanted(self):
         """Missing persisted staging dirs should fail closed back to wanted."""
         from lib.download import poll_active_downloads

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -819,6 +819,59 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             self.assertEqual(files[0].import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
+    def test_returns_false_when_persisted_current_path_missing_dir(self):
+        """Resume must fail closed when the persisted directory no longer exists."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+            )
+            album.import_folder = os.path.join(tmpdir, "missing")
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_validation_enabled = False
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertFalse(result)
+
+    def test_returns_false_when_persisted_current_path_missing_file(self):
+        """Resume dir must contain every tracked file before processing continues."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resumed_path = os.path.join(tmpdir, "staging", "Artist", "Album")
+            os.makedirs(resumed_path)
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_validation_enabled = False
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertFalse(result)
+
 
 class TestResolveSlskdLocalPath(unittest.TestCase):
     """Pure tests for the slskd on-disk path resolution helper.
@@ -1788,6 +1841,54 @@ class TestPollActiveDownloads(unittest.TestCase):
 
         entry = mock_process.call_args[0][0]
         self.assertEqual(entry.import_folder, current_path)
+
+    @patch("lib.download.process_completed_album")
+    def test_poll_legacy_processing_row_uses_canonical_fallback(self, mock_process):
+        """Legacy mid-processing rows without current_path still resume canonically."""
+        from lib.download import poll_active_downloads
+        row = self._make_downloading_row(state_dict={
+            "filetype": "flac",
+            "enqueued_at": _utc_now_iso(),
+            "processing_started_at": _utc_now_iso(),
+            "files": [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ],
+        })
+        ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+        cfg = cast(Any, ctx.cfg)
+        cfg.slskd_download_dir = "/tmp/downloads"
+
+        mock_process.return_value = True
+        poll_active_downloads(ctx)
+
+        entry = mock_process.call_args[0][0]
+        self.assertEqual(
+            entry.import_folder,
+            "/tmp/downloads/Test Artist - Test Album (2020)",
+        )
+
+    def test_poll_missing_persisted_current_path_resets_to_wanted(self):
+        """Missing persisted staging dirs should fail closed back to wanted."""
+        from lib.download import poll_active_downloads
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": os.path.join(tmpdir, "missing"),
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+
+            poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "wanted")
+            self.assertIn((1, "wanted"), fake_db.status_history)
 
     @patch("lib.download.process_completed_album")
     def test_poll_no_redownload_window(self, mock_process):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2043,6 +2043,10 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(len(fake_db.update_download_state_calls), 1)
         persisted = self._download_state(fake_db)
         self.assertIsNotNone(persisted["processing_started_at"])
+        self.assertEqual(
+            persisted["current_path"],
+            "/tmp/test_downloads/Test Artist - Test Album (2020)",
+        )
 
     @patch("lib.download.process_completed_album")
     def test_poll_resume_processing_uses_persisted_current_path(self, mock_process):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -965,7 +965,7 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
                 existing_min_bitrate=None,
             )
 
-            with patch("lib.download.dispatch_import") as mock_dispatch, \
+            with patch("lib.download.dispatch_import_core") as mock_dispatch, \
                  self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(album, [], ctx)
 
@@ -1015,7 +1015,7 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             mock_mt.load_file.return_value = MagicMock()
             mock_run_preimport_gates.return_value = MagicMock(valid=True)
 
-            with patch("lib.download.dispatch_import") as mock_dispatch, \
+            with patch("lib.download.dispatch_import_core") as mock_dispatch, \
                  self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(album, [], ctx)
 
@@ -1087,7 +1087,7 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
                 existing_min_bitrate=None,
             )
 
-            with patch("lib.download.dispatch_import") as mock_dispatch:
+            with patch("lib.download.dispatch_import_core") as mock_dispatch:
                 result = process_completed_album(album, [], ctx)
 
             self.assertTrue(result)
@@ -1291,6 +1291,7 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
     def test_request_source_without_mbid_requeues_instead_of_marking_done(self):
         """Request rows without an MBID must requeue, not mark imported."""
         from lib.download import _handle_valid_result
+        from lib.staged_album import StagedAlbum
         import tempfile
 
         album = make_grab_list_entry(
@@ -1317,7 +1318,12 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
                       encoding="utf-8") as fp:
                 fp.write("x")
 
-            outcome = _handle_valid_result(album, bv_result, import_dir, ctx)
+            outcome = _handle_valid_result(
+                album,
+                bv_result,
+                StagedAlbum(current_path=import_dir, request_id=42),
+                ctx,
+            )
 
             assert outcome is not None
             self.assertFalse(outcome.success)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -914,7 +914,7 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
         """Post-move auto-import retries must stop before re-dispatch."""
         from lib.download import process_completed_album
         from lib.quality import ValidationResult
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -985,7 +985,7 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
         """Post-move non-auto retries should re-enter and finish mark_done."""
         from lib.download import process_completed_album
         from lib.quality import ValidationResult
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -2106,7 +2106,7 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_mid_processing_row_uses_request_scoped_staging_fallback(self, mock_process):
         """Move/persist crashes should recover from request-scoped staged dirs."""
         from lib.download import poll_active_downloads
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -2246,7 +2246,7 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_post_move_staged_path_without_validation_completes(self):
         """Staged retries still finish when the auto-import branch is unavailable."""
         from lib.download import poll_active_downloads
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -2284,7 +2284,7 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_post_move_staged_path_with_missing_file_leaves_row_downloading(self):
         """Missing files under a staged current_path must block, not requeue."""
         from lib.download import poll_active_downloads
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -2325,7 +2325,7 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_post_move_auto_import_path_with_missing_dir_leaves_row_downloading(self):
         """Missing auto-import staging dirs must block, not requeue."""
         from lib.download import poll_active_downloads
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2096,10 +2096,10 @@ class TestPollActiveDownloads(unittest.TestCase):
             entry.import_folder,
             "/tmp/downloads/Test Artist - Test Album (2020)",
         )
-        self.assertEqual(len(_fake_db.update_download_state_calls), 1)
-        self.assertIn(
-            '"current_path": "/tmp/downloads/Test Artist - Test Album (2020)"',
-            _fake_db.update_download_state_calls[0][1],
+        self.assertEqual(len(_fake_db.update_download_state_current_path_calls), 1)
+        self.assertEqual(
+            _fake_db.update_download_state_current_path_calls[0],
+            (1, "/tmp/downloads/Test Artist - Test Album (2020)"),
         )
 
     @patch("lib.download.process_completed_album")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -902,10 +902,18 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
                 os.path.join(tmpdir, "downloads", "Artist - Album (2024)"),
             )
 
-    @patch("lib.download._process_beets_validation")
-    def test_returns_none_for_post_move_beets_staging_retry(self, mock_process_validation):
-        """Post-move beets staging paths must not auto-revalidate on retry."""
+    @patch("lib.preimport.run_preimport_gates")
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
+    def test_returns_none_for_post_move_auto_import_retry(
+        self,
+        mock_mt,
+        mock_beets_validate,
+        mock_run_preimport_gates,
+    ):
+        """Post-move auto-import retries must stop before re-dispatch."""
         from lib.download import process_completed_album
+        from lib.quality import ValidationResult
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -932,14 +940,95 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
             cfg.beets_staging_dir = staging_root
             cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+            mock_beets_validate.return_value = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+            mock_run_preimport_gates.return_value = MagicMock(
+                valid=True,
+                scenario=None,
+                detail=None,
+                corrupt_files=[],
+                download_spectral=None,
+                existing_spectral=None,
+                existing_min_bitrate=None,
+            )
 
-            with self.assertLogs("cratedigger", level="ERROR") as logs:
+            with patch("lib.download.dispatch_import") as mock_dispatch, \
+                 self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(album, [], ctx)
 
             self.assertIsNone(result)
-            mock_process_validation.assert_not_called()
+            mock_dispatch.assert_not_called()
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
+
+    @patch("lib.preimport.run_preimport_gates")
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
+    def test_retries_post_move_redownload_path_without_blocking(
+        self,
+        mock_mt,
+        mock_beets_validate,
+        mock_run_preimport_gates,
+    ):
+        """Post-move non-auto retries should re-enter and finish mark_done."""
+        from lib.download import process_completed_album
+        from lib.quality import ValidationResult
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = os.path.join(staging_root, "Artist", "Album")
+            os.makedirs(resumed_path)
+            with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_request_id=42,
+                db_source="redownload",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+            cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+            mock_beets_validate.return_value = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+            mock_run_preimport_gates.return_value = MagicMock(
+                valid=True,
+                scenario=None,
+                detail=None,
+                corrupt_files=[],
+                download_spectral=None,
+                existing_spectral=None,
+                existing_min_bitrate=None,
+            )
+
+            with patch("lib.download.dispatch_import") as mock_dispatch:
+                result = process_completed_album(album, [], ctx)
+
+            self.assertTrue(result)
+            mock_dispatch.assert_not_called()
+            mark_done = cast(Any, ctx.pipeline_db_source.mark_done)
+            mark_done.assert_called_once()
 
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -859,6 +859,49 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             self.assertEqual(file.import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
+    @patch("lib.download.music_tag")
+    def test_persists_canonical_current_path_for_fresh_materialization(self, mock_mt):
+        """The first local materialization must persist the canonical path to DB."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_db = FakePipelineDB()
+            fake_db.seed_request(make_request_row(
+                id=42,
+                status="downloading",
+                active_download_state={"filetype": "mp3", "files": []},
+            ))
+            source_dir = os.path.join(tmpdir, "downloads", "Music")
+            os.makedirs(source_dir)
+            source_file = os.path.join(source_dir, "01 - Track.mp3")
+            with open(source_file, "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+                db_request_id=42,
+            )
+            cfg = cast(Any, _make_ctx().cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_validation_enabled = False
+            ctx = make_ctx_with_fake_db(fake_db, cfg=cfg)
+            mock_mt.load_file.return_value = MagicMock()
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertTrue(result)
+            self.assertEqual(
+                fake_db.request(42)["active_download_state"]["current_path"],
+                os.path.join(tmpdir, "downloads", "Artist - Album (2024)"),
+            )
+
     @patch("lib.download._process_beets_validation")
     def test_returns_none_for_post_move_beets_staging_retry(self, mock_process_validation):
         """Post-move beets staging paths must not auto-revalidate on retry."""
@@ -891,10 +934,12 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             cfg.beets_validation_enabled = True
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
 
-            result = process_completed_album(album, [], ctx)
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(album, [], ctx)
 
             self.assertIsNone(result)
             mock_process_validation.assert_not_called()
+            self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""
@@ -1992,10 +2037,12 @@ class TestPollActiveDownloads(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.beets_staging_dir = staging_root
 
-            poll_active_downloads(ctx)
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                poll_active_downloads(ctx)
 
             self.assertEqual(fake_db.request(1)["status"], "downloading")
             self.assertEqual(fake_db.status_history, [])
+            self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     @patch("lib.download.process_completed_album")
     def test_poll_no_redownload_window(self, mock_process):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2042,6 +2042,10 @@ class TestPollActiveDownloads(unittest.TestCase):
 
             self.assertEqual(fake_db.request(1)["status"], "downloading")
             self.assertEqual(fake_db.status_history, [])
+            self.assertEqual(
+                fake_db.request(1)["active_download_state"]["current_path"],
+                resumed_path,
+            )
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     @patch("lib.download.process_completed_album")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2098,6 +2098,50 @@ class TestPollActiveDownloads(unittest.TestCase):
             _fake_db.update_download_state_calls[0][1],
         )
 
+    @patch("lib.download.process_completed_album")
+    def test_poll_mid_processing_row_uses_request_scoped_staging_fallback(self, mock_process):
+        """Move/persist crashes should recover from request-scoped staged dirs."""
+        from lib.download import poll_active_downloads
+        from lib.staged_album import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            staged_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=True,
+            )
+            os.makedirs(staged_path)
+            with open(os.path.join(staged_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+
+            mock_process.return_value = None
+            poll_active_downloads(ctx)
+
+            entry = mock_process.call_args[0][0]
+            self.assertEqual(entry.import_folder, staged_path)
+            self.assertEqual(
+                fake_db.request(1)["active_download_state"]["current_path"],
+                staged_path,
+            )
+            self.assertEqual(fake_db.status_history, [])
+
     def test_poll_legacy_processing_row_blocks_on_ambiguous_staged_dir(self):
         """Legacy rows must not guess a shared staged dir as current_path."""
         from lib.download import poll_active_downloads

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -976,6 +976,57 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
     @patch("lib.preimport.run_preimport_gates")
     @patch("lib.beets.beets_validate")
     @patch("lib.download.music_tag")
+    def test_returns_none_for_legacy_shared_staged_retry(
+        self,
+        mock_mt,
+        mock_beets_validate,
+        mock_run_preimport_gates,
+    ):
+        """Legacy shared staged retries must stop before validation reruns."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = os.path.join(staging_root, "Artist", "Album")
+            os.makedirs(resumed_path)
+            with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_request_id=42,
+                db_source="request",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+            cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+            mock_run_preimport_gates.return_value = MagicMock(valid=True)
+
+            with patch("lib.download.dispatch_import") as mock_dispatch, \
+                 self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(album, [], ctx)
+
+            self.assertIsNone(result)
+            mock_beets_validate.assert_not_called()
+            mock_dispatch.assert_not_called()
+            self.assertIn("legacy shared staged path", "\n".join(logs.output))
+
+    @patch("lib.preimport.run_preimport_gates")
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
     def test_retries_post_move_redownload_path_without_blocking(
         self,
         mock_mt,
@@ -2661,16 +2712,13 @@ class TestReconstructGrabListEntry(unittest.TestCase):
         state = ActiveDownloadState(
             filetype="flac",
             enqueued_at="now",
+            current_path="/tmp/legacy/A/B",
             files=[],
         )
         request = {"id": 10, "album_title": "B", "artist_name": "A",
                    "year": 2020, "mb_release_id": "mbid", "source": "request",
                    "search_filetype_override": None, "target_format": None}
-        entry = reconstruct_grab_list_entry(
-            request,
-            state,
-            fallback_current_path="/tmp/legacy/A/B",
-        )
+        entry = reconstruct_grab_list_entry(request, state)
         self.assertEqual(entry.import_folder, "/tmp/legacy/A/B")
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1989,6 +1989,46 @@ class TestPollActiveDownloads(unittest.TestCase):
             entry.import_folder,
             "/tmp/downloads/Test Artist - Test Album (2020)",
         )
+        self.assertEqual(len(_fake_db.update_download_state_calls), 1)
+        self.assertIn(
+            '"current_path": "/tmp/downloads/Test Artist - Test Album (2020)"',
+            _fake_db.update_download_state_calls[0][1],
+        )
+
+    def test_poll_legacy_processing_row_uses_staged_fallback_when_stage_exists(self):
+        """Legacy rows already moved into beets staging must fail closed there."""
+        from lib.download import poll_active_downloads
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            staged_path = os.path.join(staging_root, "Test Artist", "Test Album")
+            os.makedirs(staged_path)
+            with open(os.path.join(staged_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertEqual(
+                fake_db.request(1)["active_download_state"]["current_path"],
+                staged_path,
+            )
+            self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     def test_poll_missing_persisted_current_path_resets_to_wanted(self):
         """Missing persisted staging dirs should fail closed back to wanted."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -914,10 +914,17 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
         """Post-move auto-import retries must stop before re-dispatch."""
         from lib.download import process_completed_album
         from lib.quality import ValidationResult
+        from lib.staged_album import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
-            resumed_path = os.path.join(staging_root, "Artist", "Album")
+            resumed_path = stage_to_ai_path(
+                artist="Artist",
+                title="Album",
+                staging_dir=staging_root,
+                request_id=42,
+                auto_import=True,
+            )
             os.makedirs(resumed_path)
             with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
                 f.write("fake audio")
@@ -978,10 +985,17 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
         """Post-move non-auto retries should re-enter and finish mark_done."""
         from lib.download import process_completed_album
         from lib.quality import ValidationResult
+        from lib.staged_album import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
-            resumed_path = os.path.join(staging_root, "Artist", "Album")
+            resumed_path = stage_to_ai_path(
+                artist="Artist",
+                title="Album",
+                staging_dir=staging_root,
+                request_id=42,
+                auto_import=False,
+            )
             os.makedirs(resumed_path)
             with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
                 f.write("fake audio")
@@ -2034,7 +2048,7 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_resume_processing_uses_persisted_current_path(self, mock_process):
         """Resume path must reconstruct the post-move directory from persisted state."""
         from lib.download import poll_active_downloads
-        current_path = "/tmp/staged/Test Artist/Test Album"
+        current_path = "/tmp/staged/auto-import/Test Artist/Test Album [request-1]"
         row = self._make_downloading_row(state_dict={
             "filetype": "flac",
             "enqueued_at": _utc_now_iso(),
@@ -2145,10 +2159,17 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_post_move_staged_path_without_validation_completes(self):
         """Staged retries still finish when the auto-import branch is unavailable."""
         from lib.download import poll_active_downloads
+        from lib.staged_album import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
-            resumed_path = os.path.join(staging_root, "Test Artist", "Test Album")
+            resumed_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=False,
+            )
             os.makedirs(resumed_path)
             with open(os.path.join(resumed_path, "01.flac"), "w") as fp:
                 fp.write("audio")
@@ -2176,10 +2197,17 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_post_move_staged_path_with_missing_file_leaves_row_downloading(self):
         """Missing files under a staged current_path must block, not requeue."""
         from lib.download import poll_active_downloads
+        from lib.staged_album import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
-            resumed_path = os.path.join(staging_root, "Test Artist", "Test Album")
+            resumed_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=True,
+            )
             os.makedirs(resumed_path)
 
             row = self._make_downloading_row(state_dict={

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -781,6 +781,44 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             result = process_completed_album(album, [], ctx)
             self.assertFalse(result)
 
+    @patch("lib.download.music_tag")
+    def test_resumes_from_persisted_current_path(self, mock_mt):
+        """A post-move retry must process the persisted current_path, not slskd."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resumed_path = os.path.join(tmpdir, "staging", "Artist", "Album")
+            os.makedirs(resumed_path)
+            resumed_file = os.path.join(resumed_path, "01 - Track.mp3")
+            with open(resumed_file, "w") as f:
+                f.write("fake audio")
+
+            files = [make_download_file(
+                filename="user1\\Music\\01 - Track.mp3",
+                file_dir="user1\\Music",
+                size=len("fake audio"),
+            )]
+            album = make_grab_list_entry(
+                files=files,
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_validation_enabled = False
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertTrue(result)
+            self.assertEqual(files[0].import_path, resumed_file)
+            self.assertTrue(os.path.exists(resumed_file))
+
 
 class TestResolveSlskdLocalPath(unittest.TestCase):
     """Pure tests for the slskd on-disk path resolution helper.
@@ -1729,6 +1767,29 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertIsNotNone(persisted["processing_started_at"])
 
     @patch("lib.download.process_completed_album")
+    def test_poll_resume_processing_uses_persisted_current_path(self, mock_process):
+        """Resume path must reconstruct the post-move directory from persisted state."""
+        from lib.download import poll_active_downloads
+        current_path = "/tmp/staged/Test Artist/Test Album"
+        row = self._make_downloading_row(state_dict={
+            "filetype": "flac",
+            "enqueued_at": _utc_now_iso(),
+            "processing_started_at": _utc_now_iso(),
+            "current_path": current_path,
+            "files": [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ],
+        })
+        ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+
+        mock_process.return_value = True
+        poll_active_downloads(ctx)
+
+        entry = mock_process.call_args[0][0]
+        self.assertEqual(entry.import_folder, current_path)
+
+    @patch("lib.download.process_completed_album")
     def test_poll_no_redownload_window(self, mock_process):
         """Album stays 'downloading' during process_completed_album — no redownload window."""
         from lib.download import poll_active_downloads
@@ -2020,6 +2081,24 @@ class TestReconstructGrabListEntry(unittest.TestCase):
                    "search_filetype_override": None, "target_format": None}
         entry = reconstruct_grab_list_entry(request, state)
         self.assertEqual(entry.import_folder, "/tmp/staged/A/B")
+
+    def test_reconstruct_fallback_current_path(self):
+        from lib.download import reconstruct_grab_list_entry
+        from lib.quality import ActiveDownloadState
+        state = ActiveDownloadState(
+            filetype="flac",
+            enqueued_at="now",
+            files=[],
+        )
+        request = {"id": 10, "album_title": "B", "artist_name": "A",
+                   "year": 2020, "mb_release_id": "mbid", "source": "request",
+                   "search_filetype_override": None, "target_format": None}
+        entry = reconstruct_grab_list_entry(
+            request,
+            state,
+            fallback_current_path="/tmp/legacy/A/B",
+        )
+        self.assertEqual(entry.import_folder, "/tmp/legacy/A/B")
 
 
 # ============================================================================

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -859,6 +859,43 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             self.assertEqual(file.import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
+    @patch("lib.download._process_beets_validation")
+    def test_returns_none_for_post_move_beets_staging_retry(self, mock_process_validation):
+        """Post-move beets staging paths must not auto-revalidate on retry."""
+        from lib.download import process_completed_album
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = os.path.join(staging_root, "Artist", "Album")
+            os.makedirs(resumed_path)
+            with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_request_id=42,
+                db_source="request",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+            cfg.beets_validation_enabled = True
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertIsNone(result)
+            mock_process_validation.assert_not_called()
+
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""
         from lib.download import process_completed_album
@@ -1929,6 +1966,36 @@ class TestPollActiveDownloads(unittest.TestCase):
 
             self.assertEqual(fake_db.request(1)["status"], "wanted")
             self.assertIn((1, "wanted"), fake_db.status_history)
+
+    def test_poll_post_move_beets_staging_path_leaves_row_downloading(self):
+        """Post-move staging paths must stay untouched until manual recovery."""
+        from lib.download import poll_active_downloads
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = os.path.join(staging_root, "Test Artist", "Test Album")
+            os.makedirs(resumed_path)
+            with open(os.path.join(resumed_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": resumed_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.beets_staging_dir = staging_root
+
+            poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertEqual(fake_db.status_history, [])
 
     @patch("lib.download.process_completed_album")
     def test_poll_no_redownload_window(self, mock_process):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2279,6 +2279,46 @@ class TestPollActiveDownloads(unittest.TestCase):
             )
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
+    def test_poll_post_move_auto_import_path_with_missing_dir_leaves_row_downloading(self):
+        """Missing auto-import staging dirs must block, not requeue."""
+        from lib.download import poll_active_downloads
+        from lib.staged_album import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=True,
+            )
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": resumed_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.beets_staging_dir = staging_root
+
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertEqual(fake_db.status_history, [])
+            self.assertEqual(
+                fake_db.request(1)["active_download_state"]["current_path"],
+                resumed_path,
+            )
+            self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
+
     @patch("lib.download.process_completed_album")
     def test_poll_no_redownload_window(self, mock_process):
         """Album stays 'downloading' during process_completed_album — no redownload window."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1853,6 +1853,27 @@ class TestBuildActiveDownloadState(unittest.TestCase):
         self.assertEqual(parsed.tzinfo, tz.utc)
         self.assertEqual(state.last_progress_at, state.enqueued_at)
 
+    def test_uses_import_folder_as_current_path(self):
+        from lib.download import build_active_download_state
+        from lib.grab_list import GrabListEntry, DownloadFile
+        entry = GrabListEntry(
+            album_id=1,
+            filetype="flac",
+            title="T",
+            artist="A",
+            year="2020",
+            mb_release_id="mbid",
+            import_folder="/tmp/staged/A/T",
+            files=[
+                DownloadFile(
+                    filename="u\\M\\01.flac", id="tid-1",
+                    file_dir="u\\M", username="user1", size=1000,
+                ),
+            ],
+        )
+        state = build_active_download_state(entry)
+        self.assertEqual(state.current_path, "/tmp/staged/A/T")
+
 
 class TestReconstructGrabListEntry(unittest.TestCase):
     """Test reconstruct_grab_list_entry() — rebuild GrabListEntry from DB row + state."""
@@ -1984,6 +2005,21 @@ class TestReconstructGrabListEntry(unittest.TestCase):
                    "search_filetype_override": None, "target_format": None}
         entry = reconstruct_grab_list_entry(request, state)
         self.assertEqual(entry.year, "")
+
+    def test_reconstruct_current_path_to_import_folder(self):
+        from lib.download import reconstruct_grab_list_entry
+        from lib.quality import ActiveDownloadState
+        state = ActiveDownloadState(
+            filetype="flac",
+            enqueued_at="now",
+            current_path="/tmp/staged/A/B",
+            files=[],
+        )
+        request = {"id": 10, "album_title": "B", "artist_name": "A",
+                   "year": 2020, "mb_release_id": "mbid", "source": "request",
+                   "search_filetype_override": None, "target_format": None}
+        entry = reconstruct_grab_list_entry(request, state)
+        self.assertEqual(entry.import_folder, "/tmp/staged/A/B")
 
 
 # ============================================================================

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2084,8 +2084,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             _fake_db.update_download_state_calls[0][1],
         )
 
-    def test_poll_legacy_processing_row_uses_staged_fallback_when_stage_exists(self):
-        """Legacy rows already moved into beets staging must fail closed there."""
+    def test_poll_legacy_processing_row_blocks_on_ambiguous_staged_dir(self):
+        """Legacy rows must not guess a shared staged dir as current_path."""
         from lib.download import poll_active_downloads
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2113,11 +2113,12 @@ class TestPollActiveDownloads(unittest.TestCase):
                 poll_active_downloads(ctx)
 
             self.assertEqual(fake_db.request(1)["status"], "downloading")
-            self.assertEqual(
-                fake_db.request(1)["active_download_state"]["current_path"],
-                staged_path,
+            self.assertIsNone(fake_db.request(1)["active_download_state"].get("current_path"))
+            self.assertEqual(fake_db.update_download_state_calls, [])
+            self.assertIn(
+                "LEGACY STAGED RESUME BLOCKED",
+                "\n".join(logs.output),
             )
-            self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     def test_poll_missing_persisted_current_path_resets_to_wanted(self):
         """Missing persisted staging dirs should fail closed back to wanted."""
@@ -2141,8 +2142,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             self.assertEqual(fake_db.request(1)["status"], "wanted")
             self.assertIn((1, "wanted"), fake_db.status_history)
 
-    def test_poll_post_move_beets_staging_path_leaves_row_downloading(self):
-        """Post-move staging paths must stay untouched until manual recovery."""
+    def test_poll_post_move_staged_path_without_validation_completes(self):
+        """Staged retries still finish when the auto-import branch is unavailable."""
         from lib.download import poll_active_downloads
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2151,6 +2152,35 @@ class TestPollActiveDownloads(unittest.TestCase):
             os.makedirs(resumed_path)
             with open(os.path.join(resumed_path, "01.flac"), "w") as fp:
                 fp.write("audio")
+
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": resumed_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.beets_staging_dir = staging_root
+
+            poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "imported")
+            self.assertIn((1, "imported"), fake_db.status_history)
+            self.assertIsNone(fake_db.request(1)["active_download_state"])
+
+    def test_poll_post_move_staged_path_with_missing_file_leaves_row_downloading(self):
+        """Missing files under a staged current_path must block, not requeue."""
+        from lib.download import poll_active_downloads
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = os.path.join(staging_root, "Test Artist", "Test Album")
+            os.makedirs(resumed_path)
 
             row = self._make_downloading_row(state_dict={
                 "filetype": "flac",

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -6,6 +6,7 @@ from lib.download_recovery import (
     find_blocked_processing_path_issues,
     find_blocked_recovery_issues,
     classify_processing_path,
+    reconcile_processing_current_path,
     resolve_missing_current_path,
 )
 from lib.processing_paths import canonical_processing_path
@@ -169,6 +170,29 @@ class TestResolveMissingCurrentPath(unittest.TestCase):
         )
 
 
+class TestReconcileProcessingCurrentPath(unittest.TestCase):
+
+    def test_recovers_request_scoped_stage_when_canonical_current_path_is_stale(self):
+        staged_path = "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+        decision = reconcile_processing_current_path(
+            current_path="/tmp/downloads/Test Artist - Test Album (2020)",
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: path == staged_path,
+        )
+
+        assert decision.selected_location is not None
+        self.assertEqual(
+            decision.selected_location.kind,
+            "request_scoped_auto_import_staged",
+        )
+        self.assertEqual(decision.selected_location.path, staged_path)
+
+
 class TestFindBlockedRecoveryIssues(unittest.TestCase):
 
     def test_reports_legacy_shared_only_recovery_as_blocked(self):
@@ -256,3 +280,34 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].request_id, 1)
         self.assertIn("legacy shared staged path", issues[0].detail)
+
+    def test_skips_request_scoped_auto_import_path(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": (
+                        "/tmp/staging/auto-import/"
+                        "Test Artist/Test Album [request-1]"
+                    ),
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            existing_local_paths={
+                "/tmp/staging/auto-import/Test Artist/Test Album [request-1]",
+            },
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(issues, [])

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -1,0 +1,167 @@
+"""Tests for the shared download recovery seam."""
+
+import unittest
+
+from lib.download_recovery import (
+    canonical_processing_path,
+    classify_processing_path,
+    resolve_missing_current_path,
+)
+
+
+class TestClassifyProcessingPath(unittest.TestCase):
+
+    def test_classifies_canonical_path(self):
+        location = classify_processing_path(
+            current_path="/tmp/downloads/Test Artist - Test Album (2020)",
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(location.kind, "canonical")
+        self.assertEqual(location.display_name, "canonical processing path")
+
+    def test_classifies_request_scoped_auto_import_stage(self):
+        location = classify_processing_path(
+            current_path="/tmp/staging/auto-import/Test Artist/Test Album [request-1]",
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(location.kind, "request_scoped_auto_import_staged")
+        self.assertTrue(location.blocks_post_move_retry)
+        self.assertTrue(location.blocks_auto_import_dispatch)
+
+    def test_classifies_request_scoped_post_validation_stage(self):
+        location = classify_processing_path(
+            current_path="/tmp/staging/post-validation/Test Artist/Test Album [request-1]",
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(location.kind, "request_scoped_post_validation_staged")
+        self.assertFalse(location.blocks_post_move_retry)
+        self.assertFalse(location.blocks_auto_import_dispatch)
+
+    def test_classifies_legacy_shared_stage(self):
+        location = classify_processing_path(
+            current_path="/tmp/staging/Test Artist/Test Album",
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(location.kind, "legacy_shared_staged")
+        self.assertTrue(location.blocks_auto_import_dispatch)
+
+    def test_does_not_treat_other_request_stage_as_current_request(self):
+        location = classify_processing_path(
+            current_path="/tmp/staging/auto-import/Test Artist/Test Album [request-99]",
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(location.kind, "external")
+
+
+class TestResolveMissingCurrentPath(unittest.TestCase):
+
+    def test_falls_back_to_canonical_when_no_candidates_exist(self):
+        decision = resolve_missing_current_path(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda _path: False,
+        )
+
+        assert decision.selected_location is not None
+        self.assertEqual(decision.blocked_reason, None)
+        self.assertEqual(decision.selected_location.kind, "canonical")
+        self.assertEqual(
+            decision.selected_location.path,
+            canonical_processing_path(
+                artist="Test Artist",
+                title="Test Album",
+                year="2020",
+                slskd_download_dir="/tmp/downloads",
+            ),
+        )
+
+    def test_picks_request_scoped_stage_when_it_is_the_only_populated_candidate(self):
+        candidate = "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+        decision = resolve_missing_current_path(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: path == candidate,
+        )
+
+        assert decision.selected_location is not None
+        self.assertEqual(decision.blocked_reason, None)
+        self.assertEqual(
+            decision.selected_location.kind,
+            "request_scoped_auto_import_staged",
+        )
+        self.assertEqual(decision.selected_location.path, candidate)
+
+    def test_blocks_legacy_shared_only_recovery(self):
+        candidate = "/tmp/staging/Test Artist/Test Album"
+        decision = resolve_missing_current_path(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: path == candidate,
+        )
+
+        self.assertEqual(decision.blocked_reason, "legacy_shared_only")
+        self.assertIsNone(decision.selected_location)
+
+    def test_blocks_multiple_populated_candidates(self):
+        candidates = {
+            "/tmp/downloads/Test Artist - Test Album (2020)",
+            "/tmp/staging/Test Artist/Test Album",
+        }
+        decision = resolve_missing_current_path(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            request_id=1,
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: path in candidates,
+        )
+
+        self.assertEqual(decision.blocked_reason, "multiple_populated_paths")
+        self.assertIsNone(decision.selected_location)
+        self.assertEqual(
+            [location.short_label for location in decision.populated_locations],
+            ["canonical", "legacy-shared"],
+        )

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -3,6 +3,7 @@
 import unittest
 
 from lib.download_recovery import (
+    find_blocked_processing_path_issues,
     find_blocked_recovery_issues,
     classify_processing_path,
     resolve_missing_current_path,
@@ -224,3 +225,34 @@ class TestFindBlockedRecoveryIssues(unittest.TestCase):
         )
 
         self.assertEqual(issues, [])
+
+
+class TestFindBlockedProcessingPathIssues(unittest.TestCase):
+
+    def test_reports_legacy_shared_current_path_as_blocked(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": "/tmp/staging/Test Artist/Test Album",
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            existing_local_paths={"/tmp/staging/Test Artist/Test Album"},
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].request_id, 1)
+        self.assertIn("legacy shared staged path", issues[0].detail)

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -272,16 +272,16 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
                 },
             }],
             set(),
-            existing_local_paths={"/tmp/staging/Test Artist/Test Album"},
             staging_dir="/tmp/staging",
             slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: path == "/tmp/staging/Test Artist/Test Album",
         )
 
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].request_id, 1)
         self.assertIn("legacy shared staged path", issues[0].detail)
 
-    def test_skips_request_scoped_auto_import_path(self):
+    def test_reports_request_scoped_auto_import_path_as_blocked(self):
         issues = find_blocked_processing_path_issues(
             [{
                 "id": 1,
@@ -303,11 +303,43 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
                 },
             }],
             set(),
-            existing_local_paths={
-                "/tmp/staging/auto-import/Test Artist/Test Album [request-1]",
-            },
             staging_dir="/tmp/staging",
             slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: (
+                path
+                == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+            ),
+        )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].request_id, 1)
+        self.assertIn("request-scoped auto-import staged path", issues[0].detail)
+
+    def test_skips_stale_canonical_current_path_with_request_scoped_recovery(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": "/tmp/downloads/Test Artist - Test Album (2020)",
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: (
+                path
+                == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+            ),
         )
 
         self.assertEqual(issues, [])

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -4,10 +4,10 @@ import unittest
 
 from lib.download_recovery import (
     find_blocked_recovery_issues,
-    canonical_processing_path,
     classify_processing_path,
     resolve_missing_current_path,
 )
+from lib.processing_paths import canonical_processing_path
 
 
 class TestClassifyProcessingPath(unittest.TestCase):

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -3,6 +3,7 @@
 import unittest
 
 from lib.download_recovery import (
+    find_blocked_recovery_issues,
     canonical_processing_path,
     classify_processing_path,
     resolve_missing_current_path,
@@ -165,3 +166,61 @@ class TestResolveMissingCurrentPath(unittest.TestCase):
             [location.short_label for location in decision.populated_locations],
             ["canonical", "legacy-shared"],
         )
+
+
+class TestFindBlockedRecoveryIssues(unittest.TestCase):
+
+    def test_reports_legacy_shared_only_recovery_as_blocked(self):
+        issues = find_blocked_recovery_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: path == "/tmp/staging/Test Artist/Test Album",
+        )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].request_id, 1)
+        self.assertIn("ambiguous legacy shared staged path", issues[0].detail)
+
+    def test_skips_rows_with_recoverable_request_scoped_stage(self):
+        issues = find_blocked_recovery_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: (
+                path
+                == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+            ),
+        )
+
+        self.assertEqual(issues, [])

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -76,6 +76,20 @@ class TestFakePipelineDB(unittest.TestCase):
         row = db.request(42)
         self.assertEqual(row["active_download_state"]["current_path"], "/tmp/staged")
 
+    def test_update_download_state_current_path_noop_when_not_downloading(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="imported",
+            active_download_state=None,
+        ))
+
+        db.update_download_state_current_path(42, "/tmp/staged")
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "imported")
+        self.assertIsNone(row["active_download_state"])
+
     def test_update_spectral_state(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42))

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -90,6 +90,20 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertEqual(row["status"], "imported")
         self.assertIsNone(row["active_download_state"])
 
+    def test_update_download_state_current_path_noop_when_state_missing(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state=None,
+        ))
+
+        db.update_download_state_current_path(42, "/tmp/staged")
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "downloading")
+        self.assertIsNone(row["active_download_state"])
+
     def test_update_spectral_state(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42))

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -63,6 +63,19 @@ class TestFakePipelineDB(unittest.TestCase):
             [(42, '{"filetype":"flac"}')],
         )
 
+    def test_update_download_state_current_path_rewrites_nested_path(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={"filetype": "flac", "files": []},
+        ))
+
+        db.update_download_state_current_path(42, "/tmp/staged")
+
+        row = db.request(42)
+        self.assertEqual(row["active_download_state"]["current_path"], "/tmp/staged")
+
     def test_update_spectral_state(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42))

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -87,6 +87,7 @@ def _dispatch_valid_result_cmd(
 ):
     """Run the surviving auto-import seam and return the harness argv."""
     from lib.download import _handle_valid_result
+    from lib.staged_album import StagedAlbum
 
     album_data = album_data or _make_album_data()
     ctx = ctx or _make_ctx()
@@ -96,13 +97,28 @@ def _dispatch_valid_result_cmd(
     bv_result = _make_bv_result()
     ir = ir or make_import_result(decision="import")
 
-    with patch("lib.download.stage_to_ai", return_value="/tmp/dest"), \
-         patch("lib.download.log_validation_result"), \
-         patch_dispatch_externals() as ext, \
-         patch("lib.import_dispatch._check_quality_gate_core"), \
-         patch("lib.import_dispatch.parse_import_result", return_value=ir):
-        _handle_valid_result(album_data, bv_result, "/tmp/import", ctx)
-        return ext.run.call_args[0][0]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = os.path.join(tmpdir, "import")
+        dest_dir = os.path.join(tmpdir, "dest")
+        os.makedirs(source_dir)
+        with open(os.path.join(source_dir, "01 - Track.mp3"), "w", encoding="utf-8") as fp:
+            fp.write("fake audio")
+
+        with patch("lib.download.stage_to_ai_path", return_value=dest_dir), \
+             patch("lib.download.log_validation_result"), \
+             patch_dispatch_externals() as ext, \
+             patch("lib.import_dispatch._check_quality_gate_core"), \
+             patch("lib.import_dispatch.parse_import_result", return_value=ir):
+            _handle_valid_result(
+                album_data,
+                bv_result,
+                StagedAlbum(
+                    current_path=source_dir,
+                    request_id=album_data.db_request_id,
+                ),
+                ctx,
+            )
+            return ext.run.call_args[0][0]
 
 
 class TestPopulateDlInfoFromImportResult(unittest.TestCase):

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -1249,6 +1249,12 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(f.username, "alice")
         self.assertEqual(f.filename, "alice\\Music\\track.flac")
         self.assertEqual(f.file_dir, "alice\\Music")
+        self.assertEqual(f.size, 25000000)
+        self.assertIsNone(f.disk_no)
+        self.assertIsNone(f.disk_count)
+        self.assertEqual(f.retry_count, 0)
+        self.assertEqual(f.bytes_transferred, 0)
+        self.assertIsNone(f.last_state)
 
     def test_active_download_state_missing_current_path_defaults_none(self):
         """Pre-refactor rows without current_path still deserialize."""

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -1144,6 +1144,7 @@ class TestActiveDownloadState(unittest.TestCase):
             enqueued_at="2026-04-03T12:00:00+00:00",
             last_progress_at="2026-04-03T12:03:00+00:00",
             processing_started_at="2026-04-03T12:05:00+00:00",
+            current_path="/tmp/staged/Test Artist/Test Album",
             files=[
                 ActiveDownloadFileState(
                     username="user1",
@@ -1161,6 +1162,7 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(j["enqueued_at"], "2026-04-03T12:00:00+00:00")
         self.assertEqual(j["last_progress_at"], "2026-04-03T12:03:00+00:00")
         self.assertEqual(j["processing_started_at"], "2026-04-03T12:05:00+00:00")
+        self.assertEqual(j["current_path"], "/tmp/staged/Test Artist/Test Album")
         self.assertEqual(len(j["files"]), 1)
         self.assertEqual(j["files"][0]["username"], "user1")
         self.assertEqual(j["files"][0]["size"], 30000000)
@@ -1176,6 +1178,7 @@ class TestActiveDownloadState(unittest.TestCase):
             "enqueued_at": "2026-04-03T14:30:00+00:00",
             "last_progress_at": "2026-04-03T14:31:00+00:00",
             "processing_started_at": "2026-04-03T14:35:00+00:00",
+            "current_path": "/tmp/staged/bob/Album",
             "files": [
                 {"username": "bob", "filename": "bob\\Tunes\\01.mp3",
                  "file_dir": "bob\\Tunes", "size": 5000000, "retry_count": 1,
@@ -1191,6 +1194,7 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(state.enqueued_at, "2026-04-03T14:30:00+00:00")
         self.assertEqual(state.last_progress_at, "2026-04-03T14:31:00+00:00")
         self.assertEqual(state.processing_started_at, "2026-04-03T14:35:00+00:00")
+        self.assertEqual(state.current_path, "/tmp/staged/bob/Album")
         self.assertEqual(len(state.files), 2)
         self.assertEqual(state.files[0].username, "bob")
         self.assertEqual(state.files[0].retry_count, 1)
@@ -1211,6 +1215,7 @@ class TestActiveDownloadState(unittest.TestCase):
             enqueued_at="2026-04-03T12:00:00+00:00",
             last_progress_at="2026-04-03T12:01:00+00:00",
             processing_started_at="2026-04-03T12:02:00+00:00",
+            current_path="/tmp/staged/user1/Album",
             files=[
                 ActiveDownloadFileState(
                     username="user1", filename="user1\\Music\\01.flac",
@@ -1225,6 +1230,7 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(restored.enqueued_at, original.enqueued_at)
         self.assertEqual(restored.last_progress_at, original.last_progress_at)
         self.assertEqual(restored.processing_started_at, original.processing_started_at)
+        self.assertEqual(restored.current_path, original.current_path)
         self.assertEqual(len(restored.files), 1)
         self.assertEqual(restored.files[0].username, "user1")
         self.assertEqual(restored.files[0].disk_no, 2)
@@ -1243,12 +1249,20 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(f.username, "alice")
         self.assertEqual(f.filename, "alice\\Music\\track.flac")
         self.assertEqual(f.file_dir, "alice\\Music")
-        self.assertEqual(f.size, 25000000)
-        self.assertIsNone(f.disk_no)
-        self.assertIsNone(f.disk_count)
-        self.assertEqual(f.retry_count, 0)
-        self.assertEqual(f.bytes_transferred, 0)
-        self.assertIsNone(f.last_state)
+
+    def test_active_download_state_missing_current_path_defaults_none(self):
+        """Pre-refactor rows without current_path still deserialize."""
+        from lib.quality import ActiveDownloadState
+        raw = json.dumps({
+            "filetype": "flac",
+            "enqueued_at": "2026-04-03T12:00:00+00:00",
+            "files": [],
+        })
+        state = ActiveDownloadState.from_json(raw)
+        self.assertIsNone(state.current_path)
+        self.assertEqual(state.filetype, "flac")
+        self.assertEqual(state.enqueued_at, "2026-04-03T12:00:00+00:00")
+        self.assertEqual(state.files, [])
 
     def test_active_download_state_enqueued_at_iso(self):
         """Verify ISO8601 datetime format."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1729,15 +1729,6 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         ))
 
         from tests.helpers import make_ctx_with_fake_db
-        cfg = CratediggerConfig(
-            beets_harness_path=_HARNESS,
-            pipeline_db_enabled=True,
-            beets_distance_threshold=0.15,
-            beets_staging_dir=os.path.join(
-                tempfile.gettempdir(),
-                "unused-beets-staging",
-            ),
-        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             processing_dir = os.path.join(tmpdir, "processing")

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1836,6 +1836,80 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
             mock_dispatch.assert_called_once()
             self.assertEqual(mock_dispatch.call_args.args[2], staged_path)
 
+    def test_auto_path_not_blocked_when_processing_dir_is_under_staging_root(self):
+        """The duplicate-import guard must not quarantine the source processing dir."""
+        from lib import download as dl_mod
+        from lib.import_dispatch import DispatchOutcome
+        from lib.quality import ValidationResult
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id=self.MBID,
+            status="downloading",
+            active_download_state={
+                "filetype": "mp3",
+                "enqueued_at": "2026-04-03T12:00:00+00:00",
+                "files": [],
+                "current_path": None,
+            },
+        ))
+
+        from tests.helpers import make_ctx_with_fake_db
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "beets-staging")
+            processing_dir = os.path.join(staging_root, "downloads", "processing")
+            os.makedirs(processing_dir)
+            with open(os.path.join(processing_dir, "01 - Track.mp3"), "w") as fp:
+                fp.write("fake audio")
+
+            cfg = CratediggerConfig(
+                beets_harness_path=_HARNESS,
+                pipeline_db_enabled=True,
+                beets_distance_threshold=0.15,
+                beets_staging_dir=staging_root,
+                slskd_download_dir=os.path.join(staging_root, "downloads"),
+            )
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            entry = dl_mod.GrabListEntry(
+                album_id=42,
+                artist="Test Artist",
+                title="Test Album",
+                year="2006",
+                files=[],
+                filetype="mp3",
+                mb_release_id=self.MBID,
+                db_source="request",
+                db_request_id=42,
+                import_folder=processing_dir,
+            )
+            staged_album = dl_mod.StagedAlbum.from_entry(
+                entry,
+                default_path=processing_dir,
+            )
+            bv_result = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+
+            with patch.object(
+                dl_mod,
+                "dispatch_import",
+                return_value=DispatchOutcome(success=True, message="ok"),
+            ) as mock_dispatch:
+                outcome = dl_mod._handle_valid_result(
+                    entry,
+                    bv_result,
+                    staged_album,
+                    ctx,
+                )
+
+            assert outcome is not None
+            self.assertTrue(outcome.success)
+            mock_dispatch.assert_called_once()
+
 
 class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
     """The ``process_completed_album`` 3-way return → state-transition seam.

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1583,10 +1583,10 @@ class TestReleaseLockContention(unittest.TestCase):
 
 class TestHandleValidResultReleaseLock(unittest.TestCase):
     """Issue #132 P1 + Codex PR #136 R4 P1: release-lock acquisition
-    must happen BEFORE ``stage_to_ai`` so the filesystem stays
+    must happen BEFORE the staged move so the filesystem stays
     resumable on contention.
 
-    Pre-R4: ``_handle_valid_result`` called ``stage_to_ai`` first,
+    Pre-R4: ``_handle_valid_result`` staged into beets first,
     then invoked ``dispatch_import_core`` which checked the lock inside
     ``dispatch_import_core``. On contention, files had already moved
     from ``slskd_download_dir/<import_folder>/`` →
@@ -1597,7 +1597,8 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
     ``status='wanted'`` — breaking the contention-retry contract.
 
     Post-R4: ``_handle_valid_result`` acquires the lock BEFORE
-    ``stage_to_ai``. On contention, return deferred without staging;
+    ``StagedAlbum.move_to``. On contention, return deferred without any
+    path change;
     files stay at ``slskd_download_dir/<import_folder>/`` where
     ``process_completed_album``'s resume guard (``if os.path.exists(
     dst_file) and not os.path.exists(src_file): continue``) picks
@@ -1641,7 +1642,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         bv_result = ValidationResult(
             valid=True, distance=0.05, scenario="strong_match")
 
-        # stage_to_ai and dispatch_import_core MUST NOT run on contention.
+        # The staged move and dispatch MUST NOT run on contention.
         import_folder_fullpath = "/tmp/test-import-folder"
         with patch.object(dl_mod.StagedAlbum, "move_to") as mock_move, \
              patch.object(dl_mod, "dispatch_import_core") as mock_dispatch:

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1821,8 +1821,9 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
             self.assertTrue(outcome.success)
             staged_path = os.path.join(
                 cfg.beets_staging_dir,
+                "auto-import",
                 "Test Artist",
-                "Test Album",
+                "Test Album [request-42]",
             )
             self.assertEqual(staged_album.current_path, staged_path)
             self.assertTrue(os.path.exists(os.path.join(staged_path, "01 - Track.mp3")))

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9,6 +9,7 @@ and _check_quality_gate_core run for real, not patched.
 """
 
 import os
+from contextlib import contextmanager
 import tempfile
 import unittest
 from types import SimpleNamespace
@@ -1714,6 +1715,8 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
     def test_auto_path_persists_current_path_after_staging(self):
         from lib import download as dl_mod
         from lib.import_dispatch import DispatchOutcome
+        from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
+                                     release_id_to_lock_key)
         from lib.quality import ValidationResult
 
         db = FakePipelineDB()
@@ -1766,12 +1769,47 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
                 distance=0.05,
                 scenario="strong_match",
             )
+            move_saw_release_lock = False
+
+            original_advisory_lock = db.advisory_lock
+
+            @contextmanager
+            def tracking_advisory_lock(namespace: int, key: int):
+                nonlocal move_saw_release_lock
+                with original_advisory_lock(namespace, key) as acquired:
+                    if (
+                        acquired
+                        and namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
+                        and key == release_id_to_lock_key(self.MBID)
+                    ):
+                        move_saw_release_lock = True
+                        try:
+                            yield acquired
+                        finally:
+                            move_saw_release_lock = False
+                    else:
+                        yield acquired
+
+            original_move_to = dl_mod.StagedAlbum.move_to
+
+            def checked_move_to(album, dest, db=None):
+                self.assertTrue(move_saw_release_lock)
+                return original_move_to(album, dest, db)
 
             with patch.object(
                 dl_mod,
                 "dispatch_import",
                 return_value=DispatchOutcome(success=True, message="ok"),
-            ) as mock_dispatch:
+            ) as mock_dispatch, patch.object(
+                db,
+                "advisory_lock",
+                side_effect=tracking_advisory_lock,
+            ), patch.object(
+                dl_mod.StagedAlbum,
+                "move_to",
+                autospec=True,
+                side_effect=checked_move_to,
+            ):
                 outcome = dl_mod._handle_valid_result(
                     entry,
                     bv_result,
@@ -1789,6 +1827,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
             self.assertEqual(staged_album.current_path, staged_path)
             self.assertTrue(os.path.exists(os.path.join(staged_path, "01 - Track.mp3")))
             self.assertFalse(os.path.exists(processing_dir))
+            self.assertFalse(move_saw_release_lock)
             self.assertEqual(
                 db.request(42)["active_download_state"]["current_path"],
                 staged_path,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1798,7 +1798,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
 
             with patch.object(
                 dl_mod,
-                "dispatch_import",
+                "dispatch_import_core",
                 return_value=DispatchOutcome(success=True, message="ok"),
             ) as mock_dispatch, patch.object(
                 db,
@@ -1834,7 +1834,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
                 staged_path,
             )
             mock_dispatch.assert_called_once()
-            self.assertEqual(mock_dispatch.call_args.args[2], staged_path)
+            self.assertEqual(mock_dispatch.call_args.kwargs["path"], staged_path)
 
     def test_auto_path_not_blocked_when_processing_dir_is_under_staging_root(self):
         """The duplicate-import guard must not quarantine the source processing dir."""
@@ -1896,7 +1896,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
 
             with patch.object(
                 dl_mod,
-                "dispatch_import",
+                "dispatch_import_core",
                 return_value=DispatchOutcome(success=True, message="ok"),
             ) as mock_dispatch:
                 outcome = dl_mod._handle_valid_result(

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1643,10 +1643,17 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
 
         # stage_to_ai and dispatch_import_core MUST NOT run on contention.
         import_folder_fullpath = "/tmp/test-import-folder"
-        with patch.object(dl_mod, "stage_to_ai") as mock_stage, \
+        with patch.object(dl_mod.StagedAlbum, "move_to") as mock_move, \
              patch.object(dl_mod, "dispatch_import_core") as mock_dispatch:
             outcome = dl_mod._handle_valid_result(
-                entry, bv_result, import_folder_fullpath, ctx)
+                entry,
+                bv_result,
+                dl_mod.StagedAlbum(
+                    current_path=import_folder_fullpath,
+                    request_id=42,
+                ),
+                ctx,
+            )
 
         assert outcome is not None
         self.assertTrue(outcome.deferred)
@@ -1654,7 +1661,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         # **Critical**: staging never ran — files stay at
         # import_folder_fullpath where process_completed_album's
         # resume guard can pick them up next cycle.
-        mock_stage.assert_not_called()
+        mock_move.assert_not_called()
         mock_dispatch.assert_not_called()
 
     def test_redownload_path_does_not_take_release_lock(self):
@@ -1690,14 +1697,112 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         bv_result = ValidationResult(
             valid=True, distance=0.05, scenario="strong_match")
 
-        with patch.object(dl_mod, "stage_to_ai",
+        with patch.object(dl_mod.StagedAlbum, "move_to",
                           return_value="/tmp/staged"):
             dl_mod._handle_valid_result(
-                entry, bv_result, "/tmp/import", ctx)
+                entry,
+                bv_result,
+                dl_mod.StagedAlbum(current_path="/tmp/import", request_id=42),
+                ctx,
+            )
 
         # No RELEASE-namespace lock call — redownload path skips it.
         namespaces_used = {ns for ns, _key in db.advisory_lock_calls}
         self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
+
+    def test_auto_path_persists_current_path_after_staging(self):
+        from lib import download as dl_mod
+        from lib.import_dispatch import DispatchOutcome
+        from lib.quality import ValidationResult
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id=self.MBID,
+            status="downloading",
+            active_download_state={
+                "filetype": "mp3",
+                "enqueued_at": "2026-04-03T12:00:00+00:00",
+                "files": [],
+                "current_path": None,
+            },
+        ))
+
+        from tests.helpers import make_ctx_with_fake_db
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            beets_distance_threshold=0.15,
+            beets_staging_dir=os.path.join(
+                tempfile.gettempdir(),
+                "unused-beets-staging",
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processing_dir = os.path.join(tmpdir, "processing")
+            os.makedirs(processing_dir)
+            track_path = os.path.join(processing_dir, "01 - Track.mp3")
+            with open(track_path, "w") as fp:
+                fp.write("fake audio")
+
+            cfg = CratediggerConfig(
+                beets_harness_path=_HARNESS,
+                pipeline_db_enabled=True,
+                beets_distance_threshold=0.15,
+                beets_staging_dir=os.path.join(tmpdir, "beets-staging"),
+            )
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            entry = dl_mod.GrabListEntry(
+                album_id=42,
+                artist="Test Artist",
+                title="Test Album",
+                year="2006",
+                files=[],
+                filetype="mp3",
+                mb_release_id=self.MBID,
+                db_source="request",
+                db_request_id=42,
+                import_folder=processing_dir,
+            )
+            staged_album = dl_mod.StagedAlbum.from_entry(
+                entry,
+                default_path=processing_dir,
+            )
+            bv_result = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+
+            with patch.object(
+                dl_mod,
+                "dispatch_import",
+                return_value=DispatchOutcome(success=True, message="ok"),
+            ) as mock_dispatch:
+                outcome = dl_mod._handle_valid_result(
+                    entry,
+                    bv_result,
+                    staged_album,
+                    ctx,
+                )
+
+            assert outcome is not None
+            self.assertTrue(outcome.success)
+            staged_path = os.path.join(
+                cfg.beets_staging_dir,
+                "Test Artist",
+                "Test Album",
+            )
+            self.assertEqual(staged_album.current_path, staged_path)
+            self.assertTrue(os.path.exists(os.path.join(staged_path, "01 - Track.mp3")))
+            self.assertFalse(os.path.exists(processing_dir))
+            self.assertEqual(
+                db.request(42)["active_download_state"]["current_path"],
+                staged_path,
+            )
+            mock_dispatch.assert_called_once()
+            self.assertEqual(mock_dispatch.call_args.args[2], staged_path)
 
 
 class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1249,6 +1249,35 @@ class TestDownloadingStatus(unittest.TestCase):
         self.assertEqual(req["status"], "imported")
         self.assertIsNone(req["active_download_state"])
 
+    def test_update_download_state_current_path_noop_when_state_missing(self):
+        """update_download_state_current_path() must not fabricate a partial state."""
+        req_id = self.db.add_request(
+            mb_release_id="udscp-null-state-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        self.db.set_downloading(
+            req_id,
+            json.dumps({
+                "filetype": "flac",
+                "enqueued_at": "2026-04-03T12:00:00+00:00",
+                "files": [],
+            }),
+        )
+        self.db._execute(
+            "UPDATE album_requests SET active_download_state = NULL WHERE id = %s",
+            (req_id,),
+        )
+        self.db.conn.commit()
+
+        self.db.update_download_state_current_path(req_id, "/tmp/staged")
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["status"], "downloading")
+        self.assertIsNone(req["active_download_state"])
+
     def test_clear_download_state(self):
         """clear_download_state() nulls the JSONB column."""
         req_id = self.db.add_request(

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1197,6 +1197,33 @@ class TestDownloadingStatus(unittest.TestCase):
         assert ads is not None
         self.assertEqual(ads["processing_started_at"], "2026-04-03T12:05:00+00:00")
 
+    def test_update_download_state_current_path(self):
+        """update_download_state_current_path() rewrites only the path field."""
+        req_id = self.db.add_request(
+            mb_release_id="udscp-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        self.db.set_downloading(
+            req_id,
+            json.dumps({
+                "filetype": "flac",
+                "enqueued_at": "2026-04-03T12:00:00+00:00",
+                "files": [],
+            }),
+        )
+
+        self.db.update_download_state_current_path(req_id, "/tmp/staged")
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["status"], "downloading")
+        ads = req["active_download_state"]
+        assert ads is not None
+        self.assertEqual(ads["current_path"], "/tmp/staged")
+        self.assertEqual(ads["filetype"], "flac")
+
     def test_clear_download_state(self):
         """clear_download_state() nulls the JSONB column."""
         req_id = self.db.add_request(

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1224,6 +1224,31 @@ class TestDownloadingStatus(unittest.TestCase):
         self.assertEqual(ads["current_path"], "/tmp/staged")
         self.assertEqual(ads["filetype"], "flac")
 
+    def test_update_download_state_current_path_noop_when_not_downloading(self):
+        """update_download_state_current_path() does not recreate cleared state."""
+        req_id = self.db.add_request(
+            mb_release_id="udscp-noop-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        self.db.set_downloading(
+            req_id,
+            json.dumps({
+                "filetype": "flac",
+                "enqueued_at": "2026-04-03T12:00:00+00:00",
+                "files": [],
+            }),
+        )
+        self.db.update_status(req_id, "imported")
+
+        self.db.update_download_state_current_path(req_id, "/tmp/staged")
+
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["status"], "imported")
+        self.assertIsNone(req["active_download_state"])
+
     def test_clear_download_state(self):
         """clear_download_state() nulls the JSONB column."""
         req_id = self.db.add_request(

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -143,6 +143,17 @@ class TestFindOrphanedDownloads(unittest.TestCase):
         issues = find_orphaned_downloads(rows, set())
         self.assertEqual(len(issues), 0)
 
+    def test_processing_started_without_current_path_is_still_orphaned(self):
+        """Rows that never persisted a local path should still be repairable."""
+        rows = [{"id": 1, "status": "downloading",
+                 "active_download_state": {
+                     "filetype": "flac",
+                     "processing_started_at": "2026-04-22T00:00:00+00:00",
+                     "files": [{"username": "user1", "filename": "track.flac"}]}}]
+        issues = find_orphaned_downloads(rows, set())
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].issue_type, "orphaned_download")
+
     def test_suggest_repair_orphaned(self):
         """Orphaned download should suggest reset_to_wanted."""
         issue = OrphanInfo(request_id=1, issue_type="orphaned_download",

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -162,14 +162,27 @@ class TestFindOrphanedDownloads(unittest.TestCase):
     def test_reports_missing_local_processing_path_for_manual_review(self):
         """Blocked post-move rows should be surfaced to repair tooling."""
         rows = [{"id": 1, "status": "downloading",
+                 "artist_name": "Test",
+                 "album_title": "Album",
+                 "year": 2026,
                  "active_download_state": {
                      "filetype": "flac",
                      "processing_started_at": "2026-04-22T00:00:00+00:00",
                      "current_path": "/tmp/staging/auto-import/Test/Album [request-1]",
                      "files": [{"username": "user1", "filename": "track.flac"}]}}]
-        issues = find_orphaned_downloads(rows, set(), existing_local_paths=set())
+        issues = find_orphaned_downloads(
+            rows,
+            set(),
+            existing_local_paths=set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].issue_type, "blocked_post_move")
+        self.assertIn(
+            "request-scoped auto-import staged path",
+            issues[0].detail,
+        )
 
     def test_suggest_repair_orphaned(self):
         """Orphaned download should suggest reset_to_wanted."""

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -134,13 +134,18 @@ class TestFindOrphanedDownloads(unittest.TestCase):
 
     def test_skips_local_processing_rows_without_active_transfers(self):
         """Rows already in local processing are not orphaned downloads."""
+        current_path = "/tmp/staging/auto-import/Test/Album [request-1]"
         rows = [{"id": 1, "status": "downloading",
                  "active_download_state": {
                      "filetype": "flac",
                      "processing_started_at": "2026-04-22T00:00:00+00:00",
-                     "current_path": "/tmp/staging/auto-import/Test/Album [request-1]",
+                     "current_path": current_path,
                      "files": [{"username": "user1", "filename": "track.flac"}]}}]
-        issues = find_orphaned_downloads(rows, set())
+        issues = find_orphaned_downloads(
+            rows,
+            set(),
+            existing_local_paths={current_path},
+        )
         self.assertEqual(len(issues), 0)
 
     def test_processing_started_without_current_path_is_still_orphaned(self):
@@ -154,12 +159,33 @@ class TestFindOrphanedDownloads(unittest.TestCase):
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].issue_type, "orphaned_download")
 
+    def test_reports_missing_local_processing_path_for_manual_review(self):
+        """Blocked post-move rows should be surfaced to repair tooling."""
+        rows = [{"id": 1, "status": "downloading",
+                 "active_download_state": {
+                     "filetype": "flac",
+                     "processing_started_at": "2026-04-22T00:00:00+00:00",
+                     "current_path": "/tmp/staging/auto-import/Test/Album [request-1]",
+                     "files": [{"username": "user1", "filename": "track.flac"}]}}]
+        issues = find_orphaned_downloads(rows, set(), existing_local_paths=set())
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].issue_type, "blocked_post_move")
+
     def test_suggest_repair_orphaned(self):
         """Orphaned download should suggest reset_to_wanted."""
         issue = OrphanInfo(request_id=1, issue_type="orphaned_download",
                            detail="transfers gone")
         action = suggest_repair(issue)
         self.assertEqual(action.action, "reset_to_wanted")
+
+    def test_suggest_repair_blocked_post_move(self):
+        issue = OrphanInfo(
+            request_id=1,
+            issue_type="blocked_post_move",
+            detail="missing staged path",
+        )
+        action = suggest_repair(issue)
+        self.assertEqual(action.action, "manual_review")
 
 
 class TestSuggestRepair(unittest.TestCase):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -132,6 +132,17 @@ class TestFindOrphanedDownloads(unittest.TestCase):
         issues = find_orphaned_downloads(rows, active)
         self.assertEqual(len(issues), 0)
 
+    def test_skips_local_processing_rows_without_active_transfers(self):
+        """Rows already in local processing are not orphaned downloads."""
+        rows = [{"id": 1, "status": "downloading",
+                 "active_download_state": {
+                     "filetype": "flac",
+                     "processing_started_at": "2026-04-22T00:00:00+00:00",
+                     "current_path": "/tmp/staging/auto-import/Test/Album [request-1]",
+                     "files": [{"username": "user1", "filename": "track.flac"}]}}]
+        issues = find_orphaned_downloads(rows, set())
+        self.assertEqual(len(issues), 0)
+
     def test_suggest_repair_orphaned(self):
         """Orphaned download should suggest reset_to_wanted."""
         issue = OrphanInfo(request_id=1, issue_type="orphaned_download",

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -148,16 +148,15 @@ class TestFindOrphanedDownloads(unittest.TestCase):
         )
         self.assertEqual(len(issues), 0)
 
-    def test_processing_started_without_current_path_is_still_orphaned(self):
-        """Rows that never persisted a local path should still be repairable."""
+    def test_processing_started_without_current_path_is_not_orphaned(self):
+        """Recovery-owned rows must not be reset ahead of poll recovery."""
         rows = [{"id": 1, "status": "downloading",
                  "active_download_state": {
                      "filetype": "flac",
                      "processing_started_at": "2026-04-22T00:00:00+00:00",
                      "files": [{"username": "user1", "filename": "track.flac"}]}}]
         issues = find_orphaned_downloads(rows, set())
-        self.assertEqual(len(issues), 1)
-        self.assertEqual(issues[0].issue_type, "orphaned_download")
+        self.assertEqual(issues, [])
 
     def test_reports_missing_local_processing_path_for_manual_review(self):
         """Blocked post-move rows should be surfaced to repair tooling."""

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -90,7 +90,7 @@ class TestFindOrphanedDownloads(unittest.TestCase):
                      "filetype": "flac",
                      "files": [{"username": "user1", "filename": "track.flac"}]}}]
         active = set()  # no active transfers
-        issues = find_orphaned_downloads(rows, active)
+        issues = find_orphaned_downloads(rows, active, existing_local_paths=None)
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].issue_type, "orphaned_download")
         self.assertEqual(issues[0].request_id, 1)
@@ -102,21 +102,21 @@ class TestFindOrphanedDownloads(unittest.TestCase):
                      "filetype": "flac",
                      "files": [{"username": "user1", "filename": "track.flac"}]}}]
         active = {("user1", "track.flac")}
-        issues = find_orphaned_downloads(rows, active)
+        issues = find_orphaned_downloads(rows, active, existing_local_paths=None)
         self.assertEqual(len(issues), 0)
 
     def test_skips_non_downloading_rows(self):
         """Only downloading rows should be checked."""
         rows = [{"id": 1, "status": "wanted",
                  "active_download_state": None}]
-        issues = find_orphaned_downloads(rows, set())
+        issues = find_orphaned_downloads(rows, set(), existing_local_paths=None)
         self.assertEqual(len(issues), 0)
 
     def test_skips_downloading_without_state(self):
         """corrupt_downloading (no state) handled by find_inconsistencies."""
         rows = [{"id": 1, "status": "downloading",
                  "active_download_state": None}]
-        issues = find_orphaned_downloads(rows, set())
+        issues = find_orphaned_downloads(rows, set(), existing_local_paths=None)
         self.assertEqual(len(issues), 0)
 
     def test_partial_match_not_orphaned(self):
@@ -129,7 +129,7 @@ class TestFindOrphanedDownloads(unittest.TestCase):
                          {"username": "user1", "filename": "02.flac"},
                      ]}}]
         active = {("user1", "02.flac")}  # only 1 of 2 still active
-        issues = find_orphaned_downloads(rows, active)
+        issues = find_orphaned_downloads(rows, active, existing_local_paths=None)
         self.assertEqual(len(issues), 0)
 
     def test_skips_local_processing_rows_without_active_transfers(self):
@@ -155,7 +155,7 @@ class TestFindOrphanedDownloads(unittest.TestCase):
                      "filetype": "flac",
                      "processing_started_at": "2026-04-22T00:00:00+00:00",
                      "files": [{"username": "user1", "filename": "track.flac"}]}}]
-        issues = find_orphaned_downloads(rows, set())
+        issues = find_orphaned_downloads(rows, set(), existing_local_paths=None)
         self.assertEqual(issues, [])
 
     def test_reports_missing_local_processing_path_for_manual_review(self):
@@ -173,15 +173,10 @@ class TestFindOrphanedDownloads(unittest.TestCase):
             rows,
             set(),
             existing_local_paths=set(),
-            staging_dir="/tmp/staging",
-            slskd_download_dir="/tmp/downloads",
         )
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].issue_type, "blocked_post_move")
-        self.assertIn(
-            "request-scoped auto-import staged path",
-            issues[0].detail,
-        )
+        self.assertIn("persisted processing path missing", issues[0].detail)
 
     def test_suggest_repair_orphaned(self):
         """Orphaned download should suggest reset_to_wanted."""

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -200,6 +200,15 @@ class TestFindOrphanedDownloads(unittest.TestCase):
         action = suggest_repair(issue)
         self.assertEqual(action.action, "manual_review")
 
+    def test_suggest_repair_blocked_recovery(self):
+        issue = OrphanInfo(
+            request_id=1,
+            issue_type="blocked_recovery",
+            detail="ambiguous legacy shared staged path",
+        )
+        action = suggest_repair(issue)
+        self.assertEqual(action.action, "manual_review")
+
 
 class TestSuggestRepair(unittest.TestCase):
     """Map issues to repair actions."""

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -16,7 +16,7 @@ from scripts import repair
 
 
 class TestCmdFix(unittest.TestCase):
-    @patch("scripts.repair._transition_request")
+    @patch("scripts.repair.transition_request")
     @patch("scripts.repair._collect_issues")
     def test_reset_to_wanted_routes_through_shared_finalizer(
         self,

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -81,6 +81,34 @@ class TestStagedAlbum(unittest.TestCase):
                 target,
             )
 
+    def test_move_to_rolls_back_when_db_persist_fails(self):
+        from lib.staged_album import StagedAlbum
+
+        class ExplodingDB:
+            def update_download_state_current_path(
+                self,
+                request_id: int,
+                current_path: str | None,
+            ) -> None:
+                raise RuntimeError("db boom")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "source")
+            os.makedirs(source)
+            source_file = os.path.join(source, "track.mp3")
+            with open(source_file, "w") as fp:
+                fp.write("audio")
+
+            dest = os.path.join(tmpdir, "staging", "Artist", "Album")
+            staged_album = StagedAlbum(current_path=source, request_id=42)
+
+            with self.assertRaisesRegex(RuntimeError, "db boom"):
+                staged_album.move_to(dest, ExplodingDB())
+
+            self.assertEqual(staged_album.current_path, source)
+            self.assertTrue(os.path.exists(source_file))
+            self.assertFalse(os.path.exists(os.path.join(dest, "track.mp3")))
+
     def test_persist_current_path_noop_without_request_id(self):
         from lib.staged_album import StagedAlbum
 

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -11,7 +11,7 @@ from tests.helpers import make_download_file, make_request_row
 class TestStageToAiPath(unittest.TestCase):
 
     def test_sanitizes_artist_and_title(self):
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
 
         dest = stage_to_ai_path(
             artist='Test: "Artist"',
@@ -22,7 +22,7 @@ class TestStageToAiPath(unittest.TestCase):
         self.assertEqual(dest, "/tmp/staging/Test Artist/AlbumTitle")
 
     def test_scopes_auto_import_paths_by_request_id(self):
-        from lib.staged_album import stage_to_ai_path
+        from lib.processing_paths import stage_to_ai_path
 
         dest = stage_to_ai_path(
             artist="Test Artist",

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -1,0 +1,126 @@
+"""Tests for ``lib/staged_album.py``."""
+
+import os
+import tempfile
+import unittest
+
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_download_file, make_request_row
+
+
+class TestStageToAiPath(unittest.TestCase):
+
+    def test_sanitizes_artist_and_title(self):
+        from lib.staged_album import stage_to_ai_path
+
+        dest = stage_to_ai_path(
+            artist='Test: "Artist"',
+            title="Album/Title?",
+            staging_dir="/tmp/staging",
+        )
+
+        self.assertEqual(dest, "/tmp/staging/Test Artist/AlbumTitle")
+
+
+class TestStagedAlbum(unittest.TestCase):
+
+    def test_move_to_moves_contents_and_updates_db(self):
+        from lib.staged_album import StagedAlbum
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={"filetype": "mp3", "files": []},
+        ))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "source")
+            os.makedirs(source)
+            with open(os.path.join(source, "track.mp3"), "w") as fp:
+                fp.write("audio")
+
+            dest = os.path.join(tmpdir, "staging", "Artist", "Album")
+            staged_album = StagedAlbum(current_path=source, request_id=42)
+
+            result = staged_album.move_to(dest, db)
+
+            self.assertEqual(result, dest)
+            self.assertEqual(staged_album.current_path, dest)
+            self.assertTrue(os.path.exists(os.path.join(dest, "track.mp3")))
+            self.assertFalse(os.path.exists(source))
+            self.assertEqual(
+                db.request(42)["active_download_state"]["current_path"],
+                dest,
+            )
+
+    def test_move_to_idempotent_when_source_equals_target(self):
+        from lib.staged_album import StagedAlbum
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={"filetype": "mp3", "files": []},
+        ))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "staging")
+            os.makedirs(target)
+            with open(os.path.join(target, "track.mp3"), "w") as fp:
+                fp.write("audio")
+
+            staged_album = StagedAlbum(current_path=target, request_id=42)
+
+            result = staged_album.move_to(target, db)
+
+            self.assertEqual(result, target)
+            self.assertTrue(os.path.exists(os.path.join(target, "track.mp3")))
+            self.assertEqual(
+                db.request(42)["active_download_state"]["current_path"],
+                target,
+            )
+
+    def test_persist_current_path_noop_without_request_id(self):
+        from lib.staged_album import StagedAlbum
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={"filetype": "mp3", "files": []},
+        ))
+
+        StagedAlbum(current_path="/tmp/staged").persist_current_path(db)
+
+        self.assertNotIn(
+            "current_path",
+            db.request(42)["active_download_state"],
+        )
+
+    def test_persist_current_path_noop_without_db(self):
+        from lib.staged_album import StagedAlbum
+
+        staged_album = StagedAlbum(current_path="/tmp/staged", request_id=42)
+
+        staged_album.persist_current_path(None)
+
+        self.assertEqual(staged_album.current_path, "/tmp/staged")
+
+    def test_bind_import_paths_updates_multi_disc_names(self):
+        from lib.staged_album import StagedAlbum
+
+        file = make_download_file(
+            filename="user1\\CD2\\01 - Track.flac",
+            file_dir="user1\\CD2",
+        )
+        file.disk_no = 2
+        file.disk_count = 3
+        staged_album = StagedAlbum(current_path="/tmp/staged")
+
+        staged_album.bind_import_paths([file])
+
+        self.assertEqual(
+            file.import_path,
+            "/tmp/staged/Disk 2 - 01 - Track.flac",
+        )

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -21,6 +21,22 @@ class TestStageToAiPath(unittest.TestCase):
 
         self.assertEqual(dest, "/tmp/staging/Test Artist/AlbumTitle")
 
+    def test_scopes_auto_import_paths_by_request_id(self):
+        from lib.staged_album import stage_to_ai_path
+
+        dest = stage_to_ai_path(
+            artist="Test Artist",
+            title="Album",
+            staging_dir="/tmp/staging",
+            request_id=42,
+            auto_import=True,
+        )
+
+        self.assertEqual(
+            dest,
+            "/tmp/staging/auto-import/Test Artist/Album [request-42]",
+        )
+
 
 class TestStagedAlbum(unittest.TestCase):
 

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -109,6 +109,18 @@ class TestStagedAlbum(unittest.TestCase):
             self.assertTrue(os.path.exists(source_file))
             self.assertFalse(os.path.exists(os.path.join(dest, "track.mp3")))
 
+    def test_move_to_cleans_empty_target_on_early_failure(self):
+        from lib.staged_album import StagedAlbum
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "missing")
+            dest = os.path.join(tmpdir, "staging", "Artist", "Album")
+
+            with self.assertRaises(FileNotFoundError):
+                StagedAlbum(current_path=source).move_to(dest)
+
+            self.assertFalse(os.path.exists(dest))
+
     def test_persist_current_path_noop_without_request_id(self):
         from lib.staged_album import StagedAlbum
 

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -125,6 +125,35 @@ class TestStagedAlbum(unittest.TestCase):
             self.assertTrue(os.path.exists(source_file))
             self.assertFalse(os.path.exists(os.path.join(dest, "track.mp3")))
 
+    def test_move_to_persists_before_removing_source(self):
+        from lib.staged_album import StagedAlbum
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "source")
+            os.makedirs(source)
+            with open(os.path.join(source, "track.mp3"), "w") as fp:
+                fp.write("audio")
+
+            dest = os.path.join(tmpdir, "staging", "Artist", "Album")
+            saw_source_during_persist = False
+
+            class InspectingDB:
+                def update_download_state_current_path(
+                    self,
+                    request_id: int,
+                    current_path: str | None,
+                ) -> None:
+                    nonlocal saw_source_during_persist
+                    saw_source_during_persist = os.path.isdir(source)
+
+            staged_album = StagedAlbum(current_path=source, request_id=42)
+
+            result = staged_album.move_to(dest, InspectingDB())
+
+            self.assertEqual(result, dest)
+            self.assertTrue(saw_source_during_persist)
+            self.assertFalse(os.path.exists(source))
+
     def test_move_to_cleans_empty_target_on_early_failure(self):
         from lib.staged_album import StagedAlbum
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -130,33 +130,6 @@ class TestMoveFailedImport(unittest.TestCase):
         assert result is not None
         self.assertNotIn("bad_files", result)
 
-
-class TestStageToAi(unittest.TestCase):
-
-    def test_moves_files_to_staging(self):
-        from lib.util import stage_to_ai
-        tmpdir = tempfile.mkdtemp()
-        try:
-            source = os.path.join(tmpdir, "source")
-            staging = os.path.join(tmpdir, "staging")
-            os.makedirs(source)
-            os.makedirs(staging)
-            open(os.path.join(source, "track1.mp3"), "w").close()
-            open(os.path.join(source, "track2.mp3"), "w").close()
-
-            album_data = MagicMock()
-            album_data.artist = "Artist"
-            album_data.title = "Album"
-
-            dest = stage_to_ai(album_data, source, staging)
-            self.assertTrue(os.path.isdir(dest))
-            self.assertTrue(os.path.exists(os.path.join(dest, "track1.mp3")))
-            self.assertTrue(os.path.exists(os.path.join(dest, "track2.mp3")))
-            self.assertFalse(os.path.exists(source))
-        finally:
-            shutil.rmtree(tmpdir, ignore_errors=True)
-
-
 class TestRepairMp3Headers(unittest.TestCase):
 
     def test_calls_mp3val_on_mp3_files(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -130,6 +130,7 @@ class TestMoveFailedImport(unittest.TestCase):
         assert result is not None
         self.assertNotIn("bad_files", result)
 
+
 class TestRepairMp3Headers(unittest.TestCase):
 
     def test_calls_mp3val_on_mp3_files(self):


### PR DESCRIPTION
## Summary

Refactors the active-download staging flow around a typed `StagedAlbum` seam so the filesystem location of a staged album and the DB record of that location stay in sync by construction.

Refs #138.

## What Changed

- introduced `lib/staged_album.py` as the owner of a staged album's current filesystem location and `active_download_state.current_path` persistence
- added `current_path` to `ActiveDownloadState` with backward-compatible handling for legacy rows where the field is absent
- migrated completed-download materialization and auto-import staging to flow through `StagedAlbum.move_to(...)`
- migrated resume/reconstruction logic to read the current location from persisted state instead of reconstructing it from stale Soulseek source paths
- centralized processing/staging path construction and classification in shared helpers
- split request auto-import staging and redownload/manual-review staging into distinct request-scoped paths under `/Incoming/auto-import` and `/Incoming/post-validation`
- hardened mid-process crash recovery, including recovery from stale canonical `current_path` rows when the files already live under the request-scoped staged path
- surfaced blocked legacy shared staged-path recovery to repair tooling while avoiding false positives for healthy in-flight auto-import rows
- updated docs to reflect the new staging model and lock/recovery behavior

## Why

PR #136 review caught a real correctness bug: files could be moved into beets staging while `album_requests.active_download_state` still pointed at the old local processing directory. On the next poll cycle, the pipeline could reconstruct stale paths, attempt to move from empty source paths, and break the contention/retry contract.

The earlier fix moved lock acquisition earlier, but the deeper problem was still structural: path ownership was implicit and spread across multiple call sites. This branch makes that coupling explicit, typed, and shared.

## User / Operator Impact

- request auto-import rows now persist the real mid-process location as they move through local processing and staging
- poll recovery resumes from the correct post-move directory instead of guessing from stale Soulseek file metadata
- legacy shared staged paths are treated as ambiguous and blocked for manual recovery rather than silently guessed
- `repair.py` can surface genuinely blocked staged-path rows for operator action without flagging healthy in-flight auto-import rows as broken

## Validation

- `nix-shell --run "python3 -m unittest tests.test_staged_album tests.test_download_recovery tests.test_download tests.test_repair tests.test_integration_slices -v"`
- `nix-shell --run "pyright lib/download.py lib/download_recovery.py lib/staged_album.py scripts/repair.py tests/test_download.py tests/test_download_recovery.py tests/test_staged_album.py tests/test_repair.py tests/test_integration_slices.py"`
- `nix-shell --run "bash scripts/run_tests.sh"`
  - full suite passed: `2185` tests, `OK (skipped=53)`

## Draft Status

This is intentionally a draft PR.

The code and test state are green, but the refactor workflow's final Claude partner-review step is still pending because the Claude account hit usage quota today. The plan is to run that final partner pass tomorrow and then decide on merge/deploy.