### PR TITLE
feat: gate imports with async previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,14 +438,16 @@ Shared infrastructure lives in `tests/fakes.py` (stateful fakes) and `tests/help
 
 ## Deployment
 
-Deployed via NixOS. The upstream module at [`nix/module.nix`](nix/module.nix) builds a Python environment with dependencies and registers four systemd units:
+Deployed via NixOS. The upstream module at [`nix/module.nix`](nix/module.nix) builds a Python environment with dependencies and registers the runtime systemd units:
 
 - `cratedigger-db-migrate.service` — oneshot, runs the schema migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch`. `restartIfChanged = true` + `RemainAfterExit = true` so it always re-evaluates when the unit derivation changes but doesn't re-run between cycles.
 - `cratedigger.service` — oneshot pipeline run, triggered by `cratedigger.timer`. Runs healthcheck → prestart (renders `config.ini`) → `cratedigger.py`. `restartIfChanged = false` so deploys don't restart it mid-cycle; the next timer fire picks up the new code.
 - `cratedigger.timer` — fires every 5 minutes by default (`services.cratedigger.timer.onUnitActiveSec`).
+- `cratedigger-importer.service` — long-running serial importer that drains `import_jobs` whose async preview stage marked them importable.
+- `cratedigger-import-preview-worker.service` — long-running async preview worker. It defaults to `services.cratedigger.importer.previewWorkers = 2`, claims queued preview work, and runs validation/spectral/measurement preview before the importer sees the job.
 - `cratedigger-web.service` — long-running web UI bound to `services.cratedigger.web.port` (default 8085).
 
-`cratedigger.service` and `cratedigger-web.service` both `requires` the migrate unit, so the app cannot start against an un-migrated DB.
+`cratedigger.service`, `cratedigger-importer.service`, `cratedigger-import-preview-worker.service`, and `cratedigger-web.service` all require the migrate unit, so the app cannot start against an un-migrated DB.
 
 To deploy a new revision:
 
@@ -463,6 +465,15 @@ sudo nixos-rebuild switch --flake .       # or via --flake github:user/repo#host
 ```
 
 `restartIfChanged = false` on `cratedigger.service` means the deploy completes without restarting an in-flight cycle; the next 5-min timer fire runs the new code.
+
+After deploying importer queue changes, check:
+
+```bash
+systemctl status cratedigger-db-migrate cratedigger-import-preview-worker cratedigger-importer
+journalctl -u cratedigger-import-preview-worker -u cratedigger-importer -n 100 --no-pager
+```
+
+Healthy state is: migrations applied, the preview worker running, queued jobs moving from `preview_status='waiting'` to `would_import` or a terminal preview failure, and the importer only claiming `would_import` jobs.
 
 ### Schema migrations
 

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -11,6 +11,18 @@ release or session close), and **reentrant within a session** (a second
 acquire of the same `(namespace, key)` in the same session always
 returns true).
 
+Async import preview workers do not take the importer singleton lock because
+they must not mutate beets or source folders. They claim `import_jobs` preview
+work through row-level `FOR UPDATE SKIP LOCKED` semantics, persist preview
+audit state, and mark only `would_import` jobs as importable for the serial
+worker.
+
+Outstanding follow-up: after the preview-gated queue has run in production,
+inventory IMPORT/RELEASE lock call sites and remove any lock whose only
+remaining purpose was cross-entrypoint beets import ownership. Until then, keep
+the locks as defensive guards around the existing dispatch internals. Tracking
+issue: <https://github.com/abl030/cratedigger/issues/169>.
+
 This doc is the single source of truth for namespaces, keys, ordering,
 and reentrancy. Add a new lock only after reading the rules below and
 updating both the **namespace table** and the **call-site index**.

--- a/docs/brainstorms/importer-queue-requirements.md
+++ b/docs/brainstorms/importer-queue-requirements.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-04-25
 topic: importer-queue
+updated: 2026-04-25
 ---
 
 # Importer Queue Requirements
@@ -17,6 +18,13 @@ The product direction is to replace scattered beets-import ownership with one
 queue-backed importer. Web actions and automation should submit import work to
 the same owner, and that owner should run beets-mutating work serially.
 
+After the shared queue exists, the next direction is to split import work into
+two stages: async preview/decision workers do CPU-heavy validation, spectral
+analysis, measurements, and would-import decisions; the serial beets importer
+only consumes jobs whose preview finished as importable. This should make the
+beets lane faster and easier to reason about without trying to prove beets can
+be written in parallel.
+
 This is not just a web responsiveness patch. The force-import false-toast and UI
 freeze should be fixed as a consequence of moving imports out of request
 handlers and into a shared importer queue.
@@ -24,6 +32,12 @@ handlers and into a shared importer queue.
 Current affected areas include `web/routes/pipeline.py`,
 `web/routes/imports.py`, `lib/download.py`, `lib/import_dispatch.py`, and
 `docs/advisory-locks.md`.
+
+The UI direction for the follow-on work is intentionally narrow: add a queue
+subview under Recents. It should show the beets import timeline in importable
+order, with the next import at the top. Async preview state enriches each row
+with values and color/status changes as it lands; it does not need highly live
+streaming updates or a separate admin dashboard.
 
 ---
 
@@ -38,6 +52,10 @@ Current affected areas include `web/routes/pipeline.py`,
   jobs run.
 - A5. Planner/implementer: Needs a clear target architecture that avoids adding
   another temporary queue beside the existing lock model.
+- A6. Async preview worker: Performs validation, spectral analysis,
+  measurement, and preview decisions before the beets importer claims a job.
+- A7. Deployer/operator: Tunes async worker concurrency on doc2 based on load,
+  swap pressure, and queue throughput.
 
 ---
 
@@ -82,6 +100,38 @@ Current affected areas include `web/routes/pipeline.py`,
     actually progressing.
   - **Covered by:** R2, R5, R8
 
+- F5. Async preview readiness
+  - **Trigger:** A queued import job lacks a completed preview decision.
+  - **Actors:** A3, A6
+  - **Steps:** A6 claims preview work, validates files, runs spectral analysis
+    and measurements, persists the preview values and verdict, and marks the job
+    importable, rejected, or errored.
+  - **Outcome:** CPU-heavy decision work happens before the serial beets lane,
+    and the final importer only sees jobs that are ready to import.
+  - **Covered by:** R8, R9, R12, R13, R14, R15
+
+- F6. Recents queue view
+  - **Trigger:** A1 opens Recents to see what will import next.
+  - **Actors:** A1, A4
+  - **Steps:** A4 shows a single import-order timeline, with the next
+    beets-importable job at the top, and enriches rows with preview values,
+    verdict colors, and failure messages as they are available.
+  - **Outcome:** The operator can see queue order and preview outcomes without
+    treating queue monitoring as a separate administration product.
+  - **Covered by:** R3, R5, R16, R17
+
+- F7. Wrong Matches preview backfill
+  - **Trigger:** A7 intentionally runs a maintenance backfill after deploy or
+    after preview-cache behavior changes.
+  - **Actors:** A1, A6, A7
+  - **Steps:** Existing Wrong Matches rows with resolvable files are previewed
+    and audited; historical rows without files and already-queued imports are
+    not swept by this command.
+  - **Outcome:** The visible Wrong Matches backlog can be reduced or annotated
+    once, while normal queued imports continue to be discovered by the preview
+    worker path.
+  - **Covered by:** R18, R19
+
 ---
 
 ## Requirements
@@ -112,14 +162,47 @@ Current affected areas include `web/routes/pipeline.py`,
 
 - R8. The importer must run beets-mutating execution serially. Parallelism may be
   introduced only outside the beets-mutation lane.
-- R9. A later staged design may run preflight or spectral work in parallel, but
-  final beets mutation must remain single-lane unless beets parallel write
-  safety is deliberately proven.
+- R9. Preflight, spectral, measurement, and preview-decision work may run in
+  parallel, but final beets mutation must remain single-lane unless beets
+  parallel write safety is deliberately proven.
 - R10. Once web and automation both use the importer, existing advisory-lock and
   import-state complexity should be reviewed for deletion or simplification
   rather than preserved by default.
 - R11. Queue semantics must prevent accidental duplicate web submissions from
   creating duplicate import work for the same source/request.
+
+**Async preview stage**
+
+- R12. Queued import jobs must have a preview/decision state that distinguishes
+  at least waiting, running, would-import, confident-reject, and uncertain/error.
+- R13. Async preview workers must persist validation, spectral, measurement, and
+  preview-decision values in durable audit state before a job becomes
+  beets-importable.
+- R14. The beets importer must only claim jobs whose preview state is complete
+  and importable.
+- R15. Preview confident-reject, uncertain, or error outcomes must fail or
+  resolve the import job with a clear operator-facing message, preserve audit
+  detail, and denylist the source when attribution exists and the failure
+  belongs to that downloaded source.
+
+**Recents queue visibility**
+
+- R16. Queue visualization must live under Recents as a queue subview, not as a
+  separate global admin dashboard.
+- R17. The Recents queue subview must show a single beets import timeline sorted
+  by importable order, with the next serial import at the top; preview values
+  and row color/status should fill in when async preview completes, without
+  requiring highly live streaming behavior.
+
+**Backfill and operations**
+
+- R18. Existing Wrong Matches rows with resolvable files must be previewable by
+  an explicit one-shot backfill path, not by an always-on historical scanner.
+- R19. Queued import jobs must be continuously rediscovered by the normal async
+  preview worker path so restarts do not lose readiness work.
+- R20. Async preview worker concurrency must be deployment-tunable, default to
+  two workers on doc2, and be adjusted only after monitoring CPU, swap pressure,
+  and queue throughput.
 
 ---
 
@@ -140,6 +223,21 @@ Current affected areas include `web/routes/pipeline.py`,
   importer, when reviewing `docs/advisory-locks.md` and related call sites, any
   lock whose only purpose was cross-entrypoint beets import concurrency is a
   candidate for removal.
+- AE5. **Covers R12, R13, R14.** Given a queued automation import lacks preview
+  values, when an async preview worker completes with `would_import`, the values
+  and verdict are visible in durable state and the beets importer can claim that
+  job on its next pass.
+- AE6. **Covers R15, R17.** Given async preview finishes as uncertain/error,
+  when the operator opens the Recents queue subview, the row shows a clear
+  failure message and does not enter the beets importable lane.
+- AE7. **Covers R16, R17.** Given several queued jobs have mixed preview states,
+  when the operator opens Recents, the queue subview shows one import-order
+  timeline with the next beets import at the top and row color/status indicating
+  preview progress or outcome.
+- AE8. **Covers R18, R19, R20.** Given the feature is deployed on doc2, when the
+  operator runs the one-shot Wrong Matches backfill with the default worker cap,
+  existing wrong-match files are previewed while normal queued import jobs remain
+  handled by the continuously rediscovered worker path.
 
 ---
 
@@ -151,6 +249,10 @@ Current affected areas include `web/routes/pipeline.py`,
   import paths.
 - Import progress and failures are observable from the UI and logs.
 - The architecture is simpler to explain: beets import mutation has one owner.
+- CPU-heavy preview work can be parallelized without making beets writes
+  parallel or racing the beets importer against the preview workers.
+- Recents gives the operator a clear next-import timeline with preview outcomes
+  and errors visible without building a full queue administration surface.
 - A planner can turn this document into an implementation plan without inventing
   product behavior, queue semantics, or migration intent.
 
@@ -164,12 +266,19 @@ Current affected areas include `web/routes/pipeline.py`,
   assumption is the opposite: beets mutation is serialized.
 - This does not remove all pipeline state. Search, download, request status, and
   import history remain meaningful durable concepts.
-- This does not require the first implementation to parallelize spectral or
-  preflight work.
+- The original shared-queue pass did not require parallel spectral or preflight
+  work. The follow-on async preview stage does parallelize that work, but only
+  before the serialized beets lane.
 - This does not require changing the UI into a full queue-management product.
-  The UI only needs enough visibility to make queued work understandable.
+  The UI only needs a Recents queue subview with import-order rows and preview
+  enrichment.
 - This does not require deleting existing advisory locks in the same first step.
   Deletion should happen after the shared importer owns the relevant paths.
+- This does not require prepared import staging. Durable converted artifacts,
+  staging cleanup, and artifact lifecycle should remain future work unless
+  conversion is measured as a real bottleneck.
+- This does not require an always-on historical preview scanner. Historical
+  Wrong Matches backfill is an explicit maintenance action.
 
 ---
 
@@ -182,6 +291,18 @@ Current affected areas include `web/routes/pipeline.py`,
   that assumption.
 - Keep queue state visible to the UI: batching many force-imports needs explicit
   feedback so the operator can tell queued work from a dead UI.
+- Use a two-stage import pipeline for the follow-on work: async preview workers
+  determine import readiness first, and the serial beets importer waits for
+  preview-ready importable jobs instead of racing to do the same CPU work.
+- Put queue visualization under Recents: the operator primarily wants to see
+  what will import next and why rows changed color, not manage a separate
+  queue-control dashboard.
+- Default async worker concurrency conservatively: doc2 has spare CPU in normal
+  samples but meaningful swap usage, so start with two workers and tune through
+  deployment configuration only after monitoring.
+- Keep prepared staging out of v1: async preview cache is the valuable first
+  step; durable converted artifacts should be added only if conversion time is
+  proven to slow the serial lane materially.
 - Treat lock simplification as a goal after migration: the queue should reduce
   the need for cross-entrypoint import locks, not become another layer added on
   top forever.
@@ -197,6 +318,12 @@ Current affected areas include `web/routes/pipeline.py`,
   queue while ownership is moved.
 - Duplicate submission handling is needed because operators may click multiple
   force-import rows quickly or retry while jobs are still visible.
+- The unified import preview path can evaluate real folders and typed values,
+  so async workers should reuse that decision vocabulary instead of creating a
+  second simulator.
+- doc2 deployment starts with two async preview workers and treats higher
+  concurrency as an operational tuning decision based on observed CPU, memory,
+  swap, disk, and queue-drain behavior.
 
 ---
 
@@ -208,17 +335,45 @@ Current affected areas include `web/routes/pipeline.py`,
 
 ### Deferred to Planning
 
-- [Affects R1, R3][Technical] Decide whether the queue state is DB-backed from
-  day one or introduced behind a smaller service boundary first.
-- [Affects R4, R10][Technical] Identify the safest migration sequence for moving
-  automation from direct import execution to queue submission.
-- [Affects R5][Technical] Decide whether queue visibility appears only in Wrong
-  Matches at first or as a global queue indicator.
-- [Affects R8, R9][Needs research] Identify which parts of the current import
-  path are pure/preflight work and which parts must stay inside the serialized
-  beets-mutation lane.
+- [Affects R12-R15][Technical] Decide the exact durable state shape for preview
+  readiness, preview audit values, and job failure messages.
+- [Affects R14][Technical] Decide how the beets importer orders and claims only
+  preview-ready importable jobs while preserving existing queue ordering.
+- [Affects R16, R17][Technical] Decide the smallest Recents subview data
+  contract that can render import order, preview values, colors, and errors.
+- [Affects R18][Technical] Decide the operator command or one-shot mode for
+  Wrong Matches backfill and how it reports skipped rows.
 - [Affects R10][Technical] Inventory which advisory locks or state-machine paths
   become redundant after the importer owns both web and automation imports.
+- [Affects R20][Operational] Define the deploy verification pattern for worker
+  count changes, including which doc2 metrics to check before increasing beyond
+  the default of two workers.
+
+### Post-Implementation Status
+
+The async preview queue plan implemented the R12-R20 follow-on work:
+
+- Durable preview state now lives on `import_jobs`.
+- Async preview workers claim waiting jobs, persist no-mutation preview audit,
+  and mark only `would_import` jobs importable.
+- The serial importer claims only queued jobs whose preview is complete and
+  importable.
+- Recents has a Queue subview backed by `/api/import-jobs/timeline`.
+- Wrong Matches preview backfill is an explicit operator command.
+- The NixOS module starts `cratedigger-import-preview-worker.service` with a
+  deployment-tunable worker count that defaults to two.
+
+Remaining long-tail work is not required for the feature to deploy:
+
+- Review and remove redundant advisory locks after production observation.
+- Add durable prepared staging or converted preview artifacts only if measured
+  conversion time keeps the serial beets lane slow.
+- Add richer queue management controls, such as retry/cancel/manual-review for
+  uncertain preview results, only if the Recents Queue view is not enough.
+- Tune `services.cratedigger.importer.previewWorkers` beyond two only after
+  observing CPU, swap, disk, and queue-drain behavior on doc2.
+
+Tracking issue: <https://github.com/abl030/cratedigger/issues/169>.
 
 ---
 

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -30,12 +30,13 @@ The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosMo
 | `releaseSettings.*` / `searchSettings.*` / `downloadSettings.*` | match config.ini defaults | Pipeline tunables. |
 | `qualityRanks.*` | mirror of `QualityRankConfig.defaults()` | See README § "Tuning the quality rank model". |
 | `timer.{enable,onBootSec,onUnitActiveSec}` | every 5 min | Cycle frequency. |
+| `importer.{enable,previewWorkers}` | enabled, `2` preview workers | Long-lived serial importer plus async preview worker concurrency. `previewWorkers` must be at least 1. |
 | `logging.{level,format,datefmt}` | INFO | Python logging config. |
 
 ## What the module does
 
 1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, slskd-api).
-2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH.
+2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `scripts/importer.py` / `scripts/import_preview_worker.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH.
 3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path.
 4. Pre-start: health-check slskd → render config.ini → start `cratedigger.py`.
 
@@ -44,6 +45,8 @@ The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosMo
 - `cratedigger-db-migrate.service` — oneshot, `restartIfChanged = true`, `RemainAfterExit = true`. Runs the schema migrator on every `nixos-rebuild switch`. Both `cratedigger.service` and `cratedigger-web.service` `requires` it, so the app cannot start against an un-migrated DB.
 - `cratedigger.service` — oneshot pipeline run. `restartIfChanged = false` (5-min timer picks up new code).
 - `cratedigger.timer` — fires every 5 minutes (configurable via `timer.onUnitActiveSec`).
+- `cratedigger-importer.service` — long-running serial beets import worker. It only claims queued import jobs after async preview marks them `would_import`.
+- `cratedigger-import-preview-worker.service` — long-running async preview worker. It starts after DB migrations, defaults to two worker loops, and runs validation/spectral/measurement preview outside the beets mutation lane.
 - `cratedigger-web.service` — long-running web UI for music.ablz.au.
 
 ## Sops + per-key secrets
@@ -89,3 +92,13 @@ nix build .#checks.x86_64-linux.moduleVm    # ~30s after first build
 ```
 
 This catches: option surface breakage, prestart sed-substitution bugs, systemd dep graph cycles, wrapper script PYTHONPATH errors, missing python deps. It does NOT exercise slskd interaction or real downloads (those need fixture data — see the python suite). Run before any `nix/module.nix` change.
+
+After deploy, verify the queue workers before assuming imports will drain:
+
+```bash
+systemctl status cratedigger-db-migrate cratedigger-import-preview-worker cratedigger-importer
+journalctl -u cratedigger-import-preview-worker -u cratedigger-importer -n 100 --no-pager
+```
+
+Queued jobs should move from `preview_status='waiting'` to `would_import` or a
+terminal preview failure. The importer should only claim `would_import` jobs.

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -46,12 +46,27 @@ Key fields:
   and CLI callers.
 - `attempts`, `worker_id`, `started_at`, `heartbeat_at`, `completed_at` —
   claim and recovery metadata.
+- `preview_status TEXT` — async readiness stage: `waiting`, `running`,
+  `would_import`, `confident_reject`, `uncertain`, or `error`.
+- `preview_result JSONB`, `preview_message`, `preview_error` — durable
+  no-mutation preview audit visible in Recents and CLI output.
+- `preview_attempts`, `preview_worker_id`, `preview_started_at`,
+  `preview_heartbeat_at`, `preview_completed_at` — async preview claim and
+  recovery metadata.
+- `importable_at TIMESTAMPTZ` — set when preview returns `would_import`; the
+  serial importer claims only queued jobs with this importable preview state.
 
 On importer startup, any pre-existing `running` job is treated as abandoned
 state from a previous worker process, reset to `queued`, and retried
 immediately. The importer also holds a DB advisory singleton lock while it
 runs, so an accidentally-started second worker exits instead of requeueing a
 live worker's job.
+
+Async preview workers run outside the beets mutation lane. They claim queued
+jobs with `preview_status='waiting'`, call the no-mutation import preview path,
+then either set `preview_status='would_import'` and `importable_at` or fail the
+job with preview audit details. This lets spectral/measurement work run with
+tunable parallelism while beets writes stay serial.
 
 ## `download_log.import_result` JSONB
 
@@ -127,5 +142,13 @@ review list.
 ```bash
 pipeline_cli.py force-import <download_log_id>
 pipeline_cli.py import-jobs --status failed
+pipeline_cli.py wrong-match-preview-backfill --json
 # or: POST /api/pipeline/force-import {"download_log_id": N}
 ```
+
+`wrong-match-preview-backfill` is intentionally one-shot maintenance, not a
+daemon. It previews currently visible Wrong Matches rows with resolvable source
+folders, skips rows whose files are gone, skips rows already represented by an
+active force-import job, and records preview audit without creating import jobs.
+Use `--cleanup` only when you want cleanup-eligible confident rejects deleted as
+part of the same pass.

--- a/docs/plans/2026-04-25-005-feat-async-preview-import-queue-plan.md
+++ b/docs/plans/2026-04-25-005-feat-async-preview-import-queue-plan.md
@@ -1,0 +1,814 @@
+---
+title: "feat: Add async preview gate to importer queue"
+type: feat
+status: completed
+date: 2026-04-25
+origin: docs/brainstorms/importer-queue-requirements.md
+deepened: 2026-04-25
+---
+
+# feat: Add async preview gate to importer queue
+
+## Overview
+
+Add a durable async preview stage in front of the existing shared importer
+queue. Preview workers should claim queued import jobs, run the no-mutation
+preview path, persist audit values and verdicts, and make only `would_import`
+jobs eligible for the serial beets importer.
+
+The existing queue architecture and unified import-preview service are
+prerequisites. This plan does not rebuild them. It extends them so CPU-heavy
+validation, spectral analysis, measurement, and would-import decisions can run
+in parallel while beets mutation remains a single lane.
+
+---
+
+## Problem Frame
+
+The current implementation already moved web, CLI, and automation imports into
+`import_jobs`, drained by `scripts/importer.py`, and exposed basic queue state.
+It also already has a synchronous preview seam in `lib/import_preview.py` and
+preview-driven Wrong Matches triage.
+
+The updated requirements push the architecture one stage further: queue jobs
+should not enter the beets lane until preview has completed and said the job is
+importable. Non-importable preview results should become visible operator
+messages and durable audit state, not late surprises inside the serial
+importer. Recents should expose the queue timeline as a subview, and historical
+Wrong Matches previewing should be an explicit one-shot operation (see origin:
+`docs/brainstorms/importer-queue-requirements.md`).
+
+---
+
+## Requirements Trace
+
+- R1. Preserve one importer owner for all beets-mutating import work.
+- R2. Preserve fast-return web force/manual import enqueue behavior.
+- R3. Extend job state so the UI can distinguish queued, previewing,
+  importable, running, completed, and failed work.
+- R4. Preserve automation submission through the same importer path.
+- R5. Keep Wrong Matches feedback for queued/running import work.
+- R6. Preserve existing durable request status and download/import history.
+- R7. Surface import and preview failures as job results with useful detail.
+- R8. Keep beets-mutating execution serial.
+- R9. Move preflight, spectral, measurement, and preview-decision work outside
+  the serial beets lane.
+- R10. Continue treating old advisory-lock and import-state complexity as
+  cleanup candidates after shared ownership is stable.
+- R11. Preserve duplicate-submission protection for the same source/request.
+- R12. Add preview/decision state for waiting, running, would-import,
+  confident-reject, uncertain, and error outcomes.
+- R13. Persist validation, spectral, measurement, and decision values before a
+  job becomes importable.
+- R14. Make the beets importer claim only jobs whose preview is complete and
+  importable.
+- R15. Convert confident-reject, uncertain, and error preview outcomes into
+  clear terminal job outcomes, preserve audit detail, and denylist source-owned
+  failures when attribution exists.
+- R16. Put queue visualization under Recents rather than a separate dashboard.
+- R17. Show a single beets import timeline sorted by importable order, with
+  preview values and row colors/statuses filling in as preview completes.
+- R18. Add an explicit one-shot Wrong Matches preview backfill path for
+  resolvable files.
+- R19. Continuously rediscover queued import jobs needing preview so restarts do
+  not lose readiness work.
+- R20. Make async preview worker concurrency deployment-tunable, with a default
+  of two workers for doc2.
+
+**Origin actors:** A1 Operator, A2 Automation pipeline, A3 Importer, A4 Web UI,
+A5 Planner/implementer, A6 Async preview worker, A7 Deployer/operator
+
+**Origin flows:** F1 Web force-import queueing, F2 Automation import queueing,
+F3 Import execution, F4 Queue visibility, F5 Async preview readiness,
+F6 Recents queue view, F7 Wrong Matches preview backfill
+
+**Origin acceptance examples:** AE1 long force-import stays responsive, AE2 web
+and automation share one beets lane, AE3 batch progress and failure visibility,
+AE4 lock simplification candidates after migration, AE5 preview makes a job
+importable, AE6 uncertain/error preview stays out of the beets lane, AE7 Recents
+queue timeline, AE8 doc2 backfill and preview worker operation
+
+---
+
+## Scope Boundaries
+
+- Do not make beets writes parallel. The importer remains a single worker lane.
+- Do not replace `lib/import_preview.py`; async workers should call that seam.
+- Do not make web requests perform preview work inline.
+- Do not add a standalone queue administration product. Recents gets a queue
+  subview.
+- Do not sweep all historical failed downloads continuously. Historical Wrong
+  Matches previewing is an explicit operator command.
+- Do not delete old advisory locks in the same pass unless the touched lock is
+  proven redundant by this implementation and covered by tests.
+- Do not make preview results silently clean or denylist sources without clear
+  source attribution.
+
+### Deferred to Follow-Up Work
+
+- Broad advisory-lock deletion: do after preview-gated import ownership has
+  landed and queue behavior has been observed.
+- Highly live UI streaming: periodic refresh or manual reload is enough for the
+  Recents queue subview.
+- A full operator control surface for retries/cancellation: keep this plan to
+  visibility, preview gating, and one-shot backfill.
+- Prepared staging or durable converted preview artifacts: add only if measured
+  conversion time remains a bottleneck after async previews are deployed.
+
+Tracking issue: <https://github.com/abl030/cratedigger/issues/169>.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `migrations/003_import_jobs.sql` defines the current shared queue table with
+  `queued`, `running`, `completed`, and `failed` status.
+- `lib/import_queue.py` contains `ImportJob`, job type constants, payload
+  validation, and dedupe-key helpers.
+- `lib/pipeline_db.py` owns queue persistence: enqueue, list, claim, complete,
+  fail, stale recovery, and active dedupe handling.
+- `scripts/importer.py` claims queued jobs and runs force/manual/automation
+  import work through one beets-mutating lane under the importer advisory lock.
+- `lib/import_preview.py` already answers `would_import`,
+  `confident_reject`, and `uncertain` for values, request/path pairs, and
+  download-log rows without mutating beets, source folders, DB state, queues, or
+  denylists.
+- `lib/wrong_match_triage.py` already persists preview-driven triage audit
+  details on `download_log.validation_result`.
+- `web/routes/pipeline.py` already exposes `/api/import-jobs` and
+  `/api/import-jobs/<id>` for queue polling.
+- `web/js/recents.js` is currently a simple history view over
+  `/api/pipeline/log`; `web/index.html` has a single Recents pane without
+  subviews.
+- `nix/module.nix` already creates `cratedigger-importer` as a long-lived
+  service, with wrapper/service assertions in `tests/test_nix_module.py`.
+- Project memory requires TDD and running Python/tests through `nix-shell`.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this checkout.
+- `.claude/memory/feedback_tdd.md` requires test-first work.
+- `.claude/memory/feedback_use_nix_shell.md` requires Python commands and tests
+  to run inside `nix-shell`.
+- `.claude/memory/project_audio_quality_types.md` reinforces that quality
+  decisions should be debuggable from structured measurements and audit fields.
+
+### External References
+
+- None. This work is driven by existing repo-local queue, preview, UI, and Nix
+  patterns.
+
+---
+
+## Key Technical Decisions
+
+- Store preview state on `import_jobs` rather than creating a separate preview
+  queue. The preview stage is a readiness gate for an import job, not a second
+  product queue.
+- Keep import `status` and preview state separate. `status` remains the terminal
+  job lifecycle (`queued`, `running`, `completed`, `failed`), while preview
+  fields explain whether a queued job is waiting, previewing, importable, or
+  rejected before beets mutation.
+- Make new jobs default to `preview_status='waiting'`. The serial importer
+  should claim only `status='queued'` and `preview_status='would_import'`.
+- Persist the full preview result as JSONB and also store summary fields for
+  filtering and UI sorting. The JSONB audit should include enough measurement
+  and stage-chain detail to explain the decision.
+- Treat non-importable preview results as terminal failed import jobs for now.
+  The job never reaches beets, but the operator sees one clear failed queue row
+  with preview detail.
+- Order the beets timeline by importable readiness first: importable jobs sort
+  by `importable_at`, then `created_at`, then `id`. Waiting/previewing jobs
+  stay visible below with their preview state.
+- Build the async preview worker as a long-lived producer of readiness state,
+  separate from `scripts/importer.py`. This keeps CPU-heavy preview work outside
+  the importer lock and lets deployment tune preview concurrency independently.
+- Keep Wrong Matches backfill explicit and bounded. It should operate only on
+  current resolvable Wrong Matches rows, skip rows already represented by active
+  import jobs, and record audit results.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Preview state storage: on `import_jobs`, because readiness belongs to the
+  queued import job and Recents needs one timeline.
+- Importer claim rule: claim only queued jobs with complete `would_import`
+  preview state.
+- Recents placement: add a Recents subview, not a new top-level nav item.
+- Historical preview sweep: one-shot CLI operation, not a daemon scanner.
+- Initial worker concurrency: expose a deployment knob and use two workers as
+  the doc2 default.
+
+### Deferred to Implementation
+
+- Exact column names for timestamps and worker identifiers. Prefer clear names
+  like `preview_started_at`, `preview_completed_at`, `preview_worker_id`, and
+  `importable_at`.
+- Exact denylist helper to call for preview rejections with source attribution.
+  Use the existing request/source denylist API that matches the rejection path
+  once the implementation is in the relevant call site.
+- Exact route spelling for the Recents queue API. Prefer a focused endpoint
+  such as `/api/import-jobs/timeline` if it keeps the existing
+  `/api/import-jobs` contract stable.
+- Exact preview-worker process model. A single process with multiple worker
+  loops is likely simplest, but separate systemd instances are acceptable if
+  they fit the Nix module better.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Web as web/CLI/automation producers
+    participant DB as import_jobs
+    participant Preview as preview workers
+    participant Importer as serial importer
+    participant Beets as beets/filesystem
+    participant Recents as Recents queue subview
+
+    Web->>DB: enqueue import job (preview_status=waiting)
+    Preview->>DB: claim waiting preview work
+    Preview->>Preview: run lib.import_preview no-mutation preview
+    Preview->>DB: persist preview result
+    alt would_import
+        Preview->>DB: preview_status=would_import, importable_at=now
+        Importer->>DB: claim next importable queued job
+        Importer->>Beets: mutate beets serially
+        Importer->>DB: completed/failed import result
+    else confident_reject / uncertain / error
+        Preview->>DB: status=failed with preview message/result
+    end
+    Recents->>DB: read timeline rows with preview/import state
+```
+
+Lifecycle overlay:
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued_waiting_preview
+    queued_waiting_preview --> queued_preview_running
+    queued_preview_running --> queued_importable
+    queued_preview_running --> failed_preview_reject
+    queued_preview_running --> failed_preview_uncertain
+    queued_preview_running --> failed_preview_error
+    queued_importable --> running_import
+    running_import --> completed
+    running_import --> failed_import
+```
+
+Plan dependency graph:
+
+```mermaid
+flowchart TB
+    U1[U1 schema and DB API]
+    U2[U2 preview worker]
+    U3[U3 importer gate]
+    U4[U4 Recents queue view]
+    U5[U5 Wrong Matches backfill]
+    U6[U6 deployment and docs]
+
+    U1 --> U2
+    U1 --> U3
+    U1 --> U4
+    U2 --> U3
+    U2 --> U4
+    U2 --> U5
+    U2 --> U6
+```
+
+---
+
+## Implementation Units
+
+- U1. **Add durable preview state to import jobs**
+
+**Goal:** Extend `import_jobs` and queue APIs so every import job can carry
+preview readiness, audit payloads, worker ownership, and UI-friendly summary
+state.
+
+**Requirements:** R3, R7, R11, R12, R13, R14, R15, R17, R19; F4, F5, F6; AE5,
+AE6, AE7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `migrations/004_import_job_previews.sql`
+- Modify: `lib/import_queue.py`
+- Modify: `lib/pipeline_db.py`
+- Modify: `tests/fakes.py`
+- Modify: `tests/test_fakes.py`
+- Test: `tests/test_pipeline_db.py`
+- Test: `tests/test_import_queue.py`
+- Test: `tests/test_migrator.py`
+
+**Approach:**
+- Add preview status values: `waiting`, `running`, `would_import`,
+  `confident_reject`, `uncertain`, and `error`.
+- Add columns for preview result JSONB, preview message/error, preview attempts,
+  preview worker id, preview start/heartbeat/completion timestamps, and
+  `importable_at`.
+- Backfill existing nonterminal import jobs to `preview_status='would_import'`
+  or choose a guarded migration behavior that avoids stranding jobs created
+  before this feature. Completed/failed historical jobs can leave preview fields
+  null or use a compatible default.
+- Extend `ImportJob` serialization so API callers get preview fields without
+  unpacking raw JSON.
+- Add DB methods to claim waiting preview work atomically, heartbeat preview
+  work, mark preview importable, fail a job from preview rejection/error, and
+  list a timeline sorted for Recents.
+- Preserve active dedupe behavior. A queued job waiting for preview is still an
+  active job for dedupe purposes.
+
+**Execution note:** Implement the migration and DB API test-first. These fields
+are the contract for every later unit.
+
+**Patterns to follow:**
+- `migrations/003_import_jobs.sql` for idempotent migration style.
+- `PipelineDB.claim_next_import_job` for `FOR UPDATE SKIP LOCKED` claiming.
+- `ImportJob.to_json_dict()` for API serialization.
+- `tests/fakes.py` and `tests/test_fakes.py` parity checks.
+
+**Test scenarios:**
+- Happy path: migrations create preview columns, constraints, and claim/list
+  indexes, and reapplying migrations is idempotent.
+- Happy path: a newly enqueued import job has `preview_status='waiting'` and is
+  returned by the preview claim API.
+- Happy path: marking preview `would_import` persists preview JSONB,
+  `preview_completed_at`, and `importable_at`.
+- Edge case: active dedupe still returns an existing queued job when it is
+  waiting or running preview.
+- Edge case: completed historical jobs serialize with preview fields absent or
+  null without breaking existing API contract tests.
+- Error path: invalid preview status cannot be inserted or passed through
+  typed validation.
+- Integration: two DB sessions cannot claim the same waiting preview job.
+- Integration: stale preview-running jobs are rediscovered for retry or failure
+  without touching already importable/completed/failed jobs.
+
+**Verification:**
+- Real PostgreSQL tests prove preview claim, persistence, dedupe, and timeline
+  ordering.
+- Fake parity tests pass with the new queue methods.
+
+---
+
+- U2. **Build async preview worker execution**
+
+**Goal:** Add a long-lived preview worker that continuously finds queued import
+jobs needing preview, runs the no-mutation preview seam, and persists the
+result before the importer can see the job.
+
+**Requirements:** R7, R8, R9, R12, R13, R15, R19, R20; F5; AE5, AE6, AE8
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `scripts/import_preview_worker.py`
+- Modify: `lib/import_queue.py`
+- Modify: `lib/pipeline_db.py`
+- Test: `tests/test_import_queue.py`
+- Test: `tests/test_import_preview.py`
+
+**Approach:**
+- Add worker code that opens DB connections, claims waiting preview work, runs
+  the existing preview function for the job type, persists the preview result,
+  and loops.
+- Resolve preview input from each existing job type:
+  - `force_import`: use payload `failed_path`, `request_id`,
+    `download_log_id`, `source_username`, and force preview semantics.
+  - `manual_import`: use payload `failed_path`, `request_id`, and non-force
+    preview semantics.
+  - `automation_import`: use `album_requests.active_download_state.current_path`
+    as the source path with non-force preview semantics, preserving existing
+    automation staging assumptions.
+- On `would_import`, mark the job importable and leave `status='queued'`.
+- On `confident_reject`, `uncertain`, or preview exception, mark the job
+  `status='failed'`, store the preview payload in `result`, and write an
+  operator-facing message that names the preview reason.
+- For source-owned confident rejections with attribution, call the existing
+  request/source denylist mechanism and record the denylist effect in the job
+  result. Avoid denylisting path-missing or attribution-free errors.
+- Do not clean source folders from the preview worker. Cleanup decisions remain
+  owned by existing Wrong Matches helpers or import-dispatch failure handling.
+- Support `--once`, `--poll-interval`, `--worker-id`, and a bounded concurrency
+  option so tests and services can run deterministically.
+
+**Execution note:** Start with unit tests around job-type-to-preview-input
+mapping and terminal status transitions before wiring the loop.
+
+**Patterns to follow:**
+- `scripts/importer.py` for DB setup, loop shape, worker id, and `--once`.
+- `lib.import_preview.preview_import_from_path` and
+  `preview_import_from_download_log` for no-mutation preview behavior.
+- `lib.download.reconstruct_grab_list_entry` and `ActiveDownloadState` parsing
+  patterns for automation job state.
+
+**Test scenarios:**
+- Covers AE5. Happy path: a force-import job previews as `would_import`, stores
+  preview measurements/stage chain, and becomes importable without changing
+  import `status` from `queued`.
+- Happy path: a manual-import job maps request id and failed path into
+  `preview_import_from_path` without force semantics.
+- Happy path: an automation job uses `active_download_state.current_path` and
+  stores an importable non-force preview result.
+- Error path: missing request, missing failed path, or missing automation
+  current path fails the job with a clear preview message.
+- Covers AE6. Error path: `uncertain` preview fails the job and never sets
+  `importable_at`.
+- Error path: preview exceptions fail the job while the worker can claim the
+  next job.
+- Integration: a restarted worker can claim jobs still waiting for preview and
+  can recover stale preview-running jobs according to the DB API.
+- Denylist path: source-attributed confident reject records denylist effect;
+  attribution-free or path-missing failures do not denylist.
+
+**Verification:**
+- Preview worker tests prove no beets-mutating import function is called.
+- Job results contain enough preview detail for API and logs to explain the
+  outcome.
+
+---
+
+- U3. **Gate the serial importer on preview readiness**
+
+**Goal:** Change the beets importer claim path so only preview-complete,
+importable jobs enter the serial beets lane.
+
+**Requirements:** R1, R3, R4, R6, R7, R8, R9, R14, R15; F2, F3, F5; AE2, AE5,
+AE6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `lib/pipeline_db.py`
+- Modify: `scripts/importer.py`
+- Modify: `tests/test_import_queue.py`
+- Modify: `tests/test_download.py`
+- Test: `tests/test_import_queue.py`
+- Test: `tests/test_download.py`
+
+**Approach:**
+- Update `PipelineDB.claim_next_import_job` to filter for `status='queued'` and
+  `preview_status='would_import'`.
+- Sort importable jobs by `importable_at`, then `created_at`, then `id`, so the
+  importer drains the same order Recents presents as the beets import timeline.
+- Ensure the importer does not treat waiting/previewing jobs as "no work" in a
+  misleading way. Logs can distinguish "no importable jobs" from "queue empty"
+  if that helps operations.
+- Preserve importer advisory-lock behavior. Preview workers must not take the
+  beets importer lock.
+- Preserve existing completion/failure writes from `scripts/importer.py`; final
+  import results should augment, not erase, preview audit data.
+- Make automation polling idempotent while a job is waiting for preview. Repeat
+  polls should dedupe to the active job and avoid treating preview wait time as
+  a download timeout.
+
+**Execution note:** Add regression tests that a queued job without importable
+preview is invisible to the importer before changing the claim query.
+
+**Patterns to follow:**
+- Existing `claim_next_import_job` atomic update pattern.
+- Existing automation enqueue tests around duplicate poll cycles in
+  `tests/test_download.py`.
+- `scripts/importer.py.process_claimed_job` result persistence.
+
+**Test scenarios:**
+- Covers AE5. Happy path: a job marked preview `would_import` is claimed and
+  executed by the importer.
+- Covers AE6. Error path: jobs with preview `waiting`, `running`,
+  `confident_reject`, `uncertain`, or `error` are not claimed by the importer.
+- Integration: a web force job and automation job both become importable and
+  are drained in `importable_at` order through one importer lane.
+- Error path: import failure preserves preview result fields and writes final
+  import error detail.
+- Edge case: repeated automation polls while preview is waiting/running return
+  the existing active job instead of enqueueing duplicates.
+- Edge case: stale importer recovery does not reset preview status or make a
+  never-previewed job importable.
+
+**Verification:**
+- Importer tests prove beets mutation can only begin after preview importable
+  state exists.
+- Existing web/automation queue contracts still pass with preview fields added.
+
+---
+
+- U4. **Add the Recents queue subview**
+
+**Goal:** Show the queue under Recents as one import-order timeline with
+preview and import status visible per row.
+
+**Requirements:** R3, R5, R7, R12, R13, R16, R17; F4, F6; AE3, AE6, AE7
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `web/index.html`
+- Modify: `web/js/recents.js`
+- Modify: `web/js/main.js`
+- Modify: `web/js/state.js`
+- Modify: `web/routes/pipeline.py`
+- Modify: `tests/test_web_server.py`
+- Test: `tests/test_web_server.py`
+- Test: `tests/test_web_recents.py`
+- Optional test: `tests/test_js_recents.mjs`
+
+**Approach:**
+- Add a small Recents subnav with existing history and new queue timeline
+  choices. Keep Recents as the top-level tab.
+- Add or extend an API route that returns timeline rows with job id, job type,
+  request identity, queue status, preview status, preview verdict, preview
+  message, stage chain, import status, created/importable/run/completed times,
+  and UI summary fields.
+- Sort rows with importable queued jobs first by `importable_at`, then
+  preview-running/waiting jobs, then terminal recent jobs. The first importable
+  queued row is the next beets import.
+- Use row color/status to distinguish waiting preview, preview running,
+  importable queued, importing, completed, and failed preview/import outcomes.
+- Include preview values and messages when present, but do not require live
+  streaming. Reload on subview open and poll at a modest interval only while
+  nonterminal jobs are visible.
+- Preserve the existing Recents history behavior and counts.
+
+**Execution note:** Start with route contract tests for the timeline payload,
+then add focused JS rendering tests if the DOM behavior is non-trivial.
+
+**Patterns to follow:**
+- `web/js/recents.js` rendering and `state.recentsFilter`.
+- Existing `/api/import-jobs` serialization in `web/routes/pipeline.py`.
+- `tests/test_web_server.py` route contract style.
+- Existing JS tests such as `tests/test_js_wrong_matches.mjs`.
+
+**Test scenarios:**
+- Covers AE7. Happy path: mixed preview states render in one timeline with the
+  importable queued job at the top.
+- Happy path: a `would_import` row displays preview measurements/verdict detail
+  and an importable/next status.
+- Covers AE6. Error path: an `uncertain` or preview error row displays the
+  preview failure message and is not styled as importable.
+- Integration: Recents history filter still loads from `/api/pipeline/log`
+  unchanged.
+- Edge case: empty queue subview renders a neutral empty state.
+- Edge case: terminal failed import row can show both preview detail and final
+  import error without overlapping text or hiding the key message.
+
+**Verification:**
+- Web contract tests prove API fields and sorting.
+- UI inspection or JS tests prove Recents contains the queue subview and row
+  statuses are readable.
+
+---
+
+- U5. **Add explicit Wrong Matches preview backfill**
+
+**Goal:** Provide a one-shot operator path to preview current Wrong Matches rows
+with resolvable files, record audit results, and skip historical rows that are
+not safe to process.
+
+**Requirements:** R12, R13, R15, R18, R19, R20; F7; AE8
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `lib/wrong_match_triage.py`
+- Modify: `scripts/pipeline_cli.py`
+- Modify: `lib/pipeline_db.py`
+- Modify: `tests/fakes.py`
+- Test: `tests/test_wrong_match_triage.py`
+- Test: `tests/test_pipeline_cli.py`
+- Test: `tests/test_pipeline_db.py`
+- Test: `tests/test_fakes.py`
+
+**Approach:**
+- Add an explicit CLI command for backfill, for example
+  `pipeline-cli wrong-match-preview-backfill`, or a clearly named mode on the
+  existing wrong-match triage command.
+- Process only rows currently returned by `get_wrong_matches()` whose
+  `failed_path` resolves on disk.
+- Skip rows that already have an active force-import job for their
+  `download_log_id` dedupe key.
+- Persist preview audit for every processed row using the existing
+  `record_wrong_match_triage` shape or a compatible extension that records
+  `action='preview_backfilled'`.
+- Keep cleanup conservative. The default should be audit-only; an explicit
+  cleanup flag may reuse current cleanup-eligible reject behavior if the user
+  wants the backfill to reduce the backlog.
+- Report counts for previewed, skipped missing files, skipped active jobs,
+  would-import, confident-reject, uncertain/error, cleaned, and cleanup-failed
+  rows.
+- Do not enqueue import jobs from this backfill. Normal queued imports continue
+  through the async preview worker path.
+
+**Execution note:** Add tests for skip rules and audit payloads before exposing
+the CLI command.
+
+**Patterns to follow:**
+- `triage_wrong_match` and `triage_wrong_matches` in
+  `lib/wrong_match_triage.py`.
+- `pipeline-cli wrong-match-triage` command parsing and JSON output.
+- `PipelineDB.get_import_job_by_dedupe_key` for active queued/running skip
+  checks.
+
+**Test scenarios:**
+- Covers AE8. Happy path: a resolvable Wrong Matches row is previewed, audited,
+  and reported in summary counts.
+- Happy path: audit-only mode keeps a cleanup-eligible confident reject visible
+  but records the preview verdict.
+- Happy path: cleanup mode deletes/clears only cleanup-eligible confident
+  rejects and reports cleanup counts.
+- Edge case: missing files are skipped and counted without preview execution.
+- Edge case: a row with an active queued/running force-import job is skipped and
+  counted.
+- Error path: preview exception records an uncertain/error audit result without
+  aborting the entire backfill.
+- Integration: JSON output is stable enough for deployment logs.
+
+**Verification:**
+- CLI tests prove the backfill is explicit, bounded, and auditable.
+- DB/fake tests prove audit data survives clearing rows when cleanup mode is
+  used.
+
+---
+
+- U6. **Wire deployment knobs and documentation**
+
+**Goal:** Package the async preview workers, expose concurrency tuning, and
+document the queue/preview operating model.
+
+**Requirements:** R8, R9, R10, R12, R13, R14, R16, R17, R18, R19, R20; F5, F6,
+F7; AE4, AE8
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `nix/module.nix`
+- Modify: `tests/test_nix_module.py`
+- Modify: `docs/pipeline-db-schema.md`
+- Modify: `docs/webui-primer.md`
+- Modify: `docs/advisory-locks.md`
+- Test: `tests/test_nix_module.py`
+
+**Approach:**
+- Add deployment wiring for the preview worker service using the same Python
+  environment and state directory patterns as `cratedigger-importer`.
+- Expose preview worker concurrency through Nix/module configuration and script
+  flags. The doc2 default should be two workers, with docs explaining that CPU,
+  swap pressure, and queue throughput should drive changes.
+- Pass concurrency by service/script flag in the first pass. Avoid adding a
+  config.ini field unless implementation finds a real non-Nix runtime need.
+- Ensure preview workers start after DB migrations and do not require the
+  importer advisory lock.
+- Update schema docs with preview fields, lifecycle, and importable claim
+  semantics.
+- Update web docs to describe the Recents queue subview.
+- Update advisory-lock docs to clarify that preview parallelism is outside the
+  beets mutation lane and that remaining import locks are cleanup candidates,
+  not the primary ownership model.
+
+**Execution note:** Start with Nix module text-contract tests so wrapper and
+service details stay consistent with existing deployment guarantees.
+
+**Patterns to follow:**
+- `cratedigger-importer` wrapper/service in `nix/module.nix`.
+- Existing `tests/test_nix_module.py` assertions for wrappers and service
+  dependencies.
+- `docs/pipeline-db-schema.md` import_jobs section.
+- `docs/webui-primer.md` route and UI summaries.
+
+**Test scenarios:**
+- Happy path: Nix module defines a preview worker wrapper and systemd service
+  that starts after `cratedigger-db-migrate.service`.
+- Happy path: preview worker service receives the configured worker count or
+  process count and defaults to two in the module.
+- Error path: invalid worker count is rejected by module or CLI parser tests.
+- Integration: preview worker service environment includes `PIPELINE_DB_DSN`
+  and uses the same state directory/PYTHONPATH wrapper discipline as importer.
+- Documentation expectation: docs describe preview state, Recents queue view,
+  backfill command, and tuning guidance.
+
+**Verification:**
+- Nix and config tests prove deployment knobs render correctly.
+- Docs give the deployer enough information to tune doc2 without reading source
+  code first.
+
+---
+
+## Risk Analysis & Mitigation
+
+- **Persistent migration risk:** Preview fields change the meaning of a queued
+  job. Mitigate by explicitly handling pre-existing nonterminal jobs in the
+  migration and adding real PostgreSQL tests for claim behavior before and
+  after preview fields are set.
+- **Preview failures blocking imports:** If preview worker deployment is broken,
+  new jobs will remain waiting and never import. Mitigate with clear Recents
+  waiting status, worker service tests, and logs that distinguish queue empty
+  from no importable jobs.
+- **False confident rejects:** Preview will prevent beets import before the
+  serial lane sees the job. Mitigate by preserving full preview audit detail,
+  treating uncertain as failed-visible rather than cleanup, and making cleanup
+  opt-in for backfill.
+- **Duplicate work during restarts:** Preview and importer workers both need
+  atomic claim semantics. Mitigate with `FOR UPDATE SKIP LOCKED`, stale-running
+  recovery tests, and active dedupe preservation.
+- **UI confusion from two lifecycles:** Import status and preview status can
+  diverge. Mitigate by keeping Recents copy/status concise: waiting preview,
+  previewing, importable, importing, completed, failed.
+- **Operational overload:** Spectral/measurement work can consume CPU and swap.
+  Mitigate with default two preview workers, deployment tuning docs, and a
+  single configurable knob.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Web routes, CLI commands, automation polling, preview
+  workers, the serial importer, Recents UI, and Wrong Matches triage all read or
+  write `import_jobs`. The plan keeps `lib/pipeline_db.py` as the persistence
+  boundary and `lib/import_queue.py` as the shared vocabulary so these surfaces
+  do not invent separate job states.
+- **Error propagation:** Preview failures should become terminal job failures
+  with `preview_status` and preview JSONB detail. Import failures should remain
+  final importer failures while preserving preview audit data. UI surfaces should
+  render the highest-signal message without requiring operators to inspect logs.
+- **State lifecycle risks:** A job can be queued but not importable, importable
+  but not yet running, running after preview, or failed before import. Claim
+  queries and stale recovery need to preserve these distinctions so restarts do
+  not make unpreviewed work importable or erase audit detail.
+- **API surface parity:** `/api/import-jobs`, the new Recents queue API, CLI
+  JSON output, and Nix-managed worker commands should expose compatible
+  vocabulary for status, preview status, verdict, message, timestamps, and job
+  ids.
+- **Integration coverage:** Unit tests alone will not prove the handoff. The
+  plan calls for DB-backed claim tests, worker transition tests, automation
+  dedupe tests, and web route/UI contract tests across preview and import
+  boundaries.
+- **Unchanged invariants:** Beets mutation remains single-lane; the synchronous
+  no-mutation preview service remains the decision seam; existing request
+  status and download history remain durable import history; active queue
+  dedupe still prevents duplicate work.
+
+---
+
+## Alternative Approaches Considered
+
+- **Separate `import_previews` queue table:** Rejected for the first pass because
+  preview readiness is part of one import job lifecycle. A separate queue would
+  make Recents join two product queues and increase state reconciliation risk.
+- **Run preview inside `scripts/importer.py`:** Rejected because it would put
+  CPU-heavy validation and spectral work back into the serial beets lane,
+  undermining R9 and reducing the payoff of the async stage.
+- **Let uncertain preview results remain queued for manual review:** Deferred.
+  Failing the job with a clear preview message gives operators visible state
+  now; retry/review controls can be a later queue-management feature.
+- **Automatically sweep all historical failed downloads:** Rejected by the
+  origin scope. The backfill should be explicit and limited to current Wrong
+  Matches rows with resolvable files.
+
+---
+
+## Phased Delivery
+
+1. Land U1 and U3 together or behind a compatibility migration path so existing
+   jobs cannot be stranded by the new claim gate.
+2. Land U2 with `--once` tests before enabling any long-lived deployment
+   service.
+3. Land U4 after preview and importer state are stable enough for a useful UI.
+4. Land U5 as an operator command after audit persistence is proven.
+5. Land U6 deployment wiring and docs when the worker command behavior is
+   stable.
+
+---
+
+## Documentation Plan
+
+- `docs/pipeline-db-schema.md`: add preview fields and lifecycle rules.
+- `docs/webui-primer.md`: document Recents queue subview and preview/import
+  states.
+- `docs/advisory-locks.md`: clarify preview worker parallelism versus serial
+  beets mutation.
+- `docs/brainstorms/importer-queue-requirements.md`: leave as origin input; do
+  not rewrite it as implementation progress.
+
+---
+
+## Sources & References
+
+- Origin document: `docs/brainstorms/importer-queue-requirements.md`
+- Completed queue prerequisite:
+  `docs/plans/2026-04-25-001-refactor-importer-queue-architecture-plan.md`
+- Completed preview prerequisite:
+  `docs/plans/2026-04-25-004-unified-import-preview-plan.md`
+- Existing queue implementation: `migrations/003_import_jobs.sql`,
+  `lib/import_queue.py`, `lib/pipeline_db.py`, `scripts/importer.py`
+- Existing preview implementation: `lib/import_preview.py`,
+  `lib/wrong_match_triage.py`, `scripts/pipeline_cli.py`

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -47,6 +47,7 @@ Browser → https://music.ablz.au
 | `/api/wrong-matches/converge` | POST | Queue every wrong-match candidate within a release's loosen threshold and delete the rest |
 | `/api/wrong-matches/delete-transparent-non-flac` | POST | Bulk-delete wrong-match folders whose exact library copy is already transparent and whose pending downloads are non-FLAC |
 | `/api/import-jobs` | GET | List recent import queue jobs |
+| `/api/import-jobs/timeline` | GET | List import queue jobs in Recents timeline order |
 | `/api/import-jobs/<id>` | GET | Poll a single import queue job |
 | `/api/library/artist?name=...` | GET | Albums by artist from beets library (MB vs Discogs source) |
 | `/api/discogs/search?q=...` | GET | Search Discogs mirror (artist or release mode via `type=` param) |
@@ -72,6 +73,10 @@ Browser → https://music.ablz.au
   `import_jobs`, so long beets imports do not block the web request. Failed
   queued force-imports remove the reviewed wrong-match source from the
   actionable list while preserving the failed job/download audit.
+- **Recents Queue subview** — Recents has History and Queue subviews. Queue
+  shows import jobs in beets-import order, with preview states (`waiting`,
+  `previewing`, `importable`, `uncertain`, `failed`) and preview messages
+  visible before the serial importer claims work.
 - **Wrong Matches Converge** — each release starts with a `180` milli-distance
   loosen threshold. Candidates at or below that threshold turn green; Converge
   queues those folders as force-import jobs and deletes the non-green folders
@@ -117,6 +122,9 @@ What this creates on doc2:
 - `cratedigger-web.service` — simple type, restart on failure, ExecStart wraps `web/server.py` with the python env from `nix/package.nix`
 - `cratedigger-importer.service` — long-lived worker that drains queued
   force/manual/automation imports after DB migrations have run
+- `cratedigger-import-preview-worker.service` — long-lived async preview worker
+  that prepares queued jobs for the serial importer; defaults to two worker
+  loops via `services.cratedigger.importer.previewWorkers`
 - `services.redis.servers.cratedigger` — provided by the homelab wrapper (not the upstream module)
 - `music.ablz.au` nginx reverse proxy via `homelab.localProxy.hosts` (homelab wrapper)
 - Cloudflare DNS + ACME cert auto-provisioned
@@ -133,6 +141,11 @@ ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --ref
 ```
 
 The service auto-restarts when the Nix store path changes.
+
+After deploy, check `systemctl status cratedigger-import-preview-worker
+cratedigger-importer` and the worker journals. The Recents Queue subview should
+show new rows move from waiting preview, to previewing, to importable or a
+terminal preview failure; only importable rows enter the serial importer lane.
 
 ## MusicBrainz API Usage
 

--- a/lib/import_queue.py
+++ b/lib/import_queue.py
@@ -18,6 +18,25 @@ IMPORT_JOB_TYPES = frozenset({
 })
 IMPORT_JOB_STATUSES = frozenset({"queued", "running", "completed", "failed"})
 IMPORT_JOB_ACTIVE_STATUSES = frozenset({"queued", "running"})
+IMPORT_JOB_PREVIEW_WAITING = "waiting"
+IMPORT_JOB_PREVIEW_RUNNING = "running"
+IMPORT_JOB_PREVIEW_WOULD_IMPORT = "would_import"
+IMPORT_JOB_PREVIEW_CONFIDENT_REJECT = "confident_reject"
+IMPORT_JOB_PREVIEW_UNCERTAIN = "uncertain"
+IMPORT_JOB_PREVIEW_ERROR = "error"
+IMPORT_JOB_PREVIEW_STATUSES = frozenset({
+    IMPORT_JOB_PREVIEW_WAITING,
+    IMPORT_JOB_PREVIEW_RUNNING,
+    IMPORT_JOB_PREVIEW_WOULD_IMPORT,
+    IMPORT_JOB_PREVIEW_CONFIDENT_REJECT,
+    IMPORT_JOB_PREVIEW_UNCERTAIN,
+    IMPORT_JOB_PREVIEW_ERROR,
+})
+IMPORT_JOB_PREVIEW_FAILURE_STATUSES = frozenset({
+    IMPORT_JOB_PREVIEW_CONFIDENT_REJECT,
+    IMPORT_JOB_PREVIEW_UNCERTAIN,
+    IMPORT_JOB_PREVIEW_ERROR,
+})
 
 
 @dataclass(frozen=True)
@@ -40,6 +59,16 @@ class ImportJob:
     started_at: datetime | None
     heartbeat_at: datetime | None
     completed_at: datetime | None
+    preview_status: str | None = None
+    preview_result: dict[str, Any] | None = None
+    preview_message: str | None = None
+    preview_error: str | None = None
+    preview_attempts: int = 0
+    preview_worker_id: str | None = None
+    preview_started_at: datetime | None = None
+    preview_heartbeat_at: datetime | None = None
+    preview_completed_at: datetime | None = None
+    importable_at: datetime | None = None
     deduped: bool = False
 
     @classmethod
@@ -47,6 +76,12 @@ class ImportJob:
         payload = _json_dict(row.get("payload"))
         result_raw = row.get("result")
         result = _json_dict(result_raw) if result_raw is not None else None
+        preview_result_raw = row.get("preview_result")
+        preview_result = (
+            _json_dict(preview_result_raw)
+            if preview_result_raw is not None
+            else None
+        )
         return cls(
             id=int(row["id"]),
             job_type=str(row["job_type"]),
@@ -84,6 +119,32 @@ class ImportJob:
             started_at=row.get("started_at"),
             heartbeat_at=row.get("heartbeat_at"),
             completed_at=row.get("completed_at"),
+            preview_status=(
+                str(row["preview_status"])
+                if row.get("preview_status") is not None
+                else None
+            ),
+            preview_result=preview_result,
+            preview_message=(
+                str(row["preview_message"])
+                if row.get("preview_message") is not None
+                else None
+            ),
+            preview_error=(
+                str(row["preview_error"])
+                if row.get("preview_error") is not None
+                else None
+            ),
+            preview_attempts=int(row.get("preview_attempts") or 0),
+            preview_worker_id=(
+                str(row["preview_worker_id"])
+                if row.get("preview_worker_id") is not None
+                else None
+            ),
+            preview_started_at=row.get("preview_started_at"),
+            preview_heartbeat_at=row.get("preview_heartbeat_at"),
+            preview_completed_at=row.get("preview_completed_at"),
+            importable_at=row.get("importable_at"),
             deduped=deduped,
         )
 
@@ -105,12 +166,32 @@ class ImportJob:
             "started_at": self.started_at,
             "heartbeat_at": self.heartbeat_at,
             "completed_at": self.completed_at,
+            "preview_status": self.preview_status,
+            "preview_result": self.preview_result,
+            "preview_message": self.preview_message,
+            "preview_error": self.preview_error,
+            "preview_attempts": self.preview_attempts,
+            "preview_worker_id": self.preview_worker_id,
+            "preview_started_at": self.preview_started_at,
+            "preview_heartbeat_at": self.preview_heartbeat_at,
+            "preview_completed_at": self.preview_completed_at,
+            "importable_at": self.importable_at,
             "deduped": self.deduped,
         }
 
     def to_json_dict(self) -> dict[str, Any]:
         result = self.to_dict()
-        for key in ("created_at", "updated_at", "started_at", "heartbeat_at", "completed_at"):
+        for key in (
+            "created_at",
+            "updated_at",
+            "started_at",
+            "heartbeat_at",
+            "completed_at",
+            "preview_started_at",
+            "preview_heartbeat_at",
+            "preview_completed_at",
+            "importable_at",
+        ):
             value = result[key]
             if hasattr(value, "isoformat"):
                 result[key] = value.isoformat()
@@ -138,6 +219,19 @@ def validate_job_type(job_type: str) -> str:
 def validate_status(status: str) -> str:
     if status not in IMPORT_JOB_STATUSES:
         raise ValueError(f"Invalid import job status: {status}")
+    return status
+
+
+def validate_preview_status(status: str) -> str:
+    if status not in IMPORT_JOB_PREVIEW_STATUSES:
+        raise ValueError(f"Invalid import job preview status: {status}")
+    return status
+
+
+def validate_preview_failure_status(status: str) -> str:
+    validate_preview_status(status)
+    if status not in IMPORT_JOB_PREVIEW_FAILURE_STATUSES:
+        raise ValueError(f"Invalid import job preview failure status: {status}")
     return status
 
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -23,6 +23,7 @@ import psycopg2.extras
 
 from lib.import_queue import (
     ImportJob,
+    validate_preview_failure_status,
     validate_job_type,
     validate_payload,
     validate_status,
@@ -332,6 +333,26 @@ class PipelineDB:
         """)
         return {str(row["status"]): int(row["count"]) for row in cur.fetchall()}
 
+    def list_import_job_timeline(self, *, limit: int = 50) -> list[ImportJob]:
+        cur = self._execute("""
+            SELECT *
+            FROM import_jobs
+            ORDER BY
+              CASE
+                WHEN status = 'queued' AND preview_status = 'would_import' THEN 0
+                WHEN status = 'running' THEN 1
+                WHEN status = 'queued' AND preview_status = 'running' THEN 2
+                WHEN status = 'queued' AND preview_status = 'waiting' THEN 3
+                ELSE 4
+              END,
+              importable_at ASC NULLS LAST,
+              created_at ASC,
+              updated_at DESC,
+              id ASC
+            LIMIT %s
+        """, (limit,))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
     def claim_next_import_job(
         self,
         *,
@@ -342,7 +363,8 @@ class PipelineDB:
                 SELECT id
                 FROM import_jobs
                 WHERE status = 'queued'
-                ORDER BY created_at ASC, id ASC
+                  AND preview_status = 'would_import'
+                ORDER BY importable_at ASC NULLS LAST, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
             )
@@ -487,6 +509,171 @@ class PipelineDB:
             WHERE import_jobs.id = running.id
             RETURNING import_jobs.*
         """, (limit, message))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
+    def claim_next_import_preview_job(
+        self,
+        *,
+        worker_id: str | None = None,
+    ) -> ImportJob | None:
+        cur = self._execute("""
+            WITH next_job AS (
+                SELECT id
+                FROM import_jobs
+                WHERE status = 'queued'
+                  AND preview_status = 'waiting'
+                ORDER BY created_at ASC, id ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+            )
+            UPDATE import_jobs
+            SET preview_status = 'running',
+                preview_attempts = preview_attempts + 1,
+                preview_worker_id = %s,
+                preview_started_at = COALESCE(preview_started_at, NOW()),
+                preview_heartbeat_at = NOW(),
+                preview_message = NULL,
+                preview_error = NULL,
+                updated_at = NOW()
+            FROM next_job
+            WHERE import_jobs.id = next_job.id
+            RETURNING import_jobs.*
+        """, (worker_id,))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def heartbeat_import_job_preview(self, job_id: int) -> bool:
+        cur = self._execute("""
+            UPDATE import_jobs
+            SET preview_heartbeat_at = NOW(), updated_at = NOW()
+            WHERE id = %s
+              AND status = 'queued'
+              AND preview_status = 'running'
+            RETURNING id
+        """, (job_id,))
+        return cur.fetchone() is not None
+
+    def mark_import_job_preview_importable(
+        self,
+        job_id: int,
+        *,
+        preview_result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        cur = self._execute("""
+            UPDATE import_jobs
+            SET preview_status = 'would_import',
+                preview_result = %s,
+                preview_message = %s,
+                preview_error = NULL,
+                preview_completed_at = NOW(),
+                importable_at = COALESCE(importable_at, NOW()),
+                preview_worker_id = NULL,
+                preview_heartbeat_at = NULL,
+                updated_at = NOW()
+            WHERE id = %s
+              AND status = 'queued'
+              AND preview_status IN ('waiting', 'running')
+            RETURNING *
+        """, (
+            psycopg2.extras.Json(preview_result or {}),
+            message,
+            job_id,
+        ))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def mark_import_job_preview_failed(
+        self,
+        job_id: int,
+        *,
+        preview_status: str,
+        error: str,
+        preview_result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        validate_preview_failure_status(preview_status)
+        result = dict(preview_result or {})
+        cur = self._execute("""
+            UPDATE import_jobs
+            SET status = 'failed',
+                preview_status = %s,
+                preview_result = %s,
+                preview_message = %s,
+                preview_error = %s,
+                result = %s,
+                message = %s,
+                error = %s,
+                preview_completed_at = NOW(),
+                completed_at = NOW(),
+                preview_worker_id = NULL,
+                preview_heartbeat_at = NULL,
+                updated_at = NOW()
+            WHERE id = %s
+              AND status = 'queued'
+              AND preview_status IN ('waiting', 'running')
+            RETURNING *
+        """, (
+            preview_status,
+            psycopg2.extras.Json(result),
+            message,
+            error,
+            psycopg2.extras.Json({"preview": result}),
+            message,
+            error,
+            job_id,
+        ))
+        row = cur.fetchone()
+        return ImportJob.from_row(dict(row)) if row else None
+
+    def list_stale_import_preview_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        cutoff = datetime.now(timezone.utc) - older_than
+        cur = self._execute("""
+            SELECT *
+            FROM import_jobs
+            WHERE status = 'queued'
+              AND preview_status = 'running'
+              AND COALESCE(preview_heartbeat_at, preview_started_at, updated_at) < %s
+            ORDER BY updated_at ASC, id ASC
+            LIMIT %s
+        """, (cutoff, limit))
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
+    def requeue_stale_import_preview_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        cutoff = datetime.now(timezone.utc) - older_than
+        cur = self._execute("""
+            WITH stale AS (
+                SELECT id
+                FROM import_jobs
+                WHERE status = 'queued'
+                  AND preview_status = 'running'
+                  AND COALESCE(preview_heartbeat_at, preview_started_at, updated_at) < %s
+                ORDER BY updated_at ASC, id ASC
+                LIMIT %s
+            )
+            UPDATE import_jobs
+            SET preview_status = 'waiting',
+                preview_message = %s,
+                preview_error = NULL,
+                preview_worker_id = NULL,
+                preview_started_at = NULL,
+                preview_heartbeat_at = NULL,
+                updated_at = NOW()
+            FROM stale
+            WHERE import_jobs.id = stale.id
+            RETURNING import_jobs.*
+        """, (cutoff, limit, message))
         return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
 
     # --- album_requests CRUD ---

--- a/lib/wrong_match_triage.py
+++ b/lib/wrong_match_triage.py
@@ -7,6 +7,8 @@ from typing import Any
 import msgspec
 
 from lib.import_preview import ImportPreviewResult, preview_import_from_download_log
+from lib.import_queue import force_import_dedupe_key
+from lib.util import resolve_failed_path
 from lib.wrong_matches import cleanup_wrong_match_source, dismiss_wrong_match_source
 
 
@@ -127,3 +129,92 @@ def triage_wrong_matches(
         if limit is not None and len(results) >= limit:
             break
     return results
+
+
+def _summary_template() -> dict[str, int]:
+    return {
+        "previewed": 0,
+        "would_import": 0,
+        "confident_reject": 0,
+        "uncertain_or_error": 0,
+        "cleaned": 0,
+        "cleanup_failed": 0,
+        "skipped_missing_files": 0,
+        "skipped_active_jobs": 0,
+        "skipped_invalid_rows": 0,
+    }
+
+
+def _failed_path_from_row(row: dict[str, object]) -> str | None:
+    vr = row.get("validation_result")
+    if isinstance(vr, str):
+        try:
+            decoded = msgspec.json.decode(vr)
+        except msgspec.DecodeError:
+            return None
+        vr = decoded if isinstance(decoded, dict) else None
+    if not isinstance(vr, dict):
+        return None
+    failed_path = vr.get("failed_path")
+    return str(failed_path) if failed_path else None
+
+
+def _count_preview(summary: dict[str, int], preview: ImportPreviewResult) -> None:
+    summary["previewed"] += 1
+    if preview.would_import:
+        summary["would_import"] += 1
+    elif preview.confident_reject:
+        summary["confident_reject"] += 1
+    else:
+        summary["uncertain_or_error"] += 1
+
+
+def backfill_wrong_match_previews(
+    db: Any,
+    *,
+    request_id: int | None = None,
+    limit: int | None = None,
+    cleanup: bool = False,
+) -> dict[str, int]:
+    """Explicit one-shot preview backfill for current Wrong Matches rows."""
+    summary = _summary_template()
+    for row in db.get_wrong_matches():
+        if request_id is not None and row.get("request_id") != request_id:
+            continue
+        raw_id = row.get("download_log_id") or row.get("id")
+        if not isinstance(raw_id, int):
+            summary["skipped_invalid_rows"] += 1
+            continue
+        failed_path = _failed_path_from_row(row)
+        if not failed_path or resolve_failed_path(failed_path) is None:
+            summary["skipped_missing_files"] += 1
+            continue
+        active_job = db.get_import_job_by_dedupe_key(
+            force_import_dedupe_key(raw_id),
+        )
+        if active_job is not None:
+            summary["skipped_active_jobs"] += 1
+            continue
+
+        if cleanup:
+            result = triage_wrong_match(db, raw_id)
+            if result.preview is not None:
+                _count_preview(summary, result.preview)
+            if result.action == "deleted_reject" and result.success:
+                summary["cleaned"] += 1
+            elif result.action == "delete_failed":
+                summary["cleanup_failed"] += 1
+        else:
+            preview = preview_import_from_download_log(db, raw_id)
+            _count_preview(summary, preview)
+            _persist_triage_audit(db, WrongMatchTriageResult(
+                download_log_id=raw_id,
+                action="preview_backfilled",
+                success=True,
+                reason=preview.reason,
+                preview=preview,
+            ))
+
+        if limit is not None and summary["previewed"] >= limit:
+            break
+    return summary

--- a/migrations/004_import_job_previews.sql
+++ b/migrations/004_import_job_previews.sql
@@ -1,0 +1,50 @@
+-- 004_import_job_previews.sql - async import preview gate
+--
+-- Preview state lives on import_jobs because preview is a readiness stage for
+-- the same queued import work drained by the serial beets importer.
+
+ALTER TABLE import_jobs
+    ADD COLUMN IF NOT EXISTS preview_status TEXT NOT NULL DEFAULT 'waiting'
+        CHECK (
+            preview_status IN (
+                'waiting',
+                'running',
+                'would_import',
+                'confident_reject',
+                'uncertain',
+                'error'
+            )
+        ),
+    ADD COLUMN IF NOT EXISTS preview_result JSONB,
+    ADD COLUMN IF NOT EXISTS preview_message TEXT,
+    ADD COLUMN IF NOT EXISTS preview_error TEXT,
+    ADD COLUMN IF NOT EXISTS preview_attempts INTEGER NOT NULL DEFAULT 0
+        CHECK (preview_attempts >= 0),
+    ADD COLUMN IF NOT EXISTS preview_worker_id TEXT,
+    ADD COLUMN IF NOT EXISTS preview_started_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS preview_heartbeat_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS preview_completed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS importable_at TIMESTAMPTZ;
+
+-- Jobs already queued before this migration were created under the pre-preview
+-- contract. Let them drain instead of waiting for a preview worker that did not
+-- exist when they were enqueued.
+UPDATE import_jobs
+SET preview_status = 'would_import',
+    preview_message = COALESCE(preview_message, 'Queued before async preview gate'),
+    preview_completed_at = COALESCE(preview_completed_at, updated_at, NOW()),
+    importable_at = COALESCE(importable_at, created_at, NOW())
+WHERE status IN ('queued', 'running')
+  AND preview_status = 'waiting'
+  AND preview_attempts = 0
+  AND preview_result IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_preview_claim
+    ON import_jobs(preview_status, created_at, id)
+    WHERE status = 'queued'
+      AND preview_status = 'waiting';
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_importable_claim
+    ON import_jobs(status, preview_status, importable_at, created_at, id)
+    WHERE status = 'queued'
+      AND preview_status = 'would_import';

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -70,6 +70,14 @@
       --dsn "${cfg.pipelineDb.dsn}" "$@"
   '';
 
+  previewWorkerPkg = pkgs.writeShellScriptBin "cratedigger-import-preview-worker" ''
+    export PATH="${runtimePath}:$PATH"
+    export PYTHONPATH="${src}:''${PYTHONPATH:-}"
+    exec ${pythonEnv}/bin/python ${src}/scripts/import_preview_worker.py \
+      --dsn "${cfg.pipelineDb.dsn}" \
+      --workers ${toString cfg.importer.previewWorkers} "$@"
+  '';
+
   webPkg = pkgs.writeShellScriptBin "cratedigger-web" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:''${PYTHONPATH:-}"
@@ -303,6 +311,11 @@ in {
         type = types.bool;
         default = true;
         description = "Run the long-lived importer worker that drains the shared import queue.";
+      };
+      previewWorkers = mkOption {
+        type = types.int;
+        default = 2;
+        description = "Number of async import preview workers to run before the serial importer lane.";
       };
     };
 
@@ -630,9 +643,13 @@ in {
         assertion = !cfg.notifiers.jellyfin.enable || (cfg.notifiers.jellyfin.tokenFile != null && cfg.notifiers.jellyfin.url != "");
         message = "services.cratedigger.notifiers.jellyfin: enable requires url and tokenFile";
       }
+      {
+        assertion = cfg.importer.previewWorkers >= 1;
+        message = "services.cratedigger.importer.previewWorkers must be at least 1";
+      }
     ];
 
-    environment.systemPackages = [pipelineCli pipelineMigrate importerPkg pkgs.postgresql];
+    environment.systemPackages = [pipelineCli pipelineMigrate importerPkg previewWorkerPkg pkgs.postgresql];
 
     users.users = mkIf (cfg.user != "root") {
       ${cfg.user} = {
@@ -721,6 +738,26 @@ in {
         ExecStartPre = [preStartScript];
         Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
         ExecStart = "${importerPkg}/bin/cratedigger-importer";
+        WorkingDirectory = cfg.stateDir;
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+
+    systemd.services.cratedigger-import-preview-worker = mkIf cfg.importer.enable {
+      description = "Cratedigger async import preview worker";
+      after = ["cratedigger-db-migrate.service"];
+      requires = ["cratedigger-db-migrate.service"];
+      wantedBy = ["multi-user.target"];
+      path = [pkgs.bash pkgs.coreutils pkgs.gnugrep pkgs.gnused pkgs.curl pkgs.jq pkgs.ffmpeg pkgs.mp3val pkgs.flac pkgs.sox];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        UMask = "0000";
+        ExecStartPre = [preStartScript];
+        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        ExecStart = "${previewWorkerPkg}/bin/cratedigger-import-preview-worker";
         WorkingDirectory = cfg.stateDir;
         Restart = "on-failure";
         RestartSec = 5;

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Run async no-mutation previews for queued import jobs."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import socket
+import sys
+import threading
+import time
+from datetime import timedelta
+from typing import Any
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from lib.import_preview import ImportPreviewResult, preview_import_from_path
+from lib.import_queue import (
+    IMPORT_JOB_AUTOMATION,
+    IMPORT_JOB_FORCE,
+    IMPORT_JOB_MANUAL,
+    ImportJob,
+)
+from lib.pipeline_db import DEFAULT_DSN, PipelineDB
+from lib.quality import ActiveDownloadState
+
+logger = logging.getLogger("cratedigger-import-preview-worker")
+STALE_PREVIEW_MESSAGE = "Preview worker restarted while job was running; retry queued"
+
+
+def _preview_result_dict(result: ImportPreviewResult) -> dict[str, Any]:
+    return result.to_dict()
+
+
+def _preview_reason(result: ImportPreviewResult) -> str:
+    return result.reason or result.decision or result.verdict
+
+
+def _failure_preview_status(result: ImportPreviewResult) -> str:
+    if result.confident_reject:
+        return "confident_reject"
+    if result.uncertain:
+        return "uncertain"
+    return "error"
+
+
+def _state_from_raw(raw: Any) -> ActiveDownloadState:
+    if isinstance(raw, dict):
+        return ActiveDownloadState.from_dict(raw)
+    if isinstance(raw, str):
+        return ActiveDownloadState.from_json(raw)
+    raise ValueError("Automation import job has no active_download_state")
+
+
+def _first_state_username(state: ActiveDownloadState) -> str | None:
+    for file_state in state.files:
+        if file_state.username:
+            return file_state.username
+    return None
+
+
+def _preview_input(db: Any, job: ImportJob) -> dict[str, Any]:
+    if job.request_id is None:
+        raise ValueError("Import job has no request_id")
+
+    payload = job.payload or {}
+    if job.job_type == IMPORT_JOB_FORCE:
+        failed_path = payload.get("failed_path")
+        if not isinstance(failed_path, str) or not failed_path:
+            raise ValueError("Force import preview job is missing failed_path")
+        source_username = payload.get("source_username")
+        download_log_id = payload.get("download_log_id")
+        return {
+            "request_id": job.request_id,
+            "path": failed_path,
+            "force": True,
+            "source_username": (
+                str(source_username) if source_username is not None else None
+            ),
+            "download_log_id": (
+                int(download_log_id)
+                if isinstance(download_log_id, int)
+                else None
+            ),
+        }
+
+    if job.job_type == IMPORT_JOB_MANUAL:
+        failed_path = payload.get("failed_path")
+        if not isinstance(failed_path, str) or not failed_path:
+            raise ValueError("Manual import preview job is missing failed_path")
+        return {
+            "request_id": job.request_id,
+            "path": failed_path,
+            "force": False,
+            "source_username": None,
+            "download_log_id": None,
+        }
+
+    if job.job_type == IMPORT_JOB_AUTOMATION:
+        row = db.get_request(job.request_id)
+        if not row:
+            raise ValueError(f"Album request {job.request_id} not found")
+        state = _state_from_raw(row.get("active_download_state"))
+        if not state.current_path:
+            raise ValueError(
+                f"Album request {job.request_id} has no active download path"
+            )
+        return {
+            "request_id": job.request_id,
+            "path": state.current_path,
+            "force": False,
+            "source_username": _first_state_username(state),
+            "download_log_id": None,
+        }
+
+    raise ValueError(f"Unsupported import job type: {job.job_type}")
+
+
+def execute_preview_job(db: Any, job: ImportJob) -> ImportPreviewResult:
+    preview_input = _preview_input(db, job)
+    return preview_import_from_path(db, **preview_input)
+
+
+def _denylist_confident_reject(
+    db: Any,
+    job: ImportJob,
+    result: ImportPreviewResult,
+) -> dict[str, Any] | None:
+    if not result.confident_reject or job.request_id is None:
+        return None
+    if result.reason == "path_missing":
+        return None
+
+    try:
+        preview_input = _preview_input(db, job)
+    except Exception:
+        return None
+    source_username = preview_input.get("source_username")
+    if not source_username:
+        return None
+
+    add_denylist = getattr(db, "add_denylist", None)
+    if not callable(add_denylist):
+        return None
+    reason = f"import preview rejected: {_preview_reason(result)}"
+    add_denylist(job.request_id, str(source_username), reason)
+    return {
+        "request_id": job.request_id,
+        "username": str(source_username),
+        "reason": reason,
+    }
+
+
+def process_claimed_preview_job(db: Any, job: ImportJob) -> ImportJob | None:
+    try:
+        result = execute_preview_job(db, job)
+    except Exception as exc:
+        logger.exception("Import job %s preview crashed", job.id)
+        return db.mark_import_job_preview_failed(
+            job.id,
+            preview_status="error",
+            error=type(exc).__name__,
+            preview_result={
+                "verdict": "error",
+                "reason": type(exc).__name__,
+                "detail": str(exc),
+            },
+            message=f"Preview failed: {exc}",
+        )
+
+    preview_payload = _preview_result_dict(result)
+    if result.would_import:
+        return db.mark_import_job_preview_importable(
+            job.id,
+            preview_result=preview_payload,
+            message=f"Preview would import: {_preview_reason(result)}",
+        )
+
+    denylist = _denylist_confident_reject(db, job, result)
+    if denylist is not None:
+        preview_payload["denylist"] = denylist
+    reason = _preview_reason(result)
+    return db.mark_import_job_preview_failed(
+        job.id,
+        preview_status=_failure_preview_status(result),
+        error=reason,
+        preview_result=preview_payload,
+        message=f"Preview failed: {reason}",
+    )
+
+
+def run_once(db: PipelineDB, *, worker_id: str) -> ImportJob | None:
+    job = db.claim_next_import_preview_job(worker_id=worker_id)
+    if job is None:
+        return None
+    logger.info("Claimed import preview job %s (%s)", job.id, job.job_type)
+    return process_claimed_preview_job(db, job)
+
+
+def recover_abandoned_preview_jobs(
+    db: PipelineDB,
+    *,
+    older_than: timedelta = timedelta(hours=1),
+) -> list[ImportJob]:
+    return db.requeue_stale_import_preview_jobs(
+        older_than=older_than,
+        message=STALE_PREVIEW_MESSAGE,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run async previews for Cratedigger import jobs",
+    )
+    parser.add_argument("--dsn", default=DEFAULT_DSN)
+    parser.add_argument("--poll-interval", type=float, default=5.0)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--worker-id", default=None)
+    parser.add_argument("--workers", type=int, default=1)
+    args = parser.parse_args()
+    if args.workers < 1:
+        parser.error("--workers must be >= 1")
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    worker_id = args.worker_id or f"{socket.gethostname()}:{os.getpid()}"
+    db = PipelineDB(args.dsn)
+    try:
+        recovered = recover_abandoned_preview_jobs(db)
+        if recovered:
+            logger.warning(
+                "Requeued %s abandoned import preview job(s)",
+                len(recovered),
+            )
+
+        if args.workers > 1 and not args.once:
+            stop = threading.Event()
+
+            def worker_loop(index: int) -> None:
+                thread_db = PipelineDB(args.dsn)
+                thread_worker_id = f"{worker_id}:preview-{index}"
+                try:
+                    while not stop.is_set():
+                        job = run_once(thread_db, worker_id=thread_worker_id)
+                        if job is None:
+                            time.sleep(args.poll_interval)
+                finally:
+                    thread_db.close()
+
+            threads = [
+                threading.Thread(target=worker_loop, args=(i,), daemon=False)
+                for i in range(args.workers)
+            ]
+            for thread in threads:
+                thread.start()
+            try:
+                for thread in threads:
+                    thread.join()
+            except KeyboardInterrupt:
+                stop.set()
+                for thread in threads:
+                    thread.join()
+            return 0
+
+        while True:
+            job = run_once(db, worker_id=worker_id)
+            if args.once:
+                return 0
+            if job is None:
+                time.sleep(args.poll_interval)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1295,6 +1295,25 @@ def cmd_wrong_match_triage(db, args):
     return 0
 
 
+def cmd_wrong_match_preview_backfill(db, args):
+    """Run explicit preview backfill for current Wrong Matches rows."""
+    from lib.wrong_match_triage import backfill_wrong_match_previews
+
+    summary = backfill_wrong_match_previews(
+        db,
+        request_id=args.request_id,
+        limit=args.limit,
+        cleanup=args.cleanup,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    for key, count in sorted(summary.items()):
+        print(f"  {key}: {count}")
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description="Pipeline CLI — manage download pipeline DB")
     parser.add_argument("--dsn", default=DEFAULT_DSN, help="PostgreSQL connection string")
@@ -1417,6 +1436,19 @@ def main():
                           help="Maximum candidates to triage")
     p_triage.add_argument("--json", action="store_true")
 
+    # wrong-match-preview-backfill
+    p_backfill = sub.add_parser(
+        "wrong-match-preview-backfill",
+        help="One-shot preview audit for current Wrong Matches rows",
+    )
+    p_backfill.add_argument("--request-id", type=int,
+                            help="Limit backfill to one request")
+    p_backfill.add_argument("--limit", type=int,
+                            help="Maximum candidates to preview")
+    p_backfill.add_argument("--cleanup", action="store_true",
+                            help="Delete only cleanup-eligible confident rejects")
+    p_backfill.add_argument("--json", action="store_true")
+
     # repair-spectral
     p_repair = sub.add_parser("repair-spectral",
                               help="Fix albums stuck by stale current_spectral_bitrate (#18)")
@@ -1446,6 +1478,7 @@ def main():
         "import-jobs": cmd_import_jobs,
         "import-preview": cmd_import_preview,
         "wrong-match-triage": cmd_wrong_match_triage,
+        "wrong-match-preview-backfill": cmd_wrong_match_preview_backfill,
         "repair-spectral": cmd_repair_spectral,
     }
     commands[args.command](db, args)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -14,7 +14,13 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterator
 
-from lib.import_queue import ImportJob, validate_job_type, validate_payload, validate_status
+from lib.import_queue import (
+    ImportJob,
+    validate_job_type,
+    validate_preview_failure_status,
+    validate_payload,
+    validate_status,
+)
 from lib.pipeline_db import BACKOFF_BASE_MINUTES, BACKOFF_MAX_MINUTES, RequestSpectralStateUpdate
 from lib.release_identity import ReleaseIdentity, normalize_release_id
 
@@ -408,6 +414,16 @@ class FakePipelineDB:
             "started_at": None,
             "heartbeat_at": None,
             "completed_at": None,
+            "preview_status": "waiting",
+            "preview_result": None,
+            "preview_message": None,
+            "preview_error": None,
+            "preview_attempts": 0,
+            "preview_worker_id": None,
+            "preview_started_at": None,
+            "preview_heartbeat_at": None,
+            "preview_completed_at": None,
+            "importable_at": None,
         }
         self._import_jobs.append(row)
         return ImportJob.from_row(copy.deepcopy(row))
@@ -473,6 +489,31 @@ class FakePipelineDB:
             counts[status] = counts.get(status, 0) + 1
         return counts
 
+    def list_import_job_timeline(self, *, limit: int = 50) -> list[ImportJob]:
+        def sort_key(row: dict[str, Any]) -> tuple[int, datetime, datetime, datetime, int]:
+            status = row.get("status")
+            preview_status = row.get("preview_status")
+            if status == "queued" and preview_status == "would_import":
+                bucket = 0
+            elif status == "running":
+                bucket = 1
+            elif status == "queued" and preview_status == "running":
+                bucket = 2
+            elif status == "queued" and preview_status == "waiting":
+                bucket = 3
+            else:
+                bucket = 4
+            return (
+                bucket,
+                _as_datetime(row.get("importable_at")),
+                _as_datetime(row.get("created_at")),
+                _as_datetime(row.get("updated_at")),
+                int(row["id"]),
+            )
+
+        rows = sorted(self._import_jobs, key=sort_key)
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows[:limit]]
+
     def claim_next_import_job(
         self,
         *,
@@ -481,8 +522,13 @@ class FakePipelineDB:
         queued = [
             row for row in self._import_jobs
             if row.get("status") == "queued"
+            and row.get("preview_status") == "would_import"
         ]
-        queued.sort(key=lambda row: (_as_datetime(row.get("created_at")), row["id"]))
+        queued.sort(key=lambda row: (
+            _as_datetime(row.get("importable_at")),
+            _as_datetime(row.get("created_at")),
+            row["id"],
+        ))
         if not queued:
             return None
         row = queued[0]
@@ -608,6 +654,153 @@ class FakePipelineDB:
             row["heartbeat_at"] = None
             row["updated_at"] = now
             updated_jobs.append(ImportJob.from_row(copy.deepcopy(row)))
+        return updated_jobs
+
+    def claim_next_import_preview_job(
+        self,
+        *,
+        worker_id: str | None = None,
+    ) -> ImportJob | None:
+        queued = [
+            row for row in self._import_jobs
+            if row.get("status") == "queued"
+            and row.get("preview_status") == "waiting"
+        ]
+        queued.sort(key=lambda row: (_as_datetime(row.get("created_at")), row["id"]))
+        if not queued:
+            return None
+        row = queued[0]
+        now = _utcnow()
+        row["preview_status"] = "running"
+        row["preview_attempts"] = int(row.get("preview_attempts") or 0) + 1
+        row["preview_worker_id"] = worker_id
+        row["preview_started_at"] = row.get("preview_started_at") or now
+        row["preview_heartbeat_at"] = now
+        row["preview_message"] = None
+        row["preview_error"] = None
+        row["updated_at"] = now
+        return ImportJob.from_row(copy.deepcopy(row))
+
+    def heartbeat_import_job_preview(self, job_id: int) -> bool:
+        for row in self._import_jobs:
+            if (
+                row["id"] == job_id
+                and row.get("status") == "queued"
+                and row.get("preview_status") == "running"
+            ):
+                now = _utcnow()
+                row["preview_heartbeat_at"] = now
+                row["updated_at"] = now
+                return True
+        return False
+
+    def mark_import_job_preview_importable(
+        self,
+        job_id: int,
+        *,
+        preview_result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        for row in self._import_jobs:
+            if (
+                row["id"] == job_id
+                and row.get("status") == "queued"
+                and row.get("preview_status") in ("waiting", "running")
+            ):
+                now = _utcnow()
+                row["preview_status"] = "would_import"
+                row["preview_result"] = copy.deepcopy(preview_result or {})
+                row["preview_message"] = message
+                row["preview_error"] = None
+                row["preview_completed_at"] = now
+                row["importable_at"] = row.get("importable_at") or now
+                row["preview_worker_id"] = None
+                row["preview_heartbeat_at"] = None
+                row["updated_at"] = now
+                return ImportJob.from_row(copy.deepcopy(row))
+        return None
+
+    def mark_import_job_preview_failed(
+        self,
+        job_id: int,
+        *,
+        preview_status: str,
+        error: str,
+        preview_result: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> ImportJob | None:
+        validate_preview_failure_status(preview_status)
+        result = copy.deepcopy(preview_result or {})
+        for row in self._import_jobs:
+            if (
+                row["id"] == job_id
+                and row.get("status") == "queued"
+                and row.get("preview_status") in ("waiting", "running")
+            ):
+                now = _utcnow()
+                row["status"] = "failed"
+                row["preview_status"] = preview_status
+                row["preview_result"] = result
+                row["preview_message"] = message
+                row["preview_error"] = error
+                row["result"] = {"preview": copy.deepcopy(result)}
+                row["message"] = message
+                row["error"] = error
+                row["preview_completed_at"] = now
+                row["completed_at"] = now
+                row["preview_worker_id"] = None
+                row["preview_heartbeat_at"] = None
+                row["updated_at"] = now
+                return ImportJob.from_row(copy.deepcopy(row))
+        return None
+
+    def list_stale_import_preview_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        cutoff = _utcnow() - older_than
+        rows = []
+        for row in self._import_jobs:
+            if row.get("status") != "queued" or row.get("preview_status") != "running":
+                continue
+            last = _as_datetime(
+                row.get("preview_heartbeat_at")
+                or row.get("preview_started_at")
+                or row.get("updated_at")
+            )
+            if last < cutoff:
+                rows.append(row)
+        rows.sort(key=lambda row: (_as_datetime(row.get("updated_at")), row["id"]))
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows[:limit]]
+
+    def requeue_stale_import_preview_jobs(
+        self,
+        *,
+        older_than: timedelta,
+        message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]:
+        stale = self.list_stale_import_preview_jobs(
+            older_than=older_than,
+            limit=limit,
+        )
+        updated_jobs = []
+        for job in stale:
+            for row in self._import_jobs:
+                if row["id"] != job.id:
+                    continue
+                now = _utcnow()
+                row["preview_status"] = "waiting"
+                row["preview_message"] = message
+                row["preview_error"] = None
+                row["preview_worker_id"] = None
+                row["preview_started_at"] = None
+                row["preview_heartbeat_at"] = None
+                row["updated_at"] = now
+                updated_jobs.append(ImportJob.from_row(copy.deepcopy(row)))
+                break
         return updated_jobs
 
     # --- PipelineDB interface methods ---

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -525,6 +525,11 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         self.assertEqual(first.id, duplicate.id)
         self.assertTrue(duplicate.deduped)
         self.assertEqual(db.count_import_jobs_by_status(), {"queued": 1})
+        db.mark_import_job_preview_importable(
+            first.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
+        )
 
         claimed = db.claim_next_import_job(worker_id="fake-worker")
         assert claimed is not None
@@ -566,6 +571,58 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         )
         assert failed is not None
         self.assertEqual(failed.status, "failed")
+
+    def test_import_job_preview_methods_mirror_core_lifecycle(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        db = FakePipelineDB()
+        queued = db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key="manual:preview",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.assertEqual(queued.preview_status, "waiting")
+
+        claimed = db.claim_next_import_preview_job(worker_id="fake-preview")
+        assert claimed is not None
+        self.assertEqual(claimed.status, "queued")
+        self.assertEqual(claimed.preview_status, "running")
+        self.assertEqual(claimed.preview_attempts, 1)
+        self.assertEqual(claimed.preview_worker_id, "fake-preview")
+        self.assertTrue(db.heartbeat_import_job_preview(claimed.id))
+
+        importable = db.mark_import_job_preview_importable(
+            claimed.id,
+            preview_result={"verdict": "would_import"},
+            message="Preview would import",
+        )
+        assert importable is not None
+        self.assertEqual(importable.preview_status, "would_import")
+        self.assertEqual(importable.preview_result, {"verdict": "would_import"})
+        self.assertIsNotNone(importable.importable_at)
+
+        rejected = db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=43,
+            dedupe_key="manual:preview-reject",
+            payload=manual_import_payload(failed_path="/tmp/reject"),
+        )
+        failed = db.mark_import_job_preview_failed(
+            rejected.id,
+            preview_status="confident_reject",
+            error="spectral_reject",
+            preview_result={
+                "verdict": "confident_reject",
+                "reason": "spectral_reject",
+            },
+            message="Preview rejected: spectral_reject",
+        )
+        assert failed is not None
+        self.assertEqual(failed.status, "failed")
+        self.assertEqual(failed.preview_status, "confident_reject")
+        self.assertEqual(failed.preview_error, "spectral_reject")
+        self.assertEqual(failed.error, "spectral_reject")
 
     def test_add_request_assigns_monotonic_id(self):
         db = FakePipelineDB()

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -17,11 +17,21 @@ from lib.import_queue import (
     manual_import_dedupe_key,
     manual_import_payload,
 )
+from lib.import_preview import ImportPreviewResult
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
 
 class TestImporterWorker(unittest.TestCase):
+    def _mark_importable(self, db: FakePipelineDB, job):
+        updated = db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
+        )
+        assert updated is not None
+        return updated
+
     def _log_wrong_match(
         self,
         db: FakePipelineDB,
@@ -55,6 +65,7 @@ class TestImporterWorker(unittest.TestCase):
                 source_username="alice",
             ),
         )
+        self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="worker")
         assert claimed is not None
 
@@ -81,12 +92,13 @@ class TestImporterWorker(unittest.TestCase):
         from scripts import importer
 
         db = FakePipelineDB()
-        db.enqueue_import_job(
+        job = db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=42,
             dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
             payload=manual_import_payload(failed_path="/tmp/manual"),
         )
+        self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="worker")
         assert claimed is not None
 
@@ -110,7 +122,7 @@ class TestImporterWorker(unittest.TestCase):
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
             log_id = self._log_wrong_match(db, failed_path=source)
-            db.enqueue_import_job(
+            job = db.enqueue_import_job(
                 IMPORT_JOB_FORCE,
                 request_id=42,
                 dedupe_key=force_import_dedupe_key(log_id),
@@ -120,6 +132,7 @@ class TestImporterWorker(unittest.TestCase):
                     source_username="alice",
                 ),
             )
+            self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
 
@@ -145,7 +158,7 @@ class TestImporterWorker(unittest.TestCase):
         source = tempfile.mkdtemp()
         try:
             log_id = self._log_wrong_match(db, failed_path=source, username="old")
-            db.enqueue_import_job(
+            job = db.enqueue_import_job(
                 IMPORT_JOB_FORCE,
                 request_id=42,
                 dedupe_key=force_import_dedupe_key(log_id),
@@ -155,6 +168,7 @@ class TestImporterWorker(unittest.TestCase):
                     source_username="alice",
                 ),
             )
+            self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
 
@@ -190,12 +204,13 @@ class TestImporterWorker(unittest.TestCase):
         source = tempfile.mkdtemp()
         try:
             self._log_wrong_match(db, failed_path=source)
-            db.enqueue_import_job(
+            job = db.enqueue_import_job(
                 IMPORT_JOB_MANUAL,
                 request_id=42,
                 dedupe_key=manual_import_dedupe_key(42, source),
                 payload=manual_import_payload(failed_path=source),
             )
+            self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
 
@@ -220,7 +235,7 @@ class TestImporterWorker(unittest.TestCase):
         source = tempfile.mkdtemp()
         try:
             log_id = self._log_wrong_match(db, failed_path=source)
-            db.enqueue_import_job(
+            job = db.enqueue_import_job(
                 IMPORT_JOB_FORCE,
                 request_id=42,
                 dedupe_key=force_import_dedupe_key(log_id),
@@ -229,6 +244,7 @@ class TestImporterWorker(unittest.TestCase):
                     failed_path=source,
                 ),
             )
+            self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
 
@@ -254,12 +270,13 @@ class TestImporterWorker(unittest.TestCase):
         from scripts import importer
 
         db = FakePipelineDB()
-        db.enqueue_import_job(
+        job = db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=42,
             dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
             payload=manual_import_payload(failed_path="/tmp/manual"),
         )
+        self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="old-worker")
         assert claimed is not None
 
@@ -282,6 +299,19 @@ class TestImporterWorker(unittest.TestCase):
         assert retried is not None
         self.assertEqual(retried.attempts, 2)
 
+    def test_importer_does_not_claim_job_waiting_for_preview(self):
+        from scripts import importer
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+
+        self.assertIsNone(importer.run_once(db, worker_id="worker"))
+
     def test_automation_job_reconstructs_active_state_and_uses_processing_path(self):
         from scripts import importer
 
@@ -300,12 +330,13 @@ class TestImporterWorker(unittest.TestCase):
                 }],
             },
         ))
-        db.enqueue_import_job(
+        job = db.enqueue_import_job(
             IMPORT_JOB_AUTOMATION,
             request_id=42,
             dedupe_key=automation_import_dedupe_key(42),
             payload={},
         )
+        self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="worker")
         assert claimed is not None
 
@@ -323,3 +354,192 @@ class TestImporterWorker(unittest.TestCase):
         assert updated is not None
         self.assertEqual(updated.status, "completed")
         self.assertEqual(updated.message, "Automation import processing completed")
+
+
+class TestImportPreviewWorker(unittest.TestCase):
+    def _preview(
+        self,
+        verdict: str,
+        *,
+        reason: str | None = None,
+    ) -> ImportPreviewResult:
+        return ImportPreviewResult(
+            mode="path",
+            verdict=verdict,
+            would_import=verdict == "would_import",
+            confident_reject=verdict == "confident_reject",
+            uncertain=verdict == "uncertain",
+            decision=reason,
+            reason=reason,
+            stage_chain=[f"preview:{reason or verdict}"],
+        )
+
+    def test_force_job_preview_would_import_marks_importable(self):
+        from scripts import import_preview_worker
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(7),
+            payload=force_import_payload(
+                download_log_id=7,
+                failed_path="/tmp/failed",
+                source_username="alice",
+            ),
+        )
+        claimed = db.claim_next_import_preview_job(worker_id="preview")
+        assert claimed is not None
+
+        with patch(
+            "scripts.import_preview_worker.preview_import_from_path",
+            return_value=self._preview("would_import", reason="import"),
+        ) as preview:
+            updated = import_preview_worker.process_claimed_preview_job(db, claimed)
+
+        preview.assert_called_once_with(
+            db,
+            request_id=42,
+            path="/tmp/failed",
+            force=True,
+            source_username="alice",
+            download_log_id=7,
+        )
+        assert updated is not None
+        self.assertEqual(updated.status, "queued")
+        self.assertEqual(updated.preview_status, "would_import")
+        self.assertEqual(updated.preview_result["verdict"], "would_import")
+        self.assertIsNotNone(updated.importable_at)
+
+    def test_manual_job_preview_uses_non_force_semantics(self):
+        from scripts import import_preview_worker
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=42,
+            dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        claimed = db.claim_next_import_preview_job(worker_id="preview")
+        assert claimed is not None
+
+        with patch(
+            "scripts.import_preview_worker.preview_import_from_path",
+            return_value=self._preview("would_import", reason="import"),
+        ) as preview:
+            updated = import_preview_worker.process_claimed_preview_job(db, claimed)
+
+        preview.assert_called_once_with(
+            db,
+            request_id=42,
+            path="/tmp/manual",
+            force=False,
+            source_username=None,
+            download_log_id=None,
+        )
+        assert updated is not None
+        self.assertEqual(updated.preview_status, "would_import")
+
+    def test_automation_job_preview_uses_active_download_current_path(self):
+        from scripts import import_preview_worker
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={
+                "filetype": "flac",
+                "enqueued_at": "2026-04-25T00:00:00+00:00",
+                "current_path": "/tmp/staged",
+                "files": [{
+                    "username": "alice",
+                    "filename": "Artist\\Album\\01.flac",
+                    "file_dir": "Artist\\Album",
+                    "size": 123,
+                }],
+            },
+        ))
+        db.enqueue_import_job(
+            IMPORT_JOB_AUTOMATION,
+            request_id=42,
+            dedupe_key=automation_import_dedupe_key(42),
+            payload={},
+        )
+        claimed = db.claim_next_import_preview_job(worker_id="preview")
+        assert claimed is not None
+
+        with patch(
+            "scripts.import_preview_worker.preview_import_from_path",
+            return_value=self._preview("would_import", reason="import"),
+        ) as preview:
+            updated = import_preview_worker.process_claimed_preview_job(db, claimed)
+
+        preview.assert_called_once_with(
+            db,
+            request_id=42,
+            path="/tmp/staged",
+            force=False,
+            source_username="alice",
+            download_log_id=None,
+        )
+        assert updated is not None
+        self.assertEqual(updated.preview_status, "would_import")
+
+    def test_confident_reject_fails_job_and_denylists_source(self):
+        from scripts import import_preview_worker
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(7),
+            payload=force_import_payload(
+                download_log_id=7,
+                failed_path="/tmp/failed",
+                source_username="alice",
+            ),
+        )
+        claimed = db.claim_next_import_preview_job(worker_id="preview")
+        assert claimed is not None
+
+        with patch(
+            "scripts.import_preview_worker.preview_import_from_path",
+            return_value=self._preview("confident_reject", reason="spectral_reject"),
+        ):
+            updated = import_preview_worker.process_claimed_preview_job(db, claimed)
+
+        assert updated is not None
+        self.assertEqual(updated.status, "failed")
+        self.assertEqual(updated.preview_status, "confident_reject")
+        self.assertEqual(updated.preview_error, "spectral_reject")
+        self.assertEqual(db.get_denylisted_users(42)[0]["username"], "alice")
+
+    def test_uncertain_preview_fails_without_denylisting(self):
+        from scripts import import_preview_worker
+
+        db = FakePipelineDB()
+        db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(7),
+            payload=force_import_payload(
+                download_log_id=7,
+                failed_path="/tmp/failed",
+                source_username="alice",
+            ),
+        )
+        claimed = db.claim_next_import_preview_job(worker_id="preview")
+        assert claimed is not None
+
+        with patch(
+            "scripts.import_preview_worker.preview_import_from_path",
+            return_value=self._preview("uncertain", reason="path_missing"),
+        ):
+            updated = import_preview_worker.process_claimed_preview_job(db, claimed)
+
+        assert updated is not None
+        self.assertEqual(updated.status, "failed")
+        self.assertEqual(updated.preview_status, "uncertain")
+        self.assertEqual(updated.preview_error, "path_missing")
+        self.assertEqual(db.get_denylisted_users(42), [])

--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for web/js/recents.js queue rendering helpers.
+ * Run with: node tests/test_js_recents.mjs
+ */
+
+import { __test__ } from '../web/js/recents.js';
+
+let passed = 0;
+let failed = 0;
+
+function assertContains(haystack, needle, msg) {
+  if (haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - '${needle}' not in output`);
+  }
+}
+
+function assertExcludes(haystack, needle, msg) {
+  if (!haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - unexpectedly found '${needle}'`);
+  }
+}
+
+console.log('renderImportQueueItems() shows importable next row and preview detail');
+{
+  const html = __test__.renderImportQueueItems([{
+    id: 77,
+    job_type: 'force_import',
+    status: 'queued',
+    preview_status: 'would_import',
+    artist_name: 'Broadcast',
+    album_title: 'Tender Buttons',
+    preview_message: 'Preview would import: import',
+    preview_result: { stage_chain: ['stage2_import:import'] },
+  }]);
+  assertContains(html, 'Tender Buttons', 'album title rendered');
+  assertContains(html, 'Broadcast', 'artist name rendered');
+  assertContains(html, 'next import', 'first importable row is marked next');
+  assertContains(html, 'preview: would_import', 'preview state rendered');
+  assertContains(html, 'stage2_import:import', 'stage chain rendered');
+}
+
+console.log('renderImportQueueItems() shows uncertain preview failures without next styling');
+{
+  const html = __test__.renderImportQueueItems([{
+    id: 78,
+    job_type: 'manual_import',
+    status: 'failed',
+    preview_status: 'uncertain',
+    artist_name: 'Low',
+    album_title: 'Things We Lost in the Fire',
+    preview_message: 'Preview failed: path_missing',
+  }]);
+  assertContains(html, 'uncertain', 'uncertain badge rendered');
+  assertContains(html, 'Preview failed: path_missing', 'failure message rendered');
+  assertExcludes(html, 'next import', 'uncertain rows are not marked next');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -86,6 +86,21 @@ class TestImporterServiceContract(unittest.TestCase):
         self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
         self.assertIn("WorkingDirectory = cfg.stateDir", text)
 
+    def test_preview_worker_wrapper_service_and_worker_count_are_defined(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('writeShellScriptBin "cratedigger-import-preview-worker"', text)
+        self.assertIn("${src}/scripts/import_preview_worker.py", text)
+        self.assertIn("systemd.services.cratedigger-import-preview-worker", text)
+        self.assertIn("previewWorkers", text)
+        self.assertIn("default = 2", text)
+        self.assertIn("cfg.importer.previewWorkers >= 1", text)
+        self.assertIn("services.cratedigger.importer.previewWorkers must be at least 1", text)
+        self.assertIn('--workers ${toString cfg.importer.previewWorkers}', text)
+        self.assertIn('after = ["cratedigger-db-migrate.service"]', text)
+        self.assertIn('requires = ["cratedigger-db-migrate.service"]', text)
+        self.assertIn('ExecStart = "${previewWorkerPkg}/bin/cratedigger-import-preview-worker"', text)
+        self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -368,6 +368,38 @@ class TestCmdImportPreview(unittest.TestCase):
         self.assertIn("cleanup_eligible: yes", stdout.getvalue())
 
 
+class TestCmdWrongMatchPreviewBackfill(unittest.TestCase):
+    def test_json_output_delegates_to_backfill_service(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            request_id=42,
+            limit=5,
+            cleanup=False,
+            json=True,
+        )
+        stdout = io.StringIO()
+        with patch(
+            "lib.wrong_match_triage.backfill_wrong_match_previews",
+            return_value={
+                "previewed": 1,
+                "would_import": 1,
+                "skipped_missing_files": 0,
+                "skipped_active_jobs": 0,
+            },
+        ) as backfill, redirect_stdout(stdout):
+            rc = pipeline_cli.cmd_wrong_match_preview_backfill(db, args)
+
+        self.assertEqual(rc, 0)
+        backfill.assert_called_once_with(
+            db,
+            request_id=42,
+            limit=5,
+            cleanup=False,
+        )
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["previewed"], 1)
+
+
 class TestCmdQuery(unittest.TestCase):
     def test_query_renders_table_output_in_read_only_mode(self):
         db = MagicMock()

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -140,6 +140,74 @@ class TestSchemaCreation(unittest.TestCase):
         self.assertIn("idx_import_jobs_claim", index_names)
         db.close()
 
+    def test_import_job_preview_schema_constraints_and_indexes(self):
+        """Migration 004 adds durable async preview state to import_jobs."""
+        db = make_db()
+        req_id = db.add_request(
+            mb_release_id="queue-preview-schema-mbid",
+            artist_name="Queue",
+            album_title="Preview Schema",
+            source="request",
+        )
+
+        cur = db._execute("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'import_jobs'
+        """)
+        column_names = {r["column_name"] for r in cur.fetchall()}
+        for column in {
+            "preview_status",
+            "preview_result",
+            "preview_message",
+            "preview_error",
+            "preview_attempts",
+            "preview_worker_id",
+            "preview_started_at",
+            "preview_heartbeat_at",
+            "preview_completed_at",
+            "importable_at",
+        }:
+            self.assertIn(column, column_names)
+
+        cur = db._execute("""
+            INSERT INTO import_jobs (job_type, request_id, payload)
+            VALUES (
+                'manual_import', %s,
+                '{"failed_path": "/tmp/manual"}'::jsonb
+            )
+            RETURNING preview_status, preview_attempts
+        """, (req_id,))
+        row = cur.fetchone()
+        assert row is not None
+        self.assertEqual(row["preview_status"], "waiting")
+        self.assertEqual(row["preview_attempts"], 0)
+
+        with self.assertRaises(Exception):
+            db._execute("""
+                INSERT INTO import_jobs (
+                    job_type, request_id, payload, preview_status
+                )
+                VALUES (
+                    'manual_import', %s,
+                    '{"failed_path": "/tmp/manual"}'::jsonb,
+                    'not-a-preview-state'
+                )
+            """, (req_id,))
+        db.conn.rollback()
+
+        cur = db._execute("""
+            SELECT indexname
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'import_jobs'
+        """)
+        index_names = {r["indexname"] for r in cur.fetchall()}
+        self.assertIn("idx_import_jobs_preview_claim", index_names)
+        self.assertIn("idx_import_jobs_importable_claim", index_names)
+        db.close()
+
 
 @requires_postgres
 class TestAddAndGetRequest(unittest.TestCase):
@@ -312,11 +380,16 @@ class TestImportJobQueueAPI(unittest.TestCase):
     def test_claim_complete_and_fail_lifecycle(self):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
 
-        self.db.enqueue_import_job(
+        job = self.db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=self.req_id,
             dedupe_key="manual:1",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
         )
         claimed = self.db.claim_next_import_job(worker_id="test-worker")
         assert claimed is not None
@@ -345,11 +418,16 @@ class TestImportJobQueueAPI(unittest.TestCase):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
         from lib import pipeline_db
 
-        self.db.enqueue_import_job(
+        job = self.db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=self.req_id,
             dedupe_key="manual:claim-once",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
         )
         other = pipeline_db.PipelineDB(TEST_DSN)
         try:
@@ -363,11 +441,16 @@ class TestImportJobQueueAPI(unittest.TestCase):
     def test_stale_running_jobs_are_listed_and_failed_conservatively(self):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
 
-        self.db.enqueue_import_job(
+        job = self.db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=self.req_id,
             dedupe_key="manual:stale",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
         )
         claimed = self.db.claim_next_import_job(worker_id="stale-worker")
         assert claimed is not None
@@ -392,11 +475,16 @@ class TestImportJobQueueAPI(unittest.TestCase):
     def test_running_jobs_can_be_requeued_immediately_after_worker_restart(self):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
 
-        self.db.enqueue_import_job(
+        job = self.db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=self.req_id,
             dedupe_key="manual:restart-retry",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
         )
         claimed = self.db.claim_next_import_job(worker_id="old-worker")
         assert claimed is not None
@@ -416,6 +504,140 @@ class TestImportJobQueueAPI(unittest.TestCase):
         self.assertEqual(retried.id, claimed.id)
         self.assertEqual(retried.attempts, 2)
         self.assertEqual(retried.worker_id, "new-worker")
+
+    def test_import_claim_requires_preview_importable(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        job = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:preview-gate",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.assertIsNone(self.db.claim_next_import_job(worker_id="too-early"))
+
+        self.db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
+        )
+        claimed = self.db.claim_next_import_job(worker_id="importer")
+        assert claimed is not None
+        self.assertEqual(claimed.id, job.id)
+        self.assertEqual(claimed.status, "running")
+
+    def test_import_job_timeline_orders_importable_before_waiting(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        waiting = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:timeline-waiting",
+            payload=manual_import_payload(failed_path="/tmp/waiting"),
+        )
+        importable = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:timeline-importable",
+            payload=manual_import_payload(failed_path="/tmp/importable"),
+        )
+        self.db.mark_import_job_preview_importable(
+            importable.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
+        )
+
+        timeline = self.db.list_import_job_timeline(limit=10)
+
+        self.assertEqual([job.id for job in timeline[:2]], [importable.id, waiting.id])
+        self.assertEqual(timeline[0].preview_status, "would_import")
+
+    def test_preview_claim_and_importable_lifecycle(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        queued = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:preview",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        self.assertEqual(queued.preview_status, "waiting")
+        self.assertEqual(queued.preview_attempts, 0)
+
+        claimed = self.db.claim_next_import_preview_job(
+            worker_id="preview-worker",
+        )
+        assert claimed is not None
+        self.assertEqual(claimed.id, queued.id)
+        self.assertEqual(claimed.status, "queued")
+        self.assertEqual(claimed.preview_status, "running")
+        self.assertEqual(claimed.preview_attempts, 1)
+        self.assertEqual(claimed.preview_worker_id, "preview-worker")
+        self.assertIsNone(
+            self.db.claim_next_import_preview_job(worker_id="other-worker")
+        )
+
+        marked = self.db.mark_import_job_preview_importable(
+            claimed.id,
+            preview_result={
+                "verdict": "would_import",
+                "stage_chain": ["stage2_import:import"],
+            },
+            message="Preview would import",
+        )
+        assert marked is not None
+        self.assertEqual(marked.status, "queued")
+        self.assertEqual(marked.preview_status, "would_import")
+        self.assertEqual(marked.preview_result["verdict"], "would_import")
+        self.assertEqual(marked.preview_message, "Preview would import")
+        self.assertIsNotNone(marked.preview_completed_at)
+        self.assertIsNotNone(marked.importable_at)
+
+    def test_preview_rejection_fails_job_with_audit(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        queued = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:preview-reject",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+
+        failed = self.db.mark_import_job_preview_failed(
+            queued.id,
+            preview_status="uncertain",
+            error="path_missing",
+            preview_result={"verdict": "uncertain", "reason": "path_missing"},
+            message="Preview failed: path_missing",
+        )
+        assert failed is not None
+        self.assertEqual(failed.status, "failed")
+        self.assertEqual(failed.preview_status, "uncertain")
+        self.assertEqual(failed.preview_error, "path_missing")
+        self.assertEqual(failed.preview_result["reason"], "path_missing")
+        self.assertEqual(failed.message, "Preview failed: path_missing")
+        self.assertEqual(failed.error, "path_missing")
+        self.assertIsNotNone(failed.preview_completed_at)
+        self.assertIsNotNone(failed.completed_at)
+
+    def test_two_sessions_cannot_claim_same_preview_job(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+        from lib import pipeline_db
+
+        self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:preview-claim-once",
+            payload=manual_import_payload(failed_path="/tmp/manual"),
+        )
+        other = pipeline_db.PipelineDB(TEST_DSN)
+        try:
+            first = self.db.claim_next_import_preview_job(worker_id="one")
+            second = other.claim_next_import_preview_job(worker_id="two")
+            self.assertIsNotNone(first)
+            self.assertIsNone(second)
+        finally:
+            other.close()
 
 
 @requires_postgres

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -202,6 +202,7 @@ def _make_server():
     mock_db.enqueue_import_job.return_value = mock_job
     mock_db.get_import_job.return_value = mock_job
     mock_db.list_import_jobs.return_value = [mock_job]
+    mock_db.list_import_job_timeline.return_value = [mock_job]
     mock_db.list_active_import_jobs.return_value = []
     mock_db.count_import_jobs_by_status.return_value = {"queued": 1}
 
@@ -620,6 +621,7 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/pipeline/force-import",
         "/api/pipeline/delete",
         "/api/import-jobs",
+        "/api/import-jobs/timeline",
         r"^/api/import-jobs/(\d+)$",
         "/api/beets/search",
         "/api/beets/recent",
@@ -702,6 +704,9 @@ class TestPipelineRouteContracts(_WebServerCase):
         "id", "job_type", "status", "request_id", "dedupe_key", "payload",
         "result", "message", "error", "attempts", "worker_id", "created_at",
         "updated_at", "started_at", "heartbeat_at", "completed_at", "deduped",
+        "preview_status", "preview_result", "preview_message", "preview_error",
+        "preview_attempts", "preview_worker_id", "preview_started_at",
+        "preview_heartbeat_at", "preview_completed_at", "importable_at",
     }
 
     def setUp(self) -> None:
@@ -901,6 +906,18 @@ class TestPipelineRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, {"job"}, "import job detail response")
         _assert_required_fields(self, data["job"], self.IMPORT_JOB_REQUIRED_FIELDS,
                                 "import job detail")
+
+    def test_import_jobs_timeline_contract(self):
+        status, data = self._get("/api/import-jobs/timeline")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, {"jobs", "counts"},
+                                "import jobs timeline response")
+        _assert_required_fields(self, data["jobs"][0], self.IMPORT_JOB_REQUIRED_FIELDS,
+                                "import jobs timeline item")
+        _assert_required_fields(self, data["jobs"][0], {"artist_name", "album_title"},
+                                "import jobs timeline identity")
+        self.mock_db.list_import_job_timeline.assert_called_once_with(limit=50)
 
     def test_import_jobs_rejects_invalid_filters(self):
         status, data = self._get("/api/import-jobs?status=bad")

--- a/tests/test_wrong_match_triage.py
+++ b/tests/test_wrong_match_triage.py
@@ -7,7 +7,8 @@ import unittest
 from unittest.mock import patch
 
 from lib.import_preview import ImportPreviewResult
-from lib.wrong_match_triage import triage_wrong_match
+from lib.import_queue import IMPORT_JOB_FORCE, force_import_dedupe_key, force_import_payload
+from lib.wrong_match_triage import backfill_wrong_match_previews, triage_wrong_match
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
@@ -131,6 +132,76 @@ class TestWrongMatchTriage(unittest.TestCase):
         self.assertEqual(audit["action"], "stale_path_cleared")
         self.assertEqual(audit["reason"], "path_missing")
         self.assertNotIn("failed_path", vr)
+
+    def test_backfill_audit_only_records_resolvable_preview(self):
+        source = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            db, log_id = self._db_with_wrong_match(source)
+
+            with patch(
+                "lib.wrong_match_triage.preview_import_from_download_log",
+                return_value=ImportPreviewResult(
+                    mode="download_log",
+                    verdict="would_import",
+                    would_import=True,
+                    decision="import",
+                    reason="import",
+                    source_path=source,
+                ),
+            ) as preview:
+                summary = backfill_wrong_match_previews(db)
+
+            preview.assert_called_once_with(db, log_id)
+            self.assertEqual(summary["previewed"], 1)
+            self.assertEqual(summary["would_import"], 1)
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            entry = db.get_download_log_entry(log_id)
+            assert entry is not None
+            vr = entry["validation_result"]
+            assert isinstance(vr, dict)
+            audit = vr["wrong_match_triage"]
+            self.assertEqual(audit["action"], "preview_backfilled")
+            self.assertEqual(audit["preview_verdict"], "would_import")
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_backfill_skips_missing_files_without_clearing(self):
+        source = tempfile.mkdtemp()
+        shutil.rmtree(source)
+        db, _log_id = self._db_with_wrong_match(source)
+
+        with patch("lib.wrong_match_triage.preview_import_from_download_log") as preview:
+            summary = backfill_wrong_match_previews(db)
+
+        preview.assert_not_called()
+        self.assertEqual(summary["previewed"], 0)
+        self.assertEqual(summary["skipped_missing_files"], 1)
+        self.assertEqual(len(db.get_wrong_matches()), 1)
+
+    def test_backfill_skips_active_force_import_job(self):
+        source = tempfile.mkdtemp()
+        try:
+            db, log_id = self._db_with_wrong_match(source)
+            db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=1,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+
+            with patch("lib.wrong_match_triage.preview_import_from_download_log") as preview:
+                summary = backfill_wrong_match_previews(db)
+
+            preview.assert_not_called()
+            self.assertEqual(summary["previewed"], 0)
+            self.assertEqual(summary["skipped_active_jobs"], 1)
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -8,7 +8,7 @@
 import { state } from './state.js';
 import { searchArtists, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow } from './browse.js';
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
-import { loadRecents, setRecentsFilter, renderRecentsItems } from './recents.js';
+import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, setFilter, renderPipeline, toggleDetail, deleteRequest, updateStatus } from './pipeline.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
@@ -77,6 +77,7 @@ Object.assign(window, {
   toggleReleaseDetail,
   loadRecents,
   setRecentsFilter,
+  setRecentsSub,
   loadPipeline,
   setFilter,
   renderPipeline,

--- a/web/js/recents.js
+++ b/web/js/recents.js
@@ -13,6 +13,22 @@ export function setRecentsFilter(f) {
 }
 
 /**
+ * Switch Recents between history and import queue timeline.
+ * @param {string} sub
+ */
+export function setRecentsSub(sub) {
+  state.recentsSub = sub;
+  loadRecents();
+}
+
+function renderRecentsSubnav() {
+  return `<div style="display:flex;gap:2px;margin-bottom:12px;">
+    <button class="p-btn ${state.recentsSub === 'history' ? 'active-status' : ''}" onclick="window.setRecentsSub('history')">History</button>
+    <button class="p-btn ${state.recentsSub === 'queue' ? 'active-status' : ''}" onclick="window.setRecentsSub('queue')">Queue</button>
+  </div>`;
+}
+
+/**
  * Render recents items grouped by date.
  * @param {Array<Object>} items
  * @returns {string} HTML string
@@ -64,13 +80,94 @@ export function renderRecentsItems(items) {
   `).join('');
 }
 
+function queueBadge(job, index) {
+  if (job.status === 'completed') return ['completed', 'badge-new'];
+  if (job.status === 'failed') return ['failed', 'badge-failed'];
+  if (job.status === 'running') return ['importing', 'badge-force'];
+  if (job.preview_status === 'would_import') {
+    return [index === 0 ? 'next import' : 'importable', 'badge-new'];
+  }
+  if (job.preview_status === 'running') return ['previewing', 'badge-warn'];
+  if (job.preview_status === 'waiting') return ['waiting preview', 'badge-library'];
+  if (job.preview_status === 'confident_reject') return ['preview reject', 'badge-failed'];
+  if (job.preview_status === 'uncertain') return ['uncertain', 'badge-warn'];
+  if (job.preview_status === 'error') return ['preview error', 'badge-failed'];
+  return [job.status || 'queued', 'badge-library'];
+}
+
+function queueBorderColor(job) {
+  if (job.status === 'failed' || ['confident_reject', 'error'].includes(job.preview_status)) return '#a33';
+  if (job.preview_status === 'uncertain' || job.preview_status === 'running') return '#a93';
+  if (job.preview_status === 'would_import' || job.status === 'completed') return '#1a4a2a';
+  if (job.status === 'running') return '#36c';
+  return '#1a3a5a';
+}
+
+function queueMessage(job) {
+  return job.preview_message || job.message || job.preview_error || job.error || '';
+}
+
+/**
+ * Render import queue timeline rows.
+ * @param {Array<Object>} jobs
+ * @returns {string}
+ */
+export function renderImportQueueItems(jobs) {
+  if (jobs.length === 0) return '<div class="loading">No queued imports</div>';
+  return jobs.map((job, index) => {
+    const [badge, badgeClass] = queueBadge(job, index);
+    const title = job.album_title || `Import job ${job.id}`;
+    const artist = job.artist_name || job.job_type || '';
+    const message = queueMessage(job);
+    const stages = job.preview_result && Array.isArray(job.preview_result.stage_chain)
+      ? job.preview_result.stage_chain.join(' · ')
+      : '';
+    const meta = [
+      job.job_type,
+      job.preview_status ? `preview: ${job.preview_status}` : '',
+      job.status ? `import: ${job.status}` : '',
+    ].filter(Boolean).join(' · ');
+    return `
+      <div class="r-item" style="border-left-color:${queueBorderColor(job)}">
+        <div class="p-top">
+          <div>
+            <div class="p-title">${esc(title)} <span class="badge ${badgeClass}">${esc(badge)}</span></div>
+            <div class="p-artist">${esc(artist)}</div>
+          </div>
+          <div style="font-size:0.75em;color:#666;">#${job.id}</div>
+        </div>
+        <div class="p-meta"><span>${esc(meta)}</span></div>
+        ${message ? `<div class="p-meta"><span>${esc(message)}</span></div>` : ''}
+        ${stages ? `<div class="p-meta"><span>${esc(stages)}</span></div>` : ''}
+      </div>
+    `;
+  }).join('');
+}
+
+async function loadImportQueue() {
+  const el = document.getElementById('recents-content');
+  el.innerHTML = renderRecentsSubnav() + '<div class="loading">Loading...</div>';
+  try {
+    const r = await fetch(`${API}/api/import-jobs/timeline`);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const data = await r.json();
+    el.innerHTML = renderRecentsSubnav() + renderImportQueueItems(data.jobs || []);
+  } catch (e) {
+    el.innerHTML = renderRecentsSubnav() + '<div class="loading">Failed to load queue</div>';
+  }
+}
+
 /**
  * Load recents from API and render.
  * @returns {Promise<void>}
  */
 export async function loadRecents() {
   const el = document.getElementById('recents-content');
-  el.innerHTML = '<div class="loading">Loading...</div>';
+  if (state.recentsSub === 'queue') {
+    await loadImportQueue();
+    return;
+  }
+  el.innerHTML = renderRecentsSubnav() + '<div class="loading">Loading...</div>';
   try {
     const filterParam = state.recentsFilter === 'all' ? '' : `?outcome=${state.recentsFilter}`;
     const r = await fetch(`${API}/api/pipeline/log${filterParam}`);
@@ -79,7 +176,7 @@ export async function loadRecents() {
     const items = data.log || [];
     if (data.counts) state.recentsCounts = data.counts;
 
-    let html = `<div style="display:flex;gap:8px;margin-bottom:8px;">
+    let html = renderRecentsSubnav() + `<div style="display:flex;gap:8px;margin-bottom:8px;">
       <div class="count ${state.recentsFilter === 'all' ? 'active' : ''}" onclick="window.setRecentsFilter('all')">
         <div class="count-num">${state.recentsCounts.all}</div><div class="count-label">all</div></div>
       <div class="count ${state.recentsFilter === 'imported' ? 'active' : ''}" onclick="window.setRecentsFilter('imported')">
@@ -89,5 +186,11 @@ export async function loadRecents() {
     </div>`;
     html += renderRecentsItems(items);
     el.innerHTML = html;
-  } catch (e) { el.innerHTML = '<div class="loading">Failed to load log</div>'; }
+  } catch (e) { el.innerHTML = renderRecentsSubnav() + '<div class="loading">Failed to load log</div>'; }
 }
+
+export const __test__ = {
+  renderImportQueueItems,
+  renderRecentsItems,
+  setRecentsSub,
+};

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -7,7 +7,7 @@
 
 import { normalizeReleaseId } from './util.js';
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
@@ -18,6 +18,7 @@ export const state = {
   pipelineFilter: 'wanted',
   recentsCounts: { all: 0, imported: 0, rejected: 0 },
   recentsFilter: 'all',
+  recentsSub: 'history',
   dsConstants: null,
   disambData: null,
   searchTimer: null,

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -329,6 +329,26 @@ def get_import_jobs(h, params: dict[str, list[str]]) -> None:
     })
 
 
+def get_import_jobs_timeline(h, params: dict[str, list[str]]) -> None:
+    db = _server()._db()
+    jobs = db.list_import_job_timeline(limit=50)
+    serialized = []
+    for job in jobs:
+        item = _serialize_import_job(job)
+        request_id = item.get("request_id")
+        if request_id is not None:
+            req = db.get_request(int(request_id))
+            if req:
+                item["artist_name"] = req.get("artist_name")
+                item["album_title"] = req.get("album_title")
+                item["mb_release_id"] = req.get("mb_release_id")
+        serialized.append(item)
+    h._json({
+        "jobs": serialized,
+        "counts": db.count_import_jobs_by_status(),
+    })
+
+
 def get_import_job(h, params: dict[str, list[str]], job_id_str: str) -> None:
     job = _server()._db().get_import_job(int(job_id_str))
     if job is None:
@@ -874,6 +894,7 @@ GET_ROUTES: dict[str, object] = {
     "/api/pipeline/constants": get_pipeline_constants,
     "/api/pipeline/simulate": get_pipeline_simulate,
     "/api/import-jobs": get_import_jobs,
+    "/api/import-jobs/timeline": get_import_jobs_timeline,
 }
 
 GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [


### PR DESCRIPTION
## Summary

Adds an async no-mutation preview stage in front of the serial beets importer. New import jobs default to `preview_status='waiting'`; preview workers claim them, persist preview audit detail, and mark only `would_import` jobs importable. The serial importer now claims only importable queued jobs.

Also adds Recents Queue visibility, an explicit Wrong Matches preview backfill command, NixOS deployment wiring for `cratedigger-import-preview-worker.service`, and docs for deploy behavior plus long-tail follow-up work.

Deferred cleanup is tracked in #169.

## Testing

- `nix-shell --run "bash scripts/run_tests.sh"` — 2341 Python tests passed, 53 skipped; JS syntax/unit checks passed
- `nix build .#checks.x86_64-linux.moduleVm` — passed
- `git diff --check` — passed

## Post-Deploy Monitoring & Validation

Validation window: first deploy cycle and the next few import jobs on doc2. Owner: operator deploying the flake update.

Healthy signals:
- `cratedigger-db-migrate.service` succeeds and records migration `004_import_job_previews.sql`.
- `cratedigger-import-preview-worker.service` is active and logs claimed preview jobs or quiet polling.
- New `import_jobs` rows move from `preview_status='waiting'` to `would_import`, `confident_reject`, `uncertain`, or `error`.
- `cratedigger-importer.service` only claims jobs with `preview_status='would_import'`.
- Recents -> Queue shows waiting/previewing/importable/failed rows with preview messages.

Checks:
```bash
systemctl status cratedigger-db-migrate cratedigger-import-preview-worker cratedigger-importer
journalctl -u cratedigger-import-preview-worker -u cratedigger-importer -n 100 --no-pager
pipeline-cli import-jobs --status queued
```

Failure signals and mitigation:
- Jobs remain stuck at `preview_status='waiting'`: inspect/restart `cratedigger-import-preview-worker.service`.
- Migration failure: deployment should block dependent services; roll back the flake input or fix migration and redeploy.
- Preview workers cause CPU/swap pressure: lower `services.cratedigger.importer.previewWorkers` back to `1` and redeploy.
- Importer does not drain `would_import` rows: inspect `cratedigger-importer.service` logs and rollback if needed.