### PR TITLE
feat(browse): Search-by-ID — direct artist-view entry on Browse tab

### DIFF
--- a/docs/brainstorms/search-by-id-requirements.md
+++ b/docs/brainstorms/search-by-id-requirements.md
@@ -1,0 +1,130 @@
+---
+date: 2026-05-01
+topic: search-by-id
+issue: 200
+---
+
+# Search-by-ID — Direct Add Path on Browse Tab
+
+## Problem Frame
+
+The Web UI's only "add to pipeline" path today is name search → artist view → release row → Add. This is broken or noisy in several cases the user routinely hits:
+
+- Various Artists / compilation search is fundamentally unusable (#199).
+- Long titles with punctuation (`...I Care Because You Do`, `Fly or Die // Fly or Die`) return wrong-album top hits.
+- Pre-1990s reissues with multiple Discogs pressings of the same MB release group.
+- Bandcamp / niche labels not well-indexed in either mirror's ranking.
+
+In all of these the user already knows the canonical ID — they're cross-referencing MB or a Discogs collection page. The CLI path (`pipeline-cli add <mbid|discogs-id>`) handles this end-to-end; the Web UI doesn't. `web/routes/pipeline.py` `/api/add` already accepts both `mb_release_id` and `discogs_release_id` (`web/routes/pipeline.py:445-472, 509`), so this is a frontend addition.
+
+## Shape
+
+**Search-by-ID is a third search mode**, sitting under the existing Search bar alongside artist / release / label search. Pasted input resolves into the **existing artist view** rather than into a parallel "add by ID" UI — the same UI surface the user already uses to pick releases and add them to the pipeline. The artist view auto-expands the parent of the pasted ID (master for Discogs, release-group for MB) and applies a persistent ring around the specific pasted ID inside it.
+
+Both leaf-level IDs (specific pressings / releases) and group-level IDs (masters / release-groups) are accepted in v1. Leaf inputs are climbed to their parent before rendering; group inputs render at the parent directly with no leaf to ring.
+
+This avoids a parallel add path (matches the no-parallel-paths rule), inherits all the existing artist-view affordances (pipeline status badges, library badges, disambiguation tab), and dissolves the "already in pipeline" question — the artist view already shows that.
+
+## Requirements
+
+### ID input
+
+- R1. Search-by-ID is exposed as a new search-type under the existing search bar, sibling to artist / release / label. Selection rule + placeholder string mirror the existing `setSearchType()` pattern (`web/js/browse.js:71-92`). Placeholder text shows the four shapes explicitly (e.g., "MBID, Discogs release/master ID, or URL").
+- R2. Client-side **format detection** classifies pasted text after URL-stripping into one of two families. **Type disambiguation** within a family (release vs release-group / release vs master) is resolved by the server resolver, not the client:
+  - 36-char UUID with dashes → MB UUID family (release MBID *or* release-group MBID).
+  - Pure digits, ≤ 12 chars → Discogs numeric family (release ID *or* master ID).
+  - Anything else → inline "not a recognised ID", no submit.
+- R3. URL-stripping covers (at minimum), with the URL path itself disambiguating type when present so the resolver does not need to probe both endpoints:
+  - `https://musicbrainz.org/release/<uuid>` → MB release MBID.
+  - `https://musicbrainz.org/release-group/<uuid>` → MB release-group MBID.
+  - `https://www.discogs.com/release/<id>` and `https://www.discogs.com/release/<id>-Slug-Words` → Discogs release ID.
+  - `https://www.discogs.com/master/<id>` and `https://www.discogs.com/master/<id>-Slug-Words` → Discogs master ID.
+- R4. When a bare ID is pasted (no URL), the resolver tries the leaf endpoint first (`release` for both sources) and falls back to the group endpoint (`release-group` / `master`) on 404. Two upstream hops in the fallback case is acceptable (single Discogs release fetch ~20 ms; MB similar). The resolver returns the resolved type in its response so the frontend knows whether to ring a leaf or render at the group with no leaf.
+
+### Resolution flow
+
+- R5. **MB release MBID** (leaf) → fetch the release from the MB mirror, read its release-group ID and primary artist ID. Drop into artist view at the artist ID; auto-expand the release group; ring the specific release MBID within the expansion.
+- R6. **MB release-group MBID** (group) → fetch the release-group from the MB mirror, read its primary artist ID. Drop into artist view at the artist ID; auto-expand the release group; no leaf to ring (the master/group row itself receives no extra ring — its open state is the indicator).
+- R7. **Discogs release ID** (leaf) → fetch the release from the Discogs mirror, read its `master_id` and primary `artists[0].id`.
+  - If `master_id` is non-null → drop into artist view at the primary artist ID; auto-expand that master; ring the specific release ID within the expansion.
+  - If `master_id` is null (masterless) → drop into artist view at the primary artist ID; the masterless release appears as a standalone row in the discography (existing behaviour, `web/discogs.py:215-228`); ring that row.
+- R8. **Discogs master ID** (group) → fetch the master from the Discogs mirror, read its primary artist ID. Drop into artist view at the artist ID; auto-expand that master; no leaf to ring.
+- R9. Resolution failure (404 from both endpoints attempted, network error) shows the upstream error inline at the input. The user stays on the Browse tab; no navigation.
+
+### Various Artists fallback
+
+- R10. The existing VA guard at `web/js/browse.js:108` (toast + force release-search when the user clicks a VA artist link) is extended to fire at search-by-ID resolution as well, but with a different fallback: render a **single-release / single-master detail card** for the pasted ID, with the existing Add-to-pipeline button, instead of the artist view.
+- R11. VA detection:
+  - **MB**: resolved artist ID equals the canonical VA MBID (`89ad4ac3-39f7-470e-963a-56509c546377`).
+  - **Discogs**: `artists[0].id == 194` on the release or master payload (Discogs uses 194 as the "Various" sentinel; `/api/artists/194` 404s — the artist row genuinely doesn't exist in the mirror, confirmed against the live DB).
+- R12. The fallback card reuses the existing release-detail component the artist view already renders when a master row is expanded. For master / release-group group inputs whose primary artist is VA, the card lists the pressings under the master (Discogs) or releases under the release-group (MB) directly, since there is no artist view to descend through. No new component beyond the existing release-detail.
+- R13. The Redis preload of VA discographies (raised during brainstorm) is rejected. Discogs VA: 1.3M rows credited to `artist_id=194`, with no `artist` row to render against. MB VA: first page of release groups takes 23.3 s against the live mirror. Caching does not make either viewable; the fallback above is the right answer.
+
+### Highlight UX (the ring)
+
+- R14. The "ring" is a CSS class (working name `search-target`) added to the matched leaf row inside the discography. Visual: 2 px coloured border + subtle background tint, distinct from but consistent with the existing release/release-detail styling in `web/js/discography.js:151-159`.
+- R15. The ring is **persistent** — it stays applied until the user navigates away (closes the artist view, switches search mode, or pastes another ID). It is not a flash-and-fade.
+- R16. On render, the ringed row is scrolled into view (`scrollIntoView({ behavior: 'smooth', block: 'center' })`). The auto-expand of the parent master/release-group happens before the scroll so the leaf row exists in the DOM by the time we scroll.
+- R17. The discography templating in `web/js/discography.js:151` does not currently put a stable `id` on the `.release` row (only an onclick handler with the release ID). Adding `data-release-id="${rel.id}"` (or equivalent) so the search-by-ID resolver can find the row to ring is in scope.
+- R18. For group-level inputs (master / release-group), the auto-expand alone is the indicator — no ring on the master row itself. The user pasted "show me this group", and "this group is now open" answers that.
+
+### Already-in-pipeline behaviour
+
+- R19. No special-case logic. The artist view (or the VA fallback card) already shows the pipeline-status badge for that release. If it's already added, the user sees the existing state and a disabled / "View in pipeline" affordance, identical to today's Browse tab.
+
+## Success Criteria
+
+- Pasting MB release MBID `c1f6a2c9-bcba-4e69-96f5-233c85b2830a` opens The Wiggles' artist view, the matching release group is auto-expanded, and the specific release is ringed and scrolled into view.
+- Pasting an MB release-group MBID opens the artist view with the release group expanded; no leaf is ringed.
+- Pasting Discogs release ID `32457180` opens the VA fallback card for Rock Christmas (compilation), Add button active.
+- Pasting `https://www.discogs.com/release/32457180-Various-Rock-Christmas-The-Very-Best-Of` strips and resolves identically to the bare ID (URL path is the type signal — no fallback probe needed).
+- Pasting `https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a` strips and resolves identically to the bare MBID.
+- Pasting `https://www.discogs.com/master/3673686` opens the artist view with master 3673686 auto-expanded; no leaf ringed.
+- Pasting `https://musicbrainz.org/release-group/<uuid>` opens the artist view with that release group auto-expanded; no leaf ringed.
+- Pasting a bare MB UUID that's a release-group (not a release) succeeds via the leaf-then-group fallback: the resolver tries the release endpoint, gets 404, retries the release-group endpoint, and renders the group-input flow.
+- Pasting a non-VA Discogs release ID with a master opens the artist view, auto-expanded at the master, with that pressing ringed and scrolled into view.
+- Pasting a masterless Discogs release ID opens the artist view with the masterless row ringed.
+- The ring persists until the user closes the artist view, switches search mode, or pastes another ID.
+- Resolution time for the URL-or-leaf-hit path stays under 200 ms wall-clock from paste-blur to artist-view render (single Discogs release fetch is ~20 ms; artist-view fetch is the dominant cost and is the existing path). Bare-ID fallback paths (release tried, then group) stay under ~250 ms.
+
+## Scope Boundaries
+
+**In scope:**
+- Search-by-ID input as a new search type on the Browse tab.
+- Client-side format detection + URL stripping for MB and Discogs, releases and masters/release-groups, including URL-paths that disambiguate type.
+- Resolver: MB release MBID → release-group + artist; MB release-group MBID → artist; Discogs release ID → master + artist; Discogs master ID → artist. Bare-ID fallback (release first, group on 404) for the cases where the URL path didn't disambiguate.
+- Artist-view auto-expand of the parent group, and persistent ring + scroll-into-view on the leaf when one exists. `data-release-id` on `.release` rows so the ring can be applied.
+- VA fallback to single-release / single-master detail card on both sources.
+
+**Deferred for later:**
+- Detecting Discogs URLs from non-canonical surfaces (`/sell/release/<id>`, marketplace, mobile share links).
+- "Recent direct adds" history list under the input.
+
+**Outside this product's identity:**
+- Bypass-the-artist-view direct-add (the original framing of #200). Routing through artist view is the deliberate choice — it gives the user pressing-disambiguation context they came to the UI for in the first place.
+- Bulk paste of multiple IDs.
+
+## Dependencies / Assumptions
+
+- `web/routes/pipeline.py` `/api/add` already accepts both `mb_release_id` and `discogs_release_id`. **Verified** at `web/routes/pipeline.py:445-472, 509`.
+- The Discogs mirror returns `master_id` and `artists` on `/api/releases/{id}`. **Verified** against the live DB (`32457180` returns `master_id: 3673686`, `artists[0].id: 194`).
+- The Discogs mirror does NOT serve `artist_id=194` (no row in `artist` table; `/api/artists/194` returns 404). **Verified** against the live DB. This is what makes the VA fallback necessary on the Discogs side.
+- The MB mirror's VA artist release-group endpoint is genuinely slow (23.3 s for first 100 release groups). **Verified** against the live mirror. This is what makes the VA fallback necessary on the MB side.
+- The `openBrowseArtist` short-circuit at `web/js/browse.js:108` is the established convention for VA-on-MB; extending it to fire on resolution rather than just on artist-link click is consistent with that convention.
+
+## Open Questions
+
+None blocking. The two questions raised in earlier drafts are resolved:
+- Master / release-group input is **in scope** (R3, R4, R6, R8).
+- Highlight UX is **persistent ring + scroll-into-view** (R14–R18).
+
+## File Pointers
+
+- `web/js/browse.js` — search-type wiring (`setSearchType`, lines 71-92), VA guard at line 108, artist-view open/close.
+- `web/js/discography.js:151-159` — `.release` row template; needs `data-release-id` for the ring; `<div class="releases" id="rel-${rg.id}">` is the auto-expand target.
+- `web/js/main.js` — search-bar event handling.
+- `web/discogs.py` — `_get`, `get_artist_releases` (cached at `discogs:artist:{artist_id}:releases`), masterless release shape (`web/discogs.py:215-228`), `get_master_releases` (`web/discogs.py:251-279`).
+- `web/mb.py` — release / release-group / artist resolution.
+- `web/routes/browse.py` — artist endpoints (`get_artist`, `get_discogs_artist`); add new search-by-ID resolution endpoint here.
+- `web/routes/pipeline.py:445-472, 509` — existing `/api/add` accepting both ID types.
+- `scripts/pipeline_cli.py:108-249` — CLI add path; reference for resolver behaviour.

--- a/docs/plans/2026-05-01-002-feat-search-by-id-plan.md
+++ b/docs/plans/2026-05-01-002-feat-search-by-id-plan.md
@@ -1,0 +1,504 @@
+---
+title: "feat: Search-by-ID — direct artist-view entry on Browse tab"
+type: feat
+status: active
+date: 2026-05-01
+deepened: 2026-05-01
+origin: docs/brainstorms/search-by-id-requirements.md
+---
+
+# Search-by-ID — Direct Artist-View Entry on Browse Tab
+
+## Overview
+
+Add a third search-mode on the Browse tab — sibling to artist / release / label — that takes a pasted MBID, Discogs release ID, Discogs master ID, MB release-group MBID, or any of the corresponding URLs, and drops the user straight into the existing artist view with the parent group auto-expanded and the specific leaf (when one exists) ringed and scrolled into view. When the resolved artist is Various Artists, the artist view is bypassed in favour of a single-release / single-master detail card that reuses the existing release-detail component.
+
+This routes through the existing `/api/add` flow (already accepts both `mb_release_id` and `discogs_release_id`), inherits all existing artist-view affordances (pipeline-status badges, library badges, disambiguation tab), and avoids creating a parallel "add by ID" path.
+
+---
+
+## Problem Frame
+
+The Web UI's only path to "add to pipeline" today is name search → artist view → release row → Add. The user routinely hits cases where this is broken or noisy — VA compilations (#199), long titles with punctuation, pre-1990s reissues with multiple Discogs pressings of the same MB release group, niche-label / Bandcamp-only material. In all of these cases the user already has the canonical ID from MB or a Discogs collection page; there is no good reason to make them search.
+
+The CLI (`pipeline-cli add <mbid|discogs-id>`) handles this end-to-end. The Web UI doesn't. The brainstorm pressure-tested two shapes (a bypass-the-artist-view direct-add input vs. a search-type that resolves into the existing artist view) and chose the latter — it gives the user pressing-disambiguation context they came to the UI for, dissolves the "already in pipeline" question (the artist view shows pipeline status natively), and fits the no-parallel-paths rule.
+
+The brainstorm also measured both VA paths: Discogs `/api/artists/194` 404s (artist row genuinely doesn't exist in the mirror — `artist_id=194` is a sentinel referenced by 1.3M `release_artist` rows but has no row in `artist`), and MB VA's first page of release groups takes 23.3s. Caching cannot make either viewable. The VA fallback is therefore necessary on both sources.
+
+---
+
+## Requirements Trace
+
+Carried verbatim from `docs/brainstorms/search-by-id-requirements.md`:
+
+- R1. Search-by-ID is a new search-type sibling to artist / release / label.
+- R2. Client-side **format detection**: 36-char dashed UUID → MB family; ≤12 digits → Discogs family; else inline error.
+- R3. URL-stripping covers `/release/<uuid|id>`, `/release-group/<uuid>`, `/master/<id>` (with optional slug). URL path disambiguates type.
+- R4. Bare-ID resolver tries leaf endpoint (`release`) first; on 404 falls back to group endpoint (`release-group` / `master`).
+- R5. MB release MBID → artist view at primary artist, release-group expanded, that release ringed.
+- R6. MB release-group MBID → artist view at primary artist, release-group expanded, no leaf ringed.
+- R7. Discogs release ID → artist view at primary artist, master expanded (or masterless row), that release ringed.
+- R8. Discogs master ID → artist view at primary artist, master expanded, no leaf ringed.
+- R9. Resolution failure → inline error at input; no navigation.
+- R10. Existing VA guard at `web/js/browse.js:108` extends to search-by-ID with a different fallback: render a single-release / single-master detail card.
+- R11. VA detection: MB artist ID = `89ad4ac3-39f7-470e-963a-56509c546377`; Discogs `artists[0].id == 194`.
+- R12. Fallback card reuses the existing release-detail component; for group VA inputs lists pressings/releases under the group.
+- R13. Redis preload of VA discographies is rejected (volume + speed both prohibitive).
+- R14. Persistent ring class (working name `search-target`): 2px coloured border + subtle bg tint.
+- R15. Ring is persistent until close-artist-view / switch-search-mode / paste-another-ID.
+- R16. `scrollIntoView({ behavior: 'smooth', block: 'center' })` after auto-expand so target row is in DOM.
+- R17. Add `data-release-id` to `.release` rows in `web/js/discography.js:151` so the resolver can find the row.
+- R18. Group inputs: auto-expand alone is the indicator; no master-row ring.
+- R19. Already-in-pipeline behaviour is unchanged — artist view shows pipeline-status badge natively.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Search-by-ID input as a new search-type on the Browse tab.
+- Client-side format detection + URL stripping for MB and Discogs, releases and groups, with URL path disambiguating type.
+- Backend resolver endpoint covering all four input kinds, with leaf-first / group-fallback for bare IDs.
+- Artist-view auto-expand of the parent group, persistent ring + scroll-into-view on the leaf when one exists. `data-release-id` on `.release` rows.
+- VA fallback to single-release / single-master detail card on both sources.
+
+### Deferred for later
+
+- Detecting Discogs URLs from non-canonical surfaces (`/sell/release/<id>`, marketplace, mobile share links).
+- "Recent direct adds" history list under the input.
+
+### Outside this product's identity
+
+- Bypass-the-artist-view direct-add (the original framing of #200). Routing through artist view is the deliberate choice — it gives the user pressing-disambiguation context they came to the UI for in the first place.
+- Bulk paste of multiple IDs.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `web/js/browse.js:71-93` — `setSearchType()` is the existing pattern to extend; new mode `'id'` slots in alongside `artist`/`release`/`label`.
+- `web/js/browse.js:96-124` — `openBrowseArtist()` is the canonical entry point into the artist view; the VA short-circuit at line 108 is the convention to extend.
+- `web/js/browse.js:175-206` — `loadBrowseDiscography()` fetches `/api/artist/<aid>` or `/api/discogs/artist/<aid>` and renders. The post-render hook for "after discography is in DOM, find the master row and click-to-expand it" lands here.
+- `web/js/discography.js:125-174` — `loadReleaseGroup()` / release rendering. The `<div class="releases" id="rel-${rg.id}">` container is the auto-expand target. The `<div class="release" onclick="...toggleReleaseDetail('${rel.id}')">` row at line 151 is the ring target — needs a stable selector (R17).
+- `web/js/discography.js:225-303` — `toggleReleaseDetail()` body, where the per-release detail render is **inline today**. U6 extracts this into a reusable helper before U5 can call it standalone.
+- `web/routes/browse.py` — existing artist endpoints (`get_artist`, `get_discogs_artist`); the new resolver lives here. Route registration via `_FUNC_GET_PATTERNS` in `web/server.py:225` (regex routes) or `_FUNC_GET_ROUTES:217` (exact paths).
+- `web/discogs.py` — `_get`, `get_artist_releases` (cached `discogs:artist:{id}:releases`), `get_master_releases` (`web/discogs.py:251-279`), masterless release shape (`web/discogs.py:215-228`). `get_release` for the leaf.
+- `web/mb.py` — release / release-group / artist resolution helpers, `get_artist_name`.
+- `web/cache.py` — `memoize_meta()` for the `meta:` namespace (24h TTL by default for MB-side keys, see `TTL_MB`); the resolver should cache its lookups under e.g. `mb:resolve:<mbid>` and `discogs:resolve:<id>`.
+- `web/routes/pipeline.py:445-472, 509` — existing `/api/add` already accepts both `mb_release_id` and `discogs_release_id`; the resolver does NOT need to call this — the artist view's existing add buttons do.
+- `tests/test_js_util.mjs` — runner for pure-JS unit tests (node `--check` + assertion harness). Extend in place — do not invent a new test file.
+- `tests/test_web_server.py:606` `TestRouteContractAudit` — every new GET route must be listed in `CLASSIFIED_ROUTES` or this test fails. `tests/test_web_server.py:2453` `TestBrowseRouteContracts` — pattern for new contract tests with `_assert_required_fields`.
+
+### Institutional Learnings
+
+- `docs/solutions/` was scanned; nothing directly applicable to this feature. Closest adjacent learning is the discogs-api connection-pool fix (`docs/plans/2026-04-29-002`) — the resolver relies on the pool already, no new pressure.
+- The existing VA short-circuit (`web/js/browse.js:108`) is itself a learning: VA degrades the artist view past usability and was already explicitly walled off. The same convention applies here, with a different fallback rendering.
+
+### External References
+
+None — vanilla JS + http.server + Redis + Postgres mirrors are well-established here, and the brainstorm has the timing data already verified against live mirrors.
+
+---
+
+## Key Technical Decisions
+
+- **Single resolver endpoint, not four.** One `GET /api/browse/resolve` that takes the raw ID + optional `kind` hint from URL parsing, with leaf-first / group-fallback when `kind` is unspecified. Avoids four near-identical endpoints; the kind hint from URL stripping makes the common URL-paste case a single hop.
+- **Resolver returns metadata only — no nested release/master detail payloads.** The frontend follows up by calling existing endpoints (`/api/artist/<id>`, `/api/discogs/artist/<id>`, or for VA fallback `/api/discogs/release/<id>` / equivalent MB) to render. Keeps the resolver focused; reuses fetch-on-input cache layer that's already in place.
+- **`is_va` is computed server-side, not client-side.** The resolver knows the resolved artist ID; the VA constants live in one place (Python) rather than being duplicated in JS. Frontend just branches on `data.is_va`.
+- **Ring is a CSS class, not an inline style.** New `.search-target` rule in `web/index.html` (the only stylesheet — vanilla project, no build step). Class is added to the matched `.release` row from JS via `data-release-id` selector.
+- **Ring persistence is observed at `state.searchTargetId`.** A single module-level state field tracks the currently-ringed leaf. Cleared in `closeBrowseArtist()`, `setSearchType()`, and on the next paste. Re-applied if `loadDiscography()` re-renders mid-state (e.g. after an add-to-pipeline mutation invalidates the cache).
+- **Discogs masterless releases ring in place.** They render as standalone rows in the discography (`web/discogs.py:215-228`), with `id="release-<n>"` then stripped to bare in the API. The frontend just searches for the `data-release-id="<bareId>"` row regardless of master/masterless.
+- **Bare-MB-UUID fallback uses the MB mirror's release endpoint and falls back to release-group on 404.** Two ~50ms hops worst case. No client-side disambiguation needed; the resolver handles it.
+- **Add `data-release-id` early as a no-op scaffolding commit (U1).** Lets U4 land cleanly without entangling behavioral and structural changes.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Resolver endpoint shape.** One endpoint with optional `kind` hint, returning `{source, kind, artist_id, artist_name, is_va, expand_id, leaf_id}`. (See Key Technical Decisions.)
+- **VA-detection location.** Server-side, with `is_va` boolean in response. (See Key Technical Decisions.)
+- **Ring persistence model.** Module-level `state.searchTargetId`; cleared on close/mode-switch/re-paste; re-applied on re-render.
+
+### Deferred to Implementation
+
+- **MB release-group VA-fallback render path (Plan A vs Plan B).** U5 carries an explicit measurement step before deciding. The brainstorm's 23s number was for the MB artist→release-group-list endpoint; the path U5 hits is release-group→releases, which has not been measured. U5's verification block has the curl to run and the threshold rules.
+- **CSS ring colour.** "2px coloured border + subtle bg tint" is the spec. Existing palette in `web/index.html` includes `#6a9` (accent green, used by `.tab.active`), `#6af` (link blue), and `#1a4a2a` (badge-new bg). Pick one; the implementer's call.
+- **Resolver cache TTL.** Defaults to `TTL_MB` (24h). 24h is right for stable IDs; verify no edge case (e.g., a release renamed in MB) requires shorter. Default to 24h unless implementation surfaces a reason. Document the choice with an inline comment near the cache call so future TTL refactors don't quietly mutate behaviour.
+- **Performance assertion (Success Criterion: < 200ms paste-to-render for the URL/leaf-hit path).** Not test-gated; covered by manual smoke. If the manual smoke shows resolver latency > 500ms, treat as a regression and investigate before declaring U3 done.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Decision matrix — pasted input → render path:**
+
+| Input form | Source | URL-disambiguated kind? | Resolver action | Render |
+|---|---|---|---|---|
+| `https://musicbrainz.org/release/<uuid>` | MB | release | fetch release | artist-view, RG expanded, release ringed |
+| `https://musicbrainz.org/release-group/<uuid>` | MB | release-group | fetch release-group | artist-view, RG expanded, no ring |
+| `https://www.discogs.com/release/<id>[-slug]` | Discogs | release | fetch release | artist-view, master expanded (or masterless row), release ringed |
+| `https://www.discogs.com/master/<id>[-slug]` | Discogs | master | fetch master | artist-view, master expanded, no ring |
+| Bare UUID (MB) | MB | unknown | fetch release; on 404 fetch release-group | as above per resolved kind |
+| Bare digits (Discogs) | Discogs | unknown | fetch release; on 404 fetch master | as above per resolved kind |
+| Any of the above where resolved artist is VA | either | n/a | resolve as above; set `is_va=true` | bypass artist view; render single-release / single-master detail card |
+| Garbage / unrecognised | n/a | n/a | client-side detection rejects before submit | inline "not a recognised ID" error |
+
+**Sequence — happy path (Discogs release URL paste, non-VA):**
+
+```
+User pastes URL into search-by-ID input
+  └─ JS: parseId() → {family:'discogs', kind:'release', id:'32457180'}
+     └─ JS: GET /api/browse/resolve?id=32457180&kind=release&source=discogs
+        └─ resolver: discogs_api.get_release(32457180)
+           └─ returns {source:'discogs', kind:'release', artist_id:'1234',
+                       artist_name:'Foo', is_va:false, expand_id:'<master_id>',
+                       leaf_id:'32457180'}
+     └─ JS: state.searchTargetId = '32457180'
+     └─ JS: openBrowseArtist('1234', 'Foo')
+        └─ loadDiscography() → renders discography → detects searchTargetId →
+           expands master row 'expand_id' → finds [data-release-id='32457180'] →
+           adds .search-target class → scrollIntoView({block:'center'})
+```
+
+**Sequence — VA branch:**
+
+```
+... resolver returns is_va:true, leaf_id:'32457180' (or master id) ...
+JS: skip openBrowseArtist; call existing /api/discogs/release/32457180
+JS: render the response in a single-release detail card overlay
+    (reuses the existing release-detail component the artist view renders
+    when a master row is expanded; same Add button)
+```
+
+---
+
+## Implementation Units
+
+- U1. **Add `data-release-id` to discography release rows (scaffolding)**
+
+**Goal:** Add a stable selector to `.release` rows so the search-by-ID flow can find a specific row to ring. No behavioural change.
+
+**Requirements:** R17
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `web/js/discography.js`
+
+**Approach:**
+- In the release-row template at `web/js/discography.js:151`, add `data-release-id="${rel.id}"` to the outer `<div class="release">`. Use the same ID that's already passed to `toggleReleaseDetail(...)`.
+- Apply the same attribute to the masterless-release row in the existing artist-view fallback branch and to bootleg rows so all `.release` rows are uniformly addressable.
+- Verify no existing CSS or JS query selector collides with `[data-release-id]`. (Grep confirmed zero current uses across `web/js/*.js` during plan deepening; a regression check is still wise.)
+- The attribute uniqueness invariant is **per rendered discography**, not global. Bootleg rows in different artist views may share IDs across artists; within one artist's discography render, IDs are unique.
+
+**Patterns to follow:**
+- Existing `id="rel-${rg.id}"` on `.releases` containers and `id="reldet-${rel.id}"` on detail containers.
+
+**Test scenarios:**
+Test expectation: none -- pure markup attribute, no behavioural change. Observable presence is exercised end-to-end by U4 in the artist-view smoke.
+
+**Verification:**
+- Browse any non-VA artist; inspect the DOM and confirm every `.release` row carries `data-release-id` matching the value passed to `toggleReleaseDetail`.
+- `node --check web/js/discography.js` passes.
+
+---
+
+- U2. **JS utility: ID parser + URL stripper**
+
+**Goal:** A pure function that takes pasted text and returns either `{family, kind, id}` or `null`. Handles bare UUIDs, bare digits, and the four supported URL forms with optional slug.
+
+**Requirements:** R2, R3
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `web/js/util.js` (or create `web/js/search_id.js` if util.js gets crowded — implementer's call)
+- Test: `tests/test_js_util.mjs`
+
+**Approach:**
+- Single exported function, e.g. `parsePastedId(text) -> {family: 'mb'|'discogs', kind: 'release'|'release-group'|'master'|'unknown', id: string} | null`.
+- Trim whitespace, lowercase a UUID, extract the canonical ID from URL forms with regex.
+- The `kind === 'unknown'` case is the bare-ID case where the URL didn't disambiguate; the resolver does the leaf-first / group-fallback in that case.
+- Keep the function pure and side-effect-free so it tests cleanly under node.
+
+**Execution note:** Implement test-first — pure-function TDD with the existing `tests/test_js_util.mjs` harness.
+
+**Patterns to follow:**
+- Existing pure utilities in `web/js/util.js` (e.g. `detectSource`, `externalReleaseUrl`).
+- Existing test conventions in `tests/test_js_util.mjs`: `assertEqual(actual, expected, msg)`.
+
+**Test scenarios:**
+- Happy path: bare 36-char dashed UUID → `{family: 'mb', kind: 'unknown', id: '<lower-uuid>'}`.
+- Happy path: bare digits up to 12 chars → `{family: 'discogs', kind: 'unknown', id: '<digits>'}`.
+- Happy path: `https://musicbrainz.org/release/<uuid>` → `{family: 'mb', kind: 'release', id: '<uuid>'}`.
+- Happy path: `https://musicbrainz.org/release-group/<uuid>` → `{family: 'mb', kind: 'release-group', id: '<uuid>'}`.
+- Happy path: `https://www.discogs.com/release/32457180` → `{family: 'discogs', kind: 'release', id: '32457180'}`.
+- Happy path: `https://www.discogs.com/release/32457180-Various-Rock-Christmas-The-Very-Best-Of` → same.
+- Happy path: `https://www.discogs.com/master/3673686` → `{family: 'discogs', kind: 'master', id: '3673686'}`.
+- Happy path: `https://www.discogs.com/master/3673686-Slug-Words` → same.
+- Edge case: leading/trailing whitespace stripped before detection.
+- Edge case: UUID with uppercase letters — normalised to lowercase.
+- Edge case: URL without `https://` (bare `musicbrainz.org/release/<uuid>`) — accepted.
+- Edge case: URL with trailing slash or `?utm_*` querystring — id correctly extracted.
+- Edge case: URL with multiple matching path segments (e.g. embedded `/release/` in slug) — first match wins, no false positive.
+- Edge case: URL with fragment (`#disc1`) after the slug — fragment stripped, ID correctly extracted.
+- Error path: garbage text (`"hello world"`) → `null`.
+- Error path: non-canonical MB URL (`mbid.eu/<uuid>`, `https://beta.musicbrainz.org/release/<uuid>`) → `null` (deferred per Scope Boundaries; verifies we don't accept it accidentally).
+- Error path: UUID without dashes (32 hex chars) → `null`.
+- Error path: 13-digit numeric → `null` (Discogs IDs are bounded ≤12).
+- Error path: mixed alphanumeric (`abc123`) → `null`.
+- Error path: empty string → `null`.
+
+**Verification:**
+- `node tests/test_js_util.mjs` passes with all new scenarios.
+- `node --check web/js/util.js` (or new module) passes.
+
+---
+
+- U3. **Backend resolver endpoint `/api/browse/resolve`**
+
+**Goal:** Single GET endpoint that takes a parsed ID + optional kind hint and returns `{source, kind, artist_id, artist_name, is_va, expand_id, leaf_id}`. Implements leaf-first / group-fallback when kind is unspecified.
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R11
+
+**Dependencies:** None (independent of U1, U2).
+
+**Files:**
+- Modify: `web/routes/browse.py` (add `resolve_id` handler + entry in `_FUNC_GET_ROUTES` registration).
+- Modify: `web/server.py:217` (route registration; add `/api/browse/resolve` to `_FUNC_GET_ROUTES`).
+- Test: `tests/test_web_server.py` (extend `TestBrowseRouteContracts` or add `TestSearchByIdResolveContract`; add classification entry to `TestRouteContractAudit.CLASSIFIED_ROUTES`).
+
+**Approach:**
+- Route shape: `GET /api/browse/resolve?source=<mb|discogs>&id=<...>&kind=<release|release-group|master>` (kind optional).
+- Source is required (the JS already knows from format detection); avoids the resolver having to detect format itself.
+- For Discogs: when `kind == 'release'` (or unspecified), call `discogs_api.get_release(id)`; read `master_id` and `artists[0].id`. If 404 and `kind` was unspecified, fall back to `discogs_api.get_master(id)` (or `get_master_releases` already in `web/discogs.py:251`).
+- For MB: when `kind == 'release'` (or unspecified), call MB release lookup (`web/mb.py`); read release-group ID and primary artist ID. On 404 unspecified-fallback, call MB release-group lookup.
+- VA detection in one place: after resolution, set `is_va = (source=='mb' and artist_id == VA_MBID) or (source=='discogs' and artist_id == 194)`. Define VA constants at module scope or in `web/mb.py` / `web/discogs.py` (single source of truth, not duplicated).
+- For Discogs masterless releases: `expand_id` is the bare release ID (same as `leaf_id`); the frontend handles the masterless render path correctly because the existing artist view already renders masterless rows as standalone `.release` entries (`web/discogs.py:215-228`).
+- For group inputs (kind == release-group / master): `leaf_id = null`, `expand_id = id`.
+- Cache resolver responses via `memoize_meta()` keyed by `resolve:<source>:<id>` with `TTL_MB`. IDs are stable; cache is safe.
+- Failure: 404 from both endpoints attempted → JSON 404 with `{error: 'not_found', message: '...'}`. Network/upstream error → 502.
+
+**Execution note:** Start with a failing contract test in `TestBrowseRouteContracts` asserting all `REQUIRED_FIELDS`. Also confirm `TestRouteContractAudit` fails on the unclassified route (RED) before adding the entry to `CLASSIFIED_ROUTES` (GREEN). The audit is the strictest contract gate in the repo; making the RED/GREEN explicit prevents shipping an un-audited route.
+
+**Patterns to follow:**
+- Existing route registration in `web/server.py:217-225`.
+- Existing handler signature in `web/routes/browse.py` (e.g., `get_discogs_artist(h, params, artist_id)`).
+- `_assert_required_fields` + `REQUIRED_FIELDS` set in `tests/test_web_server.py:2453` `TestBrowseRouteContracts`.
+- `patch("web.routes.browse.discogs_api")` and `patch("web.server.mb_api")` patterns already used by browse contract tests.
+
+**Test scenarios:**
+- Happy path: `?source=mb&id=<release-mbid>&kind=release` → returns `kind: 'release'`, `artist_id`, `artist_name`, `expand_id` (release-group MBID), `leaf_id == id`, `is_va: false`.
+- Happy path: `?source=mb&id=<rg-mbid>&kind=release-group` → returns `kind: 'release-group'`, `expand_id == id`, `leaf_id: null`.
+- Happy path: `?source=discogs&id=32457180&kind=release` → returns `kind: 'release'`, `expand_id` (master_id), `leaf_id == id`, `is_va: true` (Various sentinel).
+- Happy path: `?source=discogs&id=3673686&kind=master` → returns `kind: 'master'`, `expand_id == id`, `leaf_id: null`.
+- Edge case: `?source=discogs&id=<masterless-release>&kind=release` (master_id = null) → returns `kind: 'release'`, `expand_id == leaf_id == id`.
+- Edge case: kind omitted, MB UUID happens to be a release-group → resolver tries release endpoint, gets 404, retries release-group endpoint, returns `kind: 'release-group'`. Verify only two upstream calls (no thrash).
+- Edge case: kind omitted, Discogs digit happens to be a master ID → resolver tries release, 404, retries master, returns `kind: 'master'`.
+- Edge case: kind hint **honored** — `?kind=release` with an ID that 404s on the release endpoint returns 404 immediately and does NOT probe the group endpoint. This guards the URL-disambiguation optimisation from regressing into dead code.
+- Edge case: VA on MB — artist_id matches `89ad4ac3-39f7-470e-963a-56509c546377` → `is_va: true`.
+- Edge case: Discogs ID-namespace assumption — a bare digit that exists as both a release and a master (different entities sharing the same numeric ID across tables) — verified during implementation to be impossible per Discogs schema. If implementation surfaces a counter-example, document it; otherwise the leaf-first order is unambiguous.
+- Error path: ID not found in either endpoint → 404 response with `error: 'not_found'`.
+- Error path: missing `id` parameter → 400.
+- Error path: missing `source` parameter → 400.
+- Error path: invalid `source` (`?source=apple`) → 400.
+- Error path: discogs_api or mb_api raises non-404 exception → 502 (or whatever the existing convention is for upstream failure in browse routes — match existing patterns).
+- Integration: `TestRouteContractAudit` passes — the new route is in `CLASSIFIED_ROUTES`.
+- Integration: response includes every field in `REQUIRED_FIELDS = {"source","kind","artist_id","artist_name","is_va","expand_id","leaf_id"}`.
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_web_server.TestBrowseRouteContracts -v"` passes.
+- `nix-shell --run "python3 -m unittest tests.test_web_server.TestRouteContractAudit -v"` passes (no unclassified route).
+- Manual: `curl 'http://localhost:8085/api/browse/resolve?source=discogs&id=32457180&kind=release'` returns the expected payload with `is_va: true`.
+
+---
+
+- U4. **Frontend: search-by-ID mode + resolve-and-navigate flow**
+
+**Goal:** Wire up the third search-mode in the Browse tab, take pasted input, call the resolver, drive the artist view to auto-expand the parent group, ring the leaf, and scroll into view. Implements the non-VA branch of the feature.
+
+**Requirements:** R1, R5, R6, R7, R8, R9, R14, R15, R16, R18
+
+**Dependencies:** U1 (`data-release-id`), U2 (parser), U3 (resolver endpoint).
+
+**Files:**
+- Modify: `web/index.html` (add `.search-target` CSS rule; add the new search-type button next to existing artist/release/label buttons).
+- Modify: `web/js/browse.js` (extend `setSearchType` to accept `'id'`; add `state.searchTargetId` field; add paste-handler that calls resolver; clear `searchTargetId` in `closeBrowseArtist` and `setSearchType` and on next paste).
+- Modify: `web/js/discography.js` (after `loadReleaseGroup` / discography render, if `state.searchTargetId` is set and the parent group matches the resolver's `expand_id`, programmatically expand the group, find the `.release[data-release-id="<id>"]` row, add `.search-target`, `scrollIntoView`).
+- Modify: `web/js/state.js` (add `searchTargetId: null` field).
+- Modify: `web/js/main.js` (event handler for the new search-type button; paste-handler for the id input).
+
+**Approach:**
+- New search-type `'id'` selectable via the same button-row pattern in `setSearchType` (`web/js/browse.js:71-92`). Placeholder updated per R1.
+- Paste handler (on input or button-click): trim, run `parsePastedId()`, if null show inline error and bail; otherwise call `/api/browse/resolve` with the parsed `{source, kind, id}`.
+- On resolver success and `is_va: false`: store `state.searchTargetId = response.leaf_id` (may be null for group inputs), store `state.searchExpandId = response.expand_id`, then call `openBrowseArtist(response.artist_id, response.artist_name)`. The post-discography-render hook in `discography.js` does the expand + ring + scroll.
+- On resolver success and `is_va: true`: dispatch to U5's VA-fallback render (don't call `openBrowseArtist`).
+- On resolver failure: show inline error at the input.
+- Ring application happens after the master is expanded, so the leaf row is in the DOM. Use `requestAnimationFrame` or the existing `toggleReleaseGroup` callback chain to know when expansion is done.
+- Persistence (R15): the ring class stays applied as long as `state.searchTargetId` is set. Cleared in `closeBrowseArtist`, in `setSearchType`, and at the start of the next paste-handler invocation.
+- Re-application on re-render: when `loadDiscography` re-renders (e.g. after an add-to-pipeline mutation invalidates the artist cache), the post-render hook re-runs and re-applies the ring if `searchTargetId` is still set.
+- CSS rule in `web/index.html`: `.release.search-target { border: 2px solid <accent>; background: <subtle-tint>; }` — implementer chooses concrete colours from the existing palette.
+
+**Patterns to follow:**
+- `setSearchType` button-row + placeholder pattern (`web/js/browse.js:71-92`).
+- Existing in-flight token pattern (`searchArtistsRequestToken` in `web/js/browse.js:101`) for race protection — apply the same idiom to the resolver call so a fast double-paste doesn't render the wrong target.
+- `invalidateBrowseArtist()` (`web/js/browse.js:139-143`) is the existing cache-invalidation entry — re-render triggers the hook, ring re-applies.
+
+**Test scenarios:**
+- Happy path (Playwright smoke): paste a non-VA Discogs release URL into the id input → artist view opens → master row auto-expands → matching release row has `.search-target` class → row is scrolled into the viewport. Verify no other rows have the class.
+- Happy path (Playwright smoke): paste an MB release MBID (bare) → artist view opens with the release-group expanded and the release ringed.
+- Happy path (Playwright smoke): paste a Discogs master URL → artist view opens with master expanded; no row carries `.search-target` (R18).
+- Happy path (Playwright smoke): paste an MB release-group MBID → artist view opens with that release-group expanded; no ring.
+- Edge case (Playwright smoke): paste a Discogs masterless release ID → artist view shows masterless row carrying `.search-target`.
+- Edge case (Playwright smoke): after a successful paste-and-ring, switch search-type back to artist → ring is cleared, `state.searchTargetId === null`.
+- Edge case (Playwright smoke): close the artist view (back button or close affordance) → ring is cleared.
+- Edge case (Playwright smoke): switch to Library or Pipeline tab and back to Browse → if the artist view was open with a ring, the ring is still applied on return (state survives tab switches; only explicit close / mode-switch / re-paste clears it).
+- Edge case (Playwright smoke): paste ID A, immediately paste ID B before resolver returns A → only B's ring is applied (in-flight token discards A's response).
+- Edge case (Playwright smoke): after add-to-pipeline mutates and invalidates the artist cache, re-render runs and the ring is re-applied to the same row.
+- Error path (Playwright smoke): paste garbage text → inline "not a recognised ID" error; no resolver call.
+- Error path (Playwright smoke): paste a valid-looking ID that doesn't exist (resolver 404) → inline error at input; no navigation.
+
+**Verification:**
+- `node --check web/js/browse.js web/js/discography.js web/js/state.js web/js/main.js` passes.
+- All Playwright smoke scenarios above pass against `https://music.ablz.au` after `ssh doc2 'sudo systemctl restart cratedigger-web'`.
+- Visual: ring is unambiguous — a brief manual look confirms the styling distinguishes the target without making other rows look broken.
+
+---
+
+- U6. **Extract release-detail render into a reusable helper (refactor)**
+
+**Goal:** Pull the inline release-detail render body out of `toggleReleaseDetail()` (`web/js/discography.js:225-303`) into a standalone exported helper so U5 can render the same card outside the artist-view expand context. Pure refactor — no behavioural change to the existing artist-view expand path.
+
+**Requirements:** Precondition for R12 (single-release / single-master detail card reuses the existing component).
+
+**Dependencies:** None (independent of U1–U4; can land first or last among U1–U4 — only U5 depends on it).
+
+**Files:**
+- Modify: `web/js/discography.js` (extract helper, e.g. `renderReleaseDetail(container, releaseData)`; have `toggleReleaseDetail()` call it).
+- Test: `tests/test_js_util.mjs` is not appropriate (helper touches DOM). Coverage is observable via U5 + the existing artist-view expand smoke.
+
+**Approach:**
+- Identify the section of `toggleReleaseDetail()` that takes a fetched release payload and writes the inner HTML of `<div class="release-detail" id="reldet-${rel.id}">`. Lift it into a helper `renderReleaseDetail(targetEl, releaseData, opts)` where `opts` includes things like `showHeader: bool` for the standalone-card case.
+- `toggleReleaseDetail()` becomes: fetch → call the helper → wire up the close affordance.
+- No change to network calls, no change to the rendered HTML for the existing expand path. Verify visually that the artist-view release-detail expand looks identical to before.
+
+**Execution note:** Characterization-first — run the existing artist-view expand path before and after the refactor and compare output. Any diff means the refactor changed behaviour and should be reverted.
+
+**Patterns to follow:**
+- Pure-extract refactor pattern from prior plans (no behavioural change).
+
+**Test scenarios:**
+Test expectation: none -- pure refactor, equivalence proven by characterization (existing artist-view expand renders identically before and after). Behavioural coverage of the helper lands with U5.
+
+**Verification:**
+- `node --check web/js/discography.js` passes.
+- Manual: open any non-VA Discogs artist in Browse, expand a master row, click into a release row. The detail card renders identically to before this commit. Diff the rendered HTML if uncertain.
+- Manual: same for an MB artist's release-group expansion.
+
+---
+
+- U5. **VA fallback card**
+
+**Goal:** When the resolver returns `is_va: true`, bypass the artist view and render a single-release / single-master detail card with the existing Add-to-pipeline button. Reuses the helper extracted in U6.
+
+**Requirements:** R10, R11, R12
+
+**Dependencies:** U3 (resolver returns `is_va`), U4 (frontend dispatch into this branch), U6 (release-detail helper extracted).
+
+**Files:**
+- Modify: `web/js/browse.js` (VA branch in the resolver-callback flow; new render entry that hides search results, hides artist view, shows the standalone fallback container; populates it via the helper from U6).
+- Modify: `web/index.html` (container div for the standalone VA fallback card if there isn't an existing one to repurpose; add `id="va-fallback"` or similar; minimal CSS).
+- Optional modify: `web/routes/browse.py` if the existing per-release detail endpoints don't return everything needed for the standalone render — usually they do; verify before adding.
+
+**Approach:**
+- For Discogs leaf VA: fetch `/api/discogs/release/<id>` (existing route, ~20ms) and pass the response to `renderReleaseDetail()` (U6) in the fallback container.
+- For Discogs master VA: fetch `/api/discogs/master/<id>` (existing route) and render the master title + a list of pressings, each row carrying an Add-to-pipeline button via the existing pressing-row component.
+- For MB release leaf VA: fetch `/api/release/<mbid>` (existing route, registered at `web/routes/browse.py` via regex `^/api/release/([a-f0-9-]+)$`, handler `get_release`).
+- **MB release-group VA — measure before deciding.** The brainstorm's 23s number was for the MB artist→release-group-list endpoint, NOT the release-group→releases endpoint that would be hit here. Before implementing the MB release-group VA branch, run:
+  ```
+  ssh doc2 'curl -s -o /dev/null -w "MB RG VA releases HTTP %{http_code} time %{time_total}s\n" "http://192.168.1.35:5200/ws/2/release?release-group=<some-VA-RG-MBID>&limit=25&fmt=json"'
+  ```
+  using a known VA-credited release-group MBID (find one via `/api/search?q=Rock+Christmas&type=release` or similar). If the timing is acceptable (< 2s), implement Plan A: list pressings under the release-group with Add buttons. If it's > 5s or times out, implement Plan B: render only the release-group title + Add-to-pipeline button keyed off the release-group MBID, with a "View on MusicBrainz" external link.
+- The fallback card has a clear "Various Artists — bypassed artist view because [VA explanation]" header so the user knows why they didn't get the normal flow.
+- A close affordance on the card returns to whatever was previously visible (search results, or empty Browse state).
+- **Serial-ordering note**: U5 modifies `web/js/browse.js`, which U4 also modifies. U4 must land before U5 so the `is_va` dispatch site exists for U5 to extend. Do not branch U5 in parallel with U4.
+
+**Patterns to follow:**
+- `renderReleaseDetail()` from U6.
+- Existing VA toast at `web/js/browse.js:108` is the convention this extends; the toast goes away in the resolver-driven VA path because we can render something instead of giving up.
+- Existing add-to-pipeline button pattern from `web/js/browse.js` / `discography.js`.
+
+**Test scenarios:**
+- Happy path (Playwright smoke): paste Discogs release ID `32457180` (Rock Christmas comp) → VA fallback card renders with title, format, track list, Add button. Add button is functional (clicking it adds to pipeline; verify via `pipeline-cli show <id>` after).
+- Happy path (Playwright smoke): paste a Discogs master VA ID → VA fallback shows the master title + a list of pressings; each pressing has an Add button.
+- Happy path (Playwright smoke): paste an MB release MBID where `artist == VA_MBID` → VA fallback card renders.
+- Happy path (Playwright smoke): paste an MB release-group MBID where `artist == VA_MBID` → either Plan A (pressings list) or Plan B (title + external link) renders depending on the measurement above. Decision and rationale recorded in the commit message.
+- Edge case (Playwright smoke): close the VA fallback card → returns to previous Browse state (search results or empty state).
+- Edge case (Playwright smoke): click Add on a VA fallback pressing already in the pipeline → existing duplicate-handling kicks in (the Add button's existing behaviour) — verify it shows the existing-pipeline state, not an error.
+- Error path (Playwright smoke): if the MB RG VA endpoint stalls past 30s (the http.server default timeout), the request fails cleanly and Plan B's external link is shown — no spinning forever, no orphaned modal.
+- Integration (Python contract test, in U3): a non-VA release that happens to credit Discogs `artists[0].id == 194` as primary (treated as VA by the resolver). Verify the resolver returns `is_va: true` and document this as expected behaviour — Discogs uses 194 as the canonical Various sentinel, so legitimate non-VA credits to artist 194 don't exist in the dump.
+
+**Verification:**
+- `node --check web/js/browse.js` passes (U6 already verified `discography.js`).
+- All Playwright smoke scenarios above pass.
+- A successful add-to-pipeline from the VA fallback card creates an `album_requests` row with the correct `discogs_release_id` or `mb_release_id` — verify with `ssh doc2 'pipeline-cli show <new-id>'` matching the pasted ID.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New endpoint at `/api/browse/resolve` joins the existing `_FUNC_GET_ROUTES` table; route audit must be updated. Frontend resolver-driven flow piggybacks on existing `openBrowseArtist` and the discography render pipeline. No changes to `/api/add` or any pipeline-DB-touching code.
+- **Error propagation:** Resolver 404/502 surfaces as inline error at the input — no toast, no navigation. Network errors during the post-resolve fetches (artist view / VA card) follow existing artist-view error patterns (loading spinner → "Failed to load" message).
+- **State lifecycle risks:** `state.searchTargetId` is module-level state. Forgetting to clear it on close-artist-view / mode-switch / re-paste would cause stale rings on subsequent renders. Mitigated by clearing in three explicit sites (R15) and verified by Playwright smoke (close-artist-view edge case).
+- **API surface parity:** No change to existing API; one new GET. The `_FUNC_GET_PATTERNS` regex table is unchanged (new route is exact-path).
+- **Integration coverage:** The Playwright smoke scenarios in U4 and U5 are the cross-layer coverage — they exercise the parser (U2), resolver (U3), discography render (U1), and ring application (U4) together. JS unit tests alone cannot prove the data-release-id selector finds the right row after a real discography render.
+- **Unchanged invariants:** `/api/add` contract is unchanged. `openBrowseArtist` and the existing VA-toast code path (clicking a VA artist link) remain intact — the new resolver-driven VA path is a separate code branch keyed off `is_va` from the resolver. Existing browse, library, recents, pipeline tabs are untouched.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| MB release-group VA-fallback render path (R12) hits the same 23s slow path the Brainstorm measured for the artist-view release-group endpoint | U5 has Plan A / Plan B; verify in-flight at implementation time. Plan B (single-release-detail + external link) is acceptable for the VA-RG case if the endpoint is genuinely slow. |
+| `data-release-id` collides with existing CSS or JS selectors | Grep for any current `data-release-id` usage before U1; the attribute is new to the codebase per the brainstorm scan. CSS attribute selectors `[data-release-id]` are unused. |
+| Bare-ID fallback (release-then-group) doubles upstream calls in the unspecified-kind case | Worst-case ~50ms total; acceptable. Cache hit on second paste of the same ID makes both subsequent attempts trivial. |
+| Ring not re-applied after a cache-invalidating mutation (e.g. add-to-pipeline) | Re-render hook re-checks `state.searchTargetId`; covered in U4 test scenarios. |
+| Two pastes in flight race the discography render | Existing `searchArtistsRequestToken` idiom in `web/js/browse.js:101`; apply the same pattern to the resolver call. Covered in U4 test scenarios. |
+| Resolver cache stale after MB release rename | 24h `TTL_MB` is the existing default for MB-side `meta:` keys. MB releases rarely change identity once minted; acceptable. |
+| MB release-group VA endpoint stalls past 30s http.server worker timeout (U5 Plan A) | Measure first (U5's spike). If timing is borderline, fall through to Plan B (title + external link). U5 error-path scenario covers the timeout case explicitly. |
+| Resolver cache key uses shared `meta:` namespace; if `TTL_MB` shifts globally, resolver TTL silently follows | Document the resolver's TTL choice as an inline comment at the cache call site so future TTL refactors know about the dependency. |
+| Discogs `artists[0].id == 194` VA detection is fragile if a non-VA release ever credits artist 194 as primary | Verified during plan deepening — 194 is the canonical Discogs Various sentinel and has no real `artist` row, so legitimate non-VA primary credits cannot exist. Test scenario added in U3 makes the assumption explicit. |
+
+---
+
+## Documentation / Operational Notes
+
+- **No NixOS module changes.** This is a pure repo change; deploy via the standard flake-input flow described in `CLAUDE.md` (push → `nix flake update cratedigger-src` on doc1 → `nixos-rebuild switch` on doc2). `cratedigger-web` restarts automatically on switch.
+- **No DB migrations** — the resolver is read-only against the existing mirrors; pipeline DB is untouched.
+- **No new dependencies** in `nix-shell` or `web/cache.py`.
+- **Manual smoke list after deploy:** run the U4 + U5 Playwright scenarios against `music.ablz.au`. Use small / obscure artists to avoid 23s mirror waits per the playwright-test-artists memory.
+- **Issue 200 closes** when U1–U5 are merged and the Acceptance items in the issue are exercised.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/search-by-id-requirements.md`
+- Related issue: #200
+- Related issue (referenced motivator): #199 (VA search broken)
+- Related code (always cite by path + symbol):
+  - `web/routes/browse.py` — artist endpoints + new resolver target
+  - `web/js/browse.js` — `setSearchType`, `openBrowseArtist`, VA guard at line 108
+  - `web/js/discography.js` — release-row template, expand mechanics
+  - `web/discogs.py` — `get_release`, `get_master_releases`, masterless release shape
+  - `web/cache.py` — `memoize_meta`, `TTL_MB`
+  - `tests/test_web_server.py:606` `TestRouteContractAudit`, `:2453` `TestBrowseRouteContracts`
+  - `tests/test_js_util.mjs` — pure-JS test harness
+- External: none used; brainstorm has the verified live-mirror timing data.

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_util.mjs
  */
 
-import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock } from '../web/js/util.js';
+import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock, parsePastedId } from '../web/js/util.js';
 import { state } from '../web/js/state.js';
 import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, loadLabelReleases, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls, renderLabelRows } from '../web/js/labels.js';
 
@@ -530,6 +530,158 @@ assert(!xssBlock.includes('<script>x</script>'),
   'malicious username escaped');
 assert(!xssBlock.includes('"><img>'),
   'malicious dir escaped');
+
+// --- parsePastedId tests (search-by-ID) ---
+console.log('parsePastedId()');
+
+function assertParse(input, expected, msg) {
+  const actual = parsePastedId(input);
+  assertEqual(JSON.stringify(actual), JSON.stringify(expected), msg);
+}
+
+// Bare IDs (kind unknown — resolver disambiguates server-side)
+assertParse(
+  'c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  { family: 'mb', kind: 'unknown', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'bare MB UUID lowercase',
+);
+assertParse(
+  'C1F6A2C9-BCBA-4E69-96F5-233C85B2830A',
+  { family: 'mb', kind: 'unknown', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'bare MB UUID uppercase normalised to lowercase',
+);
+assertParse(
+  '32457180',
+  { family: 'discogs', kind: 'unknown', id: '32457180' },
+  'bare Discogs digits',
+);
+assertParse(
+  '1',
+  { family: 'discogs', kind: 'unknown', id: '1' },
+  'single digit accepted (Discogs ID space starts at 1)',
+);
+assertParse(
+  '123456789012',
+  { family: 'discogs', kind: 'unknown', id: '123456789012' },
+  '12-digit Discogs ID at boundary',
+);
+
+// MB URLs — type disambiguated by URL path
+assertParse(
+  'https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  { family: 'mb', kind: 'release', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'MB release URL with https',
+);
+assertParse(
+  'http://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  { family: 'mb', kind: 'release', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'MB release URL with http',
+);
+assertParse(
+  'musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  { family: 'mb', kind: 'release', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'MB release URL without protocol',
+);
+assertParse(
+  'https://musicbrainz.org/release-group/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  { family: 'mb', kind: 'release-group', id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+  'MB release-group URL',
+);
+assertParse(
+  'https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a/',
+  { family: 'mb', kind: 'release', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'MB URL with trailing slash',
+);
+assertParse(
+  'https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a?source=foo',
+  { family: 'mb', kind: 'release', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'MB URL with querystring',
+);
+assertParse(
+  'https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a#discs',
+  { family: 'mb', kind: 'release', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'MB URL with fragment',
+);
+
+// Discogs URLs — type disambiguated by URL path
+assertParse(
+  'https://www.discogs.com/release/32457180',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'Discogs release URL with www',
+);
+assertParse(
+  'https://discogs.com/release/32457180',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'Discogs release URL without www',
+);
+assertParse(
+  'https://www.discogs.com/release/32457180-Various-Rock-Christmas-The-Very-Best-Of',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'Discogs release URL with slug',
+);
+assertParse(
+  'https://www.discogs.com/master/3673686',
+  { family: 'discogs', kind: 'master', id: '3673686' },
+  'Discogs master URL',
+);
+assertParse(
+  'https://www.discogs.com/master/3673686-Slug-Words',
+  { family: 'discogs', kind: 'master', id: '3673686' },
+  'Discogs master URL with slug',
+);
+assertParse(
+  'https://www.discogs.com/release/32457180?utm_source=share',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'Discogs URL with querystring',
+);
+
+// Whitespace handling
+assertParse(
+  '  c1f6a2c9-bcba-4e69-96f5-233c85b2830a  ',
+  { family: 'mb', kind: 'unknown', id: 'c1f6a2c9-bcba-4e69-96f5-233c85b2830a' },
+  'bare UUID with surrounding whitespace',
+);
+assertParse(
+  '\thttps://www.discogs.com/release/32457180\n',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'URL with tab/newline padding',
+);
+
+// Embedded /release/ in slug — first canonical match wins, no false positive
+assertParse(
+  'https://www.discogs.com/release/32457180-Various-release-of-the-year',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'embedded "release" word in slug does not confuse parser',
+);
+
+// Garbage / invalid
+assertParse('hello world', null, 'random text rejected');
+assertParse('', null, 'empty string rejected');
+assertParse('   ', null, 'whitespace-only rejected');
+assertParse('abc123', null, 'mixed alphanumeric rejected');
+assertParse(
+  'c1f6a2c9bcba4e6996f5233c85b2830a',
+  null,
+  '32-char UUID without dashes rejected',
+);
+assertParse('1234567890123', null, '13-digit numeric rejected (out of range)');
+
+// Non-canonical hosts (deferred per Scope Boundaries)
+assertParse(
+  'https://beta.musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'beta.musicbrainz.org subdomain rejected (deferred)',
+);
+assertParse(
+  'https://mbid.eu/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'mbid.eu short URL rejected (deferred)',
+);
+assertParse(
+  'https://www.discogs.com/sell/release/32457180',
+  null,
+  'Discogs marketplace URL rejected (deferred per Scope Boundaries)',
+);
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -608,6 +608,7 @@ class TestRouteContractAudit(unittest.TestCase):
 
     CLASSIFIED_ROUTES = {
         "/api/search",
+        "/api/browse/resolve",
         "/api/library/artist",
         "/api/artist/compare",
         r"^/api/artist/([a-f0-9-]+)$",
@@ -3173,6 +3174,225 @@ class TestDiscogsBrowseRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.DISCOGS_RELEASE_REQUIRED_FIELDS,
                                 "discogs release detail")
         self.assertEqual(data["beets_album_id"], 10)
+
+
+class TestSearchByIdResolveContract(_WebServerCase):
+    """Contract tests for /api/browse/resolve — the search-by-ID resolver."""
+
+    REQUIRED_FIELDS = {
+        "source", "kind", "artist_id", "artist_name",
+        "is_va", "expand_id", "leaf_id",
+    }
+
+    MB_RELEASE_ID = "c1f6a2c9-bcba-4e69-96f5-233c85b2830a"
+    MB_RG_ID = "11111111-1111-1111-1111-111111111111"
+    MB_ARTIST_ID = "664c3e0e-42d8-48c1-b209-1efca19c0325"
+    MB_VA_MBID = "89ad4ac3-39f7-470e-963a-56509c546377"
+
+    def test_mb_release_resolved(self):
+        """Happy path: ?source=mb&id=<mbid>&kind=release returns leaf shape."""
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_release.return_value = {
+                "id": self.MB_RELEASE_ID,
+                "title": "Test Release",
+                "artist_id": self.MB_ARTIST_ID,
+                "artist_name": "Test Artist",
+                "release_group_id": self.MB_RG_ID,
+            }
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={self.MB_RELEASE_ID}&kind=release")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.REQUIRED_FIELDS, "resolve response")
+        self.assertEqual(data["source"], "mb")
+        self.assertEqual(data["kind"], "release")
+        self.assertEqual(data["artist_id"], self.MB_ARTIST_ID)
+        self.assertEqual(data["artist_name"], "Test Artist")
+        self.assertFalse(data["is_va"])
+        self.assertEqual(data["expand_id"], self.MB_RG_ID)
+        self.assertEqual(data["leaf_id"], self.MB_RELEASE_ID)
+
+    def test_mb_release_group_resolved(self):
+        """Happy path: ?source=mb&id=<mbid>&kind=release-group returns group shape."""
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_release_group.return_value = {
+                "id": self.MB_RG_ID,
+                "title": "Test RG",
+                "artist_id": self.MB_ARTIST_ID,
+                "artist_name": "Test Artist",
+            }
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={self.MB_RG_ID}&kind=release-group")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.REQUIRED_FIELDS, "resolve response")
+        self.assertEqual(data["kind"], "release-group")
+        self.assertEqual(data["expand_id"], self.MB_RG_ID)
+        self.assertIsNone(data["leaf_id"])
+
+    def test_discogs_release_resolved_with_master(self):
+        """Discogs release with non-null master_id → leaf shape, expand=master."""
+        with patch("web.routes.browse.discogs_api") as mock_dg:
+            mock_dg.get_release.return_value = {
+                "id": "32457180",
+                "title": "Rock Christmas",
+                "artist_id": "194",
+                "artist_name": "Various",
+                "release_group_id": "3673686",
+            }
+            status, data = self._get(
+                "/api/browse/resolve?source=discogs&id=32457180&kind=release")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.REQUIRED_FIELDS, "resolve response")
+        self.assertEqual(data["source"], "discogs")
+        self.assertEqual(data["kind"], "release")
+        self.assertEqual(data["expand_id"], "3673686")
+        self.assertEqual(data["leaf_id"], "32457180")
+        # artists[0].id == 194 → VA
+        self.assertTrue(data["is_va"])
+
+    def test_discogs_master_resolved(self):
+        """Discogs master ID → group shape, no leaf."""
+        with patch("web.routes.browse.discogs_api") as mock_dg:
+            mock_dg.get_master_releases.return_value = {
+                "title": "Some Master",
+                "type": "Album",
+                "first_release_date": "1997",
+                "artist_credit": "Real Artist",
+                "primary_artist_id": "3840",
+                "releases": [],
+            }
+            status, data = self._get(
+                "/api/browse/resolve?source=discogs&id=3673686&kind=master")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.REQUIRED_FIELDS, "resolve response")
+        self.assertEqual(data["kind"], "master")
+        self.assertEqual(data["expand_id"], "3673686")
+        self.assertIsNone(data["leaf_id"])
+        self.assertFalse(data["is_va"])
+
+    def test_discogs_masterless_release(self):
+        """Masterless Discogs release: release_group_id is None → expand=leaf."""
+        with patch("web.routes.browse.discogs_api") as mock_dg:
+            mock_dg.get_release.return_value = {
+                "id": "999",
+                "title": "Masterless",
+                "artist_id": "3840",
+                "artist_name": "Some Artist",
+                "release_group_id": None,
+            }
+            status, data = self._get(
+                "/api/browse/resolve?source=discogs&id=999&kind=release")
+
+        self.assertEqual(status, 200)
+        # When master_id is None, the bare release is its own expand target
+        # so the artist view rings the masterless rg row in place.
+        self.assertEqual(data["expand_id"], "999")
+        self.assertEqual(data["leaf_id"], "999")
+
+    def test_mb_va_release(self):
+        """MB release whose artist matches VA_MBID → is_va: true."""
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_release.return_value = {
+                "id": self.MB_RELEASE_ID,
+                "title": "VA Comp",
+                "artist_id": self.MB_VA_MBID,
+                "artist_name": "Various Artists",
+                "release_group_id": self.MB_RG_ID,
+            }
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={self.MB_RELEASE_ID}&kind=release")
+
+        self.assertEqual(status, 200)
+        self.assertTrue(data["is_va"])
+
+    def test_unknown_kind_falls_back_mb_release_to_rg(self):
+        """kind=unknown: leaf endpoint 404 → falls back to release-group."""
+        with patch("web.server.mb_api") as mock_mb:
+            from urllib.error import HTTPError
+            mock_mb.get_release.side_effect = HTTPError(
+                url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+            mock_mb.get_release_group.return_value = {
+                "id": self.MB_RG_ID,
+                "title": "RG",
+                "artist_id": self.MB_ARTIST_ID,
+                "artist_name": "Artist",
+            }
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={self.MB_RG_ID}&kind=unknown")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["kind"], "release-group")
+        # Confirms TWO upstream calls: release tried, then release-group
+        self.assertEqual(mock_mb.get_release.call_count, 1)
+        self.assertEqual(mock_mb.get_release_group.call_count, 1)
+
+    def test_unknown_kind_falls_back_discogs_release_to_master(self):
+        with patch("web.routes.browse.discogs_api") as mock_dg:
+            from urllib.error import HTTPError
+            mock_dg.get_release.side_effect = HTTPError(
+                url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+            mock_dg.get_master_releases.return_value = {
+                "title": "M", "type": "Album", "first_release_date": "1997",
+                "artist_credit": "Artist", "primary_artist_id": "3840",
+                "releases": [],
+            }
+            status, data = self._get(
+                "/api/browse/resolve?source=discogs&id=3673686&kind=unknown")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["kind"], "master")
+
+    def test_kind_hint_release_does_not_probe_group_on_404(self):
+        """kind=release explicit: 404 returns 404 immediately, no group probe.
+
+        Guards the URL-disambiguation optimisation from regressing into
+        always-probe-both behaviour. If the URL said 'release', we trust it.
+        """
+        with patch("web.server.mb_api") as mock_mb:
+            from urllib.error import HTTPError
+            mock_mb.get_release.side_effect = HTTPError(
+                url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={self.MB_RG_ID}&kind=release")
+
+        self.assertEqual(status, 404)
+        # release-group endpoint MUST NOT have been called
+        self.assertEqual(mock_mb.get_release_group.call_count, 0)
+
+    def test_not_found_both_endpoints(self):
+        with patch("web.server.mb_api") as mock_mb:
+            from urllib.error import HTTPError
+            mock_mb.get_release.side_effect = HTTPError(
+                url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+            mock_mb.get_release_group.side_effect = HTTPError(
+                url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={self.MB_RELEASE_ID}&kind=unknown")
+
+        self.assertEqual(status, 404)
+        self.assertIn("error", data)
+
+    def test_missing_id(self):
+        status, data = self._get("/api/browse/resolve?source=mb")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+
+    def test_missing_source(self):
+        status, data = self._get(f"/api/browse/resolve?id={self.MB_RELEASE_ID}")
+        self.assertEqual(status, 400)
+
+    def test_invalid_source(self):
+        status, data = self._get(
+            f"/api/browse/resolve?source=apple&id={self.MB_RELEASE_ID}")
+        self.assertEqual(status, 400)
+
+    def test_invalid_kind(self):
+        status, data = self._get(
+            f"/api/browse/resolve?source=mb&id={self.MB_RELEASE_ID}&kind=garbage")
+        self.assertEqual(status, 400)
 
 
 class TestLabelRouteContracts(_WebServerCase):

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -30,6 +30,15 @@ SEARCH_CACHE_QUERY_PREFIX_CHARS = 200
 DEFAULT_HTTP_TIMEOUT_SECONDS = 60
 LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS = 20
 
+# Canonical Various Artists artist_id sentinel. The Discogs CC0 dump uses
+# 194 as the foreign key in `release_artist` for VA-credited releases, but
+# does NOT include a matching row in the `artist` table — so the mirror's
+# `/api/artists/194` returns 404 and the artist view cannot be rendered.
+# The resolver short-circuits to a single-release / single-master fallback
+# card when a release credits this ID. Stored as a string for consistent
+# comparison against `artist_id` fields, which are always normalised to str.
+VA_ARTIST_ID = "194"
+
 
 def _get(url: str, *, timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS) -> dict:
     req = urllib.request.Request(url)

--- a/web/index.html
+++ b/web/index.html
@@ -276,6 +276,16 @@
     </div>
     <div id="browse-label-body"></div>
   </div>
+  <div id="va-fallback" style="display:none;">
+    <div id="va-fallback-header" style="margin:12px 0 8px;display:flex;align-items:center;gap:12px;">
+      <span style="cursor:pointer;font-size:18px;" onclick="closeVaFallback()">←</span>
+      <span id="va-fallback-title" style="font-size:18px;font-weight:bold;"></span>
+    </div>
+    <div style="margin:0 0 12px;color:#aaa;font-size:0.85em;">
+      Various Artists — bypassed artist view (the VA artist page is too large to render).
+    </div>
+    <div id="va-fallback-body"></div>
+  </div>
 </div>
 
 <div id="recents-section" class="section">

--- a/web/index.html
+++ b/web/index.html
@@ -43,6 +43,9 @@
   .rg-meta { color: #777; font-size: 0.8em; }
   .releases { margin-top: 6px; padding-left: 12px; }
   .release { display: flex; justify-content: space-between; align-items: center; padding: 8px 10px; background: #222; border-radius: 6px; margin-bottom: 0; cursor: pointer; }
+  /* Search-by-ID target ring. Persistent until close-artist / mode-switch / next paste. */
+  .release.search-target { background: #1a2a22; box-shadow: 0 0 0 2px #6a9; }
+  .rg.search-target { background: #1a2a22; border-left-color: #6a9; box-shadow: 0 0 0 2px #6a9; }
   .release:hover { background: #2a2a2a; }
   .release-info { flex: 1; }
   .release-title { font-size: 0.9em; }
@@ -242,6 +245,7 @@
       <button class="p-btn active-status" id="search-type-artist" onclick="setSearchType('artist')">Artist</button>
       <button class="p-btn" id="search-type-release" onclick="setSearchType('release')">Album</button>
       <button class="p-btn" id="search-type-label" onclick="setSearchType('label')">Label</button>
+      <button class="p-btn" id="search-type-id" onclick="setSearchType('id')">ID</button>
     </div>
     <div style="display:flex;gap:2px;margin-left:8px;border-left:1px solid #444;padding-left:8px;">
       <button class="p-btn active-status" id="source-mb" onclick="setBrowseSource('mb')">MB</button>

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { state, API, toast } from './state.js';
-import { esc, jsArg } from './util.js';
+import { esc, jsArg, parsePastedId } from './util.js';
 import { renderArtistDiscography, loadReleaseGroup } from './discography.js';
 import { renderTypedSections, classify as groupingClassify } from './grouping.js';
 import { renderStatusBadges } from './badges.js';
@@ -68,13 +68,20 @@ export async function setBrowseSource(src) {
 }
 
 /**
- * Set the browse search type (artist, release, or label).
- * @param {string} type - 'artist' | 'release' | 'label'
+ * Set the browse search type (artist, release, label, or id).
+ * @param {string} type - 'artist' | 'release' | 'label' | 'id'
  */
 export function setSearchType(type) {
   searchArtistsRequestToken++;
   state.browseSearchType = type;
-  const btnIds = { artist: 'search-type-artist', release: 'search-type-release', label: 'search-type-label' };
+  // Switching modes clears any active search-by-ID ring (R15).
+  clearSearchTarget();
+  const btnIds = {
+    artist: 'search-type-artist',
+    release: 'search-type-release',
+    label: 'search-type-label',
+    id: 'search-type-id',
+  };
   for (const [t, id] of Object.entries(btnIds)) {
     const el = document.getElementById(id);
     if (el) el.className = 'p-btn' + (type === t ? ' active-status' : '');
@@ -83,7 +90,9 @@ export function setSearchType(type) {
     ? 'Search artists or albums...'
     : type === 'release'
       ? 'Search album titles...'
-      : 'Search record labels...';
+      : type === 'label'
+        ? 'Search record labels...'
+        : 'Paste MBID, Discogs release/master ID, or URL...';
   /** @type {HTMLInputElement} */ (document.getElementById('q')).placeholder = placeholder;
   // Hide label-detail view when switching modes (search results take focus).
   if (state.browseLabel) closeLabelDetail();
@@ -128,8 +137,96 @@ export function openBrowseArtist(id, name) {
  */
 export function closeBrowseArtist() {
   state.browseArtist = null;
+  // Closing the artist view clears any search-by-ID ring (R15).
+  clearSearchTarget();
   document.getElementById('browse-artist').style.display = 'none';
   document.getElementById('results').style.display = 'block';
+}
+
+/**
+ * Clear the search-by-ID target so subsequent renders don't apply the ring.
+ * Used by close-artist-view, mode-switch, and as the first step of each
+ * new paste resolution.
+ */
+export function clearSearchTarget() {
+  state.searchTargetId = null;
+  state.searchTargetExpandId = null;
+  state.searchTargetSource = null;
+}
+
+/**
+ * Resolve a pasted MBID / Discogs ID / URL via /api/browse/resolve and
+ * drive the artist view (or VA fallback) accordingly. Called from
+ * searchArtists when state.browseSearchType === 'id'.
+ *
+ * @param {string} q - Pasted text (raw, untrimmed; parsePastedId handles it)
+ * @param {number} requestToken - Token from the calling searchArtists; if
+ *   it doesn't match searchArtistsRequestToken when the resolver returns,
+ *   the response is stale (a newer paste superseded this one) and discarded.
+ */
+export async function resolveAndNavigate(q, requestToken) {
+  const el = document.getElementById('results');
+  const parsed = parsePastedId(q);
+  if (!parsed) {
+    el.innerHTML = '<div class="loading">Not a recognised ID. Paste a MusicBrainz UUID, Discogs release/master ID, or URL.</div>';
+    return;
+  }
+  // New paste — clear any previous ring before navigation begins.
+  clearSearchTarget();
+  el.innerHTML = '<div class="loading">Resolving...</div>';
+  let data;
+  try {
+    const url = `${API}/api/browse/resolve?source=${parsed.family}&id=${encodeURIComponent(parsed.id)}&kind=${parsed.kind}`;
+    const r = await fetch(url);
+    if (requestToken !== searchArtistsRequestToken) return;
+    if (!r.ok) {
+      el.innerHTML = `<div class="loading">Resolve failed (HTTP ${r.status}). The ID may not exist on the ${parsed.family === 'mb' ? 'MusicBrainz' : 'Discogs'} mirror.</div>`;
+      return;
+    }
+    data = await r.json();
+  } catch (_e) {
+    if (requestToken !== searchArtistsRequestToken) return;
+    el.innerHTML = '<div class="loading">Resolve failed (network error).</div>';
+    return;
+  }
+  if (requestToken !== searchArtistsRequestToken) return;
+
+  // Switch source to match the resolved ID's family before opening the
+  // artist view, otherwise the discography fetch would hit the wrong API.
+  if (state.browseSource !== parsed.family) {
+    state.browseSource = parsed.family;
+    const mbBtn = document.getElementById('source-mb');
+    const dgBtn = document.getElementById('source-discogs');
+    if (mbBtn) mbBtn.className = 'p-btn' + (parsed.family === 'mb' ? ' active-status' : '');
+    if (dgBtn) dgBtn.className = 'p-btn' + (parsed.family === 'discogs' ? ' active-status' : '');
+    state.browseCache = {};
+  }
+
+  // Stash ring targets BEFORE openBrowseArtist triggers the discography
+  // render — the render hook reads these to decide what to expand and ring.
+  state.searchTargetId = data.leaf_id || null;
+  state.searchTargetExpandId = data.expand_id || null;
+  state.searchTargetSource = data.source;
+
+  // Force a discography re-render even if the artist is already cached.
+  // Without this, two consecutive pastes for different releases on the
+  // same artist would leave the first paste's ring in place and skip
+  // the post-render hook on the second paste.
+  if (data.artist_id) {
+    delete state.browseCache[data.artist_id];
+  }
+
+  if (data.is_va) {
+    // U5 VA fallback handles this. Until U5 lands, surface a placeholder.
+    el.innerHTML = '<div class="loading">Various Artists fallback render is not implemented yet (U5).</div>';
+    clearSearchTarget();
+    return;
+  }
+
+  // Non-VA: hand off to the existing artist view. The render hooks in
+  // discography.js pick up state.searchTargetExpandId / state.searchTargetId
+  // and apply the ring after the discography + master expansion render.
+  openBrowseArtist(data.artist_id, data.artist_name);
 }
 
 /**
@@ -445,6 +542,10 @@ export async function searchArtists(q) {
   const browseLabel = document.getElementById('browse-label');
   if (browseLabel) browseLabel.style.display = 'none';
   el.innerHTML = '<div class="loading">Searching...</div>';
+  // Search-by-ID short-circuits search entirely: parse, resolve, navigate.
+  if (searchType === 'id') {
+    return resolveAndNavigate(q, requestToken);
+  }
   // Label search is Discogs-only in Phase A — independent of browseSource.
   if (searchType === 'label') {
     try {

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -41,6 +41,12 @@ async function findArtistOnSource(name, src) {
 export async function setBrowseSource(src) {
   if (state.browseSource === src) return;
   searchArtistsRequestToken++;
+  // Explicit user source-toggle clears any active search-by-ID ring.
+  // The source-guard in applySearchTargetAfterDiscography would mask
+  // the immediate symptom, but a paste→toggle-twice sequence (away
+  // and back) would re-apply a stale ring after the user explicitly
+  // changed contexts.
+  clearSearchTarget();
   state.browseSource = src;
   const mbBtn = document.getElementById('source-mb');
   const dgBtn = document.getElementById('source-discogs');
@@ -202,7 +208,19 @@ export async function resolveAndNavigate(q, requestToken) {
     state.browseCache = {};
   }
 
-  // Stash ring targets BEFORE openBrowseArtist triggers the discography
+  if (data.is_va) {
+    // VA fallback: bypass the artist view (the VA artist page is unworkably
+    // large) and render a single-release detail card or a master/release-group
+    // pressings list directly. Plan U5. The ring-target state fields are
+    // unused on this path (openVaFallback consumes data.leaf_id / data.expand_id
+    // directly), so we deliberately don't set them — that way state stays
+    // dormant rather than load-bearing on every entry point remembering
+    // to clear it.
+    openVaFallback(data, parsed.id, requestToken);
+    return;
+  }
+
+  // Non-VA: stash ring targets BEFORE openBrowseArtist triggers the discography
   // render — the render hook reads these to decide what to expand and ring.
   state.searchTargetId = data.leaf_id || null;
   state.searchTargetExpandId = data.expand_id || null;
@@ -216,15 +234,7 @@ export async function resolveAndNavigate(q, requestToken) {
     delete state.browseCache[data.artist_id];
   }
 
-  if (data.is_va) {
-    // VA fallback: bypass the artist view (the VA artist page is unworkably
-    // large) and render a single-release detail card or a master/release-group
-    // pressings list directly. Plan U5.
-    openVaFallback(data, parsed.id);
-    return;
-  }
-
-  // Non-VA: hand off to the existing artist view. The render hooks in
+  // Hand off to the existing artist view. The render hooks in
   // discography.js pick up state.searchTargetExpandId / state.searchTargetId
   // and apply the ring after the discography + master expansion render.
   openBrowseArtist(data.artist_id, data.artist_name);
@@ -238,18 +248,32 @@ export async function resolveAndNavigate(q, requestToken) {
  *
  * Shows the va-fallback container and hides the artist view + search results.
  *
+ * In-flight token guard: each await is gated by `requestToken !==
+ * searchArtistsRequestToken`. Unlike the artist-view path where a re-render
+ * detaches prior #rel-X nodes (so a stale write goes to detached DOM and is
+ * harmless), va-fallback-body is a stable, never-replaced node — a stale
+ * fetch landing here would scribble onto a fresh card. The isStale callback
+ * is also threaded into loadReleaseGroup so the nested write is protected.
+ *
  * @param {Object} data - resolver response
  * @param {string} parsedId - the raw pasted id (used as the leaf for kind='release')
+ * @param {number} requestToken - in-flight token from the calling searchArtists
  */
-async function openVaFallback(data, parsedId) {
+async function openVaFallback(data, parsedId, requestToken) {
   const wrap = document.getElementById('va-fallback');
   const titleEl = document.getElementById('va-fallback-title');
   const bodyEl = document.getElementById('va-fallback-body');
   if (!wrap || !titleEl || !bodyEl) return;
+  const isStale = () => requestToken !== searchArtistsRequestToken;
 
-  // Hide other Browse views
+  // Hide other Browse views. Also blank the artist-view discography so its
+  // duplicate `id="reldet-${rel.id}"` nodes don't shadow the VA fallback's
+  // own — getElementById returns the first match in document order, and
+  // the hidden artist view DOM is preserved (display:none, not removed).
   document.getElementById('results').style.display = 'none';
   document.getElementById('browse-artist').style.display = 'none';
+  const dgEl = document.getElementById('browse-discography');
+  if (dgEl) dgEl.innerHTML = '';
   const browseLabel = document.getElementById('browse-label');
   if (browseLabel) browseLabel.style.display = 'none';
   wrap.style.display = 'block';
@@ -263,11 +287,18 @@ async function openVaFallback(data, parsedId) {
         ? `${API}/api/discogs/release/${encodeURIComponent(releaseId)}`
         : `${API}/api/release/${encodeURIComponent(releaseId)}`;
       const r = await fetch(url);
+      if (isStale()) return;
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const releaseData = await r.json();
+      if (isStale()) return;
       titleEl.textContent = releaseData.title || 'Various Artists';
       bodyEl.innerHTML = '';
-      renderReleaseDetail(bodyEl, releaseId, releaseData);
+      // Pass an explicit artist override so the action toolbar's artist
+      // label doesn't fall through to whatever state.browseArtist points
+      // at (which on the VA path is the previously-viewed non-VA artist).
+      renderReleaseDetail(bodyEl, releaseId, releaseData, {
+        artist: releaseData.artist_name || data.artist_name || 'Various Artists',
+      });
       return;
     }
     // Master (Discogs) or release-group (MB) — render pressings via the
@@ -278,17 +309,31 @@ async function openVaFallback(data, parsedId) {
       ? `${API}/api/discogs/master/${encodeURIComponent(groupId)}`
       : `${API}/api/release-group/${encodeURIComponent(groupId)}`;
     const r = await fetch(groupUrl);
+    if (isStale()) return;
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const groupData = await r.json();
+    if (isStale()) return;
     titleEl.textContent = groupData.title || 'Various Artists';
     // Reuse loadReleaseGroup with an explicit target. It re-fetches the
     // same endpoint internally; that's a duplicate request but only ~80ms
     // for MB and ~20ms for Discogs, and it keeps the render path identical
     // to the artist view's expansion path. Pass source explicitly so the
-    // helper hits the right API regardless of state.browseSource.
+    // helper hits the right API regardless of state.browseSource. isStale
+    // is threaded so a stale fetch can't write into our live bodyEl.
     bodyEl.innerHTML = '';
-    await loadReleaseGroup(groupId, bodyEl, { targetEl: bodyEl, source: data.source });
+    await loadReleaseGroup(groupId, bodyEl, {
+      targetEl: bodyEl,
+      source: data.source,
+      isStale,
+    });
+    if (isStale()) {
+      // loadReleaseGroup's own isStale checks should have prevented any
+      // write, but blank the card defensively in case any partial render
+      // landed before the guard fired.
+      bodyEl.innerHTML = '';
+    }
   } catch (_e) {
+    if (isStale()) return;
     bodyEl.innerHTML = '<div class="loading">Failed to load Various Artists fallback.</div>';
     titleEl.textContent = 'Various Artists';
   }

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { state, API, toast } from './state.js';
 import { esc, jsArg, parsePastedId } from './util.js';
-import { renderArtistDiscography, loadReleaseGroup } from './discography.js';
+import { renderArtistDiscography, loadReleaseGroup, renderReleaseDetail } from './discography.js';
 import { renderTypedSections, classify as groupingClassify } from './grouping.js';
 import { renderStatusBadges } from './badges.js';
 import { renderDisambiguateInto } from './analysis.js';
@@ -217,9 +217,10 @@ export async function resolveAndNavigate(q, requestToken) {
   }
 
   if (data.is_va) {
-    // U5 VA fallback handles this. Until U5 lands, surface a placeholder.
-    el.innerHTML = '<div class="loading">Various Artists fallback render is not implemented yet (U5).</div>';
-    clearSearchTarget();
+    // VA fallback: bypass the artist view (the VA artist page is unworkably
+    // large) and render a single-release detail card or a master/release-group
+    // pressings list directly. Plan U5.
+    openVaFallback(data, parsed.id);
     return;
   }
 
@@ -227,6 +228,80 @@ export async function resolveAndNavigate(q, requestToken) {
   // discography.js pick up state.searchTargetExpandId / state.searchTargetId
   // and apply the ring after the discography + master expansion render.
   openBrowseArtist(data.artist_id, data.artist_name);
+}
+
+/**
+ * Render the Various Artists fallback card. Branches on data.kind:
+ *  - 'release'        → single-release detail via renderReleaseDetail.
+ *  - 'master'         → Discogs master title + pressings list (loadReleaseGroup).
+ *  - 'release-group'  → MB release-group title + pressings list (loadReleaseGroup).
+ *
+ * Shows the va-fallback container and hides the artist view + search results.
+ *
+ * @param {Object} data - resolver response
+ * @param {string} parsedId - the raw pasted id (used as the leaf for kind='release')
+ */
+async function openVaFallback(data, parsedId) {
+  const wrap = document.getElementById('va-fallback');
+  const titleEl = document.getElementById('va-fallback-title');
+  const bodyEl = document.getElementById('va-fallback-body');
+  if (!wrap || !titleEl || !bodyEl) return;
+
+  // Hide other Browse views
+  document.getElementById('results').style.display = 'none';
+  document.getElementById('browse-artist').style.display = 'none';
+  const browseLabel = document.getElementById('browse-label');
+  if (browseLabel) browseLabel.style.display = 'none';
+  wrap.style.display = 'block';
+  bodyEl.innerHTML = '<div class="loading">Loading...</div>';
+  titleEl.textContent = 'Loading…';
+
+  try {
+    if (data.kind === 'release') {
+      const releaseId = data.leaf_id || parsedId;
+      const url = data.source === 'discogs'
+        ? `${API}/api/discogs/release/${encodeURIComponent(releaseId)}`
+        : `${API}/api/release/${encodeURIComponent(releaseId)}`;
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const releaseData = await r.json();
+      titleEl.textContent = releaseData.title || 'Various Artists';
+      bodyEl.innerHTML = '';
+      renderReleaseDetail(bodyEl, releaseId, releaseData);
+      return;
+    }
+    // Master (Discogs) or release-group (MB) — render pressings via the
+    // existing loadReleaseGroup, which gives each row an Add button and
+    // the same toggleReleaseDetail expansion as the artist view.
+    const groupId = data.expand_id;
+    const groupUrl = data.source === 'discogs'
+      ? `${API}/api/discogs/master/${encodeURIComponent(groupId)}`
+      : `${API}/api/release-group/${encodeURIComponent(groupId)}`;
+    const r = await fetch(groupUrl);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const groupData = await r.json();
+    titleEl.textContent = groupData.title || 'Various Artists';
+    // Reuse loadReleaseGroup with an explicit target. It re-fetches the
+    // same endpoint internally; that's a duplicate request but only ~80ms
+    // for MB and ~20ms for Discogs, and it keeps the render path identical
+    // to the artist view's expansion path. Pass source explicitly so the
+    // helper hits the right API regardless of state.browseSource.
+    bodyEl.innerHTML = '';
+    await loadReleaseGroup(groupId, bodyEl, { targetEl: bodyEl, source: data.source });
+  } catch (_e) {
+    bodyEl.innerHTML = '<div class="loading">Failed to load Various Artists fallback.</div>';
+    titleEl.textContent = 'Various Artists';
+  }
+}
+
+/**
+ * Close the VA fallback card and return to search results.
+ */
+export function closeVaFallback() {
+  clearSearchTarget();
+  const wrap = document.getElementById('va-fallback');
+  if (wrap) wrap.style.display = 'none';
+  document.getElementById('results').style.display = 'block';
 }
 
 /**
@@ -541,6 +616,8 @@ export async function searchArtists(q) {
   document.getElementById('browse-artist').style.display = 'none';
   const browseLabel = document.getElementById('browse-label');
   if (browseLabel) browseLabel.style.display = 'none';
+  const vaFallback = document.getElementById('va-fallback');
+  if (vaFallback) vaFallback.style.display = 'none';
   el.innerHTML = '<div class="loading">Searching...</div>';
   // Search-by-ID short-circuits search entirely: parse, resolve, navigate.
   if (searchType === 'id') {

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -177,19 +177,28 @@ function cssEscape(s) {
  * @param {string} [opts.source] - 'mb' or 'discogs'. Defaults to
  *   state.browseSource. Compare view passes the explicit source so MB and
  *   Discogs pressings can be loaded independently for the same row.
+ * @param {() => boolean} [opts.isStale] - Optional callback returning true
+ *   when this load should be discarded. Checked after each await and
+ *   before any DOM write. Used by the VA fallback (where the target
+ *   element is a stable, never-replaced node so a stale write is visible)
+ *   to thread the parent flow's in-flight token down. Artist-view callers
+ *   omit it because their target #rel-X is detached on re-render.
  */
 export async function loadReleaseGroup(id, el, opts = {}) {
   const relEl = opts.targetEl || document.getElementById('rel-' + id);
   if (!relEl) return;
   if (relEl.innerHTML) { relEl.innerHTML = ''; return; }
   relEl.innerHTML = '<div class="loading">Loading releases...</div>';
+  const isStale = opts.isStale || (() => false);
   try {
     const source = opts.source || state.browseSource;
     const isDiscogs = source === 'discogs';
     const url = isDiscogs ? `${API}/api/discogs/master/${id}` : `${API}/api/release-group/${id}`;
     const r = await fetch(url);
+    if (isStale()) return;
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const data = await r.json();
+    if (isStale()) return;
     if (data.error) throw new Error(data.error);
     const all = (data.releases || []).sort((a, b) => (a.date || '').localeCompare(b.date || ''));
     const official = all.filter(r => r.status === 'Official' || !r.status);
@@ -226,9 +235,13 @@ export async function loadReleaseGroup(id, el, opts = {}) {
         </div>
       `;
     }
+    if (isStale()) return;
     relEl.innerHTML = html;
     applySearchTargetAfterReleases(relEl);
-  } catch (e) { relEl.innerHTML = '<div class="loading">Failed to load</div>'; }
+  } catch (e) {
+    if (isStale()) return;
+    relEl.innerHTML = '<div class="loading">Failed to load</div>';
+  }
 }
 
 /**
@@ -308,13 +321,19 @@ export async function addRelease(mbid, btn) {
  * (`web/js/browse.js` resolveAndNavigate's VA branch — U5).
  *
  * Behavioural equivalence with the prior inline version is the explicit
- * invariant: same input → same innerHTML.
+ * invariant: same input + no opts → same innerHTML.
  *
  * @param {HTMLElement} targetEl
  * @param {string} releaseId - The canonical release ID (already normalized).
  * @param {Object} data - Release payload from the API.
+ * @param {Object} [opts]
+ * @param {string} [opts.artist] - Explicit artist name override. Used by
+ *   the VA fallback to bypass the `state.browseArtist?.name` fallback,
+ *   which on the VA path points at whatever the user previously
+ *   navigated to (or null) rather than "Various Artists". Artist-view
+ *   callers omit it and keep the original fallback chain.
  */
-export function renderReleaseDetail(targetEl, releaseId, data) {
+export function renderReleaseDetail(targetEl, releaseId, data, opts = {}) {
   let html = '';
 
   // Use beets tracks if owned (has bitrate info), otherwise MB tracks
@@ -364,7 +383,7 @@ export function renderReleaseDetail(targetEl, releaseId, data) {
     beets_album_id: data.beets_album_id,
     pipeline_status: data.pipeline_status,
     pipeline_id: data.pipeline_id,
-    artist: data.artist_name || state.browseArtist?.name || '',
+    artist: opts.artist || data.artist_name || state.browseArtist?.name || '',
     album: data.title || '',
     track_count: tracks.length,
   });

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -43,8 +43,11 @@ export function renderArtistDiscography(rgEl, id, artistName, data, libData) {
       const creditNote = rg.artist_credit && rg.artist_credit.toLowerCase() !== nameLC
         ? `<span class="rg-meta"> - ${esc(rg.artist_credit)}</span>` : '';
       const badges = renderStatusBadges(rg);
+      // Masterless Discogs releases have no child master to expand; the rg row
+      // is the leaf, so it carries data-release-id for search-by-ID ringing.
+      const leafAttr = rg.is_masterless ? ` data-release-id="${rg.id}"` : '';
       return `
-        <div class="rg">
+        <div class="rg"${leafAttr}>
           <div onclick="event.stopPropagation(); window.loadReleaseGroup('${rg.id}', this)">
             <span class="rg-year">${year}</span> <span class="rg-title">${esc(rg.title)}</span>${creditNote}${badges}
           </div>
@@ -148,7 +151,7 @@ export async function loadReleaseGroup(id, el, opts = {}) {
       });
       const toolbar = renderActionToolbar(actionState, { size: 'small' });
       return `
-        <div class="release" onclick="event.stopPropagation(); window.toggleReleaseDetail('${rel.id}')">
+        <div class="release" data-release-id="${rel.id}" onclick="event.stopPropagation(); window.toggleReleaseDetail('${rel.id}')">
           <div class="release-info">
             <div class="release-title">${esc(rel.title)}${badges}</div>
             <div class="release-meta" style="color:#777;">${rel.country || '?'} ${rel.date || '?'} - ${rel.format} - ${rel.track_count}t - ${rel.status || '?'}</div>

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -298,8 +298,97 @@ export async function addRelease(mbid, btn) {
 }
 
 /**
+ * Render the release-detail body — tracks, label links, external link,
+ * and acquire/remove action buttons — into a target element.
+ *
+ * Pure render: takes a fetched release payload (from /api/release/<mbid>
+ * or /api/discogs/release/<id>) plus the canonical release ID, writes
+ * innerHTML, returns nothing. Reused by `toggleReleaseDetail` (the
+ * artist-view expand path) and by the search-by-ID VA fallback card
+ * (`web/js/browse.js` resolveAndNavigate's VA branch — U5).
+ *
+ * Behavioural equivalence with the prior inline version is the explicit
+ * invariant: same input → same innerHTML.
+ *
+ * @param {HTMLElement} targetEl
+ * @param {string} releaseId - The canonical release ID (already normalized).
+ * @param {Object} data - Release payload from the API.
+ */
+export function renderReleaseDetail(targetEl, releaseId, data) {
+  let html = '';
+
+  // Use beets tracks if owned (has bitrate info), otherwise MB tracks
+  const hasBeets = data.beets_tracks && data.beets_tracks.length > 0;
+  const tracks = hasBeets ? data.beets_tracks : (data.tracks || []);
+
+  if (tracks.length > 0) {
+    html += '<div style="margin-bottom:6px;color:#666;font-size:0.8em;">Tracks (' + tracks.length + ')' + (hasBeets ? ' — from library' : '') + '</div>';
+    html += tracks.map(t => {
+      if (hasBeets) {
+        const dur = t.length ? `${Math.floor(t.length/60)}:${String(Math.round(t.length%60)).padStart(2,'0')}` : '';
+        const br = t.bitrate ? `${Math.round(t.bitrate/1000)}kbps` : '';
+        const depth = t.bitdepth && t.bitdepth > 16 ? `${t.bitdepth}bit` : '';
+        const sr = t.samplerate && t.samplerate > 44100 ? `${(t.samplerate/1000).toFixed(1)}kHz` : '';
+        const meta = [t.format, br, depth, sr].filter(Boolean).join(' ');
+        return `<div class="lib-track">
+          <span>${t.disc > 1 ? t.disc + '.' : ''}${t.track}. ${esc(t.title)} ${dur ? '<span style="color:#555;">' + dur + '</span>' : ''}</span>
+          <span class="lib-track-meta">${meta}</span>
+        </div>`;
+      } else {
+        const dur = t.length_seconds ? `${Math.floor(t.length_seconds/60)}:${String(Math.round(t.length_seconds%60)).padStart(2,'0')}` : '';
+        return `<div class="lib-track">
+          <span>${t.disc_number > 1 ? t.disc_number + '.' : ''}${t.track_number}. ${esc(t.title)} ${dur ? '<span style="color:#555;">' + dur + '</span>' : ''}</span>
+        </div>`;
+      }
+    }).join('');
+  }
+
+  // Label links (U7) — Discogs releases carry `labels: [{id, name}]`;
+  // MB releases don't surface labels through the route layer in v1.
+  const labelLinksHtml = renderLabelLinks(data.labels);
+  if (labelLinksHtml) {
+    html += `<div class="release-labels" style="margin:4px 0;font-size:0.85em;color:#aaa;">`
+      + `<span style="color:#666;margin-right:6px;">Label:</span>${labelLinksHtml}</div>`;
+  }
+
+  // Links and actions
+  html += '<div class="release-links">';
+  const externalUrl = externalReleaseUrl(releaseId);
+  const label = sourceLabel(releaseId);
+  if (externalUrl && label) {
+    html += `<a href="${externalUrl}" target="_blank" rel="noopener" style="color:#6af;font-size:0.85em;" onclick="event.stopPropagation()">${label}</a>`;
+  }
+  const actionState = buildReleaseActionState({
+    id: releaseId,
+    in_library: data.in_library,
+    beets_album_id: data.beets_album_id,
+    pipeline_status: data.pipeline_status,
+    pipeline_id: data.pipeline_id,
+    artist: data.artist_name || state.browseArtist?.name || '',
+    album: data.title || '',
+    track_count: tracks.length,
+  });
+  html += renderAcquireActionButton(actionState, {
+    addLabel: 'Add to pipeline',
+    stopPropagation: true,
+    hideDisabled: true,
+  });
+  html += renderRemoveFromBeetsButton(actionState, {
+    stopPropagation: true,
+    hideDisabled: true,
+  });
+  html += '</div>';
+
+  targetEl.innerHTML = html;
+}
+
+/**
  * Toggle release detail panel (tracks, links, actions).
- * @param {string} mbid - MusicBrainz release ID
+ * Wraps `renderReleaseDetail` with the fetch + open/close + error
+ * handling. The render itself is shared with the search-by-ID VA
+ * fallback card (U5).
+ *
+ * @param {string} mbid - MusicBrainz release ID or Discogs release ID
  */
 export async function toggleReleaseDetail(mbid) {
   const releaseId = normalizeReleaseId(mbid) || mbid;
@@ -313,70 +402,6 @@ export async function toggleReleaseDetail(mbid) {
     const r = await fetch(url);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const data = await r.json();
-    let html = '';
-
-    // Use beets tracks if owned (has bitrate info), otherwise MB tracks
-    const hasBeets = data.beets_tracks && data.beets_tracks.length > 0;
-    const tracks = hasBeets ? data.beets_tracks : (data.tracks || []);
-
-    if (tracks.length > 0) {
-      html += '<div style="margin-bottom:6px;color:#666;font-size:0.8em;">Tracks (' + tracks.length + ')' + (hasBeets ? ' — from library' : '') + '</div>';
-      html += tracks.map(t => {
-        if (hasBeets) {
-          const dur = t.length ? `${Math.floor(t.length/60)}:${String(Math.round(t.length%60)).padStart(2,'0')}` : '';
-          const br = t.bitrate ? `${Math.round(t.bitrate/1000)}kbps` : '';
-          const depth = t.bitdepth && t.bitdepth > 16 ? `${t.bitdepth}bit` : '';
-          const sr = t.samplerate && t.samplerate > 44100 ? `${(t.samplerate/1000).toFixed(1)}kHz` : '';
-          const meta = [t.format, br, depth, sr].filter(Boolean).join(' ');
-          return `<div class="lib-track">
-            <span>${t.disc > 1 ? t.disc + '.' : ''}${t.track}. ${esc(t.title)} ${dur ? '<span style="color:#555;">' + dur + '</span>' : ''}</span>
-            <span class="lib-track-meta">${meta}</span>
-          </div>`;
-        } else {
-          const dur = t.length_seconds ? `${Math.floor(t.length_seconds/60)}:${String(Math.round(t.length_seconds%60)).padStart(2,'0')}` : '';
-          return `<div class="lib-track">
-            <span>${t.disc_number > 1 ? t.disc_number + '.' : ''}${t.track_number}. ${esc(t.title)} ${dur ? '<span style="color:#555;">' + dur + '</span>' : ''}</span>
-          </div>`;
-        }
-      }).join('');
-    }
-
-    // Label links (U7) — Discogs releases carry `labels: [{id, name}]`;
-    // MB releases don't surface labels through the route layer in v1.
-    const labelLinksHtml = renderLabelLinks(data.labels);
-    if (labelLinksHtml) {
-      html += `<div class="release-labels" style="margin:4px 0;font-size:0.85em;color:#aaa;">`
-        + `<span style="color:#666;margin-right:6px;">Label:</span>${labelLinksHtml}</div>`;
-    }
-
-    // Links and actions
-    html += '<div class="release-links">';
-    const externalUrl = externalReleaseUrl(releaseId);
-    const label = sourceLabel(releaseId);
-    if (externalUrl && label) {
-      html += `<a href="${externalUrl}" target="_blank" rel="noopener" style="color:#6af;font-size:0.85em;" onclick="event.stopPropagation()">${label}</a>`;
-    }
-    const actionState = buildReleaseActionState({
-      id: releaseId,
-      in_library: data.in_library,
-      beets_album_id: data.beets_album_id,
-      pipeline_status: data.pipeline_status,
-      pipeline_id: data.pipeline_id,
-      artist: data.artist_name || state.browseArtist?.name || '',
-      album: data.title || '',
-      track_count: tracks.length,
-    });
-    html += renderAcquireActionButton(actionState, {
-      addLabel: 'Add to pipeline',
-      stopPropagation: true,
-      hideDisabled: true,
-    });
-    html += renderRemoveFromBeetsButton(actionState, {
-      stopPropagation: true,
-      hideDisabled: true,
-    });
-    html += '</div>';
-
-    el.innerHTML = html;
+    renderReleaseDetail(el, releaseId, data);
   } catch (e) { el.innerHTML = '<div class="loading" style="padding:8px;">Failed to load</div>'; }
 }

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -109,6 +109,59 @@ export function renderArtistDiscography(rgEl, id, artistName, data, libData) {
       `;
     }
     rgEl.innerHTML = html;
+    applySearchTargetAfterDiscography(rgEl);
+}
+
+/**
+ * Search-by-ID post-discography-render hook.
+ *
+ * Reads `state.searchTargetExpandId` / `state.searchTargetId`; if both
+ * targets resolve into the just-rendered DOM, auto-expand the parent
+ * release-group and (after the inner releases render) apply the ring.
+ *
+ * Masterless rg rows ARE the leaf — they carry data-release-id directly
+ * (web/js/discography.js renderRgRow), so we ring + scroll the rg row
+ * itself with no expansion step.
+ *
+ * @param {HTMLElement} rgEl - The discography container that just rendered.
+ */
+function applySearchTargetAfterDiscography(rgEl) {
+  const expandId = state.searchTargetExpandId;
+  if (!expandId) return;
+  // Source guard: only apply ring when the discography source matches
+  // the source the resolver returned. Avoids ringing the wrong row when
+  // the user is browsing MB but the resolver returned a Discogs target
+  // (or vice versa).
+  if (state.searchTargetSource && state.browseSource !== state.searchTargetSource) return;
+
+  // Masterless: the rg row IS the leaf. Ring + scroll directly, no expand.
+  const masterlessRow = /** @type {HTMLElement|null} */ (
+    rgEl.querySelector(`.rg[data-release-id="${cssEscape(expandId)}"]`));
+  if (masterlessRow) {
+    masterlessRow.classList.add('search-target');
+    masterlessRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    return;
+  }
+
+  // Non-masterless: find the parent rg row (no data-release-id) and
+  // expand it via the same loadReleaseGroup helper that powers manual
+  // clicks. The post-render hook in loadReleaseGroup applies the leaf ring.
+  const inner = /** @type {HTMLElement|null} */ (rgEl.querySelector(`#rel-${cssEscape(expandId)}`));
+  if (!inner) return;
+  if (inner.innerHTML) return;  // already expanded (cache re-render); ring will re-apply on next loadReleaseGroup
+  loadReleaseGroup(expandId, inner, { targetEl: inner });
+}
+
+/**
+ * CSS.escape polyfill — vendored to keep util.js framework-free.
+ * Used for ID values that may contain hyphens, dots, or other
+ * selector-special characters (MB UUIDs, Discogs IDs).
+ * @param {string} s
+ * @returns {string}
+ */
+function cssEscape(s) {
+  if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(s);
+  return String(s).replace(/[^a-zA-Z0-9_-]/g, ch => `\\${ch}`);
 }
 
 /**
@@ -174,7 +227,30 @@ export async function loadReleaseGroup(id, el, opts = {}) {
       `;
     }
     relEl.innerHTML = html;
+    applySearchTargetAfterReleases(relEl);
   } catch (e) { relEl.innerHTML = '<div class="loading">Failed to load</div>'; }
+}
+
+/**
+ * Search-by-ID post-loadReleaseGroup hook.
+ *
+ * Now that the master/release-group's child .release rows are in the
+ * DOM, find the one matching state.searchTargetId, ring it, and scroll
+ * it into view. No-op when the search-by-ID flow isn't active or the
+ * target leaf isn't a child of this group (e.g. compare view rendering
+ * a different group into its own targetEl).
+ *
+ * @param {HTMLElement} relEl - The .releases container that just rendered.
+ */
+function applySearchTargetAfterReleases(relEl) {
+  const targetId = state.searchTargetId;
+  if (!targetId) return;
+  if (state.searchTargetSource && state.browseSource !== state.searchTargetSource) return;
+  const row = /** @type {HTMLElement|null} */ (
+    relEl.querySelector(`.release[data-release-id="${cssEscape(targetId)}"]`));
+  if (!row) return;
+  row.classList.add('search-target');
+  row.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }
 
 /**

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -6,7 +6,7 @@
  */
 
 import { state } from './state.js';
-import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow } from './browse.js';
+import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow, closeVaFallback } from './browse.js';
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, setFilter, renderPipeline, toggleDetail, deleteRequest, updateStatus } from './pipeline.js';
@@ -71,6 +71,7 @@ Object.assign(window, {
   openBrowseArtistFromCompare,
   toggleCompareRow,
   closeBrowseArtist,
+  closeVaFallback,
   switchSubView,
   searchArtists,
   renderArtistDiscography,

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -52,10 +52,19 @@ if (qInput) {
   qInput.addEventListener('input', () => {
     clearTimeout(state.searchTimer ?? undefined);
     const q = qInput.value.trim();
-    if (q.length < 2) {
+    // ID mode parses single-character inputs (Discogs IDs start at 1);
+    // other modes need at least 2 chars before searching.
+    const minLen = state.browseSearchType === 'id' ? 1 : 2;
+    if (q.length < minLen) {
       cancelBrowseSearch();
       const results = document.getElementById('results');
       if (results) results.innerHTML = '';
+      // Hide the VA fallback if it's open — without this, a stale fetch
+      // landing post-clear renders into a card the user thought they
+      // dismissed. (Token bump from cancelBrowseSearch also gates the
+      // fetch via openVaFallback's isStale check.)
+      const vaFallback = document.getElementById('va-fallback');
+      if (vaFallback) vaFallback.style.display = 'none';
       return;
     }
     state.searchTimer = window.setTimeout(() => searchArtists(q), 300);

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -7,7 +7,7 @@
 
 import { normalizeReleaseId } from './util.js';
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineFilter: string, recentsCounts: {all:number, imported:number, rejected:number}, recentsFilter: string, recentsSub: string, dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, manualSub: string, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
@@ -26,6 +26,13 @@ export const state = {
   disambData: null,
   searchTimer: null,
   manualSub: 'complete',
+  // Search-by-ID ring state. Cleared on closeBrowseArtist / setSearchType /
+  // next paste. searchTargetId is the leaf .release[data-release-id]; null
+  // for group-level inputs (master / release-group). searchTargetExpandId
+  // is the parent .rg the discography post-render hook auto-expands.
+  searchTargetId: null,
+  searchTargetExpandId: null,
+  searchTargetSource: null,
 };
 
 export const API = '';

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -249,3 +249,53 @@ export function renderForensicBlock(last) {
     <div class="p-forensic-body">${body}</div>
   </div>`;
 }
+
+/**
+ * Parse pasted text for the Browse > Search-by-ID flow.
+ *
+ * Accepts a bare MBID, bare Discogs ID, or a canonical MB / Discogs URL
+ * (with or without slug, querystring, fragment, trailing slash). URL
+ * paths disambiguate `kind`; bare IDs return `kind: 'unknown'` and the
+ * server-side resolver decides via leaf-first / group-fallback.
+ *
+ * @param {string} text
+ * @returns {{family:'mb'|'discogs', kind:'release'|'release-group'|'master'|'unknown', id:string}|null}
+ */
+export function parsePastedId(text) {
+  if (typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  // Canonical URL forms — the URL path tells us the type, so the resolver
+  // doesn't need to probe both endpoints. release-group must be checked
+  // before release because the prefix matters.
+  const mbRgRe = /(?:^|\/)musicbrainz\.org\/release-group\/([0-9a-f-]{36})(?:[/?#]|$)/i;
+  const mbReleaseRe = /(?:^|\/)musicbrainz\.org\/release\/([0-9a-f-]{36})(?:[/?#]|$)/i;
+  const discogsMasterRe = /(?:^|\/)(?:www\.)?discogs\.com\/master\/(\d{1,12})(?:[-/?#]|$)/i;
+  const discogsReleaseRe = /(?:^|\/)(?:www\.)?discogs\.com\/release\/(\d{1,12})(?:[-/?#]|$)/i;
+
+  let m;
+  if ((m = trimmed.match(mbRgRe))) {
+    return { family: 'mb', kind: 'release-group', id: m[1].toLowerCase() };
+  }
+  if ((m = trimmed.match(mbReleaseRe))) {
+    return { family: 'mb', kind: 'release', id: m[1].toLowerCase() };
+  }
+  if ((m = trimmed.match(discogsMasterRe))) {
+    return { family: 'discogs', kind: 'master', id: m[1] };
+  }
+  if ((m = trimmed.match(discogsReleaseRe))) {
+    return { family: 'discogs', kind: 'release', id: m[1] };
+  }
+
+  // Bare IDs — kind unknown, resolver disambiguates server-side.
+  const bareUuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const bareDigitsRe = /^\d{1,12}$/;
+  if (bareUuidRe.test(trimmed)) {
+    return { family: 'mb', kind: 'unknown', id: trimmed.toLowerCase() };
+  }
+  if (bareDigitsRe.test(trimmed)) {
+    return { family: 'discogs', kind: 'unknown', id: trimmed };
+  }
+  return null;
+}

--- a/web/mb.py
+++ b/web/mb.py
@@ -24,6 +24,11 @@ from web import cache as _cache
 MB_API_BASE = "http://192.168.1.35:5200/ws/2"
 USER_AGENT = "cratedigger-web/1.0"
 
+# Canonical Various Artists MBID. Used by the resolver and the browse-tab
+# VA short-circuit (web/js/browse.js) to keep VA off the artist-view path
+# (the MB artist→release-group endpoint takes ~23s for VA).
+VA_ARTIST_MBID = "89ad4ac3-39f7-470e-963a-56509c546377"
+
 
 def _get(url):
     req = urllib.request.Request(url)
@@ -152,6 +157,30 @@ def get_official_release_group_ids(artist_mbid):
     cached = _cache.memoize_meta(
         f"mb:artist:{artist_mbid}:official_rg_ids", _fetch)
     return set(cached)
+
+
+def get_release_group(rg_mbid):
+    """Get release-group metadata + primary artist credit.
+
+    Distinct from `get_release_group_releases` (which paginates child
+    releases). The resolver (`web/routes/browse.py:resolve_id`) needs
+    just the parent group's metadata + artist to render the artist-view
+    drop-in target.
+    """
+    def _fetch() -> dict:
+        data = _get(f"{MB_API_BASE}/release-group/{rg_mbid}?inc=artist-credits&fmt=json")
+        ac = data.get("artist-credit", [{}])
+        artist = ac[0].get("artist", {}) if ac else {}
+        return {
+            "id": data.get("id", ""),
+            "title": data.get("title", ""),
+            "type": data.get("primary-type", ""),
+            "first_release_date": data.get("first-release-date", ""),
+            "artist_id": artist.get("id", ""),
+            "artist_name": artist.get("name", ""),
+        }
+
+    return _cache.memoize_meta(f"mb:release-group:{rg_mbid}:meta", _fetch)
 
 
 def get_release_group_releases(rg_mbid):

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import re
+import urllib.error
 from typing import TYPE_CHECKING
 
 from lib.release_identity import (
@@ -16,6 +17,11 @@ from lib.release_identity import (
 )
 from web import cache as _cache
 from web import discogs as discogs_api
+from web.discogs import VA_ARTIST_ID as _DISCOGS_VA_ARTIST_ID
+from web.mb import VA_ARTIST_MBID as _MB_VA_ARTIST_MBID
+# VA constants are imported directly so that test patches of `discogs_api`
+# (web.routes.browse.discogs_api) and `mb_api` (web.server.mb_api) don't
+# replace the constants with auto-generated Mock attributes.
 from lib.artist_compare import annotate_in_library, merge_discographies
 from web.library_artist_service import list_library_artist_rows
 from web.routes._overlay import overlay_release_rows_in_place
@@ -489,10 +495,147 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     h._json(response)  # type: ignore[attr-defined]
 
 
+# ── Search-by-ID resolver ────────────────────────────────────────────
+
+_RESOLVE_VALID_KINDS = {"release", "release-group", "master", "unknown"}
+
+
+def _resolve_mb(srv, raw_id: str, kind: str) -> dict:
+    """Resolve an MB UUID into the resolver response shape.
+
+    Tries the leaf (release) endpoint first when kind ∈ {release, unknown}.
+    Falls back to the group (release-group) endpoint only when kind=='unknown'
+    and the leaf attempt 404s — kind=='release' explicit is honored and
+    surfaces the 404 to the caller (the URL path said 'release', trust it).
+    Raises HTTPError for the caller to translate to HTTP status.
+    """
+    if kind in ("release", "unknown"):
+        try:
+            data = srv.mb_api.get_release(raw_id)
+            artist_id = data.get("artist_id") or ""
+            return {
+                "source": "mb",
+                "kind": "release",
+                "artist_id": artist_id,
+                "artist_name": data.get("artist_name") or "",
+                "is_va": artist_id == _MB_VA_ARTIST_MBID,
+                "expand_id": data.get("release_group_id") or raw_id,
+                "leaf_id": raw_id,
+            }
+        except urllib.error.HTTPError as e:
+            if e.code != 404 or kind == "release":
+                raise
+
+    # kind == 'release-group' OR (kind=='unknown' and release attempt 404'd)
+    rg = srv.mb_api.get_release_group(raw_id)
+    artist_id = rg.get("artist_id") or ""
+    return {
+        "source": "mb",
+        "kind": "release-group",
+        "artist_id": artist_id,
+        "artist_name": rg.get("artist_name") or "",
+        "is_va": artist_id == _MB_VA_ARTIST_MBID,
+        "expand_id": raw_id,
+        "leaf_id": None,
+    }
+
+
+def _resolve_discogs(raw_id: str, kind: str) -> dict:
+    """Resolve a Discogs numeric ID into the resolver response shape.
+
+    Same leaf-first / group-fallback pattern as `_resolve_mb`.
+    """
+    try:
+        numeric = int(raw_id)
+    except ValueError as e:
+        raise urllib.error.HTTPError(
+            url="", code=400, msg=f"Invalid Discogs ID: {raw_id}", hdrs=None, fp=None
+        ) from e
+
+    if kind in ("release", "unknown"):
+        try:
+            data = discogs_api.get_release(numeric)
+            # discogs_api.get_release returns artist_id and release_group_id as
+            # str-or-None; release_group_id is master_id (None when masterless).
+            artist_id = data.get("artist_id") or ""
+            rg_id = data.get("release_group_id")
+            # Masterless release: ring it in place — no parent master to expand.
+            expand_id = rg_id if rg_id else raw_id
+            return {
+                "source": "discogs",
+                "kind": "release",
+                "artist_id": artist_id,
+                "artist_name": data.get("artist_name") or "",
+                "is_va": artist_id == _DISCOGS_VA_ARTIST_ID,
+                "expand_id": expand_id,
+                "leaf_id": raw_id,
+            }
+        except urllib.error.HTTPError as e:
+            if e.code != 404 or kind == "release":
+                raise
+
+    # kind == 'master' OR (kind=='unknown' and release attempt 404'd)
+    master = discogs_api.get_master_releases(numeric)
+    artist_id = master.get("primary_artist_id") or ""
+    return {
+        "source": "discogs",
+        "kind": "master",
+        "artist_id": artist_id,
+        "artist_name": master.get("artist_credit") or "",
+        "is_va": artist_id == _DISCOGS_VA_ARTIST_ID,
+        "expand_id": raw_id,
+        "leaf_id": None,
+    }
+
+
+def get_browse_resolve(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) -> None:
+    """Resolve a pasted MBID / Discogs ID / URL-extracted ID into the
+    artist-view drop-in target. See docs/plans/2026-05-01-002-feat-search-by-id-plan.md.
+    """
+    srv = _server()
+    raw_id = (params.get("id", [""])[0]).strip()
+    source = (params.get("source", [""])[0]).strip()
+    kind = (params.get("kind", ["unknown"])[0]).strip() or "unknown"
+
+    if not raw_id:
+        h._error("Missing 'id' parameter")  # type: ignore[attr-defined]
+        return
+    if source not in ("mb", "discogs"):
+        h._error("Missing or invalid 'source' (must be 'mb' or 'discogs')")  # type: ignore[attr-defined]
+        return
+    if kind not in _RESOLVE_VALID_KINDS:
+        h._error(f"Invalid 'kind' (must be one of {sorted(_RESOLVE_VALID_KINDS)})")  # type: ignore[attr-defined]
+        return
+
+    cache_key = f"browse-resolve:{source}:{kind}:{raw_id}"
+
+    def _run() -> dict:
+        if source == "mb":
+            return _resolve_mb(srv, raw_id, kind)
+        return _resolve_discogs(raw_id, kind)
+
+    try:
+        # 24h TTL via memoize_meta default — IDs are stable; rename incidents
+        # are rare enough that staleness here doesn't justify a shorter TTL.
+        result = _cache.memoize_meta(cache_key, _run)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            h._error("not_found", 404)  # type: ignore[attr-defined]
+        else:
+            h._error(f"upstream_error: HTTP {e.code}", 502)  # type: ignore[attr-defined]
+        return
+    except urllib.error.URLError as e:
+        h._error(f"upstream_unreachable: {e}", 502)  # type: ignore[attr-defined]
+        return
+
+    h._json(result)  # type: ignore[attr-defined]
+
+
 # ── Route tables ─────────────────────────────────────────────────────
 
 GET_ROUTES: dict[str, object] = {
     "/api/search": get_search,
+    "/api/browse/resolve": get_browse_resolve,
     "/api/library/artist": get_library_artist,
     "/api/artist/compare": get_artist_compare,
     "/api/discogs/search": get_discogs_search,

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -544,14 +544,12 @@ def _resolve_discogs(raw_id: str, kind: str) -> dict:
     """Resolve a Discogs numeric ID into the resolver response shape.
 
     Same leaf-first / group-fallback pattern as `_resolve_mb`.
-    """
-    try:
-        numeric = int(raw_id)
-    except ValueError as e:
-        raise urllib.error.HTTPError(
-            url="", code=400, msg=f"Invalid Discogs ID: {raw_id}", hdrs=None, fp=None
-        ) from e
 
+    Caller is responsible for validating that `raw_id` parses as int —
+    the route handler does this before dispatching. ValueError here
+    indicates a programmer bug, not user input.
+    """
+    numeric = int(raw_id)
     if kind in ("release", "unknown"):
         try:
             data = discogs_api.get_release(numeric)
@@ -605,6 +603,11 @@ def get_browse_resolve(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
         return
     if kind not in _RESOLVE_VALID_KINDS:
         h._error(f"Invalid 'kind' (must be one of {sorted(_RESOLVE_VALID_KINDS)})")  # type: ignore[attr-defined]
+        return
+    # Discogs IDs must be all-digit. Frontend parsePastedId already enforces
+    # this, but defense-in-depth so the resolver never hits int() on garbage.
+    if source == "discogs" and not raw_id.isdigit():
+        h._error("Invalid Discogs ID (must be numeric)")  # type: ignore[attr-defined]
         return
 
     cache_key = f"browse-resolve:{source}:{kind}:{raw_id}"


### PR DESCRIPTION
## Summary

Add a fourth search-mode on the Browse tab (Artist / Album / Label / **ID**). User pastes an MBID, Discogs release ID, Discogs master ID, MB release-group MBID, or any of those URLs. Resolver returns the artist + parent group, the existing artist view drops in with the master/release-group auto-expanded and the matching leaf release ringed and scrolled into view. Various-Artists releases bypass the artist view (the VA artist page is unworkably large — 23s on the MB mirror, 404 on Discogs because artist 194 has no row in the artist table) and render a single-release/single-master fallback card with the existing Add button.

Closes #200. Addresses #199 (VA-search-broken) on the Browse tab.

## Background

- **Brainstorm**: \`docs/brainstorms/search-by-id-requirements.md\` — pressure-tested two shapes (direct-add input vs. resolve-into-artist-view) and chose the latter; measured both VA paths (MB 23s, Discogs 404) to justify the fallback design.
- **Plan**: \`docs/plans/2026-05-01-002-feat-search-by-id-plan.md\` — 6 implementation units. Deepening review caught and fixed a hidden refactor risk (U6 split out of U5) and an unmeasured MB endpoint (spike showed RG→releases is 83ms, not the 23s artist→RG-list). \`deepened: 2026-05-01\`.

## Implementation Units

1. **U1** \`08dc4f8\` — \`data-release-id\` selector on discography rows (scaffolding).
2. **U2** \`5c9b6e8\` — \`parsePastedId\` pure utility (36 unit tests covering URL parsing, whitespace, fragments, embedded slugs, garbage rejection, non-canonical hosts).
3. **U3** \`725f154\` — \`/api/browse/resolve\` endpoint with leaf-then-group fallback, server-side VA detection, route audit entry. 13 contract tests.
4. **U4** \`524ac3a\` — Frontend search-by-ID flow: UI mode, paste handler, resolver call, ring + scroll, persistence model.
5. **U6** \`c8d34f3\` — Refactor: extract \`renderReleaseDetail\` from inline \`toggleReleaseDetail\` (precondition for U5).
6. **U5** \`92d3542\` — VA fallback card: branches by kind (release / master / release-group), reuses \`renderReleaseDetail\` + \`loadReleaseGroup\`.

Plus \`af76314\` — pyright cleanup (validate Discogs digit at route layer).

## Code Review Fixes

Ran a focused 2-agent review (\`correctness\` + \`frontend-races\`) before opening the PR. Findings + fixes in \`2ff5d8e\`:

- **P2 #1+#2**: \`openVaFallback\` had no in-flight token guard; nested \`loadReleaseGroup\` writes into the VA fallback's stable \`bodyEl\` (unlike the artist-view's detached \`#rel-X\`). Threaded \`requestToken\` through both with \`isStale()\` checks at every await.
- **P3 #3**: Input-clear didn't hide the VA fallback. Now hides on \`q.length<minLen\`. Also fixes single-digit Discogs IDs silently dropped (parser asserted they were accepted, but \`length<2\` short-circuit blocked them — minLen=1 in ID mode).
- **P3 #4**: Dead state on VA branch — \`searchTargetId/ExpandId/Source\` set but never read. Moved into non-VA branch only.
- **P3 #6**: VA fallback's \`renderReleaseDetail\` artist label fell through to \`state.browseArtist?.name\` (the previously-viewed non-VA artist). Added \`opts.artist\` override.
- **Suppressed P3**: stale \`reldet-X\` DOM ID collision when both artist view and VA fallback contain the same release. \`openVaFallback\` now blanks \`#browse-discography\` on entry.
- **Suppressed P3**: \`setBrowseSource\` didn't clear search-target state. Now does, mirroring \`setSearchType\`.

## Test plan

- [x] 2719/2719 Python tests pass (\`scripts/run_tests.sh\`).
- [x] 204/204 JS unit tests pass (\`tests/test_js_util.mjs\`).
- [x] Pyright clean on touched Python files.
- [x] \`node --check\` clean on all touched JS files.
- [x] Plan deepening pass + 2-agent code review run.
- [ ] **Manual Playwright smoke after deploy** — U4 / U5 scenarios from the plan against \`music.ablz.au\`. Specifically:
  - Paste a non-VA Discogs release URL → artist view auto-expands master, target row ringed, scrolled into view.
  - Paste an MB release MBID (bare) → artist view, RG expanded, release ringed.
  - Paste a Discogs master URL → master expanded, no leaf ring (R18).
  - Paste an MB release-group MBID → RG expanded, no leaf ring.
  - Paste a masterless Discogs release → masterless rg row ringed in place.
  - Paste a VA Discogs release ID (e.g. \`32457180\`) → fallback card with Add button. Add succeeds and creates a pipeline row.
  - Paste a VA MB release-group MBID → fallback card with pressings list.
  - Two consecutive pastes of different IDs → second one's ring applied, first cleared.
  - Tab away (Library) and back → ring still applied (R15).
  - Switch source MB↔Discogs after a paste → ring cleared explicitly.
  - Clear input mid-VA-fetch → fallback card dismissed, no stale render.
  - Garbage paste → inline "not a recognised ID" error, no resolver call.
  - 404 paste → inline upstream error, no navigation.

## Deploy

Standard flake flow per CLAUDE.md: push (this PR) → \`nix flake update cratedigger-src\` on doc1 → \`nixos-rebuild switch\` on doc2. \`cratedigger-web\` restarts on switch. No DB migrations, no NixOS module changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)