### PR TITLE
refactor: centralize imports behind queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Originally inspired by [mrusse/soularr](https://github.com/mrusse/soularr) ([Ko-
    ```
    The key works for both machines. You may need `-o StrictHostKeyChecking=no` on first use.
 3. **nixosconfig changes MUST be made on doc1.** The repo lives at `~/nixosconfig` on doc1. Doc1 has the git push credentials; doc2 and Windows do not. SSH to doc1 first, edit, commit, push, then deploy to doc2.
-4. **Pipeline DB is PostgreSQL on doc2** (nspawn container at `192.168.100.11:5432`, migrated from SQLite 2026-03-25). Data lives at `/mnt/virtio/cratedigger/postgres`. Access via `pipeline-cli` on doc2's PATH, or from doc1 via `ssh doc2 'pipeline-cli ...'`. 4 statuses: `wanted`, `downloading`, `imported`, `manual`.
+4. **Pipeline DB is PostgreSQL on doc2** (nspawn container at `192.168.100.11:5432`, migrated from SQLite 2026-03-25). Data lives at `/mnt/virtio/cratedigger/postgres`. Access via `pipeline-cli` on doc2's PATH, or from doc1 via `ssh doc2 'pipeline-cli ...'`. Request statuses: `wanted`, `downloading`, `imported`, `manual`. Import queue statuses: `queued`, `running`, `completed`, `failed`.
 5. **This is a curated music collection.** Multiple editions/pressings of the same album are intentional. NEVER delete or merge duplicate albums — they are different MusicBrainz releases (countries, track counts, labels) and the user wants them all. Beets must disambiguate them into separate folders.
 
 ## Subsystems
@@ -84,6 +84,7 @@ Key `lib/` modules:
 - `quality.py` — pure decision functions + all typed dataclasses (`ImportResult`, `ValidationResult`, `DispatchAction`, `QualityRankConfig`, `CooldownConfig`, ...)
 - `preimport.py` — shared pre-import gates (audio integrity + spectral) called by both auto and force/manual paths
 - `download.py` — async polling + completion processing + slskd transfers
+- `import_queue.py` — typed shared queue payload/result helpers
 - `import_dispatch.py` — decision tree + quality gate + dispatch_import_from_db
 - `import_service.py` — force-import / manual-import service layer
 - `grab_list.py`, `search.py`, `beets.py`, `beets_db.py`, `spectral_check.py`, `util.py`
@@ -144,12 +145,13 @@ database, or filesystem side effects. Key entries in `lib/quality.py` include
 `compute_effective_override_bitrate`, `verify_filetype`, `should_cooldown`,
 and `get_decision_tree` (feeds the web UI Decisions tab).
 
-Do not preserve the current scattered import orchestration boundary as a design
-goal. The existing split across `dispatch_import_core`,
-`dispatch_import_from_db`, `process_completed_album`, release locks, deferred
-outcomes, and status recovery is the complexity the importer-queue redesign is
-intended to replace. Keep pure quality decisions; move beets-mutating import
-ownership toward a single importer boundary.
+The importer queue is the beets-mutating ownership boundary. Web, CLI, and the
+automation poller enqueue import jobs; `cratedigger-importer` drains them
+serially. Keep pure quality decisions; avoid adding new direct beets-mutating
+entry points outside the importer worker. On startup the importer immediately
+requeues any `running` import job left by a previous worker process, then
+retries it; the worker holds a DB advisory singleton lock so only one importer
+can drain the queue.
 
 Wire-boundary types (harness, JSONB, subprocess stdout) are `msgspec.Struct`,
 not `@dataclass` — see `.claude/rules/code-quality.md` § "Wire-boundary types".
@@ -173,7 +175,7 @@ ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --ref
 
 ## Database migrations
 
-Schema lives in `migrations/NNN_name.sql`. `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs on every `nixos-rebuild switch` BEFORE `cratedigger.service` and `cratedigger-web.service`. Both `requires` the migrate unit, so a failed migration blocks the app from coming up.
+Schema lives in `migrations/NNN_name.sql`. `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs on every `nixos-rebuild switch` BEFORE `cratedigger.service`, `cratedigger-web.service`, and `cratedigger-importer.service`. These services require the migrate unit, so a failed migration blocks the app from coming up.
 
 To add a schema change: drop a new numbered SQL file in `migrations/`, test with `nix-shell --run "python3 -m unittest tests.test_migrator -v"`, commit, deploy. No manual psql. **Never** edit an already-shipped migration — frozen history. **Never** add DDL inside `PipelineDB` methods. For destructive changes, back up first: `ssh doc2 'pg_dump -h 192.168.100.11 -U cratedigger cratedigger' > /tmp/backup.sql`. Verify after deploy: `ssh doc2 'pipeline-cli query "SELECT * FROM schema_migrations ORDER BY version DESC LIMIT 5"'`.
 

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -1,9 +1,11 @@
 # PostgreSQL Advisory Locks
 
 Cratedigger uses PostgreSQL advisory locks to serialise pipeline
-operations that must not run concurrently across different DB sessions
-(the auto cycle on the systemd timer, the web UI's force-import path,
-CLI force/manual invocations). Every lock in this codebase is
+operations that must not run concurrently across different DB sessions.
+Import entry points now enqueue `import_jobs`; the long-lived importer worker
+is the intended owner of beets-mutating work. The advisory locks below remain
+as defensive guards inside the existing dispatch internals until a cleanup pass
+proves they are redundant. Every lock in this codebase is
 **non-blocking** (`pg_try_advisory_lock`), **session-scoped** (held until
 release or session close), and **reentrant within a session** (a second
 acquire of the same `(namespace, key)` in the same session always
@@ -42,6 +44,7 @@ namespace, second is the per-lock key.
 |---|---|---|---|---|---|
 | Per-request import | `ADVISORY_LOCK_NAMESPACE_IMPORT` | `0x46494D50` | "FIMP" | `request_id` | Force/manual-import double-click protection |
 | Per-release pipeline | `ADVISORY_LOCK_NAMESPACE_RELEASE` | `0x52454C45` | "RELE" | `release_id_to_lock_key(mb_release_id)` | Cross-process same-MBID serialisation |
+| Importer worker | `ADVISORY_LOCK_NAMESPACE_IMPORTER` | `0x51554555` | "QUEU" | `1` | One importer process drains the beets-mutating lane |
 
 The ASCII-visible hex lets `pg_locks` rows be interpreted at a glance
 during debugging:
@@ -50,6 +53,7 @@ during debugging:
 SELECT classid, objid FROM pg_locks WHERE locktype = 'advisory';
 -- classid=0x46494D50 → force/manual-import lock
 -- classid=0x52454C45 → release-level lock
+-- classid=0x51554555 → importer-worker singleton lock
 ```
 
 ### IMPORT — per-request lock
@@ -60,11 +64,10 @@ on the same `request_id`, writing duplicate `download_log` rows and
 running `import_one.py` twice against the same files. The second caller
 would crash or produce bogus state.
 
-**Scope**: Only held by `dispatch_import_from_db` — the sole entry
-point for force/manual imports. The auto-import path does not acquire
-this lock because it has no concurrent-duplicate vector (the systemd
-timer only fires one pipeline at a time, and the RELEASE lock already
-covers cross-timer-cycle races).
+**Scope**: Held by `dispatch_import_from_db` inside the importer worker.
+Web and CLI force/manual paths no longer call this directly; they dedupe at
+`import_jobs` enqueue time. Keep this lock until a follow-up cleanup proves the
+queue invariant fully replaces the old double-click protection.
 
 **Key**: The raw `request_id` (int4 auto-increment on
 `album_requests.id` — fits trivially in an int4 lock key).
@@ -77,7 +80,7 @@ incident itself had a different proximate cause — see `CLAUDE.md` §
 Resolved canonical RCs — but this race is a real independent vector
 worth closing).
 
-The race: two processes (the auto cycle and a web force-import, or
+The historical race: two processes (the auto cycle and a web force-import, or
 two racing force-import clicks on sibling requests for the same MBID)
 each hold their own per-request lock while targeting the same
 MusicBrainz release. The harness's post-import `max(post_import_ids)`
@@ -96,6 +99,18 @@ Covers both MB UUIDs and Discogs numeric IDs since both share the
 `mb_release_id` column. See the docstring on `release_id_to_lock_key`
 in `lib/pipeline_db.py` for the collision analysis (probability
 ~N²/2^31; false collision delays an unrelated release by one cycle).
+
+### IMPORTER — worker singleton lock
+
+**Why**: The import queue is the durable state owner, but beets mutation is
+still intentionally one lane. A second accidentally-started importer must not
+claim another queued job in parallel, and it must not requeue a live worker's
+`running` job during startup recovery.
+
+**Scope**: Held by `scripts/importer.py` for the full worker process lifetime
+before it requeues abandoned `running` jobs or claims new jobs.
+
+**Key**: Constant `1`. There is only one logical importer lane.
 
 ## Acquisition order
 
@@ -231,10 +246,12 @@ session and returns False — revisit the ordering rules.
 | Auto-import outer | `lib/download.py` | `_handle_valid_result` | RELEASE | `release_id_to_lock_key(album_data.mb_release_id)` |
 | Auto + force/manual inner | `lib/import_dispatch.py` | `dispatch_import_core` | RELEASE | `release_id_to_lock_key(mb_release_id)` |
 | Force/manual outer | `lib/import_dispatch.py` | `dispatch_import_from_db` | IMPORT | `request_id` |
+| Importer worker singleton | `scripts/importer.py` | `main` | IMPORTER | `1` |
+| Import queue dedupe | `lib/pipeline_db.py` | `enqueue_import_job` | unique index | `dedupe_key` |
 
 Every acquire site carries a comment linking back here. Line numbers
 are intentionally omitted — grep for `advisory_lock(` to find them.
-`git log -S 'advisory_lock(' -- lib/` is the archaeology path.
+`git log -S 'advisory_lock(' -- lib/ scripts/` is the archaeology path.
 
 ## Extending
 

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -27,6 +27,32 @@ Full schema lives in `migrations/*.sql`. This doc covers the fields that appear 
 - `existing_spectral_bitrate INTEGER` — spectral estimate of existing files before download.
 - `outcome TEXT` — one of 6 values: `success`, `rejected`, `failed`, `timeout`, `force_import`, `manual_import`.
 
+## `import_jobs` — shared importer queue
+
+All beets-mutating import work is submitted to `import_jobs` and drained by
+`cratedigger-importer`. Web force-import, web/manual import, automation
+completed-download processing, and CLI force/manual import all share this table.
+
+Key fields:
+
+- `job_type TEXT` — `force_import`, `manual_import`, or `automation_import`.
+- `status TEXT` — `queued`, `running`, `completed`, or `failed`.
+- `request_id INTEGER` — the related `album_requests.id`.
+- `dedupe_key TEXT` — active queue dedupe key. A partial unique index prevents
+  duplicate queued/running jobs while allowing a later job after completion.
+- `payload JSONB` — typed job input. Force/manual jobs carry `failed_path`;
+  force jobs also carry `download_log_id` and optional `source_username`.
+- `result JSONB`, `message`, `error` — terminal worker result visible to web
+  and CLI callers.
+- `attempts`, `worker_id`, `started_at`, `heartbeat_at`, `completed_at` —
+  claim and recovery metadata.
+
+On importer startup, any pre-existing `running` job is treated as abandoned
+state from a previous worker process, reset to `queued`, and retried
+immediately. The importer also holds a DB advisory singleton lock while it
+runs, so an accidentally-started second worker exits instead of requeueing a
+live worker's job.
+
 ## `download_log.import_result` JSONB
 
 `import_one.py` emits an `ImportResult` JSON blob (`__IMPORT_RESULT__` sentinel on stdout). Contains: decision, conversion details, per-track spectral analysis (grade, hf_deficit, cliff detection per track), quality comparison (new vs prev bitrate), postflight verification (beets_id, path). Every import path (success, downgrade, transcode, error, timeout, crash) logs to download_log.
@@ -62,18 +88,19 @@ Outcomes: `found` (matched + enqueued), `no_match` (results but no suitable down
 
 ## Force-Import (rejected downloads)
 
-Albums rejected by beets validation (high distance, wrong pressing) are moved to `failed_imports/` under the slskd download dir, with their `failed_path` stored in `download_log.validation_result` JSONB. After manual review, force-import bypasses the distance check and imports them.
+Albums rejected by beets validation (high distance, wrong pressing) are moved to `failed_imports/` under the slskd download dir, with their `failed_path` stored in `download_log.validation_result` JSONB. After manual review, force-import bypasses the distance check. The request handler or CLI command validates the row/path synchronously, then enqueues a `force_import` job. `cratedigger-importer` runs the actual beets mutation.
 
 **Path resolution**: old entries stored relative paths (`failed_imports/Foo - Bar`), new entries store absolute paths. Force-import resolves relative paths against `/mnt/virtio/music/slskd/` automatically.
 
 1. Look up `download_log` entry by ID via `get_download_log_entry()` → extract `failed_path` from `validation_result` JSONB.
 2. Resolve path (handle both relative and absolute) → verify files still exist.
 3. Look up `mb_release_id` from `album_requests` via `request_id`.
-4. Call `import_one.py --force` (sets `MAX_DISTANCE=999` — everything else runs normally: conversion, spectral, quality comparison).
-5. Log result to new `download_log` row with `outcome='force_import'`.
-6. Update `album_requests` status to `imported` on success.
+4. Enqueue `import_jobs(job_type='force_import')` with a dedupe key for the `download_log` row.
+5. `cratedigger-importer` claims the job and calls the existing dispatch path, including `import_one.py --force` (sets `MAX_DISTANCE=999` — everything else runs normally: conversion, spectral, quality comparison).
+6. The worker marks the job `completed` or `failed`; the import internals still write `download_log` and `album_requests` outcomes.
 
 ```bash
 pipeline_cli.py force-import <download_log_id>
+pipeline_cli.py import-jobs --status failed
 # or: POST /api/pipeline/force-import {"download_log_id": N}
 ```

--- a/docs/plans/2026-04-25-001-refactor-importer-queue-architecture-plan.md
+++ b/docs/plans/2026-04-25-001-refactor-importer-queue-architecture-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Centralize imports behind a shared importer queue"
 type: refactor
-status: active
+status: completed
 date: 2026-04-25
 origin: docs/brainstorms/importer-queue-requirements.md
 ---

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -41,7 +41,10 @@ Browser → https://music.ablz.au
 | `/api/pipeline/add` | POST | Add a release to the pipeline DB `{"mb_release_id": "..."}` or `{"discogs_release_id": "..."}` |
 | `/api/pipeline/status` | GET | Pipeline DB status counts + wanted list |
 | `/api/pipeline/<id>` | GET | Single request details |
-| `/api/pipeline/force-import` | POST | Force-import a rejected download `{"download_log_id": N}` |
+| `/api/pipeline/force-import` | POST | Queue force-import for a rejected download `{"download_log_id": N}`; returns `202` + job id |
+| `/api/manual-import/import` | POST | Queue manual import for a matched folder |
+| `/api/import-jobs` | GET | List recent import queue jobs |
+| `/api/import-jobs/<id>` | GET | Poll a single import queue job |
 | `/api/library/artist?name=...` | GET | Albums by artist from beets library (MB vs Discogs source) |
 | `/api/discogs/search?q=...` | GET | Search Discogs mirror (artist or release mode via `type=` param) |
 | `/api/discogs/artist/<id>` | GET | Artist's releases grouped by master (via `/api/artists/{id}/releases`) |
@@ -62,6 +65,8 @@ Browser → https://music.ablz.au
   - Click release metadata to open MB release page in new tab
 - **Add button** — adds release to pipeline DB (same logic as `pipeline-cli add`)
 - **Pipeline tab** — status dashboard (wanted/imported/manual counts + wanted list)
+- **Wrong Matches / Manual Import** — import buttons queue work and poll
+  `import_jobs`, so long beets imports do not block the web request.
 - **Decisions tab** — pipeline decision diagram generated from `get_decision_tree()` with FLAC/MP3 branching paths, all stages/rules/thresholds from live code. Includes a "dispatch" stage showing post-import action mapping (mark_done/failed, denylist, requeue) driven by `dispatch_action()`. Interactive simulator calls `full_pipeline_decision()` via `/api/pipeline/simulate` with presets for known scenarios.
 
 ## NixOS Configuration
@@ -90,6 +95,8 @@ homelab.services.cratedigger.enable = true;
 
 What this creates on doc2:
 - `cratedigger-web.service` — simple type, restart on failure, ExecStart wraps `web/server.py` with the python env from `nix/package.nix`
+- `cratedigger-importer.service` — long-lived worker that drains queued
+  force/manual/automation imports after DB migrations have run
 - `services.redis.servers.cratedigger` — provided by the homelab wrapper (not the upstream module)
 - `music.ablz.au` nginx reverse proxy via `homelab.localProxy.hosts` (homelab wrapper)
 - Cloudflare DNS + ACME cert auto-provisioned

--- a/lib/download.py
+++ b/lib/download.py
@@ -39,6 +39,11 @@ from lib import transitions
 from lib.import_dispatch import (DispatchOutcome, _build_download_info,
                                  _record_rejection_and_maybe_requeue,
                                  dispatch_import_core)
+from lib.import_queue import (
+    IMPORT_JOB_AUTOMATION,
+    automation_import_dedupe_key,
+    automation_import_payload,
+)
 from lib.staged_album import StagedAlbum
 from lib.util import move_failed_import, log_validation_result
 
@@ -1429,7 +1434,7 @@ def _run_completed_processing(
     state: ActiveDownloadState,
     db: Any,
     ctx: CratediggerContext,
-) -> None:
+) -> bool | None:
     """Run or resume local post-download processing for a completed album."""
     if state.processing_started_at is None:
         if entry.import_folder is None:
@@ -1445,7 +1450,7 @@ def _run_completed_processing(
     except Exception:
         logger.exception(f"Error processing completed download {entry.artist} - {entry.title} "
                          f"— will retry local processing next cycle")
-        return
+        return None
 
     # Three-valued return from ``process_completed_album``:
     # - True  → processing succeeded; flip to 'imported' if status is
@@ -1457,7 +1462,7 @@ def _run_completed_processing(
     #   request rejects that require manual recovery. Do NOT touch state
     #   here.
     if outcome is None:
-        return
+        return None
 
     refreshed = db.get_request(request_id)
     if refreshed and refreshed["status"] == "downloading":
@@ -1482,6 +1487,136 @@ def _run_completed_processing(
                     attempt_type="download",
                 ),
             )
+    return outcome
+
+
+def _active_automation_import_job(db: Any, request_id: int):
+    return db.get_import_job_by_dedupe_key(
+        automation_import_dedupe_key(request_id),
+        active_only=True,
+    )
+
+
+def _enqueue_completed_processing(
+    entry: GrabListEntry,
+    request_id: int,
+    state: ActiveDownloadState,
+    db: Any,
+    ctx: CratediggerContext,
+) -> Any:
+    """Submit completed-download processing to the shared import queue."""
+    if state.processing_started_at is None:
+        if entry.import_folder is None:
+            entry.import_folder = _canonical_import_folder_path(
+                entry,
+                ctx.cfg.slskd_download_dir,
+            )
+        state.processing_started_at = datetime.now(timezone.utc).isoformat()
+        _persist_updated_download_state(db, request_id, entry, state)
+    job = db.enqueue_import_job(
+        IMPORT_JOB_AUTOMATION,
+        request_id=request_id,
+        dedupe_key=automation_import_dedupe_key(request_id),
+        payload=automation_import_payload(),
+        message=f"Automation import queued for {entry.artist} - {entry.title}",
+    )
+    if getattr(job, "deduped", False):
+        logger.info(
+            "Automation import already queued/running for request %s "
+            "(job %s)",
+            request_id,
+            getattr(job, "id", "?"),
+        )
+    else:
+        logger.info(
+            "Queued automation import for request %s as job %s",
+            request_id,
+            getattr(job, "id", "?"),
+        )
+    return job
+
+
+def _processing_path_ready_for_importer(
+    entry: GrabListEntry,
+    request_id: int,
+    state: ActiveDownloadState,
+    db: Any,
+    ctx: CratediggerContext,
+) -> bool:
+    """Fail closed before enqueueing a job that cannot resume local files."""
+    if state.processing_started_at is None or state.current_path is None:
+        return True
+
+    current_path_location = classify_processing_path(
+        current_path=state.current_path,
+        artist=entry.artist,
+        title=entry.title,
+        year=entry.year,
+        request_id=request_id,
+        staging_dir=ctx.cfg.beets_staging_dir,
+        slskd_download_dir=ctx.cfg.slskd_download_dir,
+    )
+    if not os.path.isdir(state.current_path):
+        if current_path_location.blocks_post_move_retry:
+            _log_post_move_resume_blocked(
+                entry,
+                current_path=state.current_path,
+                detail=(
+                    "already lives at the request-scoped auto-import "
+                    "staged path but the directory is missing. "
+                    "Automatic retry is disabled because beets may "
+                    "already have consumed the staged folder; manual "
+                    "recovery is required."
+                ),
+            )
+            return False
+        logger.error("Current staged path missing: %s", state.current_path)
+        transitions.finalize_request(
+            db,
+            request_id,
+            transitions.RequestTransition.to_wanted(
+                from_status="downloading",
+                attempt_type="download",
+            ),
+        )
+        return False
+
+    staged_album = StagedAlbum.from_entry(entry, default_path=state.current_path)
+    staged_album.bind_import_paths(entry.files)
+    missing_paths: list[str] = []
+    for file in entry.files:
+        import_path = file.import_path
+        if import_path is not None and not os.path.isfile(import_path):
+            missing_paths.append(import_path)
+    if not missing_paths:
+        return True
+
+    if current_path_location.blocks_post_move_retry:
+        _log_post_move_resume_blocked(
+            entry,
+            current_path=state.current_path,
+            detail=(
+                "already lives at the request-scoped auto-import "
+                f"staged path but tracked files are missing ({', '.join(missing_paths)}). "
+                "Automatic retry is disabled because import may "
+                "already have started; manual recovery is required."
+            ),
+        )
+        return False
+
+    logger.error(
+        "Current staged path is missing tracked files: %s",
+        ", ".join(missing_paths),
+    )
+    transitions.finalize_request(
+        db,
+        request_id,
+        transitions.RequestTransition.to_wanted(
+            from_status="downloading",
+            attempt_type="download",
+        ),
+    )
+    return False
 
 
 def poll_active_downloads(ctx: CratediggerContext) -> None:
@@ -1533,6 +1668,15 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             state = ActiveDownloadState.from_dict(raw_state)
         else:
             state = ActiveDownloadState.from_json(raw_state)
+        active_import_job = _active_automation_import_job(db, request_id)
+        if active_import_job is not None:
+            logger.info(
+                "Request %s is waiting on importer job %s (%s)",
+                request_id,
+                getattr(active_import_job, "id", "?"),
+                getattr(active_import_job, "status", "?"),
+            )
+            continue
         if state.processing_started_at is not None:
             recovery_decision = reconcile_processing_current_path(
                 current_path=state.current_path,
@@ -1585,7 +1729,15 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
         entry = reconstruct_grab_list_entry(row, state)
 
         if state.processing_started_at is not None:
-            _run_completed_processing(entry, request_id, state, db, ctx)
+            if not _processing_path_ready_for_importer(
+                entry,
+                request_id,
+                state,
+                db,
+                ctx,
+            ):
+                continue
+            _enqueue_completed_processing(entry, request_id, state, db, ctx)
             continue
 
         # Re-derive transfer IDs from pre-fetched snapshot
@@ -1652,7 +1804,7 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
 
         if verdict.decision == DownloadDecision.complete:
             logger.info(f"Download complete: {entry.artist} - {entry.title}")
-            _run_completed_processing(entry, request_id, state, db, ctx)
+            _enqueue_completed_processing(entry, request_id, state, db, ctx)
             continue
 
         if verdict.decision == DownloadDecision.timeout_all_errored:

--- a/lib/import_queue.py
+++ b/lib/import_queue.py
@@ -1,0 +1,186 @@
+"""Typed helpers for the shared importer queue."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+IMPORT_JOB_FORCE = "force_import"
+IMPORT_JOB_MANUAL = "manual_import"
+IMPORT_JOB_AUTOMATION = "automation_import"
+
+IMPORT_JOB_TYPES = frozenset({
+    IMPORT_JOB_FORCE,
+    IMPORT_JOB_MANUAL,
+    IMPORT_JOB_AUTOMATION,
+})
+IMPORT_JOB_STATUSES = frozenset({"queued", "running", "completed", "failed"})
+IMPORT_JOB_ACTIVE_STATUSES = frozenset({"queued", "running"})
+
+
+@dataclass(frozen=True)
+class ImportJob:
+    """One row from ``import_jobs`` with JSONB fields normalized to dicts."""
+
+    id: int
+    job_type: str
+    status: str
+    request_id: int | None
+    dedupe_key: str | None
+    payload: dict[str, Any]
+    result: dict[str, Any] | None
+    message: str | None
+    error: str | None
+    attempts: int
+    worker_id: str | None
+    created_at: datetime | None
+    updated_at: datetime | None
+    started_at: datetime | None
+    heartbeat_at: datetime | None
+    completed_at: datetime | None
+    deduped: bool = False
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any], *, deduped: bool = False) -> "ImportJob":
+        payload = _json_dict(row.get("payload"))
+        result_raw = row.get("result")
+        result = _json_dict(result_raw) if result_raw is not None else None
+        return cls(
+            id=int(row["id"]),
+            job_type=str(row["job_type"]),
+            status=str(row["status"]),
+            request_id=(
+                int(row["request_id"])
+                if row.get("request_id") is not None
+                else None
+            ),
+            dedupe_key=(
+                str(row["dedupe_key"])
+                if row.get("dedupe_key") is not None
+                else None
+            ),
+            payload=payload,
+            result=result,
+            message=(
+                str(row["message"])
+                if row.get("message") is not None
+                else None
+            ),
+            error=(
+                str(row["error"])
+                if row.get("error") is not None
+                else None
+            ),
+            attempts=int(row.get("attempts") or 0),
+            worker_id=(
+                str(row["worker_id"])
+                if row.get("worker_id") is not None
+                else None
+            ),
+            created_at=row.get("created_at"),
+            updated_at=row.get("updated_at"),
+            started_at=row.get("started_at"),
+            heartbeat_at=row.get("heartbeat_at"),
+            completed_at=row.get("completed_at"),
+            deduped=deduped,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "job_type": self.job_type,
+            "status": self.status,
+            "request_id": self.request_id,
+            "dedupe_key": self.dedupe_key,
+            "payload": self.payload,
+            "result": self.result,
+            "message": self.message,
+            "error": self.error,
+            "attempts": self.attempts,
+            "worker_id": self.worker_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "started_at": self.started_at,
+            "heartbeat_at": self.heartbeat_at,
+            "completed_at": self.completed_at,
+            "deduped": self.deduped,
+        }
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result = self.to_dict()
+        for key in ("created_at", "updated_at", "started_at", "heartbeat_at", "completed_at"):
+            value = result[key]
+            if hasattr(value, "isoformat"):
+                result[key] = value.isoformat()
+        return result
+
+
+def _json_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        parsed = json.loads(value)
+        if isinstance(parsed, dict):
+            return parsed
+    raise ValueError("import job JSON payload must be an object")
+
+
+def validate_job_type(job_type: str) -> str:
+    if job_type not in IMPORT_JOB_TYPES:
+        raise ValueError(f"Invalid import job type: {job_type}")
+    return job_type
+
+
+def validate_status(status: str) -> str:
+    if status not in IMPORT_JOB_STATUSES:
+        raise ValueError(f"Invalid import job status: {status}")
+    return status
+
+
+def validate_payload(job_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    validate_job_type(job_type)
+    payload = _json_dict(payload)
+    if job_type in (IMPORT_JOB_FORCE, IMPORT_JOB_MANUAL):
+        failed_path = payload.get("failed_path")
+        if not isinstance(failed_path, str) or not failed_path:
+            raise ValueError(f"{job_type} payload requires failed_path")
+    return payload
+
+
+def force_import_dedupe_key(download_log_id: int) -> str:
+    return f"{IMPORT_JOB_FORCE}:download_log:{int(download_log_id)}"
+
+
+def manual_import_dedupe_key(request_id: int, path: str) -> str:
+    return f"{IMPORT_JOB_MANUAL}:request:{int(request_id)}:path:{path}"
+
+
+def automation_import_dedupe_key(request_id: int) -> str:
+    return f"{IMPORT_JOB_AUTOMATION}:request:{int(request_id)}"
+
+
+def force_import_payload(
+    *,
+    download_log_id: int,
+    failed_path: str,
+    source_username: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "download_log_id": int(download_log_id),
+        "failed_path": failed_path,
+    }
+    if source_username:
+        payload["source_username"] = source_username
+    return payload
+
+
+def manual_import_payload(*, failed_path: str) -> dict[str, Any]:
+    return {"failed_path": failed_path}
+
+
+def automation_import_payload() -> dict[str, Any]:
+    return {}

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -20,6 +20,12 @@ from typing import Any, Iterator
 import psycopg2
 import psycopg2.extras
 
+from lib.import_queue import (
+    ImportJob,
+    validate_job_type,
+    validate_payload,
+    validate_status,
+)
 from lib.quality import CooldownConfig, SpectralMeasurement, should_cooldown
 from lib.release_identity import ReleaseIdentity, normalize_release_id
 
@@ -52,6 +58,12 @@ ADVISORY_LOCK_NAMESPACE_IMPORT = 0x46494D50
 # the lock were missing. Key = ``release_id_to_lock_key(mb_release_id)``.
 # ``0x52454C45`` = ASCII "RELE", recognisable alongside FIMP in ``pg_locks``.
 ADVISORY_LOCK_NAMESPACE_RELEASE = 0x52454C45
+
+# Singleton importer-worker lock. The DB queue serializes claims, but beets
+# mutation is intentionally a single lane, so the worker process itself also
+# takes a process-wide lock before recovering or claiming jobs.
+# ``0x51554555`` = ASCII "QUEU", recognisable in ``pg_locks``.
+ADVISORY_LOCK_NAMESPACE_IMPORTER = 0x51554555
 
 
 def release_id_to_lock_key(mb_release_id: str) -> int:
@@ -180,6 +192,301 @@ class PipelineDB:
                         "SELECT pg_advisory_unlock(%s, %s)", (namespace, key)
                     )
                     cur.fetchone()
+
+    # --- import_jobs queue ---
+
+    def enqueue_import_job(
+        self,
+        job_type: str,
+        *,
+        request_id: int | None = None,
+        dedupe_key: str | None = None,
+        payload: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob:
+        """Create an import job or return the active job with the same key."""
+        validate_job_type(job_type)
+        payload = validate_payload(job_type, payload or {})
+        cur = self._execute("""
+            WITH inserted AS (
+                INSERT INTO import_jobs (
+                    job_type, request_id, dedupe_key, payload, message
+                )
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (dedupe_key)
+                    WHERE dedupe_key IS NOT NULL
+                      AND status IN ('queued', 'running')
+                DO NOTHING
+                RETURNING *
+            )
+            SELECT inserted.*, false AS deduped
+            FROM inserted
+            UNION ALL
+            SELECT import_jobs.*, true AS deduped
+            FROM import_jobs
+            WHERE %s IS NOT NULL
+              AND dedupe_key = %s
+              AND status IN ('queued', 'running')
+              AND NOT EXISTS (SELECT 1 FROM inserted)
+            ORDER BY deduped
+            LIMIT 1
+        """, (
+            job_type,
+            request_id,
+            dedupe_key,
+            psycopg2.extras.Json(payload),
+            message,
+            dedupe_key,
+            dedupe_key,
+        ))
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError("import job enqueue returned no row")
+        return ImportJob.from_row(dict(row), deduped=bool(row["deduped"]))
+
+    def get_import_job(self, job_id: int) -> ImportJob | None:
+        cur = self._execute(
+            "SELECT * FROM import_jobs WHERE id = %s",
+            (job_id,),
+        )
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def get_import_job_by_dedupe_key(
+        self,
+        dedupe_key: str,
+        *,
+        active_only: bool = True,
+    ) -> ImportJob | None:
+        status_filter = (
+            "AND status IN ('queued', 'running')"
+            if active_only
+            else ""
+        )
+        cur = self._execute(f"""
+            SELECT *
+            FROM import_jobs
+            WHERE dedupe_key = %s
+            {status_filter}
+            ORDER BY updated_at DESC, id DESC
+            LIMIT 1
+        """, (dedupe_key,))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def list_import_jobs(
+        self,
+        *,
+        status: str | None = None,
+        request_id: int | None = None,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        params: list[Any] = []
+        clauses: list[str] = []
+        if status is not None:
+            validate_status(status)
+            clauses.append("status = %s")
+            params.append(status)
+        if request_id is not None:
+            clauses.append("request_id = %s")
+            params.append(request_id)
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        params.append(limit)
+        cur = self._execute(f"""
+            SELECT *
+            FROM import_jobs
+            {where}
+            ORDER BY updated_at DESC, id DESC
+            LIMIT %s
+        """, tuple(params))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
+    def list_active_import_jobs(
+        self,
+        *,
+        request_id: int | None = None,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        params: list[Any] = []
+        request_filter = ""
+        if request_id is not None:
+            request_filter = "AND request_id = %s"
+            params.append(request_id)
+        params.append(limit)
+        cur = self._execute(f"""
+            SELECT *
+            FROM import_jobs
+            WHERE status IN ('queued', 'running')
+            {request_filter}
+            ORDER BY created_at ASC, id ASC
+            LIMIT %s
+        """, tuple(params))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
+    def count_import_jobs_by_status(self) -> dict[str, int]:
+        cur = self._execute("""
+            SELECT status, COUNT(*) AS count
+            FROM import_jobs
+            GROUP BY status
+        """)
+        return {str(row["status"]): int(row["count"]) for row in cur.fetchall()}
+
+    def claim_next_import_job(
+        self,
+        *,
+        worker_id: str | None = None,
+    ) -> ImportJob | None:
+        cur = self._execute("""
+            WITH next_job AS (
+                SELECT id
+                FROM import_jobs
+                WHERE status = 'queued'
+                ORDER BY created_at ASC, id ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+            )
+            UPDATE import_jobs
+            SET status = 'running',
+                attempts = attempts + 1,
+                worker_id = %s,
+                started_at = COALESCE(started_at, NOW()),
+                heartbeat_at = NOW(),
+                updated_at = NOW()
+            FROM next_job
+            WHERE import_jobs.id = next_job.id
+            RETURNING import_jobs.*
+        """, (worker_id,))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def heartbeat_import_job(self, job_id: int) -> bool:
+        cur = self._execute("""
+            UPDATE import_jobs
+            SET heartbeat_at = NOW(), updated_at = NOW()
+            WHERE id = %s AND status = 'running'
+            RETURNING id
+        """, (job_id,))
+        return cur.fetchone() is not None
+
+    def mark_import_job_completed(
+        self,
+        job_id: int,
+        *,
+        result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        cur = self._execute("""
+            UPDATE import_jobs
+            SET status = 'completed',
+                result = %s,
+                message = %s,
+                error = NULL,
+                completed_at = NOW(),
+                updated_at = NOW()
+            WHERE id = %s
+              AND status IN ('queued', 'running')
+            RETURNING *
+        """, (psycopg2.extras.Json(result or {}), message, job_id))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def mark_import_job_failed(
+        self,
+        job_id: int,
+        *,
+        error: str,
+        result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        cur = self._execute("""
+            UPDATE import_jobs
+            SET status = 'failed',
+                result = %s,
+                message = %s,
+                error = %s,
+                completed_at = NOW(),
+                updated_at = NOW()
+            WHERE id = %s
+              AND status IN ('queued', 'running')
+            RETURNING *
+        """, (psycopg2.extras.Json(result or {}), message, error, job_id))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def list_stale_running_import_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        cutoff = datetime.now(timezone.utc) - older_than
+        cur = self._execute("""
+            SELECT *
+            FROM import_jobs
+            WHERE status = 'running'
+              AND COALESCE(heartbeat_at, started_at, updated_at) < %s
+            ORDER BY updated_at ASC, id ASC
+            LIMIT %s
+        """, (cutoff, limit))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
+    def fail_stale_running_import_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        cutoff = datetime.now(timezone.utc) - older_than
+        cur = self._execute("""
+            WITH stale AS (
+                SELECT id
+                FROM import_jobs
+                WHERE status = 'running'
+                  AND COALESCE(heartbeat_at, started_at, updated_at) < %s
+                ORDER BY updated_at ASC, id ASC
+                LIMIT %s
+            )
+            UPDATE import_jobs
+            SET status = 'failed',
+                error = %s,
+                message = %s,
+                completed_at = NOW(),
+                updated_at = NOW()
+            FROM stale
+            WHERE import_jobs.id = stale.id
+            RETURNING import_jobs.*
+        """, (cutoff, limit, message, message))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
+    def requeue_running_import_jobs(
+        self,
+        *,
+        message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        """Reset abandoned running jobs to queued for immediate retry."""
+        cur = self._execute("""
+            WITH running AS (
+                SELECT id
+                FROM import_jobs
+                WHERE status = 'running'
+                ORDER BY updated_at ASC, id ASC
+                LIMIT %s
+            )
+            UPDATE import_jobs
+            SET status = 'queued',
+                message = %s,
+                error = NULL,
+                worker_id = NULL,
+                started_at = NULL,
+                heartbeat_at = NULL,
+                updated_at = NOW()
+            FROM running
+            WHERE import_jobs.id = running.id
+            RETURNING import_jobs.*
+        """, (limit, message))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
 
     # --- album_requests CRUD ---
 

--- a/migrations/003_import_jobs.sql
+++ b/migrations/003_import_jobs.sql
@@ -1,0 +1,42 @@
+-- 003_import_jobs.sql — shared importer queue
+--
+-- Durable queue used by web, CLI, automation, and the importer service to
+-- funnel beets-mutating import work through one serial owner.
+
+CREATE TABLE IF NOT EXISTS import_jobs (
+    id SERIAL PRIMARY KEY,
+    job_type TEXT NOT NULL CHECK (
+        job_type IN ('force_import', 'manual_import', 'automation_import')
+    ),
+    status TEXT NOT NULL DEFAULT 'queued' CHECK (
+        status IN ('queued', 'running', 'completed', 'failed')
+    ),
+    request_id INTEGER REFERENCES album_requests(id) ON DELETE SET NULL,
+    dedupe_key TEXT,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    result JSONB,
+    message TEXT,
+    error TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    worker_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    heartbeat_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_jobs_active_dedupe
+    ON import_jobs(dedupe_key)
+    WHERE dedupe_key IS NOT NULL
+      AND status IN ('queued', 'running');
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_claim
+    ON import_jobs(status, created_at, id)
+    WHERE status = 'queued';
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_request_recent
+    ON import_jobs(request_id, updated_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_recent
+    ON import_jobs(updated_at DESC, id DESC);

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -63,6 +63,13 @@
       --migrations-dir "${src}/migrations" "$@"
   '';
 
+  importerPkg = pkgs.writeShellScriptBin "cratedigger-importer" ''
+    export PATH="${runtimePath}:$PATH"
+    export PYTHONPATH="${src}:''${PYTHONPATH:-}"
+    exec ${pythonEnv}/bin/python ${src}/scripts/importer.py \
+      --dsn "${cfg.pipelineDb.dsn}" "$@"
+  '';
+
   webPkg = pkgs.writeShellScriptBin "cratedigger-web" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:''${PYTHONPATH:-}"
@@ -288,6 +295,14 @@ in {
         type = types.str;
         default = "5min";
         description = "Interval between cycles.";
+      };
+    };
+
+    importer = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Run the long-lived importer worker that drains the shared import queue.";
       };
     };
 
@@ -617,7 +632,7 @@ in {
       }
     ];
 
-    environment.systemPackages = [pipelineCli pipelineMigrate pkgs.postgresql];
+    environment.systemPackages = [pipelineCli pipelineMigrate importerPkg pkgs.postgresql];
 
     users.users = mkIf (cfg.user != "root") {
       ${cfg.user} = {
@@ -689,6 +704,26 @@ in {
         OnBootSec = cfg.timer.onBootSec;
         OnUnitActiveSec = cfg.timer.onUnitActiveSec;
         Persistent = true;
+      };
+    };
+
+    systemd.services.cratedigger-importer = mkIf cfg.importer.enable {
+      description = "Cratedigger importer queue worker";
+      after = ["cratedigger-db-migrate.service"];
+      requires = ["cratedigger-db-migrate.service"];
+      wantedBy = ["multi-user.target"];
+      path = [pkgs.bash pkgs.coreutils pkgs.gnugrep pkgs.gnused pkgs.curl pkgs.jq pkgs.ffmpeg pkgs.mp3val pkgs.flac pkgs.sox];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        UMask = "0000";
+        ExecStartPre = [preStartScript];
+        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        ExecStart = "${importerPkg}/bin/cratedigger-importer";
+        WorkingDirectory = cfg.stateDir;
+        Restart = "on-failure";
+        RestartSec = 5;
       };
     };
 

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Drain the shared import queue through one beets-mutating lane."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import socket
+import sys
+import time
+from typing import Any
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from lib.import_dispatch import DispatchOutcome
+from lib.import_queue import (
+    IMPORT_JOB_AUTOMATION,
+    IMPORT_JOB_FORCE,
+    IMPORT_JOB_MANUAL,
+    ImportJob,
+)
+from lib.pipeline_db import (
+    ADVISORY_LOCK_NAMESPACE_IMPORTER,
+    DEFAULT_DSN,
+    PipelineDB,
+)
+from lib.quality import ActiveDownloadState
+
+logger = logging.getLogger("cratedigger-importer")
+RESTART_REQUEUE_MESSAGE = "Importer restarted while job was running; retry queued"
+
+
+def _job_result(outcome: DispatchOutcome) -> dict[str, Any]:
+    return {
+        "success": outcome.success,
+        "message": outcome.message,
+        "deferred": outcome.deferred,
+    }
+
+
+def execute_import_job(
+    db: PipelineDB,
+    job: ImportJob,
+    *,
+    ctx: Any = None,
+) -> DispatchOutcome:
+    """Execute one claimed import job without mutating job status."""
+    if job.request_id is None:
+        return DispatchOutcome(
+            success=False,
+            message="Import job has no request_id",
+        )
+
+    if job.job_type in (IMPORT_JOB_FORCE, IMPORT_JOB_MANUAL):
+        from lib.import_dispatch import dispatch_import_from_db
+
+        payload = job.payload
+        failed_path = str(payload.get("failed_path") or "")
+        if not failed_path:
+            return DispatchOutcome(
+                success=False,
+                message="Import job payload is missing failed_path",
+            )
+        source_username = payload.get("source_username")
+        return dispatch_import_from_db(
+            db,
+            request_id=job.request_id,
+            failed_path=failed_path,
+            force=job.job_type == IMPORT_JOB_FORCE,
+            outcome_label=job.job_type,
+            source_username=(
+                str(source_username)
+                if source_username is not None
+                else None
+            ),
+        )
+
+    if job.job_type == IMPORT_JOB_AUTOMATION:
+        return execute_automation_import_job(db, job, ctx=ctx)
+
+    return DispatchOutcome(
+        success=False,
+        message=f"Unsupported import job type: {job.job_type}",
+    )
+
+
+def _build_runtime_context(db: PipelineDB):
+    """Build the minimal CratediggerContext needed by download processing."""
+    from album_source import DatabaseSource
+    from lib.config import read_runtime_config
+    from lib.context import CratediggerContext
+
+    cfg = read_runtime_config()
+    source = DatabaseSource(db.dsn)
+    return CratediggerContext(cfg=cfg, slskd=None, pipeline_db_source=source)
+
+
+def execute_automation_import_job(
+    db: PipelineDB,
+    job: ImportJob,
+    *,
+    ctx: Any = None,
+) -> DispatchOutcome:
+    """Run completed-download processing from an automation queue job."""
+    from lib.download import _run_completed_processing, reconstruct_grab_list_entry
+
+    request_id = job.request_id
+    if request_id is None:
+        return DispatchOutcome(False, "Automation import job has no request_id")
+
+    row = db.get_request(request_id)
+    if not row:
+        return DispatchOutcome(False, f"Album request {request_id} not found")
+
+    raw_state = row.get("active_download_state")
+    if not raw_state:
+        return DispatchOutcome(
+            False,
+            f"Album request {request_id} has no active_download_state",
+        )
+    state = (
+        ActiveDownloadState.from_dict(raw_state)
+        if isinstance(raw_state, dict)
+        else ActiveDownloadState.from_json(str(raw_state))
+    )
+    entry = reconstruct_grab_list_entry(row, state)
+    created_ctx = ctx is None
+    runtime_ctx = ctx or _build_runtime_context(db)
+    try:
+        result = _run_completed_processing(entry, request_id, state, db, runtime_ctx)
+    finally:
+        if created_ctx:
+            runtime_ctx.pipeline_db_source.close()
+    if result is None:
+        return DispatchOutcome(
+            success=False,
+            message=(
+                "Automation import was deferred or requires manual recovery"
+            ),
+            deferred=True,
+        )
+    if result:
+        return DispatchOutcome(
+            success=True,
+            message="Automation import processing completed",
+        )
+    return DispatchOutcome(
+        success=False,
+        message="Automation import processing failed",
+    )
+
+
+def process_claimed_job(
+    db: PipelineDB,
+    job: ImportJob,
+    *,
+    ctx: Any = None,
+) -> ImportJob | None:
+    """Execute a claimed job and persist its terminal queue status."""
+    try:
+        outcome = execute_import_job(db, job, ctx=ctx)
+    except Exception as exc:
+        logger.exception("Import job %s crashed", job.id)
+        return db.mark_import_job_failed(
+            job.id,
+            error=type(exc).__name__,
+            message=str(exc),
+            result={"success": False},
+        )
+
+    result = _job_result(outcome)
+    if outcome.success:
+        return db.mark_import_job_completed(
+            job.id,
+            result=result,
+            message=outcome.message,
+        )
+    return db.mark_import_job_failed(
+        job.id,
+        error=outcome.message,
+        message=outcome.message,
+        result=result,
+    )
+
+
+def run_once(
+    db: PipelineDB,
+    *,
+    worker_id: str,
+    ctx: Any = None,
+) -> ImportJob | None:
+    job = db.claim_next_import_job(worker_id=worker_id)
+    if job is None:
+        return None
+    logger.info("Claimed import job %s (%s)", job.id, job.job_type)
+    return process_claimed_job(db, job, ctx=ctx)
+
+
+def recover_abandoned_running_jobs(db: PipelineDB) -> list[ImportJob]:
+    """Requeue jobs left running by a previous importer process."""
+    return db.requeue_running_import_jobs(message=RESTART_REQUEUE_MESSAGE)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Drain the Cratedigger import queue",
+    )
+    parser.add_argument("--dsn", default=DEFAULT_DSN)
+    parser.add_argument("--poll-interval", type=float, default=5.0)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--worker-id", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    worker_id = args.worker_id or f"{socket.gethostname()}:{os.getpid()}"
+    db = PipelineDB(args.dsn)
+    try:
+        # Keep the beets-mutating queue to one worker process. See
+        # docs/advisory-locks.md for namespace rules.
+        with db.advisory_lock(ADVISORY_LOCK_NAMESPACE_IMPORTER, 1) as acquired:
+            if not acquired:
+                logger.error("Another cratedigger importer is already running")
+                return 1
+
+            recovered = recover_abandoned_running_jobs(db)
+            if recovered:
+                logger.warning(
+                    "Requeued %s abandoned running import job(s)",
+                    len(recovered),
+                )
+
+            while True:
+                job = run_once(db, worker_id=worker_id)
+                if args.once:
+                    return 0
+                if job is None:
+                    time.sleep(args.poll_interval)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -48,6 +48,14 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 from lib import transitions
+from lib.import_queue import (
+    IMPORT_JOB_FORCE,
+    IMPORT_JOB_MANUAL,
+    force_import_dedupe_key,
+    force_import_payload,
+    manual_import_dedupe_key,
+    manual_import_payload,
+)
 from lib.pipeline_db import PipelineDB, DEFAULT_DSN
 from lib.release_identity import detect_release_source, normalize_release_id
 from lib.util import resolve_failed_path as _shared_resolve_failed_path
@@ -973,22 +981,23 @@ def cmd_force_import(db, args):
     print(f"  Path: {failed_path}")
     print(f"  MBID: {mbid}")
 
-    from lib.import_dispatch import dispatch_import_from_db
-    outcome = dispatch_import_from_db(
-        db, request_id=request_id, failed_path=failed_path,
-        force=True, outcome_label="force_import",
-        source_username=entry.get("soulseek_username"),
+    job = db.enqueue_import_job(
+        IMPORT_JOB_FORCE,
+        request_id=request_id,
+        dedupe_key=force_import_dedupe_key(log_id),
+        payload=force_import_payload(
+            download_log_id=log_id,
+            failed_path=failed_path,
+            source_username=entry.get("soulseek_username"),
+        ),
+        message=f"Force import queued for {req['artist_name']} - {req['album_title']}",
     )
-    if outcome.success:
-        print(f"  [OK] {outcome.message}")
-    else:
-        print(f"  [WARN] {outcome.message}")
+    deduped = " existing" if job.deduped else ""
+    print(f"  [OK] Queued{deduped} import job #{job.id} ({job.status}).")
 
 
 def cmd_manual_import(db, args):
     """Import a local folder as a pipeline request."""
-    from lib.import_dispatch import dispatch_import_from_db
-
     request_id = args.id
     path = args.path
 
@@ -1018,14 +1027,30 @@ def cmd_manual_import(db, args):
     print(f"  Path: {path}")
     print(f"  MBID: {mbid}")
 
-    outcome = dispatch_import_from_db(
-        db, request_id=request_id, failed_path=path,
-        force=False, outcome_label="manual_import",
+    job = db.enqueue_import_job(
+        IMPORT_JOB_MANUAL,
+        request_id=request_id,
+        dedupe_key=manual_import_dedupe_key(request_id, path),
+        payload=manual_import_payload(failed_path=path),
+        message=f"Manual import queued for {req['artist_name']} - {req['album_title']}",
     )
-    if outcome.success:
-        print(f"  [OK] {outcome.message}")
-    else:
-        print(f"  [FAIL] {outcome.message}")
+    deduped = " existing" if job.deduped else ""
+    print(f"  [OK] Queued{deduped} import job #{job.id} ({job.status}).")
+
+
+def cmd_import_jobs(db, args):
+    """List recent import queue jobs."""
+    jobs = db.list_import_jobs(status=args.status, limit=args.limit)
+    if not jobs:
+        print("  No import jobs found.")
+        return
+    for job in jobs:
+        request = f"request={job.request_id}" if job.request_id is not None else "request=-"
+        msg = job.message or job.error or ""
+        print(
+            f"  [{job.id:4d}] {job.status:9s} {job.job_type:17s} "
+            f"{request:12s} attempts={job.attempts} {msg}"
+        )
 
 
 def cmd_repair_spectral(db, args):
@@ -1195,6 +1220,11 @@ def main():
     p_manual.add_argument("--verified-lossless-target",
                           help="Override the runtime verified-lossless target for this import")
 
+    # import-jobs
+    p_jobs = sub.add_parser("import-jobs", help="List recent import queue jobs")
+    p_jobs.add_argument("--status", choices=["queued", "running", "completed", "failed"])
+    p_jobs.add_argument("--limit", type=int, default=20)
+
     # repair-spectral
     p_repair = sub.add_parser("repair-spectral",
                               help="Fix albums stuck by stale current_spectral_bitrate (#18)")
@@ -1221,6 +1251,7 @@ def main():
         "quality": cmd_quality,
         "force-import": cmd_force_import,
         "manual-import": cmd_manual_import,
+        "import-jobs": cmd_import_jobs,
         "repair-spectral": cmd_repair_spectral,
     }
     commands[args.command](db, args)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterator
 
+from lib.import_queue import ImportJob, validate_job_type, validate_payload, validate_status
 from lib.pipeline_db import BACKOFF_BASE_MINUTES, BACKOFF_MAX_MINUTES, RequestSpectralStateUpdate
 from lib.release_identity import ReleaseIdentity, normalize_release_id
 
@@ -299,6 +300,7 @@ class FakePipelineDB:
         self._requests: dict[int, dict[str, Any]] = {}
         self._tracks: dict[int, list[dict[str, Any]]] = {}
         self.download_logs: list[DownloadLogRow] = []
+        self._import_jobs: list[dict[str, Any]] = []
         self.search_logs: list[SearchLogRow] = []
         self.user_cooldowns: dict[str, UserCooldownRow] = {}
         self.denylist: list[DenylistEntry] = []
@@ -312,6 +314,7 @@ class FakePipelineDB:
         self.closed = False
         self._next_request_id = 0
         self._next_download_log_id = 0
+        self._next_import_job_id = 0
         self._next_search_log_id = 0
         self._cooldown_result: bool | Callable[[str], bool] = False
         self._advisory_lock_result: (
@@ -367,6 +370,245 @@ class FakePipelineDB:
             if callable(self._advisory_lock_result)
             else self._advisory_lock_result)
         yield acquired
+
+    # --- import_jobs queue ---
+
+    def enqueue_import_job(
+        self,
+        job_type: str,
+        *,
+        request_id: int | None = None,
+        dedupe_key: str | None = None,
+        payload: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob:
+        validate_job_type(job_type)
+        payload = validate_payload(job_type, payload or {})
+        if dedupe_key is not None:
+            existing = self.get_import_job_by_dedupe_key(dedupe_key)
+            if existing is not None:
+                return ImportJob.from_row(existing.to_dict(), deduped=True)
+
+        self._next_import_job_id += 1
+        now = _utcnow()
+        row: dict[str, Any] = {
+            "id": self._next_import_job_id,
+            "job_type": job_type,
+            "status": "queued",
+            "request_id": request_id,
+            "dedupe_key": dedupe_key,
+            "payload": copy.deepcopy(payload),
+            "result": None,
+            "message": message,
+            "error": None,
+            "attempts": 0,
+            "worker_id": None,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "heartbeat_at": None,
+            "completed_at": None,
+        }
+        self._import_jobs.append(row)
+        return ImportJob.from_row(copy.deepcopy(row))
+
+    def get_import_job(self, job_id: int) -> ImportJob | None:
+        for row in self._import_jobs:
+            if row["id"] == job_id:
+                return ImportJob.from_row(copy.deepcopy(row))
+        return None
+
+    def get_import_job_by_dedupe_key(
+        self,
+        dedupe_key: str,
+        *,
+        active_only: bool = True,
+    ) -> ImportJob | None:
+        rows = [
+            row for row in self._import_jobs
+            if row.get("dedupe_key") == dedupe_key
+            and (
+                not active_only
+                or row.get("status") in ("queued", "running")
+            )
+        ]
+        rows.sort(key=lambda row: (_as_datetime(row.get("updated_at")), row["id"]), reverse=True)
+        return ImportJob.from_row(copy.deepcopy(rows[0])) if rows else None
+
+    def list_import_jobs(
+        self,
+        *,
+        status: str | None = None,
+        request_id: int | None = None,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        if status is not None:
+            validate_status(status)
+        rows = list(self._import_jobs)
+        if status is not None:
+            rows = [row for row in rows if row.get("status") == status]
+        if request_id is not None:
+            rows = [row for row in rows if row.get("request_id") == request_id]
+        rows.sort(key=lambda row: (_as_datetime(row.get("updated_at")), row["id"]), reverse=True)
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows[:limit]]
+
+    def list_active_import_jobs(
+        self,
+        *,
+        request_id: int | None = None,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        rows = [
+            row for row in self._import_jobs
+            if row.get("status") in ("queued", "running")
+            and (request_id is None or row.get("request_id") == request_id)
+        ]
+        rows.sort(key=lambda row: (_as_datetime(row.get("created_at")), row["id"]))
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows[:limit]]
+
+    def count_import_jobs_by_status(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for row in self._import_jobs:
+            status = str(row.get("status"))
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    def claim_next_import_job(
+        self,
+        *,
+        worker_id: str | None = None,
+    ) -> ImportJob | None:
+        queued = [
+            row for row in self._import_jobs
+            if row.get("status") == "queued"
+        ]
+        queued.sort(key=lambda row: (_as_datetime(row.get("created_at")), row["id"]))
+        if not queued:
+            return None
+        row = queued[0]
+        now = _utcnow()
+        row["status"] = "running"
+        row["attempts"] = int(row.get("attempts") or 0) + 1
+        row["worker_id"] = worker_id
+        row["started_at"] = row.get("started_at") or now
+        row["heartbeat_at"] = now
+        row["updated_at"] = now
+        return ImportJob.from_row(copy.deepcopy(row))
+
+    def heartbeat_import_job(self, job_id: int) -> bool:
+        for row in self._import_jobs:
+            if row["id"] == job_id and row.get("status") == "running":
+                now = _utcnow()
+                row["heartbeat_at"] = now
+                row["updated_at"] = now
+                return True
+        return False
+
+    def mark_import_job_completed(
+        self,
+        job_id: int,
+        *,
+        result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        for row in self._import_jobs:
+            if row["id"] == job_id and row.get("status") in ("queued", "running"):
+                now = _utcnow()
+                row["status"] = "completed"
+                row["result"] = copy.deepcopy(result or {})
+                row["message"] = message
+                row["error"] = None
+                row["completed_at"] = now
+                row["updated_at"] = now
+                return ImportJob.from_row(copy.deepcopy(row))
+        return None
+
+    def mark_import_job_failed(
+        self,
+        job_id: int,
+        *,
+        error: str,
+        result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        for row in self._import_jobs:
+            if row["id"] == job_id and row.get("status") in ("queued", "running"):
+                now = _utcnow()
+                row["status"] = "failed"
+                row["result"] = copy.deepcopy(result or {})
+                row["message"] = message
+                row["error"] = error
+                row["completed_at"] = now
+                row["updated_at"] = now
+                return ImportJob.from_row(copy.deepcopy(row))
+        return None
+
+    def list_stale_running_import_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        cutoff = _utcnow() - older_than
+        rows = []
+        for row in self._import_jobs:
+            if row.get("status") != "running":
+                continue
+            last = _as_datetime(
+                row.get("heartbeat_at")
+                or row.get("started_at")
+                or row.get("updated_at")
+            )
+            if last < cutoff:
+                rows.append(row)
+        rows.sort(key=lambda row: (_as_datetime(row.get("updated_at")), row["id"]))
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows[:limit]]
+
+    def fail_stale_running_import_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        stale = self.list_stale_running_import_jobs(
+            older_than=older_than,
+            limit=limit,
+        )
+        failed = []
+        for job in stale:
+            updated = self.mark_import_job_failed(
+                job.id,
+                error=message,
+                message=message,
+            )
+            if updated is not None:
+                failed.append(updated)
+        return failed
+
+    def requeue_running_import_jobs(
+        self,
+        *,
+        message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        running = [
+            row for row in self._import_jobs
+            if row.get("status") == "running"
+        ]
+        running.sort(key=lambda row: (_as_datetime(row.get("updated_at")), row["id"]))
+        updated_jobs = []
+        for row in running[:limit]:
+            now = _utcnow()
+            row["status"] = "queued"
+            row["message"] = message
+            row["error"] = None
+            row["worker_id"] = None
+            row["started_at"] = None
+            row["heartbeat_at"] = None
+            row["updated_at"] = now
+            updated_jobs.append(ImportJob.from_row(copy.deepcopy(row)))
+        return updated_jobs
 
     # --- PipelineDB interface methods ---
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2042,9 +2042,35 @@ class TestPollActiveDownloads(unittest.TestCase):
         poll_active_downloads(ctx)
         self.assertEqual(fake_db.clear_download_state_calls, [])
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_all_complete(self, mock_process):
-        """1 downloading album, all files complete → calls process_completed_album."""
+    def test_poll_active_all_complete(self):
+        """1 downloading album, all files complete → enqueues importer job."""
+        from lib.download import poll_active_downloads
+        from lib.import_queue import IMPORT_JOB_AUTOMATION
+        row = self._make_downloading_row()
+        ctx, fake_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                }]}],
+            }],
+        )
+
+        poll_active_downloads(ctx)
+
+        self.assertEqual(len(fake_db.update_download_state_calls), 1)
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
+        jobs = fake_db.list_import_jobs()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0].job_type, IMPORT_JOB_AUTOMATION)
+        self.assertEqual(jobs[0].request_id, 1)
+
+    def test_poll_active_all_complete_no_beets(self):
+        """beets_validation_enabled=False still queues importer ownership."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         ctx, fake_db = self._make_poll_ctx(
@@ -2060,41 +2086,12 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        def mark_imported(*args):
-            fake_db.update_status(1, "imported")
-            return True
-
-        mock_process.side_effect = mark_imported
         poll_active_downloads(ctx)
 
         self.assertEqual(len(fake_db.update_download_state_calls), 1)
-        self.assertEqual(fake_db.request(1)["status"], "imported")
-        mock_process.assert_called_once()
-
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_all_complete_no_beets(self, mock_process):
-        """beets_validation_enabled=False → process returns True, poll sets imported."""
-        from lib.download import poll_active_downloads
-        row = self._make_downloading_row()
-        ctx, fake_db = self._make_poll_ctx(
-            downloading_rows=[row],
-            slskd_downloads=[{
-                "username": "user1",
-                "directories": [{"directory": "user1\\Music", "files": [{
-                    "filename": "user1\\Music\\01.flac",
-                    "id": "tid-1",
-                    "state": "Completed, Succeeded",
-                    "bytesTransferred": 30000000,
-                }]}],
-            }],
-        )
-
-        mock_process.return_value = True
-        poll_active_downloads(ctx)
-
-        self.assertEqual(len(fake_db.update_download_state_calls), 1)
-        self.assertEqual(fake_db.request(1)["status"], "imported")
-        self.assertIsNone(fake_db.request(1)["active_download_state"])
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
+        self.assertIsNotNone(fake_db.request(1)["active_download_state"])
+        self.assertEqual(len(fake_db.list_import_jobs()), 1)
 
     def test_poll_active_timeout(self):
         """No byte/state progress for stalled_timeout → cancel, log, reset to wanted."""
@@ -2184,9 +2181,8 @@ class TestPollActiveDownloads(unittest.TestCase):
         fake_db.assert_log(self, 0, outcome="timeout")
         self.assertEqual(fake_db.request(1)["status"], "wanted")
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_completed_removed_transfer_uses_snapshot_status(self, mock_process):
-        """Completed transfers from includeRemoved=true should import, not timeout."""
+    def test_poll_active_completed_removed_transfer_uses_snapshot_status(self):
+        """Completed transfers from includeRemoved=true should enqueue, not timeout."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         ctx, fake_db = self._make_poll_ctx(
@@ -2205,19 +2201,13 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        def mark_imported(*args):
-            fake_db.update_status(1, "imported")
-            return True
-
-        mock_process.side_effect = mark_imported
-
         with patch("lib.download.slskd_download_status") as mock_status:
             poll_active_downloads(ctx)
 
         mock_status.assert_not_called()
-        mock_process.assert_called_once()
         self.assertEqual(fake_db.download_logs, [])
-        self.assertEqual(fake_db.request(1)["status"], "imported")
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
+        self.assertEqual(len(fake_db.list_import_jobs()), 1)
 
     def test_poll_active_in_progress(self):
         """Files still downloading with fresh state transition → persist progress snapshot."""
@@ -2243,8 +2233,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.download_logs, [])
         self.assertEqual(fake_db.request(1)["status"], "downloading")
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_multiple_albums(self, mock_process):
+    def test_poll_active_multiple_albums(self):
         """2 albums: 1 completes, 1 in progress → correct handling."""
         from lib.download import poll_active_downloads
         row1 = self._make_downloading_row(request_id=1)
@@ -2287,11 +2276,6 @@ class TestPollActiveDownloads(unittest.TestCase):
         # slskd returns transfers for both users
         self.assertEqual(cast(FakeSlskdAPI, ctx.slskd).transfers.get_all_downloads_calls, [])
 
-        def mark_imported(*args):
-            fake_db.update_status(1, "imported")
-            return True
-
-        mock_process.side_effect = mark_imported
         poll_active_downloads(ctx)
 
         # Album 1 persists processing_started_at, album 2 persists progress.
@@ -2300,9 +2284,9 @@ class TestPollActiveDownloads(unittest.TestCase):
             request_id for request_id, _ in fake_db.update_download_state_calls
         ]
         self.assertEqual(update_request_ids, [1, 2])
-        self.assertIsNone(fake_db.request(1)["active_download_state"])
+        self.assertIsNotNone(fake_db.request(1)["active_download_state"])
         self.assertIsNotNone(self._download_state(fake_db, 2)["last_progress_at"])
-        mock_process.assert_called_once()
+        self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
     def test_poll_crash_recovery_no_state(self):
         """Downloading album with no active_download_state → reset to wanted."""
@@ -2556,9 +2540,8 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.request(1)["status"], "downloading")
         self.assertEqual(fake_db.status_history, [])
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_completion_exception_persists_processing_state(self, mock_process):
-        """Exceptions after completion should leave persisted state for the next cycle to resume."""
+    def test_poll_active_completion_queues_and_persists_processing_state(self):
+        """Completion should leave persisted state for the importer to resume."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         ctx, fake_db = self._make_poll_ctx(
@@ -2574,7 +2557,6 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        mock_process.side_effect = RuntimeError("boom")
         poll_active_downloads(ctx)
 
         self.assertEqual(fake_db.download_logs, [])
@@ -2586,63 +2568,90 @@ class TestPollActiveDownloads(unittest.TestCase):
             persisted["current_path"],
             "/tmp/test_downloads/Test Artist - Test Album (2020)",
         )
+        self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_resume_processing_uses_persisted_current_path(self, mock_process):
-        """Resume path must reconstruct the post-move directory from persisted state."""
+    def test_poll_resume_processing_queues_persisted_current_path(self):
+        """Resume path keeps the post-move directory for the importer."""
         from lib.download import poll_active_downloads
-        current_path = "/tmp/staged/auto-import/Test Artist/Test Album [request-1]"
-        row = self._make_downloading_row(state_dict={
-            "filetype": "flac",
-            "enqueued_at": _utc_now_iso(),
-            "processing_started_at": _utc_now_iso(),
-            "current_path": current_path,
-            "files": [
-                {"username": "user1", "filename": "user1\\Music\\01.flac",
-                 "file_dir": "user1\\Music", "size": 30000000},
-            ],
-        })
-        ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+        from lib.processing_paths import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            current_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=False,
+            )
+            os.makedirs(current_path)
+            with open(os.path.join(current_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": current_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.beets_staging_dir = staging_root
 
-        mock_process.return_value = True
-        poll_active_downloads(ctx)
+            poll_active_downloads(ctx)
 
-        entry = mock_process.call_args[0][0]
-        self.assertEqual(entry.import_folder, current_path)
+            self.assertEqual(
+                _fake_db.request(1)["active_download_state"]["current_path"],
+                current_path,
+            )
+            self.assertEqual(len(_fake_db.list_import_jobs(request_id=1)), 1)
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_legacy_processing_row_uses_canonical_fallback(self, mock_process):
+    def test_poll_legacy_processing_row_uses_canonical_fallback(self):
         """Legacy mid-processing rows without current_path still resume canonically."""
         from lib.download import poll_active_downloads
-        row = self._make_downloading_row(state_dict={
-            "filetype": "flac",
-            "enqueued_at": _utc_now_iso(),
-            "processing_started_at": _utc_now_iso(),
-            "files": [
-                {"username": "user1", "filename": "user1\\Music\\01.flac",
-                 "file_dir": "user1\\Music", "size": 30000000},
-            ],
-        })
-        ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
-        cfg = cast(Any, ctx.cfg)
-        cfg.slskd_download_dir = "/tmp/downloads"
+        from lib.processing_paths import canonical_processing_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            canonical_path = canonical_processing_path(
+                artist="Test Artist",
+                title="Test Album",
+                year="2020",
+                slskd_download_dir=downloads_root,
+            )
+            os.makedirs(canonical_path)
+            with open(os.path.join(canonical_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = downloads_root
 
-        mock_process.return_value = True
-        poll_active_downloads(ctx)
+            poll_active_downloads(ctx)
 
-        entry = mock_process.call_args[0][0]
-        self.assertEqual(
-            entry.import_folder,
-            "/tmp/downloads/Test Artist - Test Album (2020)",
-        )
-        self.assertEqual(len(_fake_db.update_download_state_current_path_calls), 1)
-        self.assertEqual(
-            _fake_db.update_download_state_current_path_calls[0],
-            (1, "/tmp/downloads/Test Artist - Test Album (2020)"),
-        )
+            self.assertEqual(
+                _fake_db.request(1)["active_download_state"]["current_path"],
+                canonical_path,
+            )
+            self.assertEqual(len(_fake_db.update_download_state_current_path_calls), 1)
+            self.assertEqual(
+                _fake_db.update_download_state_current_path_calls[0],
+                (1, canonical_path),
+            )
+            self.assertEqual(len(_fake_db.list_import_jobs(request_id=1)), 1)
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_mid_processing_row_uses_request_scoped_staging_fallback(self, mock_process):
+    def test_poll_mid_processing_row_uses_request_scoped_staging_fallback(self):
         """Move/persist crashes should recover from request-scoped staged dirs."""
         from lib.download import poll_active_downloads
         from lib.processing_paths import stage_to_ai_path
@@ -2674,21 +2683,17 @@ class TestPollActiveDownloads(unittest.TestCase):
             cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
             cfg.beets_staging_dir = staging_root
 
-            mock_process.return_value = None
             poll_active_downloads(ctx)
 
-            entry = mock_process.call_args[0][0]
-            self.assertEqual(entry.import_folder, staged_path)
             self.assertEqual(
                 fake_db.request(1)["active_download_state"]["current_path"],
                 staged_path,
             )
             self.assertEqual(fake_db.status_history, [])
+            self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
-    @patch("lib.download.process_completed_album")
     def test_poll_stale_canonical_current_path_uses_request_scoped_staging_fallback(
         self,
-        mock_process,
     ):
         """A stale canonical current_path must recover to the staged location."""
         from lib.download import poll_active_downloads
@@ -2729,15 +2734,13 @@ class TestPollActiveDownloads(unittest.TestCase):
             cfg.slskd_download_dir = downloads_root
             cfg.beets_staging_dir = staging_root
 
-            mock_process.return_value = None
             poll_active_downloads(ctx)
 
-            entry = mock_process.call_args[0][0]
-            self.assertEqual(entry.import_folder, staged_path)
             self.assertEqual(
                 fake_db.request(1)["active_download_state"]["current_path"],
                 staged_path,
             )
+            self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
     def test_poll_legacy_processing_row_blocks_on_ambiguous_staged_dir(self):
         """Legacy rows must not guess a shared staged dir as current_path."""
@@ -2836,8 +2839,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             self.assertEqual(fake_db.request(1)["status"], "wanted")
             self.assertIn((1, "wanted"), fake_db.status_history)
 
-    def test_poll_post_move_staged_path_without_validation_completes(self):
-        """Staged retries still finish when the auto-import branch is unavailable."""
+    def test_poll_post_move_staged_path_without_validation_queues(self):
+        """Staged retries are queued for importer ownership."""
         from lib.download import poll_active_downloads
         from lib.processing_paths import stage_to_ai_path
         import tempfile
@@ -2870,9 +2873,13 @@ class TestPollActiveDownloads(unittest.TestCase):
 
             poll_active_downloads(ctx)
 
-            self.assertEqual(fake_db.request(1)["status"], "imported")
-            self.assertIn((1, "imported"), fake_db.status_history)
-            self.assertIsNone(fake_db.request(1)["active_download_state"])
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertEqual(fake_db.status_history, [])
+            self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
+            self.assertEqual(
+                fake_db.request(1)["active_download_state"]["current_path"],
+                resumed_path,
+            )
 
     def test_poll_post_move_staged_path_with_missing_file_leaves_row_downloading(self):
         """Missing files under a staged current_path must block, not requeue."""
@@ -2955,9 +2962,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             )
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_no_redownload_window(self, mock_process):
-        """Album stays 'downloading' during process_completed_album — no redownload window."""
+    def test_poll_no_redownload_window(self):
+        """Album stays 'downloading' while queued for importer."""
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         ctx, fake_db = self._make_poll_ctx(
@@ -2973,18 +2979,12 @@ class TestPollActiveDownloads(unittest.TestCase):
             }],
         )
 
-        def mark_imported(*args):
-            fake_db.update_status(1, "imported")
-            return True
-
-        mock_process.side_effect = mark_imported
         poll_active_downloads(ctx)
 
-        # process_completed_album ran
-        mock_process.assert_called_once()
         self.assertEqual(len(fake_db.update_download_state_calls), 1)
         self.assertNotIn((1, "wanted"), fake_db.status_history)
-        self.assertEqual(fake_db.request(1)["status"], "imported")
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
+        self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
 
 class TestBuildActiveDownloadState(unittest.TestCase):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -505,6 +505,67 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         db.close()
         self.assertTrue(db.closed)
 
+    def test_import_job_queue_methods_mirror_core_lifecycle(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        db = FakePipelineDB()
+        first = db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key="manual:42",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        duplicate = db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key="manual:42",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.assertEqual(first.id, duplicate.id)
+        self.assertTrue(duplicate.deduped)
+        self.assertEqual(db.count_import_jobs_by_status(), {"queued": 1})
+
+        claimed = db.claim_next_import_job(worker_id="fake-worker")
+        assert claimed is not None
+        self.assertEqual(claimed.status, "running")
+        self.assertEqual(claimed.attempts, 1)
+        self.assertEqual(claimed.worker_id, "fake-worker")
+        self.assertTrue(db.heartbeat_import_job(claimed.id))
+
+        requeued = db.requeue_running_import_jobs(message="retry")
+        self.assertEqual([job.id for job in requeued], [claimed.id])
+        self.assertEqual(requeued[0].status, "queued")
+        self.assertIsNone(requeued[0].worker_id)
+
+        claimed = db.claim_next_import_job(worker_id="fake-worker-2")
+        assert claimed is not None
+        self.assertEqual(claimed.status, "running")
+        self.assertEqual(claimed.attempts, 2)
+        self.assertEqual(claimed.worker_id, "fake-worker-2")
+
+        completed = db.mark_import_job_completed(
+            claimed.id,
+            result={"success": True},
+            message="done",
+        )
+        assert completed is not None
+        self.assertEqual(completed.status, "completed")
+
+        later = db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key="manual:42",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.assertNotEqual(first.id, later.id)
+        failed = db.mark_import_job_failed(
+            later.id,
+            error="boom",
+            message="failed",
+        )
+        assert failed is not None
+        self.assertEqual(failed.status, "failed")
+
     def test_add_request_assigns_monotonic_id(self):
         db = FakePipelineDB()
         rid1 = db.add_request("Artist A", "Album A", source="request")

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -1,0 +1,154 @@
+"""Tests for the shared import queue worker."""
+
+import unittest
+from unittest.mock import patch
+
+from lib.import_dispatch import DispatchOutcome
+from lib.import_queue import (
+    IMPORT_JOB_AUTOMATION,
+    IMPORT_JOB_FORCE,
+    IMPORT_JOB_MANUAL,
+    automation_import_dedupe_key,
+    force_import_dedupe_key,
+    force_import_payload,
+    manual_import_dedupe_key,
+    manual_import_payload,
+)
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_request_row
+
+
+class TestImporterWorker(unittest.TestCase):
+    def test_force_import_job_calls_existing_dispatch_and_completes(self):
+        from scripts import importer
+
+        db = FakePipelineDB()
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(7),
+            payload=force_import_payload(
+                download_log_id=7,
+                failed_path="/tmp/failed",
+                source_username="alice",
+            ),
+        )
+        claimed = db.claim_next_import_job(worker_id="worker")
+        assert claimed is not None
+
+        with patch(
+            "lib.import_dispatch.dispatch_import_from_db",
+            return_value=DispatchOutcome(True, "imported"),
+        ) as dispatch:
+            updated = importer.process_claimed_job(db, claimed)
+
+        dispatch.assert_called_once_with(
+            db,
+            request_id=42,
+            failed_path="/tmp/failed",
+            force=True,
+            outcome_label=IMPORT_JOB_FORCE,
+            source_username="alice",
+        )
+        assert updated is not None
+        self.assertEqual(updated.status, "completed")
+        self.assertEqual(updated.result["success"], True)
+        self.assertEqual(job.id, updated.id)
+
+    def test_manual_import_failure_marks_job_failed(self):
+        from scripts import importer
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        claimed = db.claim_next_import_job(worker_id="worker")
+        assert claimed is not None
+
+        with patch(
+            "lib.import_dispatch.dispatch_import_from_db",
+            return_value=DispatchOutcome(False, "quality gate rejected"),
+        ):
+            updated = importer.process_claimed_job(db, claimed)
+
+        assert updated is not None
+        self.assertEqual(updated.status, "failed")
+        self.assertEqual(updated.error, "quality gate rejected")
+        self.assertEqual(updated.result["success"], False)
+
+    def test_startup_requeues_abandoned_running_job_for_retry(self):
+        from scripts import importer
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        claimed = db.claim_next_import_job(worker_id="old-worker")
+        assert claimed is not None
+
+        recovered = importer.recover_abandoned_running_jobs(db)
+
+        self.assertEqual([job.id for job in recovered], [claimed.id])
+        self.assertEqual(recovered[0].status, "queued")
+        self.assertIsNone(recovered[0].worker_id)
+        self.assertIsNone(recovered[0].heartbeat_at)
+
+        with patch(
+            "lib.import_dispatch.dispatch_import_from_db",
+            return_value=DispatchOutcome(True, "imported on retry"),
+        ):
+            updated = importer.run_once(db, worker_id="new-worker")
+
+        assert updated is not None
+        self.assertEqual(updated.status, "completed")
+        retried = db.get_import_job(claimed.id)
+        assert retried is not None
+        self.assertEqual(retried.attempts, 2)
+
+    def test_automation_job_reconstructs_active_state_and_uses_processing_path(self):
+        from scripts import importer
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={
+                "filetype": "flac",
+                "enqueued_at": "2026-04-25T00:00:00+00:00",
+                "files": [{
+                    "username": "alice",
+                    "filename": "Artist\\Album\\01.flac",
+                    "file_dir": "Artist\\Album",
+                    "size": 123,
+                }],
+            },
+        ))
+        db.enqueue_import_job(
+            IMPORT_JOB_AUTOMATION,
+            request_id=42,
+            dedupe_key=automation_import_dedupe_key(42),
+            payload={},
+        )
+        claimed = db.claim_next_import_job(worker_id="worker")
+        assert claimed is not None
+
+        with patch(
+            "lib.download._run_completed_processing",
+            return_value=True,
+        ) as processing:
+            updated = importer.process_claimed_job(
+                db,
+                claimed,
+                ctx=object(),
+            )
+
+        processing.assert_called_once()
+        assert updated is not None
+        self.assertEqual(updated.status, "completed")
+        self.assertEqual(updated.message, "Automation import processing completed")

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -74,5 +74,18 @@ class TestPythonPathCarriesOnlyRepoRoot(unittest.TestCase):
         )
 
 
+class TestImporterServiceContract(unittest.TestCase):
+    def test_importer_wrapper_and_service_are_defined(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('writeShellScriptBin "cratedigger-importer"', text)
+        self.assertIn("${src}/scripts/importer.py", text)
+        self.assertIn("systemd.services.cratedigger-importer", text)
+        self.assertIn('after = ["cratedigger-db-migrate.service"]', text)
+        self.assertIn('requires = ["cratedigger-db-migrate.service"]', text)
+        self.assertIn('ExecStart = "${importerPkg}/bin/cratedigger-importer"', text)
+        self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
+        self.assertIn("WorkingDirectory = cfg.stateDir", text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -43,7 +43,7 @@ SAMPLE_MB_RELEASE = {
 def make_db():
     from lib.pipeline_db import PipelineDB
     db = PipelineDB(TEST_DSN)
-    for table in ["source_denylist", "download_log", "album_tracks", "album_requests"]:
+    for table in ["import_jobs", "source_denylist", "download_log", "album_tracks", "album_requests"]:
         db._execute(f"TRUNCATE {table} CASCADE")
     db.conn.commit()
     return db
@@ -179,8 +179,8 @@ class TestTracksFromMbRelease(unittest.TestCase):
 class TestCmdForceImport(unittest.TestCase):
     @patch("builtins.print")
     @patch("scripts.pipeline_cli._resolve_failed_path", return_value="/tmp/Test Album")
-    def test_force_import_passes_source_username_to_dispatch(self, _mock_resolve, _mock_print):
-        from lib.import_dispatch import DispatchOutcome
+    def test_force_import_passes_source_username_to_queue(self, _mock_resolve, _mock_print):
+        from lib.import_queue import IMPORT_JOB_FORCE, force_import_dedupe_key
 
         db = MagicMock()
         db.get_download_log_entry.return_value = {
@@ -192,63 +192,69 @@ class TestCmdForceImport(unittest.TestCase):
             id=123, status="manual", min_bitrate=320,
             mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
         )
-
-        mock_outcome = DispatchOutcome(success=True, message="ok")
-        with patch("lib.import_dispatch.dispatch_import_from_db",
-                    return_value=mock_outcome) as mock_dispatch:
-            args = MagicMock(download_log_id=42)
-            pipeline_cli.cmd_force_import(db, args)
-
-        mock_dispatch.assert_called_once_with(
-            db, request_id=123, failed_path="/tmp/Test Album",
-            force=True, outcome_label="force_import",
-            source_username="baduser",
+        db.enqueue_import_job.return_value = SimpleNamespace(
+            id=55,
+            status="queued",
+            deduped=False,
         )
+
+        args = MagicMock(download_log_id=42)
+        pipeline_cli.cmd_force_import(db, args)
+
+        db.enqueue_import_job.assert_called_once()
+        args_, kwargs = db.enqueue_import_job.call_args
+        self.assertEqual(args_, (IMPORT_JOB_FORCE,))
+        self.assertEqual(kwargs["request_id"], 123)
+        self.assertEqual(kwargs["dedupe_key"], force_import_dedupe_key(42))
+        self.assertEqual(kwargs["payload"]["failed_path"], "/tmp/Test Album")
+        self.assertEqual(kwargs["payload"]["source_username"], "baduser")
 
 
 class TestCmdManualImport(unittest.TestCase):
     @patch("builtins.print")
     @patch("scripts.pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
-    def test_failed_manual_import_prints_error(self, _mock_resolve, _mock_print):
-        from lib.import_dispatch import DispatchOutcome
+    def test_manual_import_prints_queued_job(self, _mock_resolve, _mock_print):
         db = MagicMock()
         db.get_request.return_value = make_request_row(
             id=123, status="manual", min_bitrate=320,
             mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
         )
-
-        mock_outcome = DispatchOutcome(
-            success=False,
-            message="Rejected: quality_downgrade — new 192kbps <= existing 320kbps",
+        db.enqueue_import_job.return_value = SimpleNamespace(
+            id=66,
+            status="queued",
+            deduped=False,
         )
-        with patch("lib.import_dispatch.dispatch_import_from_db",
-                    return_value=mock_outcome):
-            args = MagicMock(id=123, path="/tmp/Album")
-            pipeline_cli.cmd_manual_import(db, args)
 
-        # Should print failure message
-        _mock_print.assert_any_call("  [FAIL] Rejected: quality_downgrade — new 192kbps <= existing 320kbps")
+        args = MagicMock(id=123, path="/tmp/Album")
+        pipeline_cli.cmd_manual_import(db, args)
+
+        _mock_print.assert_any_call("  [OK] Queued import job #66 (queued).")
 
     @patch("builtins.print")
     @patch("scripts.pipeline_cli._resolve_failed_path", return_value="/tmp/Album")
-    def test_manual_import_calls_dispatch_from_db(self, _mock_resolve, _mock_print):
-        from lib.import_dispatch import DispatchOutcome
+    def test_manual_import_enqueues_job(self, _mock_resolve, _mock_print):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_dedupe_key
+
         db = MagicMock()
         db.get_request.return_value = make_request_row(
             id=123, status="manual", min_bitrate=320,
             mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
         )
-
-        mock_outcome = DispatchOutcome(success=True, message="ok")
-        with patch("lib.import_dispatch.dispatch_import_from_db",
-                    return_value=mock_outcome) as mock_dispatch:
-            args = MagicMock(id=123, path="/tmp/Album")
-            pipeline_cli.cmd_manual_import(db, args)
-
-        mock_dispatch.assert_called_once_with(
-            db, request_id=123, failed_path="/tmp/Album",
-            force=False, outcome_label="manual_import",
+        db.enqueue_import_job.return_value = SimpleNamespace(
+            id=66,
+            status="queued",
+            deduped=False,
         )
+
+        args = MagicMock(id=123, path="/tmp/Album")
+        pipeline_cli.cmd_manual_import(db, args)
+
+        db.enqueue_import_job.assert_called_once()
+        args_, kwargs = db.enqueue_import_job.call_args
+        self.assertEqual(args_, (IMPORT_JOB_MANUAL,))
+        self.assertEqual(kwargs["request_id"], 123)
+        self.assertEqual(kwargs["dedupe_key"], manual_import_dedupe_key(123, "/tmp/Album"))
+        self.assertEqual(kwargs["payload"]["failed_path"], "/tmp/Album")
 
     @patch("builtins.print")
     @patch("scripts.pipeline_cli._resolve_failed_path",
@@ -258,23 +264,23 @@ class TestCmdManualImport(unittest.TestCase):
         does, so a user can type ``failed_imports/Foo - Bar`` without
         pre-absolutizing. Matches cmd_force_import behavior.
         """
-        from lib.import_dispatch import DispatchOutcome
         db = MagicMock()
         db.get_request.return_value = make_request_row(
             id=123, status="manual", min_bitrate=320,
             mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
         )
-        mock_outcome = DispatchOutcome(success=True, message="ok")
-        with patch("lib.import_dispatch.dispatch_import_from_db",
-                    return_value=mock_outcome) as mock_dispatch:
-            args = MagicMock(id=123, path="failed_imports/Foo - Bar")
-            pipeline_cli.cmd_manual_import(db, args)
+        db.enqueue_import_job.return_value = SimpleNamespace(
+            id=66,
+            status="queued",
+            deduped=False,
+        )
+        args = MagicMock(id=123, path="failed_imports/Foo - Bar")
+        pipeline_cli.cmd_manual_import(db, args)
 
         _mock_resolve.assert_called_once_with("failed_imports/Foo - Bar")
-        mock_dispatch.assert_called_once_with(
-            db, request_id=123,
-            failed_path="/mnt/virtio/music/slskd/failed_imports/Foo - Bar",
-            force=False, outcome_label="manual_import",
+        self.assertEqual(
+            db.enqueue_import_job.call_args.kwargs["payload"]["failed_path"],
+            "/mnt/virtio/music/slskd/failed_imports/Foo - Bar",
         )
 
     @patch("builtins.print")
@@ -288,10 +294,9 @@ class TestCmdManualImport(unittest.TestCase):
             id=123, status="manual", min_bitrate=320,
             mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
         )
-        with patch("lib.import_dispatch.dispatch_import_from_db") as mock_dispatch:
-            args = MagicMock(id=123, path="nonexistent/path")
-            pipeline_cli.cmd_manual_import(db, args)
-        mock_dispatch.assert_not_called()
+        args = MagicMock(id=123, path="nonexistent/path")
+        pipeline_cli.cmd_manual_import(db, args)
+        db.enqueue_import_job.assert_not_called()
         mock_print.assert_any_call("  Files not found at: nonexistent/path")
 
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -35,7 +35,7 @@ def make_db():
     """
     from lib import pipeline_db
     db = pipeline_db.PipelineDB(TEST_DSN)
-    for table in ["user_cooldowns", "source_denylist", "search_log", "download_log", "album_tracks", "album_requests"]:
+    for table in ["import_jobs", "user_cooldowns", "source_denylist", "search_log", "download_log", "album_tracks", "album_requests"]:
         db._execute(f"TRUNCATE {table} CASCADE")
     db.conn.commit()
     return db
@@ -57,8 +57,85 @@ class TestSchemaCreation(unittest.TestCase):
         self.assertIn("search_log", table_names)
         self.assertIn("source_denylist", table_names)
         self.assertIn("user_cooldowns", table_names)
+        self.assertIn("import_jobs", table_names)
         # The migrator's own tracking table must also exist
         self.assertIn("schema_migrations", table_names)
+        db.close()
+
+    def test_import_jobs_schema_constraints_and_indexes(self):
+        """Migration 003 creates the durable shared importer queue."""
+        db = make_db()
+        req_id = db.add_request(
+            mb_release_id="queue-schema-mbid",
+            artist_name="Queue",
+            album_title="Schema",
+            source="request",
+        )
+
+        cur = db._execute("""
+            INSERT INTO import_jobs (
+                job_type, status, request_id, dedupe_key, payload
+            )
+            VALUES (
+                'force_import', 'queued', %s, 'force_import:download_log:1',
+                '{"failed_path": "/tmp/failed"}'::jsonb
+            )
+            RETURNING id
+        """, (req_id,))
+        first_id = cur.fetchone()["id"]
+        self.assertIsInstance(first_id, int)
+
+        with self.assertRaises(Exception):
+            db._execute("""
+                INSERT INTO import_jobs (
+                    job_type, status, request_id, dedupe_key, payload
+                )
+                VALUES (
+                    'force_import', 'queued', %s, 'force_import:download_log:1',
+                    '{"failed_path": "/tmp/other"}'::jsonb
+                )
+            """, (req_id,))
+        db.conn.rollback()
+
+        db._execute(
+            "UPDATE import_jobs SET status = 'completed' WHERE id = %s",
+            (first_id,),
+        )
+        db._execute("""
+            INSERT INTO import_jobs (
+                job_type, status, request_id, dedupe_key, payload
+            )
+            VALUES (
+                'force_import', 'queued', %s, 'force_import:download_log:1',
+                '{"failed_path": "/tmp/new"}'::jsonb
+            )
+        """, (req_id,))
+
+        for column, bad_value in (("status", "bogus"), ("job_type", "bogus")):
+            with self.subTest(column=column):
+                with self.assertRaises(Exception):
+                    db._execute(f"""
+                        INSERT INTO import_jobs (
+                            job_type, status, payload
+                        )
+                        VALUES (
+                            %s, %s, '{"failed_path": "/tmp/bad"}'::jsonb
+                        )
+                    """, (
+                        bad_value if column == "job_type" else "force_import",
+                        bad_value if column == "status" else "queued",
+                    ))
+                db.conn.rollback()
+
+        indexes = db._execute("""
+            SELECT indexname
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'import_jobs'
+        """).fetchall()
+        index_names = {row["indexname"] for row in indexes}
+        self.assertIn("idx_import_jobs_active_dedupe", index_names)
+        self.assertIn("idx_import_jobs_claim", index_names)
         db.close()
 
 
@@ -171,6 +248,172 @@ class TestAddAndGetRequest(unittest.TestCase):
         )
         self.db.delete_request(req_id)
         self.assertIsNone(self.db.get_request(req_id))
+
+
+@requires_postgres
+class TestImportJobQueueAPI(unittest.TestCase):
+    def setUp(self):
+        self.db = make_db()
+        self.req_id = self.db.add_request(
+            mb_release_id="queue-api-mbid",
+            artist_name="Queue",
+            album_title="API",
+            source="request",
+        )
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_enqueue_dedupes_active_job_and_allows_after_completion(self):
+        from lib.import_queue import (
+            IMPORT_JOB_FORCE,
+            force_import_dedupe_key,
+            force_import_payload,
+        )
+
+        dedupe = force_import_dedupe_key(17)
+        payload = force_import_payload(
+            download_log_id=17,
+            failed_path="/tmp/failed",
+            source_username="alice",
+        )
+        first = self.db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=self.req_id,
+            dedupe_key=dedupe,
+            payload=payload,
+        )
+        duplicate = self.db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=self.req_id,
+            dedupe_key=dedupe,
+            payload=payload,
+        )
+
+        self.assertEqual(first.id, duplicate.id)
+        self.assertFalse(first.deduped)
+        self.assertTrue(duplicate.deduped)
+
+        self.db.mark_import_job_completed(
+            first.id,
+            result={"success": True},
+            message="done",
+        )
+        later = self.db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=self.req_id,
+            dedupe_key=dedupe,
+            payload=payload,
+        )
+        self.assertNotEqual(first.id, later.id)
+
+    def test_claim_complete_and_fail_lifecycle(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:1",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        claimed = self.db.claim_next_import_job(worker_id="test-worker")
+        assert claimed is not None
+        self.assertEqual(claimed.status, "running")
+        self.assertEqual(claimed.worker_id, "test-worker")
+        self.assertEqual(claimed.attempts, 1)
+        self.assertIsNone(self.db.claim_next_import_job(worker_id="other"))
+
+        completed = self.db.mark_import_job_completed(
+            claimed.id,
+            result={"success": True},
+            message="imported",
+        )
+        assert completed is not None
+        self.assertEqual(completed.status, "completed")
+        self.assertEqual(completed.result, {"success": True})
+
+        missing = self.db.mark_import_job_failed(
+            999999,
+            error="missing",
+            message="missing",
+        )
+        self.assertIsNone(missing)
+
+    def test_two_sessions_cannot_claim_same_job(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+        from lib import pipeline_db
+
+        self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:claim-once",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        other = pipeline_db.PipelineDB(TEST_DSN)
+        try:
+            first = self.db.claim_next_import_job(worker_id="one")
+            second = other.claim_next_import_job(worker_id="two")
+            self.assertIsNotNone(first)
+            self.assertIsNone(second)
+        finally:
+            other.close()
+
+    def test_stale_running_jobs_are_listed_and_failed_conservatively(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:stale",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        claimed = self.db.claim_next_import_job(worker_id="stale-worker")
+        assert claimed is not None
+        old = datetime.now(timezone.utc) - timedelta(hours=8)
+        self.db._execute(
+            "UPDATE import_jobs SET heartbeat_at = %s, updated_at = %s WHERE id = %s",
+            (old, old, claimed.id),
+        )
+
+        stale = self.db.list_stale_running_import_jobs(
+            older_than=timedelta(hours=4),
+        )
+        self.assertEqual([job.id for job in stale], [claimed.id])
+
+        failed = self.db.fail_stale_running_import_jobs(
+            older_than=timedelta(hours=4),
+            message="stale importer job",
+        )
+        self.assertEqual([job.id for job in failed], [claimed.id])
+        self.assertEqual(failed[0].status, "failed")
+
+    def test_running_jobs_can_be_requeued_immediately_after_worker_restart(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:restart-retry",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        claimed = self.db.claim_next_import_job(worker_id="old-worker")
+        assert claimed is not None
+
+        recovered = self.db.requeue_running_import_jobs(
+            message="worker restarted",
+        )
+        self.assertEqual([job.id for job in recovered], [claimed.id])
+        self.assertEqual(recovered[0].status, "queued")
+        self.assertIsNone(recovered[0].worker_id)
+        self.assertIsNone(recovered[0].started_at)
+        self.assertIsNone(recovered[0].heartbeat_at)
+        self.assertEqual(recovered[0].attempts, 1)
+
+        retried = self.db.claim_next_import_job(worker_id="new-worker")
+        assert retried is not None
+        self.assertEqual(retried.id, claimed.id)
+        self.assertEqual(retried.attempts, 2)
+        self.assertEqual(retried.worker_id, "new-worker")
 
 
 @requires_postgres

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 from lib.manual_import import FolderInfo, FolderMatch, ImportRequest
+from lib.import_queue import ImportJob
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 from web.library_album_row import LibraryAlbumRow
@@ -180,6 +181,29 @@ def _make_server():
     mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
     mock_db.clear_wrong_match_path.return_value = True
     mock_db.list_requests_by_artist.return_value = []
+    mock_job = ImportJob(
+        id=77,
+        job_type="force_import",
+        status="queued",
+        request_id=100,
+        dedupe_key="force_import:download_log:42",
+        payload={"failed_path": "/tmp/Test Album"},
+        result=None,
+        message="Import queued",
+        error=None,
+        attempts=0,
+        worker_id=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        started_at=None,
+        heartbeat_at=None,
+        completed_at=None,
+    )
+    mock_db.enqueue_import_job.return_value = mock_job
+    mock_db.get_import_job.return_value = mock_job
+    mock_db.list_import_jobs.return_value = [mock_job]
+    mock_db.list_active_import_jobs.return_value = []
+    mock_db.count_import_jobs_by_status.return_value = {"queued": 1}
 
     def _get_request_by_release_id(release_id):
         normalized = normalize_release_id(release_id)
@@ -373,8 +397,9 @@ class TestServerEndpoints(unittest.TestCase):
         self.assertEqual(data["intent"], "lossless")
 
     @patch("web.routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
-    @patch("lib.import_dispatch.dispatch_import_from_db")
-    def test_post_force_import_passes_source_username(self, mock_dispatch, _mock_resolve):
+    def test_post_force_import_passes_source_username(self, _mock_resolve):
+        from lib.import_queue import IMPORT_JOB_FORCE, force_import_dedupe_key
+
         self.mock_db.get_download_log_entry.return_value = {
             "id": 42,
             "request_id": 100,
@@ -384,22 +409,20 @@ class TestServerEndpoints(unittest.TestCase):
                 "scenario": "high_distance",
             },
         }
-        mock_dispatch.return_value = MagicMock(success=True, message="Import successful")
 
         status, data = self._post("/api/pipeline/force-import", {"download_log_id": 42})
 
-        self.assertEqual(status, 200)
-        self.assertEqual(data["status"], "ok")
+        self.assertEqual(status, 202)
+        self.assertEqual(data["status"], "queued")
         self.assertEqual(data["artist"], _MOCK_PIPELINE_REQUEST["artist_name"])
         self.assertEqual(data["album"], _MOCK_PIPELINE_REQUEST["album_title"])
-        mock_dispatch.assert_called_once_with(
-            self.mock_db,
-            request_id=100,
-            failed_path="/tmp/Test Album",
-            force=True,
-            outcome_label="force_import",
-            source_username="baduser",
-        )
+        self.mock_db.enqueue_import_job.assert_called_once()
+        args, kwargs = self.mock_db.enqueue_import_job.call_args
+        self.assertEqual(args, (IMPORT_JOB_FORCE,))
+        self.assertEqual(kwargs["request_id"], 100)
+        self.assertEqual(kwargs["dedupe_key"], force_import_dedupe_key(42))
+        self.assertEqual(kwargs["payload"]["failed_path"], "/tmp/Test Album")
+        self.assertEqual(kwargs["payload"]["source_username"], "baduser")
 
     def test_post_set_intent_default_clears_stale_lossless_override(self):
         self.mock_db.get_request.return_value = make_request_row(
@@ -596,6 +619,8 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/pipeline/ban-source",
         "/api/pipeline/force-import",
         "/api/pipeline/delete",
+        "/api/import-jobs",
+        r"^/api/import-jobs/(\d+)$",
         "/api/beets/search",
         "/api/beets/recent",
         r"^/api/beets/album/(\d+)$",
@@ -661,6 +686,11 @@ class TestPipelineRouteContracts(_WebServerCase):
         "stage1_spectral", "stage2_import", "stage3_quality_gate",
         "final_status", "imported", "denylisted", "keep_searching",
         "target_final_format",
+    }
+    IMPORT_JOB_REQUIRED_FIELDS = {
+        "id", "job_type", "status", "request_id", "dedupe_key", "payload",
+        "result", "message", "error", "attempts", "worker_id", "created_at",
+        "updated_at", "started_at", "heartbeat_at", "completed_at", "deduped",
     }
 
     def setUp(self) -> None:
@@ -794,6 +824,31 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.SIMULATE_REQUIRED_FIELDS,
                                 "pipeline simulate response")
+
+    def test_import_jobs_contract(self):
+        status, data = self._get("/api/import-jobs")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, {"jobs", "counts"}, "import jobs response")
+        _assert_required_fields(self, data["jobs"][0], self.IMPORT_JOB_REQUIRED_FIELDS,
+                                "import jobs item")
+
+    def test_import_job_detail_contract(self):
+        status, data = self._get("/api/import-jobs/77")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, {"job"}, "import job detail response")
+        _assert_required_fields(self, data["job"], self.IMPORT_JOB_REQUIRED_FIELDS,
+                                "import job detail")
+
+    def test_import_jobs_rejects_invalid_filters(self):
+        status, data = self._get("/api/import-jobs?status=bad")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+
+        status, data = self._get("/api/import-jobs?request_id=abc")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
 
     @patch("web.routes.pipeline.full_pipeline_decision")
     def test_pipeline_simulate_threads_target_format(self, mock_simulate):
@@ -1236,13 +1291,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
                                 "pipeline ban-source response")
 
     @patch("web.routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
-    @patch("lib.import_dispatch.dispatch_import_from_db")
-    def test_pipeline_force_import_contract(self, mock_dispatch, _mock_resolve):
-        mock_dispatch.return_value = MagicMock(success=True, message="Import successful")
-
+    def test_pipeline_force_import_contract(self, _mock_resolve):
         status, data = self._post("/api/pipeline/force-import", {"download_log_id": 42})
 
-        self.assertEqual(status, 200)
+        self.assertEqual(status, 202)
         _assert_required_fields(self, data, self.FORCE_IMPORT_REQUIRED_FIELDS,
                                 "pipeline force-import response")
 
@@ -1772,16 +1824,15 @@ class TestManualImportRouteContracts(_WebServerCase):
         _assert_required_fields(self, data["folders"][0]["match"], self.MATCH_REQUIRED_FIELDS,
                                 "manual import match")
 
-    @patch("lib.import_dispatch.dispatch_import_from_db")
-    def test_manual_import_post_contract(self, mock_dispatch):
-        mock_dispatch.return_value = MagicMock(success=True, message="Imported")
-
+    @patch("web.routes.imports.resolve_failed_path",
+           return_value="/complete/Test Artist - Test Album")
+    def test_manual_import_post_contract(self, _mock_resolve):
         status, data = self._post(
             "/api/manual-import/import",
             {"request_id": 100, "path": "/complete/Test Artist - Test Album"},
         )
 
-        self.assertEqual(status, 200)
+        self.assertEqual(status, 202)
         _assert_required_fields(self, data, self.IMPORT_REQUIRED_FIELDS,
                                 "manual import response")
 

--- a/web/js/manual.js
+++ b/web/js/manual.js
@@ -62,6 +62,43 @@ export function renderManualImport(data, el) {
 }
 
 /**
+ * Poll a queued import job until completion or failure.
+ * @param {number} jobId
+ * @param {HTMLButtonElement} btn
+ */
+async function pollImportJob(jobId, btn) {
+  for (let i = 0; i < 240; i++) {
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    try {
+      const r = await fetch(`${API}/api/import-jobs/${jobId}`);
+      if (!r.ok) continue;
+      const data = await r.json();
+      const job = data.job || {};
+      if (job.status === 'queued' || job.status === 'running') {
+        btn.textContent = job.status[0].toUpperCase() + job.status.slice(1);
+        continue;
+      }
+      if (job.status === 'completed') {
+        btn.textContent = 'Imported';
+        btn.style.background = '#1a4a2a';
+        toast(job.message || 'Import completed');
+        return;
+      }
+      if (job.status === 'failed') {
+        btn.textContent = 'Failed';
+        btn.style.background = '#5a2a2a';
+        btn.style.color = '#f88';
+        toast(job.message || job.error || 'Import failed', true);
+        return;
+      }
+    } catch (_e) {
+      // Keep polling through transient request failures.
+    }
+  }
+  btn.textContent = 'Queued';
+}
+
+/**
  * Run manual import for a folder matched to a pipeline request.
  * @param {number} requestId
  * @param {string} path
@@ -78,10 +115,13 @@ export async function runManualImport(requestId, path, btn) {
       body: JSON.stringify({request_id: requestId, path: path}),
     });
     const data = await r.json();
-    if (data.status === 'ok') {
-      btn.textContent = 'Imported';
-      btn.style.background = '#1a4a2a';
-      toast(`Imported: ${data.artist} - ${data.album}`);
+    if (data.status === 'queued') {
+      btn.textContent = 'Queued';
+      btn.style.background = '#1a3654';
+      toast(`Queued import: ${data.artist} - ${data.album}`);
+      if (data.job_id) {
+        await pollImportJob(data.job_id, btn);
+      }
     } else {
       btn.textContent = 'Failed';
       btn.style.background = '#5a2a2a';

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -240,6 +240,8 @@ function renderGroup(g) {
 function renderEntry(e) {
   const detailId = `wm-entry-${e.download_log_id}`;
   const dist = e.distance != null ? e.distance.toFixed(3) : '?';
+  const job = e.import_job || null;
+  const jobBadge = job ? `<span class="badge" style="background:#222;color:#9bf;margin-left:8px;">${esc(job.status)}</span>` : '';
 
   const header = `
     <div class="p-item" style="background:#1a1a1a;margin:4px 0;" onclick="window.toggleWrongMatchEntry('${detailId}')">
@@ -247,6 +249,7 @@ function renderEntry(e) {
         <div>
           <span style="font-family:monospace;color:#aaa;">#${e.download_log_id}</span>
           <span style="color:#6a9;margin-left:8px;">${esc(e.soulseek_username || '?')}</span>
+          ${jobBadge}
         </div>
       </div>
       <div class="p-meta">
@@ -255,7 +258,7 @@ function renderEntry(e) {
       </div>
     </div>
     <div class="p-detail" id="${detailId}">
-      ${renderEntryDetail(e)}
+      ${renderEntryDetail(e, job)}
     </div>`;
 
   return header;
@@ -266,7 +269,7 @@ function renderEntry(e) {
  * @param {Object} e - entry payload
  * @returns {string}
  */
-function renderEntryDetail(e) {
+function renderEntryDetail(e, job) {
   let html = '';
   const c = e.candidate;
 
@@ -337,7 +340,9 @@ function renderEntryDetail(e) {
   }
 
   html += '<div class="p-actions" style="margin-top:10px;">';
-  html += `<button class="p-btn" style="border-color:#6a9;color:#6a9;" onclick="event.stopPropagation(); window.forceImportWrongMatch(${e.download_log_id}, this)">Force Import</button>`;
+  const active = job && (job.status === 'queued' || job.status === 'running');
+  const label = active ? job.status[0].toUpperCase() + job.status.slice(1) : 'Force Import';
+  html += `<button class="p-btn" style="border-color:#6a9;color:#6a9;" ${active ? 'disabled' : ''} onclick="event.stopPropagation(); window.forceImportWrongMatch(${e.download_log_id}, this)">${label}</button>`;
   html += `<button class="p-btn delete" onclick="event.stopPropagation(); window.deleteWrongMatch(${e.download_log_id}, this)">Delete</button>`;
   html += '</div>';
 
@@ -388,6 +393,45 @@ async function _refreshWrongMatches() {
 }
 
 /**
+ * Poll a queued import job until it reaches a terminal state.
+ * @param {number} jobId
+ * @param {HTMLButtonElement} btn
+ */
+async function _pollImportJob(jobId, btn) {
+  for (let i = 0; i < 240; i++) {
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    try {
+      const r = await fetch(`${API}/api/import-jobs/${jobId}`);
+      if (!r.ok) continue;
+      const data = await r.json();
+      const job = data.job || {};
+      if (job.status === 'queued' || job.status === 'running') {
+        btn.textContent = job.status[0].toUpperCase() + job.status.slice(1);
+        continue;
+      }
+      if (job.status === 'completed') {
+        btn.textContent = 'Imported';
+        btn.style.borderColor = '#6d6';
+        btn.style.color = '#6d6';
+        toast(job.message || 'Import completed');
+        invalidateWrongMatches();
+        await _refreshWrongMatches();
+        return;
+      }
+      if (job.status === 'failed') {
+        btn.textContent = 'Failed';
+        btn.style.color = '#f88';
+        toast(job.message || job.error || 'Import failed', true);
+        return;
+      }
+    } catch (_e) {
+      // Keep polling through transient web/DB errors.
+    }
+  }
+  btn.textContent = 'Queued';
+}
+
+/**
  * Force-import a wrong match.
  * @param {number} logId
  * @param {HTMLButtonElement} btn
@@ -403,16 +447,14 @@ export async function forceImportWrongMatch(logId, btn) {
       body: JSON.stringify({download_log_id: logId}),
     });
     const data = await r.json();
-    if (data.status === 'ok') {
-      btn.textContent = 'Imported';
-      btn.style.borderColor = '#6d6';
-      btn.style.color = '#6d6';
-      toast(`Force imported: ${data.artist} - ${data.album}`);
-      invalidateWrongMatches();
-      // A successful force-import cleans the source folder, so the entry (and
-      // possibly the whole group) should disappear. Refresh the view so the
-      // count badge and sibling list reflect the new state.
-      await _refreshWrongMatches();
+    if (data.status === 'queued') {
+      btn.textContent = data.deduped ? 'Queued' : 'Queued';
+      btn.style.borderColor = '#9bf';
+      btn.style.color = '#9bf';
+      toast(`Queued import: ${data.artist} - ${data.album}`);
+      if (data.job_id) {
+        await _pollImportJob(data.job_id, btn);
+      }
     } else {
       btn.textContent = 'Failed';
       btn.style.color = '#f88';

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -8,7 +8,13 @@ from lib.manual_import import (
     match_folders_to_requests,
     ImportRequest,
 )
+from lib.import_queue import (
+    IMPORT_JOB_MANUAL,
+    manual_import_dedupe_key,
+    manual_import_payload,
+)
 from lib.util import resolve_failed_path
+from web.routes.pipeline import _serialize_import_job
 
 
 def _server():
@@ -128,19 +134,29 @@ def post_manual_import(h, body: dict) -> None:
         h._error("Request has no MusicBrainz release ID")
         return
 
-    from lib.import_dispatch import dispatch_import_from_db
-    outcome = dispatch_import_from_db(
-        srv._db(), request_id=int(request_id), failed_path=path,
-        force=False, outcome_label="manual_import",
+    resolved_path = resolve_failed_path(str(path))
+    if resolved_path is None:
+        h._error(f"Files not found at: {path}")
+        return
+
+    job = srv._db().enqueue_import_job(
+        IMPORT_JOB_MANUAL,
+        request_id=int(request_id),
+        dedupe_key=manual_import_dedupe_key(int(request_id), resolved_path),
+        payload=manual_import_payload(failed_path=resolved_path),
+        message=f"Manual import queued for {req['artist_name']} - {req['album_title']}",
     )
 
     h._json({
-        "status": "ok" if outcome.success else "error",
-        "message": outcome.message,
+        "status": "queued",
+        "message": "Import queued",
+        "job_id": job.id,
+        "job": _serialize_import_job(job),
+        "deduped": bool(getattr(job, "deduped", False)),
         "request_id": request_id,
         "artist": req["artist_name"],
         "album": req["album_title"],
-    })
+    }, status=202)
 
 
 def _quality_summary(row: dict[str, object],
@@ -271,6 +287,17 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
     srv = _server()
     pdb = srv._db()
     rows = pdb.get_wrong_matches()
+    active_import_jobs = pdb.list_active_import_jobs(limit=200)
+    active_jobs_by_log_id: dict[int, object] = {}
+    active_jobs_by_request_id: dict[int, list[object]] = {}
+    for job in active_import_jobs:
+        payload = getattr(job, "payload", {}) or {}
+        request_id = getattr(job, "request_id", None)
+        if isinstance(request_id, int):
+            active_jobs_by_request_id.setdefault(request_id, []).append(job)
+        download_log_id = payload.get("download_log_id")
+        if isinstance(download_log_id, int):
+            active_jobs_by_log_id[download_log_id] = job
     mbids = [
         mbid for row in rows
         for mbid in [row.get("mb_release_id")]
@@ -309,6 +336,10 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
                 "in_library": in_library,
                 "pending_count": 0,
                 "entries": [],
+                "import_jobs": [
+                    _serialize_import_job(job)
+                    for job in active_jobs_by_request_id.get(request_id, [])
+                ],
                 "latest_import": None,  # filled in after the loop
                 **_quality_summary(row, beets_info, presence),
             }
@@ -329,6 +360,11 @@ def get_wrong_matches(h, params: dict[str, list[str]]) -> None:
                 or vr.get("soulseek_username"),
             "candidate": target,
             "local_items": vr.get("items", []),
+            "import_job": (
+                _serialize_import_job(active_jobs_by_log_id[row["download_log_id"]])
+                if row["download_log_id"] in active_jobs_by_log_id
+                else None
+            ),
         })
         group["pending_count"] = len(entries_list)
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -5,6 +5,11 @@ import re
 import msgspec
 
 from lib import transitions
+from lib.import_queue import (
+    IMPORT_JOB_FORCE,
+    force_import_dedupe_key,
+    force_import_payload,
+)
 from web.download_history_view import (
     build_download_history_row,
     build_download_history_rows,
@@ -290,6 +295,43 @@ def get_pipeline_detail(h, params: dict[str, list[str]], req_id_str: str) -> Non
         if tracks is not None:
             result["beets_tracks"] = tracks
     h._json(result)
+
+
+def _serialize_import_job(job) -> dict[str, object]:
+    if hasattr(job, "to_json_dict"):
+        return job.to_json_dict()
+    return dict(job)
+
+
+def get_import_jobs(h, params: dict[str, list[str]]) -> None:
+    status = params.get("status", [None])[0]
+    request_id_raw = params.get("request_id", [None])[0]
+    if status not in (None, "", "queued", "running", "completed", "failed"):
+        h._error("Invalid import job status")
+        return
+    status = status or None
+    try:
+        request_id = int(request_id_raw) if request_id_raw else None
+    except ValueError:
+        h._error("Invalid request_id")
+        return
+    jobs = _server()._db().list_import_jobs(
+        status=status,
+        request_id=request_id,
+        limit=50,
+    )
+    h._json({
+        "jobs": [_serialize_import_job(job) for job in jobs],
+        "counts": _server()._db().count_import_jobs_by_status(),
+    })
+
+
+def get_import_job(h, params: dict[str, list[str]], job_id_str: str) -> None:
+    job = _server()._db().get_import_job(int(job_id_str))
+    if job is None:
+        h._error("Import job not found", 404)
+        return
+    h._json({"job": _serialize_import_job(job)})
 
 
 # ── POST handlers ────────────────────────────────────────────────
@@ -747,8 +789,6 @@ def post_pipeline_ban_source(h, body: dict) -> None:
 
 
 def post_pipeline_force_import(h, body: dict) -> None:
-    from lib.import_dispatch import dispatch_import_from_db
-
     s = _server()
     log_id = body.get("download_log_id")
 
@@ -783,19 +823,28 @@ def post_pipeline_force_import(h, body: dict) -> None:
         h._error(f"Files not found at: {failed_path}")
         return
 
-    outcome = dispatch_import_from_db(
-        s._db(), request_id=request_id, failed_path=resolved_path,
-        force=True, outcome_label="force_import",
-        source_username=entry.get("soulseek_username"),
+    job = s._db().enqueue_import_job(
+        IMPORT_JOB_FORCE,
+        request_id=request_id,
+        dedupe_key=force_import_dedupe_key(int(log_id)),
+        payload=force_import_payload(
+            download_log_id=int(log_id),
+            failed_path=resolved_path,
+            source_username=entry.get("soulseek_username"),
+        ),
+        message=f"Force import queued for {req['artist_name']} - {req['album_title']}",
     )
 
     h._json({
-        "status": "ok" if outcome.success else "error",
+        "status": "queued",
+        "job_id": job.id,
+        "job": _serialize_import_job(job),
+        "deduped": bool(getattr(job, "deduped", False)),
         "request_id": request_id,
         "artist": req["artist_name"],
         "album": req["album_title"],
-        "message": outcome.message,
-    })
+        "message": "Import queued",
+    }, status=202)
 
 
 def post_pipeline_delete(h, body: dict) -> None:
@@ -821,10 +870,12 @@ GET_ROUTES: dict[str, object] = {
     "/api/pipeline/all": get_pipeline_all,
     "/api/pipeline/constants": get_pipeline_constants,
     "/api/pipeline/simulate": get_pipeline_simulate,
+    "/api/import-jobs": get_import_jobs,
 }
 
 GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/pipeline/(\d+)$"), get_pipeline_detail),
+    (re.compile(r"^/api/import-jobs/(\d+)$"), get_import_job),
 ]
 
 POST_ROUTES: dict[str, object] = {


### PR DESCRIPTION
## Summary

Cratedigger imports now flow through a durable Postgres queue instead of running beets-mutating work inline from web, CLI, or automation paths. Web requests and CLI commands enqueue work quickly, `cratedigger-importer` drains the queue serially, and operators can inspect queued, running, completed, and failed jobs through the API, UI, and CLI.

Closes #164.

## What Changed

| Area | Result |
| --- | --- |
| Queue storage | Added `import_jobs` with typed job payloads, active dedupe keys, claim metadata, and terminal result fields. |
| Import worker | Added `cratedigger-importer`, which claims jobs, runs the existing import dispatch paths, and records completed or failed state. |
| Restart recovery | Importer startup now takes a singleton DB advisory lock, requeues abandoned `running` jobs immediately, and retries them on the next claim. |
| Web and CLI | Force import, manual import, and CLI import commands now validate synchronously, enqueue jobs, and return job metadata instead of blocking on beets. |
| Automation | Completed download processing now submits `automation_import` jobs so the one importer service owns beets mutation. |
| Deployment | Nix installs and starts a long-lived `cratedigger-importer` service after DB migrations. |

## Compatibility Notes

Force/manual import callers now receive queued job metadata rather than the final import result in the initial response. The actual import outcome is available from `/api/import-jobs`, `/api/import-jobs/<id>`, and `pipeline-cli import-jobs`.

The existing import dispatch code still performs the beets work, quality gates, download log writes, request transitions, and advisory release/request locking. The queue changes the ownership boundary, not the import semantics.

## Testing

- `nix-shell --run "bash scripts/run_tests.sh"`: 2277 tests passed, 53 skipped.
- `git diff --check`: passed.
- `python -m py_compile ...`: passed for changed Python files.
- Focused queue, fake DB, PipelineDB, web route, CLI, Nix, and download poller tests were run during implementation.

## Post-Deploy Monitoring & Validation

Watch logs for the first deploy and first import cycle:

```bash
journalctl -u cratedigger-importer -f
journalctl -u cratedigger-web -f
```

Useful DB checks:

```sql
SELECT status, COUNT(*) FROM import_jobs GROUP BY status ORDER BY status;
SELECT id, job_type, status, attempts, worker_id, updated_at, error
FROM import_jobs
ORDER BY updated_at DESC, id DESC
LIMIT 20;
```

Healthy signals:

- `cratedigger-importer.service` is active after `cratedigger-db-migrate.service`.
- New force/manual/automation imports move `queued -> running -> completed` or a visible `failed` state.
- A deploy restart with an in-flight job logs a requeue and the job is retried immediately.
- Web import endpoints return `202` with `job_id`, and polling reaches a terminal job state.

Failure signals and mitigation:

- Repeated `failed` jobs with the same `error`, importer crash loops, or jobs stuck in `running` after the importer is active indicate intervention is needed.
- If a deploy causes repeated retries, stop `cratedigger-importer`, inspect the latest `import_jobs` rows and beets/file state, then either fix the job input or roll back to the previous Nix generation.

Validation window and owner: operator watches the first deploy plus the first successful web/automation import after deploy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)
