### PR TITLE
feat: Record curator bad-rip click as a download_log event

### DIFF
--- a/migrations/009_curator_ban_outcome.sql
+++ b/migrations/009_curator_ban_outcome.sql
@@ -1,0 +1,12 @@
+-- 009_curator_ban_outcome.sql - record curator-marked bad-rip events
+--
+-- The "Bad rip" button (issue #188) is treated as just another download_log
+-- event so it surfaces uniformly on the recents tab, the pipeline tab's
+-- "last:" verdict line, and the per-row download history. Add the outcome
+-- to the CHECK constraint; the route writes the row via log_download with
+-- outcome='curator_ban'.
+
+ALTER TABLE download_log DROP CONSTRAINT IF EXISTS download_log_outcome_check;
+ALTER TABLE download_log ADD CONSTRAINT download_log_outcome_check
+    CHECK (outcome IN ('success', 'rejected', 'failed', 'timeout',
+                       'force_import', 'manual_import', 'curator_ban'));

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -566,6 +566,22 @@ class TestClassifyBadge(unittest.TestCase):
         self.assertEqual(result.badge, "Force imported")
         self.assertEqual(result.badge_class, "badge-force")
 
+    def test_curator_ban_with_username(self):
+        """#188 follow-up: bad-rip click surfaces as a download_log event."""
+        result = classify_log_entry(_entry(
+            outcome="curator_ban", soulseek_username="H@rco"))
+        self.assertEqual(result.badge, "Bad rip")
+        self.assertEqual(result.badge_class, "badge-rejected")
+        self.assertIn("H@rco", result.verdict)
+        self.assertIn("Marked bad rip", result.verdict)
+
+    def test_curator_ban_without_username(self):
+        """E1.1 — no uploader resolved → still surfaces, terser verdict."""
+        result = classify_log_entry(_entry(
+            outcome="curator_ban", soulseek_username=None))
+        self.assertEqual(result.badge, "Bad rip")
+        self.assertEqual(result.verdict, "Marked bad rip")
+
     def test_failed(self):
         result = classify_log_entry(_entry(outcome="failed", beets_scenario="exception"))
         self.assertEqual(result.badge, "Failed")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2027,6 +2027,7 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.mock_db.add_bad_audio_hashes.reset_mock()
         self.mock_db.add_bad_audio_hashes.return_value = 0
         self.mock_db.add_denylist.reset_mock()
+        self.mock_db.log_download.reset_mock()
         self.mock_db.get_request.return_value = make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
@@ -2079,6 +2080,17 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.mock_db.add_denylist.assert_called_once_with(
             1704, "Hxrco", "manually banned via web UI"
         )
+        # #188 follow-up: a download_log row records the ban event.
+        self.mock_db.log_download.assert_called_once()
+        log_kwargs = self.mock_db.log_download.call_args.kwargs
+        self.assertEqual(log_kwargs["request_id"], 1704)
+        self.assertEqual(log_kwargs["soulseek_username"], "Hxrco")
+        self.assertEqual(log_kwargs["outcome"], "curator_ban")
+        self.assertIn("Marked bad rip", log_kwargs["beets_detail"])
+        ban_meta = json.loads(log_kwargs["validation_result"])
+        self.assertEqual(ban_meta["scenario"], "curator_ban")
+        self.assertEqual(ban_meta["hashes_recorded"], 2)
+        self.assertEqual(ban_meta["denylisted_username"], "Hxrco")
 
     # AE4 — partial hash failure does not block the ban.
     @patch("web.routes.pipeline.hash_audio_content")
@@ -2148,6 +2160,11 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.assertIsNone(data["username"])
         self.assertEqual(data["hashes_recorded"], 1)
         self.assertNotIn("partial_failures", data)
+        # #188 follow-up: ban event still logged with NULL username.
+        self.mock_db.log_download.assert_called_once()
+        log_kwargs = self.mock_db.log_download.call_args.kwargs
+        self.assertEqual(log_kwargs["outcome"], "curator_ban")
+        self.assertIsNone(log_kwargs["soulseek_username"])
         # Hashes recorded with username=None.
         call_args = self.mock_db.add_bad_audio_hashes.call_args
         self.assertIsNone(call_args.args[1])

--- a/web/classify.py
+++ b/web/classify.py
@@ -414,6 +414,17 @@ def _classify(entry: LogEntry) -> tuple[str, str, str, str]:
         return ("Force imported", "badge-force", "#46a",
                 "Force imported after manual review")
 
+    # --- Curator ban (#188 follow-up: bad-rip click is just another event) ---
+    if entry.outcome == "curator_ban":
+        # validation_result JSONB carries hashes_recorded and the banned
+        # username; surface a terse human-readable verdict here. Detail
+        # already lives in beets_detail (e.g. "Marked bad rip; 12 hashes
+        # captured") which the row renderer can display directly.
+        verdict = "Marked bad rip"
+        if entry.soulseek_username:
+            verdict = f"Marked bad rip — denylisted {entry.soulseek_username}"
+        return ("Bad rip", "badge-rejected", "#a33", verdict)
+
     # --- Success ---
     if entry.outcome == "success":
         if _entry_decision(entry) == "provisional_lossless_upgrade":

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -920,6 +920,31 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     if hash_capture_errors:
         partial_failures["hash_capture_errors"] = hash_capture_errors
 
+    # Record the ban as a download_log event (#188 follow-up). It's just
+    # another event — surfacing it through the same audit channel makes
+    # it appear uniformly on recents, the pipeline tab's "last:" verdict
+    # line, and per-row download history without per-surface plumbing.
+    ban_detail = (
+        f"Marked bad rip; {hashes_recorded} hashes captured"
+        if hashes_recorded > 0
+        else "Marked bad rip (no tracks hashed)"
+    )
+    ban_validation = json.dumps({
+        "scenario": "curator_ban",
+        "hashes_recorded": hashes_recorded,
+        "denylisted_username": reported_username,
+        "reason": reason,
+        "cleanup_errors": cleanup_errors,
+        "hash_capture_errors": hash_capture_errors,
+    })
+    db.log_download(
+        request_id=request_id_int,
+        soulseek_username=reported_username,
+        outcome="curator_ban",
+        beets_detail=ban_detail,
+        validation_result=ban_validation,
+    )
+
     payload: dict[str, object] = {
         "status": "ok",
         "username": reported_username,


### PR DESCRIPTION
Follow-up to #190 / #191 — addresses the misleading "last: Force imported after manual review" line that persists on a row even after the curator bans it. The ban IS just another event, so write it to `download_log` and let every UI surface that reads download_log (recents, pipeline tab "last:" verdict, per-row download history) pick it up uniformly.

## Changes

- **`migrations/009_curator_ban_outcome.sql`** — extends the `download_log_outcome_check` CHECK to include `'curator_ban'` alongside the existing six outcomes.
- **`web/routes/pipeline.py`** — `post_pipeline_ban_source` writes a `download_log` row after hashes/denylist/remove/requeue settle. Reuses the existing `log_download` method (no new PipelineDB helper). `validation_result` JSONB carries the structured ban metadata; `beets_detail` carries a human-readable summary.
- **`web/classify.py`** — renders `outcome='curator_ban'` as badge "Bad rip" with red treatment, verdict `"Marked bad rip — denylisted <user>"` (or terser `"Marked bad rip"` for the E1.1 no-uploader case).

## Why a download_log row, not a separate audit table

Every existing UI surface (recents tab, pipeline tab "last:" line, library row download history) already reads `download_log`. Adding a new outcome value lets all three pick the event up for free; a separate audit table would need plumbing on every surface.

## Tests
- Two new `TestClassifyBadge` cases (with + without resolved username).
- Existing ban-source contract tests extended to assert `log_download` is called once per click with the right outcome, username, and `validation_result` JSONB shape (the test setUp now resets `log_download.reset_mock()` since `mock_db` is class-shared).
- Full suite: 2600 tests pass (was 2598; 2 new). pyright clean in nix-shell.

## Test plan
- [ ] After deploy, click "Bad rip" on the still-misleading Broken Social Scene row from before.
- [ ] Verify recents tab shows a "Bad rip" badge entry for the album.
- [ ] Verify pipeline tab's "last:" line for the row now reads "Marked bad rip — denylisted H@rco" (or similar) instead of "Force imported after manual review".
- [ ] Verify expanding the row shows a third entry in Download History titled "Bad rip" alongside the historical force-import + rejected attempts.

## Post-Deploy Monitoring & Validation

- `pipeline-cli query "SELECT COUNT(*) FROM download_log WHERE outcome='curator_ban'"` — expect to grow with curator clicks.
- No additional log monitoring required — this is a pure persistence change; the route was already audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)