### PR TITLE
feat: Label viewer Phase A (Discogs-first)

### DIFF
--- a/docs/brainstorms/label-viewer-requirements.md
+++ b/docs/brainstorms/label-viewer-requirements.md
@@ -1,0 +1,135 @@
+---
+date: 2026-04-29
+topic: label-viewer
+---
+
+# Label Viewer
+
+## Problem Frame
+
+When the user finds a release they like — e.g. Gridlock on Hymen Records — they want to see what else came out on that label, and quickly tell which of those they already own and which they haven't heard. Today the cratedigger web UI surfaces labels only as plain-text fields on Discogs release payloads (`web/discogs.py:231`, `web/discogs.py:282`); there is no way to navigate from a release to the rest of its label, no way to search by label name, and no library overlay to mark "already mine". The workaround is leaving cratedigger and using Discogs.com directly, which loses the library overlay that makes the local mirror valuable in the first place.
+
+This is fundamentally a discovery surface, not a navigation surface — the goal is "what I haven't heard but probably want to", not "let me look up Warp's catalogue". That framing drives the filter priorities below.
+
+Origin: GitHub issue #183.
+
+---
+
+## Key Flows
+
+- F1. Drill-in from a release
+  - **Trigger:** User is viewing a release in the browse tab or library and clicks the label name.
+  - **Steps:** Label page opens with the label's name, optional metadata (country, parent label if applicable), and the full release list. Library overlay marks each release as `in library` / `in pipeline` / `not held`. Year and format filters available; sort newest-first by default.
+  - **Outcome:** User can scan the label end-to-end and instantly see which releases are new to them.
+  - **Covered by:** R1, R2, R5, R6, R7, R9, R10
+
+- F2. Top-down label search
+  - **Trigger:** User types a label name (e.g. "Hymen") into a search box in the browse tab.
+  - **Steps:** Search returns a disambiguation list of matching label entities with enough context to pick the right one (release count, country, parent label where present). User clicks a result to land on the same label page from F1.
+  - **Outcome:** User reaches the label page without first needing to find a release on it.
+  - **Covered by:** R3, R4, R5
+
+- F3. Era-bounded browse on a large label
+  - **Trigger:** User is on a label page for a high-volume label (Warp, Blue Note) where the flat list is unwieldy.
+  - **Steps:** User applies year filter and/or format filter (album / EP / single, optionally physical format) to narrow the list. Library overlay still applies.
+  - **Outcome:** User sees a scoped, scannable list for that era / format.
+  - **Covered by:** R6, R7, R9
+
+---
+
+## Requirements
+
+**Search and navigation**
+- R1. A release detail view that today shows label names as plain text MUST expose each label as a clickable link to that label's page.
+- R2. The label page MUST be reachable directly by URL (deep-linkable, shareable, refresh-safe).
+- R3. The browse tab MUST offer label search alongside the existing artist search, returning a disambiguation list of matching label entities.
+- R4. Label search results MUST include enough context to disambiguate similarly-named labels: at minimum release count and country; parent label name shown when the result is a sub-label.
+
+**Label page content**
+- R5. The label page MUST list every release on the label that the data source knows about, paginated or virtualized for labels with hundreds or thousands of entries.
+- R6. Each release row MUST show release title, primary artist, year, and format/type, and link to the existing release detail page.
+- R7. The label page MUST split releases by primary type the same way the artist discography view does (album / EP / single / other), preserving the existing visual conventions.
+
+**Library overlay (primary discovery filter)**
+- R8. Each release on the label page MUST be marked with its current library status: `in beets library`, `in pipeline (any non-imported state)`, or `not held`. The marking MUST be visually scannable, not require hover.
+- R9. The label page MUST allow filtering to "not held" releases as a single-click toggle, since this is the dominant discovery move.
+
+**Secondary filters**
+- R10. The label page MUST provide year and format/type filters that compose with the library overlay (all three layered).
+- R11. Default sort MUST be year descending (newest first); within the same year, secondary sort is stable but unspecified.
+
+**Source-agnostic plumbing (enables Phase B without rework)**
+- R12. The label entity model exposed to the UI MUST be source-tagged (e.g. `{source: "discogs" | "musicbrainz", id, name, ...}`), not Discogs-shaped, even though only Discogs is wired in v1.
+- R13. The label page route MUST accept a source-qualified identifier, so adding MusicBrainz later is a new source adapter behind the same route shape rather than a parallel route.
+- R14. The release-list rendering on the label page MUST work from a source-agnostic release shape compatible with the artist discography view's existing release shape, so the same component renders MB and Discogs label release lists when MB is added.
+- R15. The "add MusicBrainz label support" follow-up MUST NOT require schema, route, or component changes to anything shipped in v1 — only a new source adapter implementation and the search-side wiring.
+- R16. The source-agnostic shape MUST be defined to accommodate what the upstream MusicBrainz API actually returns, not what we'd prefer it to return. The MusicBrainz mirror runs the upstream MusicBrainz Server codebase and we cannot modify its API surface; the Discogs mirror is ours and we can extend its endpoints freely. This asymmetry MUST be reflected in the v1 design: any normalization or denormalization required to hit the source-agnostic shape happens in our Python web layer (per-source adapter), not server-side.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R8, R9.** Given the user is viewing a Gridlock release on Hymen Records, when they click "Hymen Records" in the labels field, then they land on the Hymen label page showing every Hymen release, with their owned Gridlock releases marked `in library`, the rest marked `not held`, and a one-click "hide held" toggle visible.
+- AE2. **Covers R3, R4.** Given the user types "warp" in label search, when results return, then they see "Warp Records (UK)", "Warp Singles (UK, sub-label of Warp Records)", and any other near-name labels with their release counts, sufficient to pick the intended entity.
+- AE3. **Covers R6, R10.** Given the user is on the Warp Records label page, when they apply year filter `2001-2003` and format filter `EP`, then the list shows only Warp EPs released in that range, with library overlay still applied.
+- AE4. **Covers R12, R13, R14, R15.** Given Phase B (MusicBrainz label support) is later attempted, when the developer adds an MB label adapter, then no v1 route, page component, or release-list rendering needs to be modified — the addition is wiring, not redesign.
+
+---
+
+## Success Criteria
+
+- The user reaches an unfamiliar release on a label they like and, within one click + a quick scan, can identify what else exists on that label and which of those they don't own.
+- For the Hymen / Gridlock concrete case from this brainstorm, the full label catalogue is visible on a single page with library overlay correct.
+- A planner picking this up can implement v1 (Approach A) without inventing product behavior, filter semantics, or scope boundaries.
+- When Phase B (MusicBrainz labels) is later planned, it is clearly a wiring task — the v1 brainstorm doc and code make obvious where the MB adapter plugs in.
+
+---
+
+## Scope Boundaries
+
+- **No labelmate-recommendation sort in v1.** The "rank releases by labelmates of artists in your library first" surface (Approach D in brainstorm) is rejected for v1. May revisit if flat list + filters proves thin in practice.
+- **No MusicBrainz label support in v1.** Phase B is a separate follow-up. The v1 plumbing must be source-agnostic enough that B is wiring, but B itself is out of scope here.
+- **No cover art on Discogs labels in v1.** The Discogs CC0 dump has no images (already a known limitation, issue #82). Any image on the label page is best-effort or absent.
+- **No editorial label metadata.** Bios, discography summaries, "label history" prose — not in scope. v1 is a release index, not a label profile.
+- **No multi-label intersection ("releases on Hymen AND in genre X").** Genre/style filtering is not a v1 axis even though Discogs has the data.
+- **No cross-label artist navigation enrichment.** "What other labels has this artist been on?" is the artist view's job, not the label viewer's.
+
+---
+
+## Key Decisions
+
+- **Discogs first, MB next, no toggle in v1**: Discogs has materially better label data (sub-labels, catalog numbers, format detail) and the user's driving use cases (Hymen, Gridlock, IDM/electronic boutique labels) are Discogs-native. Symmetry with the artist-view source toggle is deferred to Phase B rather than blocking v1.
+- **Library overlay is the load-bearing filter, not year**: The actual user goal is "what I haven't heard", not "what came out in year X". Year and format are secondary refinements that compose with the overlay; the overlay is what makes flat lists tolerable on big labels.
+- **Source-agnostic plumbing from day one**: Even though only Discogs is wired in v1, the entity model, route shape, and rendering components are designed so MB is a source adapter, not a re-architecture. This is a directive from the user, not a speculative future-proofing call.
+- **API ownership asymmetry shapes the design**: We own the Discogs mirror API (Rust, can add `/api/labels` and any other endpoints freely) but we do NOT own the MusicBrainz API — the local mirror runs upstream MusicBrainz Server and we consume whatever its public API gives us. v1 should add whatever endpoints we want to the Discogs mirror but design the source-agnostic shape to fit what the MB API actually returns when Phase B comes around. Adapter logic lives in our Python web layer (`web/discogs.py`, future `web/mb.py` label code), not in either mirror.
+- **No labelmate recommendations**: Considered as Approach D, dropped. Library overlay + year + format are sufficient for the discovery workflow on the user's library scale; the recommendation surface added design complexity for a benefit that isn't yet observed to be missing.
+
+---
+
+## Dependencies / Assumptions
+
+- The Discogs mirror at `discogs.ablz.au` already exposes label data on every release (verified — `web/discogs.py:231`, `web/discogs.py:282`). A new label search endpoint and label-detail endpoint on the Rust mirror will need to be added — the existing `web/discogs.py` only exposes release and artist search (verified by grep). The Rust mirror is ours; we extend it as needed.
+- The beets library DB join needed for the library-overlay marking is already used elsewhere (e.g. `web/routes/library.py`) and can be reused.
+- The local MusicBrainz mirror at `192.168.1.35:5200` runs the upstream MusicBrainz Server codebase. **We do not own the MB API and cannot modify it.** Phase B must consume whatever MB's stock label endpoints return (label search by name, label-detail with releases). It is **assumed but not verified** that those endpoints exist and return enough data to populate the label page; verifying this is a Phase B planning task. v1 does not depend on it.
+- Cardinality assumption: small/boutique labels (the dominant case in this user's collection) have <500 releases; large labels (Warp, Blue Note) may have thousands. v1 design must remain usable at both scales — pagination/virtualization is a planning concern, not a product one.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(none — all product decisions resolved.)
+
+### Deferred to Planning
+
+- [Affects R5][Technical] How to paginate / virtualize the release list for high-volume labels (Warp, Blue Note) — page size, infinite scroll vs paged, default visible count. Not a product decision; pick whatever matches existing artist-view conventions.
+- [Affects R3, R4][Needs research] Whether the Discogs mirror's existing search infrastructure can serve label search, or whether label search needs its own indexed endpoint on the Rust API.
+- [Affects R5, R7][Needs research] Sub-label rollup behavior: when the user lands on a parent label like "Warp Records", should the release list include sub-label releases by default with a sub-label badge, or only direct-parent releases with sub-labels reachable via a separate link? Recommended default: include sub-label releases with a badge, since the discovery workflow benefits from breadth — but verify against Discogs data shape during planning.
+- [Affects R12-R15][Technical] What exact source-agnostic shape the label entity should take. Pick a shape that minimally generalizes Discogs label payloads while leaving room for MB label fields (e.g. label MBID, MB label-type, MB area). Should not block v1; can be settled at planning time.
+
+---
+
+## Next Steps
+
+-> `/ce-plan` for structured implementation planning of v1 (Approach A: Discogs-first label viewer).

--- a/docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
+++ b/docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
@@ -1,0 +1,525 @@
+---
+title: feat: Label viewer Phase A (Discogs-first)
+type: feat
+status: completed
+date: 2026-04-29
+origin: docs/brainstorms/label-viewer-requirements.md
+---
+
+# feat: Label viewer Phase A (Discogs-first)
+
+## Overview
+
+Add a label viewer to the cratedigger web UI: search for record labels (e.g. "Hymen Records"), open a label-detail page that lists every release on that label split by primary type (album / EP / single), with the existing library overlay marking each release as `in library` / `in pipeline` / `not held`, and year + format filters layered over that overlay. Drill-in from release detail by making the label name a clickable link.
+
+Phase A wires Discogs only. The data model, route shape, and rendering components are designed source-agnostic so Phase B (MusicBrainz labels) is a source adapter, not a redesign. We own the Discogs Rust mirror and extend its API; we do not own the MusicBrainz mirror and Phase B will consume whatever upstream MB returns.
+
+This plan touches **two repositories**:
+
+- **cratedigger** (this repo) — primary target. Python web layer, JS, tests.
+- **discogs-api** (`~/discogs-api/`, GitHub: `abl030/discogs-api`) — Rust mirror. Two new endpoints + one schema migration. Implementation units that target this repo are tagged `[discogs-api]` in their headers; all other units are `[cratedigger]`.
+
+---
+
+## Problem Frame
+
+The user finds a release they like — Gridlock on Hymen Records — and wants to see what else came out on that label, fast, with clear marking of what they already own. Today cratedigger surfaces labels only as plain-text fields on Discogs release payloads (`web/discogs.py:231`, `web/discogs.py:282`). There is no way to navigate from a release to the rest of its label, no label search, no library overlay. The workaround is leaving cratedigger for Discogs.com, which loses the library overlay that makes the local mirror valuable.
+
+The discovery framing — "what I haven't heard but probably want to" — is what drives the filter priorities. Library overlay is the load-bearing filter; year and format are secondary refinements that compose on top.
+
+Origin: GitHub issue #183. Brainstorm: `docs/brainstorms/label-viewer-requirements.md`.
+
+---
+
+## Requirements Trace
+
+Carrying forward from origin:
+
+- R1, R2. Release-detail label names become clickable links to deep-linkable label pages → covered by U7, U4.
+- R3, R4. Browse tab offers label search returning disambiguated entities (release count, country, parent label) → covered by U1, U3, U4, U5.
+- R5, R6, R7. Label page lists every release with title/artist/year/format, paginated, split by primary type → covered by U2, U4, U6.
+- R8, R9. Library overlay marks each release as in-library / in-pipeline / not-held; one-click "hide held" toggle → covered by U4, U6 (reuses the existing `check_beets_library` / `check_pipeline` mechanism unchanged).
+- R10, R11. Year and format filters layered with overlay; default sort year-desc → covered by U6.
+- R12-R16. Source-agnostic plumbing: source-tagged label entity, source-qualified routes, source-agnostic release shape, Phase B = adapter wiring, normalization in our Python web layer (Discogs mirror is ours, MB mirror is upstream code we can't modify) → covered by U3, U4 (entity model + routes shaped to fit MB's stock API rather than our preference).
+
+**Origin acceptance examples:** AE1 (Hymen drill-in with overlay), AE2 (Warp search disambiguation with sub-labels), AE3 (Warp 2001-2003 EP filter), AE4 (Phase B is wiring not redesign).
+
+---
+
+## Scope Boundaries
+
+- **No labelmate-recommendation sort in v1.** Origin Approach D is rejected.
+- **No MusicBrainz label support in v1.** Phase B is a separate plan.
+- **No cover art on Discogs labels in v1.** CC0 dump has no images (#82).
+- **No editorial label metadata** (bios, history prose, label profiles). Release index only.
+- **No multi-axis search** ("releases on Hymen AND in genre X"). Year + format filters only.
+- **No cross-label artist enrichment** ("what other labels has this artist been on?"). That's the artist view's job.
+
+### Deferred to Follow-Up Work
+
+- **Phase B: MusicBrainz label support.** Separate plan once the v1 source-agnostic shape lands. Will require a `web/mb.py` adapter and verification of the upstream MB API for label search and label-detail endpoints.
+- **Phase B: source toggle on label search UI.** v1 has no toggle because Discogs is the only source; toggle UX comes with Phase B alongside the artist-view convention.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Discogs Rust mirror (`~/discogs-api/`):**
+- Axum router in `src/server.rs`; query functions in `src/db.rs`; types in `src/types.rs`; schema constants in `src/schema.rs`.
+- `label` table exists (`id`, `name`, `parent_label_id`, `profile`, `data_quality`).
+- `release_label` join exists (`release_id`, `label_id`, `label_name`, `catno`).
+- Indexes on `release_label.label_id` and `label.parent_label_id` exist.
+- **Missing**: GIN trigram/FTS index on `label.name` — needs to be added in U1.
+- `/api/artists/{id}/releases` (`db.rs` lines 666-743) is the exact analog for `/api/labels/{id}/releases`. Mirror its query shape, pagination clamp (1-100), and `fetch_release_enrichments()` call for artists/labels/formats.
+- `infer_primary_type()` (`db.rs` lines 990-1002) already classifies Album/EP/Single/Other from `release_format.descriptions`.
+- FTS pattern: `to_tsvector('english', name) @@ plainto_tsquery('english', $1)` with `ts_rank()` scoring and exact-match prioritization. Mirror the existing `/api/artists` search (`db.rs` lines 745-783).
+
+**Cratedigger web (`web/`):**
+- Route registration: `web/routes/browse.py` registers `GET_ROUTES` (exact paths) and `GET_PATTERNS` (regex). Existing artist routes: `/api/artist/{uuid}` (MB), `/api/discogs/artist/{id}` (Discogs). Mirror this for labels.
+- Discogs API helpers: `web/discogs.py` — `search_artists`, `search_releases`, `get_artist_releases`, `get_master_releases`, `get_release`. Add `search_labels`, `get_label`, `get_label_releases` here.
+- Library overlay: `srv.check_beets_library(ids)` returns set of held IDs; `srv.check_pipeline(ids)` returns dict of `{id → pipeline_state}`. Both are single-batch queries. Reuse unchanged.
+- Frontend rendering: `web/js/discography.js` `renderArtistDiscography` + `renderTypedSections` from `web/js/grouping.js` does the album/EP split. The release row component reads `in_library`, `library_format`, `library_min_bitrate`, `library_rank`, `pipeline_status`, `pipeline_id` fields from the payload — payload contract is already source-agnostic. Reuse the row renderer from labels view; only the page wrapper is new.
+- Status badges: `web/js/badges.js` `renderStatusBadges()` reads the same overlay fields. Reuse unchanged.
+- JS module conventions: `// @ts-check`, ES6 modules, JSDoc on exports, served at `/js/*.js`.
+
+**Wire boundary (`msgspec.Struct`)**:
+- `lib/quality.py` and `lib/beets_album_op.py` for examples of `msgspec.Struct` types crossing JSON. Define `DiscogsLabel`, `DiscogsLabelHit`, `DiscogsLabelRelease` as Structs decoded at the `web/discogs.py` boundary via `msgspec.convert(payload, type=...)`.
+
+**Tests:**
+- `tests/test_web_server.py::TestRouteContractAudit.CLASSIFIED_ROUTES` is the guard set every new route must be added to.
+- `tests/test_web_server.py::_WebServerCase` provides `self._get(path)`; `_assert_required_fields(self, payload, REQUIRED_FIELDS, label)` is the contract-test helper.
+- Existing `TestPipelineRouteContracts`, `TestBrowseRouteContracts` (lines ~661-805) are the patterns to mirror.
+
+### Institutional Learnings
+
+The repo has no `docs/solutions/` directory — research surfaced only the per-subsystem primer docs. Relevant constraints baked into rules:
+
+- `.claude/rules/web.md` — vanilla JS, no build step, beets queries via `lib/beets_db.py`'s `BeetsDB` class only, contract tests for every route.
+- `.claude/rules/code-quality.md` — wire-boundary types are `msgspec.Struct`, every API endpoint needs `REQUIRED_FIELDS` contract test + entry in `TestRouteContractAudit.CLASSIFIED_ROUTES`.
+- `.claude/rules/nix-shell.md` — all Python including tests via `nix-shell --run`.
+- `.claude/rules/pipeline-db.md` — schema migrations via `migrations/NNN_*.sql`. (Not applicable to this plan; cratedigger DB is untouched.)
+
+### External References
+
+None used — pattern is clearly modeled by the existing artist view; Discogs API extension is mirroring our own existing endpoints.
+
+---
+
+## Key Technical Decisions
+
+- **Two routes per source, not a single multi-source route.** Phase A ships `/api/discogs/label/search` and `/api/discogs/label/{id}`. Phase B will add `/api/label/{mbid}` (UUID-routed to MB) parallel to the existing artist convention. R13's "source-qualified" is satisfied by the URL prefix, and consistency with the artist view matters more than collapsing into one route shape.
+- **Source-agnostic label entity.** A `LabelEntity` shape exposed to the frontend has fields: `source` (`"discogs" | "musicbrainz"`), `id` (string), `name`, `country` (nullable), `profile` (nullable, plain-text excerpt only — no editorial metadata expansion in v1), `parent_label_id` (nullable), `parent_label_name` (nullable, denormalized for UI badge), `release_count` (int). Designed to fit what stock MB returns without forcing Discogs into a less-natural shape: nullable fields cover MB→empty, denormalization is acceptable because the entity is read-mostly. Normalization happens in our Python web layer per source adapter, never server-side on either mirror.
+- **Source-agnostic release shape on the label page.** Reuse the existing release-row payload shape that `web/js/discography.js` already renders (id, title, primary_artist, date, format, primary_type, in_library, library_format, library_min_bitrate, library_rank, pipeline_status, pipeline_id). Avoids parallel rendering code; same row component handles artist-view and label-view rows.
+- **Sub-label rollup on by default.** `/api/discogs/label/{id}/releases` returns parent + sub-label releases by default with a `sub_label_name` field on each row populated when the release belongs to a sub-label. `?include_sublabels=false` is the opt-out. The recursive CTE for the sub-label tree is bounded in practice (single-digit hierarchy depth on every label inspected); add an `EXPLAIN ANALYZE` check during U2 implementation on a worst-case label like "Universal Music Group" before declaring done.
+- **Label search backend uses GIN FTS on `label.name` plus exact-match prioritization.** Mirrors the existing `/api/artists` search at `db.rs` lines 745-783 — ranks exact name matches first, then `ts_rank()` score. Add `release_count` to result rows via `LEFT JOIN release_label ... GROUP BY label.id` so disambiguation context (R4) is present in the same query.
+- **`web/routes/labels.py` is a new file.** browse.py is already 22KB and labels are a coherent new domain. Same registration mechanism (`GET_ROUTES`, `GET_PATTERNS`); imported alongside browse from `web/routes/__init__.py` (or `web/server.py`, depending on where existing route modules are imported — confirm during U4).
+- **Discogs adapter Structs decode at the `_get()` boundary.** New `DiscogsLabelHit`, `DiscogsLabelDetail`, `DiscogsLabelRelease` `msgspec.Struct`s in `web/discogs.py`, decoded via `msgspec.convert(payload, type=...)` immediately after the HTTP call. Downstream Python sees typed objects, not dicts.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Sub-label rollup default → include by default with badge; `?include_sublabels=false` opt-out (see Key Decisions).
+- New file vs extending `browse.py` → new `web/routes/labels.py` (see Key Decisions).
+- Route shape (single multi-source vs per-source) → per-source, mirroring artist convention (see Key Decisions).
+- Year filter is server-side or client-side? → Client-side. The label-releases response carries every release; filter is a JS predicate. Pagination is the only server-side concern. (Acceptable up to ~10K releases per label; revisit if a label exceeds that.)
+
+### Deferred to Implementation
+
+- Exact pagination defaults (`per_page` default, lazy-load vs explicit pagination UI). Mirror artist-view convention discovered during U6.
+- Sub-label badge text format ("via Warp Singles" vs "Warp Singles" vs label-id link). Settle when wiring U6.
+- Whether Phase A also benefits from a "labels for this artist" tab on the artist view. Out of scope here; flag during U7 if it reveals itself.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant UI as web/js/labels.js
+    participant Route as web/routes/labels.py
+    participant Adapter as web/discogs.py
+    participant Mirror as discogs-api (Rust)
+    participant Beets as lib/beets_db.py + pipeline DB
+
+    Note over UI,Mirror: Label search (F2)
+    UI->>Route: GET /api/discogs/label/search?q=hymen
+    Route->>Adapter: search_labels("hymen")
+    Adapter->>Mirror: GET /api/labels?name=hymen
+    Mirror-->>Adapter: [{id, name, country, parent, release_count, score}]
+    Adapter-->>Route: list[LabelEntity]
+    Route-->>UI: {results: [LabelEntity, ...]}
+
+    Note over UI,Beets: Label detail (F1, F3)
+    UI->>Route: GET /api/discogs/label/757
+    Route->>Adapter: get_label(757) + get_label_releases(757)
+    Adapter->>Mirror: GET /api/labels/757
+    Adapter->>Mirror: GET /api/labels/757/releases?include_sublabels=true
+    Mirror-->>Adapter: label entity + release list (with sub_label_name)
+    Adapter-->>Route: LabelEntity + list[Release]
+    Route->>Beets: check_beets_library(release_ids)
+    Route->>Beets: check_pipeline(release_ids)
+    Beets-->>Route: held_set + pipeline_map
+    Route-->>UI: {label, releases: [release with overlay], sub_labels: [...]}
+    UI->>UI: renderTypedSections (album/EP split) + filters (year/format/hide-held)
+```
+
+The drill-in flow (F1 trigger from a release-detail row) is just a click handler on the existing label name in the release row — it navigates to the label-detail URL above.
+
+---
+
+## Implementation Units
+
+- U1. **[discogs-api] Add label FTS index and `/api/labels` search endpoint**
+
+**Goal:** Enable label search by name on the Discogs mirror with disambiguation context (release count, country, parent label).
+
+**Requirements:** R3, R4 (origin), and the "release_count in disambiguation" decision in Key Technical Decisions.
+
+**Dependencies:** None.
+
+**Files** *(target repo: discogs-api):*
+- Modify: `src/schema.rs` (add `CREATE INDEX idx_label_name_fts ON label USING GIN (to_tsvector('english', name))`)
+- Modify: `src/db.rs` (add `query_label_search` mirroring `query_artist_search` at lines 745-783)
+- Modify: `src/server.rs` (register `GET /api/labels` route + handler)
+- Modify: `src/types.rs` (add `LabelSearchParams`, `LabelHit`, `LabelSearchResponse`)
+- Test: live integration check via `curl https://discogs.ablz.au/api/labels?name=hymen` after deploy. Rust handler unit testing is not the project convention (per discogs-api CLAUDE.md, only XML parsers are unit-tested).
+
+**Approach:**
+- The `release_count` per label hit is a `LEFT JOIN release_label ... GROUP BY label.id` aggregate inside the search query. Avoid fetching it in a second pass.
+- Clamp `per_page` to 1-100 like the existing search endpoints.
+- Order by exact-match-first (lowercase comparison), then `ts_rank()` desc, then `length(name)`, then `id` — mirrors `query_artist_search`.
+- The new GIN index needs to be created on existing data — verify at deploy time that the index build completes in reasonable time on the production mirror (`label` table is in the millions of rows but not tens of millions; should be fast).
+
+**Patterns to follow:**
+- `query_artist_search` (`src/db.rs:745-783`) for FTS + scoring + exact-match.
+- `SearchParams` and `Pagination` (`src/types.rs`) for query parameter shape.
+- Existing `serde::Serialize` rename conventions on response types.
+
+**Test scenarios:**
+- Happy path: search "hymen" returns `Hymen Records` as top hit with non-zero `release_count` and `country == "Germany"` (or whatever Discogs has).
+- Happy path: search "warp" returns `Warp Records (UK)` and at least one sub-label (e.g. "Warp Singles") with `parent_label_id` set on the sub-label hit.
+- Edge case: empty `name` parameter returns 400 (or matches existing search-endpoint behavior — verify).
+- Edge case: search with only stop-words ("the") returns empty results without 500.
+- Edge case: `per_page=200` clamps to 100 like existing endpoints.
+- Performance: search "hymen" responds in <100ms after the GIN index is built (`EXPLAIN ANALYZE` during dev).
+
+**Verification:**
+- `curl 'https://discogs.ablz.au/api/labels?name=hymen'` returns Hymen Records with non-zero release_count after deploy.
+- `EXPLAIN` on the search query shows the GIN index is used (`Bitmap Index Scan on idx_label_name_fts`).
+
+---
+
+- U2. **[discogs-api] Add `/api/labels/{id}` and `/api/labels/{id}/releases` endpoints**
+
+**Goal:** Serve full label detail and the release list (with sub-label rollup) needed by the label-detail page.
+
+**Requirements:** R5, R6, R7 (origin), Key Decision sub-label rollup.
+
+**Dependencies:** None on U1 directly (different endpoints), but typically ships in the same discogs-api PR.
+
+**Files** *(target repo: discogs-api):*
+- Modify: `src/db.rs` (add `query_label`, `query_label_releases`)
+- Modify: `src/server.rs` (register routes + handlers)
+- Modify: `src/types.rs` (add `LabelDetail`, `LabelReleasesResponse`)
+- Test: live integration via `curl` after deploy.
+
+**Approach:**
+- `query_label_releases` mirrors `query_artist_releases` (`db.rs:666-743`): validate label exists, count releases, fetch with pagination, enrich via `fetch_release_enrichments`, infer `primary_type` via `infer_primary_type`.
+- Sub-label rollup: when `include_sublabels=true` (default), the WHERE clause uses a recursive CTE to expand `parent_label_id` → label tree, and the SELECT adds `sub_label_id`/`sub_label_name` from `release_label` for each release row (NULL when the release is on the parent label itself).
+- Label detail (`/api/labels/{id}`) returns: id, name, country (derived from majority country of releases — or NULL if Discogs has no first-class country field on `label`; verify the schema during implementation), profile, parent_label_id, parent_label_name (denormalized via JOIN), total_releases, sub_labels (list of `{id, name, release_count}` for direct children).
+- Order by `r.released ASC, r.id` to match the artist endpoint convention; the cratedigger UI re-sorts to year-desc client-side per R11.
+
+**Execution note:** Run `EXPLAIN ANALYZE` on `/api/labels/{id}/releases?include_sublabels=true` for a wide-tree label (e.g. "Universal Music Group" or "Sony Music Entertainment") before declaring done — recursive CTE perf is the one real risk on the Rust side and the only thing that warrants looking at query plans here.
+
+**Patterns to follow:**
+- `query_artist_releases` (`src/db.rs:666-743`).
+- `fetch_release_enrichments` (`src/db.rs:1290-1308`) for batched artist/label/format joins.
+- `infer_primary_type` (`src/db.rs:990-1002`) for type classification.
+
+**Test scenarios:**
+- Happy path: `GET /api/labels/{hymen_id}/releases` returns Hymen catalogue with `primary_type` populated and `sub_label_name` NULL on direct-Hymen releases.
+- Happy path with rollup: `GET /api/labels/{warp_id}/releases?include_sublabels=true` includes Warp Singles releases with `sub_label_name == "Warp Singles"`.
+- Edge case: `?include_sublabels=false` on Warp returns ONLY direct Warp Records releases.
+- Edge case: invalid label id returns 404 (mirror artist-endpoint behavior).
+- Edge case: label with zero releases returns empty `results` and `pagination.items == 0`.
+- Performance: recursive CTE plan on a worst-case label (>5K releases, multiple sub-label depths) completes in <500ms; if not, add a `LIMIT` on the CTE depth or denormalize.
+
+**Verification:**
+- `curl 'https://discogs.ablz.au/api/labels/{hymen_id}/releases'` returns Hymen catalogue with `primary_type` populated.
+- `?include_sublabels=true` vs `=false` produce different result counts on Warp.
+
+---
+
+- U3. **[cratedigger] Discogs label adapter and source-agnostic label entity**
+
+**Goal:** Type-safe Python helpers to fetch from the new Discogs label endpoints, plus the source-agnostic `LabelEntity` shape consumed by route handlers.
+
+**Requirements:** R12, R14, R15, R16 (source-agnostic plumbing carried into v1).
+
+**Dependencies:** U1, U2 (Discogs endpoints must exist for the adapter to call).
+
+**Files:**
+- Modify: `web/discogs.py` (add `search_labels(query)`, `get_label(label_id)`, `get_label_releases(label_id, include_sublabels=True)`; add `DiscogsLabelHit`, `DiscogsLabelDetail`, `DiscogsLabelRelease` `msgspec.Struct` types)
+- Modify: `tests/test_discogs_api.py` (extend with label-adapter coverage; this is the existing test file for `web/discogs.py`)
+
+**Approach:**
+- Wire-boundary Structs: `DiscogsLabelHit` (search result), `DiscogsLabelDetail` (full label entity), `DiscogsLabelRelease` (release row from label-releases endpoint). All decoded via `msgspec.convert(payload, type=...)` at the `_get()` boundary, not as `dict`.
+- Output Python types: a `LabelEntity` (`msgspec.Struct`, source-tagged) returned to the route layer. Fields per Key Technical Decisions: `source`, `id`, `name`, `country`, `profile`, `parent_label_id`, `parent_label_name`, `release_count`. Discogs adapter populates `source="discogs"`; future MB adapter populates `source="musicbrainz"`. **This is the load-bearing source-agnostic shape — get it right here, not in U4.**
+- The release row returned to routes uses the same shape as the existing artist-view release row (the route layer overlays library/pipeline state in U4). Adapter just normalizes Discogs fields to that shape: `id, title, primary_artist, date, format, primary_type, sub_label_name`.
+- Sub-label denormalization: the adapter passes `sub_label_name` straight through. Route layer overlays it as a UI badge (U6).
+- Cache memoization: use the same `_cache.memoize_meta` pattern as `search_releases` / `search_artists` for label search; label-detail endpoints can also be cached (label data is monthly-stable).
+
+**Execution note:** Add the strict-boundary regression test from `.claude/rules/code-quality.md` Wire-boundary section — feed a malformed payload (e.g. `release_count` as string) and assert `msgspec.ValidationError`.
+
+**Patterns to follow:**
+- `search_artists`, `search_releases`, `get_artist_releases` in `web/discogs.py` for memoization, error handling, and `_get()` wrapper usage.
+- `HarnessItem`, `ChooseMatchMessage`, `ImportResult` in `lib/quality.py` for `msgspec.Struct` decode-at-boundary patterns.
+
+**Test scenarios:**
+- Happy path: `search_labels("hymen")` mocks `_get` to return `[{id, name, country, parent_label_id, release_count, score}]` and asserts `LabelEntity` list with correct `source="discogs"`.
+- Happy path: `get_label(123)` returns a `LabelEntity` with all fields populated; profile and country may be NULL.
+- Happy path: `get_label_releases(123)` returns release rows with `primary_type` and `sub_label_name` populated where applicable.
+- Wire boundary regression: feed a payload with `release_count` as a string and assert `msgspec.ValidationError`.
+- Edge case: `search_labels` returns empty list when mirror returns empty results (no exception).
+- Edge case: `get_label_releases(invalid_id)` raises (or returns empty — mirror artist-endpoint behavior; verify).
+- Edge case: `parent_label_id` is `None` on top-level labels and a populated string on sub-labels.
+
+**Verification:**
+- `LabelEntity.source` is always `"discogs"` from this adapter; field set is exactly the source-agnostic shape declared in Key Decisions.
+- Route layer (U4) consumes only `LabelEntity` and the existing release-row shape — no Discogs-specific fields leak past `web/discogs.py`.
+
+---
+
+- U4. **[cratedigger] Label routes in new `web/routes/labels.py` with contract tests**
+
+**Goal:** HTTP routes for label search and label detail, with library + pipeline overlay and contract coverage.
+
+**Requirements:** R1, R2, R3, R4, R5, R8, R9, R12, R13.
+
+**Dependencies:** U3 (adapter + entity shape).
+
+**Files:**
+- Create: `web/routes/labels.py`
+- Modify: `web/server.py` or `web/routes/__init__.py` (whichever currently imports `web/routes/browse.py` — register the new module's `GET_ROUTES` / `GET_PATTERNS`; verify the import site during implementation)
+- Modify: `tests/test_web_server.py` (add `TestLabelRouteContracts(_WebServerCase)`; add new route patterns to `TestRouteContractAudit.CLASSIFIED_ROUTES`)
+
+**Approach:**
+- Register two routes:
+  - `GET /api/discogs/label/search?q=...` (exact route; handler `get_discogs_label_search`)
+  - `GET /api/discogs/label/{id}` (pattern `^/api/discogs/label/(\d+)$`; handler `get_discogs_label_detail`)
+- `get_discogs_label_search`: call `search_labels(q)`, return `{results: [LabelEntity, ...]}`. No library overlay needed at search time (search hits are label entities, not releases).
+- `get_discogs_label_detail`:
+  1. Call `get_label(label_id)` → `LabelEntity`.
+  2. Call `get_label_releases(label_id, include_sublabels=...)` → list of release rows. Read `include_sublabels` from query param; default `true`.
+  3. Collect all `release_id`s into a single list.
+  4. Call `srv.check_beets_library(release_ids)` (single batch query).
+  5. Call `srv.check_pipeline(release_ids)` (single batch query).
+  6. Overlay each release row with `in_library`, `library_format`, `library_min_bitrate`, `library_rank`, `pipeline_status`, `pipeline_id` — same fields the artist view uses, populated identically.
+  7. Return `{label: LabelEntity, releases: [...], sub_labels: [...]}`.
+- **Reuse** `srv.check_beets_library`, `srv.check_pipeline`, and the artist view's release-row overlay logic. If the artist view has a helper that does steps 4-6 in one shot (likely `annotate_in_library` or a sibling), reuse it directly. If it's currently inlined in `web/routes/browse.py`, extract to a shared helper in this unit (clean-as-you-go per `scope.md`).
+- **Contract test additions:**
+  - `LABEL_HIT_REQUIRED_FIELDS = {source, id, name, country, profile, parent_label_id, parent_label_name, release_count}`
+  - `LABEL_RELEASE_REQUIRED_FIELDS = {id, title, primary_artist, date, format, primary_type, sub_label_name, in_library, library_format, library_min_bitrate, library_rank, pipeline_status, pipeline_id}`
+  - `LABEL_DETAIL_RESPONSE_REQUIRED_FIELDS = {label, releases, sub_labels}`
+  - Add `/api/discogs/label/search` and `^/api/discogs/label/(\d+)$` to `TestRouteContractAudit.CLASSIFIED_ROUTES` — without this the existing audit fails on the new routes.
+
+**Execution note:** Add the contract tests + `CLASSIFIED_ROUTES` entries first (RED), then wire the route to make them pass (GREEN). Per `.claude/rules/code-quality.md` API Contract Tests.
+
+**Patterns to follow:**
+- `web/routes/browse.py::get_discogs_artist` (lines 303-320) for fetch + overlay pattern.
+- `tests/test_web_server.py::TestPipelineRouteContracts` (lines 661-805) for `_WebServerCase` contract test layout.
+- `tests/test_web_server.py::TestRouteContractAudit` (lines 599-659) for the audit registration pattern.
+
+**Test scenarios:**
+- Covers AE2. Happy path: `GET /api/discogs/label/search?q=hymen` returns `{results: [LabelEntity, ...]}`; first hit is Hymen Records with `release_count > 0`; all required fields present.
+- Covers AE1. Happy path: `GET /api/discogs/label/{hymen_id}` returns `{label, releases, sub_labels}`; releases have `in_library` populated; held releases have `library_format` and `library_min_bitrate` set; in-pipeline releases have `pipeline_status` set.
+- Happy path: `GET /api/discogs/label/{warp_id}?include_sublabels=true` returns releases including those with `sub_label_name == "Warp Singles"`.
+- Edge case: invalid label id (`/api/discogs/label/99999999`) returns 404.
+- Edge case: search with empty `q` returns 400 (or matches existing search-route behavior).
+- Edge case: label with zero releases returns `releases: []` not 404.
+- Integration: with one release of the label already in the pipeline DB and one in beets library, the response correctly marks both — proves the overlay join (not just that the helpers were called).
+- Audit: `TestRouteContractAudit.test_all_web_routes_are_classified_for_contract_coverage` passes after the two new routes are added to `CLASSIFIED_ROUTES`.
+
+**Verification:**
+- All contract tests pass.
+- `TestRouteContractAudit` passes.
+- Hitting the deployed route on doc2 returns the expected payload shape.
+
+---
+
+- U5. **[cratedigger] Label search UI in browse tab**
+
+**Goal:** Frontend label search entry point alongside the existing artist search.
+
+**Requirements:** R3, R4 (search and disambiguation surface).
+
+**Dependencies:** U4 (route must exist).
+
+**Files:**
+- Create: `web/js/labels.js` (new module exporting `searchLabels`, `renderLabelSearchResults`, `openLabelDetail`)
+- Modify: `web/js/browse.js` (add label-search trigger; depending on existing UX, either a search-mode toggle "artists | labels" or a separate input field — verify existing pattern when implementing)
+- Modify: `web/index.html` (add the UI affordance for label search; minimal markup — input + results container)
+- Modify: `web/js/state.js` (add `browseLabelMode` or equivalent state flag if needed for the toggle)
+- Test: extend `tests/test_js_util.mjs` for any pure helpers extracted (e.g. URL builders), but UI rendering itself is tested via `playwright` (see Verification).
+
+**Approach:**
+- Mirror `searchArtists` and the existing search-results renderer in `web/js/browse.js`. Each label result card shows: name, country, parent-label badge (when present), release count. Click → navigates to label detail (U6).
+- URL builder: `${API}/api/discogs/label/search?q=${encodeURIComponent(q)}` for v1. Phase B will add toggle.
+- Module conventions: `// @ts-check`, ES6 module, JSDoc on exports.
+- Deep-linking: store `state.browseLabel = {id, name}` and `state.browseSubView = 'label'`, mirroring the artist pattern.
+
+**Patterns to follow:**
+- `web/js/browse.js::searchArtists` and `openBrowseArtist` for fetch + state-transition pattern.
+- `web/js/discography.js` import header for the `// @ts-check` + ES6 module convention.
+
+**Test scenarios:**
+- Pure helper unit tests (if URL builder extracted): test that the encoded query string is correct for unicode and special chars.
+- Playwright golden path: type "hymen" in the label search input → result list renders with Hymen Records and a release count → click → URL changes to label-detail and label page renders. Run via the playwright agent (see Verification).
+- Test expectation for view-only changes: covered by playwright; no unit-test coverage owed for pure DOM rendering since the existing artist search has the same pattern uncovered.
+
+**Verification:**
+- Local manual: type a label name, see disambiguated results, click through to label page.
+- Playwright agent test on `https://music.ablz.au` after deploy: search "hymen", click result, verify label-detail page loads with correct catalogue.
+
+---
+
+- U6. **[cratedigger] Label detail page with album/EP split, library overlay, and filters**
+
+**Goal:** The label-detail page rendering — the load-bearing UX of this feature.
+
+**Requirements:** R5, R6, R7, R8, R9, R10, R11.
+
+**Dependencies:** U4, U5.
+
+**Files:**
+- Modify: `web/js/labels.js` (extend with `renderLabelDetail`, `loadLabelReleases`, `applyLabelFilters`)
+- Modify: `web/index.html` (add `<div id="browse-label">` container mirroring `browse-artist`)
+- Modify: `web/js/state.js` (`browseLabel`, `labelFilters: {year_min, year_max, format, hide_held}` state)
+- Modify: possibly `web/js/discography.js` ONLY if a release-row helper needs to be extracted for reuse — prefer importing the existing renderer over duplicating
+- Test: pure filter-predicate logic tested via `tests/test_js_util.mjs` (or sibling); DOM tested via playwright.
+
+**Approach:**
+- Page layout: header with label name, country, parent-label badge, total release count; filter bar (year range, format dropdown, "hide held" toggle); body with `renderTypedSections` doing the album/EP/single split.
+- Reuse `renderTypedSections` from `web/js/grouping.js` and `renderStatusBadges` from `web/js/badges.js` unchanged. The release-row component reads the same overlay fields populated by U4.
+- Filters are pure JS predicates over the in-memory release list. No re-fetch on filter change. If a sub-label badge is present, render it inline in the row near the format badge.
+- Default sort: year descending; secondary sort by `id` for stability.
+- "Hide held" toggle: filters out rows where `in_library === true`. Default off — discovery happens by *seeing* what you don't have, not by hiding what you do.
+- Pagination: if the response carries >500 releases, render the first 200 and lazy-load the rest as the user scrolls (mirror existing artist-view convention; verify exact threshold during implementation).
+- Sub-label badge: when `sub_label_name` is set on a row, render a small inline badge (e.g. `<span class="badge sub-label">via Warp Singles</span>`). Hide otherwise.
+
+**Patterns to follow:**
+- `web/js/discography.js::renderArtistDiscography` for layout + section split.
+- `web/js/grouping.js::renderTypedSections` for the album/EP/single grouping.
+- `web/js/badges.js::renderStatusBadges` for overlay rendering — reuse, do not reimplement.
+
+**Test scenarios:**
+- Covers AE3. Pure filter predicate: given a release list, applying year filter `[2001, 2003]` + format filter `EP` returns only matching rows.
+- Pure filter predicate: "hide held" excludes rows with `in_library === true` and includes all others.
+- Pure filter predicate: empty filter set returns all rows in input order (pre-sort).
+- Pure sort: default sort is year-desc; stable across equal years.
+- Edge case: a release with `released = NULL` sorts to the end and survives year-filter being applied.
+- Playwright integration: load a label with sub-label rollup → click "hide held" → toggle resets → load a label with no sub-labels → no sub-label badges render anywhere.
+- Playwright integration: load Warp Records → release count matches the API response → applying year filter hides rows outside the range → rows are still grouped by primary_type after filtering.
+
+**Verification:**
+- Manual: open `/?label/{hymen_id}` (or whatever the path/state shape ends up); verify all Hymen releases listed with library overlay; toggle "hide held" works; year filter narrows correctly.
+- Playwright: scripted run against `https://music.ablz.au` covers happy path + filter combinations.
+
+---
+
+- U7. **[cratedigger] Drill-in "View label" link from release-detail rows**
+
+**Goal:** Make the label name in any release row clickable, navigating to the label-detail page.
+
+**Requirements:** R1 (release-detail label is a clickable link).
+
+**Dependencies:** U6 (label-detail page must render to land on).
+
+**Files:**
+- Modify: `web/js/discography.js` or wherever release rows render label names. Verify exact location in implementation; the row component is the right place since release rows are shared between artist view and library view.
+- Modify: `web/js/library.js` if library cards also render label names and should drill-in (`web/js/library.js:213` is a likely site).
+
+**Approach:**
+- Find every JS site rendering a release's label name as plain text. Replace the text node with `<a href="#label/{discogs_label_id}" data-label-id="{id}">{name}</a>` (or whatever URL convention U5/U6 settled on).
+- For Discogs source releases, the `labels[]` array on the release payload already carries `{id, name, catno}` (verified `web/discogs.py:231`). Use `labels[0].id` as the navigation target. If multiple labels are present, render each as a separate link.
+- For MB source releases (already rendered today on the artist view), label names exist as text only and have no MB label ID surfaced through the route layer in v1. Render those as plain text in v1 — they become links in Phase B. **Do not invent a half-link or fake fallback.**
+- Click handler: same as U5's `openLabelDetail` — sets state, hides current view, navigates to label-detail.
+
+**Patterns to follow:**
+- The existing Discogs/MB release-link patterns in `web/js/discography.js` (e.g. `externalReleaseUrl`, `sourceLabel`).
+
+**Test scenarios:**
+- Pure helper test: given a release row with `labels: [{id: 757, name: "Hymen Records"}]`, the label name is rendered as a link with the correct data-label-id.
+- Pure helper test: given a release row with no labels (or empty `labels: []`), the label area renders nothing or a dash, no broken link.
+- Pure helper test: given an MB-source release with label only as a text field, no link is rendered (Phase B placeholder).
+- Playwright integration: from a Gridlock release on the artist view, click "Hymen Records" → land on Hymen label page → AE1 acceptance scenario passes end-to-end.
+
+**Verification:**
+- Hymen / Gridlock walkthrough end-to-end on `https://music.ablz.au` after deploy: artist view → release detail → click label → label-detail page → library overlay correct → "hide held" filters as expected.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New routes register into the existing `GET_ROUTES` / `GET_PATTERNS` dispatch in `web/server.py`. Discogs adapter additions to `web/discogs.py` follow the existing memoization pattern. No changes to beets-import path, pipeline, or any background process. No new advisory locks, no migrations on cratedigger DB.
+- **Error propagation:** Discogs mirror unreachable → `_get()` raises → route returns 5xx. Mirror schema returns malformed payload → `msgspec.ValidationError` at the wire boundary → route returns 5xx with logged error (this is the protective behavior — fail loudly rather than serve drift). Beets/pipeline overlay queries are best-effort — if either errors, the page renders without overlay (mirror the artist view's behavior; verify during U4).
+- **State lifecycle risks:** None — label data is read-only on the cratedigger side; no new write paths. Cache TTLs match existing patterns (`web/discogs.py` memoize_meta).
+- **API surface parity:** The new `/api/discogs/label/*` routes mirror `/api/discogs/artist/*` conventions. Phase B will add `/api/label/{mbid}` (UUID-routed) parallel to `/api/artist/{mbid}` — no v1 surface changes needed for that.
+- **Integration coverage:** U4's "library overlay correctness" integration test (one release in library + one in pipeline) is the primary cross-layer guard. U6's playwright happy path covers route → render → filter end-to-end. U7's playwright walkthrough covers the AE1 drill-in scenario as the acceptance gate.
+- **Unchanged invariants:** No changes to beets DB queries, pipeline DB schema, slskd integration, import paths, harness, or quality model. The library overlay helpers (`check_beets_library`, `check_pipeline`) are reused unchanged and are the only contact point with stateful infrastructure.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Recursive CTE on deep sub-label trees performs poorly | `EXPLAIN ANALYZE` during U2 on a worst-case label (Universal Music Group / Sony); cap CTE depth or add a denormalized "label_root_id" column as a follow-up if perf is bad. Must verify before declaring U2 done. |
+| Discogs label endpoint not yet deployed when cratedigger code lands | Deploy discogs-api (U1, U2) first and verify endpoints via `curl`; only then bump cratedigger flake input. The two repos deploy independently. |
+| `release_count` on label search hits joined-aggregate is expensive on big labels | Verify `EXPLAIN` during U1 — should use the existing `idx_release_label_label_id` index. If it blows up, denormalize `release_count` onto `label` table at import time as a follow-up. |
+| Frontend re-fetch on filter change creates sluggish UX | All filters operate on the in-memory release list; no re-fetch. Sub-label rollup is a single load-time fetch parameter. |
+| Big labels (Warp, Blue Note, Universal) overload the page DOM | U6 mitigates with lazy-load above ~200 rows; verify in playwright on a worst-case label before declaring U6 done. |
+| Half-built MB label support tempting during U3 to "save time later" | Resist — Phase A is Discogs-only by explicit scope. The source-agnostic shape is the bridge; MB adapter is its own plan. |
+| Discogs mirror staleness (~30 days) means a brand-new label release is invisible | Accepted — this is the known mirror cadence and matches the user's discovery (boutique retrospective) workflow. Document only if confusion arises. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/discogs-mirror.md` API Endpoints table to include `/api/labels`, `/api/labels/{id}`, `/api/labels/{id}/releases` after U1+U2 deploy.
+- Update `docs/webui-primer.md` to mention the new browse mode + drill-in link.
+- No new sops secrets, no new systemd services, no new infrastructure. The discogs-api deploy is its own existing pipeline (`nixosconfig` flake input bump on doc1 → `nixos-rebuild switch` doc2). The cratedigger deploy follows the standard sequence in `.claude/rules/deploy.md`.
+- Verification commands after deploy:
+  - `curl https://discogs.ablz.au/api/labels?name=hymen` (U1)
+  - `curl https://discogs.ablz.au/api/labels/{id}/releases?include_sublabels=true` (U2)
+  - Playwright walkthrough of AE1 (Gridlock → Hymen) on `https://music.ablz.au` (U7)
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/label-viewer-requirements.md`
+- **Issue:** GitHub #183
+- **Discogs mirror primer:** `docs/discogs-mirror.md`
+- **MusicBrainz mirror primer:** `docs/musicbrainz-mirror.md`
+- **Web UI primer:** `docs/webui-primer.md`
+- **Related code:**
+  - `web/routes/browse.py` (artist view, route registration patterns)
+  - `web/discogs.py` (Discogs adapter conventions)
+  - `web/js/discography.js`, `web/js/grouping.js`, `web/js/badges.js` (rendering reuse)
+  - `tests/test_web_server.py::TestRouteContractAudit`, `tests/test_web_server.py::TestPipelineRouteContracts` (test patterns)
+  - `lib/quality.py::HarnessItem`, `lib/quality.py::ChooseMatchMessage` (`msgspec.Struct` decode-at-boundary patterns)
+- **Related discogs-api code** (`~/discogs-api/`):
+  - `src/server.rs` (route registration)
+  - `src/db.rs::query_artist_search` (lines 745-783, FTS pattern to mirror)
+  - `src/db.rs::query_artist_releases` (lines 666-743, releases-by-entity pattern to mirror)
+  - `src/db.rs::infer_primary_type` (lines 990-1002, primary-type classification)
+  - `src/db.rs::fetch_release_enrichments` (lines 1290-1308, batch enrichment)
+  - `src/schema.rs` (label + release_label tables; needs new GIN index)

--- a/docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
+++ b/docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
@@ -503,6 +503,41 @@ The drill-in flow (F1 trigger from a release-detail row) is just a click handler
 
 ---
 
+## Post-merge follow-ups (from code review 2026-04-29)
+
+Captured from `/ce-code-review` Tier 2 pass on PR #185. Run artifacts: `/tmp/compound-engineering/ce-code-review/20260429-ded45010/`. The P0 + safe_auto cluster were applied in commits `bf2d929` (cratedigger) and `cf22645` (discogs-api). The items below were surfaced but deferred — they did not block merge but warrant follow-up work.
+
+**Priority order: tackle P1 + P2 #6 first; the P3 cleanup cluster can land in one consolidation PR.**
+
+### P1 — fix soon
+
+- **Pagination plumbed but not consumed.** `web/discogs.py::get_label_releases` accepts `page`/`per_page`; route doesn't forward; UI shows "Showing first 100 of N". Plan U6 explicitly accepted this for v1, but it leaves R5 ("paginated for hundreds/thousands") unsatisfied. Forward query params from the route, add page controls in `web/js/labels.js`.
+- **Recursive CTE uses `UNION ALL` — cycle in `parent_label_id` would infinite-loop.** `discogs-api/src/db.rs:163`. Discogs probably has no label cycles in practice but defensive: switch to `UNION` (dedups exact tuples) or PG14+ `CYCLE` clause. Apply to both the count CTE and the matched CTE.
+- **Rust struct fields typed `String` for nullable `label.profile` / `contactinfo` / `data_quality`** would panic on NULL. `discogs-api/src/db.rs:80`. Schema has `NOT NULL DEFAULT ''` so unlikely in practice; read as `Option<String>` and `.unwrap_or_default()` for safety.
+
+### P2 — fix when convenient
+
+- **Big-label fallback dead code.** `web/js/labels.js` empty-results refetch never triggers because `loadLabelReleases` throws on `!r.ok`. Either remove the branch or replace with a real heuristic that checks `release_count` from a cheap detail call before deciding `include_sublabels`.
+- **Total-count header mismatch on rolled-up labels.** `web/discogs.py` ~ release-count display: header says "X releases" (direct count) but list shows direct + sub-label rows when `include_sublabels=true`. Either compute total over the recursive CTE Rust-side, or surface `payload.pagination.items` as the header count when the list is rolled up.
+- **`openLabelDetail` has no in-flight token: late response can stomp newer label.** `web/js/labels.js:298`. Rapid clicks across labels could land out of order. Stamp each fetch with a request token in module scope, discard responses whose token is stale.
+- **Upstream 503 handling on cratedigger side.** Discovered during the fix pass: the Rust mirror now returns 503 when the recursive CTE exceeds 5s `statement_timeout`. The cratedigger route surfaces this as a 500 to the browser. The auto-flip should prevent the 503 in the happy path, but a user explicitly passing `?include_sublabels=true` on a UMG-class label would still see a 500. Consider a graceful retry-without-sublabels on 503.
+
+### P3 — cleanup cluster (one consolidation PR)
+
+- **`overlay_release_rows` mutation contract is implicit.** `web/routes/_overlay.py:46-66`. If a future caller passes a cached dict, the in-place mutation could poison the cache. Document the mutation in the docstring or rename to make it explicit (`overlay_release_rows_in_place`), or return a new list.
+- **`overlay_release_rows` lacks a direct unit test.** Currently only indirectly covered through `get_release_group` and `get_discogs_master`. Add direct test per `.claude/rules/code-quality.md` "every pure function must have direct unit tests".
+- **Hardcoded `sub_labels: []` in label-detail response.** `web/routes/labels.py`. discogs-api returns `LabelDetail.sub_labels` populated; the route drops them. Either pass through (UI doesn't render today but Phase B may) or remove the field from the response shape.
+- **Year inputs fire on every keystroke without debounce.** `web/js/labels.js`. Negligible at 100 rows; will matter when pagination lands and the in-memory list grows.
+- **Adapter accepts arbitrary `int|str` `label_id` and interpolates raw into URL.** `web/discogs.py`. Defence-in-depth: `assert str(label_id).isdigit()`. Route regex already restricts at the entry.
+- **Rust `via_label_id` field naming differs from rest-of-schema `label_id`.** `discogs-api/src/types.rs`. Rename has consumers in cratedigger Python so coordinate the change.
+
+### Pre-existing (not blocking, but worth noting)
+
+- Stale results can overwrite fresh ones — same race exists in the existing artist search. Single fix in `web/js/browse.js` would address both.
+- Cache key for label search uses unbounded user query (no length cap) — same pattern as existing `search_artists`. Consider a 200-char cap.
+
+---
+
 ## Sources & References
 
 - **Origin document:** `docs/brainstorms/label-viewer-requirements.md`

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -6,6 +6,8 @@ import sys
 import unittest
 from unittest.mock import patch, MagicMock
 
+import msgspec
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from web.discogs import (
@@ -19,6 +21,10 @@ from web.discogs import (
     search_releases,
     search_artists,
     get_artist_name,
+    search_labels,
+    get_label,
+    get_label_releases,
+    LabelEntity,
 )
 
 
@@ -353,6 +359,257 @@ class TestGetArtistName(unittest.TestCase):
     def test_returns_name(self):
         with _mock_urlopen({"id": 3840, "name": "Radiohead"}):
             self.assertEqual(get_artist_name(3840), "Radiohead")
+
+
+# ── Label adapter tests (U3) ────────────────────────────────────────────
+
+
+class TestSearchLabels(unittest.TestCase):
+    """search_labels() hits /api/labels?name= and returns LabelEntity list."""
+
+    LABEL_SEARCH_DATA = {
+        "results": [
+            {
+                "id": 2294,
+                "name": "Parlophone",
+                "profile": "British record label founded in 1896.",
+                "parent_label_id": None,
+                "parent_label_name": None,
+                "release_count": 18452,
+                "score": 0.087,
+            },
+            {
+                "id": 25693,
+                "name": "Parlophone Records Ltd.",
+                "profile": "Subsidiary trading name.",
+                "parent_label_id": 2294,
+                "parent_label_name": "Parlophone",
+                "release_count": 412,
+                "score": 0.072,
+            },
+        ],
+        "total": 2,
+        "page": 1,
+        "per_page": 25,
+    }
+
+    def test_returns_label_entities(self):
+        with _mock_urlopen(self.LABEL_SEARCH_DATA) as mock:
+            results = search_labels("Parlophone")
+
+        called_url = mock.call_args[0][0].full_url
+        self.assertIn("/api/labels?name=", called_url)
+
+        self.assertEqual(len(results), 2)
+        first = results[0]
+        self.assertIsInstance(first, LabelEntity)
+        self.assertEqual(first.source, "discogs")
+        self.assertEqual(first.id, "2294")  # int → str coercion
+        self.assertEqual(first.name, "Parlophone")
+        self.assertIsNone(first.country)  # discogs has no country column
+        self.assertEqual(first.profile, "British record label founded in 1896.")
+        self.assertIsNone(first.parent_label_id)
+        self.assertIsNone(first.parent_label_name)
+        self.assertEqual(first.release_count, 18452)
+
+        sub = results[1]
+        self.assertEqual(sub.id, "25693")
+        self.assertEqual(sub.parent_label_id, "2294")  # int → str coercion
+        self.assertEqual(sub.parent_label_name, "Parlophone")
+
+    def test_empty_results_returns_empty_list(self):
+        with _mock_urlopen({"results": [], "total": 0, "page": 1, "per_page": 25}):
+            results = search_labels("zzzzznosuchlabel")
+        self.assertEqual(results, [])
+
+    def test_wire_boundary_validates_release_count_int(self):
+        """RED-first regression guard: a release_count arriving as a STRING
+        instead of int must raise msgspec.ValidationError at the boundary.
+        Per .claude/rules/code-quality.md, every wire-boundary type owes
+        at least one test that proves it actually catches drift."""
+        bad = {
+            "results": [
+                {
+                    "id": 2294,
+                    "name": "Parlophone",
+                    "profile": "x",
+                    "parent_label_id": None,
+                    "parent_label_name": None,
+                    "release_count": "18452",  # WRONG: string, not int
+                    "score": 0.087,
+                },
+            ],
+            "total": 1,
+            "page": 1,
+            "per_page": 25,
+        }
+        with _mock_urlopen(bad):
+            with self.assertRaises(msgspec.ValidationError):
+                search_labels("Parlophone")
+
+
+class TestGetLabel(unittest.TestCase):
+    """get_label() hits /api/labels/{id} and returns a LabelEntity."""
+
+    TOP_LEVEL_DATA = {
+        "id": 2294,
+        "name": "Parlophone",
+        "profile": "British record label.",
+        "contactinfo": "",
+        "data_quality": "Correct",
+        "parent_label_id": None,
+        "parent_label_name": None,
+        "total_releases": 18452,
+        "sub_labels": [
+            {"id": 25693, "name": "Parlophone Records Ltd.", "release_count": 412},
+        ],
+    }
+
+    SUB_LABEL_DATA = {
+        "id": 25693,
+        "name": "Parlophone Records Ltd.",
+        "profile": "",
+        "contactinfo": "",
+        "data_quality": "Needs Vote",
+        "parent_label_id": 2294,
+        "parent_label_name": "Parlophone",
+        "total_releases": 412,
+        "sub_labels": [],
+    }
+
+    def test_top_level_label(self):
+        with _mock_urlopen(self.TOP_LEVEL_DATA) as mock:
+            entity = get_label(2294)
+
+        called_url = mock.call_args[0][0].full_url
+        self.assertIn("/api/labels/2294", called_url)
+
+        self.assertIsInstance(entity, LabelEntity)
+        self.assertEqual(entity.source, "discogs")
+        self.assertEqual(entity.id, "2294")
+        self.assertEqual(entity.name, "Parlophone")
+        self.assertIsNone(entity.country)
+        self.assertEqual(entity.profile, "British record label.")
+        self.assertIsNone(entity.parent_label_id)
+        self.assertIsNone(entity.parent_label_name)
+        self.assertEqual(entity.release_count, 18452)  # comes from total_releases
+
+    def test_sub_label_has_parent(self):
+        with _mock_urlopen(self.SUB_LABEL_DATA):
+            entity = get_label(25693)
+
+        self.assertEqual(entity.parent_label_id, "2294")
+        self.assertEqual(entity.parent_label_name, "Parlophone")
+        self.assertEqual(entity.release_count, 412)
+
+
+class TestGetLabelReleases(unittest.TestCase):
+    """get_label_releases() hits /api/labels/{id}/releases."""
+
+    RELEASES_DATA = {
+        "results": [
+            {
+                "id": 83182,
+                "title": "OK Computer",
+                "country": "Europe",
+                "released": "1997-06-16",
+                "master_id": 21491,
+                "master_title": "OK Computer",
+                "master_first_released": "1997",
+                "primary_type": "Album",
+                "via_label_id": 2294,
+                "sub_label_name": None,
+                "artists": [{"id": 3840, "name": "Radiohead", "role": "", "anv": ""}],
+                "labels": [{"id": 2294, "name": "Parlophone", "catno": "NODATA 02"}],
+                "formats": [
+                    {"name": "CD", "qty": 1, "descriptions": "Album", "free_text": ""}
+                ],
+            },
+            {
+                "id": 999111,
+                "title": "Some Sub-label Release",
+                "country": "UK",
+                "released": "2001",
+                "master_id": None,
+                "primary_type": "Single",
+                "via_label_id": 25693,
+                "sub_label_name": "Parlophone Records Ltd.",
+                "artists": [{"id": 1, "name": "Various", "role": "", "anv": ""}],
+                "labels": [
+                    {"id": 25693, "name": "Parlophone Records Ltd.", "catno": "PRL 1"}
+                ],
+                "formats": [
+                    {"name": "Vinyl", "qty": 1, "descriptions": "7\"", "free_text": ""}
+                ],
+            },
+        ],
+        "pagination": {"page": 1, "per_page": 100, "pages": 1, "items": 2},
+        "include_sublabels": True,
+    }
+
+    def test_returns_release_rows(self):
+        with _mock_urlopen(self.RELEASES_DATA) as mock:
+            payload = get_label_releases(2294, include_sublabels=True, page=1, per_page=100)
+
+        called_url = mock.call_args[0][0].full_url
+        self.assertIn("/api/labels/2294/releases", called_url)
+        self.assertIn("include_sublabels=true", called_url)
+        self.assertIn("page=1", called_url)
+        self.assertIn("per_page=100", called_url)
+
+        self.assertIn("results", payload)
+        self.assertIn("pagination", payload)
+        self.assertIn("include_sublabels", payload)
+        self.assertTrue(payload["include_sublabels"])
+        self.assertEqual(payload["pagination"]["items"], 2)
+
+        rows = payload["results"]
+        self.assertEqual(len(rows), 2)
+
+        direct = rows[0]
+        # Match shape used by web/discogs.py::get_master_releases / get_release
+        # so the U4 route layer can overlay library/pipeline state without
+        # renaming fields. ID is stringified, year derived from `released`,
+        # primary_artist_id surfaces for cross-source overlay.
+        self.assertEqual(direct["id"], "83182")
+        self.assertEqual(direct["title"], "OK Computer")
+        self.assertEqual(direct["primary_type"], "Album")
+        self.assertEqual(direct["country"], "Europe")
+        self.assertEqual(direct["date"], "1997-06-16")
+        self.assertEqual(direct["year"], 1997)
+        self.assertEqual(direct["release_group_id"], "21491")
+        self.assertEqual(direct["master_title"], "OK Computer")
+        self.assertEqual(direct["master_first_released"], "1997")
+        self.assertEqual(direct["artist_name"], "Radiohead")
+        self.assertEqual(direct["artist_id"], "3840")
+        self.assertEqual(direct["via_label_id"], "2294")
+        self.assertIsNone(direct["sub_label_name"])  # direct-parent release
+        self.assertEqual(direct["format"], "CD")
+
+        sub = rows[1]
+        self.assertEqual(sub["id"], "999111")
+        self.assertEqual(sub["sub_label_name"], "Parlophone Records Ltd.")
+        self.assertEqual(sub["via_label_id"], "25693")
+        self.assertIsNone(sub["release_group_id"])  # masterless
+        self.assertEqual(sub["primary_type"], "Single")
+        self.assertEqual(sub["format"], "Vinyl")
+
+    def test_default_pagination_kwargs(self):
+        with _mock_urlopen(self.RELEASES_DATA) as mock:
+            get_label_releases(2294)
+
+        called_url = mock.call_args[0][0].full_url
+        # Defaults per signature: include_sublabels=True, page=1, per_page=100
+        self.assertIn("include_sublabels=true", called_url)
+        self.assertIn("page=1", called_url)
+        self.assertIn("per_page=100", called_url)
+
+    def test_include_sublabels_false_passes_through(self):
+        with _mock_urlopen({**self.RELEASES_DATA, "include_sublabels": False}) as mock:
+            payload = get_label_releases(2294, include_sublabels=False)
+        called_url = mock.call_args[0][0].full_url
+        self.assertIn("include_sublabels=false", called_url)
+        self.assertFalse(payload["include_sublabels"])
 
 
 if __name__ == "__main__":

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -4,7 +4,7 @@
  */
 
 import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
-import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, parseYear } from '../web/js/labels.js';
+import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, parseYear, renderLabelLinks } from '../web/js/labels.js';
 
 let passed = 0;
 let failed = 0;
@@ -231,6 +231,72 @@ assertEqual(STABLE.map(r => r.id).join(','), 'a,b,c', 'equal years preserve inpu
 const ORIG = [{ id: '1', date: '2000' }, { id: '2', date: '2010' }];
 sortByYearDesc(ORIG);
 assertEqual(ORIG[0].id, '1', 'sortByYearDesc does not mutate input');
+
+// --- renderLabelLinks tests (U7) ---
+console.log('renderLabelLinks()');
+
+// Single Discogs-style label (id + name) → clickable link.
+const hymen = renderLabelLinks([{ id: 757, name: 'Hymen Records' }]);
+assert(hymen.includes('Hymen Records'), 'renders the label name');
+assert(hymen.includes('data-label-id="757"'), 'tags the link with data-label-id="757"');
+assert(hymen.includes('window.openLabelDetail'), 'wires window.openLabelDetail call');
+assert(hymen.includes('class="label-link"'), 'tags the anchor with the label-link class');
+assert(/<a\b/i.test(hymen), 'renders an anchor element');
+
+// Empty input → empty string.
+assertEqual(renderLabelLinks([]), '', 'empty array → empty string');
+assertEqual(renderLabelLinks(null), '', 'null → empty string');
+assertEqual(renderLabelLinks(undefined), '', 'undefined → empty string');
+
+// MB-style label (no id) → plain text, no anchor.
+const mbOnly = renderLabelLinks([{ name: 'Some MB Label' }]);
+assertEqual(mbOnly, 'Some MB Label', 'MB-style (no id) renders plain text');
+assert(!/<a\b/i.test(mbOnly), 'MB-style renders no anchor element');
+
+// id explicitly null → plain text (Phase B placeholder).
+const mbExplicitNull = renderLabelLinks([{ id: null, name: 'MB Label' }]);
+assertEqual(mbExplicitNull, 'MB Label', 'explicit id=null renders plain text');
+
+// Multiple labels with usable IDs → comma-separated links.
+const warpDual = renderLabelLinks([
+  { id: 757, name: 'Warp Records' },
+  { id: 758, name: 'Warp Singles' },
+]);
+assert(warpDual.includes('Warp Records'), 'first label name rendered');
+assert(warpDual.includes('Warp Singles'), 'second label name rendered');
+assert(warpDual.includes('data-label-id="757"'), 'first link has correct id attr');
+assert(warpDual.includes('data-label-id="758"'), 'second link has correct id attr');
+assertEqual((warpDual.match(/<a\b/gi) || []).length, 2, 'two anchor elements rendered');
+assert(warpDual.includes('</a>, <a'), 'anchors are separated by ", "');
+
+// Mixed: one with id (link), one without (text).
+const mixed = renderLabelLinks([
+  { id: 757, name: 'Hymen Records' },
+  { name: 'Plaintext Co.' },
+]);
+assert(mixed.includes('Hymen Records'), 'mixed: linked name present');
+assert(mixed.includes('Plaintext Co.'), 'mixed: plain name present');
+assertEqual((mixed.match(/<a\b/gi) || []).length, 1, 'mixed: only the id-bearing entry becomes a link');
+
+// XSS guard — name with <script> is escaped, no raw tag in output.
+const xss = renderLabelLinks([{ id: 1, name: '<script>alert(1)</script>' }]);
+assert(!xss.includes('<script>'), 'XSS guard: raw <script> tag not present in output');
+assert(xss.includes('&lt;script&gt;'), 'XSS guard: angle brackets entity-escaped');
+
+// XSS guard via name with quotes — should not break out of jsArg().
+const xssQuote = renderLabelLinks([{ id: 1, name: 'Bad", alert(1), "X' }]);
+assert(!xssQuote.includes('", alert'), 'XSS guard: quote escapes prevent attribute break-out');
+assert(xssQuote.includes('&quot;'), 'XSS guard: double quotes are entity-escaped');
+
+// Empty / falsy entries skipped.
+assertEqual(renderLabelLinks([null, undefined, { id: 1, name: '' }, { id: 2, name: 'OK' }]),
+  '<a href="#" class="label-link" data-label-id="2" onclick="event.stopPropagation(); event.preventDefault(); window.openLabelDetail(&quot;2&quot;, &quot;OK&quot;)">OK</a>',
+  'null/undefined/empty-name entries are skipped');
+
+// Numeric-string id is honored.
+const stringId = renderLabelLinks([{ id: '12345', name: 'String ID Label' }]);
+assert(stringId.includes('data-label-id="12345"'), 'string id is preserved');
+assert(stringId.includes('<a'), 'string id renders as link');
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -4,6 +4,7 @@
  */
 
 import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
+import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, parseYear } from '../web/js/labels.js';
 
 let passed = 0;
 let failed = 0;
@@ -142,6 +143,94 @@ console.log('sourceLabel()');
 assertEqual(sourceLabel('89ad4ac3-39f7-470e-963a-56509c546377'), 'MusicBrainz', 'UUID → MusicBrainz');
 assertEqual(sourceLabel('2048516'), 'Discogs', 'numeric → Discogs');
 assertEqual(sourceLabel('not-a-real-id'), '', 'unknown id → empty source label');
+
+// --- parseYear tests ---
+console.log('parseYear()');
+assertEqual(parseYear('2003'), 2003, 'year-only string');
+assertEqual(parseYear('2003-04-15'), 2003, 'full ISO date');
+assertEqual(parseYear('2003-04'), 2003, 'year-month');
+assertEqual(parseYear(''), null, 'empty string → null');
+assertEqual(parseYear(null), null, 'null → null');
+assertEqual(parseYear(undefined), null, 'undefined → null');
+assertEqual(parseYear('not-a-year'), null, 'garbage → null');
+
+// --- buildLabelSearchUrl tests ---
+console.log('buildLabelSearchUrl()');
+assertEqual(buildLabelSearchUrl('hymen'), '/api/discogs/label/search?q=hymen', 'simple query');
+assertEqual(buildLabelSearchUrl('warp records'), '/api/discogs/label/search?q=warp%20records', 'spaces encoded');
+assertEqual(buildLabelSearchUrl('a&b'), '/api/discogs/label/search?q=a%26b', 'special chars encoded');
+assertEqual(buildLabelSearchUrl('björk'), '/api/discogs/label/search?q=bj%C3%B6rk', 'unicode encoded');
+
+// --- applyLabelFilters tests ---
+console.log('applyLabelFilters()');
+const ROWS = [
+  { id: '1', title: 'A', date: '2000-01-01', format: 'CD',  in_library: false },
+  { id: '2', title: 'B', date: '2001-06-15', format: 'LP',  in_library: true  },
+  { id: '3', title: 'C', date: '2002',       format: 'CD, EP', in_library: false },
+  { id: '4', title: 'D', date: '2003-04-01', format: 'LP, Album', in_library: true },
+  { id: '5', title: 'E', date: '2004-12-01', format: 'Vinyl', in_library: false },
+  { id: '6', title: 'F', date: '',           format: 'CD',  in_library: false },
+];
+
+assertEqual(applyLabelFilters(ROWS, {}).length, 6, 'empty filters returns all rows');
+assertEqual(applyLabelFilters(ROWS, { yearMin: null, yearMax: null, format: '', hideHeld: false }).length, 6, 'null/empty filters returns all rows');
+
+const yearFilt = applyLabelFilters(ROWS, { yearMin: 2001, yearMax: 2003 });
+assertEqual(yearFilt.length, 3, 'year [2001..2003] inclusive matches 3 rows');
+assertEqual(yearFilt.map(r => r.id).join(','), '2,3,4', 'year filter keeps correct rows');
+
+const yearOnlyMin = applyLabelFilters(ROWS, { yearMin: 2003 });
+assertEqual(yearOnlyMin.map(r => r.id).join(','), '4,5', 'yearMin alone (drops empty-date row when filtered)');
+
+const yearOnlyMax = applyLabelFilters(ROWS, { yearMax: 2001 });
+assertEqual(yearOnlyMax.map(r => r.id).join(','), '1,2', 'yearMax alone');
+
+// Empty-date rows survive year filtering ONLY when no year filter applied
+const emptyDateNoFilter = applyLabelFilters(ROWS, { format: '' });
+assertEqual(emptyDateNoFilter.find(r => r.id === '6') !== undefined, true,
+  'empty-date row survives when no year filter applied');
+const emptyDateYearFilter = applyLabelFilters(ROWS, { yearMin: 2000, yearMax: 2010 });
+assertEqual(emptyDateYearFilter.find(r => r.id === '6'), undefined,
+  'empty-date row dropped when year filter active');
+
+const fmtLP = applyLabelFilters(ROWS, { format: 'LP' });
+assertEqual(fmtLP.map(r => r.id).join(','), '2,4', 'format LP matches substring');
+const fmtCD = applyLabelFilters(ROWS, { format: 'CD' });
+assertEqual(fmtCD.map(r => r.id).join(','), '1,3,6', 'format CD matches substring');
+const fmtEmpty = applyLabelFilters(ROWS, { format: '' });
+assertEqual(fmtEmpty.length, 6, 'empty format means no filter');
+
+const hideHeld = applyLabelFilters(ROWS, { hideHeld: true });
+assertEqual(hideHeld.map(r => r.id).join(','), '1,3,5,6', 'hideHeld excludes in_library:true');
+
+// All filters layered
+const layered = applyLabelFilters(ROWS, { yearMin: 2000, yearMax: 2003, format: 'CD', hideHeld: true });
+assertEqual(layered.map(r => r.id).join(','), '1,3', 'layered filters intersect correctly');
+
+// --- sortByYearDesc tests ---
+console.log('sortByYearDesc()');
+const SORTED = sortByYearDesc([
+  { id: '1', date: '2003-04-01' },
+  { id: '2', date: '2001-01-01' },
+  { id: '3', date: '' },
+  { id: '4', date: '2003-12-31' },
+  { id: '5', date: null },
+]);
+assertEqual(SORTED.map(r => r.id).join(','), '1,4,2,3,5',
+  'year desc; missing year sorts last; equal-year stable by input order');
+
+// stability across equal years
+const STABLE = sortByYearDesc([
+  { id: 'a', date: '2010' },
+  { id: 'b', date: '2010' },
+  { id: 'c', date: '2010' },
+]);
+assertEqual(STABLE.map(r => r.id).join(','), 'a,b,c', 'equal years preserve input order (stable)');
+
+// does not mutate input
+const ORIG = [{ id: '1', date: '2000' }, { id: '2', date: '2010' }];
+sortByYearDesc(ORIG);
+assertEqual(ORIG[0].id, '1', 'sortByYearDesc does not mutate input');
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -4,7 +4,7 @@
  */
 
 import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
-import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, parseYear, renderLabelLinks } from '../web/js/labels.js';
+import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, parseYear, renderLabelLinks, distinctFormats } from '../web/js/labels.js';
 
 let passed = 0;
 let failed = 0;
@@ -297,6 +297,77 @@ assertEqual(renderLabelLinks([null, undefined, { id: 1, name: '' }, { id: 2, nam
 const stringId = renderLabelLinks([{ id: '12345', name: 'String ID Label' }]);
 assert(stringId.includes('data-label-id="12345"'), 'string id is preserved');
 assert(stringId.includes('<a'), 'string id renders as link');
+
+// --- distinctFormats tests (review-fix #9) ---
+console.log('distinctFormats()');
+
+// Empty input → empty array.
+const emptyFmts = distinctFormats([]);
+assertEqual(Array.isArray(emptyFmts), true, 'empty input returns an array');
+assertEqual(emptyFmts.length, 0, 'empty input → empty array');
+
+// Single row, single format.
+assertEqual(distinctFormats([{ format: 'CD' }]).join(','), 'CD',
+  'single row single format');
+
+// Duplicates dedup'd; sorted alphabetically.
+const dups = distinctFormats([
+  { format: 'CD' }, { format: 'CD' }, { format: 'LP' }, { format: 'CD' },
+]);
+assertEqual(dups.join(','), 'CD,LP', 'duplicates collapse, sort applied');
+
+// Multi-value formats (joined Discogs string) split on commas.
+const multi = distinctFormats([
+  { format: 'LP, Album' },
+  { format: 'CD, EP' },
+  { format: 'Vinyl, LP' }, // LP appears in two rows, dedup'd
+]);
+assertEqual(multi.join(','), 'Album,CD,EP,LP,Vinyl',
+  'comma-joined formats split, dedup, alphabetized');
+
+// Whitespace trimmed; empty tokens dropped.
+const ws = distinctFormats([
+  { format: '  CD  ,  LP ,, ' },
+  { format: '' },
+]);
+assertEqual(ws.join(','), 'CD,LP', 'whitespace trimmed, empty tokens dropped');
+
+// Missing/null format field on a row — row skipped, no crash.
+const nullFmt = distinctFormats([
+  { format: null },
+  { format: undefined },
+  { /* no format key */ },
+  { format: 'CD' },
+]);
+assertEqual(nullFmt.join(','), 'CD', 'null/undefined/missing format fields skipped');
+
+// All missing → empty.
+assertEqual(distinctFormats([{}, { format: '' }]).join(','), '',
+  'no usable formats → empty array');
+
+// --- applyLabelFilters NaN year guard tests (review-fix #10) ---
+console.log('applyLabelFilters() NaN year guard');
+
+const NAN_ROWS = [
+  { id: '1', date: '2000-01-01', format: 'CD', in_library: false },
+  { id: '2', date: '2010-01-01', format: 'CD', in_library: false },
+  { id: '3', date: '',           format: 'CD', in_library: false },
+];
+
+// Explicit NaN bounds must behave as "no bound", not "drop everything".
+const nanMin = applyLabelFilters(NAN_ROWS, { yearMin: NaN });
+assertEqual(nanMin.length, 3, 'NaN yearMin treated as no lower bound');
+
+const nanMax = applyLabelFilters(NAN_ROWS, { yearMax: NaN });
+assertEqual(nanMax.length, 3, 'NaN yearMax treated as no upper bound');
+
+const nanBoth = applyLabelFilters(NAN_ROWS, { yearMin: NaN, yearMax: NaN });
+assertEqual(nanBoth.length, 3, 'both NaN bounds → no filter');
+
+// NaN min + valid max → max still applies, undated still drops.
+const mixedNan = applyLabelFilters(NAN_ROWS, { yearMin: NaN, yearMax: 2005 });
+assertEqual(mixedNan.map(r => r.id).join(','), '1',
+  'valid yearMax with NaN yearMin still filters correctly');
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -611,6 +611,8 @@ class TestRouteContractAudit(unittest.TestCase):
         r"^/api/discogs/artist/(\d+)$",
         r"^/api/discogs/master/(\d+)$",
         r"^/api/discogs/release/(\d+)$",
+        "/api/discogs/label/search",
+        r"^/api/discogs/label/(\d+)$",
         "/api/pipeline/log",
         "/api/pipeline/status",
         "/api/pipeline/recent",
@@ -2755,6 +2757,216 @@ class TestDiscogsBrowseRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.DISCOGS_RELEASE_REQUIRED_FIELDS,
                                 "discogs release detail")
         self.assertEqual(data["beets_album_id"], 10)
+
+
+class TestLabelRouteContracts(_WebServerCase):
+    """Contract tests for the Discogs label routes (Phase A)."""
+
+    LABEL_HIT_REQUIRED_FIELDS = {
+        "source", "id", "name", "country", "profile",
+        "parent_label_id", "parent_label_name", "release_count",
+    }
+    # Required fields the frontend reads on each release row in the
+    # label-detail response. Mirrors `web/js/discography.js` and
+    # `web/js/badges.js`. The overlay sets `library_format` /
+    # `library_min_bitrate` / `library_rank` only when a row is in
+    # the beets library — same convention as the existing
+    # `DISCOGS_MASTER_RELEASE_REQUIRED_FIELDS`. The JS reads them
+    # defensively (`item.library_format || ''`), so the contract
+    # asserts only the always-present overlay fields here, plus the
+    # label-specific `sub_label_name`. The integration test below
+    # exercises the populated path explicitly.
+    LABEL_RELEASE_REQUIRED_FIELDS = {
+        "id", "title", "artist_name", "date", "format", "primary_type",
+        "sub_label_name", "in_library", "beets_album_id",
+        "pipeline_status", "pipeline_id",
+    }
+    LABEL_DETAIL_RESPONSE_REQUIRED_FIELDS = {
+        "label", "releases", "sub_labels", "pagination", "include_sublabels",
+    }
+
+    def _make_label_entity(self, **overrides):
+        """Build a `LabelEntity` with sensible defaults for tests."""
+        from web.discogs import LabelEntity
+        defaults = {
+            "source": "discogs",
+            "id": "757",
+            "name": "Hymen Records",
+            "country": None,
+            "profile": "Industrial / IDM label",
+            "parent_label_id": None,
+            "parent_label_name": None,
+            "release_count": 42,
+        }
+        defaults.update(overrides)
+        return LabelEntity(**defaults)
+
+    def _make_release_row(self, **overrides):
+        """Build a release row matching `get_label_releases` adapter shape."""
+        row = {
+            "id": "1001",
+            "title": "Roniwasp",
+            "country": "Germany",
+            "date": "2002-01-01",
+            "year": 2002,
+            "primary_type": "Album",
+            "release_group_id": None,
+            "master_title": None,
+            "master_first_released": None,
+            "artist_name": "Gridlock",
+            "artist_id": "1234",
+            "via_label_id": "757",
+            "sub_label_name": None,
+            "format": "CD",
+            "media_count": 1,
+            "labels": [],
+            "formats": [],
+        }
+        row.update(overrides)
+        return row
+
+    def test_label_search_contract(self):
+        """Search hits expose every disambiguation field the UI needs."""
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.search_labels.return_value = [
+                self._make_label_entity(),
+                self._make_label_entity(
+                    id="999", name="Hymen Substream",
+                    parent_label_id="757", parent_label_name="Hymen Records",
+                    release_count=7),
+            ]
+            status, data = self._get("/api/discogs/label/search?q=hymen")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, {"results"}, "label search response")
+        self.assertEqual(len(data["results"]), 2)
+        for hit in data["results"]:
+            _assert_required_fields(self, hit, self.LABEL_HIT_REQUIRED_FIELDS,
+                                    "label search hit")
+        self.assertEqual(data["results"][1]["parent_label_id"], "757")
+
+    def test_label_search_missing_query(self):
+        status, data = self._get("/api/discogs/label/search?q=")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+
+    def test_label_detail_contract(self):
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [self._make_release_row()],
+                "pagination": {"page": 1, "per_page": 100, "pages": 1, "items": 1},
+                "include_sublabels": True,
+            }
+            status, data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data,
+                                self.LABEL_DETAIL_RESPONSE_REQUIRED_FIELDS,
+                                "label detail response")
+        _assert_required_fields(self, data["label"],
+                                self.LABEL_HIT_REQUIRED_FIELDS,
+                                "label detail entity")
+        self.assertEqual(len(data["releases"]), 1)
+        _assert_required_fields(self, data["releases"][0],
+                                self.LABEL_RELEASE_REQUIRED_FIELDS,
+                                "label release row")
+
+    def test_label_detail_overlay_integration(self):
+        """End-to-end overlay: with one release in library AND one in
+        pipeline, both rows are correctly annotated. This is the test
+        that proves the overlay actually runs — not just that helpers
+        were called."""
+        held_id = "1001"
+        in_pipeline_id = "1002"
+        mock_beets = MagicMock()
+        mock_beets.get_album_ids_by_mbids.return_value = {held_id: 17}
+        mock_beets.check_mbids_detail.return_value = {
+            held_id: {"beets_format": "FLAC", "beets_bitrate": 1100},
+        }
+
+        def _compute_rank(fmt, br):
+            return "lossless" if fmt == "FLAC" else "transparent"
+
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library",
+                      return_value={held_id}), \
+                patch("web.server.check_pipeline",
+                      return_value={in_pipeline_id: {"id": 99, "status": "wanted"}}), \
+                patch("web.server._beets_db", return_value=mock_beets), \
+                patch("web.server.compute_library_rank",
+                      side_effect=_compute_rank):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [
+                    self._make_release_row(id=held_id, title="Roniwasp"),
+                    self._make_release_row(
+                        id=in_pipeline_id, title="Formless",
+                        sub_label_name="Hymen Substream"),
+                ],
+                "pagination": {"page": 1, "per_page": 100, "pages": 1, "items": 2},
+                "include_sublabels": True,
+            }
+            status, data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 200)
+        held_row = next(r for r in data["releases"] if r["id"] == held_id)
+        pipeline_row = next(r for r in data["releases"] if r["id"] == in_pipeline_id)
+
+        # In-library row: overlay populated, pipeline empty
+        self.assertTrue(held_row["in_library"])
+        self.assertEqual(held_row["beets_album_id"], 17)
+        self.assertEqual(held_row["library_format"], "FLAC")
+        self.assertEqual(held_row["library_min_bitrate"], 1100)
+        self.assertEqual(held_row["library_rank"], "lossless")
+        self.assertIsNone(held_row["pipeline_status"])
+        self.assertIsNone(held_row["pipeline_id"])
+
+        # In-pipeline row: pipeline populated, library empty
+        self.assertFalse(pipeline_row["in_library"])
+        self.assertIsNone(pipeline_row["beets_album_id"])
+        self.assertEqual(pipeline_row["pipeline_status"], "wanted")
+        self.assertEqual(pipeline_row["pipeline_id"], 99)
+        self.assertEqual(pipeline_row["sub_label_name"], "Hymen Substream")
+
+    def test_label_detail_404(self):
+        """Adapter raises HTTPError(404) → route returns 404 JSON, not 5xx."""
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def _raise_404(_label_id):
+            raise HTTPError(
+                "https://discogs.ablz.au/api/labels/99999999",
+                404, "Not Found", hdrs=None, fp=BytesIO(b""),  # type: ignore[arg-type]
+            )
+
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.side_effect = _raise_404
+            status, data = self._get("/api/discogs/label/99999999")
+
+        self.assertEqual(status, 404)
+        self.assertIn("error", data)
+
+    def test_label_detail_include_sublabels_param_forwarded(self):
+        """`?include_sublabels=false` flows through to the adapter call."""
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": False,
+            }
+            status, _data = self._get("/api/discogs/label/757?include_sublabels=false")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "757", include_sublabels=False)
 
 
 class TestBeetsRouteContracts(_WebServerCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2968,6 +2968,123 @@ class TestLabelRouteContracts(_WebServerCase):
         mock_dg.get_label_releases.assert_called_once_with(
             "757", include_sublabels=False)
 
+    def test_label_detail_auto_flips_include_sublabels_for_big_labels(self):
+        """Big label (release_count > BIG_LABEL_THRESHOLD) without an
+        explicit `include_sublabels=` query param auto-flips to False so
+        the recursive sub-label CTE never hits the upstream timeout."""
+        big_entity = self._make_label_entity(
+            id="1", name="Universal Music Group", release_count=5000)
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = big_entity
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": False,
+            }
+            status, _data = self._get("/api/discogs/label/1")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "1", include_sublabels=False)
+
+    def test_label_detail_respects_explicit_include_sublabels_on_big_labels(self):
+        """If the caller explicitly opts in via `?include_sublabels=true`,
+        the auto-flip MUST NOT override their choice — even for big
+        labels. This is the API consumer's escape hatch."""
+        big_entity = self._make_label_entity(
+            id="1", name="Universal Music Group", release_count=5000)
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = big_entity
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": True,
+            }
+            status, _data = self._get("/api/discogs/label/1?include_sublabels=true")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "1", include_sublabels=True)
+
+    def test_label_detail_does_not_auto_flip_small_labels(self):
+        """Boutique labels (release_count <= threshold) keep the
+        default `include_sublabels=True` even with no explicit param."""
+        small_entity = self._make_label_entity(
+            id="757", name="Hymen Records", release_count=42)
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = small_entity
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": True,
+            }
+            status, _data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "757", include_sublabels=True)
+
+    def test_label_detail_rejects_malformed_include_sublabels(self):
+        """`?include_sublabels=` must be one of true/false/1/0 (case-
+        insensitive). Anything else → 400. Silently coercing typos
+        masks frontend bugs and lets bots pollute caches."""
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.return_value = self._make_label_entity()
+            status, data = self._get("/api/discogs/label/757?include_sublabels=yes")
+
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+        # And get_label_releases should NEVER be called when the param is bad.
+        self.assertFalse(mock_dg.get_label_releases.called)
+
+    def test_label_detail_accepts_truthy_synonyms(self):
+        """`include_sublabels=1` and `=0` are valid spellings."""
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": False,
+            }
+            status, _data = self._get("/api/discogs/label/757?include_sublabels=0")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "757", include_sublabels=False)
+
+    def test_label_detail_releases_404_propagates(self):
+        """If `get_label` succeeds but `get_label_releases` raises 404
+        (label vanished mid-flight), surface 404 to the client — not a
+        generic 500."""
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def _raise_404(_label_id, **_kwargs):
+            raise HTTPError(
+                "https://discogs.ablz.au/api/labels/757/releases",
+                404, "Not Found", hdrs=None, fp=BytesIO(b""),  # type: ignore[arg-type]
+            )
+
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.side_effect = _raise_404
+            status, data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 404)
+        self.assertIn("error", data)
+
 
 class TestBeetsRouteContracts(_WebServerCase):
     """Contract tests for frontend-consumed beets library routes."""

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -15,7 +15,7 @@ import json
 import re
 import urllib.parse
 import urllib.request
-from typing import Literal, Optional
+from typing import Literal
 
 import msgspec
 
@@ -321,8 +321,8 @@ class _DiscogsLabelHit(msgspec.Struct):
     id: int
     name: str
     profile: str
-    parent_label_id: Optional[int]
-    parent_label_name: Optional[str]
+    parent_label_id: int | None
+    parent_label_name: str | None
     release_count: int
     score: float
 
@@ -349,8 +349,8 @@ class _DiscogsLabelDetail(msgspec.Struct):
     profile: str
     contactinfo: str
     data_quality: str
-    parent_label_id: Optional[int]
-    parent_label_name: Optional[str]
+    parent_label_id: int | None
+    parent_label_name: str | None
     total_releases: int
     sub_labels: list[_DiscogsSubLabel]
 
@@ -381,18 +381,17 @@ class _DiscogsLabelReleaseEntry(msgspec.Struct):
     title: str
     country: str
     released: str
-    master_id: Optional[int]
+    master_id: int | None
     primary_type: str
     via_label_id: int
     artists: list[_DiscogsApiArtistCredit]
     labels: list[_DiscogsApiLabel]
     formats: list[_DiscogsApiFormat]
-    # Optional fields (skipped on the Rust side when None) — declared
-    # Optional[...] with a default so msgspec accepts payloads where the
-    # key is omitted entirely.
-    master_title: Optional[str] = None
-    master_first_released: Optional[str] = None
-    sub_label_name: Optional[str] = None
+    # Optional fields (skipped on the Rust side when None) — declared with
+    # a default so msgspec accepts payloads where the key is omitted entirely.
+    master_title: str | None = None
+    master_first_released: str | None = None
+    sub_label_name: str | None = None
 
 
 class _DiscogsLabelPagination(msgspec.Struct):
@@ -431,10 +430,10 @@ class LabelEntity(msgspec.Struct):
     source: Literal["discogs", "musicbrainz"]
     id: str
     name: str
-    country: Optional[str]
-    profile: Optional[str]
-    parent_label_id: Optional[str]
-    parent_label_name: Optional[str]
+    country: str | None
+    profile: str | None
+    parent_label_id: str | None
+    parent_label_name: str | None
     release_count: int
 
 
@@ -464,25 +463,7 @@ def _label_entity_from_detail(detail: _DiscogsLabelDetail) -> LabelEntity:
     )
 
 
-def _label_entity_to_dict(entity: LabelEntity) -> dict:
-    """Round-trip helper for Redis cache (`memoize_meta` uses json.dumps)."""
-    return {
-        "source": entity.source,
-        "id": entity.id,
-        "name": entity.name,
-        "country": entity.country,
-        "profile": entity.profile,
-        "parent_label_id": entity.parent_label_id,
-        "parent_label_name": entity.parent_label_name,
-        "release_count": entity.release_count,
-    }
-
-
-def _label_entity_from_dict(d: dict) -> LabelEntity:
-    return msgspec.convert(d, type=LabelEntity)
-
-
-def search_labels(query: str) -> list[LabelEntity]:
+def search_labels(query: str, *, page: int = 1, per_page: int = 25) -> list[LabelEntity]:
     """Search labels by name via `/api/labels?name=`.
 
     Decodes the response at the wire boundary into a typed
@@ -490,18 +471,24 @@ def search_labels(query: str) -> list[LabelEntity]:
     arriving as a string instead of int) raises
     `msgspec.ValidationError` from inside `_fetch`.
 
-    Returns a list of `LabelEntity` (typed), with the cache layer
-    storing the dict form so Redis JSON-serialization stays lossless.
+    Returns a list of `LabelEntity` (typed). The cache layer stores
+    the dict form (via `msgspec.to_builtins`) so Redis JSON encoding
+    stays lossless; on read we rehydrate via `msgspec.convert`. Per
+    `.claude/rules/code-quality.md` § "Wire-boundary types".
     """
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
-        raw = _get(f"{DISCOGS_API_BASE}/api/labels?name={q}&per_page=25")
+        raw = _get(
+            f"{DISCOGS_API_BASE}/api/labels"
+            f"?name={q}&page={page}&per_page={per_page}"
+        )
         decoded = msgspec.convert(raw, type=_DiscogsLabelSearchResponse)
-        return [_label_entity_to_dict(_label_entity_from_hit(h))
+        return [msgspec.to_builtins(_label_entity_from_hit(h))
                 for h in decoded.results]
 
-    cached = _cache.memoize_meta(f"discogs:search:labels:{query}", _fetch)
-    return [_label_entity_from_dict(d) for d in cached]
+    cache_key = f"discogs:search:labels:{query}:p={page}:pp={per_page}"
+    cached = _cache.memoize_meta(cache_key, _fetch)
+    return [msgspec.convert(d, type=LabelEntity) for d in cached]
 
 
 def get_label(label_id: int | str) -> LabelEntity:
@@ -514,10 +501,10 @@ def get_label(label_id: int | str) -> LabelEntity:
     def _fetch() -> dict:
         raw = _get(f"{DISCOGS_API_BASE}/api/labels/{label_id}")
         decoded = msgspec.convert(raw, type=_DiscogsLabelDetail)
-        return _label_entity_to_dict(_label_entity_from_detail(decoded))
+        return msgspec.to_builtins(_label_entity_from_detail(decoded))
 
     cached = _cache.memoize_meta(f"discogs:label:{label_id}", _fetch)
-    return _label_entity_from_dict(cached)
+    return msgspec.convert(cached, type=LabelEntity)
 
 
 def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -15,6 +15,9 @@ import json
 import re
 import urllib.parse
 import urllib.request
+from typing import Literal, Optional
+
+import msgspec
 
 from web import cache as _cache
 
@@ -294,3 +297,296 @@ def get_artist_name(artist_id: int) -> str:
         return data.get("name", "")
 
     return _cache.memoize_meta(f"discogs:artist:{artist_id}:name", _fetch)
+
+
+# ── Label adapter (U3) ──────────────────────────────────────────────────
+#
+# Wire-boundary types. The Rust mirror at `discogs.ablz.au` returns label
+# search/detail/release JSON shaped exactly per these Structs (see the
+# reference definitions in `discogs-api/src/types.rs`). They are decoded at
+# the `_get` boundary via `msgspec.convert(...)` — any int-vs-str drift,
+# missing required field, or wrong nested shape raises
+# `msgspec.ValidationError` immediately. Per
+# `.claude/rules/code-quality.md` § "Wire-boundary types": these are
+# `msgspec.Struct`, not `@dataclass`. Strict ≠ coerce — declare the field
+# as the type the wire actually carries.
+#
+# These are private to this module (leading underscore) — the public
+# contract is `LabelEntity`, defined below, which is the source-agnostic
+# shape consumed by the route layer (U4) and frontend.
+
+
+class _DiscogsLabelHit(msgspec.Struct):
+    """One hit from `GET /api/labels?name=...`."""
+    id: int
+    name: str
+    profile: str
+    parent_label_id: Optional[int]
+    parent_label_name: Optional[str]
+    release_count: int
+    score: float
+
+
+class _DiscogsLabelSearchResponse(msgspec.Struct):
+    results: list[_DiscogsLabelHit]
+    total: int
+    page: int
+    per_page: int
+
+
+class _DiscogsSubLabel(msgspec.Struct):
+    id: int
+    name: str
+    release_count: int
+
+
+class _DiscogsLabelDetail(msgspec.Struct):
+    """Response of `GET /api/labels/{id}`. Discogs labels have NO country
+    column upstream — the `LabelEntity.country` field is `None` for the
+    Discogs adapter; the future MB adapter will populate it."""
+    id: int
+    name: str
+    profile: str
+    contactinfo: str
+    data_quality: str
+    parent_label_id: Optional[int]
+    parent_label_name: Optional[str]
+    total_releases: int
+    sub_labels: list[_DiscogsSubLabel]
+
+
+class _DiscogsApiArtistCredit(msgspec.Struct):
+    id: int
+    name: str
+    role: str
+    anv: str
+
+
+class _DiscogsApiLabel(msgspec.Struct):
+    id: int
+    name: str
+    catno: str
+
+
+class _DiscogsApiFormat(msgspec.Struct):
+    name: str
+    qty: int
+    descriptions: str
+    free_text: str
+
+
+class _DiscogsLabelReleaseEntry(msgspec.Struct):
+    """One release row from `/api/labels/{id}/releases`."""
+    id: int
+    title: str
+    country: str
+    released: str
+    master_id: Optional[int]
+    primary_type: str
+    via_label_id: int
+    artists: list[_DiscogsApiArtistCredit]
+    labels: list[_DiscogsApiLabel]
+    formats: list[_DiscogsApiFormat]
+    # Optional fields (skipped on the Rust side when None) — declared
+    # Optional[...] with a default so msgspec accepts payloads where the
+    # key is omitted entirely.
+    master_title: Optional[str] = None
+    master_first_released: Optional[str] = None
+    sub_label_name: Optional[str] = None
+
+
+class _DiscogsLabelPagination(msgspec.Struct):
+    page: int
+    per_page: int
+    pages: int
+    items: int
+
+
+class _DiscogsLabelReleasesResponse(msgspec.Struct):
+    results: list[_DiscogsLabelReleaseEntry]
+    pagination: _DiscogsLabelPagination
+    include_sublabels: bool
+
+
+# ── Source-agnostic public contract ─────────────────────────────────────
+
+
+class LabelEntity(msgspec.Struct):
+    """Cross-source label representation. Populated by the Discogs adapter
+    today, and by the planned MusicBrainz adapter in Phase B.
+
+    Field design notes:
+    - `source` distinguishes downstream routing (e.g. "view label" links).
+    - `id` is stringified at the adapter boundary so route/JSON callers
+      see one consistent shape regardless of upstream id type
+      (Discogs int, MB UUID).
+    - `country` is `Optional` because the Discogs label table has no
+      country column; MB labels do, so the field stays in the contract.
+    - `parent_label_id` / `parent_label_name` are `Optional` to handle
+      both top-level labels (no parent) and sub-labels.
+    - `release_count` is the rolled-up count the upstream provided —
+      Discogs reports `total_releases` on detail and `release_count` on
+      search hits; both map here.
+    """
+    source: Literal["discogs", "musicbrainz"]
+    id: str
+    name: str
+    country: Optional[str]
+    profile: Optional[str]
+    parent_label_id: Optional[str]
+    parent_label_name: Optional[str]
+    release_count: int
+
+
+def _label_entity_from_hit(hit: _DiscogsLabelHit) -> LabelEntity:
+    return LabelEntity(
+        source="discogs",
+        id=str(hit.id),
+        name=hit.name,
+        country=None,  # Discogs label table has no country column
+        profile=hit.profile or None,
+        parent_label_id=str(hit.parent_label_id) if hit.parent_label_id is not None else None,
+        parent_label_name=hit.parent_label_name,
+        release_count=hit.release_count,
+    )
+
+
+def _label_entity_from_detail(detail: _DiscogsLabelDetail) -> LabelEntity:
+    return LabelEntity(
+        source="discogs",
+        id=str(detail.id),
+        name=detail.name,
+        country=None,
+        profile=detail.profile or None,
+        parent_label_id=str(detail.parent_label_id) if detail.parent_label_id is not None else None,
+        parent_label_name=detail.parent_label_name,
+        release_count=detail.total_releases,
+    )
+
+
+def _label_entity_to_dict(entity: LabelEntity) -> dict:
+    """Round-trip helper for Redis cache (`memoize_meta` uses json.dumps)."""
+    return {
+        "source": entity.source,
+        "id": entity.id,
+        "name": entity.name,
+        "country": entity.country,
+        "profile": entity.profile,
+        "parent_label_id": entity.parent_label_id,
+        "parent_label_name": entity.parent_label_name,
+        "release_count": entity.release_count,
+    }
+
+
+def _label_entity_from_dict(d: dict) -> LabelEntity:
+    return msgspec.convert(d, type=LabelEntity)
+
+
+def search_labels(query: str) -> list[LabelEntity]:
+    """Search labels by name via `/api/labels?name=`.
+
+    Decodes the response at the wire boundary into a typed
+    `_DiscogsLabelSearchResponse`; any drift (e.g. `release_count`
+    arriving as a string instead of int) raises
+    `msgspec.ValidationError` from inside `_fetch`.
+
+    Returns a list of `LabelEntity` (typed), with the cache layer
+    storing the dict form so Redis JSON-serialization stays lossless.
+    """
+    def _fetch() -> list[dict]:
+        q = urllib.parse.quote(query)
+        raw = _get(f"{DISCOGS_API_BASE}/api/labels?name={q}&per_page=25")
+        decoded = msgspec.convert(raw, type=_DiscogsLabelSearchResponse)
+        return [_label_entity_to_dict(_label_entity_from_hit(h))
+                for h in decoded.results]
+
+    cached = _cache.memoize_meta(f"discogs:search:labels:{query}", _fetch)
+    return [_label_entity_from_dict(d) for d in cached]
+
+
+def get_label(label_id: int | str) -> LabelEntity:
+    """Fetch a single label by Discogs ID via `/api/labels/{id}`.
+
+    Mirrors `get_release` / `get_artist_name`: relies on `_get` raising
+    HTTPError on 404 (the caller surfaces the 404 as needed). Returns
+    a typed `LabelEntity` on success.
+    """
+    def _fetch() -> dict:
+        raw = _get(f"{DISCOGS_API_BASE}/api/labels/{label_id}")
+        decoded = msgspec.convert(raw, type=_DiscogsLabelDetail)
+        return _label_entity_to_dict(_label_entity_from_detail(decoded))
+
+    cached = _cache.memoize_meta(f"discogs:label:{label_id}", _fetch)
+    return _label_entity_from_dict(cached)
+
+
+def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
+                       page: int = 1, per_page: int = 100) -> dict:
+    """Fetch a label's releases via `/api/labels/{id}/releases`.
+
+    Returns a dict shaped to match the existing release-row contract
+    used elsewhere in this module (`get_master_releases`,
+    `get_artist_releases`) so the U4 route layer can overlay
+    library/pipeline state with the same field names — `id` (str),
+    `title`, `country`, `date` (released), `year` (parsed from date),
+    `primary_type`, `release_group_id` (str | None), `artist_name`,
+    `artist_id` (str | None), `format` (joined names) — plus
+    label-specific fields `via_label_id` (str), `sub_label_name`
+    (str | None), `master_title`, `master_first_released`, `labels`,
+    `formats`.
+    """
+    def _fetch() -> dict:
+        sub_flag = "true" if include_sublabels else "false"
+        raw = _get(
+            f"{DISCOGS_API_BASE}/api/labels/{label_id}/releases"
+            f"?include_sublabels={sub_flag}&page={page}&per_page={per_page}"
+        )
+        decoded = msgspec.convert(raw, type=_DiscogsLabelReleasesResponse)
+        rows: list[dict] = []
+        for r in decoded.results:
+            artist_name = r.artists[0].name if r.artists else "Unknown"
+            artist_id = r.artists[0].id if r.artists else None
+            format_names = [f.name for f in r.formats]
+            rows.append({
+                "id": str(r.id),
+                "title": r.title,
+                "country": r.country,
+                "date": r.released,
+                "year": _parse_year(r.released),
+                "primary_type": r.primary_type,
+                "release_group_id": str(r.master_id) if r.master_id else None,
+                "master_title": r.master_title,
+                "master_first_released": r.master_first_released,
+                "artist_name": artist_name,
+                "artist_id": str(artist_id) if artist_id is not None else None,
+                "via_label_id": str(r.via_label_id),
+                "sub_label_name": r.sub_label_name,
+                "format": ", ".join(format_names) if format_names else "?",
+                "media_count": len(r.formats),
+                "labels": [
+                    {"id": lab.id, "name": lab.name, "catno": lab.catno}
+                    for lab in r.labels
+                ],
+                "formats": [
+                    {"name": f.name, "qty": f.qty,
+                     "descriptions": f.descriptions, "free_text": f.free_text}
+                    for f in r.formats
+                ],
+            })
+        return {
+            "results": rows,
+            "pagination": {
+                "page": decoded.pagination.page,
+                "per_page": decoded.pagination.per_page,
+                "pages": decoded.pagination.pages,
+                "items": decoded.pagination.items,
+            },
+            "include_sublabels": decoded.include_sublabels,
+        }
+
+    sub_flag = "true" if include_sublabels else "false"
+    cache_key = (
+        f"discogs:label:{label_id}:releases"
+        f":sub={sub_flag}:p={page}:pp={per_page}"
+    )
+    return _cache.memoize_meta(cache_key, _fetch)

--- a/web/index.html
+++ b/web/index.html
@@ -81,6 +81,7 @@
   .badge-downloading { background: #1a3a5a; color: #6cf; }
   .badge-imported { background: #1a4a2a; color: #6d6; }
   .badge-manual { background: #3a3a3a; color: #aaa; }
+  .badge-sublabel { background: #2a2a3a; color: #9ac; font-style: italic; }
   .status-card { background: #1a1a1a; padding: 16px; border-radius: 8px; margin-bottom: 12px; }
   .status-counts { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
   .count { text-align: center; padding: 8px 16px; background: #222; border-radius: 6px; cursor: pointer; border: 1px solid #333; flex: 1; min-width: 80px; }
@@ -225,6 +226,7 @@
     <div style="display:flex;gap:2px;">
       <button class="p-btn active-status" id="search-type-artist" onclick="setSearchType('artist')">Artist</button>
       <button class="p-btn" id="search-type-release" onclick="setSearchType('release')">Album</button>
+      <button class="p-btn" id="search-type-label" onclick="setSearchType('label')">Label</button>
     </div>
     <div style="display:flex;gap:2px;margin-left:8px;border-left:1px solid #444;padding-left:8px;">
       <button class="p-btn active-status" id="source-mb" onclick="setBrowseSource('mb')">MB</button>
@@ -247,6 +249,13 @@
     <div id="browse-analysis" style="display:none;"></div>
     <div id="browse-library" style="display:none;"></div>
     <div id="browse-compare" style="display:none;"></div>
+  </div>
+  <div id="browse-label" style="display:none;">
+    <div id="browse-label-header" style="margin:12px 0 8px;display:flex;align-items:center;gap:12px;">
+      <span style="cursor:pointer;font-size:18px;" onclick="closeLabelDetail()">←</span>
+      <span id="browse-label-name" style="font-size:18px;font-weight:bold;"></span>
+    </div>
+    <div id="browse-label-body"></div>
   </div>
 </div>
 

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -6,6 +6,7 @@ import { renderTypedSections, classify as groupingClassify } from './grouping.js
 import { renderStatusBadges } from './badges.js';
 import { renderDisambiguateInto } from './analysis.js';
 import { renderLibraryResultsInto } from './library.js';
+import { searchLabels, renderLabelSearchResults, openLabelDetail, closeLabelDetail } from './labels.js';
 
 /**
  * Look up an artist on the requested source by name. Returns the best match
@@ -66,14 +67,24 @@ export async function setBrowseSource(src) {
 }
 
 /**
- * Set the browse search type (artist or release).
- * @param {string} type - 'artist' or 'release'
+ * Set the browse search type (artist, release, or label).
+ * @param {string} type - 'artist' | 'release' | 'label'
  */
 export function setSearchType(type) {
   state.browseSearchType = type;
-  document.getElementById('search-type-artist').className = 'p-btn' + (type === 'artist' ? ' active-status' : '');
-  document.getElementById('search-type-release').className = 'p-btn' + (type === 'release' ? ' active-status' : '');
-  document.getElementById('q').placeholder = type === 'artist' ? 'Search artists or albums...' : 'Search album titles...';
+  const btnIds = { artist: 'search-type-artist', release: 'search-type-release', label: 'search-type-label' };
+  for (const [t, id] of Object.entries(btnIds)) {
+    const el = document.getElementById(id);
+    if (el) el.className = 'p-btn' + (type === t ? ' active-status' : '');
+  }
+  const placeholder = type === 'artist'
+    ? 'Search artists or albums...'
+    : type === 'release'
+      ? 'Search album titles...'
+      : 'Search record labels...';
+  /** @type {HTMLInputElement} */ (document.getElementById('q')).placeholder = placeholder;
+  // Hide label-detail view when switching modes (search results take focus).
+  if (state.browseLabel) closeLabelDetail();
   // Re-trigger search if there's a query
   const q = /** @type {HTMLInputElement} */ (document.getElementById('q')).value.trim();
   if (q.length >= 2) searchArtists(q);
@@ -421,7 +432,19 @@ export async function searchArtists(q) {
   const el = document.getElementById('results');
   el.style.display = 'block';
   document.getElementById('browse-artist').style.display = 'none';
+  const browseLabel = document.getElementById('browse-label');
+  if (browseLabel) browseLabel.style.display = 'none';
   el.innerHTML = '<div class="loading">Searching...</div>';
+  // Label search is Discogs-only in Phase A — independent of browseSource.
+  if (state.browseSearchType === 'label') {
+    try {
+      const hits = await searchLabels(q);
+      renderLabelSearchResults(el, hits, openLabelDetail);
+    } catch (_e) {
+      el.innerHTML = '<div class="loading">Label search failed</div>';
+    }
+    return;
+  }
   const isDiscogs = state.browseSource === 'discogs';
   const searchBase = isDiscogs ? `${API}/api/discogs/search` : `${API}/api/search`;
   try {

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -6,6 +6,7 @@ import { buildReleaseActionState } from './release_action_state.js';
 import { renderActionToolbar, renderAcquireActionButton, renderRemoveFromBeetsButton } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
 import { invalidateBrowseArtist } from './browse.js';
+import { renderLabelLinks } from './labels.js';
 
 /**
  * Render the artist discography into a target element.
@@ -259,6 +260,14 @@ export async function toggleReleaseDetail(mbid) {
           </div>`;
         }
       }).join('');
+    }
+
+    // Label links (U7) — Discogs releases carry `labels: [{id, name}]`;
+    // MB releases don't surface labels through the route layer in v1.
+    const labelLinksHtml = renderLabelLinks(data.labels);
+    if (labelLinksHtml) {
+      html += `<div class="release-labels" style="margin:4px 0;font-size:0.85em;color:#aaa;">`
+        + `<span style="color:#666;margin-right:6px;">Label:</span>${labelLinksHtml}</div>`;
     }
 
     // Links and actions

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -15,7 +15,7 @@
  */
 
 import { state, API, toast } from './state.js';
-import { esc } from './util.js';
+import { esc, jsArg } from './util.js';
 import { renderTypedSections } from './grouping.js';
 import { renderStatusBadges } from './badges.js';
 import { loadReleaseGroup } from './discography.js';
@@ -151,6 +151,65 @@ export function distinctFormats(releases) {
     }
   }
   return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * @typedef {Object} LabelRef
+ * @property {number|string} [id] - Discogs label ID (numeric/string). Absent
+ *   or falsy → render as plain text (no drill-in available).
+ * @property {string} [name] - Display name. Required to render anything.
+ */
+
+/**
+ * Render a release's `labels[]` array as inline HTML for the
+ * release-detail panel (U7 / AE1 drill-in).
+ *
+ * Per the label-viewer Phase A plan:
+ *   - Discogs source labels carry `{id, name}` → render as a clickable
+ *     `<a>` that calls `window.openLabelDetail(id, name)` (already wired
+ *     by U5/U6).
+ *   - MusicBrainz source labels arrive without an MB label ID surfaced
+ *     through the route layer in v1, so they render as plain text. They
+ *     become links in Phase B (separate plan). No half-link / fake
+ *     fallback.
+ *   - Mixed arrays (some entries with `id`, some without) render each
+ *     entry per its own rule, separated by ", ".
+ *
+ * Names are HTML-escaped via `esc()`; IDs are coerced to strings and
+ * passed through `jsArg()` for safe interpolation inside the inline
+ * `onclick` attribute (mirrors the established `release_actions.js` /
+ * `library.js` pattern). XSS regression test in
+ * `tests/test_js_util.mjs` covers a `<script>`-tagged label name.
+ *
+ * Empty / missing input → empty string. Callers decide whether to wrap
+ * the result in a row label.
+ *
+ * @param {Array<LabelRef>|null|undefined} labels
+ * @returns {string} HTML
+ */
+export function renderLabelLinks(labels) {
+  if (!Array.isArray(labels) || labels.length === 0) return '';
+  /** @type {string[]} */
+  const parts = [];
+  for (const lbl of labels) {
+    if (!lbl) continue;
+    const name = lbl.name == null ? '' : String(lbl.name);
+    if (!name) continue;
+    const idRaw = lbl.id;
+    const idStr = (idRaw === null || idRaw === undefined) ? '' : String(idRaw).trim();
+    if (idStr) {
+      // Discogs-style: clickable link → openLabelDetail.
+      parts.push(
+        `<a href="#" class="label-link" data-label-id="${esc(idStr)}"`
+        + ` onclick="event.stopPropagation(); event.preventDefault();`
+        + ` window.openLabelDetail(${jsArg(idStr)}, ${jsArg(name)})">${esc(name)}</a>`
+      );
+    } else {
+      // MB-style or untyped: plain text, Phase B will fill in.
+      parts.push(esc(name));
+    }
+  }
+  return parts.join(', ');
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -18,7 +18,6 @@ import { state, API, toast } from './state.js';
 import { esc, jsArg } from './util.js';
 import { renderTypedSections } from './grouping.js';
 import { renderStatusBadges } from './badges.js';
-import { loadReleaseGroup } from './discography.js';
 
 /**
  * Threshold above which the initial label-detail fetch defaults to
@@ -85,8 +84,17 @@ export function parseYear(dateStr) {
  * @returns {Array<Object>}
  */
 export function applyLabelFilters(releases, filters) {
-  const yMin = (filters && filters.yearMin != null) ? Number(filters.yearMin) : null;
-  const yMax = (filters && filters.yearMax != null) ? Number(filters.yearMax) : null;
+  // NaN slipped past the bare null check pre-fix #10: an empty input that
+  // happened to be `Number(NaN)` would silently drop every dated release
+  // because all comparisons against NaN are false. Treat non-finite values
+  // as "no bound."
+  const coerceYear = (v) => {
+    if (v == null) return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
+  const yMin = coerceYear(filters && filters.yearMin);
+  const yMax = coerceYear(filters && filters.yearMax);
   const yearActive = yMin != null || yMax != null;
   const fmtRaw = (filters && filters.format) ? String(filters.format).trim() : '';
   const fmt = fmtRaw.toLowerCase();
@@ -218,19 +226,21 @@ export function renderLabelLinks(labels) {
 
 /**
  * Search for labels via `/api/discogs/label/search`.
+ *
+ * Errors propagate to the caller — `browse.js` wraps the call in
+ * its own try/catch and renders a "Label search failed" notice.
+ * Don't swallow here; that hid the original 503 vs network-failure
+ * distinction during big-label triage.
+ *
  * @param {string} query
  * @returns {Promise<Array<Object>>}
  */
 export async function searchLabels(query) {
   const url = `${API}${buildLabelSearchUrl(query)}`;
-  try {
-    const r = await fetch(url);
-    if (!r.ok) return [];
-    const data = await r.json();
-    return Array.isArray(data.results) ? data.results : [];
-  } catch (_e) {
-    return [];
-  }
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const data = await r.json();
+  return Array.isArray(data.results) ? data.results : [];
 }
 
 /**
@@ -529,9 +539,17 @@ export function onLabelFilterChange() {
 
   const yMinRaw = yMinEl && yMinEl.value.trim();
   const yMaxRaw = yMaxEl && yMaxEl.value.trim();
+  // Number('foo') is NaN, which silently passes through the predicate
+  // (every comparison is false). Guard with Number.isFinite so a typo
+  // in the year field becomes "no filter" instead of "drop everything".
+  const parseYearInput = (raw) => {
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  };
   state.labelFilters = {
-    yearMin: yMinRaw ? Number(yMinRaw) : null,
-    yearMax: yMaxRaw ? Number(yMaxRaw) : null,
+    yearMin: parseYearInput(yMinRaw),
+    yearMax: parseYearInput(yMaxRaw),
     format: fmtEl ? fmtEl.value : '',
     hideHeld: !!(hideEl && hideEl.checked),
   };

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -1,0 +1,499 @@
+// @ts-check
+
+/**
+ * Label search + label-detail rendering for the browse tab.
+ *
+ * Phase A wires Discogs only. The page is structured so a Phase B
+ * MusicBrainz adapter is a route swap, not a redesign — the
+ * `LabelEntity` and release-row contracts the route layer returns
+ * are source-agnostic and read identically here.
+ *
+ * Pure helpers (`applyLabelFilters`, `sortByYearDesc`, `parseYear`,
+ * `buildLabelSearchUrl`) are testable via Node — see
+ * `tests/test_js_util.mjs`. Render helpers are DOM-bound and
+ * verified via playwright.
+ */
+
+import { state, API, toast } from './state.js';
+import { esc } from './util.js';
+import { renderTypedSections } from './grouping.js';
+import { renderStatusBadges } from './badges.js';
+import { loadReleaseGroup } from './discography.js';
+
+/**
+ * Threshold above which the initial label-detail fetch defaults to
+ * `include_sublabels=false`. Per U1+U2 EXPLAIN findings, mega-labels
+ * (UMG, Sony, etc.) with full sub-label rollup take 30+ seconds. For
+ * boutique labels (Hymen 659, Warp ~3000) this never trips.
+ */
+export const BIG_LABEL_THRESHOLD = 1000;
+
+/**
+ * Soft limit on releases rendered in the body. The route returns up
+ * to 100 today; if the upstream ever exceeds this we render the first
+ * `MAX_RENDERED` and surface a hint.
+ */
+export const MAX_RENDERED = 100;
+
+/**
+ * Build the URL for `/api/discogs/label/search`.
+ * Pure for testability.
+ * @param {string} q
+ * @returns {string}
+ */
+export function buildLabelSearchUrl(q) {
+  return `/api/discogs/label/search?q=${encodeURIComponent(q)}`;
+}
+
+/**
+ * Parse the `release.date` field (Discogs `released`) into a year.
+ * Accepts "2003", "2003-04", "2003-04-15"; returns null for missing
+ * or unparseable values.
+ * @param {string|null|undefined} dateStr
+ * @returns {number|null}
+ */
+export function parseYear(dateStr) {
+  if (!dateStr) return null;
+  const m = String(dateStr).match(/^(\d{4})/);
+  if (!m) return null;
+  const y = Number(m[1]);
+  return Number.isFinite(y) ? y : null;
+}
+
+/**
+ * @typedef {Object} LabelFilters
+ * @property {number|null} [yearMin]
+ * @property {number|null} [yearMax]
+ * @property {string} [format] - Substring match against `release.format`
+ * @property {boolean} [hideHeld] - When true, exclude rows with `in_library === true`
+ */
+
+/**
+ * Pure filter predicate over label release rows. No DOM access.
+ *
+ * Year filter is inclusive on both ends. When either yearMin or
+ * yearMax is set, rows with no parseable year are dropped (you cannot
+ * place an undated release inside a year range). When no year filter
+ * is active, undated rows survive.
+ *
+ * Format filter is a case-insensitive substring match on the joined
+ * `release.format` string (e.g. "LP, Album" matches both "LP" and
+ * "Album"). Empty string means no filter.
+ *
+ * @param {Array<Object>} releases
+ * @param {LabelFilters} filters
+ * @returns {Array<Object>}
+ */
+export function applyLabelFilters(releases, filters) {
+  const yMin = (filters && filters.yearMin != null) ? Number(filters.yearMin) : null;
+  const yMax = (filters && filters.yearMax != null) ? Number(filters.yearMax) : null;
+  const yearActive = yMin != null || yMax != null;
+  const fmtRaw = (filters && filters.format) ? String(filters.format).trim() : '';
+  const fmt = fmtRaw.toLowerCase();
+  const hideHeld = !!(filters && filters.hideHeld);
+
+  return releases.filter((r) => {
+    if (hideHeld && r.in_library === true) return false;
+    if (fmt) {
+      const f = String(r.format || '').toLowerCase();
+      if (!f.includes(fmt)) return false;
+    }
+    if (yearActive) {
+      const y = parseYear(r.date);
+      if (y == null) return false;
+      if (yMin != null && y < yMin) return false;
+      if (yMax != null && y > yMax) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Stable sort by year descending. Rows with no parseable year sort
+ * to the end. Stable across equal years (preserves input order).
+ *
+ * Returns a new array — does not mutate input.
+ *
+ * @param {Array<Object>} releases
+ * @returns {Array<Object>}
+ */
+export function sortByYearDesc(releases) {
+  return releases
+    .map((r, i) => ({ r, i, y: parseYear(r.date) }))
+    .sort((a, b) => {
+      // Missing year always sorts last (regardless of direction).
+      if (a.y == null && b.y == null) return a.i - b.i;
+      if (a.y == null) return 1;
+      if (b.y == null) return -1;
+      if (a.y !== b.y) return b.y - a.y; // desc
+      return a.i - b.i; // stable
+    })
+    .map((entry) => entry.r);
+}
+
+/**
+ * Distinct format keys for the filter dropdown. Splits joined Discogs
+ * format strings ("LP, Album, Repress") on commas and de-dupes.
+ * Returns lowercase tokens for use as substring filters; the UI
+ * renders them title-cased.
+ * @param {Array<Object>} releases
+ * @returns {string[]}
+ */
+export function distinctFormats(releases) {
+  /** @type {Set<string>} */
+  const set = new Set();
+  for (const r of releases) {
+    const raw = String(r.format || '').trim();
+    if (!raw) continue;
+    for (const part of raw.split(',')) {
+      const tok = part.trim();
+      if (tok) set.add(tok);
+    }
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// DOM-bound functions below — verified via playwright, not unit tests.
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Search for labels via `/api/discogs/label/search`.
+ * @param {string} query
+ * @returns {Promise<Array<Object>>}
+ */
+export async function searchLabels(query) {
+  const url = `${API}${buildLabelSearchUrl(query)}`;
+  try {
+    const r = await fetch(url);
+    if (!r.ok) return [];
+    const data = await r.json();
+    return Array.isArray(data.results) ? data.results : [];
+  } catch (_e) {
+    return [];
+  }
+}
+
+/**
+ * Render label search hits into a container element.
+ *
+ * @param {HTMLElement} containerEl
+ * @param {Array<Object>} hits
+ * @param {(labelId: string, labelName: string) => void} onClickHandler
+ */
+export function renderLabelSearchResults(containerEl, hits, onClickHandler) {
+  if (!hits.length) {
+    containerEl.innerHTML = '<div class="loading">No label results</div>';
+    return;
+  }
+  // Stash handler on the element so the inline onclick can find it
+  // by index without leaking globals. Mirrors the label-id-array
+  // approach we use elsewhere when an onclick needs typed args.
+  /** @type {any} */ (containerEl)._labelHits = hits;
+  /** @type {any} */ (containerEl)._labelClick = onClickHandler;
+  containerEl.innerHTML = hits.map((h, i) => {
+    const country = h.country ? `<span class="artist-dis"> · ${esc(h.country)}</span>` : '';
+    const parent = h.parent_label_id
+      ? `<span class="badge badge-sublabel" style="margin-left:6px;">via ${esc(h.parent_label_name || 'parent')}</span>`
+      : '';
+    const count = (typeof h.release_count === 'number' && h.release_count > 0)
+      ? `<span class="artist-dis" style="margin-left:6px;">${h.release_count} release${h.release_count === 1 ? '' : 's'}</span>`
+      : '';
+    return `
+      <div class="artist">
+        <div class="artist-header" onclick="window.openLabelDetailFromList(this.closest('.artist'), ${i})">
+          <span class="artist-name">${esc(h.name || '')}</span>
+          ${country}
+          ${parent}
+          ${count}
+        </div>
+      </div>`;
+  }).join('');
+}
+
+/**
+ * Click-resolver for a search-result row. Looks up the hit by index
+ * on the parent container that `renderLabelSearchResults` annotated.
+ * @param {HTMLElement} rowEl
+ * @param {number} index
+ */
+export function openLabelDetailFromList(rowEl, index) {
+  const containerEl = /** @type {any} */ (rowEl.parentElement);
+  if (!containerEl || !containerEl._labelHits) return;
+  const hit = containerEl._labelHits[index];
+  const handler = containerEl._labelClick;
+  if (!hit) return;
+  if (typeof handler === 'function') {
+    handler(String(hit.id), String(hit.name));
+  } else {
+    openLabelDetail(String(hit.id), String(hit.name));
+  }
+}
+
+/**
+ * Open the label detail view: hides search results + artist view,
+ * shows the label-detail container, fetches and renders.
+ * @param {string} labelId
+ * @param {string} labelName
+ */
+export async function openLabelDetail(labelId, labelName) {
+  state.browseLabel = { id: labelId, name: labelName };
+  state.browseSubView = 'label';
+
+  const results = document.getElementById('results');
+  if (results) results.style.display = 'none';
+  const browseArtist = document.getElementById('browse-artist');
+  if (browseArtist) browseArtist.style.display = 'none';
+  const browseLabel = document.getElementById('browse-label');
+  if (browseLabel) browseLabel.style.display = 'block';
+
+  const nameEl = document.getElementById('browse-label-name');
+  if (nameEl) nameEl.textContent = labelName;
+
+  const body = document.getElementById('browse-label-body');
+  if (!body) return;
+  body.innerHTML = '<div class="loading">Loading label catalogue...</div>';
+
+  // First fetch with default include_sublabels=true. After we have
+  // the label entity we may decide to retry without sub-labels for
+  // very large labels.
+  try {
+    let payload = await loadLabelReleases(labelId, { include_sublabels: true });
+    const totalCount = (payload && payload.label && payload.label.release_count) || 0;
+    if (totalCount > BIG_LABEL_THRESHOLD && payload.releases && payload.releases.length === 0) {
+      // Defensive: if the big-label query timed out and returned empty,
+      // refetch without sub-labels. (Cheap insurance — happy path on
+      // boutique labels never enters this branch.)
+      payload = await loadLabelReleases(labelId, { include_sublabels: false });
+    } else if (totalCount > BIG_LABEL_THRESHOLD) {
+      // Surface the sub-label opt-in toggle even when the first fetch
+      // succeeded — UX hint that this label has a long tail.
+      state.labelFilters = state.labelFilters || {};
+      /** @type {any} */ (state.labelFilters).bigLabel = true;
+    }
+    renderLabelDetail(body, payload);
+  } catch (e) {
+    body.innerHTML = '<div class="loading">Failed to load label</div>';
+  }
+}
+
+/**
+ * Close the label detail view; show search results.
+ */
+export function closeLabelDetail() {
+  state.browseLabel = null;
+  state.labelFilters = { yearMin: null, yearMax: null, format: '', hideHeld: false };
+  const browseLabel = document.getElementById('browse-label');
+  if (browseLabel) browseLabel.style.display = 'none';
+  const results = document.getElementById('results');
+  if (results) results.style.display = 'block';
+}
+
+/**
+ * Fetch label detail + releases.
+ * @param {string} labelId
+ * @param {{include_sublabels?: boolean}} [opts]
+ * @returns {Promise<Object>}
+ */
+export async function loadLabelReleases(labelId, opts = {}) {
+  const includeSub = opts.include_sublabels !== false;
+  const url = `${API}/api/discogs/label/${encodeURIComponent(labelId)}?include_sublabels=${includeSub}`;
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return await r.json();
+}
+
+/**
+ * Render the label detail page: header + filter bar + grouped body.
+ * @param {HTMLElement} containerEl
+ * @param {Object} payload
+ */
+export function renderLabelDetail(containerEl, payload) {
+  const label = payload.label || {};
+  const allReleases = Array.isArray(payload.releases) ? payload.releases : [];
+  const totalCount = (typeof label.release_count === 'number')
+    ? label.release_count : allReleases.length;
+  const includeSub = payload.include_sublabels !== false;
+
+  // Stash full release list on the container for filter re-renders.
+  /** @type {any} */ (containerEl)._releases = allReleases;
+  /** @type {any} */ (containerEl)._totalCount = totalCount;
+  /** @type {any} */ (containerEl)._labelId = String(label.id || '');
+  /** @type {any} */ (containerEl)._labelName = String(label.name || '');
+  /** @type {any} */ (containerEl)._includeSub = includeSub;
+
+  const hasAnySubLabel = allReleases.some((r) => r.sub_label_name);
+  /** @type {any} */ (containerEl)._hasAnySubLabel = hasAnySubLabel;
+
+  // Initialise / preserve filters in state. Default off everywhere.
+  if (!state.labelFilters) {
+    state.labelFilters = { yearMin: null, yearMax: null, format: '', hideHeld: false };
+  }
+  /** @type {LabelFilters} */
+  const filters = state.labelFilters;
+
+  const formats = distinctFormats(allReleases);
+
+  // Header
+  const profile = (label.profile || '').toString();
+  const profileShort = profile.length > 200 ? profile.slice(0, 200) + '…' : profile;
+  const parentBadge = label.parent_label_id
+    ? `<span class="badge badge-sublabel">via ${esc(label.parent_label_name || 'parent')}</span>`
+    : '';
+  const country = label.country ? ` · ${esc(label.country)}` : '';
+  const renderedNote = (allReleases.length < totalCount)
+    ? `<div class="loading" style="text-align:left;padding:6px 0;color:#888;">Showing first ${allReleases.length} of ${totalCount} — pagination coming.</div>`
+    : '';
+  const bigLabelToggle = (totalCount > BIG_LABEL_THRESHOLD)
+    ? `<label style="margin-left:10px;font-size:0.85em;color:#aaa;">
+         <input type="checkbox" id="label-include-sublabels" ${includeSub ? 'checked' : ''}
+                onchange="window.toggleLabelIncludeSublabels(this.checked)"> include sub-labels
+       </label>`
+    : '';
+
+  const fmtOptions = ['<option value="">All formats</option>']
+    .concat(formats.map((f) => {
+      const sel = (filters.format && filters.format.toLowerCase() === f.toLowerCase()) ? ' selected' : '';
+      return `<option value="${esc(f)}"${sel}>${esc(f)}</option>`;
+    })).join('');
+
+  const yMinVal = (filters.yearMin != null) ? String(filters.yearMin) : '';
+  const yMaxVal = (filters.yearMax != null) ? String(filters.yearMax) : '';
+  const hideHeldChecked = filters.hideHeld ? 'checked' : '';
+
+  containerEl.innerHTML = `
+    <div style="margin-bottom:12px;">
+      <div style="display:flex;gap:10px;align-items:baseline;flex-wrap:wrap;">
+        <span style="font-size:18px;font-weight:bold;">${esc(label.name || '')}</span>
+        ${parentBadge}
+        <span style="color:#888;font-size:0.85em;">${totalCount} release${totalCount === 1 ? '' : 's'}${country}</span>
+      </div>
+      ${profileShort ? `<div style="color:#888;font-size:0.85em;margin-top:6px;">${esc(profileShort)}</div>` : ''}
+    </div>
+    <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:10px;padding:8px;background:#1a1a1a;border-radius:6px;">
+      <span style="font-size:0.8em;color:#888;">Year</span>
+      <input type="number" id="label-year-min" placeholder="min" value="${yMinVal}"
+             style="width:80px;padding:4px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:13px;"
+             oninput="window.onLabelFilterChange()">
+      <span style="color:#666;">–</span>
+      <input type="number" id="label-year-max" placeholder="max" value="${yMaxVal}"
+             style="width:80px;padding:4px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:13px;"
+             oninput="window.onLabelFilterChange()">
+      <span style="font-size:0.8em;color:#888;margin-left:8px;">Format</span>
+      <select id="label-format" onchange="window.onLabelFilterChange()"
+              style="padding:4px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:13px;">
+        ${fmtOptions}
+      </select>
+      <label style="font-size:0.85em;color:#aaa;margin-left:8px;">
+        <input type="checkbox" id="label-hide-held" ${hideHeldChecked}
+               onchange="window.onLabelFilterChange()"> hide held
+      </label>
+      ${bigLabelToggle}
+    </div>
+    ${renderedNote}
+    <div id="browse-label-rows"></div>
+  `;
+
+  renderLabelRows(containerEl);
+}
+
+/**
+ * Re-render the rows section based on the current filter state.
+ * @param {HTMLElement} containerEl
+ */
+export function renderLabelRows(containerEl) {
+  const rows = /** @type {any} */ (containerEl)._releases || [];
+  const hasAnySubLabel = /** @type {any} */ (containerEl)._hasAnySubLabel;
+  /** @type {LabelFilters} */
+  const filters = state.labelFilters || { yearMin: null, yearMax: null, format: '', hideHeld: false };
+  const filtered = applyLabelFilters(rows, filters);
+  const sorted = sortByYearDesc(filtered);
+  const visible = sorted.slice(0, MAX_RENDERED);
+
+  const body = containerEl.querySelector('#browse-label-rows');
+  if (!body) return;
+  if (!visible.length) {
+    body.innerHTML = '<div class="loading">No releases match the current filters.</div>';
+    return;
+  }
+
+  const renderRow = (rel) => {
+    const year = parseYear(rel.date);
+    const yearStr = year != null ? String(year) : '?';
+    const subBadge = (hasAnySubLabel && rel.sub_label_name)
+      ? `<span class="badge badge-sublabel" style="margin-left:6px;">via ${esc(rel.sub_label_name)}</span>`
+      : '';
+    const badges = renderStatusBadges(rel);
+    const fmt = rel.format ? `<span class="rg-meta"> — ${esc(rel.format)}</span>` : '';
+    const artist = rel.artist_name ? `<span class="rg-meta" style="color:#999;"> — ${esc(rel.artist_name)}</span>` : '';
+    return `
+      <div class="rg" onclick="event.stopPropagation(); window.loadReleaseGroup('${esc(String(rel.id))}', this)">
+        <div>
+          <span class="rg-year">${yearStr}</span>
+          <span class="rg-title">${esc(rel.title || '')}</span>
+          ${artist}
+          ${fmt}
+          ${subBadge}
+          ${badges}
+        </div>
+        <div class="releases" id="rel-${esc(String(rel.id))}"></div>
+      </div>
+    `;
+  };
+
+  body.innerHTML = renderTypedSections(visible, renderRow, {
+    classify: (r) => {
+      const t = String(r.primary_type || '').toLowerCase();
+      if (t === 'album') return 'Albums';
+      if (t === 'ep') return 'EPs';
+      if (t === 'single') return 'Singles';
+      if (t === 'compilation' || t === 'soundtrack') return 'Compilations';
+      if (t === 'live') return 'Live';
+      return 'Other';
+    },
+    dateOf: (r) => String(r.date || ''),
+    defaultOpen: 'Albums',
+  });
+}
+
+/**
+ * Inputs/selects in the filter bar all funnel through this handler.
+ * Reads DOM, updates state, re-renders rows.
+ */
+export function onLabelFilterChange() {
+  const containerEl = document.getElementById('browse-label-body');
+  if (!containerEl) return;
+  const yMinEl = /** @type {HTMLInputElement|null} */ (document.getElementById('label-year-min'));
+  const yMaxEl = /** @type {HTMLInputElement|null} */ (document.getElementById('label-year-max'));
+  const fmtEl = /** @type {HTMLSelectElement|null} */ (document.getElementById('label-format'));
+  const hideEl = /** @type {HTMLInputElement|null} */ (document.getElementById('label-hide-held'));
+
+  const yMinRaw = yMinEl && yMinEl.value.trim();
+  const yMaxRaw = yMaxEl && yMaxEl.value.trim();
+  state.labelFilters = {
+    yearMin: yMinRaw ? Number(yMinRaw) : null,
+    yearMax: yMaxRaw ? Number(yMaxRaw) : null,
+    format: fmtEl ? fmtEl.value : '',
+    hideHeld: !!(hideEl && hideEl.checked),
+  };
+  renderLabelRows(containerEl);
+}
+
+/**
+ * Toggle the include-sublabels opt-in (only shown for big labels).
+ * Triggers a refetch.
+ * @param {boolean} include
+ */
+export async function toggleLabelIncludeSublabels(include) {
+  if (!state.browseLabel) return;
+  const body = document.getElementById('browse-label-body');
+  if (!body) return;
+  body.innerHTML = '<div class="loading">Reloading...</div>';
+  try {
+    const payload = await loadLabelReleases(state.browseLabel.id, { include_sublabels: include });
+    renderLabelDetail(body, payload);
+  } catch (_e) {
+    body.innerHTML = '<div class="loading">Failed to reload label</div>';
+    toast('Failed to reload label', true);
+  }
+}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -15,6 +15,7 @@ import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
 import { loadManualImport, runManualImport } from './manual.js';
 import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup, deleteTransparentNonFlacWrongMatches, deleteLosslessOpusWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold, setWrongMatchConvergeCleanup } from './wrong-matches.js';
+import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, toggleLabelIncludeSublabels } from './labels.js';
 import { toast } from './state.js';
 
 // --- Tab management ---
@@ -113,5 +114,10 @@ Object.assign(window, {
   convergeWrongMatches,
   setWrongMatchConvergeThreshold,
   setWrongMatchConvergeCleanup,
+  openLabelDetail,
+  openLabelDetailFromList,
+  closeLabelDetail,
+  onLabelFilterChange,
+  toggleLabelIncludeSublabels,
   toast,
 });

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -7,11 +7,13 @@
 
 import { normalizeReleaseId } from './util.js';
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
   browseArtist: null,
+  browseLabel: null,
+  labelFilters: { yearMin: null, yearMax: null, format: '', hideHeld: false },
   browseSubView: 'discography',
   browseCache: {},
   pipelineData: null,

--- a/web/routes/_overlay.py
+++ b/web/routes/_overlay.py
@@ -1,0 +1,66 @@
+"""Shared release-row overlay helpers for browse / label routes.
+
+Every "list of releases" route (release-group pressings, Discogs master
+releases, label catalogue) overlays the same library + pipeline state
+onto each row. The exact shape of those fields — `in_library`,
+`beets_album_id`, `library_format`, `library_min_bitrate`,
+`library_rank`, `pipeline_status`, `pipeline_id` — is the contract the
+frontend reads (see `web/js/badges.js`). Keeping a single helper
+prevents drift across routes when new fields are added.
+
+The helper mutates rows in place. Callers that need to preserve a
+cached input must deep-copy first (mirrors `_overlay_disambiguate`'s
+contract in `web/routes/browse.py`).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def overlay_release_rows(rows: list[dict], release_ids: Iterable[str]) -> None:
+    """Annotate each release row with library + pipeline state in place.
+
+    Parameters
+    ----------
+    rows
+        Mutable list of release-row dicts. Each row must have an `id`
+        key (string release id, MB UUID or stringified Discogs id).
+        After overlay each row carries:
+        `in_library`, `beets_album_id`, `library_format`,
+        `library_min_bitrate`, `library_rank`, `pipeline_status`,
+        `pipeline_id`. Library quality fields are only set when the
+        release is in the beets library AND the beets DB returned
+        details for it.
+    release_ids
+        Iterable of release ids to batch-query against beets / pipeline.
+        Typically `[r["id"] for r in rows]`; passed in so callers that
+        need to filter (e.g. skip empty ids) control the input.
+    """
+    # Local import keeps the routes._overlay → server.py edge consistent
+    # with the rest of routes/* (which all use the lazy `_server()` shim).
+    from web import server as srv
+
+    ids_list = list(release_ids)
+    in_library = srv.check_beets_library(ids_list) if ids_list else set()
+    in_pipeline = srv.check_pipeline(ids_list) if ids_list else {}
+    b = srv._beets_db()
+    beets_ids = b.get_album_ids_by_mbids(list(in_library)) if in_library and b else {}
+    quality = b.check_mbids_detail(list(in_library)) if in_library and b else {}
+
+    for r in rows:
+        rid = r["id"]
+        r["in_library"] = rid in in_library
+        r["beets_album_id"] = beets_ids.get(rid)
+        q = quality.get(rid)
+        if q:
+            fmt_raw = q.get("beets_format")
+            fmt = fmt_raw if isinstance(fmt_raw, str) else ""
+            br_raw = q.get("beets_bitrate")
+            br = br_raw if isinstance(br_raw, int) else 0
+            r["library_format"] = fmt
+            r["library_min_bitrate"] = br
+            r["library_rank"] = srv.compute_library_rank(fmt, br)
+        pi = in_pipeline.get(rid)
+        r["pipeline_status"] = pi["status"] if pi else None
+        r["pipeline_id"] = pi["id"] if pi else None

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -18,6 +18,7 @@ from web import cache as _cache
 from web import discogs as discogs_api
 from lib.artist_compare import annotate_in_library, merge_discographies
 from web.library_artist_service import list_library_artist_rows
+from web.routes._overlay import overlay_release_rows
 
 if TYPE_CHECKING:
     from http.server import BaseHTTPRequestHandler
@@ -223,29 +224,10 @@ def get_artist_disambiguate(h: BaseHTTPRequestHandler, params: dict[str, list[st
 def get_release_group(h: BaseHTTPRequestHandler, params: dict[str, list[str]], rg_id: str) -> None:
     srv = _server()
     data = srv.mb_api.get_release_group_releases(rg_id)
-    # Check which releases are in pipeline/library
-    mbids = [r["id"] for r in data["releases"]]
-    in_library = srv.check_beets_library(mbids)
-    in_pipeline = srv.check_pipeline(mbids)
-    # Map mbid -> beets album id + on-disk quality so the standard
-    # toolbar (Remove from beets) and badge renderer (in library +
-    # codec-aware rank) can render without extra round-trips.
-    b = srv._beets_db()
-    beets_ids = b.get_album_ids_by_mbids(list(in_library)) if in_library and b else {}
-    quality = b.check_mbids_detail(list(in_library)) if in_library and b else {}
-    for r in data["releases"]:
-        rid = r["id"]
-        r["in_library"] = rid in in_library
-        r["beets_album_id"] = beets_ids.get(rid)
-        q = quality.get(rid)
-        if q:
-            r["library_format"] = q.get("beets_format") or ""
-            r["library_min_bitrate"] = q.get("beets_bitrate") or 0
-            r["library_rank"] = srv.compute_library_rank(
-                r["library_format"], r["library_min_bitrate"])
-        pi = in_pipeline.get(rid)
-        r["pipeline_status"] = pi["status"] if pi else None
-        r["pipeline_id"] = pi["id"] if pi else None
+    # Standard toolbar (Remove from beets) and badge renderer (in library
+    # + codec-aware rank) read these overlay fields per row, so route
+    # them through the shared helper.
+    overlay_release_rows(data["releases"], [r["id"] for r in data["releases"]])
     h._json(data)  # type: ignore[attr-defined]
 
 
@@ -321,28 +303,8 @@ def get_discogs_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]], 
 
 
 def get_discogs_master(h: BaseHTTPRequestHandler, params: dict[str, list[str]], master_id: str) -> None:
-    srv = _server()
     data = discogs_api.get_master_releases(int(master_id))
-    # Enrich releases with pipeline/library status
-    release_ids = [r["id"] for r in data["releases"]]
-    in_library = srv.check_beets_library(release_ids)
-    in_pipeline = srv.check_pipeline(release_ids)
-    b = srv._beets_db()
-    beets_ids = b.get_album_ids_by_mbids(list(in_library)) if in_library and b else {}
-    quality = b.check_mbids_detail(list(in_library)) if in_library and b else {}
-    for r in data["releases"]:
-        rid = r["id"]
-        r["in_library"] = rid in in_library
-        r["beets_album_id"] = beets_ids.get(rid)
-        q = quality.get(rid)
-        if q:
-            r["library_format"] = q.get("beets_format") or ""
-            r["library_min_bitrate"] = q.get("beets_bitrate") or 0
-            r["library_rank"] = srv.compute_library_rank(
-                r["library_format"], r["library_min_bitrate"])
-        pi = in_pipeline.get(rid)
-        r["pipeline_status"] = pi["status"] if pi else None
-        r["pipeline_id"] = pi["id"] if pi else None
+    overlay_release_rows(data["releases"], [r["id"] for r in data["releases"]])
     h._json(data)  # type: ignore[attr-defined]
 
 

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -1,0 +1,114 @@
+"""Label GET route handlers — Discogs (Phase A).
+
+Source-qualified URL prefix follows the artist convention: Phase A
+ships `/api/discogs/label/*`; Phase B will add a `/api/label/{mbid}`
+parallel route once the MB label adapter exists. The `LabelEntity`
+contract is source-tagged and identical across sources so the
+frontend renders the same shape regardless of upstream.
+"""
+from __future__ import annotations
+
+import re
+import urllib.error
+from typing import TYPE_CHECKING
+
+import msgspec
+
+from web import discogs as discogs_api
+from web.routes._overlay import overlay_release_rows
+
+if TYPE_CHECKING:
+    from http.server import BaseHTTPRequestHandler
+
+
+def _server():
+    """Lazy import to avoid the circular dependency with server.py."""
+    from web import server
+    return server
+
+
+def _label_entity_payload(entity) -> dict:
+    """Convert a `LabelEntity` Struct to a JSON-safe dict.
+
+    Per `.claude/rules/code-quality.md` § "Wire-boundary types":
+    `msgspec.to_builtins` recurses into nested Structs;
+    `dataclasses.asdict` would not. We never round-trip a Struct
+    through `asdict` — it returns the Struct unchanged and `json.dumps`
+    fails downstream.
+    """
+    return msgspec.to_builtins(entity)
+
+
+def get_discogs_label_search(
+    h: BaseHTTPRequestHandler, params: dict[str, list[str]]
+) -> None:
+    """`GET /api/discogs/label/search?q=...`.
+
+    Search hits are label entities, not releases — no library overlay
+    here. The frontend uses the entity fields (`release_count`,
+    `country`, `parent_label_name`) for disambiguation.
+    """
+    q = params.get("q", [""])[0].strip()
+    if not q:
+        h._error("Missing query parameter 'q'")  # type: ignore[attr-defined]
+        return
+    hits = discogs_api.search_labels(q)
+    h._json({"results": [_label_entity_payload(e) for e in hits]})  # type: ignore[attr-defined]
+
+
+def get_discogs_label_detail(
+    h: BaseHTTPRequestHandler, params: dict[str, list[str]], label_id: str
+) -> None:
+    """`GET /api/discogs/label/{id}` — label entity + overlaid catalogue.
+
+    Defaults `include_sublabels=true` per Key Decisions; opt-out via
+    `?include_sublabels=false`. The Discogs adapter raises
+    `urllib.error.HTTPError` on a 404 from the mirror; we surface that
+    as a JSON 404 so the frontend can render a "label not found" state
+    rather than a 5xx.
+    """
+    raw_flag = params.get("include_sublabels", ["true"])[0].strip().lower()
+    include_sublabels = raw_flag != "false"
+
+    try:
+        entity = discogs_api.get_label(label_id)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            h._error("Label not found", 404)  # type: ignore[attr-defined]
+            return
+        raise
+
+    releases_resp = discogs_api.get_label_releases(
+        label_id, include_sublabels=include_sublabels)
+    releases = releases_resp["results"]
+
+    overlay_release_rows(releases, [r["id"] for r in releases])
+
+    # Sub-labels come through the entity's parent — we don't have a
+    # `sub_labels` list on the public LabelEntity by design (it's source-
+    # agnostic and MB will not return that shape). Phase A surfaces an
+    # empty list here; the discogs-api detail endpoint carries
+    # `sub_labels`, but the cratedigger adapter elides them on the
+    # entity. Frontend (U6) reads `sub_label_name` per release row for
+    # the rollup badge, which is what actually matters for rendering.
+    sub_labels: list[dict] = []
+
+    h._json({  # type: ignore[attr-defined]
+        "label": _label_entity_payload(entity),
+        "releases": releases,
+        "sub_labels": sub_labels,
+        "pagination": releases_resp.get("pagination", {}),
+        "include_sublabels": releases_resp.get(
+            "include_sublabels", include_sublabels),
+    })
+
+
+# ── Route tables ─────────────────────────────────────────────────────
+
+GET_ROUTES: dict[str, object] = {
+    "/api/discogs/label/search": get_discogs_label_search,
+}
+
+GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
+    (re.compile(r"^/api/discogs/label/(\d+)$"), get_discogs_label_detail),
+]

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -27,6 +27,23 @@ def _server():
     return server
 
 
+# Auto-flip threshold: if the label's `release_count` exceeds this AND the
+# caller did not pass `?include_sublabels=` explicitly, default to False.
+# Mirrors `BIG_LABEL_THRESHOLD` in `web/js/labels.js`; keep in sync. The
+# recursive sub-label CTE on UMG-class labels takes 30+s upstream and the
+# single-threaded HTTPServer here would freeze the whole UI for any other
+# in-flight request. Direct API consumers can still opt in by passing
+# `?include_sublabels=true` explicitly.
+BIG_LABEL_THRESHOLD = 1000
+
+# Accepted spellings for the `?include_sublabels=` query parameter. Anything
+# outside this set returns 400 — silently coercing typos masks frontend bugs
+# and lets bots scribble cache entries with garbage payload-flag combos.
+_INCLUDE_SUBLABELS_TRUE = {"true", "1"}
+_INCLUDE_SUBLABELS_FALSE = {"false", "0"}
+_INCLUDE_SUBLABELS_VALID = _INCLUDE_SUBLABELS_TRUE | _INCLUDE_SUBLABELS_FALSE
+
+
 def _label_entity_payload(entity) -> dict:
     """Convert a `LabelEntity` Struct to a JSON-safe dict.
 
@@ -62,13 +79,32 @@ def get_discogs_label_detail(
     """`GET /api/discogs/label/{id}` — label entity + overlaid catalogue.
 
     Defaults `include_sublabels=true` per Key Decisions; opt-out via
-    `?include_sublabels=false`. The Discogs adapter raises
-    `urllib.error.HTTPError` on a 404 from the mirror; we surface that
-    as a JSON 404 so the frontend can render a "label not found" state
-    rather than a 5xx.
+    `?include_sublabels=false`. Big labels (release_count >
+    BIG_LABEL_THRESHOLD) auto-flip to `include_sublabels=False` unless
+    the caller explicitly opted in — protects the single-threaded web
+    server from the upstream UMG-class recursive CTE (30+s).
+
+    The Discogs adapter raises `urllib.error.HTTPError` on a 404 from
+    the mirror; we surface that as a JSON 404 so the frontend can
+    render a "label not found" state rather than a 5xx. Both
+    `get_label` and `get_label_releases` are wrapped — the label can
+    vanish between the two calls.
     """
-    raw_flag = params.get("include_sublabels", ["true"])[0].strip().lower()
-    include_sublabels = raw_flag != "false"
+    # Distinguish "user passed nothing" (apply auto-flip) from "user passed
+    # something" (respect their choice). `params` only contains keys actually
+    # present in the query string.
+    explicit = "include_sublabels" in params
+    if explicit:
+        raw_flag = params["include_sublabels"][0].strip().lower()
+        if raw_flag not in _INCLUDE_SUBLABELS_VALID:
+            h._error(  # type: ignore[attr-defined]
+                "Invalid include_sublabels — expected one of "
+                "true/false/1/0", 400)
+            return
+        include_sublabels = raw_flag in _INCLUDE_SUBLABELS_TRUE
+    else:
+        # Default; possibly auto-flipped below once we know release_count.
+        include_sublabels = True
 
     try:
         entity = discogs_api.get_label(label_id)
@@ -78,8 +114,18 @@ def get_discogs_label_detail(
             return
         raise
 
-    releases_resp = discogs_api.get_label_releases(
-        label_id, include_sublabels=include_sublabels)
+    # Auto-flip for big labels — only when the caller did not opt in or out.
+    if not explicit and entity.release_count > BIG_LABEL_THRESHOLD:
+        include_sublabels = False
+
+    try:
+        releases_resp = discogs_api.get_label_releases(
+            label_id, include_sublabels=include_sublabels)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            h._error("Label not found", 404)  # type: ignore[attr-defined]
+            return
+        raise
     releases = releases_resp["results"]
 
     overlay_release_rows(releases, [r["id"] for r in releases])

--- a/web/server.py
+++ b/web/server.py
@@ -39,6 +39,7 @@ from web import mb as mb_api
 from lib.beets_db import BeetsDB
 from lib.pipeline_db import PipelineDB
 from web.routes import browse as _browse_routes
+from web.routes import labels as _labels_routes
 from web.routes import library as _library_routes
 from web.routes import imports as _imports_routes
 from web.routes import pipeline as _pipeline_routes
@@ -215,6 +216,7 @@ class Handler(BaseHTTPRequestHandler):
     # Route modules export their own dicts; we merge them here.
     _FUNC_GET_ROUTES: dict[str, object] = {
         **_browse_routes.GET_ROUTES,
+        **_labels_routes.GET_ROUTES,
         **_pipeline_routes.GET_ROUTES,
         **_library_routes.GET_ROUTES,
         **_imports_routes.GET_ROUTES,
@@ -222,6 +224,7 @@ class Handler(BaseHTTPRequestHandler):
 
     _FUNC_GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
         *_browse_routes.GET_PATTERNS,
+        *_labels_routes.GET_PATTERNS,
         *_pipeline_routes.GET_PATTERNS,
         *_library_routes.GET_PATTERNS,
     ]


### PR DESCRIPTION
Implements the label viewer for cratedigger ([#183](https://github.com/abl030/cratedigger/issues/183)) per `docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md`. Search labels, browse a label's catalogue with album/EP split + library overlay + year/format filters, drill-in from any release row.

Phase A is Discogs-only with source-agnostic plumbing so Phase B (MusicBrainz labels) is a wiring task.

## Scope

Two repositories:

- **discogs-api** ([abl030/discogs-api@07f7e5e](https://github.com/abl030/discogs-api/commit/07f7e5e)) — three new Rust endpoints + GIN FTS index. Already deployed.
- **cratedigger** (this PR) — adapter, routes, UI, drill-in.

## Implementation units (matches plan U-IDs)

| Unit | Commit | Summary |
|------|--------|---------|
| U1+U2 | discogs-api `07f7e5e` | `/api/labels` search, `/api/labels/{id}`, `/api/labels/{id}/releases` with recursive-CTE sub-label rollup |
| U3 | `767d354` | `web/discogs.py`: `search_labels`, `get_label`, `get_label_releases` + source-agnostic `LabelEntity` (`msgspec.Struct`) decoded at the wire boundary |
| U4 | `f45739b` | `web/routes/labels.py` + library/pipeline overlay; extracted shared helper `web/routes/_overlay.py` and refactored two call sites in `browse.py` to use it |
| U5+U6 | `1316a1d` | `web/js/labels.js`: search UI as a third toggle in browse tab + label-detail page with `renderTypedSections` reuse, year/format/hide-held filters as pure JS predicates |
| U7 | `55a9039` | Clickable label links in release-detail panel; `renderLabelLinks` helper in `web/js/labels.js` (escapes user-controlled text, falls back to plain text for MB releases without IDs) |

## Key decisions

- **Source-agnostic from day one.** `LabelEntity` shape is shared across MB and Discogs adapters; nullable fields (country, parent_label_id) accommodate both. Phase B is a wiring task.
- **Sub-label rollup on by default.** `?include_sublabels=false` opt-out. Frontend defaults to `false` for labels with `release_count > 1000` (UMG-class) to dodge the recursive-CTE perf cliff.
- **`/api/discogs/label/*` route shape** mirrors existing `/api/discogs/artist/*` convention (per-source URL prefix). Phase B will add `/api/label/{mbid}` parallel to `/api/artist/{mbid}`.
- **`browse.py` overlay refactor**: extracted near-duplicate inline overlay logic from `get_release_group` and `get_discogs_master` into `web/routes/_overlay.py::overlay_release_rows`. Identical behavior preserved; covered by existing tests.
- **Library overlay is the load-bearing filter** (per brainstorm). Year + format are secondary refinements that compose on top.
- **No labelmate-recommendation sort** (Approach D dropped from brainstorm). No editorial label metadata, no cover art (Discogs CC0 has none — #82).

## Testing

- **Python:** 2,487 tests pass. New `TestLabelRouteContracts` adds 6 contract tests including the integration scenario (one release in beets + one in pipeline DB → both correctly overlaid). `TestRouteContractAudit` registers the two new patterns. Pyright clean inside nix-shell.
- **JS:** 122/122 pure-function tests pass (`node tests/test_js_util.mjs`). New coverage on `applyLabelFilters`, `parseYear`, `sortByYearDesc`, `buildLabelSearchUrl`, `renderLabelLinks` (including XSS guard).
- **Wire-boundary regression:** msgspec.ValidationError test feeds `release_count` as a string and asserts the boundary catches it.
- **Live smoke test:** `curl https://discogs.ablz.au/api/labels?name=hymen+records` returns Hymen Records (id=265, 659 releases) — endpoints deployed and working before this PR.

## Post-Deploy Monitoring & Validation

After merging this PR and bumping the cratedigger flake input on doc1:

- **Validation window:** First 30 min after `nixos-rebuild switch` on doc2.
- **Owner:** abl030 (manual playwright walkthrough).
- **Healthy signals:**
  - `ssh doc2 'curl -s "http://127.0.0.1:8080/api/discogs/label/search?q=hymen"'` returns JSON with non-empty `results`
  - `curl https://music.ablz.au/api/discogs/label/265` returns label + 100 releases with overlay populated
  - Browser walkthrough of AE1 (Gridlock release → click "Hymen Records" → label page renders with library overlay correct) succeeds
  - `cratedigger-web.service` starts cleanly: `ssh doc2 'sudo journalctl -u cratedigger-web --since "5 min ago"'`
- **Failure signals & rollback:**
  - 500s on `/api/discogs/label/*` → check `journalctl -u cratedigger-web` for adapter exceptions; likely msgspec.ValidationError on Discogs payload drift → rollback flake input
  - Artist view broken (overlay missing) → `_overlay.py` extraction regressed something not caught by tests; rollback
  - JS console errors on browse tab → likely `state.js` schema drift; rollback
- **Log searches:** `journalctl -u cratedigger-web | grep -E '(/api/discogs/label|labels\.py|overlay_release_rows)'`

## Known follow-ups (deliberate, not blockers)

- **FTS index activation.** `idx_label_name_fts` on `discogs-api` takes effect on the next monthly `discogs-import` run. Until then, label search uses sequential scan over 2.36M label rows (slow but functional). Trigger a manual import if needed.
- **Big-label recursive CTE.** UMG-scale labels (>2.7M releases via tree) take 36s with `include_sublabels=true`. Frontend mitigation in place (auto-flips to `false` when `release_count > 1000`); follow-up: add covering composite index `release_label(label_id, release_id)` if needed.
- **Pagination forwarding.** Route doesn't yet forward `?page` / `?per_page` to the adapter (which already supports them). First page (100 rows) is enough for Phase A; deep pagination is a small follow-up if any label exposes the gap in practice.
- **Phase B (MusicBrainz labels).** Separate plan. Plumbing is ready (`LabelEntity` source-tagged shape, route convention parallel to artist view).

## Closes

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)