### PR TITLE
feat(search): escalation ladder + forensic capture for stuck releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 # Claude Code — only ignore machine-specific files
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 tests/.slskd-creds.json
 tests/fixtures/albums/
 tests/fixtures/analysis_cache.json

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -550,9 +550,28 @@ def _log_search_result(album, result, ctx) -> None:
     )
     # Increment search_attempts + backoff for any non-found outcome.
     # Exhausted variants do not increment — the request will be flipped to
-    # manual by U6 and the attempt counter is the variant-ladder index.
+    # manual below and the attempt counter is the variant-ladder index.
     if result.outcome not in ("found", "exhausted"):
         db.record_attempt(request_id, "search")
+
+    # U6: variant ladder exhausted → flip request to status='manual' with
+    # manual_reason='search_exhausted'. The search_log row above is the
+    # audit trail; this status flip is a side effect after.
+    #
+    # Defensive: skip if status is already 'manual' to avoid clobbering an
+    # operator-set hold (a request flipped to 'manual' for an unrelated
+    # reason). `set_manual` itself will not overwrite an existing
+    # `manual_reason` with NULL, but re-flipping idempotently still
+    # rewrites the row's `updated_at` and broadcasts another status_history
+    # entry — neither is appropriate for an operator-held row.
+    if result.outcome == "exhausted":
+        row = db.get_request(request_id)
+        if row is not None and row.get("status") != "manual":
+            logger.info(
+                f"Flipping request {request_id} to manual "
+                f"(reason='search_exhausted')"
+            )
+            db.set_manual(request_id, manual_reason="search_exhausted")
 
 
 def _apply_find_download_result(album, result, find_result, failed_grab) -> None:

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -189,9 +189,15 @@ def _select_variant_for_album(album, search_cfg, db):
                 str(t["title"]) for t in tracks if t.get("title")
             ]
         except Exception:
-            logger.exception(
-                f"Failed to load variant inputs for request {request_id}; "
-                "falling back to default variant"
+            # Stable-greppable prefix: operators can count silent
+            # escalation-ladder bypasses via
+            # `journalctl -u cratedigger | grep VARIANT_SELECT_FALLBACK`.
+            # The fallback itself is intentional for DB resilience —
+            # this is the observability hook for it.
+            logger.warning(
+                "VARIANT_SELECT_FALLBACK request_id=%s artist=%s album=%s",
+                request_id, album.artist_name, album.title,
+                exc_info=True,
             )
             return SearchVariant(
                 kind="default", query=base_query or "",

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -82,6 +82,7 @@ from lib.matching import (
     check_ratio,
     get_album_by_id,
 )
+from lib.quality import top_candidates
 
 
 def filter_list(albums: Sequence[Any], filter_cfg: CratediggerConfig) -> list[Any] | None:
@@ -514,23 +515,6 @@ def _merge_search_result(result, ctx):
             ctx._dir_audio_count_ts.setdefault(username, {})[d] = time.time()
 
 
-def _top_candidates(candidates, limit=20):
-    """Return the top-N candidates sorted by (matched_tracks, avg_ratio) DESC.
-
-    Pure helper — no DB, no I/O. The forensic blob in `search_log.candidates`
-    must be capped so we don't write 1000+ rows of JSONB per cycle. Sorting
-    by matched_tracks first surfaces the closest peers; avg_ratio is the
-    secondary tiebreak so a 24/26 dir with high ratio beats a 24/26 dir with
-    low ratio.
-    """
-    sorted_candidates = sorted(
-        candidates,
-        key=lambda c: (c.matched_tracks, c.avg_ratio),
-        reverse=True,
-    )
-    return list(sorted_candidates[:limit])
-
-
 def _log_search_result(album, result, ctx) -> None:
     """Persist search outcome to search_log and record_attempt on failure."""
     request_id = getattr(album, "db_request_id", None)
@@ -545,7 +529,7 @@ def _log_search_result(album, result, ctx) -> None:
     outcome = result.outcome or "error"
     OUTCOMES_WITH_CANDIDATE_CONCEPT = ("no_results", "no_match", "found")
     if result.candidates:
-        top: list | None = _top_candidates(result.candidates)
+        top: list | None = top_candidates(result.candidates)
     elif outcome in OUTCOMES_WITH_CANDIDATE_CONCEPT:
         top = []
     else:

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -537,13 +537,25 @@ def _log_search_result(album, result, ctx) -> None:
     if not request_id:
         return
     db = ctx.pipeline_db_source._get_db()
-    top = _top_candidates(result.candidates) if result.candidates else None
+    # Plan U5 contract: outcomes where slskd actually ran but produced 0 hits
+    # ("no_results", "no_match") write candidates=[] (empty list, not NULL) so
+    # downstream readers can distinguish "search ran, found nothing" from
+    # "search never produced a candidate concept" (error, timeout, exhausted,
+    # empty_query — those write NULL).
+    outcome = result.outcome or "error"
+    OUTCOMES_WITH_CANDIDATE_CONCEPT = ("no_results", "no_match", "found")
+    if result.candidates:
+        top: list | None = _top_candidates(result.candidates)
+    elif outcome in OUTCOMES_WITH_CANDIDATE_CONCEPT:
+        top = []
+    else:
+        top = None
     db.log_search(
         request_id=request_id,
         query=result.query or None,
         result_count=result.result_count,
         elapsed_s=result.elapsed_s or None,
-        outcome=result.outcome or "error",
+        outcome=outcome,
         candidates=top,
         variant=result.variant_tag,
         final_state=result.final_state,

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -232,7 +232,11 @@ def search_for_album(album, ctx):
     t0 = time.time()
 
     db = ctx.pipeline_db_source._get_db()
-    variant, base_query = _select_variant_for_album(album, cfg, db)
+    # Use ctx.cfg (typed CratediggerContext) instead of the module-global
+    # `cfg`. The parallel path (`_submit_search`) takes its config as the
+    # `search_cfg` param wired from `ctx.cfg` at the call site, and this
+    # serial path matches that convention now.
+    variant, base_query = _select_variant_for_album(album, ctx.cfg, db)
     query = variant.query
 
     if variant.kind == "exhausted":

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -343,46 +343,38 @@ def search_for_album(album, ctx):
     return result
 
 
-def _submit_search(album, search_cfg, slskd_client, ctx):
+def _submit_search(album, variant, search_cfg, slskd_client):
     """Submit a search to slskd and return the search ID (no waiting).
 
     slskd has a SemaphoreSlim(1,1) on POST /searches — only one submission
     at a time. The semaphore releases after the search is queued (~100ms),
     so we submit sequentially but wait for results in parallel.
 
-    Returns (search_id, query, album_id, variant_tag) or:
-        ("__exhausted__", base_query, album_id, "exhausted") for the
-        variant-exhaustion sentinel — caller emits a SearchResult and skips
-        the slskd round-trip.
-        None on submission failure.
+    The caller is responsible for:
+      - selecting the variant (so the variant tag is known regardless of
+        outcome — see findings #9 and #18 in ce-code-review run
+        20260430-051904-682683b5)
+      - short-circuiting variant.kind == "exhausted" without calling here
+      - guarding against an empty `variant.query` if it ever happens
+
+    Returns (search_id, query, album_id, variant_tag) on success.
+    Returns None on submission failure — the caller still has `variant.tag`
+    available to record the failure with the right metadata.
 
     Variant-selection currency invariant:
-        We read `search_attempts` here (submit time) but `record_attempt`
-        increments at log time. Within a single album's lifecycle the
-        sequence submit→collect→log is strictly ordered, so the variant
-        selected here is what `_log_search_result` will persist. **If a
-        future refactor allows the same album to be submitted twice in
-        the same batch, both submissions will silently choose the same
-        variant — this comment is the regression fence.**
+        Variant selection happens at the caller (submit-time). The
+        sequence submit→collect→log is strictly ordered for a single
+        album, so the variant chosen by the caller is what
+        `_log_search_result` will persist.
     """
     import requests
 
     album_title = album.title
     artist_name = album.artist_name
     album_id = album.id
-
-    db = ctx.pipeline_db_source._get_db()
-    variant, base_query = _select_variant_for_album(album, search_cfg, db)
     query = variant.query
-
-    if variant.kind == "exhausted":
-        logger.info(
-            f"Variant ladder exhausted for '{artist_name} - {album_title}'; "
-            f"will record exhaustion without searching"
-        )
-        return ("__exhausted__", base_query or "", album_id, variant.tag)
-
     if not query:
+        # Defensive: caller should have caught this, but never submit empty.
         logger.warning(f"Cannot build search query for '{artist_name} - {album_title}'")
         return None
 
@@ -643,36 +635,65 @@ def _search_and_queue_parallel(albums, ctx):
     wall_start = time.time()
 
     def _submit_next() -> tuple[Any, Any] | None:
-        """Submit the next album from the queue. Returns (future, album) or None."""
+        """Submit the next album from the queue. Returns (future, album) or None.
+
+        Variant selection happens HERE, not inside ``_submit_search``. This
+        ensures every code path — exhausted, empty_query, slskd error — has
+        access to the chosen ``variant.tag`` so the persisted forensic row
+        always records which variant was attempted (findings #9 and #18 in
+        ce-code-review run 20260430-051904-682683b5).
+        """
+        from lib.search import SearchResult
+
         while album_queue:
             album = album_queue.pop(0)
-            submit_result = _submit_search(album, cfg, slskd, ctx)
-            if submit_result is None:
-                # Log the submission failure — reconstruct query for the log
-                from lib.search import build_query, SearchResult
-                query = build_query(album.artist_name, album.title,
-                                    prepend_artist=cfg.album_prepend_artist)
-                sr = SearchResult(
-                    album_id=album.id, success=False,
-                    query=query or "",
-                    outcome="empty_query" if not query else "error",
-                )
-                _log_search_result(album, sr, ctx)
-                failed_search.append(album)
-                continue
-            search_id, query, album_id, variant_tag = submit_result
-            if search_id == "__exhausted__":
+            db = ctx.pipeline_db_source._get_db()
+            variant, base_query = _select_variant_for_album(album, cfg, db)
+
+            if variant.kind == "exhausted":
                 # Variant ladder exhausted — emit a SearchResult inline, no
                 # slskd round-trip. U6 will flip the request to manual.
-                from lib.search import SearchResult
+                logger.info(
+                    f"Variant ladder exhausted for '{album.artist_name} - {album.title}'; "
+                    f"will record exhaustion without searching"
+                )
                 sr = SearchResult(
-                    album_id=album_id, success=False,
-                    query=query or "", elapsed_s=0.0, outcome="exhausted",
-                    variant_tag=variant_tag,
+                    album_id=album.id, success=False,
+                    query=base_query or "", elapsed_s=0.0, outcome="exhausted",
+                    variant_tag=variant.tag,
                 )
                 _log_search_result(album, sr, ctx)
                 failed_search.append(album)
                 continue
+
+            if not variant.query:
+                # No buildable query at all (no artist/title) — record
+                # empty_query with the chosen variant tag so forensics can
+                # still tell which variant was attempted.
+                sr = SearchResult(
+                    album_id=album.id, success=False,
+                    query=base_query or "",
+                    outcome="empty_query",
+                    variant_tag=variant.tag,
+                )
+                _log_search_result(album, sr, ctx)
+                failed_search.append(album)
+                continue
+
+            submit_result = _submit_search(album, variant, cfg, slskd)
+            if submit_result is None:
+                # slskd round-trip failed — preserve variant_tag in the log.
+                sr = SearchResult(
+                    album_id=album.id, success=False,
+                    query=variant.query,
+                    outcome="error",
+                    variant_tag=variant.tag,
+                )
+                _log_search_result(album, sr, ctx)
+                failed_search.append(album)
+                continue
+
+            search_id, query, album_id, variant_tag = submit_result
             future = pool.submit(
                 _collect_search_results, search_id, query, album_id, cfg, slskd,
                 variant_tag,

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -153,22 +153,108 @@ def _build_search_cache(
     return cache_entries, upload_speeds, dir_audio_counts
 
 
+def _select_variant_for_album(album, search_cfg, db):
+    """Choose which query variant to issue for `album` this cycle.
+
+    Pure-ish helper: reads `album_requests` + `album_tracks` (no slskd), feeds
+    the typed inputs into `lib.search.select_variant`. Returns the
+    ``SearchVariant`` and the deterministic base query so callers can
+    surface it in logs / SearchResult metadata.
+    """
+    from lib.search import build_query, select_variant, SearchVariant
+
+    base_query = build_query(
+        album.artist_name, album.title,
+        prepend_artist=search_cfg.album_prepend_artist,
+    )
+
+    request_id = getattr(album, "db_request_id", None)
+    search_attempts = 0
+    year: str | None = None
+    track_titles: list[str] = []
+    if request_id:
+        try:
+            row = db.get_request(request_id)
+            if row is not None:
+                attempts_val = row.get("search_attempts")
+                if isinstance(attempts_val, int):
+                    search_attempts = attempts_val
+                year_val = row.get("year")
+                # PostgreSQL returns int for INTEGER columns; coerce to str.
+                if year_val is not None:
+                    year = str(year_val)
+            tracks = db.get_tracks(request_id)
+            track_titles = [
+                str(t["title"]) for t in tracks if t.get("title")
+            ]
+        except Exception:
+            logger.exception(
+                f"Failed to load variant inputs for request {request_id}; "
+                "falling back to default variant"
+            )
+            return SearchVariant(
+                kind="default", query=base_query or "",
+                tag="default", slice_index=None,
+            ), base_query
+
+    # AlbumRecord falls back to year="0000" — select_variant treats that as
+    # unknown so V1 will be skipped.
+    if year is None:
+        rd = getattr(album, "release_date", None)
+        if isinstance(rd, str) and rd:
+            year = rd[:4]
+
+    if not base_query:
+        # Caller still needs a SearchVariant so the code path stays uniform.
+        return SearchVariant(
+            kind="default", query=None,
+            tag="default", slice_index=None,
+        ), base_query
+
+    variant = select_variant(
+        search_attempts=search_attempts,
+        threshold=search_cfg.search_escalation_threshold,
+        base_query=base_query,
+        year=year,
+        track_titles=track_titles,
+    )
+    return variant, base_query
+
+
 def search_for_album(album, ctx):
     """Search slskd for an album. Returns SearchResult (always non-None)."""
-    from lib.search import build_query, SearchResult
+    from lib.search import SearchResult
 
     album_title = album.title
     artist_name = album.artist_name
     album_id = album.id
     t0 = time.time()
-    query = build_query(artist_name, album_title, prepend_artist=cfg.album_prepend_artist)
+
+    db = ctx.pipeline_db_source._get_db()
+    variant, base_query = _select_variant_for_album(album, cfg, db)
+    query = variant.query
+
+    if variant.kind == "exhausted":
+        # No slskd round-trip — this is the cycle that flips to manual in U6.
+        logger.info(
+            f"Variant ladder exhausted for '{artist_name} - {album_title}'; "
+            f"recording exhaustion without searching"
+        )
+        return SearchResult(
+            album_id=album_id, success=False, query=base_query or "",
+            elapsed_s=0.0, outcome="exhausted",
+            variant_tag=variant.tag,
+        )
 
     if not query:
         logger.warning(f"Cannot build search query for '{artist_name} - {album_title}'")
-        return SearchResult(album_id=album_id, success=False, outcome="empty_query")
+        return SearchResult(
+            album_id=album_id, success=False, outcome="empty_query",
+            variant_tag=variant.tag,
+        )
 
     logger.info(f"Searching for album: {query} "
-                f"(from '{artist_name} - {album_title}')")
+                f"(from '{artist_name} - {album_title}', variant={variant.tag})")
     try:
         search = slskd.searches.search_text(
             searchText=query,
@@ -176,11 +262,15 @@ def search_for_album(album, ctx):
             filterResponses=True,
             maximumPeerQueueLength=cfg.maximum_peer_queue,
             minimumPeerUploadSpeed=cfg.minimum_peer_upload_speed,
+            responseLimit=cfg.search_response_limit,
         )
     except Exception:
         logger.exception(f"Failed to perform search via SLSKD: {query}")
-        return SearchResult(album_id=album_id, success=False, query=query,
-                            elapsed_s=time.time() - t0, outcome="error")
+        return SearchResult(
+            album_id=album_id, success=False, query=query,
+            elapsed_s=time.time() - t0, outcome="error",
+            variant_tag=variant.tag,
+        )
 
     # Wait for slskd to process the search. Searches go through:
     #   Queued -> InProgress -> Completed, (TimedOut|ResponseLimitReached|Errored)
@@ -190,15 +280,21 @@ def search_for_album(album, ctx):
     slskd_timeout_s = cfg.search_timeout / 1000 if cfg.search_timeout > 1000 else cfg.search_timeout
     poll_timeout_s = slskd_timeout_s * 2 + 15
     start_time = time.time()
+    final_state: str | None = None
     while True:
-        state = slskd.searches.state(search["id"], False)["state"]
+        state_resp = slskd.searches.state(search["id"], False)
+        state = state_resp["state"]
+        final_state = state
         if "Completed" in state or ("InProgress" not in state and "Queued" not in state):
             break
         time.sleep(1)
         if (time.time() - start_time) > poll_timeout_s:
             logger.error("Failed to perform search via SLSKD due to timeout on search results.")
-            return SearchResult(album_id=album_id, success=False, query=query,
-                                elapsed_s=time.time() - t0, outcome="timeout")
+            return SearchResult(
+                album_id=album_id, success=False, query=query,
+                elapsed_s=time.time() - t0, outcome="timeout",
+                variant_tag=variant.tag, final_state=final_state,
+            )
 
     search_results = slskd.searches.search_responses(search["id"])
     elapsed = time.time() - t0
@@ -207,8 +303,11 @@ def search_for_album(album, ctx):
         slskd.searches.delete(search["id"])
 
     if not len(search_results) > 0:
-        return SearchResult(album_id=album_id, success=False, query=query,
-                            result_count=0, elapsed_s=elapsed, outcome="no_results")
+        return SearchResult(
+            album_id=album_id, success=False, query=query,
+            result_count=0, elapsed_s=elapsed, outcome="no_results",
+            variant_tag=variant.tag, final_state=final_state,
+        )
 
     filter_specs = list(zip(cfg.allowed_filetypes, cfg.allowed_specs))
     cache_entries, upload_speeds, dir_audio_counts = _build_search_cache(
@@ -225,35 +324,59 @@ def search_for_album(album, ctx):
         query=query,
         result_count=len(search_results),
         elapsed_s=elapsed,
+        variant_tag=variant.tag,
+        final_state=final_state,
     )
     # Reuse the same merge path as the parallel pipeline
     _merge_search_result(result, ctx)
     return result
 
 
-def _submit_search(album, search_cfg, slskd_client):
+def _submit_search(album, search_cfg, slskd_client, ctx):
     """Submit a search to slskd and return the search ID (no waiting).
 
     slskd has a SemaphoreSlim(1,1) on POST /searches — only one submission
     at a time. The semaphore releases after the search is queued (~100ms),
     so we submit sequentially but wait for results in parallel.
 
-    Returns (search_id, query, album_id) or None on failure.
+    Returns (search_id, query, album_id, variant_tag) or:
+        ("__exhausted__", base_query, album_id, "exhausted") for the
+        variant-exhaustion sentinel — caller emits a SearchResult and skips
+        the slskd round-trip.
+        None on submission failure.
+
+    Variant-selection currency invariant:
+        We read `search_attempts` here (submit time) but `record_attempt`
+        increments at log time. Within a single album's lifecycle the
+        sequence submit→collect→log is strictly ordered, so the variant
+        selected here is what `_log_search_result` will persist. **If a
+        future refactor allows the same album to be submitted twice in
+        the same batch, both submissions will silently choose the same
+        variant — this comment is the regression fence.**
     """
-    from lib.search import build_query
     import requests
 
     album_title = album.title
     artist_name = album.artist_name
     album_id = album.id
-    query = build_query(artist_name, album_title, prepend_artist=search_cfg.album_prepend_artist)
+
+    db = ctx.pipeline_db_source._get_db()
+    variant, base_query = _select_variant_for_album(album, search_cfg, db)
+    query = variant.query
+
+    if variant.kind == "exhausted":
+        logger.info(
+            f"Variant ladder exhausted for '{artist_name} - {album_title}'; "
+            f"will record exhaustion without searching"
+        )
+        return ("__exhausted__", base_query or "", album_id, variant.tag)
 
     if not query:
         logger.warning(f"Cannot build search query for '{artist_name} - {album_title}'")
         return None
 
     logger.info(f"Submitting search: {query} "
-                f"(from '{artist_name} - {album_title}')")
+                f"(from '{artist_name} - {album_title}', variant={variant.tag})")
 
     # Retry on 429 (rate limit) or 409 (semaphore busy) with backoff.
     # slskd has SemaphoreSlim(1,1) — 409 means another search is still being submitted.
@@ -265,8 +388,9 @@ def _submit_search(album, search_cfg, slskd_client):
                 filterResponses=True,
                 maximumPeerQueueLength=search_cfg.maximum_peer_queue,
                 minimumPeerUploadSpeed=search_cfg.minimum_peer_upload_speed,
+                responseLimit=search_cfg.search_response_limit,
             )
-            return (search["id"], query, album_id)
+            return (search["id"], query, album_id, variant.tag)
         except requests.exceptions.HTTPError as e:
             status = e.response.status_code if e.response is not None else 0
             if status in (429, 409) and attempt < 5:
@@ -283,10 +407,14 @@ def _submit_search(album, search_cfg, slskd_client):
     return None
 
 
-def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client):
+def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client,
+                            variant_tag=None):
     """Wait for a submitted search to complete and collect results.
 
     This is the part that can run in parallel — it's just polling + reading.
+    `variant_tag` is the persisted tag chosen by `_submit_search` and is
+    plumbed onto the returned ``SearchResult`` so `_log_search_result` can
+    persist it without re-running variant selection.
     """
     from lib.search import SearchResult
 
@@ -301,10 +429,12 @@ def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client
     slskd_timeout_s = search_cfg.search_timeout / 1000 if search_cfg.search_timeout > 1000 else search_cfg.search_timeout
     timeout_s = slskd_timeout_s + slskd_timeout_s + 15  # worst case: responses arrive at T=timeout, then wait another timeout
     start_time = time.time()
+    final_state: str | None = None
     while True:
         try:
             state_resp = slskd_client.searches.state(search_id, False)
             state = state_resp["state"]
+            final_state = state
             if "Completed" in state or ("InProgress" not in state and "Queued" not in state):
                 break
         except Exception:
@@ -313,8 +443,11 @@ def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client
         time.sleep(1)
         if (time.time() - start_time) > timeout_s:
             logger.error(f"Search timed out for {query}")
-            return SearchResult(album_id=album_id, success=False, query=query,
-                                elapsed_s=time.time() - t0, outcome="timeout")
+            return SearchResult(
+                album_id=album_id, success=False, query=query,
+                elapsed_s=time.time() - t0, outcome="timeout",
+                variant_tag=variant_tag, final_state=final_state,
+            )
 
     search_results = slskd_client.searches.search_responses(search_id)
     elapsed = time.time() - t0
@@ -323,8 +456,11 @@ def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client
         slskd_client.searches.delete(search_id)
 
     if not len(search_results) > 0:
-        return SearchResult(album_id=album_id, success=False, query=query,
-                            result_count=0, elapsed_s=elapsed, outcome="no_results")
+        return SearchResult(
+            album_id=album_id, success=False, query=query,
+            result_count=0, elapsed_s=elapsed, outcome="no_results",
+            variant_tag=variant_tag, final_state=final_state,
+        )
 
     filter_specs = list(zip(search_cfg.allowed_filetypes, search_cfg.allowed_specs))
     cache_entries, upload_speeds, dir_audio_counts = _build_search_cache(
@@ -340,6 +476,8 @@ def _collect_search_results(search_id, query, album_id, search_cfg, slskd_client
         query=query,
         result_count=len(search_results),
         elapsed_s=elapsed,
+        variant_tag=variant_tag,
+        final_state=final_state,
     )
 
 
@@ -376,26 +514,53 @@ def _merge_search_result(result, ctx):
             ctx._dir_audio_count_ts.setdefault(username, {})[d] = time.time()
 
 
+def _top_candidates(candidates, limit=20):
+    """Return the top-N candidates sorted by (matched_tracks, avg_ratio) DESC.
+
+    Pure helper — no DB, no I/O. The forensic blob in `search_log.candidates`
+    must be capped so we don't write 1000+ rows of JSONB per cycle. Sorting
+    by matched_tracks first surfaces the closest peers; avg_ratio is the
+    secondary tiebreak so a 24/26 dir with high ratio beats a 24/26 dir with
+    low ratio.
+    """
+    sorted_candidates = sorted(
+        candidates,
+        key=lambda c: (c.matched_tracks, c.avg_ratio),
+        reverse=True,
+    )
+    return list(sorted_candidates[:limit])
+
+
 def _log_search_result(album, result, ctx) -> None:
     """Persist search outcome to search_log and record_attempt on failure."""
     request_id = getattr(album, "db_request_id", None)
     if not request_id:
         return
     db = ctx.pipeline_db_source._get_db()
+    top = _top_candidates(result.candidates) if result.candidates else None
     db.log_search(
         request_id=request_id,
         query=result.query or None,
         result_count=result.result_count,
         elapsed_s=result.elapsed_s or None,
         outcome=result.outcome or "error",
+        candidates=top,
+        variant=result.variant_tag,
+        final_state=result.final_state,
     )
-    # Increment search_attempts + backoff for any non-found outcome
-    if result.outcome != "found":
+    # Increment search_attempts + backoff for any non-found outcome.
+    # Exhausted variants do not increment — the request will be flipped to
+    # manual by U6 and the attempt counter is the variant-ladder index.
+    if result.outcome not in ("found", "exhausted"):
         db.record_attempt(request_id, "search")
 
 
 def _apply_find_download_result(album, result, find_result, failed_grab) -> None:
     """Translate matching/enqueue outcome into search_log telemetry."""
+    # Forensic capture: copy the per-(user, dir, filetype) score list off the
+    # find_download result onto the SearchResult so `_log_search_result` can
+    # persist the top-20 to `search_log.candidates`.
+    result.candidates = tuple(find_result.candidates)
     if find_result.outcome == "found":
         result.outcome = "found"
         return
@@ -456,7 +621,7 @@ def _search_and_queue_parallel(albums, ctx):
         """Submit the next album from the queue. Returns (future, album) or None."""
         while album_queue:
             album = album_queue.pop(0)
-            submit_result = _submit_search(album, cfg, slskd)
+            submit_result = _submit_search(album, cfg, slskd, ctx)
             if submit_result is None:
                 # Log the submission failure — reconstruct query for the log
                 from lib.search import build_query, SearchResult
@@ -470,9 +635,22 @@ def _search_and_queue_parallel(albums, ctx):
                 _log_search_result(album, sr, ctx)
                 failed_search.append(album)
                 continue
-            search_id, query, album_id = submit_result
+            search_id, query, album_id, variant_tag = submit_result
+            if search_id == "__exhausted__":
+                # Variant ladder exhausted — emit a SearchResult inline, no
+                # slskd round-trip. U6 will flip the request to manual.
+                from lib.search import SearchResult
+                sr = SearchResult(
+                    album_id=album_id, success=False,
+                    query=query or "", elapsed_s=0.0, outcome="exhausted",
+                    variant_tag=variant_tag,
+                )
+                _log_search_result(album, sr, ctx)
+                failed_search.append(album)
+                continue
             future = pool.submit(
-                _collect_search_results, search_id, query, album_id, cfg, slskd
+                _collect_search_results, search_id, query, album_id, cfg, slskd,
+                variant_tag,
             )
             return (future, album)
         return None

--- a/docs/brainstorms/search-escalation-and-forensics-requirements.md
+++ b/docs/brainstorms/search-escalation-and-forensics-requirements.md
@@ -1,0 +1,138 @@
+---
+date: 2026-04-29
+topic: search-escalation-and-forensics
+---
+
+# Search Escalation and Forensics for Stuck Releases
+
+## Problem Frame
+
+Releases like #1843 (The Wiggles, 1991 AU, 26 tracks) sit in `wanted` for weeks across dozens of search cycles, with `search_log` showing identical queries (`*he *iggles`), identical outcomes (`no_match`), and identical `result_count` (99–100). This is not a Soulseek availability problem — a manual search for `wiggles 1991` returns FLAC dirs with 26 tracks within seconds. It is a pipeline problem with three independent layers:
+
+1. **`responseLimit` defaults to 100** in the slskd-api Python client (`SlskdClient.searches.search_text`). Cratedigger does not override it. Every search caps at 100 peer responses, in arrival order, regardless of how many peers actually have matching content. For obscure releases the right peer never makes it into the cap.
+2. **The query never varies.** Cycle N issues exactly the same `build_query()` output as cycle 1. Re-running an identical search against a non-deterministic peer set is a closed loop: same query → same ~100-peer cap → same rejection → same 30-min sleep.
+3. **`album_match()` returns `bool`.** Per-track sequence-match ratios are computed (`lib/matching.py:29`) but discarded. A peer with 24 of 26 expected tracks looks identical to a peer with 0 of 26 in `search_log`. Operators cannot diagnose why a release is stuck because no forensic record of considered candidates is retained.
+
+This document defines the changes needed to (a) widen the search net, (b) escalate query strategy when a release fails to match, and (c) capture enough per-search forensics to make stuck releases self-explaining.
+
+The existing strict-match rule (a peer must score above `minimum_match_ratio` on **every** expected track to be accepted) is **out of scope and must be preserved**. Strict matching is also a defence at import time — confirming that 26/26 named tracks are present is how Cratedigger knows the candidate is the right release.
+
+---
+
+## Actors
+
+- A1. Pipeline search loop: builds queries, submits to slskd, collects responses, builds the grab list (`cratedigger.py:search_for_album`, `_submit_search`, `_collect_search_results`).
+- A2. Album matcher: scores candidate directories against the expected track list (`lib/matching.py:album_match`).
+- A3. Operator: inspects stuck releases via the web UI / `pipeline-cli` and decides whether to source manually, swap MBID, or abandon.
+- A4. NixOS module: exposes the `responseLimit` knob so it can be tuned without a code change.
+
+---
+
+## Key Flows
+
+- F1. Default search (cycles 1–4)
+  - **Trigger:** Release in `wanted` is selected for a search cycle.
+  - **Actors:** A1
+  - **Steps:** Build artist+album wildcarded query via the existing `lib/search.py:build_query`. Submit with `responseLimit=cfg.search_response_limit` (default 1000). Collect responses, build grab list, attempt to match.
+  - **Outcome:** Same as today for releases that match cycle 1; significantly more candidate peers per cycle for the rest.
+  - **Covered by:** R1, R2, R8
+
+- F2. Escalated search (cycles 5+)
+  - **Trigger:** `album_requests.search_attempts >= cfg.search_escalation_threshold` (default 5) with no successful match.
+  - **Actors:** A1
+  - **Steps:** Select a query variant deterministically from the cycle index. V1 first, then V4 with rotating track-token slices. Each cycle uses one variant.
+  - **Outcome:** Each escalated cycle samples a different ~1000-peer slice driven by a different query, increasing odds the correct peer enters the response cap.
+  - **Covered by:** R3, R4, R5
+
+- F3. Search exhaustion
+  - **Trigger:** Escalated search has cycled through V1 plus every distinct V4 token slice without a match.
+  - **Actors:** A1, A3
+  - **Steps:** Flip the request to `manual` with reason `search_exhausted`. The web UI surfaces the request as needing operator intervention. Forensic blob from the last N searches is queryable to inform the operator's decision.
+  - **Outcome:** The pipeline stops grinding on the release; the operator decides whether to source manually, swap MBID, abandon, or reset.
+  - **Covered by:** R6, R12
+
+- F4. Forensic capture per search
+  - **Trigger:** Every search cycle, regardless of outcome.
+  - **Actors:** A1, A2
+  - **Steps:** `album_match()` returns a structured score per candidate directory instead of a `bool`. The pipeline persists the top-20 candidates by score as a JSONB blob on `search_log.candidates`. The strict accept/reject decision (every track above `minimum_match_ratio`) is unchanged — only the intermediate state is now retained.
+  - **Outcome:** Operators can answer "did the right peer ever appear?" by reading `pipeline-cli show <id>` or querying the JSONB.
+  - **Covered by:** R7, R9, R10
+
+---
+
+## Requirements
+
+**Search Cap**
+
+- R1. The slskd-api `responseLimit` parameter must be passed explicitly on every search submission in `cratedigger.py:search_for_album` and `cratedigger.py:_submit_search`. The value must come from a typed config field on `CratediggerConfig`.
+- R2. The default value must be `1000`, with the ability to override via `cfg.search_response_limit`. The setting must be exposed as a NixOS module option in `nix/module.nix` so it can be tuned without a code change.
+
+**Query Escalation**
+
+- R3. A new typed config field `search_escalation_threshold` (default `5`) must control when escalation begins. While `search_attempts < threshold`, the search loop must use the existing `build_query()` output unchanged.
+- R4. Variant V1 ("append year"): take the existing `build_query()` output and append the release year (e.g. `1991`) as an additional token. If the release year is unknown, V1 must be skipped and the loop must advance directly to V4.
+- R5. Variant V4 ("distinctive track tokens"): build a candidate token pool from `album_tracks.title` for the request, normalize via the existing `strip_special_chars` / `strip_short_tokens` helpers, dedupe case-insensitively, and sort descending by length. Each V4 cycle takes the next 3 tokens from the pool. No artist tokens. No wildcarding.
+- R6. When V1 has run and V4 has exhausted its token pool without a match, the request must be flipped to `status='manual'` with a structured reason of `search_exhausted` recorded in the existing manual-reason audit field (or equivalent). The request must not re-enter the wanted queue automatically.
+
+**Forensic Capture**
+
+- R7. `lib/matching.py:album_match` must be refactored to return a structured per-directory score: `{matched_tracks: int, total_tracks: int, avg_ratio: float, missing_titles: list[str], best_per_track: list[float]}`. The current accept/reject behaviour must be preserved by a thin wrapper that reads `matched_tracks == total_tracks` from the structured score.
+- R8. A new column `search_log.candidates` (JSONB) must record up to the top 20 candidates per search, ordered by `matched_tracks DESC, avg_ratio DESC`. Each entry: `{username, dir, filetype, matched_tracks, total_tracks, avg_ratio, missing_titles, file_count}`.
+- R9. A new column `search_log.variant` (TEXT) must record which variant was used for the search (`default`, `v1_year`, `v4_tracks_<slice_index>`).
+- R10. A new column `search_log.final_state` (TEXT) must record the slskd terminal state (`Completed`, `ResponseLimitReached`, `TimedOut`, `Errored`) so operators can distinguish "we capped at 1000" from "slskd ran out of peers" without code spelunking.
+
+**Wire-up & Diagnostics**
+
+- R11. `pipeline-cli show <id>` must include the `variant` and top-3 candidate scores from the most recent search log row, so an operator triaging a release can see at a glance how the pipeline searched and what it found.
+- R12. The web UI's request detail view must display the search exhaustion state and surface a copy of the last forensic blob, so an operator does not need shell access to triage.
+
+---
+
+## Scope Boundaries
+
+**In scope**
+- Raising the slskd `responseLimit` and exposing it via the Nix module.
+- Variant-based query escalation after a configurable number of failed cycles.
+- Forensic capture of per-candidate scores for every search.
+- Search exhaustion as a terminal state.
+- Refactoring `album_match` to return structured scores while preserving its current accept/reject behaviour.
+
+**Deferred for later**
+- Loosening the strict 26/26 rule (e.g. accepting 24/26 with a high avg ratio). Out of scope by design — strict matching is also an import-time defence and a personal hard rule.
+- Variants V2 (country/format hints) and V3 (artist + tracks). User noted that release country and physical format almost never appear in Soulseek filenames; V2/V3 would burn cycles on signals peers don't index.
+- Pagination within a single slskd search. slskd has no "next page" concept; we widen via a higher `responseLimit` and via query variation across cycles.
+- Adaptive `responseLimit` (smaller for popular releases, larger for stuck ones). Premature optimisation; flat 1000 is the simple baseline. Revisit if slskd CPU pressure becomes an issue.
+- Retiring the `search_type = incrementing_page` legacy config key. It is read nowhere; cleanup can ride a later commit but is not required for this work.
+
+**Outside this brainstorm**
+- Anything about `responseFileLimit`, `minimumResponseFileCount`, `minimumPeerUploadSpeed` tuning. The current values are working for the rest of the catalogue.
+- Beets distance scoring at search time. The grab list scoring path lives in `lib/matching.py` and is the appropriate boundary; we are not introducing beets to the pre-import pipeline.
+
+---
+
+## Dependencies / Assumptions
+
+- D1. `album_tracks` is reliably populated for every release. Verified for #1843 (26 rows). If a release has no track rows, V4 cannot run and the loop must fall back to default + V1 only, then exhaust.
+- D2. The slskd default `responseLimit=100` is a soft, peer-side cap that slskd terminates gracefully at; raising to 1000 has no schema or protocol implication on slskd itself, only more CPU per search. (Verified empirically by inspecting `slskd-api` `search_text` defaults; needs operational confirmation under load.)
+- D3. `search_attempts` is incremented exactly once per cycle and is the single source of truth for which variant to dispatch. (Verified — `_log_search_result` in `cratedigger.py` calls `record_attempt` on failure.)
+- D4. Existing `search_log` rows do not need backfilling. New columns will be NULL for historical rows; tooling that reads them must accept NULL.
+
+---
+
+## Success Criteria
+
+- S1. After deploy, a single search cycle for #1843 (and other releases stuck at `search_attempts >= 5`) yields a `search_log.candidates` JSONB blob with at least one peer scoring `matched_tracks >= 20/26`, OR the loop reaches search exhaustion within ~4 hours and surfaces the request to the UI.
+- S2. The Nix module exposes a `services.cratedigger.searchResponseLimit` option (or equivalent) that flows into the rendered `config.ini` and is observable via `ssh doc2 'sudo cat /var/lib/cratedigger/config.ini'`.
+- S3. `pipeline-cli show <id>` for a stuck release shows the most recent variant and top candidate scores without requiring raw SQL.
+- S4. Existing tests in `tests/test_matching.py` and any harness/integration tests covering `album_match`'s accept/reject behaviour continue to pass without modification — strict match behaviour is preserved.
+- S5. New tests cover: variant selection from cycle index (pure function), V4 token pool construction (pure function over `album_tracks` rows), `album_match` structured-return refactor (RED test first that asserts structured shape; GREEN behaviour-preservation test), forensic JSONB capture (orchestration test asserting `search_log.candidates` shape post-search).
+- S6. Migration NNN_search_forensics.sql adds `candidates JSONB`, `variant TEXT`, `final_state TEXT` to `search_log` and runs cleanly via `tests.test_migrator`.
+
+---
+
+## Open Questions (defer to planning unless flagged)
+
+- O1. Where does the `search_exhausted` reason live exactly? `album_requests` does not currently have a `manual_reason` column; do we add one, reuse `import_result` JSONB with a sentinel, or create a dedicated `request_exhaustion` row? Planning decision.
+- O2. Should `search_attempts` be reset when an operator manually re-queues an exhausted release from the UI, so the variant ladder restarts at default? Probably yes; confirm in planning.
+- O3. The existing `_log_search_result` path runs after grab list construction. The forensic candidates list must be populated before persistence — confirm the call ordering does not require restructuring the search loop. Planning to verify.
+- O4. Does the Discogs-source path also flow through `album_match` and `search_log`, or is its grab list constructed differently? If the latter, decide whether forensic capture extends there or stays MB-only for now.

--- a/docs/plans/2026-04-29-006-feat-search-escalation-and-forensics-plan.md
+++ b/docs/plans/2026-04-29-006-feat-search-escalation-and-forensics-plan.md
@@ -1,0 +1,550 @@
+---
+title: Search Escalation and Forensics for Stuck Releases
+type: feat
+status: active
+date: 2026-04-29
+origin: docs/brainstorms/search-escalation-and-forensics-requirements.md
+---
+
+# Search Escalation and Forensics for Stuck Releases
+
+## Overview
+
+Cratedigger releases that fail to match on the first cycle (e.g. #1843 — The Wiggles 1991 AU, 26 tracks) currently grind through dozens of identical search cycles with no learning. The brainstorm identified three independent layers driving this: an unset `responseLimit` capping every search at 100 peer responses, a query that never varies cycle-to-cycle, and an `album_match()` boolean return that discards the per-track scores it computes.
+
+This plan implements: (a) raising `responseLimit` to 1000 by default and exposing it via the NixOS module; (b) a query escalation ladder that activates after 5 failed cycles, layering in V1 (append year) then V4 (rotating distinctive track-name tokens); (c) forensic capture of the top-20 candidate scores per search as JSONB on `search_log`; and (d) a terminal `search_exhausted` state that flips chronically stuck requests to `manual` for operator triage.
+
+The strict 26/26 accept rule in `album_match` is preserved — the refactor only stops discarding the intermediate scores. Strict matching remains a primary defence at both search time and import time.
+
+---
+
+## Problem Frame
+
+See origin: `docs/brainstorms/search-escalation-and-forensics-requirements.md`. The pipeline DB has 28 `search_log` rows for #1843, all with identical query (`*he *iggles`), all with `result_count` 99–100, all with outcome `no_match`, spanning a week. No record of what the 100 candidates were, no record of why they were rejected, and no mechanism to broaden the search across cycles. A manual Soulseek search for `wiggles 1991` returns FLAC dirs with 26 tracks within seconds — the data is on the network, the pipeline is asking the wrong question.
+
+---
+
+## Requirements Trace
+
+- R1. Pass `responseLimit` explicitly on every search; sourced from typed config field. *(see origin: R1)*
+- R2. Default 1000, exposed as a NixOS module option. *(see origin: R2)*
+- R3. Typed config field `search_escalation_threshold` (default 5) gates escalation. *(see origin: R3)*
+- R4. V1 = append year token; skip if year unknown. *(see origin: R4)*
+- R5. V4 = rotating 3-token slices of distinctive track tokens, no artist, no wildcard. *(see origin: R5)*
+- R6. Exhaustion flips request to `status='manual'` with structured `manual_reason='search_exhausted'`. *(see origin: R6)*
+- R7. `album_match` returns structured score; existing accept/reject behaviour preserved by thin wrapper. *(see origin: R7)*
+- R8. New JSONB `search_log.candidates` records top 20 by score. *(see origin: R8)*
+- R9. New `search_log.variant` text column. *(see origin: R9)*
+- R10. New `search_log.final_state` text column captures slskd terminal state. *(see origin: R10)*
+- R11. `pipeline-cli show <id>` surfaces variant + top-3 candidate scores. *(see origin: R11)*
+- R12. Web UI request detail surfaces exhaustion state and last forensic blob. *(see origin: R12)*
+
+**Origin actors:** A1 (pipeline search loop), A2 (album matcher), A3 (operator), A4 (NixOS module).
+**Origin flows:** F1 (default search), F2 (escalated search), F3 (search exhaustion), F4 (forensic capture per search).
+
+---
+
+## Scope Boundaries
+
+- Loosening the strict 26/26 rule is **not** in scope — explicit hard rule from origin and operator preference. *(see origin: Deferred for later)*
+- Variants V2 (country) and V3 (format hints) are **not** implemented — peers don't index those tokens. *(see origin: Deferred for later)*
+- No in-search pagination (slskd has no "next page"; we widen via `responseLimit` and across-cycle variation). *(see origin: Deferred for later)*
+- No adaptive `responseLimit` — flat 1000 baseline only. *(see origin: Deferred for later)*
+- The dead `search_type = incrementing_page` config key is left in place; cleanup is out of scope here. *(see origin: Deferred for later)*
+- No tuning of `responseFileLimit`, `minimumResponseFileCount`, `minimumPeerUploadSpeed`. *(see origin: Outside this brainstorm)*
+- No beets distance scoring at search time. *(see origin: Outside this brainstorm)*
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `cratedigger.py:search_for_album` (single-album path) and `cratedigger.py:_submit_search` / `_collect_search_results` (parallel path) both call `slskd.searches.search_text(...)` — `responseLimit` argument must be added to both call sites.
+- `cratedigger.py:_log_search_result` is the single persistence point for search outcomes; it is invoked from both the serial and parallel search loops after `find_download` runs. It calls `lib/pipeline_db.py:PipelineDB.log_search`. New columns will plumb through this function's signature.
+- `cratedigger.py:_apply_find_download_result` is the seam where `FindDownloadResult` is translated into `SearchResult.outcome`. This is where the candidates list will be copied off the find-download result onto the search result.
+- `lib/search.py:build_query` is the existing query builder. V1 reuses it as base. V4 bypasses it (no artist, no wildcard) and constructs its own token list using the same `strip_special_chars` / `strip_short_tokens` helpers.
+- `lib/matching.py:album_match` is the current bool-returning matcher. Per-track sequence-match ratios are computed via `difflib.SequenceMatcher.ratio()` and `check_ratio` retries. Today the function returns `True` only if every expected track scores above `minimum_match_ratio`; otherwise `False` with all intermediate state discarded.
+- `lib/matching.py:check_for_match` (line 171) is the function that iterates `dirs_to_try`, browses each, calls `album_track_num`, and **gates `album_match` behind `tracks_info["count"] == track_num and tracks_info["filetype"] != ""`** (line 244). It returns `tuple[bool, Any, str]` and stops at the first match. This is the actual forensic seam — extending its return type to include per-dir candidate scores is required, since `album_match` itself is invoked from here.
+- `lib/enqueue.py:try_enqueue` (line 180) and `try_multi_enqueue` (line 290) call `check_for_match` and currently consume only the bool/dir/file_dir tuple. Both must accept and forward the per-dir candidate scores.
+- `lib/enqueue.py:_try_filetype` (line 345) drives `try_enqueue`/`try_multi_enqueue` per filetype attempt; it is the natural aggregation point for candidate scores across filetype tries.
+- `lib/enqueue.py:find_download` (around line 413) drives `_try_filetype` per allowed filetype and returns `FindDownloadResult`. Extending `FindDownloadResult` with a `candidates: list[CandidateScore]` is the outermost plumbing seam — populated by `_try_filetype` from accumulated `check_for_match` results.
+- **The count-gate blind spot is load-bearing.** Today, dirs that fail `tracks_info["count"] == track_num` (e.g. a peer with 22 of 26 expected audio files) never reach `album_match` and would never produce a `CandidateScore`. Forensic capture MUST emit a cheap `CandidateScore` for sub-count dirs too — built from `album_track_num`'s output (`matched_tracks=0, total_tracks=expected_count, file_count=actual_count, missing_titles=[]`, `avg_ratio=0.0`). Without this, the JSONB blob would only contain the same handful of dirs that already pass the count gate, defeating the headline diagnostic goal of "did the right peer ever appear, even partially?".
+- `lib/matching.py:_track_titles_cross_check` runs **after** `album_match` returns True and gates the final accept. The strict-accept ordering (score → bool → cross-check → enqueue) must be preserved by U2.
+- `lib/config.py:CratediggerConfig` is the typed config dataclass; new fields (`search_response_limit`, `search_escalation_threshold`) follow the existing pattern in `from_ini`.
+- `nix/module.nix` lines 552+ define the `searchSettings` mkOption block; lines 143–155 render those values into the `config.ini` template. New options follow the same shape.
+- `migrations/` follows versioned-NNN convention; `001_initial.sql` defines `album_requests` (no `manual_reason` column today), `album_tracks`, and `search_log`. New migration is `009_search_forensics_and_manual_reason.sql`.
+- `lib/pipeline_db.py:log_search` is the only writer for `search_log` — its signature is the single-point change for new columns.
+- `tests/test_search.py` already exists for query-builder tests (extend for variant generator).
+- No `tests/test_matching.py` exists today; matching is exercised via `tests/test_integration.py` and `tests/test_integration_slices.py`. New test file `tests/test_matching.py` is the right home for the album_match refactor's pure-function tests.
+- `tests/fakes.py:FakePipelineDB` and `tests/helpers.py` provide the orchestration test surface; `_WebServerCase` in `tests/test_web_server.py` is the contract-test harness for U7's web changes.
+
+### Institutional Learnings
+
+- `.claude/rules/code-quality.md` § "Wire-boundary types": JSONB blobs read back from the DB and consumed at multiple sites are `msgspec.Struct`. The `CandidateScore` type written into `search_log.candidates` and read back in `pipeline-cli show` and the web UI is therefore a `msgspec.Struct` with symmetric `msgspec.json.encode` / `msgspec.convert` at the boundary.
+- `.claude/rules/code-quality.md` § "Pipeline Decision Debugging — Simulator-First TDD": variant selection is decision logic; the variant generator must be a pure function with subTest-table tests. `pipeline-cli quality`'s pattern is the right template — consider extending or adding `pipeline-cli search-variant <id> [--cycle N]` to dry-run variant selection without touching slskd.
+- `.claude/rules/code-quality.md` § "No Parallel Code Paths": both `search_for_album` (serial) and `_submit_search` (parallel) currently duplicate the slskd call site. New params (`responseLimit`) must be added in both. The serial path is rarely hit in production but must stay in lockstep.
+- `.claude/rules/pipeline-db.md`: schema lives in `migrations/NNN_name.sql` only. No DDL inside `PipelineDB` methods.
+- `.claude/rules/deploy.md`: cratedigger-db-migrate runs before cratedigger-web/cratedigger; the new migration applies automatically on `nixos-rebuild switch`.
+- Recent feat plans (e.g. `2026-04-29-005-feat-bad-rip-button-and-content-hash-defense-plan.md`) follow the unit/test/migration pattern this plan mirrors.
+
+### External References
+
+- slskd-api Python client `SlskdClient.searches.search_text` defaults: `responseLimit=100`, `fileLimit=10000`, `minimumResponseFileCount=1`, `searchTimeout=15000`, `filterResponses=True`. Confirmed via `inspect.signature` in dev shell.
+- slskd search states: `Queued -> InProgress -> Completed`, terminal: `TimedOut | ResponseLimitReached | Errored`. Already documented in `cratedigger.py` comments at lines 186 and 296.
+
+---
+
+## Key Technical Decisions
+
+- **Manual-reason column on `album_requests`.** Resolves origin O1. Add `manual_reason TEXT` (NULL by default; populated on system-driven flips like `search_exhausted`, available for future system flips). Rejected alternative: stuffing the reason into `reasoning` (used by request-creation flow for human-authored notes — overloading risks UI confusion). Rejected alternative: dedicated `request_exhaustion` table (over-modelling for one row per request; structured column on `album_requests` is queryable via `WHERE manual_reason = 'search_exhausted'`).
+- **Re-queue from manual resets `search_attempts` and clears `manual_reason`.** Resolves origin O2. The variant ladder is purely a function of `search_attempts`; restarting at 0 means the operator's manual re-queue starts at the default query, which is the right behaviour after an MBID swap or fix.
+- **Forensic candidates plumbed via `check_for_match` → `try_enqueue` → `_try_filetype` → `FindDownloadResult.candidates`.** Resolves origin O3. The seam is `check_for_match` (matching.py:171), not `_try_filetype` directly — `album_match` is invoked only from inside `check_for_match`. Both the count-gate-passing path (where `album_match` runs) and the count-gate-failing path (where `album_track_num` returns a sub-count) must emit a `CandidateScore`. `check_for_match` returns `(bool, dir, file_dir, list[CandidateScore])` (signature change). `try_enqueue` / `try_multi_enqueue` accumulate scores across dirs they iterate. `_try_filetype` aggregates across filetype attempts. `find_download` returns them on `FindDownloadResult`. `_apply_find_download_result` copies them onto `SearchResult.candidates`. `_log_search_result` passes them to `db.log_search` for top-20-by-score persistence.
+- **Discogs path inherits forensic capture for free.** Resolves origin O4. The Discogs source flows through the same `find_download` → `_try_filetype` → `album_match` path as MusicBrainz; the only difference is upstream metadata. No additional work needed; verify in U5 test scenarios.
+- **`CandidateScore` is a `msgspec.Struct`, not a `@dataclass`.** It crosses JSON twice — written into `search_log.candidates` JSONB by `log_search`, read back by `pipeline-cli show` and the web UI request-detail route. Symmetric strict validation at both boundaries per `code-quality.md` § Wire-boundary types.
+- **Variant generator is a pure function in `lib/search.py`.** No I/O, no DB, no slskd. Inputs: `search_attempts`, `escalation_threshold`, base-query string, `year: int | None`, `track_titles: list[str]`. Output: `SearchVariant` with kind (`default | v1_year | v4_tracks | exhausted`), the query string to issue, a `slice_index` for V4, and a stable `tag` (e.g. `default`, `v1_year`, `v4_tracks_3`) used for `search_log.variant`. The generator is deterministic for a given input — testable via subTest tables.
+- **V4 token pool ordering is by length descending, dedupe case-insensitively, drop short tokens (<=2 chars).** The token pool is computed once per search cycle (cheap — typically <30 tokens); the cycle index selects the slice. Pool exhaustion is detectable at generator level: `slice_index * 3 >= len(pool)` returns the `exhausted` sentinel.
+- **`search_log.final_state` captured from slskd's `state` field.** Both `search_for_album` and `_collect_search_results` already read `state_resp["state"]`; today they only check whether the search has terminated. They will record the final state string into the `SearchResult` so it can be persisted. This requires no extra slskd round-trip.
+- **`responseLimit=1000` flat, not adaptive.** Per origin scope. Slskd CPU impact is acknowledged (D2) but not measured here; if slskd performance regresses under load, revisit in a follow-up.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does `search_exhausted` reason live?** New `album_requests.manual_reason TEXT` column (NULL by default). See Key Technical Decisions.
+- **Reset `search_attempts` on manual re-queue?** Yes — and clear `manual_reason` at the same time. See Key Technical Decisions.
+- **Forensic plumbing without restructuring the search loop?** Yes — extend `FindDownloadResult` with a `candidates` list and copy through the existing `_apply_find_download_result` seam. See Key Technical Decisions.
+- **Discogs path forensic capture?** Inherits for free; same matching codepath. Test scenario added to U5 to verify.
+
+### Deferred to Implementation
+
+- The exact attribute name on `FindDownloadResult` for the candidates list — `candidates` is the working name; finalise during U5 if a clearer one emerges.
+- Whether the variant tag for V4 is `v4_tracks_<slice_index>` or includes the actual tokens. Implementation should pick whatever the diagnostics consumers (CLI + web UI) display most cleanly. Tag content is not a stable contract — purely informational for operators.
+- Whether to delete the dead `search_type = incrementing_page` config key during this work or in a follow-up. Origin says follow-up; revisit only if it actively interferes with U3.
+- Exact slskd-state mapping (e.g. is the status string `"Completed"` or `"Completed,ResponseLimitReached"` when both flags are set?). Verify by inspecting one live search response; not knowable until U5 implementation reads real state strings.
+- Whether `check_for_match` widens its return to a tuple `(bool, dict, str, list[CandidateScore])` or to a `MatchResult` dataclass. The dataclass is cleaner; the tuple is a smaller diff. Implementer's call.
+- Whether the U5 test infrastructure extension is `FakeSlskdSearches` (preferred for reuse) or an inline `MagicMock` (acceptable for a one-off). Decide at test-writing time based on whether other concurrent work also needs the fake.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Variant ladder (pure function):**
+
+```text
+inputs: search_attempts, threshold=5, base_query, year, track_titles
+
+if search_attempts < threshold:
+    -> SearchVariant(kind=default, query=base_query, tag="default")
+
+# escalation index = how many escalated cycles have happened
+esc_idx = search_attempts - threshold     # 0, 1, 2, ...
+
+if esc_idx == 0 and year is not None:
+    -> SearchVariant(kind=v1_year, query=base_query + " " + year, tag="v1_year")
+
+# V1 either ran (esc_idx 0) or was skipped (year missing). V4 starts at:
+v4_start = 1 if year is not None else 0
+v4_idx = esc_idx - v4_start
+
+pool = sorted(distinctive_tokens(track_titles), key=len, descending)
+slice_start = v4_idx * 3
+if slice_start >= len(pool):
+    -> SearchVariant(kind=exhausted)
+slice = pool[slice_start : slice_start + 3]
+-> SearchVariant(kind=v4_tracks, query=" ".join(slice), tag=f"v4_tracks_{v4_idx}")
+```
+
+**Forensic plumbing (data flow):**
+
+```mermaid
+flowchart LR
+    ATN["album_track_num<br/>per-dir audio count"] -->|count<expected| LOWSCORE["cheap CandidateScore<br/>(matched=0, file_count=N)"]
+    ATN -->|count==expected| AM["album_match (pure)<br/>returns AlbumMatchScore"]
+    AM --> CFM["check_for_match<br/>collects CandidateScore[]<br/>(returns bool, dir, file_dir, scores)"]
+    LOWSCORE --> CFM
+    CFM --> TE["try_enqueue / try_multi_enqueue<br/>aggregates across dirs"]
+    TE --> TF["_try_filetype<br/>aggregates across filetypes"]
+    TF --> FD["find_download<br/>FindDownloadResult.candidates"]
+    FD --> AFR["_apply_find_download_result<br/>copies onto SearchResult"]
+    AFR --> LSR["_log_search_result<br/>db.log_search(candidates=...)"]
+    LSR --> DB[("search_log<br/>candidates JSONB")]
+```
+
+The ownership boundary between matching and persistence does not change — `album_match` stays pure, `_log_search_result` stays the only writer. The signature changes propagate through `check_for_match` → `try_enqueue`/`try_multi_enqueue` → `_try_filetype` → `find_download`, but each is a strict expansion of the existing return tuple, not a behavioural change.
+
+---
+
+## Implementation Units
+
+- U1. **Migration: forensic columns + manual_reason**
+
+**Goal:** Add `candidates JSONB`, `variant TEXT`, `final_state TEXT` to `search_log`; add `manual_reason TEXT` to `album_requests`. All NULL-defaulting so historical rows remain readable.
+
+**Requirements:** R6, R8, R9, R10
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `migrations/009_search_forensics_and_manual_reason.sql`
+- Test: `tests/test_migrator.py` (existing — verifies the migration applies cleanly)
+
+**Approach:**
+- Plain SQL `ALTER TABLE … ADD COLUMN` statements, no `IF NOT EXISTS` guards (per `pipeline-db.md`: versioned migrations run once).
+- Single migration file covers both tables — they're applied atomically per the migrator's per-file transaction.
+- The migration also replaces the inline `search_log.outcome` CHECK constraint to add `'exhausted'`. The constraint at `migrations/001_initial.sql:119–121` is unnamed and inline, so Postgres auto-named it `search_log_outcome_check`. The replacement is:
+  ```sql
+  ALTER TABLE search_log DROP CONSTRAINT search_log_outcome_check;
+  ALTER TABLE search_log ADD CONSTRAINT search_log_outcome_check
+    CHECK (outcome IN ('found','no_match','no_results','timeout','error','empty_query','exhausted'));
+  ```
+  The migrator runs each file in its own transaction, so the DROP+ADD is atomic — no window where the constraint is missing.
+
+**Patterns to follow:**
+- `migrations/008_bad_audio_hashes.sql` for SQL style and column ordering.
+
+**Test scenarios:**
+- Happy path: migration applies cleanly to a fresh DB and the resulting `search_log` and `album_requests` have the new columns with correct types and NULL defaults. Covered by the existing `tests.test_migrator.TestMigrator` mechanism, which loads each migration file and asserts the resulting schema.
+- Edge case: migration applies cleanly when re-run against an already-migrated DB (handled by the migrator's `schema_migrations` version check, but verify the migration file doesn't accidentally include any non-idempotent operations).
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_migrator -v"` passes with the new migration in place.
+- After deploy, `ssh doc2 'pipeline-cli query "SELECT column_name FROM information_schema.columns WHERE table_name=\\'search_log\\'"'` includes `candidates`, `variant`, `final_state`. Same query on `album_requests` includes `manual_reason`.
+
+---
+
+- U2. **Refactor `album_match` to return structured scores; widen `check_for_match` to capture sub-count dirs**
+
+**Goal:** Replace `album_match`'s `bool` return with an `AlbumMatchScore` dataclass exposing the per-track scores already computed. Extend `check_for_match` to (a) accumulate scores across every dir it iterates and (b) emit a cheap `CandidateScore` for dirs that fail the count gate (so the forensic log captures "this peer had 22 of 26 audio files"). Preserve the current accept/reject behaviour exactly: strict match still requires every track above `minimum_match_ratio` AND the existing `_track_titles_cross_check`.
+
+**Requirements:** R7
+
+**Dependencies:** None (pure-function refactor; can land before or after U1).
+
+**Files:**
+- Modify: `lib/matching.py` (`album_match`, `check_for_match`)
+- Modify: `lib/enqueue.py` (`try_enqueue`, `try_multi_enqueue`, `_try_filetype` — accept and forward the candidate scores list)
+- Create: `tests/test_matching.py`
+
+**Approach:**
+- Define `AlbumMatchScore` (`@dataclass` — purely internal, never crosses JSON in this form): `matched_tracks: int, total_tracks: int, avg_ratio: float, missing_titles: list[str], best_per_track: list[float]`. The persisted forensic record (`CandidateScore` in U5) is a derivative struct that adds `username`, `dir`, `filetype`, `file_count`.
+- Refactor `album_match` to compute and return `AlbumMatchScore` for every input. The `ignored_users` check stays out of the pure scoring function (handled at the `check_for_match` layer).
+- Refactor `check_for_match` to return `tuple[bool, dict, str, list[CandidateScore]]` (or a small `MatchResult` dataclass — pick during implementation; the tuple is conservative). For every dir in `dirs_to_try`:
+  - If `tracks_info["count"] != track_num` or `tracks_info["filetype"] == ""`: emit a cheap `CandidateScore` with `matched_tracks=0`, `total_tracks=len(tracks)`, `avg_ratio=0.0`, `missing_titles=[]`, `file_count=tracks_info["count"]`. This is the count-gate-failure capture.
+  - If the count gate passes: call `album_match`, build a full `CandidateScore` from the resulting `AlbumMatchScore` plus the contextual `username`, `dir`, `filetype`, and `file_count`.
+  - The existing strict-accept logic (every track above ratio + `_track_titles_cross_check`) stays in place, in this order: score → bool → cross-check → return True. When the cross-check fails, the dir is logged as a warning today (matching.py:248) and the loop continues — preserve this behaviour, and also append the score to the candidates list so the forensic record captures the cross-check rejection.
+- `try_enqueue` (enqueue.py:180) and `try_multi_enqueue` (enqueue.py:290) must be updated to accept the new return shape and forward the candidate scores. Their existing return type to `_try_filetype` must also widen to carry the scores.
+- `_try_filetype` (enqueue.py:345) accumulates candidate scores across filetype attempts (each filetype try iterates dirs separately). Pass the accumulated list back via the existing return path.
+
+**Execution note:** Test-first. Write `tests/test_matching.py` with the structured-return shape assertions and the strict-accept regression cases before changing `lib/matching.py`. The refactor is observable behaviour-preserving — the test suite must still pass after the bool→score swap.
+
+**Patterns to follow:**
+- Existing typed `@dataclass` returns elsewhere in `lib/matching.py` (e.g. `album_track_num`'s dict return — replace this idiom with a typed return on touch, but only if it's directly impacted; otherwise out of scope).
+- subTest table style from `tests/test_quality_decisions.py:TestSpectralImportDecision`.
+
+**Execution note:** Test-first. Write `tests/test_matching.py` with the structured-return shape assertions and the strict-accept regression cases before changing `lib/matching.py`. The refactor is observable behaviour-preserving — the test suite must still pass after the bool→score swap.
+
+**Patterns to follow:**
+- Existing typed `@dataclass` returns elsewhere in `lib/matching.py` (e.g. `album_track_num`'s dict return — replace this idiom with a typed return on touch, but only if it's directly impacted; otherwise out of scope).
+- subTest table style from `tests/test_quality_decisions.py:TestSpectralImportDecision`.
+
+**Test scenarios:**
+
+`album_match` (pure):
+- Happy path: dir with all 26 tracks named exactly → `matched_tracks==total_tracks==26`, `avg_ratio` near 1.0, `missing_titles=[]`. Strict-accept callers see True.
+- Happy path: dir with 24 of 26 tracks (2 missing entirely from filenames) → `matched_tracks=24`, `total_tracks=26`, `missing_titles=[<2 titles>]`. Strict-accept callers see False; structured score is still returned for forensic capture.
+- Edge case: dir where every track filename has prefix `01 - Title` style → `check_ratio` separator logic kicks in; matched_tracks should still be 26.
+- Edge case: dir with album-name prefix `The Wiggles - Title.mp3` → matched via the `album_name + " " + expected_filename` retry path.
+- Edge case: catch-all filetype (`*`) — extension comes from slskd filename; per-track ratios computed against `<title>.<inferred-ext>`.
+- Edge case: empty `slskd_tracks` list → `matched_tracks=0`, `total_tracks=len(expected)`, `missing_titles` lists every expected title.
+- Error path: `expected_tracks` is empty (defensive — should never happen in practice but the function dereferences `expected_tracks[0]` for album metadata) → document the precondition; either raise or short-circuit, decide during implementation.
+
+`check_for_match` (sub-count capture):
+- Happy path: every dir in `dirs_to_try` passes the count gate → list of `CandidateScore` has one entry per dir, all built from `album_match` output.
+- Happy path (sub-count): dir with `tracks_info["count"]=22, track_num=26` → cheap `CandidateScore` emitted with `matched_tracks=0, total_tracks=26, file_count=22, avg_ratio=0.0`. `album_match` is NOT called for this dir. List ordering is preserved.
+- Edge case: dir with `tracks_info["filetype"]==""` (no audio files at all) → cheap `CandidateScore` with `file_count=0`.
+- Edge case: cross-check failure on an otherwise-strict-accept dir → the dir is added to `negative_matches`, the loop continues, AND the score is appended to the candidates list with the per-track scores intact (cross-check failure is observable in forensic output even though it doesn't have a dedicated field — operators can infer from "matched_tracks==total_tracks but no enqueue").
+- Edge case: first dir already strict-accepts → `check_for_match` returns True immediately; only this dir's score is in the list (the historical short-circuit behaviour is preserved).
+- Strict-accept regression: every existing accept-then-cross-check-then-return path still produces the same final `(bool, dir, file_dir)` triplet today (the new fourth element is additive).
+
+Integration:
+- `tests/test_integration.py` and `tests/test_integration_slices.py` cases that exercise the matching path must still pass without modification (S4).
+
+**Verification:**
+- New tests pass; the full suite (`nix-shell --run "bash scripts/run_tests.sh"`) shows no regressions in `tests/test_integration*` or any other matching-adjacent tests.
+
+---
+
+- U3. **Config + Nix module wiring for `responseLimit` and `escalation_threshold`**
+
+**Goal:** Add `search_response_limit: int = 1000` and `search_escalation_threshold: int = 5` to `CratediggerConfig`. Render via `config.ini`. Expose `search_response_limit` as a NixOS module option (escalation threshold can be config-only for now — operators rarely tune it).
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `lib/config.py`
+- Modify: `nix/module.nix`
+- Test: extend `tests/test_config.py` (existing) for the new fields.
+- Test: `nix-shell --run "nix build .#checks.x86_64-linux.moduleVm"` for the module change.
+
+**Approach:**
+- Add typed fields to `CratediggerConfig` with defaults; read via `getint` in `from_ini`.
+- Render in `config.ini` template under `[Search Settings]` next to `search_timeout` and friends.
+- Add `searchSettings.searchResponseLimit` to the mkOption block, default 1000, description ties it to slskd's `responseLimit` ceiling.
+- Both options carry safe defaults so the module change is transparent to existing deployments.
+
+**Patterns to follow:**
+- Existing `searchSettings.searchTimeout` mkOption (line 553 area) for option declaration shape.
+- Existing config rendering at module.nix lines 143–156 for the formatting.
+- Existing `getint` usage in `lib/config.py:from_ini` for the loader.
+
+**Test scenarios:**
+- Happy path: `from_ini` with `[Search Settings]\nsearch_response_limit = 1500` produces a config with `search_response_limit == 1500`.
+- Happy path: missing `[Search Settings]` keys → defaults of 1000 and 5 respectively.
+- Edge case: `from_ini` with `search_response_limit = 0` — document expected behaviour. Either accept and let slskd reject, or reject in `from_ini`. Recommend: accept and let it fall through; defensive validation at config layer is out of scope.
+- Integration (Nix module VM): the rendered `config.ini` contains the `search_response_limit = 1000` line under `[Search Settings]`.
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_config -v"` passes.
+- `nix-shell --run "nix build .#checks.x86_64-linux.moduleVm"` passes.
+
+---
+
+- U4. **Variant generator (pure function)**
+
+**Goal:** Implement `select_variant(search_attempts, threshold, base_query, year, track_titles) -> SearchVariant` in `lib/search.py`. Pure function. Single source of truth for which query to issue per cycle.
+
+**Requirements:** R3, R4, R5, R6 (exhaustion sentinel)
+
+**Dependencies:** None (pure function; testable in isolation).
+
+**Files:**
+- Modify: `lib/search.py` (add `SearchVariant` dataclass, `select_variant`, helper `_distinctive_token_pool`)
+- Modify: `tests/test_search.py` (extend with variant-generator subTest tables)
+
+**Approach:**
+- `SearchVariant` is a `@dataclass` (internal, never crosses JSON): `kind: Literal["default", "v1_year", "v4_tracks", "exhausted"]`, `query: str | None` (None for `exhausted`), `tag: str` (persisted to `search_log.variant`), `slice_index: int | None` (V4 only, for diagnostics).
+- `_distinctive_token_pool(track_titles)` reuses `strip_special_chars` and `strip_short_tokens`; dedupes case-insensitively; sorts by token length descending. Returns `list[str]`.
+- `select_variant` is the deterministic ladder per the High-Level Technical Design pseudo-code. No I/O.
+- **Year input is `str | None`, with `"0000"` treated as unknown.** `AlbumRecord.release_date` (album_source.py:119–130) falls back to the literal string `"0000"` when MB has no year. `select_variant` must treat `year is None or year.startswith("0000")` as "year unknown" and skip V1. Caller is responsible for parsing the 4-char prefix; the function accepts the raw string for simplicity.
+- The `tag` value is what gets persisted: `default`, `v1_year`, `v4_tracks_0`, `v4_tracks_1`, etc. `exhausted` is also a tag, used by the search loop to short-circuit before hitting slskd.
+
+**Execution note:** Test-first. The variant ladder is decision logic; per `code-quality.md` § Pipeline Decision Debugging, the simulator-style test is the spec.
+
+**Patterns to follow:**
+- subTest table style from `tests/test_quality_decisions.py:TestSpectralImportDecision`.
+- Pure-function discipline from `lib/search.py:build_query` (already pure).
+
+**Test scenarios:**
+- Happy path (table): cycle 0–4 → kind=default, query=base_query, tag=default. Cycle 5 with year=1991 → kind=v1_year, query=`<base> 1991`, tag=v1_year. Cycle 6 → kind=v4_tracks, slice_index=0, query=top-3 tokens, tag=v4_tracks_0. Cycle 7 → slice_index=1, etc.
+- Edge case: year=None → cycle 5 skips V1, goes directly to V4 slice 0.
+- Edge case: year=`"0000"` (literal MB-fallback string) → treated as unknown; cycle 5 skips V1.
+- Edge case: year=`"0000-00-00"` → also treated as unknown via the `startswith("0000")` check.
+- Edge case: track_titles=[] (no track rows) → cycle 5 with year=1991 returns v1_year; cycle 6 returns exhausted (V4 has no pool).
+- Edge case: track_titles=[] and year=None → cycle 5 returns exhausted immediately.
+- Edge case: `_distinctive_token_pool` with all duplicate-after-dedupe tokens → pool is the deduped set; slice_index that overshoots returns exhausted.
+- Edge case: cycle 100 with a 3-token pool → exhausted (only one V4 slice available; subsequent cycles all exhausted).
+- Edge case: token pool of size 7 with year present → v1 at cycle 5, v4 slices at cycles 6 (idx 0, tokens 0-2), 7 (idx 1, tokens 3-5), 8 (idx 2, tokens 6-6 — single token), 9 (exhausted).
+- Happy path: tag value matches the format `v4_tracks_<idx>` exactly so it can be parsed by diagnostics.
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_search -v"` shows the new variant tests passing.
+- All existing `tests.test_search` cases still pass.
+
+---
+
+- U5. **Wire variants + responseLimit + forensic capture into the search loop**
+
+**Goal:** Pass `responseLimit` on every slskd search; route every cycle through `select_variant`; capture top-20 candidate scores per search; record final slskd state. End-to-end plumbing across `search_for_album`, `_submit_search`, `_collect_search_results`, `_apply_find_download_result`, `_log_search_result`, `lib/enqueue.py:find_download`, `lib/matching.py:_try_filetype`.
+
+**Requirements:** R1, R2, R7 (consumer), R8, R9, R10
+
+**Dependencies:** U1 (DB columns), U2 (album_match returns scores), U3 (config fields), U4 (variant generator).
+
+**Files:**
+- Modify: `cratedigger.py` (search_for_album, _submit_search, _collect_search_results, _apply_find_download_result, _log_search_result)
+- Modify: `lib/enqueue.py` (find_download, FindDownloadResult)
+- Modify: `lib/matching.py` (_try_filetype to accumulate CandidateScore entries)
+- Modify: `lib/search.py` (extend SearchResult with candidates, variant_tag, final_state fields)
+- Modify: `lib/pipeline_db.py` (extend log_search signature with candidates, variant, final_state kwargs)
+- Create: `lib/quality.py` *or* a new `lib/search_forensics.py` module — define `CandidateScore` as `msgspec.Struct` (this is the wire-boundary type written into JSONB). Decide module placement during implementation; bias toward `lib/quality.py` since it's where the existing wire-boundary types like `ImportResult` live.
+- Test: extend `tests/test_integration_slices.py` with a slice that runs find_download + log_search end-to-end with FakePipelineDB.
+- Test: `tests/test_pipeline_db.py` — log_search persists candidates as JSONB.
+- Test: extend `tests/test_search.py` or add `tests/test_search_loop.py` for the search_for_album wrap that selects a variant and passes it to slskd.
+
+**Approach:**
+- Look up `db_request_id` (and from there, `search_attempts`, `release_date`, track titles) at the top of `search_for_album` / pre-`_submit_search`. Call `select_variant` with those inputs to get the variant. Use `variant.query` for the slskd call instead of `build_query()`. Short-circuit on `kind=="exhausted"` — do not call slskd; mark the SearchResult with outcome=`exhausted` (new outcome value — handled by U1's CHECK constraint replacement) and let `_log_search_result` flip the request to `manual` in U6.
+- Pass `responseLimit=cfg.search_response_limit` on the `slskd.searches.search_text` call in both `search_for_album` and `_submit_search`.
+- Capture `state_resp["state"]` as the final state when polling terminates and carry it on `SearchResult.final_state`. **Serial-path note:** `cratedigger.py:194` currently reads `state` as a one-line expression and does not bind `state_resp`. Refactor to `state_resp = slskd.searches.state(search["id"], False); state = state_resp["state"]; ...; result.final_state = state` so the value is available at termination. Parallel path at `cratedigger.py:306` already binds `state_resp` correctly.
+- Forensic plumbing follows the corrected call graph (see Key Technical Decisions and the High-Level Technical Design diagram): `check_for_match` accumulates the `CandidateScore` list (covering both the count-gate-passing path through `album_match` and the count-gate-failing path with cheap synthetic scores). `try_enqueue` and `try_multi_enqueue` forward the list back to `_try_filetype`, which aggregates across filetype attempts. The same dir scored under two different filetypes is two distinct entries (legitimate diagnostic information). `find_download` returns the aggregated list on `FindDownloadResult.candidates`.
+- `_apply_find_download_result` copies `find_result.candidates` onto `SearchResult.candidates`.
+- `_log_search_result` truncates to top-20 by `(matched_tracks DESC, avg_ratio DESC)` and passes through to `db.log_search(candidates=..., variant=..., final_state=...)`. `log_search` encodes via `msgspec.json.encode` per `code-quality.md` § Wire-boundary types and writes the `candidates` parameter as JSONB.
+- **Other `SearchResult` construction sites (parallel-path failure handling).** `cratedigger.py:462–470` (parallel submit failure — empty query / submit raise) and `cratedigger.py:498` (parallel collection crash — exception during `future.result()`) both construct ad-hoc `SearchResult` objects without forensic fields. These call `_log_search_result` and must continue to. The new `candidates`, `variant`, and `final_state` fields default to `[]` / `None` / `None` for these failure rows — explicitly NULL in the DB. This is correct behaviour: failure rows have no scoring data to report.
+- **Variant-selection currency invariant (brittle but currently safe).** Variant selection reads `search_attempts` at submit time; `record_attempt` increments at log time. In the parallel pipeline, two albums in flight are always different albums (the `wanted` queue does not duplicate). Within a single album's lifecycle, submit→collect→log is sequential per album, so `search_attempts` cannot drift between submit and log. **Add a one-line comment in `_submit_search` flagging this invariant** — any future refactor that allowed the same album to be submitted twice in one batch would silently pick the same variant.
+
+**Execution note:** Implement after U1, U2, U3, U4 are merged or stacked. The integration test in `tests/test_integration_slices.py` is the verification surface — RED first against the empty `candidates` JSONB, GREEN after plumbing.
+
+**Patterns to follow:**
+- `_apply_find_download_result` for the cross-module mapping idiom.
+- `lib/pipeline_db.py` JSONB write style — see existing JSONB columns like `download_log.beets_detail`.
+- `tests/test_integration_slices.py:TestSpectralPropagationSlice` for the run-real-orchestration-with-FakePipelineDB pattern.
+- `code-quality.md` § Wire-boundary types: `CandidateScore` as `msgspec.Struct`; one decode site (the read in U7); symmetric encode at write time.
+
+**Test infrastructure note:** `tests/fakes.py:FakeSlskdAPI` (line 214) currently exposes only `transfers` and `users` — it has no `searches` attribute. To assert that `responseLimit=1000` is passed and to drive search responses in orchestration tests, U5 must extend `FakeSlskdAPI` with a `FakeSlskdSearches` stub that records `search_text` kwargs, returns a fake search id, exposes a `state()` poll, and returns canned `search_responses(search_id)` payloads. Self-test the new fake via `tests/test_fakes.py` per the existing pattern. (Alternative: drop in a `MagicMock` for the searches client in just the U5 tests — acceptable for a one-off but the fake is preferred for reuse in future search-touching tests.)
+
+**Test scenarios:**
+- Happy path: search succeeds with one matching peer → SearchResult contains candidates with that peer at top, search_log row persists JSONB with `[{username, dir, filetype, matched_tracks: 26, total_tracks: 26, avg_ratio: 0.92, missing_titles: [], file_count: 26}]`, variant=default, final_state=Completed.
+- Happy path (escalation): with `search_attempts=5` and a year set, the variant generator returns v1_year; search uses the year-augmented query; search_log.variant='v1_year'.
+- Happy path (V4 escalation): with `search_attempts=6` and track titles populated, variant is v4_tracks_0; search uses top-3 token query; search_log.variant='v4_tracks_0'.
+- Happy path: `responseLimit` is passed to the slskd-api call (assert via mock) on both serial and parallel paths.
+- Happy path (forensic): a search returning 0 hits still writes a `search_log` row with `candidates=[]` (empty array, not NULL).
+- Happy path (forensic order): a search where peer A has 24/26 and peer B has 26/26 → candidates JSONB lists peer B first, then peer A.
+- Edge case: more than 20 candidates → JSONB contains only the top 20.
+- Edge case: final_state=ResponseLimitReached → persisted on search_log row, distinguishable from final_state=Completed.
+- Edge case: variant=exhausted → no slskd call made; SearchResult.outcome='exhausted', search_log row persists with outcome='exhausted', variant='exhausted'. (This row enables U6's flip.)
+- Edge case (Discogs path): a Discogs-source request with the same flow produces the same candidates JSONB shape — verify via test that explicitly sets `source='request'` with `discogs_release_id` populated and an MB-equivalent track list.
+- Error path: slskd raises during search → SearchResult.outcome='error', candidates=[], variant=<whatever was selected>, final_state=NULL or 'Errored'.
+- Integration: `tests/test_integration_slices.py` slice that runs `search_and_queue` end-to-end with mocked slskd + FakePipelineDB and asserts the JSONB blob shape on `db.search_logs[0]`.
+
+**Verification:**
+- After deploy, `ssh doc2 "pipeline-cli query \"SELECT id, variant, final_state, jsonb_array_length(candidates) FROM search_log WHERE request_id=1843 ORDER BY id DESC LIMIT 5\""` returns rows with non-NULL variant, non-NULL final_state, and `jsonb_array_length` between 0 and 20.
+- For #1843 specifically: at least one of the next 5 search cycles after deploy yields a `candidates` JSONB blob with at least one entry where `matched_tracks >= 20` (S1).
+- Full test suite green; pyright clean on touched files.
+
+---
+
+- U6. **Search exhaustion → flip request to manual; manual re-queue resets state**
+
+**Goal:** When the variant generator returns `kind=exhausted`, the request is flipped to `status='manual'` with `manual_reason='search_exhausted'`. When an operator re-queues a manual request from the UI, both `search_attempts` and `manual_reason` reset.
+
+**Requirements:** R6
+
+**Dependencies:** U1 (manual_reason column), U4 (exhausted variant), U5 (the search loop emits exhaustion).
+
+**Files:**
+- Modify: `cratedigger.py:_log_search_result` (handle the exhausted outcome by flipping status with manual_reason).
+- Modify: `lib/pipeline_db.py` — extend the existing manual-flip path with a `manual_reason` parameter; extend the existing re-queue path to reset both `search_attempts` and `manual_reason`.
+- Test: `tests/test_pipeline_db.py` for the reset-on-requeue behaviour.
+- Test: extend the U5 integration slice with the exhaustion flow assertion.
+
+**Approach:**
+- Identify the existing manual-flip method on `PipelineDB` (likely a `set_status`-like function); extend its signature to accept `manual_reason: str | None = None`. When non-None, write to the new column.
+- **Single-seam reset.** All re-queue paths (web UI button, `pipeline-cli`, importer requeue) funnel through `lib/transitions.py:apply_transition` → `db.reset_to_wanted()` (`lib/pipeline_db.py:917`, with `search_attempts = 0` already set at line 927). Adding `manual_reason = NULL` to `reset_to_wanted` is therefore a one-line change that covers every caller transparently. No multi-site audit needed.
+- In `_log_search_result`, after the existing `record_attempt` branch, check for `result.outcome == 'exhausted'` and call the flip method. The flip is idempotent for the search-exhausted case — re-flipping is a no-op.
+
+**Patterns to follow:**
+- Existing status-flip methods in `lib/pipeline_db.py`. Search for `UPDATE album_requests SET status` to find the flip sites.
+- `lib/transitions.py:apply_transition` (line 373) is the single seam for status transitions including reset to wanted.
+
+**Test scenarios:**
+- Happy path: variant=exhausted → request status flips to 'manual' and manual_reason='search_exhausted'.
+- Happy path: a request with status='manual' and manual_reason='search_exhausted' is re-queued via the UI → status='wanted', search_attempts=0, manual_reason=NULL.
+- Happy path: a manually-created request (status='manual' from inception, manual_reason=NULL) is unaffected by the new flip path; re-queue from this state still works.
+- Edge case: variant=exhausted on a request that is already status='manual' for an unrelated reason (e.g. an operator-set hold) → defensive behaviour: do not overwrite an existing manual_reason. Either skip the flip (if status already 'manual') or document and accept the overwrite. Recommend: skip if status is already 'manual' to avoid clobbering operator state.
+- Integration: full search cycle ending in exhaustion writes the search_log row, flips the request, and the next `get_wanted` call does NOT return this request.
+
+**Verification:**
+- After deploy, deliberately re-queue a stuck release at search_attempts >= 5 and watch one cycle: if all variants exhaust, the request appears in the manual list with the new reason. If variants find a candidate, normal flow continues.
+- The test slice asserts the full lifecycle.
+
+---
+
+- U7. **Diagnostics: pipeline-cli show + web UI request detail**
+
+**Goal:** Make the new forensic data visible without raw SQL. `pipeline-cli show <id>` displays the most recent variant tag and the top-3 candidate scores. The web UI request-detail view displays the same plus the manual_reason and a button to expand the full last forensic blob.
+
+**Requirements:** R11, R12
+
+**Dependencies:** U1 (columns), U5 (data being persisted), U6 (manual_reason populated for exhausted requests).
+
+**Files:**
+- Modify: `scripts/pipeline_cli.py` (the `cmd_show` command, around line 627–636 where the per-row `search_history` print loop already exists).
+- Modify: `web/routes/pipeline.py` — the request-detail handler is `get_pipeline_detail` registered in `_FUNC_GET_PATTERNS` at line 1022 (`(re.compile(r"^/api/pipeline/(\d+)$"), get_pipeline_detail)`).
+- Modify: `web/js/<request-detail-module>.js` to render the new fields. Verify exact module during implementation.
+- Modify: `web/index.html` only if a new section/template is needed.
+- Test: extend `tests/test_web_server.py` with a contract test for the new fields on the `/api/pipeline/<id>` route. The route is pattern-routed (already classified under GET patterns) so `TestRouteContractAudit` should already cover it — verify and update `REQUIRED_FIELDS` accordingly.
+- Test: extend `tests/test_web_server.py` `_assert_required_fields` for `manual_reason`, `last_search_variant`, `last_search_top_candidates`.
+
+**Approach:**
+- Backend route reads `manual_reason` from `album_requests` and the most recent `search_log` row (joined or fetched separately). The response payload exposes `manual_reason`, `last_search.variant`, `last_search.final_state`, and `last_search.top_candidates: list[CandidateScore]` — top 3 by score for compactness in list views; full blob available via an "expand" toggle that hits a separate route or returns the full top-20 inline.
+- Decode the JSONB blob via `msgspec.convert(row['candidates'], type=list[CandidateScore])` — single decode site per `code-quality.md` § Wire-boundary types. The route's response serialization re-encodes via `msgspec.to_builtins`.
+- `pipeline-cli show` already iterates `search_history` per row (lines 627–636) and prints `outcome`, `result_count`, `elapsed_s`, `query`. Append `variant` to that per-row line so operators triaging stuck releases see the variant ladder progression at a glance, not just the latest. Also add a separate summary block above or below the search-history table that shows the top-3 candidates from the most recent search row (the wider forensic detail).
+- Web UI renders manual_reason as a chip near the status (e.g. red "search exhausted" tag). Forensic blob renders as a collapsed table.
+
+**Execution note:** Frontend changes follow `web.md` rules: vanilla JS, no build step, JSDoc types, `// @ts-check`.
+
+**Patterns to follow:**
+- `pipeline-cli show`'s existing rendering of quality columns and download history (the brainstorm references this pattern).
+- `_WebServerCase` and `_assert_required_fields` from `tests/test_web_server.py`.
+- Existing forensic blob rendering in the validation-log / wrong-matches view (similar JSONB-driven UI).
+
+**Test scenarios:**
+- Happy path (CLI): `pipeline-cli show 1843` after a deployed search cycle prints variant, final_state, top-3 candidates inline.
+- Happy path (web): GET `/api/requests/1843` returns `manual_reason`, `last_search.variant`, `last_search.final_state`, `last_search.top_candidates` in the contract response.
+- Happy path (web, exhausted): a request with `manual_reason='search_exhausted'` displays the chip in the UI list view.
+- Edge case (web): a request with no search_log rows yet → `last_search` is null in the response; UI handles gracefully.
+- Edge case (CLI): `pipeline-cli show` for a request whose latest search_log row has `candidates=[]` prints variant + final_state but no candidate lines.
+- Edge case (web, JSONB decode): a search_log row written before this work (NULL candidates) reads as `top_candidates=[]`. No msgspec.ValidationError.
+- Contract: `TestRouteContractAudit` continues to pass with the request-detail route's REQUIRED_FIELDS expanded.
+- Integration: the full path — search → exhaustion → manual_reason populated → CLI displays it → web UI displays it — works end-to-end on a real deployed release.
+
+**Verification:**
+- All web contract tests pass.
+- CLI manual smoke: `ssh doc2 'pipeline-cli show 1843'` after deploy shows the new fields populated.
+- Browser manual smoke: load `music.ablz.au`, find #1843 (or another stuck request), confirm the exhaustion chip and forensic blob display per UX intent.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `search_for_album` and `_submit_search` are both upstream entry points — both must take the new `responseLimit` plumbing. `_log_search_result` is the single persistence sink; all changes converge here. `check_for_match` is the matching seam where `CandidateScore` accumulation begins (covering both count-gate-passing and count-gate-failing dirs); the list propagates through `try_enqueue` / `try_multi_enqueue` → `_try_filetype` → `find_download` → `FindDownloadResult.candidates` → `_apply_find_download_result` → `SearchResult.candidates` → `_log_search_result`. Six function signatures widen, no behaviour changes. The Discogs-source flow uses the same path with no special-casing — verified in U5 test.
+- **Error propagation:** slskd timeouts and errors must still produce a `search_log` row (existing behaviour). The new fields default to NULL on error rows; the `final_state` field captures whatever slskd reported. Variant=exhausted bypasses slskd entirely; its outcome is the new `'exhausted'` value (CHECK constraint update in U1).
+- **State lifecycle risks:** Re-queue must reset both `search_attempts` AND `manual_reason` — missing one is a partial reset and the request will incorrectly skip default search or display a stale exhaustion chip. The single-seam reset via `db.reset_to_wanted` (lib/pipeline_db.py:917) handles both. The variant-selection currency invariant (read attempts at submit, increment at log) holds because the same album is never in flight twice in a single batch — see U5 brittle-invariant comment.
+- **API surface parity:** `pipeline-cli show` and the web UI request-detail route must surface the same fields. The contract test in U7 enforces this. JSONB decode happens at exactly one site (the route) per wire-boundary discipline.
+- **Integration coverage:** The U5 integration slice exercises the full search → match → log_search path with FakePipelineDB and a mocked slskd. The U7 contract test exercises the read path.
+- **Unchanged invariants:**
+  - `album_match`'s strict 26/26 accept rule (R7): structurally preserved by the wrapper. Tests in U2 explicitly assert.
+  - `record_attempt` is still called for every non-found, non-exhausted outcome (U5 must not regress this).
+  - `search_log.outcome` enum still gates writes — extending it to include `'exhausted'` happens once in U1.
+  - Existing search_log rows remain readable. New columns NULL-default. Tools must accept NULL.
+  - `search_for_album` (serial) and `_submit_search` (parallel) must stay in lockstep; both touched in U5.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Raising `responseLimit` to 1000 stresses slskd CPU under parallel search load. | Document in deploy notes; observe `journalctl -u slskd` for the first day; revert via Nix option if needed. Adaptive cap is explicitly deferred (origin scope). |
+| The variant generator runs on a request with NULL year and zero track rows (e.g. a freshly-added request whose track populator hasn't run yet) → exhausted at cycle 5 immediately. | Acceptable: this is an edge case for releases with truly no metadata. The exhaustion chip in the UI alerts the operator. Could harden later by gating exhaustion until track rows exist; out of scope. |
+| `album_match` refactor accidentally changes accept/reject behaviour. | U2's strict-accept regression scenarios + the existing `tests/test_integration*` suite are the guard. Pre-commit pyright + full test run in CI. |
+| Migration ordering with manual data in prod (someone has manually flipped a request to 'manual' with a custom `reasoning`). | `manual_reason` is a new column; existing `reasoning` is untouched. No conflict. |
+| Discogs-source request hits the search loop before `album_tracks` is populated → V4 has no pool. | Variant generator returns `exhausted` cleanly; the operator sees the chip and re-queues after metadata catches up. Acceptable. |
+| The `search_log.outcome` CHECK constraint update in U1 fails if any in-flight migration concurrent with deploy violates it. | Migration runs in `cratedigger-db-migrate.service` BEFORE the app starts (per `pipeline-db.md`); no concurrency. |
+| `responseLimit=1000` exposes a latent slskd-api or slskd-server bug under heavier response counts. | Operationally observable; revertible via Nix module option. No code rollback required for that revert. |
+
+---
+
+## Documentation / Operational Notes
+
+- After deploy, verify the migration: `ssh doc2 'pipeline-cli query "SELECT * FROM schema_migrations ORDER BY version DESC LIMIT 3"'`.
+- Sanity-check #1843 (or whichever release was used as the test bed) over 1–2 search cycles after deploy. Inspect via `ssh doc2 'pipeline-cli show 1843'`.
+- Update `docs/pipeline-db-schema.md` and `docs/quality-verification.md` (or the search-specific subsystem doc) to mention the new `search_log` columns and the `manual_reason` column. Brainstorm/plan references can stay as primary sources for the rationale.
+- Update `CLAUDE.md` "Critical invariants" only if `search_response_limit` becomes a known frequent-tune-target. Otherwise the Nix module option description is sufficient operator documentation.
+- No backfill needed; historical search_log rows remain queryable with NULL forensic columns.
+- Slskd has no operational rollback hook — if `responseLimit=1000` causes problems, lower the Nix option and `nixos-rebuild switch`.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/search-escalation-and-forensics-requirements.md`
+- Related code: `cratedigger.py:search_for_album`, `cratedigger.py:_submit_search`, `cratedigger.py:_collect_search_results`, `cratedigger.py:_apply_find_download_result`, `cratedigger.py:_log_search_result`, `lib/search.py:build_query`, `lib/matching.py:album_match`, `lib/matching.py:_try_filetype`, `lib/enqueue.py:find_download`, `lib/pipeline_db.py:log_search`, `nix/module.nix` (`searchSettings` block), `migrations/`
+- Related rules: `.claude/rules/code-quality.md` (Wire-boundary types, Pipeline Decision Debugging, No Parallel Code Paths), `.claude/rules/pipeline-db.md`, `.claude/rules/deploy.md`, `.claude/rules/web.md`
+- Live test bed: pipeline DB request id `1843` (The Wiggles, 1991 AU, 26 tracks). Search log rows: 28 entries, 2026-04-22 → 2026-04-29, all `*he *iggles` / `result_count` 99–100 / `outcome` no_match.

--- a/docs/plans/2026-04-29-006-feat-search-escalation-and-forensics-plan.md
+++ b/docs/plans/2026-04-29-006-feat-search-escalation-and-forensics-plan.md
@@ -1,7 +1,7 @@
 ---
 title: Search Escalation and Forensics for Stuck Releases
 type: feat
-status: active
+status: completed
 date: 2026-04-29
 origin: docs/brainstorms/search-escalation-and-forensics-requirements.md
 ---

--- a/lib/config.py
+++ b/lib/config.py
@@ -82,6 +82,8 @@ class CratediggerConfig:
     parallel_searches: int = 8
     browse_parallelism: int = 4
     title_blacklist: tuple[str, ...] = ()
+    search_response_limit: int = 1000
+    search_escalation_threshold: int = 5
 
     # --- Release ---
     use_most_common_tracknum: bool = True
@@ -246,6 +248,8 @@ class CratediggerConfig:
             parallel_searches=getint("Search Settings", "parallel_searches", 8),
             browse_parallelism=min(getint("Search Settings", "browse_parallelism", 4), 8),
             title_blacklist=title_blacklist,
+            search_response_limit=getint("Search Settings", "search_response_limit", 1000),
+            search_escalation_threshold=getint("Search Settings", "search_escalation_threshold", 5),
             # Release
             use_most_common_tracknum=getbool("Release Settings", "use_most_common_tracknum", True),
             allow_multi_disc=getbool("Release Settings", "allow_multi_disc", True),

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Any, Literal, Sequence, cast
 from lib.browse import download_filter
 from lib.download import cancel_and_delete, slskd_do_enqueue
 from lib.grab_list import GrabListEntry
-from lib.matching import CandidateScore, check_for_match, get_album_by_id
+from lib.matching import check_for_match, get_album_by_id
+from lib.quality import CandidateScore
 
 if TYPE_CHECKING:
     from cratedigger import SlskdDirectory, TrackRecord
@@ -38,9 +39,17 @@ class EnqueueAttempt:
 
 @dataclass(frozen=True)
 class FindDownloadResult:
-    """Final outcome of matching + enqueue for one album."""
+    """Final outcome of matching + enqueue for one album.
+
+    ``candidates`` is the per-dir forensic score list aggregated across every
+    filetype attempt that ran for this album. The same dir under different
+    filetypes shows up as two distinct entries — that is intentional
+    diagnostic information. U5 plumbs this onto ``SearchResult.candidates``
+    and persists the top-20 to ``search_log.candidates`` JSONB.
+    """
 
     outcome: Literal["found", "no_match", "enqueue_failed"]
+    candidates: tuple[CandidateScore, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -49,8 +58,7 @@ class _FiletypeAttemptResult:
 
     Carries the same outcome as `FindDownloadResult` plus the per-dir
     `CandidateScore` accumulated across every release/dir/user touched while
-    trying this filetype. U5 will plumb `candidates` through `find_download`
-    into `search_log.candidates`; in U2 it stops here.
+    trying this filetype.
     """
 
     outcome: Literal["found", "no_match", "enqueue_failed"]
@@ -493,11 +501,15 @@ def find_download(
         )
 
     had_enqueue_failure = False
+    accumulated: list[CandidateScore] = []
     for allowed_filetype in filetypes_to_try:
         logger.info(f"Checking for Quality: {allowed_filetype}")
         result = _try_filetype(album, results, allowed_filetype, grab_list, ctx)
+        accumulated.extend(result.candidates)
         if result.outcome == "found":
-            return FindDownloadResult(outcome="found")
+            return FindDownloadResult(
+                outcome="found", candidates=tuple(accumulated),
+            )
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
 
@@ -510,11 +522,15 @@ def find_download(
             f"trying catch-all (any audio format)"
         )
         result = _try_filetype(album, results, "*", grab_list, ctx)
+        accumulated.extend(result.candidates)
         if result.outcome == "found":
-            return FindDownloadResult(outcome="found")
+            return FindDownloadResult(
+                outcome="found", candidates=tuple(accumulated),
+            )
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
 
     return FindDownloadResult(
-        outcome="enqueue_failed" if had_enqueue_failure else "no_match"
+        outcome="enqueue_failed" if had_enqueue_failure else "no_match",
+        candidates=tuple(accumulated),
     )

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, Sequence, cast
 from lib.browse import download_filter
 from lib.download import cancel_and_delete, slskd_do_enqueue
 from lib.grab_list import GrabListEntry
-from lib.matching import check_for_match, get_album_by_id
+from lib.matching import CandidateScore, check_for_match, get_album_by_id
 
 if TYPE_CHECKING:
     from cratedigger import SlskdDirectory, TrackRecord
@@ -22,11 +22,18 @@ logger = logging.getLogger("cratedigger")
 
 @dataclass(frozen=True)
 class EnqueueAttempt:
-    """Outcome of a single enqueue path after matching candidate directories."""
+    """Outcome of a single enqueue path after matching candidate directories.
+
+    ``candidates`` carries the per-dir forensic scores collected by
+    `check_for_match` for every dir touched during this attempt — including
+    sub-count gate failures and cross-check rejections. U5 will surface this
+    list in the persisted `search_log.candidates` JSONB blob.
+    """
 
     matched: bool
     downloads: list[Any] | None = None
     enqueue_failed: bool = False
+    candidates: tuple[CandidateScore, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -34,6 +41,20 @@ class FindDownloadResult:
     """Final outcome of matching + enqueue for one album."""
 
     outcome: Literal["found", "no_match", "enqueue_failed"]
+
+
+@dataclass(frozen=True)
+class _FiletypeAttemptResult:
+    """Internal return shape of `_try_filetype`.
+
+    Carries the same outcome as `FindDownloadResult` plus the per-dir
+    `CandidateScore` accumulated across every release/dir/user touched while
+    trying this filetype. U5 will plumb `candidates` through `find_download`
+    into `search_log.candidates`; in U2 it stops here.
+    """
+
+    outcome: Literal["found", "no_match", "enqueue_failed"]
+    candidates: tuple[CandidateScore, ...] = ()
 
 
 def release_trackcount_mode(releases: list[Any]) -> Any:
@@ -195,6 +216,7 @@ def try_enqueue(
         reverse=True,
     )
     had_enqueue_failure = False
+    accumulated: list[CandidateScore] = []
     for username in sorted_users:
         if username in ctx.cooled_down_users:
             logger.info(
@@ -212,21 +234,26 @@ def try_enqueue(
         if file_dirs is None:
             continue
         logger.debug(f"Parsing result from user: {username}")
-        found, directory, file_dir = check_for_match(
+        match_result = check_for_match(
             all_tracks, allowed_filetype, file_dirs, username, ctx
         )
-        if found:
-            directory = download_filter(allowed_filetype, directory, ctx.cfg)
-            files_to_enqueue = _prefixed_directory_files(directory, file_dir)
+        accumulated.extend(match_result.candidates)
+        if match_result.matched:
+            directory = download_filter(allowed_filetype, match_result.directory, ctx.cfg)
+            files_to_enqueue = _prefixed_directory_files(directory, match_result.file_dir)
             try:
                 downloads = slskd_do_enqueue(
                     username=username,
                     files=files_to_enqueue,
-                    file_dir=file_dir,
+                    file_dir=match_result.file_dir,
                     ctx=ctx,
                 )
                 if downloads is not None:
-                    return EnqueueAttempt(matched=True, downloads=downloads)
+                    return EnqueueAttempt(
+                        matched=True,
+                        downloads=downloads,
+                        candidates=tuple(accumulated),
+                    )
                 had_enqueue_failure = True
                 logger.info(
                     f"Failed to enqueue download to slskd for "
@@ -240,7 +267,11 @@ def try_enqueue(
                     f"{artist_name} - {album_name} from {username}"
                 )
     logger.info(f"Failed to enqueue {artist_name} - {album_name}")
-    return EnqueueAttempt(matched=False, enqueue_failed=had_enqueue_failure)
+    return EnqueueAttempt(
+        matched=False,
+        enqueue_failed=had_enqueue_failure,
+        candidates=tuple(accumulated),
+    )
 
 
 def try_multi_enqueue(
@@ -269,6 +300,7 @@ def try_multi_enqueue(
     album_name = album.title
     artist_name = album.artist_name
     denied_users = _get_denied_users(album_id, ctx)
+    accumulated: list[CandidateScore] = []
     for disk in split_release:
         ctx.negative_matches.clear()
         for username in results:
@@ -287,16 +319,19 @@ def try_multi_enqueue(
             file_dirs = _get_user_dirs(results[username], allowed_filetype)
             if file_dirs is None:
                 continue
-            found, directory, file_dir = check_for_match(
+            match_result = check_for_match(
                 disk["tracks"], allowed_filetype, file_dirs, username, ctx
             )
-            if found:
-                directory = download_filter(allowed_filetype, directory, ctx.cfg)
-                disk["source"] = (username, directory, file_dir)
+            accumulated.extend(match_result.candidates)
+            if match_result.matched:
+                directory = download_filter(
+                    allowed_filetype, match_result.directory, ctx.cfg,
+                )
+                disk["source"] = (username, directory, match_result.file_dir)
                 count_found += 1
                 break
         else:
-            return EnqueueAttempt(matched=False)
+            return EnqueueAttempt(matched=False, candidates=tuple(accumulated))
     if count_found == total:
         all_downloads = []
         enqueued = 0
@@ -323,7 +358,11 @@ def try_multi_enqueue(
                     )
                     if len(all_downloads) > 0:
                         cancel_and_delete(all_downloads, ctx)
-                    return EnqueueAttempt(matched=False, enqueue_failed=True)
+                    return EnqueueAttempt(
+                        matched=False,
+                        enqueue_failed=True,
+                        candidates=tuple(accumulated),
+                    )
             except Exception:
                 logger.exception("Exception enqueueing tracks")
                 logger.info(
@@ -332,14 +371,26 @@ def try_multi_enqueue(
                 )
                 if len(all_downloads) > 0:
                     cancel_and_delete(all_downloads, ctx)
-                return EnqueueAttempt(matched=False, enqueue_failed=True)
+                return EnqueueAttempt(
+                    matched=False,
+                    enqueue_failed=True,
+                    candidates=tuple(accumulated),
+                )
         if enqueued == total:
-            return EnqueueAttempt(matched=True, downloads=all_downloads)
+            return EnqueueAttempt(
+                matched=True,
+                downloads=all_downloads,
+                candidates=tuple(accumulated),
+            )
         if len(all_downloads) > 0:
             cancel_and_delete(all_downloads, ctx)
-        return EnqueueAttempt(matched=False, enqueue_failed=True)
+        return EnqueueAttempt(
+            matched=False,
+            enqueue_failed=True,
+            candidates=tuple(accumulated),
+        )
 
-    return EnqueueAttempt(matched=False)
+    return EnqueueAttempt(matched=False, candidates=tuple(accumulated))
 
 
 def _try_filetype(
@@ -348,13 +399,14 @@ def _try_filetype(
     allowed_filetype: str,
     grab_list: dict[int, GrabListEntry],
     ctx: CratediggerContext,
-) -> FindDownloadResult:
+) -> _FiletypeAttemptResult:
     """Try to match and enqueue an album at a specific filetype quality."""
     album_id = album.id
     artist_name = album.artist_name
     releases = list(album.releases)
     has_monitored = any(r.monitored for r in releases)
     had_enqueue_failure = False
+    accumulated: list[CandidateScore] = []
 
     for _ in range(len(releases)):
         if not releases:
@@ -370,10 +422,12 @@ def _try_filetype(
             continue
 
         attempt = try_enqueue(all_tracks, results, allowed_filetype, ctx)
+        accumulated.extend(attempt.candidates)
         if not attempt.matched and len(release.media) > 1:
             attempt = try_multi_enqueue(
                 release, all_tracks, results, allowed_filetype, ctx
             )
+            accumulated.extend(attempt.candidates)
 
         if attempt.matched:
             assert attempt.downloads is not None
@@ -390,7 +444,9 @@ def _try_filetype(
                 db_search_filetype_override=album.db_search_filetype_override,
                 db_target_format=album.db_target_format,
             )
-            return FindDownloadResult(outcome="found")
+            return _FiletypeAttemptResult(
+                outcome="found", candidates=tuple(accumulated),
+            )
 
         if attempt.enqueue_failed:
             had_enqueue_failure = True
@@ -405,8 +461,9 @@ def _try_filetype(
         if has_monitored and not release.monitored:
             break
 
-    return FindDownloadResult(
-        outcome="enqueue_failed" if had_enqueue_failure else "no_match"
+    return _FiletypeAttemptResult(
+        outcome="enqueue_failed" if had_enqueue_failure else "no_match",
+        candidates=tuple(accumulated),
     )
 
 
@@ -440,7 +497,7 @@ def find_download(
         logger.info(f"Checking for Quality: {allowed_filetype}")
         result = _try_filetype(album, results, allowed_filetype, grab_list, ctx)
         if result.outcome == "found":
-            return result
+            return FindDownloadResult(outcome="found")
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
 
@@ -454,7 +511,7 @@ def find_download(
         )
         result = _try_filetype(album, results, "*", grab_list, ctx)
         if result.outcome == "found":
-            return result
+            return FindDownloadResult(outcome="found")
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
 

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -52,19 +52,6 @@ class FindDownloadResult:
     candidates: tuple[CandidateScore, ...] = ()
 
 
-@dataclass(frozen=True)
-class _FiletypeAttemptResult:
-    """Internal return shape of `_try_filetype`.
-
-    Carries the same outcome as `FindDownloadResult` plus the per-dir
-    `CandidateScore` accumulated across every release/dir/user touched while
-    trying this filetype.
-    """
-
-    outcome: Literal["found", "no_match", "enqueue_failed"]
-    candidates: tuple[CandidateScore, ...] = ()
-
-
 def release_trackcount_mode(releases: list[Any]) -> Any:
     """Return the most common track count among candidate releases."""
     track_count: dict[Any, int] = {}
@@ -407,7 +394,7 @@ def _try_filetype(
     allowed_filetype: str,
     grab_list: dict[int, GrabListEntry],
     ctx: CratediggerContext,
-) -> _FiletypeAttemptResult:
+) -> FindDownloadResult:
     """Try to match and enqueue an album at a specific filetype quality."""
     album_id = album.id
     artist_name = album.artist_name
@@ -452,7 +439,7 @@ def _try_filetype(
                 db_search_filetype_override=album.db_search_filetype_override,
                 db_target_format=album.db_target_format,
             )
-            return _FiletypeAttemptResult(
+            return FindDownloadResult(
                 outcome="found", candidates=tuple(accumulated),
             )
 
@@ -469,7 +456,7 @@ def _try_filetype(
         if has_monitored and not release.monitored:
             break
 
-    return _FiletypeAttemptResult(
+    return FindDownloadResult(
         outcome="enqueue_failed" if had_enqueue_failure else "no_match",
         candidates=tuple(accumulated),
     )

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Sequence, TYPE_CHECKING
 
 from lib.browse import _browse_directories, rank_candidate_dirs
+from lib.quality import CandidateScore
 from lib.util import _track_titles_cross_check
 
 if TYPE_CHECKING:
@@ -23,6 +24,24 @@ logger = logging.getLogger("cratedigger")
 # ---------------------------------------------------------------------------
 # Structured return types (U2 of search-escalation-and-forensics)
 # ---------------------------------------------------------------------------
+#
+# `CandidateScore` is the wire-boundary type written into
+# ``search_log.candidates`` JSONB. It lives in ``lib/quality.py`` alongside
+# other ``msgspec.Struct`` boundaries (``ImportResult``, ``ValidationResult``)
+# and is re-exported here only so existing ``from lib.matching import
+# CandidateScore`` callers keep working. Construct via keyword arguments only.
+
+__all__ = [
+    "AlbumMatchScore",
+    "CandidateScore",
+    "MatchResult",
+    "album_match",
+    "album_track_num",
+    "check_for_match",
+    "check_ratio",
+    "get_album_by_id",
+]
+
 
 @dataclass
 class AlbumMatchScore:
@@ -33,8 +52,7 @@ class AlbumMatchScore:
     callers from these fields — this dataclass carries facts only.
 
     Internal — not a wire-boundary type. Forensic persistence uses
-    `CandidateScore` (defined below; will move to lib/quality.py as a
-    msgspec.Struct in U5).
+    `CandidateScore` (re-exported above from ``lib.quality``).
     """
 
     matched_tracks: int
@@ -42,27 +60,6 @@ class AlbumMatchScore:
     avg_ratio: float
     missing_titles: list[str]
     best_per_track: list[float]
-
-
-@dataclass
-class CandidateScore:
-    """Forensic record of one (user, dir, filetype) candidate's match score.
-
-    NOTE: this is the U2 internal placeholder. U5 will replace this dataclass
-    with a `msgspec.Struct` of the same shape and move it to `lib/quality.py`
-    so it can persist as JSONB. To make that swap painless, **construct
-    CandidateScore only via keyword arguments** — a Struct-based replacement
-    will not accept positional construction.
-    """
-
-    username: str
-    dir: str
-    filetype: str
-    matched_tracks: int
-    total_tracks: int
-    avg_ratio: float
-    missing_titles: list[str]
-    file_count: int
 
 
 @dataclass

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import difflib
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import Any, Sequence, TYPE_CHECKING
 
 from lib.browse import _browse_directories, rank_candidate_dirs
@@ -17,6 +18,81 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("cratedigger")
+
+
+# ---------------------------------------------------------------------------
+# Structured return types (U2 of search-escalation-and-forensics)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AlbumMatchScore:
+    """Per-track filename-similarity score for one (user, dir, filetype) triple.
+
+    Pure-function output of `album_match`. The strict-accept decision
+    (every track above ratio AND _track_titles_cross_check) is computed by
+    callers from these fields — this dataclass carries facts only.
+
+    Internal — not a wire-boundary type. Forensic persistence uses
+    `CandidateScore` (defined below; will move to lib/quality.py as a
+    msgspec.Struct in U5).
+    """
+
+    matched_tracks: int
+    total_tracks: int
+    avg_ratio: float
+    missing_titles: list[str]
+    best_per_track: list[float]
+
+
+@dataclass
+class CandidateScore:
+    """Forensic record of one (user, dir, filetype) candidate's match score.
+
+    NOTE: this is the U2 internal placeholder. U5 will replace this dataclass
+    with a `msgspec.Struct` of the same shape and move it to `lib/quality.py`
+    so it can persist as JSONB. To make that swap painless, **construct
+    CandidateScore only via keyword arguments** — a Struct-based replacement
+    will not accept positional construction.
+    """
+
+    username: str
+    dir: str
+    filetype: str
+    matched_tracks: int
+    total_tracks: int
+    avg_ratio: float
+    missing_titles: list[str]
+    file_count: int
+
+
+@dataclass
+class MatchResult:
+    """Return shape of `check_for_match`.
+
+    `matched=True` means: a dir strictly accepted (every track above ratio AND
+    cross-check passed). `directory` and `file_dir` describe that dir. The
+    `candidates` list captures every dir the loop iterated, including the
+    sub-count gate failures and cross-check rejections — used by U5 to persist
+    a `search_log.candidates` JSONB blob for post-hoc forensics.
+
+    Iterable as `(matched, directory, file_dir)` for backwards compatibility
+    with the historical 3-tuple return shape — pre-U2 callers in
+    `tests/test_integration.py` still unpack the result that way. New callers
+    should prefer attribute access.
+    """
+
+    matched: bool
+    directory: Any
+    file_dir: str
+    candidates: list[CandidateScore] = field(default_factory=list)
+
+    def __iter__(self) -> Any:
+        # Preserve historical unpacking: (matched, directory, file_dir).
+        # `candidates` is intentionally NOT yielded — old callers unpack three
+        # values; yielding four would silently break them.
+        yield self.matched
+        yield self.directory
+        yield self.file_dir
 
 
 def get_album_by_id(album_id: int, ctx: CratediggerContext) -> Any:
@@ -32,11 +108,15 @@ def album_match(
     username: str,
     filetype: str,
     ctx: CratediggerContext,
-) -> bool:
-    """Check whether the browsed directory matches the expected album."""
+) -> AlbumMatchScore:
+    """Compute the per-track filename-similarity score for a candidate dir.
+
+    Returns an `AlbumMatchScore` for every input. The strict-accept decision
+    (matched_tracks == total_tracks AND ignored_users gate) is left to the
+    caller — see `check_for_match`. This function is pure: no I/O, no
+    side effects, no decision logic beyond the per-track ratio comparison.
+    """
     match_cfg = ctx.cfg
-    counted = []
-    total_match = 0.0
 
     album_info = get_album_by_id(expected_tracks[0]["albumId"], ctx)
     album_name = album_info.title
@@ -45,6 +125,12 @@ def album_match(
 
     spec = parse_filetype_config(filetype)
     is_catch_all = spec.extension == "*"
+
+    matched_titles: list[str] = []
+    missing_titles: list[str] = []
+    best_per_track: list[float] = []
+    total_match = 0.0
+
     for expected_track in expected_tracks:
         best_match = 0.0
         expected_filename = expected_track["title"]
@@ -88,21 +174,33 @@ def album_match(
             if ratio > best_match:
                 best_match = ratio
 
+        best_per_track.append(best_match)
         if best_match > match_cfg.minimum_match_ratio:
-            counted.append(expected_filename)
+            matched_titles.append(expected_track["title"])
             total_match += best_match
+        else:
+            missing_titles.append(expected_track["title"])
 
-    if len(counted) == len(expected_tracks) and username not in match_cfg.ignored_users:
+    matched_tracks = len(matched_titles)
+    total_tracks = len(expected_tracks)
+    avg_ratio = (total_match / matched_tracks) if matched_tracks else 0.0
+
+    if matched_tracks == total_tracks and username not in match_cfg.ignored_users:
         logger.info(
-            f"Found match from user: {username} for {len(counted)} tracks! "
+            f"Found match from user: {username} for {matched_tracks} tracks! "
             f"Track attributes: {filetype}"
         )
-        logger.info(f"Average sequence match ratio: {total_match / len(counted)}")
+        logger.info(f"Average sequence match ratio: {avg_ratio}")
         logger.info("SUCCESSFUL MATCH")
         logger.info("-------------------")
-        return True
 
-    return False
+    return AlbumMatchScore(
+        matched_tracks=matched_tracks,
+        total_tracks=total_tracks,
+        avg_ratio=avg_ratio,
+        missing_titles=missing_titles,
+        best_per_track=best_per_track,
+    )
 
 
 def check_ratio(
@@ -174,11 +272,21 @@ def check_for_match(
     file_dirs: list[str],
     username: str,
     ctx: CratediggerContext,
-) -> tuple[bool, Any, str]:
-    """Check candidate directories for an album match."""
+) -> MatchResult:
+    """Check candidate directories for an album match.
+
+    Returns a `MatchResult` with the strict-accept boolean, the matched
+    directory + name (if any), and a list of `CandidateScore` entries
+    capturing every dir the loop touched — including dirs that failed the
+    sub-count gate (cheap zero-score entry) and dirs that strict-accepted
+    on filename ratio but failed `_track_titles_cross_check` (full score
+    plus a negative_matches entry). U5 persists `candidates` to
+    `search_log.candidates` for forensic introspection.
+    """
+    candidates: list[CandidateScore] = []
     logger.debug(f"Current broken users {ctx.broken_user}")
     if username in ctx.broken_user:
-        return False, {}, ""
+        return MatchResult(matched=False, directory={}, file_dir="", candidates=candidates)
     track_num = len(tracks)
     album_info = get_album_by_id(tracks[0]["albumId"], ctx)
     ranked_dirs = rank_candidate_dirs(file_dirs, album_info.title, album_info.artist_name)
@@ -207,7 +315,7 @@ def check_for_match(
         dirs_to_try.append(file_dir)
 
     if not dirs_to_try:
-        return False, {}, ""
+        return MatchResult(matched=False, directory={}, file_dir="", candidates=candidates)
 
     if username not in ctx.folder_cache:
         ctx.folder_cache[username] = {}
@@ -231,7 +339,9 @@ def check_for_match(
         if not browsed and len(uncached) == len(dirs_to_try):
             ctx.broken_user.append(username)
             logger.debug(f"All browses failed for {username}, marked as broken")
-            return False, {}, ""
+            return MatchResult(
+                matched=False, directory={}, file_dir="", candidates=candidates,
+            )
 
     for file_dir in dirs_to_try:
         if file_dir not in ctx.folder_cache[username]:
@@ -241,13 +351,52 @@ def check_for_match(
         tracks_info = album_track_num(directory, ctx.cfg)
         neg_key = (username, file_dir, track_num, allowed_filetype)
 
-        if tracks_info["count"] == track_num and tracks_info["filetype"] != "":
-            if album_match(tracks, directory["files"], username, allowed_filetype, ctx):
-                if _track_titles_cross_check(tracks, directory["files"]):
-                    return True, directory, file_dir
-                logger.warning(
-                    f"Track title cross-check FAILED for user {username}, "
-                    f"dir {file_dir} — skipping (wrong pressing?)"
+        # Sub-count gate: cheap CandidateScore, do NOT call album_match.
+        if tracks_info["count"] != track_num or tracks_info["filetype"] == "":
+            candidates.append(CandidateScore(
+                username=username,
+                dir=file_dir,
+                filetype=allowed_filetype,
+                matched_tracks=0,
+                total_tracks=track_num,
+                avg_ratio=0.0,
+                missing_titles=[],
+                file_count=tracks_info["count"],
+            ))
+            ctx.negative_matches.add(neg_key)
+            continue
+
+        # Count gate passed — score the dir.
+        score = album_match(tracks, directory["files"], username, allowed_filetype, ctx)
+        candidates.append(CandidateScore(
+            username=username,
+            dir=file_dir,
+            filetype=allowed_filetype,
+            matched_tracks=score.matched_tracks,
+            total_tracks=score.total_tracks,
+            avg_ratio=score.avg_ratio,
+            missing_titles=list(score.missing_titles),
+            file_count=tracks_info["count"],
+        ))
+
+        strict_accept = (
+            score.matched_tracks == score.total_tracks
+            and username not in ctx.cfg.ignored_users
+        )
+        if strict_accept:
+            if _track_titles_cross_check(tracks, directory["files"]):
+                return MatchResult(
+                    matched=True,
+                    directory=directory,
+                    file_dir=file_dir,
+                    candidates=candidates,
                 )
+            logger.warning(
+                f"Track title cross-check FAILED for user {username}, "
+                f"dir {file_dir} — skipping (wrong pressing?)"
+            )
         ctx.negative_matches.add(neg_key)
-    return False, {}, ""
+
+    return MatchResult(
+        matched=False, directory={}, file_dir="", candidates=candidates,
+    )

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -27,13 +27,11 @@ logger = logging.getLogger("cratedigger")
 #
 # `CandidateScore` is the wire-boundary type written into
 # ``search_log.candidates`` JSONB. It lives in ``lib/quality.py`` alongside
-# other ``msgspec.Struct`` boundaries (``ImportResult``, ``ValidationResult``)
-# and is re-exported here only so existing ``from lib.matching import
-# CandidateScore`` callers keep working. Construct via keyword arguments only.
+# other ``msgspec.Struct`` boundaries (``ImportResult``, ``ValidationResult``).
+# Import it from ``lib.quality`` directly — no re-export here.
 
 __all__ = [
     "AlbumMatchScore",
-    "CandidateScore",
     "MatchResult",
     "album_match",
     "album_track_num",

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -70,24 +70,15 @@ class MatchResult:
     sub-count gate failures and cross-check rejections — used by U5 to persist
     a `search_log.candidates` JSONB blob for post-hoc forensics.
 
-    Iterable as `(matched, directory, file_dir)` for backwards compatibility
-    with the historical 3-tuple return shape — pre-U2 callers in
-    `tests/test_integration.py` still unpack the result that way. New callers
-    should prefer attribute access.
+    Callers must use attribute access (`.matched`, `.directory`, `.file_dir`,
+    `.candidates`). Tuple-unpacking is intentionally not supported — the old
+    3-tuple shim silently dropped the `candidates` field.
     """
 
     matched: bool
     directory: Any
     file_dir: str
     candidates: list[CandidateScore] = field(default_factory=list)
-
-    def __iter__(self) -> Any:
-        # Preserve historical unpacking: (matched, directory, file_dir).
-        # `candidates` is intentionally NOT yielded — old callers unpack three
-        # values; yielding four would silently break them.
-        yield self.matched
-        yield self.directory
-        yield self.file_dir
 
 
 def get_album_by_id(album_id: int, ctx: CratediggerContext) -> Any:

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -180,15 +180,6 @@ def album_match(
     total_tracks = len(expected_tracks)
     avg_ratio = (total_match / matched_tracks) if matched_tracks else 0.0
 
-    if matched_tracks == total_tracks and username not in match_cfg.ignored_users:
-        logger.info(
-            f"Found match from user: {username} for {matched_tracks} tracks! "
-            f"Track attributes: {filetype}"
-        )
-        logger.info(f"Average sequence match ratio: {avg_ratio}")
-        logger.info("SUCCESSFUL MATCH")
-        logger.info("-------------------")
-
     return AlbumMatchScore(
         matched_tracks=matched_tracks,
         total_tracks=total_tracks,
@@ -380,6 +371,19 @@ def check_for_match(
         )
         if strict_accept:
             if _track_titles_cross_check(tracks, directory["files"]):
+                # Log SUCCESSFUL MATCH at the one place enqueue is going to
+                # happen — the previous log site in album_match fired before
+                # the cross-check / ignored_users gate at the caller, which
+                # was misleading for ignored users and for cross-check
+                # failures.
+                logger.info(
+                    f"Found match from user: {username} for "
+                    f"{score.matched_tracks} tracks! "
+                    f"Track attributes: {allowed_filetype}"
+                )
+                logger.info(f"Average sequence match ratio: {score.avg_ratio}")
+                logger.info("SUCCESSFUL MATCH")
+                logger.info("-------------------")
                 return MatchResult(
                     matched=True,
                     directory=directory,

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -1485,12 +1485,31 @@ class PipelineDB:
     def log_search(self, request_id: int, query: str | None = None,
                    result_count: int | None = None,
                    elapsed_s: float | None = None,
-                   outcome: str = "error") -> None:
-        """Record one search attempt for an album request."""
+                   outcome: str = "error",
+                   candidates: "list[Any] | None" = None,
+                   variant: str | None = None,
+                   final_state: str | None = None) -> None:
+        """Record one search attempt for an album request.
+
+        ``candidates`` is the top-N forensic ``CandidateScore`` list (already
+        truncated by the caller). It is encoded via ``msgspec.json.encode``
+        and written to ``search_log.candidates`` JSONB. ``None`` writes SQL
+        NULL — error / submission-failure rows have no scoring data to
+        report. See ``.claude/rules/code-quality.md`` § Wire-boundary types
+        for the symmetric encode/decode contract.
+        """
+        candidates_json: str | None = None
+        if candidates is not None:
+            import msgspec  # local import keeps top-of-module deps narrow
+            candidates_json = msgspec.json.encode(candidates).decode()
         self._execute("""
-            INSERT INTO search_log (request_id, query, result_count, elapsed_s, outcome)
-            VALUES (%s, %s, %s, %s, %s)
-        """, (request_id, query, result_count, elapsed_s, outcome))
+            INSERT INTO search_log (
+                request_id, query, result_count, elapsed_s, outcome,
+                candidates, variant, final_state
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """, (request_id, query, result_count, elapsed_s, outcome,
+              candidates_json, variant, final_state))
         self.conn.commit()
 
     def get_search_history(self, request_id: int) -> list[dict[str, object]]:

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -16,7 +16,10 @@ import zlib
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
+
+if TYPE_CHECKING:
+    from lib.quality import CandidateScore
 
 import psycopg2
 import psycopg2.extras
@@ -1528,7 +1531,7 @@ class PipelineDB:
                    result_count: int | None = None,
                    elapsed_s: float | None = None,
                    outcome: str = "error",
-                   candidates: "list[Any] | None" = None,
+                   candidates: "list[CandidateScore] | None" = None,
                    variant: str | None = None,
                    final_state: str | None = None) -> None:
         """Record one search attempt for an album request.

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -861,6 +861,42 @@ class PipelineDB:
         )
         self.conn.commit()
 
+    def set_manual(
+        self,
+        request_id: int,
+        *,
+        manual_reason: str | None = None,
+    ) -> None:
+        """Flip a request to ``status='manual'``, optionally writing a reason.
+
+        - ``manual_reason`` is a system-driven cause string (e.g.
+          ``'search_exhausted'``). When non-None, it is written to the
+          new ``album_requests.manual_reason`` column.
+        - When ``manual_reason`` is None (the default), the column is left
+          untouched — never overwritten with NULL. This protects an
+          existing reason when a generic flip path runs against a row
+          that already has a populated reason.
+
+        Re-queue is the only path that clears ``manual_reason``; that
+        clearing happens in ``reset_to_wanted``.
+        """
+        now = datetime.now(timezone.utc)
+        sets = [
+            "status = 'manual'",
+            "active_download_state = NULL",
+            "updated_at = %s",
+        ]
+        params: list[object] = [now]
+        if manual_reason is not None:
+            sets.append("manual_reason = %s")
+            params.append(manual_reason)
+        params.append(request_id)
+        self._execute(
+            f"UPDATE album_requests SET {', '.join(sets)} WHERE id = %s",
+            params,
+        )
+        self.conn.commit()
+
     def update_spectral_state(
         self,
         request_id: int,
@@ -920,6 +956,11 @@ class PipelineDB:
         Only fields explicitly passed are updated — omitted fields are
         preserved.  Pass ``search_filetype_override=None`` to clear the column;
         omitting it leaves the existing value untouched.
+
+        Always clears ``manual_reason`` — re-queueing past a manual flip
+        means the operator wants a clean slate. Per U6: every re-queue path
+        funnels through this method, so a single ``manual_reason = NULL``
+        write here covers web UI, CLI, and importer requeue paths.
         """
         now = datetime.now(timezone.utc)
         sets = [
@@ -930,6 +971,7 @@ class PipelineDB:
             "next_retry_after = NULL",
             "last_attempt_at = NULL",
             "active_download_state = NULL",
+            "manual_reason = NULL",
             "updated_at = %s",
         ]
         params: list[object] = [now]

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -424,6 +424,32 @@ class ValidationResult(msgspec.Struct):
         return msgspec.json.decode(s.encode(), type=cls)
 
 
+class CandidateScore(msgspec.Struct):
+    """Forensic record of one (user, dir, filetype) candidate's match score.
+
+    Wire-boundary type — written into ``search_log.candidates`` JSONB by
+    ``PipelineDB.log_search`` and decoded by U7 readers (CLI + web UI).
+    Encode via ``msgspec.json.encode``; decode via
+    ``msgspec.convert(blob, type=list[CandidateScore])`` — symmetric strict
+    validation at both boundaries per ``.claude/rules/code-quality.md`` §
+    Wire-boundary types.
+
+    Construct via keyword arguments only. ``check_for_match`` builds the
+    full-score variant when ``album_match`` runs; the count-gate-failure
+    variant is the cheap zero-score record (``matched_tracks=0``,
+    ``avg_ratio=0.0``, ``missing_titles=[]``) so the forensic blob still
+    captures peers that had a sub-count audio file count.
+    """
+    username: str
+    dir: str
+    filetype: str
+    matched_tracks: int
+    total_tracks: int
+    avg_ratio: float
+    missing_titles: list[str]
+    file_count: int
+
+
 @dataclass
 class SpectralContext:
     """Gathered spectral analysis data for both new and existing files.

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -9,7 +9,7 @@ import enum
 import json
 from dataclasses import dataclass, field, asdict
 from enum import IntEnum, StrEnum
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Sequence
 
 import msgspec
 
@@ -448,6 +448,32 @@ class CandidateScore(msgspec.Struct):
     avg_ratio: float
     missing_titles: list[str]
     file_count: int
+
+
+def top_candidates(
+    candidates: Sequence[CandidateScore], limit: int = 20,
+) -> list[CandidateScore]:
+    """Return the top-N candidates sorted by (matched_tracks, avg_ratio) DESC.
+
+    Pure helper — no DB, no I/O. Single source of truth for the candidate
+    ranking used by:
+
+    - ``cratedigger._log_search_result`` (top-20 written to
+      ``search_log.candidates`` JSONB)
+    - ``web/routes/pipeline.py:_build_last_search_payload`` (top-3 surfaced
+      on ``/api/pipeline/<id>``)
+    - ``scripts/pipeline_cli.py:_render_search_forensics_summary`` (top-3 in
+      ``pipeline-cli show <id>``)
+
+    Sorting by matched_tracks first surfaces the closest peers; avg_ratio is
+    the secondary tiebreak so a 24/26 dir with high ratio beats a 24/26 dir
+    with low ratio.
+    """
+    return sorted(
+        candidates,
+        key=lambda c: (c.matched_tracks, c.avg_ratio),
+        reverse=True,
+    )[:limit]
 
 
 @dataclass

--- a/lib/search.py
+++ b/lib/search.py
@@ -17,6 +17,7 @@ Pure functions — no I/O, no external dependencies.
 
 import re
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 @dataclass
@@ -163,3 +164,135 @@ def build_query(artist, title, prepend_artist=True, max_tokens=MAX_SEARCH_TOKENS
     all_tokens = cap_tokens(all_tokens, max_tokens)
 
     return " ".join(all_tokens)
+
+
+# ---------------------------------------------------------------------------
+# Variant generator (U4 of search-escalation-and-forensics)
+#
+# Pure function: given the current cycle counter, escalation threshold, base
+# query, year, and track titles, return which query to issue next. Single
+# source of truth for the search-cycle ladder. No I/O.
+#
+# Ladder:
+#   cycle < threshold        → kind="default",   query=base_query
+#   cycle == threshold       → kind="v1_year",   query="<base> <yyyy>" (if year known)
+#   cycle == threshold + N   → kind="v4_tracks", query=N×3 distinctive tokens
+#   pool exhausted           → kind="exhausted", query=None (search loop short-circuits)
+#
+# Year is treated as unknown when None or starts with "0000" (the AlbumRecord
+# fallback string when MusicBrainz has no year). When unknown, V1 is skipped
+# and V4 starts at the threshold cycle.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SearchVariant:
+    """One cycle's variant decision.
+
+    Internal type — never crosses JSON. The `tag` field is the persisted
+    label written to `search_log.variant`. `kind` drives loop behaviour:
+    "exhausted" tells the search loop to short-circuit before hitting slskd.
+    """
+    kind: Literal["default", "v1_year", "v4_tracks", "exhausted"]
+    query: str | None  # None for kind="exhausted"
+    tag: str           # "default" | "v1_year" | "v4_tracks_<idx>" | "exhausted"
+    slice_index: int | None  # V4 only, for diagnostics
+
+
+def _distinctive_token_pool(track_titles: list[str]) -> list[str]:
+    """Build the V4 token pool from track titles.
+
+    Rules:
+      - Strip punctuation via `strip_special_chars` (already used by the query
+        builder so the pool matches what slskd will tolerate).
+      - Drop tokens of length <= 2 (mirrors `strip_short_tokens` behaviour).
+      - Dedupe case-insensitively, preserving first-seen casing.
+      - Sort by length descending; alphabetical-lowercase secondary order
+        for determinism on length ties.
+    """
+    seen_lower: set[str] = set()
+    distinct: list[str] = []
+    for title in track_titles:
+        cleaned = strip_special_chars(title)
+        for token in cleaned.split():
+            if len(token) <= 2:
+                continue
+            lower = token.lower()
+            if lower in seen_lower:
+                continue
+            seen_lower.add(lower)
+            distinct.append(token)
+
+    # Sort by (-length, lowercase) for deterministic ordering on length ties.
+    distinct.sort(key=lambda t: (-len(t), t.lower()))
+    return distinct
+
+
+def _year_is_known(year: str | None) -> bool:
+    """Year is unknown when None or starts with the MB-fallback "0000"."""
+    if year is None:
+        return False
+    if year.startswith("0000"):
+        return False
+    return True
+
+
+def select_variant(
+    search_attempts: int,
+    threshold: int,
+    base_query: str,
+    year: str | None,
+    track_titles: list[str],
+) -> SearchVariant:
+    """Select the variant for this search cycle.
+
+    Deterministic for a given input — testable via subTest tables.
+
+    `search_attempts` is how many search cycles this album has already
+    consumed (0 on first attempt). `threshold` is the count at which
+    escalation begins. Below the threshold the default query repeats; at
+    and above, the ladder advances by one step per cycle.
+    """
+    if search_attempts < threshold:
+        return SearchVariant(
+            kind="default",
+            query=base_query,
+            tag="default",
+            slice_index=None,
+        )
+
+    year_known = _year_is_known(year)
+    esc_idx = search_attempts - threshold
+
+    if esc_idx == 0 and year_known:
+        # year_known guarantees year is not None; year[:4] yields the 4-char
+        # year prefix (e.g. "1991" from "1991" or "1991-08-01").
+        assert year is not None  # for type checker
+        return SearchVariant(
+            kind="v1_year",
+            query=f"{base_query} {year[:4]}",
+            tag="v1_year",
+            slice_index=None,
+        )
+
+    # V1 either ran (esc_idx 0 with year) or was skipped (year unknown).
+    v4_start = 1 if year_known else 0
+    v4_idx = esc_idx - v4_start
+
+    pool = _distinctive_token_pool(track_titles)
+    slice_start = v4_idx * 3
+    if slice_start >= len(pool):
+        return SearchVariant(
+            kind="exhausted",
+            query=None,
+            tag="exhausted",
+            slice_index=None,
+        )
+
+    slice_tokens = pool[slice_start : slice_start + 3]
+    return SearchVariant(
+        kind="v4_tracks",
+        query=" ".join(slice_tokens),
+        tag=f"v4_tracks_{v4_idx}",
+        slice_index=v4_idx,
+    )

--- a/lib/search.py
+++ b/lib/search.py
@@ -17,7 +17,10 @@ Pure functions — no I/O, no external dependencies.
 
 import re
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.quality import CandidateScore
 
 
 @dataclass
@@ -38,7 +41,20 @@ class SearchResult:
     query: str = ""
     result_count: int | None = None
     elapsed_s: float = 0.0
-    outcome: str = ""  # found, no_match, no_results, timeout, error, empty_query
+    # found, no_match, no_results, timeout, error, empty_query, exhausted
+    outcome: str = ""
+    # U5 forensic capture (search-escalation-and-forensics):
+    # - candidates: per-(user, dir, filetype) match scores collected from
+    #   `find_download` → `_apply_find_download_result`. Persisted to
+    #   `search_log.candidates` JSONB after top-20 truncation.
+    # - variant_tag: "default" | "v1_year" | "v4_tracks_<idx>" | "exhausted",
+    #   produced by `select_variant`. Persisted to `search_log.variant`.
+    # - final_state: slskd's terminal state string ("Completed",
+    #   "TimedOut", "ResponseLimitReached", "Errored"...). Persisted to
+    #   `search_log.final_state`.
+    candidates: tuple["CandidateScore", ...] = ()
+    variant_tag: str | None = None
+    final_state: str | None = None
 
 # Soulseek's distributed search times out with too many tokens.
 # 4 is the safe maximum.

--- a/lib/search.py
+++ b/lib/search.py
@@ -15,6 +15,8 @@ banned word list.
 Pure functions — no I/O, no external dependencies.
 """
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass, field
 from typing import Literal, TYPE_CHECKING
@@ -52,7 +54,7 @@ class SearchResult:
     # - final_state: slskd's terminal state string ("Completed",
     #   "TimedOut", "ResponseLimitReached", "Errored"...). Persisted to
     #   `search_log.final_state`.
-    candidates: tuple["CandidateScore", ...] = ()
+    candidates: tuple[CandidateScore, ...] = ()
     variant_tag: str | None = None
     final_state: str | None = None
 

--- a/lib/search.py
+++ b/lib/search.py
@@ -247,12 +247,20 @@ def _distinctive_token_pool(track_titles: list[str]) -> list[str]:
 
 
 def _year_is_known(year: str | None) -> bool:
-    """Year is unknown when None or starts with the MB-fallback "0000"."""
-    if year is None:
-        return False
-    if year.startswith("0000"):
-        return False
-    return True
+    """Year is known iff the first 4 chars are all digits and not "0000".
+
+    MB sometimes returns a fallback "0000" year, an empty string, whitespace,
+    or non-numeric placeholders ("unknown"). Treat all of those as unknown
+    so the V1 cycle does not append a meaningless year token to the slskd
+    query (degrading match recall). Also rejects shorter-than-4-char numeric
+    prefixes ("199") because they are clearly malformed.
+    """
+    return (
+        year is not None
+        and len(year) >= 4
+        and year[:4].isdigit()
+        and year[:4] != "0000"
+    )
 
 
 def select_variant(

--- a/migrations/010_search_forensics_and_manual_reason.sql
+++ b/migrations/010_search_forensics_and_manual_reason.sql
@@ -1,0 +1,26 @@
+-- 010_search_forensics_and_manual_reason.sql - Search forensics + manual reason
+--
+-- U1 of search-escalation-and-forensics. Adds the columns the upcoming search
+-- escalation logic and the web "Manual review" UI need to record what actually
+-- happened at search time and why a request ended up in manual:
+--
+--   * search_log.candidates  - top-20 candidate scores per search (JSONB)
+--   * search_log.variant     - variant tag like 'default', 'v1_year', 'v4_tracks_0'
+--   * search_log.final_state - slskd terminal state string
+--   * album_requests.manual_reason - human/decision-readable manual cause
+--
+-- Also extends search_log.outcome to allow 'exhausted' (every variant tried,
+-- nothing matched). Postgres auto-named the original inline CHECK
+-- search_log_outcome_check (see migrations/001_initial.sql:119-121); we drop
+-- and recreate it here so the constraint stays named and can be evolved by
+-- future migrations.
+
+ALTER TABLE search_log ADD COLUMN candidates JSONB;
+ALTER TABLE search_log ADD COLUMN variant TEXT;
+ALTER TABLE search_log ADD COLUMN final_state TEXT;
+
+ALTER TABLE album_requests ADD COLUMN manual_reason TEXT;
+
+ALTER TABLE search_log DROP CONSTRAINT search_log_outcome_check;
+ALTER TABLE search_log ADD CONSTRAINT search_log_outcome_check
+  CHECK (outcome IN ('found','no_match','no_results','timeout','error','empty_query','exhausted'));

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -154,6 +154,7 @@
     number_of_albums_to_grab = ${toString cfg.searchSettings.numberOfAlbumsToGrab}
     title_blacklist = ${concatStringsSep "," cfg.searchSettings.titleBlacklist}
     search_blacklist = ${concatStringsSep "," cfg.searchSettings.searchBlacklist}
+    search_response_limit = ${toString cfg.searchSettings.searchResponseLimit}
 
     [Download Settings]
     download_filtering = ${if cfg.downloadSettings.downloadFiltering then "True" else "False"}
@@ -576,6 +577,15 @@ in {
       };
       parallelSearches = mkOption { type = types.int; default = 8; };
       numberOfAlbumsToGrab = mkOption { type = types.int; default = 16; };
+      searchResponseLimit = mkOption {
+        type = types.int;
+        default = 1000;
+        description = ''
+          Caps how many peer responses slskd collects per search. Maps to
+          slskd's `responseLimit` ceiling — raising this lets the matcher
+          consider more peers per query at the cost of a longer search window.
+        '';
+      };
       titleBlacklist = mkOption {
         type = types.listOf types.str;
         default = [];

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -547,6 +547,73 @@ def _render_import_result(ir_raw):
     return lines
 
 
+def _render_search_forensics_summary(
+    request_row: dict, latest_search: dict,
+) -> list[str]:
+    """Build the U7 forensic summary block printed above search history.
+
+    Inputs:
+    - ``request_row``: the row dict from ``PipelineDB.get_request``. Used
+      for ``manual_reason`` (None when not exhausted / pre-U7).
+    - ``latest_search``: the most recent ``search_log`` row dict (already
+      ordered newest-first by ``get_search_history``). The candidates
+      JSONB blob is decoded here via ``msgspec.convert(blob,
+      type=list[CandidateScore])`` — single decode site for the CLI side
+      per ``.claude/rules/code-quality.md`` § Wire-boundary types.
+
+    Empty lists / NULL JSONB blobs render gracefully (no
+    ``msgspec.ValidationError``); rows without forensic fields (e.g.
+    pre-U1 search_log entries) print "no forensic data yet".
+    """
+    from lib.quality import CandidateScore
+
+    lines: list[str] = ["", "  Search Forensics:"]
+    variant = latest_search.get("variant")
+    final_state = latest_search.get("final_state")
+    manual_reason = request_row.get("manual_reason")
+
+    if variant:
+        lines.append(f"    variant:        {variant}")
+    if final_state:
+        lines.append(f"    final_state:    {final_state}")
+    if manual_reason:
+        lines.append(f"    manual_reason:  {manual_reason}")
+
+    raw_candidates = latest_search.get("candidates")
+    if raw_candidates is None:
+        if not (variant or final_state or manual_reason):
+            lines.append("    (no forensic data yet)")
+        else:
+            lines.append("    candidates:     (none captured)")
+        return lines
+
+    try:
+        candidates = msgspec.convert(raw_candidates, type=list[CandidateScore])
+    except msgspec.ValidationError as e:
+        # Defensive — production writes via the same Struct so this should
+        # never trip in practice, but a corrupted historical row should
+        # not crash `pipeline-cli show`.
+        lines.append(f"    candidates:     <decode error: {e}>")
+        return lines
+
+    if not candidates:
+        lines.append("    candidates:     (empty list)")
+        return lines
+
+    # Top-3 by (matched_tracks DESC, avg_ratio DESC) — same ordering as the
+    # web UI route, so CLI and web surfaces show the same scoring.
+    candidates.sort(key=lambda c: (c.matched_tracks, c.avg_ratio), reverse=True)
+    top = candidates[:3]
+    lines.append(f"    top candidates ({len(top)} of {len(candidates)}):")
+    for c in top:
+        lines.append(
+            f"      {c.username} | {c.dir} | "
+            f"{c.matched_tracks}/{c.total_tracks} | "
+            f"avg={c.avg_ratio:.2f} | {c.filetype}"
+        )
+    return lines
+
+
 def cmd_show(db, args):
     req = db.get_request(args.id)
     if not req:
@@ -626,6 +693,14 @@ def cmd_show(db, args):
 
     searches = db.get_search_history(req['id'])
     if searches:
+        # U7: print a forensic summary above the row table — the most
+        # recent variant + final_state, the request's manual_reason if
+        # populated, and the top-3 candidates from the latest search_log
+        # row's JSONB blob. The blob is decoded once via msgspec.convert
+        # per single-decode-site discipline (code-quality.md § Wire-
+        # boundary types). Older rows / NULL blobs render gracefully.
+        for line in _render_search_forensics_summary(req, searches[0]):
+            print(line)
         print(f"\n  Search History ({len(searches)}):")
         for s in searches:
             q = s['query'] or "(no query)"
@@ -633,7 +708,8 @@ def cmd_show(db, args):
             rc_str = f"{rc} results" if rc is not None else "n/a"
             el = s['elapsed_s']
             el_str = f"{el:.1f}s" if el is not None else ""
-            print(f"    [{s['created_at']}] {s['outcome']:12s} {rc_str:>12s} {el_str:>6s}  {q}")
+            variant = s.get('variant') or "-"
+            print(f"    [{s['created_at']}] {s['outcome']:12s} {variant:14s} {rc_str:>12s} {el_str:>6s}  {q}")
 
     history = db.get_download_history(req['id'])
     if history:

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -565,7 +565,7 @@ def _render_search_forensics_summary(
     ``msgspec.ValidationError``); rows without forensic fields (e.g.
     pre-U1 search_log entries) print "no forensic data yet".
     """
-    from lib.quality import CandidateScore
+    from lib.quality import CandidateScore, top_candidates
 
     lines: list[str] = ["", "  Search Forensics:"]
     variant = latest_search.get("variant")
@@ -601,9 +601,9 @@ def _render_search_forensics_summary(
         return lines
 
     # Top-3 by (matched_tracks DESC, avg_ratio DESC) — same ordering as the
-    # web UI route, so CLI and web surfaces show the same scoring.
-    candidates.sort(key=lambda c: (c.matched_tracks, c.avg_ratio), reverse=True)
-    top = candidates[:3]
+    # web UI route, so CLI and web surfaces show the same scoring. Shared
+    # ranking lives in lib/quality.py.
+    top = top_candidates(candidates, limit=3)
     lines.append(f"    top candidates ({len(top)} of {len(candidates)}):")
     for c in top:
         lines.append(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1851,6 +1851,17 @@ class FakePipelineDB:
 
     @staticmethod
     def _search_log_to_dict(entry: SearchLogRow) -> dict[str, object]:
+        # Match production JSONB read behaviour: psycopg2 deserializes
+        # ``search_log.candidates`` (JSONB) into a Python list/dict on
+        # ``SELECT *``. The fake stores the encoded JSON string, so decode
+        # here so consumers (e.g. the U7 web route + CLI) see the same
+        # parsed-list shape they get from the real DB.
+        candidates: object | None
+        if entry.candidates is None:
+            candidates = None
+        else:
+            import json as _json
+            candidates = _json.loads(entry.candidates)
         return {
             "id": entry.id,
             "request_id": entry.request_id,
@@ -1859,7 +1870,7 @@ class FakePipelineDB:
             "elapsed_s": entry.elapsed_s,
             "outcome": entry.outcome,
             "created_at": entry.created_at,
-            "candidates": entry.candidates,
+            "candidates": candidates,
             "variant": entry.variant,
             "final_state": entry.final_state,
         }

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -102,6 +102,13 @@ class SearchLogRow:
     outcome: str = "error"
     id: int = 0
     created_at: datetime = field(default_factory=_utcnow)
+    # Forensic capture (U5 of search-escalation-and-forensics).
+    # ``candidates`` is the JSONB blob persisted by ``log_search`` — the
+    # in-memory representation is the JSON string the production code
+    # would have written via ``msgspec.json.encode``. NULL on error rows.
+    candidates: str | None = None
+    variant: str | None = None
+    final_state: str | None = None
 
 
 @dataclass
@@ -211,6 +218,92 @@ class FakeSlskdUsers:
         return copy.deepcopy(self._directories.get((username, directory), []))
 
 
+@dataclass
+class SearchTextCall:
+    """One slskd ``searches.search_text`` call captured by FakeSlskdSearches."""
+    search_text: str
+    kwargs: dict[str, Any]
+
+
+class FakeSlskdSearches:
+    """Stateful fake for the slskd searches API.
+
+    Drives orchestration tests over `search_for_album` / `_submit_search`:
+    pre-seed canned ``state``, ``responses`` for known search ids; record
+    every ``search_text`` kwargs (especially ``responseLimit``) for later
+    assertion.
+
+    Usage:
+        searches = FakeSlskdSearches()
+        searches.add_search(search_id=1, state="Completed", responses=[...])
+        searches.search_text_id_sequence = [1]   # next call returns id=1
+        # ... drive code under test ...
+        assert searches.search_text_calls[0].kwargs["responseLimit"] == 1000
+    """
+
+    def __init__(self) -> None:
+        self.search_text_calls: list[SearchTextCall] = []
+        self.state_calls: list[tuple[Any, bool]] = []
+        self.responses_calls: list[Any] = []
+        self.delete_calls: list[Any] = []
+        self.search_text_error: Exception | None = None
+        # Each call returns the next id from this list; falls back to a
+        # monotonically incrementing counter once the list is exhausted.
+        self.search_text_id_sequence: list[Any] = []
+        self._next_auto_id = 1
+        # search_id -> {"state": str, "responses": list[dict]}
+        self._searches: dict[Any, dict[str, Any]] = {}
+
+    def add_search(
+        self,
+        *,
+        search_id: Any,
+        state: str = "Completed",
+        responses: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Pre-register a canned response set for a search id."""
+        self._searches[search_id] = {
+            "state": state,
+            "responses": copy.deepcopy(responses or []),
+        }
+
+    def search_text(self, **kwargs: Any) -> dict[str, Any]:
+        text = kwargs.pop("searchText", "")
+        self.search_text_calls.append(
+            SearchTextCall(search_text=text, kwargs=copy.deepcopy(kwargs)))
+        if self.search_text_error is not None:
+            raise self.search_text_error
+        if self.search_text_id_sequence:
+            search_id = self.search_text_id_sequence.pop(0)
+        else:
+            search_id = self._next_auto_id
+            self._next_auto_id += 1
+        # Default state for an unconfigured id keeps the fake usable
+        # without explicit ``add_search`` for one-shot tests.
+        self._searches.setdefault(search_id, {
+            "state": "Completed",
+            "responses": [],
+        })
+        return {"id": search_id}
+
+    def state(self, search_id: Any, _include_responses: bool = False) -> dict[str, Any]:
+        self.state_calls.append((search_id, _include_responses))
+        cfg = self._searches.get(search_id, {"state": "Completed", "responses": []})
+        return {
+            "id": search_id,
+            "state": cfg["state"],
+            "isComplete": True,
+        }
+
+    def search_responses(self, search_id: Any) -> list[dict[str, Any]]:
+        self.responses_calls.append(search_id)
+        cfg = self._searches.get(search_id)
+        return copy.deepcopy(cfg["responses"]) if cfg else []
+
+    def delete(self, search_id: Any) -> None:
+        self.delete_calls.append(search_id)
+
+
 class FakeSlskdAPI:
     """In-memory fake for slskd API clients used by download tests."""
 
@@ -222,6 +315,7 @@ class FakeSlskdAPI:
     ) -> None:
         self.transfers = FakeSlskdTransfers(self)
         self.users = FakeSlskdUsers()
+        self.searches = FakeSlskdSearches()
         self._downloads = copy.deepcopy(downloads or [])
         self._download_snapshots = [
             copy.deepcopy(snapshot) for snapshot in (download_snapshots or [])
@@ -1686,8 +1780,22 @@ class FakePipelineDB:
     def log_search(self, request_id: int, query: str | None = None,
                    result_count: int | None = None,
                    elapsed_s: float | None = None,
-                   outcome: str = "error") -> None:
+                   outcome: str = "error",
+                   candidates: list[Any] | None = None,
+                   variant: str | None = None,
+                   final_state: str | None = None) -> None:
+        """Mirror PipelineDB.log_search wire boundary.
+
+        ``candidates`` is encoded via ``msgspec.json.encode`` (same as the
+        real DB writer) and stored as a JSON string so tests can decode it
+        with ``msgspec.convert(json.loads(row.candidates), type=list[CandidateScore])``
+        — the same path U7 will use to read the JSONB blob back.
+        """
         self._next_search_log_id += 1
+        candidates_json: str | None = None
+        if candidates is not None:
+            import msgspec
+            candidates_json = msgspec.json.encode(candidates).decode()
         self.search_logs.append(SearchLogRow(
             request_id=request_id,
             query=query,
@@ -1695,6 +1803,9 @@ class FakePipelineDB:
             elapsed_s=elapsed_s,
             outcome=outcome,
             id=self._next_search_log_id,
+            candidates=candidates_json,
+            variant=variant,
+            final_state=final_state,
         ))
 
     def get_search_history(self,
@@ -1727,6 +1838,9 @@ class FakePipelineDB:
             "elapsed_s": entry.elapsed_s,
             "outcome": entry.outcome,
             "created_at": entry.created_at,
+            "candidates": entry.candidates,
+            "variant": entry.variant,
+            "final_state": entry.final_state,
         }
 
     # --- User cooldowns ---

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -12,7 +12,10 @@ import json
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator
+
+if TYPE_CHECKING:
+    from lib.quality import CandidateScore
 
 from lib.import_queue import (
     ImportJob,
@@ -1802,7 +1805,7 @@ class FakePipelineDB:
                    result_count: int | None = None,
                    elapsed_s: float | None = None,
                    outcome: str = "error",
-                   candidates: list[Any] | None = None,
+                   candidates: list[CandidateScore] | None = None,
                    variant: str | None = None,
                    final_state: str | None = None) -> None:
         """Mirror PipelineDB.log_search wire boundary.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1019,6 +1019,7 @@ class FakePipelineDB:
         row["next_retry_after"] = None
         row["last_attempt_at"] = None
         row["active_download_state"] = None
+        row["manual_reason"] = None
         row["updated_at"] = now
         if "search_filetype_override" in fields:
             row["search_filetype_override"] = fields["search_filetype_override"]
@@ -1028,6 +1029,25 @@ class FakePipelineDB:
                 row["prev_min_bitrate"] = current_min_bitrate
             row["min_bitrate"] = fields["min_bitrate"]
         self.status_history.append((request_id, "wanted"))
+
+    def set_manual(
+        self,
+        request_id: int,
+        *,
+        manual_reason: str | None = None,
+    ) -> None:
+        """Mirror ``PipelineDB.set_manual``: flip to ``status='manual'``,
+        write ``manual_reason`` only when non-None (no NULL clobber).
+        """
+        row = self._requests.get(request_id)
+        if row is None:
+            return
+        row["status"] = "manual"
+        row["active_download_state"] = None
+        row["updated_at"] = _utcnow()
+        if manual_reason is not None:
+            row["manual_reason"] = manual_reason
+        self.status_history.append((request_id, "manual"))
 
     def set_downloading(self, request_id: int, state_json: str) -> bool:
         row = self._requests.get(request_id)
@@ -1388,6 +1408,7 @@ class FakePipelineDB:
             "current_lossless_source_v0_probe_avg_bitrate": None,
             "current_lossless_source_v0_probe_median_bitrate": None,
             "active_download_state": None,
+            "manual_reason": None,
             "created_at": now,
             "updated_at": now,
         }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -75,6 +75,7 @@ def make_request_row(**overrides: Any) -> dict[str, Any]:
         "current_lossless_source_v0_probe_avg_bitrate": None,
         "current_lossless_source_v0_probe_median_bitrate": None,
         "active_download_state": None,
+        "manual_reason": None,
         "created_at": datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         "updated_at": datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,6 +104,52 @@ class TestConfigFromIni(unittest.TestCase):
         cfg = CratediggerConfig.from_ini(ini)
         self.assertEqual(cfg.browse_parallelism, 8)
 
+    def test_search_response_limit_explicit(self):
+        """Explicit search_response_limit is parsed verbatim."""
+        ini = configparser.ConfigParser()
+        ini.read_string("[Search Settings]\nsearch_response_limit = 1500\n")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_response_limit, 1500)
+
+    def test_search_escalation_threshold_explicit(self):
+        """Explicit search_escalation_threshold is parsed verbatim."""
+        ini = configparser.ConfigParser()
+        ini.read_string("[Search Settings]\nsearch_escalation_threshold = 9\n")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_escalation_threshold, 9)
+
+    def test_search_response_limit_default(self):
+        """Missing key falls back to default of 1000."""
+        ini = configparser.ConfigParser()
+        ini.add_section("Search Settings")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_response_limit, 1000)
+
+    def test_search_escalation_threshold_default(self):
+        """Missing key falls back to default of 5."""
+        ini = configparser.ConfigParser()
+        ini.add_section("Search Settings")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_escalation_threshold, 5)
+
+    def test_search_settings_defaults_when_section_missing(self):
+        """Missing [Search Settings] section yields the documented defaults."""
+        ini = configparser.ConfigParser()
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_response_limit, 1000)
+        self.assertEqual(cfg.search_escalation_threshold, 5)
+
+    def test_search_response_limit_zero_passes_through(self):
+        """`from_ini` does not validate; a literal 0 is accepted as-is.
+
+        Defensive validation belongs further down the stack (slskd will reject
+        nonsense values); the config layer must remain a transparent loader.
+        """
+        ini = configparser.ConfigParser()
+        ini.read_string("[Search Settings]\nsearch_response_limit = 0\n")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_response_limit, 0)
+
     # --- Release ---
     def test_use_most_common_tracknum(self):
         self.assertTrue(self.cfg.use_most_common_tracknum)

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -119,8 +119,11 @@ class TestEnqueueCooldownFiltering(unittest.TestCase):
         ]
         results = {"gooduser": {"flac": ["Music\\Album"]}}
 
-        with patch("lib.enqueue.check_for_match",
-                   return_value=(False, None, None)):
+        from lib.matching import MatchResult
+        with patch(
+            "lib.enqueue.check_for_match",
+            return_value=MatchResult(matched=False, directory=None, file_dir=""),
+        ):
             attempt = try_enqueue(tracks, results, "flac", ctx)
 
         # check_for_match WAS called for the non-cooled user

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -390,6 +390,68 @@ class TestFakeSlskdAPI(unittest.TestCase):
         ])
 
 
+class TestFakeSlskdSearches(unittest.TestCase):
+    """Self-test for the FakeSlskdSearches stub introduced in U5."""
+
+    def test_search_text_records_kwargs_and_returns_id(self):
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [101]
+        result = slskd.searches.search_text(
+            searchText="*rtist Album",
+            searchTimeout=30000,
+            filterResponses=True,
+            maximumPeerQueueLength=5,
+            minimumPeerUploadSpeed=0,
+            responseLimit=1000,
+        )
+        self.assertEqual(result, {"id": 101})
+        call = slskd.searches.search_text_calls[0]
+        self.assertEqual(call.search_text, "*rtist Album")
+        self.assertEqual(call.kwargs["responseLimit"], 1000)
+        self.assertEqual(call.kwargs["searchTimeout"], 30000)
+
+    def test_state_returns_canned_terminal_state(self):
+        slskd = FakeSlskdAPI()
+        slskd.searches.add_search(search_id=7, state="ResponseLimitReached")
+
+        state = slskd.searches.state(7, False)
+
+        self.assertEqual(state["state"], "ResponseLimitReached")
+        self.assertEqual(slskd.searches.state_calls, [(7, False)])
+
+    def test_search_responses_returns_canned_payload(self):
+        slskd = FakeSlskdAPI()
+        responses = [
+            {"username": "u1", "uploadSpeed": 100, "files": [
+                {"filename": "u1\\Music\\01.flac"},
+            ]},
+        ]
+        slskd.searches.add_search(search_id=11, responses=responses)
+
+        out = slskd.searches.search_responses(11)
+
+        self.assertEqual(out, responses)
+        # Response list must be a deep copy — tests can mutate freely.
+        out[0]["files"].append({"filename": "tampered.flac"})
+        again = slskd.searches.search_responses(11)
+        self.assertEqual(len(again[0]["files"]), 1)
+
+    def test_search_text_error_propagates(self):
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_error = RuntimeError("slskd offline")
+        with self.assertRaises(RuntimeError):
+            slskd.searches.search_text(searchText="x", responseLimit=1000)
+
+    def test_unknown_search_id_returns_completed_with_no_responses(self):
+        slskd = FakeSlskdAPI()
+        # No add_search() call — the fake should still answer politely.
+        state = slskd.searches.search_text(
+            searchText="x", responseLimit=1000)
+        sid = state["id"]
+        self.assertEqual(slskd.searches.state(sid)["state"], "Completed")
+        self.assertEqual(slskd.searches.search_responses(sid), [])
+
+
 class TestBuilders(unittest.TestCase):
     def test_make_download_file_defaults(self):
         f = make_download_file()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -330,6 +330,45 @@ class TestFakePipelineDB(unittest.TestCase):
             self.assertFalse(acquired)
         self.assertEqual(db.advisory_lock_calls, [(0x1234, 42)])
 
+    def test_set_manual_writes_reason(self):
+        """U6 fake parity: ``set_manual`` flips status and writes reason."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+
+        db.set_manual(42, manual_reason="search_exhausted")
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["manual_reason"], "search_exhausted")
+        self.assertIn((42, "manual"), db.status_history)
+
+    def test_set_manual_does_not_overwrite_existing_reason_when_none(self):
+        """U6 fake parity: a None reason must NOT clobber a populated reason."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", manual_reason="operator_hold"))
+
+        db.set_manual(42)
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["manual_reason"], "operator_hold")
+
+    def test_reset_to_wanted_clears_manual_reason(self):
+        """U6 fake parity: re-queue clears ``manual_reason`` and counters."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual", manual_reason="search_exhausted",
+            search_attempts=7,
+        ))
+
+        db.reset_to_wanted(42)
+
+        row = db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_attempts"], 0)
+        self.assertIsNone(row["manual_reason"])
+
 
 class TestFakeSlskdAPI(unittest.TestCase):
     def test_get_downloads_returns_queued_snapshots(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -403,7 +403,7 @@ class TestContextDependencyPropagation(unittest.TestCase):
         }
         ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
-        found, _, _ = cratedigger.check_for_match(
+        result = cratedigger.check_for_match(
             make_tracks((1, "Track One", 1)),
             "flac",
             ["Music\\Album"],
@@ -411,7 +411,7 @@ class TestContextDependencyPropagation(unittest.TestCase):
             ctx,
         )
 
-        self.assertTrue(found)
+        self.assertTrue(result.matched)
 
     def test_get_denied_users_uses_ctx_pipeline_db_source(self):
         """Denylist lookups should use ctx.pipeline_db_source."""
@@ -897,13 +897,13 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
 
         # First call: match with 1 track, 1 audio file
         tracks = make_tracks((1, "Track One", 1))
-        found, directory, file_dir = cratedigger.check_for_match(
+        result = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Album"], "testuser", self.ctx
         )
-        self.assertTrue(found)
+        self.assertTrue(result.matched)
 
         # Mutate the returned directory via download_filter (as try_enqueue does)
-        cratedigger.download_filter("flac", directory, self.ctx.cfg)
+        cratedigger.download_filter("flac", result.directory, self.ctx.cfg)
 
         # folder_cache should still have ALL 3 files (including .nfo)
         cached = self.ctx.folder_cache["testuser"]["Music\\Album"]
@@ -925,21 +925,21 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
         tracks = make_tracks((1, "Track One", 1))
 
         # First match
-        found1, dir1, _ = cratedigger.check_for_match(
+        result1 = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Album"], "testuser", self.ctx
         )
-        self.assertTrue(found1)
+        self.assertTrue(result1.matched)
 
         # Mutate it
-        cratedigger.download_filter("flac", dir1, self.ctx.cfg)
+        cratedigger.download_filter("flac", result1.directory, self.ctx.cfg)
 
         # Second match on the same cached dir should still succeed
-        found2, dir2, _ = cratedigger.check_for_match(
+        result2 = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Album"], "testuser", self.ctx
         )
-        self.assertTrue(found2)
+        self.assertTrue(result2.matched)
         # And should have both files (not the filtered version)
-        self.assertEqual(len(dir2["files"]), 2)
+        self.assertEqual(len(result2.directory["files"]), 2)
 
     def test_successful_match_does_not_call_deepcopy(self):
         """check_for_match should return the cached directory directly on success."""
@@ -955,7 +955,7 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
             "deepcopy",
             side_effect=AssertionError("deepcopy should not be used"),
         ):
-            found, directory, file_dir = cratedigger.check_for_match(
+            result = cratedigger.check_for_match(
                 make_tracks((1, "Track One", 1)),
                 "flac",
                 ["Music\\Album"],
@@ -963,9 +963,9 @@ class TestDeepcopyDeferredToMatch(unittest.TestCase):
                 self.ctx,
             )
 
-        self.assertTrue(found)
-        self.assertEqual(file_dir, "Music\\Album")
-        self.assertIs(directory, self.ctx.folder_cache["testuser"]["Music\\Album"])
+        self.assertTrue(result.matched)
+        self.assertEqual(result.file_dir, "Music\\Album")
+        self.assertIs(result.directory, self.ctx.folder_cache["testuser"]["Music\\Album"])
 
 
 class TestSingleEnqueuePathPrefixing(unittest.TestCase):
@@ -1220,16 +1220,16 @@ class TestNegativeMatchCache(unittest.TestCase):
         )
 
         # First call — misses (1 file vs 3 tracks)
-        found1, _, _ = cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
-        self.assertFalse(found1)
+        result1 = cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        self.assertFalse(result1.matched)
 
         # Negative cache should contain (user1, Music\Album, 3, flac)
         self.assertIn(("user1", "Music\\Album", 3, "flac"), self.ctx.negative_matches)
 
         # Second call with same track count — should skip (no album_track_num re-eval)
         # We verify by checking that the negative cache hit prevents redundant work
-        found2, _, _ = cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
-        self.assertFalse(found2)
+        result2 = cratedigger.check_for_match(tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+        self.assertFalse(result2.matched)
 
     def test_same_dir_different_filetype_not_skipped(self):
         """A dir cached as negative for 'flac' should still be tried for '*'."""
@@ -1267,8 +1267,8 @@ class TestNegativeMatchCache(unittest.TestCase):
 
         # Now try with 1 track — should NOT be skipped (different track count)
         tracks_1 = make_tracks((1, "Track One", 1))
-        found, _, _ = cratedigger.check_for_match(tracks_1, "flac", ["Music\\Album"], "user1", self.ctx)
-        self.assertTrue(found)  # 1 file matches 1 track
+        result = cratedigger.check_for_match(tracks_1, "flac", ["Music\\Album"], "user1", self.ctx)
+        self.assertTrue(result.matched)  # 1 file matches 1 track
 
 
 class TestSearchResultPreFiltering(unittest.TestCase):
@@ -1494,10 +1494,10 @@ class TestParallelDirectoryBrowsing(unittest.TestCase):
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         tracks = make_tracks((1, "Track One", 1))
 
-        found, _, _ = cratedigger.check_for_match(
+        result = cratedigger.check_for_match(
             tracks, "flac", ["Music\\Dir1", "Music\\Dir2"], "user1", self.ctx
         )
-        self.assertFalse(found)
+        self.assertFalse(result.matched)
         self.assertIn("user1", self.ctx.broken_user)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1111,6 +1111,9 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
             result_count=None,
             elapsed_s=None,
             outcome="error",
+            candidates=None,
+            variant=None,
+            final_state=None,
         )
         db.record_attempt.assert_called_once_with(42, "search")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -775,12 +775,13 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
             }],
         )
 
+        from lib.matching import MatchResult
         with patch.object(
             enqueue_module,
             "check_for_match",
             side_effect=[
-                (True, dir1, "Music\\Disc1"),
-                (True, dir2, "Music\\Disc2"),
+                MatchResult(matched=True, directory=dir1, file_dir="Music\\Disc1"),
+                MatchResult(matched=True, directory=dir2, file_dir="Music\\Disc2"),
             ],
         ), patch("time.sleep"):
             cratedigger.try_multi_enqueue(release, tracks, results, "flac", self.ctx)
@@ -821,12 +822,13 @@ class TestMultiEnqueueNoDeepCopy(unittest.TestCase):
             }],
         )
 
+        from lib.matching import MatchResult
         with patch.object(
             enqueue_module,
             "check_for_match",
             side_effect=[
-                (True, dir1, "Music\\Disc1"),
-                (True, dir2, "Music\\Disc2"),
+                MatchResult(matched=True, directory=dir1, file_dir="Music\\Disc1"),
+                MatchResult(matched=True, directory=dir2, file_dir="Music\\Disc2"),
             ],
         ), patch("time.sleep"):
             attempt = cratedigger.try_multi_enqueue(
@@ -1002,10 +1004,13 @@ class TestSingleEnqueuePathPrefixing(unittest.TestCase):
             }]}],
         }])
 
+        from lib.matching import MatchResult
         with patch.object(
             enqueue_module,
             "check_for_match",
-            return_value=(True, directory, "Music\\Album"),
+            return_value=MatchResult(
+                matched=True, directory=directory, file_dir="Music\\Album",
+            ),
         ), patch("time.sleep"):
             attempt = cratedigger.try_enqueue(
                 make_tracks((1, "Track One", 1)),
@@ -1148,10 +1153,13 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
         ])
         results = {"user1": {"flac": ["Music\\Album"]}}
 
+        from lib.matching import MatchResult
         with patch.object(
             enqueue_module,
             "check_for_match",
-            return_value=(True, directory, "Music\\Album"),
+            return_value=MatchResult(
+                matched=True, directory=directory, file_dir="Music\\Album",
+            ),
         ):
             attempt = cratedigger.try_enqueue(
                 make_tracks((1, "Track One", 1)),

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2494,18 +2494,30 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         self._cratedigger._module_ctx = self._orig_module_ctx
 
     def _make_cfg(self, **overrides):
+        """Build CratediggerConfig via from_ini, then apply overrides.
+
+        CLAUDE.md / code-quality.md forbids partial-kwarg construction —
+        partial configs silently diverge when new fields are added. INI
+        key names match lib/config.py:from_ini (e.g. minimum_match_ratio
+        is loaded from the INI key 'minimum_filename_match_ratio').
+        """
+        import configparser
+        from dataclasses import replace as _replace
         from lib.config import CratediggerConfig
-        defaults: dict[str, Any] = dict(
-            allowed_filetypes=("flac",),
-            search_response_limit=1000,
-            search_escalation_threshold=5,
-            search_timeout=30000,
-            delete_searches=False,
-            album_prepend_artist=False,
-            minimum_match_ratio=0.5,
-        )
-        defaults.update(overrides)
-        return CratediggerConfig(**defaults)
+        ini = configparser.ConfigParser()
+        ini["Slskd"] = {"delete_searches": "False"}
+        ini["Search Settings"] = {
+            "allowed_filetypes": "flac",
+            "search_response_limit": "1000",
+            "search_escalation_threshold": "5",
+            "search_timeout": "30000",
+            "album_prepend_artist": "False",
+            "minimum_filename_match_ratio": "0.5",
+        }
+        cfg = CratediggerConfig.from_ini(ini)
+        if overrides:
+            cfg = _replace(cfg, **overrides)
+        return cfg
 
     def _make_album(self, *, request_id=1843, source="request",
                     discogs_release_id=None, mb_release_id="mbid-test"):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2729,7 +2729,15 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         self.assertEqual(db.recorded_attempts, [])
 
     def test_no_results_writes_empty_candidates_and_final_state(self):
-        """A search that returns 0 hits still writes a row, candidates NULL."""
+        """no_results writes candidates=[] (empty JSONB array, not NULL).
+
+        Plan U5 contract: a search that ran successfully but returned 0 hits
+        still wrote a search_log row, and the candidates blob distinguishes
+        "search ran, no peers" (``[]``) from "search never produced a
+        candidate concept" (``None`` — error, timeout, exhausted,
+        empty_query). FakePipelineDB serialises ``[]`` to the JSON literal
+        ``"[]"``.
+        """
         from tests.fakes import FakePipelineDB, FakeSlskdAPI
 
         cfg = self._make_cfg()
@@ -2755,8 +2763,8 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         row = db.search_logs[0]
         self.assertEqual(row.outcome, "no_results")
         self.assertEqual(row.final_state, "ResponseLimitReached")
-        # No candidates collected — find_download didn't run.
-        self.assertIsNone(row.candidates)
+        # search ran but no peers responded → candidates=[] (empty array).
+        self.assertEqual(row.candidates, "[]")
 
     def test_top_20_truncation_when_many_candidates(self):
         """JSONB blob caps at top-20 by (matched_tracks, avg_ratio) DESC."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2857,6 +2857,130 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         self.assertEqual(decoded[0]["username"], "discog_peer")
         self.assertEqual(decoded[0]["matched_tracks"], 1)
 
+    def test_parallel_submit_search_forwards_response_limit(self):
+        """Parallel path (_submit_search) wires search_response_limit too.
+
+        The serial path test above asserts the responseLimit kwarg on the
+        slskd call. The parallel path is a separate function and was missing
+        the same coverage; if a future refactor regressed the kwarg only on
+        the parallel path, the existing test would not catch it.
+        """
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg(search_response_limit=2500)
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [501]
+        slskd.searches.add_search(search_id=501, state="Completed", responses=[])
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-p", year=1991,
+        )
+        db.set_tracks(rid, [{"track_number": 1, "title": "Track"}])
+        album = self._make_album(request_id=rid, mb_release_id="mbid-p")
+        ctx = self._wire(cfg, slskd, db, album)
+
+        submit = self._cratedigger._submit_search(album, cfg, slskd, ctx)
+        self.assertIsNotNone(submit)
+        # responseLimit was forwarded to slskd at the wire boundary on the
+        # parallel path (no _collect_search_results call needed for this
+        # assertion).
+        self.assertEqual(len(slskd.searches.search_text_calls), 1)
+        call = slskd.searches.search_text_calls[0]
+        self.assertEqual(call.kwargs.get("responseLimit"),
+                         cfg.search_response_limit)
+
+    def test_v4_tracks_variant_used_when_search_attempts_past_v1(self):
+        """Cycle 6 (threshold+1) with year + tracks → variant=v4_tracks_0.
+
+        Mirrors test_v1_year_variant_used_when_search_attempts_at_threshold
+        but for the V4 token-slice escalation. Asserts:
+        - SearchResult.variant_tag == "v4_tracks_0"
+        - The slskd query carries the first 3 distinctive title tokens (no
+          artist tokens — V4 strips the artist prefix to bypass any name ban
+          plus the existing year/title combos that already failed).
+        - search_log persists variant='v4_tracks_0'.
+        """
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg(search_escalation_threshold=5)
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [777]
+        slskd.searches.add_search(search_id=777, state="Completed", responses=[])
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-v4", year=1991,
+        )
+        # search_attempts=6 → cycle past V1 → V4 slice 0.
+        db.update_request_fields(rid, search_attempts=6)
+        # Distinctive titles (>3 chars, varied) so the pool has at least 3.
+        db.set_tracks(rid, [
+            {"track_number": 1, "title": "Tallahassee"},
+            {"track_number": 2, "title": "Idylls"},
+            {"track_number": 3, "title": "Frontier"},
+            {"track_number": 4, "title": "Treasure"},
+        ])
+        album = self._make_album(request_id=rid, mb_release_id="mbid-v4")
+        ctx = self._wire(cfg, slskd, db, album)
+
+        result = self._cratedigger.search_for_album(album, ctx)
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        self.assertEqual(result.variant_tag, "v4_tracks_0")
+        self.assertEqual(len(slskd.searches.search_text_calls), 1)
+        call = slskd.searches.search_text_calls[0]
+        # V4 query is 3 distinctive title tokens — no wildcarded artist.
+        self.assertNotIn("*iggles", call.search_text)
+        # The pool sorts by length DESC then alpha; first 3 of
+        # [Tallahassee(11), Frontier(8), Treasure(8), Idylls(6)] is
+        # Tallahassee, Frontier, Treasure.
+        for tok in ("Tallahassee", "Frontier", "Treasure"):
+            self.assertIn(tok, call.search_text)
+        # search_log persisted the variant.
+        self.assertEqual(db.search_logs[0].variant, "v4_tracks_0")
+
+    def test_slskd_error_writes_default_variant_and_null_candidates(self):
+        """slskd raises during search → outcome=error, candidates=NULL.
+
+        Per FIX-3 of the search-escalation-and-forensics review queue,
+        outcomes that lack a candidate concept (error, timeout, exhausted,
+        empty_query) keep candidates=NULL — distinct from no_results /
+        no_match which write []. Drive the serial search loop with a
+        pre-seeded slskd error and assert the persisted forensic state.
+        """
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg()
+        slskd = FakeSlskdAPI()
+        # Cause search_text() to raise — search_for_album catches it and
+        # emits outcome="error".
+        slskd.searches.search_text_error = RuntimeError("offline")
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-err", year=1991,
+        )
+        db.set_tracks(rid, [{"track_number": 1, "title": "Track"}])
+        album = self._make_album(request_id=rid, mb_release_id="mbid-err")
+        ctx = self._wire(cfg, slskd, db, album)
+
+        result = self._cratedigger.search_for_album(album, ctx)
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        self.assertEqual(result.outcome, "error")
+        row = db.search_logs[0]
+        self.assertEqual(row.outcome, "error")
+        # Default variant — escalation never had a chance to advance.
+        self.assertEqual(row.variant, "default")
+        # No candidate concept — JSONB stays NULL (FakePipelineDB writes
+        # None as the JSON serialisation, distinct from "[]" used by
+        # no_results / no_match).
+        self.assertIsNone(row.candidates)
+
 
 class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
     """U6 integration slice: variant=exhausted → manual flip + re-queue reset.

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2876,6 +2876,10 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         slskd call. The parallel path is a separate function and was missing
         the same coverage; if a future refactor regressed the kwarg only on
         the parallel path, the existing test would not catch it.
+
+        Post-#9/#18 refactor: variant selection is hoisted to the caller, so
+        this test selects the variant via the same helper the parallel loop
+        uses, then passes it into ``_submit_search``.
         """
         from tests.fakes import FakePipelineDB, FakeSlskdAPI
 
@@ -2891,9 +2895,12 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         )
         db.set_tracks(rid, [{"track_number": 1, "title": "Track"}])
         album = self._make_album(request_id=rid, mb_release_id="mbid-p")
-        ctx = self._wire(cfg, slskd, db, album)
+        self._wire(cfg, slskd, db, album)
 
-        submit = self._cratedigger._submit_search(album, cfg, slskd, ctx)
+        variant, _base_query = self._cratedigger._select_variant_for_album(
+            album, cfg, db,
+        )
+        submit = self._cratedigger._submit_search(album, variant, cfg, slskd)
         self.assertIsNotNone(submit)
         # responseLimit was forwarded to slskd at the wire boundary on the
         # parallel path (no _collect_search_results call needed for this

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2469,5 +2469,386 @@ class TestBadAudioHashSlice(unittest.TestCase):
         self.assertEqual(len(db.denylist), 0)
 
 
+class TestSearchForensicsCaptureSlice(unittest.TestCase):
+    """U5 integration slice: search_for_album → find_download → log_search.
+
+    Drives the production search loop end-to-end with FakeSlskdSearches +
+    FakePipelineDB and asserts the persisted ``search_log.candidates``
+    JSONB shape, ``variant``, and ``final_state``. Covers the headline U5
+    test scenarios from the plan: response limit, variant ladder, top-20
+    truncation, exhaustion short-circuit, and Discogs-source parity.
+    """
+
+    def setUp(self):
+        import cratedigger
+        self._cratedigger = cratedigger
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+        self._orig_pdb = cratedigger.pipeline_db_source
+        self._orig_module_ctx = cratedigger._module_ctx
+
+    def tearDown(self):
+        self._cratedigger.cfg = self._orig_cfg
+        self._cratedigger.slskd = self._orig_slskd
+        self._cratedigger.pipeline_db_source = self._orig_pdb
+        self._cratedigger._module_ctx = self._orig_module_ctx
+
+    def _make_cfg(self, **overrides):
+        from lib.config import CratediggerConfig
+        defaults: dict[str, Any] = dict(
+            allowed_filetypes=("flac",),
+            search_response_limit=1000,
+            search_escalation_threshold=5,
+            search_timeout=30000,
+            delete_searches=False,
+            album_prepend_artist=False,
+            minimum_match_ratio=0.5,
+        )
+        defaults.update(overrides)
+        return CratediggerConfig(**defaults)
+
+    def _make_album(self, *, request_id=1843, source="request",
+                    discogs_release_id=None, mb_release_id="mbid-test"):
+        """Build an AlbumRecord matching the production from_db_row shape."""
+        from album_source import AlbumRecord, ReleaseRecord, MediaRecord
+
+        media = [MediaRecord(medium_number=1, medium_format="CD", track_count=2)]
+        release = ReleaseRecord(
+            id=-request_id, foreign_release_id=mb_release_id or "",
+            title="Album", track_count=2, medium_count=1,
+            format="CD", media=media, monitored=True,
+            country=["US"], status="Official",
+        )
+        return AlbumRecord(
+            id=-request_id, title="Album",
+            release_date="1991-01-01T00:00:00Z",
+            artist_id=0, artist_name="Wiggles",
+            foreign_artist_id="",
+            releases=[release],
+            db_request_id=request_id, db_source=source,
+            db_mb_release_id=mb_release_id or "",
+            db_search_filetype_override=None, db_target_format=None,
+        )
+
+    def _wire(self, cfg, slskd, db, album):
+        """Wire module globals + ctx so search_for_album can run.
+
+        The pipeline_db_source mock proxies ``_get_db`` to the FakePipelineDB,
+        and ``get_tracks(album)`` to the same fake's per-request tracks list
+        re-shaped into the ``TrackRecord`` dicts that ``find_download``
+        expects (``albumId`` = -request_id, mirroring the real DatabaseSource).
+        """
+        from lib.context import CratediggerContext
+        cratedigger = self._cratedigger
+        cratedigger.cfg = cfg
+        cratedigger.slskd = slskd
+        source = MagicMock()
+        source._get_db.return_value = db
+
+        def _get_tracks(album_record: Any) -> list[dict[str, Any]]:
+            request_id = getattr(album_record, "db_request_id", None)
+            if not request_id:
+                return []
+            rows = db.get_tracks(request_id)
+            album_id = request_id * -1
+            return [{
+                "title": r["title"],
+                "trackNumber": str(r["track_number"]),
+                "mediumNumber": r.get("disc_number", 1),
+                "duration": 0,
+                "id": 0,
+                "albumId": album_id,
+            } for r in rows]
+        source.get_tracks.side_effect = _get_tracks
+
+        cratedigger.pipeline_db_source = source
+        ctx = CratediggerContext(
+            cfg=cfg, slskd=slskd, pipeline_db_source=source,
+        )
+        cratedigger._module_ctx = ctx
+        # search_for_album / find_download read the album from the cache.
+        ctx.current_album_cache[album.id] = album
+        return ctx
+
+    def test_default_variant_passes_response_limit_and_persists_candidates(self):
+        """Happy path: default variant, slskd returns peers, candidates persist."""
+        import json
+        import msgspec
+        from lib.quality import CandidateScore
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg(search_response_limit=1500)
+        slskd = FakeSlskdAPI()
+        # One peer returns a full 2-track FLAC dir for the album.
+        slskd.searches.add_search(
+            search_id=42,
+            state="Completed",
+            responses=[{
+                "username": "good_peer",
+                "uploadSpeed": 100_000,
+                "files": [
+                    {"filename": "Music\\Album\\01 - Track One.flac", "bitRate": 1411},
+                    {"filename": "Music\\Album\\02 - Track Two.flac", "bitRate": 1411},
+                ],
+            }],
+        )
+        slskd.searches.search_text_id_sequence = [42]
+        # find_download → check_for_match → users.directory(); seed it
+        # with the same files so the count gate passes.
+        slskd.users.set_directory("good_peer", "Music\\Album", [{
+            "directory": "Music\\Album",
+            "files": [
+                {"filename": "01 - Track One.flac", "size": 1, "id": "tid-1"},
+                {"filename": "02 - Track Two.flac", "size": 1, "id": "tid-2"},
+            ],
+        }])
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-test", year=1991,
+        )
+        db.set_tracks(rid, [
+            {"track_number": 1, "title": "Track One"},
+            {"track_number": 2, "title": "Track Two"},
+        ])
+        album = self._make_album(request_id=rid)
+        ctx = self._wire(cfg, slskd, db, album)
+
+        # Stub slskd_do_enqueue so we do not exercise the real download path.
+        with patch("lib.enqueue.slskd_do_enqueue", return_value=[
+            MagicMock(),
+        ]):
+            result = self._cratedigger.search_for_album(album, ctx)
+            grab_list: dict[Any, Any] = {}
+            from lib.enqueue import find_download
+            find_result = find_download(album, grab_list, ctx)
+            self._cratedigger._apply_find_download_result(
+                album, result, find_result, [])
+            self._cratedigger._log_search_result(album, result, ctx)
+
+        # responseLimit was forwarded to slskd at the wire boundary.
+        call = slskd.searches.search_text_calls[0]
+        self.assertEqual(call.kwargs["responseLimit"], 1500)
+
+        # SearchResult carries the variant and final state.
+        self.assertEqual(result.variant_tag, "default")
+        self.assertEqual(result.final_state, "Completed")
+
+        # search_log row was written with variant + final_state + candidates.
+        self.assertEqual(len(db.search_logs), 1)
+        row = db.search_logs[0]
+        self.assertEqual(row.variant, "default")
+        self.assertEqual(row.final_state, "Completed")
+        # JSONB blob round-trips through msgspec.convert.
+        assert row.candidates is not None, "expected candidates to persist"
+        decoded = msgspec.convert(
+            json.loads(row.candidates), type=list[CandidateScore])
+        self.assertGreaterEqual(len(decoded), 1)
+        self.assertEqual(decoded[0].username, "good_peer")
+        self.assertEqual(decoded[0].matched_tracks, 2)
+        self.assertEqual(decoded[0].total_tracks, 2)
+
+    def test_v1_year_variant_used_when_search_attempts_at_threshold(self):
+        """Cycle 5 with year known → variant=v1_year, query includes year."""
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg(search_escalation_threshold=5)
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [99]
+        slskd.searches.add_search(search_id=99, state="Completed", responses=[])
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-y", year=1991,
+        )
+        # Bump search_attempts to the threshold — cycle 5 selects v1_year.
+        db.update_request_fields(rid, search_attempts=5)
+        db.set_tracks(rid, [{"track_number": 1, "title": "Hot Potato"}])
+        album = self._make_album(request_id=rid, mb_release_id="mbid-y")
+        ctx = self._wire(cfg, slskd, db, album)
+
+        result = self._cratedigger.search_for_album(album, ctx)
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        self.assertEqual(result.variant_tag, "v1_year")
+        # Query was the base + year suffix.
+        call = slskd.searches.search_text_calls[0]
+        self.assertIn("1991", call.search_text)
+        # search_log persisted the variant.
+        self.assertEqual(db.search_logs[0].variant, "v1_year")
+
+    def test_exhausted_variant_short_circuits_without_slskd_call(self):
+        """search_attempts past pool size → exhausted; no slskd round-trip."""
+        from album_source import AlbumRecord, MediaRecord, ReleaseRecord
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg(search_escalation_threshold=5)
+        slskd = FakeSlskdAPI()
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-x", year=None,
+        )
+        # No tracks, no year — variant ladder exhausts at cycle 5.
+        db.update_request_fields(rid, search_attempts=5)
+        # Build the AlbumRecord with an unknown-year release_date so the
+        # variant generator sees year as None and falls straight to V4 →
+        # exhausted (empty track pool).
+        media = [MediaRecord(medium_number=1, medium_format="CD", track_count=0)]
+        release = ReleaseRecord(
+            id=-rid, foreign_release_id="mbid-x", title="Album",
+            track_count=0, medium_count=1, format="CD", media=media,
+            monitored=True, country=["US"], status="Official",
+        )
+        album = AlbumRecord(
+            id=-rid, title="Album",
+            release_date="0000-01-01T00:00:00Z",
+            artist_id=0, artist_name="Wiggles", foreign_artist_id="",
+            releases=[release], db_request_id=rid, db_source="request",
+            db_mb_release_id="mbid-x",
+            db_search_filetype_override=None, db_target_format=None,
+        )
+        ctx = self._wire(cfg, slskd, db, album)
+
+        result = self._cratedigger.search_for_album(album, ctx)
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        # No slskd search was submitted.
+        self.assertEqual(slskd.searches.search_text_calls, [])
+        # Outcome propagates and search_log persists exhausted.
+        self.assertEqual(result.outcome, "exhausted")
+        self.assertEqual(result.variant_tag, "exhausted")
+        row = db.search_logs[0]
+        self.assertEqual(row.outcome, "exhausted")
+        self.assertEqual(row.variant, "exhausted")
+        self.assertIsNone(row.candidates)
+        # Exhaustion doesn't bump search_attempts (U6 will flip to manual).
+        self.assertEqual(db.recorded_attempts, [])
+
+    def test_no_results_writes_empty_candidates_and_final_state(self):
+        """A search that returns 0 hits still writes a row, candidates NULL."""
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg()
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [7]
+        slskd.searches.add_search(
+            search_id=7, state="ResponseLimitReached", responses=[])
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Wiggles", album_title="Album",
+            source="request", mb_release_id="mbid-n", year=1991,
+        )
+        db.set_tracks(rid, [{"track_number": 1, "title": "Track"}])
+        album = self._make_album(request_id=rid, mb_release_id="mbid-n")
+        ctx = self._wire(cfg, slskd, db, album)
+
+        result = self._cratedigger.search_for_album(album, ctx)
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        self.assertEqual(result.outcome, "no_results")
+        self.assertEqual(result.final_state, "ResponseLimitReached")
+        row = db.search_logs[0]
+        self.assertEqual(row.outcome, "no_results")
+        self.assertEqual(row.final_state, "ResponseLimitReached")
+        # No candidates collected — find_download didn't run.
+        self.assertIsNone(row.candidates)
+
+    def test_top_20_truncation_when_many_candidates(self):
+        """JSONB blob caps at top-20 by (matched_tracks, avg_ratio) DESC."""
+        import json
+        from lib.quality import CandidateScore
+        from lib.search import SearchResult
+        from tests.fakes import FakePipelineDB
+
+        cfg = self._make_cfg()
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="A", album_title="B", source="request",
+        )
+        ctx = self._wire(cfg, MagicMock(), db, self._make_album(request_id=rid))
+
+        # Build 30 synthetic candidates, descending matched_tracks.
+        many = tuple(
+            CandidateScore(
+                username=f"u{i}", dir=f"d{i}", filetype="flac",
+                matched_tracks=30 - i, total_tracks=30,
+                avg_ratio=0.5, missing_titles=[], file_count=30 - i,
+            )
+            for i in range(30)
+        )
+        result = SearchResult(
+            album_id=-rid, success=False, query="q", outcome="no_match",
+            variant_tag="default", final_state="Completed",
+            candidates=many,
+        )
+        album = self._make_album(request_id=rid)
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        row = db.search_logs[0]
+        assert row.candidates is not None
+        decoded = json.loads(row.candidates)
+        self.assertEqual(len(decoded), 20, "must truncate to top 20")
+        # The very top entry has matched_tracks=30 (i=0 in the source list).
+        self.assertEqual(decoded[0]["matched_tracks"], 30)
+        self.assertEqual(decoded[-1]["matched_tracks"], 11)
+
+    def test_discogs_source_request_produces_same_blob_shape(self):
+        """A Discogs-source request flows through the same forensic capture."""
+        import json
+        from tests.fakes import FakePipelineDB, FakeSlskdAPI
+
+        cfg = self._make_cfg()
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [123]
+        slskd.searches.add_search(
+            search_id=123, state="Completed", responses=[{
+                "username": "discog_peer",
+                "uploadSpeed": 1,
+                "files": [
+                    {"filename": "A\\B\\Disco Track.flac", "bitRate": 1411},
+                ],
+            }])
+        slskd.users.set_directory("discog_peer", "A\\B", [{
+            "directory": "A\\B",
+            "files": [{"filename": "Disco Track.flac", "size": 1, "id": "z"}],
+        }])
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="Disco Artist", album_title="Disco",
+            source="request",
+            # Discogs-numeric id stored in the dedicated column.
+            discogs_release_id="123456", year=1991,
+        )
+        db.set_tracks(rid, [{"track_number": 1, "title": "Disco Track"}])
+        album = self._make_album(
+            request_id=rid, source="request",
+            mb_release_id="",  # MB unknown; release id sits in discogs col.
+        )
+        ctx = self._wire(cfg, slskd, db, album)
+
+        result = self._cratedigger.search_for_album(album, ctx)
+        grab_list: dict[Any, Any] = {}
+        from lib.enqueue import find_download
+        with patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]):
+            find_result = find_download(album, grab_list, ctx)
+        self._cratedigger._apply_find_download_result(
+            album, result, find_result, [])
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        # Same blob shape regardless of MB-vs-Discogs origin.
+        row = db.search_logs[0]
+        self.assertEqual(row.variant, "default")
+        assert row.candidates is not None
+        decoded = json.loads(row.candidates)
+        self.assertEqual(decoded[0]["username"], "discog_peer")
+        self.assertEqual(decoded[0]["matched_tracks"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2994,6 +2994,67 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         self.assertIsNone(row.candidates)
 
 
+class TestVariantSelectFallbackObservability(unittest.TestCase):
+    """Finding #14: VARIANT_SELECT_FALLBACK log line is the observability hook
+    for silent escalation-ladder bypasses.
+
+    The fallback itself is intentional for DB resilience — when ``get_request``
+    or ``get_tracks`` raises (transient DB outage, etc.), the helper falls back
+    to a default variant and the next cycle retries. Without the stable log
+    prefix operators have no way to count silent fallbacks; they show up as
+    "requests grinding on default forever". The prefix
+    ``VARIANT_SELECT_FALLBACK`` lets operators run
+    ``journalctl -u cratedigger | grep VARIANT_SELECT_FALLBACK | wc -l``.
+    """
+
+    def test_db_exception_logs_stable_prefix_and_falls_back(self):
+        from album_source import AlbumRecord, MediaRecord, ReleaseRecord
+        from cratedigger import _select_variant_for_album
+        from lib.config import CratediggerConfig
+
+        ini_cfg = CratediggerConfig.from_ini(__import__("configparser").ConfigParser())
+
+        media = [MediaRecord(medium_number=1, medium_format="CD", track_count=1)]
+        release = ReleaseRecord(
+            id=-1, foreign_release_id="mbid-x", title="Album",
+            track_count=1, medium_count=1, format="CD", media=media,
+            monitored=True, country=["US"], status="Official",
+        )
+        album = AlbumRecord(
+            id=-1, title="Album", release_date="1990-01-01T00:00:00Z",
+            artist_id=0, artist_name="Artist", foreign_artist_id="",
+            releases=[release], db_request_id=42, db_source="request",
+            db_mb_release_id="mbid-x", db_search_filetype_override=None,
+            db_target_format=None,
+        )
+
+        # Mock DB that raises on get_request — simulates transient DB outage.
+        class _BoomDB:
+            def get_request(self, _rid):
+                raise RuntimeError("transient connection error")
+            def get_tracks(self, _rid):
+                return []
+
+        # Capture warnings logged on the cratedigger logger.
+        with self.assertLogs("cratedigger", level="WARNING") as captured:
+            variant, base_query = _select_variant_for_album(album, ini_cfg, _BoomDB())
+
+        # Existing fallback behaviour preserved: kind='default'.
+        self.assertEqual(variant.kind, "default")
+        self.assertEqual(variant.tag, "default")
+        # base_query computed from album info, independent of the DB call.
+        self.assertTrue(base_query)
+
+        # Stable greppable prefix is the observability hook.
+        joined = "\n".join(captured.output)
+        self.assertIn("VARIANT_SELECT_FALLBACK", joined)
+        # Includes the request_id and album metadata for triage.
+        self.assertIn("request_id=42", joined)
+        self.assertIn("artist=Artist", joined)
+        # exc_info=True => traceback is included.
+        self.assertIn("RuntimeError", joined)
+
+
 class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
     """U6 integration slice: variant=exhausted → manual flip + re-queue reset.
 

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2850,5 +2850,194 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         self.assertEqual(decoded[0]["matched_tracks"], 1)
 
 
+class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
+    """U6 integration slice: variant=exhausted → manual flip + re-queue reset.
+
+    Drives ``_log_search_result`` end-to-end with FakePipelineDB and asserts:
+    - happy path: status flips to ``manual``, manual_reason='search_exhausted'
+    - re-queue via ``apply_transition`` clears manual_reason + search_attempts
+    - defensive: status='manual' with no reason is not retroactively flipped
+    - defensive: status='manual' with operator_hold reason is not clobbered
+    """
+
+    def setUp(self):
+        import cratedigger
+        self._cratedigger = cratedigger
+        self._orig_pdb = cratedigger.pipeline_db_source
+        self._orig_module_ctx = cratedigger._module_ctx
+
+    def tearDown(self):
+        self._cratedigger.pipeline_db_source = self._orig_pdb
+        self._cratedigger._module_ctx = self._orig_module_ctx
+
+    def _ctx_with_db(self, db):
+        from lib.context import CratediggerContext
+        source = MagicMock()
+        source._get_db.return_value = db
+        self._cratedigger.pipeline_db_source = source
+        ctx = CratediggerContext(
+            cfg=self._cratedigger.cfg, slskd=MagicMock(),
+            pipeline_db_source=source,
+        )
+        self._cratedigger._module_ctx = ctx
+        return ctx
+
+    def _make_album(self, request_id):
+        from album_source import AlbumRecord, MediaRecord, ReleaseRecord
+        media = [MediaRecord(medium_number=1, medium_format="CD", track_count=0)]
+        release = ReleaseRecord(
+            id=-request_id, foreign_release_id="mbid", title="T",
+            track_count=0, medium_count=1, format="CD", media=media,
+            monitored=True, country=["US"], status="Official",
+        )
+        return AlbumRecord(
+            id=-request_id, title="T", release_date="0000-01-01T00:00:00Z",
+            artist_id=0, artist_name="A", foreign_artist_id="",
+            releases=[release], db_request_id=request_id, db_source="request",
+            db_mb_release_id="mbid",
+            db_search_filetype_override=None, db_target_format=None,
+        )
+
+    def _make_exhausted_result(self, *, album_id):
+        from lib.search import SearchResult
+        return SearchResult(
+            album_id=album_id, success=False, query="",
+            elapsed_s=0.0, outcome="exhausted", variant_tag="exhausted",
+        )
+
+    def test_exhausted_flips_to_manual_with_reason_and_skips_get_wanted(self):
+        """Happy path: search_log row + status='manual' + reason populated.
+
+        Asserts the next get_wanted does NOT return the flipped request —
+        proving the flip actually re-routes the request out of the
+        search/download loop.
+        """
+        from tests.fakes import FakePipelineDB
+
+        db = FakePipelineDB()
+        # Start the request as 'downloading' (the realistic state — the
+        # search loop only runs against rows that are wanted/downloading).
+        rid = db.add_request(
+            artist_name="A", album_title="B", source="request",
+            mb_release_id="mb-exh", status="downloading",
+        )
+        # Bump search_attempts so this isn't a fresh request.
+        db.update_request_fields(rid, search_attempts=7)
+
+        album = self._make_album(rid)
+        ctx = self._ctx_with_db(db)
+        result = self._make_exhausted_result(album_id=-rid)
+
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        # search_log row persists with outcome='exhausted'.
+        self.assertEqual(len(db.search_logs), 1)
+        self.assertEqual(db.search_logs[0].outcome, "exhausted")
+
+        # Request flipped to manual with the reason.
+        row = db.request(rid)
+        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["manual_reason"], "search_exhausted")
+
+        # get_wanted does NOT return this request anymore.
+        wanted_ids = [r["id"] for r in db.get_wanted()]
+        self.assertNotIn(rid, wanted_ids)
+
+    def test_requeue_via_apply_transition_clears_state(self):
+        """Operator re-queue via the single-seam transition resets state."""
+        from typing import cast
+        from lib.pipeline_db import PipelineDB
+        from lib.transitions import apply_transition
+        from tests.fakes import FakePipelineDB
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="A", album_title="B", source="request",
+            mb_release_id="mb-req", status="manual",
+        )
+        # Simulate prior state: search_attempts=7, manual_reason populated.
+        db.update_request_fields(
+            rid, search_attempts=7, manual_reason="search_exhausted")
+
+        # The web UI button / pipeline-cli requeue / importer requeue all
+        # funnel through apply_transition('manual' -> 'wanted'). Cast to
+        # the concrete type — FakePipelineDB is duck-typed for the
+        # methods apply_transition uses (get_request, reset_to_wanted).
+        apply_transition(
+            cast(PipelineDB, db), rid, "wanted", from_status="manual")
+
+        row = db.request(rid)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_attempts"], 0)
+        self.assertIsNone(row["manual_reason"])
+        # Re-queued request is back in the wanted pool.
+        wanted_ids = [r["id"] for r in db.get_wanted()]
+        self.assertIn(rid, wanted_ids)
+
+    def test_already_manual_request_is_not_reflipped(self):
+        """Defensive: status already 'manual' → no flip, no log_history pollution.
+
+        A request that's already in manual (operator-set hold or prior flip)
+        must not have its manual_reason rewritten and must not generate a
+        spurious status_history entry. The search_log row IS still written —
+        that's the audit trail.
+        """
+        from tests.fakes import FakePipelineDB
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="A", album_title="B", source="request",
+            mb_release_id="mb-am", status="manual",
+        )
+        # Pre-existing operator hold with no reason populated (a manually
+        # created request, never flipped by the system).
+        # Snapshot history so we can assert no new entry was added.
+        prior_history = list(db.status_history)
+
+        album = self._make_album(rid)
+        ctx = self._ctx_with_db(db)
+        result = self._make_exhausted_result(album_id=-rid)
+
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        # search_log row was still written — the audit trail is preserved.
+        self.assertEqual(len(db.search_logs), 1)
+
+        row = db.request(rid)
+        self.assertEqual(row["status"], "manual")
+        # manual_reason was NOT populated by the flip (it was None and
+        # stays None — set_manual was never called).
+        self.assertIsNone(row["manual_reason"])
+        # No new status_history entry from a redundant flip.
+        self.assertEqual(db.status_history, prior_history)
+
+    def test_already_manual_with_other_reason_is_not_clobbered(self):
+        """Defensive: an unrelated reason on a manual row is preserved.
+
+        If a request is in manual for a different reason (e.g. operator
+        hold), the exhaustion flip path must not overwrite that reason.
+        """
+        from tests.fakes import FakePipelineDB
+
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="A", album_title="B", source="request",
+            mb_release_id="mb-oh", status="manual",
+        )
+        # Inject an operator-hold reason directly (no production code path
+        # writes this today — that's the point of the defensive check).
+        db.update_request_fields(rid, manual_reason="operator_hold")
+
+        album = self._make_album(rid)
+        ctx = self._ctx_with_db(db)
+        result = self._make_exhausted_result(album_id=-rid)
+
+        self._cratedigger._log_search_result(album, result, ctx)
+
+        row = db.request(rid)
+        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["manual_reason"], "operator_hold")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_util.mjs
  */
 
-import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel } from '../web/js/util.js';
+import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock } from '../web/js/util.js';
 import { state } from '../web/js/state.js';
 import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, loadLabelReleases, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls, renderLabelRows } from '../web/js/labels.js';
 
@@ -467,6 +467,69 @@ assertEqual(nanBoth.length, 3, 'both NaN bounds → no filter');
 const mixedNan = applyLabelFilters(NAN_ROWS, { yearMin: NaN, yearMax: 2005 });
 assertEqual(mixedNan.map(r => r.id).join(','), '1',
   'valid yearMax with NaN yearMin still filters correctly');
+
+// --- manualReasonLabel tests ---
+console.log('manualReasonLabel()');
+assertEqual(manualReasonLabel(null), '', 'null → empty string');
+assertEqual(manualReasonLabel(undefined), '', 'undefined → empty string');
+assertEqual(manualReasonLabel(''), '', 'empty string → empty string');
+assertEqual(manualReasonLabel('search_exhausted'), 'search exhausted',
+  'search_exhausted → friendly label');
+assertEqual(manualReasonLabel('custom_reason'), 'custom_reason',
+  'unknown reason passes through unchanged');
+
+// --- renderForensicBlock tests ---
+console.log('renderForensicBlock()');
+const noBlock = renderForensicBlock(null);
+assert(noBlock.includes('No search forensic data yet'),
+  'null last_search → "no forensic data" message');
+assert(noBlock.includes('p-forensic'),
+  'null last_search still wraps in .p-forensic for layout');
+
+const emptyTopBlock = renderForensicBlock({
+  variant: 'v1_year', final_state: 'Completed', outcome: 'no_match',
+  top_candidates: [],
+});
+assert(emptyTopBlock.includes('v1_year'),
+  'variant tag rendered');
+assert(emptyTopBlock.includes('Completed'),
+  'final_state rendered');
+assert(emptyTopBlock.includes('No candidates captured'),
+  'empty top_candidates → no-candidates body');
+
+const populatedBlock = renderForensicBlock({
+  variant: 'default', final_state: 'Completed', outcome: 'no_match',
+  top_candidates: [
+    { username: 'alice', dir: 'A\\Album', filetype: 'flac',
+      matched_tracks: 26, total_tracks: 26, avg_ratio: 0.95,
+      missing_titles: [], file_count: 26 },
+    { username: 'bob', dir: 'B\\Album', filetype: 'mp3',
+      matched_tracks: 22, total_tracks: 26, avg_ratio: 0.80,
+      missing_titles: ['x'], file_count: 22 },
+  ],
+});
+assert(populatedBlock.includes('alice'), 'first candidate username rendered');
+assert(populatedBlock.includes('bob'), 'second candidate username rendered');
+assert(populatedBlock.includes('26/26'),
+  'matched/total rendered for first row');
+assert(populatedBlock.includes('0.95'),
+  'avg_ratio rendered to 2 decimals');
+assert(populatedBlock.includes('flac'),
+  'filetype rendered');
+
+// HTML-escape coverage — adversarial username/dir must not leak markup.
+const xssBlock = renderForensicBlock({
+  variant: 'default', final_state: 'Completed', outcome: 'no_match',
+  top_candidates: [{
+    username: '<script>x</script>', dir: '"><img>', filetype: 'flac',
+    matched_tracks: 1, total_tracks: 1, avg_ratio: 0,
+    missing_titles: [], file_count: 1,
+  }],
+});
+assert(!xssBlock.includes('<script>x</script>'),
+  'malicious username escaped');
+assert(!xssBlock.includes('"><img>'),
+  'malicious dir escaped');
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -21,10 +21,10 @@ from lib.config import CratediggerConfig
 from lib.context import CratediggerContext
 from lib.matching import (
     AlbumMatchScore,
-    CandidateScore,
     album_match,
     check_for_match,
 )
+from lib.quality import CandidateScore
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,380 @@
+"""Unit tests for lib/matching.py — album_match + check_for_match.
+
+U2 of search-escalation-and-forensics: album_match returns AlbumMatchScore
+(structured per-track scores) and check_for_match accumulates a list of
+CandidateScore entries — including cheap entries for dirs that fail the
+sub-count gate without ever calling album_match.
+
+Strict-accept behaviour (every track above ratio AND _track_titles_cross_check)
+is preserved — these tests are the regression guard.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from typing import Any
+from unittest.mock import MagicMock
+
+from lib.config import CratediggerConfig
+from lib.context import CratediggerContext
+from lib.matching import (
+    AlbumMatchScore,
+    CandidateScore,
+    album_match,
+    check_for_match,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+def _make_cfg(**overrides: Any) -> CratediggerConfig:
+    """Build a CratediggerConfig with only the fields matching needs."""
+    cfg = CratediggerConfig(
+        minimum_match_ratio=0.5,
+        ignored_users=(),
+        allowed_filetypes=("flac", "mp3"),
+        browse_parallelism=4,
+    )
+    if overrides:
+        cfg = replace(cfg, **overrides)
+    return cfg
+
+
+def _make_album(title: str = "Test Album", artist: str = "Test Artist") -> Any:
+    """Build a minimal album-info object with the .title/.artist_name attributes
+    that matching code reads off ctx.current_album_cache."""
+    album = MagicMock()
+    album.title = title
+    album.artist_name = artist
+    return album
+
+
+def _make_ctx(
+    cfg: CratediggerConfig,
+    *,
+    album_id: int = 1,
+    album_title: str = "Test Album",
+    album_artist: str = "Test Artist",
+) -> CratediggerContext:
+    ctx = CratediggerContext(
+        cfg=cfg,
+        slskd=MagicMock(),
+        pipeline_db_source=MagicMock(),
+    )
+    ctx.current_album_cache[album_id] = _make_album(album_title, album_artist)
+    return ctx
+
+
+def _track(album_id: int, title: str, medium: int = 1) -> dict[str, Any]:
+    return {"albumId": album_id, "title": title, "mediumNumber": medium}
+
+
+def _file(filename: str, **extra: Any) -> dict[str, Any]:
+    return {"filename": filename, **extra}
+
+
+# ---------------------------------------------------------------------------
+# album_match — pure function returning AlbumMatchScore
+# ---------------------------------------------------------------------------
+
+class TestAlbumMatchScore(unittest.TestCase):
+    """Pure-function score computation for every input shape."""
+
+    def setUp(self) -> None:
+        self.cfg = _make_cfg()
+        self.ctx = _make_ctx(self.cfg, album_id=1, album_title="Cool Album")
+
+    def test_returns_album_match_score_dataclass(self) -> None:
+        """album_match must return AlbumMatchScore, NOT bool (RED for U2)."""
+        tracks = [_track(1, "Song One")]
+        files = [_file("Song One.flac")]
+        result = album_match(tracks, files, "user1", "flac", self.ctx)
+        self.assertIsInstance(result, AlbumMatchScore)
+
+    def test_happy_path_all_tracks_match(self) -> None:
+        """All 3 tracks named exactly → matched=total, avg_ratio≈1.0, no missing."""
+        tracks = [_track(1, f"Song {n}") for n in ("One", "Two", "Three")]
+        files = [_file(f"Song {n}.flac") for n in ("One", "Two", "Three")]
+
+        score = album_match(tracks, files, "user1", "flac", self.ctx)
+
+        self.assertEqual(score.matched_tracks, 3)
+        self.assertEqual(score.total_tracks, 3)
+        self.assertAlmostEqual(score.avg_ratio, 1.0, places=2)
+        self.assertEqual(score.missing_titles, [])
+        self.assertEqual(len(score.best_per_track), 3)
+        for ratio in score.best_per_track:
+            self.assertAlmostEqual(ratio, 1.0, places=2)
+
+    def test_partial_match_lists_missing_titles(self) -> None:
+        """2 of 4 tracks unmatched → matched=2, total=4, missing populated."""
+        tracks = [_track(1, t) for t in ("Alpha", "Bravo", "Charlie", "Delta")]
+        files = [
+            _file("Alpha.flac"),
+            _file("Bravo.flac"),
+            _file("Random Junk Filename.flac"),
+            _file("Another Unrelated.flac"),
+        ]
+        score = album_match(tracks, files, "user1", "flac", self.ctx)
+
+        self.assertEqual(score.matched_tracks, 2)
+        self.assertEqual(score.total_tracks, 4)
+        self.assertCountEqual(score.missing_titles, ["Charlie", "Delta"])
+
+    def test_track_number_prefix_separator_logic(self) -> None:
+        """`01 - Title.flac` style — check_ratio separator path keeps matches."""
+        tracks = [_track(1, "Song One"), _track(1, "Song Two")]
+        files = [_file("01 - Song One.flac"), _file("02 - Song Two.flac")]
+        score = album_match(tracks, files, "user1", "flac", self.ctx)
+        self.assertEqual(score.matched_tracks, 2)
+        self.assertEqual(score.total_tracks, 2)
+
+    def test_album_name_prefix_retry_path(self) -> None:
+        """`Cool Album - Title.flac` matches via album_name + filename retry."""
+        tracks = [_track(1, "Song One")]
+        files = [_file("Cool Album - Song One.flac")]
+        score = album_match(tracks, files, "user1", "flac", self.ctx)
+        self.assertEqual(score.matched_tracks, 1)
+        self.assertEqual(score.missing_titles, [])
+
+    def test_catch_all_filetype_uses_inferred_extension(self) -> None:
+        """`*` filetype derives extension from each slskd file."""
+        tracks = [_track(1, "Song One"), _track(1, "Song Two")]
+        files = [_file("Song One.mp3"), _file("Song Two.ogg")]
+        score = album_match(tracks, files, "user1", "*", self.ctx)
+        self.assertEqual(score.matched_tracks, 2)
+
+    def test_empty_slskd_files_lists_every_expected(self) -> None:
+        """Empty slskd_tracks → matched=0, missing lists every title."""
+        tracks = [_track(1, "Alpha"), _track(1, "Bravo")]
+        files: list[dict[str, Any]] = []
+        score = album_match(tracks, files, "user1", "flac", self.ctx)
+        self.assertEqual(score.matched_tracks, 0)
+        self.assertEqual(score.total_tracks, 2)
+        self.assertCountEqual(score.missing_titles, ["Alpha", "Bravo"])
+        # best_per_track has one zero entry per expected track
+        self.assertEqual(len(score.best_per_track), 2)
+        for ratio in score.best_per_track:
+            self.assertEqual(ratio, 0.0)
+
+    def test_ignored_user_does_not_affect_score(self) -> None:
+        """ignored_users gate is a check_for_match concern, not a score concern.
+        Pure scoring returns the same numbers regardless of who the user is."""
+        cfg = _make_cfg(ignored_users=("badguy",))
+        ctx = _make_ctx(cfg, album_id=1, album_title="Cool Album")
+        tracks = [_track(1, "Song One")]
+        files = [_file("Song One.flac")]
+
+        good_score = album_match(tracks, files, "goodguy", "flac", ctx)
+        bad_score = album_match(tracks, files, "badguy", "flac", ctx)
+
+        self.assertEqual(good_score.matched_tracks, bad_score.matched_tracks)
+        self.assertEqual(good_score.total_tracks, bad_score.total_tracks)
+        self.assertEqual(good_score.missing_titles, bad_score.missing_titles)
+
+
+# ---------------------------------------------------------------------------
+# check_for_match — accumulates CandidateScore for every iterated dir
+# ---------------------------------------------------------------------------
+
+class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
+    """check_for_match returns the per-dir CandidateScore list as the 4th element
+    (or .candidates on a MatchResult dataclass)."""
+
+    def setUp(self) -> None:
+        self.cfg = _make_cfg()
+        self.ctx = _make_ctx(self.cfg, album_id=1, album_title="Cool Album")
+        self.username = "user1"
+        self.tracks = [
+            _track(1, "Alpha"),
+            _track(1, "Bravo"),
+            _track(1, "Charlie"),
+        ]
+
+    def _set_browse(self, file_dir: str, files: list[dict[str, Any]]) -> None:
+        """Pre-populate folder_cache so the real browse never runs."""
+        self.ctx.folder_cache.setdefault(self.username, {})[file_dir] = {
+            "directory": file_dir,
+            "files": files,
+        }
+
+    @staticmethod
+    def _candidates(result: Any) -> list[CandidateScore]:
+        """Pull candidate list off either tuple or dataclass return shape."""
+        if hasattr(result, "candidates"):
+            return result.candidates
+        # tuple shape (matched, directory, file_dir, candidates)
+        return result[3]
+
+    @staticmethod
+    def _matched(result: Any) -> bool:
+        return result.matched if hasattr(result, "matched") else result[0]
+
+    @staticmethod
+    def _file_dir(result: Any) -> str:
+        return result.file_dir if hasattr(result, "file_dir") else result[2]
+
+    def test_strict_accept_first_dir_short_circuits(self) -> None:
+        """First dir matches strictly → returns True immediately, candidates has
+        exactly one entry."""
+        self._set_browse("dirA", [
+            _file("Alpha.flac"), _file("Bravo.flac"), _file("Charlie.flac"),
+        ])
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+        self.assertTrue(self._matched(result))
+        self.assertEqual(self._file_dir(result), "dirA")
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].dir, "dirA")
+        self.assertEqual(candidates[0].matched_tracks, 3)
+        self.assertEqual(candidates[0].total_tracks, 3)
+        self.assertEqual(candidates[0].file_count, 3)
+        self.assertEqual(candidates[0].filetype, "flac")
+        self.assertEqual(candidates[0].username, self.username)
+
+    def test_subcount_dir_gets_cheap_candidate_entry(self) -> None:
+        """Dir with file_count != track_num emits a cheap CandidateScore
+        (matched=0, missing=[], avg_ratio=0.0) — album_match is NOT called."""
+        # dirA has only 2 of 3 audio files
+        self._set_browse("dirA", [
+            _file("Alpha.flac"), _file("Bravo.flac"),
+        ])
+        # dirB has all 3 — strict accept here
+        self._set_browse("dirB", [
+            _file("Alpha.flac"), _file("Bravo.flac"), _file("Charlie.flac"),
+        ])
+        result = check_for_match(
+            self.tracks, "flac", ["dirA", "dirB"], self.username, self.ctx,
+        )
+        self.assertTrue(self._matched(result))
+        candidates = self._candidates(result)
+        # Both dirs should be in candidates, in iteration order
+        self.assertEqual(len(candidates), 2)
+        # rank_candidate_dirs may reorder; find by dir name
+        by_dir = {c.dir: c for c in candidates}
+        cheap = by_dir["dirA"]
+        self.assertEqual(cheap.matched_tracks, 0)
+        self.assertEqual(cheap.total_tracks, 3)
+        self.assertEqual(cheap.avg_ratio, 0.0)
+        self.assertEqual(cheap.missing_titles, [])
+        self.assertEqual(cheap.file_count, 2)
+
+    def test_dir_with_no_audio_files_emits_zero_filecount_candidate(self) -> None:
+        """Dir with `tracks_info["filetype"]==""` (no audio) → cheap candidate
+        with file_count=0."""
+        self._set_browse("dirEmpty", [_file("cover.jpg"), _file("readme.txt")])
+        result = check_for_match(
+            self.tracks, "flac", ["dirEmpty"], self.username, self.ctx,
+        )
+        self.assertFalse(self._matched(result))
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].file_count, 0)
+        self.assertEqual(candidates[0].matched_tracks, 0)
+
+    def test_cross_check_failure_continues_loop_and_records_score(self) -> None:
+        """When _track_titles_cross_check fails, dir is added to negative_matches
+        and the score is still appended to candidates so the forensic record
+        captures the cross-check rejection."""
+        # Files match the count gate but titles are wildly different — cross-check
+        # tolerates 1/5 mismatch but here every title is wrong, so cross-check fails.
+        # However, album_match's filename-ratio path happily accepts these because
+        # of separator/album-name retries... we need filenames that pass album_match
+        # filename ratio but fail _track_titles_cross_check. The cross-check uses
+        # _normalize_title + extracted-title fuzzy matching with 0.5 threshold.
+        # Easiest construction: tracks all named distinctly, files use those titles
+        # *embedded* but with very different content elsewhere.
+        # In practice, the strict-accept path is: all tracks above ratio AND
+        # cross-check passes. If the filenames are exact title matches, cross-check
+        # also passes — they're correlated. To force cross-check failure we need
+        # the album_match per-track ratios to clear minimum_match_ratio while the
+        # extracted-title fuzzy check fails.
+        # We achieve this with a low minimum_match_ratio so the strict accept path
+        # triggers, but slskd filenames are very long so extracted_title differs.
+        cfg = _make_cfg(minimum_match_ratio=0.1)
+        ctx = _make_ctx(cfg, album_id=1, album_title="Cool Album")
+        ctx.folder_cache.setdefault(self.username, {})["dirX"] = {
+            "directory": "dirX",
+            "files": [
+                _file("Alpha.flac"),
+                _file("Bravo.flac"),
+                _file("Charlie.flac"),
+            ],
+        }
+        # Make tracks barely passing the filename ratio (>=0.1) but with names
+        # that differ enough for cross-check.
+        tracks = [
+            _track(1, "Alpha"),
+            _track(1, "Bravo"),
+            _track(1, "Charlie"),
+        ]
+        # With identical filenames and titles, both will accept. To force cross-
+        # check failure we need filenames that pass album_match's per-track filename
+        # ratio but produce extracted titles that fail _track_titles_cross_check.
+        # In practice this means matching is tight — skip this case if cross-check
+        # ends up succeeding. The contract we care about: IF cross-check fails,
+        # THEN candidate is still appended. We test that contract by mocking.
+        from unittest.mock import patch
+        with patch("lib.matching._track_titles_cross_check", return_value=False):
+            result = check_for_match(
+                tracks, "flac", ["dirX"], self.username, ctx,
+            )
+        self.assertFalse(self._matched(result))
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        # The score still reflects a strict filename match
+        self.assertEqual(candidates[0].matched_tracks, 3)
+        self.assertEqual(candidates[0].total_tracks, 3)
+        self.assertEqual(candidates[0].file_count, 3)
+        # And the dir was added to negative_matches
+        self.assertIn(
+            (self.username, "dirX", 3, "flac"),
+            ctx.negative_matches,
+        )
+
+    def test_no_dirs_returns_empty_candidates(self) -> None:
+        """No dirs to try → empty candidate list, no match."""
+        result = check_for_match(
+            self.tracks, "flac", [], self.username, self.ctx,
+        )
+        self.assertFalse(self._matched(result))
+        self.assertEqual(self._candidates(result), [])
+
+    def test_broken_user_returns_empty_candidates(self) -> None:
+        """Broken-user short-circuit returns empty candidates."""
+        self.ctx.broken_user.append(self.username)
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+        self.assertFalse(self._matched(result))
+        self.assertEqual(self._candidates(result), [])
+
+    def test_partial_match_dir_records_partial_score(self) -> None:
+        """Dir with full file_count but only 2 of 3 titles matching →
+        full CandidateScore with matched_tracks=2, total_tracks=3, and
+        missing_titles populated. Strict accept fails (2 != 3)."""
+        # Need 3 audio files (so count gate passes), but only 2 match titles
+        self._set_browse("dirA", [
+            _file("Alpha.flac"),
+            _file("Bravo.flac"),
+            _file("Random Junk.flac"),
+        ])
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+        self.assertFalse(self._matched(result))
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].matched_tracks, 2)
+        self.assertEqual(candidates[0].total_tracks, 3)
+        self.assertCountEqual(candidates[0].missing_titles, ["Charlie"])
+        self.assertEqual(candidates[0].file_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -11,6 +11,7 @@ is preserved — these tests are the regression guard.
 
 from __future__ import annotations
 
+import configparser
 import unittest
 from dataclasses import replace
 from typing import Any, cast
@@ -32,13 +33,22 @@ from lib.quality import CandidateScore
 # ---------------------------------------------------------------------------
 
 def _make_cfg(**overrides: Any) -> CratediggerConfig:
-    """Build a CratediggerConfig with only the fields matching needs."""
-    cfg = CratediggerConfig(
-        minimum_match_ratio=0.5,
-        ignored_users=(),
-        allowed_filetypes=("flac", "mp3"),
-        browse_parallelism=4,
-    )
+    """Build a CratediggerConfig via from_ini, then apply overrides.
+
+    CLAUDE.md / code-quality.md forbids partial-kwarg construction —
+    "Always use CratediggerConfig.from_ini() with the runtime config file.
+    Partial configs silently diverge when new config fields are added."
+    Per-test field tweaks are applied via dataclasses.replace AFTER from_ini,
+    so we still benefit from the loader's defaults.
+    """
+    ini = configparser.ConfigParser()
+    ini["Search Settings"] = {
+        "minimum_filename_match_ratio": "0.5",
+        "ignored_users": "",
+        "allowed_filetypes": "flac, mp3",
+        "browse_parallelism": "4",
+    }
+    cfg = CratediggerConfig.from_ini(ini)
     if overrides:
         cfg = replace(cfg, **overrides)
     return cfg

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import unittest
 from dataclasses import replace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
+from cratedigger import SlskdFile, TrackRecord
 from lib.config import CratediggerConfig
 from lib.context import CratediggerContext
 from lib.matching import (
@@ -68,12 +69,15 @@ def _make_ctx(
     return ctx
 
 
-def _track(album_id: int, title: str, medium: int = 1) -> dict[str, Any]:
-    return {"albumId": album_id, "title": title, "mediumNumber": medium}
+def _track(album_id: int, title: str, medium: int = 1) -> TrackRecord:
+    return cast(
+        TrackRecord,
+        {"albumId": album_id, "title": title, "mediumNumber": medium},
+    )
 
 
-def _file(filename: str, **extra: Any) -> dict[str, Any]:
-    return {"filename": filename, **extra}
+def _file(filename: str, **extra: Any) -> SlskdFile:
+    return cast(SlskdFile, {"filename": filename, **extra})
 
 
 # ---------------------------------------------------------------------------
@@ -111,18 +115,28 @@ class TestAlbumMatchScore(unittest.TestCase):
 
     def test_partial_match_lists_missing_titles(self) -> None:
         """2 of 4 tracks unmatched → matched=2, total=4, missing populated."""
-        tracks = [_track(1, t) for t in ("Alpha", "Bravo", "Charlie", "Delta")]
+        # Use long, distinctive titles so the .flac suffix doesn't carry the
+        # SequenceMatcher ratio above 0.5.
+        tracks = [
+            _track(1, "Walking In The Rain Tonight"),
+            _track(1, "Catching Up With The Sunshine"),
+            _track(1, "MissingThirdTrackUnique"),
+            _track(1, "MissingFourthTrackUnique"),
+        ]
         files = [
-            _file("Alpha.flac"),
-            _file("Bravo.flac"),
-            _file("Random Junk Filename.flac"),
-            _file("Another Unrelated.flac"),
+            _file("Walking In The Rain Tonight.flac"),
+            _file("Catching Up With The Sunshine.flac"),
+            _file("zzzz.flac"),
+            _file("yyyy.flac"),
         ]
         score = album_match(tracks, files, "user1", "flac", self.ctx)
 
         self.assertEqual(score.matched_tracks, 2)
         self.assertEqual(score.total_tracks, 4)
-        self.assertCountEqual(score.missing_titles, ["Charlie", "Delta"])
+        self.assertCountEqual(
+            score.missing_titles,
+            ["MissingThirdTrackUnique", "MissingFourthTrackUnique"],
+        )
 
     def test_track_number_prefix_separator_logic(self) -> None:
         """`01 - Title.flac` style — check_ratio separator path keeps matches."""
@@ -150,7 +164,7 @@ class TestAlbumMatchScore(unittest.TestCase):
     def test_empty_slskd_files_lists_every_expected(self) -> None:
         """Empty slskd_tracks → matched=0, missing lists every title."""
         tracks = [_track(1, "Alpha"), _track(1, "Bravo")]
-        files: list[dict[str, Any]] = []
+        files: list[SlskdFile] = []
         score = album_match(tracks, files, "user1", "flac", self.ctx)
         self.assertEqual(score.matched_tracks, 0)
         self.assertEqual(score.total_tracks, 2)
@@ -194,7 +208,7 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
             _track(1, "Charlie"),
         ]
 
-    def _set_browse(self, file_dir: str, files: list[dict[str, Any]]) -> None:
+    def _set_browse(self, file_dir: str, files: list[SlskdFile]) -> None:
         """Pre-populate folder_cache so the real browse never runs."""
         self.ctx.folder_cache.setdefault(self.username, {})[file_dir] = {
             "directory": file_dir,
@@ -358,21 +372,29 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
         """Dir with full file_count but only 2 of 3 titles matching →
         full CandidateScore with matched_tracks=2, total_tracks=3, and
         missing_titles populated. Strict accept fails (2 != 3)."""
-        # Need 3 audio files (so count gate passes), but only 2 match titles
+        # Use distinctive long names so the `.flac` suffix doesn't carry the
+        # SequenceMatcher ratio above the minimum_match_ratio threshold.
+        partial_tracks = [
+            _track(1, "First Track Distinct Name"),
+            _track(1, "Second Track Distinct Name"),
+            _track(1, "QQQQQQQQQQQ"),
+        ]
         self._set_browse("dirA", [
-            _file("Alpha.flac"),
-            _file("Bravo.flac"),
-            _file("Random Junk.flac"),
+            _file("First Track Distinct Name.flac"),
+            _file("Second Track Distinct Name.flac"),
+            _file("XXXXXXXXXXXXX.flac"),
         ])
         result = check_for_match(
-            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+            partial_tracks, "flac", ["dirA"], self.username, self.ctx,
         )
         self.assertFalse(self._matched(result))
         candidates = self._candidates(result)
         self.assertEqual(len(candidates), 1)
         self.assertEqual(candidates[0].matched_tracks, 2)
         self.assertEqual(candidates[0].total_tracks, 3)
-        self.assertCountEqual(candidates[0].missing_titles, ["Charlie"])
+        self.assertCountEqual(
+            candidates[0].missing_titles, ["QQQQQQQQQQQ"],
+        )
         self.assertEqual(candidates[0].file_count, 3)
 
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1186,5 +1186,136 @@ class TestCmdQuality(unittest.TestCase):
         self.assertNotIn("(rank=EXCELLENT)", output)
 
 
+class TestCmdShowSearchForensics(unittest.TestCase):
+    """Unit cover for U7 forensic surfacing in `pipeline-cli show`.
+
+    No TEST_DB_DSN required — stubs the DB and verifies the printed text
+    contains variant + final_state + manual_reason + the top-3 candidate
+    table from the JSONB blob, and degrades gracefully on NULL/empty
+    candidates.
+    """
+
+    def _row(self, **overrides):
+        row = make_request_row(**overrides)
+        return row
+
+    def _capture(self, db, request_id):
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            pipeline_cli.cmd_show(db, SimpleNamespace(id=request_id))
+        return stdout.getvalue()
+
+    def test_show_renders_variant_final_state_and_top_3(self):
+        db = MagicMock()
+        db.get_request.return_value = self._row(
+            id=1843, manual_reason=None, status="wanted",
+        )
+        db.get_tracks.return_value = []
+        # JSONB candidates blob — psycopg2 returns parsed Python list.
+        candidates_blob = [
+            {"username": "alice", "dir": "A\\Album", "filetype": "flac",
+             "matched_tracks": 26, "total_tracks": 26, "avg_ratio": 0.95,
+             "missing_titles": [], "file_count": 26},
+            {"username": "bob", "dir": "B\\Album", "filetype": "mp3",
+             "matched_tracks": 22, "total_tracks": 26, "avg_ratio": 0.80,
+             "missing_titles": ["x"], "file_count": 22},
+            {"username": "carol", "dir": "C\\Album", "filetype": "flac",
+             "matched_tracks": 26, "total_tracks": 26, "avg_ratio": 0.85,
+             "missing_titles": [], "file_count": 26},
+            {"username": "dave", "dir": "D\\Album", "filetype": "flac",
+             "matched_tracks": 20, "total_tracks": 26, "avg_ratio": 0.99,
+             "missing_titles": ["a", "b"], "file_count": 20},
+        ]
+        db.get_search_history.return_value = [{
+            "id": 99, "request_id": 1843, "query": "*lice Album",
+            "result_count": 100, "elapsed_s": 1.2, "outcome": "no_match",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": candidates_blob,
+            "variant": "v3_artist_only", "final_state": "Completed",
+        }]
+        db.get_download_history.return_value = []
+        db.get_denylisted_users.return_value = []
+
+        out = self._capture(db, 1843)
+
+        self.assertIn("Search Forensics:", out)
+        self.assertIn("variant:        v3_artist_only", out)
+        self.assertIn("final_state:    Completed", out)
+        # Per-row variant column appears in Search History.
+        self.assertIn("v3_artist_only", out)
+        # Top-3 ordering: alice (26, 0.95) > carol (26, 0.85) > bob (22, 0.80).
+        # dave (20, 0.99) is excluded because matched_tracks dominates avg_ratio.
+        alice_idx = out.find("alice")
+        carol_idx = out.find("carol")
+        bob_idx = out.find("bob")
+        dave_idx = out.find("dave")
+        self.assertGreater(alice_idx, 0)
+        self.assertGreater(carol_idx, alice_idx)
+        self.assertGreater(bob_idx, carol_idx)
+        self.assertEqual(dave_idx, -1, "4th candidate must be truncated")
+
+    def test_show_renders_manual_reason_chip(self):
+        db = MagicMock()
+        db.get_request.return_value = self._row(
+            id=2, manual_reason="search_exhausted", status="manual",
+        )
+        db.get_tracks.return_value = []
+        db.get_search_history.return_value = [{
+            "id": 1, "request_id": 2, "query": "q",
+            "result_count": 0, "elapsed_s": 0.1, "outcome": "exhausted",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": None,
+            "variant": "exhausted", "final_state": None,
+        }]
+        db.get_download_history.return_value = []
+        db.get_denylisted_users.return_value = []
+
+        out = self._capture(db, 2)
+
+        self.assertIn("manual_reason:  search_exhausted", out)
+        self.assertIn("variant:        exhausted", out)
+
+    def test_show_handles_null_candidates_gracefully(self):
+        """Historical row with NULL candidates → no crash, no top list."""
+        db = MagicMock()
+        db.get_request.return_value = self._row(id=3, manual_reason=None)
+        db.get_tracks.return_value = []
+        db.get_search_history.return_value = [{
+            "id": 1, "request_id": 3, "query": "q",
+            "result_count": None, "elapsed_s": None, "outcome": "timeout",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": None, "variant": None, "final_state": None,
+        }]
+        db.get_download_history.return_value = []
+        db.get_denylisted_users.return_value = []
+
+        out = self._capture(db, 3)
+
+        # Pre-U1 / NULL row prints the "no forensic data" sentinel because
+        # variant + final_state + manual_reason are all NULL.
+        self.assertIn("(no forensic data yet)", out)
+        # And the per-row table renders the variant column as a dash.
+        self.assertIn("-", out)
+
+    def test_show_handles_empty_candidates_list(self):
+        db = MagicMock()
+        db.get_request.return_value = self._row(id=4, manual_reason=None)
+        db.get_tracks.return_value = []
+        db.get_search_history.return_value = [{
+            "id": 1, "request_id": 4, "query": "q",
+            "result_count": 0, "elapsed_s": 0.1, "outcome": "no_results",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": [], "variant": "v2_artist_album_no_year",
+            "final_state": "Completed",
+        }]
+        db.get_download_history.return_value = []
+        db.get_denylisted_users.return_value = []
+
+        out = self._capture(db, 4)
+
+        self.assertIn("variant:        v2_artist_album_no_year", out)
+        self.assertIn("(empty list)", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1058,6 +1058,96 @@ class TestSearchLog(unittest.TestCase):
         history = self.db.get_search_history(self.req_id)
         self.assertEqual(len(history), 6)
 
+    def test_exhausted_outcome_now_allowed_post_migration_010(self):
+        """Migration 010 widened the CHECK constraint to include 'exhausted'."""
+        self.db.log_search(
+            self.req_id, query=None, outcome="exhausted",
+            variant="exhausted",
+        )
+        history = self.db.get_search_history(self.req_id)
+        self.assertEqual(history[0]["outcome"], "exhausted")
+        self.assertEqual(history[0]["variant"], "exhausted")
+
+    def test_log_search_persists_candidates_jsonb_and_round_trips(self):
+        """U5 wire-boundary: encode list[CandidateScore] → JSONB → decode."""
+        import json
+        import msgspec
+        from lib.quality import CandidateScore
+
+        candidates = [
+            CandidateScore(
+                username="u1", dir="A\\Album", filetype="flac",
+                matched_tracks=26, total_tracks=26, avg_ratio=0.95,
+                missing_titles=[], file_count=26,
+            ),
+            CandidateScore(
+                username="u2", dir="B\\Album", filetype="flac",
+                matched_tracks=22, total_tracks=26, avg_ratio=0.0,
+                missing_titles=[], file_count=22,
+            ),
+        ]
+        self.db.log_search(
+            request_id=self.req_id,
+            query="*rtist Album",
+            result_count=10,
+            elapsed_s=2.5,
+            outcome="no_match",
+            candidates=candidates,
+            variant="default",
+            final_state="Completed",
+        )
+
+        history = self.db.get_search_history(self.req_id)
+        self.assertEqual(len(history), 1)
+        row = history[0]
+        self.assertEqual(row["variant"], "default")
+        self.assertEqual(row["final_state"], "Completed")
+
+        # psycopg2 returns JSONB as already-decoded Python objects, but
+        # accept a str fallback in case driver settings differ.
+        raw = row["candidates"]
+        if isinstance(raw, str):
+            raw = json.loads(raw)
+        assert isinstance(raw, list)
+        self.assertEqual(len(raw), 2)
+        decoded = msgspec.convert(raw, type=list[CandidateScore])
+        self.assertEqual(decoded[0].username, "u1")
+        self.assertEqual(decoded[0].matched_tracks, 26)
+        self.assertEqual(decoded[1].file_count, 22)
+
+    def test_log_search_with_null_candidates_writes_sql_null(self):
+        """Failure rows (timeout/error) still write a row, candidates NULL."""
+        self.db.log_search(
+            request_id=self.req_id, query="q", outcome="timeout",
+            variant="v1_year", final_state="TimedOut",
+            candidates=None,
+        )
+        history = self.db.get_search_history(self.req_id)
+        self.assertIsNone(history[0]["candidates"])
+        self.assertEqual(history[0]["variant"], "v1_year")
+        self.assertEqual(history[0]["final_state"], "TimedOut")
+
+    def test_log_search_candidates_decode_rejects_wrong_type(self):
+        """Wire-boundary regression: msgspec.convert raises on type drift.
+
+        At least one RED test that feeds the wrong type at the boundary and
+        asserts ``msgspec.ValidationError`` — the strict-typed decoder is
+        what catches int-vs-str drift in the JSONB blob downstream.
+        """
+        import msgspec
+        from lib.quality import CandidateScore
+
+        # ``matched_tracks`` is declared int — passing a string at the wire
+        # must trip msgspec on read, not silently coerce.
+        wrong = [{
+            "username": "u1", "dir": "A", "filetype": "flac",
+            "matched_tracks": "26",  # WRONG: string for int field
+            "total_tracks": 26, "avg_ratio": 0.9,
+            "missing_titles": [], "file_count": 26,
+        }]
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert(wrong, type=list[CandidateScore])
+
 
 @requires_postgres
 class TestDenylist(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1350,6 +1350,71 @@ class TestResetToWanted(unittest.TestCase):
         self.assertEqual(req["min_bitrate"], 320)
         self.assertEqual(req["prev_min_bitrate"], 192)
 
+    def test_clears_manual_reason(self):
+        """U6: re-queue clears ``manual_reason`` alongside attempt counters.
+
+        Single-seam reset: every re-queue path funnels through
+        ``reset_to_wanted``, so this one assertion covers web UI button,
+        ``pipeline-cli`` requeue, and importer requeue transparently.
+        """
+        req_id = self._make_request("clear-mr")
+        # Bump search_attempts and populate manual_reason as if the
+        # variant ladder had exhausted earlier.
+        self.db._execute(
+            "UPDATE album_requests SET search_attempts = 7, manual_reason = %s "
+            "WHERE id = %s",
+            ("search_exhausted", req_id),
+        )
+        self.db.conn.commit()
+        self.db.reset_to_wanted(req_id)
+        req = self.db.get_request(req_id)
+        assert req is not None
+        self.assertEqual(req["search_attempts"], 0)
+        self.assertIsNone(req["manual_reason"])
+
+
+@requires_postgres
+class TestSetManual(unittest.TestCase):
+    """U6: ``set_manual`` flip sites for system-driven manual transitions."""
+
+    def setUp(self):
+        self.db = make_db()
+        self.req_id = self.db.add_request(
+            mb_release_id="set-manual-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_writes_manual_reason_when_provided(self):
+        self.db.set_manual(self.req_id, manual_reason="search_exhausted")
+        req = self.db.get_request(self.req_id)
+        assert req is not None
+        self.assertEqual(req["status"], "manual")
+        self.assertEqual(req["manual_reason"], "search_exhausted")
+
+    def test_does_not_overwrite_existing_manual_reason_when_none(self):
+        """Defensive: a None reason must NOT clobber a populated reason.
+
+        Generic flip paths that don't carry a system reason should leave
+        any existing populated reason in place.
+        """
+        # Pre-populate manual_reason directly (simulates an operator hold or
+        # a previous system flip).
+        self.db._execute(
+            "UPDATE album_requests SET manual_reason = %s WHERE id = %s",
+            ("operator_hold", self.req_id),
+        )
+        self.db.conn.commit()
+        self.db.set_manual(self.req_id)
+        req = self.db.get_request(self.req_id)
+        assert req is not None
+        self.assertEqual(req["status"], "manual")
+        self.assertEqual(req["manual_reason"], "operator_hold")
+
 
 @requires_postgres
 class TestClearOnDiskQualityFields(unittest.TestCase):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -275,9 +275,9 @@ class TestDistinctiveTokenPool(unittest.TestCase):
 
     def test_sort_is_stable_deterministic(self):
         # Same-length tokens should be ordered deterministically (alpha lowercase)
-        pool = _distinctive_token_pool(["Beta Alpha Gamma"])
+        pool = _distinctive_token_pool(["Delta Alpha Gamma"])
         # All length 5, secondary sort alphabetical lowercase
-        self.assertEqual(pool, ["Alpha", "Beta", "Gamma"])
+        self.assertEqual(pool, ["Alpha", "Delta", "Gamma"])
 
 
 class TestSelectVariant(unittest.TestCase):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from lib.search import (
     build_query, strip_special_chars, strip_short_tokens,
     wildcard_artist_tokens, cap_tokens,
+    SearchVariant, _distinctive_token_pool, select_variant,
 )
 
 
@@ -229,6 +230,291 @@ class TestBuildQuery(unittest.TestCase):
         assert q is not None
         self.assertEqual(q, "Abbey Road")
         self.assertNotIn("*eatles", q)
+
+
+class TestDistinctiveTokenPool(unittest.TestCase):
+    """Token pool ordering: dedup case-insensitive, sort length-desc, drop short."""
+
+    def test_basic_length_desc_sort(self):
+        pool = _distinctive_token_pool(["Tallahassee", "Idylls", "Peg"])
+        # All >2 chars; sorted by length desc
+        self.assertEqual(pool, ["Tallahassee", "Idylls", "Peg"])
+
+    def test_drops_short_tokens(self):
+        # Tokens of length <=2 are dropped
+        pool = _distinctive_token_pool(["Of A Hum", "In It"])
+        # "Of", "A", "In", "It" all dropped; "Hum" kept (3 chars)
+        self.assertEqual(pool, ["Hum"])
+
+    def test_dedupe_case_insensitive_preserves_first_seen(self):
+        # First-seen casing is preserved
+        pool = _distinctive_token_pool(["Hello World", "hello there", "WORLD peace"])
+        # "Hello" (kept), "World" (kept), "hello" dropped (dup), "there" kept,
+        # "WORLD" dropped (dup), "peace" kept
+        # By length desc: "there"(5), "peace"(5), "Hello"(5), "World"(5)
+        # Stable secondary alphabetical lowercase: hello, peace, there, world
+        self.assertEqual(set(pool), {"Hello", "World", "there", "peace"})
+        # All kept in case from first-seen
+        self.assertIn("Hello", pool)
+        self.assertIn("World", pool)
+        self.assertNotIn("hello", pool)
+        self.assertNotIn("WORLD", pool)
+
+    def test_strips_special_chars(self):
+        pool = _distinctive_token_pool(["Don't Stop", "Hum, Sound"])
+        # "Don" "t" "Stop" "Hum" "Sound" → drop t (1 char)
+        # Remaining: ["Don", "Stop", "Hum", "Sound"] → length desc
+        self.assertEqual(pool, ["Sound", "Stop", "Don", "Hum"])
+
+    def test_empty_input(self):
+        self.assertEqual(_distinctive_token_pool([]), [])
+
+    def test_all_short_tokens(self):
+        # If every token is length <=2, pool is empty
+        self.assertEqual(_distinctive_token_pool(["A B", "If So", "Of It"]), [])
+
+    def test_sort_is_stable_deterministic(self):
+        # Same-length tokens should be ordered deterministically (alpha lowercase)
+        pool = _distinctive_token_pool(["Beta Alpha Gamma"])
+        # All length 5, secondary sort alphabetical lowercase
+        self.assertEqual(pool, ["Alpha", "Beta", "Gamma"])
+
+
+class TestSelectVariant(unittest.TestCase):
+    """Variant generator ladder — pure decision logic via subTest table."""
+
+    # Reusable token pools
+    POOL_BIG = ["Tallahassee", "Idylls", "Frontier", "Treasure", "Going", "Peg"]
+    # _distinctive_token_pool sorted: Tallahassee(11), Treasure(8), Frontier(8),
+    # Idylls(6), Going(5), Peg(3) → stable alpha for ties
+    # → ["Tallahassee", "Frontier", "Treasure", "Idylls", "Going", "Peg"]
+
+    POOL_SEVEN = ["Aaaaaaa", "Bbbbbb", "Ccccc", "Dddd", "Eee", "Fff", "Ggg"]
+    # length: 7,6,5,4,3,3,3 → sorted desc + alpha lowercase tie-break
+    # → ["Aaaaaaa", "Bbbbbb", "Ccccc", "Dddd", "Eee", "Fff", "Ggg"]
+
+    def test_default_branch_attempts_below_threshold(self):
+        # cycles 0-4 with threshold=5 all return default
+        cases = [
+            ("attempt_0", 0),
+            ("attempt_1", 1),
+            ("attempt_2", 2),
+            ("attempt_3", 3),
+            ("attempt_4", 4),
+        ]
+        for desc, attempts in cases:
+            with self.subTest(desc=desc, attempts=attempts):
+                v = select_variant(
+                    search_attempts=attempts,
+                    threshold=5,
+                    base_query="*ountain *oats Tallahassee",
+                    year="1991",
+                    track_titles=["Tallahassee", "Idylls"],
+                )
+                self.assertEqual(v.kind, "default")
+                self.assertEqual(v.query, "*ountain *oats Tallahassee")
+                self.assertEqual(v.tag, "default")
+                self.assertIsNone(v.slice_index)
+
+    def test_v1_year_at_threshold_with_known_year(self):
+        v = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="*he *eatles Abbey Road",
+            year="1969",
+            track_titles=["Something", "Octopus's Garden"],
+        )
+        self.assertEqual(v.kind, "v1_year")
+        self.assertEqual(v.query, "*he *eatles Abbey Road 1969")
+        self.assertEqual(v.tag, "v1_year")
+        self.assertIsNone(v.slice_index)
+
+    def test_v1_year_with_long_date_uses_4char_prefix(self):
+        v = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="base",
+            year="1991-08-01",
+            track_titles=["Track"],
+        )
+        self.assertEqual(v.kind, "v1_year")
+        self.assertEqual(v.query, "base 1991")
+        self.assertEqual(v.tag, "v1_year")
+
+    def test_v4_first_slice_after_v1(self):
+        # cycle 6 with year known → V4 slice 0 (first 3 tokens of pool)
+        v = select_variant(
+            search_attempts=6,
+            threshold=5,
+            base_query="base",
+            year="1991",
+            track_titles=self.POOL_BIG,
+        )
+        self.assertEqual(v.kind, "v4_tracks")
+        self.assertEqual(v.tag, "v4_tracks_0")
+        self.assertEqual(v.slice_index, 0)
+        # Pool: Tallahassee, Frontier, Treasure, Idylls, Going, Peg
+        # First 3
+        self.assertEqual(v.query, "Tallahassee Frontier Treasure")
+
+    def test_v4_second_slice(self):
+        v = select_variant(
+            search_attempts=7,
+            threshold=5,
+            base_query="base",
+            year="1991",
+            track_titles=self.POOL_BIG,
+        )
+        self.assertEqual(v.kind, "v4_tracks")
+        self.assertEqual(v.tag, "v4_tracks_1")
+        self.assertEqual(v.slice_index, 1)
+        self.assertEqual(v.query, "Idylls Going Peg")
+
+    def test_year_none_skips_v1_goes_to_v4(self):
+        # cycle 5 with year=None → V4 slice 0 directly
+        v = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="base",
+            year=None,
+            track_titles=self.POOL_BIG,
+        )
+        self.assertEqual(v.kind, "v4_tracks")
+        self.assertEqual(v.tag, "v4_tracks_0")
+        self.assertEqual(v.slice_index, 0)
+        self.assertEqual(v.query, "Tallahassee Frontier Treasure")
+
+    def test_year_0000_treated_as_unknown(self):
+        # Literal "0000" string → unknown → skip V1
+        v = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="base",
+            year="0000",
+            track_titles=self.POOL_BIG,
+        )
+        self.assertEqual(v.kind, "v4_tracks")
+        self.assertEqual(v.tag, "v4_tracks_0")
+        self.assertEqual(v.slice_index, 0)
+
+    def test_year_0000_dash_treated_as_unknown(self):
+        # "0000-00-00" → also unknown via startswith("0000")
+        v = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="base",
+            year="0000-00-00",
+            track_titles=self.POOL_BIG,
+        )
+        self.assertEqual(v.kind, "v4_tracks")
+        self.assertEqual(v.tag, "v4_tracks_0")
+        self.assertEqual(v.slice_index, 0)
+
+    def test_empty_tracks_with_year_v1_then_exhausted(self):
+        # cycle 5: year present → v1_year (still works without tracks)
+        v5 = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="base",
+            year="1991",
+            track_titles=[],
+        )
+        self.assertEqual(v5.kind, "v1_year")
+        # cycle 6: V4 with empty pool → exhausted
+        v6 = select_variant(
+            search_attempts=6,
+            threshold=5,
+            base_query="base",
+            year="1991",
+            track_titles=[],
+        )
+        self.assertEqual(v6.kind, "exhausted")
+        self.assertIsNone(v6.query)
+        self.assertEqual(v6.tag, "exhausted")
+        self.assertIsNone(v6.slice_index)
+
+    def test_empty_tracks_no_year_immediate_exhausted(self):
+        # cycle 5, year=None → skip V1 → V4 with empty pool → exhausted
+        v = select_variant(
+            search_attempts=5,
+            threshold=5,
+            base_query="base",
+            year=None,
+            track_titles=[],
+        )
+        self.assertEqual(v.kind, "exhausted")
+        self.assertIsNone(v.query)
+        self.assertEqual(v.tag, "exhausted")
+
+    def test_dedup_after_pool_overshoots(self):
+        # All-duplicate-after-dedupe titles → small pool
+        v = select_variant(
+            search_attempts=10,  # esc_idx=5, v4_idx=4, slice_start=12
+            threshold=5,
+            base_query="base",
+            year="1991",
+            track_titles=["Hello hello HELLO", "hello"],
+        )
+        # Pool: ["Hello"] (only 1 distinct token after case-insensitive dedup)
+        # slice_start = 12 (or any large index) >= 1 → exhausted
+        self.assertEqual(v.kind, "exhausted")
+
+    def test_cycle_100_with_3_token_pool_exhausted(self):
+        v = select_variant(
+            search_attempts=100,
+            threshold=5,
+            base_query="base",
+            year="1991",
+            track_titles=["Alpha Beta Gamma"],
+        )
+        # Pool size 3 → only one V4 slice (slice 0)
+        # esc_idx=95, v4_idx=94 → way past pool
+        self.assertEqual(v.kind, "exhausted")
+
+    def test_seven_token_pool_with_year_full_ladder(self):
+        # POOL_SEVEN length 7. With year present:
+        # cycle 5 → v1_year
+        # cycle 6 → v4_tracks_0 tokens 0-2
+        # cycle 7 → v4_tracks_1 tokens 3-5
+        # cycle 8 → v4_tracks_2 tokens 6-6 (single token)
+        # cycle 9 → exhausted
+        cases = [
+            (5, "v1_year", None, "base 1991"),
+            (6, "v4_tracks", 0, "Aaaaaaa Bbbbbb Ccccc"),
+            (7, "v4_tracks", 1, "Dddd Eee Fff"),
+            (8, "v4_tracks", 2, "Ggg"),
+            (9, "exhausted", None, None),
+        ]
+        for attempts, kind, slice_idx, expected_query in cases:
+            with self.subTest(attempts=attempts, kind=kind):
+                v = select_variant(
+                    search_attempts=attempts,
+                    threshold=5,
+                    base_query="base",
+                    year="1991",
+                    track_titles=self.POOL_SEVEN,
+                )
+                self.assertEqual(v.kind, kind)
+                self.assertEqual(v.slice_index, slice_idx)
+                self.assertEqual(v.query, expected_query)
+
+    def test_v4_tag_format_exact(self):
+        # Tag for V4 must be exactly "v4_tracks_<idx>"
+        for idx in [0, 1, 2, 5, 17]:
+            with self.subTest(idx=idx):
+                attempts = 5 + 1 + idx  # threshold + v1 + idx
+                # Build a pool large enough for the slice
+                pool_titles = [f"Token{n:03d}xxxx" for n in range((idx + 1) * 3)]
+                v = select_variant(
+                    search_attempts=attempts,
+                    threshold=5,
+                    base_query="base",
+                    year="1991",
+                    track_titles=pool_titles,
+                )
+                self.assertEqual(v.kind, "v4_tracks")
+                self.assertEqual(v.tag, f"v4_tracks_{idx}")
+                self.assertEqual(v.slice_index, idx)
 
 
 if __name__ == "__main__":

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -398,7 +398,7 @@ class TestSelectVariant(unittest.TestCase):
         self.assertEqual(v.slice_index, 0)
 
     def test_year_0000_dash_treated_as_unknown(self):
-        # "0000-00-00" → also unknown via startswith("0000")
+        # "0000-00-00" → also unknown
         v = select_variant(
             search_attempts=5,
             threshold=5,
@@ -409,6 +409,34 @@ class TestSelectVariant(unittest.TestCase):
         self.assertEqual(v.kind, "v4_tracks")
         self.assertEqual(v.tag, "v4_tracks_0")
         self.assertEqual(v.slice_index, 0)
+
+    def test_malformed_year_strings_treated_as_unknown(self):
+        """Year strings that aren't a 4-char numeric prefix → V4, not V1.
+
+        Adversarial review A2: the original ``_year_is_known`` only checked
+        ``startswith("0000")`` so "0", "", whitespace, "unknown", and short
+        numeric prefixes like "199" all leaked through and produced a V1
+        query that appended a meaningless year token.
+        """
+        bad_years = [
+            ("single_digit", "0"),
+            ("empty_string", ""),
+            ("whitespace_only", "   "),
+            ("non_numeric", "unknown"),
+            ("three_digit_prefix", "199"),
+        ]
+        for desc, year in bad_years:
+            with self.subTest(desc=desc, year=repr(year)):
+                v = select_variant(
+                    search_attempts=5,
+                    threshold=5,
+                    base_query="base",
+                    year=year,
+                    track_titles=self.POOL_BIG,
+                )
+                self.assertEqual(v.kind, "v4_tracks")
+                self.assertEqual(v.tag, "v4_tracks_0")
+                self.assertEqual(v.slice_index, 0)
 
     def test_empty_tracks_with_year_v1_then_exhausted(self):
         # cycle 5: year present → v1_year (still works without tracks)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -183,6 +183,7 @@ def _make_server():
         },
     ]
 
+    mock_db.get_search_history.return_value = []
     mock_db.get_wrong_matches.return_value = [copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)]
     mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
     mock_db.clear_wrong_match_path.return_value = True
@@ -823,16 +824,128 @@ class TestPipelineRouteContracts(_WebServerCase):
         _assert_required_fields(self, data["wanted"][0], self.PIPELINE_ITEM_REQUIRED_FIELDS,
                                 "pipeline all item")
 
+    DETAIL_RESPONSE_REQUIRED_FIELDS = {
+        "request", "history", "tracks", "manual_reason", "last_search",
+    }
+    LAST_SEARCH_REQUIRED_FIELDS = {
+        "variant", "final_state", "outcome", "top_candidates",
+    }
+    CANDIDATE_SCORE_REQUIRED_FIELDS = {
+        "username", "dir", "filetype", "matched_tracks", "total_tracks",
+        "avg_ratio", "missing_titles", "file_count",
+    }
+
     def test_pipeline_detail_contract(self):
         status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
-        _assert_required_fields(self, data, {"request", "history", "tracks"},
+        _assert_required_fields(self, data, self.DETAIL_RESPONSE_REQUIRED_FIELDS,
                                 "pipeline detail response")
         _assert_required_fields(self, data["request"], self.PIPELINE_ITEM_REQUIRED_FIELDS,
                                 "pipeline detail request")
         _assert_required_fields(self, data["history"][0], self.HISTORY_REQUIRED_FIELDS,
                                 "pipeline detail history item")
+        # Default mock state: no search history → last_search is None and
+        # manual_reason is None. Both keys are still present.
+        self.assertIsNone(data["last_search"])
+        self.assertIsNone(data["manual_reason"])
+
+    def test_pipeline_detail_surfaces_last_search_top_candidates(self):
+        """When the latest search_log row has candidates, the route emits the
+        top-3 by (matched_tracks DESC, avg_ratio DESC) via msgspec.to_builtins."""
+        candidates_blob = [
+            {"username": "u1", "dir": "A", "filetype": "flac",
+             "matched_tracks": 26, "total_tracks": 26, "avg_ratio": 0.95,
+             "missing_titles": [], "file_count": 26},
+            {"username": "u2", "dir": "B", "filetype": "mp3",
+             "matched_tracks": 22, "total_tracks": 26, "avg_ratio": 0.80,
+             "missing_titles": ["x"], "file_count": 22},
+            {"username": "u3", "dir": "C", "filetype": "flac",
+             "matched_tracks": 26, "total_tracks": 26, "avg_ratio": 0.85,
+             "missing_titles": [], "file_count": 26},
+            {"username": "u4", "dir": "D", "filetype": "flac",
+             "matched_tracks": 20, "total_tracks": 26, "avg_ratio": 0.99,
+             "missing_titles": ["a", "b"], "file_count": 20},
+        ]
+        self.mock_db.get_search_history.return_value = [{
+            "id": 99, "request_id": 100, "query": "*rtist Album",
+            "result_count": 100, "elapsed_s": 1.2, "outcome": "no_match",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": candidates_blob,
+            "variant": "v3_artist_only", "final_state": "Completed",
+        }]
+
+        try:
+            status, data = self._get("/api/pipeline/100")
+        finally:
+            self.mock_db.get_search_history.return_value = []
+
+        self.assertEqual(status, 200)
+        last = data["last_search"]
+        self.assertIsNotNone(last)
+        _assert_required_fields(self, last, self.LAST_SEARCH_REQUIRED_FIELDS,
+                                "last_search payload")
+        self.assertEqual(last["variant"], "v3_artist_only")
+        self.assertEqual(last["final_state"], "Completed")
+        self.assertEqual(last["outcome"], "no_match")
+        # Top-3, sorted by (matched_tracks DESC, avg_ratio DESC):
+        # u1 (26, 0.95) → u3 (26, 0.85) → u2 (22, 0.80)
+        usernames = [c["username"] for c in last["top_candidates"]]
+        self.assertEqual(usernames, ["u1", "u3", "u2"])
+        for cand in last["top_candidates"]:
+            _assert_required_fields(self, cand,
+                                    self.CANDIDATE_SCORE_REQUIRED_FIELDS,
+                                    "candidate score")
+
+    def test_pipeline_detail_handles_null_candidates_gracefully(self):
+        """Historical search_log row with NULL candidates → top_candidates=[]."""
+        self.mock_db.get_search_history.return_value = [{
+            "id": 1, "request_id": 100, "query": "q",
+            "result_count": None, "elapsed_s": None, "outcome": "timeout",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": None, "variant": None, "final_state": None,
+        }]
+        try:
+            status, data = self._get("/api/pipeline/100")
+        finally:
+            self.mock_db.get_search_history.return_value = []
+
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(data["last_search"])
+        self.assertEqual(data["last_search"]["top_candidates"], [])
+        self.assertIsNone(data["last_search"]["variant"])
+
+    def test_pipeline_detail_handles_empty_candidates_list(self):
+        """Latest search row with an empty candidates list → top_candidates=[]."""
+        self.mock_db.get_search_history.return_value = [{
+            "id": 1, "request_id": 100, "query": "q",
+            "result_count": 0, "elapsed_s": 0.5, "outcome": "no_results",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": [], "variant": "v2_artist_album_no_year",
+            "final_state": "Completed",
+        }]
+        try:
+            status, data = self._get("/api/pipeline/100")
+        finally:
+            self.mock_db.get_search_history.return_value = []
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["last_search"]["top_candidates"], [])
+        self.assertEqual(data["last_search"]["variant"], "v2_artist_album_no_year")
+
+    def test_pipeline_detail_surfaces_manual_reason(self):
+        """manual_reason='search_exhausted' is exposed on the detail response."""
+        row = copy.deepcopy(_MOCK_PIPELINE_REQUEST)
+        row["manual_reason"] = "search_exhausted"
+        row["status"] = "manual"
+        self.mock_db.get_request.return_value = row
+        try:
+            status, data = self._get("/api/pipeline/100")
+        finally:
+            self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["manual_reason"], "search_exhausted")
 
     def test_pipeline_detail_history_surfaces_wrong_match_triage_audit(self):
         original_history = copy.deepcopy(self.mock_db.get_download_history.return_value)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -933,6 +933,33 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.assertEqual(data["last_search"]["top_candidates"], [])
         self.assertEqual(data["last_search"]["variant"], "v2_artist_album_no_year")
 
+    def test_pipeline_detail_handles_malformed_candidates_blob(self):
+        """Corrupted search_log.candidates JSONB → 200 with top_candidates=[].
+
+        Guard the route against historical rows whose JSONB shape no longer
+        matches CandidateScore. The CLI already wraps msgspec.convert in
+        try/except msgspec.ValidationError; the web route must do the same so
+        a corrupt row does not 500 the detail page.
+        """
+        self.mock_db.get_search_history.return_value = [{
+            "id": 7, "request_id": 100, "query": "q",
+            "result_count": 5, "elapsed_s": 0.5, "outcome": "no_match",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            # Wrong shape — missing every required CandidateScore field.
+            "candidates": [{"foo": "bar"}],
+            "variant": "v2_artist_album_no_year", "final_state": "Completed",
+        }]
+        try:
+            status, data = self._get("/api/pipeline/100")
+        finally:
+            self.mock_db.get_search_history.return_value = []
+
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(data["last_search"])
+        self.assertEqual(data["last_search"]["top_candidates"], [])
+        self.assertEqual(data["last_search"]["variant"],
+                         "v2_artist_album_no_year")
+
     def test_pipeline_detail_surfaces_manual_reason(self):
         """manual_reason='search_exhausted' is exposed on the detail response."""
         row = copy.deepcopy(_MOCK_PIPELINE_REQUEST)

--- a/web/index.html
+++ b/web/index.html
@@ -111,6 +111,21 @@
   .p-hist-label { color: #666; display: inline-block; min-width: 80px; }
   .p-hist-verdict { color: #bbb; padding: 2px 0 0 8px; font-size: 0.95em; }
   .p-actions { display: flex; gap: 6px; margin-top: 8px; }
+  /* Manual-reason chip — small inline tag near the request title or status.
+     Currently used for `search_exhausted` (red/amber) flips written by the
+     variant ladder when all variants exhaust without finding a candidate. */
+  .p-manual-chip { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.7em; font-weight: 600; margin-left: 6px; background: #4a2a1a; color: #d96; }
+  /* Forensic block — collapsed by default summary of the most recent search
+     row (variant + final_state + top-3 candidates). Click toggles open. */
+  .p-forensic { margin-top: 8px; font-size: 0.78em; color: #888; }
+  .p-forensic-summary { cursor: pointer; user-select: none; color: #888; }
+  .p-forensic-summary:hover { color: #bbb; }
+  .p-forensic-body { display: none; margin-top: 4px; padding: 6px 8px; background: #161616; border-radius: 4px; }
+  .p-forensic.open .p-forensic-body { display: block; }
+  .p-forensic-meta { color: #888; padding-bottom: 4px; }
+  .p-forensic-table { width: 100%; border-collapse: collapse; font-size: 0.92em; }
+  .p-forensic-table th { color: #666; text-align: left; font-weight: 500; padding: 2px 6px 2px 0; }
+  .p-forensic-table td { color: #aaa; padding: 1px 6px 1px 0; }
   .p-btn { padding: 4px 12px; border: 1px solid #444; background: #222; color: #aaa; border-radius: 4px; cursor: pointer; font-size: 0.78em; }
   .p-btn:hover { background: #333; color: #eee; }
   .p-btn.active-status { border-color: #6a9; color: #6a9; background: #2a3a2a; }

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { state, API, toast } from './state.js';
-import { esc, awstDate, awstDateTime, qualityLabel, externalReleaseUrl, sourceLabel } from './util.js';
+import { esc, awstDate, awstDateTime, qualityLabel, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock } from './util.js';
 import { renderDownloadHistoryItem } from './history.js';
 import { renderBadRipButton } from './release_actions.js';
 
@@ -170,6 +170,13 @@ export async function toggleDetail(elId, requestId) {
     const history = data.history || [];
 
     let html = '';
+    // Manual-reason chip (e.g. search_exhausted) — surfaces the reason a
+    // request landed in `manual` so the operator does not have to query
+    // JSONB. Hidden when null (manually-set or pre-U7 rows).
+    const reasonLabel = manualReasonLabel(data.manual_reason);
+    if (reasonLabel) {
+      html += `<div class="p-detail-row"><span class="p-detail-label">Manual reason</span><span class="p-detail-value"><span class="p-manual-chip">${esc(reasonLabel)}</span></span></div>`;
+    }
     // External link (MB or Discogs)
     if (req.mb_release_id) {
       const label = sourceLabel(req.mb_release_id);
@@ -244,6 +251,10 @@ export async function toggleDetail(elId, requestId) {
       html += history.map(renderDownloadHistoryItem).join('');
       html += '</div>';
     }
+
+    // Search forensics (last_search) — variant tag + top-3 candidates from
+    // the most recent search_log row. Collapsed by default; click expands.
+    html += renderForensicBlock(/** @type {any} */ (data.last_search));
 
     // Status change buttons
     html += `<div class="p-actions">

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -170,3 +170,82 @@ export function sourceLabel(id) {
   if (source === 'discogs') return 'Discogs';
   return '';
 }
+
+/**
+ * Map a `manual_reason` enum value to a short, human-friendly label for the
+ * inline chip on the request-detail view. Returns the empty string for
+ * NULL / unknown reasons so the caller can branch on truthiness.
+ * @param {string|null|undefined} reason
+ * @returns {string}
+ */
+export function manualReasonLabel(reason) {
+  if (!reason) return '';
+  if (reason === 'search_exhausted') return 'search exhausted';
+  return reason;
+}
+
+/**
+ * @typedef {Object} CandidateScore
+ * @property {string} username
+ * @property {string} dir
+ * @property {string} filetype
+ * @property {number} matched_tracks
+ * @property {number} total_tracks
+ * @property {number} avg_ratio
+ * @property {string[]} missing_titles
+ * @property {number} file_count
+ */
+
+/**
+ * @typedef {Object} LastSearchPayload
+ * @property {string|null} variant
+ * @property {string|null} final_state
+ * @property {string|null} outcome
+ * @property {CandidateScore[]} top_candidates
+ */
+
+/**
+ * Render the "search forensics" block for the request-detail view.
+ *
+ * UX: collapsed-by-default summary that shows the variant tag + final_state
+ * tag and a top-3 candidates table (`username · dir · matched/total ·
+ * avg_ratio · filetype`). When `last` is null (no search rows yet), returns
+ * a small "no forensic data yet" line. Pure HTML producer — testable
+ * without a DOM.
+ *
+ * @param {LastSearchPayload|null|undefined} last
+ * @returns {string} HTML string
+ */
+export function renderForensicBlock(last) {
+  if (!last) {
+    return `<div class="p-forensic"><div class="p-forensic-summary">No search forensic data yet</div></div>`;
+  }
+  const variant = last.variant || '?';
+  const finalState = last.final_state || '?';
+  const outcome = last.outcome || '?';
+  const cands = Array.isArray(last.top_candidates) ? last.top_candidates : [];
+  const summary = `Last search: ${esc(variant)} → ${esc(outcome)} <span style="color:#666;">(${esc(finalState)}, top ${cands.length})</span>`;
+  let body = `<div class="p-forensic-meta">variant: ${esc(variant)} · final_state: ${esc(finalState)} · outcome: ${esc(outcome)}</div>`;
+  if (cands.length === 0) {
+    body += `<div style="color:#666;">No candidates captured for this search.</div>`;
+  } else {
+    body += '<table class="p-forensic-table"><thead><tr>'
+      + '<th>user</th><th>dir</th><th>match</th><th>avg</th><th>type</th>'
+      + '</tr></thead><tbody>'
+      + cands.map((c) => {
+        const ratio = (typeof c.avg_ratio === 'number') ? c.avg_ratio.toFixed(2) : '?';
+        return `<tr>
+          <td>${esc(c.username || '?')}</td>
+          <td style="color:#777;">${esc(c.dir || '?')}</td>
+          <td>${c.matched_tracks ?? '?'}/${c.total_tracks ?? '?'}</td>
+          <td>${ratio}</td>
+          <td>${esc(c.filetype || '?')}</td>
+        </tr>`;
+      }).join('')
+      + '</tbody></table>';
+  }
+  return `<div class="p-forensic" id="p-forensic-block">
+    <div class="p-forensic-summary" onclick="event.stopPropagation(); this.parentElement.classList.toggle('open');">${summary}</div>
+    <div class="p-forensic-body">${body}</div>
+  </div>`;
+}

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -19,6 +19,7 @@ from web.download_history_view import (
     classify_download_log_row,
 )
 from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
+                         CandidateScore,
                          resolve_user_requeue_override,
                          should_clear_lossless_search_override,
                          get_decision_tree)
@@ -299,6 +300,44 @@ def get_pipeline_simulate(h, params: dict[str, list[str]]) -> None:
     h._json(preview.simulation or {})
 
 
+def _build_last_search_payload(
+    search_history: list[dict[str, object]],
+) -> dict[str, object] | None:
+    """Build the ``last_search`` slice of the request-detail response.
+
+    Single decode site (per ``.claude/rules/code-quality.md`` § Wire-boundary
+    types) for the ``search_log.candidates`` JSONB blob: ``msgspec.convert``
+    turns it into ``list[CandidateScore]`` here, and the response is
+    re-encoded via ``msgspec.to_builtins`` for symmetric strictness. Older
+    rows with ``candidates=NULL`` (or missing) read as ``[]`` — no
+    ``ValidationError``. Returns ``None`` when the request has no
+    search_log rows yet.
+    """
+    if not search_history:
+        return None
+    latest = search_history[0]  # get_search_history orders newest first
+    raw_candidates = latest.get("candidates")
+    candidates: list[CandidateScore]
+    if raw_candidates is None:
+        candidates = []
+    else:
+        candidates = msgspec.convert(raw_candidates, type=list[CandidateScore])
+    # Top-3 by (matched_tracks DESC, avg_ratio DESC) for compact list view;
+    # full forensic blob still reachable via the search history for
+    # operators who want it.
+    candidates.sort(
+        key=lambda c: (c.matched_tracks, c.avg_ratio),
+        reverse=True,
+    )
+    top = candidates[:3]
+    return {
+        "variant": latest.get("variant"),
+        "final_state": latest.get("final_state"),
+        "outcome": latest.get("outcome"),
+        "top_candidates": [msgspec.to_builtins(c) for c in top],
+    }
+
+
 def get_pipeline_detail(h, params: dict[str, list[str]], req_id_str: str) -> None:
     s = _server()
     req_id = int(req_id_str)
@@ -309,10 +348,14 @@ def get_pipeline_detail(h, params: dict[str, list[str]], req_id_str: str) -> Non
     tracks = s._db().get_tracks(req_id)
     history = s._db().get_download_history(req_id)
     history_items = [item.to_dict() for item in build_download_history_rows(history)]
+    search_history = s._db().get_search_history(req_id)
+    last_search = _build_last_search_payload(search_history)
     result: dict[str, object] = {
         "request": s._serialize_row(req),
         "tracks": tracks,
         "history": history_items,
+        "manual_reason": req.get("manual_reason"),
+        "last_search": last_search,
     }
     mbid = req.get("mb_release_id")
     b = s._beets_db()

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1,9 +1,12 @@
 """Pipeline API route handlers, extracted from server.py."""
 
 import json
+import logging
 import re
 from pathlib import Path
 import msgspec
+
+logger = logging.getLogger(__name__)
 
 from lib import transitions
 from lib.audio_hash import AudioHashError, hash_audio_content
@@ -321,7 +324,21 @@ def _build_last_search_payload(
     if raw_candidates is None:
         candidates = []
     else:
-        candidates = msgspec.convert(raw_candidates, type=list[CandidateScore])
+        try:
+            candidates = msgspec.convert(
+                raw_candidates, type=list[CandidateScore]
+            )
+        except msgspec.ValidationError as exc:
+            # Mirrors the CLI's defensive guard in
+            # scripts/pipeline_cli.py:_render_search_forensics_summary —
+            # production writes via the same Struct so this should never trip,
+            # but a corrupted historical row must not 500 the detail route.
+            logger.warning(
+                "search_log.candidates JSONB failed msgspec validation "
+                "(request_id=%s, search_log_id=%s): %s",
+                latest.get("request_id"), latest.get("id"), exc,
+            )
+            candidates = []
     # Top-3 by (matched_tracks DESC, avg_ratio DESC) for compact list view;
     # full forensic blob still reachable via the search history for
     # operators who want it.

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -25,6 +25,7 @@ from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
                          CandidateScore,
                          resolve_user_requeue_override,
                          should_clear_lossless_search_override,
+                         top_candidates,
                          get_decision_tree)
 from lib.import_preview import ImportPreviewValues, preview_import_from_values
 from lib.release_identity import detect_release_source, normalize_release_id
@@ -341,12 +342,8 @@ def _build_last_search_payload(
             candidates = []
     # Top-3 by (matched_tracks DESC, avg_ratio DESC) for compact list view;
     # full forensic blob still reachable via the search history for
-    # operators who want it.
-    candidates.sort(
-        key=lambda c: (c.matched_tracks, c.avg_ratio),
-        reverse=True,
-    )
-    top = candidates[:3]
+    # operators who want it. Shared ranking lives in lib/quality.py.
+    top = top_candidates(candidates, limit=3)
     return {
         "variant": latest.get("variant"),
         "final_state": latest.get("final_state"),


### PR DESCRIPTION
## Summary

Releases that fail to match in Soulseek currently grind through identical search cycles forever — same query, same result count, no learning, no manual triage path. Request #1843 (The Wiggles 1991 AU, 26 tracks) accumulated 28 cycles over a week, all `no_match`, with no record of which peers appeared.

This PR adds search escalation and forensic capture: each cycle now selects a variant from a pure-function ladder, persists the top 20 candidate scores as JSONB, and flips chronically stuck requests to `manual` so operators can intervene. The strict 26/26 accept rule in `album_match` is preserved — the refactor only stops discarding the per-track scores it already computes.

## Variant ladder

`select_variant(search_attempts, threshold, base_query, year, track_titles)` is a deterministic pure function in `lib/search.py`. Cycle by cycle:

- **Cycles 0–4** → `default` (existing query, unchanged)
- **Cycle 5 with year known** → `v1_year` (`<base> <year>`)
- **Cycle 6 onward** → `v4_tracks_<idx>` — rotating 3-token slices of distinctive track titles, sorted length-descending
- **Pool exhausted** → `exhausted` sentinel; no slskd call

V2 (country) and V3 (format hints) are deferred — peers don't index those tokens.

## Forensic capture

Every cycle now writes `search_log.candidates` JSONB with the top 20 scored peers (by `matched_tracks DESC, avg_ratio DESC`), plus `variant` (e.g., `v4_tracks_2`) and `final_state` (slskd's terminal state).

Two capture paths reviewers usually miss:

- **Count-gate failures** — a peer with 22/26 audio files never reaches `album_match`. We emit a cheap `CandidateScore` for it anyway so the headline diagnostic ("did the right peer ever appear, even partially?") works.
- **Cross-check rejections** — a dir that passes `album_match` but fails `_track_titles_cross_check` is recorded with full per-track scores, so the near-miss is visible in forensics.

## Exhaustion → manual

When the variant generator returns `exhausted`, the request flips to `status='manual'` with `manual_reason='search_exhausted'` (new `album_requests` column). Operators see an exhaustion chip in the web UI and a summary block in `pipeline-cli show`.

Manual re-queue funnels through one seam — `lib/transitions.py:apply_transition` → `db.reset_to_wanted` — which now clears both `search_attempts=0` and `manual_reason=NULL`. Single-line change because every re-queue caller (web UI, CLI, importer requeue) already routes through `reset_to_wanted`.

## Wire-boundary discipline

`CandidateScore` is a `msgspec.Struct` (not a dataclass). Encoded via `msgspec.json.encode` at write time; decoded via `msgspec.convert(blob, type=list[CandidateScore])` at exactly one site per consumer (web route, CLI). Field types are strict (`str`, not `str | int`) — type drift fails fast at the boundary instead of silently coercing.

## Schema

`migrations/010_search_forensics_and_manual_reason.sql` adds `search_log.{candidates JSONB, variant TEXT, final_state TEXT}`, `album_requests.manual_reason TEXT`, and extends the `search_log_outcome_check` constraint to include `'exhausted'`. All NULL-defaulting; historical rows remain queryable. The migration unit `cratedigger-db-migrate.service` runs before `cratedigger.service` and `cratedigger-web.service` per the existing deploy gate.

## Operational notes

- `responseLimit=1000` (up from slskd-api's default 100) is exposed via the NixOS `searchSettings.searchResponseLimit` option. Slskd CPU pressure is acknowledged; revertible via the option without a code rollback.
- `_select_variant_for_album` swallows DB exceptions and falls back to `kind=default` (intentional for resilience). The fallback emits a stable-prefix log: `journalctl -u cratedigger | grep VARIANT_SELECT_FALLBACK` counts silent escalation-ladder bypasses.
- Variant selection reads `search_attempts` at submit time; `record_attempt` increments at log time. The currency invariant holds because `get_wanted` row-uniqueness prevents same-album duplicate submission within a batch — comment-fenced in `_submit_search` for future maintainers.

## Test plan

```
nix-shell --run "bash scripts/run_tests.sh"  # 2681 OK, 53 skipped, 0 failures
```

The diff adds ~700 lines of test coverage:

- `tests/test_matching.py` (new file) — 15 tests on `AlbumMatchScore` + `check_for_match` (sub-count, cross-check, strict-accept regression)
- `tests/test_search.py` — 21 new variant-ladder subTest cases
- `tests/test_integration_slices.py` — end-to-end slices including parallel-path `responseLimit` propagation, V4 escalation, slskd-error path, exhaustion flip, re-queue reset, operator-hold preservation, malformed JSONB graceful-fail
- `tests/test_pipeline_db.py` — `TestSearchLog` (round-trip, NULL, `msgspec.ValidationError`, exhausted), `TestSetManual` (no-clobber), `TestResetToWanted.test_clears_manual_reason`
- `tests/test_web_server.py` — contract tests for `manual_reason` + `last_search.{variant,final_state,outcome,top_candidates}` + malformed-JSONB resilience
- `tests/test_pipeline_cli.py` (new file) — `TestCmdShowSearchForensics`
- `tests/test_js_util.mjs` — 16 new assertions for `manualReasonLabel` + `renderForensicBlock` with XSS escaping

Pyright clean on touched files (1 pre-existing error in `lib/quality.py` unchanged from main).

## Code review

`ce-code-review` (autofix mode) dispatched 8 reviewers and produced 1 P1 + 13 P2 + 6 P3. All 13 safe_auto + 5 residual findings landed:

- **P1**: web `/api/pipeline/<id>` now guards `msgspec.convert` against `ValidationError` (mirroring the CLI's pattern; previously a malformed historical JSONB row could 500 the request-detail page).
- **4-reviewer corroborated**: `log_search.candidates` parameter typed `list[CandidateScore]`, not `list[Any]`.
- `MatchResult.__iter__` 3-tuple back-compat shim removed (silently dropped `.candidates` on tuple-unpack).
- `__exhausted__` string sentinel in parallel `_submit_search` eliminated by hoisting variant selection to the caller — failure paths now preserve `variant.tag` cleanly.
- `_year_is_known` tightened to require a 4-digit numeric prefix; rejects `"0"`, `""`, whitespace, `"unknown"`, `"199"`.
- Tri-site sort duplication consolidated into `lib/quality.py:top_candidates`.

Run artifact: `/tmp/compound-engineering/ce-code-review/20260430-051904-682683b5/`.

## Post-deploy monitoring

- After `nixos-rebuild switch` on doc2: verify migration applied via `pipeline-cli query "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1"` → expect `010`.
- Tail `journalctl -u cratedigger -f` for the first cycle. Watch for `VARIANT_SELECT_FALLBACK` (DB read failure surface) or slskd response-limit timeouts under the new `responseLimit=1000`.
- Sanity-check #1843 over 1–2 cycles: `pipeline-cli show 1843` displays the `variant` column on subsequent search rows; if escalation reaches V4, the top-candidates block shows the peers slskd returned for token-slice queries.
- Failure signal: slskd CPU regression. Mitigation: lower `searchSettings.searchResponseLimit` in `~/nixosconfig` and `nixos-rebuild switch` again — no cratedigger code change required.
- Validation window: 48 hours. Owner: @abl030.

## Plan reference

`docs/plans/2026-04-29-006-feat-search-escalation-and-forensics-plan.md` (now `status: completed`).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)