### PR TITLE
feat: lock lossy candidates against existing lossless-source V0 probe

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1388,7 +1388,12 @@ def main():
 
     if provisional.confident_reject:
         r.exit_code = 5
-        _log(f"[SUSPECT LOSSLESS REJECT] {provisional.reason}")
+        log_prefix = (
+            "[LOSSLESS SOURCE LOCKED]"
+            if decision == "lossless_source_locked"
+            else "[SUSPECT LOSSLESS REJECT]"
+        )
+        _log(f"{log_prefix} {provisional.reason}")
         if args.preserve_source and not keep_lossless and converted > 0:
             _remove_files_by_ext(work_path, "." + V0_SPEC.extension)
             _log(f"  [PRESERVE-SOURCE] Removed temporary V0 artifacts; "

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -1035,6 +1035,19 @@ def dispatch_import_core(
                         logger.warning(
                             f"SUSPECT LOSSLESS REJECTED: {label} "
                             "missing comparable V0 probe")
+                    elif decision == "lossless_source_locked":
+                        fail_scenario = "lossless_source_locked"
+                        existing_avg = (
+                            ir.existing_v0_probe.avg_bitrate_kbps
+                            if ir.existing_v0_probe else None
+                        )
+                        fail_detail = ir.error or (
+                            f"lossy candidate cannot override existing "
+                            f"lossless-source V0 probe {existing_avg}kbps"
+                        )
+                        logger.warning(
+                            f"LOSSLESS SOURCE LOCKED: {label} "
+                            f"existing_v0_avg={existing_avg}kbps")
                     elif decision == "duplicate_remove_guard_failed":
                         fail_scenario = "duplicate_remove_guard_failed"
                         fail_detail = _guard_failure_detail(ir)
@@ -1077,6 +1090,7 @@ def dispatch_import_core(
                             "transcode_downgrade",
                             "suspect_lossless_downgrade",
                             "suspect_lossless_probe_missing",
+                            "lossless_source_locked",
                         )
                         else None
                     )

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -156,6 +156,7 @@ _REJECT_STAGE_DECISIONS: frozenset[str] = frozenset({
     "transcode_downgrade",
     "suspect_lossless_downgrade",
     "suspect_lossless_probe_missing",
+    "lossless_source_locked",
 })
 _QUALITY_GATE_REQUEUE_DECISIONS: frozenset[str] = frozenset({
     "requeue_upgrade",

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -27,6 +27,7 @@ V0_PROBE_KINDS = frozenset({
 DECISION_PROVISIONAL_LOSSLESS_UPGRADE = "provisional_lossless_upgrade"
 DECISION_SUSPECT_LOSSLESS_DOWNGRADE = "suspect_lossless_downgrade"
 DECISION_SUSPECT_LOSSLESS_PROBE_MISSING = "suspect_lossless_probe_missing"
+DECISION_LOSSLESS_SOURCE_LOCKED = "lossless_source_locked"
 
 # Deprecated aliases — keep for old code that references them
 QUALITY_FLAC_ONLY = QUALITY_LOSSLESS
@@ -1958,11 +1959,42 @@ def provisional_lossless_decision(
     sources). For suspect supported lossless sources, V0 probe avg bitrate is
     the v1 comparison signal and ``within_rank_tolerance_kbps`` is the only
     tolerance knob.
+
+    When ``supported_lossless_source`` is False (lossy candidate) AND
+    ``existing_probe`` is a comparable lossless-source probe, the function
+    returns ``DECISION_LOSSLESS_SOURCE_LOCKED`` — a lossy candidate cannot
+    produce a comparable measurement, and the recorded probe is the truth-
+    of-source anchor. ``candidate_probe`` is ignored in that branch.
     """
     if cfg is None:
         cfg = QualityRankConfig.defaults()
 
     if not candidate.supported_lossless_source:
+        # Lossless-source lock: when the existing album was previously
+        # imported as a provisional lossless source we transcoded down (so
+        # current_lossless_source_v0_probe_avg_bitrate is the only V0-grade
+        # signal we have), a lossy candidate cannot produce comparable
+        # evidence and must not be allowed to override on raw avg alone.
+        # The recorded V0 probe is the truth-of-source anchor; only another
+        # lossless-container candidate (which can be ground to V0) is
+        # eligible to displace it.
+        if is_comparable_lossless_source_probe(candidate.existing_probe):
+            assert candidate.existing_probe is not None
+            existing_avg = candidate.existing_probe.avg_bitrate_kbps
+            decision = DECISION_LOSSLESS_SOURCE_LOCKED
+            return ProvisionalLosslessDecisionResult(
+                decision=decision,
+                would_import=False,
+                confident_reject=True,
+                cleanup_eligible=True,
+                reason=(
+                    f"existing has lossless-source V0 probe "
+                    f"{existing_avg}kbps; lossy candidate cannot produce "
+                    f"comparable evidence (only another lossless source "
+                    f"can override)"
+                ),
+                stage_chain=[f"stage2_provisional:{decision}"],
+            )
         return ProvisionalLosslessDecisionResult()
 
     if candidate.spectral_grade not in SPECTRAL_TRANSCODE_GRADES:
@@ -2306,6 +2338,7 @@ def dispatch_action(decision: str) -> DispatchAction:
     elif decision in (
         DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
         DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
+        DECISION_LOSSLESS_SOURCE_LOCKED,
     ):
         return DispatchAction(record_rejection=True, denylist=True,
                               requeue=True, cleanup=True)
@@ -2883,6 +2916,10 @@ def get_decision_tree(
                            "spectral_grade",
                            "cfg.within_rank_tolerance_kbps"],
                 "rules": [
+                    {"condition": "lossy candidate AND existing has comparable lossless-source V0 probe",
+                     "result": DECISION_LOSSLESS_SOURCE_LOCKED,
+                     "color": "red",
+                     "effect": "reject; only another lossless source can override the recorded V0 anchor"},
                     {"condition": "spectral = genuine/marginal",
                      "result": "continue", "color": "green",
                      "effect": "clean sources stay on the verified-lossless path"},
@@ -2907,6 +2944,7 @@ def get_decision_tree(
                     DECISION_PROVISIONAL_LOSSLESS_UPGRADE,
                     DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
                     DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
+                    DECISION_LOSSLESS_SOURCE_LOCKED,
                 ],
                 "note": "Uses source-probe avg as evidence. Native lossy "
                         "research probes are non-comparable in v1.",
@@ -3479,6 +3517,28 @@ def full_pipeline_decision(
             is_cbr=is_cbr,
             spectral_grade=spectral_grade,
             spectral_bitrate_kbps=spectral_bitrate)
+        # Lossless-source lock: a recorded existing lossless-source V0 probe
+        # is the truth-of-source anchor. Lossy candidates have no comparable
+        # measurement and are rejected before measured_import_decision can
+        # be misled by an on-disk avg that is just our own transcode floor.
+        lossy_lock = provisional_lossless_decision(
+            ProvisionalLosslessDecisionInput(
+                candidate_probe=None,
+                existing_probe=V0ProbeEvidence(
+                    kind=existing_v0_probe_kind or V0_PROBE_LOSSLESS_SOURCE,
+                    avg_bitrate_kbps=existing_v0_probe_avg,
+                ) if existing_v0_probe_avg is not None else None,
+                spectral_grade=spectral_grade,
+                supported_lossless_source=False,
+            ),
+            cfg=cfg,
+        )
+        if lossy_lock.decision == DECISION_LOSSLESS_SOURCE_LOCKED:
+            result["stage2_import"] = lossy_lock.decision
+            result["final_status"] = "wanted"
+            result["denylisted"] = True
+            result["keep_searching"] = True
+            return result
         measured = measured_import_decision(
             MeasuredImportDecisionInput(new_m, existing_m), cfg=cfg)
         result["stage2_import"] = measured.decision

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -675,6 +675,10 @@ def cmd_quality(db, args):
     final_format = req.get("final_format")
     target_format = req.get("target_format")
     verified_lossless_target = _load_runtime_verified_lossless_target() or None
+    # Existing-side lossless-source V0 probe — anchors the lossless_source_locked
+    # rule. When set, lossy candidates short-circuit to reject inside the
+    # provisional lane regardless of how their on-disk avg compares.
+    existing_v0_probe_avg = req.get("current_lossless_source_v0_probe_avg_bitrate")
 
     print(f"  {label}")
     print(f"  Status: {req['status']}")
@@ -730,6 +734,9 @@ def cmd_quality(db, args):
             print(f"    current_spectral_bitrate={current_br}kbps")
         if spectral_grade:
             print(f"    current_spectral_grade={spectral_grade}")
+        if existing_v0_probe_avg is not None:
+            print(f"    current_lossless_source_v0_probe_avg={existing_v0_probe_avg}kbps "
+                  f"(locks lossy candidates)")
         if q_override:
             print(f"    searching: {q_override}")
     else:
@@ -870,6 +877,7 @@ def cmd_quality(db, args):
             verified_lossless=verified,
             target_format=target_format,
             verified_lossless_target=verified_lossless_target,
+            existing_v0_probe_avg=existing_v0_probe_avg,
             cfg=rank_cfg,
             **params_with_runtime)
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -567,6 +567,50 @@ class TestDispatchImport(unittest.TestCase):
         )
         self.assertTrue(len(r["db"].denylist) > 0)
 
+    def test_lossless_source_locked_rejects_lossy_candidate(self):
+        # Wire-boundary test: import_one.py emits decision=lossless_source_locked
+        # for a lossy candidate the gate refused to compare against an
+        # existing lossless-source V0 probe. Dispatch must:
+        #   - record a rejected download_log with beets_scenario=lossless_source_locked
+        #   - put a human-readable detail referencing the existing probe
+        #   - clear ir.error from the stored row (it's a domain rejection, not a crash)
+        #   - denylist + requeue the request to wanted
+        existing = V0ProbeEvidence(
+            kind=V0_PROBE_LOSSLESS_SOURCE,
+            min_bitrate_kbps=210,
+            avg_bitrate_kbps=240,
+            median_bitrate_kbps=235,
+        )
+        ir = make_import_result(
+            decision="lossless_source_locked",
+            new_min_bitrate=176,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            verified_lossless=False,
+            existing_v0_probe=existing,
+            error=("existing has lossless-source V0 probe 240kbps; lossy "
+                   "candidate cannot produce comparable evidence"),
+        )
+
+        r = self._dispatch(ir, request_overrides={
+            "current_lossless_source_v0_probe_avg_bitrate": 240,
+        })
+
+        row = r["db"].request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["current_lossless_source_v0_probe_avg_bitrate"], 240)
+        self.assertEqual(r["db"].download_logs[0].outcome, "rejected")
+        self.assertEqual(r["db"].download_logs[0].beets_scenario,
+                         "lossless_source_locked")
+        self.assertIn(
+            "240",
+            r["db"].download_logs[0].beets_detail or "",
+        )
+        # ir.error is suppressed for lossless_source_locked — domain rejections
+        # should not bleed into the error_message column (mirrors suspect_lossless_*).
+        self.assertIsNone(r["db"].download_logs[0].error_message)
+        self.assertTrue(len(r["db"].denylist) > 0)
+
     def test_error_decision(self):
         ir = make_import_result(decision="conversion_failed",
                                 error="ffmpeg failed")

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -156,6 +156,31 @@ class TestImportPreviewValues(unittest.TestCase):
         self.assertTrue(preview.cleanup_eligible)
         self.assertEqual(preview.reason, "suspect_lossless_downgrade")
 
+    def test_values_preview_classifies_lossless_source_locked(self):
+        # Lossy candidate (is_flac=False) facing existing with comparable
+        # lossless-source V0 probe — preview must classify as confident
+        # reject so the importer never schedules it. Parallel to the
+        # suspect_lossless_downgrade case above.
+        preview = preview_import_from_values(
+            ImportPreviewValues(
+                is_flac=False,
+                is_cbr=False,
+                is_vbr=True,
+                min_bitrate=176,
+                avg_bitrate=205,
+                spectral_grade="likely_transcode",
+                spectral_bitrate=128,
+                existing_min_bitrate=116,
+                existing_avg_bitrate=131,
+                existing_format="opus",
+                existing_v0_probe_avg=240,
+            )
+        )
+
+        self.assertEqual(preview.verdict, "confident_reject")
+        self.assertTrue(preview.cleanup_eligible)
+        self.assertEqual(preview.reason, "lossless_source_locked")
+
 
 class TestImportPreviewPath(unittest.TestCase):
     def _db(self) -> FakePipelineDB:

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -697,6 +697,93 @@ class TestSpectralPropagationSlice(unittest.TestCase):
         self.assertEqual(row["current_spectral_bitrate"], 280)
 
 
+class TestLosslessSourceLockedSlice(unittest.TestCase):
+    """Integration slice: lossy candidate vs existing with lossless-source V0
+    probe → real parse_import_result → lossless_source_locked dispatch path
+    → domain state assertions.
+
+    Replaces the per-step mocking with end-to-end coverage of the wire
+    boundary: import_one.py emits a real ImportResult JSON sentinel,
+    dispatch_import_core parses it, dispatch_action maps the decision to
+    record_rejection+denylist+requeue, and the rejection lands in
+    download_log + denylist + status=wanted.
+    """
+
+    def test_lossy_candidate_locked_records_rejection_and_requeues(self):
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import V0ProbeEvidence, V0_PROBE_LOSSLESS_SOURCE
+
+        existing_probe = V0ProbeEvidence(
+            kind=V0_PROBE_LOSSLESS_SOURCE,
+            min_bitrate_kbps=210,
+            avg_bitrate_kbps=240,
+            median_bitrate_kbps=235,
+        )
+        ir = make_import_result(
+            decision="lossless_source_locked",
+            new_min_bitrate=176,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            verified_lossless=False,
+            existing_v0_probe=existing_probe,
+            error=("existing has lossless-source V0 probe 240kbps; lossy "
+                   "candidate cannot produce comparable evidence"),
+        )
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="downloading", mb_release_id="mbid-123",
+            current_lossless_source_v0_probe_min_bitrate=210,
+            current_lossless_source_v0_probe_avg_bitrate=240,
+            current_lossless_source_v0_probe_median_bitrate=235,
+        ))
+
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(None)):
+                ext.run.return_value = MagicMock(
+                    returncode=5, stdout=_make_stdout(ir), stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id="mbid-123",
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=DownloadInfo(username="user1"),
+                    distance=0.131,
+                    scenario="strong_match",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=cfg,
+                )
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        # The recorded V0 probe must survive the rejection — it's the anchor
+        # the next attempt will compare against, not state to clear.
+        self.assertEqual(
+            row["current_lossless_source_v0_probe_avg_bitrate"], 240)
+        self.assertEqual(len(db.download_logs), 1)
+        db.assert_log(self, 0, outcome="rejected",
+                      beets_scenario="lossless_source_locked")
+        # ir.error is suppressed for domain rejections — error_message
+        # must be None so downstream UIs don't render it as a crash.
+        self.assertIsNone(db.download_logs[0].error_message)
+        self.assertIn("240", db.download_logs[0].beets_detail or "")
+        self.assertEqual(len(db.denylist), 1)
+        self.assertEqual(db.denylist[0].username, "user1")
+
+
 class TestDispatchNoJsonResult(unittest.TestCase):
     """Integration slice: sp.run returns no sentinel -> record rejection."""
 

--- a/tests/test_js_decisions.mjs
+++ b/tests/test_js_decisions.mjs
@@ -450,6 +450,32 @@ console.log('\ndsPreset() live examples');
     'renderSimulatorResults marks suspect lossless missing-probe as red');
 }
 
+{
+  // The JS red list and python _REJECT_STAGE_DECISIONS must stay in sync —
+  // a divergence would silently render a real rejection in amber/green.
+  const resultsEl = { innerHTML: '' };
+  global.document = {
+    getElementById(id) {
+      return id === 'ds-results' ? resultsEl : null;
+    },
+  };
+  renderSimulatorResults({
+    preimport_audio: 'pass',
+    preimport_nested: 'skipped_auto',
+    stage0_spectral_gate: 'skipped_vbr_high_avg',
+    stage1_spectral: null,
+    stage2_import: 'lossless_source_locked',
+    stage3_quality_gate: null,
+    final_status: 'wanted',
+    imported: false,
+    denylisted: true,
+    keep_searching: true,
+  });
+  assertContains(resultsEl.innerHTML,
+    '<span class="ds-outcome ds-red">lossless_source_locked</span>',
+    'renderSimulatorResults marks lossless_source_locked as red');
+}
+
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -44,6 +44,7 @@ from lib.quality import (
     DECISION_PROVISIONAL_LOSSLESS_UPGRADE,
     DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
     DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
+    DECISION_LOSSLESS_SOURCE_LOCKED,
 )
 
 
@@ -421,13 +422,56 @@ class TestProvisionalLosslessDecision(unittest.TestCase):
                 self.assertIsNone(result.decision)
                 self.assertFalse(result.would_import)
 
-    def test_native_lossy_research_probe_is_ignored(self):
-        result = self._decide(avg=320, existing=self._probe(171),
-                              supported=False,
-                              kind="native_lossy_research_v0")
+    def test_lossy_candidate_locks_when_existing_has_lossless_source_probe(self):
+        # Message to Bears EP1 shape: existing on-disk is a transcoded opus
+        # we made from a suspect FLAC, with the original lossless-source V0
+        # probe (240kbps) recorded. A lossy candidate cannot produce a
+        # comparable measurement, so it must be rejected outright.
+        result = self._decide(avg=320, existing=self._probe(240),
+                              supported=False)
+        self.assertEqual(result.decision, DECISION_LOSSLESS_SOURCE_LOCKED)
+        self.assertTrue(result.confident_reject)
+        self.assertTrue(result.cleanup_eligible)
+        self.assertIn("240kbps", result.reason or "")
+
+    def test_lossy_candidate_locks_regardless_of_spectral_grade(self):
+        # The lock is structural — a lossy candidate cannot be ground to V0
+        # to compare against the recorded probe regardless of how clean its
+        # own spectral looks. Grade is informational here, not load-bearing.
+        for grade in ("genuine", "marginal", "suspect", "likely_transcode"):
+            with self.subTest(grade=grade):
+                result = self._decide(avg=320, existing=self._probe(240),
+                                      supported=False, grade=grade)
+                self.assertEqual(result.decision, DECISION_LOSSLESS_SOURCE_LOCKED)
+
+    def test_lossy_candidate_passes_when_no_existing_probe(self):
+        # No recorded lossless-source V0 probe means nothing to lock against —
+        # the regular import_quality_decision path still runs.
+        result = self._decide(avg=320, existing=None, supported=False)
+        self.assertIsNone(result.decision)
+
+    def test_supported_lossless_source_bypasses_lock(self):
+        # The lock fires only on lossy candidates. A FLAC candidate facing
+        # an existing lossless-source V0 probe must still be eligible to
+        # override via the normal V0 grind-up comparison — never short-
+        # circuit to lossless_source_locked. Guards against future refactors
+        # that move the lock above the supported_lossless_source check.
+        result = self._decide(avg=320, supported=True, grade="suspect",
+                              existing=self._probe(240))
+        self.assertNotEqual(result.decision, DECISION_LOSSLESS_SOURCE_LOCKED)
+
+    def test_lossy_candidate_passes_when_existing_probe_is_research_only(self):
+        # Only lossless_source_v0 probes are load-bearing evidence; on-disk
+        # research probes don't lock. is_comparable_lossless_source_probe
+        # is the single source of truth for what counts.
+        result = self._decide(avg=320, supported=False,
+                              existing=self._probe(300,
+                                                   kind="on_disk_research_v0"))
         self.assertIsNone(result.decision)
 
     def test_research_existing_probe_is_not_comparable(self):
+        # FLAC-side: a research-kind existing probe is not comparable, so
+        # we treat existing as absent and import provisionally.
         result = self._decide(
             avg=250,
             existing=self._probe(300, kind="on_disk_research_v0"),
@@ -798,7 +842,8 @@ VALID_STAGE2 = {None, "import", "downgrade", "transcode_upgrade",
                 "preflight_existing",
                 DECISION_PROVISIONAL_LOSSLESS_UPGRADE,
                 DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
-                DECISION_SUSPECT_LOSSLESS_PROBE_MISSING}
+                DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
+                DECISION_LOSSLESS_SOURCE_LOCKED}
 VALID_STAGE3 = {None, "accept", "requeue_upgrade", "requeue_lossless"}
 VALID_FINAL_STATUS = {None, "imported", "wanted"}
 
@@ -1672,6 +1717,53 @@ class TestFullPipelineContract(unittest.TestCase):
         self.assertIsNone(r["target_final_format"])
         self.assertIsNone(r["stage3_quality_gate"])
 
+    def test_lossy_candidate_locked_by_existing_lossless_source_probe(self):
+        """Message to Bears EP1 / k1d_pr1mus shape, 2026-04-27 21:16.
+
+        Existing on-disk file is opus 128 (avg ~131kbps) transcoded from a
+        provisional suspect FLAC source whose lossless-source V0 probe was
+        recorded at 240kbps. A subsequent lossy candidate at avg 205kbps with
+        spectral cliff ~128kbps must be rejected by the lossless-source lock
+        before measured_import_decision gets a chance to compare it against
+        the on-disk avg, because there is no V0-comparable evidence the
+        lossy side could produce.
+        """
+        r = full_pipeline_decision(
+            is_flac=False,
+            min_bitrate=176,
+            avg_bitrate=205,
+            is_cbr=False,
+            is_vbr=True,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            existing_min_bitrate=116,
+            existing_avg_bitrate=131,
+            existing_format="opus",
+            existing_v0_probe_avg=240,
+            verified_lossless_target="opus 128",
+        )
+        self.assertEqual(r["stage2_import"], DECISION_LOSSLESS_SOURCE_LOCKED)
+        self.assertFalse(r["imported"])
+        self.assertTrue(r["denylisted"])
+        self.assertTrue(r["keep_searching"])
+        self.assertEqual(r["final_status"], "wanted")
+        self.assertIsNone(r["stage3_quality_gate"])
+
+    def test_lossy_candidate_passes_when_no_lossless_source_probe(self):
+        """Without a recorded lossless-source V0 probe the lock has nothing
+        to anchor against — the legacy import_quality_decision path runs."""
+        r = full_pipeline_decision(
+            is_flac=False,
+            min_bitrate=320,
+            avg_bitrate=320,
+            is_cbr=True,
+            existing_min_bitrate=192,
+            existing_avg_bitrate=192,
+            existing_is_cbr=True,
+        )
+        self.assertNotEqual(r["stage2_import"], DECISION_LOSSLESS_SOURCE_LOCKED)
+        self.assertTrue(r["imported"])
+
     def test_target_conversion_mp3_skips(self):
         """MP3 path + verified_lossless_target → no target conversion."""
         r = full_pipeline_decision(
@@ -1827,6 +1919,9 @@ class TestDispatchAction(unittest.TestCase):
          dict(mark_done=False, record_rejection=True, denylist=True,
               requeue=True, cleanup=True)),
         ("suspect_lossless_probe_missing",
+         dict(mark_done=False, record_rejection=True, denylist=True,
+              requeue=True, cleanup=True)),
+        ("lossless_source_locked",
          dict(mark_done=False, record_rejection=True, denylist=True,
               requeue=True, cleanup=True)),
         ("conversion_failed", dict(record_rejection=True, denylist=False)),

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -46,6 +46,12 @@ class AlbumState:
     # diverges from min; the CBR-conditional override in full_pipeline_decision
     # needs this to behave correctly (see test_unter_null_failure_epiphany_vbr_loop).
     avg_bitrate: int | None = None
+    # current_lossless_source_v0_probe_avg_bitrate — when set, this album
+    # was previously imported as a provisional suspect-FLAC source and the
+    # source's V0 grind is the truth-of-source anchor. Lossy candidates
+    # short-circuit to lossless_source_locked instead of comparing against
+    # the on-disk transcode floor (avg_bitrate).
+    existing_v0_probe_avg: int | None = None
 
 
 def _derive_album_format(album: "AlbumState") -> str | None:
@@ -159,6 +165,17 @@ ALBUM_STATES = [
                "genuine", 96, False, None,
                avg_bitrate=128,
                existing_format="MP3"),
+    # Message to Bears - EP1 (req 1446, 2026-04-27 21:16). A previous
+    # provisional FLAC source (k1d_pr1mus, suspect likely_transcode) was
+    # accepted with V0 grind 240kbps, then transcoded to opus 128 on disk.
+    # current_lossless_source_v0_probe_avg_bitrate stays at 240 — the
+    # truth-of-source anchor. Lossy candidates from this point forward must
+    # short-circuit to lossless_source_locked: the on-disk opus 128 avg
+    # (~131kbps) is just our own transcode floor, not a comparable signal.
+    AlbumState("provisional_locked_opus", 116, False,
+               "likely_transcode", None, False, None,
+               avg_bitrate=131, existing_format="opus",
+               existing_v0_probe_avg=240),
 ]
 
 ALBUM_MAP = {a.name: a for a in ALBUM_STATES}
@@ -270,6 +287,7 @@ def simulate(album: AlbumState, download: DownloadScenario,
         verified_lossless=album.verified_lossless,
         verified_lossless_target=verified_lossless_target,
         target_format=album.target_format,
+        existing_v0_probe_avg=album.existing_v0_probe_avg,
         **download.dl_params(),
     )
 
@@ -418,11 +436,39 @@ class TestSimulatorInvariants(unittest.TestCase):
                                                 "transcode_first",
                                                 "provisional_lossless_upgrade",
                                                 "suspect_lossless_downgrade",
-                                                "suspect_lossless_probe_missing"),
+                                                "suspect_lossless_probe_missing",
+                                                "lossless_source_locked"),
                             r.stage3_quality_gate == "requeue_upgrade",
                         )
                         self.assertTrue(any(causes),
                                         f"Denylisted without valid cause: {r}")
+
+    def test_provisional_locked_album_rejects_all_lossy_candidates(self):
+        """When existing has a recorded lossless-source V0 probe, every lossy
+        download scenario must short-circuit to lossless_source_locked.
+
+        FLAC candidates are exempt — they hit the regular provisional V0
+        grind-up lane. This invariant locks in the rule that motivated the
+        Message to Bears EP1 fix: lossy candidates have no V0-comparable
+        evidence, so the recorded probe wins by default.
+        """
+        album = ALBUM_MAP["provisional_locked_opus"]
+        for dl in DOWNLOAD_SCENARIOS:
+            with self.subTest(dl=dl.name):
+                r = simulate(album, dl)
+                if dl.is_flac:
+                    self.assertNotEqual(
+                        r.stage2_import, "lossless_source_locked",
+                        "FLAC candidates must not be locked — they can be "
+                        "ground to V0 and compared against the recorded probe.")
+                else:
+                    self.assertEqual(
+                        r.stage2_import, "lossless_source_locked",
+                        f"Lossy {dl.name} must be locked against the "
+                        f"recorded V0 probe; got {r.stage2_import}")
+                    self.assertFalse(r.imported)
+                    self.assertEqual(r.final_status, "wanted")
+                    self.assertTrue(r.keep_searching)
 
     def test_genuine_flac_on_fresh_is_verified_and_done(self):
         """Genuine/marginal FLAC on fresh request: imported, accepted, done."""

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -473,6 +473,31 @@ class TestClassifyBadge(unittest.TestCase):
         self.assertIn("not meaningfully better", result.verdict)
         self.assertIn("searching continues", result.verdict)
 
+    def test_rejected_lossless_source_locked(self):
+        # Lossy candidate offered against an existing album whose original
+        # lossless-source V0 probe is recorded — the lock fires before the
+        # comparator runs. Verdict copy must surface (a) the candidate's real
+        # bitrate + spectral context, (b) the recorded existing probe, and
+        # (c) the structural reason ("only another lossless source can
+        # override"). All three are read by users in the recents log to
+        # understand WHY the candidate was rejected even though its avg
+        # exceeded the on-disk transcode floor.
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="lossless_source_locked",
+            actual_min_bitrate=176,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            existing_v0_probe_avg_bitrate=240,
+        ))
+        self.assertEqual(result.badge, "Rejected")
+        self.assertEqual(result.badge_class, "badge-rejected")
+        self.assertIn("Lossless-source locked", result.verdict)
+        self.assertIn("240", result.verdict)
+        self.assertIn(
+            "only another lossless source can override", result.verdict)
+        self.assertIn("searching continues", result.verdict)
+
     def test_rejected_high_distance(self):
         result = classify_log_entry(_entry(
             outcome="rejected", beets_scenario="high_distance", beets_distance=0.45))

--- a/web/classify.py
+++ b/web/classify.py
@@ -682,6 +682,9 @@ def _quality_verdict_from_import_result(entry: LogEntry) -> str | None:
     if ir.decision == "suspect_lossless_probe_missing":
         return _provisional_verdict(entry, imported=False)
 
+    if ir.decision == "lossless_source_locked":
+        return _lossless_source_locked_verdict(entry)
+
     if ir.error:
         return f"Import error: {ir.error}"
 
@@ -728,6 +731,32 @@ def _spectral_phrase(entry: LogEntry) -> str | None:
     if entry.spectral_bitrate:
         phrase += f" ~{entry.spectral_bitrate}kbps"
     return phrase
+
+
+def _lossless_source_locked_verdict(entry: LogEntry) -> str:
+    """Verdict copy for the lossless-source lock rejection.
+
+    Fires when a lossy candidate is offered against an existing album whose
+    original lossless-source V0 probe is already recorded. The candidate
+    cannot produce comparable evidence — only another lossless-container
+    source can override the recorded probe.
+    """
+    _, existing_avg, _ = _probe_values(entry)
+    new_kbps = _downloaded_min_bitrate_kbps(entry)
+    parts: list[str] = []
+    if new_kbps is not None:
+        spectral = _spectral_phrase(entry)
+        new_phrase = f"{new_kbps}kbps lossy candidate"
+        if spectral:
+            new_phrase += f" ({spectral})"
+        parts.append(new_phrase)
+    if existing_avg is not None:
+        parts.append(
+            f"existing has lossless-source V0 probe {existing_avg}kbps"
+        )
+    parts.append("only another lossless source can override")
+    parts.append("searching continues")
+    return "Lossless-source locked: " + "; ".join(parts)
 
 
 def _provisional_verdict(entry: LogEntry, *, imported: bool) -> str:
@@ -810,12 +839,15 @@ def _rejection_verdict(entry: LogEntry) -> str:
         "transcode_downgrade",
         "suspect_lossless_downgrade",
         "suspect_lossless_probe_missing",
+        "lossless_source_locked",
     ):
         ir_verdict = _quality_verdict_from_import_result(entry)
         if ir_verdict is not None:
             return ir_verdict
         if scenario.startswith("suspect_lossless"):
             return _provisional_verdict(entry, imported=False)
+        if scenario == "lossless_source_locked":
+            return _lossless_source_locked_verdict(entry)
         # Fallback: use real file bitrate, not spectral
         new_kbps = _downloaded_min_bitrate_kbps(entry)
         old_kbps = entry.existing_min_bitrate or entry.existing_spectral_bitrate

--- a/web/js/decisions.js
+++ b/web/js/decisions.js
@@ -592,6 +592,7 @@ export function renderSimulatorResults(r) {
          'skipped_vbr_high_avg', 'skipped_flac', 'skipped_auto'].includes(val)) return 'ds-green';
     if (['reject', 'downgrade', 'transcode_downgrade',
          'suspect_lossless_downgrade', 'suspect_lossless_probe_missing',
+         'lossless_source_locked',
          'reject_corrupt', 'reject_nested'].includes(val)) return 'ds-red';
     return 'ds-amber';
   }


### PR DESCRIPTION
## Summary

When an album has already been imported as a provisional suspect-FLAC source and transcoded down to a lossy target (e.g. opus 128), the on-disk avg bitrate is just our own transcode floor — not a comparable signal. The recorded `current_lossless_source_v0_probe_avg_bitrate` is the truth-of-source anchor.

This PR adds a structural `lossless_source_locked` rejection lane. When existing has a comparable lossless-source V0 probe AND the candidate is not a supported lossless container (FLAC/WAV/M4A/ALAC), the candidate is rejected before the avg-vs-avg comparator runs. Only another lossless-container candidate (which can be ground to V0 and compared against the recorded probe) is eligible to override.

The motivating live shape was Message to Bears EP1, request 1446 — a previously imported provisional FLAC source with V0 grind 240kbps stored as opus 128 on disk (avg ~131kbps). New 205kbps lossy candidates were being rejected with verdict text like "205kbps avg is not better than existing 131kbps avg" — a false-positive comparison against a number that was just our own opus transcode floor.

## Decision lane

```
existing has comparable lossless_source_v0 probe + candidate is lossy
  → lossless_source_locked
       (record rejection, denylist source, requeue, cleanup)

existing has comparable lossless_source_v0 probe + candidate is FLAC
  → falls through to provisional V0 grind-up (existing behavior)

existing has no probe (or research-kind probe)
  → falls through to import_quality_decision (existing behavior)
```

## Where it's wired

- `lib/quality.py` — `DECISION_LOSSLESS_SOURCE_LOCKED` constant; extends `provisional_lossless_decision` (not a parallel lane); extends `dispatch_action`; called from `full_pipeline_decision` MP3 path; new decision-tree rule
- `harness/import_one.py` — log prefix branch (`[LOSSLESS SOURCE LOCKED]`)
- `lib/import_dispatch.py` — `fail_scenario`, `fail_detail`, `error_message` suppression mirroring the `suspect_lossless_*` siblings
- `lib/import_preview.py` — added to `_REJECT_STAGE_DECISIONS`
- `web/classify.py` — `_lossless_source_locked_verdict` + scenario routing
- `web/js/decisions.js` — red color class
- `scripts/pipeline_cli.py` — surfaces recorded probe in gate header; threads `existing_v0_probe_avg` to `full_pipeline_decision`

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 2445 tests, OK (skipped=53). Six new tests:
  - `TestProvisionalLosslessDecision.test_lossy_candidate_locks_*` (4 tests covering lock, structural-across-grades, FLAC bypass, no-probe bypass, research-probe bypass)
  - `TestFullPipelineContract.test_lossy_candidate_locked_by_existing_lossless_source_probe` (Message to Bears EP1 shape)
  - `TestFullPipelineContract.test_lossy_candidate_passes_when_no_lossless_source_probe`
  - `TestDispatchAction.CASES` — new row for `lossless_source_locked`
  - `TestDispatchImport.test_lossless_source_locked_rejects_lossy_candidate` (orchestration: dispatch maps decision → DB state)
  - `TestLosslessSourceLockedSlice` (integration slice: real ImportResult JSON through `dispatch_import_core`)
  - `TestRecentsClassification.test_rejected_lossless_source_locked` (web verdict)
  - `TestImportPreviewValues.test_values_preview_classifies_lossless_source_locked`
  - `TestSimulatorInvariants.test_provisional_locked_album_rejects_all_lossy_candidates` + new `provisional_locked_opus` fixture
- [x] `node tests/test_js_decisions.mjs` — 118 passed, including new `lossless_source_locked` red-class test
- [x] Pyright: no new errors on touched files (pre-existing msgspec stub gaps + 7 pre-existing test optional-access errors are unchanged)

## Multi-agent review

Three parallel review agents (correctness, testing, project-standards) ran before commit. Findings addressed in this branch:

- **P0** (testing): missing dispatch orchestration test for the new `elif decision == "lossless_source_locked"` branch — added `TestDispatchImport.test_lossless_source_locked_rejects_lossy_candidate`
- **P1** (testing × 4): FLAC-side bypass test, integration slice, web verdict test, JS red-class test — all added
- **P2** (testing): simulator scenarios fixture + invariant — added; brittleness on `"240"` substring tightened to `"240kbps"`
- **P2** (correctness): `pipeline_cli.py` truthy probe check normalized to `is not None`
- **P2** (correctness): docstring note that `candidate_probe` is ignored when `supported_lossless_source=False`
- **P3** (testing): import_preview parity test — added
- Deferred (P2/P3, cosmetic): "searching continues" suffix duplication; `provisional_lossless_decision` rename now that it owns a non-FLAC decision; decision-tree rule path tag; `stage_chain` dead-data on FLAC branch

## Live verification on request 1446

Ran the simulator against the real DB row before pushing:

```
$ pipeline-cli quality 1446
Quality gate: ...
  current_lossless_source_v0_probe_avg=240kbps (locks lossy candidates)
What would happen if we downloaded:
  MP3 V0 (low, avg 205kbps, gate runs):
    → REJECT, denylist, keep searching (final: wanted)
    chain: ... stage2_import=lossless_source_locked
```

Existing FLAC scenarios still hit the regular provisional V0 grind-up lane (verified in the simulator invariant test).

## Post-Deploy Monitoring & Validation

After deploy, watch for:

- **`pipeline-cli query`** — expect new `download_log.beets_scenario = 'lossless_source_locked'` rows on requests with non-NULL `current_lossless_source_v0_probe_avg_bitrate` whose history previously oscillated between rejection-and-retry (Message to Bears EP1 = req 1446 is the canonical test case).
- **`ssh doc2 'sudo journalctl -u cratedigger -f'`** — expect `LOSSLESS SOURCE LOCKED: <album> existing_v0_avg=<N>kbps` on the relevant requests.
- **Web recents tab** — affected requests render the new "Lossless-source locked: ... 240kbps ... only another lossless source can override; searching continues" verdict instead of misleading avg-vs-avg comparisons.
- **Healthy signals** — search continues running for these requests; FLAC matches still import via the provisional lane; `current_lossless_source_v0_probe_avg_bitrate` is preserved across rejections (don't expect it to be cleared).
- **Failure signals** — if FLAC candidates start rejecting via `lossless_source_locked`, the `supported_lossless_source` detection in `harness/import_one.py:1206` is wrong; revert. If lossy candidates are NOT rejected and we see false-positive imports against opus baselines, the dispatch wiring is broken.
- **Validation window** — first 48h after deploy, focused on requests with non-NULL `current_lossless_source_v0_probe_avg_bitrate`.
- **Owner** — abl030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)