### PR TITLE
feat(search): add searchFileLimit NixOS option (default 50000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,18 @@ mp3 v0,mp3 320,flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,aac,opus
 - `tests/test_quality_decisions.py:TestQualityRankConfigDefaults` -- pin tests that fail loudly on any drift.
 - `lib/quality.py:file_identity()` / `filetype_matches()` / `parse_filetype_config()` -- the search-side filetype spec model that backs `allowed_filetypes`.
 
+### Search loop tunables
+
+Three Nix options control the slskd search window and the variant escalation ladder. All live under `services.cratedigger.searchSettings.*` and render into `[Search Settings]` in `config.ini`. See [`docs/pipeline-db-schema.md`](docs/pipeline-db-schema.md#search_log) for what the variants do; see GitHub issue #196 for the long-term plan to escape these caps entirely.
+
+| Option | Default | Maps to | What it caps |
+|--------|---------|---------|--------------|
+| `searchResponseLimit` | `1000` | slskd `responseLimit` | Number of peer responses slskd buffers per search. Raising this gives the matcher more peer diversity. Caps at this value when peers stop responding. |
+| `searchFileLimit` | `50000` | slskd `fileLimit` | Total files across all peer responses. Multi-disc / OST / compilation searches fill this fast (each peer holds 50+ tracks); the slskd-api default of 10000 terminates such searches in ~3s, possibly before the right peer responds. |
+| `searchEscalationThreshold` | `5` | (cratedigger only) | After this many failed cycles the variant ladder kicks in: V1 (year-augmented) → V4 (rotating 3-token track-name slices) → exhausted → wrap. See `lib/search.py:select_variant`. |
+
+**What you cannot tune from here**: the per-search `searchTimeout` is fixed at 30s by slskd itself (see `cfg.search_timeout` in `config.ini`, but slskd ignores values above 30000ms). The dominant cycle cost is searches running to that timeout because vague variants don't fill the response/file caps. Issue #196 tracks options to remove this ceiling.
+
 ## Audit trail
 
 Every download stores two JSONB blobs in `download_log` for complete auditability:

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -274,6 +274,7 @@ def search_for_album(album, ctx):
             maximumPeerQueueLength=cfg.maximum_peer_queue,
             minimumPeerUploadSpeed=cfg.minimum_peer_upload_speed,
             responseLimit=cfg.search_response_limit,
+            fileLimit=cfg.search_file_limit,
         )
     except Exception:
         logger.exception(f"Failed to perform search via SLSKD: {query}")
@@ -392,6 +393,7 @@ def _submit_search(album, variant, search_cfg, slskd_client):
                 maximumPeerQueueLength=search_cfg.maximum_peer_queue,
                 minimumPeerUploadSpeed=search_cfg.minimum_peer_upload_speed,
                 responseLimit=search_cfg.search_response_limit,
+                fileLimit=search_cfg.search_file_limit,
             )
             return (search["id"], query, album_id, variant.tag)
         except requests.exceptions.HTTPError as e:

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -27,13 +27,25 @@ The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosMo
 | `notifiers.plex.{enable,url,tokenFile,librarySectionId,pathMap}` | disabled | Plex notifier. |
 | `notifiers.jellyfin.{enable,url,tokenFile}` | disabled | Jellyfin notifier. |
 | `healthCheck.{enable,onFailureCommand}` | enabled, no recovery | Pre-cycle slskd healthcheck. `onFailureCommand` runs to recover (e.g. `systemctl restart slskd.service`). |
-| `releaseSettings.*` / `searchSettings.*` / `downloadSettings.*` | match config.ini defaults | Pipeline tunables. |
+| `releaseSettings.*` / `searchSettings.*` / `downloadSettings.*` | match config.ini defaults | Pipeline tunables. See "Search loop tunables" below for the trio that caps the slskd search window. |
 | `qualityRanks.*` | mirror of `QualityRankConfig.defaults()` | See README § "Tuning the quality rank model". |
 | `timer.{enable,onBootSec,onUnitActiveSec}` | every 5 min | Cycle frequency. |
 | `importer.enable` | `true` | Long-lived serial importer that drains queued import work. |
 | `importer.preview.enable` | `false` | Enable the async preview gate. When disabled, new import jobs are marked importable immediately for backward-compatible draining. |
 | `importer.previewWorkers` | `2` | Async preview worker concurrency when `importer.preview.enable = true`. Must be at least 1. |
 | `logging.{level,format,datefmt}` | INFO | Python logging config. |
+
+## Search loop tunables
+
+Three options under `services.cratedigger.searchSettings.*` control the slskd search window and the variant escalation ladder shipped in PR #193. Listed together here because they're easy to forget when triaging stuck releases.
+
+| Option | Default | Maps to | Effect |
+|--------|---------|---------|--------|
+| `searchResponseLimit` | `1000` | slskd `responseLimit` | Caps peer responses per search. The slskd-api default is 100; popular albums returning more than 100 peers had their results truncated. 1000 covers ~99% of observed searches without triggering the cap. |
+| `searchFileLimit` | `50000` | slskd `fileLimit` | Caps total files across all peer responses. The slskd-api default is 10000; popular multi-disc/OST/compilation searches (peers each holding 50+ tracks) fill 10000 in ~3 seconds and terminate the search early — sometimes before the right peer responds. 50000 lets the buffer run to the search timeout for these. |
+| `searchEscalationThreshold` | `5` | cratedigger only | After this many failed cycles, `lib/search.py:select_variant` switches from the default `<artist> <album>` query to V1 (year-augmented), V4 (rotating 3-token track-name slices), then `exhausted` (which resets `search_attempts=0` so the ladder wraps; see [`docs/pipeline-db-schema.md`](pipeline-db-schema.md#search_log)). |
+
+**The 30s cycle floor is upstream.** `cfg.search_timeout` exists but slskd caps it at 30000ms; values above that are silently ignored. With response/file limits high enough that they rarely cap, every search runs the full 30s. The path to shorter cycles is changing the client (issue #196), not tuning these options.
 
 ## What the module does
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -83,6 +83,7 @@ class CratediggerConfig:
     browse_parallelism: int = 4
     title_blacklist: tuple[str, ...] = ()
     search_response_limit: int = 1000
+    search_file_limit: int = 50000
     search_escalation_threshold: int = 5
 
     # --- Release ---
@@ -249,6 +250,7 @@ class CratediggerConfig:
             browse_parallelism=min(getint("Search Settings", "browse_parallelism", 4), 8),
             title_blacklist=title_blacklist,
             search_response_limit=getint("Search Settings", "search_response_limit", 1000),
+            search_file_limit=getint("Search Settings", "search_file_limit", 50000),
             search_escalation_threshold=getint("Search Settings", "search_escalation_threshold", 5),
             # Release
             use_most_common_tracknum=getbool("Release Settings", "use_most_common_tracknum", True),

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -155,6 +155,7 @@
     title_blacklist = ${concatStringsSep "," cfg.searchSettings.titleBlacklist}
     search_blacklist = ${concatStringsSep "," cfg.searchSettings.searchBlacklist}
     search_response_limit = ${toString cfg.searchSettings.searchResponseLimit}
+    search_file_limit = ${toString cfg.searchSettings.searchFileLimit}
 
     [Download Settings]
     download_filtering = ${if cfg.downloadSettings.downloadFiltering then "True" else "False"}
@@ -584,6 +585,18 @@ in {
           Caps how many peer responses slskd collects per search. Maps to
           slskd's `responseLimit` ceiling — raising this lets the matcher
           consider more peers per query at the cost of a longer search window.
+        '';
+      };
+      searchFileLimit = mkOption {
+        type = types.int;
+        default = 50000;
+        description = ''
+          Caps how many total files slskd collects across all peer responses
+          per search. Maps to slskd's `fileLimit` ceiling. The slskd-api
+          default (10000) terminates popular multi-disc searches in a few
+          seconds — possibly before the right peer responds. 50000 gives the
+          matcher more peer diversity for albums where each peer holds 50+
+          files (compilations, OSTs, multi-disc reissues).
         '';
       };
       titleBlacklist = mkOption {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,7 +137,22 @@ class TestConfigFromIni(unittest.TestCase):
         ini = configparser.ConfigParser()
         cfg = CratediggerConfig.from_ini(ini)
         self.assertEqual(cfg.search_response_limit, 1000)
+        self.assertEqual(cfg.search_file_limit, 50000)
         self.assertEqual(cfg.search_escalation_threshold, 5)
+
+    def test_search_file_limit_explicit(self):
+        """Explicit search_file_limit is parsed verbatim."""
+        ini = configparser.ConfigParser()
+        ini.read_string("[Search Settings]\nsearch_file_limit = 100000\n")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_file_limit, 100000)
+
+    def test_search_file_limit_default(self):
+        """Missing key falls back to default of 50000."""
+        ini = configparser.ConfigParser()
+        ini.add_section("Search Settings")
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.search_file_limit, 50000)
 
     def test_search_response_limit_zero_passes_through(self):
         """`from_ini` does not validate; a literal 0 is accepted as-is.


### PR DESCRIPTION
## Summary

slskd-api defaults `fileLimit` to 10000. Popular multi-disc / OST / compilation searches (peers each holding 50+ files) hit that cap in ~3 seconds, terminating the search early — sometimes before the right peer responds. Exposing `fileLimit` as a NixOS option mirrors the `searchResponseLimit` pattern; default bumped to 50000.

## Why

Forensic data from 90 minutes post the search-escalation deploy:

| final_state | count | avg time | avg results |
|-------------|-------|----------|-------------|
| `Completed, TimedOut` | 259 | 33.0s | 8 |
| `Completed, FileLimitReached` | 4 | **4.3s** | **259** |
| `Completed, ResponseLimitReached` | 0 | — | — |

The 4 FileLimitReached cases were Iron & Wine, Katamari OST x3 — popular albums where the buffer fills in seconds. `responseLimit=1000` is never being hit; `fileLimit=10000` is.

## Changes

- `lib/config.py` — new `search_file_limit: int = 50000` field, loaded from `[Search Settings] search_file_limit`.
- `cratedigger.py` — both slskd `search_text` call sites (serial + parallel) now pass `fileLimit=cfg.search_file_limit`.
- `nix/module.nix` — new `searchSettings.searchFileLimit` mkOption with description tying it to slskd's `fileLimit` and the multi-disc-album rationale; rendered into the config.ini template.
- `tests/test_config.py` — explicit + default coverage for the new field.
- `README.md` — new "Search loop tunables" section listing the trio (`searchResponseLimit`, `searchFileLimit`, `searchEscalationThreshold`) so they're discoverable next to the existing `allowedFiletypes` discussion.
- `docs/nixos-module.md` — same trio described in the upstream module doc, with the 30s `searchTimeout` floor noted as upstream-fixed.

## Test plan

- `nix-shell --run "python3 -m unittest tests.test_config -v"` → 84 tests OK.
- `nix-shell --run "bash scripts/run_tests.sh"` → 2681 tests OK.
- `nix-shell --run "nix build .#checks.x86_64-linux.moduleVm"` → green.

## Post-deploy

After `nixos-rebuild switch` doc2:
- `ssh doc2 'sudo cat /var/lib/cratedigger/config.ini | grep search_file_limit'` → `search_file_limit = 50000`.
- The `Completed, FileLimitReached` final_state count should drop close to 0 over a 90-minute window. If it stays elevated, the popular searches are still hitting it and we'd want to raise the option further.

## See also

- #196 (open) — feasibility issue for a custom Soulseek client to escape both `responseLimit` and `fileLimit` caps and the 30s `searchTimeout` floor.
- #193 (merged) — original variant ladder + responseLimit=1000 deploy.
- #194 (merged) — exhaustion → counter-reset behavior change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)