### PR TITLE
fix: guard wrong-match cleanup backfill

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -153,6 +153,8 @@ review list.
 pipeline_cli.py force-import <download_log_id>
 pipeline_cli.py import-jobs --status failed
 pipeline_cli.py wrong-match-preview-backfill --json
+pipeline_cli.py wrong-match-preview-backfill --cleanup --json
+pipeline_cli.py wrong-match-preview-backfill --cleanup --apply --request-id <id>
 # or: POST /api/pipeline/force-import {"download_log_id": N}
 ```
 
@@ -160,5 +162,8 @@ pipeline_cli.py wrong-match-preview-backfill --json
 daemon. It previews currently visible Wrong Matches rows with resolvable source
 folders, skips rows whose files are gone, skips rows already represented by an
 active force-import job, and records preview audit without creating import jobs.
-Use `--cleanup` only when you want cleanup-eligible confident rejects deleted as
-part of the same pass.
+Use `--cleanup` by itself as the cleanup dry-run: it counts cleanup-eligible
+confident rejects without writing audit rows or deleting files. Destructive
+cleanup requires `--cleanup --apply` and either `--request-id`, `--limit`, or
+explicit `--all`. The older `wrong-match-triage` command follows the same
+destructive-operation guard: `--apply` plus a scope, or explicit `--all`.

--- a/lib/wrong_match_triage.py
+++ b/lib/wrong_match_triage.py
@@ -117,6 +117,9 @@ def triage_wrong_matches(
     request_id: int | None = None,
     limit: int | None = None,
 ) -> list[WrongMatchTriageResult]:
+    if limit is not None and limit <= 0:
+        return []
+
     rows = db.get_wrong_matches()
     results: list[WrongMatchTriageResult] = []
     for row in rows:
@@ -137,6 +140,7 @@ def _summary_template() -> dict[str, int]:
         "would_import": 0,
         "confident_reject": 0,
         "uncertain_or_error": 0,
+        "cleanup_candidates": 0,
         "cleaned": 0,
         "cleanup_failed": 0,
         "skipped_missing_files": 0,
@@ -169,15 +173,28 @@ def _count_preview(summary: dict[str, int], preview: ImportPreviewResult) -> Non
         summary["uncertain_or_error"] += 1
 
 
+def _count_cleanup_candidate(summary: dict[str, int], preview: ImportPreviewResult) -> None:
+    if preview.confident_reject and preview.cleanup_eligible:
+        summary["cleanup_candidates"] += 1
+
+
 def backfill_wrong_match_previews(
     db: Any,
     *,
     request_id: int | None = None,
     limit: int | None = None,
     cleanup: bool = False,
+    dry_run: bool = False,
 ) -> dict[str, int]:
-    """Explicit one-shot preview backfill for current Wrong Matches rows."""
+    """Explicit one-shot preview backfill for current Wrong Matches rows.
+
+    ``dry_run`` previews and counts candidate outcomes without persisting audit
+    details or deleting cleanup-eligible rows.
+    """
     summary = _summary_template()
+    if limit is not None and limit <= 0:
+        return summary
+
     for row in db.get_wrong_matches():
         if request_id is not None and row.get("request_id") != request_id:
             continue
@@ -196,10 +213,15 @@ def backfill_wrong_match_previews(
             summary["skipped_active_jobs"] += 1
             continue
 
-        if cleanup:
+        if dry_run:
+            preview = preview_import_from_download_log(db, raw_id)
+            _count_preview(summary, preview)
+            _count_cleanup_candidate(summary, preview)
+        elif cleanup:
             result = triage_wrong_match(db, raw_id)
             if result.preview is not None:
                 _count_preview(summary, result.preview)
+                _count_cleanup_candidate(summary, result.preview)
             if result.action == "deleted_reject" and result.success:
                 summary["cleaned"] += 1
             elif result.action == "delete_failed":
@@ -207,6 +229,7 @@ def backfill_wrong_match_previews(
         else:
             preview = preview_import_from_download_log(db, raw_id)
             _count_preview(summary, preview)
+            _count_cleanup_candidate(summary, preview)
             _persist_triage_audit(db, WrongMatchTriageResult(
                 download_log_id=raw_id,
                 action="preview_backfilled",

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1268,6 +1268,28 @@ def cmd_wrong_match_triage(db, args):
     """Run conservative preview-driven cleanup for Wrong Matches rows."""
     from lib.wrong_match_triage import triage_wrong_match, triage_wrong_matches
 
+    if args.limit is not None and args.limit <= 0:
+        print("  --limit must be positive.", file=sys.stderr)
+        return 2
+    if not args.apply:
+        print(
+            "  Refusing destructive wrong-match triage without --apply. "
+            "Use wrong-match-preview-backfill --cleanup for a dry run.",
+            file=sys.stderr,
+        )
+        return 2
+    if (
+        args.download_log_id is None
+        and args.request_id is None
+        and args.limit is None
+        and not args.all
+    ):
+        print(
+            "  Refusing bulk triage without --request-id, --limit, or --all.",
+            file=sys.stderr,
+        )
+        return 2
+
     if args.download_log_id is not None:
         results = [triage_wrong_match(db, args.download_log_id)]
     else:
@@ -1299,16 +1321,44 @@ def cmd_wrong_match_preview_backfill(db, args):
     """Run explicit preview backfill for current Wrong Matches rows."""
     from lib.wrong_match_triage import backfill_wrong_match_previews
 
+    if args.limit is not None and args.limit <= 0:
+        print("  --limit must be positive.", file=sys.stderr)
+        return 2
+    if args.apply and args.dry_run:
+        print("  --apply and --dry-run cannot be combined.", file=sys.stderr)
+        return 2
+    if args.apply and not args.cleanup:
+        print("  --apply is only valid with --cleanup.", file=sys.stderr)
+        return 2
+    if (
+        args.cleanup
+        and args.apply
+        and args.request_id is None
+        and args.limit is None
+        and not args.all
+    ):
+        print(
+            "  Refusing cleanup apply without --request-id, --limit, or --all.",
+            file=sys.stderr,
+        )
+        return 2
+
+    dry_run = args.dry_run or (args.cleanup and not args.apply)
     summary = backfill_wrong_match_previews(
         db,
         request_id=args.request_id,
         limit=args.limit,
         cleanup=args.cleanup,
+        dry_run=dry_run,
     )
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))
         return 0
 
+    if dry_run:
+        print("  mode: dry_run")
+    elif args.cleanup:
+        print("  mode: apply")
     for key, count in sorted(summary.items()):
         print(f"  {key}: {count}")
     return 0
@@ -1434,6 +1484,10 @@ def main():
                           help="Limit batch triage to one request")
     p_triage.add_argument("--limit", type=int,
                           help="Maximum candidates to triage")
+    p_triage.add_argument("--apply", action="store_true",
+                          help="Allow destructive triage")
+    p_triage.add_argument("--all", action="store_true",
+                          help="Allow --apply to process every candidate")
     p_triage.add_argument("--json", action="store_true")
 
     # wrong-match-preview-backfill
@@ -1446,7 +1500,13 @@ def main():
     p_backfill.add_argument("--limit", type=int,
                             help="Maximum candidates to preview")
     p_backfill.add_argument("--cleanup", action="store_true",
-                            help="Delete only cleanup-eligible confident rejects")
+                            help="Preview cleanup-eligible confident rejects; add --apply to delete")
+    p_backfill.add_argument("--apply", action="store_true",
+                            help="Allow --cleanup to delete candidates")
+    p_backfill.add_argument("--all", action="store_true",
+                            help="Allow --cleanup --apply to process every candidate")
+    p_backfill.add_argument("--dry-run", action="store_true",
+                            help="Preview without writing audit or deleting files")
     p_backfill.add_argument("--json", action="store_true")
 
     # repair-spectral
@@ -1481,8 +1541,12 @@ def main():
         "wrong-match-preview-backfill": cmd_wrong_match_preview_backfill,
         "repair-spectral": cmd_repair_spectral,
     }
-    commands[args.command](db, args)
-    db.close()
+    try:
+        rc = commands[args.command](db, args)
+    finally:
+        db.close()
+    if isinstance(rc, int):
+        sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -375,6 +375,9 @@ class TestCmdWrongMatchPreviewBackfill(unittest.TestCase):
             request_id=42,
             limit=5,
             cleanup=False,
+            apply=False,
+            all=False,
+            dry_run=False,
             json=True,
         )
         stdout = io.StringIO()
@@ -395,9 +398,213 @@ class TestCmdWrongMatchPreviewBackfill(unittest.TestCase):
             request_id=42,
             limit=5,
             cleanup=False,
+            dry_run=False,
         )
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["previewed"], 1)
+
+    def test_cleanup_without_apply_runs_dry_run(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            request_id=None,
+            limit=None,
+            cleanup=True,
+            apply=False,
+            all=False,
+            dry_run=False,
+            json=True,
+        )
+        stdout = io.StringIO()
+        with patch(
+            "lib.wrong_match_triage.backfill_wrong_match_previews",
+            return_value={
+                "previewed": 1,
+                "confident_reject": 1,
+                "cleanup_candidates": 1,
+                "cleaned": 0,
+            },
+        ) as backfill, redirect_stdout(stdout):
+            rc = pipeline_cli.cmd_wrong_match_preview_backfill(db, args)
+
+        self.assertEqual(rc, 0)
+        backfill.assert_called_once_with(
+            db,
+            request_id=None,
+            limit=None,
+            cleanup=True,
+            dry_run=True,
+        )
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["cleanup_candidates"], 1)
+        self.assertEqual(payload["cleaned"], 0)
+
+    def test_cleanup_apply_requires_scope_or_all(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            request_id=None,
+            limit=None,
+            cleanup=True,
+            apply=True,
+            all=False,
+            dry_run=False,
+            json=False,
+        )
+        stderr = io.StringIO()
+        with patch(
+            "lib.wrong_match_triage.backfill_wrong_match_previews",
+        ) as backfill, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_preview_backfill(db, args)
+
+        self.assertEqual(rc, 2)
+        backfill.assert_not_called()
+        self.assertIn("--request-id, --limit, or --all", stderr.getvalue())
+
+    def test_cleanup_rejects_non_positive_limit(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            request_id=None,
+            limit=0,
+            cleanup=True,
+            apply=True,
+            all=False,
+            dry_run=False,
+            json=False,
+        )
+        stderr = io.StringIO()
+        with patch(
+            "lib.wrong_match_triage.backfill_wrong_match_previews",
+        ) as backfill, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_preview_backfill(db, args)
+
+        self.assertEqual(rc, 2)
+        backfill.assert_not_called()
+        self.assertIn("--limit must be positive", stderr.getvalue())
+
+    def test_cleanup_apply_delegates_when_scoped(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            request_id=42,
+            limit=None,
+            cleanup=True,
+            apply=True,
+            all=False,
+            dry_run=False,
+            json=True,
+        )
+        stdout = io.StringIO()
+        with patch(
+            "lib.wrong_match_triage.backfill_wrong_match_previews",
+            return_value={"previewed": 1, "cleaned": 1},
+        ) as backfill, redirect_stdout(stdout):
+            rc = pipeline_cli.cmd_wrong_match_preview_backfill(db, args)
+
+        self.assertEqual(rc, 0)
+        backfill.assert_called_once_with(
+            db,
+            request_id=42,
+            limit=None,
+            cleanup=True,
+            dry_run=False,
+        )
+
+
+class TestCmdWrongMatchTriage(unittest.TestCase):
+    def test_triage_requires_apply(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            download_log_id=99,
+            request_id=None,
+            limit=None,
+            apply=False,
+            all=False,
+            json=False,
+        )
+        stderr = io.StringIO()
+        with patch("lib.wrong_match_triage.triage_wrong_match") as triage, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_triage(db, args)
+
+        self.assertEqual(rc, 2)
+        triage.assert_not_called()
+        self.assertIn("--apply", stderr.getvalue())
+
+    def test_bulk_triage_apply_requires_scope_or_all(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            download_log_id=None,
+            request_id=None,
+            limit=None,
+            apply=True,
+            all=False,
+            json=False,
+        )
+        stderr = io.StringIO()
+        with patch("lib.wrong_match_triage.triage_wrong_matches") as triage, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_triage(db, args)
+
+        self.assertEqual(rc, 2)
+        triage.assert_not_called()
+        self.assertIn("--request-id, --limit, or --all", stderr.getvalue())
+
+    def test_triage_rejects_non_positive_limit(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            download_log_id=None,
+            request_id=None,
+            limit=0,
+            apply=True,
+            all=False,
+            json=False,
+        )
+        stderr = io.StringIO()
+        with patch("lib.wrong_match_triage.triage_wrong_matches") as triage, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_triage(db, args)
+
+        self.assertEqual(rc, 2)
+        triage.assert_not_called()
+        self.assertIn("--limit must be positive", stderr.getvalue())
+
+    def test_triage_apply_delegates_when_scoped(self):
+        db = MagicMock()
+        args = SimpleNamespace(
+            download_log_id=None,
+            request_id=42,
+            limit=None,
+            apply=True,
+            all=False,
+            json=True,
+        )
+        result = MagicMock()
+        result.to_dict.return_value = {"action": "deleted_reject"}
+        with patch(
+            "lib.wrong_match_triage.triage_wrong_matches",
+            return_value=[result],
+        ) as triage, redirect_stdout(io.StringIO()):
+            rc = pipeline_cli.cmd_wrong_match_triage(db, args)
+
+        self.assertEqual(rc, 0)
+        triage.assert_called_once_with(db, request_id=42, limit=None)
+
+
+class TestMainExitCodes(unittest.TestCase):
+    def test_main_propagates_command_return_code(self):
+        argv = [
+            "pipeline_cli.py",
+            "--dsn",
+            "postgresql://example/test",
+            "wrong-match-preview-backfill",
+            "--cleanup",
+            "--apply",
+        ]
+        db = MagicMock()
+        with patch.object(sys, "argv", argv), patch(
+            "scripts.pipeline_cli.PipelineDB",
+            return_value=db,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                pipeline_cli.main()
+
+        self.assertEqual(raised.exception.code, 2)
+        db.close.assert_called_once_with()
 
 
 class TestCmdQuery(unittest.TestCase):

--- a/tests/test_wrong_match_triage.py
+++ b/tests/test_wrong_match_triage.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 
 from lib.import_preview import ImportPreviewResult
 from lib.import_queue import IMPORT_JOB_FORCE, force_import_dedupe_key, force_import_payload
-from lib.wrong_match_triage import backfill_wrong_match_previews, triage_wrong_match
+from lib.wrong_match_triage import (
+    backfill_wrong_match_previews,
+    triage_wrong_match,
+    triage_wrong_matches,
+)
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
@@ -164,6 +168,81 @@ class TestWrongMatchTriage(unittest.TestCase):
             audit = vr["wrong_match_triage"]
             self.assertEqual(audit["action"], "preview_backfilled")
             self.assertEqual(audit["preview_verdict"], "would_import")
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_backfill_dry_run_counts_cleanup_candidates_without_mutating(self):
+        source = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            db, log_id = self._db_with_wrong_match(source)
+
+            with patch(
+                "lib.wrong_match_triage.preview_import_from_download_log",
+                return_value=ImportPreviewResult(
+                    mode="download_log",
+                    verdict="confident_reject",
+                    confident_reject=True,
+                    cleanup_eligible=True,
+                    decision="requeue_upgrade",
+                    reason="requeue_upgrade",
+                    source_path=source,
+                ),
+            ) as preview:
+                summary = backfill_wrong_match_previews(
+                    db,
+                    cleanup=True,
+                    dry_run=True,
+                )
+
+            preview.assert_called_once_with(db, log_id)
+            self.assertEqual(summary["previewed"], 1)
+            self.assertEqual(summary["confident_reject"], 1)
+            self.assertEqual(summary["cleanup_candidates"], 1)
+            self.assertEqual(summary["cleaned"], 0)
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            entry = db.get_download_log_entry(log_id)
+            assert entry is not None
+            vr = entry["validation_result"]
+            assert isinstance(vr, dict)
+            self.assertNotIn("wrong_match_triage", vr)
+            self.assertIn("failed_path", vr)
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_backfill_non_positive_limit_does_not_process_rows(self):
+        source = tempfile.mkdtemp()
+        try:
+            db, _log_id = self._db_with_wrong_match(source)
+
+            with patch("lib.wrong_match_triage.preview_import_from_download_log") as preview:
+                summary = backfill_wrong_match_previews(
+                    db,
+                    cleanup=True,
+                    limit=0,
+                )
+
+            preview.assert_not_called()
+            self.assertEqual(summary["previewed"], 0)
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_triage_non_positive_limit_does_not_process_rows(self):
+        source = tempfile.mkdtemp()
+        try:
+            db, _log_id = self._db_with_wrong_match(source)
+
+            with patch("lib.wrong_match_triage.preview_import_from_download_log") as preview:
+                results = triage_wrong_matches(db, limit=0)
+
+            preview.assert_not_called()
+            self.assertEqual(results, [])
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
         finally:
             shutil.rmtree(source, ignore_errors=True)
 


### PR DESCRIPTION
## Summary
- make `wrong-match-preview-backfill --cleanup` a dry-run unless `--apply` is present
- require destructive wrong-match cleanup/triage to be scoped by `--request-id`, `--limit`, or explicit `--all`
- reject non-positive limits and propagate CLI refusal exit codes
- document the safe wrong-match cleanup workflow

## Verification
- `nix-shell --run "pyright lib/wrong_match_triage.py scripts/pipeline_cli.py tests/test_pipeline_cli.py tests/test_wrong_match_triage.py"`
- `nix-shell --run "bash scripts/run_tests.sh"` (2358 tests, 53 skipped)
- Codex self-review: no actionable correctness issues after fixes