### PR TITLE
feat: Bad-rip button on pipeline tab

### DIFF
--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -2,6 +2,7 @@
 import { state, API, toast } from './state.js';
 import { esc, awstDate, awstDateTime, qualityLabel, externalReleaseUrl, sourceLabel } from './util.js';
 import { renderDownloadHistoryItem } from './history.js';
+import { renderBadRipButton } from './release_actions.js';
 
 /**
  * Load pipeline data from API and render.
@@ -249,8 +250,14 @@ export async function toggleDetail(elId, requestId) {
       <span class="p-detail-label" style="line-height:28px;">Status:</span>
       <button class="p-btn ${req.status === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'wanted')">wanted</button>
       <button class="p-btn ${req.status === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'imported')">imported</button>
-      <button class="p-btn ${req.status === 'manual' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'manual')">manual</button>
-      <button class="p-btn delete" onclick="event.stopPropagation(); window.deleteRequest(${id})">delete</button>
+      <button class="p-btn ${req.status === 'manual' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'manual')">manual</button>`;
+    // Bad-rip reuses the library renderer — pipelineId + releaseId are all
+    // it needs from state. Hidden when either is absent (issue #188).
+    html += renderBadRipButton(/** @type {any} */ ({pipelineId: id, releaseId: req.mb_release_id}), {
+      className: 'p-btn delete',
+      stopPropagation: true,
+    });
+    html += `<button class="p-btn delete" onclick="event.stopPropagation(); window.deleteRequest(${id})">delete</button>
     </div>`;
 
     el.innerHTML = html;


### PR DESCRIPTION
Follow-up to #190 — surfaces the same "Bad rip" action on the pipeline tab's detail panel so a row in `wanted` / `manual` / `imported` can be banned without first navigating to the library tab.

Pure reuse: imports `renderBadRipButton` from `web/js/release_actions.js` and feeds it a minimal `{pipelineId, releaseId}` state. Same `window.banSource(requestId, mbid)` onclick, same backend route, same toast handling.

## Test plan
- [ ] Open the pipeline tab on `music.ablz.au`, expand a row that's been imported (so `mb_release_id` is set), click "Bad rip" between the status buttons and the delete button — confirm the same confirmation dialog and toast as the library tab.
- [ ] `node --check web/js/pipeline.js` — already verified locally.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — pure UI surface calling an already-deployed and monitored route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)