### PR TITLE
feat(#198): browse fan-out + pipeline depth (U2/U3/U4 + review fixups)

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -626,7 +626,11 @@ def _search_and_queue_parallel(albums, ctx):
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    MAX_INFLIGHT = 2  # matches slskd maximumConcurrentSearches
+    # Pipeline depth — number of search-collection futures in flight at once.
+    # Configurable via cfg.search_max_inflight (issue #198 U4). Submission
+    # stays sequential through the existing 429-retry loop; only the
+    # collect-side concurrency increases.
+    max_inflight = ctx.cfg.search_max_inflight
 
     grab_list: dict[Any, Any] = {}
     failed_grab: list[Any] = []
@@ -634,7 +638,7 @@ def _search_and_queue_parallel(albums, ctx):
     total = len(albums)
     album_queue = list(albums)  # mutable copy we pop from
 
-    logger.info(f"Pipelined search: {total} albums, {MAX_INFLIGHT} in flight")
+    logger.info(f"Pipelined search: {total} albums, {max_inflight} in flight")
     wall_start = time.time()
 
     def _submit_next() -> tuple[Any, Any] | None:
@@ -704,10 +708,10 @@ def _search_and_queue_parallel(albums, ctx):
             return (future, album)
         return None
 
-    with ThreadPoolExecutor(max_workers=MAX_INFLIGHT) as pool:
+    with ThreadPoolExecutor(max_workers=max_inflight) as pool:
         # Seed the pipeline with initial searches
         inflight: dict[Any, Any] = {}
-        for _ in range(min(MAX_INFLIGHT, len(album_queue))):
+        for _ in range(min(max_inflight, len(album_queue))):
             submitted = _submit_next()
             if submitted:
                 future, album = submitted

--- a/lib/browse.py
+++ b/lib/browse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures.thread as _futures_thread
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -146,16 +147,25 @@ def _fanout_browse_users(
 
     The wave deadline is enforced via `as_completed(timeout=...)` plus manual
     executor lifetime + `shutdown(wait=False, cancel_futures=True)` so a
-    single hung peer cannot stretch the wave to its TCP timeout. Running
-    futures whose results are abandoned continue until their own TCP timeout
-    elapses — accepted cost on a 5-minute oneshot cycle.
+    single hung peer cannot stretch the wave to its TCP timeout.
 
-    Thread-safety contract: user buckets in `ctx.folder_cache` and
-    `ctx._folder_cache_ts` are pre-created in the calling thread BEFORE any
-    future is submitted. After that, each `(user, dir)` pair is owned by
-    exactly one future, so per-key writes are race-free under CPython's GIL.
-    Without this pre-creation, two futures sharing a user would race on the
-    compound `setdefault + nested-write` and could lose entries (issue #198).
+    Thread-safety: workers only return tuples — the calling thread is the
+    sole writer to `ctx.folder_cache`. The Step 1 pre-create is therefore
+    not a race fix; it makes "all dirs failed for this user" observable to
+    callers (the inner dict exists but is empty). Without it, the regression
+    test couldn't distinguish "tried, every browse raised" from "user was
+    never in the work plan."
+
+    Orphan-thread cost: futures whose results are abandoned past the wave
+    deadline keep running until their own TCP timeout (~30–60s). Plain
+    `ThreadPoolExecutor` workers are non-daemon and tracked in
+    `concurrent.futures.thread._threads_queues`; on interpreter exit, an
+    atexit handler joins every entry — even after `shutdown(wait=False,
+    cancel_futures=True)`. For a 5-min oneshot, that lets orphan TCP timeouts
+    bleed past the cycle boundary and delay the next systemd-timer fire. We
+    detach the pool's workers from the registry so atexit doesn't wait on
+    them; they still finish their network calls naturally, we just don't
+    block the process exit on them.
 
     Returns the set of usernames whose futures had not completed by the
     deadline (any one outstanding `(user, dir)` future puts that user in
@@ -164,7 +174,8 @@ def _fanout_browse_users(
     if not work_items:
         return set()
 
-    # Step 1: pre-create user buckets so futures never race on setdefault.
+    # Step 1: pre-create user buckets so callers can observe "every dir
+    # failed for this user" via an empty inner dict.
     for user, _file_dir in work_items:
         ctx.folder_cache.setdefault(user, {})
         ctx._folder_cache_ts.setdefault(user, {})
@@ -181,7 +192,6 @@ def _fanout_browse_users(
                 user, file_dir = futures[fut]
                 _file_dir, result = fut.result()
                 if result is not None:
-                    # Inner dicts already exist (Step 1); per-key write is GIL-safe.
                     ctx.folder_cache[user][file_dir] = result
                     ctx._folder_cache_ts[user][file_dir] = time.time()
         except FuturesTimeoutError:
@@ -193,5 +203,34 @@ def _fanout_browse_users(
         # tasks. Running tasks keep running but their results are abandoned.
         # This is what makes the wave deadline actually bound wall-clock.
         pool.shutdown(wait=False, cancel_futures=True)
+        _detach_workers_from_atexit(pool)
 
     return timed_out_users
+
+
+def _detach_workers_from_atexit(pool: ThreadPoolExecutor) -> None:
+    """Remove `pool`'s workers from concurrent.futures' atexit registry.
+
+    `ThreadPoolExecutor` registers each worker thread in the module-level
+    `_threads_queues` dict; an atexit handler joins every entry on
+    interpreter shutdown — even after `shutdown(wait=False, cancel_futures=
+    True)`. For an orphaned worker stuck on a 30–60 s slskd TCP timeout,
+    that means the cratedigger oneshot cannot exit until the timeout
+    elapses, defeating the wave deadline at the *process* boundary.
+
+    Popping the workers from `_threads_queues` detaches them from the join
+    — the threads still finish their network calls naturally and any
+    pending I/O completes; we just don't make the process wait for them.
+
+    Uses a private CPython attribute. Wrapped in try/except so a future
+    Python release that renames or removes the registry degrades to the
+    pre-existing behavior (slow-but-correct exit) rather than crashing.
+    """
+    try:
+        # `pool._threads` is a set of Thread objects; remove each from the
+        # global registry. Iterate a copy to keep the dict mutation safe.
+        registry: dict[Any, Any] = _futures_thread._threads_queues  # type: ignore[assignment]
+        for thread in list(getattr(pool, "_threads", []) or []):
+            registry.pop(thread, None)
+    except Exception:
+        logger.debug("Could not detach fan-out workers from atexit registry", exc_info=True)

--- a/lib/browse.py
+++ b/lib/browse.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
+    from lib.context import CratediggerContext
     from cratedigger import SlskdDirectory
 
 
@@ -106,8 +110,6 @@ def _browse_directories(
     max_workers: int = 4,
 ) -> dict[str, Any]:
     """Browse multiple directories in parallel."""
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
     if not dirs_to_browse:
         return {}
 
@@ -127,3 +129,69 @@ def _browse_directories(
                 results[file_dir] = result
 
     return results
+
+
+def _fanout_browse_users(
+    work_items: list[tuple[str, str]],
+    slskd_client: Any,
+    ctx: CratediggerContext,
+    max_workers: int,
+    deadline_s: float,
+) -> set[str]:
+    """Bounded parallel browse fan-out across (user, dir) pairs.
+
+    Submits each `(username, file_dir)` browse to a single bounded
+    ThreadPoolExecutor and writes successful results into
+    `ctx.folder_cache[user][dir]` and `ctx._folder_cache_ts[user][dir]`.
+
+    The wave deadline is enforced via `as_completed(timeout=...)` plus manual
+    executor lifetime + `shutdown(wait=False, cancel_futures=True)` so a
+    single hung peer cannot stretch the wave to its TCP timeout. Running
+    futures whose results are abandoned continue until their own TCP timeout
+    elapses — accepted cost on a 5-minute oneshot cycle.
+
+    Thread-safety contract: user buckets in `ctx.folder_cache` and
+    `ctx._folder_cache_ts` are pre-created in the calling thread BEFORE any
+    future is submitted. After that, each `(user, dir)` pair is owned by
+    exactly one future, so per-key writes are race-free under CPython's GIL.
+    Without this pre-creation, two futures sharing a user would race on the
+    compound `setdefault + nested-write` and could lose entries (issue #198).
+
+    Returns the set of usernames whose futures had not completed by the
+    deadline (any one outstanding `(user, dir)` future puts that user in
+    the set; the caller treats them as broken-for-this-cycle).
+    """
+    if not work_items:
+        return set()
+
+    # Step 1: pre-create user buckets so futures never race on setdefault.
+    for user, _file_dir in work_items:
+        ctx.folder_cache.setdefault(user, {})
+        ctx._folder_cache_ts.setdefault(user, {})
+
+    timed_out_users: set[str] = set()
+    pool = ThreadPoolExecutor(max_workers=max_workers)
+    try:
+        futures = {
+            pool.submit(_browse_one, user, file_dir, slskd_client): (user, file_dir)
+            for (user, file_dir) in work_items
+        }
+        try:
+            for fut in as_completed(futures, timeout=deadline_s):
+                user, file_dir = futures[fut]
+                _file_dir, result = fut.result()
+                if result is not None:
+                    # Inner dicts already exist (Step 1); per-key write is GIL-safe.
+                    ctx.folder_cache[user][file_dir] = result
+                    ctx._folder_cache_ts[user][file_dir] = time.time()
+        except FuturesTimeoutError:
+            for fut, (user, _file_dir) in futures.items():
+                if not fut.done():
+                    timed_out_users.add(user)
+    finally:
+        # cancel_futures=True (Python 3.9+) cancels queued, not-yet-started
+        # tasks. Running tasks keep running but their results are abandoned.
+        # This is what makes the wave deadline actually bound wall-clock.
+        pool.shutdown(wait=False, cancel_futures=True)
+
+    return timed_out_users

--- a/lib/config.py
+++ b/lib/config.py
@@ -86,6 +86,14 @@ class CratediggerConfig:
     search_file_limit: int = 50000
     search_escalation_threshold: int = 5
 
+    # --- Browse fan-out (issue #198) ---
+    # Top-K + lazy-tail parallel browse across peers. See
+    # docs/plans/2026-05-01-001-feat-browse-fanout-and-pipeline-depth-plan.md.
+    browse_top_k: int = 20
+    browse_wave_deadline_s: float = 20.0
+    browse_global_max_workers: int = 32
+    browse_cycle_budget_s: float = 240.0
+
     # --- Release ---
     use_most_common_tracknum: bool = True
     allow_multi_disc: bool = True
@@ -252,6 +260,10 @@ class CratediggerConfig:
             search_response_limit=getint("Search Settings", "search_response_limit", 1000),
             search_file_limit=getint("Search Settings", "search_file_limit", 50000),
             search_escalation_threshold=getint("Search Settings", "search_escalation_threshold", 5),
+            browse_top_k=getint("Search Settings", "browse_top_k", 20),
+            browse_wave_deadline_s=getfloat("Search Settings", "browse_wave_deadline_s", 20.0),
+            browse_global_max_workers=getint("Search Settings", "browse_global_max_workers", 32),
+            browse_cycle_budget_s=getfloat("Search Settings", "browse_cycle_budget_s", 240.0),
             # Release
             use_most_common_tracknum=getbool("Release Settings", "use_most_common_tracknum", True),
             allow_multi_disc=getbool("Release Settings", "allow_multi_disc", True),

--- a/lib/config.py
+++ b/lib/config.py
@@ -93,6 +93,12 @@ class CratediggerConfig:
     browse_wave_deadline_s: float = 20.0
     browse_global_max_workers: int = 32
     browse_cycle_budget_s: float = 240.0
+    # Pipeline depth for _search_and_queue_parallel — number of in-flight
+    # search-collect futures. Submission stays sequential through the existing
+    # 429-retry loop in _submit_search (slskd's SearchRequestLimiter is on POST
+    # only). Raised from the legacy hard-coded 2 to keep the search-collection
+    # thread fed once browse stops being the dominant cost.
+    search_max_inflight: int = 4
 
     # --- Release ---
     use_most_common_tracknum: bool = True
@@ -264,6 +270,7 @@ class CratediggerConfig:
             browse_wave_deadline_s=getfloat("Search Settings", "browse_wave_deadline_s", 20.0),
             browse_global_max_workers=getint("Search Settings", "browse_global_max_workers", 32),
             browse_cycle_budget_s=getfloat("Search Settings", "browse_cycle_budget_s", 240.0),
+            search_max_inflight=getint("Search Settings", "search_max_inflight", 4),
             # Release
             use_most_common_tracknum=getbool("Release Settings", "use_most_common_tracknum", True),
             allow_multi_disc=getbool("Release Settings", "allow_multi_disc", True),

--- a/lib/config.py
+++ b/lib/config.py
@@ -266,11 +266,15 @@ class CratediggerConfig:
             search_response_limit=getint("Search Settings", "search_response_limit", 1000),
             search_file_limit=getint("Search Settings", "search_file_limit", 50000),
             search_escalation_threshold=getint("Search Settings", "search_escalation_threshold", 5),
-            browse_top_k=getint("Search Settings", "browse_top_k", 20),
-            browse_wave_deadline_s=getfloat("Search Settings", "browse_wave_deadline_s", 20.0),
-            browse_global_max_workers=getint("Search Settings", "browse_global_max_workers", 32),
-            browse_cycle_budget_s=getfloat("Search Settings", "browse_cycle_budget_s", 240.0),
-            search_max_inflight=getint("Search Settings", "search_max_inflight", 4),
+            # Clamp the parallel-browse / pipeline-depth knobs to safe minima.
+            # ThreadPoolExecutor(max_workers=0), range(0, n, 0), and a negative
+            # deadline all crash the cycle on the first album — reject them at
+            # parse time so a config typo doesn't take the whole timer down.
+            browse_top_k=max(1, getint("Search Settings", "browse_top_k", 20)),
+            browse_wave_deadline_s=max(0.0, getfloat("Search Settings", "browse_wave_deadline_s", 20.0)),
+            browse_global_max_workers=max(1, getint("Search Settings", "browse_global_max_workers", 32)),
+            browse_cycle_budget_s=max(0.0, getfloat("Search Settings", "browse_cycle_budget_s", 240.0)),
+            search_max_inflight=max(1, getint("Search Settings", "search_max_inflight", 4)),
             # Release
             use_most_common_tracknum=getbool("Release Settings", "use_most_common_tracknum", True),
             allow_multi_disc=getbool("Release Settings", "allow_multi_disc", True),

--- a/lib/context.py
+++ b/lib/context.py
@@ -45,11 +45,19 @@ class CratediggerContext:
     # search is wrapped around _search_and_queue_parallel in cratedigger.py;
     # cache_load is set once by lib/cache.load_caches; cycle_browse_time_s
     # is the running counter that U3's per-cycle budget guard reads.
+    #
+    # peers_browsed is the fan-out path's count (every (user, dir) submitted
+    # to a wave, success or failure). peers_browsed_lazy is the fallback
+    # path in lib/matching.py — it fires when fan-out left a (user, dir)
+    # unwritten via _browse_one's exception swallow, since timed-out users
+    # are skipped earlier via ctx.broken_user. Splitting them avoids
+    # double-counting that same (user, dir) when the lazy path retries it.
     browse_time_s: float = 0.0
     match_time_s: float = 0.0
     search_time_s: float = 0.0
     cache_load_s: float = 0.0
     cycle_browse_time_s: float = 0.0
     peers_browsed: int = 0
+    peers_browsed_lazy: int = 0
     peers_timed_out: int = 0
     fanout_waves: int = 0

--- a/lib/cycle_summary.py
+++ b/lib/cycle_summary.py
@@ -26,6 +26,7 @@ def format_cycle_summary(ctx: CratediggerContext, elapsed_s: float) -> str:
         f"search_time_s={ctx.search_time_s:.1f} "
         f"cache_load_s={ctx.cache_load_s:.1f} "
         f"peers_browsed={ctx.peers_browsed} "
+        f"peers_browsed_lazy={ctx.peers_browsed_lazy} "
         f"peers_timed_out={ctx.peers_timed_out} "
         f"fanout_waves={ctx.fanout_waves} "
         f"cycle_total_s={elapsed_s:.1f}"

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -280,6 +280,13 @@ def _iter_wave_matches(
 
         work: list[tuple[str, str]] = []
         for username in wave:
+            # Skip users that already timed out in a previous wave (or in
+            # disc-1's waves when called per-disc from try_multi_enqueue).
+            # Re-submitting them re-pays browse_wave_deadline_s on known-dead
+            # peers — the match loop already skips them, but the work-list
+            # builder needs the same guard to keep waves cheap.
+            if username in ctx.broken_user:
+                continue
             cached = ctx.folder_cache.get(username, {})
             for file_dir in user_dirs.get(username, []):
                 if file_dir not in cached:

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Sequence, cast
+import time
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, cast
 
-from lib.browse import download_filter
+from lib.browse import _fanout_browse_users, download_filter
 from lib.download import cancel_and_delete, slskd_do_enqueue
 from lib.grab_list import GrabListEntry
-from lib.matching import check_for_match, get_album_by_id
+from lib.matching import MatchResult, check_for_match, get_album_by_id
 from lib.quality import CandidateScore
 
 if TYPE_CHECKING:
@@ -193,25 +194,29 @@ def get_album_tracks(album: Any, ctx: CratediggerContext) -> list[TrackRecord]:
     return cast("list[TrackRecord]", ctx.pipeline_db_source.get_tracks(album))
 
 
-def try_enqueue(
-    all_tracks: Sequence[TrackRecord],
+def _eligible_user_dirs(
     results: dict[str, dict[str, list[str]]],
     allowed_filetype: str,
+    album_id: int,
     ctx: CratediggerContext,
-) -> EnqueueAttempt:
-    """Single album match and enqueue."""
-    album_id = all_tracks[0]["albumId"]
-    album = get_album_by_id(album_id, ctx)
-    album_name = album.title
-    artist_name = album.artist_name
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Filter+rank users into a fan-out work plan.
+
+    Returns ``(ordered_users, user_dirs)`` where:
+      * ``ordered_users`` is the iteration order — descending upload speed,
+        skipping cooled-down / denylisted users and users with no candidate
+        dirs at this filetype.
+      * ``user_dirs`` maps surviving username → candidate dirs at this
+        filetype, used to build the fan-out work list.
+    """
     denied_users = _get_denied_users(album_id, ctx)
     sorted_users = sorted(
         results.keys(),
         key=lambda u: ctx.user_upload_speed.get(u, 0),
         reverse=True,
     )
-    had_enqueue_failure = False
-    accumulated: list[CandidateScore] = []
+    ordered: list[str] = []
+    user_dirs: dict[str, list[str]] = {}
     for username in sorted_users:
         if username in ctx.cooled_down_users:
             logger.info(
@@ -228,39 +233,156 @@ def try_enqueue(
         file_dirs = _get_user_dirs(results[username], allowed_filetype)
         if file_dirs is None:
             continue
-        logger.debug(f"Parsing result from user: {username}")
-        match_result = check_for_match(
-            all_tracks, allowed_filetype, file_dirs, username, ctx
+        ordered.append(username)
+        user_dirs[username] = file_dirs
+    return ordered, user_dirs
+
+
+def _iter_wave_matches(
+    tracks: Sequence[TrackRecord],
+    eligible_users: list[str],
+    user_dirs: dict[str, list[str]],
+    allowed_filetype: str,
+    ctx: CratediggerContext,
+    accumulated: list[CandidateScore],
+) -> Iterator[tuple[str, MatchResult]]:
+    """Yield ``(username, match_result)`` for every dir that matches strictly.
+
+    Wave-based fan-out (issue #198 U3): chunks ``eligible_users`` into waves
+    of ``cfg.browse_top_k``, runs ``_fanout_browse_users`` to populate
+    ``ctx.folder_cache`` for the wave's uncached ``(user, dir)`` pairs in
+    parallel, then iterates ``check_for_match`` against the warm cache in
+    upload-speed order. Honors ``cfg.browse_cycle_budget_s`` — short-circuits
+    before any wave (and between waves) once cumulative cycle browse time
+    exceeds the budget.
+
+    Side effects: appends per-dir ``CandidateScore`` entries into
+    ``accumulated`` (caller-owned), bumps ``ctx.cycle_browse_time_s``,
+    ``ctx.fanout_waves``, ``ctx.peers_browsed``, ``ctx.peers_timed_out``;
+    extends ``ctx.broken_user`` with timed-out usernames (per-cycle scope —
+    a fresh ``CratediggerContext`` next cycle starts empty).
+
+    Caller is responsible for stopping iteration (``break``) once a match is
+    enqueued; the generator stops fan-out work as soon as iteration stops.
+    """
+    cfg = ctx.cfg
+    if ctx.cycle_browse_time_s >= cfg.browse_cycle_budget_s:
+        logger.info(
+            f"cycle_browse_budget_exhausted: skipping wave (budget="
+            f"{cfg.browse_cycle_budget_s:.0f}s, used="
+            f"{ctx.cycle_browse_time_s:.1f}s)"
         )
-        accumulated.extend(match_result.candidates)
-        if match_result.matched:
-            directory = download_filter(allowed_filetype, match_result.directory, ctx.cfg)
-            files_to_enqueue = _prefixed_directory_files(directory, match_result.file_dir)
-            try:
-                downloads = slskd_do_enqueue(
-                    username=username,
-                    files=files_to_enqueue,
-                    file_dir=match_result.file_dir,
-                    ctx=ctx,
+        return
+
+    K = cfg.browse_top_k
+    for wave_start in range(0, len(eligible_users), K):
+        wave = eligible_users[wave_start:wave_start + K]
+
+        work: list[tuple[str, str]] = []
+        for username in wave:
+            cached = ctx.folder_cache.get(username, {})
+            for file_dir in user_dirs.get(username, []):
+                if file_dir not in cached:
+                    work.append((username, file_dir))
+
+        if work:
+            t0 = time.monotonic()
+            timed_out = _fanout_browse_users(
+                work, ctx.slskd, ctx,
+                max_workers=cfg.browse_global_max_workers,
+                deadline_s=cfg.browse_wave_deadline_s,
+            )
+            elapsed = time.monotonic() - t0
+            ctx.cycle_browse_time_s += elapsed
+            ctx.fanout_waves += 1
+            ctx.peers_browsed += len(work)
+            ctx.peers_timed_out += len(timed_out)
+            for username in timed_out:
+                if username not in ctx.broken_user:
+                    ctx.broken_user.append(username)
+            n_returned = sum(
+                1 for (u, d) in work if d in ctx.folder_cache.get(u, {})
+            )
+            logger.info(
+                f"wave: K={K} n_uncached={len(work)} n_returned={n_returned} "
+                f"n_timed_out={len(timed_out)} elapsed_s={elapsed:.1f}"
+            )
+
+        for username in wave:
+            if username in ctx.broken_user:
+                continue
+            file_dirs = user_dirs.get(username)
+            if not file_dirs:
+                continue
+            match_result = check_for_match(
+                tracks, allowed_filetype, file_dirs, username, ctx,
+            )
+            accumulated.extend(match_result.candidates)
+            if match_result.matched:
+                yield username, match_result
+
+        if ctx.cycle_browse_time_s >= cfg.browse_cycle_budget_s:
+            logger.info(
+                f"cycle_browse_budget_exhausted: stopping waves (budget="
+                f"{cfg.browse_cycle_budget_s:.0f}s, used="
+                f"{ctx.cycle_browse_time_s:.1f}s)"
+            )
+            return
+
+
+def try_enqueue(
+    all_tracks: Sequence[TrackRecord],
+    results: dict[str, dict[str, list[str]]],
+    allowed_filetype: str,
+    ctx: CratediggerContext,
+) -> EnqueueAttempt:
+    """Single album match and enqueue.
+
+    Wave-based: eligible users are chunked into waves of
+    ``cfg.browse_top_k``; each wave runs ``_fanout_browse_users`` in
+    parallel, then iterates matching against the warm cache. Returns on
+    the first successful enqueue; falls through to the next user (and
+    next wave) on enqueue failure.
+    """
+    album_id = all_tracks[0]["albumId"]
+    album = get_album_by_id(album_id, ctx)
+    album_name = album.title
+    artist_name = album.artist_name
+
+    eligible, user_dirs = _eligible_user_dirs(results, allowed_filetype, album_id, ctx)
+
+    had_enqueue_failure = False
+    accumulated: list[CandidateScore] = []
+    for username, match_result in _iter_wave_matches(
+        all_tracks, eligible, user_dirs, allowed_filetype, ctx, accumulated,
+    ):
+        directory = download_filter(allowed_filetype, match_result.directory, ctx.cfg)
+        files_to_enqueue = _prefixed_directory_files(directory, match_result.file_dir)
+        try:
+            downloads = slskd_do_enqueue(
+                username=username,
+                files=files_to_enqueue,
+                file_dir=match_result.file_dir,
+                ctx=ctx,
+            )
+            if downloads is not None:
+                return EnqueueAttempt(
+                    matched=True,
+                    downloads=downloads,
+                    candidates=tuple(accumulated),
                 )
-                if downloads is not None:
-                    return EnqueueAttempt(
-                        matched=True,
-                        downloads=downloads,
-                        candidates=tuple(accumulated),
-                    )
-                had_enqueue_failure = True
-                logger.info(
-                    f"Failed to enqueue download to slskd for "
-                    f"{artist_name} - {album_name} from {username}"
-                )
-            except Exception as e:
-                had_enqueue_failure = True
-                logger.warning(f"Exception enqueueing tracks: {e}")
-                logger.info(
-                    f"Exception enqueueing download to slskd for "
-                    f"{artist_name} - {album_name} from {username}"
-                )
+            had_enqueue_failure = True
+            logger.info(
+                f"Failed to enqueue download to slskd for "
+                f"{artist_name} - {album_name} from {username}"
+            )
+        except Exception as e:
+            had_enqueue_failure = True
+            logger.warning(f"Exception enqueueing tracks: {e}")
+            logger.info(
+                f"Exception enqueueing download to slskd for "
+                f"{artist_name} - {album_name} from {username}"
+            )
     logger.info(f"Failed to enqueue {artist_name} - {album_name}")
     return EnqueueAttempt(
         matched=False,
@@ -276,7 +398,13 @@ def try_multi_enqueue(
     allowed_filetype: str,
     ctx: CratediggerContext,
 ) -> EnqueueAttempt:
-    """Locate and enqueue a multi-disc album."""
+    """Locate and enqueue a multi-disc album.
+
+    Uses the same wave-based fan-out as ``try_enqueue``, applied per disc.
+    The folder cache populated by disc-1's waves carries into disc-2 (and
+    so on) — successive discs find their peers warm-cached and skip the
+    fan-out network round-trip.
+    """
     split_release: list[dict[str, Any]] = []
     for media in release.media:
         disk: dict[str, Any] = {}
@@ -294,39 +422,25 @@ def try_multi_enqueue(
     album = get_album_by_id(album_id, ctx)
     album_name = album.title
     artist_name = album.artist_name
-    denied_users = _get_denied_users(album_id, ctx)
+    eligible, user_dirs = _eligible_user_dirs(results, allowed_filetype, album_id, ctx)
     accumulated: list[CandidateScore] = []
     for disk in split_release:
         ctx.negative_matches.clear()
-        for username in results:
-            if username in ctx.cooled_down_users:
-                logger.info(
-                    f"Skipping user '{username}' for album ID {album_id} "
-                    f"(multi-disc): on cooldown (recent download failures)"
-                )
-                continue
-            if username in denied_users:
-                logger.info(
-                    f"Skipping user '{username}' for album ID {album_id} "
-                    f"(multi-disc): denylisted (previously provided mislabeled quality)"
-                )
-                continue
-            file_dirs = _get_user_dirs(results[username], allowed_filetype)
-            if file_dirs is None:
-                continue
-            match_result = check_for_match(
-                disk["tracks"], allowed_filetype, file_dirs, username, ctx
-            )
-            accumulated.extend(match_result.candidates)
-            if match_result.matched:
-                directory = download_filter(
-                    allowed_filetype, match_result.directory, ctx.cfg,
-                )
-                disk["source"] = (username, directory, match_result.file_dir)
-                count_found += 1
-                break
-        else:
+        first_match = next(
+            _iter_wave_matches(
+                disk["tracks"], eligible, user_dirs, allowed_filetype, ctx,
+                accumulated,
+            ),
+            None,
+        )
+        if first_match is None:
             return EnqueueAttempt(matched=False, candidates=tuple(accumulated))
+        username, match_result = first_match
+        directory = download_filter(
+            allowed_filetype, match_result.directory, ctx.cfg,
+        )
+        disk["source"] = (username, directory, match_result.file_dir)
+        count_found += 1
     if count_found == total:
         all_downloads = []
         enqueued = 0

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -317,7 +317,12 @@ def check_for_match(
             )
         finally:
             ctx.browse_time_s += time.monotonic() - browse_t0
-            ctx.peers_browsed += len(uncached)
+            # Lazy-fallback path: fan-out either swallowed an exception via
+            # _browse_one (no entry written, user not in broken_user) or
+            # this caller bypassed the wave loop. Either way, count
+            # separately from peers_browsed so the cycle summary can
+            # distinguish primary fan-out load from residual lazy retries.
+            ctx.peers_browsed_lazy += len(uncached)
         for d, result in browsed.items():
             ctx.folder_cache[username][d] = result
             ctx._folder_cache_ts.setdefault(username, {})[d] = time.time()

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -160,6 +160,7 @@
     browse_wave_deadline_s = ${toString cfg.searchSettings.browseWaveDeadlineS}
     browse_global_max_workers = ${toString cfg.searchSettings.browseGlobalMaxWorkers}
     browse_cycle_budget_s = ${toString cfg.searchSettings.browseCycleBudgetS}
+    search_max_inflight = ${toString cfg.searchSettings.searchMaxInflight}
 
     [Download Settings]
     download_filtering = ${if cfg.downloadSettings.downloadFiltering then "True" else "False"}
@@ -646,6 +647,18 @@ in {
           exceeded, remaining `wanted` records short-circuit (no further
           browse waves) and stay queued for the next cycle. Defends against
           multi-album-no-match cycles compounding into 50+ minute runs.
+        '';
+      };
+      searchMaxInflight = mkOption {
+        type = types.int;
+        default = 4;
+        description = ''
+          Pipeline depth for the parallel search executor — number of
+          in-flight search-collection futures at once. Submission stays
+          sequential (slskd's `SearchRequestLimiter` is on POST only, with
+          a built-in 429-retry loop), but the collect-side workload runs
+          in this many threads. Raised from the legacy hard-coded 2 once
+          browse fan-out (issue #198) stops being the dominant cost.
         '';
       };
       titleBlacklist = mkOption {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -156,6 +156,10 @@
     search_blacklist = ${concatStringsSep "," cfg.searchSettings.searchBlacklist}
     search_response_limit = ${toString cfg.searchSettings.searchResponseLimit}
     search_file_limit = ${toString cfg.searchSettings.searchFileLimit}
+    browse_top_k = ${toString cfg.searchSettings.browseTopK}
+    browse_wave_deadline_s = ${toString cfg.searchSettings.browseWaveDeadlineS}
+    browse_global_max_workers = ${toString cfg.searchSettings.browseGlobalMaxWorkers}
+    browse_cycle_budget_s = ${toString cfg.searchSettings.browseCycleBudgetS}
 
     [Download Settings]
     download_filtering = ${if cfg.downloadSettings.downloadFiltering then "True" else "False"}
@@ -597,6 +601,51 @@ in {
           seconds — possibly before the right peer responds. 50000 gives the
           matcher more peer diversity for albums where each peer holds 50+
           files (compilations, OSTs, multi-disc reissues).
+        '';
+      };
+      browseTopK = mkOption {
+        type = types.int;
+        default = 20;
+        description = ''
+          First wave size for parallel peer browse fan-out. After ranking
+          eligible peers by upload speed, the top K are browsed concurrently
+          and the cache is matched against them. If no match is found, the
+          tail is browsed in further chunks of K. Tune downward if first-match
+          rank is consistently low; tune upward only if browse budget allows.
+          See issue #198.
+        '';
+      };
+      browseWaveDeadlineS = mkOption {
+        type = types.float;
+        default = 20.0;
+        description = ''
+          Wall-clock deadline per fan-out wave, in seconds. Peers that have
+          not returned a directory listing by the deadline are abandoned for
+          the rest of this cycle (added to a per-cycle broken-user set).
+          Soulseek's per-peer TCP timeout is ~30–60s and is not configurable
+          per-call, so this client-side deadline is the only effective tail-
+          latency defense.
+        '';
+      };
+      browseGlobalMaxWorkers = mkOption {
+        type = types.int;
+        default = 32;
+        description = ''
+          Global cap on the ThreadPoolExecutor used by browse fan-out. Limits
+          simultaneous in-flight `users.directory()` calls across all users
+          and all dirs in a wave. Higher than browseTopK so a single user
+          contributing many candidate dirs still gets meaningful parallelism.
+          Watch slskd's own logs for serialisation if raised.
+        '';
+      };
+      browseCycleBudgetS = mkOption {
+        type = types.float;
+        default = 240.0;
+        description = ''
+          Per-cycle cumulative browse wall-time budget, in seconds. When
+          exceeded, remaining `wanted` records short-circuit (no further
+          browse waves) and stay queued for the next cycle. Defends against
+          multi-album-no-match cycles compounding into 50+ minute runs.
         '';
       };
       titleBlacklist = mkOption {

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import json
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -194,6 +195,10 @@ class FakeSlskdUsers:
         self.directory_error: Exception | None = None
         self._directories: dict[tuple[str, str], list[Any]] = {}
         self._directory_errors: dict[tuple[str, str], Exception] = {}
+        self._directory_delays: dict[tuple[str, str], float] = {}
+        # Optional concurrency probe — set to a callable taking a +/-1 delta to
+        # observe in-flight count (used by fan-out concurrency-cap tests).
+        self.in_flight_probe: Callable[[int], None] | None = None
 
     def set_directory(
         self,
@@ -211,14 +216,34 @@ class FakeSlskdUsers:
     ) -> None:
         self._directory_errors[(username, directory)] = error
 
+    def set_directory_delay(
+        self,
+        username: str,
+        directory: str,
+        seconds: float,
+    ) -> None:
+        """Sleep `seconds` inside `directory(...)` before returning the registered
+        result. Lets tests exercise fan-out wave deadlines and concurrency caps
+        without mocking time. Default is 0.0 (no sleep)."""
+        self._directory_delays[(username, directory)] = seconds
+
     def directory(self, username: str, directory: str) -> list[Any]:
         self.directory_calls.append((username, directory))
-        if self.directory_error is not None:
-            raise self.directory_error
-        directory_error = self._directory_errors.get((username, directory))
-        if directory_error is not None:
-            raise directory_error
-        return copy.deepcopy(self._directories.get((username, directory), []))
+        if self.in_flight_probe is not None:
+            self.in_flight_probe(1)
+        try:
+            delay = self._directory_delays.get((username, directory), 0.0)
+            if delay > 0:
+                time.sleep(delay)
+            if self.directory_error is not None:
+                raise self.directory_error
+            directory_error = self._directory_errors.get((username, directory))
+            if directory_error is not None:
+                raise directory_error
+            return copy.deepcopy(self._directories.get((username, directory), []))
+        finally:
+            if self.in_flight_probe is not None:
+                self.in_flight_probe(-1)
 
 
 @dataclass

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -258,5 +258,34 @@ class TestFanoutBrowseRaceRegression(unittest.TestCase):
             )
 
 
+class TestFanoutBrowseAtexitDetach(unittest.TestCase):
+    def test_workers_removed_from_atexit_registry_on_return(self):
+        """Workers must be detached from concurrent.futures' atexit registry.
+
+        Otherwise the process's shutdown handler joins them on exit, which
+        on a slow slskd peer (30-60 s TCP timeout) bleeds past the cycle
+        boundary and delays the next systemd-timer fire. Production fix
+        for issue #198 code-review finding #2.
+        """
+        import concurrent.futures.thread as _cft
+        slskd = FakeSlskdAPI()
+        for i in range(5):
+            slskd.users.set_directory(f"u{i}", f"d{i}", [_make_directory(f"d{i}")])
+        work = [(f"u{i}", f"d{i}") for i in range(5)]
+
+        ctx = _make_ctx(slskd)
+        registry_before = set(_cft._threads_queues)
+        _fanout_browse_users(work, slskd, ctx, max_workers=4, deadline_s=5.0)
+        registry_after = set(_cft._threads_queues)
+
+        # No new fan-out workers should remain in the global atexit registry.
+        new_entries = registry_after - registry_before
+        self.assertEqual(
+            new_entries, set(),
+            f"fan-out left {len(new_entries)} workers in atexit registry — "
+            f"these would block process exit on slow peers",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -1,0 +1,262 @@
+"""Tests for the bounded parallel browse fan-out primitive (issue #198 U2).
+
+The fan-out function `_fanout_browse_users` lives in `lib/browse.py` next to
+`_browse_directories`. It accepts a flat list of `(username, file_dir)` work
+items, submits each to a bounded `ThreadPoolExecutor`, and bounds wall-clock
+via a per-wave deadline. Returns the set of usernames whose futures had not
+completed by the deadline.
+
+These tests pin down:
+  * happy-path bucket population
+  * pre-create-bucket invariant (no `setdefault` race across futures)
+  * empty work, all-exceptions, all-failure tolerance
+  * deadline trips populate the timed-out set
+  * wall-clock bound (manual `shutdown(wait=False, cancel_futures=True)` works)
+  * deadline=0 short-circuit
+  * concurrency cap honored
+  * 1-user × N-dirs race regression (the case Step 1 pre-create fixes)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from typing import Any
+from unittest.mock import MagicMock
+
+from lib.browse import _fanout_browse_users
+from lib.context import CratediggerContext
+from tests.fakes import FakeSlskdAPI
+
+
+def _make_ctx(slskd: Any) -> CratediggerContext:
+    """Minimal context wired to a slskd fake — only fields the fan-out reads."""
+    return CratediggerContext(
+        cfg=MagicMock(),
+        slskd=slskd,
+        pipeline_db_source=MagicMock(),
+    )
+
+
+def _make_directory(dir_path: str) -> dict[str, Any]:
+    """Slskd-shaped directory listing (single track)."""
+    return {
+        "directory": dir_path,
+        "files": [{"filename": "01 - Track.flac", "size": 100}],
+    }
+
+
+class TestFanoutBrowseHappyPath(unittest.TestCase):
+    def test_populates_cache_for_all_user_dir_pairs(self):
+        """5 users × 3 dirs all return immediately → 15 cache entries, no timeouts."""
+        slskd = FakeSlskdAPI()
+        users = [f"user{i}" for i in range(5)]
+        dirs = ["A", "B", "C"]
+        work = []
+        for u in users:
+            for d in dirs:
+                slskd.users.set_directory(u, d, [_make_directory(d)])
+                work.append((u, d))
+
+        ctx = _make_ctx(slskd)
+        timed_out = _fanout_browse_users(
+            work, slskd, ctx, max_workers=8, deadline_s=5.0
+        )
+
+        self.assertEqual(timed_out, set())
+        self.assertEqual(set(ctx.folder_cache.keys()), set(users))
+        for u in users:
+            self.assertEqual(set(ctx.folder_cache[u].keys()), set(dirs))
+            self.assertEqual(set(ctx._folder_cache_ts[u].keys()), set(dirs))
+
+    def test_pre_creates_user_buckets_for_every_work_item(self):
+        """Every user in the wave must have an inner dict before any future writes.
+
+        Pin the contract that fixes the `setdefault + nested-write` race: the
+        function must pre-create `ctx.folder_cache[user] = {}` for every user
+        in the wave before submitting any future. We probe this by checking
+        that the inner dict exists for users whose dirs ALL fail — if buckets
+        were created lazily on success, those users would be absent from
+        `folder_cache` entirely.
+        """
+        slskd = FakeSlskdAPI()
+        # user_ok succeeds, user_fail's dir raises.
+        slskd.users.set_directory("user_ok", "A", [_make_directory("A")])
+        slskd.users.set_directory_error("user_fail", "B", Exception("peer gone"))
+        work = [("user_ok", "A"), ("user_fail", "B")]
+
+        ctx = _make_ctx(slskd)
+        _fanout_browse_users(
+            work, slskd, ctx, max_workers=4, deadline_s=5.0
+        )
+
+        self.assertIn("user_ok", ctx.folder_cache)
+        self.assertIn("user_fail", ctx.folder_cache)
+        self.assertEqual(ctx.folder_cache["user_fail"], {})
+
+
+class TestFanoutBrowseEdgeCases(unittest.TestCase):
+    def test_empty_work_list_returns_empty_set_no_exception(self):
+        slskd = FakeSlskdAPI()
+        ctx = _make_ctx(slskd)
+        timed_out = _fanout_browse_users(
+            [], slskd, ctx, max_workers=4, deadline_s=5.0
+        )
+        self.assertEqual(timed_out, set())
+        self.assertEqual(ctx.folder_cache, {})
+
+    def test_all_peers_fail_with_exceptions_no_writes_no_timeouts(self):
+        """Per-task exceptions are not timeouts — folder_cache stays empty."""
+        slskd = FakeSlskdAPI()
+        slskd.users.set_directory_error("user1", "A", RuntimeError("x"))
+        slskd.users.set_directory_error("user2", "B", ConnectionError("y"))
+        work = [("user1", "A"), ("user2", "B")]
+
+        ctx = _make_ctx(slskd)
+        timed_out = _fanout_browse_users(
+            work, slskd, ctx, max_workers=4, deadline_s=5.0
+        )
+
+        self.assertEqual(timed_out, set())
+        # Buckets pre-created but empty; no per-(user,dir) write succeeded.
+        self.assertEqual(ctx.folder_cache["user1"], {})
+        self.assertEqual(ctx.folder_cache["user2"], {})
+
+
+class TestFanoutBrowseDeadline(unittest.TestCase):
+    def test_deadline_trips_marks_slow_users_as_timed_out(self):
+        slskd = FakeSlskdAPI()
+        # user_a: two dirs, both fast.
+        slskd.users.set_directory("user_a", "A1", [_make_directory("A1")])
+        slskd.users.set_directory("user_a", "A2", [_make_directory("A2")])
+        # users B and C: one dir each, delayed past the deadline.
+        slskd.users.set_directory("user_b", "B", [_make_directory("B")])
+        slskd.users.set_directory("user_c", "C", [_make_directory("C")])
+        slskd.users.set_directory_delay("user_b", "B", 0.5)
+        slskd.users.set_directory_delay("user_c", "C", 0.5)
+        work = [
+            ("user_a", "A1"), ("user_a", "A2"),
+            ("user_b", "B"), ("user_c", "C"),
+        ]
+
+        ctx = _make_ctx(slskd)
+        t0 = time.monotonic()
+        timed_out = _fanout_browse_users(
+            work, slskd, ctx, max_workers=8, deadline_s=0.2
+        )
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(timed_out, {"user_b", "user_c"})
+        self.assertEqual(set(ctx.folder_cache["user_a"].keys()), {"A1", "A2"})
+        self.assertEqual(ctx.folder_cache["user_b"], {})
+        self.assertEqual(ctx.folder_cache["user_c"], {})
+        self.assertLess(elapsed, 1.0, f"deadline did not bound wall-clock (elapsed={elapsed:.3f}s)")
+
+    def test_wall_clock_bound_by_deadline_not_slowest_task(self):
+        """A 5s task should NOT keep the function blocked past `deadline_s`.
+
+        The naive `with ThreadPoolExecutor(...)` exit calls `shutdown(wait=True)`
+        which would block on every running future. The implementation must use
+        manual lifetime + `shutdown(wait=False, cancel_futures=True)`.
+        """
+        slskd = FakeSlskdAPI()
+        slskd.users.set_directory("user_slow", "X", [_make_directory("X")])
+        slskd.users.set_directory_delay("user_slow", "X", 5.0)
+        work = [("user_slow", "X")]
+
+        ctx = _make_ctx(slskd)
+        t0 = time.monotonic()
+        timed_out = _fanout_browse_users(
+            work, slskd, ctx, max_workers=4, deadline_s=0.2
+        )
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(timed_out, {"user_slow"})
+        self.assertLess(
+            elapsed, 0.5,
+            f"shutdown(wait=False) did not short-circuit (elapsed={elapsed:.3f}s)",
+        )
+
+    def test_deadline_zero_short_circuits_all_users(self):
+        slskd = FakeSlskdAPI()
+        slskd.users.set_directory("u1", "A", [_make_directory("A")])
+        slskd.users.set_directory("u2", "B", [_make_directory("B")])
+        # Tiny delay so the futures definitely haven't finished by deadline.
+        slskd.users.set_directory_delay("u1", "A", 0.05)
+        slskd.users.set_directory_delay("u2", "B", 0.05)
+        work = [("u1", "A"), ("u2", "B")]
+
+        ctx = _make_ctx(slskd)
+        timed_out = _fanout_browse_users(
+            work, slskd, ctx, max_workers=4, deadline_s=0.0
+        )
+
+        self.assertEqual(timed_out, {"u1", "u2"})
+        self.assertEqual(ctx.folder_cache["u1"], {})
+        self.assertEqual(ctx.folder_cache["u2"], {})
+
+
+class TestFanoutBrowseConcurrencyCap(unittest.TestCase):
+    def test_max_workers_caps_in_flight_directory_calls(self):
+        slskd = FakeSlskdAPI()
+        peak = 0
+        in_flight = 0
+        lock = threading.Lock()
+
+        def probe(delta: int) -> None:
+            nonlocal peak, in_flight
+            with lock:
+                in_flight += delta
+                if in_flight > peak:
+                    peak = in_flight
+
+        slskd.users.in_flight_probe = probe
+
+        work = []
+        for i in range(50):
+            u, d = f"u{i}", f"d{i}"
+            slskd.users.set_directory(u, d, [_make_directory(d)])
+            slskd.users.set_directory_delay(u, d, 0.05)  # hold each call long enough to overlap
+            work.append((u, d))
+
+        ctx = _make_ctx(slskd)
+        _fanout_browse_users(
+            work, slskd, ctx, max_workers=4, deadline_s=10.0
+        )
+
+        self.assertLessEqual(peak, 4, f"max_workers=4 cap was violated; peak={peak}")
+        # Sanity: most of the 50 work items completed within the 10s deadline.
+        self.assertGreaterEqual(len(ctx.folder_cache), 40)
+
+
+class TestFanoutBrowseRaceRegression(unittest.TestCase):
+    def test_one_user_eight_dirs_no_lost_entries_across_iterations(self):
+        """Regression for the `setdefault + nested-write` race.
+
+        With one user contributing 8 different dirs, all 8 futures share the
+        same inner dict. The pre-create-buckets step removes the race; this
+        test pins that no entries are lost across many iterations.
+        """
+        for iteration in range(50):
+            slskd = FakeSlskdAPI()
+            user = "user1"
+            dirs = [f"d{i}" for i in range(8)]
+            for d in dirs:
+                slskd.users.set_directory(user, d, [_make_directory(d)])
+            work = [(user, d) for d in dirs]
+
+            ctx = _make_ctx(slskd)
+            timed_out = _fanout_browse_users(
+                work, slskd, ctx, max_workers=8, deadline_s=5.0
+            )
+
+            self.assertEqual(timed_out, set(), f"iteration {iteration}: unexpected timeouts")
+            self.assertEqual(
+                len(ctx.folder_cache[user]), 8,
+                f"iteration {iteration}: expected 8 entries, got {len(ctx.folder_cache[user])}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -685,5 +685,53 @@ class TestMainCLIParsing(unittest.TestCase):
                 )
 
 
+class TestFanoutConfigClamping(unittest.TestCase):
+    """Reject zero/negative fan-out config at parse time so a typo doesn't
+    crash the first album of every cycle (issue #198 review finding #4)."""
+
+    def _parse(self, **search_settings) -> CratediggerConfig:
+        ini = configparser.RawConfigParser()
+        ini["Search Settings"] = {k: str(v) for k, v in search_settings.items()}
+        return CratediggerConfig.from_ini(ini)
+
+    def test_browse_top_k_zero_clamps_to_one(self):
+        cfg = self._parse(browse_top_k=0)
+        self.assertEqual(cfg.browse_top_k, 1)
+
+    def test_browse_top_k_negative_clamps_to_one(self):
+        cfg = self._parse(browse_top_k=-5)
+        self.assertEqual(cfg.browse_top_k, 1)
+
+    def test_browse_global_max_workers_zero_clamps_to_one(self):
+        cfg = self._parse(browse_global_max_workers=0)
+        self.assertEqual(cfg.browse_global_max_workers, 1)
+
+    def test_search_max_inflight_zero_clamps_to_one(self):
+        cfg = self._parse(search_max_inflight=0)
+        self.assertEqual(cfg.search_max_inflight, 1)
+
+    def test_browse_wave_deadline_negative_clamps_to_zero(self):
+        cfg = self._parse(browse_wave_deadline_s=-1.0)
+        self.assertEqual(cfg.browse_wave_deadline_s, 0.0)
+
+    def test_browse_cycle_budget_negative_clamps_to_zero(self):
+        cfg = self._parse(browse_cycle_budget_s=-100.0)
+        self.assertEqual(cfg.browse_cycle_budget_s, 0.0)
+
+    def test_valid_values_pass_through_unchanged(self):
+        cfg = self._parse(
+            browse_top_k=15,
+            browse_wave_deadline_s=10.0,
+            browse_global_max_workers=64,
+            browse_cycle_budget_s=300.0,
+            search_max_inflight=2,
+        )
+        self.assertEqual(cfg.browse_top_k, 15)
+        self.assertEqual(cfg.browse_wave_deadline_s, 10.0)
+        self.assertEqual(cfg.browse_global_max_workers, 64)
+        self.assertEqual(cfg.browse_cycle_budget_s, 300.0)
+        self.assertEqual(cfg.search_max_inflight, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -1,9 +1,11 @@
 """Tests for global user cooldown system (issue #39)."""
 
+import configparser
 import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
+from lib.config import CratediggerConfig
 from lib.context import CratediggerContext
 from lib.quality import CooldownConfig, should_cooldown
 from cratedigger import TrackRecord
@@ -80,8 +82,12 @@ class TestEnqueueCooldownFiltering(unittest.TestCase):
             {"username": u} for u in (denied_users or [])
         ]
         source._get_db.return_value = db
+        # Use a real CratediggerConfig with defaults so wave-based enqueue
+        # (issue #198 U3) reads numeric values for browse_top_k /
+        # browse_cycle_budget_s rather than MagicMock proxies.
+        cfg = CratediggerConfig.from_ini(configparser.ConfigParser())
         ctx = CratediggerContext(
-            cfg=MagicMock(),
+            cfg=cfg,
             slskd=MagicMock(),
             pipeline_db_source=source,
             cooled_down_users=cooled_down_users or set(),

--- a/tests/test_cycle_summary.py
+++ b/tests/test_cycle_summary.py
@@ -149,6 +149,7 @@ class TestFormatCycleSummary(unittest.TestCase):
         "match_time_s=",
         "cache_load_s=",
         "peers_browsed=",
+        "peers_browsed_lazy=",
         "peers_timed_out=",
         "fanout_waves=",
         "cycle_total_s=",
@@ -166,6 +167,7 @@ class TestFormatCycleSummary(unittest.TestCase):
         ctx.match_time_s = 4.5
         ctx.cache_load_s = 6.7
         ctx.peers_browsed = 42
+        ctx.peers_browsed_lazy = 5
         ctx.peers_timed_out = 3
         ctx.fanout_waves = 2
         line = format_cycle_summary(ctx, elapsed_s=99.9)
@@ -173,6 +175,7 @@ class TestFormatCycleSummary(unittest.TestCase):
         self.assertIn("match_time_s=4.5", line)
         self.assertIn("cache_load_s=6.7", line)
         self.assertIn("peers_browsed=42", line)
+        self.assertIn("peers_browsed_lazy=5", line)
         self.assertIn("peers_timed_out=3", line)
         self.assertIn("fanout_waves=2", line)
         self.assertIn("cycle_total_s=99.9", line)
@@ -287,8 +290,10 @@ class TestBrowseTimeAccumulator(unittest.TestCase):
             ctx.browse_time_s, 0.0,
             "exception inside _browse_directories must still credit browse_time_s",
         )
-        # peers_browsed should also be credited (we tried)
-        self.assertEqual(ctx.peers_browsed, 1)
+        # The lazy-fallback path bumps peers_browsed_lazy (issue #198 review #5);
+        # peers_browsed is reserved for fan-out submissions in lib/enqueue.py.
+        self.assertEqual(ctx.peers_browsed_lazy, 1)
+        self.assertEqual(ctx.peers_browsed, 0, "fan-out path should not be credited")
 
     def test_browse_time_zero_when_cache_warm(self):
         ctx = _make_real_ctx()
@@ -302,6 +307,7 @@ class TestBrowseTimeAccumulator(unittest.TestCase):
             "cache hit shouldn't count as browse work",
         )
         self.assertEqual(ctx.peers_browsed, 0)
+        self.assertEqual(ctx.peers_browsed_lazy, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -1,0 +1,498 @@
+"""Wave-based fan-out tests for try_enqueue / try_multi_enqueue (issue #198 U3).
+
+The refactor replaces the sequential per-user iteration in `try_enqueue` and
+`try_multi_enqueue` with: (1) chunk eligible users into waves of
+`cfg.browse_top_k`, (2) parallel browse via `_fanout_browse_users`, (3) match
+in upload-speed order against the now-warm folder cache, (4) exit on first
+successful enqueue. A per-cycle browse budget short-circuits remaining work.
+
+These tests pin:
+  * top-K hit → only first wave fans out
+  * lazy-tail hit → second wave fans out, third never
+  * all-miss → every eligible user fans out, matched=False
+  * 0 eligible (cooldown/denylist) → no fan-out
+  * fewer than K eligible → single short wave
+  * cached entries skipped from the work list
+  * cycle budget short-circuit between albums and between waves
+  * wave deadline trips → users land in broken_user
+  * match-rate regression (high-rank user wins when low-rank users timed out)
+  * per-cycle scope of broken_user
+  * had_enqueue_failure tracking when enqueue raises
+  * try_multi_enqueue: per-disc wave loop reuses populated cache
+"""
+
+from __future__ import annotations
+
+import configparser
+import unittest
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+from cratedigger import TrackRecord
+from lib.config import CratediggerConfig
+from lib.context import CratediggerContext
+from lib.enqueue import try_enqueue, try_multi_enqueue
+from lib.matching import MatchResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_cfg(
+    *,
+    browse_top_k: int = 20,
+    browse_wave_deadline_s: float = 20.0,
+    browse_global_max_workers: int = 32,
+    browse_cycle_budget_s: float = 240.0,
+) -> CratediggerConfig:
+    """Build a CratediggerConfig with the four U2 fan-out knobs configurable."""
+    ini = configparser.ConfigParser()
+    ini["Search Settings"] = {
+        "minimum_filename_match_ratio": "0.5",
+        "ignored_users": "",
+        "allowed_filetypes": "flac,mp3",
+        "browse_parallelism": "4",
+        "browse_top_k": str(browse_top_k),
+        "browse_wave_deadline_s": str(browse_wave_deadline_s),
+        "browse_global_max_workers": str(browse_global_max_workers),
+        "browse_cycle_budget_s": str(browse_cycle_budget_s),
+    }
+    return CratediggerConfig.from_ini(ini)
+
+
+def _make_ctx(
+    cfg: CratediggerConfig,
+    *,
+    user_upload_speed: dict[str, int] | None = None,
+    cooled_down_users: set[str] | None = None,
+    denied_users: list[str] | None = None,
+    cycle_browse_time_s: float = 0.0,
+) -> CratediggerContext:
+    """Build a context with controllable cooldowns and denylist."""
+    source = MagicMock()
+    db = MagicMock()
+    db.get_denylisted_users.return_value = [
+        {"username": u} for u in (denied_users or [])
+    ]
+    source._get_db.return_value = db
+    ctx = CratediggerContext(
+        cfg=cfg,
+        slskd=MagicMock(),
+        pipeline_db_source=source,
+        user_upload_speed=user_upload_speed or {},
+        cooled_down_users=cooled_down_users or set(),
+        cycle_browse_time_s=cycle_browse_time_s,
+    )
+    ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
+    return ctx
+
+
+def _make_results(users: list[str]) -> dict[str, dict[str, list[str]]]:
+    """Build a search-results dict where each user has one flac dir."""
+    return {u: {"flac": [f"Music\\{u}\\Album"]} for u in users}
+
+
+def _make_tracks() -> list[TrackRecord]:
+    return cast(
+        "list[TrackRecord]",
+        [{"albumId": 1, "title": "Track 1", "mediumNumber": 1}],
+    )
+
+
+def _ranked_users(n: int) -> list[str]:
+    """Return n usernames with descending upload speeds (fastest first)."""
+    return [f"u{i:02d}" for i in range(n)]
+
+
+def _upload_speeds(users: list[str]) -> dict[str, int]:
+    """Map usernames to upload speeds so list order = upload-speed order desc."""
+    return {u: 10_000 - i for i, u in enumerate(users)}
+
+
+def _match_for(username: str, file_dir: str) -> MatchResult:
+    """Build a MatchResult that matches strictly for one user."""
+    return MatchResult(
+        matched=True,
+        directory={"directory": file_dir, "files": []},
+        file_dir=file_dir,
+        candidates=[],
+    )
+
+
+def _nomatch() -> MatchResult:
+    return MatchResult(matched=False, directory={}, file_dir="", candidates=[])
+
+
+# ---------------------------------------------------------------------------
+# Wave-shape tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaveShape(unittest.TestCase):
+    """Pin how many users land in each fan-out wave."""
+
+    def test_top_k_hit_fans_out_once(self):
+        """Match in top-5 of 30 users, K=20 → single fan-out wave covering top-20."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(30)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        winner = users[3]
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            if username == winner:
+                return _match_for(winner, f"Music\\{winner}\\Album")
+            return _nomatch()
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()) as m_fan, \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(m_fan.call_count, 1, "expected a single fan-out wave for top-K hit")
+        work = m_fan.call_args[0][0]
+        wave_users = {u for (u, _d) in work}
+        # Match was at rank 3, but the entire wave's work is submitted before
+        # matching iterates — the work covers the top-K (20) by upload speed.
+        self.assertEqual(len(wave_users), 20, f"expected 20 users in wave-1 work, got {len(wave_users)}")
+        self.assertEqual(wave_users, set(users[:20]))
+
+    def test_lazy_tail_hit_fans_out_two_waves(self):
+        """Match at rank 35 of 50, K=20 → two fan-out waves, third never."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(50)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        winner = users[35]
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            if username == winner:
+                return _match_for(winner, f"Music\\{winner}\\Album")
+            return _nomatch()
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()) as m_fan, \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(m_fan.call_count, 2, "expected exactly two fan-out waves")
+        wave2_work = m_fan.call_args_list[1][0][0]
+        wave2_users = {u for (u, _d) in wave2_work}
+        self.assertEqual(wave2_users, set(users[20:40]))
+
+    def test_all_peers_miss_fans_out_every_wave(self):
+        """30 users, no match → ceil(30/20)=2 fan-outs, matched=False."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(30)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()) as m_fan, \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()), \
+             patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        self.assertFalse(attempt.enqueue_failed)
+        self.assertEqual(m_fan.call_count, 2)
+
+    def test_zero_eligible_users_skips_fanout(self):
+        """All users on cooldown or denylisted → no fan-out call at all."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(5)
+        ctx = _make_ctx(
+            cfg,
+            user_upload_speed=_upload_speeds(users),
+            cooled_down_users={users[0], users[1], users[2]},
+            denied_users=[users[3], users[4]],
+        )
+        results = _make_results(users)
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()) as m_fan, \
+             patch("lib.enqueue.check_for_match") as m_match:
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        m_fan.assert_not_called()
+        m_match.assert_not_called()
+
+    def test_fewer_than_k_eligible_runs_single_short_wave(self):
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(10)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()) as m_fan, \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()):
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertEqual(m_fan.call_count, 1)
+        work = m_fan.call_args[0][0]
+        wave_users = {u for (u, _d) in work}
+        self.assertEqual(wave_users, set(users))
+
+    def test_cached_entries_skipped_from_work_list(self):
+        """Pre-populate folder_cache for half the dirs → only uncached are submitted."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(4)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        # Pre-cache the first two users' directories.
+        for u in users[:2]:
+            ctx.folder_cache[u] = {f"Music\\{u}\\Album": {"directory": "x", "files": []}}
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()) as m_fan, \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()):
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertEqual(m_fan.call_count, 1)
+        work = m_fan.call_args[0][0]
+        # Only the two un-cached users contribute work items.
+        work_users = {u for (u, _d) in work}
+        self.assertEqual(work_users, set(users[2:]))
+
+
+# ---------------------------------------------------------------------------
+# Cycle budget short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestCycleBudget(unittest.TestCase):
+    def test_budget_exhausted_inter_album_skips_fanout(self):
+        """If ctx.cycle_browse_time_s already > budget at entry, no fan-out."""
+        cfg = _make_cfg(browse_cycle_budget_s=1.0)
+        users = _ranked_users(5)
+        ctx = _make_ctx(
+            cfg,
+            user_upload_speed=_upload_speeds(users),
+            cycle_browse_time_s=2.0,  # already over budget
+        )
+        results = _make_results(users)
+
+        with patch("lib.enqueue._fanout_browse_users") as m_fan, \
+             patch("lib.enqueue.check_for_match") as m_match:
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        self.assertFalse(attempt.enqueue_failed)
+        m_fan.assert_not_called()
+        m_match.assert_not_called()
+
+    def test_budget_exhausted_inter_wave_stops_subsequent_waves(self):
+        """First wave inflates cycle_browse_time_s above budget → no second wave."""
+        cfg = _make_cfg(browse_top_k=20, browse_cycle_budget_s=1.0)
+        users = _ranked_users(40)  # would normally take 2 waves
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+
+        # Side effect: bump cycle_browse_time_s past budget on the first call.
+        def bump_budget(*args, **kwargs):
+            ctx.cycle_browse_time_s += 1.5
+            return set()
+
+        with patch("lib.enqueue._fanout_browse_users", side_effect=bump_budget) as m_fan, \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        self.assertEqual(m_fan.call_count, 1, "second wave must be short-circuited")
+
+
+# ---------------------------------------------------------------------------
+# Wave deadline → broken_user updates
+# ---------------------------------------------------------------------------
+
+
+class TestWaveDeadline(unittest.TestCase):
+    def test_timed_out_users_added_to_broken_user(self):
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(5)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+
+        # First two users time out.
+        slow_users = {users[0], users[1]}
+
+        def fake_fanout(work, slskd, ctx, max_workers, deadline_s):
+            return slow_users
+
+        with patch("lib.enqueue._fanout_browse_users", side_effect=fake_fanout), \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()) as m_match:
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        for u in slow_users:
+            self.assertIn(u, ctx.broken_user)
+        # Match was not invoked for the timed-out users (they were skipped).
+        match_users = {call.args[3] for call in m_match.call_args_list}
+        self.assertTrue(slow_users.isdisjoint(match_users))
+
+    def test_match_rate_regression_high_rank_user_wins(self):
+        """Wave-1 users all time out, wave-2 user X is the only true match."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(40)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        winner = users[25]
+
+        # Wave 1 (top-20): everyone times out.
+        # Wave 2 (next 20): no timeouts.
+        def fake_fanout(work, slskd, ctx, max_workers, deadline_s):
+            wave_users = {u for (u, _d) in work}
+            if wave_users <= set(users[:20]):
+                return wave_users
+            return set()
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            if username == winner:
+                return _match_for(winner, f"Music\\{winner}\\Album")
+            return _nomatch()
+
+        with patch("lib.enqueue._fanout_browse_users", side_effect=fake_fanout), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        for u in users[:20]:
+            self.assertIn(u, ctx.broken_user, f"wave-1 user {u} should be broken")
+
+    def test_broken_user_is_per_cycle_not_persistent(self):
+        """A fresh CratediggerContext starts with empty broken_user."""
+        cfg = _make_cfg()
+        ctx = CratediggerContext(cfg=cfg, slskd=MagicMock(), pipeline_db_source=MagicMock())
+        self.assertEqual(ctx.broken_user, [])
+
+
+# ---------------------------------------------------------------------------
+# Enqueue-failure path (had_enqueue_failure tracking)
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueFailureTracking(unittest.TestCase):
+    def test_enqueue_exception_marks_flag_and_keeps_iterating(self):
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(3)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        # Every user matches; first user's enqueue raises, second returns None,
+        # third also matches but enqueue should be tried until success or end.
+        match_returns = {
+            u: _match_for(u, f"Music\\{u}\\Album") for u in users
+        }
+
+        enqueue_calls: list[str] = []
+
+        def fake_enqueue(*, username, files, file_dir, ctx):
+            enqueue_calls.append(username)
+            if username == users[0]:
+                raise RuntimeError("transient slskd hiccup")
+            if username == users[1]:
+                return None  # treated as failure, keep iterating
+            return [MagicMock()]
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch(
+                 "lib.enqueue.check_for_match",
+                 side_effect=lambda tracks, ft, dirs, u, ctx: match_returns[u],
+             ), \
+             patch("lib.enqueue.slskd_do_enqueue", side_effect=fake_enqueue):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        # All three users were tried; final user succeeded.
+        self.assertEqual(enqueue_calls, list(users))
+        self.assertTrue(attempt.matched)
+
+    def test_enqueue_failure_with_no_eventual_success_sets_flag(self):
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(2)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        match_returns = {
+            u: _match_for(u, f"Music\\{u}\\Album") for u in users
+        }
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch(
+                 "lib.enqueue.check_for_match",
+                 side_effect=lambda tracks, ft, dirs, u, ctx: match_returns[u],
+             ), \
+             patch("lib.enqueue.slskd_do_enqueue", return_value=None):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        self.assertTrue(attempt.enqueue_failed)
+
+
+# ---------------------------------------------------------------------------
+# Multi-disc
+# ---------------------------------------------------------------------------
+
+
+class TestMultiDiscFanout(unittest.TestCase):
+    def test_multi_disc_per_disc_uses_warm_cache_across_discs(self):
+        """2 discs, disc 1 finds match in user X, disc 2 in user Y. Cache populated
+        by disc 1's wave is reused for disc 2 — no duplicate (user, dir) work."""
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(5)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        # Each user has one dir; results dict shape: {user: {ft: [dirs]}}
+        results = _make_results(users)
+
+        # Build a 2-disc release.
+        release = MagicMock()
+        media1 = MagicMock(medium_number=1)
+        media2 = MagicMock(medium_number=2)
+        release.media = [media1, media2]
+
+        all_tracks = cast(
+            "list[TrackRecord]",
+            [
+                {"albumId": 1, "title": "Disc1 Track 1", "mediumNumber": 1},
+                {"albumId": 1, "title": "Disc2 Track 1", "mediumNumber": 2},
+            ],
+        )
+
+        # Side-effect: simulate the fan-out populating folder_cache for the
+        # work items it received. Track which (user, dir) pairs were actually
+        # submitted across calls so the test can assert no duplicates.
+        seen_work: list[tuple[str, str]] = []
+
+        def fake_fanout(work, slskd, ctx, max_workers, deadline_s):
+            for u, d in work:
+                seen_work.append((u, d))
+                ctx.folder_cache.setdefault(u, {})[d] = {"directory": d, "files": []}
+            return set()
+
+        # disc 1 matches user X (rank 2), disc 2 matches user Y (rank 4).
+        disc1_winner = users[2]
+        disc2_winner = users[4]
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            disc_no = tracks[0]["mediumNumber"]
+            if disc_no == 1 and username == disc1_winner:
+                return _match_for(disc1_winner, file_dirs[0])
+            if disc_no == 2 and username == disc2_winner:
+                return _match_for(disc2_winner, file_dirs[0])
+            return _nomatch()
+
+        with patch("lib.enqueue._fanout_browse_users", side_effect=fake_fanout), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]), \
+             patch("lib.enqueue.cancel_and_delete"):
+            attempt = try_multi_enqueue(release, all_tracks, results, "flac", ctx)
+
+        self.assertTrue(attempt.matched, f"expected match, got {attempt!r}")
+        # No (user, dir) duplicate across the per-disc passes — the cache from
+        # disc 1's wave eliminates re-browsing for disc 2.
+        self.assertEqual(
+            len(seen_work), len(set(seen_work)),
+            f"duplicate (user, dir) work across disc waves: {seen_work}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -330,6 +330,45 @@ class TestWaveDeadline(unittest.TestCase):
         match_users = {call.args[3] for call in m_match.call_args_list}
         self.assertTrue(slow_users.isdisjoint(match_users))
 
+    def test_broken_users_excluded_from_subsequent_wave_work_list(self):
+        """Wave-1 timeouts must NOT be re-submitted in wave-2's work plan.
+
+        Regression for the #198 code-review finding: the match loop already
+        skips broken users, but the work-list builder didn't — paying another
+        browse_wave_deadline_s to re-confirm dead peers each wave. With a
+        2-wave album where wave-1 times out users, wave-2's submitted work
+        must contain ZERO of those usernames.
+        """
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(40)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+        wave1_users = set(users[:20])
+
+        call_history: list[set[str]] = []
+
+        def fake_fanout(work, slskd, ctx, max_workers, deadline_s):
+            wave_users = {u for (u, _d) in work}
+            call_history.append(wave_users)
+            # Wave 1: every user times out. Wave 2: nobody times out.
+            if wave_users <= wave1_users:
+                return wave_users
+            return set()
+
+        with patch("lib.enqueue._fanout_browse_users", side_effect=fake_fanout), \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()):
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertEqual(len(call_history), 2, "expected 2 waves")
+        wave2_users = call_history[1]
+        self.assertTrue(
+            wave2_users.isdisjoint(wave1_users),
+            f"wave-2 must not re-submit wave-1's timed-out users; "
+            f"overlap was {wave2_users & wave1_users}",
+        )
+        # And wave-2 should contain the actual rank 20-39 users.
+        self.assertEqual(wave2_users, set(users[20:40]))
+
     def test_match_rate_regression_high_rank_user_wins(self):
         """Wave-1 users all time out, wave-2 user X is the only true match."""
         cfg = _make_cfg(browse_top_k=20)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,6 +11,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -1083,9 +1084,15 @@ class TestSearchLoggingOutcomes(unittest.TestCase):
     """Search logging should preserve telemetry semantics across failures."""
 
     def setUp(self):
+        # Use a real CratediggerConfig with defaults so wave-based enqueue
+        # (issue #198 U3) reads numeric values from cfg.browse_* fields.
+        # MagicMock-as-cfg silently swallowed missing fields and is the exact
+        # anti-pattern code-quality.md § "Decision Logic" warns against.
+        import configparser
+        from lib.config import CratediggerConfig
         self._orig_cfg = cratedigger.cfg
-        cratedigger.cfg = MagicMock()
-        cratedigger.cfg.parallel_searches = 1
+        cratedigger.cfg = CratediggerConfig.from_ini(configparser.ConfigParser())
+        cratedigger.cfg = replace(cratedigger.cfg, parallel_searches=1)
 
     def tearDown(self):
         cratedigger.cfg = self._orig_cfg

--- a/tests/test_search_max_inflight.py
+++ b/tests/test_search_max_inflight.py
@@ -1,0 +1,75 @@
+"""Contract tests for cfg.search_max_inflight (issue #198 U4).
+
+The hard-coded MAX_INFLIGHT=2 in `_search_and_queue_parallel` is replaced
+with `cfg.search_max_inflight` (default 4). These tests pin:
+
+  * The configured value is used to size the ThreadPoolExecutor and the
+    initial seed loop — verified via the "Pipelined search: N albums,
+    K in flight" log line.
+  * Default (4) and a non-default override (1) both round-trip correctly.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import unittest
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+import cratedigger
+from lib.config import CratediggerConfig
+
+
+def _empty_cfg(**overrides) -> CratediggerConfig:
+    """A real CratediggerConfig built from an empty INI (all defaults), then
+    optionally overridden via dataclasses.replace."""
+    cfg = CratediggerConfig.from_ini(configparser.ConfigParser())
+    if overrides:
+        cfg = replace(cfg, **overrides)
+    return cfg
+
+
+class TestSearchMaxInflightPipelineLog(unittest.TestCase):
+    """The pipeline log line must report the configured value, not the
+    legacy hard-coded 2."""
+
+    def setUp(self) -> None:
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+
+    def tearDown(self) -> None:
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+
+    def _run_with(self, cfg: CratediggerConfig) -> str:
+        """Run _search_and_queue_parallel with an empty album list, return
+        the captured "Pipelined search" log line."""
+        cratedigger.cfg = cfg
+        cratedigger.slskd = MagicMock()
+        ctx = MagicMock()
+        ctx.cfg = cfg
+        with self.assertLogs("cratedigger", level=logging.INFO) as captured:
+            cratedigger._search_and_queue_parallel([], ctx)
+        for record in captured.records:
+            if "Pipelined search" in record.message:
+                return record.message
+        self.fail("Expected 'Pipelined search' log line not emitted")
+
+    def test_default_search_max_inflight_is_four(self):
+        cfg = _empty_cfg()
+        self.assertEqual(
+            cfg.search_max_inflight, 4,
+            "default raised from legacy 2 to 4 (issue #198 U4)",
+        )
+        line = self._run_with(cfg)
+        self.assertIn("4 in flight", line)
+
+    def test_configured_value_is_used(self):
+        cfg = _empty_cfg(search_max_inflight=1)
+        line = self._run_with(cfg)
+        self.assertIn("1 in flight", line)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes most of #198. U2/U3/U4 from `docs/plans/2026-05-01-001-feat-browse-fanout-and-pipeline-depth-plan.md`, plus all blocking findings from a 2-reviewer ce-code-review. Two non-blocking findings deferred to #207.

## What ships

| Commit | Summary |
|---|---|
| `8b1ec8d` U2 | `_fanout_browse_users` primitive in `lib/browse.py` — bounded parallel browse with manual `ThreadPoolExecutor` lifetime, `as_completed(timeout=deadline_s)`, `shutdown(wait=False, cancel_futures=True)`. 4 new config knobs. |
| `fb7f14a` U3 | Wave-based refactor of `try_enqueue` / `try_multi_enqueue` via `_iter_wave_matches` generator. Per-cycle `browse_cycle_budget_s` short-circuit. Per-wave R14 log line. |
| `f0ce996` U4 | `cfg.search_max_inflight` (default 4) replaces hard-coded `MAX_INFLIGHT=2` for the search pipeline. |
| `8c0f556` | ce-code-review fixups: 5 findings applied (broken_user filter, atexit detach, docstring, config clamping, peers_browsed split). |

## Why

Production cratedigger cycles routinely topped 27–70 min, with the worst-observed at 7230s (2h0m). The U1 baseline (issue #198 comment) showed browse owning 70% of total wall-clock across 68 cycles. ~97% of the worst outliers' time was a serial per-user browse loop. This PR replaces that loop.

## Key invariants pinned by tests

- **Wave shape**: top-K hit fans out exactly once; lazy tail fans out twice on rank-35 match; zero-eligible skips fan-out entirely.
- **Wall-clock bound**: 5s task with 0.2s deadline returns in <0.5s (proves `cancel_futures=True` actually short-circuits).
- **Race regression**: 50 iterations × 1 user × 8 dirs → no entries lost (single-writer pattern after pre-create-buckets).
- **Cycle budget**: short-circuits both inter-album (entry guard) and inter-wave (between waves of same album).
- **Match-rate regression**: rank-25 user X wins when ranks 1–20 timed out (timed-out peers skipped, not failures-against-X).
- **Multi-disc cache reuse**: 2-disc release submits each `(user, dir)` at most once across discs.
- **broken_user filter** (review fix): wave-2 work plan excludes wave-1's timed-out users.
- **atexit detach** (review fix): fan-out workers do not remain in `concurrent.futures.thread._threads_queues`.

## Quality gate

- Full suite: **2753 pass, 53 skipped** (added 34 new tests across U2/U3/U4 + review fixups)
- pyright: 0 errors on touched files
- `nix build .#checks.x86_64-linux.moduleVm`: green
- INI round-trip: 5 new keys parse correctly

## Code review

Ran ce-code-review with 2 sub-agents (correctness + adversarial, both Opus). Cross-reviewer corroboration on 1 P2 finding. All 5 actionable findings applied in the fixup commit. 2 deferred to research issue #207 (cycle budget undercount + broken_user list-vs-set) — both bounded by per-cycle wave count and pre-existing respectively; right fix depends on `peers_browsed_lazy` data we'll collect post-deploy.

## Test plan after deploy

- [ ] Verify cycle summary log line emits new keys (`peers_browsed_lazy=`)
- [ ] Watch first ~6 cycles for outlier reduction — pre-PR p95 was 3284s, target is < 600s
- [ ] Confirm `cycle_browse_budget_exhausted` log fires at most rarely (would indicate K is too low or peers genuinely flaky)
- [ ] Watch slskd journalctl for new connection-pool errors under raised concurrency
- [ ] Sample `peers_browsed_lazy` for 24 h to inform #207 disposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)