### PR TITLE
fix: label-viewer P1+P2 ship-fast cluster

### DIFF
--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -611,6 +611,92 @@ class TestGetLabelReleases(unittest.TestCase):
         self.assertIn("include_sublabels=false", called_url)
         self.assertFalse(payload["include_sublabels"])
 
+    def test_sub_labels_dropped_default_false(self):
+        """Plan 003 U4: every successful response carries
+        `sub_labels_dropped` so the contract is stable. Default False."""
+        with _mock_urlopen(self.RELEASES_DATA):
+            payload = get_label_releases(2294, include_sublabels=True)
+        self.assertIn("sub_labels_dropped", payload)
+        self.assertFalse(payload["sub_labels_dropped"])
+
+    def test_503_falls_back_to_no_sublabels(self):
+        """Plan 003 U4: when the upstream returns 503 (timeout) and the
+        caller asked for sub-labels, the adapter retries once with
+        include_sublabels=False and flags the response."""
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        # First call (sub=true) raises 503; second call (sub=false) succeeds.
+        success_resp = MagicMock()
+        success_resp.read.return_value = json.dumps(
+            {**self.RELEASES_DATA, "include_sublabels": False}).encode()
+        success_resp.__enter__ = lambda s: s
+        success_resp.__exit__ = MagicMock(return_value=False)
+
+        def _urlopen(req, *_args, **_kwargs):
+            if "include_sublabels=true" in req.full_url:
+                raise HTTPError(
+                    req.full_url, 503, "Service Unavailable",
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=BytesIO(b'{"error":"timeout"}'))
+            return success_resp
+
+        with patch("web.discogs.urllib.request.urlopen", side_effect=_urlopen):
+            payload = get_label_releases(99887766, include_sublabels=True)
+
+        self.assertTrue(payload["sub_labels_dropped"])
+        # Fallback fetch ran and surfaced its successful payload
+        self.assertFalse(payload["include_sublabels"])
+        self.assertEqual(len(payload["results"]), 2)
+
+    def test_503_then_503_reraises(self):
+        """Plan 003 U4: if the fallback also 503s, the original HTTPError
+        re-raises. No infinite retry."""
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def _always_503(req, *_args, **_kwargs):
+            raise HTTPError(
+                req.full_url, 503, "Service Unavailable",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=BytesIO(b'{"error":"timeout"}'))
+
+        with patch("web.discogs.urllib.request.urlopen", side_effect=_always_503):
+            with self.assertRaises(HTTPError):
+                get_label_releases(99887765, include_sublabels=True)
+
+    def test_503_when_sub_labels_already_false_reraises(self):
+        """Plan 003 U4: 503 with include_sublabels=False has nothing to fall
+        back to — re-raise."""
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def _503(req, *_args, **_kwargs):
+            raise HTTPError(
+                req.full_url, 503, "Service Unavailable",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=BytesIO(b'{"error":"timeout"}'))
+
+        with patch("web.discogs.urllib.request.urlopen", side_effect=_503):
+            with self.assertRaises(HTTPError):
+                get_label_releases(99887764, include_sublabels=False)
+
+    def test_404_propagates_unchanged(self):
+        """Plan 003 U4: 404 surfaces as 404 (existing route maps it). The
+        503 retry must not swallow other HTTP errors."""
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def _404(req, *_args, **_kwargs):
+            raise HTTPError(
+                req.full_url, 404, "Not Found",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=BytesIO(b'{"error":"not found"}'))
+
+        with patch("web.discogs.urllib.request.urlopen", side_effect=_404):
+            with self.assertRaises(HTTPError):
+                get_label_releases(99887763, include_sublabels=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -4,7 +4,7 @@
  */
 
 import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
-import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, parseYear, renderLabelLinks, distinctFormats } from '../web/js/labels.js';
+import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls } from '../web/js/labels.js';
 
 let passed = 0;
 let failed = 0;
@@ -160,6 +160,46 @@ assertEqual(buildLabelSearchUrl('hymen'), '/api/discogs/label/search?q=hymen', '
 assertEqual(buildLabelSearchUrl('warp records'), '/api/discogs/label/search?q=warp%20records', 'spaces encoded');
 assertEqual(buildLabelSearchUrl('a&b'), '/api/discogs/label/search?q=a%26b', 'special chars encoded');
 assertEqual(buildLabelSearchUrl('björk'), '/api/discogs/label/search?q=bj%C3%B6rk', 'unicode encoded');
+
+// --- buildLabelDetailUrl tests ---
+console.log('buildLabelDetailUrl()');
+assertEqual(buildLabelDetailUrl('757'), '/api/discogs/label/757', 'no opts: no query string');
+assertEqual(
+  buildLabelDetailUrl('757', { include_sublabels: true }),
+  '/api/discogs/label/757?include_sublabels=true',
+  'include_sublabels=true emitted');
+assertEqual(
+  buildLabelDetailUrl('757', { include_sublabels: false }),
+  '/api/discogs/label/757?include_sublabels=false',
+  'include_sublabels=false emitted');
+assertEqual(
+  buildLabelDetailUrl('757', { include_sublabels: true, page: 2, per_page: 50 }),
+  '/api/discogs/label/757?include_sublabels=true&page=2&per_page=50',
+  'pagination params emitted in order');
+assertEqual(
+  buildLabelDetailUrl(757, { page: 3 }),
+  '/api/discogs/label/757?page=3',
+  'numeric labelId coerced to string');
+assertEqual(
+  buildLabelDetailUrl('757', { include_sublabels: undefined, page: undefined, per_page: undefined }),
+  '/api/discogs/label/757',
+  'undefined opts produce no params');
+
+// --- renderPaginationControls tests ---
+console.log('renderPaginationControls()');
+assertEqual(renderPaginationControls(1, 1), '', 'pages=1 → empty');
+assertEqual(renderPaginationControls(1, 0), '', 'pages=0 → empty');
+const ctrl_p1_of_5 = renderPaginationControls(1, 5);
+assert(ctrl_p1_of_5.includes('Page 1 of 5'), 'p1/5: position label rendered');
+assert(ctrl_p1_of_5.includes('disabled'), 'p1/5: prev button is disabled');
+assert(ctrl_p1_of_5.includes('window.goToLabelPage(2)'), 'p1/5: next button targets page 2');
+const ctrl_p5_of_5 = renderPaginationControls(5, 5);
+assert(ctrl_p5_of_5.includes('window.goToLabelPage(4)'), 'p5/5: prev button targets page 4');
+assert(ctrl_p5_of_5.match(/disabled/g).length === 1, 'p5/5: only next button is disabled');
+const ctrl_p3_of_5 = renderPaginationControls(3, 5);
+assert(!ctrl_p3_of_5.includes('disabled'), 'p3/5: neither button disabled');
+assert(ctrl_p3_of_5.includes('window.goToLabelPage(2)'), 'p3/5: prev → page 2');
+assert(ctrl_p3_of_5.includes('window.goToLabelPage(4)'), 'p3/5: next → page 4');
 
 // --- applyLabelFilters tests ---
 console.log('applyLabelFilters()');

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2966,7 +2966,7 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_dg.get_label_releases.assert_called_once_with(
-            "757", include_sublabels=False)
+            "757", include_sublabels=False, page=1, per_page=100)
 
     def test_label_detail_auto_flips_include_sublabels_for_big_labels(self):
         """Big label (release_count > BIG_LABEL_THRESHOLD) without an
@@ -2988,7 +2988,7 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_dg.get_label_releases.assert_called_once_with(
-            "1", include_sublabels=False)
+            "1", include_sublabels=False, page=1, per_page=100)
 
     def test_label_detail_respects_explicit_include_sublabels_on_big_labels(self):
         """If the caller explicitly opts in via `?include_sublabels=true`,
@@ -3010,7 +3010,7 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_dg.get_label_releases.assert_called_once_with(
-            "1", include_sublabels=True)
+            "1", include_sublabels=True, page=1, per_page=100)
 
     def test_label_detail_does_not_auto_flip_small_labels(self):
         """Boutique labels (release_count <= threshold) keep the
@@ -3031,7 +3031,7 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_dg.get_label_releases.assert_called_once_with(
-            "757", include_sublabels=True)
+            "757", include_sublabels=True, page=1, per_page=100)
 
     def test_label_detail_rejects_malformed_include_sublabels(self):
         """`?include_sublabels=` must be one of true/false/1/0 (case-
@@ -3062,7 +3062,7 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_dg.get_label_releases.assert_called_once_with(
-            "757", include_sublabels=False)
+            "757", include_sublabels=False, page=1, per_page=100)
 
     def test_label_detail_releases_404_propagates(self):
         """If `get_label` succeeds but `get_label_releases` raises 404
@@ -3084,6 +3084,93 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 404)
         self.assertIn("error", data)
+
+    def test_label_detail_forwards_pagination_params(self):
+        """`?page=2&per_page=50` flows through to the adapter — Plan 003 U1."""
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 2, "per_page": 50, "pages": 3, "items": 120},
+                "include_sublabels": True,
+            }
+            status, data = self._get(
+                "/api/discogs/label/757?page=2&per_page=50")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "757", include_sublabels=True, page=2, per_page=50)
+        self.assertEqual(data["pagination"]["page"], 2)
+        self.assertEqual(data["pagination"]["per_page"], 50)
+
+    def test_label_detail_clamps_per_page(self):
+        """`?per_page=500` clamps to the 200 max so a malicious or misbehaving
+        client can't exfiltrate the whole catalogue in one shot."""
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 200, "pages": 1, "items": 0},
+                "include_sublabels": True,
+            }
+            status, _data = self._get(
+                "/api/discogs/label/757?per_page=500")
+
+        self.assertEqual(status, 200)
+        mock_dg.get_label_releases.assert_called_once_with(
+            "757", include_sublabels=True, page=1, per_page=200)
+
+    def test_label_detail_rejects_non_integer_page(self):
+        """`?page=foo` returns 400 — silently coercing to 1 would mask
+        frontend pagination bugs."""
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.return_value = self._make_label_entity()
+            status, data = self._get(
+                "/api/discogs/label/757?page=foo")
+
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+        self.assertFalse(mock_dg.get_label_releases.called)
+
+    def test_label_detail_rejects_zero_page(self):
+        """`?page=0` returns 400 — pages are 1-indexed."""
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.return_value = self._make_label_entity()
+            status, data = self._get(
+                "/api/discogs/label/757?page=0")
+
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+        self.assertFalse(mock_dg.get_label_releases.called)
+
+    def test_label_detail_rejects_non_integer_per_page(self):
+        """`?per_page=foo` returns 400."""
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.return_value = self._make_label_entity()
+            status, data = self._get(
+                "/api/discogs/label/757?per_page=foo")
+
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+        self.assertFalse(mock_dg.get_label_releases.called)
+
+    def test_label_detail_rejects_zero_per_page(self):
+        """`?per_page=0` returns 400 — would otherwise cause divide-by-zero
+        on the pages calculation."""
+        with patch("web.routes.labels.discogs_api") as mock_dg:
+            mock_dg.get_label.return_value = self._make_label_entity()
+            status, data = self._get(
+                "/api/discogs/label/757?per_page=0")
+
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+        self.assertFalse(mock_dg.get_label_releases.called)
 
 
 class TestBeetsRouteContracts(_WebServerCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2783,6 +2783,7 @@ class TestLabelRouteContracts(_WebServerCase):
     }
     LABEL_DETAIL_RESPONSE_REQUIRED_FIELDS = {
         "label", "releases", "sub_labels", "pagination", "include_sublabels",
+        "sub_labels_dropped",
     }
 
     def _make_label_entity(self, **overrides):
@@ -3171,6 +3172,45 @@ class TestLabelRouteContracts(_WebServerCase):
         self.assertEqual(status, 400)
         self.assertIn("error", data)
         self.assertFalse(mock_dg.get_label_releases.called)
+
+    def test_label_detail_forwards_sub_labels_dropped(self):
+        """Plan 003 U4: when the adapter signals a 503 fallback, the route
+        forwards `sub_labels_dropped=True` so the UI can surface a banner."""
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 1, "items": 0},
+                "include_sublabels": False,
+                "sub_labels_dropped": True,
+            }
+            status, data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 200)
+        self.assertTrue(data["sub_labels_dropped"])
+
+    def test_label_detail_default_sub_labels_dropped_false(self):
+        """Plan 003 U4: every label-detail response carries the field with
+        default False so the contract is stable."""
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity()
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": True,
+                "sub_labels_dropped": False,
+            }
+            status, data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 200)
+        self.assertIn("sub_labels_dropped", data)
+        self.assertFalse(data["sub_labels_dropped"])
 
 
 class TestBeetsRouteContracts(_WebServerCase):

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -13,6 +13,7 @@ into Redis (issue #101).
 
 import json
 import re
+import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Literal
@@ -569,6 +570,10 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
                 "items": decoded.pagination.items,
             },
             "include_sublabels": decoded.include_sublabels,
+            # Always present so the contract is stable. The 503-fallback
+            # branch below overrides this to True; the wire payload itself
+            # never carries a stale True (the upstream doesn't know).
+            "sub_labels_dropped": False,
         }
 
     sub_flag = "true" if include_sublabels else "false"
@@ -576,4 +581,22 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
         f"discogs:label:{label_id}:releases"
         f":sub={sub_flag}:p={page}:pp={per_page}"
     )
-    return _cache.memoize_meta(cache_key, _fetch)
+    try:
+        return _cache.memoize_meta(cache_key, _fetch)
+    except urllib.error.HTTPError as e:
+        # Plan 003 U4. The discogs-api mirror returns 503 when the
+        # recursive sub-label CTE exceeds its statement_timeout (P0 plan).
+        # Retry once with sub-labels disabled so the user sees the direct
+        # catalogue rather than a hard error. The fallback uses its own
+        # cache key (`sub=false`), so a successful retry is memoized
+        # independently — repeat hits skip the failing call entirely.
+        if e.code == 503 and include_sublabels:
+            fallback = get_label_releases(
+                label_id, include_sublabels=False,
+                page=page, per_page=per_page)
+            # Don't mutate the fallback dict in place — it is the cached
+            # value for a different cache key, and direct callers of
+            # `include_sublabels=False` would see a false-positive
+            # `sub_labels_dropped` if we wrote through.
+            return {**fallback, "sub_labels_dropped": True}
+        raise

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -349,20 +349,18 @@ export async function openLabelDetail(labelId, labelName) {
   if (!body) return;
   body.innerHTML = '<div class="loading">Loading label catalogue...</div>';
 
-  // First fetch with default include_sublabels=true. After we have
-  // the label entity we may decide to retry without sub-labels for
-  // very large labels.
+  // Single fetch; the route auto-flips include_sublabels=false on big
+  // labels, and the adapter's 503 fallback (Plan 003 U4) handles the
+  // genuinely-degraded case via `payload.sub_labels_dropped`. The old
+  // empty-results retry was dead code once those two landed — removed
+  // in Plan 003 U5.
   try {
-    let payload = await loadLabelReleases(labelId, { include_sublabels: true, page: 1 });
+    const payload = await loadLabelReleases(labelId, { include_sublabels: true, page: 1 });
     const totalCount = (payload && payload.label && payload.label.release_count) || 0;
-    if (totalCount > BIG_LABEL_THRESHOLD && payload.releases && payload.releases.length === 0) {
-      // Defensive: if the big-label query timed out and returned empty,
-      // refetch without sub-labels. (Cheap insurance — happy path on
-      // boutique labels never enters this branch.)
-      payload = await loadLabelReleases(labelId, { include_sublabels: false, page: 1 });
-    } else if (totalCount > BIG_LABEL_THRESHOLD) {
-      // Surface the sub-label opt-in toggle even when the first fetch
-      // succeeded — UX hint that this label has a long tail.
+    if (totalCount > BIG_LABEL_THRESHOLD) {
+      // Flag the label as big so any future affordance that wants to
+      // know can branch on it. (The toggle itself reads totalCount
+      // directly today, but the flag is cheap to keep.)
       state.labelFilters = state.labelFilters || {};
       /** @type {any} */ (state.labelFilters).bigLabel = true;
     }

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -45,6 +45,31 @@ export function buildLabelSearchUrl(q) {
 }
 
 /**
+ * Build the URL for `/api/discogs/label/{id}` with optional pagination
+ * and sub-label flag. Pure for testability.
+ * @param {string|number} labelId
+ * @param {{include_sublabels?: boolean, page?: number, per_page?: number}} [opts]
+ * @returns {string}
+ */
+export function buildLabelDetailUrl(labelId, opts = {}) {
+  const params = new URLSearchParams();
+  // include_sublabels: only emit when caller specified — the route applies
+  // an auto-flip when the param is absent and explicit ?true/false matters
+  // to the route's "respect the user's choice" branch.
+  if (opts.include_sublabels !== undefined) {
+    params.set('include_sublabels', opts.include_sublabels ? 'true' : 'false');
+  }
+  if (opts.page !== undefined && opts.page !== null) {
+    params.set('page', String(opts.page));
+  }
+  if (opts.per_page !== undefined && opts.per_page !== null) {
+    params.set('per_page', String(opts.per_page));
+  }
+  const qs = params.toString();
+  return `/api/discogs/label/${encodeURIComponent(String(labelId))}${qs ? '?' + qs : ''}`;
+}
+
+/**
  * Parse the `release.date` field (Discogs `released`) into a year.
  * Accepts "2003", "2003-04", "2003-04-15"; returns null for missing
  * or unparseable values.
@@ -308,6 +333,7 @@ export function openLabelDetailFromList(rowEl, index) {
 export async function openLabelDetail(labelId, labelName) {
   state.browseLabel = { id: labelId, name: labelName };
   state.browseSubView = 'label';
+  state.labelPage = 1;
 
   const results = document.getElementById('results');
   if (results) results.style.display = 'none';
@@ -327,13 +353,13 @@ export async function openLabelDetail(labelId, labelName) {
   // the label entity we may decide to retry without sub-labels for
   // very large labels.
   try {
-    let payload = await loadLabelReleases(labelId, { include_sublabels: true });
+    let payload = await loadLabelReleases(labelId, { include_sublabels: true, page: 1 });
     const totalCount = (payload && payload.label && payload.label.release_count) || 0;
     if (totalCount > BIG_LABEL_THRESHOLD && payload.releases && payload.releases.length === 0) {
       // Defensive: if the big-label query timed out and returned empty,
       // refetch without sub-labels. (Cheap insurance — happy path on
       // boutique labels never enters this branch.)
-      payload = await loadLabelReleases(labelId, { include_sublabels: false });
+      payload = await loadLabelReleases(labelId, { include_sublabels: false, page: 1 });
     } else if (totalCount > BIG_LABEL_THRESHOLD) {
       // Surface the sub-label opt-in toggle even when the first fetch
       // succeeded — UX hint that this label has a long tail.
@@ -343,6 +369,36 @@ export async function openLabelDetail(labelId, labelName) {
     renderLabelDetail(body, payload);
   } catch (e) {
     body.innerHTML = '<div class="loading">Failed to load label</div>';
+  }
+}
+
+/**
+ * Navigate to a different page of the current label's releases.
+ * Wired via inline onclick on prev/next controls.
+ * @param {number} page
+ */
+export async function goToLabelPage(page) {
+  if (!state.browseLabel) return;
+  const labelId = state.browseLabel.id;
+  const includeSub = !!(state.labelFilters && /** @type {any} */ (state.labelFilters).includeSubFromUI);
+  // Read the current toggle state if present — bigLabel labels show an
+  // explicit checkbox; default otherwise comes from the original load.
+  const toggle = /** @type {HTMLInputElement|null} */ (
+    document.getElementById('label-include-sublabels'));
+  const useSub = toggle ? toggle.checked : includeSub;
+
+  state.labelPage = page;
+  const body = document.getElementById('browse-label-body');
+  if (!body) return;
+  body.innerHTML = '<div class="loading">Loading page ' + page + '...</div>';
+  try {
+    const payload = await loadLabelReleases(labelId, {
+      include_sublabels: useSub,
+      page,
+    });
+    renderLabelDetail(body, payload);
+  } catch (_e) {
+    body.innerHTML = '<div class="loading">Failed to load page ' + page + '</div>';
   }
 }
 
@@ -361,12 +417,16 @@ export function closeLabelDetail() {
 /**
  * Fetch label detail + releases.
  * @param {string} labelId
- * @param {{include_sublabels?: boolean}} [opts]
+ * @param {{include_sublabels?: boolean, page?: number, per_page?: number}} [opts]
  * @returns {Promise<Object>}
  */
 export async function loadLabelReleases(labelId, opts = {}) {
   const includeSub = opts.include_sublabels !== false;
-  const url = `${API}/api/discogs/label/${encodeURIComponent(labelId)}?include_sublabels=${includeSub}`;
+  const url = `${API}${buildLabelDetailUrl(labelId, {
+    include_sublabels: includeSub,
+    page: opts.page,
+    per_page: opts.per_page,
+  })}`;
   const r = await fetch(url);
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
   return await r.json();
@@ -380,8 +440,23 @@ export async function loadLabelReleases(labelId, opts = {}) {
 export function renderLabelDetail(containerEl, payload) {
   const label = payload.label || {};
   const allReleases = Array.isArray(payload.releases) ? payload.releases : [];
-  const totalCount = (typeof label.release_count === 'number')
-    ? label.release_count : allReleases.length;
+  // Header count: prefer payload.pagination.items (the rolled-up CTE total
+  // when include_sublabels=true; the direct count otherwise). Fixes the
+  // P2 #2 mismatch where the header advertised the entity's release_count
+  // but the list rendered the rolled-up rows. Falls back to the entity
+  // value if pagination is missing (defensive — older payloads, tests).
+  const pagination = (payload && typeof payload.pagination === 'object' && payload.pagination)
+    ? payload.pagination : null;
+  const paginationItems = (pagination && typeof pagination.items === 'number')
+    ? pagination.items : null;
+  const totalCount = (paginationItems != null)
+    ? paginationItems
+    : ((typeof label.release_count === 'number')
+        ? label.release_count : allReleases.length);
+  const pages = (pagination && typeof pagination.pages === 'number')
+    ? pagination.pages : 1;
+  const currentPage = (pagination && typeof pagination.page === 'number')
+    ? pagination.page : 1;
   const includeSub = payload.include_sublabels !== false;
 
   // Stash full release list on the container for filter re-renders.
@@ -410,8 +485,10 @@ export function renderLabelDetail(containerEl, payload) {
     ? `<span class="badge badge-sublabel">via ${esc(label.parent_label_name || 'parent')}</span>`
     : '';
   const country = label.country ? ` · ${esc(label.country)}` : '';
-  const renderedNote = (allReleases.length < totalCount)
-    ? `<div class="loading" style="text-align:left;padding:6px 0;color:#888;">Showing first ${allReleases.length} of ${totalCount} — pagination coming.</div>`
+  // Page-position note. The prev/next controls render below the rows; this
+  // line just situates the user inside the dataset.
+  const renderedNote = (pages > 1)
+    ? `<div class="loading" style="text-align:left;padding:6px 0;color:#888;">Page ${currentPage} of ${pages} — ${totalCount} release${totalCount === 1 ? '' : 's'} total</div>`
     : '';
   const bigLabelToggle = (totalCount > BIG_LABEL_THRESHOLD)
     ? `<label style="margin-left:10px;font-size:0.85em;color:#aaa;">
@@ -461,9 +538,39 @@ export function renderLabelDetail(containerEl, payload) {
     </div>
     ${renderedNote}
     <div id="browse-label-rows"></div>
+    ${renderPaginationControls(currentPage, pages)}
   `;
 
   renderLabelRows(containerEl);
+}
+
+/**
+ * Render prev/next page controls. Returns empty string when only one
+ * page exists. Pure for testability — the click handlers are wired
+ * via window.goToLabelPage.
+ * @param {number} currentPage
+ * @param {number} pages
+ * @returns {string} HTML
+ */
+export function renderPaginationControls(currentPage, pages) {
+  if (!pages || pages < 2) return '';
+  const prevDisabled = currentPage <= 1;
+  const nextDisabled = currentPage >= pages;
+  const btn = (label, page, disabled) => {
+    const style = 'padding:6px 12px;background:#222;color:'
+      + (disabled ? '#555' : '#eee')
+      + ';border:1px solid #444;border-radius:4px;font-size:13px;'
+      + (disabled ? 'cursor:not-allowed;' : 'cursor:pointer;');
+    const onclick = disabled ? '' : ` onclick="window.goToLabelPage(${page})"`;
+    return `<button${onclick} style="${style}"${disabled ? ' disabled' : ''}>${label}</button>`;
+  };
+  return `
+    <div style="display:flex;gap:8px;align-items:center;justify-content:center;margin-top:14px;padding:10px 0;">
+      ${btn('← Prev', currentPage - 1, prevDisabled)}
+      <span style="color:#888;font-size:13px;">Page ${currentPage} of ${pages}</span>
+      ${btn('Next →', currentPage + 1, nextDisabled)}
+    </div>
+  `;
 }
 
 /**

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -458,6 +458,7 @@ export function renderLabelDetail(containerEl, payload) {
   const currentPage = (pagination && typeof pagination.page === 'number')
     ? pagination.page : 1;
   const includeSub = payload.include_sublabels !== false;
+  const subLabelsDropped = payload.sub_labels_dropped === true;
 
   // Stash full release list on the container for filter re-renders.
   /** @type {any} */ (containerEl)._releases = allReleases;
@@ -489,6 +490,13 @@ export function renderLabelDetail(containerEl, payload) {
   // line just situates the user inside the dataset.
   const renderedNote = (pages > 1)
     ? `<div class="loading" style="text-align:left;padding:6px 0;color:#888;">Page ${currentPage} of ${pages} — ${totalCount} release${totalCount === 1 ? '' : 's'} total</div>`
+    : '';
+  // Plan 003 U4 banner: the upstream returned 503 on the recursive
+  // sub-label CTE; the adapter retried with sub-labels off. Surface
+  // that to the user so they understand why the catalogue looks thinner
+  // than the entity's release_count would suggest.
+  const subLabelsDroppedBanner = subLabelsDropped
+    ? '<div class="loading" style="text-align:left;padding:6px 10px;margin:6px 0;color:#e0c060;background:#2a2410;border:1px solid #44391a;border-radius:4px;font-size:0.85em;">Sub-labels temporarily unavailable for this label — showing direct releases only.</div>'
     : '';
   const bigLabelToggle = (totalCount > BIG_LABEL_THRESHOLD)
     ? `<label style="margin-left:10px;font-size:0.85em;color:#aaa;">
@@ -536,6 +544,7 @@ export function renderLabelDetail(containerEl, payload) {
       </label>
       ${bigLabelToggle}
     </div>
+    ${subLabelsDroppedBanner}
     ${renderedNote}
     <div id="browse-label-rows"></div>
     ${renderPaginationControls(currentPage, pages)}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -15,7 +15,7 @@ import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
 import { loadManualImport, runManualImport } from './manual.js';
 import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup, deleteTransparentNonFlacWrongMatches, deleteLosslessOpusWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold, setWrongMatchConvergeCleanup } from './wrong-matches.js';
-import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, toggleLabelIncludeSublabels } from './labels.js';
+import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, toggleLabelIncludeSublabels, goToLabelPage } from './labels.js';
 import { toast } from './state.js';
 
 // --- Tab management ---
@@ -119,5 +119,6 @@ Object.assign(window, {
   closeLabelDetail,
   onLabelFilterChange,
   toggleLabelIncludeSublabels,
+  goToLabelPage,
   toast,
 });

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -7,13 +7,14 @@
 
 import { normalizeReleaseId } from './util.js';
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
   browseArtist: null,
   browseLabel: null,
   labelFilters: { yearMin: null, yearMax: null, format: '', hideHeld: false },
+  labelPage: 1,
   browseSubView: 'discography',
   browseCache: {},
   pipelineData: null,

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -43,6 +43,32 @@ _INCLUDE_SUBLABELS_TRUE = {"true", "1"}
 _INCLUDE_SUBLABELS_FALSE = {"false", "0"}
 _INCLUDE_SUBLABELS_VALID = _INCLUDE_SUBLABELS_TRUE | _INCLUDE_SUBLABELS_FALSE
 
+# Pagination defaults + per_page upper bound. The discogs-api mirror clamps
+# per_page to 100 internally, but we accept up to 200 here so the bound is
+# governed by our policy, not happenstance of upstream behavior.
+_DEFAULT_PAGE = 1
+_DEFAULT_PER_PAGE = 100
+_MAX_PER_PAGE = 200
+
+
+def _parse_positive_int(
+    raw: str, *, max_value: int | None = None
+) -> int | None:
+    """Parse a positive int with an optional upper clamp.
+
+    Returns the clamped int on valid input, ``None`` on parse failure
+    or non-positive values. Caller turns ``None`` into a 400.
+    """
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if v < 1:
+        return None
+    if max_value is not None and v > max_value:
+        return max_value
+    return v
+
 
 def _label_entity_payload(entity) -> dict:
     """Convert a `LabelEntity` Struct to a JSON-safe dict.
@@ -106,6 +132,27 @@ def get_discogs_label_detail(
         # Default; possibly auto-flipped below once we know release_count.
         include_sublabels = True
 
+    # Pagination — always parsed and forwarded so the adapter call shape is
+    # explicit at every site. 400 on invalid input rather than silent default
+    # coercion: a frontend pagination bug should fail loudly, not show page 1.
+    if "page" in params:
+        page = _parse_positive_int(params["page"][0])
+        if page is None:
+            h._error(  # type: ignore[attr-defined]
+                "Invalid page — expected a positive integer", 400)
+            return
+    else:
+        page = _DEFAULT_PAGE
+    if "per_page" in params:
+        per_page = _parse_positive_int(
+            params["per_page"][0], max_value=_MAX_PER_PAGE)
+        if per_page is None:
+            h._error(  # type: ignore[attr-defined]
+                "Invalid per_page — expected a positive integer", 400)
+            return
+    else:
+        per_page = _DEFAULT_PER_PAGE
+
     try:
         entity = discogs_api.get_label(label_id)
     except urllib.error.HTTPError as e:
@@ -120,7 +167,8 @@ def get_discogs_label_detail(
 
     try:
         releases_resp = discogs_api.get_label_releases(
-            label_id, include_sublabels=include_sublabels)
+            label_id, include_sublabels=include_sublabels,
+            page=page, per_page=per_page)
     except urllib.error.HTTPError as e:
         if e.code == 404:
             h._error("Label not found", 404)  # type: ignore[attr-defined]

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -194,6 +194,10 @@ def get_discogs_label_detail(
         "pagination": releases_resp.get("pagination", {}),
         "include_sublabels": releases_resp.get(
             "include_sublabels", include_sublabels),
+        # Plan 003 U4. Adapter sets True when an upstream 503 forced a
+        # fallback to include_sublabels=False; the UI surfaces a banner.
+        # Default False on every successful response.
+        "sub_labels_dropped": releases_resp.get("sub_labels_dropped", False),
     })
 
 


### PR DESCRIPTION
## Summary

Phase A label-viewer follow-up — the P1 + P2#6 ship-fast cluster from the post-merge review. Coordinated with [discogs-api PR #5](https://github.com/abl030/discogs-api/pull/5) which lands U2 + U3 (recursive CTE cycle guard, nullable label types).

Three commits, one per implementation unit:

- **U1** \`feat(web): wire label-detail pagination + UI page controls\` — the route now reads/validates \`?page=\`/\`?per_page=\`, clamps \`per_page\` to 200, returns 400 on invalid input, and forwards explicit defaults to \`get_label_releases\` (which already supported them). New pure JS helpers \`buildLabelDetailUrl(id, opts)\` + \`renderPaginationControls(curr, pages)\` + \`goToLabelPage(n)\` wire prev/next controls into the label-detail body when \`pagination.pages > 1\`. Header release count now sources from \`payload.pagination.items\` — fixes the P2 #2 mismatch where the header showed the entity's direct count but the list rendered the rolled-up CTE rows.
- **U4** \`feat(web): graceful 503 fallback on label-detail recursive CTE\` — adapter \`get_label_releases\` catches HTTPError(503) when \`include_sublabels=True\`, retries once with \`include_sublabels=False\`, and flags the response with \`sub_labels_dropped=True\`. Other errors (404, double-503, 503 already without sub-labels) re-raise. Route forwards the field; JS renders an amber banner. Until [cratedigger #2026-04-29-002 P0 plan](docs/plans/2026-04-29-002-fix-discogs-api-connection-pool-plan.md) ships a connection pool that re-introduces \`statement_timeout\`, this is dormant for the actual 503 path but defensive against any other source.
- **U5** \`refactor(web): remove redundant empty-results retry in openLabelDetail\` — drops the dead-code client-side retry that could never fire after the route's BIG_LABEL_THRESHOLD auto-flip + the new adapter 503 fallback. The \`bigLabel\` flag setter is preserved.

Plan: [docs/plans/2026-04-29-003-fix-label-viewer-p1-p2-plan.md](docs/plans/2026-04-29-003-fix-label-viewer-p1-p2-plan.md).

## Test plan

- [x] Full test suite: 2506 tests, OK (53 skipped)
- [x] \`pyright web/discogs.py web/routes/labels.py\` — 0 errors
- [x] All 18 \`TestLabelRouteContracts\` tests pass (6 new contract tests, 6 updated assert_called_once_with calls)
- [x] All 8 \`TestGetLabelReleases\` adapter tests pass (5 new tests covering default-false, 503→fallback, 503→503 re-raise, already-false re-raise, 404 unchanged)
- [x] \`tests/test_js_util.mjs\` — 150 passed (new \`buildLabelDetailUrl\` + \`renderPaginationControls\` coverage)
- [x] \`node --check\` clean on all touched JS files
- [ ] Post-deploy: open Hymen Records → page renders normally, no page controls (under per_page=100)
- [ ] Post-deploy: open Warp Records → page controls appear if total exceeds 100; Next advances to page 2
- [ ] Post-deploy: header release count matches the rolled-up rendered list (was off by sub-label total before)
- [ ] Post-deploy: only one \`/api/discogs/label/{id}\` fetch per label load (network panel)
- [ ] Post-deploy (after [discogs-api #5](https://github.com/abl030/discogs-api/pull/5) ships and the P0 connection pool lands): force a 503 on a UMG-class label and verify the amber "Sub-labels temporarily unavailable" banner renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)