### PR TITLE
fix: propagate automation rejection outcomes

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -764,9 +764,8 @@ def _process_beets_validation(album_data: GrabListEntry,
     if bv_result.valid:
         return _handle_valid_result(
             album_data, bv_result, staged_album, ctx)
-    _handle_rejected_result(
+    return _handle_rejected_result(
         album_data, bv_result, staged_album, ctx)
-    return None
 
 
 def _resolved_request_rejection_id(
@@ -1073,7 +1072,7 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
 
 def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResult,
                             staged_album: StagedAlbum,
-                            ctx: CratediggerContext) -> None:
+                            ctx: CratediggerContext) -> DispatchOutcome:
     """Handle a rejected beets validation result."""
     failed_dest = move_failed_import(
         staged_album.current_path,
@@ -1113,6 +1112,12 @@ def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResu
                    f"distance={bv_result.distance}, "
                    f"detail={bv_result.detail}) "
                    f"| denylisted users: {', '.join(usernames)}")
+    scenario = bv_result.scenario or "validation_rejected"
+    detail = bv_result.detail or bv_result.error
+    message = f"Rejected: {scenario}"
+    if detail:
+        message = f"{message} - {detail}"
+    return DispatchOutcome(success=False, message=message)
 
 
 def _compute_rejection_backfill(album_data: GrabListEntry,

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -369,10 +369,21 @@ class PipelineDB:
                 WHEN status = 'queued' AND preview_status = 'waiting' THEN 3
                 ELSE 4
               END,
-              importable_at ASC NULLS LAST,
-              created_at ASC,
-              updated_at DESC,
-              id ASC
+              CASE
+                WHEN status IN ('queued', 'running') THEN importable_at
+              END ASC NULLS LAST,
+              CASE
+                WHEN status IN ('queued', 'running') THEN created_at
+              END ASC NULLS LAST,
+              CASE
+                WHEN status NOT IN ('queued', 'running') THEN updated_at
+              END DESC NULLS LAST,
+              CASE
+                WHEN status IN ('queued', 'running') THEN id
+              END ASC NULLS LAST,
+              CASE
+                WHEN status NOT IN ('queued', 'running') THEN id
+              END DESC NULLS LAST
             LIMIT %s
         """, (limit,))
         return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -507,7 +507,7 @@ class FakePipelineDB:
         return counts
 
     def list_import_job_timeline(self, *, limit: int = 50) -> list[ImportJob]:
-        def sort_key(row: dict[str, Any]) -> tuple[int, datetime, datetime, datetime, int]:
+        def sort_key(row: dict[str, Any]) -> tuple[int, datetime, datetime, float, int, int]:
             status = row.get("status")
             preview_status = row.get("preview_status")
             if status == "queued" and preview_status == "would_import":
@@ -520,12 +520,15 @@ class FakePipelineDB:
                 bucket = 3
             else:
                 bucket = 4
+            is_active = status in ("queued", "running")
             return (
                 bucket,
-                _as_datetime(row.get("importable_at")),
-                _as_datetime(row.get("created_at")),
-                _as_datetime(row.get("updated_at")),
-                int(row["id"]),
+                _as_datetime(row.get("importable_at")) if is_active else datetime.max.replace(tzinfo=timezone.utc),
+                _as_datetime(row.get("created_at")) if is_active else datetime.max.replace(tzinfo=timezone.utc),
+                -_as_datetime(row.get("updated_at")).timestamp()
+                if not is_active else 0.0,
+                int(row["id"]) if is_active else 0,
+                -int(row["id"]) if not is_active else 0,
             )
 
         rows = sorted(self._import_jobs, key=sort_key)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -970,6 +970,71 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertIs(result, mock_validation.return_value)
             mock_validation.assert_called_once()
 
+    @patch("lib.beets.beets_validate")
+    @patch("lib.download.music_tag")
+    def test_beets_rejection_summary_is_returned_to_queue_owner(
+        self,
+        mock_mt,
+        mock_beets_validate,
+    ):
+        """Validation rejections must fail the queue job, not look completed."""
+        from lib.download import process_completed_album
+        from lib.import_dispatch import DispatchOutcome
+        from lib.quality import ValidationResult
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            downloads_root = os.path.join(tmpdir, "downloads")
+            source_dir = os.path.join(downloads_root, "Music")
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, "01 - Track.mp3"), "w") as f:
+                f.write("fake audio")
+
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=42,
+                status="downloading",
+                artist_name="Artist",
+                album_title="Album",
+                year=2024,
+                mb_release_id="test-mbid",
+            ))
+            cfg = cast(Any, _make_ctx().cfg)
+            cfg.slskd_download_dir = downloads_root
+            cfg.beets_validation_enabled = True
+            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
+            ctx = make_ctx_with_fake_db(db, cfg=cfg)
+            mock_mt.load_file.return_value = MagicMock()
+            mock_beets_validate.return_value = ValidationResult(
+                valid=False,
+                distance=0.1919,
+                scenario="high_distance",
+                detail="distance=0.1919",
+            )
+            album = make_grab_list_entry(
+                files=[make_download_file(
+                    filename="user1\\Music\\01 - Track.mp3",
+                    file_dir="user1\\Music",
+                )],
+                artist="Artist",
+                title="Album",
+                year="2024",
+                mb_release_id="test-mbid",
+                db_request_id=42,
+                db_source="request",
+            )
+
+            result = process_completed_album(album, [], ctx)
+
+            assert isinstance(result, DispatchOutcome)
+            self.assertFalse(result.success)
+            self.assertFalse(result.deferred)
+            self.assertEqual(
+                result.message,
+                "Rejected: high_distance - distance=0.1919",
+            )
+            ctx.pipeline_db_source.reject_and_requeue.assert_called_once()
+
     def test_returns_false_on_file_move_failure(self):
         """File move failure returns False."""
         from lib.download import process_completed_album

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -636,6 +636,62 @@ class TestImportJobQueueAPI(unittest.TestCase):
         self.assertEqual([job.id for job in timeline[:2]], [importable.id, waiting.id])
         self.assertEqual(timeline[0].preview_status, "would_import")
 
+    def test_import_job_timeline_orders_recent_terminal_jobs_after_active(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        importable = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:timeline-active",
+            payload=manual_import_payload(failed_path="/tmp/active"),
+            preview_enabled=True,
+        )
+        self.db.mark_import_job_preview_importable(
+            importable.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
+        )
+        older = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:timeline-old-terminal",
+            payload=manual_import_payload(failed_path="/tmp/old"),
+        )
+        newer = self.db.enqueue_import_job(
+            IMPORT_JOB_MANUAL,
+            request_id=self.req_id,
+            dedupe_key="manual:timeline-new-terminal",
+            payload=manual_import_payload(failed_path="/tmp/new"),
+        )
+        self.db.mark_import_job_failed(
+            older.id,
+            error="old",
+            message="old",
+        )
+        self.db.mark_import_job_failed(
+            newer.id,
+            error="new",
+            message="new",
+        )
+        old_time = datetime.now(timezone.utc) - timedelta(hours=2)
+        new_time = datetime.now(timezone.utc) - timedelta(minutes=1)
+        self.db._execute(
+            "UPDATE import_jobs SET updated_at = %s WHERE id = %s",
+            (old_time, older.id),
+        )
+        self.db._execute(
+            "UPDATE import_jobs SET updated_at = %s WHERE id = %s",
+            (new_time, newer.id),
+        )
+
+        timeline = self.db.list_import_job_timeline(limit=10)
+
+        self.assertEqual([job.id for job in timeline[:3]], [
+            importable.id,
+            newer.id,
+            older.id,
+        ])
+
     def test_preview_claim_and_importable_lifecycle(self):
         from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
 


### PR DESCRIPTION
## Summary

Two queue audit bugs surfaced during the async-preview incident recovery:

- `_handle_rejected_result` returned `None`, so beets-validation rejections were collapsed by the importer queue into the generic "Automation import was deferred or requires manual recovery" message (or worse, `status=completed` when the outer path also returned True). Now returns a `DispatchOutcome(success=False, message="Rejected: <scenario> - <detail>")` so the queue records the real terminal verdict.
- `list_import_job_timeline` sorted terminal rows by `created_at`, pushing recent repaired/incident terminal jobs off page 1. Active jobs still sort by `importable_at` ASC; terminal rows now sort by `updated_at` DESC.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 2365 tests, 53 skipped, OK
- [x] Pyright clean on touched files (2 pre-existing errors on main remain)
- [x] New RED→GREEN tests:
  - `test_beets_rejection_summary_is_returned_to_queue_owner` (DispatchOutcome propagation)
  - `test_import_job_timeline_orders_recent_terminal_jobs_after_active` (timeline sort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)