### PR TITLE
fix: make import previews explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,11 +443,11 @@ Deployed via NixOS. The upstream module at [`nix/module.nix`](nix/module.nix) bu
 - `cratedigger-db-migrate.service` — oneshot, runs the schema migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch`. `restartIfChanged = true` + `RemainAfterExit = true` so it always re-evaluates when the unit derivation changes but doesn't re-run between cycles.
 - `cratedigger.service` — oneshot pipeline run, triggered by `cratedigger.timer`. Runs healthcheck → prestart (renders `config.ini`) → `cratedigger.py`. `restartIfChanged = false` so deploys don't restart it mid-cycle; the next timer fire picks up the new code.
 - `cratedigger.timer` — fires every 5 minutes by default (`services.cratedigger.timer.onUnitActiveSec`).
-- `cratedigger-importer.service` — long-running serial importer that drains `import_jobs` whose async preview stage marked them importable.
-- `cratedigger-import-preview-worker.service` — long-running async preview worker. It defaults to `services.cratedigger.importer.previewWorkers = 2`, claims queued preview work, and runs validation/spectral/measurement preview before the importer sees the job.
+- `cratedigger-importer.service` — long-running serial importer that drains `import_jobs` whose async preview stage marked them importable. When the async preview gate is disabled, newly queued jobs are marked importable immediately.
+- `cratedigger-import-preview-worker.service` — optional long-running async preview worker enabled by `services.cratedigger.importer.preview.enable = true`. It defaults to `services.cratedigger.importer.previewWorkers = 2`, claims queued preview work, and runs validation/spectral/measurement preview before the importer sees the job.
 - `cratedigger-web.service` — long-running web UI bound to `services.cratedigger.web.port` (default 8085).
 
-`cratedigger.service`, `cratedigger-importer.service`, `cratedigger-import-preview-worker.service`, and `cratedigger-web.service` all require the migrate unit, so the app cannot start against an un-migrated DB.
+`cratedigger.service`, `cratedigger-importer.service`, `cratedigger-import-preview-worker.service` when enabled, and `cratedigger-web.service` all require the migrate unit, so the app cannot start against an un-migrated DB. These units can start in parallel after migration; their prestart renders `/var/lib/cratedigger/config.ini` through an atomic temp-file-and-rename step so concurrent service starts do not race on the shared config file.
 
 To deploy a new revision:
 
@@ -473,11 +473,17 @@ systemctl status cratedigger-db-migrate cratedigger-import-preview-worker crated
 journalctl -u cratedigger-import-preview-worker -u cratedigger-importer -n 100 --no-pager
 ```
 
-Healthy state is: migrations applied, the preview worker running, queued jobs moving from `preview_status='waiting'` to `would_import` or a terminal preview failure, and the importer only claiming `would_import` jobs.
+With preview enabled, healthy state is: migrations applied, the preview worker
+running, queued jobs moving from `preview_status='waiting'` to `would_import`
+or a terminal preview failure, and the importer only claiming `would_import`
+jobs.
+If `services.cratedigger.importer.preview.enable = false`, the preview worker
+is intentionally absent and new jobs should enter the queue as
+`preview_status='would_import'` with `preview_message='Preview gate disabled'`.
 
 ### Schema migrations
 
-Schema lives in `migrations/NNN_name.sql`, applied by a tiny custom migrator (`lib/migrator.py`) that tracks applied versions in a `schema_migrations` table. The deploy systemd unit `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE the app services start. `cratedigger.service` and `cratedigger-web.service` both `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
+Schema lives in `migrations/NNN_name.sql`, applied by a tiny custom migrator (`lib/migrator.py`) that tracks applied versions in a `schema_migrations` table. The deploy systemd unit `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE the app services start. The app services `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
 
 To add a schema change:
 

--- a/docs/brainstorms/importer-queue-requirements.md
+++ b/docs/brainstorms/importer-queue-requirements.md
@@ -361,7 +361,15 @@ The async preview queue plan implemented the R12-R20 follow-on work:
 - Recents has a Queue subview backed by `/api/import-jobs/timeline`.
 - Wrong Matches preview backfill is an explicit operator command.
 - The NixOS module starts `cratedigger-import-preview-worker.service` with a
-  deployment-tunable worker count that defaults to two.
+  deployment-tunable worker count that defaults to two when
+  `services.cratedigger.importer.preview.enable = true`.
+- The async preview gate is opt-in for backward compatibility. When preview is
+  disabled, application and database defaults mark new jobs
+  `preview_status='would_import'` with `preview_message='Preview gate disabled'`
+  so the serial importer drains without preview workers.
+- Nix prestart now renders the shared `config.ini` atomically because importer,
+  preview, web, and timer-driven services can start concurrently after DB
+  migrations.
 
 Remaining long-tail work is not required for the feature to deploy:
 

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -30,23 +30,25 @@ The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosMo
 | `releaseSettings.*` / `searchSettings.*` / `downloadSettings.*` | match config.ini defaults | Pipeline tunables. |
 | `qualityRanks.*` | mirror of `QualityRankConfig.defaults()` | See README § "Tuning the quality rank model". |
 | `timer.{enable,onBootSec,onUnitActiveSec}` | every 5 min | Cycle frequency. |
-| `importer.{enable,previewWorkers}` | enabled, `2` preview workers | Long-lived serial importer plus async preview worker concurrency. `previewWorkers` must be at least 1. |
+| `importer.enable` | `true` | Long-lived serial importer that drains queued import work. |
+| `importer.preview.enable` | `false` | Enable the async preview gate. When disabled, new import jobs are marked importable immediately for backward-compatible draining. |
+| `importer.previewWorkers` | `2` | Async preview worker concurrency when `importer.preview.enable = true`. Must be at least 1. |
 | `logging.{level,format,datefmt}` | INFO | Python logging config. |
 
 ## What the module does
 
 1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, slskd-api).
 2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `scripts/importer.py` / `scripts/import_preview_worker.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH.
-3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path.
+3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path. App units render through an atomic temp-file-and-rename step because importer, preview, web, and timer-driven services can start concurrently after migrations.
 4. Pre-start: health-check slskd → render config.ini → start `cratedigger.py`.
 
 ## Systemd units
 
-- `cratedigger-db-migrate.service` — oneshot, `restartIfChanged = true`, `RemainAfterExit = true`. Runs the schema migrator on every `nixos-rebuild switch`. Both `cratedigger.service` and `cratedigger-web.service` `requires` it, so the app cannot start against an un-migrated DB.
+- `cratedigger-db-migrate.service` — oneshot, `restartIfChanged = true`, `RemainAfterExit = true`. Runs the schema migrator on every `nixos-rebuild switch`. The app units `requires` it, so they cannot start against an un-migrated DB.
 - `cratedigger.service` — oneshot pipeline run. `restartIfChanged = false` (5-min timer picks up new code).
 - `cratedigger.timer` — fires every 5 minutes (configurable via `timer.onUnitActiveSec`).
 - `cratedigger-importer.service` — long-running serial beets import worker. It only claims queued import jobs after async preview marks them `would_import`.
-- `cratedigger-import-preview-worker.service` — long-running async preview worker. It starts after DB migrations, defaults to two worker loops, and runs validation/spectral/measurement preview outside the beets mutation lane.
+- `cratedigger-import-preview-worker.service` — optional long-running async preview worker. It starts after DB migrations when `importer.preview.enable = true`, defaults to two worker loops, and runs validation/spectral/measurement preview outside the beets mutation lane.
 - `cratedigger-web.service` — long-running web UI for music.ablz.au.
 
 ## Sops + per-key secrets
@@ -102,3 +104,6 @@ journalctl -u cratedigger-import-preview-worker -u cratedigger-importer -n 100 -
 
 Queued jobs should move from `preview_status='waiting'` to `would_import` or a
 terminal preview failure. The importer should only claim `would_import` jobs.
+If `importer.preview.enable = false`, `cratedigger-import-preview-worker.service`
+should not exist and newly queued jobs should already have
+`preview_status='would_import'` with `preview_message='Preview gate disabled'`.

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -47,14 +47,18 @@ Key fields:
 - `attempts`, `worker_id`, `started_at`, `heartbeat_at`, `completed_at` —
   claim and recovery metadata.
 - `preview_status TEXT` — async readiness stage: `waiting`, `running`,
-  `would_import`, `confident_reject`, `uncertain`, or `error`.
+  `would_import`, `confident_reject`, `uncertain`, or `error`. New jobs use
+  `waiting` only when the async preview gate is enabled; preview-disabled or
+  raw/default inserts are `would_import` immediately with
+  `preview_message='Preview gate disabled'`.
 - `preview_result JSONB`, `preview_message`, `preview_error` — durable
   no-mutation preview audit visible in Recents and CLI output.
 - `preview_attempts`, `preview_worker_id`, `preview_started_at`,
   `preview_heartbeat_at`, `preview_completed_at` — async preview claim and
   recovery metadata.
-- `importable_at TIMESTAMPTZ` — set when preview returns `would_import`; the
-  serial importer claims only queued jobs with this importable preview state.
+- `importable_at TIMESTAMPTZ` — set when preview returns `would_import`, or at
+  enqueue time when the preview gate is disabled; the serial importer claims
+  only queued jobs with this importable preview state.
 
 On importer startup, any pre-existing `running` job is treated as abandoned
 state from a previous worker process, reset to `queued`, and retried
@@ -67,6 +71,10 @@ jobs with `preview_status='waiting'`, call the no-mutation import preview path,
 then either set `preview_status='would_import'` and `importable_at` or fail the
 job with preview audit details. This lets spectral/measurement work run with
 tunable parallelism while beets writes stay serial.
+
+The preview gate is opt-in at deployment time. When disabled, no preview worker
+is required for compatibility: `PipelineDB.enqueue_import_job()` and the schema
+defaults both make jobs importable immediately.
 
 ## `download_log.import_result` JSONB
 

--- a/docs/plans/2026-04-25-005-feat-async-preview-import-queue-plan.md
+++ b/docs/plans/2026-04-25-005-feat-async-preview-import-queue-plan.md
@@ -171,8 +171,10 @@ Tracking issue: <https://github.com/abl030/cratedigger/issues/169>.
   job lifecycle (`queued`, `running`, `completed`, `failed`), while preview
   fields explain whether a queued job is waiting, previewing, importable, or
   rejected before beets mutation.
-- Make new jobs default to `preview_status='waiting'`. The serial importer
-  should claim only `status='queued'` and `preview_status='would_import'`.
+- Make new jobs enter `preview_status='waiting'` when the async preview gate is
+  enabled. Keep preview disabled by default for deployment compatibility: in
+  that mode, new jobs are `preview_status='would_import'` immediately and the
+  serial importer can drain without preview workers.
 - Persist the full preview result as JSONB and also store summary fields for
   filtering and UI sorting. The JSONB audit should include enough measurement
   and stage-chain detail to explain the decision.
@@ -303,6 +305,7 @@ AE6, AE7
 
 **Files:**
 - Create: `migrations/004_import_job_previews.sql`
+- Create: `migrations/005_import_preview_opt_in_default.sql`
 - Modify: `lib/import_queue.py`
 - Modify: `lib/pipeline_db.py`
 - Modify: `tests/fakes.py`
@@ -342,7 +345,9 @@ are the contract for every later unit.
 - Happy path: migrations create preview columns, constraints, and claim/list
   indexes, and reapplying migrations is idempotent.
 - Happy path: a newly enqueued import job has `preview_status='waiting'` and is
-  returned by the preview claim API.
+  returned by the preview claim API when preview is enabled.
+- Happy path: a newly enqueued import job is immediately `would_import` when
+  preview is disabled or the preview columns are omitted by a raw/default insert.
 - Happy path: marking preview `would_import` persists preview JSONB,
   `preview_completed_at`, and `importable_at`.
 - Edge case: active dedupe still returns an existing queued job when it is
@@ -661,6 +666,9 @@ F7; AE4, AE8
 **Approach:**
 - Add deployment wiring for the preview worker service using the same Python
   environment and state directory patterns as `cratedigger-importer`.
+- Add an explicit `importer.preview.enable` option so the preview worker starts
+  only for deployments that opt into the gate. Export the same gate into Python
+  wrappers so enqueue semantics match the systemd service graph.
 - Expose preview worker concurrency through Nix/module configuration and script
   flags. The doc2 default should be two workers, with docs explaining that CPU,
   swap pressure, and queue throughput should drive changes.
@@ -668,6 +676,9 @@ F7; AE4, AE8
   config.ini field unless implementation finds a real non-Nix runtime need.
 - Ensure preview workers start after DB migrations and do not require the
   importer advisory lock.
+- Render the shared `config.ini` atomically in prestart because importer,
+  preview, web, and timer-driven services can start concurrently after
+  migrations.
 - Update schema docs with preview fields, lifecycle, and importable claim
   semantics.
 - Update web docs to describe the Recents queue subview.
@@ -688,6 +699,9 @@ service details stay consistent with existing deployment guarantees.
 **Test scenarios:**
 - Happy path: Nix module defines a preview worker wrapper and systemd service
   that starts after `cratedigger-db-migrate.service`.
+- Happy path: preview worker service is gated behind
+  `services.cratedigger.importer.preview.enable`, and disabled deployments mark
+  new jobs importable immediately.
 - Happy path: preview worker service receives the configured worker count or
   process count and defaults to two in the module.
 - Error path: invalid worker count is rejected by module or CLI parser tests.

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -123,7 +123,8 @@ What this creates on doc2:
 - `cratedigger-importer.service` — long-lived worker that drains queued
   force/manual/automation imports after DB migrations have run
 - `cratedigger-import-preview-worker.service` — long-lived async preview worker
-  that prepares queued jobs for the serial importer; defaults to two worker
+  that prepares queued jobs for the serial importer when
+  `services.cratedigger.importer.preview.enable = true`; defaults to two worker
   loops via `services.cratedigger.importer.previewWorkers`
 - `services.redis.servers.cratedigger` — provided by the homelab wrapper (not the upstream module)
 - `music.ablz.au` nginx reverse proxy via `homelab.localProxy.hosts` (homelab wrapper)
@@ -146,6 +147,9 @@ After deploy, check `systemctl status cratedigger-import-preview-worker
 cratedigger-importer` and the worker journals. The Recents Queue subview should
 show new rows move from waiting preview, to previewing, to importable or a
 terminal preview failure; only importable rows enter the serial importer lane.
+On doc2 the homelab wrapper opts into the preview gate explicitly. Deployments
+that leave `services.cratedigger.importer.preview.enable = false` should not
+start the preview worker; their newly queued jobs are importable immediately.
 
 ## MusicBrainz API Usage
 

--- a/lib/import_queue.py
+++ b/lib/import_queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -37,6 +38,15 @@ IMPORT_JOB_PREVIEW_FAILURE_STATUSES = frozenset({
     IMPORT_JOB_PREVIEW_UNCERTAIN,
     IMPORT_JOB_PREVIEW_ERROR,
 })
+IMPORT_JOB_PREVIEW_ENABLED_ENV = "CRATEDIGGER_IMPORT_PREVIEW_ENABLE"
+IMPORT_JOB_PREVIEW_DISABLED_MESSAGE = "Preview gate disabled"
+
+
+def import_preview_enabled_from_env() -> bool:
+    value = os.environ.get(IMPORT_JOB_PREVIEW_ENABLED_ENV)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass(frozen=True)

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -23,6 +23,10 @@ import psycopg2.extras
 
 from lib.import_queue import (
     ImportJob,
+    IMPORT_JOB_PREVIEW_DISABLED_MESSAGE,
+    IMPORT_JOB_PREVIEW_WAITING,
+    IMPORT_JOB_PREVIEW_WOULD_IMPORT,
+    import_preview_enabled_from_env,
     validate_preview_failure_status,
     validate_job_type,
     validate_payload,
@@ -205,16 +209,32 @@ class PipelineDB:
         dedupe_key: str | None = None,
         payload: dict[str, Any] | None = None,
         message: str | None = None,
+        preview_enabled: bool | None = None,
     ) -> ImportJob:
         """Create an import job or return the active job with the same key."""
         validate_job_type(job_type)
         payload = validate_payload(job_type, payload or {})
+        preview_enabled = (
+            import_preview_enabled_from_env()
+            if preview_enabled is None
+            else preview_enabled
+        )
+        preview_status = (
+            IMPORT_JOB_PREVIEW_WAITING
+            if preview_enabled
+            else IMPORT_JOB_PREVIEW_WOULD_IMPORT
+        )
+        preview_message = None if preview_enabled else IMPORT_JOB_PREVIEW_DISABLED_MESSAGE
+        preview_completed_at = None if preview_enabled else datetime.now(timezone.utc)
+        importable_at = None if preview_enabled else preview_completed_at
         cur = self._execute("""
             WITH inserted AS (
                 INSERT INTO import_jobs (
-                    job_type, request_id, dedupe_key, payload, message
+                    job_type, request_id, dedupe_key, payload, message,
+                    preview_status, preview_message, preview_completed_at,
+                    importable_at
                 )
-                VALUES (%s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (dedupe_key)
                     WHERE dedupe_key IS NOT NULL
                       AND status IN ('queued', 'running')
@@ -238,6 +258,10 @@ class PipelineDB:
             dedupe_key,
             psycopg2.extras.Json(payload),
             message,
+            preview_status,
+            preview_message,
+            preview_completed_at,
+            importable_at,
             dedupe_key,
             dedupe_key,
         ))

--- a/migrations/005_import_preview_opt_in_default.sql
+++ b/migrations/005_import_preview_opt_in_default.sql
@@ -1,0 +1,12 @@
+-- 005_import_preview_opt_in_default.sql - keep async import previews opt-in
+--
+-- Migration 004 introduced preview state with a database default of `waiting`.
+-- Application code now writes `waiting` only when the preview gate is enabled.
+-- Keep raw/older enqueue paths backward-compatible by making omitted preview
+-- columns importable immediately.
+
+ALTER TABLE import_jobs
+    ALTER COLUMN preview_status SET DEFAULT 'would_import',
+    ALTER COLUMN preview_message SET DEFAULT 'Preview gate disabled',
+    ALTER COLUMN preview_completed_at SET DEFAULT NOW(),
+    ALTER COLUMN importable_at SET DEFAULT NOW();

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -34,10 +34,12 @@
     pkgs.flac
     pkgs.sox
   ];
+  importPreviewEnableEnv = if cfg.importer.preview.enable then "1" else "0";
 
   # CLI wrappers — the only place PYTHONPATH is set.
   cratediggerPkg = pkgs.writeShellScriptBin "cratedigger" ''
     export PATH="${runtimePath}:$PATH"
+    export CRATEDIGGER_IMPORT_PREVIEW_ENABLE="${importPreviewEnableEnv}"
     exec ${pythonEnv}/bin/python ${src}/cratedigger.py "$@"
   '';
 
@@ -52,6 +54,7 @@
   pipelineCli = pkgs.writeShellScriptBin "pipeline-cli" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:''${PYTHONPATH:-}"
+    export CRATEDIGGER_IMPORT_PREVIEW_ENABLE="${importPreviewEnableEnv}"
     exec ${pythonEnv}/bin/python ${src}/scripts/pipeline_cli.py \
       --dsn "${cfg.pipelineDb.dsn}" "$@"
   '';
@@ -66,6 +69,7 @@
   importerPkg = pkgs.writeShellScriptBin "cratedigger-importer" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:''${PYTHONPATH:-}"
+    export CRATEDIGGER_IMPORT_PREVIEW_ENABLE="${importPreviewEnableEnv}"
     exec ${pythonEnv}/bin/python ${src}/scripts/importer.py \
       --dsn "${cfg.pipelineDb.dsn}" "$@"
   '';
@@ -73,6 +77,7 @@
   previewWorkerPkg = pkgs.writeShellScriptBin "cratedigger-import-preview-worker" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:''${PYTHONPATH:-}"
+    export CRATEDIGGER_IMPORT_PREVIEW_ENABLE="${importPreviewEnableEnv}"
     exec ${pythonEnv}/bin/python ${src}/scripts/import_preview_worker.py \
       --dsn "${cfg.pipelineDb.dsn}" \
       --workers ${toString cfg.importer.previewWorkers} "$@"
@@ -81,6 +86,7 @@
   webPkg = pkgs.writeShellScriptBin "cratedigger-web" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}:''${PYTHONPATH:-}"
+    export CRATEDIGGER_IMPORT_PREVIEW_ENABLE="${importPreviewEnableEnv}"
     exec ${pythonEnv}/bin/python ${src}/web/server.py \
       --port ${toString cfg.web.port} \
       --dsn "${cfg.pipelineDb.dsn}" \
@@ -197,7 +203,12 @@
     set -euo pipefail
     config_dir="${cfg.stateDir}"
     mkdir -p "$config_dir"
-    ${pkgs.coreutils}/bin/install -m 0644 ${configTemplate} "$config_dir/config.ini"
+    tmp="$(${pkgs.coreutils}/bin/mktemp "$config_dir/.config.ini.XXXXXX")"
+    trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
+    ${pkgs.coreutils}/bin/cp ${configTemplate} "$tmp"
+    ${pkgs.coreutils}/bin/chmod 0644 "$tmp"
+    ${pkgs.coreutils}/bin/mv -f "$tmp" "$config_dir/config.ini"
+    trap - EXIT
     rm -f "$config_dir/.cratedigger.lock"
   '';
 
@@ -311,6 +322,15 @@ in {
         type = types.bool;
         default = true;
         description = "Run the long-lived importer worker that drains the shared import queue.";
+      };
+      preview.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the async preview gate before the serial importer. When false,
+          newly enqueued import jobs are marked importable immediately for
+          backward-compatible draining without preview workers.
+        '';
       };
       previewWorkers = mkOption {
         type = types.int;
@@ -744,7 +764,7 @@ in {
       };
     };
 
-    systemd.services.cratedigger-import-preview-worker = mkIf cfg.importer.enable {
+    systemd.services.cratedigger-import-preview-worker = mkIf (cfg.importer.enable && cfg.importer.preview.enable) {
       description = "Cratedigger async import preview worker";
       after = ["cratedigger-db-migrate.service"];
       requires = ["cratedigger-db-migrate.service"];

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -16,6 +16,10 @@ from typing import Any, Callable, Iterator
 
 from lib.import_queue import (
     ImportJob,
+    IMPORT_JOB_PREVIEW_DISABLED_MESSAGE,
+    IMPORT_JOB_PREVIEW_WAITING,
+    IMPORT_JOB_PREVIEW_WOULD_IMPORT,
+    import_preview_enabled_from_env,
     validate_job_type,
     validate_preview_failure_status,
     validate_payload,
@@ -387,9 +391,15 @@ class FakePipelineDB:
         dedupe_key: str | None = None,
         payload: dict[str, Any] | None = None,
         message: str | None = None,
+        preview_enabled: bool | None = None,
     ) -> ImportJob:
         validate_job_type(job_type)
         payload = validate_payload(job_type, payload or {})
+        preview_enabled = (
+            import_preview_enabled_from_env()
+            if preview_enabled is None
+            else preview_enabled
+        )
         if dedupe_key is not None:
             existing = self.get_import_job_by_dedupe_key(dedupe_key)
             if existing is not None:
@@ -397,6 +407,7 @@ class FakePipelineDB:
 
         self._next_import_job_id += 1
         now = _utcnow()
+        preview_completed_at = None if preview_enabled else now
         row: dict[str, Any] = {
             "id": self._next_import_job_id,
             "job_type": job_type,
@@ -414,16 +425,22 @@ class FakePipelineDB:
             "started_at": None,
             "heartbeat_at": None,
             "completed_at": None,
-            "preview_status": "waiting",
+            "preview_status": (
+                IMPORT_JOB_PREVIEW_WAITING
+                if preview_enabled
+                else IMPORT_JOB_PREVIEW_WOULD_IMPORT
+            ),
             "preview_result": None,
-            "preview_message": None,
+            "preview_message": (
+                None if preview_enabled else IMPORT_JOB_PREVIEW_DISABLED_MESSAGE
+            ),
             "preview_error": None,
             "preview_attempts": 0,
             "preview_worker_id": None,
             "preview_started_at": None,
             "preview_heartbeat_at": None,
-            "preview_completed_at": None,
-            "importable_at": None,
+            "preview_completed_at": preview_completed_at,
+            "importable_at": None if preview_enabled else now,
         }
         self._import_jobs.append(row)
         return ImportJob.from_row(copy.deepcopy(row))

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -4,6 +4,7 @@ import inspect
 import unittest
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from unittest.mock import patch
 
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.pipeline_db import PipelineDB, RequestSpectralStateUpdate
@@ -515,12 +516,14 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             request_id=42,
             dedupe_key="manual:42",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         duplicate = db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=42,
             dedupe_key="manual:42",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.assertEqual(first.id, duplicate.id)
         self.assertTrue(duplicate.deduped)
@@ -562,6 +565,7 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             request_id=42,
             dedupe_key="manual:42",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.assertNotEqual(first.id, later.id)
         failed = db.mark_import_job_failed(
@@ -572,6 +576,29 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         assert failed is not None
         self.assertEqual(failed.status, "failed")
 
+    def test_import_job_queue_defaults_to_importable_without_preview_gate(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        db = FakePipelineDB()
+        with patch.dict("os.environ", {}, clear=True):
+            queued = db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=42,
+                dedupe_key="manual:preview-disabled",
+                payload=manual_import_payload(failed_path="/tmp/manual"),
+            )
+
+        self.assertEqual(queued.preview_status, "would_import")
+        self.assertEqual(queued.preview_message, "Preview gate disabled")
+        self.assertIsNotNone(queued.preview_completed_at)
+        self.assertIsNotNone(queued.importable_at)
+        self.assertIsNone(db.claim_next_import_preview_job(worker_id="preview"))
+
+        claimed = db.claim_next_import_job(worker_id="fake-worker")
+        assert claimed is not None
+        self.assertEqual(claimed.id, queued.id)
+        self.assertEqual(claimed.status, "running")
+
     def test_import_job_preview_methods_mirror_core_lifecycle(self):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
 
@@ -581,6 +608,7 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             request_id=42,
             dedupe_key="manual:preview",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.assertEqual(queued.preview_status, "waiting")
 
@@ -607,6 +635,7 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             request_id=43,
             dedupe_key="manual:preview-reject",
             payload=manual_import_payload(failed_path="/tmp/reject"),
+            preview_enabled=True,
         )
         failed = db.mark_import_job_preview_failed(
             rejected.id,

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -64,6 +64,7 @@ class TestImporterWorker(unittest.TestCase):
                 failed_path="/tmp/failed",
                 source_username="alice",
             ),
+            preview_enabled=True,
         )
         self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="worker")
@@ -97,6 +98,7 @@ class TestImporterWorker(unittest.TestCase):
             request_id=42,
             dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="worker")
@@ -131,6 +133,7 @@ class TestImporterWorker(unittest.TestCase):
                     failed_path=source,
                     source_username="alice",
                 ),
+                preview_enabled=True,
             )
             self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
@@ -167,6 +170,7 @@ class TestImporterWorker(unittest.TestCase):
                     failed_path=source,
                     source_username="alice",
                 ),
+                preview_enabled=True,
             )
             self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
@@ -209,6 +213,7 @@ class TestImporterWorker(unittest.TestCase):
                 request_id=42,
                 dedupe_key=manual_import_dedupe_key(42, source),
                 payload=manual_import_payload(failed_path=source),
+                preview_enabled=True,
             )
             self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
@@ -243,6 +248,7 @@ class TestImporterWorker(unittest.TestCase):
                     download_log_id=log_id,
                     failed_path=source,
                 ),
+                preview_enabled=True,
             )
             self._mark_importable(db, job)
             claimed = db.claim_next_import_job(worker_id="worker")
@@ -275,6 +281,7 @@ class TestImporterWorker(unittest.TestCase):
             request_id=42,
             dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="old-worker")
@@ -299,6 +306,23 @@ class TestImporterWorker(unittest.TestCase):
         assert retried is not None
         self.assertEqual(retried.attempts, 2)
 
+    def test_importer_claims_job_immediately_when_preview_disabled_by_default(self):
+        db = FakePipelineDB()
+        with patch.dict(os.environ, {}, clear=True):
+            job = db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=42,
+                dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
+                payload=manual_import_payload(failed_path="/tmp/manual"),
+            )
+
+        claimed = db.claim_next_import_job(worker_id="worker")
+
+        assert claimed is not None
+        self.assertEqual(claimed.id, job.id)
+        self.assertEqual(claimed.preview_status, "would_import")
+        self.assertEqual(claimed.preview_message, "Preview gate disabled")
+
     def test_importer_does_not_claim_job_waiting_for_preview(self):
         from scripts import importer
 
@@ -308,6 +332,7 @@ class TestImporterWorker(unittest.TestCase):
             request_id=42,
             dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
 
         self.assertIsNone(importer.run_once(db, worker_id="worker"))
@@ -335,6 +360,7 @@ class TestImporterWorker(unittest.TestCase):
             request_id=42,
             dedupe_key=automation_import_dedupe_key(42),
             payload={},
+            preview_enabled=True,
         )
         self._mark_importable(db, job)
         claimed = db.claim_next_import_job(worker_id="worker")
@@ -387,6 +413,7 @@ class TestImportPreviewWorker(unittest.TestCase):
                 failed_path="/tmp/failed",
                 source_username="alice",
             ),
+            preview_enabled=True,
         )
         claimed = db.claim_next_import_preview_job(worker_id="preview")
         assert claimed is not None
@@ -420,6 +447,7 @@ class TestImportPreviewWorker(unittest.TestCase):
             request_id=42,
             dedupe_key=manual_import_dedupe_key(42, "/tmp/manual"),
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         claimed = db.claim_next_import_preview_job(worker_id="preview")
         assert claimed is not None
@@ -465,6 +493,7 @@ class TestImportPreviewWorker(unittest.TestCase):
             request_id=42,
             dedupe_key=automation_import_dedupe_key(42),
             payload={},
+            preview_enabled=True,
         )
         claimed = db.claim_next_import_preview_job(worker_id="preview")
         assert claimed is not None
@@ -499,6 +528,7 @@ class TestImportPreviewWorker(unittest.TestCase):
                 failed_path="/tmp/failed",
                 source_username="alice",
             ),
+            preview_enabled=True,
         )
         claimed = db.claim_next_import_preview_job(worker_id="preview")
         assert claimed is not None
@@ -528,6 +558,7 @@ class TestImportPreviewWorker(unittest.TestCase):
                 failed_path="/tmp/failed",
                 source_username="alice",
             ),
+            preview_enabled=True,
         )
         claimed = db.claim_next_import_preview_job(worker_id="preview")
         assert claimed is not None

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -86,11 +86,19 @@ class TestImporterServiceContract(unittest.TestCase):
         self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
         self.assertIn("WorkingDirectory = cfg.stateDir", text)
 
+    def test_prestart_renders_config_atomically_for_parallel_services(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('mktemp "$config_dir/.config.ini.XXXXXX"', text)
+        self.assertIn('mv -f "$tmp" "$config_dir/config.ini"', text)
+
     def test_preview_worker_wrapper_service_and_worker_count_are_defined(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")
         self.assertIn('writeShellScriptBin "cratedigger-import-preview-worker"', text)
         self.assertIn("${src}/scripts/import_preview_worker.py", text)
         self.assertIn("systemd.services.cratedigger-import-preview-worker", text)
+        self.assertIn("cfg.importer.enable && cfg.importer.preview.enable", text)
+        self.assertIn("preview.enable = mkOption", text)
+        self.assertIn("CRATEDIGGER_IMPORT_PREVIEW_ENABLE", text)
         self.assertIn("previewWorkers", text)
         self.assertIn("default = 2", text)
         self.assertIn("cfg.importer.previewWorkers >= 1", text)

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -11,6 +11,7 @@ import os
 import sys
 import unittest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 # Bootstrap ephemeral PostgreSQL if available
 sys.path.insert(0, os.path.dirname(__file__))
@@ -177,12 +178,16 @@ class TestSchemaCreation(unittest.TestCase):
                 'manual_import', %s,
                 '{"failed_path": "/tmp/manual"}'::jsonb
             )
-            RETURNING preview_status, preview_attempts
+            RETURNING preview_status, preview_message, preview_attempts,
+                      preview_completed_at, importable_at
         """, (req_id,))
         row = cur.fetchone()
         assert row is not None
-        self.assertEqual(row["preview_status"], "waiting")
+        self.assertEqual(row["preview_status"], "would_import")
+        self.assertEqual(row["preview_message"], "Preview gate disabled")
         self.assertEqual(row["preview_attempts"], 0)
+        self.assertIsNotNone(row["preview_completed_at"])
+        self.assertIsNotNone(row["importable_at"])
 
         with self.assertRaises(Exception):
             db._execute("""
@@ -385,6 +390,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:1",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.db.mark_import_job_preview_importable(
             job.id,
@@ -414,6 +420,30 @@ class TestImportJobQueueAPI(unittest.TestCase):
         )
         self.assertIsNone(missing)
 
+    def test_enqueue_defaults_to_importable_when_preview_env_absent(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        with patch.dict(os.environ, {}, clear=True):
+            job = self.db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=self.req_id,
+                dedupe_key="manual:preview-disabled",
+                payload=manual_import_payload(failed_path="/tmp/manual"),
+            )
+
+        self.assertEqual(job.preview_status, "would_import")
+        self.assertEqual(job.preview_message, "Preview gate disabled")
+        self.assertIsNotNone(job.preview_completed_at)
+        self.assertIsNotNone(job.importable_at)
+        self.assertIsNone(
+            self.db.claim_next_import_preview_job(worker_id="preview-worker")
+        )
+
+        claimed = self.db.claim_next_import_job(worker_id="test-worker")
+        assert claimed is not None
+        self.assertEqual(claimed.id, job.id)
+        self.assertEqual(claimed.status, "running")
+
     def test_two_sessions_cannot_claim_same_job(self):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
         from lib import pipeline_db
@@ -423,6 +453,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:claim-once",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.db.mark_import_job_preview_importable(
             job.id,
@@ -446,6 +477,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:stale",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.db.mark_import_job_preview_importable(
             job.id,
@@ -480,6 +512,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:restart-retry",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.db.mark_import_job_preview_importable(
             job.id,
@@ -513,6 +546,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:preview-gate",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.assertIsNone(self.db.claim_next_import_job(worker_id="too-early"))
 
@@ -534,12 +568,14 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:timeline-waiting",
             payload=manual_import_payload(failed_path="/tmp/waiting"),
+            preview_enabled=True,
         )
         importable = self.db.enqueue_import_job(
             IMPORT_JOB_MANUAL,
             request_id=self.req_id,
             dedupe_key="manual:timeline-importable",
             payload=manual_import_payload(failed_path="/tmp/importable"),
+            preview_enabled=True,
         )
         self.db.mark_import_job_preview_importable(
             importable.id,
@@ -560,6 +596,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:preview",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         self.assertEqual(queued.preview_status, "waiting")
         self.assertEqual(queued.preview_attempts, 0)
@@ -601,6 +638,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:preview-reject",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
 
         failed = self.db.mark_import_job_preview_failed(
@@ -629,6 +667,7 @@ class TestImportJobQueueAPI(unittest.TestCase):
             request_id=self.req_id,
             dedupe_key="manual:preview-claim-once",
             payload=manual_import_payload(failed_path="/tmp/manual"),
+            preview_enabled=True,
         )
         other = pipeline_db.PipelineDB(TEST_DSN)
         try:


### PR DESCRIPTION
## Summary
- add an explicit preview-gate enable flag and keep preview-disabled enqueues importable immediately
- gate the Nix preview worker service behind services.cratedigger.importer.preview.enable
- render config.ini atomically so concurrently-starting Cratedigger units do not race
- add migration 005 so raw/default inserts remain importable when preview columns are omitted
- update deployment/docs for the opt-in gate and startup race

## Verification
- nix-shell --run "python3 -m unittest tests.test_import_queue tests.test_fakes.TestFakePipelineDBNewStubs tests.test_pipeline_db.TestSchemaCreation tests.test_pipeline_db.TestImportJobQueueAPI tests.test_nix_module.TestImporterServiceContract -v"
- nix-shell --run "bash scripts/run_tests.sh"
- nix build .#checks.x86_64-linux.moduleVm