### PR TITLE
fix(browse): include release-groups in MB release lookup (#203 follow-up)

### DIFF
--- a/web/mb.py
+++ b/web/mb.py
@@ -235,7 +235,7 @@ def get_release(release_mbid, *, fresh: bool = False):
     def _fetch() -> dict:
         data = _get(
             f"{MB_API_BASE}/release/{release_mbid}"
-            f"?inc=recordings+artist-credits+media&fmt=json"
+            f"?inc=recordings+artist-credits+media+release-groups&fmt=json"
         )
         artist_credit = data.get("artist-credit", [{}])
         artist_name = artist_credit[0].get("name", "Unknown") if artist_credit else "Unknown"


### PR DESCRIPTION
Smoke-caught regression in #203. `mb.get_release()` omitted `release-groups` from the upstream `inc` parameter, so the MB mirror's response didn't include the release-group object. Resolver fell back to release MBID for `expand_id`, the discography hook's `#rel-{expand_id}` selector never matched, and the search-by-ID ring never fired for MB pastes.

Mocked tests in `TestSearchByIdResolveContract` couldn't catch this — they assert resolver behavior given a fully-populated `get_release` return value. The bug lived in the helper-to-mirror integration.

One-line fix. Verified the underlying MB query now returns the release-group object and the deployed resolver returns correct `expand_id` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)