### PR TITLE
Harden Discogs label releases

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -12,5 +12,6 @@ paths:
 - MusicBrainz queries through local mirror at `http://192.168.1.35:5200` via `web/mb.py`
 - Redis cache: MB data 24h TTL, beets/pipeline 5min TTL, explicit invalidation on POST mutations
 - Static JS served at `/js/*.js` — `node --check` validates syntax in CI
+- Fetch-on-input UI must stamp requests with a module-scoped in-flight token and discard stale responses before rendering
 - The web UI reads download_log JSONB columns (import_result, validation_result) — use the typed field names from the dataclasses, not arbitrary strings
 - After changes: `ssh doc2 'sudo systemctl restart cratedigger-web'`

--- a/docs/discogs-mirror.md
+++ b/docs/discogs-mirror.md
@@ -33,6 +33,22 @@ A self-hosted mirror of the Discogs music database, serving a JSON API at `https
 | GET | `/api/masters/{id}` | Master release with all child releases |
 | GET | `/api/artists/{id}` | Artist profile, aliases, name variations |
 | GET | `/api/artists/{id}/releases?page=1&per_page=100` | Paginated releases for an artist (includes masterless) |
+| GET | `/api/labels?name=X&page=1&per_page=25` | Label search with release counts and parent-label context |
+| GET | `/api/labels/{id}` | Label profile, direct release count, parent, and direct sub-labels |
+| GET | `/api/labels/{id}/releases?page=1&per_page=100&include_sublabels=true` | Paginated releases for a label, optionally including recursive sub-label releases |
+
+Label release pagination is capped at `per_page=100` in both cratedigger and
+discogs-api. Release rows currently include both `label_id` and the legacy
+`via_label_id` key during the cross-repo rollout; new code should read
+`label_id`.
+
+The label releases endpoint can return `503 Service Unavailable` with
+`{"error":"timeout","label_id":<id>}` when `include_sublabels=true` exceeds
+the mirror's 15 second recursive CTE statement timeout. Cratedigger's
+`web.discogs.get_label_releases()` retries once with `include_sublabels=false`
+on HTTP 503 or timeout-class upstream failures and returns
+`sub_labels_dropped=true` so the UI can show direct releases instead of failing
+the label page.
 
 ### API Examples
 
@@ -89,7 +105,11 @@ data.discogs.com (monthly XML dumps, ~12 GB compressed)
 
 Two binaries from one crate:
 - **`discogs-import`**: discovers latest dump, downloads to `.partial` (atomic rename), streams XML through `flate2::GzDecoder`, parses with `quick-xml`, sends 10K batches through an `mpsc` channel to async binary COPY. Full import ~18 minutes for 19M releases.
-- **`discogs-api`**: axum server with `tokio-postgres`. Single connection, no pool (low-traffic internal API).
+- **`discogs-api`**: axum server with `tokio-postgres` through a
+  `deadpool-postgres` connection pool. Each HTTP query helper acquires one
+  connection for the request; the importer remains a separate single-client
+  COPY pipeline. The pool has bounded wait/create/recycle timeouts so saturated
+  label-release requests shed as 503 instead of waiting indefinitely.
 
 ## Source Repo Structure
 

--- a/docs/plans/2026-04-29-002-fix-discogs-api-connection-pool-plan.md
+++ b/docs/plans/2026-04-29-002-fix-discogs-api-connection-pool-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: discogs-api connection pool + safe statement_timeout (P0 redo)"
 type: fix
-status: active
+status: implemented
 date: 2026-04-29
 origin: docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
 ---
@@ -13,6 +13,12 @@ origin: docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
 ## Overview
 
 Replace the multiplexed `tokio_postgres::Client` shared across Axum handlers with a connection pool (`deadpool-postgres`), then re-introduce a transaction-scoped `statement_timeout` on the recursive sub-label CTE so a UMG-class label cannot hang the cratedigger HTTP server. Deploy the cratedigger-side 503-aware fallback (graceful retry without sub-labels) alongside the new behavior.
+
+**Implementation note:** the final shipped timeout is 15 seconds, not the 5
+seconds drafted below. Live doc2 measurement showed UMG completes in about 12
+seconds, and the user accepted a 15s budget. The pool also ships with bounded
+wait/create/recycle timeouts so saturation returns a typed 503 instead of
+waiting indefinitely.
 
 This redoes the work that landed in `cf22645` (broken: serialized all requests through one connection, corrupted session state on timeout) and was reverted in `6053896`. The architectural prerequisite is the connection pool — without it, transaction-scoped `SET LOCAL` is unsafe on a multiplexed client.
 
@@ -43,10 +49,10 @@ Origin: post-merge follow-up section of `docs/plans/2026-04-29-001-feat-label-vi
 ## Requirements Trace
 
 - R1. Multiplex client replaced with a per-request connection pool. → U1
-- R2. `query_label_releases` (recursive branch) wraps its query in `BEGIN; SET LOCAL statement_timeout='5s'; ... COMMIT;` on a pool-acquired connection. → U2
+- R2. `query_label_releases` (recursive branch) wraps its query in `BEGIN; SET LOCAL statement_timeout='15s'; ... COMMIT;` on a pool-acquired connection. → U2
 - R3. Timeout maps to HTTP 503 (`SERVICE_UNAVAILABLE`) with a typed error body the client can branch on. → U2
 - R4. Cratedigger handles 503 from `get_label_releases` by retrying once with `include_sublabels=false` and surfacing a banner. → U3
-- R5. `nix flake check` (or equivalent) and a smoke test against a real label confirm: small labels OK, UMG-class label returns 503 fast (<6s) instead of hanging, single 503 does not impact subsequent requests. → U4
+- R5. `nix flake check` (or equivalent) and a smoke test against a real label confirm: small labels OK, UMG-class labels complete or degrade within the accepted 15s recursive budget, and one timeout does not impact subsequent requests. → U4
 
 **Non-requirements:** Replacing `UNION ALL` with `UNION` (cycle guard) and the nullable `String → Option<String>` field corrections live in the P1 plan (`docs/plans/2026-04-29-003-fix-label-viewer-p1-p2-plan.md`). They are independent and can land before, during, or after this plan.
 

--- a/docs/plans/2026-04-29-003-fix-label-viewer-p1-p2-plan.md
+++ b/docs/plans/2026-04-29-003-fix-label-viewer-p1-p2-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: label viewer P1 + P2 ship-fast cluster"
 type: fix
-status: active
+status: implemented
 date: 2026-04-29
 origin: docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
 ---

--- a/docs/plans/2026-04-29-004-fix-label-viewer-p3-cleanup-plan.md
+++ b/docs/plans/2026-04-29-004-fix-label-viewer-p3-cleanup-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: label viewer P3 cleanup consolidation"
 type: fix
-status: active
+status: implemented
 date: 2026-04-29
 origin: docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
 ---
@@ -13,6 +13,13 @@ origin: docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
 ## Overview
 
 Consolidation PR for the P3 cluster from the Phase A code review (`docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md` lines 530-541) plus the two pre-existing items called out at lines 539-541. Each item is small; landing them as a single consolidation PR keeps the review surface coherent and avoids the per-item ceremony tax.
+
+**Implementation note:** after final review, this PR also folded in the P1/P2
+fixes and the remaining P3 review items. The `via_label_id` rename shipped as
+an additive compatibility window (`label_id` and `via_label_id` both emitted and
+accepted), release search cache keys are bounded like artist/label search keys,
+label `per_page` is aligned to the mirror's 100-row cap, and clearing the
+browse search box cancels stale in-flight search responses.
 
 Eight items, grouped into two natural commits:
 

--- a/docs/solutions/architecture/multiplexed-postgres-client-and-set-local-incompatibility.md
+++ b/docs/solutions/architecture/multiplexed-postgres-client-and-set-local-incompatibility.md
@@ -1,0 +1,87 @@
+---
+title: "Multiplexed Postgres clients and SET LOCAL do not mix"
+date: 2026-04-29
+category: architecture
+problem_type: production-hardening
+component: discogs-api
+tags:
+  - postgres
+  - tokio-postgres
+  - deadpool-postgres
+  - statement-timeout
+  - connection-pool
+related_plans:
+  - docs/plans/2026-04-29-001-feat-label-viewer-phase-a-plan.md
+  - docs/plans/2026-04-29-002-fix-discogs-api-connection-pool-plan.md
+---
+
+# Multiplexed Postgres clients and SET LOCAL do not mix
+
+## Context
+
+The Discogs label viewer added a recursive sub-label release query. On
+UMG-class label trees, that query can run long enough to block cratedigger's
+single-threaded web server while it waits on the Discogs mirror.
+
+The first attempted hardening wrapped the recursive CTE in
+`BEGIN; SET LOCAL statement_timeout = '5s'; ... COMMIT;` on the existing
+shared `tokio_postgres::Client`. That was reverted because the client was
+multiplexed over one TCP connection.
+
+## Guidance
+
+Do not put transaction-scoped or session-scoped state on a shared multiplexed
+Postgres client that serves unrelated HTTP requests. If a query needs
+`SET LOCAL`, advisory state, temp tables, or any transaction-local behavior,
+first acquire a dedicated connection from a pool and run the transaction on
+that connection.
+
+For `discogs-api`, the safe shape is:
+
+```rust
+let mut client = get_client(pool).await?;
+let tx = client.transaction().await?;
+tx.batch_execute("SET LOCAL statement_timeout = '15s'").await?;
+let rows = tx.query(sql, params).await?;
+tx.commit().await?;
+```
+
+The importer is different: it is a single-purpose oneshot process doing COPY
+work, so a dedicated `tokio_postgres::Client` is still appropriate there.
+
+## Why This Matters
+
+`tokio_postgres::Client` supports pipelining over a single connection. That is
+good for simple independent queries, but explicit transactions serialize
+everything behind the same session. If a statement inside the transaction times
+out, PostgreSQL can leave the transaction aborted until rollback. On a shared
+client, that aborted state can bleed into later requests and make healthy
+routes fail.
+
+A pool scopes the blast radius. One slow recursive CTE can time out, roll back,
+and return a typed 503 while other requests acquire separate connections and
+continue normally.
+
+## When To Apply
+
+Apply this rule when a service uses one long-lived async Postgres client across
+handlers and a new feature needs any of:
+
+- `SET LOCAL statement_timeout`
+- explicit `BEGIN` / `COMMIT`
+- temporary session settings
+- transaction-local advisory locks
+- logic that must survive a canceled statement without poisoning other traffic
+
+## Example
+
+In Plan 002, `discogs-api` moved Axum query handlers from a shared
+`tokio_postgres::Client` to a `deadpool-postgres` pool. Only the recursive
+label releases branch gets a transaction-scoped `statement_timeout`, currently
+15 seconds after live measurement showed UMG-class rollups take about 12
+seconds on doc2. When PostgreSQL raises SQLSTATE `57014` (`query_canceled`),
+the handler returns HTTP 503 and cratedigger retries once without sub-label
+rollup.
+
+The pool itself also has bounded wait/create/recycle timeouts. A saturated pool
+returns a typed 503 instead of letting request tasks await a connection forever.

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -252,6 +252,16 @@ class TestSearchReleases(unittest.TestCase):
         self.assertFalse(masterless["is_master"])
         self.assertEqual(masterless["first_release_date"], "1996")  # falls back to released
 
+    def test_long_query_uses_bounded_cache_key(self):
+        long_query = "r" * 250
+        with patch("web.discogs._cache.memoize_meta", return_value=[]) as memo:
+            search_releases(long_query)
+
+        cache_key = memo.call_args[0][0]
+        self.assertTrue(cache_key.startswith("discogs:search:releases:"))
+        self.assertIn(f":#{len(long_query)}:", cache_key)
+        self.assertLess(len(cache_key), len(f"discogs:search:releases:{long_query}"))
+
 
 class TestSearchArtists(unittest.TestCase):
     """search_artists() now hits /api/artists?name= (real artist-name index)."""
@@ -291,6 +301,16 @@ class TestSearchArtists(unittest.TestCase):
         self.assertEqual(results[0]["disambiguation"], "")  # left empty intentionally
         self.assertEqual(results[0]["score"], 6)  # int(0.06 * 100)
         self.assertEqual(results[1]["name"], "Radioheads")
+
+    def test_long_query_uses_bounded_cache_key(self):
+        long_query = "a" * 250
+        with patch("web.discogs._cache.memoize_meta", return_value=[]) as memo:
+            search_artists(long_query)
+
+        cache_key = memo.call_args[0][0]
+        self.assertTrue(cache_key.startswith("discogs:search:artists:"))
+        self.assertIn(f":#{len(long_query)}:", cache_key)
+        self.assertLess(len(cache_key), len(f"discogs:search:artists:{long_query}"))
 
 
 class TestGetArtistReleases(unittest.TestCase):
@@ -447,6 +467,21 @@ class TestSearchLabels(unittest.TestCase):
             with self.assertRaises(msgspec.ValidationError):
                 search_labels("Parlophone")
 
+    def test_long_query_uses_bounded_distinct_cache_key(self):
+        q1 = "x" * 250
+        q2 = ("x" * 200) + ("y" * 50)
+
+        with patch("web.discogs._cache.memoize_meta", return_value=[]) as memo:
+            search_labels(q1)
+            search_labels(q2)
+
+        key1 = memo.call_args_list[0].args[0]
+        key2 = memo.call_args_list[1].args[0]
+        self.assertNotEqual(key1, key2)
+        self.assertIn(f":#{len(q1)}:", key1)
+        self.assertIn(f":#{len(q2)}:", key2)
+        self.assertLess(len(key1), len(f"discogs:search:labels:{q1}:p=1:pp=25"))
+
 
 class TestGetLabel(unittest.TestCase):
     """get_label() hits /api/labels/{id} and returns a LabelEntity."""
@@ -493,6 +528,9 @@ class TestGetLabel(unittest.TestCase):
         self.assertIsNone(entity.parent_label_id)
         self.assertIsNone(entity.parent_label_name)
         self.assertEqual(entity.release_count, 18452)  # comes from total_releases
+        self.assertEqual(entity.sub_labels, [
+            {"id": 25693, "name": "Parlophone Records Ltd.", "release_count": 412},
+        ])
 
     def test_sub_label_has_parent(self):
         with _mock_urlopen(self.SUB_LABEL_DATA):
@@ -501,6 +539,14 @@ class TestGetLabel(unittest.TestCase):
         self.assertEqual(entity.parent_label_id, "2294")
         self.assertEqual(entity.parent_label_name, "Parlophone")
         self.assertEqual(entity.release_count, 412)
+        self.assertEqual(entity.sub_labels, [])
+
+    def test_rejects_non_numeric_label_id(self):
+        with self.assertRaises(AssertionError):
+            get_label("../etc/passwd")
+
+        with self.assertRaises(AssertionError):
+            get_label("123 OR 1=1")
 
 
 class TestGetLabelReleases(unittest.TestCase):
@@ -517,7 +563,7 @@ class TestGetLabelReleases(unittest.TestCase):
                 "master_title": "OK Computer",
                 "master_first_released": "1997",
                 "primary_type": "Album",
-                "via_label_id": 2294,
+                "label_id": 2294,
                 "sub_label_name": None,
                 "artists": [{"id": 3840, "name": "Radiohead", "role": "", "anv": ""}],
                 "labels": [{"id": 2294, "name": "Parlophone", "catno": "NODATA 02"}],
@@ -532,7 +578,7 @@ class TestGetLabelReleases(unittest.TestCase):
                 "released": "2001",
                 "master_id": None,
                 "primary_type": "Single",
-                "via_label_id": 25693,
+                "label_id": 25693,
                 "sub_label_name": "Parlophone Records Ltd.",
                 "artists": [{"id": 1, "name": "Various", "role": "", "anv": ""}],
                 "labels": [
@@ -582,6 +628,7 @@ class TestGetLabelReleases(unittest.TestCase):
         self.assertEqual(direct["master_first_released"], "1997")
         self.assertEqual(direct["artist_name"], "Radiohead")
         self.assertEqual(direct["artist_id"], "3840")
+        self.assertEqual(direct["label_id"], "2294")
         self.assertEqual(direct["via_label_id"], "2294")
         self.assertIsNone(direct["sub_label_name"])  # direct-parent release
         self.assertEqual(direct["format"], "CD")
@@ -589,10 +636,22 @@ class TestGetLabelReleases(unittest.TestCase):
         sub = rows[1]
         self.assertEqual(sub["id"], "999111")
         self.assertEqual(sub["sub_label_name"], "Parlophone Records Ltd.")
+        self.assertEqual(sub["label_id"], "25693")
         self.assertEqual(sub["via_label_id"], "25693")
         self.assertIsNone(sub["release_group_id"])  # masterless
         self.assertEqual(sub["primary_type"], "Single")
         self.assertEqual(sub["format"], "Vinyl")
+
+    def test_accepts_legacy_via_label_id_payload(self):
+        legacy = json.loads(json.dumps(self.RELEASES_DATA))
+        for row in legacy["results"]:
+            row["via_label_id"] = row.pop("label_id")
+
+        with _mock_urlopen(legacy):
+            payload = get_label_releases(112294, include_sublabels=True)
+
+        self.assertEqual(payload["results"][0]["label_id"], "2294")
+        self.assertEqual(payload["results"][0]["via_label_id"], "2294")
 
     def test_default_pagination_kwargs(self):
         with _mock_urlopen(self.RELEASES_DATA) as mock:
@@ -604,6 +663,13 @@ class TestGetLabelReleases(unittest.TestCase):
         self.assertIn("page=1", called_url)
         self.assertIn("per_page=100", called_url)
 
+    def test_rejects_non_numeric_label_id(self):
+        with self.assertRaises(AssertionError):
+            get_label_releases("../etc/passwd")
+
+        with self.assertRaises(AssertionError):
+            get_label_releases("123 OR 1=1")
+
     def test_include_sublabels_false_passes_through(self):
         with _mock_urlopen({**self.RELEASES_DATA, "include_sublabels": False}) as mock:
             payload = get_label_releases(2294, include_sublabels=False)
@@ -612,7 +678,7 @@ class TestGetLabelReleases(unittest.TestCase):
         self.assertFalse(payload["include_sublabels"])
 
     def test_sub_labels_dropped_default_false(self):
-        """Plan 003 U4: every successful response carries
+        """Plan 002 U3: every successful response carries
         `sub_labels_dropped` so the contract is stable. Default False."""
         with _mock_urlopen(self.RELEASES_DATA):
             payload = get_label_releases(2294, include_sublabels=True)
@@ -620,7 +686,7 @@ class TestGetLabelReleases(unittest.TestCase):
         self.assertFalse(payload["sub_labels_dropped"])
 
     def test_503_falls_back_to_no_sublabels(self):
-        """Plan 003 U4: when the upstream returns 503 (timeout) and the
+        """Plan 002 U3: when the upstream returns 503 (timeout) and the
         caller asked for sub-labels, the adapter retries once with
         include_sublabels=False and flags the response."""
         from urllib.error import HTTPError
@@ -633,7 +699,10 @@ class TestGetLabelReleases(unittest.TestCase):
         success_resp.__enter__ = lambda s: s
         success_resp.__exit__ = MagicMock(return_value=False)
 
+        seen_urls = []
+
         def _urlopen(req, *_args, **_kwargs):
+            seen_urls.append(req.full_url)
             if "include_sublabels=true" in req.full_url:
                 raise HTTPError(
                     req.full_url, 503, "Service Unavailable",
@@ -642,15 +711,59 @@ class TestGetLabelReleases(unittest.TestCase):
             return success_resp
 
         with patch("web.discogs.urllib.request.urlopen", side_effect=_urlopen):
-            payload = get_label_releases(99887766, include_sublabels=True)
+            payload = get_label_releases(
+                99887766, include_sublabels=True, page=3, per_page=50)
 
         self.assertTrue(payload["sub_labels_dropped"])
         # Fallback fetch ran and surfaced its successful payload
         self.assertFalse(payload["include_sublabels"])
         self.assertEqual(len(payload["results"]), 2)
+        self.assertIn("include_sublabels=true", seen_urls[0])
+        self.assertIn("page=3", seen_urls[0])
+        self.assertIn("per_page=50", seen_urls[0])
+        self.assertIn("include_sublabels=false", seen_urls[1])
+        self.assertIn("page=3", seen_urls[1])
+        self.assertIn("per_page=50", seen_urls[1])
+
+    def test_timeout_falls_back_to_no_sublabels(self):
+        success_resp = MagicMock()
+        success_resp.read.return_value = json.dumps(
+            {**self.RELEASES_DATA, "include_sublabels": False}).encode()
+        success_resp.__enter__ = lambda s: s
+        success_resp.__exit__ = MagicMock(return_value=False)
+
+        def _urlopen(req, *_args, **_kwargs):
+            if "include_sublabels=true" in req.full_url:
+                raise TimeoutError("timed out")
+            return success_resp
+
+        with patch("web.discogs.urllib.request.urlopen", side_effect=_urlopen):
+            payload = get_label_releases(99887762, include_sublabels=True)
+
+        self.assertTrue(payload["sub_labels_dropped"])
+        self.assertFalse(payload["include_sublabels"])
+
+    def test_include_sublabels_uses_bounded_timeout(self):
+        seen_timeouts = []
+
+        def _urlopen(req, *_args, **kwargs):
+            seen_timeouts.append(kwargs.get("timeout"))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(self.RELEASES_DATA).encode()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("web.discogs._cache.memoize_meta",
+                   side_effect=lambda _key, fn: fn()), \
+                patch("web.discogs.urllib.request.urlopen", side_effect=_urlopen):
+            get_label_releases(99887761, include_sublabels=True)
+            get_label_releases(99887760, include_sublabels=False)
+
+        self.assertEqual(seen_timeouts, [20, 60])
 
     def test_503_then_503_reraises(self):
-        """Plan 003 U4: if the fallback also 503s, the original HTTPError
+        """Plan 002 U3: if the fallback also 503s, the original HTTPError
         re-raises. No infinite retry."""
         from urllib.error import HTTPError
         from io import BytesIO
@@ -666,7 +779,7 @@ class TestGetLabelReleases(unittest.TestCase):
                 get_label_releases(99887765, include_sublabels=True)
 
     def test_503_when_sub_labels_already_false_reraises(self):
-        """Plan 003 U4: 503 with include_sublabels=False has nothing to fall
+        """Plan 002 U3: 503 with include_sublabels=False has nothing to fall
         back to — re-raise."""
         from urllib.error import HTTPError
         from io import BytesIO
@@ -682,7 +795,7 @@ class TestGetLabelReleases(unittest.TestCase):
                 get_label_releases(99887764, include_sublabels=False)
 
     def test_404_propagates_unchanged(self):
-        """Plan 003 U4: 404 surfaces as 404 (existing route maps it). The
+        """Plan 002 U3: 404 surfaces as 404 (existing route maps it). The
         503 retry must not swallow other HTTP errors."""
         from urllib.error import HTTPError
         from io import BytesIO

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -4,7 +4,7 @@
  */
 
 import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
-import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls } from '../web/js/labels.js';
+import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, loadLabelReleases, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls } from '../web/js/labels.js';
 
 let passed = 0;
 let failed = 0;
@@ -184,6 +184,34 @@ assertEqual(
   buildLabelDetailUrl('757', { include_sublabels: undefined, page: undefined, per_page: undefined }),
   '/api/discogs/label/757',
   'undefined opts produce no params');
+
+async function captureLoadLabelUrl(opts) {
+  const originalFetch = globalThis.fetch;
+  let seenUrl = '';
+  globalThis.fetch = async (url) => {
+    seenUrl = String(url);
+    return { ok: true, json: async () => ({ ok: true }) };
+  };
+  try {
+    await loadLabelReleases('757', opts);
+    return seenUrl;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+assertEqual(
+  await captureLoadLabelUrl({ page: 1 }),
+  '/api/discogs/label/757?page=1',
+  'default label load omits include_sublabels so route auto-flip can run');
+assertEqual(
+  await captureLoadLabelUrl({ include_sublabels: true, page: 2 }),
+  '/api/discogs/label/757?include_sublabels=true&page=2',
+  'explicit include_sublabels=true is preserved');
+assertEqual(
+  await captureLoadLabelUrl({ include_sublabels: false, page: 2 }),
+  '/api/discogs/label/757?include_sublabels=false&page=2',
+  'explicit include_sublabels=false is preserved');
 
 // --- renderPaginationControls tests ---
 console.log('renderPaginationControls()');

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,94 @@
+"""Direct tests for shared release-row overlay helpers."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from web.routes._overlay import overlay_release_rows_in_place
+
+
+class TestOverlayReleaseRowsInPlace(unittest.TestCase):
+    def test_populates_library_and_pipeline_state(self):
+        rows = [
+            {"id": "held", "title": "Held Release"},
+            {"id": "queued", "title": "Queued Release"},
+            {"id": "both", "title": "Both Release"},
+            {"id": "neither", "title": "Neither Release"},
+            {"id": "bad-quality", "title": "Bad Quality Release"},
+        ]
+        mock_beets = MagicMock()
+        mock_beets.get_album_ids_by_mbids.return_value = {
+            "held": 10,
+            "both": 11,
+            "bad-quality": 12,
+        }
+        mock_beets.check_mbids_detail.return_value = {
+            "held": {"beets_format": "FLAC", "beets_bitrate": 1100},
+            "both": {"beets_format": "MP3", "beets_bitrate": 320},
+            "bad-quality": {"beets_format": None, "beets_bitrate": None},
+        }
+
+        def _rank(fmt, bitrate):
+            return f"{fmt or 'unknown'}:{bitrate}"
+
+        with patch("web.server.check_beets_library",
+                   return_value={"held", "both", "bad-quality"}), \
+                patch("web.server.check_pipeline",
+                      return_value={
+                          "queued": {"id": 21, "status": "wanted"},
+                          "both": {"id": 22, "status": "queued"},
+                      }), \
+                patch("web.server._beets_db", return_value=mock_beets), \
+                patch("web.server.compute_library_rank", side_effect=_rank):
+            overlay_release_rows_in_place(rows, [r["id"] for r in rows])
+
+        by_id = {row["id"]: row for row in rows}
+
+        self.assertTrue(by_id["held"]["in_library"])
+        self.assertEqual(by_id["held"]["beets_album_id"], 10)
+        self.assertEqual(by_id["held"]["library_format"], "FLAC")
+        self.assertEqual(by_id["held"]["library_min_bitrate"], 1100)
+        self.assertEqual(by_id["held"]["library_rank"], "FLAC:1100")
+        self.assertIsNone(by_id["held"]["pipeline_status"])
+
+        self.assertFalse(by_id["queued"]["in_library"])
+        self.assertIsNone(by_id["queued"]["beets_album_id"])
+        self.assertEqual(by_id["queued"]["pipeline_status"], "wanted")
+        self.assertEqual(by_id["queued"]["pipeline_id"], 21)
+
+        self.assertTrue(by_id["both"]["in_library"])
+        self.assertEqual(by_id["both"]["beets_album_id"], 11)
+        self.assertEqual(by_id["both"]["pipeline_status"], "queued")
+        self.assertEqual(by_id["both"]["pipeline_id"], 22)
+
+        self.assertFalse(by_id["neither"]["in_library"])
+        self.assertIsNone(by_id["neither"]["beets_album_id"])
+        self.assertIsNone(by_id["neither"]["pipeline_status"])
+        self.assertIsNone(by_id["neither"]["pipeline_id"])
+
+        self.assertEqual(by_id["bad-quality"]["library_format"], "")
+        self.assertEqual(by_id["bad-quality"]["library_min_bitrate"], 0)
+        self.assertEqual(by_id["bad-quality"]["library_rank"], "unknown:0")
+
+    def test_empty_inputs_do_not_touch_backends(self):
+        with patch("web.server.check_beets_library") as check_lib, \
+                patch("web.server.check_pipeline") as check_pipeline, \
+                patch("web.server._beets_db", return_value=None):
+            overlay_release_rows_in_place([], [])
+
+        check_lib.assert_not_called()
+        check_pipeline.assert_not_called()
+
+    def test_missing_row_id_raises_key_error(self):
+        with patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            with self.assertRaises(KeyError):
+                overlay_release_rows_in_place([{"title": "No ID"}], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2816,7 +2816,7 @@ class TestLabelRouteContracts(_WebServerCase):
             "master_first_released": None,
             "artist_name": "Gridlock",
             "artist_id": "1234",
-            "via_label_id": "757",
+            "label_id": "757",
             "sub_label_name": None,
             "format": "CD",
             "media_count": 1,
@@ -2875,6 +2875,28 @@ class TestLabelRouteContracts(_WebServerCase):
         _assert_required_fields(self, data["releases"][0],
                                 self.LABEL_RELEASE_REQUIRED_FIELDS,
                                 "label release row")
+
+    def test_label_detail_forwards_sub_labels(self):
+        with patch("web.routes.labels.discogs_api") as mock_dg, \
+                patch("web.server.check_beets_library", return_value=set()), \
+                patch("web.server.check_pipeline", return_value={}), \
+                patch("web.server._beets_db", return_value=None):
+            mock_dg.get_label.return_value = self._make_label_entity(
+                sub_labels=[
+                    {"id": 25693, "name": "Hymen Substream", "release_count": 7},
+                ]
+            )
+            mock_dg.get_label_releases.return_value = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": True,
+            }
+            status, data = self._get("/api/discogs/label/757")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["sub_labels"], [
+            {"id": 25693, "name": "Hymen Substream", "release_count": 7},
+        ])
 
     def test_label_detail_overlay_integration(self):
         """End-to-end overlay: with one release in library AND one in
@@ -3108,8 +3130,7 @@ class TestLabelRouteContracts(_WebServerCase):
         self.assertEqual(data["pagination"]["per_page"], 50)
 
     def test_label_detail_clamps_per_page(self):
-        """`?per_page=500` clamps to the 200 max so a malicious or misbehaving
-        client can't exfiltrate the whole catalogue in one shot."""
+        """`?per_page=500` clamps to the mirror's 100-row label-release max."""
         with patch("web.routes.labels.discogs_api") as mock_dg, \
                 patch("web.server.check_beets_library", return_value=set()), \
                 patch("web.server.check_pipeline", return_value={}), \
@@ -3117,7 +3138,7 @@ class TestLabelRouteContracts(_WebServerCase):
             mock_dg.get_label.return_value = self._make_label_entity()
             mock_dg.get_label_releases.return_value = {
                 "results": [],
-                "pagination": {"page": 1, "per_page": 200, "pages": 1, "items": 0},
+                "pagination": {"page": 1, "per_page": 100, "pages": 1, "items": 0},
                 "include_sublabels": True,
             }
             status, _data = self._get(
@@ -3125,7 +3146,7 @@ class TestLabelRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_dg.get_label_releases.assert_called_once_with(
-            "757", include_sublabels=True, page=1, per_page=200)
+            "757", include_sublabels=True, page=1, per_page=100)
 
     def test_label_detail_rejects_non_integer_page(self):
         """`?page=foo` returns 400 — silently coercing to 1 would mask
@@ -3174,7 +3195,7 @@ class TestLabelRouteContracts(_WebServerCase):
         self.assertFalse(mock_dg.get_label_releases.called)
 
     def test_label_detail_forwards_sub_labels_dropped(self):
-        """Plan 003 U4: when the adapter signals a 503 fallback, the route
+        """Plan 002 U3: when the adapter signals a 503 fallback, the route
         forwards `sub_labels_dropped=True` so the UI can surface a banner."""
         with patch("web.routes.labels.discogs_api") as mock_dg, \
                 patch("web.server.check_beets_library", return_value=set()), \
@@ -3193,7 +3214,7 @@ class TestLabelRouteContracts(_WebServerCase):
         self.assertTrue(data["sub_labels_dropped"])
 
     def test_label_detail_default_sub_labels_dropped_false(self):
-        """Plan 003 U4: every label-detail response carries the field with
+        """Plan 002 U3: every label-detail response carries the field with
         default False so the contract is stable."""
         with patch("web.routes.labels.discogs_api") as mock_dg, \
                 patch("web.server.check_beets_library", return_value=set()), \

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -11,8 +11,10 @@ so that per-user pipeline / library overlay state is never baked
 into Redis (issue #101).
 """
 
+import hashlib
 import json
 import re
+import socket
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -24,9 +26,12 @@ from web import cache as _cache
 
 DISCOGS_API_BASE = "https://discogs.ablz.au"
 USER_AGENT = "cratedigger-web/1.0"
+SEARCH_CACHE_QUERY_PREFIX_CHARS = 200
+DEFAULT_HTTP_TIMEOUT_SECONDS = 60
+LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS = 20
 
 
-def _get(url: str) -> dict:
+def _get(url: str, *, timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS) -> dict:
     req = urllib.request.Request(url)
     req.add_header("User-Agent", USER_AGENT)
     req.add_header("Connection", "close")
@@ -34,8 +39,34 @@ def _get(url: str) -> dict:
     # mirror; the request always succeeds eventually. Generous timeout so the
     # web UI doesn't 500 on broad queries (use the in-flight Redis cache to
     # short-circuit repeats).
-    with urllib.request.urlopen(req, timeout=60) as resp:
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
+
+
+def _is_timeout_error(exc: BaseException) -> bool:
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return True
+    if isinstance(exc, urllib.error.URLError):
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, (TimeoutError, socket.timeout)):
+            return True
+        reason_text = str(reason).lower()
+        return "timed out" in reason_text or "timeout" in reason_text
+    return False
+
+
+def _search_cache_query_part(query: str) -> str:
+    """Bound user-controlled search text before embedding it in cache keys."""
+    if len(query) <= SEARCH_CACHE_QUERY_PREFIX_CHARS:
+        return query
+    digest = hashlib.sha256(query.encode("utf-8")).hexdigest()[:12]
+    return f"{query[:SEARCH_CACHE_QUERY_PREFIX_CHARS]}:#{len(query)}:{digest}"
+
+
+def _assert_discogs_label_id(label_id: int | str) -> str:
+    label_id_str = str(label_id)
+    assert label_id_str.isdigit()
+    return label_id_str
 
 
 def _parse_duration(duration_str: str) -> float | None:
@@ -134,7 +165,8 @@ def search_releases(query: str) -> list[dict]:
             })
         return results
 
-    return _cache.memoize_meta(f"discogs:search:releases:{query}", _fetch)
+    cache_query = _search_cache_query_part(query)
+    return _cache.memoize_meta(f"discogs:search:releases:{cache_query}", _fetch)
 
 
 def search_artists(query: str) -> list[dict]:
@@ -156,7 +188,8 @@ def search_artists(query: str) -> list[dict]:
             for r in data.get("results", [])
         ]
 
-    return _cache.memoize_meta(f"discogs:search:artists:{query}", _fetch)
+    cache_query = _search_cache_query_part(query)
+    return _cache.memoize_meta(f"discogs:search:artists:{cache_query}", _fetch)
 
 
 def get_artist_releases(artist_id: int) -> list[dict]:
@@ -321,7 +354,7 @@ class _DiscogsLabelHit(msgspec.Struct):
     """One hit from `GET /api/labels?name=...`."""
     id: int
     name: str
-    profile: str
+    profile: str | None
     parent_label_id: int | None
     parent_label_name: str | None
     release_count: int
@@ -347,9 +380,9 @@ class _DiscogsLabelDetail(msgspec.Struct):
     Discogs adapter; the future MB adapter will populate it."""
     id: int
     name: str
-    profile: str
-    contactinfo: str
-    data_quality: str
+    profile: str | None
+    contactinfo: str | None
+    data_quality: str | None
     parent_label_id: int | None
     parent_label_name: str | None
     total_releases: int
@@ -384,10 +417,14 @@ class _DiscogsLabelReleaseEntry(msgspec.Struct):
     released: str
     master_id: int | None
     primary_type: str
-    via_label_id: int
     artists: list[_DiscogsApiArtistCredit]
     labels: list[_DiscogsApiLabel]
     formats: list[_DiscogsApiFormat]
+    # Rollout compatibility: Plan 004 renamed the wire field to `label_id`,
+    # but older mirror deployments emit `via_label_id`. Accept both while
+    # cratedigger and discogs-api can be deployed independently.
+    label_id: int | None = None
+    via_label_id: int | None = None
     # Optional fields (skipped on the Rust side when None) — declared with
     # a default so msgspec accepts payloads where the key is omitted entirely.
     master_title: str | None = None
@@ -406,6 +443,14 @@ class _DiscogsLabelReleasesResponse(msgspec.Struct):
     results: list[_DiscogsLabelReleaseEntry]
     pagination: _DiscogsLabelPagination
     include_sublabels: bool
+
+
+def _label_release_label_id(row: _DiscogsLabelReleaseEntry) -> int:
+    if row.label_id is not None:
+        return row.label_id
+    if row.via_label_id is not None:
+        return row.via_label_id
+    raise msgspec.ValidationError("label release row missing label_id/via_label_id")
 
 
 # ── Source-agnostic public contract ─────────────────────────────────────
@@ -436,6 +481,7 @@ class LabelEntity(msgspec.Struct):
     parent_label_id: str | None
     parent_label_name: str | None
     release_count: int
+    sub_labels: list[dict] = msgspec.field(default_factory=list)
 
 
 def _label_entity_from_hit(hit: _DiscogsLabelHit) -> LabelEntity:
@@ -448,6 +494,7 @@ def _label_entity_from_hit(hit: _DiscogsLabelHit) -> LabelEntity:
         parent_label_id=str(hit.parent_label_id) if hit.parent_label_id is not None else None,
         parent_label_name=hit.parent_label_name,
         release_count=hit.release_count,
+        sub_labels=[],
     )
 
 
@@ -461,6 +508,7 @@ def _label_entity_from_detail(detail: _DiscogsLabelDetail) -> LabelEntity:
         parent_label_id=str(detail.parent_label_id) if detail.parent_label_id is not None else None,
         parent_label_name=detail.parent_label_name,
         release_count=detail.total_releases,
+        sub_labels=[msgspec.to_builtins(s) for s in detail.sub_labels],
     )
 
 
@@ -487,7 +535,8 @@ def search_labels(query: str, *, page: int = 1, per_page: int = 25) -> list[Labe
         return [msgspec.to_builtins(_label_entity_from_hit(h))
                 for h in decoded.results]
 
-    cache_key = f"discogs:search:labels:{query}:p={page}:pp={per_page}"
+    cache_query = _search_cache_query_part(query)
+    cache_key = f"discogs:search:labels:{cache_query}:p={page}:pp={per_page}"
     cached = _cache.memoize_meta(cache_key, _fetch)
     return [msgspec.convert(d, type=LabelEntity) for d in cached]
 
@@ -499,12 +548,14 @@ def get_label(label_id: int | str) -> LabelEntity:
     HTTPError on 404 (the caller surfaces the 404 as needed). Returns
     a typed `LabelEntity` on success.
     """
+    label_id_str = _assert_discogs_label_id(label_id)
+
     def _fetch() -> dict:
-        raw = _get(f"{DISCOGS_API_BASE}/api/labels/{label_id}")
+        raw = _get(f"{DISCOGS_API_BASE}/api/labels/{label_id_str}")
         decoded = msgspec.convert(raw, type=_DiscogsLabelDetail)
         return msgspec.to_builtins(_label_entity_from_detail(decoded))
 
-    cached = _cache.memoize_meta(f"discogs:label:{label_id}", _fetch)
+    cached = _cache.memoize_meta(f"discogs:label:v2:{label_id_str}", _fetch)
     return msgspec.convert(cached, type=LabelEntity)
 
 
@@ -519,15 +570,21 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
     `title`, `country`, `date` (released), `year` (parsed from date),
     `primary_type`, `release_group_id` (str | None), `artist_name`,
     `artist_id` (str | None), `format` (joined names) — plus
-    label-specific fields `via_label_id` (str), `sub_label_name`
+    label-specific fields `label_id` (str), `sub_label_name`
     (str | None), `master_title`, `master_first_released`, `labels`,
     `formats`.
     """
+    label_id_str = _assert_discogs_label_id(label_id)
+
     def _fetch() -> dict:
         sub_flag = "true" if include_sublabels else "false"
         raw = _get(
-            f"{DISCOGS_API_BASE}/api/labels/{label_id}/releases"
-            f"?include_sublabels={sub_flag}&page={page}&per_page={per_page}"
+            f"{DISCOGS_API_BASE}/api/labels/{label_id_str}/releases"
+            f"?include_sublabels={sub_flag}&page={page}&per_page={per_page}",
+            timeout=(
+                LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS
+                if include_sublabels else DEFAULT_HTTP_TIMEOUT_SECONDS
+            ),
         )
         decoded = msgspec.convert(raw, type=_DiscogsLabelReleasesResponse)
         rows: list[dict] = []
@@ -535,6 +592,7 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
             artist_name = r.artists[0].name if r.artists else "Unknown"
             artist_id = r.artists[0].id if r.artists else None
             format_names = [f.name for f in r.formats]
+            label_id_for_row = str(_label_release_label_id(r))
             rows.append({
                 "id": str(r.id),
                 "title": r.title,
@@ -547,7 +605,8 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
                 "master_first_released": r.master_first_released,
                 "artist_name": artist_name,
                 "artist_id": str(artist_id) if artist_id is not None else None,
-                "via_label_id": str(r.via_label_id),
+                "label_id": label_id_for_row,
+                "via_label_id": label_id_for_row,
                 "sub_label_name": r.sub_label_name,
                 "format": ", ".join(format_names) if format_names else "?",
                 "media_count": len(r.formats),
@@ -578,25 +637,33 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
 
     sub_flag = "true" if include_sublabels else "false"
     cache_key = (
-        f"discogs:label:{label_id}:releases"
+        f"discogs:label:v2:{label_id_str}:releases"
         f":sub={sub_flag}:p={page}:pp={per_page}"
     )
+
+    def _fallback_without_sublabels() -> dict:
+        fallback = get_label_releases(
+            label_id, include_sublabels=False,
+            page=page, per_page=per_page)
+        # Don't mutate the fallback dict in place — it is the cached
+        # value for a different cache key, and direct callers of
+        # `include_sublabels=False` would see a false-positive
+        # `sub_labels_dropped` if we wrote through.
+        return {**fallback, "sub_labels_dropped": True}
+
     try:
         return _cache.memoize_meta(cache_key, _fetch)
     except urllib.error.HTTPError as e:
-        # Plan 003 U4. The discogs-api mirror returns 503 when the
+        # Plan 002 U3. The discogs-api mirror returns 503 when the
         # recursive sub-label CTE exceeds its statement_timeout (P0 plan).
         # Retry once with sub-labels disabled so the user sees the direct
         # catalogue rather than a hard error. The fallback uses its own
-        # cache key (`sub=false`), so a successful retry is memoized
-        # independently — repeat hits skip the failing call entirely.
+        # cache key (`sub=false`), so the direct-label fallback can be
+        # reused while future full-rollup attempts still probe upstream.
         if e.code == 503 and include_sublabels:
-            fallback = get_label_releases(
-                label_id, include_sublabels=False,
-                page=page, per_page=per_page)
-            # Don't mutate the fallback dict in place — it is the cached
-            # value for a different cache key, and direct callers of
-            # `include_sublabels=False` would see a false-positive
-            # `sub_labels_dropped` if we wrote through.
-            return {**fallback, "sub_labels_dropped": True}
+            return _fallback_without_sublabels()
+        raise
+    except (TimeoutError, socket.timeout, urllib.error.URLError) as e:
+        if include_sublabels and _is_timeout_error(e):
+            return _fallback_without_sublabels()
         raise

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { state, API, toast } from './state.js';
-import { esc } from './util.js';
+import { esc, jsArg } from './util.js';
 import { renderArtistDiscography, loadReleaseGroup } from './discography.js';
 import { renderTypedSections, classify as groupingClassify } from './grouping.js';
 import { renderStatusBadges } from './badges.js';
@@ -40,6 +40,7 @@ async function findArtistOnSource(name, src) {
  */
 export async function setBrowseSource(src) {
   if (state.browseSource === src) return;
+  searchArtistsRequestToken++;
   state.browseSource = src;
   const mbBtn = document.getElementById('source-mb');
   const dgBtn = document.getElementById('source-discogs');
@@ -71,6 +72,7 @@ export async function setBrowseSource(src) {
  * @param {string} type - 'artist' | 'release' | 'label'
  */
 export function setSearchType(type) {
+  searchArtistsRequestToken++;
   state.browseSearchType = type;
   const btnIds = { artist: 'search-type-artist', release: 'search-type-release', label: 'search-type-label' };
   for (const [t, id] of Object.entries(btnIds)) {
@@ -96,6 +98,11 @@ export function setSearchType(type) {
  * @param {string} name - Artist name
  */
 const VA_MBID = '89ad4ac3-39f7-470e-963a-56509c546377';
+let searchArtistsRequestToken = 0;
+
+export function cancelBrowseSearch() {
+  searchArtistsRequestToken++;
+}
 
 export function openBrowseArtist(id, name) {
   if (id === VA_MBID) {
@@ -284,8 +291,8 @@ function compareRow(mb, discogs) {
   // Show only the badges for sources that have this row. No muted
   // placeholders — single-source rows just show one badge.
   const badges = [];
-  if (mb) badges.push(`<span class="library-src library-src-mb" style="cursor:pointer;" onclick="event.stopPropagation(); window.openBrowseArtistFromCompare('${mb.primary_artist_id}', '${esc(mb.artist_credit || '')}', 'mb')">MB</span>`);
-  if (discogs) badges.push(`<span class="library-src library-src-discogs" style="cursor:pointer;" onclick="event.stopPropagation(); window.openBrowseArtistFromCompare('${discogs.primary_artist_id}', '${esc(discogs.artist_credit || '')}', 'discogs')">Discogs</span>`);
+  if (mb) badges.push(`<span class="library-src library-src-mb" style="cursor:pointer;" onclick="event.stopPropagation(); window.openBrowseArtistFromCompare(${jsArg(mb.primary_artist_id)}, ${jsArg(mb.artist_credit || '')}, ${jsArg('mb')})">MB</span>`);
+  if (discogs) badges.push(`<span class="library-src library-src-discogs" style="cursor:pointer;" onclick="event.stopPropagation(); window.openBrowseArtistFromCompare(${jsArg(discogs.primary_artist_id)}, ${jsArg(discogs.artist_credit || '')}, ${jsArg('discogs')})">Discogs</span>`);
   // Row-level in-library badge via the unified renderer. Pull quality
   // fields off whichever side is in library (prefer MB when both — MB
   // rows are the canonical match key).
@@ -301,8 +308,8 @@ function compareRow(mb, discogs) {
   return `
     <div class="rg">
       <div style="display:flex;align-items:center;gap:8px;padding:4px 0;cursor:pointer;"
-           onclick="window.toggleCompareRow('${slot}', '${mbId}', '${dgId}')">
-        <span style="color:#888;font-size:0.8em;width:10px;display:inline-block;" id="cmp-chev-${slot}">▶</span>
+           onclick="window.toggleCompareRow(${jsArg(slot)}, ${jsArg(mbId)}, ${jsArg(dgId)})">
+        <span style="color:#888;font-size:0.8em;width:10px;display:inline-block;" id="cmp-chev-${esc(slot)}">▶</span>
         <span class="rg-year">${year}</span>
         <span class="rg-title">${esc(title)}</span>
         ${type ? `<span class="rg-meta" style="color:#777;">(${esc(type)})</span>` : ''}
@@ -429,6 +436,9 @@ export function openBrowseArtistFromCompare(id, name, src) {
  * @param {string} q - Search query
  */
 export async function searchArtists(q) {
+  const requestToken = ++searchArtistsRequestToken;
+  const searchType = state.browseSearchType;
+  const browseSource = state.browseSource;
   const el = document.getElementById('results');
   el.style.display = 'block';
   document.getElementById('browse-artist').style.display = 'none';
@@ -436,53 +446,61 @@ export async function searchArtists(q) {
   if (browseLabel) browseLabel.style.display = 'none';
   el.innerHTML = '<div class="loading">Searching...</div>';
   // Label search is Discogs-only in Phase A — independent of browseSource.
-  if (state.browseSearchType === 'label') {
+  if (searchType === 'label') {
     try {
       const hits = await searchLabels(q);
+      if (requestToken !== searchArtistsRequestToken) return;
       renderLabelSearchResults(el, hits, openLabelDetail);
     } catch (_e) {
+      if (requestToken !== searchArtistsRequestToken) return;
       el.innerHTML = '<div class="loading">Label search failed</div>';
     }
     return;
   }
-  const isDiscogs = state.browseSource === 'discogs';
+  const isDiscogs = browseSource === 'discogs';
   const searchBase = isDiscogs ? `${API}/api/discogs/search` : `${API}/api/search`;
   try {
-    if (state.browseSearchType === 'release') {
+    if (searchType === 'release') {
       const r = await fetch(`${searchBase}?q=${encodeURIComponent(q)}&type=release`);
       const data = await r.json();
+      if (requestToken !== searchArtistsRequestToken) return;
       const rgs = data.release_groups || [];
       if (!rgs.length) { el.innerHTML = '<div class="loading">No results</div>'; return; }
       el.innerHTML = rgs.map(rg => {
         const isVA = rg.artist_id === VA_MBID;
         // Discogs releases without a master: show pressings inline instead of dead-end artist page
         const isMasterless = isDiscogs && rg.is_master === false;
+        const releaseId = isMasterless ? rg.discogs_release_id || rg.id : rg.id;
         const onclick = (isVA || isMasterless)
-          ? `window.loadReleaseGroup('${isMasterless ? rg.discogs_release_id || rg.id : rg.id}', this)`
-          : `window.openBrowseArtist('${rg.artist_id}', '${esc(rg.artist_name)}')`;
+          ? `window.loadReleaseGroup(${jsArg(releaseId)}, this)`
+          : `window.openBrowseArtist(${jsArg(rg.artist_id)}, ${jsArg(rg.artist_name)})`;
         return `
         <div class="artist" style="cursor:pointer;padding:6px 0;" onclick="${onclick}">
           <span class="artist-name">${esc(rg.artist_name)}</span>
           <span class="artist-dis"> — ${esc(rg.title)}</span>
           ${rg.primary_type ? `<span class="artist-dis" style="color:#888;"> (${esc(rg.primary_type)})</span>` : ''}
         </div>
-        <div id="rel-${rg.id}"></div>`;
+        <div id="rel-${esc(String(rg.id))}"></div>`;
       }).join('');
     } else {
       const r = await fetch(`${searchBase}?q=${encodeURIComponent(q)}`);
       const data = await r.json();
+      if (requestToken !== searchArtistsRequestToken) return;
       if (!data.artists || !data.artists.length) {
         el.innerHTML = '<div class="loading">No results</div>';
         return;
       }
       el.innerHTML = data.artists.map(a => `
         <div class="artist">
-          <div class="artist-header" onclick="window.openBrowseArtist('${a.id}', '${esc(a.name)}')">
+          <div class="artist-header" onclick="window.openBrowseArtist(${jsArg(a.id)}, ${jsArg(a.name)})">
             <span class="artist-name">${esc(a.name)}</span>
             ${a.disambiguation ? `<span class="artist-dis"> - ${esc(a.disambiguation)}</span>` : ''}
           </div>
         </div>
       `).join('');
     }
-  } catch (e) { el.innerHTML = '<div class="loading">Search failed</div>'; }
+  } catch (e) {
+    if (requestToken !== searchArtistsRequestToken) return;
+    el.innerHTML = '<div class="loading">Search failed</div>';
+  }
 }

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -34,6 +34,10 @@ export const BIG_LABEL_THRESHOLD = 1000;
  */
 export const MAX_RENDERED = 100;
 
+const LABEL_YEAR_FILTER_DEBOUNCE_MS = 300;
+let labelYearFilterTimer = 0;
+let labelDetailRequestToken = 0;
+
 /**
  * Build the URL for `/api/discogs/label/search`.
  * Pure for testability.
@@ -331,6 +335,7 @@ export function openLabelDetailFromList(rowEl, index) {
  * @param {string} labelName
  */
 export async function openLabelDetail(labelId, labelName) {
+  const requestToken = ++labelDetailRequestToken;
   state.browseLabel = { id: labelId, name: labelName };
   state.browseSubView = 'label';
   state.labelPage = 1;
@@ -350,12 +355,13 @@ export async function openLabelDetail(labelId, labelName) {
   body.innerHTML = '<div class="loading">Loading label catalogue...</div>';
 
   // Single fetch; the route auto-flips include_sublabels=false on big
-  // labels, and the adapter's 503 fallback (Plan 003 U4) handles the
+  // labels, and the adapter's 503 fallback (Plan 002 U3) handles the
   // genuinely-degraded case via `payload.sub_labels_dropped`. The old
   // empty-results retry was dead code once those two landed — removed
-  // in Plan 003 U5.
+  // in the follow-up label pagination work.
   try {
-    const payload = await loadLabelReleases(labelId, { include_sublabels: true, page: 1 });
+    const payload = await loadLabelReleases(labelId, { page: 1 });
+    if (requestToken !== labelDetailRequestToken) return;
     const totalCount = (payload && payload.label && payload.label.release_count) || 0;
     if (totalCount > BIG_LABEL_THRESHOLD) {
       // Flag the label as big so any future affordance that wants to
@@ -366,6 +372,7 @@ export async function openLabelDetail(labelId, labelName) {
     }
     renderLabelDetail(body, payload);
   } catch (e) {
+    if (requestToken !== labelDetailRequestToken) return;
     body.innerHTML = '<div class="loading">Failed to load label</div>';
   }
 }
@@ -377,13 +384,15 @@ export async function openLabelDetail(labelId, labelName) {
  */
 export async function goToLabelPage(page) {
   if (!state.browseLabel) return;
+  const requestToken = ++labelDetailRequestToken;
   const labelId = state.browseLabel.id;
-  const includeSub = !!(state.labelFilters && /** @type {any} */ (state.labelFilters).includeSubFromUI);
   // Read the current toggle state if present — bigLabel labels show an
   // explicit checkbox; default otherwise comes from the original load.
   const toggle = /** @type {HTMLInputElement|null} */ (
     document.getElementById('label-include-sublabels'));
-  const useSub = toggle ? toggle.checked : includeSub;
+  const currentBody = /** @type {any} */ (
+    document.getElementById('browse-label-body'));
+  const useSub = toggle ? toggle.checked : currentBody?._includeSub !== false;
 
   state.labelPage = page;
   const body = document.getElementById('browse-label-body');
@@ -394,8 +403,10 @@ export async function goToLabelPage(page) {
       include_sublabels: useSub,
       page,
     });
+    if (requestToken !== labelDetailRequestToken) return;
     renderLabelDetail(body, payload);
   } catch (_e) {
+    if (requestToken !== labelDetailRequestToken) return;
     body.innerHTML = '<div class="loading">Failed to load page ' + page + '</div>';
   }
 }
@@ -404,6 +415,7 @@ export async function goToLabelPage(page) {
  * Close the label detail view; show search results.
  */
 export function closeLabelDetail() {
+  labelDetailRequestToken++;
   state.browseLabel = null;
   state.labelFilters = { yearMin: null, yearMax: null, format: '', hideHeld: false };
   const browseLabel = document.getElementById('browse-label');
@@ -419,12 +431,7 @@ export function closeLabelDetail() {
  * @returns {Promise<Object>}
  */
 export async function loadLabelReleases(labelId, opts = {}) {
-  const includeSub = opts.include_sublabels !== false;
-  const url = `${API}${buildLabelDetailUrl(labelId, {
-    include_sublabels: includeSub,
-    page: opts.page,
-    per_page: opts.per_page,
-  })}`;
+  const url = `${API}${buildLabelDetailUrl(labelId, opts)}`;
   const r = await fetch(url);
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
   return await r.json();
@@ -489,12 +496,12 @@ export function renderLabelDetail(containerEl, payload) {
   const renderedNote = (pages > 1)
     ? `<div class="loading" style="text-align:left;padding:6px 0;color:#888;">Page ${currentPage} of ${pages} — ${totalCount} release${totalCount === 1 ? '' : 's'} total</div>`
     : '';
-  // Plan 003 U4 banner: the upstream returned 503 on the recursive
+  // Plan 002 U3 banner: the upstream returned 503 on the recursive
   // sub-label CTE; the adapter retried with sub-labels off. Surface
   // that to the user so they understand why the catalogue looks thinner
   // than the entity's release_count would suggest.
   const subLabelsDroppedBanner = subLabelsDropped
-    ? '<div class="loading" style="text-align:left;padding:6px 10px;margin:6px 0;color:#e0c060;background:#2a2410;border:1px solid #44391a;border-radius:4px;font-size:0.85em;">Sub-labels temporarily unavailable for this label — showing direct releases only.</div>'
+    ? '<div class="loading" style="text-align:left;padding:6px 10px;margin:6px 0;color:#e0c060;background:#2a2410;border:1px solid #44391a;border-radius:4px;font-size:0.85em;">Sub-labels unavailable for this label — showing direct releases only.</div>'
     : '';
   const bigLabelToggle = (totalCount > BIG_LABEL_THRESHOLD)
     ? `<label style="margin-left:10px;font-size:0.85em;color:#aaa;">
@@ -526,11 +533,11 @@ export function renderLabelDetail(containerEl, payload) {
       <span style="font-size:0.8em;color:#888;">Year</span>
       <input type="number" id="label-year-min" placeholder="min" value="${yMinVal}"
              style="width:80px;padding:4px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:13px;"
-             oninput="window.onLabelFilterChange()">
+             oninput="window.onLabelYearFilterInput()">
       <span style="color:#666;">–</span>
       <input type="number" id="label-year-max" placeholder="max" value="${yMaxVal}"
              style="width:80px;padding:4px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:13px;"
-             oninput="window.onLabelFilterChange()">
+             oninput="window.onLabelYearFilterInput()">
       <span style="font-size:0.8em;color:#888;margin-left:8px;">Format</span>
       <select id="label-format" onchange="window.onLabelFilterChange()"
               style="padding:4px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:13px;">
@@ -610,7 +617,7 @@ export function renderLabelRows(containerEl) {
     const fmt = rel.format ? `<span class="rg-meta"> — ${esc(rel.format)}</span>` : '';
     const artist = rel.artist_name ? `<span class="rg-meta" style="color:#999;"> — ${esc(rel.artist_name)}</span>` : '';
     return `
-      <div class="rg" onclick="event.stopPropagation(); window.loadReleaseGroup('${esc(String(rel.id))}', this)">
+      <div class="rg" onclick="event.stopPropagation(); window.loadReleaseGroup(${jsArg(String(rel.id))}, this)">
         <div>
           <span class="rg-year">${yearStr}</span>
           <span class="rg-title">${esc(rel.title || '')}</span>
@@ -670,6 +677,16 @@ export function onLabelFilterChange() {
   renderLabelRows(containerEl);
 }
 
+export function onLabelYearFilterInput() {
+  if (labelYearFilterTimer) {
+    window.clearTimeout(labelYearFilterTimer);
+  }
+  labelYearFilterTimer = window.setTimeout(() => {
+    labelYearFilterTimer = 0;
+    onLabelFilterChange();
+  }, LABEL_YEAR_FILTER_DEBOUNCE_MS);
+}
+
 /**
  * Toggle the include-sublabels opt-in (only shown for big labels).
  * Triggers a refetch.
@@ -677,13 +694,16 @@ export function onLabelFilterChange() {
  */
 export async function toggleLabelIncludeSublabels(include) {
   if (!state.browseLabel) return;
+  const requestToken = ++labelDetailRequestToken;
   const body = document.getElementById('browse-label-body');
   if (!body) return;
   body.innerHTML = '<div class="loading">Reloading...</div>';
   try {
     const payload = await loadLabelReleases(state.browseLabel.id, { include_sublabels: include });
+    if (requestToken !== labelDetailRequestToken) return;
     renderLabelDetail(body, payload);
   } catch (_e) {
+    if (requestToken !== labelDetailRequestToken) return;
     body.innerHTML = '<div class="loading">Failed to reload label</div>';
     toast('Failed to reload label', true);
   }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -6,7 +6,7 @@
  */
 
 import { state } from './state.js';
-import { searchArtists, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow } from './browse.js';
+import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow } from './browse.js';
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, setFilter, renderPipeline, toggleDetail, deleteRequest, updateStatus } from './pipeline.js';
@@ -15,7 +15,7 @@ import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
 import { loadManualImport, runManualImport } from './manual.js';
 import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup, deleteTransparentNonFlacWrongMatches, deleteLosslessOpusWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold, setWrongMatchConvergeCleanup } from './wrong-matches.js';
-import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, toggleLabelIncludeSublabels, goToLabelPage } from './labels.js';
+import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, onLabelYearFilterInput, toggleLabelIncludeSublabels, goToLabelPage } from './labels.js';
 import { toast } from './state.js';
 
 // --- Tab management ---
@@ -53,6 +53,7 @@ if (qInput) {
     clearTimeout(state.searchTimer ?? undefined);
     const q = qInput.value.trim();
     if (q.length < 2) {
+      cancelBrowseSearch();
       const results = document.getElementById('results');
       if (results) results.innerHTML = '';
       return;
@@ -118,6 +119,7 @@ Object.assign(window, {
   openLabelDetailFromList,
   closeLabelDetail,
   onLabelFilterChange,
+  onLabelYearFilterInput,
   toggleLabelIncludeSublabels,
   goToLabelPage,
   toast,

--- a/web/routes/_overlay.py
+++ b/web/routes/_overlay.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import Iterable
 
 
-def overlay_release_rows(rows: list[dict], release_ids: Iterable[str]) -> None:
+def overlay_release_rows_in_place(rows: list[dict], release_ids: Iterable[str]) -> None:
     """Annotate each release row with library + pipeline state in place.
 
     Parameters

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -18,7 +18,7 @@ from web import cache as _cache
 from web import discogs as discogs_api
 from lib.artist_compare import annotate_in_library, merge_discographies
 from web.library_artist_service import list_library_artist_rows
-from web.routes._overlay import overlay_release_rows
+from web.routes._overlay import overlay_release_rows_in_place
 
 if TYPE_CHECKING:
     from http.server import BaseHTTPRequestHandler
@@ -227,7 +227,7 @@ def get_release_group(h: BaseHTTPRequestHandler, params: dict[str, list[str]], r
     # Standard toolbar (Remove from beets) and badge renderer (in library
     # + codec-aware rank) read these overlay fields per row, so route
     # them through the shared helper.
-    overlay_release_rows(data["releases"], [r["id"] for r in data["releases"]])
+    overlay_release_rows_in_place(data["releases"], [r["id"] for r in data["releases"]])
     h._json(data)  # type: ignore[attr-defined]
 
 
@@ -304,7 +304,7 @@ def get_discogs_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]], 
 
 def get_discogs_master(h: BaseHTTPRequestHandler, params: dict[str, list[str]], master_id: str) -> None:
     data = discogs_api.get_master_releases(int(master_id))
-    overlay_release_rows(data["releases"], [r["id"] for r in data["releases"]])
+    overlay_release_rows_in_place(data["releases"], [r["id"] for r in data["releases"]])
     h._json(data)  # type: ignore[attr-defined]
 
 

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import msgspec
 
 from web import discogs as discogs_api
-from web.routes._overlay import overlay_release_rows
+from web.routes._overlay import overlay_release_rows_in_place
 
 if TYPE_CHECKING:
     from http.server import BaseHTTPRequestHandler
@@ -43,12 +43,12 @@ _INCLUDE_SUBLABELS_TRUE = {"true", "1"}
 _INCLUDE_SUBLABELS_FALSE = {"false", "0"}
 _INCLUDE_SUBLABELS_VALID = _INCLUDE_SUBLABELS_TRUE | _INCLUDE_SUBLABELS_FALSE
 
-# Pagination defaults + per_page upper bound. The discogs-api mirror clamps
-# per_page to 100 internally, but we accept up to 200 here so the bound is
-# governed by our policy, not happenstance of upstream behavior.
+# Pagination defaults + per_page upper bound. Match the discogs-api mirror's
+# label-release clamp so route tests and live upstream behavior share one
+# contract.
 _DEFAULT_PAGE = 1
 _DEFAULT_PER_PAGE = 100
-_MAX_PER_PAGE = 200
+_MAX_PER_PAGE = 100
 
 
 def _parse_positive_int(
@@ -176,25 +176,16 @@ def get_discogs_label_detail(
         raise
     releases = releases_resp["results"]
 
-    overlay_release_rows(releases, [r["id"] for r in releases])
-
-    # Sub-labels come through the entity's parent — we don't have a
-    # `sub_labels` list on the public LabelEntity by design (it's source-
-    # agnostic and MB will not return that shape). Phase A surfaces an
-    # empty list here; the discogs-api detail endpoint carries
-    # `sub_labels`, but the cratedigger adapter elides them on the
-    # entity. Frontend (U6) reads `sub_label_name` per release row for
-    # the rollup badge, which is what actually matters for rendering.
-    sub_labels: list[dict] = []
+    overlay_release_rows_in_place(releases, [r["id"] for r in releases])
 
     h._json({  # type: ignore[attr-defined]
         "label": _label_entity_payload(entity),
         "releases": releases,
-        "sub_labels": sub_labels,
+        "sub_labels": entity.sub_labels,
         "pagination": releases_resp.get("pagination", {}),
         "include_sublabels": releases_resp.get(
             "include_sublabels", include_sublabels),
-        # Plan 003 U4. Adapter sets True when an upstream 503 forced a
+        # Plan 002 U3. Adapter sets True when an upstream 503 forced a
         # fallback to include_sublabels=False; the UI surfaces a banner.
         # Default False on every successful response.
         "sub_labels_dropped": releases_resp.get("sub_labels_dropped", False),


### PR DESCRIPTION
## Summary
- make Discogs label detail avoid recursive rollups by default and fall back on timeout/503
- preserve pagination/sub-label UI state and harden inline JS arguments
- document the pool/timeout rollout and add regression coverage

## Verification
- nix-shell --run "bash scripts/run_tests.sh"
- focused Discogs/label Python tests
- pyright on touched Python
- node --check + JS util tests
- git diff --check