### PR TITLE
[codex] refactor: own the library album detail contract

### DIFF
--- a/tests/test_library_album_detail_service.py
+++ b/tests/test_library_album_detail_service.py
@@ -135,6 +135,16 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
                 target_format="lossless",
             ),
             download_history=[_history_row(
+                import_result={
+                    "version": 2,
+                    "decision": "import",
+                    "postflight": {
+                        "disambiguation_failure": {
+                            "reason": "timeout",
+                            "detail": "timeout after 120s",
+                        },
+                    },
+                },
                 validation_result={"detail": "distance too high"},
             )],
         )
@@ -153,6 +163,11 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
         self.assertTrue(detail.download_history[0].verdict)
         self.assertEqual(detail.download_history[0].actual_min_bitrate, 320)
         self.assertEqual(detail.download_history[0].slskd_bitrate, 320000)
+        self.assertEqual(detail.download_history[0].disambiguation_failure, "timeout")
+        self.assertEqual(
+            detail.download_history[0].disambiguation_detail,
+            "timeout after 120s",
+        )
         self.assertEqual(
             detail.download_history[0].validation_result,
             {"detail": "distance too high"},
@@ -187,6 +202,33 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
             detail.tracks[0].path,
             "/music/Test Artist/Test Album/01 Track 1.mp3",
         )
+        self.assertEqual(detail.download_history, [])
+
+    def test_build_library_album_detail_preserves_string_added_shape(self) -> None:
+        detail = build_library_album_detail(
+            detail_row=_beets_detail(added="2026-03-30T12:00:00+00:00"),
+            pipeline_request=None,
+            download_history=[],
+        )
+
+        self.assertEqual(detail.added, "2026-03-30T12:00:00+00:00")
+
+    def test_build_library_album_detail_handles_missing_beets_format_keys(self) -> None:
+        track_without_format = _track(track=2, title="Track 2")
+        del track_without_format["format"]
+        detail = build_library_album_detail(
+            detail_row=_beets_detail(
+                tracks=[_track(), track_without_format],
+                source="",
+                min_bitrate=None,
+            ),
+            pipeline_request=None,
+            download_history=[],
+        )
+
+        self.assertEqual(detail.formats, "MP3")
+        self.assertEqual(detail.min_bitrate, 320000)
+        self.assertIsNone(detail.tracks[1].format)
 
     def test_load_library_album_detail_resolves_discogs_request(self) -> None:
         fake_db = FakePipelineDB()
@@ -258,6 +300,43 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
         self.assertEqual(detail.mb_albumid, "fixture-release-1")
         self.assertEqual(detail.source, "unknown")
         self.assertEqual(detail.pipeline_id, 77)
+
+    def test_load_library_album_detail_prefers_mb_albumid_for_unknown_legacy_ids(self) -> None:
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=90,
+            mb_release_id="fixture-mb-id",
+            artist_name="Fixture Artist",
+            album_title="Fixture Album",
+            source="request",
+            status="wanted",
+        ))
+        fake_db.seed_request(make_request_row(
+            id=91,
+            mb_release_id="fixture-discogs-id",
+            artist_name="Fixture Artist",
+            album_title="Fixture Album",
+            source="request",
+            status="wanted",
+        ))
+        lookup = _StubLibraryLookup(_beets_detail(
+            album="Fixture Album",
+            artist="Fixture Artist",
+            mb_albumid="fixture-mb-id",
+            discogs_albumid="fixture-discogs-id",
+            source="unknown",
+        ))
+
+        detail = load_library_album_detail(
+            library_lookup=lookup,
+            pipeline_db=fake_db,
+            album_id=7,
+        )
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(detail.mb_albumid, "fixture-mb-id")
+        self.assertEqual(detail.pipeline_id, 90)
 
     def test_load_library_album_detail_preserves_string_history_json_blobs(self) -> None:
         fake_db = FakePipelineDB()

--- a/tests/test_library_album_detail_service.py
+++ b/tests/test_library_album_detail_service.py
@@ -144,6 +144,28 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
         self.assertEqual(detail.download_history[0].downloaded_label, "MP3 320")
         self.assertTrue(detail.download_history[0].verdict)
 
+    def test_build_library_album_detail_preserves_nullable_legacy_fields(self) -> None:
+        detail = build_library_album_detail(
+            detail_row=_beets_detail(
+                added=None,
+                tracks=[
+                    _track(
+                        disc=None,
+                        track=None,
+                        title=None,
+                    ),
+                ],
+            ),
+            pipeline_request=None,
+            download_history=[],
+        )
+
+        self.assertIsNone(detail.added)
+        self.assertEqual(len(detail.tracks), 1)
+        self.assertIsNone(detail.tracks[0].disc)
+        self.assertIsNone(detail.tracks[0].track)
+        self.assertIsNone(detail.tracks[0].title)
+
     def test_load_library_album_detail_resolves_discogs_request(self) -> None:
         fake_db = FakePipelineDB()
         fake_db.seed_request(make_request_row(

--- a/tests/test_library_album_detail_service.py
+++ b/tests/test_library_album_detail_service.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 import unittest
 
@@ -19,6 +20,8 @@ RELEASE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
 def _track(**overrides: object) -> dict[str, object]:
     track: dict[str, object] = {
+        "id": 11,
+        "artist": "Test Artist",
         "disc": 1,
         "track": 1,
         "title": "Track 1",
@@ -27,6 +30,7 @@ def _track(**overrides: object) -> dict[str, object]:
         "bitrate": 320000,
         "samplerate": 44100,
         "bitdepth": 16,
+        "path": "/music/Test Artist/Test Album/01 Track 1.mp3",
     }
     track.update(overrides)
     return track
@@ -43,6 +47,7 @@ def _beets_detail(**overrides: object) -> dict[str, object]:
         "label": "Test Label",
         "country": "US",
         "added": 1773651901.0,
+        "artpath": "/music/Test Artist/Test Album/cover.jpg",
         "tracks": [_track(), _track(track=2, title="Track 2")],
         "path": "/music/Test Artist/Test Album",
         "source": "musicbrainz",
@@ -71,6 +76,7 @@ def _history_row(**overrides: object) -> dict[str, object]:
         "existing_spectral_bitrate": None,
         "import_result": None,
         "validation_result": None,
+        "source": "request",
     }
     row.update(overrides)
     return row
@@ -128,7 +134,9 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
                 search_filetype_override="flac",
                 target_format="lossless",
             ),
-            download_history=[_history_row()],
+            download_history=[_history_row(
+                validation_result={"detail": "distance too high"},
+            )],
         )
 
         self.assertEqual(detail.pipeline_id, 42)
@@ -143,6 +151,13 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
         self.assertEqual(detail.download_history[0].beets_scenario, "strong_match")
         self.assertEqual(detail.download_history[0].downloaded_label, "MP3 320")
         self.assertTrue(detail.download_history[0].verdict)
+        self.assertEqual(detail.download_history[0].actual_min_bitrate, 320)
+        self.assertEqual(detail.download_history[0].slskd_bitrate, 320000)
+        self.assertEqual(
+            detail.download_history[0].validation_result,
+            {"detail": "distance too high"},
+        )
+        self.assertEqual(detail.download_history[0].source, "request")
 
     def test_build_library_album_detail_preserves_nullable_legacy_fields(self) -> None:
         detail = build_library_album_detail(
@@ -162,9 +177,16 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
 
         self.assertIsNone(detail.added)
         self.assertEqual(len(detail.tracks), 1)
+        self.assertEqual(detail.artpath, "/music/Test Artist/Test Album/cover.jpg")
+        self.assertEqual(detail.tracks[0].id, 11)
+        self.assertEqual(detail.tracks[0].artist, "Test Artist")
         self.assertIsNone(detail.tracks[0].disc)
         self.assertIsNone(detail.tracks[0].track)
         self.assertIsNone(detail.tracks[0].title)
+        self.assertEqual(
+            detail.tracks[0].path,
+            "/music/Test Artist/Test Album/01 Track 1.mp3",
+        )
 
     def test_load_library_album_detail_resolves_discogs_request(self) -> None:
         fake_db = FakePipelineDB()
@@ -207,6 +229,82 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
         self.assertEqual(detail.source, "discogs")
         self.assertEqual(detail.pipeline_id, 55)
         self.assertEqual(detail.download_history[0].soulseek_username, "discogs-user")
+
+    def test_load_library_album_detail_preserves_unknown_release_ids(self) -> None:
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=77,
+            mb_release_id="fixture-release-1",
+            artist_name="Fixture Artist",
+            album_title="Fixture Album",
+            source="request",
+            status="wanted",
+        ))
+        lookup = _StubLibraryLookup(_beets_detail(
+            album="Fixture Album",
+            artist="Fixture Artist",
+            mb_albumid="fixture-release-1",
+            source="unknown",
+        ))
+
+        detail = load_library_album_detail(
+            library_lookup=lookup,
+            pipeline_db=fake_db,
+            album_id=7,
+        )
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(detail.mb_albumid, "fixture-release-1")
+        self.assertEqual(detail.source, "unknown")
+        self.assertEqual(detail.pipeline_id, 77)
+
+    def test_load_library_album_detail_preserves_string_history_json_blobs(self) -> None:
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=88,
+            mb_release_id=RELEASE_ID,
+            artist_name="Test Artist",
+            album_title="Test Album",
+            source="request",
+            status="wanted",
+        ))
+        fake_db.log_download(
+            88,
+            outcome="success",
+            import_result=json.dumps({
+                "version": 2,
+                "exit_code": 0,
+                "decision": "import",
+            }),
+            validation_result=json.dumps({
+                "failed_path": "/mnt/virtio/music/slskd/failed_imports/Test",
+            }),
+        )
+        lookup = _StubLibraryLookup(_beets_detail())
+
+        detail = load_library_album_detail(
+            library_lookup=lookup,
+            pipeline_db=fake_db,
+            album_id=7,
+        )
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(
+            detail.download_history[0].import_result,
+            json.dumps({
+                "version": 2,
+                "exit_code": 0,
+                "decision": "import",
+            }),
+        )
+        self.assertEqual(
+            detail.download_history[0].validation_result,
+            json.dumps({
+                "failed_path": "/mnt/virtio/music/slskd/failed_imports/Test",
+            }),
+        )
 
     def test_load_library_album_detail_returns_none_when_album_missing(self) -> None:
         lookup = _StubLibraryLookup(None)

--- a/tests/test_library_album_detail_service.py
+++ b/tests/test_library_album_detail_service.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Direct tests for the `/api/beets/album/<id>` detail seam."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_request_row
+from web.library_album_detail_service import (
+    build_library_album_detail,
+    load_library_album_detail,
+)
+
+
+RELEASE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def _track(**overrides: object) -> dict[str, object]:
+    track: dict[str, object] = {
+        "disc": 1,
+        "track": 1,
+        "title": "Track 1",
+        "length": 240.5,
+        "format": "MP3",
+        "bitrate": 320000,
+        "samplerate": 44100,
+        "bitdepth": 16,
+    }
+    track.update(overrides)
+    return track
+
+
+def _beets_detail(**overrides: object) -> dict[str, object]:
+    detail: dict[str, object] = {
+        "id": 7,
+        "album": "Test Album",
+        "artist": "Test Artist",
+        "year": 2024,
+        "mb_albumid": RELEASE_ID,
+        "type": "album",
+        "label": "Test Label",
+        "country": "US",
+        "added": 1773651901.0,
+        "tracks": [_track(), _track(track=2, title="Track 2")],
+        "path": "/music/Test Artist/Test Album",
+        "source": "musicbrainz",
+    }
+    detail.update(overrides)
+    return detail
+
+
+def _history_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "id": 1,
+        "request_id": 42,
+        "outcome": "success",
+        "created_at": datetime(2026, 3, 30, 12, 0, 0, tzinfo=timezone.utc),
+        "soulseek_username": "testuser",
+        "beets_scenario": "strong_match",
+        "beets_distance": 0.012,
+        "bitrate": 320000,
+        "slskd_filetype": "mp3",
+        "slskd_bitrate": 320000,
+        "actual_filetype": "mp3",
+        "actual_min_bitrate": 320,
+        "spectral_grade": None,
+        "spectral_bitrate": None,
+        "existing_min_bitrate": None,
+        "existing_spectral_bitrate": None,
+        "import_result": None,
+        "validation_result": None,
+    }
+    row.update(overrides)
+    return row
+
+
+class _StubLibraryLookup:
+    def __init__(self, detail: dict[str, object] | None) -> None:
+        self._detail = detail
+        self.calls: list[int] = []
+
+    def get_album_detail(self, album_id: int) -> dict[str, object] | None:
+        self.calls.append(album_id)
+        if self._detail is None:
+            return None
+        return dict(self._detail)
+
+
+class TestLibraryAlbumDetailService(unittest.TestCase):
+    def test_build_library_album_detail_backfills_contract_fields_from_tracks(self) -> None:
+        detail = build_library_album_detail(
+            detail_row=_beets_detail(
+                tracks=[
+                    _track(track=1, bitrate=320000),
+                    _track(track=2, title="Track 2", bitrate=256000),
+                ],
+                source="",
+                mb_releasegroupid=None,
+                release_group_title="",
+                formats="",
+                min_bitrate=None,
+            ),
+            pipeline_request=None,
+            download_history=[],
+        )
+
+        self.assertEqual(detail.track_count, 2)
+        self.assertIsNone(detail.mb_releasegroupid)
+        self.assertEqual(detail.release_group_title, "Test Album")
+        self.assertEqual(detail.formats, "MP3")
+        self.assertEqual(detail.min_bitrate, 256000)
+        self.assertEqual(detail.source, "musicbrainz")
+        self.assertIsNone(detail.pipeline_id)
+        self.assertFalse(detail.upgrade_queued)
+        self.assertEqual(detail.download_history, [])
+
+    def test_build_library_album_detail_overlays_pipeline_state_and_history(self) -> None:
+        detail = build_library_album_detail(
+            detail_row=_beets_detail(),
+            pipeline_request=make_request_row(
+                id=42,
+                mb_release_id=RELEASE_ID,
+                status="wanted",
+                source="request",
+                min_bitrate=320,
+                search_filetype_override="flac",
+                target_format="lossless",
+            ),
+            download_history=[_history_row()],
+        )
+
+        self.assertEqual(detail.pipeline_id, 42)
+        self.assertEqual(detail.pipeline_status, "wanted")
+        self.assertEqual(detail.pipeline_source, "request")
+        self.assertEqual(detail.pipeline_min_bitrate, 320)
+        self.assertEqual(detail.search_filetype_override, "flac")
+        self.assertEqual(detail.target_format, "lossless")
+        self.assertTrue(detail.upgrade_queued)
+        self.assertEqual(len(detail.download_history), 1)
+        self.assertEqual(detail.download_history[0].soulseek_username, "testuser")
+        self.assertEqual(detail.download_history[0].beets_scenario, "strong_match")
+        self.assertEqual(detail.download_history[0].downloaded_label, "MP3 320")
+        self.assertTrue(detail.download_history[0].verdict)
+
+    def test_load_library_album_detail_resolves_discogs_request(self) -> None:
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(
+            id=55,
+            mb_release_id="12856590",
+            discogs_release_id="12856590",
+            artist_name="Test Artist",
+            album_title="Discogs Import",
+            source="request",
+            status="wanted",
+        ))
+        fake_db.log_download(
+            55,
+            outcome="success",
+            soulseek_username="discogs-user",
+            beets_scenario="strong_match",
+            beets_distance=0.01,
+            actual_filetype="mp3",
+            actual_min_bitrate=245,
+            slskd_filetype="mp3",
+            slskd_bitrate=245000,
+        )
+        lookup = _StubLibraryLookup(_beets_detail(
+            album="Discogs Import",
+            mb_albumid="12856590",
+            source="discogs",
+        ))
+
+        detail = load_library_album_detail(
+            library_lookup=lookup,
+            pipeline_db=fake_db,
+            album_id=7,
+        )
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(lookup.calls, [7])
+        self.assertEqual(detail.mb_albumid, "12856590")
+        self.assertEqual(detail.source, "discogs")
+        self.assertEqual(detail.pipeline_id, 55)
+        self.assertEqual(detail.download_history[0].soulseek_username, "discogs-user")
+
+    def test_load_library_album_detail_returns_none_when_album_missing(self) -> None:
+        lookup = _StubLibraryLookup(None)
+
+        detail = load_library_album_detail(
+            library_lookup=lookup,
+            pipeline_db=FakePipelineDB(),
+            album_id=99,
+        )
+
+        self.assertEqual(lookup.calls, [99])
+        self.assertIsNone(detail)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -24,6 +24,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 from lib.manual_import import FolderInfo, FolderMatch, ImportRequest
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
+from web.download_history_view import DownloadHistoryViewRow
+from web.library_album_detail_service import LibraryAlbumDetail, LibraryAlbumTrack
 from web.library_album_row import LibraryAlbumRow
 
 _MOCK_PIPELINE_REQUEST = make_request_row(
@@ -2500,18 +2502,9 @@ class TestBeetsRouteContracts(_WebServerCase):
         "mb_releasegroupid", "release_group_title", "added", "formats",
         "min_bitrate", "type", "label", "country", "source",
     }
-    DETAIL_REQUIRED_FIELDS = (
-        ALBUM_REQUIRED_FIELDS | {
-            "path", "tracks", "pipeline_id", "pipeline_status",
-            "pipeline_source", "pipeline_min_bitrate",
-            "search_filetype_override", "target_format", "upgrade_queued",
-            "download_history",
-        }
-    )
-    TRACK_REQUIRED_FIELDS = {
-        "disc", "track", "title", "length", "format", "bitrate",
-        "samplerate", "bitdepth",
-    }
+    DETAIL_REQUIRED_FIELDS = set(LibraryAlbumDetail.__struct_fields__)
+    TRACK_REQUIRED_FIELDS = set(LibraryAlbumTrack.__struct_fields__)
+    HISTORY_REQUIRED_FIELDS = set(DownloadHistoryViewRow.__struct_fields__)
     DELETE_REQUIRED_FIELDS = {
         "status", "id", "album", "artist", "deleted_files",
         "pipeline_deleted", "pipeline_id",
@@ -2621,6 +2614,12 @@ class TestBeetsRouteContracts(_WebServerCase):
                                 "beets album detail")
         _assert_required_fields(self, data["tracks"][0], self.TRACK_REQUIRED_FIELDS,
                                 "beets album track")
+        _assert_required_fields(
+            self,
+            data["download_history"][0],
+            self.HISTORY_REQUIRED_FIELDS,
+            "beets album detail history",
+        )
 
     def test_beets_album_detail_discogs_contract(self):
         detail = self._album()
@@ -2641,6 +2640,12 @@ class TestBeetsRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.DETAIL_REQUIRED_FIELDS,
                                 "beets album detail (discogs)")
+        _assert_required_fields(
+            self,
+            data["download_history"][0],
+            self.HISTORY_REQUIRED_FIELDS,
+            "beets album detail history (discogs)",
+        )
         self.assertEqual(data["source"], "discogs")
         self.assertEqual(data["mb_albumid"], "12856590")
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2649,6 +2649,28 @@ class TestBeetsRouteContracts(_WebServerCase):
         self.assertEqual(data["source"], "discogs")
         self.assertEqual(data["mb_albumid"], "12856590")
 
+    def test_beets_album_detail_allows_nullable_legacy_fields(self):
+        detail = self._album()
+        detail["added"] = None
+        detail["path"] = "/music/Test Artist/Test Album"
+        detail["tracks"] = [
+            {
+                **self._track(),
+                "disc": None,
+                "track": None,
+                "title": None,
+            }
+        ]
+        self.beets.get_album_detail.return_value = detail
+
+        status, data = self._get("/api/beets/album/7")
+
+        self.assertEqual(status, 200)
+        self.assertIsNone(data["added"])
+        self.assertIsNone(data["tracks"][0]["disc"])
+        self.assertIsNone(data["tracks"][0]["track"])
+        self.assertIsNone(data["tracks"][0]["title"])
+
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
     @patch("lib.library_delete_service.os.path.exists", return_value=True)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -643,8 +643,8 @@ class TestPipelineRouteContracts(_WebServerCase):
     HISTORY_REQUIRED_FIELDS = {
         "id", "request_id", "outcome", "created_at", "soulseek_username",
         "downloaded_label", "verdict", "beets_scenario", "beets_distance",
-        "spectral_grade", "spectral_bitrate", "existing_min_bitrate",
-        "existing_spectral_bitrate",
+        "disambiguation_failure", "disambiguation_detail", "spectral_grade",
+        "spectral_bitrate", "existing_min_bitrate", "existing_spectral_bitrate",
     }
     STATUS_WANTED_REQUIRED_FIELDS = {
         "id", "artist", "album", "mb_release_id", "source", "created_at",
@@ -2521,11 +2521,11 @@ class TestBeetsRouteContracts(_WebServerCase):
         "error_message", "import_result", "validation_result", "filetype",
         "bitrate", "was_converted", "original_filetype", "actual_filetype",
         "actual_min_bitrate", "slskd_filetype", "slskd_bitrate",
-        "downloaded_label", "verdict", "spectral_grade",
-        "spectral_bitrate", "existing_min_bitrate",
-        "existing_spectral_bitrate", "album_title", "artist_name",
-        "mb_release_id", "request_status", "request_min_bitrate",
-        "search_filetype_override", "source",
+        "downloaded_label", "verdict", "disambiguation_failure",
+        "disambiguation_detail", "spectral_grade", "spectral_bitrate",
+        "existing_min_bitrate", "existing_spectral_bitrate", "album_title",
+        "artist_name", "mb_release_id", "request_status",
+        "request_min_bitrate", "search_filetype_override", "source",
     }
     DELETE_REQUIRED_FIELDS = {
         "status", "id", "album", "artist", "deleted_files",
@@ -2702,6 +2702,24 @@ class TestBeetsRouteContracts(_WebServerCase):
         self.assertIsNone(data["tracks"][0]["disc"])
         self.assertIsNone(data["tracks"][0]["track"])
         self.assertIsNone(data["tracks"][0]["title"])
+
+    def test_beets_album_detail_preserves_string_added_and_missing_format(self):
+        detail = self._album()
+        detail["added"] = "2026-03-30T12:00:00+00:00"
+        detail["artpath"] = "/music/Test Artist/Test Album/cover.jpg"
+        detail["path"] = "/music/Test Artist/Test Album"
+        detail.pop("formats")
+        track = self._track()
+        del track["format"]
+        detail["tracks"] = [track]
+        self.beets.get_album_detail.return_value = detail
+
+        status, data = self._get("/api/beets/album/7")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["added"], "2026-03-30T12:00:00+00:00")
+        self.assertEqual(data["formats"], "")
+        self.assertIsNone(data["tracks"][0]["format"])
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -24,8 +24,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 from lib.manual_import import FolderInfo, FolderMatch, ImportRequest
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
-from web.download_history_view import DownloadHistoryViewRow
-from web.library_album_detail_service import LibraryAlbumDetail, LibraryAlbumTrack
 from web.library_album_row import LibraryAlbumRow
 
 _MOCK_PIPELINE_REQUEST = make_request_row(
@@ -2502,9 +2500,33 @@ class TestBeetsRouteContracts(_WebServerCase):
         "mb_releasegroupid", "release_group_title", "added", "formats",
         "min_bitrate", "type", "label", "country", "source",
     }
-    DETAIL_REQUIRED_FIELDS = set(LibraryAlbumDetail.__struct_fields__)
-    TRACK_REQUIRED_FIELDS = set(LibraryAlbumTrack.__struct_fields__)
-    HISTORY_REQUIRED_FIELDS = set(DownloadHistoryViewRow.__struct_fields__)
+    DETAIL_REQUIRED_FIELDS = (
+        ALBUM_REQUIRED_FIELDS | {
+            "artpath", "path", "tracks", "pipeline_id", "pipeline_status",
+            "pipeline_source", "pipeline_min_bitrate",
+            "search_filetype_override", "target_format", "upgrade_queued",
+            "download_history",
+        }
+    )
+    TRACK_REQUIRED_FIELDS = {
+        "id", "artist", "disc", "track", "title", "length", "format",
+        "bitrate", "samplerate", "bitdepth", "path",
+    }
+    # `/api/beets/album/<id>` historically forwarded the full LogEntry JSON
+    # plus derived verdict/downloaded_label. Keep the explicit list here so
+    # route contract coverage catches accidental payload narrowing.
+    HISTORY_REQUIRED_FIELDS = {
+        "id", "request_id", "outcome", "created_at", "beets_scenario",
+        "beets_distance", "beets_detail", "soulseek_username",
+        "error_message", "import_result", "validation_result", "filetype",
+        "bitrate", "was_converted", "original_filetype", "actual_filetype",
+        "actual_min_bitrate", "slskd_filetype", "slskd_bitrate",
+        "downloaded_label", "verdict", "spectral_grade",
+        "spectral_bitrate", "existing_min_bitrate",
+        "existing_spectral_bitrate", "album_title", "artist_name",
+        "mb_release_id", "request_status", "request_min_bitrate",
+        "search_filetype_override", "source",
+    }
     DELETE_REQUIRED_FIELDS = {
         "status", "id", "album", "artist", "deleted_files",
         "pipeline_deleted", "pipeline_id",
@@ -2554,6 +2576,8 @@ class TestBeetsRouteContracts(_WebServerCase):
 
     def _track(self) -> dict:
         return {
+            "id": 11,
+            "artist": "Test Artist",
             "disc": 1,
             "track": 1,
             "title": "Track",
@@ -2562,6 +2586,7 @@ class TestBeetsRouteContracts(_WebServerCase):
             "bitrate": 320000,
             "samplerate": 44100,
             "bitdepth": 16,
+            "path": "/music/Test Artist/Test Album/01 Track.mp3",
         }
 
     def _configure_beets_delete_mock(
@@ -2603,6 +2628,7 @@ class TestBeetsRouteContracts(_WebServerCase):
 
     def test_beets_album_detail_contract(self):
         detail = self._album()
+        detail["artpath"] = "/music/Test Artist/Test Album/cover.jpg"
         detail["path"] = "/music/Test Artist/Test Album"
         detail["tracks"] = [self._track()]
         self.beets.get_album_detail.return_value = detail
@@ -2620,11 +2646,16 @@ class TestBeetsRouteContracts(_WebServerCase):
             self.HISTORY_REQUIRED_FIELDS,
             "beets album detail history",
         )
+        self.assertEqual(data["artpath"], "/music/Test Artist/Test Album/cover.jpg")
+        self.assertEqual(data["tracks"][0]["id"], 11)
+        self.assertEqual(data["tracks"][0]["path"], "/music/Test Artist/Test Album/01 Track.mp3")
+        self.assertEqual(data["download_history"][0]["actual_min_bitrate"], 320)
 
     def test_beets_album_detail_discogs_contract(self):
         detail = self._album()
         detail["mb_albumid"] = "12856590"
         detail["source"] = "discogs"
+        detail["artpath"] = "/music/Test Artist/Test Album/cover.jpg"
         detail["path"] = "/music/Test Artist/Test Album"
         detail["tracks"] = [self._track()]
         self.beets.get_album_detail.return_value = detail
@@ -2652,6 +2683,7 @@ class TestBeetsRouteContracts(_WebServerCase):
     def test_beets_album_detail_allows_nullable_legacy_fields(self):
         detail = self._album()
         detail["added"] = None
+        detail["artpath"] = "/music/Test Artist/Test Album/cover.jpg"
         detail["path"] = "/music/Test Artist/Test Album"
         detail["tracks"] = [
             {

--- a/web/download_history_view.py
+++ b/web/download_history_view.py
@@ -17,15 +17,34 @@ class DownloadHistoryViewRow(msgspec.Struct, frozen=True):
     request_id: int
     outcome: str
     created_at: str | None
-    soulseek_username: str | None
-    downloaded_label: str
-    verdict: str
     beets_scenario: str | None
     beets_distance: float | None
+    beets_detail: str | None
+    soulseek_username: str | None
+    error_message: str | None
+    import_result: str | dict[str, object] | None
+    validation_result: str | dict[str, object] | None
+    filetype: str | None
+    bitrate: int | None
+    was_converted: bool | None
+    original_filetype: str | None
+    actual_filetype: str | None
+    actual_min_bitrate: int | None
+    slskd_filetype: str | None
+    slskd_bitrate: int | None
+    downloaded_label: str
+    verdict: str
     spectral_grade: str | None
     spectral_bitrate: int | None
     existing_min_bitrate: int | None
     existing_spectral_bitrate: int | None
+    album_title: str
+    artist_name: str
+    mb_release_id: str | None
+    request_status: str | None
+    request_min_bitrate: int | None
+    search_filetype_override: str | None
+    source: str | None
 
     def to_dict(self) -> dict[str, object]:
         return cast(dict[str, object], msgspec.to_builtins(self))
@@ -41,19 +60,9 @@ def build_download_history_rows(
         classified = classify_log_entry(entry)
         items.append(msgspec.convert(
             {
-                "id": entry.id,
-                "request_id": entry.request_id,
-                "outcome": entry.outcome,
-                "created_at": entry.created_at,
-                "soulseek_username": entry.soulseek_username,
+                **entry.to_json_dict(),
                 "downloaded_label": classified.downloaded_label,
                 "verdict": classified.verdict,
-                "beets_scenario": entry.beets_scenario,
-                "beets_distance": entry.beets_distance,
-                "spectral_grade": entry.spectral_grade,
-                "spectral_bitrate": entry.spectral_bitrate,
-                "existing_min_bitrate": entry.existing_min_bitrate,
-                "existing_spectral_bitrate": entry.existing_spectral_bitrate,
             },
             type=DownloadHistoryViewRow,
         ))

--- a/web/download_history_view.py
+++ b/web/download_history_view.py
@@ -1,0 +1,60 @@
+"""Typed download-history rows for detail views."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+import msgspec
+
+from web.classify import LogEntry, classify_log_entry
+
+
+class DownloadHistoryViewRow(msgspec.Struct, frozen=True):
+    """Frontend contract shared by detail-view download-history panels."""
+
+    id: int
+    request_id: int
+    outcome: str
+    created_at: str | None
+    soulseek_username: str | None
+    downloaded_label: str
+    verdict: str
+    beets_scenario: str | None
+    beets_distance: float | None
+    spectral_grade: str | None
+    spectral_bitrate: int | None
+    existing_min_bitrate: int | None
+    existing_spectral_bitrate: int | None
+
+    def to_dict(self) -> dict[str, object]:
+        return cast(dict[str, object], msgspec.to_builtins(self))
+
+
+def build_download_history_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> list[DownloadHistoryViewRow]:
+    """Classify raw download_log rows into the shared detail-view contract."""
+    items: list[DownloadHistoryViewRow] = []
+    for row in rows:
+        entry = LogEntry.from_row(dict(row))
+        classified = classify_log_entry(entry)
+        items.append(msgspec.convert(
+            {
+                "id": entry.id,
+                "request_id": entry.request_id,
+                "outcome": entry.outcome,
+                "created_at": entry.created_at,
+                "soulseek_username": entry.soulseek_username,
+                "downloaded_label": classified.downloaded_label,
+                "verdict": classified.verdict,
+                "beets_scenario": entry.beets_scenario,
+                "beets_distance": entry.beets_distance,
+                "spectral_grade": entry.spectral_grade,
+                "spectral_bitrate": entry.spectral_bitrate,
+                "existing_min_bitrate": entry.existing_min_bitrate,
+                "existing_spectral_bitrate": entry.existing_spectral_bitrate,
+            },
+            type=DownloadHistoryViewRow,
+        ))
+    return items

--- a/web/download_history_view.py
+++ b/web/download_history_view.py
@@ -1,13 +1,22 @@
-"""Typed download-history rows for detail views."""
+"""Typed download-log presentation helpers shared by detail and pipeline views."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import cast
 
 import msgspec
 
-from web.classify import LogEntry, classify_log_entry
+from web.classify import ClassifiedEntry, LogEntry, classify_log_entry
+
+
+@dataclass(frozen=True)
+class ClassifiedDownloadLogRow:
+    """One raw download_log row plus its shared UI classification."""
+
+    entry: LogEntry
+    classified: ClassifiedEntry
 
 
 class DownloadHistoryViewRow(msgspec.Struct, frozen=True):
@@ -34,6 +43,8 @@ class DownloadHistoryViewRow(msgspec.Struct, frozen=True):
     slskd_bitrate: int | None
     downloaded_label: str
     verdict: str
+    disambiguation_failure: str | None
+    disambiguation_detail: str | None
     spectral_grade: str | None
     spectral_bitrate: int | None
     existing_min_bitrate: int | None
@@ -54,16 +65,34 @@ def build_download_history_rows(
     rows: Sequence[Mapping[str, object]],
 ) -> list[DownloadHistoryViewRow]:
     """Classify raw download_log rows into the shared detail-view contract."""
-    items: list[DownloadHistoryViewRow] = []
-    for row in rows:
-        entry = LogEntry.from_row(dict(row))
-        classified = classify_log_entry(entry)
-        items.append(msgspec.convert(
-            {
-                **entry.to_json_dict(),
-                "downloaded_label": classified.downloaded_label,
-                "verdict": classified.verdict,
-            },
-            type=DownloadHistoryViewRow,
-        ))
-    return items
+    return [build_download_history_row(row) for row in rows]
+
+
+def classify_download_log_row(
+    row: Mapping[str, object],
+) -> ClassifiedDownloadLogRow:
+    """Build the shared typed classification for one raw download_log row."""
+    entry = LogEntry.from_row(dict(row))
+    return ClassifiedDownloadLogRow(
+        entry=entry,
+        classified=classify_log_entry(entry),
+    )
+
+
+def build_download_history_row(
+    row: Mapping[str, object],
+) -> DownloadHistoryViewRow:
+    """Build one detail-view history row from a raw download_log row."""
+    classified_row = classify_download_log_row(row)
+    entry = classified_row.entry
+    classified = classified_row.classified
+    return msgspec.convert(
+        {
+            **entry.to_json_dict(),
+            "downloaded_label": classified.downloaded_label,
+            "verdict": classified.verdict,
+            "disambiguation_failure": classified.disambiguation_failure,
+            "disambiguation_detail": classified.disambiguation_detail,
+        },
+        type=DownloadHistoryViewRow,
+    )

--- a/web/library_album_detail_service.py
+++ b/web/library_album_detail_service.py
@@ -42,7 +42,8 @@ class SupportsLibraryAlbumDetailPipelineDB(
         ...
 
 
-def _timestamp(value: object | None) -> float | None:
+def _timestamp(value: object | None) -> float | str | None:
+    """Preserve legacy beets ``added`` shapes while normalizing datetimes."""
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -51,8 +52,10 @@ def _timestamp(value: object | None) -> float | None:
         return value
     if isinstance(value, int):
         return float(value)
+    if isinstance(value, str):
+        return value
     raise TypeError(
-        "LibraryAlbumDetail added must be datetime|float|int, "
+        "LibraryAlbumDetail added must be datetime|float|int|str, "
         f"got {type(value).__name__}"
     )
 
@@ -79,7 +82,11 @@ def _min_track_bitrate(tracks: Sequence["LibraryAlbumTrack"]) -> int | None:
 
 
 def _detail_release_id(detail_row: Mapping[str, object]) -> str | None:
-    """Preserve exact-release IDs across canonical and unknown legacy shapes."""
+    """Preserve exact-release IDs across canonical and unknown legacy shapes.
+
+    When both legacy columns carry non-canonical non-empty strings, prefer the
+    ``mb_albumid`` value so pipeline lookup matches the pre-service route.
+    """
     frontend_id = frontend_release_id(
         detail_row.get("mb_albumid"),
         detail_row.get("discogs_albumid"),
@@ -104,7 +111,7 @@ class LibraryAlbumTrack(msgspec.Struct, frozen=True):
     track: int | None
     title: str | None
     length: float | None
-    format: str
+    format: str | None
     bitrate: int | None
     samplerate: int | None
     bitdepth: int | None
@@ -133,7 +140,7 @@ class LibraryAlbumDetail(msgspec.Struct, frozen=True):
     track_count: int
     mb_releasegroupid: str | None
     release_group_title: str
-    added: float | None
+    added: float | str | None
     formats: str
     min_bitrate: int | None
     type: str
@@ -172,7 +179,11 @@ def build_library_album_detail(
                 "track": track.get("track"),
                 "title": track.get("title"),
                 "length": track.get("length"),
-                "format": str(track.get("format") or ""),
+                "format": (
+                    None
+                    if track.get("format") is None
+                    else str(track.get("format"))
+                ),
                 "bitrate": track.get("bitrate"),
                 "samplerate": track.get("samplerate"),
                 "bitdepth": track.get("bitdepth"),

--- a/web/library_album_detail_service.py
+++ b/web/library_album_detail_service.py
@@ -1,0 +1,248 @@
+"""Typed service seam for `/api/beets/album/<id>` detail shaping.
+
+Issue #155 moves the library-detail payload shaping out of
+`web/routes/library.py` so the route only validates params, delegates to
+this service, and serializes one owned contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Protocol, cast
+
+import msgspec
+
+from lib.library_delete_service import (
+    SupportsLibraryPipelineLookupDB,
+    resolve_pipeline_request,
+)
+from lib.release_identity import detect_release_source, frontend_release_id
+from web.download_history_view import DownloadHistoryViewRow, build_download_history_rows
+
+
+class SupportsLibraryAlbumDetailLookup(Protocol):
+    """Minimal beets-facing surface for one library album detail lookup."""
+
+    def get_album_detail(self, album_id: int) -> dict[str, object] | None:
+        ...
+
+
+class SupportsLibraryAlbumDetailPipelineDB(
+    SupportsLibraryPipelineLookupDB,
+    Protocol,
+):
+    """Pipeline DB surface needed for library album detail overlays."""
+
+    def get_download_history(self, request_id: int) -> list[dict[str, object]]:
+        ...
+
+
+def _timestamp(value: object | None) -> float:
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, float):
+        return value
+    if isinstance(value, int):
+        return float(value)
+    raise TypeError(
+        "LibraryAlbumDetail added must be datetime|float|int, "
+        f"got {type(value).__name__}"
+    )
+
+
+def _track_formats(tracks: Sequence["LibraryAlbumTrack"]) -> str:
+    seen: set[str] = set()
+    formats: list[str] = []
+    for track in tracks:
+        raw = str(track.format or "")
+        if not raw or raw in seen:
+            continue
+        seen.add(raw)
+        formats.append(raw)
+    return ",".join(formats)
+
+
+def _min_track_bitrate(tracks: Sequence["LibraryAlbumTrack"]) -> int | None:
+    bitrates = [
+        track.bitrate
+        for track in tracks
+        if isinstance(track.bitrate, int) and track.bitrate > 0
+    ]
+    return min(bitrates) if bitrates else None
+
+
+class LibraryAlbumTrack(msgspec.Struct, frozen=True):
+    """Typed frontend contract for one library album track."""
+
+    disc: int
+    track: int
+    title: str
+    length: float | None
+    format: str
+    bitrate: int | None
+    samplerate: int | None
+    bitdepth: int | None
+
+
+class LibraryAlbumDetail(msgspec.Struct, frozen=True):
+    """Owned `/api/beets/album/<id>` contract.
+
+    Field notes:
+    - `mb_albumid` is the single release key the frontend uses for actions.
+      It intentionally carries either a MusicBrainz UUID or a Discogs numeric
+      release ID string.
+    - `release_group_title`, `track_count`, `formats`, and `min_bitrate` are
+      guaranteed even when the raw beets detail row omits them; this service
+      owns those frontend-compatibility fallbacks.
+    - Pipeline overlay fields are always present so the frontend does not need
+      `dict.get()` shape branching.
+    """
+
+    id: int
+    album: str
+    artist: str
+    year: int | None
+    mb_albumid: str | None
+    track_count: int
+    mb_releasegroupid: str | None
+    release_group_title: str
+    added: float
+    formats: str
+    min_bitrate: int | None
+    type: str
+    label: str
+    country: str | None
+    source: str
+    path: str | None
+    tracks: list[LibraryAlbumTrack]
+    pipeline_id: int | None
+    pipeline_status: str | None
+    pipeline_source: str | None
+    pipeline_min_bitrate: int | None
+    search_filetype_override: str | None
+    target_format: str | None
+    upgrade_queued: bool
+    download_history: list[DownloadHistoryViewRow]
+
+    def to_dict(self) -> dict[str, object]:
+        return cast(dict[str, object], msgspec.to_builtins(self))
+
+
+def build_library_album_detail(
+    *,
+    detail_row: Mapping[str, object],
+    pipeline_request: Mapping[str, object] | None,
+    download_history: Sequence[Mapping[str, object]],
+) -> LibraryAlbumDetail:
+    """Build the owned library-detail contract from raw beets + pipeline rows."""
+    tracks = [
+        msgspec.convert(
+            {
+                "disc": track["disc"],
+                "track": track["track"],
+                "title": track["title"],
+                "length": track.get("length"),
+                "format": str(track.get("format") or ""),
+                "bitrate": track.get("bitrate"),
+                "samplerate": track.get("samplerate"),
+                "bitdepth": track.get("bitdepth"),
+            },
+            type=LibraryAlbumTrack,
+        )
+        for track in cast(Sequence[Mapping[str, object]], detail_row.get("tracks") or [])
+    ]
+    frontend_id = frontend_release_id(
+        detail_row.get("mb_albumid"),
+        detail_row.get("discogs_albumid"),
+    )
+    raw_formats = str(detail_row.get("formats") or "")
+    source = str(detail_row.get("source") or detect_release_source(frontend_id))
+    history_items = build_download_history_rows(download_history)
+    return msgspec.convert(
+        {
+            "id": detail_row["id"],
+            "album": detail_row["album"],
+            "artist": detail_row["artist"],
+            "year": detail_row.get("year"),
+            "mb_albumid": frontend_id,
+            "track_count": detail_row.get("track_count") or len(tracks),
+            "mb_releasegroupid": detail_row.get("mb_releasegroupid"),
+            "release_group_title": (
+                detail_row.get("release_group_title") or detail_row["album"]
+            ),
+            "added": _timestamp(detail_row.get("added")),
+            "formats": raw_formats or _track_formats(tracks),
+            "min_bitrate": detail_row.get("min_bitrate") or _min_track_bitrate(tracks),
+            "type": str(detail_row.get("type") or ""),
+            "label": str(detail_row.get("label") or ""),
+            "country": detail_row.get("country"),
+            "source": source or "unknown",
+            "path": detail_row.get("path"),
+            "tracks": tracks,
+            "pipeline_id": pipeline_request.get("id") if pipeline_request else None,
+            "pipeline_status": (
+                pipeline_request.get("status") if pipeline_request else None
+            ),
+            "pipeline_source": (
+                pipeline_request.get("source") if pipeline_request else None
+            ),
+            "pipeline_min_bitrate": (
+                pipeline_request.get("min_bitrate") if pipeline_request else None
+            ),
+            "search_filetype_override": (
+                pipeline_request.get("search_filetype_override")
+                if pipeline_request
+                else None
+            ),
+            "target_format": (
+                pipeline_request.get("target_format") if pipeline_request else None
+            ),
+            "upgrade_queued": bool(
+                pipeline_request
+                and pipeline_request.get("status") == "wanted"
+                and (
+                    pipeline_request.get("search_filetype_override")
+                    or pipeline_request.get("target_format")
+                )
+            ),
+            "download_history": history_items,
+        },
+        type=LibraryAlbumDetail,
+    )
+
+
+def load_library_album_detail(
+    *,
+    library_lookup: SupportsLibraryAlbumDetailLookup,
+    pipeline_db: SupportsLibraryAlbumDetailPipelineDB | None,
+    album_id: int,
+) -> LibraryAlbumDetail | None:
+    """Load and shape one `/api/beets/album/<id>` response."""
+    detail = library_lookup.get_album_detail(album_id)
+    if detail is None:
+        return None
+
+    release_id = frontend_release_id(
+        detail.get("mb_albumid"),
+        detail.get("discogs_albumid"),
+    )
+    pipeline_request = (
+        resolve_pipeline_request(
+            pipeline_db,
+            pipeline_id=None,
+            release_id=release_id or "",
+        )
+        if release_id
+        else None
+    )
+    history = (
+        pipeline_db.get_download_history(int(pipeline_request["id"]))
+        if pipeline_db is not None and pipeline_request is not None
+        else []
+    )
+    return build_library_album_detail(
+        detail_row=detail,
+        pipeline_request=pipeline_request,
+        download_history=history,
+    )

--- a/web/library_album_detail_service.py
+++ b/web/library_album_detail_service.py
@@ -38,7 +38,9 @@ class SupportsLibraryAlbumDetailPipelineDB(
         ...
 
 
-def _timestamp(value: object | None) -> float:
+def _timestamp(value: object | None) -> float | None:
+    if value is None:
+        return None
     if isinstance(value, datetime):
         return value.timestamp()
     if isinstance(value, float):
@@ -75,9 +77,9 @@ def _min_track_bitrate(tracks: Sequence["LibraryAlbumTrack"]) -> int | None:
 class LibraryAlbumTrack(msgspec.Struct, frozen=True):
     """Typed frontend contract for one library album track."""
 
-    disc: int
-    track: int
-    title: str
+    disc: int | None
+    track: int | None
+    title: str | None
     length: float | None
     format: str
     bitrate: int | None
@@ -107,7 +109,7 @@ class LibraryAlbumDetail(msgspec.Struct, frozen=True):
     track_count: int
     mb_releasegroupid: str | None
     release_group_title: str
-    added: float
+    added: float | None
     formats: str
     min_bitrate: int | None
     type: str
@@ -139,9 +141,9 @@ def build_library_album_detail(
     tracks = [
         msgspec.convert(
             {
-                "disc": track["disc"],
-                "track": track["track"],
-                "title": track["title"],
+                "disc": track.get("disc"),
+                "track": track.get("track"),
+                "title": track.get("title"),
                 "length": track.get("length"),
                 "format": str(track.get("format") or ""),
                 "bitrate": track.get("bitrate"),

--- a/web/library_album_detail_service.py
+++ b/web/library_album_detail_service.py
@@ -17,7 +17,11 @@ from lib.library_delete_service import (
     SupportsLibraryPipelineLookupDB,
     resolve_pipeline_request,
 )
-from lib.release_identity import detect_release_source, frontend_release_id
+from lib.release_identity import (
+    detect_release_source,
+    frontend_release_id,
+    normalize_release_id,
+)
 from web.download_history_view import DownloadHistoryViewRow, build_download_history_rows
 
 
@@ -74,9 +78,28 @@ def _min_track_bitrate(tracks: Sequence["LibraryAlbumTrack"]) -> int | None:
     return min(bitrates) if bitrates else None
 
 
+def _detail_release_id(detail_row: Mapping[str, object]) -> str | None:
+    """Preserve exact-release IDs across canonical and unknown legacy shapes."""
+    frontend_id = frontend_release_id(
+        detail_row.get("mb_albumid"),
+        detail_row.get("discogs_albumid"),
+    )
+    if frontend_id:
+        return frontend_id
+
+    legacy_id = normalize_release_id(detail_row.get("mb_albumid"))
+    if legacy_id:
+        return legacy_id
+
+    discogs_id = normalize_release_id(detail_row.get("discogs_albumid"))
+    return discogs_id or None
+
+
 class LibraryAlbumTrack(msgspec.Struct, frozen=True):
     """Typed frontend contract for one library album track."""
 
+    id: int | None
+    artist: str | None
     disc: int | None
     track: int | None
     title: str | None
@@ -85,6 +108,7 @@ class LibraryAlbumTrack(msgspec.Struct, frozen=True):
     bitrate: int | None
     samplerate: int | None
     bitdepth: int | None
+    path: str | None
 
 
 class LibraryAlbumDetail(msgspec.Struct, frozen=True):
@@ -116,6 +140,7 @@ class LibraryAlbumDetail(msgspec.Struct, frozen=True):
     label: str
     country: str | None
     source: str
+    artpath: str | None
     path: str | None
     tracks: list[LibraryAlbumTrack]
     pipeline_id: int | None
@@ -141,6 +166,8 @@ def build_library_album_detail(
     tracks = [
         msgspec.convert(
             {
+                "id": track.get("id"),
+                "artist": track.get("artist"),
                 "disc": track.get("disc"),
                 "track": track.get("track"),
                 "title": track.get("title"),
@@ -149,15 +176,13 @@ def build_library_album_detail(
                 "bitrate": track.get("bitrate"),
                 "samplerate": track.get("samplerate"),
                 "bitdepth": track.get("bitdepth"),
+                "path": track.get("path"),
             },
             type=LibraryAlbumTrack,
         )
         for track in cast(Sequence[Mapping[str, object]], detail_row.get("tracks") or [])
     ]
-    frontend_id = frontend_release_id(
-        detail_row.get("mb_albumid"),
-        detail_row.get("discogs_albumid"),
-    )
+    frontend_id = _detail_release_id(detail_row)
     raw_formats = str(detail_row.get("formats") or "")
     source = str(detail_row.get("source") or detect_release_source(frontend_id))
     history_items = build_download_history_rows(download_history)
@@ -180,6 +205,7 @@ def build_library_album_detail(
             "label": str(detail_row.get("label") or ""),
             "country": detail_row.get("country"),
             "source": source or "unknown",
+            "artpath": detail_row.get("artpath"),
             "path": detail_row.get("path"),
             "tracks": tracks,
             "pipeline_id": pipeline_request.get("id") if pipeline_request else None,
@@ -225,10 +251,7 @@ def load_library_album_detail(
     if detail is None:
         return None
 
-    release_id = frontend_release_id(
-        detail.get("mb_albumid"),
-        detail.get("discogs_albumid"),
-    )
+    release_id = _detail_release_id(detail)
     pipeline_request = (
         resolve_pipeline_request(
             pipeline_db,

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -23,49 +23,23 @@ def get_beets_search(h, params: dict[str, list[str]]) -> None:
 
 
 def get_beets_album(h, params: dict[str, list[str]], album_id_str: str) -> None:
-    from lib.library_delete_service import resolve_pipeline_request
+    from web.library_album_detail_service import load_library_album_detail
 
     album_id = int(album_id_str)
-    b = _server()._beets_db()
+    srv = _server()
+    b = srv._beets_db()
     if not b:
         h._error("Beets DB not available")
         return
-    detail = b.get_album_detail(album_id)
+    detail = load_library_album_detail(
+        library_lookup=b,
+        pipeline_db=srv.db,
+        album_id=album_id,
+    )
     if not detail:
         h._error("Not found", 404)
         return
-    result: dict[str, object] = dict(detail)
-    # Include pipeline download history if available
-    mb_id = detail.get("mb_albumid")
-    srv = _server()
-    if mb_id and srv.db:
-        req = resolve_pipeline_request(
-            srv.db,
-            pipeline_id=None,
-            release_id=str(mb_id),
-        )
-        if req:
-            history = srv._db().get_download_history(req["id"])
-            result["pipeline_id"] = req["id"]
-            result["pipeline_status"] = req["status"]
-            result["pipeline_source"] = req.get("source")
-            result["pipeline_min_bitrate"] = req.get("min_bitrate")
-            result["search_filetype_override"] = req.get("search_filetype_override")
-            result["target_format"] = req.get("target_format")
-            result["upgrade_queued"] = (
-                req["status"] == "wanted" and bool(req.get("search_filetype_override") or req.get("target_format"))
-            )
-            from web.classify import classify_log_entry as _clf, LogEntry as _LE
-            dh = []
-            for h_entry in history:
-                he = _LE.from_row(h_entry)
-                hi = he.to_json_dict()
-                _c = _clf(he)
-                hi["verdict"] = _c.verdict
-                hi["downloaded_label"] = _c.downloaded_label
-                dh.append(hi)
-            result["download_history"] = dh
-    h._json(result)
+    h._json(detail.to_dict())
 
 
 def get_beets_recent(h, params: dict[str, list[str]]) -> None:

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -5,8 +5,12 @@ import re
 import msgspec
 from typing import TypedDict
 
-from web.classify import classify_log_entry, LogEntry
 from lib.import_dispatch import transition_request as _transition_request
+from web.download_history_view import (
+    build_download_history_row,
+    build_download_history_rows,
+    classify_download_log_row,
+)
 from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
                          resolve_user_requeue_override,
                          should_clear_lossless_search_override,
@@ -44,8 +48,9 @@ def get_pipeline_log(h, params: dict[str, list[str]]) -> None:
     beets_info = _server().check_beets_library_detail(mbids) if mbids else {}
     result = []
     for e in entries:
-        entry = LogEntry.from_row(e)
-        classified = classify_log_entry(entry)
+        classified_row = classify_download_log_row(e)
+        entry = classified_row.entry
+        classified = classified_row.classified
         item = entry.to_json_dict()
         mbid = entry.mb_release_id
         bi = beets_info.get(mbid) if mbid else None
@@ -163,12 +168,10 @@ def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
         for item in status_items[status]:
             history = history_batch.get(item["id"], [])
             if history:
-                last = history[0]
-                entry = LogEntry.from_row(last)
-                classified = classify_log_entry(entry)
-                item["last_verdict"] = classified.verdict
-                item["last_outcome"] = last.get("outcome")
-                item["last_username"] = last.get("soulseek_username")
+                last = build_download_history_row(history[0])
+                item["last_verdict"] = last.verdict
+                item["last_outcome"] = last.outcome
+                item["last_username"] = last.soulseek_username
                 item["download_count"] = len(history)
             items.append(item)
         all_data[status] = items
@@ -281,14 +284,7 @@ def get_pipeline_detail(h, params: dict[str, list[str]], req_id_str: str) -> Non
         return
     tracks = s._db().get_tracks(req_id)
     history = s._db().get_download_history(req_id)
-    history_items = []
-    for dl in history:
-        he = LogEntry.from_row(dl)
-        hi = he.to_json_dict()
-        classified = classify_log_entry(he)
-        hi["verdict"] = classified.verdict
-        hi["downloaded_label"] = classified.downloaded_label
-        history_items.append(hi)
+    history_items = [item.to_dict() for item in build_download_history_rows(history)]
     result: dict[str, object] = {
         "request": s._serialize_row(req),
         "tracks": tracks,


### PR DESCRIPTION
## Summary
- move `/api/beets/album/<id>` payload shaping out of `web/routes/library.py` into a dedicated service seam
- add typed library album detail and download-history view models that own pipeline lookup, upgrade-queued calculation, and history classification
- preserve nullable legacy beets `added` and track metadata fields so the refactor keeps the old best-effort route behaviour

## Why
Issue #155 is about getting browse/library row shaping out of the route layer so one contract owns the detail payload. This keeps the route thin and makes the album detail surface directly testable. During Codex review, nullable legacy beets fields were flagged as a regression risk, so the service now preserves those nullable values explicitly instead of crashing the detail response.

## Validation
- `nix-shell --run "python3 -m unittest tests.test_library_album_detail_service tests.test_web_server -v"`
- `nix-shell --run "pyright web/download_history_view.py web/library_album_detail_service.py web/routes/library.py tests/test_library_album_detail_service.py tests/test_web_server.py"`

Closes #155.
