### PR TITLE
fix: normalize legacy import preview history

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -74,7 +74,9 @@ tunable parallelism while beets writes stay serial.
 
 The preview gate is opt-in at deployment time. When disabled, no preview worker
 is required for compatibility: `PipelineDB.enqueue_import_job()` and the schema
-defaults both make jobs importable immediately.
+defaults both make jobs importable immediately. Legacy completed/failed rows
+from before async previews are also normalized to `would_import` so historical
+terminal import history does not look like active preview backlog.
 
 ## `download_log.import_result` JSONB
 

--- a/migrations/006_normalize_legacy_terminal_preview_jobs.sql
+++ b/migrations/006_normalize_legacy_terminal_preview_jobs.sql
@@ -1,0 +1,24 @@
+-- 006_normalize_legacy_terminal_preview_jobs.sql - clean legacy queue display
+--
+-- Before async previews existed, completed/failed import jobs had no preview
+-- lifecycle. Migration 004 added preview_status with a temporary default of
+-- `waiting`, which made old terminal history look like live preview backlog in
+-- Recents. Terminal jobs already ran the importer path, so mark their preview
+-- stage as effectively importable while preserving the import result itself.
+
+UPDATE import_jobs
+SET preview_status = 'would_import',
+    preview_message = CASE
+        WHEN preview_message IS NULL
+          OR preview_message = 'Preview gate disabled'
+          THEN 'Queued before async preview gate'
+        ELSE preview_message
+    END,
+    preview_completed_at = COALESCE(preview_completed_at, completed_at, updated_at, NOW()),
+    importable_at = COALESCE(importable_at, created_at, updated_at, NOW())
+WHERE status IN ('completed', 'failed')
+  AND preview_status = 'waiting'
+  AND preview_attempts = 0
+  AND preview_result IS NULL
+  AND preview_started_at IS NULL
+  AND preview_heartbeat_at IS NULL;

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -11,6 +11,7 @@ import os
 import sys
 import unittest
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 # Bootstrap ephemeral PostgreSQL if available
@@ -139,6 +140,53 @@ class TestSchemaCreation(unittest.TestCase):
         index_names = {row["indexname"] for row in indexes}
         self.assertIn("idx_import_jobs_active_dedupe", index_names)
         self.assertIn("idx_import_jobs_claim", index_names)
+        db.close()
+
+    def test_legacy_terminal_preview_jobs_are_normalized(self):
+        """Migration 006 keeps old terminal history out of preview backlog."""
+        db = make_db()
+        req_id = db.add_request(
+            mb_release_id="queue-preview-legacy-terminal-mbid",
+            artist_name="Queue",
+            album_title="Legacy Terminal Preview",
+            source="request",
+        )
+        cur = db._execute("""
+            INSERT INTO import_jobs (
+                job_type, status, request_id, payload, preview_status,
+                preview_attempts, message, completed_at
+            )
+            VALUES (
+                'automation_import', 'completed', %s, '{}'::jsonb, 'waiting',
+                0, 'Automation import processing completed', NOW()
+            )
+            RETURNING id
+        """, (req_id,))
+        row = cur.fetchone()
+        assert row is not None
+
+        migration = (
+            Path(__file__).resolve().parents[1]
+            / "migrations"
+            / "006_normalize_legacy_terminal_preview_jobs.sql"
+        )
+        db._execute(migration.read_text(encoding="utf-8"))
+
+        cur = db._execute("""
+            SELECT preview_status, preview_message, preview_completed_at,
+                   importable_at
+            FROM import_jobs
+            WHERE id = %s
+        """, (row["id"],))
+        normalized = cur.fetchone()
+        assert normalized is not None
+        self.assertEqual(normalized["preview_status"], "would_import")
+        self.assertEqual(
+            normalized["preview_message"],
+            "Queued before async preview gate",
+        )
+        self.assertIsNotNone(normalized["preview_completed_at"])
+        self.assertIsNotNone(normalized["importable_at"])
         db.close()
 
     def test_import_job_preview_schema_constraints_and_indexes(self):


### PR DESCRIPTION
## Summary
- add migration 006 to normalize completed/failed pre-preview jobs from preview_status=waiting to would_import
- preserve actual preview failures and actual preview attempts
- document why terminal legacy rows should not appear as active preview backlog

## Verification
- nix-shell --run "python3 -m unittest tests.test_pipeline_db.TestSchemaCreation -v"
- nix-shell --run "bash scripts/run_tests.sh"
- nix build .#checks.x86_64-linux.moduleVm