### PR TITLE
feat(cycle): cycle_max_runtime_s gate stops new searches past deadline (#198)

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -578,7 +578,20 @@ def search_and_queue(albums, ctx):
     failed_grab = []
     failed_search = []
     total = len(albums)
+    deadline = ctx.cycle_deadline
     for i, album in enumerate(albums, 1):
+        # Cycle deadline gate (issue #198): once the wall-clock cap is
+        # exceeded, stop submitting new searches. The remaining albums
+        # stay `wanted` for the next cycle — they are NOT marked failed,
+        # so no cascade of forensic rows or wasted retries.
+        if deadline is not None and time.time() > deadline:
+            remaining = total - (i - 1)
+            ctx.cycle_deadline_skipped = remaining
+            logger.info(
+                f"cycle deadline reached: deferring {remaining} album(s) "
+                f"to next cycle (cycle_max_runtime_s={cfg.cycle_max_runtime_s})"
+            )
+            break
         logger.info(f"Album {i}/{total}: {album.artist_name} - {album.title}")
         result = search_for_album(album, ctx)
         if result.success:
@@ -632,8 +645,27 @@ def _search_and_queue_parallel(albums, ctx):
         access to the chosen ``variant.tag`` so the persisted forensic row
         always records which variant was attempted (findings #9 and #18 in
         ce-code-review run 20260430-051904-682683b5).
+
+        Cycle deadline gate (issue #198): once `time.time()` is past
+        `ctx.cycle_deadline`, this stops popping. Albums still on the
+        queue stay `wanted` for the next cycle — never written as
+        `failed_search`, never logged as a `timeout` outcome. In-flight
+        futures continue to completion; only entry of *new* work is
+        gated. See the 2026-05-02 rollback comment on issue #198 for
+        why mid-call termination and cascading skips are forbidden.
         """
         from lib.search import SearchResult
+
+        if (ctx.cycle_deadline is not None
+                and time.time() > ctx.cycle_deadline
+                and album_queue):
+            ctx.cycle_deadline_skipped += len(album_queue)
+            logger.info(
+                f"cycle deadline reached: deferring {len(album_queue)} album(s) "
+                f"to next cycle (cycle_max_runtime_s={cfg.cycle_max_runtime_s})"
+            )
+            album_queue.clear()
+            return None
 
         while album_queue:
             album = album_queue.pop(0)
@@ -884,6 +916,13 @@ def main():
             logger.warning(f"Failed to load user cooldowns: {e}")
 
         cycle_start = time.time()
+        # Cycle deadline (issue #198): None disables the cap (opt-out via
+        # cfg.cycle_max_runtime_s <= 0). The search-phase entry gates in
+        # search_and_queue / _submit_next consult this to stop submitting
+        # *new* searches once exceeded; in-flight work always completes.
+        from lib.context import compute_cycle_deadline
+        _module_ctx.cycle_deadline = compute_cycle_deadline(cfg, now=cycle_start)
+        _module_ctx.cycle_deadline_skipped = 0
 
         # --- Phase 1 + Phase 2 run concurrently ---
         # Phase 1 (poll downloads) operates on status='downloading' rows.

--- a/lib/config.py
+++ b/lib/config.py
@@ -100,6 +100,13 @@ class CratediggerConfig:
     # only). Raised from the legacy hard-coded 2 to keep the search-collection
     # thread fed once browse stops being the dominant cost.
     search_max_inflight: int = 4
+    # Soft per-cycle wall-clock ceiling (seconds). When exceeded, the search
+    # phase stops submitting new searches; in-flight work continues to
+    # completion. Albums not yet submitted stay `wanted` and the next cycle
+    # picks them up. <= 0 disables the cap (preserves the 2026-05-02 rollback
+    # behaviour where slskd is the sole authority — kept as an emergency
+    # opt-out). See issue #198.
+    cycle_max_runtime_s: int = 600
 
     # --- Release ---
     use_most_common_tracknum: bool = True
@@ -274,6 +281,10 @@ class CratediggerConfig:
             browse_top_k=max(1, getint("Search Settings", "browse_top_k", 20)),
             browse_global_max_workers=max(1, getint("Search Settings", "browse_global_max_workers", 32)),
             search_max_inflight=max(1, getint("Search Settings", "search_max_inflight", 4)),
+            # cycle_max_runtime_s is *not* clamped to a minimum: 0 / negative
+            # is the documented opt-out. See `compute_cycle_deadline` in
+            # lib/context.py for the gate logic.
+            cycle_max_runtime_s=getint("Search Settings", "cycle_max_runtime_s", 600),
             # Release
             use_most_common_tracknum=getbool("Release Settings", "use_most_common_tracknum", True),
             allow_multi_disc=getbool("Release Settings", "allow_multi_disc", True),

--- a/lib/context.py
+++ b/lib/context.py
@@ -57,3 +57,24 @@ class CratediggerContext:
     peers_browsed: int = 0
     peers_browsed_lazy: int = 0
     fanout_waves: int = 0
+
+    # --- Cycle deadline (issue #198 follow-up to the 2026-05-02 rollback).
+    # Absolute epoch seconds; None means "no client-side cap" (the rollback
+    # default). Set in main() at cycle_start from cfg.cycle_max_runtime_s.
+    # Search-phase entry gates check `time.time() > cycle_deadline` and
+    # stop submitting *new* work — in-flight searches always finish.
+    cycle_deadline: float | None = None
+    cycle_deadline_skipped: int = 0
+
+
+def compute_cycle_deadline(cfg, now: float) -> float | None:
+    """Return the absolute deadline for this cycle, or None if disabled.
+
+    `cfg.cycle_max_runtime_s <= 0` means the cap is opted out — keeping the
+    2026-05-02 rollback behaviour where slskd's own timeouts are the sole
+    authority. Anything positive becomes `now + cap`.
+    """
+    cap = getattr(cfg, "cycle_max_runtime_s", 0)
+    if cap <= 0:
+        return None
+    return now + cap

--- a/lib/cycle_summary.py
+++ b/lib/cycle_summary.py
@@ -28,5 +28,6 @@ def format_cycle_summary(ctx: CratediggerContext, elapsed_s: float) -> str:
         f"peers_browsed={ctx.peers_browsed} "
         f"peers_browsed_lazy={ctx.peers_browsed_lazy} "
         f"fanout_waves={ctx.fanout_waves} "
+        f"cycle_deadline_skipped={ctx.cycle_deadline_skipped} "
         f"cycle_total_s={elapsed_s:.1f}"
     )

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -159,6 +159,7 @@
     browse_top_k = ${toString cfg.searchSettings.browseTopK}
     browse_global_max_workers = ${toString cfg.searchSettings.browseGlobalMaxWorkers}
     search_max_inflight = ${toString cfg.searchSettings.searchMaxInflight}
+    cycle_max_runtime_s = ${toString cfg.searchSettings.cycleMaxRuntimeS}
 
     [Download Settings]
     download_filtering = ${if cfg.downloadSettings.downloadFiltering then "True" else "False"}
@@ -635,6 +636,27 @@ in {
           a built-in 429-retry loop), but the collect-side workload runs
           in this many threads. Raised from the legacy hard-coded 2 once
           browse fan-out (issue #198) stops being the dominant cost.
+        '';
+      };
+      cycleMaxRuntimeS = mkOption {
+        type = types.int;
+        default = 600;
+        description = ''
+          Soft per-cycle wall-clock ceiling (seconds). Once exceeded, the
+          search phase stops submitting new searches; in-flight work runs
+          to completion and albums not yet submitted stay `wanted` for the
+          next cycle. Worst-case cycle wall is therefore
+          `cycleMaxRuntimeS + longest_in_flight_search`, not unbounded.
+
+          `<= 0` disables the cap and restores the 2026-05-02 rollback
+          behaviour where slskd's own timeouts are the sole authority
+          (kept as an emergency opt-out — see issue #198 for the cure
+          for the 8h hung-cycle failure mode this gate addresses).
+
+          Unlike the rolled-back `browseWaveDeadlineS` and
+          `browseCycleBudgetS`, this gate never terminates work mid-call
+          and never cascades skips to subsequent albums in the same
+          cycle: deferred albums simply roll over.
         '';
       };
       titleBlacklist = mkOption {

--- a/tests/test_cycle_max_runtime.py
+++ b/tests/test_cycle_max_runtime.py
@@ -1,0 +1,311 @@
+"""Cycle deadline gate (issue #198 follow-up to the 2026-05-02 rollback).
+
+The 2026-05-02 rollback (commit 10d8af3) removed every client-side wall-clock
+guard — wave deadlines, cycle browse budget, and the legacy
+`slskd_timeout * 2 + 15` per-search poll cap — because they were terminating
+productive work mid-call and cascading skips across albums (search outcome
+`timeout` jumped from ~1% to 35%, found rate dropped 13.7% → 2.2%).
+
+The cure for the *opposite* failure mode (search 16/16 stalled forever, cycle
+ran 8h53m) is **not** to bring back the same kind of guards. It is to add a
+single cycle-level entry gate:
+
+  * Past `cfg.cycle_max_runtime_s`, do not submit any new searches.
+  * In-flight work continues to completion (no mid-call termination).
+  * Albums not yet submitted stay `wanted` for the next cycle (no cascade
+    write of "failed" or "skipped" outcomes).
+
+This file pins those four invariants. Default is 600 s; opt-out with `<= 0`
+preserves the rollback's "no client-side cap" behaviour for emergencies.
+"""
+from __future__ import annotations
+
+import configparser
+import logging
+import time
+import unittest
+from dataclasses import replace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import cratedigger
+from lib.config import CratediggerConfig
+from lib.context import CratediggerContext
+from lib.cycle_summary import format_cycle_summary
+
+
+def _empty_cfg(**overrides) -> CratediggerConfig:
+    cfg = CratediggerConfig.from_ini(configparser.ConfigParser())
+    if overrides:
+        cfg = replace(cfg, **overrides)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Plumbing: config + context + cycle summary
+# ---------------------------------------------------------------------------
+
+
+class TestCycleMaxRuntimeConfig(unittest.TestCase):
+    """`cfg.cycle_max_runtime_s` exists, defaults to 600, parses from INI."""
+
+    def test_default_is_600(self):
+        cfg = _empty_cfg()
+        self.assertEqual(cfg.cycle_max_runtime_s, 600)
+
+    def test_ini_override(self):
+        ini = configparser.ConfigParser()
+        ini["Search Settings"] = {"cycle_max_runtime_s": "120"}
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.cycle_max_runtime_s, 120)
+
+    def test_zero_means_no_cap(self):
+        """Opt-out: <= 0 preserves the rollback's "no client-side cap"
+        behaviour. The deadline gate must treat this as disabled, not as
+        "deadline = now → skip everything"."""
+        ini = configparser.ConfigParser()
+        ini["Search Settings"] = {"cycle_max_runtime_s": "0"}
+        cfg = CratediggerConfig.from_ini(ini)
+        self.assertEqual(cfg.cycle_max_runtime_s, 0)
+
+
+class TestCycleDeadlineContext(unittest.TestCase):
+    """`ctx.cycle_deadline` and `ctx.cycle_deadline_skipped` exist with safe
+    defaults so consumers can reference them unconditionally."""
+
+    def test_deadline_default_none(self):
+        ctx = CratediggerContext(
+            cfg=MagicMock(), slskd=MagicMock(), pipeline_db_source=MagicMock(),
+        )
+        self.assertIsNone(ctx.cycle_deadline)
+        self.assertEqual(ctx.cycle_deadline_skipped, 0)
+
+
+class TestCycleSummaryDeadlineField(unittest.TestCase):
+    """The cycle-summary line surfaces `cycle_deadline_skipped` so we can
+    grep for cycles that hit the deadline (and how many albums deferred)."""
+
+    def _ctx(self, **fields) -> CratediggerContext:
+        ctx = CratediggerContext(
+            cfg=MagicMock(), slskd=MagicMock(), pipeline_db_source=MagicMock(),
+        )
+        for k, v in fields.items():
+            setattr(ctx, k, v)
+        return ctx
+
+    def test_deadline_skipped_zero_is_emitted(self):
+        line = format_cycle_summary(self._ctx(), elapsed_s=412.3)
+        self.assertIn("cycle_deadline_skipped=0", line)
+
+    def test_deadline_skipped_nonzero(self):
+        line = format_cycle_summary(self._ctx(cycle_deadline_skipped=7), elapsed_s=611.0)
+        self.assertIn("cycle_deadline_skipped=7", line)
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: parallel pipeline gate
+# ---------------------------------------------------------------------------
+
+
+class _Album:
+    """Minimal stand-in for an AlbumRecord that the parallel pipeline
+    reads `id`, `title`, and `artist_name` off."""
+    def __init__(self, album_id: int):
+        self.id = album_id
+        self.title = f"Title{album_id}"
+        self.artist_name = f"Artist{album_id}"
+
+
+def _stub_submit_next_returns_albums(albums: list[_Album]):
+    """Build a fake `_submit_search` that always succeeds — returns a tuple
+    shaped like the real submit_result so the pipeline keeps marching."""
+    from itertools import count
+    counter = count()
+
+    def _fake_submit_search(album, variant, search_cfg, slskd_client):
+        return (next(counter), variant.query or f"q{album.id}", album.id, variant.tag)
+
+    return _fake_submit_search
+
+
+class TestParallelPipelineDeadlineGate(unittest.TestCase):
+    """When `time.time() > ctx.cycle_deadline`, `_submit_next` must return
+    None and log how many albums are deferred. Albums are NOT marked
+    `failed_search` — they simply stay on the queue for the next cycle.
+    """
+
+    def setUp(self) -> None:
+        self._orig_cfg = cratedigger.cfg
+        self._orig_slskd = cratedigger.slskd
+
+    def tearDown(self) -> None:
+        cratedigger.cfg = self._orig_cfg
+        cratedigger.slskd = self._orig_slskd
+
+    def _make_ctx(self, deadline: float | None) -> CratediggerContext:
+        cfg = _empty_cfg(cycle_max_runtime_s=120)
+        cratedigger.cfg = cfg
+        cratedigger.slskd = MagicMock()
+        ctx = CratediggerContext(
+            cfg=cfg,
+            slskd=cratedigger.slskd,
+            pipeline_db_source=MagicMock(),
+        )
+        ctx.cycle_deadline = deadline
+        return ctx
+
+    def test_no_deadline_runs_all_albums(self):
+        """Sanity baseline: with cycle_deadline=None, every album submitted."""
+        ctx = self._make_ctx(deadline=None)
+        albums = [_Album(i) for i in range(5)]
+
+        # Patch the variant selector + submitter + collector to no-op happily.
+        from lib.search import SearchResult, SearchVariant
+        variant = SearchVariant(kind="default", query="q", tag="default", slice_index=None)
+
+        with patch.object(cratedigger, "_select_variant_for_album",
+                          return_value=(variant, "q")), \
+             patch.object(cratedigger, "_submit_search",
+                          side_effect=_stub_submit_next_returns_albums(albums)), \
+             patch.object(cratedigger, "_collect_search_results",
+                          side_effect=lambda *a, **k: SearchResult(
+                              album_id=0, success=False, query="q", outcome="not_found",
+                              variant_tag="default",
+                          )), \
+             patch.object(cratedigger, "_log_search_result"), \
+             patch.object(cratedigger, "find_download"):
+            cratedigger._search_and_queue_parallel(albums, ctx)
+
+        self.assertEqual(ctx.cycle_deadline_skipped, 0)
+
+    def test_past_deadline_skips_remaining(self):
+        """When the deadline has elapsed BEFORE the seed loop runs,
+        no albums get submitted and the deferred counter equals the queue
+        length."""
+        ctx = self._make_ctx(deadline=time.time() - 1.0)  # already past
+        albums = [_Album(i) for i in range(8)]
+
+        submit_calls: list[Any] = []
+
+        def _track_submit(album, variant, search_cfg, slskd_client):
+            submit_calls.append(album.id)
+            return (album.id, "q", album.id, variant.tag)
+
+        from lib.search import SearchVariant
+        variant = SearchVariant(kind="default", query="q", tag="default", slice_index=None)
+
+        with patch.object(cratedigger, "_select_variant_for_album",
+                          return_value=(variant, "q")), \
+             patch.object(cratedigger, "_submit_search", side_effect=_track_submit), \
+             patch.object(cratedigger, "_collect_search_results"), \
+             patch.object(cratedigger, "_log_search_result"), \
+             patch.object(cratedigger, "find_download"), \
+             self.assertLogs("cratedigger", level=logging.INFO) as captured:
+            cratedigger._search_and_queue_parallel(albums, ctx)
+
+        self.assertEqual(submit_calls, [],
+                         "no slskd searches should be submitted past the deadline")
+        self.assertEqual(ctx.cycle_deadline_skipped, 8)
+        deadline_lines = [r.message for r in captured.records
+                          if "cycle deadline" in r.message.lower()]
+        self.assertTrue(deadline_lines, "expected a cycle-deadline log line")
+        self.assertTrue(any("8" in m for m in deadline_lines),
+                        "deferred count should appear in the log line")
+
+    def test_deadline_does_not_mark_failed_search(self):
+        """Deferred albums must not appear in any "failed" bucket — they
+        remain `wanted` and the next cycle picks them up. The skipped
+        counter is the only signal."""
+        ctx = self._make_ctx(deadline=time.time() - 1.0)
+        albums = [_Album(i) for i in range(4)]
+
+        # If the function ever calls _log_search_result on a deferred album
+        # with an outcome != deferred, that would write a forensic row and
+        # consume the album. We assert it is never called.
+        log_calls: list[Any] = []
+
+        def _track_log(album, result, ctx):
+            log_calls.append((album.id, result.outcome))
+
+        from lib.search import SearchVariant
+        variant = SearchVariant(kind="default", query="q", tag="default", slice_index=None)
+
+        with patch.object(cratedigger, "_select_variant_for_album",
+                          return_value=(variant, "q")), \
+             patch.object(cratedigger, "_submit_search"), \
+             patch.object(cratedigger, "_collect_search_results"), \
+             patch.object(cratedigger, "_log_search_result", side_effect=_track_log), \
+             patch.object(cratedigger, "find_download"):
+            cratedigger._search_and_queue_parallel(albums, ctx)
+
+        self.assertEqual(log_calls, [],
+                         "deferred albums must not be logged as failed/timeout")
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: serial pipeline gate
+# ---------------------------------------------------------------------------
+
+
+class TestSerialPipelineDeadlineGate(unittest.TestCase):
+    """The serial path (`search_and_queue` when parallel_searches <= 1 or
+    only one album) must honour the same cycle deadline."""
+
+    def setUp(self) -> None:
+        self._orig_cfg = cratedigger.cfg
+
+    def tearDown(self) -> None:
+        cratedigger.cfg = self._orig_cfg
+
+    def _ctx(self, deadline: float | None) -> CratediggerContext:
+        cfg = _empty_cfg(parallel_searches=1, cycle_max_runtime_s=60)
+        cratedigger.cfg = cfg
+        ctx = CratediggerContext(
+            cfg=cfg, slskd=MagicMock(), pipeline_db_source=MagicMock(),
+        )
+        ctx.cycle_deadline = deadline
+        return ctx
+
+    def test_serial_skips_remaining_past_deadline(self):
+        ctx = self._ctx(deadline=time.time() - 1.0)
+        albums = [_Album(i) for i in range(3)]
+
+        with patch.object(cratedigger, "search_for_album") as mock_search:
+            cratedigger.search_and_queue(albums, ctx)
+
+        self.assertEqual(mock_search.call_count, 0,
+                         "no album should hit search_for_album past deadline")
+        self.assertEqual(ctx.cycle_deadline_skipped, 3)
+
+
+# ---------------------------------------------------------------------------
+# Opt-out: cycle_max_runtime_s <= 0
+# ---------------------------------------------------------------------------
+
+
+class TestZeroMeansDisabled(unittest.TestCase):
+    """`cycle_max_runtime_s <= 0` must NOT cause the deadline to be set
+    (or, equivalently, the gate must treat None and 0 the same). Pinned
+    so the opt-out switch keeps working."""
+
+    def test_zero_disables_deadline_in_ctx(self):
+        cfg = _empty_cfg(cycle_max_runtime_s=0)
+        ctx = CratediggerContext(
+            cfg=cfg, slskd=MagicMock(), pipeline_db_source=MagicMock(),
+        )
+        # Helper used by main() to compute the deadline. Returns None when
+        # the cap is disabled so the gate short-circuits.
+        from lib.context import compute_cycle_deadline
+        self.assertIsNone(compute_cycle_deadline(cfg, now=time.time()))
+
+    def test_positive_returns_future_timestamp(self):
+        from lib.context import compute_cycle_deadline
+        cfg = _empty_cfg(cycle_max_runtime_s=120)
+        now = time.time()
+        deadline = compute_cycle_deadline(cfg, now=now)
+        assert deadline is not None
+        self.assertAlmostEqual(deadline - now, 120.0, places=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a single cycle-level entry gate that bounds cycle wall-time without re-introducing the 2026-05-02 rollback's failure mode. The gate stops submitting *new* searches past `cfg.cycle_max_runtime_s` (default 600s); in-flight work always finishes; deferred albums stay `wanted` and roll over to the next cycle.

Worst-case cycle wall becomes `cycle_max_runtime_s + longest_in_flight_search` (~12–15 min with defaults) instead of unbounded. The 8h53m hung cycle observed on #198 today would have been capped at ~13 min.

## Why this is different from what we rolled back

The 2026-05-02 rollback (10d8af3) deleted three guards because they killed productive work:

| Rolled-back guard | Why it failed | This PR |
|---|---|---|
| `browse_wave_deadline_s` (20s) | Killed peer browses mid-call | No mid-call termination — gates entry of new work only |
| `browse_cycle_budget_s` (240s) | Cascaded skips to 30+ subsequent albums in the same cycle | No cascade — deferred albums roll over fully to the next cycle |
| `slskd_timeout * 2 + 15` (~75s) per-search poll cap | Fired on legitimately slow searches | No per-search cap — slskd's `searchTimeout` remains the primary authority |

The principle: **bound cycle entry, not individual operations.** Once a search/browse is in flight, it runs to completion. Once the cycle wall budget elapses, no *new* albums are submitted, but everything in flight drains naturally.

## Wiring

- `cfg.cycle_max_runtime_s: int = 600` — `<= 0` opts out (preserves rollback "no client-side cap" mode for emergencies)
- `compute_cycle_deadline(cfg, now)` in `lib/context.py` — returns `now + cap` or `None`
- `ctx.cycle_deadline` set in `main()` at `cycle_start`
- Gate in `_submit_next` (parallel) and the serial `search_and_queue` loop
- `cycle_deadline_skipped=N` field appended to the cycle-summary log line
- NixOS option `cycleMaxRuntimeS` mirrors the cfg field

## Test plan

- [x] `python3 -m unittest tests.test_cycle_max_runtime -v` (12/12 OK)
  - Config: default 600, INI override, `<= 0` opt-out
  - Context: `cycle_deadline=None` and `cycle_deadline_skipped=0` defaults
  - Cycle summary: `cycle_deadline_skipped=N` appears
  - Parallel pipeline: no submissions past deadline; deferred albums NOT logged as failed/timeout
  - Serial pipeline: same gate
  - `compute_cycle_deadline` opt-out semantics
- [x] Full suite: `2754 tests in 25.6s, OK (skipped=53)`
- [x] Pyright clean on touched files
- [x] `nix build .#checks.x86_64-linux.moduleVm` passes
- [ ] Deploy to doc2 and verify next cycle's summary line carries `cycle_deadline_skipped=` (defaults to 0 on healthy cycles)
- [ ] Force a long cycle to confirm the deferral path logs and stops submitting

## What this does NOT do

- Does not bring back any per-call timeout (browse waves, per-search poll caps, etc.) — slskd is still the sole authority on individual operations.
- Does not detect `slskd lost the search`-class hangs faster than the cycle deadline. A future PR could add a *progress-based* (state hasn't advanced AND no new responses in M seconds) per-search watchdog as defense-in-depth, but the cycle gate alone caps the blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)