### PR TITLE
[codex] fix staged-path reflection loose ends

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -615,10 +615,11 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
       dispatch succeeded.
     - ``False`` — a non-deferred failure happened. Outer caller resets to
       ``wanted`` only if the request row is still ``downloading``.
-    - ``None`` — processing left the row untouched. This covers both
-      release-lock contention and post-move staged paths that must not
-      be auto-retried because they already live under
-      ``beets_staging_dir``. Outer caller must NOT touch status.
+    - ``None`` — processing left the row untouched. This covers release-lock
+      contention, post-move staged paths that must not be auto-retried
+      because they already live under ``beets_staging_dir``, and guarded
+      request rejects where ownership cannot be proven. Outer caller must
+      NOT touch status.
     """
     staged_album = StagedAlbum.from_entry(
         album_data,
@@ -669,8 +670,10 @@ def _process_beets_validation(album_data: GrabListEntry,
     Returns the dispatch outcome when the auto-import path fires,
     ``None`` when beets validation rejects (``_handle_rejected_result``
     already handles the state transition) or when the non-auto
-    redownload path takes over in ``_handle_valid_result``. Caller
-    uses the ``deferred`` flag to decide whether to flip status.
+    redownload path takes over in ``_handle_valid_result``. Guarded
+    ownership-less rejects also return a deferred outcome so callers
+    keep the row untouched for manual recovery. Caller uses the
+    ``deferred`` flag to decide whether to flip status.
     """
     from lib.beets import beets_validate as _bv
     from lib.preimport import run_preimport_gates
@@ -729,6 +732,10 @@ def _resolved_request_rejection_id(
     candidate_request_id = album_data.album_id
     if not isinstance(candidate_request_id, int) or isinstance(candidate_request_id, bool):
         return db, None
+    # ``AlbumRecord.id`` is negative on the search path, so only positive
+    # ids can safely be treated as ``album_requests.id`` candidates here.
+    if candidate_request_id <= 0:
+        return db, None
 
     request_row = db.get_request(candidate_request_id)
     if not isinstance(request_row, dict):
@@ -738,12 +745,18 @@ def _resolved_request_rejection_id(
     if str(request_row.get("album_title") or "") != album_data.title:
         return db, None
     request_year = request_row.get("year")
-    if request_year not in (None, "") and str(request_year) != album_data.year:
+    if (
+        album_data.year
+        and request_year not in (None, "")
+        and str(request_year) != album_data.year
+    ):
         return db, None
+    album_release_id = str(album_data.mb_release_id or "")
     request_release_id = str(request_row.get("mb_release_id") or "")
-    if album_data.mb_release_id and request_release_id:
-        if request_release_id != album_data.mb_release_id:
-            return db, None
+    if bool(album_release_id) != bool(request_release_id):
+        return db, None
+    if album_release_id and request_release_id != album_release_id:
+        return db, None
     return db, candidate_request_id
 
 
@@ -757,7 +770,26 @@ def _reject_request_auto_import(
     scenario: str,
     error: str,
 ) -> DispatchOutcome:
-    """Move a rejected request auto-import to failed_imports and requeue it."""
+    """Reject a request auto-import when ownership can be proven safely."""
+    db, request_id = _resolved_request_rejection_id(album_data, ctx)
+    if db is None or request_id is None:
+        logger.error(
+            "AUTO-IMPORT REJECT BLOCKED WITHOUT REQUEST AUDIT: album_id=%s %s - %s "
+            "(scenario=%s) could not resolve a safe pipeline request row; "
+            "files remain at %s and automatic retry/import is disabled until "
+            "manual recovery.",
+            album_data.album_id,
+            album_data.artist,
+            album_data.title,
+            scenario,
+            staged_album.current_path,
+        )
+        return DispatchOutcome(
+            success=False,
+            message=detail,
+            deferred=True,
+        )
+
     failed_result = ValidationResult(
         distance=bv_result.distance if bv_result.distance is not None else 0.0,
         scenario=scenario,
@@ -776,26 +808,24 @@ def _reject_request_auto_import(
     )
     log_validation_result(album_data, failed_result, ctx.cfg)
 
-    db, request_id = _resolved_request_rejection_id(album_data, ctx)
-    if db is not None and request_id is not None:
-        dl_info = _build_download_info(album_data)
-        if album_data.download_spectral is not None:
-            dl_info.download_spectral = album_data.download_spectral
-            dl_info.current_spectral = album_data.current_spectral
-            dl_info.existing_min_bitrate = album_data.current_min_bitrate
-            dl_info.slskd_filetype = dl_info.filetype
-            dl_info.actual_filetype = dl_info.filetype
-        _record_rejection_and_maybe_requeue(
-            db,
-            request_id,
-            dl_info,
-            distance=failed_result.distance if failed_result.distance is not None else 0.0,
-            scenario=failed_result.scenario or scenario,
-            detail=detail,
-            error=failed_result.error,
-            requeue=True,
-            validation_result=failed_result.to_json(),
-        )
+    dl_info = _build_download_info(album_data)
+    if album_data.download_spectral is not None:
+        dl_info.download_spectral = album_data.download_spectral
+        dl_info.current_spectral = album_data.current_spectral
+        dl_info.existing_min_bitrate = album_data.current_min_bitrate
+        dl_info.slskd_filetype = dl_info.filetype
+        dl_info.actual_filetype = dl_info.filetype
+    _record_rejection_and_maybe_requeue(
+        db,
+        request_id,
+        dl_info,
+        distance=failed_result.distance if failed_result.distance is not None else 0.0,
+        scenario=failed_result.scenario or scenario,
+        detail=detail,
+        error=failed_result.error,
+        requeue=True,
+        validation_result=failed_result.to_json(),
+    )
 
     return DispatchOutcome(success=False, message=detail)
 
@@ -1425,9 +1455,10 @@ def _run_completed_processing(
     #   still 'downloading'.
     # - False → a non-deferred failure path returned; reset to
     #   'wanted' only if the request row is still 'downloading'.
-    # - None  → leave the row untouched. This covers both release-lock
-    #   contention and guarded post-move staged paths where auto-retry
-    #   would risk duplicate import. Do NOT touch state here.
+    # - None  → leave the row untouched. This covers release-lock
+    #   contention, guarded post-move staged paths, and ownership-less
+    #   request rejects that require manual recovery. Do NOT touch state
+    #   here.
     if outcome is None:
         return
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -24,7 +24,10 @@ from lib.grab_list import GrabListEntry, DownloadFile
 from lib.processing_paths import (
     canonical_processing_path,
     directory_has_entries,
+    normalize_processing_path,
+    path_is_within_root,
     stage_to_ai_path,
+    stage_to_ai_root,
 )
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          DownloadDecision, ValidationResult,
@@ -68,6 +71,7 @@ def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
 
 _TICKS_SUFFIX = re.compile(r"^(?P<base>.+)_(?P<ticks>\d{17,20})$")
 _REMOTE_PATH_SEPARATORS = re.compile(r"[\\/]+")
+_REQUEST_SCOPED_STAGE_SUFFIX = re.compile(r" \[request-\d+\]$")
 
 
 def _remote_path_components(path: str) -> list[str]:
@@ -80,6 +84,21 @@ def slskd_local_folder(file_dir: str, slskd_download_dir: str) -> str:
     components = _remote_path_components(file_dir)
     leaf = components[-1] if components else file_dir
     return os.path.join(slskd_download_dir, leaf)
+
+
+def _is_request_scoped_auto_import_path(
+    *,
+    current_path: str,
+    staging_dir: str,
+) -> bool:
+    """Return True when ``current_path`` is under auto-import request staging."""
+    normalized_path = normalize_processing_path(current_path)
+    if not _REQUEST_SCOPED_STAGE_SUFFIX.search(os.path.basename(normalized_path)):
+        return False
+    return path_is_within_root(
+        normalized_path,
+        stage_to_ai_root(staging_dir=staging_dir, auto_import=True),
+    )
 
 
 def _matching_slskd_paths(
@@ -443,12 +462,28 @@ def _materialize_processing_dir(
         album_data, ctx.cfg.slskd_download_dir)
     db = (ctx.pipeline_db_source._get_db()
           if ctx.pipeline_db_source is not None else None)
+    request_id = album_data.db_request_id
+    if request_id is None and _is_request_scoped_auto_import_path(
+        current_path=staged_album.current_path,
+        staging_dir=ctx.cfg.beets_staging_dir,
+    ):
+        _log_post_move_resume_blocked(
+            album_data,
+            current_path=staged_album.current_path,
+            detail=(
+                "already lives at the request-scoped auto-import staged "
+                "path but is missing db_request_id. Automatic retry is "
+                "disabled because import ownership can no longer be "
+                "verified; manual recovery is required."
+            ),
+        )
+        return None
     current_path_location = classify_processing_path(
         current_path=staged_album.current_path,
         artist=album_data.artist,
         title=album_data.title,
         year=album_data.year,
-        request_id=album_data.db_request_id or 0,
+        request_id=request_id or 0,
         staging_dir=ctx.cfg.beets_staging_dir,
         slskd_download_dir=ctx.cfg.slskd_download_dir,
     )
@@ -576,10 +611,10 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
     """Process a fully-downloaded album: move files, tag, validate, stage/import.
 
     Returns three-valued ``bool | None``:
-    - ``True`` — files moved and tagged successfully. Auto-import (if
-      fired) either landed or recorded a rejection; outer caller flips
-      status to ``imported``.
-    - ``False`` — file moves failed; outer caller resets to ``wanted``.
+    - ``True`` — files moved and tagged successfully, and any auto-import
+      dispatch succeeded.
+    - ``False`` — a non-deferred failure happened. Outer caller resets to
+      ``wanted`` only if the request row is still ``downloading``.
     - ``None`` — processing left the row untouched. This covers both
       release-lock contention and post-move staged paths that must not
       be auto-retried because they already live under
@@ -610,12 +645,14 @@ def process_completed_album(album_data: GrabListEntry, failed_grab: list[Any],
     if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
         outcome = _process_beets_validation(
             album_data, staged_album, ctx)
-        if outcome is not None and outcome.deferred:
-            # Release-lock contention. Propagate ``None`` so
-            # ``_run_completed_processing`` leaves the request's
-            # status, active_download_state, and staged files
-            # untouched for the next cycle to retry.
-            return None
+        if outcome is not None:
+            if outcome.deferred:
+                # Release-lock contention. Propagate ``None`` so
+                # ``_run_completed_processing`` leaves the request's
+                # status, active_download_state, and staged files
+                # untouched for the next cycle to retry.
+                return None
+            return outcome.success
     return True
 
 
@@ -676,6 +713,93 @@ def _process_beets_validation(album_data: GrabListEntry,
     _handle_rejected_result(
         album_data, bv_result, staged_album, ctx)
     return None
+
+
+def _resolved_request_rejection_id(
+    album_data: GrabListEntry,
+    ctx: CratediggerContext,
+) -> tuple[Any | None, int | None]:
+    """Resolve the backing request row for defensive auto-import rejects."""
+    if ctx.pipeline_db_source is None:
+        return None, None
+    db = ctx.pipeline_db_source._get_db()
+    if album_data.db_request_id is not None:
+        return db, album_data.db_request_id
+
+    candidate_request_id = album_data.album_id
+    if not isinstance(candidate_request_id, int) or isinstance(candidate_request_id, bool):
+        return db, None
+
+    request_row = db.get_request(candidate_request_id)
+    if not isinstance(request_row, dict):
+        return db, None
+    if str(request_row.get("artist_name") or "") != album_data.artist:
+        return db, None
+    if str(request_row.get("album_title") or "") != album_data.title:
+        return db, None
+    request_year = request_row.get("year")
+    if request_year not in (None, "") and str(request_year) != album_data.year:
+        return db, None
+    request_release_id = str(request_row.get("mb_release_id") or "")
+    if album_data.mb_release_id and request_release_id:
+        if request_release_id != album_data.mb_release_id:
+            return db, None
+    return db, candidate_request_id
+
+
+def _reject_request_auto_import(
+    album_data: GrabListEntry,
+    bv_result: ValidationResult,
+    staged_album: StagedAlbum,
+    ctx: CratediggerContext,
+    *,
+    detail: str,
+    scenario: str,
+    error: str,
+) -> DispatchOutcome:
+    """Move a rejected request auto-import to failed_imports and requeue it."""
+    failed_result = ValidationResult(
+        distance=bv_result.distance if bv_result.distance is not None else 0.0,
+        scenario=scenario,
+        detail=detail,
+        error=error,
+    )
+    failed_result.failed_path = move_failed_import(
+        staged_album.current_path,
+        scenario=failed_result.scenario,
+    )
+    logger.error(
+        "AUTO-IMPORT REJECTED: %s - %s — %s",
+        album_data.artist,
+        album_data.title,
+        detail,
+    )
+    log_validation_result(album_data, failed_result, ctx.cfg)
+
+    db, request_id = _resolved_request_rejection_id(album_data, ctx)
+    if db is not None and request_id is not None:
+        dl_info = _build_download_info(album_data)
+        if album_data.download_spectral is not None:
+            dl_info.download_spectral = album_data.download_spectral
+            dl_info.current_spectral = album_data.current_spectral
+            dl_info.existing_min_bitrate = album_data.current_min_bitrate
+            dl_info.slskd_filetype = dl_info.filetype
+            dl_info.actual_filetype = dl_info.filetype
+        _record_rejection_and_maybe_requeue(
+            db,
+            request_id,
+            dl_info,
+            distance=failed_result.distance if failed_result.distance is not None else 0.0,
+            scenario=failed_result.scenario or scenario,
+            detail=detail,
+            error=failed_result.error,
+            requeue=True,
+            validation_result=failed_result.to_json(),
+        )
+
+    return DispatchOutcome(success=False, message=detail)
+
+
 def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
                          staged_album: StagedAlbum,
                          ctx: CratediggerContext) -> "DispatchOutcome | None":
@@ -713,6 +837,21 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     wants_auto_import = (
         source_type == "request"
         and dist <= ctx.cfg.beets_distance_threshold)
+
+    if wants_auto_import and request_id is None:
+        return _reject_request_auto_import(
+            album_data,
+            bv_result,
+            staged_album,
+            ctx,
+            detail=(
+                "Request auto-import is missing db_request_id; automatic "
+                "resume/import is disabled."
+            ),
+            scenario="request_missing_request_id",
+            error="missing_request_id",
+        )
+
     current_path_location = classify_processing_path(
         current_path=staged_album.current_path,
         artist=album_data.artist,
@@ -724,44 +863,15 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     )
 
     if wants_auto_import and not album_data.mb_release_id:
-        detail = "Request auto-import requires a MusicBrainz release ID"
-        failed_result = ValidationResult(
-            distance=bv_result.distance if bv_result.distance is not None else 0.0,
+        return _reject_request_auto_import(
+            album_data,
+            bv_result,
+            staged_album,
+            ctx,
+            detail="Request auto-import requires a MusicBrainz release ID",
             scenario="request_missing_mbid",
-            detail=detail,
             error="missing_mbid",
         )
-        failed_result.failed_path = move_failed_import(
-            staged_album.current_path,
-            scenario=failed_result.scenario,
-        )
-        logger.error(
-            f"AUTO-IMPORT REJECTED: {album_data.artist} - {album_data.title} — "
-            f"{detail}"
-        )
-        log_validation_result(album_data, failed_result, ctx.cfg)
-        if request_id is not None:
-            db = ctx.pipeline_db_source._get_db()
-            dl_info = _build_download_info(album_data)
-            if album_data.download_spectral is not None:
-                dl_info.download_spectral = album_data.download_spectral
-                dl_info.current_spectral = album_data.current_spectral
-                dl_info.existing_min_bitrate = album_data.current_min_bitrate
-                dl_info.slskd_filetype = dl_info.filetype
-                dl_info.actual_filetype = dl_info.filetype
-            validation_json = failed_result.to_json()
-            _record_rejection_and_maybe_requeue(
-                db,
-                request_id,
-                dl_info,
-                distance=failed_result.distance if failed_result.distance is not None else 0.0,
-                scenario=failed_result.scenario or "request_missing_mbid",
-                detail=detail,
-                error=failed_result.error,
-                requeue=True,
-                validation_result=validation_json,
-            )
-        return DispatchOutcome(success=False, message=detail)
 
     will_auto_import = wants_auto_import
     pdb = None
@@ -1311,10 +1421,10 @@ def _run_completed_processing(
         return
 
     # Three-valued return from ``process_completed_album``:
-    # - True  → imported (or auto-import recorded a rejection); flip to
-    #   'imported' if status is still 'downloading'.
-    # - False → file moves failed; reset to 'wanted' (genuine failure
-    #   that DOES deserve a backoff-scored attempt).
+    # - True  → processing succeeded; flip to 'imported' if status is
+    #   still 'downloading'.
+    # - False → a non-deferred failure path returned; reset to
+    #   'wanted' only if the request row is still 'downloading'.
     # - None  → leave the row untouched. This covers both release-lock
     #   contention and guarded post-move staged paths where auto-retry
     #   would risk duplicate import. Do NOT touch state here.

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -470,23 +470,25 @@ def find_blocked_processing_path_issues(
         location = recovery_decision.selected_location
         if location.path != current_path:
             continue
-        if not has_entries(current_path):
-            issues.append(BlockedRecoveryIssue(
-                request_id=request_id,
-                detail=(
-                    "persisted processing path missing after local "
-                    f"processing: {current_path}"
-                ),
-            ))
-            continue
         if location.kind == "request_scoped_auto_import_staged":
+            has_path_entries = has_entries(current_path)
             mb_release_id = row.get("mb_release_id")
             normalized_mbid = (
                 str(mb_release_id)
                 if isinstance(mb_release_id, str) and mb_release_id
                 else None
             )
+            in_progress: bool | None = False
             if normalized_mbid is None:
+                if not has_path_entries:
+                    issues.append(BlockedRecoveryIssue(
+                        request_id=request_id,
+                        detail=(
+                            "persisted processing path missing after local "
+                            f"processing: {current_path}"
+                        ),
+                    ))
+                    continue
                 issues.append(BlockedRecoveryIssue(
                     request_id=request_id,
                     detail=(
@@ -506,6 +508,27 @@ def find_blocked_processing_path_issues(
                 in_progress = auto_import_in_progress(request_id, normalized_mbid)
                 if in_progress is True:
                     continue
+            if not has_path_entries:
+                if in_progress is None:
+                    issues.append(BlockedRecoveryIssue(
+                        request_id=request_id,
+                        detail=(
+                            "persisted request-scoped auto-import staged "
+                            "path is missing, but the repair scan could "
+                            "not determine whether auto-import is still "
+                            f"running: {location.path}"
+                        ),
+                    ))
+                    continue
+                issues.append(BlockedRecoveryIssue(
+                    request_id=request_id,
+                    detail=(
+                        "persisted processing path missing after local "
+                        f"processing: {current_path}"
+                    ),
+                ))
+                continue
+            if auto_import_in_progress is not None:
                 if in_progress is None:
                     issues.append(BlockedRecoveryIssue(
                         request_id=request_id,
@@ -523,6 +546,15 @@ def find_blocked_processing_path_issues(
                     "persisted request-scoped auto-import staged path is "
                     "still populated, but no auto-import is currently "
                     f"running: {location.path}"
+                ),
+            ))
+            continue
+        if not has_entries(current_path):
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "persisted processing path missing after local "
+                    f"processing: {current_path}"
                 ),
             ))
             continue

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import os
 from typing import Callable, Literal
 
 from lib.processing_paths import (
     canonical_processing_path,
     normalize_processing_path,
+    path_is_within_root,
     stage_to_ai_path,
 )
 
@@ -210,7 +210,7 @@ def classify_processing_path(
         request_id=request_id,
         auto_import=True,
     )
-    if _path_is_within(current_path, request_scoped_auto_import):
+    if path_is_within_root(current_path, request_scoped_auto_import):
         return ProcessingPathLocation(
             path=current_path,
             kind="request_scoped_auto_import_staged",
@@ -223,7 +223,7 @@ def classify_processing_path(
         request_id=request_id,
         auto_import=False,
     )
-    if _path_is_within(current_path, request_scoped_post_validation):
+    if path_is_within_root(current_path, request_scoped_post_validation):
         return ProcessingPathLocation(
             path=current_path,
             kind="request_scoped_post_validation_staged",
@@ -234,7 +234,7 @@ def classify_processing_path(
         title=title,
         staging_dir=staging_dir,
     )
-    if _path_is_within(current_path, legacy_shared_path):
+    if path_is_within_root(current_path, legacy_shared_path):
         return ProcessingPathLocation(
             path=current_path,
             kind="legacy_shared_staged",
@@ -401,6 +401,7 @@ def find_blocked_processing_path_issues(
     staging_dir: str,
     slskd_download_dir: str,
     has_entries: Callable[[str], bool],
+    auto_import_in_progress: Callable[[int, str | None], bool | None] | None = None,
 ) -> list[BlockedRecoveryIssue]:
     """Find persisted processing paths that block automatic resume."""
     issues: list[BlockedRecoveryIssue] = []
@@ -478,6 +479,53 @@ def find_blocked_processing_path_issues(
                 ),
             ))
             continue
+        if location.kind == "request_scoped_auto_import_staged":
+            mb_release_id = row.get("mb_release_id")
+            normalized_mbid = (
+                str(mb_release_id)
+                if isinstance(mb_release_id, str) and mb_release_id
+                else None
+            )
+            if normalized_mbid is None:
+                issues.append(BlockedRecoveryIssue(
+                    request_id=request_id,
+                    detail=(
+                        "persisted request-scoped auto-import staged path is "
+                        "still populated, but this request has no "
+                        f"mb_release_id so auto-import cannot resume: {location.path}"
+                    ),
+                ))
+                continue
+            if auto_import_in_progress is not None:
+                # ``album_requests.mb_release_id`` is UNIQUE and
+                # ``request_scoped_auto_import_staged`` only matches when
+                # the request suffix in ``current_path`` belongs to this row,
+                # so a held RELEASE lock for ``normalized_mbid`` is the best
+                # read-only liveness hint that this staged path still belongs
+                # to an in-flight auto-import for this exact row.
+                in_progress = auto_import_in_progress(request_id, normalized_mbid)
+                if in_progress is True:
+                    continue
+                if in_progress is None:
+                    issues.append(BlockedRecoveryIssue(
+                        request_id=request_id,
+                        detail=(
+                            "persisted request-scoped auto-import staged "
+                            "path is still populated, but the repair scan "
+                            "could not determine whether auto-import is "
+                            f"still running: {location.path}"
+                        ),
+                    ))
+                    continue
+            issues.append(BlockedRecoveryIssue(
+                request_id=request_id,
+                detail=(
+                    "persisted request-scoped auto-import staged path is "
+                    "still populated, but no auto-import is currently "
+                    f"running: {location.path}"
+                ),
+            ))
+            continue
         if not location.blocks_auto_import_dispatch:
             continue
         issues.append(BlockedRecoveryIssue(
@@ -488,15 +536,3 @@ def find_blocked_processing_path_issues(
             ),
         ))
     return issues
-
-
-def _path_is_within(path: str, root: str) -> bool:
-    """Return True when ``path`` is located under ``root``."""
-    if not root:
-        return False
-    abs_path = normalize_processing_path(path)
-    abs_root = normalize_processing_path(root)
-    try:
-        return os.path.commonpath([abs_path, abs_root]) == abs_root
-    except ValueError:
-        return False

--- a/lib/processing_paths.py
+++ b/lib/processing_paths.py
@@ -19,6 +19,18 @@ def normalize_processing_path(path: str) -> str:
     return os.path.abspath(os.path.normpath(path))
 
 
+def path_is_within_root(path: str, root: str) -> bool:
+    """Return True when ``path`` is located under ``root``."""
+    if not root:
+        return False
+    abs_path = normalize_processing_path(path)
+    abs_root = normalize_processing_path(root)
+    try:
+        return os.path.commonpath([abs_path, abs_root]) == abs_root
+    except ValueError:
+        return False
+
+
 def canonical_processing_path(
     *,
     artist: str,

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -95,7 +95,8 @@ class StagedAlbum:
             self.persist_current_path(db)
             shutil.rmtree(source, ignore_errors=True)
             return self.current_path
-        except Exception:
+        except Exception as exc:
+            rollback_failures: list[tuple[str, str]] = []
             if moved_entries:
                 os.makedirs(source, exist_ok=True)
                 for source_entry, target_entry in reversed(moved_entries):
@@ -103,6 +104,7 @@ class StagedAlbum:
                         try:
                             shutil.move(target_entry, source_entry)
                         except Exception:
+                            rollback_failures.append((source_entry, target_entry))
                             logger.exception(
                                 "Failed to roll back staged move %s -> %s",
                                 target_entry,
@@ -111,4 +113,10 @@ class StagedAlbum:
             elif not target_preexisted and os.path.isdir(target) and not os.listdir(target):
                 shutil.rmtree(target, ignore_errors=True)
             self.current_path = source
+            if rollback_failures:
+                first_source, first_target = rollback_failures[0]
+                raise RuntimeError(
+                    "Failed to roll back staged move cleanly after a staging "
+                    f"error: {first_target} -> {first_source}"
+                ) from exc
             raise

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -81,6 +81,7 @@ def _auto_import_in_progress(
                 WHERE locktype = 'advisory'
                   AND classid = %s
                   AND objid = %s
+                  AND objsubid = 2
                   AND mode = 'ExclusiveLock'
                   AND granted
                   AND database = (

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -22,7 +22,8 @@ from lib.config import read_runtime_config
 from lib.download_recovery import (find_blocked_processing_path_issues,
                                    find_blocked_recovery_issues)
 from lib.import_dispatch import transition_request
-from lib.pipeline_db import PipelineDB
+from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE, PipelineDB,
+                             release_id_to_lock_key)
 from lib.processing_paths import directory_has_entries
 from lib.quality import (OrphanInfo, find_inconsistencies,
                          find_orphaned_downloads, suggest_repair)
@@ -50,6 +51,64 @@ def _get_slskd_active_transfers(host: str, api_key: str) -> set[tuple[str, str]]
     return pairs
 
 
+def _dedupe_issues(issues: list[OrphanInfo]) -> list[OrphanInfo]:
+    """Return issues with duplicate (request_id, type, detail) rows removed."""
+    seen: set[tuple[int, str, str]] = set()
+    deduped: list[OrphanInfo] = []
+    for issue in issues:
+        key = (issue.request_id, issue.issue_type, issue.detail)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(issue)
+    return deduped
+
+
+def _auto_import_in_progress(
+    db: PipelineDB,
+    request_id: int,
+    mb_release_id: str | None,
+) -> bool | None:
+    """Return True when another session currently holds the release lock."""
+    if not mb_release_id:
+        return False
+    try:
+        cur = db._execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_locks
+                WHERE locktype = 'advisory'
+                  AND classid = %s
+                  AND objid = %s
+                  AND mode = 'ExclusiveLock'
+                  AND granted
+                  AND database = (
+                      SELECT oid
+                      FROM pg_database
+                      WHERE datname = current_database()
+                  )
+            ) AS held
+            """,
+            (
+                ADVISORY_LOCK_NAMESPACE_RELEASE,
+                release_id_to_lock_key(mb_release_id),
+            ),
+        )
+        row = cur.fetchone()
+        if isinstance(row, dict):
+            return bool(row.get("held"))
+        if row:
+            return bool(row[0])
+        return False
+    except Exception as e:
+        print(
+            "  slskd: could not probe auto-import lock for "
+            f"request {request_id}: {e}",
+        )
+        return None
+
+
 def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     slskd_key: str | None) -> list:
     """Collect all issues: DB inconsistencies + optional orphaned downloads."""
@@ -57,13 +116,28 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
     issues = find_inconsistencies(rows)
     if slskd_host and slskd_key:
         try:
-            cfg = read_runtime_config()
             active = _get_slskd_active_transfers(slskd_host, slskd_key)
-            orphans = find_orphaned_downloads(
-                rows,
-                active,
-                existing_local_paths=None,
-            )
+        except Exception as e:
+            print(f"  slskd: could not check orphans: {e}")
+            return _dedupe_issues(issues)
+
+        orphans = find_orphaned_downloads(
+            rows,
+            active,
+            existing_local_paths=None,
+        )
+        issues.extend(orphans)
+
+        try:
+            cfg = read_runtime_config()
+        except Exception as e:
+            print(f"  slskd: could not load runtime config for local-path checks: {e}")
+            return _dedupe_issues(issues)
+
+        blocked_processing_path_issues: list[OrphanInfo] = []
+        blocked_recovery_issues: list[OrphanInfo] = []
+        local_path_scan_failed = False
+        try:
             blocked_processing_path_issues = [
                 OrphanInfo(
                     request_id=issue.request_id,
@@ -76,8 +150,20 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     staging_dir=cfg.beets_staging_dir,
                     slskd_download_dir=cfg.slskd_download_dir,
                     has_entries=directory_has_entries,
+                    auto_import_in_progress=(
+                        lambda request_id, mb_release_id: _auto_import_in_progress(
+                            db,
+                            request_id,
+                            mb_release_id,
+                        )
+                    ),
                 )
             ]
+        except Exception as e:
+            print(f"  slskd: could not inspect local recovery paths: {e}")
+            local_path_scan_failed = True
+
+        try:
             blocked_recovery_issues = [
                 OrphanInfo(
                     request_id=issue.request_id,
@@ -92,20 +178,28 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     has_entries=directory_has_entries,
                 )
             ]
-            issues.extend(orphans)
-            issues.extend(blocked_processing_path_issues)
-            issues.extend(blocked_recovery_issues)
-            if not orphans and not blocked_processing_path_issues and not blocked_recovery_issues:
-                print(f"  slskd: checked {len(active)} active transfers, no orphans.")
         except Exception as e:
-            print(f"  slskd: could not check orphans: {e}")
-    else:
-        downloading = [r for r in rows if r["status"] == "downloading"
-                       and r.get("active_download_state")]
-        if downloading:
-            print(f"  Note: {len(downloading)} downloading row(s) — pass "
-                  "--slskd-host/--slskd-key to check for orphans.")
-    return issues
+            print(f"  slskd: could not inspect local recovery paths: {e}")
+            local_path_scan_failed = True
+
+        issues.extend(blocked_processing_path_issues)
+        issues.extend(blocked_recovery_issues)
+        issues = _dedupe_issues(issues)
+        if (
+            not local_path_scan_failed
+            and not orphans
+            and not blocked_processing_path_issues
+            and not blocked_recovery_issues
+        ):
+            print(f"  slskd: checked {len(active)} active transfers, no orphans.")
+        return issues
+
+    downloading = [r for r in rows if r["status"] == "downloading"
+                   and r.get("active_download_state")]
+    if downloading:
+        print(f"  Note: {len(downloading)} downloading row(s) — pass "
+              "--slskd-host/--slskd-key to check for orphans.")
+    return _dedupe_issues(issues)
 
 
 def cmd_scan(db: PipelineDB, slskd_host: str | None = None,
@@ -155,7 +249,7 @@ def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
 def _get_all_rows(db: PipelineDB) -> list:
     """Fetch all album_requests rows for inspection."""
     cur = db._execute(
-        "SELECT id, status, artist_name, album_title, year, "
+        "SELECT id, status, artist_name, album_title, year, mb_release_id, "
         "active_download_state, imported_path "
         "FROM album_requests ORDER BY id"
     )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -973,6 +973,216 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
             mock_dispatch.assert_not_called()
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
+    @patch("lib.download.music_tag")
+    def test_request_scoped_staged_path_without_request_id_blocks_manual_recovery(
+        self,
+        mock_mt,
+    ):
+        """Request-scoped auto-import staging without request id must stay blocked."""
+        from lib.download import process_completed_album
+        from lib.processing_paths import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = stage_to_ai_path(
+                artist="Artist",
+                title="Album",
+                staging_dir=staging_root,
+                request_id=42,
+                auto_import=True,
+            )
+            os.makedirs(resumed_path)
+            with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+                db_request_id=None,
+                db_source="request",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+            cfg.beets_validation_enabled = False
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(album, [], ctx)
+
+            self.assertIsNone(result)
+            self.assertIn("missing db_request_id", "\n".join(logs.output))
+
+    @patch("lib.download.music_tag")
+    def test_post_validation_staged_path_without_request_id_still_resumes(
+        self,
+        mock_mt,
+    ):
+        """Post-validation staging remains resumable without the auto-import guard."""
+        from lib.download import process_completed_album
+        from lib.processing_paths import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = stage_to_ai_path(
+                artist="Artist",
+                title="Album",
+                staging_dir=staging_root,
+                request_id=42,
+                auto_import=False,
+            )
+            os.makedirs(resumed_path)
+            resumed_file = os.path.join(resumed_path, "01 - Track.mp3")
+            with open(resumed_file, "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="",
+                db_request_id=None,
+                db_source="redownload",
+            )
+            album.import_folder = resumed_path
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
+            cfg.beets_staging_dir = staging_root
+            cfg.beets_validation_enabled = False
+            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
+            mock_mt.load_file.return_value = MagicMock()
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertTrue(result)
+            self.assertEqual(album.files[0].import_path, resumed_file)
+
+    @patch("lib.preimport.run_preimport_gates")
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
+    def test_request_auto_import_without_request_id_fails_before_staging_move(
+        self,
+        mock_mt,
+        mock_beets_validate,
+        mock_run_preimport_gates,
+    ):
+        """Fresh request auto-imports must fail before moving into staged auto-import."""
+        from lib.download import process_completed_album
+        from lib.processing_paths import stage_to_ai_path
+        from lib.quality import ValidationResult
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            source_dir = os.path.join(downloads_root, "Music")
+            os.makedirs(source_dir)
+            source_file = os.path.join(source_dir, "01 - Track.mp3")
+            with open(source_file, "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                album_id=1,
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_request_id=None,
+                db_source="request",
+            )
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=1,
+                status="downloading",
+                artist_name="Artist",
+                album_title="Album",
+                year=2024,
+                mb_release_id="test-mbid",
+            ))
+            cfg = cast(Any, _make_ctx().cfg)
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = downloads_root
+            cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
+            cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
+            mock_mt.load_file.return_value = MagicMock()
+            mock_beets_validate.return_value = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+            mock_run_preimport_gates.return_value = MagicMock(
+                valid=True,
+                scenario=None,
+                detail=None,
+                corrupt_files=[],
+                download_spectral=None,
+                existing_spectral=None,
+                existing_min_bitrate=None,
+            )
+
+            expected_canonical = os.path.join(
+                downloads_root,
+                "Artist - Album (2024)",
+            )
+            unexpected_staged = stage_to_ai_path(
+                artist="Artist",
+                title="Album",
+                staging_dir=cfg.beets_staging_dir,
+                request_id=None,
+                auto_import=True,
+            )
+
+            with patch("lib.download.dispatch_import_core") as mock_dispatch, \
+                 self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(album, [], ctx)
+
+            self.assertFalse(result)
+            failed_path = os.path.join(
+                downloads_root,
+                "failed_imports",
+                "Artist - Album (2024)",
+            )
+            self.assertFalse(os.path.exists(expected_canonical))
+            self.assertTrue(os.path.isfile(
+                os.path.join(failed_path, "01 - Track.mp3")))
+            self.assertFalse(os.path.exists(unexpected_staged))
+            mock_dispatch.assert_not_called()
+            self.assertEqual(db.request(1)["status"], "wanted")
+            self.assertEqual(db.recorded_attempts, [(1, "validation")])
+            self.assertEqual(len(db.download_logs), 1)
+            self.assertEqual(
+                db.download_logs[0].beets_scenario,
+                "request_missing_request_id",
+            )
+            self.assertIsNotNone(db.download_logs[0].validation_result)
+            self.assertIn(
+                "missing_request_id",
+                str(db.download_logs[0].validation_result),
+            )
+            self.assertIn(
+                "failed_imports",
+                str(db.download_logs[0].validation_result),
+            )
+            self.assertIn("missing db_request_id", "\n".join(logs.output))
+
     @patch("lib.preimport.run_preimport_gates")
     @patch("lib.beets.beets_validate")
     @patch("lib.download.music_tag")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -115,6 +115,86 @@ class TestBuildDownloadInfo(unittest.TestCase):
         self.assertEqual(dl.username, "alpha_user, beta_user")
 
 
+class TestRequestScopedAutoImportPath(unittest.TestCase):
+
+    CASES = [
+        (
+            "under auto-import root with request suffix",
+            "/tmp/staging/auto-import/Artist/Album [request-42]",
+            "/tmp/staging",
+            True,
+        ),
+        (
+            "under auto-import root without request suffix",
+            "/tmp/staging/auto-import/Artist/Album",
+            "/tmp/staging",
+            False,
+        ),
+        (
+            "request suffix outside auto-import root",
+            "/tmp/downloads/Artist/Album [request-42]",
+            "/tmp/staging",
+            False,
+        ),
+        (
+            "request suffix under post-validation root",
+            "/tmp/staging/post-validation/Artist/Album [request-42]",
+            "/tmp/staging",
+            False,
+        ),
+    ]
+
+    def test_matches_only_request_scoped_auto_import_paths(self):
+        from lib.download import _is_request_scoped_auto_import_path
+
+        for desc, current_path, staging_dir, expected in self.CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    _is_request_scoped_auto_import_path(
+                        current_path=current_path,
+                        staging_dir=staging_dir,
+                    ),
+                    expected,
+                )
+
+
+class TestResolveRequestRejectionId(unittest.TestCase):
+
+    def test_refuses_release_id_presence_mismatch(self):
+        from lib.download import _resolved_request_rejection_id
+
+        for desc, row_mbid, album_mbid in [
+            ("row missing mbid", "", "test-mbid"),
+            ("album missing mbid", "test-mbid", ""),
+        ]:
+            with self.subTest(desc=desc):
+                db = FakePipelineDB()
+                db.seed_request(make_request_row(
+                    id=1,
+                    status="downloading",
+                    artist_name="Artist",
+                    album_title="Album",
+                    year=2024,
+                    mb_release_id=row_mbid,
+                ))
+                cfg = cast(Any, _make_ctx().cfg)
+                ctx = make_ctx_with_fake_db(db, cfg=cfg)
+                album = make_grab_list_entry(
+                    album_id=1,
+                    artist="Artist",
+                    title="Album",
+                    year="2024",
+                    mb_release_id=album_mbid,
+                    db_request_id=None,
+                    db_source="request",
+                )
+
+                resolved_db, request_id = _resolved_request_rejection_id(album, ctx)
+
+                self.assertIs(resolved_db, db)
+                self.assertIsNone(request_id)
+
+
 ## TestGatherSpectralContext and TestCheckQualityGateDecision removed:
 ## - TestGatherSpectralContext never called the function it claimed to test —
 ##   it reimplemented the condition logic in test code and asserted on that.
@@ -1182,6 +1262,162 @@ class TestProcessCompletedAlbumReturnsBool(unittest.TestCase):
                 str(db.download_logs[0].validation_result),
             )
             self.assertIn("missing db_request_id", "\n".join(logs.output))
+
+    @patch("lib.preimport.run_preimport_gates")
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
+    def test_request_auto_import_without_resolvable_request_logs_warning(
+        self,
+        mock_mt,
+        mock_beets_validate,
+        mock_run_preimport_gates,
+    ):
+        """Unresolvable request ids must block in place, not orphan files."""
+        from lib.download import process_completed_album
+        from lib.quality import ValidationResult
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            source_dir = os.path.join(downloads_root, "Music")
+            os.makedirs(source_dir)
+            source_file = os.path.join(source_dir, "01 - Track.mp3")
+            with open(source_file, "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                album_id=-1,
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_request_id=None,
+                db_source="request",
+            )
+            db = FakePipelineDB()
+            cfg = cast(Any, _make_ctx().cfg)
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = downloads_root
+            cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
+            cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
+            mock_mt.load_file.return_value = MagicMock()
+            mock_beets_validate.return_value = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+            mock_run_preimport_gates.return_value = MagicMock(
+                valid=True,
+                scenario=None,
+                detail=None,
+                corrupt_files=[],
+                download_spectral=None,
+                existing_spectral=None,
+                existing_min_bitrate=None,
+            )
+
+            expected_canonical = os.path.join(
+                downloads_root,
+                "Artist - Album (2024)",
+            )
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(album, [], ctx)
+
+            self.assertIsNone(result)
+            self.assertEqual(db.download_logs, [])
+            self.assertEqual(db.status_history, [])
+            self.assertTrue(os.path.isfile(
+                os.path.join(expected_canonical, "01 - Track.mp3")))
+            self.assertFalse(os.path.exists(os.path.join(
+                downloads_root,
+                "failed_imports",
+                "Artist - Album (2024)",
+            )))
+            self.assertIn(
+                "BLOCKED WITHOUT REQUEST AUDIT",
+                "\n".join(logs.output),
+            )
+
+    @patch("lib.preimport.run_preimport_gates")
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
+    def test_request_auto_import_without_request_id_matches_row_when_album_year_blank(
+        self,
+        mock_mt,
+        mock_beets_validate,
+        mock_run_preimport_gates,
+    ):
+        """Blank album years must not block safe request-row recovery."""
+        from lib.download import process_completed_album
+        from lib.quality import ValidationResult
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            source_dir = os.path.join(downloads_root, "Music")
+            os.makedirs(source_dir)
+            source_file = os.path.join(source_dir, "01 - Track.mp3")
+            with open(source_file, "w") as f:
+                f.write("fake audio")
+
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                album_id=1,
+                artist="Artist",
+                title="Album",
+                year="",
+                mb_release_id="test-mbid",
+                db_request_id=None,
+                db_source="request",
+            )
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=1,
+                status="downloading",
+                artist_name="Artist",
+                album_title="Album",
+                year=2024,
+                mb_release_id="test-mbid",
+            ))
+            cfg = cast(Any, _make_ctx().cfg)
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = downloads_root
+            cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
+            cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
+            mock_mt.load_file.return_value = MagicMock()
+            mock_beets_validate.return_value = ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            )
+            mock_run_preimport_gates.return_value = MagicMock(
+                valid=True,
+                scenario=None,
+                detail=None,
+                corrupt_files=[],
+                download_spectral=None,
+                existing_spectral=None,
+                existing_min_bitrate=None,
+            )
+
+            result = process_completed_album(album, [], ctx)
+
+            self.assertFalse(result)
+            self.assertEqual(db.request(1)["status"], "wanted")
+            self.assertEqual(len(db.download_logs), 1)
+            self.assertEqual(
+                db.download_logs[0].beets_scenario,
+                "request_missing_request_id",
+            )
 
     @patch("lib.preimport.run_preimport_gates")
     @patch("lib.beets.beets_validate")

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -281,11 +281,12 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
         self.assertEqual(issues[0].request_id, 1)
         self.assertIn("legacy shared staged path", issues[0].detail)
 
-    def test_reports_request_scoped_auto_import_path_as_blocked(self):
+    def test_skips_request_scoped_auto_import_path_while_import_is_still_running(self):
         issues = find_blocked_processing_path_issues(
             [{
                 "id": 1,
                 "status": "downloading",
+                "mb_release_id": "test-mbid",
                 "artist_name": "Test Artist",
                 "album_title": "Test Album",
                 "year": 2020,
@@ -309,11 +310,120 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
                 path
                 == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
             ),
+            auto_import_in_progress=lambda request_id, mb_release_id: (
+                request_id == 1 and mb_release_id == "test-mbid"
+            ),
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_reports_request_scoped_auto_import_path_when_import_is_not_running(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "mb_release_id": "test-mbid",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": (
+                        "/tmp/staging/auto-import/"
+                        "Test Artist/Test Album [request-1]"
+                    ),
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: (
+                path
+                == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+            ),
+            auto_import_in_progress=lambda _request_id, _mb_release_id: False,
         )
 
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].request_id, 1)
-        self.assertIn("request-scoped auto-import staged path", issues[0].detail)
+        self.assertIn("no auto-import is currently running", issues[0].detail)
+
+    def test_reports_request_scoped_auto_import_path_when_liveness_probe_is_unknown(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "mb_release_id": "test-mbid",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": (
+                        "/tmp/staging/auto-import/"
+                        "Test Artist/Test Album [request-1]"
+                    ),
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: (
+                path
+                == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+            ),
+            auto_import_in_progress=lambda _request_id, _mb_release_id: None,
+        )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].request_id, 1)
+        self.assertIn("could not determine whether auto-import is still running", issues[0].detail)
+
+    def test_reports_request_scoped_auto_import_path_without_mbid_as_non_resumable(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "mb_release_id": None,
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": (
+                        "/tmp/staging/auto-import/"
+                        "Test Artist/Test Album [request-1]"
+                    ),
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda path: (
+                path
+                == "/tmp/staging/auto-import/Test Artist/Test Album [request-1]"
+            ),
+            auto_import_in_progress=lambda _request_id, _mb_release_id: False,
+        )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].request_id, 1)
+        self.assertIn("has no mb_release_id so auto-import cannot resume", issues[0].detail)
 
     def test_skips_stale_canonical_current_path_with_request_scoped_recovery(self):
         issues = find_blocked_processing_path_issues(

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -317,6 +317,39 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
 
         self.assertEqual(issues, [])
 
+    def test_skips_missing_auto_import_path_while_import_is_still_running(self):
+        issues = find_blocked_processing_path_issues(
+            [{
+                "id": 1,
+                "status": "downloading",
+                "mb_release_id": "test-mbid",
+                "artist_name": "Test Artist",
+                "album_title": "Test Album",
+                "year": 2020,
+                "active_download_state": {
+                    "filetype": "flac",
+                    "processing_started_at": "2026-04-22T00:00:00+00:00",
+                    "current_path": (
+                        "/tmp/staging/auto-import/"
+                        "Test Artist/Test Album [request-1]"
+                    ),
+                    "files": [{
+                        "username": "user1",
+                        "filename": "track.flac",
+                    }],
+                },
+            }],
+            set(),
+            staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+            has_entries=lambda _path: False,
+            auto_import_in_progress=lambda request_id, mb_release_id: (
+                request_id == 1 and mb_release_id == "test-mbid"
+            ),
+        )
+
+        self.assertEqual(issues, [])
+
     def test_reports_request_scoped_auto_import_path_when_import_is_not_running(self):
         issues = find_blocked_processing_path_issues(
             [{

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -11,6 +11,7 @@ and _check_quality_gate_core run for real, not patched.
 import os
 from contextlib import contextmanager
 import tempfile
+from typing import Any, cast
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -1989,6 +1990,45 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             dl_mod._run_completed_processing(
                 self._entry(), 42, self._state(), db, self._ctx(db))
         self.assertEqual(db.request(42)["status"], "wanted")
+
+    def test_false_outcome_after_inner_rejection_does_not_double_transition(self):
+        """If ``process_completed_album`` already requeued the row, the outer
+        ``False`` branch must not apply a second reset-to-wanted transition.
+        """
+        from lib import download as dl_mod
+        from lib.import_dispatch import DispatchOutcome, finalize_request
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+
+        def reject_inside_process(*_args, **_kwargs):
+            finalize_request(
+                cast(Any, db),
+                42,
+                DispatchOutcome.transition(
+                    to_status="wanted",
+                    success=False,
+                    message="Rejected: request_missing_request_id",
+                    from_status="downloading",
+                ),
+            )
+            return False
+
+        with patch.object(
+            dl_mod,
+            "process_completed_album",
+            side_effect=reject_inside_process,
+        ):
+            dl_mod._run_completed_processing(
+                self._entry(),
+                42,
+                self._state(),
+                db,
+                self._ctx(db),
+            )
+
+        self.assertEqual(db.request(42)["status"], "wanted")
+        self.assertEqual(db.status_history, [(42, "wanted")])
 
 
 class TestSiblingImportedPathPropagation(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2030,6 +2030,89 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(db.status_history, [(42, "wanted")])
 
+    def test_real_missing_request_id_rejection_transitions_once(self):
+        """The real missing-request-id reject path must transition exactly once."""
+        from lib import download as dl_mod
+        from lib.quality import ValidationResult
+        from tests.helpers import (
+            make_ctx_with_fake_db,
+            make_download_file,
+            make_grab_list_entry,
+        )
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            artist_name="Artist",
+            album_title="Album",
+            year=2024,
+            mb_release_id="test-mbid",
+        ))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            source_dir = os.path.join(downloads_root, "Music")
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, "01 - Track.mp3"), "w") as fp:
+                fp.write("fake audio")
+
+            cfg = CratediggerConfig(
+                beets_harness_path=_HARNESS,
+                pipeline_db_enabled=True,
+                beets_validation_enabled=True,
+                beets_distance_threshold=0.15,
+                beets_staging_dir=os.path.join(tmpdir, "staging"),
+                slskd_download_dir=downloads_root,
+                beets_tracking_file=os.path.join(tmpdir, "beets-tracking.jsonl"),
+            )
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            entry = make_grab_list_entry(
+                album_id=42,
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_source="request",
+                db_request_id=None,
+            )
+
+            with patch("lib.download.music_tag.load_file", return_value=MagicMock()), \
+                 patch("lib.beets.beets_validate", return_value=ValidationResult(
+                     valid=True,
+                     distance=0.05,
+                     scenario="strong_match",
+                 )), \
+                 patch("lib.preimport.run_preimport_gates", return_value=MagicMock(
+                     valid=True,
+                     scenario=None,
+                     detail=None,
+                     corrupt_files=[],
+                     download_spectral=None,
+                     existing_spectral=None,
+                     existing_min_bitrate=None,
+                 )):
+                dl_mod._run_completed_processing(
+                    entry,
+                    42,
+                    self._state(),
+                    db,
+                    ctx,
+                )
+
+        self.assertEqual(db.request(42)["status"], "wanted")
+        self.assertEqual(db.status_history, [(42, "wanted")])
+        self.assertEqual(db.recorded_attempts, [(42, "validation")])
+        self.assertEqual(len(db.download_logs), 1)
+        self.assertEqual(
+            db.download_logs[0].beets_scenario,
+            "request_missing_request_id",
+        )
+
 
 class TestSiblingImportedPathPropagation(unittest.TestCase):
     """Integration slice for issue #132 P2 / issue #133: after

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -7,6 +7,7 @@ import os
 import sys
 import unittest
 from contextlib import redirect_stdout
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -44,6 +45,176 @@ class TestCmdFix(unittest.TestCase):
             message="Repair reset orphaned download to wanted",
         )
         self.assertIn("Reset to wanted", stdout.getvalue())
+
+
+class TestCollectIssues(unittest.TestCase):
+    def test_dedupe_issues_drops_exact_duplicates(self) -> None:
+        detail = "persisted processing path missing after local processing: /tmp/path"
+        issues = repair._dedupe_issues(
+            [
+                OrphanInfo(
+                    request_id=17,
+                    issue_type="blocked_post_move",
+                    detail=detail,
+                ),
+                OrphanInfo(
+                    request_id=17,
+                    issue_type="blocked_post_move",
+                    detail=detail,
+                ),
+                OrphanInfo(
+                    request_id=17,
+                    issue_type="blocked_post_move",
+                    detail="different detail",
+                ),
+            ]
+        )
+
+        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[0].detail, detail)
+        self.assertEqual(issues[1].detail, "different detail")
+
+    def test_auto_import_in_progress_returns_true_when_lock_is_held(self) -> None:
+        db = MagicMock()
+        db._execute.return_value.fetchone.return_value = {"held": True}
+
+        result = repair._auto_import_in_progress(db, 17, "test-mbid")
+
+        self.assertTrue(result)
+        db._execute.assert_called_once()
+        sql, params = db._execute.call_args[0]
+        self.assertIn("FROM pg_locks", sql)
+        self.assertEqual(params[0], repair.ADVISORY_LOCK_NAMESPACE_RELEASE)
+
+    def test_auto_import_in_progress_returns_false_when_no_lock_is_held(self) -> None:
+        db = MagicMock()
+        db._execute.return_value.fetchone.return_value = {"held": False}
+
+        result = repair._auto_import_in_progress(db, 17, "test-mbid")
+
+        self.assertFalse(result)
+
+    def test_auto_import_in_progress_returns_false_without_mbid(self) -> None:
+        db = MagicMock()
+
+        result = repair._auto_import_in_progress(db, 17, None)
+
+        self.assertFalse(result)
+        db._execute.assert_not_called()
+
+    def test_auto_import_in_progress_reports_probe_failure(self) -> None:
+        db = MagicMock()
+        db._execute.side_effect = RuntimeError("db boom")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            result = repair._auto_import_in_progress(db, 17, "test-mbid")
+
+        self.assertIsNone(result)
+        self.assertIn("could not probe auto-import lock for request 17", stdout.getvalue())
+
+    @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
+    @patch("scripts.repair.read_runtime_config", side_effect=RuntimeError("cfg boom"))
+    @patch("scripts.repair._get_all_rows", return_value=[])
+    def test_collect_issues_reports_runtime_config_failure_separately(
+        self,
+        _mock_get_rows,
+        _mock_read_runtime_config,
+        _mock_active_transfers,
+    ) -> None:
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            issues = repair._collect_issues(
+                MagicMock(),
+                slskd_host="http://slskd",
+                slskd_key="secret",
+            )
+
+        self.assertEqual(issues, [])
+        self.assertIn(
+            "could not load runtime config for local-path checks: cfg boom",
+            stdout.getvalue(),
+        )
+
+    @patch("scripts.repair.find_orphaned_downloads")
+    @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
+    @patch("scripts.repair.read_runtime_config", side_effect=RuntimeError("cfg boom"))
+    @patch("scripts.repair._get_all_rows", return_value=[])
+    def test_collect_issues_keeps_orphans_when_runtime_config_load_fails(
+        self,
+        _mock_get_rows,
+        _mock_read_runtime_config,
+        _mock_active_transfers,
+        mock_find_orphaned,
+    ) -> None:
+        mock_find_orphaned.return_value = [
+            OrphanInfo(
+                request_id=17,
+                issue_type="orphaned_download",
+                detail="no active slskd transfers (users: user1)",
+            ),
+        ]
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            issues = repair._collect_issues(
+                MagicMock(),
+                slskd_host="http://slskd",
+                slskd_key="secret",
+            )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].issue_type, "orphaned_download")
+        self.assertIn(
+            "could not load runtime config for local-path checks: cfg boom",
+            stdout.getvalue(),
+        )
+
+    @patch("scripts.repair.find_blocked_recovery_issues", return_value=[])
+    @patch(
+        "scripts.repair.find_blocked_processing_path_issues",
+        side_effect=PermissionError("perm boom"),
+    )
+    @patch("scripts.repair.find_orphaned_downloads")
+    @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
+    @patch("scripts.repair.read_runtime_config")
+    @patch("scripts.repair._get_all_rows", return_value=[])
+    def test_collect_issues_keeps_orphans_when_local_path_probe_fails(
+        self,
+        _mock_get_rows,
+        mock_read_runtime_config,
+        _mock_active_transfers,
+        mock_find_orphaned,
+        _mock_find_blocked_processing,
+        _mock_find_blocked_recovery,
+    ) -> None:
+        mock_read_runtime_config.return_value = SimpleNamespace(
+            beets_staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+        mock_find_orphaned.return_value = [
+            OrphanInfo(
+                request_id=17,
+                issue_type="orphaned_download",
+                detail="no active slskd transfers (users: user1)",
+            )
+        ]
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            issues = repair._collect_issues(
+                MagicMock(),
+                slskd_host="http://slskd",
+                slskd_key="secret",
+            )
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].issue_type, "orphaned_download")
+        self.assertIn(
+            "could not inspect local recovery paths: perm boom",
+            stdout.getvalue(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -84,6 +84,7 @@ class TestCollectIssues(unittest.TestCase):
         db._execute.assert_called_once()
         sql, params = db._execute.call_args[0]
         self.assertIn("FROM pg_locks", sql)
+        self.assertIn("objsubid = 2", sql)
         self.assertEqual(params[0], repair.ADVISORY_LOCK_NAMESPACE_RELEASE)
 
     def test_auto_import_in_progress_returns_false_when_no_lock_is_held(self) -> None:

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -1,8 +1,10 @@
 """Tests for ``lib/staged_album.py``."""
 
 import os
+import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_download_file, make_request_row
@@ -36,6 +38,23 @@ class TestStageToAiPath(unittest.TestCase):
             dest,
             "/tmp/staging/auto-import/Test Artist/Album [request-42]",
         )
+
+
+class TestStagedFilename(unittest.TestCase):
+
+    CASES = [
+        ("backslashes only", "user1\\Album\\01 - Track.flac", "01 - Track.flac"),
+        ("forward slashes only", "user1/Album/01 - Track.flac", "01 - Track.flac"),
+        ("mixed separators", "user1\\Album/Disc 1\\01 - Track.flac", "01 - Track.flac"),
+    ]
+
+    def test_extracts_leaf_filename_across_separator_variants(self):
+        from lib.staged_album import staged_filename
+
+        for desc, remote_path, expected in self.CASES:
+            with self.subTest(desc=desc):
+                file = make_download_file(filename=remote_path)
+                self.assertEqual(staged_filename(file), expected)
 
 
 class TestStagedAlbum(unittest.TestCase):
@@ -124,6 +143,48 @@ class TestStagedAlbum(unittest.TestCase):
             self.assertEqual(staged_album.current_path, source)
             self.assertTrue(os.path.exists(source_file))
             self.assertFalse(os.path.exists(os.path.join(dest, "track.mp3")))
+
+    def test_move_to_raises_explicit_error_when_rollback_move_fails(self):
+        from lib.staged_album import StagedAlbum
+
+        class ExplodingDB:
+            def update_download_state_current_path(
+                self,
+                request_id: int,
+                current_path: str | None,
+            ) -> None:
+                raise RuntimeError("db boom")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "source")
+            os.makedirs(source)
+            source_file = os.path.join(source, "track.mp3")
+            with open(source_file, "w") as fp:
+                fp.write("audio")
+
+            dest = os.path.join(tmpdir, "staging", "Artist", "Album")
+            dest_file = os.path.join(dest, "track.mp3")
+            real_move = shutil.move
+
+            def move_with_rollback_failure(src: str, dst: str) -> str:
+                if src == dest_file and dst == source_file:
+                    raise OSError("rollback boom")
+                return real_move(src, dst)
+
+            staged_album = StagedAlbum(current_path=source, request_id=42)
+
+            with patch(
+                "lib.staged_album.shutil.move",
+                side_effect=move_with_rollback_failure,
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Failed to roll back staged move cleanly",
+                ):
+                    staged_album.move_to(dest, ExplodingDB())
+
+            self.assertTrue(os.path.exists(dest_file))
+            self.assertFalse(os.path.exists(source_file))
 
     def test_move_to_persists_before_removing_source(self):
         from lib.staged_album import StagedAlbum


### PR DESCRIPTION
## Why this exists

This is a handoff PR that stages the post-PR-156 follow-up work before resetting local state.

The starting point was the post-deploy Claude reflection after PR 156, which called out a handful of "low-severity loose ends" around the staged-path seam:
- add a direct separator matrix test for `staged_filename`
- pin the `db_request_id or 0` fallback behavior at the seam
- add a test for mid-rollback failure in `StagedAlbum.move_to`
- clarify or dedup overlapping repair issue reporting
- narrow the broad `except Exception` in `scripts/repair.py`

Those looked like separate cleanup nits, but they all led back to the same invariant:

> persisted `active_download_state.current_path` must keep a single truthful owner for a download across canonical processing, request-scoped staging, auto-import dispatch, and repair/recovery scans.

## What We Are Actually Solving

The risky cases here are not normal downloads. They are the broken-edge paths where a request has already moved out of the canonical processing dir and the system is deciding whether it is still safe to auto-retry, requeue, mark a failure, or tell repair/manual recovery to stop touching it.

If that seam lies, we either strand files in staging with no audit trail, let repair/poller act as if a staged path is abandoned when it is still live, or reset a request twice after an inner rejection already handled it.

## What Changed

- centralizes path containment in `lib/processing_paths.py` so `download.py` and `download_recovery.py` classify staged roots the same way
- hardens `StagedAlbum.move_to` rollback surfacing and adds direct separator / rollback tests
- routes request auto-import with missing `db_request_id` through the same failed-import + rejection/requeue bookkeeping seam as other auto-import rejects, when the backing request row can be resolved
- keeps missing-id request-scoped staged paths blocked for manual recovery instead of guessing ownership
- switches repair's auto-import liveness probe to a read-only `pg_locks` check instead of transiently acquiring the release lock itself
- clarifies blocked-path reporting when a request-scoped staged path has no MBID, because auto-import cannot resume at all in that case
- replaces an impossible repair dedupe test with direct tests for dedupe and lock-probe behavior
- adds an explicit slice proving `process_completed_album() -> False` does not cause a second transition after an inner rejection already requeued the row

## Why The Weeds Got This Deep

This follow-up wandered because each "small" reflection item exposed another place where the staged-path seam was partially duplicated or partially unaudited. The next reviewer should review this as one seam cleanup, not as ten unrelated test additions.

The real question for review is:

> when a request is partway between canonical processing, request-scoped staging, and auto-import, does every caller still agree about who owns the path and what recovery actions are safe?

## Reviewer Focus

Please focus on:
- whether `_resolved_request_rejection_id()` is the right defensive way to recover the backing row when `db_request_id` is missing
- whether the `pg_locks` probe in `scripts/repair.py` matches the release-lock shape we actually hold in production
- whether the changed repair wording and no-MBID handling reflect the intended operator story
- whether the false-outcome / no-double-transition contract is now pinned tightly enough

## Validation

- `nix-shell --run "python3 -m unittest tests.test_staged_album tests.test_download tests.test_download_recovery tests.test_repair_cli tests.test_integration_slices -v"`
- `nix-shell --run "pyright lib/download.py lib/download_recovery.py lib/processing_paths.py scripts/repair.py tests/test_download.py tests/test_download_recovery.py tests/test_repair_cli.py tests/test_integration_slices.py"`
- `nix-shell --run "python3 -m unittest tests.test_integration_slices.TestRunCompletedProcessingOutcomeBranching -v"`

All green locally.

## Reviewer Note

I started another partner-review pass while packaging this and then stopped because the goal here is to checkpoint the work before resetting state. Treat this PR as the handoff artifact for the next review round.
