### PR TITLE
fix(search): exhausted variant resets search_attempts instead of flipping to manual

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -547,29 +547,24 @@ def _log_search_result(album, result, ctx) -> None:
         final_state=result.final_state,
     )
     # Increment search_attempts + backoff for any non-found outcome.
-    # Exhausted variants do not increment — the request will be flipped to
-    # manual below and the attempt counter is the variant-ladder index.
+    # Exhausted variants do not increment — the counter is reset below so
+    # the variant ladder wraps back to default on the next cycle.
     if result.outcome not in ("found", "exhausted"):
         db.record_attempt(request_id, "search")
 
-    # U6: variant ladder exhausted → flip request to status='manual' with
-    # manual_reason='search_exhausted'. The search_log row above is the
-    # audit trail; this status flip is a side effect after.
-    #
-    # Defensive: skip if status is already 'manual' to avoid clobbering an
-    # operator-set hold (a request flipped to 'manual' for an unrelated
-    # reason). `set_manual` itself will not overwrite an existing
-    # `manual_reason` with NULL, but re-flipping idempotently still
-    # rewrites the row's `updated_at` and broadcasts another status_history
-    # entry — neither is appropriate for an operator-held row.
+    # Variant ladder exhausted → reset ``search_attempts`` so the ladder
+    # wraps back to default on the next cycle. The request stays
+    # ``wanted``; the standard ``next_retry_after`` cooldown still governs
+    # when the next search runs. Soulseek peers come and go, so cycling
+    # the variants again is more useful than parking the request for
+    # operator triage. The ``search_log`` row above (with
+    # ``outcome='exhausted'``, ``variant='exhausted'``) is the audit trail.
     if result.outcome == "exhausted":
-        row = db.get_request(request_id)
-        if row is not None and row.get("status") != "manual":
-            logger.info(
-                f"Flipping request {request_id} to manual "
-                f"(reason='search_exhausted')"
-            )
-            db.set_manual(request_id, manual_reason="search_exhausted")
+        logger.info(
+            f"Variant ladder exhausted for request {request_id}; "
+            f"resetting search_attempts to wrap"
+        )
+        db.reset_search_attempts(request_id)
 
 
 def _apply_find_download_result(album, result, find_result, failed_grab) -> None:

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -992,6 +992,21 @@ class PipelineDB:
         )
         self.conn.commit()
 
+    def reset_search_attempts(self, request_id: int) -> None:
+        """Reset ``search_attempts`` to 0; leave status/backoff/other counters alone.
+
+        Used by the variant-ladder exhaustion path: when the V4 token pool
+        runs out, the request stays ``wanted`` and the ladder wraps back to
+        the default query. The standard ``next_retry_after`` cooldown still
+        governs when the next cycle picks it up.
+        """
+        now = datetime.now(timezone.utc)
+        self._execute(
+            "UPDATE album_requests SET search_attempts = 0, updated_at = %s WHERE id = %s",
+            (now, request_id),
+        )
+        self.conn.commit()
+
     def update_imported_path_by_release_id(
         self,
         *,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1052,6 +1052,16 @@ class FakePipelineDB:
             row["manual_reason"] = manual_reason
         self.status_history.append((request_id, "manual"))
 
+    def reset_search_attempts(self, request_id: int) -> None:
+        """Mirror ``PipelineDB.reset_search_attempts``: clear search counter,
+        leave status/backoff/other counters alone.
+        """
+        row = self._requests.get(request_id)
+        if row is None:
+            return
+        row["search_attempts"] = 0
+        row["updated_at"] = _utcnow()
+
     def set_downloading(self, request_id: int, state_json: str) -> bool:
         row = self._requests.get(request_id)
         if row is None or row["status"] != "wanted":

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -3062,14 +3062,17 @@ class TestVariantSelectFallbackObservability(unittest.TestCase):
         self.assertIn("RuntimeError", joined)
 
 
-class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
-    """U6 integration slice: variant=exhausted → manual flip + re-queue reset.
+class TestSearchExhaustionResetsCounterSlice(unittest.TestCase):
+    """Integration slice: variant=exhausted → reset search_attempts, stay wanted.
 
     Drives ``_log_search_result`` end-to-end with FakePipelineDB and asserts:
-    - happy path: status flips to ``manual``, manual_reason='search_exhausted'
-    - re-queue via ``apply_transition`` clears manual_reason + search_attempts
-    - defensive: status='manual' with no reason is not retroactively flipped
-    - defensive: status='manual' with operator_hold reason is not clobbered
+    - happy path: search_log row written with outcome='exhausted'; the
+      request stays ``wanted`` and ``search_attempts`` is reset to 0 so
+      the variant ladder wraps back to default on the next cycle.
+    - re-queue via ``apply_transition`` (operator-driven manual→wanted)
+      clears ``manual_reason`` and ``search_attempts`` — this seam is
+      independent of the exhaustion path but worth covering since
+      ``manual_reason`` exists for future operator-hold workflows.
     """
 
     def setUp(self):
@@ -3117,23 +3120,23 @@ class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
             elapsed_s=0.0, outcome="exhausted", variant_tag="exhausted",
         )
 
-    def test_exhausted_flips_to_manual_with_reason_and_skips_get_wanted(self):
-        """Happy path: search_log row + status='manual' + reason populated.
+    def test_exhausted_resets_search_attempts_and_stays_wanted(self):
+        """Happy path: search_log row recorded; counter reset; stays wanted.
 
-        Asserts the next get_wanted does NOT return the flipped request —
-        proving the flip actually re-routes the request out of the
-        search/download loop.
+        After exhaustion the variant ladder wraps — ``search_attempts``
+        goes back to 0, status stays ``wanted``, ``manual_reason`` is
+        never set, and the request remains in ``get_wanted()`` for the
+        next cycle.
         """
         from tests.fakes import FakePipelineDB
 
         db = FakePipelineDB()
-        # Start the request as 'downloading' (the realistic state — the
-        # search loop only runs against rows that are wanted/downloading).
         rid = db.add_request(
             artist_name="A", album_title="B", source="request",
-            mb_release_id="mb-exh", status="downloading",
+            mb_release_id="mb-exh", status="wanted",
         )
-        # Bump search_attempts so this isn't a fresh request.
+        # Bump search_attempts to a value past the threshold so the
+        # request is at the end of the variant ladder.
         db.update_request_fields(rid, search_attempts=7)
 
         album = self._make_album(rid)
@@ -3142,18 +3145,19 @@ class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
 
         self._cratedigger._log_search_result(album, result, ctx)
 
-        # search_log row persists with outcome='exhausted'.
+        # search_log row persists with outcome='exhausted' — the audit trail.
         self.assertEqual(len(db.search_logs), 1)
         self.assertEqual(db.search_logs[0].outcome, "exhausted")
 
-        # Request flipped to manual with the reason.
+        # search_attempts wraps back to 0; status stays 'wanted'.
         row = db.request(rid)
-        self.assertEqual(row["status"], "manual")
-        self.assertEqual(row["manual_reason"], "search_exhausted")
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_attempts"], 0)
+        self.assertIsNone(row["manual_reason"])
 
-        # get_wanted does NOT return this request anymore.
+        # Request is still in the wanted pool for the next cycle.
         wanted_ids = [r["id"] for r in db.get_wanted()]
-        self.assertNotIn(rid, wanted_ids)
+        self.assertIn(rid, wanted_ids)
 
     def test_requeue_via_apply_transition_clears_state(self):
         """Operator re-queue via the single-seam transition resets state."""
@@ -3185,70 +3189,6 @@ class TestSearchExhaustionFlipsToManualSlice(unittest.TestCase):
         # Re-queued request is back in the wanted pool.
         wanted_ids = [r["id"] for r in db.get_wanted()]
         self.assertIn(rid, wanted_ids)
-
-    def test_already_manual_request_is_not_reflipped(self):
-        """Defensive: status already 'manual' → no flip, no log_history pollution.
-
-        A request that's already in manual (operator-set hold or prior flip)
-        must not have its manual_reason rewritten and must not generate a
-        spurious status_history entry. The search_log row IS still written —
-        that's the audit trail.
-        """
-        from tests.fakes import FakePipelineDB
-
-        db = FakePipelineDB()
-        rid = db.add_request(
-            artist_name="A", album_title="B", source="request",
-            mb_release_id="mb-am", status="manual",
-        )
-        # Pre-existing operator hold with no reason populated (a manually
-        # created request, never flipped by the system).
-        # Snapshot history so we can assert no new entry was added.
-        prior_history = list(db.status_history)
-
-        album = self._make_album(rid)
-        ctx = self._ctx_with_db(db)
-        result = self._make_exhausted_result(album_id=-rid)
-
-        self._cratedigger._log_search_result(album, result, ctx)
-
-        # search_log row was still written — the audit trail is preserved.
-        self.assertEqual(len(db.search_logs), 1)
-
-        row = db.request(rid)
-        self.assertEqual(row["status"], "manual")
-        # manual_reason was NOT populated by the flip (it was None and
-        # stays None — set_manual was never called).
-        self.assertIsNone(row["manual_reason"])
-        # No new status_history entry from a redundant flip.
-        self.assertEqual(db.status_history, prior_history)
-
-    def test_already_manual_with_other_reason_is_not_clobbered(self):
-        """Defensive: an unrelated reason on a manual row is preserved.
-
-        If a request is in manual for a different reason (e.g. operator
-        hold), the exhaustion flip path must not overwrite that reason.
-        """
-        from tests.fakes import FakePipelineDB
-
-        db = FakePipelineDB()
-        rid = db.add_request(
-            artist_name="A", album_title="B", source="request",
-            mb_release_id="mb-oh", status="manual",
-        )
-        # Inject an operator-hold reason directly (no production code path
-        # writes this today — that's the point of the defensive check).
-        db.update_request_fields(rid, manual_reason="operator_hold")
-
-        album = self._make_album(rid)
-        ctx = self._ctx_with_db(db)
-        result = self._make_exhausted_result(album_id=-rid)
-
-        self._cratedigger._log_search_result(album, result, ctx)
-
-        row = db.request(rid)
-        self.assertEqual(row["status"], "manual")
-        self.assertEqual(row["manual_reason"], "operator_hold")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Inverts the exhaustion behavior we just shipped in #193. Variant ladder exhaustion now resets `search_attempts=0` and the request stays `wanted`, so the ladder wraps back to `default` on the next cycle. Previously it flipped to `status='manual'` with `manual_reason='search_exhausted'` for operator triage.

## Why

Soulseek peers come and go; a release that exhausted the variant pool today may have new peers next week. Cycling the variants again is more useful than parking the request for human review — the operator only needs to intervene when it's clear the release is genuinely unfindable, not on every variant-pool exhaustion.

The `search_log` row (`outcome='exhausted'`, `variant='exhausted'`) still records every exhaustion event, so the audit trail is preserved.

## Changes

- `cratedigger.py:_log_search_result` — call `db.reset_search_attempts(request_id)` instead of `db.set_manual(request_id, manual_reason='search_exhausted')`.
- `lib/pipeline_db.py` — new `reset_search_attempts(request_id)` (single-purpose, mirrors the inline UPDATE pattern). `manual_reason` column and `set_manual` method stay — manual_reason is now generic operator-hold for future workflows.
- `tests/fakes.py` — `FakePipelineDB.reset_search_attempts` parity. Fixed an editing slip that had moved the `set_manual` status_history append into the new method.
- `tests/test_integration_slices.py` — `TestSearchExhaustionFlipsToManualSlice` → `TestSearchExhaustionResetsCounterSlice`. Two now-obsolete defensive tests removed (`already_manual_request_is_not_reflipped`, `already_manual_with_other_reason_is_not_clobbered`) — exhaustion no longer touches manual at all, so the defensive paths don't apply.

Suite: `Ran 2679 tests, OK (53 skipped)`.

## Production cleanup

3 requests that flipped to `manual` with `manual_reason='search_exhausted'` during the original deploy were reset back to `wanted` directly:
- `37` Letting Up Despite Great Faults — Hide. Pretend.
- `165` Susperia-Electrica — Life On Another Planet
- `67` Various Artists — Burt Bacharach: One Amazing Night

## Post-deploy

- Watch `journalctl -u cratedigger | grep "Variant ladder exhausted"` — should now log a wrap message rather than a manual flip.
- `pipeline-cli query "SELECT COUNT(*) FROM album_requests WHERE manual_reason = 'search_exhausted'"` should stay at 0.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)