### PR TITLE
[codex] refactor: finalize request status through one seam

### DIFF
--- a/album_source.py
+++ b/album_source.py
@@ -193,12 +193,20 @@ class DatabaseSource:
 
     def update_status(self, album_record, status, **extra):
         """Update album status in the pipeline DB."""
-        from lib.transitions import apply_transition
+        from lib.import_dispatch import DispatchOutcome, finalize_request
         request_id = getattr(album_record, "db_request_id", None)
         if not request_id:
             return
         db = self._get_db()
-        apply_transition(db, request_id, status, **extra)
+        finalize_request(
+            db,
+            request_id,
+            DispatchOutcome.transition(
+                to_status=status,
+                success=status == "imported",
+                transition_fields=extra,
+            ),
+        )
 
     def mark_done(self, album_record, bv_result, dest_path=None,
                   download_info=None):
@@ -232,15 +240,25 @@ class DatabaseSource:
 
         db = self._get_db()
         dl = download_info if isinstance(download_info, DownloadInfo) else DownloadInfo()
-        from lib.transitions import apply_transition
+        from lib.import_dispatch import DispatchOutcome, finalize_request
         transition_kwargs: dict[str, object] = dict(
             beets_distance=bv_result.distance,
             beets_scenario=bv_result.scenario,
         )
         if search_filetype_override is not None:
             transition_kwargs["search_filetype_override"] = search_filetype_override
-        apply_transition(db, request_id, "wanted", **transition_kwargs)
-        db.record_attempt(request_id, "validation")
+        finalize_request(
+            db,
+            request_id,
+            DispatchOutcome.transition(
+                to_status="wanted",
+                success=False,
+                message="Validation rejected",
+                from_status="downloading",
+                attempt_type="validation",
+                transition_fields=transition_kwargs,
+            ),
+        )
 
         db.log_download(
             request_id=request_id,

--- a/album_source.py
+++ b/album_source.py
@@ -191,23 +191,6 @@ class DatabaseSource:
             for t in tracks
         ]
 
-    def update_status(self, album_record, status, **extra):
-        """Update album status in the pipeline DB."""
-        from lib.import_dispatch import DispatchOutcome, finalize_request
-        request_id = getattr(album_record, "db_request_id", None)
-        if not request_id:
-            return
-        db = self._get_db()
-        finalize_request(
-            db,
-            request_id,
-            DispatchOutcome.transition(
-                to_status=status,
-                success=status == "imported",
-                transition_fields=extra,
-            ),
-        )
-
     def mark_done(self, album_record, bv_result, dest_path=None,
                   download_info=None):
         """Mark album as imported."""
@@ -254,11 +237,10 @@ class DatabaseSource:
                 to_status="wanted",
                 success=False,
                 message="Validation rejected",
-                from_status="downloading",
-                attempt_type="validation",
                 transition_fields=transition_kwargs,
             ),
         )
+        db.record_attempt(request_id, "validation")
 
         db.log_download(
             request_id=request_id,

--- a/album_source.py
+++ b/album_source.py
@@ -224,10 +224,7 @@ class DatabaseSource:
         db = self._get_db()
         dl = download_info if isinstance(download_info, DownloadInfo) else DownloadInfo()
         from lib.import_dispatch import DispatchOutcome, finalize_request
-        transition_kwargs: dict[str, object] = dict(
-            beets_distance=bv_result.distance,
-            beets_scenario=bv_result.scenario,
-        )
+        transition_kwargs: dict[str, object] = {}
         if search_filetype_override is not None:
             transition_kwargs["search_filetype_override"] = search_filetype_override
         finalize_request(

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -118,15 +118,14 @@ FORCE/MANUAL (dispatch_import_from_db)
 The auto path only holds RELEASE, and acquires it at
 `_handle_valid_result` *before* `stage_to_ai` runs (Codex PR #136 R4
 P1 — see below). `dispatch_import_core`'s inner acquisition of the
-same key — reached via `dispatch_import` (the auto-path orchestration
+same key — reached via `dispatch_import_core` (the auto-path orchestration
 wrapper in `lib/import_dispatch.py`) — is a no-op reentrant acquire:
 
 ```
 AUTO (_handle_valid_result in lib/download.py)
   └─ acquire RELEASE(release_id_to_lock_key(mbid))             ← outer
       └─ stage_to_ai                                           ← moves files
-      └─ dispatch_import
-          └─ dispatch_import_core
+      └─ dispatch_import_core
               └─ acquire RELEASE(...)                          ← reentrant no-op
                   └─ import_one.py subprocess
 ```

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -117,17 +117,18 @@ FORCE/MANUAL (dispatch_import_from_db)
 
 The auto path only holds RELEASE, and acquires it at
 `_handle_valid_result` *before* `stage_to_ai` runs (Codex PR #136 R4
-P1 — see below). `dispatch_import_core`'s inner acquisition of the
-same key — reached via `dispatch_import_core` (the auto-path orchestration
-wrapper in `lib/import_dispatch.py`) — is a no-op reentrant acquire:
+P1 — see below). `_handle_valid_result` now calls
+`dispatch_import_core` directly; its inner acquisition of the same
+RELEASE key is therefore just a no-op reentrant acquire against the
+outer lock already held by the auto path:
 
 ```
 AUTO (_handle_valid_result in lib/download.py)
   └─ acquire RELEASE(release_id_to_lock_key(mbid))             ← outer
       └─ stage_to_ai                                           ← moves files
       └─ dispatch_import_core
-              └─ acquire RELEASE(...)                          ← reentrant no-op
-                  └─ import_one.py subprocess
+          └─ acquire RELEASE(...)                              ← reentrant no-op
+              └─ import_one.py subprocess
 ```
 
 **Why RELEASE outer at `_handle_valid_result`, not at

--- a/docs/async-downloads-plan.md
+++ b/docs/async-downloads-plan.md
@@ -647,7 +647,7 @@ if refreshed and refreshed["status"] == "downloading":
 **Files**: `lib/pipeline_db.py`
 
 **Why**: `reset_to_wanted()` and `update_status()` are called from many places (quality gate,
-mark_done, reject_and_requeue, dispatch_import). If any of these runs on an album that still has
+mark_done, reject_and_requeue, dispatch_import_core). If any of these runs on an album that still has
 `active_download_state` set (e.g., due to a bug or race), the stale JSONB persists. Clearing
 it in these methods is defensive — it should already be NULL by the time they run, but this
 prevents stale state from accumulating.

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -194,11 +194,11 @@ Albums that were downloaded as FLAC, converted to V0 at or above the `cfg.mp3_vb
 
 ## Downgrade prevention
 
-- `--override-min-bitrate` arg: `dispatch_import()` passes `min(min_bitrate, current_spectral_bitrate)` from the pipeline DB. When spectral says the existing files are 128 kbps but the container says 320 kbps (fake CBR), the spectral truth is used so genuine upgrades aren't blocked.
+- `--override-min-bitrate` arg: `dispatch_import_core()` passes `min(min_bitrate, current_spectral_bitrate)` from the pipeline DB. When spectral says the existing files are 128 kbps but the container says 320 kbps (fake CBR), the spectral truth is used so genuine upgrades aren't blocked.
 - `mark_done()` respects `verified_lossless_override` from import_one.py instead of re-deriving via `is_verified_lossless()`. When verified lossless, `current_spectral_bitrate` is set to the actual V0 min bitrate (not the spectral cliff estimate, which can miscalibrate on genuine files).
 - Spectral state writes always go through `RequestSpectralStateUpdate` — grade and bitrate are always written together (including explicit NULLs for genuine files with no cliff). This prevents stale spectral data from persisting after an upgrade.
-- `--target-format` flag: when `target_format="lossless"` (or legacy `"flac"`), skips V0 conversion and keeps lossless on disk. ALAC/WAV sources are normalized to FLAC via `FLAC_SPEC`. Genuine lossless on disk is marked `verified_lossless`. Passed from `dispatch_import()` when `album_data.db_target_format` is set.
-- `--verified-lossless-target` flag: target format after verified lossless (e.g. "opus 128", "mp3 v2", "aac 128"). Passed from `dispatch_import()` when `cfg.verified_lossless_target` is set. When the target has the same `.mp3` extension as V0, V0 files are removed before target conversion.
+- `--target-format` flag: when `target_format="lossless"` (or legacy `"flac"`), skips V0 conversion and keeps lossless on disk. ALAC/WAV sources are normalized to FLAC via `FLAC_SPEC`. Genuine lossless on disk is marked `verified_lossless`. Passed from `dispatch_import_core()` when `album_data.db_target_format` is set.
+- `--verified-lossless-target` flag: target format after verified lossless (e.g. "opus 128", "mp3 v2", "aac 128"). Passed from `dispatch_import_core()` when `cfg.verified_lossless_target` is set. When the target has the same `.mp3` extension as V0, V0 files are removed before target conversion.
 - `--force` flag: skips the distance check (`MAX_DISTANCE=999`) for force-importing rejected albums. Used by `pipeline_cli.py force-import` and `POST /api/pipeline/force-import`.
 - Exit codes: 0=imported, 1=conversion failed, 2=beets failed, 3=path not found, 5=downgrade, 6=transcode (may or may not have imported as upgrade).
 

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1004,8 +1004,12 @@ def _canonicalize_siblings(
 # ---------------------------------------------------------------------------
 
 def update_pipeline_db(request_id, status, imported_path=None, distance=None, scenario=None):
-    """Update pipeline DB status. Best-effort — failures logged but don't block."""
+    """Update pipeline DB via the shared finalization seam.
+
+    Best-effort — failures are logged but do not block the import harness.
+    """
     try:
+        from lib.import_dispatch import DispatchOutcome, finalize_request
         from lib.pipeline_db import PipelineDB
         dsn = os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger")
         db = PipelineDB(dsn)
@@ -1016,8 +1020,19 @@ def update_pipeline_db(request_id, status, imported_path=None, distance=None, sc
             extra["beets_distance"] = distance
         if scenario:
             extra["beets_scenario"] = scenario
-        db.update_status(request_id, status, **extra)
-        db.close()
+        try:
+            finalize_request(
+                db,
+                request_id,
+                DispatchOutcome.transition(
+                    to_status=status,
+                    success=status == "imported",
+                    message=f"Harness updated request to {status}",
+                    transition_fields=extra or None,
+                ),
+            )
+        finally:
+            db.close()
     except Exception as e:
         print(f"  [WARN] Pipeline DB update failed: {e}", file=sys.stderr)
 

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1031,6 +1031,8 @@ def update_pipeline_db(request_id, status, imported_path=None, distance=None, sc
                     transition_fields=extra or None,
                 ),
             )
+        except ValueError as e:
+            print(f"  [WARN] Pipeline DB transition rejected: {e}", file=sys.stderr)
         finally:
             db.close()
     except Exception as e:

--- a/lib/download.py
+++ b/lib/download.py
@@ -568,28 +568,39 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
 
     if wants_auto_import and not album_data.mb_release_id:
         detail = "Request auto-import requires a MusicBrainz release ID"
+        failed_result = ValidationResult(
+            distance=bv_result.distance if bv_result.distance is not None else 0.0,
+            scenario="request_missing_mbid",
+            detail=detail,
+            error="missing_mbid",
+        )
+        failed_result.failed_path = move_failed_import(
+            import_folder_fullpath,
+            scenario=failed_result.scenario,
+        )
         logger.error(
             f"AUTO-IMPORT REJECTED: {album_data.artist} - {album_data.title} — "
             f"{detail}"
         )
+        log_validation_result(album_data, failed_result, ctx.cfg)
         if request_id is not None:
             db = ctx.pipeline_db_source._get_db()
             dl_info = _build_download_info(album_data)
-            validation_json = ValidationResult(
-                distance=bv_result.distance if bv_result.distance is not None else 0.0,
-                scenario="request_missing_mbid",
-                detail=detail,
-                error="missing_mbid",
-            ).to_json()
-            dl_info.validation_result = validation_json
+            if album_data.download_spectral is not None:
+                dl_info.download_spectral = album_data.download_spectral
+                dl_info.current_spectral = album_data.current_spectral
+                dl_info.existing_min_bitrate = album_data.current_min_bitrate
+                dl_info.slskd_filetype = dl_info.filetype
+                dl_info.actual_filetype = dl_info.filetype
+            validation_json = failed_result.to_json()
             _record_rejection_and_maybe_requeue(
                 db,
                 request_id,
                 dl_info,
-                distance=bv_result.distance if bv_result.distance is not None else 0.0,
-                scenario="request_missing_mbid",
+                distance=failed_result.distance if failed_result.distance is not None else 0.0,
+                scenario=failed_result.scenario or "request_missing_mbid",
                 detail=detail,
-                error="missing_mbid",
+                error=failed_result.error,
                 requeue=True,
                 validation_result=validation_json,
             )

--- a/lib/download.py
+++ b/lib/download.py
@@ -19,10 +19,11 @@ import music_tag
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, decide_download_action,
+                         compute_effective_override_bitrate,
                          extract_usernames,
                          rejection_backfill_override)
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
-                                 dispatch_import)
+                                 dispatch_import_core, finalize_request)
 from lib.transitions import apply_transition
 from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
                       log_validation_result)
@@ -471,73 +472,56 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
             except Exception:
                 logger.exception(f"Error writing tags for: {file.import_path}")
         if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
-            outcome = _process_beets_validation(
-                album_data, import_folder_fullpath, ctx)
-            if outcome is not None and outcome.deferred:
-                # Release-lock contention. Propagate ``None`` so
-                # ``_run_completed_processing`` leaves the request's
-                # status, active_download_state, and staged files
-                # untouched for the next cycle to retry.
-                return None
+            from lib.beets import beets_validate as _bv
+            from lib.preimport import run_preimport_gates
+
+            bv_result = _bv(ctx.cfg.beets_harness_path, import_folder_fullpath,
+                            album_data.mb_release_id, ctx.cfg.beets_distance_threshold)
+            usernames_pre = set(f.username for f in album_data.files if f.username)
+            bv_result.soulseek_username = (
+                ", ".join(sorted(usernames_pre)) if usernames_pre else None
+            )
+            bv_result.download_folder = import_folder_fullpath
+
+            if bv_result.valid:
+                dl_pre = _build_download_info(album_data)
+                db = (ctx.pipeline_db_source._get_db()
+                      if ctx.pipeline_db_source is not None else None)
+                preimport = run_preimport_gates(
+                    path=import_folder_fullpath,
+                    mb_release_id=album_data.mb_release_id or "",
+                    label=f"{album_data.artist} - {album_data.title}",
+                    download_filetype=dl_pre.filetype or "",
+                    download_min_bitrate_bps=dl_pre.bitrate,
+                    download_is_vbr=dl_pre.is_vbr,
+                    cfg=ctx.cfg,
+                    db=db,
+                    request_id=album_data.db_request_id,
+                    usernames=usernames_pre,
+                )
+                album_data.download_spectral = preimport.download_spectral
+                album_data.current_spectral = preimport.existing_spectral
+                album_data.current_min_bitrate = preimport.existing_min_bitrate
+                if not preimport.valid:
+                    bv_result.valid = False
+                    bv_result.scenario = preimport.scenario
+                    bv_result.detail = preimport.detail
+                    if preimport.corrupt_files:
+                        bv_result.corrupt_files = preimport.corrupt_files
+
+            if bv_result.valid:
+                outcome = _handle_valid_result(
+                    album_data, bv_result, import_folder_fullpath, ctx)
+                if outcome is not None and outcome.deferred:
+                    # Release-lock contention. Propagate ``None`` so
+                    # ``_run_completed_processing`` leaves the request's
+                    # status, active_download_state, and staged files
+                    # untouched for the next cycle to retry.
+                    return None
+            else:
+                _handle_rejected_result(
+                    album_data, bv_result, import_folder_fullpath, ctx)
         return True
-
-
-def _process_beets_validation(album_data: GrabListEntry, import_folder_fullpath: str,
-                              ctx: CratediggerContext) -> "DispatchOutcome | None":
-    """Beets validation sub-path of process_completed_album.
-
-    After beets validation passes, delegates to ``lib.preimport.run_preimport_gates``
-    for the shared audio + spectral gates. The force/manual-import path
-    (``dispatch_import_from_db``) calls the same function — only the beets
-    distance check is path-specific.
-
-    Returns the dispatch outcome when the auto-import path fires,
-    ``None`` when beets validation rejects (``_handle_rejected_result``
-    already handles the state transition) or when the non-auto
-    redownload path takes over in ``_handle_valid_result``. Caller
-    uses the ``deferred`` flag to decide whether to flip status.
-    """
-    from lib.beets import beets_validate as _bv
-    from lib.preimport import run_preimport_gates
-    bv_result = _bv(ctx.cfg.beets_harness_path, import_folder_fullpath,
-                    album_data.mb_release_id, ctx.cfg.beets_distance_threshold)
-    # Populate source info
-    usernames_pre = set(f.username for f in album_data.files if f.username)
-    bv_result.soulseek_username = ", ".join(sorted(usernames_pre)) if usernames_pre else None
-    bv_result.download_folder = import_folder_fullpath
-
-    if bv_result.valid:
-        dl_pre = _build_download_info(album_data)
-        db = (ctx.pipeline_db_source._get_db()
-              if ctx.pipeline_db_source is not None else None)
-        preimport = run_preimport_gates(
-            path=import_folder_fullpath,
-            mb_release_id=album_data.mb_release_id or "",
-            label=f"{album_data.artist} - {album_data.title}",
-            download_filetype=dl_pre.filetype or "",
-            download_min_bitrate_bps=dl_pre.bitrate,
-            download_is_vbr=dl_pre.is_vbr,
-            cfg=ctx.cfg,
-            db=db,
-            request_id=album_data.db_request_id,
-            usernames=usernames_pre,
-        )
-        album_data.download_spectral = preimport.download_spectral
-        album_data.current_spectral = preimport.existing_spectral
-        album_data.current_min_bitrate = preimport.existing_min_bitrate
-        if not preimport.valid:
-            bv_result.valid = False
-            bv_result.scenario = preimport.scenario
-            bv_result.detail = preimport.detail
-            if preimport.corrupt_files:
-                bv_result.corrupt_files = preimport.corrupt_files
-
-    if bv_result.valid:
-        return _handle_valid_result(
-            album_data, bv_result, import_folder_fullpath, ctx)
-    _handle_rejected_result(
-        album_data, bv_result, import_folder_fullpath, ctx)
-    return None
 
 
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
@@ -545,10 +529,10 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                          ctx: CratediggerContext) -> "DispatchOutcome | None":
     """Handle a valid beets validation result: stage and optionally auto-import.
 
-    Returns the ``DispatchOutcome`` from ``dispatch_import`` when the
+    Returns the ``DispatchOutcome`` from ``dispatch_import_core`` when the
     auto-import path fires (source='request', distance within
     threshold), or ``None`` for the redownload path that just stages
-    and marks done. ``_process_beets_validation`` propagates the
+    and marks done. ``process_completed_album()`` propagates the
     outcome upward so ``_run_completed_processing`` can distinguish
     ``deferred`` from ``success`` / ``failure`` on the release-lock
     contention path.
@@ -567,7 +551,6 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     ``dispatch_import_core``).
     """
     from contextlib import nullcontext
-    from lib.import_dispatch import DispatchOutcome
     from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE,
                                  release_id_to_lock_key)
 
@@ -577,9 +560,9 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     will_auto_import = (
         source_type == "request"
         and dist <= ctx.cfg.beets_distance_threshold)
+    pdb = ctx.pipeline_db_source._get_db()
 
     if will_auto_import and album_data.mb_release_id:
-        pdb = ctx.pipeline_db_source._get_db()
         lock_ctx = pdb.advisory_lock(
             ADVISORY_LOCK_NAMESPACE_RELEASE,
             release_id_to_lock_key(album_data.mb_release_id))
@@ -619,8 +602,36 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
             dl_info.actual_filetype = dl_info.filetype
         if will_auto_import:
             assert request_id is not None, "pipeline request must have db_request_id"
-            return dispatch_import(
-                album_data, bv_result, dest, dl_info, request_id, ctx)
+            override_min_bitrate: int | None = None
+            try:
+                req = pdb.get_request(request_id)
+                if req:
+                    override_min_bitrate = compute_effective_override_bitrate(
+                        req.get("min_bitrate"),
+                        req.get("current_spectral_bitrate"),
+                        req.get("current_spectral_grade"),
+                    )
+            except Exception:
+                logger.debug("DB lookup failed for override-min-bitrate")
+
+            return dispatch_import_core(
+                path=dest,
+                mb_release_id=album_data.mb_release_id or "",
+                request_id=request_id,
+                label=f"{album_data.artist} - {album_data.title}",
+                override_min_bitrate=override_min_bitrate,
+                target_format=album_data.db_target_format,
+                verified_lossless_target=ctx.cfg.verified_lossless_target,
+                beets_harness_path=ctx.cfg.beets_harness_path,
+                db=pdb,
+                dl_info=dl_info,
+                distance=bv_result.distance if bv_result.distance is not None else 0.0,
+                scenario=bv_result.scenario or "auto_import",
+                files=album_data.files,
+                cfg=ctx.cfg,
+                requeue_on_failure=True,
+                cooled_down_users=ctx.cooled_down_users,
+            )
         ctx.pipeline_db_source.mark_done(
             album_data, bv_result, dest_path=dest, download_info=dl_info)
         return None
@@ -950,9 +961,17 @@ def _timeout_album(
     for username in extract_usernames(entry.files):
         if db.check_and_apply_cooldown(username):
             ctx.cooled_down_users.add(username)
-    apply_transition(db, request_id, "wanted",
-                     from_status="downloading",
-                     attempt_type="download")
+    finalize_request(
+        db,
+        request_id,
+        DispatchOutcome.transition(
+            to_status="wanted",
+            success=False,
+            message="Download timed out",
+            from_status="downloading",
+            attempt_type="download",
+        ),
+    )
 
 
 def _persist_updated_download_state(
@@ -1058,14 +1077,30 @@ def _run_completed_processing(
         if outcome:
             logger.info(f"  process_completed_album succeeded without "
                         f"setting status — setting imported")
-            apply_transition(db, request_id, "imported",
-                             from_status="downloading")
+            finalize_request(
+                db,
+                request_id,
+                DispatchOutcome.transition(
+                    to_status="imported",
+                    success=True,
+                    message="Completed local processing",
+                    from_status="downloading",
+                ),
+            )
         else:
             logger.warning(f"  process_completed_album failed without "
                            f"setting status — resetting to wanted")
-            apply_transition(db, request_id, "wanted",
-                             from_status="downloading",
-                             attempt_type="download")
+            finalize_request(
+                db,
+                request_id,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    message="Completed processing failed",
+                    from_status="downloading",
+                    attempt_type="download",
+                ),
+            )
 
 
 def poll_active_downloads(ctx: CratediggerContext) -> None:
@@ -1103,8 +1138,16 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             # crashed on a previous run. Reset to wanted so it gets re-searched.
             logger.error(f"Downloading album {request_id} has no active_download_state — "
                          f"resetting to wanted")
-            apply_transition(db, request_id, "wanted",
-                             from_status="downloading")
+            finalize_request(
+                db,
+                request_id,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    message="Missing active download state",
+                    from_status="downloading",
+                ),
+            )
             continue
 
         # psycopg2 returns JSONB as dict, not string — use from_dict directly

--- a/lib/download.py
+++ b/lib/download.py
@@ -564,6 +564,8 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     will_auto_import = (
         source_type == "request"
         and dist <= ctx.cfg.beets_distance_threshold)
+    if will_auto_import and not album_data.mb_release_id:
+        will_auto_import = False
     pdb = None
 
     if will_auto_import and album_data.mb_release_id:

--- a/lib/download.py
+++ b/lib/download.py
@@ -179,7 +179,12 @@ def _slskd_search_roots(
     file_dir: str,
     slskd_download_dir: str,
 ) -> list[tuple[str, int, str]]:
-    """Ordered search roots for resolving one downloaded file on disk."""
+    """Ordered search roots for resolving one downloaded file on disk.
+
+    Intentionally stops at the album/ancestor folders derived from the
+    Soulseek remote path. A whole-download-root scan can silently pick an
+    unrelated sibling album that happens to contain the same basename.
+    """
     components = _remote_path_components(file_dir)
     incomplete_root = os.path.join(slskd_download_dir, "incomplete")
     plans: list[tuple[str, int, str]] = []
@@ -206,9 +211,6 @@ def _slskd_search_roots(
     for component in reversed(components[-3:]):
         add(os.path.join(slskd_download_dir, component), 2, "ancestor folder")
         add(os.path.join(incomplete_root, component), 2, "incomplete ancestor folder")
-
-    add(slskd_download_dir, 2, "download root")
-    add(incomplete_root, 2, "incomplete root")
     return plans
 
 
@@ -221,7 +223,9 @@ def resolve_slskd_local_path(file: "DownloadFile",
     ``_<ticks>`` collision-rename variants. When multiple collision variants
     exist, prefers the one whose byte size matches ``file.size``, else
     picks deterministically and logs a warning so ambiguous cases are
-    visible in journald.
+    visible in journald. The fallback search is restricted to path-derived
+    album folders; it never walks the whole slskd root because basename-only
+    matches there can cross album boundaries.
     """
     filename_components = _remote_path_components(file.filename)
     expected_name = filename_components[-1] if filename_components else file.filename

--- a/lib/download.py
+++ b/lib/download.py
@@ -18,11 +18,13 @@ import music_tag
 
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
-                         DownloadDecision, decide_download_action,
+                         DownloadDecision, ValidationResult,
+                         decide_download_action,
                          compute_effective_override_bitrate,
                          extract_usernames,
                          rejection_backfill_override)
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
+                                 _record_rejection_and_maybe_requeue,
                                  dispatch_import_core, finalize_request)
 from lib.transitions import apply_transition
 from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
@@ -30,7 +32,6 @@ from lib.util import (sanitize_folder_name, move_failed_import, stage_to_ai,
 
 if TYPE_CHECKING:
     from lib.context import CratediggerContext
-    from lib.quality import ValidationResult
 
 logger = logging.getLogger("cratedigger")
 MAX_FILE_RETRIES = 5
@@ -561,14 +562,43 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     source_type = album_data.db_source or "redownload"
     request_id = album_data.db_request_id
     dist = bv_result.distance if bv_result.distance is not None else 1.0
-    will_auto_import = (
+    wants_auto_import = (
         source_type == "request"
         and dist <= ctx.cfg.beets_distance_threshold)
-    if will_auto_import and not album_data.mb_release_id:
-        will_auto_import = False
+
+    if wants_auto_import and not album_data.mb_release_id:
+        detail = "Request auto-import requires a MusicBrainz release ID"
+        logger.error(
+            f"AUTO-IMPORT REJECTED: {album_data.artist} - {album_data.title} — "
+            f"{detail}"
+        )
+        if request_id is not None:
+            db = ctx.pipeline_db_source._get_db()
+            dl_info = _build_download_info(album_data)
+            validation_json = ValidationResult(
+                distance=bv_result.distance if bv_result.distance is not None else 0.0,
+                scenario="request_missing_mbid",
+                detail=detail,
+                error="missing_mbid",
+            ).to_json()
+            dl_info.validation_result = validation_json
+            _record_rejection_and_maybe_requeue(
+                db,
+                request_id,
+                dl_info,
+                distance=bv_result.distance if bv_result.distance is not None else 0.0,
+                scenario="request_missing_mbid",
+                detail=detail,
+                error="missing_mbid",
+                requeue=True,
+                validation_result=validation_json,
+            )
+        return DispatchOutcome(success=False, message=detail)
+
+    will_auto_import = wants_auto_import
     pdb = None
 
-    if will_auto_import and album_data.mb_release_id:
+    if will_auto_import:
         pdb = ctx.pipeline_db_source._get_db()
         lock_ctx = pdb.advisory_lock(
             ADVISORY_LOCK_NAMESPACE_RELEASE,

--- a/lib/download.py
+++ b/lib/download.py
@@ -560,9 +560,10 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     will_auto_import = (
         source_type == "request"
         and dist <= ctx.cfg.beets_distance_threshold)
-    pdb = ctx.pipeline_db_source._get_db()
+    pdb = None
 
     if will_auto_import and album_data.mb_release_id:
+        pdb = ctx.pipeline_db_source._get_db()
         lock_ctx = pdb.advisory_lock(
             ADVISORY_LOCK_NAMESPACE_RELEASE,
             release_id_to_lock_key(album_data.mb_release_id))
@@ -602,6 +603,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
             dl_info.actual_filetype = dl_info.filetype
         if will_auto_import:
             assert request_id is not None, "pipeline request must have db_request_id"
+            assert pdb is not None, "auto-import path must hold a pipeline DB handle"
             override_min_bitrate: int | None = None
             try:
                 req = pdb.get_request(request_id)

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -204,7 +204,9 @@ def finalize_request(
     if outcome.deferred or outcome.target_status is None:
         return
 
-    reserved_fields = {"from_status", "attempt_type"} & set(outcome.transition_fields)
+    reserved_fields = {"from_status", "attempt_type", "state_json"} & set(
+        outcome.transition_fields
+    )
     if reserved_fields:
         names = ", ".join(sorted(reserved_fields))
         raise ValueError(
@@ -226,6 +228,7 @@ def transition_request(
     request_id: int,
     to_status: str,
     *,
+    success: bool = False,
     from_status: str | None = None,
     attempt_type: str | None = None,
     message: str = "",
@@ -238,7 +241,7 @@ def transition_request(
         request_id,
         DispatchOutcome.transition(
             to_status=to_status,
-            success=to_status == "imported",
+            success=success,
             message=message or f"Transitioned request to {to_status}",
             from_status=from_status,
             attempt_type=attempt_type,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -39,7 +39,13 @@ _SPECIAL_TRANSITION_FIELDS = frozenset({
     "state_json",
 })
 
-_ALLOWED_TRANSITION_FIELDS = frozenset({
+_COMMON_TRANSITION_FIELDS = frozenset({
+    "min_bitrate",
+    "prev_min_bitrate",
+    "search_filetype_override",
+})
+
+_IMPORTED_TRANSITION_FIELDS = frozenset({
     "beets_distance",
     "beets_scenario",
     "current_spectral_bitrate",
@@ -48,11 +54,15 @@ _ALLOWED_TRANSITION_FIELDS = frozenset({
     "imported_path",
     "last_download_spectral_bitrate",
     "last_download_spectral_grade",
-    "min_bitrate",
-    "prev_min_bitrate",
-    "search_filetype_override",
     "verified_lossless",
 })
+
+_ALLOWED_TRANSITION_FIELDS_BY_TARGET: dict[str, frozenset[str]] = {
+    "downloading": frozenset(),
+    "imported": _COMMON_TRANSITION_FIELDS | _IMPORTED_TRANSITION_FIELDS,
+    "manual": frozenset(),
+    "wanted": _COMMON_TRANSITION_FIELDS,
+}
 
 
 # Scenarios whose ``path`` is the user's source data (``failed_imports/…``),
@@ -226,18 +236,20 @@ def finalize_request(
         return
 
     if outcome.target_status is None:
-        if outcome.success:
-            raise ValueError(
-                "Successful DispatchOutcome passed to finalize_request() "
-                "must declare target_status."
-            )
-        return
+        raise ValueError(
+            "DispatchOutcome passed to finalize_request() "
+            "must declare target_status."
+        )
 
     transition_field_names = set(outcome.transition_fields)
     reserved_fields = _SPECIAL_TRANSITION_FIELDS & transition_field_names
+    allowed_fields = _ALLOWED_TRANSITION_FIELDS_BY_TARGET.get(
+        outcome.target_status,
+        frozenset(),
+    )
     unknown_fields = (
         transition_field_names
-        - _ALLOWED_TRANSITION_FIELDS
+        - allowed_fields
         - _SPECIAL_TRANSITION_FIELDS
     )
     if reserved_fields:
@@ -416,10 +428,7 @@ def _record_rejection_and_maybe_requeue(
     via action.denylist, not here.
     """
     if requeue:
-        transition_kwargs: dict[str, object] = dict(
-            beets_distance=distance,
-            beets_scenario=scenario,
-        )
+        transition_kwargs: dict[str, object] = {}
         if search_filetype_override is not None:
             transition_kwargs["search_filetype_override"] = search_filetype_override
         finalize_request(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -204,6 +204,14 @@ def finalize_request(
     if outcome.deferred or outcome.target_status is None:
         return
 
+    reserved_fields = {"from_status", "attempt_type"} & set(outcome.transition_fields)
+    if reserved_fields:
+        names = ", ".join(sorted(reserved_fields))
+        raise ValueError(
+            "DispatchOutcome.transition_fields must not include reserved keys: "
+            f"{names}. Use the explicit DispatchOutcome fields instead."
+        )
+
     transition_kwargs = dict(outcome.transition_fields)
     if outcome.from_status is not None:
         transition_kwargs["from_status"] = outcome.from_status
@@ -211,6 +219,32 @@ def finalize_request(
         transition_kwargs["attempt_type"] = outcome.attempt_type
 
     apply_transition(db, request_id, outcome.target_status, **transition_kwargs)
+
+
+def transition_request(
+    db: "PipelineDB",
+    request_id: int,
+    to_status: str,
+    *,
+    from_status: str | None = None,
+    attempt_type: str | None = None,
+    message: str = "",
+    **transition_fields: object,
+) -> None:
+    """Finalize one request-state transition through the shared seam."""
+
+    finalize_request(
+        db,
+        request_id,
+        DispatchOutcome.transition(
+            to_status=to_status,
+            success=to_status == "imported",
+            message=message or f"Transitioned request to {to_status}",
+            from_status=from_status,
+            attempt_type=attempt_type,
+            transition_fields=transition_fields or None,
+        ),
+    )
 
 
 def _do_mark_done(

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -429,10 +429,10 @@ def _record_rejection_and_maybe_requeue(
                 to_status="wanted",
                 success=False,
                 message=f"Rejected: {scenario}",
-                attempt_type="validation",
                 transition_fields=transition_kwargs,
             ),
         )
+        db.record_attempt(request_id, "validation")
 
     db.log_download(
         request_id=request_id,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -33,6 +33,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("cratedigger")
 
+_SPECIAL_TRANSITION_FIELDS = frozenset({
+    "from_status",
+    "attempt_type",
+    "state_json",
+})
+
+_ALLOWED_TRANSITION_FIELDS = frozenset({
+    "beets_distance",
+    "beets_scenario",
+    "current_spectral_bitrate",
+    "current_spectral_grade",
+    "final_format",
+    "imported_path",
+    "last_download_spectral_bitrate",
+    "last_download_spectral_grade",
+    "min_bitrate",
+    "prev_min_bitrate",
+    "search_filetype_override",
+    "verified_lossless",
+})
+
 
 # Scenarios whose ``path`` is the user's source data (``failed_imports/…``),
 # NOT a disposable staging directory. Used to gate ``_cleanup_staged_dir``
@@ -201,17 +222,35 @@ def finalize_request(
     decisions into ``album_requests.status`` writes.
     """
 
-    if outcome.deferred or outcome.target_status is None:
+    if outcome.deferred:
         return
 
-    reserved_fields = {"from_status", "attempt_type", "state_json"} & set(
-        outcome.transition_fields
+    if outcome.target_status is None:
+        if outcome.success:
+            raise ValueError(
+                "Successful DispatchOutcome passed to finalize_request() "
+                "must declare target_status."
+            )
+        return
+
+    transition_field_names = set(outcome.transition_fields)
+    reserved_fields = _SPECIAL_TRANSITION_FIELDS & transition_field_names
+    unknown_fields = (
+        transition_field_names
+        - _ALLOWED_TRANSITION_FIELDS
+        - _SPECIAL_TRANSITION_FIELDS
     )
     if reserved_fields:
         names = ", ".join(sorted(reserved_fields))
         raise ValueError(
             "DispatchOutcome.transition_fields must not include reserved keys: "
             f"{names}. Use the explicit DispatchOutcome fields instead."
+        )
+    if unknown_fields:
+        names = ", ".join(sorted(unknown_fields))
+        raise ValueError(
+            "DispatchOutcome.transition_fields includes unknown keys: "
+            f"{names}."
         )
 
     transition_kwargs = dict(outcome.transition_fields)
@@ -390,7 +429,6 @@ def _record_rejection_and_maybe_requeue(
                 to_status="wanted",
                 success=False,
                 message=f"Rejected: {scenario}",
-                from_status="downloading",
                 attempt_type="validation",
                 transition_fields=transition_kwargs,
             ),

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -11,8 +11,8 @@ import os
 import shutil
 import subprocess as sp
 import sys
-from dataclasses import dataclass
-from typing import Sequence, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence, TYPE_CHECKING
 
 from lib.quality import (parse_import_result, DispatchAction, DownloadInfo,
                          ImportResult, SpectralMeasurement, ValidationResult,
@@ -27,7 +27,6 @@ from lib.preimport import inspect_local_files, run_preimport_gates
 
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
-    from lib.context import CratediggerContext
     from lib.grab_list import GrabListEntry
     from lib.pipeline_db import PipelineDB
     from lib.quality import AudioQualityMeasurement, QualityRankConfig
@@ -147,6 +146,73 @@ def load_quality_gate_state(
     )
 
 
+@dataclass(frozen=True)
+class DispatchOutcome:
+    """Summary of an import / request-status outcome.
+
+    ``target_status`` + ``transition_fields`` describe the request mutation
+    that ``finalize_request()`` should apply. Callers that only need a result
+    summary can leave them unset.
+    """
+
+    success: bool
+    message: str
+    deferred: bool = False
+    target_status: str | None = None
+    from_status: str | None = None
+    attempt_type: str | None = None
+    transition_fields: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def transition(
+        cls,
+        *,
+        to_status: str,
+        success: bool,
+        message: str = "",
+        from_status: str | None = None,
+        attempt_type: str | None = None,
+        transition_fields: Mapping[str, object] | None = None,
+    ) -> "DispatchOutcome":
+        """Build an outcome that owns one request-status transition."""
+
+        return cls(
+            success=success,
+            message=message,
+            target_status=to_status,
+            from_status=from_status,
+            attempt_type=attempt_type,
+            transition_fields=(
+                dict(transition_fields)
+                if transition_fields is not None
+                else {}
+            ),
+        )
+
+
+def finalize_request(
+    db: "PipelineDB",
+    request_id: int,
+    outcome: "DispatchOutcome",
+) -> None:
+    """Apply the request-status transition described by ``outcome``.
+
+    This is the only production seam that should turn import / requeue
+    decisions into ``album_requests.status`` writes.
+    """
+
+    if outcome.deferred or outcome.target_status is None:
+        return
+
+    transition_kwargs = dict(outcome.transition_fields)
+    if outcome.from_status is not None:
+        transition_kwargs["from_status"] = outcome.from_status
+    if outcome.attempt_type is not None:
+        transition_kwargs["attempt_type"] = outcome.attempt_type
+
+    apply_transition(db, request_id, outcome.target_status, **transition_kwargs)
+
+
 def _do_mark_done(
     db: "PipelineDB",
     request_id: int,
@@ -206,7 +272,16 @@ def _do_mark_done(
                 ).as_update_fields()
         )
     update_fields["final_format"] = dl_info.final_format
-    apply_transition(db, request_id, "imported", **update_fields)
+    finalize_request(
+        db,
+        request_id,
+        DispatchOutcome.transition(
+            to_status="imported",
+            success=True,
+            message="Import successful",
+            transition_fields=update_fields,
+        ),
+    )
 
     db.log_download(
         request_id=request_id,
@@ -271,8 +346,18 @@ def _record_rejection_and_maybe_requeue(
         )
         if search_filetype_override is not None:
             transition_kwargs["search_filetype_override"] = search_filetype_override
-        apply_transition(db, request_id, "wanted", **transition_kwargs)
-        db.record_attempt(request_id, "validation")
+        finalize_request(
+            db,
+            request_id,
+            DispatchOutcome.transition(
+                to_status="wanted",
+                success=False,
+                message=f"Rejected: {scenario}",
+                from_status="downloading",
+                attempt_type="validation",
+                transition_fields=transition_kwargs,
+            ),
+        )
 
     db.log_download(
         request_id=request_id,
@@ -523,10 +608,20 @@ def _check_quality_gate_core(
 
         if decision == "requeue_upgrade":
             upgrade_override = QUALITY_UPGRADE_TIERS
-            apply_transition(db, request_id, "wanted",
-                             from_status="imported",
-                             search_filetype_override=upgrade_override,
-                             min_bitrate=min_br_kbps)
+            finalize_request(
+                db,
+                request_id,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    message="Queued for upgrade",
+                    from_status="imported",
+                    transition_fields={
+                        "search_filetype_override": upgrade_override,
+                        "min_bitrate": min_br_kbps,
+                    },
+                ),
+            )
             usernames = extract_usernames(files)
             gate_br = compute_effective_override_bitrate(
                 min_br_kbps, spectral_br, spectral_grade) or min_br_kbps
@@ -547,22 +642,38 @@ def _check_quality_gate_core(
                 f"(searching {upgrade_override})")
         elif decision == "requeue_lossless":
             lossless_override = QUALITY_LOSSLESS
-            apply_transition(db, request_id, "wanted",
-                             from_status="imported",
-                             search_filetype_override=lossless_override,
-                             min_bitrate=min_br_kbps)
+            finalize_request(
+                db,
+                request_id,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    message="Queued for lossless verification",
+                    from_status="imported",
+                    transition_fields={
+                        "search_filetype_override": lossless_override,
+                        "min_bitrate": min_br_kbps,
+                    },
+                ),
+            )
             logger.info(
                 f"QUALITY GATE: {label} "
                 f"min_bitrate={min_br_kbps}kbps CBR, not verified lossless — "
                 f"searching for lossless to verify")
         else:  # accept
-            apply_transition(
+            finalize_request(
                 db,
                 request_id,
-                "imported",
-                from_status="imported",
-                min_bitrate=min_br_kbps,
-                search_filetype_override=None,  # done searching
+                DispatchOutcome.transition(
+                    to_status="imported",
+                    success=True,
+                    message="Quality gate accepted",
+                    from_status="imported",
+                    transition_fields={
+                        "min_bitrate": min_br_kbps,
+                        "search_filetype_override": None,  # done searching
+                    },
+                ),
             )
             if current.verified_lossless:
                 logger.info(f"QUALITY GATE: {label} min_bitrate={min_br_kbps}kbps — quality OK")
@@ -599,8 +710,8 @@ def dispatch_import_core(
     Runs import_one.py, parses result, dispatches on decision (mark_done/failed,
     denylist, quality gate, media server notifiers, cleanup). Returns DispatchOutcome.
 
-    Used by dispatch_import() (auto-import adapter) and dispatch_import_from_db()
-    (force/manual import) — eliminates the need for heavyweight wrapper objects.
+    Used by the auto-import flow in ``lib.download`` and by
+    ``dispatch_import_from_db()`` (force/manual import).
     """
     from lib.util import trigger_meelo_scan as _trigger_meelo
     from lib.util import trigger_plex_scan as _trigger_plex
@@ -640,7 +751,7 @@ def dispatch_import_core(
         release_lock_key = release_id_to_lock_key(mb_release_id)
     else:
         # Defensive: ``dispatch_import_from_db`` already rejects empty
-        # mbids before reaching here; ``dispatch_import`` uses
+        # mbids before reaching here; the auto-import flow passes
         # ``album_data.mb_release_id or ""``. An empty mbid means
         # there's nothing to serialise across, so skip the lock.
         release_lock_key = None
@@ -785,10 +896,20 @@ def dispatch_import_core(
                     if decision in ("import", "preflight_existing"):
                         if prev_br is not None or new_br is not None:
                             try:
-                                apply_transition(db, request_id, "imported",
-                                                 from_status="imported",
-                                                 prev_min_bitrate=prev_br,
-                                                 min_bitrate=new_br)
+                                finalize_request(
+                                    db,
+                                    request_id,
+                                    DispatchOutcome.transition(
+                                        to_status="imported",
+                                        success=True,
+                                        message="Updated upgrade delta",
+                                        from_status="imported",
+                                        transition_fields={
+                                            "prev_min_bitrate": prev_br,
+                                            "min_bitrate": new_br,
+                                        },
+                                    ),
+                                )
                             except Exception:
                                 logger.exception("Failed to update upgrade delta")
                     outcome_success = True
@@ -891,7 +1012,17 @@ def dispatch_import_core(
                     }
                     if action.mark_done and new_br is not None:
                         requeue_fields["min_bitrate"] = new_br
-                    apply_transition(db, request_id, "wanted", **requeue_fields)
+                    finalize_request(
+                        db,
+                        request_id,
+                        DispatchOutcome.transition(
+                            to_status="wanted",
+                            success=False,
+                            message="Queued for another upgrade pass",
+                            from_status="imported",
+                            transition_fields=requeue_fields,
+                        ),
+                    )
 
                 if action.run_quality_gate:
                     _check_quality_gate_core(
@@ -956,89 +1087,6 @@ def dispatch_import_core(
             outcome_message = "Unhandled exception"
 
     return DispatchOutcome(success=outcome_success, message=outcome_message)
-
-
-def dispatch_import(album_data: "GrabListEntry", bv_result: ValidationResult, dest: str,
-                    dl_info: DownloadInfo, request_id: int,
-                    ctx: "CratediggerContext", *, force: bool = False
-                    ) -> "DispatchOutcome":
-    """Import decision tree — thin adapter extracting plain params for the core.
-
-    Called from ``process_completed_album()`` for auto-import.
-
-    Returns ``DispatchOutcome`` so the auto-path caller
-    (``_run_completed_processing``) can distinguish three terminal
-    states: ``success=True`` (import landed; flip to ``imported``),
-    ``deferred=True`` (release lock held; leave row alone for the
-    next cycle), or ``success=False`` with ``deferred=False`` (actual
-    failure; caller's existing fallback reset handles it).
-
-    Pre-#133 this returned ``None`` and callers inferred success from
-    ``process_completed_album``'s boolean. That branch mis-flipped
-    contention to ``imported`` (the C1 bug fixed in commit 43e83e8).
-    The Codex R3 follow-up widened the fix: threading ``deferred``
-    explicitly lets the caller preserve all resumable state
-    (staging, spectral, status) on contention, not just skip the
-    flip.
-    """
-    db = ctx.pipeline_db_source._get_db()
-
-    # Compute override_min_bitrate from DB — grade-aware: current_spectral_bitrate
-    # only lowers the override when current_spectral_grade is suspect/likely_transcode.
-    override_min_bitrate: int | None = None
-    try:
-        req = db.get_request(request_id)
-        if req:
-            override_min_bitrate = compute_effective_override_bitrate(
-                req.get("min_bitrate"),
-                req.get("current_spectral_bitrate"),
-                req.get("current_spectral_grade"))
-    except Exception:
-        logger.debug("DB lookup failed for override-min-bitrate")
-
-    return dispatch_import_core(
-        path=dest,
-        mb_release_id=album_data.mb_release_id or "",
-        request_id=request_id,
-        label=f"{album_data.artist} - {album_data.title}",
-        force=force,
-        override_min_bitrate=override_min_bitrate,
-        target_format=album_data.db_target_format,
-        verified_lossless_target=ctx.cfg.verified_lossless_target,
-        beets_harness_path=ctx.cfg.beets_harness_path,
-        db=db,
-        dl_info=dl_info,
-        distance=bv_result.distance if bv_result.distance is not None else 0.0,
-        scenario=bv_result.scenario or "auto_import",
-        files=album_data.files,
-        cfg=ctx.cfg,
-        requeue_on_failure=True,
-        cooled_down_users=ctx.cooled_down_users,
-    )
-
-
-@dataclass(frozen=True)
-class DispatchOutcome:
-    """Result of ``dispatch_import_*`` — typed return for every caller
-    (auto-path, web/CLI force/manual, tests).
-
-    - ``success``: the import landed in beets and the request is now
-      ``imported``. Callers that further transition the request (the
-      auto-path's ``_run_completed_processing``) branch on this.
-    - ``message``: human-readable summary for UI / logs; never parsed.
-    - ``deferred``: the import did NOT run because a competing process
-      holds the release advisory lock (issue #132 P1 / #133). The
-      request's state is UNTOUCHED — no status transition, no staged
-      cleanup, no spectral clear — so the next cycle can resume
-      exactly where this one left off. Callers MUST check
-      ``deferred`` before applying any "on failure" fallback state
-      transition (Codex PR #136 R2 P1 + R3 P2/P3: every round of
-      review surfaced a different piece of state the old eager
-      reset-to-wanted was clobbering).
-    """
-    success: bool
-    message: str
-    deferred: bool = False
 
 def dispatch_import_from_db(
     db: "PipelineDB",

--- a/lib/import_service.py
+++ b/lib/import_service.py
@@ -1,7 +1,7 @@
 """Import service — extraction helpers for ImportResult JSON.
 
 The subprocess execution and dispatch logic lives in lib/import_dispatch.py
-(dispatch_import + dispatch_import_from_db). This module provides helpers for
+(dispatch_import_core + dispatch_import_from_db). This module provides helpers for
 extracting typed fields from ImportResult JSON blobs.
 """
 
@@ -144,5 +144,4 @@ def extract_import_log_fields(import_result_json: str | None) -> dict[str, objec
             fields["existing_spectral_bitrate"] = existing_m.spectral_bitrate_kbps
 
     return fields
-
 

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -8,10 +8,11 @@ check — that is what --force on import_one.py overrides. Every other gate is
 shared, so it lives here in a single function.
 
 Rationale: force-import previously called dispatch_import_core() directly,
-skipping the audio + spectral gates that _process_beets_validation ran in the
-auto path. A transcode rejected by auto-import's spectral gate could be
-force-imported into beets, replacing an existing copy of the same quality with
-no real upgrade. See the "No Parallel Code Paths" rule in
+skipping the audio + spectral gates that ``process_completed_album()`` now
+runs before handing off to the shared auto-import seam. A transcode rejected
+by auto-import's spectral gate could be force-imported into beets, replacing
+an existing copy of the same quality with no real upgrade. See the
+"No Parallel Code Paths" rule in
 .claude/rules/code-quality.md.
 """
 

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1950,7 +1950,7 @@ class DispatchAction:
 def dispatch_action(decision: str) -> DispatchAction:
     """Map an ImportResult.decision string to the set of actions to take (pure).
 
-    Encodes the if/elif dispatch chain from dispatch_import().
+    Encodes the if/elif dispatch chain from the import dispatch flow.
     """
     if decision in ("import", "preflight_existing"):
         return DispatchAction(mark_done=True, trigger_notifiers=True,
@@ -1993,9 +1993,9 @@ def compute_effective_override_bitrate(
     returned untouched.
 
     When spectral is authorized, the function returns the lower of the two
-    available values (conservative). Used by ``dispatch_import()`` to derive
-    ``--override-min-bitrate`` for ``import_one.py`` and by the quality gate
-    to determine whether to apply a spectral override to the gate bitrate.
+    available values (conservative). Used by the auto / force import seams to
+    derive ``--override-min-bitrate`` for ``import_one.py`` and by the quality
+    gate to determine whether to apply a spectral override to the gate bitrate.
     """
     if spectral_grade not in SPECTRAL_TRANSCODE_GRADES:
         return container_bitrate

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -33,7 +33,7 @@ from datetime import date, datetime, time
 from decimal import Decimal
 
 # Surface INFO-level log lines (e.g. the [import] stderr passthrough from
-# dispatch_import) so force-import / manual-import failures are visible to
+# dispatch_import_core) so force-import / manual-import failures are visible to
 # the user instead of silently swallowed by Python's default WARNING-only
 # logger configuration.
 logging.basicConfig(
@@ -47,6 +47,7 @@ import psycopg2
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
+from lib.import_dispatch import transition_request as _transition_request
 from lib.pipeline_db import PipelineDB, DEFAULT_DSN
 from lib.release_identity import detect_release_source, normalize_release_id
 from lib.util import resolve_failed_path as _shared_resolve_failed_path
@@ -261,33 +262,6 @@ def cmd_status(db, args):
         c = counts.get(status, 0)
         if c > 0:
             print(f"    {status:15s} {c:4d}")
-
-
-def _transition_request(
-    db,
-    request_id: int,
-    to_status: str,
-    *,
-    from_status: str | None = None,
-    attempt_type: str | None = None,
-    message: str = "",
-    **transition_fields: object,
-) -> None:
-    """Route request-state mutations through the shared finalization seam."""
-    from lib.import_dispatch import DispatchOutcome, finalize_request
-
-    finalize_request(
-        db,
-        request_id,
-        DispatchOutcome.transition(
-            to_status=to_status,
-            success=to_status == "imported",
-            message=message or f"Transitioned request to {to_status}",
-            from_status=from_status,
-            attempt_type=attempt_type,
-            transition_fields=transition_fields or None,
-        ),
-    )
 
 
 def cmd_retry(db, args):

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -263,23 +263,60 @@ def cmd_status(db, args):
             print(f"    {status:15s} {c:4d}")
 
 
+def _transition_request(
+    db,
+    request_id: int,
+    to_status: str,
+    *,
+    from_status: str | None = None,
+    attempt_type: str | None = None,
+    message: str = "",
+    **transition_fields: object,
+) -> None:
+    """Route request-state mutations through the shared finalization seam."""
+    from lib.import_dispatch import DispatchOutcome, finalize_request
+
+    finalize_request(
+        db,
+        request_id,
+        DispatchOutcome.transition(
+            to_status=to_status,
+            success=to_status == "imported",
+            message=message or f"Transitioned request to {to_status}",
+            from_status=from_status,
+            attempt_type=attempt_type,
+            transition_fields=transition_fields or None,
+        ),
+    )
+
+
 def cmd_retry(db, args):
-    from lib.transitions import apply_transition
     req = db.get_request(args.id)
     if not req:
         print(f"  Request {args.id} not found.")
         return
-    apply_transition(db, args.id, "wanted", from_status=req["status"])
+    _transition_request(
+        db,
+        args.id,
+        "wanted",
+        from_status=req["status"],
+        message="Reset request to wanted",
+    )
     print(f"  Reset to wanted: [{args.id}] {req['artist_name']} - {req['album_title']}")
 
 
 def cmd_cancel(db, args):
-    from lib.transitions import apply_transition
     req = db.get_request(args.id)
     if not req:
         print(f"  Request {args.id} not found.")
         return
-    apply_transition(db, args.id, "manual", from_status=req["status"])
+    _transition_request(
+        db,
+        args.id,
+        "manual",
+        from_status=req["status"],
+        message="Marked request for manual handling",
+    )
     print(f"  Marked for manual download: [{args.id}] {req['artist_name']} - {req['album_title']}")
 
 
@@ -287,7 +324,6 @@ VALID_STATUSES = ["wanted", "imported", "manual"]
 
 
 def cmd_set(db, args):
-    from lib.transitions import apply_transition
     req = db.get_request(args.id)
     if not req:
         print(f"  Request {args.id} not found.")
@@ -296,7 +332,13 @@ def cmd_set(db, args):
     if old_status == args.status:
         print(f"  [{args.id}] already has status '{args.status}'.")
         return
-    apply_transition(db, args.id, args.status, from_status=old_status)
+    _transition_request(
+        db,
+        args.id,
+        args.status,
+        from_status=old_status,
+        message=f"Admin set status to {args.status}",
+    )
     print(f"  [{args.id}] {req['artist_name']} - {req['album_title']}: {old_status} → {args.status}")
 
 
@@ -307,7 +349,6 @@ def cmd_set_intent(db, args):
     'default'  — pipeline decides (uses global verified_lossless_target)
     """
     from lib.quality import QUALITY_LOSSLESS, should_clear_lossless_search_override
-    from lib.transitions import apply_transition
 
     target_format = QUALITY_LOSSLESS if args.intent == "lossless" else None
 
@@ -324,9 +365,15 @@ def cmd_set_intent(db, args):
     if req["status"] == "imported" and target_format:
         # Re-queue to search for lossless source
         min_br = req.get("min_bitrate")
-        apply_transition(db, args.id, "wanted", from_status="imported",
-                         search_filetype_override=QUALITY_LOSSLESS,
-                         min_bitrate=min_br)
+        _transition_request(
+            db,
+            args.id,
+            "wanted",
+            from_status="imported",
+            message="Re-queued imported request for lossless search",
+            search_filetype_override=QUALITY_LOSSLESS,
+            min_bitrate=min_br,
+        )
         db.update_request_fields(args.id, target_format=target_format)
         print(f"  [{args.id}] {label}: lossless on disk, re-queued for search")
     else:
@@ -1096,13 +1143,14 @@ def cmd_repair_spectral(db, args):
 
         # If quality gate would accept, transition to imported
         if decision == "accept" and effective_min_br is not None:
-            db._execute("""
-                UPDATE album_requests
-                SET status = 'imported',
-                    min_bitrate = %s,
-                    updated_at = NOW()
-                WHERE id = %s
-            """, (effective_min_br, rid))
+            _transition_request(
+                db,
+                rid,
+                "imported",
+                from_status="wanted",
+                message="Repaired stale spectral gate state",
+                min_bitrate=effective_min_br,
+            )
             print(f"         → transitioned to imported")
         else:
             print(f"         → remains wanted (gate says {decision})")

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -18,6 +18,7 @@ from typing import Any
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from lib.import_dispatch import transition_request as _transition_request
 from lib.pipeline_db import PipelineDB
 from lib.quality import find_inconsistencies, find_orphaned_downloads, suggest_repair
 
@@ -25,34 +26,6 @@ DEFAULT_DSN = os.environ.get(
     "PIPELINE_DB_DSN",
     "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
 )
-
-
-def _transition_request(
-    db: PipelineDB,
-    request_id: int,
-    to_status: str,
-    *,
-    from_status: str | None = None,
-    attempt_type: str | None = None,
-    message: str = "",
-    **transition_fields: object,
-) -> None:
-    """Route repair status changes through the shared finalization seam."""
-    from lib.import_dispatch import DispatchOutcome, finalize_request
-
-    finalize_request(
-        db,
-        request_id,
-        DispatchOutcome.transition(
-            to_status=to_status,
-            success=to_status == "imported",
-            message=message or f"Repaired request to {to_status}",
-            from_status=from_status,
-            attempt_type=attempt_type,
-            transition_fields=transition_fields or None,
-        ),
-    )
-
 
 def _get_slskd_active_transfers(host: str, api_key: str) -> set[tuple[str, str]]:
     """Fetch active (username, filename) pairs from slskd API."""

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -20,12 +20,38 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.pipeline_db import PipelineDB
 from lib.quality import find_inconsistencies, find_orphaned_downloads, suggest_repair
-from lib.transitions import apply_transition
 
 DEFAULT_DSN = os.environ.get(
     "PIPELINE_DB_DSN",
     "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
 )
+
+
+def _transition_request(
+    db: PipelineDB,
+    request_id: int,
+    to_status: str,
+    *,
+    from_status: str | None = None,
+    attempt_type: str | None = None,
+    message: str = "",
+    **transition_fields: object,
+) -> None:
+    """Route repair status changes through the shared finalization seam."""
+    from lib.import_dispatch import DispatchOutcome, finalize_request
+
+    finalize_request(
+        db,
+        request_id,
+        DispatchOutcome.transition(
+            to_status=to_status,
+            success=to_status == "imported",
+            message=message or f"Repaired request to {to_status}",
+            from_status=from_status,
+            attempt_type=attempt_type,
+            transition_fields=transition_fields or None,
+        ),
+    )
 
 
 def _get_slskd_active_transfers(host: str, api_key: str) -> set[tuple[str, str]]:
@@ -101,8 +127,13 @@ def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
     for issue in issues:
         repair = suggest_repair(issue)
         if repair.action == "reset_to_wanted":
-            apply_transition(db, issue.request_id, "wanted",
-                             from_status="downloading")
+            _transition_request(
+                db,
+                issue.request_id,
+                "wanted",
+                from_status="downloading",
+                message="Repair reset orphaned download to wanted",
+            )
             print(f"  [{issue.request_id}] Reset to wanted ({issue.issue_type})")
         else:
             print(f"  [{issue.request_id}] Skipped: {repair.action} (manual review required)")

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -261,6 +261,25 @@ class TestDatabaseSource(unittest.TestCase):
         assert req is not None
         self.assertEqual(req["search_filetype_override"], "flac,mp3 v0")
 
+    def test_reject_and_requeue_uses_db_loaded_from_status(self):
+        source, db = self._make_source()
+        req_id = db.add_request(
+            mb_release_id="fail-manual-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        db.update_status(req_id, "manual")
+        record = _make_record(db_request_id=req_id, db_source="request")
+        bv_result = ValidationResult(valid=False, distance=0.35, scenario="high_distance")
+
+        source.reject_and_requeue(record, bv_result)
+
+        req = db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["status"], "wanted")
+        self.assertEqual(req["validation_attempts"], 1)
+
     def test_mark_done_sets_on_disk_spectral(self):
         """Successful import updates current_spectral_grade/bitrate."""
         from lib.quality import DownloadInfo, SpectralMeasurement

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -15,6 +15,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tagging-
 from album_source import AlbumRecord, DatabaseSource
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.quality import DownloadInfo, ValidationResult
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_request_row
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 
@@ -88,6 +90,37 @@ class TestAlbumRecordFromDbRow(unittest.TestCase):
         """DB records use negative IDs."""
         record = AlbumRecord.from_db_row(SAMPLE_DB_ROW, SAMPLE_TRACKS)
         self.assertLess(record.id, 0)
+
+
+class TestDatabaseSourceRejectAndRequeueSeam(unittest.TestCase):
+    """Pin the non-DB seam around reject-and-requeue finalization."""
+
+    @patch("lib.import_dispatch.finalize_request")
+    def test_reject_and_requeue_defers_from_status_to_shared_seam(
+        self,
+        mock_finalize: MagicMock,
+    ) -> None:
+        fake_db = FakePipelineDB()
+        fake_db.seed_request(make_request_row(id=42, status="manual"))
+
+        source = DatabaseSource.__new__(DatabaseSource)
+        source._db = fake_db  # type: ignore[assignment]
+
+        album_record = MagicMock()
+        album_record.db_request_id = 42
+        bv_result = ValidationResult(
+            valid=False,
+            distance=0.35,
+            scenario="high_distance",
+        )
+
+        source.reject_and_requeue(album_record, bv_result)
+
+        db_arg, request_id, outcome = mock_finalize.call_args.args
+        self.assertIs(db_arg, fake_db)
+        self.assertEqual(request_id, 42)
+        self.assertEqual(outcome.target_status, "wanted")
+        self.assertIsNone(outcome.from_status)
 
 
 @unittest.skipUnless(TEST_DSN, "TEST_DB_DSN not set — skipping PostgreSQL tests")

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -166,10 +166,10 @@ class TestCooldownTriggerOnTimeout(unittest.TestCase):
         db.set_cooldown_result(True)
         ctx = make_ctx_with_fake_db(db)
 
-        with patch("lib.download.cancel_and_delete"), \
-             patch("lib.download.apply_transition"):
+        with patch("lib.download.cancel_and_delete"):
             _timeout_album(entry, 42, "stalled", ctx)
 
+        self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(len(db.download_logs), 1)
         db.assert_log(self, 0, outcome="timeout")
         self.assertIn("deaduser", db.cooldowns_applied)
@@ -196,10 +196,10 @@ class TestCooldownTriggerOnTimeout(unittest.TestCase):
         db.set_cooldown_result(lambda u: u == "disc1user")
         ctx = make_ctx_with_fake_db(db)
 
-        with patch("lib.download.cancel_and_delete"), \
-             patch("lib.download.apply_transition"):
+        with patch("lib.download.cancel_and_delete"):
             _timeout_album(entry, 42, "stalled", ctx)
 
+        self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(set(db.cooldowns_applied), {"disc1user", "disc2user"})
         self.assertEqual(ctx.cooled_down_users, {"disc1user"})
 
@@ -218,10 +218,10 @@ class TestCooldownTriggerOnTimeout(unittest.TestCase):
         db.seed_request(make_request_row(id=42, status="downloading"))
         ctx = make_ctx_with_fake_db(db)
 
-        with patch("lib.download.cancel_and_delete"), \
-             patch("lib.download.apply_transition"):
+        with patch("lib.download.cancel_and_delete"):
             _timeout_album(entry, 42, "stalled", ctx)
 
+        self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(db.cooldowns_applied, [])
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -904,6 +904,23 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
             )
             self.assertEqual(resolve_slskd_local_path(f, tmpdir), src)
 
+    def test_does_not_cross_album_match_from_download_root(self):
+        """Never fall back to a basename-only hit from an unrelated album."""
+        from lib.download import resolve_slskd_local_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wrong_folder = os.path.join(tmpdir, "Other Album", "CD1")
+            os.makedirs(wrong_folder)
+            wrong = os.path.join(wrong_folder, "04.mp3")
+            with open(wrong, "w") as fp:
+                fp.write("x" * 4096)
+            f = make_download_file(
+                filename="@@user\\Wanted Album\\CD1\\04.mp3",
+                file_dir="@@user\\Wanted Album\\CD1",
+                size=4096,
+            )
+            self.assertIsNone(resolve_slskd_local_path(f, tmpdir))
+
     def test_returns_none_when_file_missing(self):
         from lib.download import resolve_slskd_local_path
         import tempfile

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -924,6 +924,7 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
     def test_request_source_without_mbid_requeues_instead_of_marking_done(self):
         """Request rows without an MBID must requeue, not mark imported."""
         from lib.download import _handle_valid_result
+        import tempfile
 
         album = make_grab_list_entry(
             files=[make_download_file()],
@@ -941,12 +942,23 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
         ctx = make_ctx_with_fake_db(db)
         ctx.cfg.beets_distance_threshold = 0.15
 
-        with patch("lib.download.stage_to_ai", return_value="/tmp/staged"), \
+        with tempfile.TemporaryDirectory() as tmpdir, \
              patch("lib.download.log_validation_result"):
-            outcome = _handle_valid_result(album, bv_result, "/tmp/import", ctx)
+            import_dir = os.path.join(tmpdir, "Test Artist - Test Album")
+            os.makedirs(import_dir)
+            with open(os.path.join(import_dir, "01 - Track.mp3"), "w",
+                      encoding="utf-8") as fp:
+                fp.write("x")
 
-        assert outcome is not None
-        self.assertFalse(outcome.success)
+            outcome = _handle_valid_result(album, bv_result, import_dir, ctx)
+
+            assert outcome is not None
+            self.assertFalse(outcome.success)
+            self.assertFalse(os.path.exists(import_dir))
+            failed_dir = os.path.join(tmpdir, "failed_imports")
+            self.assertTrue(os.path.isdir(failed_dir))
+            self.assertEqual(len(os.listdir(failed_dir)), 1)
+
         self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(db.request(42)["validation_attempts"], 1)
         self.assertEqual(len(db.download_logs), 1)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -921,6 +921,32 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
             )
             self.assertIsNone(resolve_slskd_local_path(f, tmpdir))
 
+    def test_request_source_without_mbid_stages_without_auto_import(self):
+        """Auto-import requires an MBID; blank IDs should not assert."""
+        from lib.download import _handle_valid_result
+
+        album = make_grab_list_entry(
+            files=[make_download_file()],
+            mb_release_id="",
+            db_source="request",
+            db_request_id=42,
+        )
+        bv_result = MagicMock()
+        bv_result.distance = 0.05
+        bv_result.scenario = "strong_match"
+        bv_result.to_json.return_value = '{"valid": true}'
+
+        source = MagicMock()
+        ctx = _make_ctx(pipeline_db_source=source)
+
+        with patch("lib.download.stage_to_ai", return_value="/tmp/staged"), \
+             patch("lib.download.log_validation_result"):
+            outcome = _handle_valid_result(album, bv_result, "/tmp/import", ctx)
+
+        self.assertIsNone(outcome)
+        source._get_db.assert_not_called()
+        source.mark_done.assert_called_once()
+
     def test_returns_none_when_file_missing(self):
         from lib.download import resolve_slskd_local_path
         import tempfile

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -921,8 +921,8 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
             )
             self.assertIsNone(resolve_slskd_local_path(f, tmpdir))
 
-    def test_request_source_without_mbid_stages_without_auto_import(self):
-        """Auto-import requires an MBID; blank IDs should not assert."""
+    def test_request_source_without_mbid_requeues_instead_of_marking_done(self):
+        """Request rows without an MBID must requeue, not mark imported."""
         from lib.download import _handle_valid_result
 
         album = make_grab_list_entry(
@@ -936,16 +936,20 @@ class TestResolveSlskdLocalPath(unittest.TestCase):
         bv_result.scenario = "strong_match"
         bv_result.to_json.return_value = '{"valid": true}'
 
-        source = MagicMock()
-        ctx = _make_ctx(pipeline_db_source=source)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        ctx = make_ctx_with_fake_db(db)
+        ctx.cfg.beets_distance_threshold = 0.15
 
         with patch("lib.download.stage_to_ai", return_value="/tmp/staged"), \
              patch("lib.download.log_validation_result"):
             outcome = _handle_valid_result(album, bv_result, "/tmp/import", ctx)
 
-        self.assertIsNone(outcome)
-        source._get_db.assert_not_called()
-        source.mark_done.assert_called_once()
+        assert outcome is not None
+        self.assertFalse(outcome.success)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        self.assertEqual(db.request(42)["validation_attempts"], 1)
+        self.assertEqual(len(db.download_logs), 1)
 
     def test_returns_none_when_file_missing(self):
         from lib.download import resolve_slskd_local_path

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -5,8 +5,8 @@ may only skip the beets *distance* check. All other pre-import gates
 (audio integrity, spectral transcode detection) run identically.
 
 These tests FAIL against the current code because dispatch_import_from_db
-calls dispatch_import_core directly, bypassing the audio + spectral gates
-that _process_beets_validation runs in the auto path.
+called dispatch_import_core directly, bypassing the shared pre-import gates
+that the auto path now runs inline before dispatch.
 """
 
 from __future__ import annotations
@@ -312,7 +312,7 @@ class TestForceImportRunsAudioCheck(unittest.TestCase):
     """Force-import must run the audio corruption check.
 
     The auto path rejects corrupt audio via validate_audio in
-    _process_beets_validation. Force-import currently skips this entirely,
+    the shared pre-import gate path. Force-import currently skips this entirely,
     so a corrupt MP3 can be force-imported into beets.
     """
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -226,7 +226,8 @@ class TestRecordRejectionAndRequeueSeam(unittest.TestCase):
         _db_arg, request_id, outcome = mock_finalize.call_args.args
         self.assertEqual(request_id, 42)
         self.assertIsNone(outcome.from_status)
-        self.assertEqual(outcome.attempt_type, "validation")
+        self.assertIsNone(outcome.attempt_type)
+        self.assertEqual(db.request(42)["validation_attempts"], 1)
 
 
 class TestDispatchImport(unittest.TestCase):

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -229,6 +229,30 @@ class TestRecordRejectionAndRequeueSeam(unittest.TestCase):
         self.assertIsNone(outcome.attempt_type)
         self.assertEqual(db.request(42)["validation_attempts"], 1)
 
+    def test_requeue_only_forwards_fields_persisted_by_wanted_transition(self) -> None:
+        from lib.import_dispatch import _record_rejection_and_maybe_requeue
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+
+        _record_rejection_and_maybe_requeue(
+            db,  # type: ignore[arg-type]
+            42,
+            DownloadInfo(username="user1"),
+            distance=0.5,
+            scenario="quality_downgrade",
+            detail="too low",
+            error=None,
+            requeue=True,
+            search_filetype_override="flac,mp3 v0",
+        )
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_filetype_override"], "flac,mp3 v0")
+        self.assertIsNone(row["beets_distance"])
+        self.assertIsNone(row["beets_scenario"])
+
 
 class TestDispatchImport(unittest.TestCase):
     """Orchestration tests — assert domain state via FakePipelineDB."""

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -2,7 +2,8 @@
 
 Orchestration tests (TestDispatchImport, TestQualityGate*) use FakePipelineDB
 and assert domain state. Seam tests (TestOverrideMinBitrate, TestOpus*,
-TestTargetFormat*) test subprocess argv and adapter wiring via MagicMock.
+TestTargetFormat*) exercise the surviving auto-import seam in
+``lib.download._handle_valid_result`` and the core subprocess wiring.
 Pure function tests (TestPopulateDlInfo*, TestCleanupStagedDir) test in/out.
 """
 
@@ -21,7 +22,7 @@ from tests.fakes import FakePipelineDB
 from tests.helpers import make_import_result, make_request_row, patch_dispatch_externals
 
 
-# --- Local helpers for seam tests that call dispatch_import() (adapter) ---
+# --- Local helpers for auto-import seam tests ---
 
 def _make_album_data(artist="Test Artist", title="Test Album",
                      mb_release_id="test-mbid", db_request_id=42,
@@ -33,7 +34,15 @@ def _make_album_data(artist="Test Artist", title="Test Album",
     mock.mb_release_id = mb_release_id
     mock.db_request_id = db_request_id
     mock.db_source = db_source
-    mock.files = [MagicMock(username="user1", filename="01 - Track.mp3")]
+    mock.db_target_format = None
+    mock.files = [MagicMock(
+        username="user1",
+        filename="01 - Track.mp3",
+        bitRate=None,
+        sampleRate=None,
+        bitDepth=None,
+        isVariableBitRate=None,
+    )]
     return mock
 
 
@@ -42,10 +51,15 @@ def _make_ctx():
     ctx = MagicMock()
     ctx.cfg.beets_harness_path = "/nix/store/fake/harness/run_beets_harness.sh"
     ctx.cfg.beets_distance_threshold = 0.15
+    ctx.cfg.beets_staging_dir = "/tmp/staging"
+    ctx.cfg.verified_lossless_target = ""
+    ctx.cfg.quality_ranks.to_json.return_value = "{}"
     ctx.cooled_down_users = set()
     ctx.pipeline_db_source = MagicMock()
     db_mock = MagicMock()
     db_mock.get_request.return_value = make_request_row(status="downloading")
+    db_mock.advisory_lock.return_value.__enter__.return_value = True
+    db_mock.advisory_lock.return_value.__exit__.return_value = False
     ctx.pipeline_db_source._get_db.return_value = db_mock
     return ctx
 
@@ -62,6 +76,33 @@ def _make_bv_result(distance=0.05):
 
 
 _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"
+
+
+def _dispatch_valid_result_cmd(
+    *,
+    album_data=None,
+    ctx=None,
+    db_fields=None,
+    ir=None,
+):
+    """Run the surviving auto-import seam and return the harness argv."""
+    from lib.download import _handle_valid_result
+
+    album_data = album_data or _make_album_data()
+    ctx = ctx or _make_ctx()
+    db_mock = ctx.pipeline_db_source._get_db.return_value
+    if db_fields is not None:
+        db_mock.get_request.return_value = db_fields
+    bv_result = _make_bv_result()
+    ir = ir or make_import_result(decision="import")
+
+    with patch("lib.download.stage_to_ai", return_value="/tmp/dest"), \
+         patch("lib.download.log_validation_result"), \
+         patch_dispatch_externals() as ext, \
+         patch("lib.import_dispatch._check_quality_gate_core"), \
+         patch("lib.import_dispatch.parse_import_result", return_value=ir):
+        _handle_valid_result(album_data, bv_result, "/tmp/import", ctx)
+        return ext.run.call_args[0][0]
 
 
 class TestPopulateDlInfoFromImportResult(unittest.TestCase):
@@ -332,8 +373,7 @@ class TestDispatchImport(unittest.TestCase):
 class TestOverrideMinBitrate(unittest.TestCase):
     """Seam tests — subprocess arg wiring for --override-min-bitrate.
 
-    Tests the dispatch_import() adapter's override computation. Will break
-    if import_one becomes a library call (#48).
+    Tests the surviving auto-import seam's override computation.
 
     The override must be grade-aware: spectral bitrate only participates when
     current_spectral_grade is in {suspect, likely_transcode}. Genuine/marginal/
@@ -341,21 +381,7 @@ class TestOverrideMinBitrate(unittest.TestCase):
     """
 
     def _get_override_value(self, db_fields):
-        from lib.import_dispatch import dispatch_import
-        album_data = _make_album_data()
-        ctx = _make_ctx()
-        db_mock = ctx.pipeline_db_source._get_db.return_value
-        db_mock.get_request.return_value = db_fields
-        bv_result = _make_bv_result()
-        dl_info = DownloadInfo(filetype="mp3")
-        ir = make_import_result(decision="import")
-
-        with patch_dispatch_externals() as ext, \
-             patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir):
-            dispatch_import(album_data, bv_result, "/tmp/dest", dl_info,
-                            42, ctx)
-            cmd = ext.run.call_args[0][0]
+        cmd = _dispatch_valid_result_cmd(db_fields=db_fields)
 
         for i, arg in enumerate(cmd):
             if arg == "--override-min-bitrate" and i + 1 < len(cmd):
@@ -890,25 +916,16 @@ class TestQualityGatePreservesTargetFormat(unittest.TestCase):
 class TestOpusConversionDispatch(unittest.TestCase):
     """Seam tests — --verified-lossless-target flag wiring.
 
-    Will break if import_one becomes a library call (#48).
+    Exercised through the surviving auto-import seam in lib.download.
     """
 
     def _get_cmd(self, verified_lossless_target=""):
-        from lib.import_dispatch import dispatch_import
         album_data = _make_album_data()
         ctx = _make_ctx()
         ctx.cfg.verified_lossless_target = verified_lossless_target
-        bv_result = _make_bv_result()
-        dl_info = DownloadInfo(filetype="flac")
         ir = make_import_result(decision="import", was_converted=True,
                                 original_filetype="flac", target_filetype="mp3")
-
-        with patch_dispatch_externals() as ext, \
-             patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir):
-            dispatch_import(album_data, bv_result, "/tmp/dest", dl_info,
-                            42, ctx)
-            return ext.run.call_args[0][0]
+        return _dispatch_valid_result_cmd(album_data=album_data, ctx=ctx, ir=ir)
 
     def test_target_flag_passed_when_set(self):
         cmd = self._get_cmd(verified_lossless_target="opus 128")
@@ -945,25 +962,16 @@ class TestOpusConversionDispatch(unittest.TestCase):
 class TestTargetFormatDispatch(unittest.TestCase):
     """Seam tests — --target-format flag wiring.
 
-    Will break if import_one becomes a library call (#48).
+    Exercised through the surviving auto-import seam in lib.download.
     """
 
     def _get_cmd(self, target_format=None):
-        from lib.import_dispatch import dispatch_import
         album_data = _make_album_data()
         album_data.db_target_format = target_format
         ctx = _make_ctx()
         ctx.cfg.verified_lossless_target = ""
-        bv_result = _make_bv_result()
-        dl_info = DownloadInfo(filetype="flac")
         ir = make_import_result(decision="import")
-
-        with patch_dispatch_externals() as ext, \
-             patch("lib.import_dispatch._check_quality_gate_core"), \
-             patch("lib.import_dispatch.parse_import_result", return_value=ir):
-            dispatch_import(album_data, bv_result, "/tmp/dest", dl_info,
-                            42, ctx)
-            return ext.run.call_args[0][0]
+        return _dispatch_valid_result_cmd(album_data=album_data, ctx=ctx, ir=ir)
 
     def test_target_format_passed_when_set(self):
         cmd = self._get_cmd(target_format="flac")

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -198,6 +198,37 @@ class TestCleanupStagedDir(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+class TestRecordRejectionAndRequeueSeam(unittest.TestCase):
+    """Seam tests for the shared rejection finalizer."""
+
+    @patch("lib.import_dispatch.finalize_request")
+    def test_requeue_defers_from_status_lookup_to_finalize_request(
+        self,
+        mock_finalize,
+    ) -> None:
+        from lib.import_dispatch import _record_rejection_and_maybe_requeue
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="manual"))
+
+        _record_rejection_and_maybe_requeue(
+            db,  # type: ignore[arg-type]
+            42,
+            DownloadInfo(username="user1"),
+            distance=0.5,
+            scenario="quality_downgrade",
+            detail="too low",
+            error=None,
+            requeue=True,
+        )
+
+        mock_finalize.assert_called_once()
+        _db_arg, request_id, outcome = mock_finalize.call_args.args
+        self.assertEqual(request_id, 42)
+        self.assertIsNone(outcome.from_status)
+        self.assertEqual(outcome.attempt_type, "validation")
+
+
 class TestDispatchImport(unittest.TestCase):
     """Orchestration tests — assert domain state via FakePipelineDB."""
 

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 import unittest
+from unittest.mock import MagicMock, patch
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
@@ -49,6 +50,43 @@ class TestImportBootstrap(unittest.TestCase):
             f"Standalone import_one import failed:\nstdout:{proc.stdout}\nstderr:{proc.stderr}"
         )
         self.assertIn("OK", proc.stdout)
+
+
+class TestPipelineDbUpdate(unittest.TestCase):
+    @patch("lib.import_dispatch.finalize_request")
+    @patch("lib.pipeline_db.PipelineDB")
+    def test_update_pipeline_db_routes_through_shared_finalizer(
+        self,
+        mock_db_cls,
+        mock_finalize,
+    ) -> None:
+        from harness import import_one
+
+        db = MagicMock()
+        mock_db_cls.return_value = db
+
+        import_one.update_pipeline_db(
+            42,
+            "imported",
+            imported_path="/Beets/Artist/Album",
+            distance=0.12,
+            scenario="preflight_existing",
+        )
+
+        mock_finalize.assert_called_once()
+        called_db, called_request_id, outcome = mock_finalize.call_args.args
+        self.assertIs(called_db, db)
+        self.assertEqual(called_request_id, 42)
+        self.assertEqual(outcome.target_status, "imported")
+        self.assertEqual(
+            outcome.transition_fields,
+            {
+                "imported_path": "/Beets/Artist/Album",
+                "beets_distance": 0.12,
+                "beets_scenario": "preflight_existing",
+            },
+        )
+        db.close.assert_called_once()
 
 
 # ============================================================================

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -5,6 +5,7 @@ These test the decision points extracted from main() — each stage function
 takes data inputs and returns a StageResult without I/O.
 """
 
+import io
 import importlib
 import os
 import subprocess
@@ -87,6 +88,25 @@ class TestPipelineDbUpdate(unittest.TestCase):
             },
         )
         db.close.assert_called_once()
+
+    @patch("lib.import_dispatch.finalize_request", side_effect=RuntimeError("boom"))
+    @patch("lib.pipeline_db.PipelineDB")
+    def test_update_pipeline_db_closes_db_when_finalizer_raises(
+        self,
+        mock_db_cls,
+        _mock_finalize,
+    ) -> None:
+        from harness import import_one
+
+        db = MagicMock()
+        mock_db_cls.return_value = db
+        stderr = io.StringIO()
+
+        with patch("sys.stderr", stderr):
+            import_one.update_pipeline_db(42, "imported")
+
+        db.close.assert_called_once()
+        self.assertIn("Pipeline DB update failed", stderr.getvalue())
 
 
 # ============================================================================

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -108,6 +108,31 @@ class TestPipelineDbUpdate(unittest.TestCase):
         db.close.assert_called_once()
         self.assertIn("Pipeline DB update failed", stderr.getvalue())
 
+    @patch("lib.import_dispatch.apply_transition")
+    @patch("lib.pipeline_db.PipelineDB")
+    def test_update_pipeline_db_distinguishes_transition_whitelist_errors(
+        self,
+        mock_db_cls,
+        mock_transition,
+    ) -> None:
+        from harness import import_one
+
+        db = MagicMock()
+        mock_db_cls.return_value = db
+        stderr = io.StringIO()
+
+        with patch("sys.stderr", stderr):
+            import_one.update_pipeline_db(
+                42,
+                "wanted",
+                imported_path="/Beets/Artist/Album",
+            )
+
+        mock_transition.assert_not_called()
+        db.close.assert_called_once()
+        self.assertIn("Pipeline DB transition rejected", stderr.getvalue())
+        self.assertIn("unknown keys: imported_path", stderr.getvalue())
+
 
 # ============================================================================
 # StageResult

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1587,7 +1587,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
     resumable on contention.
 
     Pre-R4: ``_handle_valid_result`` called ``stage_to_ai`` first,
-    then invoked ``dispatch_import`` which checked the lock inside
+    then invoked ``dispatch_import_core`` which checked the lock inside
     ``dispatch_import_core``. On contention, files had already moved
     from ``slskd_download_dir/<import_folder>/`` →
     ``beets_staging_dir/``, but ``active_download_state`` still

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -447,7 +447,7 @@ class TestSpectralPropagationSlice(unittest.TestCase):
     """Integration slice: shared run_preimport_gates updates spectral state + denylists.
 
     Exercises the pre-import gate pipeline that both the auto-import path
-    (lib.download._process_beets_validation) and the force/manual-import path
+    (lib.download.process_completed_album) and the force/manual-import path
     (lib.import_dispatch.dispatch_import_from_db) delegate to. Proves the
     function does its side effects — spectral state write + denylist —
     consistently regardless of caller.

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1641,10 +1641,10 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         bv_result = ValidationResult(
             valid=True, distance=0.05, scenario="strong_match")
 
-        # stage_to_ai and dispatch_import MUST NOT run on contention.
+        # stage_to_ai and dispatch_import_core MUST NOT run on contention.
         import_folder_fullpath = "/tmp/test-import-folder"
         with patch.object(dl_mod, "stage_to_ai") as mock_stage, \
-             patch.object(dl_mod, "dispatch_import") as mock_dispatch:
+             patch.object(dl_mod, "dispatch_import_core") as mock_dispatch:
             outcome = dl_mod._handle_valid_result(
                 entry, bv_result, import_folder_fullpath, ctx)
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -141,6 +141,34 @@ class TestCmdCancel(unittest.TestCase):
         self.assertEqual(req["status"], "manual")
 
 
+class TestCmdSet(unittest.TestCase):
+    @patch("builtins.print")
+    @patch("scripts.pipeline_cli._transition_request")
+    def test_set_routes_dynamic_status_through_shared_finalizer(
+        self,
+        mock_transition,
+        _mock_print,
+    ):
+        db = MagicMock()
+        db.get_request.return_value = make_request_row(
+            id=9,
+            status="manual",
+            artist_name="A",
+            album_title="B",
+        )
+
+        args = MagicMock(id=9, status="imported")
+        pipeline_cli.cmd_set(db, args)
+
+        mock_transition.assert_called_once_with(
+            db,
+            9,
+            "imported",
+            from_status="manual",
+            message="Admin set status to imported",
+        )
+
+
 class TestTracksFromMbRelease(unittest.TestCase):
     def test_extract_tracks(self):
         tracks = pipeline_cli.tracks_from_mb_release(SAMPLE_MB_RELEASE)
@@ -453,7 +481,7 @@ class TestCmdSetIntent(unittest.TestCase):
         db.update_request_fields.assert_called_once_with(1, target_format=None)
 
     @patch("builtins.print")
-    @patch("lib.transitions.apply_transition")
+    @patch("scripts.pipeline_cli._transition_request")
     def test_set_lossless_on_imported_requeues(self, mock_transition, _mock_print):
         db = MagicMock()
         db.get_request.return_value = make_request_row(
@@ -462,9 +490,15 @@ class TestCmdSetIntent(unittest.TestCase):
         )
         args = MagicMock(id=2, intent="lossless")
         pipeline_cli.cmd_set_intent(db, args)
-        mock_transition.assert_called_once()
-        call_kwargs = mock_transition.call_args.kwargs or mock_transition.call_args[1]
-        self.assertEqual(call_kwargs.get("search_filetype_override"), "lossless")
+        mock_transition.assert_called_once_with(
+            db,
+            2,
+            "wanted",
+            from_status="imported",
+            message="Re-queued imported request for lossless search",
+            search_filetype_override="lossless",
+            min_bitrate=245,
+        )
         db.update_request_fields.assert_called_once_with(2, target_format="lossless")
 
     @patch("builtins.print")
@@ -529,7 +563,7 @@ class TestCmdRepairSpectral(unittest.TestCase):
             clear_cur = MagicMock()
             delete_cur = MagicMock()
             delete_cur.fetchall.return_value = []
-            import_cur = MagicMock()
+            finalize_request = MagicMock()
 
             db = MagicMock()
             db.get_request.return_value = make_request_row(
@@ -548,7 +582,6 @@ class TestCmdRepairSpectral(unittest.TestCase):
                 candidate_cur,
                 clear_cur,
                 delete_cur,
-                import_cur,
             ]
 
             beets_info = AlbumInfo(
@@ -570,16 +603,22 @@ class TestCmdRepairSpectral(unittest.TestCase):
             stdout = io.StringIO()
             with patch.dict(os.environ, {"CRATEDIGGER_RUNTIME_CONFIG": cfg_path}), \
                  patch("lib.beets_db.BeetsDB", return_value=mock_beets), \
+                 patch("scripts.pipeline_cli._transition_request", finalize_request), \
                  redirect_stdout(stdout):
                 pipeline_cli.cmd_repair_spectral(db, args)
 
             output = stdout.getvalue()
             self.assertIn("quality_gate_decision → accept", output)
             self.assertIn("→ transitioned to imported", output)
-            self.assertEqual(db._execute.call_count, 4)
-            imported_sql, imported_params = db._execute.call_args_list[3][0]
-            self.assertIn("SET status = 'imported'", imported_sql)
-            self.assertEqual(imported_params, (207, 42))
+            self.assertEqual(db._execute.call_count, 3)
+            finalize_request.assert_called_once_with(
+                db,
+                42,
+                "imported",
+                from_status="wanted",
+                message="Repaired stale spectral gate state",
+                min_bitrate=207,
+            )
         finally:
             os.unlink(cfg_path)
 

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -1,0 +1,50 @@
+"""Tests for scripts/repair.py CLI wiring."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lib.quality import OrphanInfo
+from scripts import repair
+
+
+class TestCmdFix(unittest.TestCase):
+    @patch("scripts.repair._transition_request")
+    @patch("scripts.repair._collect_issues")
+    def test_reset_to_wanted_routes_through_shared_finalizer(
+        self,
+        mock_collect_issues,
+        mock_transition,
+    ) -> None:
+        db = MagicMock()
+        mock_collect_issues.return_value = [
+            OrphanInfo(
+                request_id=17,
+                issue_type="orphaned_download",
+                detail="transfers gone",
+            )
+        ]
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            repair.cmd_fix(db)
+
+        mock_transition.assert_called_once_with(
+            db,
+            17,
+            "wanted",
+            from_status="downloading",
+            message="Repair reset orphaned download to wanted",
+        )
+        self.assertIn("Reset to wanted", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -10,6 +10,9 @@ from unittest.mock import MagicMock, patch
 from lib.import_dispatch import DispatchOutcome, finalize_request
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+PRODUCTION_ROOTS = ("lib", "web", "harness", "scripts")
+PRODUCTION_FILES = ("album_source.py",)
+RAW_SQL_ALLOWED_PATHS = {"lib/pipeline_db.py"}
 
 
 class TestFinalizeRequest(unittest.TestCase):
@@ -76,12 +79,63 @@ class TestFinalizeRequest(unittest.TestCase):
         )
 
 
-class _TerminalTransitionVisitor(ast.NodeVisitor):
-    """Collect direct terminal status writes in production Python modules."""
+class _RequestStatusWriteVisitor(ast.NodeVisitor):
+    """Collect request-status writes that bypass the shared finalization seam."""
 
     def __init__(self, rel_path: str) -> None:
         self.rel_path = rel_path
-        self.offending: list[tuple[int, str]] = []
+        self.offending: list[tuple[int, str, str]] = []
+
+    def _status_arg(self, func_name: str, node: ast.Call) -> ast.expr | None:
+        arg_index = 2 if func_name == "apply_transition" else 1
+        if len(node.args) > arg_index:
+            return node.args[arg_index]
+        kw_name = "to_status" if func_name == "apply_transition" else "status"
+        for kw in node.keywords:
+            if kw.arg == kw_name:
+                return kw.value
+        return None
+
+    def _allow_direct_transition_call(self, func_name: str, node: ast.Call) -> bool:
+        if self.rel_path in {
+            "lib/import_dispatch.py",
+            "lib/pipeline_db.py",
+            "lib/transitions.py",
+        }:
+            return True
+
+        if self.rel_path != "lib/download.py":
+            return False
+
+        status_expr = self._status_arg(func_name, node)
+        return (
+            isinstance(status_expr, ast.Constant)
+            and status_expr.value == "downloading"
+        )
+
+    def _maybe_record_raw_sql(self, node: ast.Call) -> None:
+        func_name: str | None = None
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            func_name = node.func.attr
+
+        if func_name not in {"execute", "_execute"}:
+            return
+        if self.rel_path in RAW_SQL_ALLOWED_PATHS or not node.args:
+            return
+
+        sql = node.args[0]
+        if not isinstance(sql, ast.Constant) or not isinstance(sql.value, str):
+            return
+
+        normalized = " ".join(sql.value.lower().split())
+        if "update album_requests" in normalized and "set status" in normalized:
+            self.offending.append((
+                node.lineno,
+                "raw SQL status write",
+                ast.unparse(node),
+            ))
 
     def visit_Call(self, node: ast.Call) -> None:
         func_name: str | None = None
@@ -90,48 +144,49 @@ class _TerminalTransitionVisitor(ast.NodeVisitor):
         elif isinstance(node.func, ast.Attribute):
             func_name = node.func.attr
 
-        if func_name not in {"apply_transition", "update_status"}:
-            self.generic_visit(node)
-            return
-
-        statuses: list[str] = []
-        for arg in node.args:
-            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-                statuses.append(arg.value)
-        for kw in node.keywords:
-            if kw.arg == "status" and isinstance(kw.value, ast.Constant):
-                if isinstance(kw.value.value, str):
-                    statuses.append(kw.value.value)
-
-        if any(status in {"wanted", "imported"} for status in statuses):
-            snippet = ast.unparse(node)
-            self.offending.append((node.lineno, snippet))
-
+        if func_name in {"apply_transition", "update_status"}:
+            if not self._allow_direct_transition_call(func_name, node):
+                self.offending.append((
+                    node.lineno,
+                    "direct transition call",
+                    ast.unparse(node),
+                ))
+        self._maybe_record_raw_sql(node)
         self.generic_visit(node)
 
 
 class TestTerminalTransitionContract(unittest.TestCase):
-    """Terminal request-state writes must route through finalize_request()."""
+    """Production request-state writes must route through finalize_request()."""
 
-    def test_no_direct_terminal_status_writes_in_lib_or_web(self) -> None:
-        offending: list[tuple[str, int, str]] = []
+    def test_no_direct_request_status_writes_outside_the_shared_seam(self) -> None:
+        offending: list[tuple[str, int, str, str]] = []
 
-        for root_name in ("lib", "web"):
+        for rel_path in PRODUCTION_FILES:
+            path = REPO_ROOT / rel_path
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel_path)
+            visitor = _RequestStatusWriteVisitor(rel_path)
+            visitor.visit(tree)
+            for lineno, reason, snippet in visitor.offending:
+                offending.append((rel_path, lineno, reason, snippet))
+
+        for root_name in PRODUCTION_ROOTS:
             root = REPO_ROOT / root_name
             for path in sorted(root.rglob("*.py")):
                 rel = path.relative_to(REPO_ROOT).as_posix()
                 tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
-                visitor = _TerminalTransitionVisitor(rel)
+                visitor = _RequestStatusWriteVisitor(rel)
                 visitor.visit(tree)
-                for lineno, snippet in visitor.offending:
-                    offending.append((rel, lineno, snippet))
+                for lineno, reason, snippet in visitor.offending:
+                    offending.append((rel, lineno, reason, snippet))
 
         if offending:
-            lines = [f"  {rel}:{lineno}: {snippet}" for rel, lineno, snippet in offending]
+            lines = [
+                f"  {rel}:{lineno}: {reason}: {snippet}"
+                for rel, lineno, reason, snippet in offending
+            ]
             self.fail(
-                "Direct terminal request status writes remain in production code. "
-                "Route wanted/imported transitions through lib.import_dispatch."
-                "finalize_request(...).\n"
+                "Direct request status writes remain outside the shared seam. "
+                "Route them through lib.import_dispatch.finalize_request(...).\n"
                 + "\n".join(lines)
             )
 

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -11,7 +11,7 @@ from lib.import_dispatch import DispatchOutcome, finalize_request, transition_re
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PRODUCTION_ROOTS = ("lib", "web", "harness", "scripts")
-PRODUCTION_FILES = ("album_source.py",)
+PRODUCTION_FILES = ("album_source.py", "cratedigger.py")
 RAW_SQL_ALLOWED_PATHS = {"lib/pipeline_db.py"}
 
 
@@ -123,6 +123,19 @@ class TestFinalizeRequest(unittest.TestCase):
             )
 
         mock_transition.assert_not_called()
+
+        with self.assertRaisesRegex(ValueError, "reserved keys: state_json"):
+            finalize_request(
+                MagicMock(),
+                42,
+                DispatchOutcome.transition(
+                    to_status="downloading",
+                    success=False,
+                    transition_fields={"state_json": "{}"},
+                ),
+            )
+
+        self.assertEqual(mock_transition.call_count, 0)
 
 
 class _RequestStatusWriteVisitor(ast.NodeVisitor):

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -33,20 +33,7 @@ class TestFinalizeRequest(unittest.TestCase):
         mock_transition.assert_not_called()
 
     @patch("lib.import_dispatch.apply_transition")
-    def test_unsuccessful_outcome_without_target_status_skips_transition(
-        self,
-        mock_transition: MagicMock,
-    ) -> None:
-        finalize_request(
-            MagicMock(),
-            42,
-            DispatchOutcome(success=False, message="failed summary"),
-        )
-
-        mock_transition.assert_not_called()
-
-    @patch("lib.import_dispatch.apply_transition")
-    def test_successful_outcome_without_target_status_is_rejected(
+    def test_outcome_without_target_status_is_rejected(
         self,
         mock_transition: MagicMock,
     ) -> None:
@@ -54,7 +41,7 @@ class TestFinalizeRequest(unittest.TestCase):
             finalize_request(
                 MagicMock(),
                 42,
-                DispatchOutcome(success=True, message="ok"),
+                DispatchOutcome(success=False, message="failed summary"),
             )
 
         mock_transition.assert_not_called()
@@ -161,6 +148,17 @@ class TestFinalizeRequest(unittest.TestCase):
                     to_status="wanted",
                     success=False,
                     transition_fields={"min_birate": 245},
+                ),
+            )
+
+        with self.assertRaisesRegex(ValueError, "unknown keys: beets_distance"):
+            finalize_request(
+                MagicMock(),
+                42,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    transition_fields={"beets_distance": 0.12},
                 ),
             )
 

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -33,15 +33,29 @@ class TestFinalizeRequest(unittest.TestCase):
         mock_transition.assert_not_called()
 
     @patch("lib.import_dispatch.apply_transition")
-    def test_outcome_without_target_status_skips_transition(
+    def test_unsuccessful_outcome_without_target_status_skips_transition(
         self,
         mock_transition: MagicMock,
     ) -> None:
         finalize_request(
             MagicMock(),
             42,
-            DispatchOutcome(success=True, message="ok"),
+            DispatchOutcome(success=False, message="failed summary"),
         )
+
+        mock_transition.assert_not_called()
+
+    @patch("lib.import_dispatch.apply_transition")
+    def test_successful_outcome_without_target_status_is_rejected(
+        self,
+        mock_transition: MagicMock,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "must declare target_status"):
+            finalize_request(
+                MagicMock(),
+                42,
+                DispatchOutcome(success=True, message="ok"),
+            )
 
         mock_transition.assert_not_called()
 
@@ -139,14 +153,30 @@ class TestFinalizeRequest(unittest.TestCase):
                 ),
             )
 
+        with self.assertRaisesRegex(ValueError, "unknown keys: min_birate"):
+            finalize_request(
+                MagicMock(),
+                42,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    transition_fields={"min_birate": 245},
+                ),
+            )
+
         self.assertEqual(mock_transition.call_count, 0)
 
 
 class _RequestStatusWriteVisitor(ast.NodeVisitor):
     """Collect request-status writes that bypass the shared finalization seam."""
 
-    def __init__(self, rel_path: str) -> None:
+    def __init__(
+        self,
+        rel_path: str,
+        module_string_constants: dict[str, str] | None = None,
+    ) -> None:
         self.rel_path = rel_path
+        self.module_string_constants = module_string_constants or {}
         self.offending: list[tuple[int, str, str]] = []
 
     def _status_arg(self, func_name: str, node: ast.Call) -> ast.expr | None:
@@ -157,6 +187,13 @@ class _RequestStatusWriteVisitor(ast.NodeVisitor):
         for kw in node.keywords:
             if kw.arg == kw_name:
                 return kw.value
+        return None
+
+    def _resolve_status_value(self, expr: ast.expr | None) -> str | None:
+        if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+            return expr.value
+        if isinstance(expr, ast.Name):
+            return self.module_string_constants.get(expr.id)
         return None
 
     def _allow_direct_transition_call(self, func_name: str, node: ast.Call) -> bool:
@@ -170,11 +207,7 @@ class _RequestStatusWriteVisitor(ast.NodeVisitor):
         if self.rel_path != "lib/download.py":
             return False
 
-        status_expr = self._status_arg(func_name, node)
-        return (
-            isinstance(status_expr, ast.Constant)
-            and status_expr.value == "downloading"
-        )
+        return self._resolve_status_value(self._status_arg(func_name, node)) == "downloading"
 
     def _maybe_record_raw_sql(self, node: ast.Call) -> None:
         func_name: str | None = None
@@ -227,7 +260,10 @@ class TestTerminalTransitionContract(unittest.TestCase):
         for rel_path in PRODUCTION_FILES:
             path = REPO_ROOT / rel_path
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel_path)
-            visitor = _RequestStatusWriteVisitor(rel_path)
+            visitor = _RequestStatusWriteVisitor(
+                rel_path,
+                _module_string_constants(tree),
+            )
             visitor.visit(tree)
             for lineno, reason, snippet in visitor.offending:
                 offending.append((rel_path, lineno, reason, snippet))
@@ -237,7 +273,10 @@ class TestTerminalTransitionContract(unittest.TestCase):
             for path in sorted(root.rglob("*.py")):
                 rel = path.relative_to(REPO_ROOT).as_posix()
                 tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
-                visitor = _RequestStatusWriteVisitor(rel)
+                visitor = _RequestStatusWriteVisitor(
+                    rel,
+                    _module_string_constants(tree),
+                )
                 visitor.visit(tree)
                 for lineno, reason, snippet in visitor.offending:
                     offending.append((rel, lineno, reason, snippet))
@@ -252,6 +291,56 @@ class TestTerminalTransitionContract(unittest.TestCase):
                 "Route them through lib.import_dispatch.finalize_request(...).\n"
                 + "\n".join(lines)
             )
+
+
+def _module_string_constants(tree: ast.AST) -> dict[str, str]:
+    constants: dict[str, str] = {}
+    if not isinstance(tree, ast.Module):
+        return constants
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                constants[node.targets[0].id] = node.value.value
+        elif isinstance(node, ast.AnnAssign):
+            if not isinstance(node.target, ast.Name):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                constants[node.target.id] = node.value.value
+
+    return constants
+
+
+class TestRequestStatusWriteVisitor(unittest.TestCase):
+    def test_allows_module_constant_for_downloading_in_download_module(self) -> None:
+        tree = ast.parse(
+            "STATUS_DOWNLOADING = 'downloading'\n"
+            "apply_transition(db, 42, STATUS_DOWNLOADING)\n"
+        )
+        visitor = _RequestStatusWriteVisitor(
+            "lib/download.py",
+            _module_string_constants(tree),
+        )
+
+        visitor.visit(tree)
+
+        self.assertEqual(visitor.offending, [])
+
+    def test_rejects_non_downloading_module_constant_in_download_module(self) -> None:
+        tree = ast.parse(
+            "STATUS_MANUAL = 'manual'\n"
+            "apply_transition(db, 42, STATUS_MANUAL)\n"
+        )
+        visitor = _RequestStatusWriteVisitor(
+            "lib/download.py",
+            _module_string_constants(tree),
+        )
+
+        visitor.visit(tree)
+
+        self.assertEqual(len(visitor.offending), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from lib.import_dispatch import DispatchOutcome, finalize_request
+from lib.import_dispatch import DispatchOutcome, finalize_request, transition_request
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PRODUCTION_ROOTS = ("lib", "web", "harness", "scripts")
@@ -77,6 +77,52 @@ class TestFinalizeRequest(unittest.TestCase):
             search_filetype_override="flac,mp3 v0",
             min_bitrate=245,
         )
+
+    @patch("lib.import_dispatch.apply_transition")
+    def test_transition_request_routes_explicit_fields_through_finalize_request(
+        self,
+        mock_transition: MagicMock,
+    ) -> None:
+        db = MagicMock()
+
+        transition_request(
+            db,
+            42,
+            "wanted",
+            from_status="downloading",
+            attempt_type="download",
+            search_filetype_override="flac,mp3 v0",
+            min_bitrate=245,
+        )
+
+        mock_transition.assert_called_once_with(
+            db,
+            42,
+            "wanted",
+            from_status="downloading",
+            attempt_type="download",
+            search_filetype_override="flac,mp3 v0",
+            min_bitrate=245,
+        )
+
+    @patch("lib.import_dispatch.apply_transition")
+    def test_rejects_reserved_transition_fields_in_outcome(
+        self,
+        mock_transition: MagicMock,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "reserved keys: from_status"):
+            finalize_request(
+                MagicMock(),
+                42,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    from_status="downloading",
+                    transition_fields={"from_status": "manual"},
+                ),
+            )
+
+        mock_transition.assert_not_called()
 
 
 class _RequestStatusWriteVisitor(ast.NodeVisitor):

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -64,6 +64,7 @@ class TestFinalizeRequest(unittest.TestCase):
                 transition_fields={
                     "search_filetype_override": "flac,mp3 v0",
                     "min_bitrate": 245,
+                    "prev_min_bitrate": 320,
                 },
             ),
         )
@@ -76,6 +77,7 @@ class TestFinalizeRequest(unittest.TestCase):
             attempt_type="download",
             search_filetype_override="flac,mp3 v0",
             min_bitrate=245,
+            prev_min_bitrate=320,
         )
 
     @patch("lib.import_dispatch.apply_transition")
@@ -93,6 +95,7 @@ class TestFinalizeRequest(unittest.TestCase):
             attempt_type="download",
             search_filetype_override="flac,mp3 v0",
             min_bitrate=245,
+            prev_min_bitrate=320,
         )
 
         mock_transition.assert_called_once_with(
@@ -103,6 +106,7 @@ class TestFinalizeRequest(unittest.TestCase):
             attempt_type="download",
             search_filetype_override="flac,mp3 v0",
             min_bitrate=245,
+            prev_min_bitrate=320,
         )
 
     @patch("lib.import_dispatch.apply_transition")

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -1,0 +1,140 @@
+"""Contract tests for the shared request-finalization seam."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lib.import_dispatch import DispatchOutcome, finalize_request
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestFinalizeRequest(unittest.TestCase):
+    """Unit tests for the shared request-finalization seam."""
+
+    @patch("lib.import_dispatch.apply_transition")
+    def test_deferred_outcome_skips_transition(self, mock_transition: MagicMock) -> None:
+        finalize_request(
+            MagicMock(),
+            42,
+            DispatchOutcome(
+                success=False,
+                message="busy",
+                deferred=True,
+            ),
+        )
+
+        mock_transition.assert_not_called()
+
+    @patch("lib.import_dispatch.apply_transition")
+    def test_outcome_without_target_status_skips_transition(
+        self,
+        mock_transition: MagicMock,
+    ) -> None:
+        finalize_request(
+            MagicMock(),
+            42,
+            DispatchOutcome(success=True, message="ok"),
+        )
+
+        mock_transition.assert_not_called()
+
+    @patch("lib.import_dispatch.apply_transition")
+    def test_forwards_transition_fields_and_attempt_type(
+        self,
+        mock_transition: MagicMock,
+    ) -> None:
+        db = MagicMock()
+
+        finalize_request(
+            db,
+            42,
+            DispatchOutcome.transition(
+                to_status="wanted",
+                success=False,
+                message="retry",
+                from_status="downloading",
+                attempt_type="download",
+                transition_fields={
+                    "search_filetype_override": "flac,mp3 v0",
+                    "min_bitrate": 245,
+                },
+            ),
+        )
+
+        mock_transition.assert_called_once_with(
+            db,
+            42,
+            "wanted",
+            from_status="downloading",
+            attempt_type="download",
+            search_filetype_override="flac,mp3 v0",
+            min_bitrate=245,
+        )
+
+
+class _TerminalTransitionVisitor(ast.NodeVisitor):
+    """Collect direct terminal status writes in production Python modules."""
+
+    def __init__(self, rel_path: str) -> None:
+        self.rel_path = rel_path
+        self.offending: list[tuple[int, str]] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func_name: str | None = None
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            func_name = node.func.attr
+
+        if func_name not in {"apply_transition", "update_status"}:
+            self.generic_visit(node)
+            return
+
+        statuses: list[str] = []
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                statuses.append(arg.value)
+        for kw in node.keywords:
+            if kw.arg == "status" and isinstance(kw.value, ast.Constant):
+                if isinstance(kw.value.value, str):
+                    statuses.append(kw.value.value)
+
+        if any(status in {"wanted", "imported"} for status in statuses):
+            snippet = ast.unparse(node)
+            self.offending.append((node.lineno, snippet))
+
+        self.generic_visit(node)
+
+
+class TestTerminalTransitionContract(unittest.TestCase):
+    """Terminal request-state writes must route through finalize_request()."""
+
+    def test_no_direct_terminal_status_writes_in_lib_or_web(self) -> None:
+        offending: list[tuple[str, int, str]] = []
+
+        for root_name in ("lib", "web"):
+            root = REPO_ROOT / root_name
+            for path in sorted(root.rglob("*.py")):
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+                visitor = _TerminalTransitionVisitor(rel)
+                visitor.visit(tree)
+                for lineno, snippet in visitor.offending:
+                    offending.append((rel, lineno, snippet))
+
+        if offending:
+            lines = [f"  {rel}:{lineno}: {snippet}" for rel, lineno, snippet in offending]
+            self.fail(
+                "Direct terminal request status writes remain in production code. "
+                "Route wanted/imported transitions through lib.import_dispatch."
+                "finalize_request(...).\n"
+                + "\n".join(lines)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -172,9 +172,11 @@ class _RequestStatusWriteVisitor(ast.NodeVisitor):
         self,
         rel_path: str,
         module_string_constants: dict[str, str] | None = None,
+        transition_aliases: dict[str, str] | None = None,
     ) -> None:
         self.rel_path = rel_path
         self.module_string_constants = module_string_constants or {}
+        self.transition_aliases = transition_aliases or {}
         self.offending: list[tuple[int, str, str]] = []
 
     def _status_arg(self, func_name: str, node: ast.Call) -> ast.expr | None:
@@ -234,7 +236,7 @@ class _RequestStatusWriteVisitor(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         func_name: str | None = None
         if isinstance(node.func, ast.Name):
-            func_name = node.func.id
+            func_name = self.transition_aliases.get(node.func.id, node.func.id)
         elif isinstance(node.func, ast.Attribute):
             func_name = node.func.attr
 
@@ -261,6 +263,7 @@ class TestTerminalTransitionContract(unittest.TestCase):
             visitor = _RequestStatusWriteVisitor(
                 rel_path,
                 _module_string_constants(tree),
+                _transition_aliases(tree),
             )
             visitor.visit(tree)
             for lineno, reason, snippet in visitor.offending:
@@ -274,6 +277,7 @@ class TestTerminalTransitionContract(unittest.TestCase):
                 visitor = _RequestStatusWriteVisitor(
                     rel,
                     _module_string_constants(tree),
+                    _transition_aliases(tree),
                 )
                 visitor.visit(tree)
                 for lineno, reason, snippet in visitor.offending:
@@ -311,6 +315,24 @@ def _module_string_constants(tree: ast.AST) -> dict[str, str]:
     return constants
 
 
+def _transition_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    if not isinstance(tree, ast.Module):
+        return aliases
+
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module != "lib.transitions":
+            continue
+        for imported in node.names:
+            if imported.name != "apply_transition":
+                continue
+            aliases[imported.asname or imported.name] = imported.name
+
+    return aliases
+
+
 class TestRequestStatusWriteVisitor(unittest.TestCase):
     def test_allows_module_constant_for_downloading_in_download_module(self) -> None:
         tree = ast.parse(
@@ -320,6 +342,7 @@ class TestRequestStatusWriteVisitor(unittest.TestCase):
         visitor = _RequestStatusWriteVisitor(
             "lib/download.py",
             _module_string_constants(tree),
+            _transition_aliases(tree),
         )
 
         visitor.visit(tree)
@@ -334,11 +357,43 @@ class TestRequestStatusWriteVisitor(unittest.TestCase):
         visitor = _RequestStatusWriteVisitor(
             "lib/download.py",
             _module_string_constants(tree),
+            _transition_aliases(tree),
         )
 
         visitor.visit(tree)
 
         self.assertEqual(len(visitor.offending), 1)
+
+    def test_rejects_aliased_apply_transition_import(self) -> None:
+        tree = ast.parse(
+            "from lib.transitions import apply_transition as _do_transition\n"
+            "_do_transition(db, 42, 'wanted')\n"
+        )
+        visitor = _RequestStatusWriteVisitor(
+            "web/routes/pipeline.py",
+            _module_string_constants(tree),
+            _transition_aliases(tree),
+        )
+
+        visitor.visit(tree)
+
+        self.assertEqual(len(visitor.offending), 1)
+
+    def test_allows_aliased_apply_transition_for_downloading_in_download_module(self) -> None:
+        tree = ast.parse(
+            "from lib.transitions import apply_transition as _do_transition\n"
+            "STATUS_DOWNLOADING = 'downloading'\n"
+            "_do_transition(db, 42, STATUS_DOWNLOADING)\n"
+        )
+        visitor = _RequestStatusWriteVisitor(
+            "lib/download.py",
+            _module_string_constants(tree),
+            _transition_aliases(tree),
+        )
+
+        visitor.visit(tree)
+
+        self.assertEqual(visitor.offending, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1102,16 +1102,16 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.EXISTS_REQUIRED_FIELDS,
                                 "pipeline add discogs exists response")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_pipeline_update_contract(self, _mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_pipeline_update_contract(self, _mock_finalize):
         status, data = self._post("/api/pipeline/update", {"id": 100, "status": "manual"})
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.UPDATE_REQUIRED_FIELDS,
                                 "pipeline update response")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_pipeline_upgrade_contract(self, _mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_pipeline_upgrade_contract(self, _mock_finalize):
         self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
 
         status, data = self._post("/api/pipeline/upgrade", {"mb_release_id": "abc-123"})
@@ -1120,11 +1120,11 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response")
 
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     @patch("web.routes.pipeline.discogs_api.get_release")
     @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_upgrade_discogs_new_request_uses_discogs_api(
-        self, mock_mb_get, mock_dg_get, _mock_transition,
+        self, mock_mb_get, mock_dg_get, _mock_finalize,
     ):
         """Numeric mb_release_id (Discogs) routes to discogs_api, not mb_api."""
         self.mock_db.get_request_by_mb_release_id.return_value = None
@@ -1154,8 +1154,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response (discogs)")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_pipeline_set_quality_contract(self, _mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_pipeline_set_quality_contract(self, _mock_finalize):
         self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
 
         status, data = self._post(
@@ -1167,9 +1167,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_QUALITY_REQUIRED_FIELDS,
                                 "pipeline set-quality response")
 
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     def test_pipeline_set_quality_discogs_request_normalizes_and_falls_back(
-        self, _mock_transition,
+        self, _mock_finalize,
     ):
         import web.server as srv
 
@@ -1191,8 +1191,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_QUALITY_REQUIRED_FIELDS,
                                 "pipeline set-quality response (discogs)")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_pipeline_upgrade_normalizes_uppercase_uuid(self, mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_pipeline_upgrade_normalizes_uppercase_uuid(self, mock_finalize):
         import web.server as srv
 
         fake_db = FakePipelineDB()
@@ -1212,7 +1212,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response (uppercase)")
-        self.assertEqual(mock_transition.call_args.args[1], 1704)
+        self.assertEqual(mock_finalize.call_args.args[1], 1704)
 
     def test_pipeline_set_intent_contract(self):
         self.mock_db.get_request.return_value = make_request_row(id=100, status="wanted")
@@ -1224,8 +1224,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_INTENT_REQUIRED_FIELDS,
                                 "pipeline set-intent response")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_pipeline_ban_source_contract(self, _mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_pipeline_ban_source_contract(self, _mock_finalize):
         status, data = self._post(
             "/api/pipeline/ban-source",
             {"request_id": 100, "username": "baduser", "mb_release_id": "abc-123"},
@@ -1298,10 +1298,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         mock_get_release.assert_called_once_with(83182, fresh=True)
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("routes.pipeline.finalize_request")
     @patch("routes.pipeline.mb_api.get_release")
     def test_pipeline_upgrade_new_mb_fetches_release_fresh(
-            self, mock_get_release, _mock_transition):
+            self, mock_get_release, _mock_finalize):
         """POST /api/pipeline/upgrade creating a brand-new MB request
         MUST bypass the meta cache — same rationale as add."""
         self.mock_db.get_request_by_mb_release_id.return_value = None
@@ -1321,10 +1321,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         mock_get_release.assert_called_once_with(
             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", fresh=True)
 
-    @patch("routes.pipeline.apply_transition")
+    @patch("routes.pipeline.finalize_request")
     @patch("routes.pipeline.discogs_api.get_release")
     def test_pipeline_upgrade_new_discogs_fetches_release_fresh(
-            self, mock_get_release, _mock_transition):
+            self, mock_get_release, _mock_finalize):
         """POST /api/pipeline/upgrade creating a brand-new Discogs request
         MUST bypass the meta cache — same rationale as add."""
         self.mock_db.get_request_by_mb_release_id.return_value = None
@@ -1415,17 +1415,17 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     def tearDown(self) -> None:
         self._srv._beets = self._orig_beets
 
-    def _override_passed(self, mock_transition) -> object:
-        """Extract the search_filetype_override kwarg from the last apply_transition call."""
-        self.assertTrue(mock_transition.call_args_list,
-                        "apply_transition was not called")
-        last = mock_transition.call_args_list[-1]
-        return last.kwargs.get("search_filetype_override", "<MISSING>")
+    def _override_passed(self, mock_finalize) -> object:
+        """Extract the search override from the last finalized outcome."""
+        self.assertTrue(mock_finalize.call_args_list,
+                        "finalize_request was not called")
+        outcome = mock_finalize.call_args_list[-1].args[2]
+        return outcome.transition_fields.get("search_filetype_override", "<MISSING>")
 
     # -- Upgrade --------------------------------------------------------
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_upgrade_preserves_stricter_override(self, mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_upgrade_preserves_stricter_override(self, mock_finalize):
         """Upgrade on an imported album with override='lossless' must keep it."""
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
             id=1704, status="imported", min_bitrate=320,
@@ -1436,10 +1436,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"mb_release_id": self.RELEASE_ID})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_transition), "lossless")
+        self.assertEqual(self._override_passed(mock_finalize), "lossless")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_upgrade_preserves_narrowed_override(self, mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_upgrade_preserves_narrowed_override(self, mock_finalize):
         """Upgrade must preserve a post-downgrade-narrow like 'lossless,mp3 v0'."""
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
             id=1704, status="imported", min_bitrate=320,
@@ -1450,10 +1450,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"mb_release_id": self.RELEASE_ID})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_transition), "lossless,mp3 v0")
+        self.assertEqual(self._override_passed(mock_finalize), "lossless,mp3 v0")
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_upgrade_falls_back_to_full_tiers_when_no_override(self, mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_upgrade_falls_back_to_full_tiers_when_no_override(self, mock_finalize):
         """Upgrade on an imported album with no override falls back to the full ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
 
@@ -1466,13 +1466,13 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"mb_release_id": self.RELEASE_ID})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_transition),
+        self.assertEqual(self._override_passed(mock_finalize),
                          QUALITY_UPGRADE_TIERS)
 
     # -- Update (status → wanted) ---------------------------------------
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_update_to_wanted_preserves_stricter_override(self, mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_update_to_wanted_preserves_stricter_override(self, mock_finalize):
         """Flipping an imported album back to wanted must preserve 'lossless'."""
         self.mock_db.get_request.return_value = make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
@@ -1484,11 +1484,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"id": 1704, "status": "wanted"})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_transition), "lossless")
+        self.assertEqual(self._override_passed(mock_finalize), "lossless")
 
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     def test_update_to_wanted_falls_back_to_full_tiers_when_no_override(
-            self, mock_transition):
+            self, mock_finalize):
         """Flipping imported→wanted with no override uses the full upgrade ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
 
@@ -1502,13 +1502,13 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"id": 1704, "status": "wanted"})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_transition),
+        self.assertEqual(self._override_passed(mock_finalize),
                          QUALITY_UPGRADE_TIERS)
 
     # -- Ban source (regression pin) ------------------------------------
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_ban_source_preserves_stricter_override(self, mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_ban_source_preserves_stricter_override(self, mock_finalize):
         """Pin: ban_source already preserves override. Guard against future regression."""
         self.mock_db.get_request.return_value = make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
@@ -1522,12 +1522,12 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         })
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_transition), "lossless")
+        self.assertEqual(self._override_passed(mock_finalize), "lossless")
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     def test_ban_source_clears_on_disk_quality_fields(
-            self, _mock_transition, mock_subprocess):
+            self, _mock_finalize, mock_subprocess):
         """After ``beet remove -d``, pipeline DB must forget on-disk quality.
 
         ``current_spectral_*`` and ``verified_lossless`` describe files that
@@ -1563,9 +1563,9 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     def test_ban_source_skips_clear_when_beet_remove_failed(
-            self, _mock_transition, mock_subprocess):
+            self, _mock_finalize, mock_subprocess):
         """Conservative: if beets still holds the album after the remove
         attempts (e.g. permissions error, wrong column and no legacy
         fallback matched), the on-disk quality state is still accurate,
@@ -1606,9 +1606,9 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertFalse(data["beets_removed"])
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     def test_ban_source_uses_discogs_selector_for_numeric_id(
-            self, _mock_transition, mock_subprocess):
+            self, _mock_finalize, mock_subprocess):
         """Discogs-backed requests carry a numeric ID. ``beet remove -d``
         must try ``discogs_albumid:<id>`` (the new layout) AND
         ``mb_albumid:<id>`` (the legacy layout documented in
@@ -1646,9 +1646,9 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                       "so older beets libraries don't regress.")
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.apply_transition")
+    @patch("web.routes.pipeline.finalize_request")
     def test_ban_source_clears_stale_state_when_album_already_gone(
-            self, _mock_transition, mock_subprocess):
+            self, _mock_finalize, mock_subprocess):
         """Ghost state can pre-date the handler: a user runs
         ``beet rm mb_albumid:X`` manually, then days later bans the
         source. ``locate`` returns 'absent' before ban-source even
@@ -1684,8 +1684,8 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         # No remove ran — the handler had nothing to remove.
         mock_subprocess.assert_not_called()
 
-    @patch("web.routes.pipeline.apply_transition")
-    def test_ban_source_skips_clear_when_mbid_missing(self, _mock_transition):
+    @patch("web.routes.pipeline.finalize_request")
+    def test_ban_source_skips_clear_when_mbid_missing(self, _mock_finalize):
         """Without ``mb_release_id`` we never query beets and never run
         ``beet remove``, so there's no positive evidence the album is gone.
         Clearing the on-disk quality fields anyway would erase state for

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1102,16 +1102,16 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.EXISTS_REQUIRED_FIELDS,
                                 "pipeline add discogs exists response")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_pipeline_update_contract(self, _mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_pipeline_update_contract(self, _mock_transition):
         status, data = self._post("/api/pipeline/update", {"id": 100, "status": "manual"})
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.UPDATE_REQUIRED_FIELDS,
                                 "pipeline update response")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_pipeline_upgrade_contract(self, _mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_pipeline_upgrade_contract(self, _mock_transition):
         self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
 
         status, data = self._post("/api/pipeline/upgrade", {"mb_release_id": "abc-123"})
@@ -1120,11 +1120,11 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response")
 
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     @patch("web.routes.pipeline.discogs_api.get_release")
     @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_upgrade_discogs_new_request_uses_discogs_api(
-        self, mock_mb_get, mock_dg_get, _mock_finalize,
+        self, mock_mb_get, mock_dg_get, _mock_transition,
     ):
         """Numeric mb_release_id (Discogs) routes to discogs_api, not mb_api."""
         self.mock_db.get_request_by_mb_release_id.return_value = None
@@ -1154,8 +1154,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response (discogs)")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_pipeline_set_quality_contract(self, _mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_pipeline_set_quality_contract(self, _mock_transition):
         self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
 
         status, data = self._post(
@@ -1167,9 +1167,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_QUALITY_REQUIRED_FIELDS,
                                 "pipeline set-quality response")
 
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     def test_pipeline_set_quality_discogs_request_normalizes_and_falls_back(
-        self, _mock_finalize,
+        self, _mock_transition,
     ):
         import web.server as srv
 
@@ -1191,8 +1191,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_QUALITY_REQUIRED_FIELDS,
                                 "pipeline set-quality response (discogs)")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_pipeline_upgrade_normalizes_uppercase_uuid(self, mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_pipeline_upgrade_normalizes_uppercase_uuid(self, mock_transition):
         import web.server as srv
 
         fake_db = FakePipelineDB()
@@ -1212,7 +1212,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response (uppercase)")
-        self.assertEqual(mock_finalize.call_args.args[1], 1704)
+        self.assertEqual(mock_transition.call_args.args[1], 1704)
 
     def test_pipeline_set_intent_contract(self):
         self.mock_db.get_request.return_value = make_request_row(id=100, status="wanted")
@@ -1224,8 +1224,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.SET_INTENT_REQUIRED_FIELDS,
                                 "pipeline set-intent response")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_pipeline_ban_source_contract(self, _mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_pipeline_ban_source_contract(self, _mock_transition):
         status, data = self._post(
             "/api/pipeline/ban-source",
             {"request_id": 100, "username": "baduser", "mb_release_id": "abc-123"},
@@ -1298,10 +1298,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         mock_get_release.assert_called_once_with(83182, fresh=True)
 
-    @patch("routes.pipeline.finalize_request")
+    @patch("routes.pipeline._transition_request")
     @patch("routes.pipeline.mb_api.get_release")
     def test_pipeline_upgrade_new_mb_fetches_release_fresh(
-            self, mock_get_release, _mock_finalize):
+            self, mock_get_release, _mock_transition):
         """POST /api/pipeline/upgrade creating a brand-new MB request
         MUST bypass the meta cache — same rationale as add."""
         self.mock_db.get_request_by_mb_release_id.return_value = None
@@ -1321,10 +1321,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         mock_get_release.assert_called_once_with(
             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", fresh=True)
 
-    @patch("routes.pipeline.finalize_request")
+    @patch("routes.pipeline._transition_request")
     @patch("routes.pipeline.discogs_api.get_release")
     def test_pipeline_upgrade_new_discogs_fetches_release_fresh(
-            self, mock_get_release, _mock_finalize):
+            self, mock_get_release, _mock_transition):
         """POST /api/pipeline/upgrade creating a brand-new Discogs request
         MUST bypass the meta cache — same rationale as add."""
         self.mock_db.get_request_by_mb_release_id.return_value = None
@@ -1415,17 +1415,19 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     def tearDown(self) -> None:
         self._srv._beets = self._orig_beets
 
-    def _override_passed(self, mock_finalize) -> object:
-        """Extract the search override from the last finalized outcome."""
-        self.assertTrue(mock_finalize.call_args_list,
-                        "finalize_request was not called")
-        outcome = mock_finalize.call_args_list[-1].args[2]
-        return outcome.transition_fields.get("search_filetype_override", "<MISSING>")
+    def _override_passed(self, mock_transition) -> object:
+        """Extract the search override from the last routed transition."""
+        self.assertTrue(mock_transition.call_args_list,
+                        "_transition_request was not called")
+        return mock_transition.call_args_list[-1].kwargs.get(
+            "search_filetype_override",
+            "<MISSING>",
+        )
 
     # -- Upgrade --------------------------------------------------------
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_upgrade_preserves_stricter_override(self, mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_upgrade_preserves_stricter_override(self, mock_transition):
         """Upgrade on an imported album with override='lossless' must keep it."""
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
             id=1704, status="imported", min_bitrate=320,
@@ -1436,10 +1438,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"mb_release_id": self.RELEASE_ID})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_finalize), "lossless")
+        self.assertEqual(self._override_passed(mock_transition), "lossless")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_upgrade_preserves_narrowed_override(self, mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_upgrade_preserves_narrowed_override(self, mock_transition):
         """Upgrade must preserve a post-downgrade-narrow like 'lossless,mp3 v0'."""
         self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
             id=1704, status="imported", min_bitrate=320,
@@ -1450,10 +1452,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"mb_release_id": self.RELEASE_ID})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_finalize), "lossless,mp3 v0")
+        self.assertEqual(self._override_passed(mock_transition), "lossless,mp3 v0")
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_upgrade_falls_back_to_full_tiers_when_no_override(self, mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_upgrade_falls_back_to_full_tiers_when_no_override(self, mock_transition):
         """Upgrade on an imported album with no override falls back to the full ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
 
@@ -1466,13 +1468,13 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"mb_release_id": self.RELEASE_ID})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_finalize),
+        self.assertEqual(self._override_passed(mock_transition),
                          QUALITY_UPGRADE_TIERS)
 
     # -- Update (status → wanted) ---------------------------------------
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_update_to_wanted_preserves_stricter_override(self, mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_update_to_wanted_preserves_stricter_override(self, mock_transition):
         """Flipping an imported album back to wanted must preserve 'lossless'."""
         self.mock_db.get_request.return_value = make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
@@ -1484,11 +1486,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"id": 1704, "status": "wanted"})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_finalize), "lossless")
+        self.assertEqual(self._override_passed(mock_transition), "lossless")
 
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     def test_update_to_wanted_falls_back_to_full_tiers_when_no_override(
-            self, mock_finalize):
+            self, mock_transition):
         """Flipping imported→wanted with no override uses the full upgrade ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
 
@@ -1502,13 +1504,13 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                                     {"id": 1704, "status": "wanted"})
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_finalize),
+        self.assertEqual(self._override_passed(mock_transition),
                          QUALITY_UPGRADE_TIERS)
 
     # -- Ban source (regression pin) ------------------------------------
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_ban_source_preserves_stricter_override(self, mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_ban_source_preserves_stricter_override(self, mock_transition):
         """Pin: ban_source already preserves override. Guard against future regression."""
         self.mock_db.get_request.return_value = make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
@@ -1522,12 +1524,12 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         })
 
         self.assertEqual(status, 200)
-        self.assertEqual(self._override_passed(mock_finalize), "lossless")
+        self.assertEqual(self._override_passed(mock_transition), "lossless")
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     def test_ban_source_clears_on_disk_quality_fields(
-            self, _mock_finalize, mock_subprocess):
+            self, _mock_transition, mock_subprocess):
         """After ``beet remove -d``, pipeline DB must forget on-disk quality.
 
         ``current_spectral_*`` and ``verified_lossless`` describe files that
@@ -1563,9 +1565,9 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     def test_ban_source_skips_clear_when_beet_remove_failed(
-            self, _mock_finalize, mock_subprocess):
+            self, _mock_transition, mock_subprocess):
         """Conservative: if beets still holds the album after the remove
         attempts (e.g. permissions error, wrong column and no legacy
         fallback matched), the on-disk quality state is still accurate,
@@ -1606,9 +1608,9 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         self.assertFalse(data["beets_removed"])
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     def test_ban_source_uses_discogs_selector_for_numeric_id(
-            self, _mock_finalize, mock_subprocess):
+            self, _mock_transition, mock_subprocess):
         """Discogs-backed requests carry a numeric ID. ``beet remove -d``
         must try ``discogs_albumid:<id>`` (the new layout) AND
         ``mb_albumid:<id>`` (the legacy layout documented in
@@ -1646,15 +1648,15 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
                       "so older beets libraries don't regress.")
 
     @patch("lib.beets_album_op.sp.run")
-    @patch("web.routes.pipeline.finalize_request")
+    @patch("web.routes.pipeline._transition_request")
     def test_ban_source_clears_stale_state_when_album_already_gone(
-            self, _mock_finalize, mock_subprocess):
+            self, _mock_transition, mock_subprocess):
         """Ghost state can pre-date the handler: a user runs
         ``beet rm mb_albumid:X`` manually, then days later bans the
         source. ``locate`` returns 'absent' before ban-source even
         starts, so no ``beet remove`` runs — but the pipeline DB still
         carries the old ``current_spectral_*`` / ``imported_path``.
-        The handler must still clear those fields so ``dispatch_import``
+        The handler must still clear those fields so ``dispatch_import_core``
         doesn't keep deriving ``--override-min-bitrate`` from phantom
         baselines on the next import attempt.
         """
@@ -1684,8 +1686,8 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         # No remove ran — the handler had nothing to remove.
         mock_subprocess.assert_not_called()
 
-    @patch("web.routes.pipeline.finalize_request")
-    def test_ban_source_skips_clear_when_mbid_missing(self, _mock_finalize):
+    @patch("web.routes.pipeline._transition_request")
+    def test_ban_source_skips_clear_when_mbid_missing(self, _mock_transition):
         """Without ``mb_release_id`` we never query beets and never run
         ``beet remove``, so there's no positive evidence the album is gone.
         Clearing the on-disk quality fields anyway would erase state for

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -5,13 +5,13 @@ import re
 import msgspec
 
 from web.classify import classify_log_entry, LogEntry
+from lib.import_dispatch import DispatchOutcome, finalize_request
 from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
                          resolve_user_requeue_override,
                          should_clear_lossless_search_override,
                          get_decision_tree, full_pipeline_decision)
 from lib.release_identity import detect_release_source, normalize_release_id
 from lib.release_cleanup import remove_and_reset_release
-from lib.transitions import apply_transition
 from lib.util import resolve_failed_path
 from lib.spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,
                                 ALBUM_SUSPECT_PCT, MIN_CLIFF_SLICES,
@@ -24,6 +24,20 @@ def _server():
     """Deferred import to avoid circular deps."""
     from web import server
     return server
+
+
+def _transition_request(db, request_id: int, status: str, **extra: object) -> None:
+    """Route request-status writes through the shared finalization seam."""
+
+    finalize_request(
+        db,
+        request_id,
+        DispatchOutcome.transition(
+            to_status=status,
+            success=status == "imported",
+            transition_fields=extra,
+        ),
+    )
 
 
 # ── GET handlers ─────────────────────────────────────────────────
@@ -423,10 +437,10 @@ def post_pipeline_update(h, body: dict) -> None:
             kwargs["search_filetype_override"] = quality
         if min_br is not None:
             kwargs["min_bitrate"] = min_br
-        apply_transition(s._db(), int(req_id), "wanted", **kwargs)
+        _transition_request(s._db(), int(req_id), "wanted", **kwargs)
     else:
-        apply_transition(s._db(), int(req_id), new_status,
-                         from_status=req["status"])
+        _transition_request(
+            s._db(), int(req_id), new_status, from_status=req["status"])
 
     h._json({"status": "ok", "id": req_id, "new_status": new_status})
 
@@ -455,10 +469,14 @@ def post_pipeline_upgrade(h, body: dict) -> None:
         quality = resolve_user_requeue_override(
             existing.get("search_filetype_override"))
         req_id = existing["id"]
-        apply_transition(s._db(), req_id, "wanted",
-                         from_status=existing["status"],
-                         search_filetype_override=quality,
-                         min_bitrate=min_bitrate)
+        _transition_request(
+            s._db(),
+            req_id,
+            "wanted",
+            from_status=existing["status"],
+            search_filetype_override=quality,
+            min_bitrate=min_bitrate,
+        )
         h._json({
             "status": "upgrade_queued",
             "id": req_id,
@@ -498,10 +516,14 @@ def post_pipeline_upgrade(h, body: dict) -> None:
         if release.get("tracks"):
             s._db().set_tracks(req_id, release["tracks"])
         # Newly added request — status is already 'wanted', set quality override
-        apply_transition(s._db(), req_id, "wanted",
-                         from_status="wanted",
-                         search_filetype_override=quality,
-                         min_bitrate=min_bitrate)
+        _transition_request(
+            s._db(),
+            req_id,
+            "wanted",
+            from_status="wanted",
+            search_filetype_override=quality,
+            min_bitrate=min_bitrate,
+        )
         h._json({
             "status": "upgrade_queued",
             "id": req_id,
@@ -544,14 +566,19 @@ def post_pipeline_set_quality(h, body: dict) -> None:
             extra: dict[str, object] = {"search_filetype_override": None}
             if min_bitrate is not None:
                 extra["min_bitrate"] = int(min_bitrate)
-            apply_transition(s._db(), req_id, "imported",
-                             from_status=existing["status"], **extra)
+            _transition_request(
+                s._db(),
+                req_id,
+                "imported",
+                from_status=existing["status"],
+                **extra,
+            )
         elif new_status == "wanted" and existing["status"] != "wanted":
-            apply_transition(s._db(), req_id, "wanted",
-                             from_status=existing["status"])
+            _transition_request(
+                s._db(), req_id, "wanted", from_status=existing["status"])
         else:
-            apply_transition(s._db(), req_id, new_status,
-                             from_status=existing["status"])
+            _transition_request(
+                s._db(), req_id, new_status, from_status=existing["status"])
 
     h._json({
         "status": "ok",
@@ -597,10 +624,14 @@ def post_pipeline_set_intent(h, body: dict) -> None:
     if req["status"] == "imported" and target_format:
         # Re-queue to search for lossless source
         min_br = req.get("min_bitrate")
-        apply_transition(s._db(), int(req_id), "wanted",
-                         from_status="imported",
-                         search_filetype_override=QUALITY_LOSSLESS,
-                         min_bitrate=min_br)
+        _transition_request(
+            s._db(),
+            int(req_id),
+            "wanted",
+            from_status="imported",
+            search_filetype_override=QUALITY_LOSSLESS,
+            min_bitrate=min_br,
+        )
         s._db().update_request_fields(int(req_id), target_format=target_format)
         h._json({
             "status": "ok",
@@ -685,7 +716,7 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         }
         if min_br is not None:
             ban_kwargs["min_bitrate"] = min_br
-        apply_transition(s._db(), int(req_id), "wanted", **ban_kwargs)
+        _transition_request(s._db(), int(req_id), "wanted", **ban_kwargs)
 
     h._json({
         "status": "ok",

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -5,7 +5,7 @@ import re
 import msgspec
 
 from web.classify import classify_log_entry, LogEntry
-from lib.import_dispatch import DispatchOutcome, finalize_request
+from lib.import_dispatch import transition_request as _transition_request
 from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
                          resolve_user_requeue_override,
                          should_clear_lossless_search_override,
@@ -24,21 +24,6 @@ def _server():
     """Deferred import to avoid circular deps."""
     from web import server
     return server
-
-
-def _transition_request(db, request_id: int, status: str, **extra: object) -> None:
-    """Route request-status writes through the shared finalization seam."""
-
-    finalize_request(
-        db,
-        request_id,
-        DispatchOutcome.transition(
-            to_status=status,
-            success=status == "imported",
-            transition_fields=extra,
-        ),
-    )
-
 
 # ── GET handlers ─────────────────────────────────────────────────
 
@@ -432,12 +417,38 @@ def post_pipeline_update(h, body: dict) -> None:
                 quality = resolve_user_requeue_override(
                     req.get("search_filetype_override"))
                 min_br = b.get_min_bitrate(mbid)
-        kwargs: dict[str, object] = {"from_status": req["status"]}
-        if quality is not None:
-            kwargs["search_filetype_override"] = quality
-        if min_br is not None:
-            kwargs["min_bitrate"] = min_br
-        _transition_request(s._db(), int(req_id), "wanted", **kwargs)
+        if quality is not None and min_br is not None:
+            _transition_request(
+                s._db(),
+                int(req_id),
+                "wanted",
+                from_status=req["status"],
+                search_filetype_override=quality,
+                min_bitrate=min_br,
+            )
+        elif quality is not None:
+            _transition_request(
+                s._db(),
+                int(req_id),
+                "wanted",
+                from_status=req["status"],
+                search_filetype_override=quality,
+            )
+        elif min_br is not None:
+            _transition_request(
+                s._db(),
+                int(req_id),
+                "wanted",
+                from_status=req["status"],
+                min_bitrate=min_br,
+            )
+        else:
+            _transition_request(
+                s._db(),
+                int(req_id),
+                "wanted",
+                from_status=req["status"],
+            )
     else:
         _transition_request(
             s._db(), int(req_id), new_status, from_status=req["status"])
@@ -563,16 +574,23 @@ def post_pipeline_set_quality(h, body: dict) -> None:
                 b = s._beets_db()
                 if b:
                     min_bitrate = b.get_avg_bitrate_kbps(mbid)
-            extra: dict[str, object] = {"search_filetype_override": None}
             if min_bitrate is not None:
-                extra["min_bitrate"] = int(min_bitrate)
-            _transition_request(
-                s._db(),
-                req_id,
-                "imported",
-                from_status=existing["status"],
-                **extra,
-            )
+                _transition_request(
+                    s._db(),
+                    req_id,
+                    "imported",
+                    from_status=existing["status"],
+                    search_filetype_override=None,
+                    min_bitrate=int(min_bitrate),
+                )
+            else:
+                _transition_request(
+                    s._db(),
+                    req_id,
+                    "imported",
+                    from_status=existing["status"],
+                    search_filetype_override=None,
+                )
         elif new_status == "wanted" and existing["status"] != "wanted":
             _transition_request(
                 s._db(), req_id, "wanted", from_status=existing["status"])
@@ -710,13 +728,23 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         quality = resolve_user_requeue_override(
             req.get("search_filetype_override"))
         min_br = req.get("min_bitrate")
-        ban_kwargs: dict[str, object] = {
-            "from_status": req["status"],
-            "search_filetype_override": quality,
-        }
         if min_br is not None:
-            ban_kwargs["min_bitrate"] = min_br
-        _transition_request(s._db(), int(req_id), "wanted", **ban_kwargs)
+            _transition_request(
+                s._db(),
+                int(req_id),
+                "wanted",
+                from_status=req["status"],
+                search_filetype_override=quality,
+                min_bitrate=min_br,
+            )
+        else:
+            _transition_request(
+                s._db(),
+                int(req_id),
+                "wanted",
+                from_status=req["status"],
+                search_filetype_override=quality,
+            )
 
     h._json({
         "status": "ok",

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -3,6 +3,7 @@
 import json
 import re
 import msgspec
+from typing import TypedDict
 
 from web.classify import classify_log_entry, LogEntry
 from lib.import_dispatch import transition_request as _transition_request
@@ -18,6 +19,11 @@ from lib.spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,
                                 CLIFF_THRESHOLD_DB_PER_KHZ)
 from web import mb as mb_api
 from web import discogs as discogs_api
+
+
+class _TransitionFields(TypedDict, total=False):
+    search_filetype_override: str | None
+    min_bitrate: int
 
 
 def _server():
@@ -417,38 +423,18 @@ def post_pipeline_update(h, body: dict) -> None:
                 quality = resolve_user_requeue_override(
                     req.get("search_filetype_override"))
                 min_br = b.get_min_bitrate(mbid)
-        if quality is not None and min_br is not None:
-            _transition_request(
-                s._db(),
-                int(req_id),
-                "wanted",
-                from_status=req["status"],
-                search_filetype_override=quality,
-                min_bitrate=min_br,
-            )
-        elif quality is not None:
-            _transition_request(
-                s._db(),
-                int(req_id),
-                "wanted",
-                from_status=req["status"],
-                search_filetype_override=quality,
-            )
-        elif min_br is not None:
-            _transition_request(
-                s._db(),
-                int(req_id),
-                "wanted",
-                from_status=req["status"],
-                min_bitrate=min_br,
-            )
-        else:
-            _transition_request(
-                s._db(),
-                int(req_id),
-                "wanted",
-                from_status=req["status"],
-            )
+        transition_fields: _TransitionFields = {}
+        if quality is not None:
+            transition_fields["search_filetype_override"] = quality
+        if min_br is not None:
+            transition_fields["min_bitrate"] = min_br
+        _transition_request(
+            s._db(),
+            int(req_id),
+            "wanted",
+            from_status=req["status"],
+            **transition_fields,
+        )
     else:
         _transition_request(
             s._db(), int(req_id), new_status, from_status=req["status"])
@@ -574,23 +560,18 @@ def post_pipeline_set_quality(h, body: dict) -> None:
                 b = s._beets_db()
                 if b:
                     min_bitrate = b.get_avg_bitrate_kbps(mbid)
+            transition_fields: _TransitionFields = {
+                "search_filetype_override": None,
+            }
             if min_bitrate is not None:
-                _transition_request(
-                    s._db(),
-                    req_id,
-                    "imported",
-                    from_status=existing["status"],
-                    search_filetype_override=None,
-                    min_bitrate=int(min_bitrate),
-                )
-            else:
-                _transition_request(
-                    s._db(),
-                    req_id,
-                    "imported",
-                    from_status=existing["status"],
-                    search_filetype_override=None,
-                )
+                transition_fields["min_bitrate"] = int(min_bitrate)
+            _transition_request(
+                s._db(),
+                req_id,
+                "imported",
+                from_status=existing["status"],
+                **transition_fields,
+            )
         elif new_status == "wanted" and existing["status"] != "wanted":
             _transition_request(
                 s._db(), req_id, "wanted", from_status=existing["status"])
@@ -728,23 +709,18 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         quality = resolve_user_requeue_override(
             req.get("search_filetype_override"))
         min_br = req.get("min_bitrate")
+        ban_fields: _TransitionFields = {
+            "search_filetype_override": quality,
+        }
         if min_br is not None:
-            _transition_request(
-                s._db(),
-                int(req_id),
-                "wanted",
-                from_status=req["status"],
-                search_filetype_override=quality,
-                min_bitrate=min_br,
-            )
-        else:
-            _transition_request(
-                s._db(),
-                int(req_id),
-                "wanted",
-                from_status=req["status"],
-                search_filetype_override=quality,
-            )
+            ban_fields["min_bitrate"] = min_br
+        _transition_request(
+            s._db(),
+            int(req_id),
+            "wanted",
+            from_status=req["status"],
+            **ban_fields,
+        )
 
     h._json({
         "status": "ok",

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -23,7 +23,8 @@ from web import discogs as discogs_api
 
 class _TransitionFields(TypedDict, total=False):
     search_filetype_override: str | None
-    min_bitrate: int
+    min_bitrate: int | None
+    prev_min_bitrate: int | None
 
 
 def _server():


### PR DESCRIPTION
## Summary
- route terminal `album_requests.status` writes through `lib.import_dispatch.finalize_request(...)`
- collapse the auto-import forwarding chain so `process_completed_album()` hands valid request imports straight to `dispatch_import_core`
- patch the remaining harness/admin-script bypasses and widen the contract guard to cover `harness/`, `scripts/`, dynamic status args, and raw SQL status writes outside the DB seam

## Invariant
Every terminal request-state transition now flows through the shared finalization seam instead of letting `lib`, `web`, the harness, and the admin scripts drift independently.

## Acceptance Checklist
- [x] `album_source.py`, `lib/`, `web/`, `harness/import_one.py`, `scripts/pipeline_cli.py`, and `scripts/repair.py` no longer bypass the shared request-finalization seam for terminal status writes
- [x] the auto path now runs `process_completed_album()` -> `_handle_valid_result()` -> `dispatch_import_core()` without the old forwarding wrapper chain
- [x] regression tests pin the dynamic CLI/harness call sites and fail on direct transition calls or raw SQL status writes outside the allowed seam layers

## Review
Claude was unavailable for this round, so convergence used Codex reviews only.

## Verification
- `nix-shell --run "python3 -m unittest tests.test_request_finalization tests.test_pipeline_cli tests.test_repair tests.test_repair_cli tests.test_import_one_stages tests.test_import_dispatch tests.test_integration_slices tests.test_web_server tests.test_download tests.test_album_source tests.test_do_mark -v"`
- `nix-shell --run "pyright harness/import_one.py scripts/pipeline_cli.py scripts/repair.py tests/test_request_finalization.py tests/test_pipeline_cli.py tests/test_repair_cli.py tests/test_import_one_stages.py"`
