### PR TITLE
fix(spectral): decode AAC/ALAC via ffmpeg + V0-avg trust override for spoken-word lossless

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -60,7 +60,8 @@ from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          build_existing_quality_measurement,
                          comparison_format_hint, determine_verified_lossless,
                          measured_import_decision,
-                         provisional_lossless_decision, transcode_detection)
+                         provisional_lossless_decision, transcode_detection,
+                         v0_probe_overrides_spectral)
 HARNESS = os.path.join(os.path.dirname(__file__), "..", "harness", "run_beets_harness.sh")
 HARNESS_TIMEOUT = 300
 IMPORT_TIMEOUT = 1800
@@ -1320,9 +1321,22 @@ def main():
     if new_avg_br is not None:
         _log(f"  new_avg_bitrate={new_avg_br}")
 
-    # Verified lossless: single source of truth in quality.py
+    # Verified lossless: single source of truth in quality.py. r.v0_probe is
+    # populated above (lossless source path) and lets the V0-avg trust
+    # override flip a spectral-suspect spoken-word/sparse-HF lossless source
+    # to verified when the V0 evidence corroborates a genuine master.
     will_be_verified_lossless = determine_verified_lossless(
-        args.target_format, spectral_grade, converted, is_transcode)
+        args.target_format, spectral_grade, converted, is_transcode,
+        v0_probe=r.v0_probe)
+    if (will_be_verified_lossless and is_transcode
+            and v0_probe_overrides_spectral(r.v0_probe)):
+        # Audit log: the V0 probe overrode the spectral-derived transcode
+        # signal. Operators chasing a counter-intuitive verified_lossless
+        # decision in download_log JSONB should see this in stderr too.
+        _log(f"[V0_OVERRIDE] spectral={spectral_grade} but lossless_source_v0 "
+             f"avg={r.v0_probe.avg_bitrate_kbps if r.v0_probe else '?'}kbps / "
+             f"min={r.v0_probe.min_bitrate_kbps if r.v0_probe else '?'}kbps "
+             "→ verified_lossless=True")
 
     # Final format label for the NEW measurement. Compute conv_target early
     # (originally it was computed after the quality decision — hoisted for

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2264,11 +2264,42 @@ def transcode_detection(converted_count, post_conversion_min_bitrate,
 _LOSSLESS_EXTS = {"flac", "m4a", "wav", "alac"}
 
 
+# V0-avg trust override thresholds. A lossless_source_v0 probe with avg
+# AND min at-or-above these levels is strong evidence the source carried
+# enough HF complexity that LAME couldn't strip it — i.e. a real lossless
+# master, not a fake-FLAC of a lossy intermediate. Below either bar we
+# defer to spectral as before. Tuned against Bill Hicks 1990 "Dangerous"
+# (avg=241/min=219, spoken-word lossless that spectral false-positives as
+# suspect because speech has no HF energy for the music-tuned thresholds
+# to measure against).
+V0_OVERRIDE_AVG_KBPS: int = 230
+V0_OVERRIDE_MIN_KBPS: int = 200
+
+
+def v0_probe_overrides_spectral(probe: "V0ProbeEvidence | None") -> bool:
+    """Decide whether a V0 probe is strong enough to override a suspect
+    spectral grade and certify the source as genuine lossless.
+
+    Only ``lossless_source_v0`` probes are eligible — research probes
+    (``native_lossy_research_v0``, ``on_disk_research_v0``) carry no
+    policy weight here.
+    """
+    if not is_comparable_lossless_source_probe(probe):
+        return False
+    assert probe is not None  # narrowed by the helper above
+    avg = probe.avg_bitrate_kbps
+    mn = probe.min_bitrate_kbps
+    if avg is None or mn is None:
+        return False
+    return avg >= V0_OVERRIDE_AVG_KBPS and mn >= V0_OVERRIDE_MIN_KBPS
+
+
 def determine_verified_lossless(
     target_format: Optional[str],
     spectral_grade: Optional[str],
     converted_count: int,
     is_transcode: bool,
+    v0_probe: "V0ProbeEvidence | None" = None,
 ) -> bool:
     """Single source of truth for verified lossless status (pure).
 
@@ -2278,10 +2309,22 @@ def determine_verified_lossless(
        The lossless source IS on disk — no conversion needed to prove it.
     2. Default (lossless→V0/target): verified if we actually converted
        lossless files AND spectral didn't flag them as transcodes.
+
+    V0-avg trust override (issue #205-style — Bill Hicks): in either path,
+    when spectral disagrees with V0 evidence (suspect grade but a
+    ``lossless_source_v0`` probe at avg≥230kbps AND min≥200kbps), trust
+    the V0 probe and certify as verified. The override is monotonic — it
+    only flips False→True, never True→False.
     """
     if target_format in ("flac", "lossless"):
-        return spectral_grade in ("genuine", "marginal", None)
-    return converted_count > 0 and not is_transcode
+        if spectral_grade in ("genuine", "marginal", None):
+            return True
+        return v0_probe_overrides_spectral(v0_probe)
+    if converted_count > 0 and not is_transcode:
+        return True
+    if converted_count > 0 and v0_probe_overrides_spectral(v0_probe):
+        return True
+    return False
 
 
 OPUS_DELETE_SKIP_REASON_SPECTRAL = "spectral_suspect"
@@ -3254,9 +3297,10 @@ def full_pipeline_decision(
     cfg: "QualityRankConfig | None" = None,
     *,
     candidate_v0_probe_avg: int | None = None,
+    candidate_v0_probe_min: int | None = None,
     existing_v0_probe_avg: int | None = None,
-    candidate_v0_probe_kind: str | None = None,
     existing_v0_probe_kind: str | None = None,
+    candidate_v0_probe_kind: str | None = None,
     supported_lossless_source: bool | None = None,
 ):
     """Run the full decision chain and return the final outcome.
@@ -3460,8 +3504,18 @@ def full_pipeline_decision(
             return result
         result["imported"] = True
 
-        # Genuine FLAC on disk is verified lossless (for quality gate)
-        if spectral_grade in ("genuine", "marginal", None):
+        # Genuine FLAC on disk is verified lossless (for quality gate). Route
+        # through determine_verified_lossless so the V0-avg trust override is
+        # consulted and the simulator stays in lockstep with import_one.py.
+        candidate_probe_full = V0ProbeEvidence(
+            kind=candidate_v0_probe_kind or V0_PROBE_LOSSLESS_SOURCE,
+            avg_bitrate_kbps=candidate_v0_probe_avg,
+            min_bitrate_kbps=candidate_v0_probe_min,
+        ) if candidate_v0_probe_avg is not None else None
+        if determine_verified_lossless(
+                target_format, spectral_grade,
+                converted_count=0, is_transcode=False,
+                v0_probe=candidate_probe_full):
             verified_lossless = True
             result["verified_lossless"] = True
 
@@ -3549,9 +3603,20 @@ def full_pipeline_decision(
         else:
             result["imported"] = True
 
-        # For genuine FLAC→V0, set verified_lossless
-        if (converted_count > 0 and not is_transcode and
-                spectral_grade in ("genuine", "marginal", None)):
+        # Genuine FLAC→V0 sets verified_lossless. Routed through
+        # determine_verified_lossless so the V0-avg trust override (Bill
+        # Hicks shape — spectral=suspect on spoken-word with high V0
+        # evidence) flips False→True consistently with import_one.py.
+        candidate_probe_full = V0ProbeEvidence(
+            kind=candidate_v0_probe_kind or V0_PROBE_LOSSLESS_SOURCE,
+            avg_bitrate_kbps=candidate_v0_probe_avg,
+            min_bitrate_kbps=candidate_v0_probe_min,
+        ) if candidate_v0_probe_avg is not None else None
+        if determine_verified_lossless(
+                target_format, spectral_grade,
+                converted_count=converted_count,
+                is_transcode=is_transcode,
+                v0_probe=candidate_probe_full):
             verified_lossless = True
             result["verified_lossless"] = True
 

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2241,10 +2241,13 @@ def transcode_detection(converted_count, post_conversion_min_bitrate,
         return False
     if post_conversion_min_bitrate is None:
         return False
-    # When spectral data is available, it's authoritative
+    # When spectral data is available, it's authoritative.
+    # 'error' is inconclusive (decoder failed on every track — usually a
+    # missing codec or hostile input). Fail closed: treat as transcode so
+    # determine_verified_lossless can't pass it without V0 corroboration.
     if spectral_grade is not None:
-        # Cliff detected = transcode regardless of bitrate
-        if spectral_grade in ("suspect", "likely_transcode"):
+        # Cliff detected, suspect, or analysis failed = treat as transcode
+        if spectral_grade in ("suspect", "likely_transcode", "error"):
             return True
         # No cliff = not a transcode (lo-fi lossless produces low V0 bitrates)
         return False

--- a/lib/spectral_check.py
+++ b/lib/spectral_check.py
@@ -65,13 +65,22 @@ class AlbumResult:
 # --- Core functions ---
 
 def parse_rms_from_stat(stderr_output):
-    """Parse RMS amplitude from sox stat stderr output. Returns float or None."""
+    """Parse RMS amplitude from sox stat stderr output. Returns float or None.
+
+    Rejects NaN and inf — those are sentinels for sox internal failures
+    (filter-rejected band, decoder produced no samples, etc.) and would
+    otherwise short-circuit every threshold comparison to False, silently
+    grading the track 'genuine'. Same failure shape as the codec-blindness
+    bug; same fix shape (fail closed instead of silent-pass)."""
     for line in stderr_output.split("\n"):
         if "RMS     amplitude:" in line:
             try:
-                return float(line.split()[-1])
+                v = float(line.split()[-1])
             except (ValueError, IndexError):
                 return None
+            if math.isnan(v) or math.isinf(v):
+                return None
+            return v
     return None
 
 
@@ -203,39 +212,57 @@ class _DecodeFailedError(Exception):
     """
 
 
+def _safe_path(filepath: str) -> str:
+    """Prefix relative paths with './' so sox/ffmpeg never see a leading
+    dash as a flag. Soulseek peers control filenames; ``-evil.flac``
+    arriving via slskd would otherwise be parsed as an argv flag by both
+    binaries (list-form ``subprocess.run`` blocks shell injection but not
+    argv-flag confusion). Absolute paths are passed through unchanged."""
+    if filepath.startswith(("/", "./")):
+        return filepath
+    return "./" + filepath
+
+
 def _get_band_rms(filepath, lo_hz, hi_hz, trim_seconds=30):
     """Get RMS amplitude of audio filtered to a frequency band via sox.
 
-    Returns the measured RMS (float, possibly ~0 for silent input), or None
-    if sox returned no RMS line but exited cleanly (legacy permissive path).
-    Raises ``_DecodeFailedError`` when sox exited non-zero — in that case
-    the file is undecodable and the caller MUST NOT treat the missing
-    measurement as a clean spectrum.
-    """
-    cmd = ["sox", filepath, "-n"]
+    Returns the measured RMS (float, possibly ~0 for silent input). Raises
+    ``_DecodeFailedError`` when sox returned no RMS line OR exited non-zero
+    — both are decode-side failures, distinct from a genuinely silent
+    track (which still returns a valid near-zero RMS). Conflating the two
+    silently grades undecodable input as 'genuine' (the codec-blindness
+    bug class this fix closes for the rc=0 leg too)."""
+    cmd = ["sox", _safe_path(filepath), "-n"]
     if trim_seconds:
         cmd.extend(["trim", "0", str(trim_seconds)])
     cmd.extend(["sinc", "%d-%d" % (lo_hz, hi_hz), "stat"])
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
     rms = parse_rms_from_stat(result.stderr)
-    if rms is None and result.returncode != 0:
+    if rms is None:
         last_line = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else f"sox exit {result.returncode}"
         raise _DecodeFailedError(last_line)
     return rms
 
 
 def _ffmpeg_to_wav(src, dst, trim_seconds=30):
-    """Decode src to WAV at dst (already trimmed to trim_seconds).
+    """Decode src to WAV at dst (trimmed to trim_seconds).
 
     One ffmpeg call per file replaces 17 ffmpeg calls (one per sox band)
-    when AAC/ALAC/WMA inputs reach analyze_track. Raises
-    ``_DecodeFailedError`` if ffmpeg can't decode.
-    """
-    cmd = ["ffmpeg", "-nostdin", "-loglevel", "error", "-y", "-i", src]
+    when AAC/ALAC/WMA inputs reach analyze_track. Probe bounds
+    (``-analyzeduration`` / ``-probesize``) cap atom-table parsing so a
+    hostile MP4 with deeply-nested moov boxes can't spin until timeout;
+    the 30s wall clock backstops anything that slips past. Output is
+    forced to 48kHz/2ch — spectral analysis tops at 20kHz so anything
+    higher is wasted I/O. Raises ``_DecodeFailedError`` on any failure."""
+    cmd = [
+        "ffmpeg", "-nostdin", "-loglevel", "error", "-y",
+        "-analyzeduration", "5M", "-probesize", "5M",
+        "-i", _safe_path(src),
+    ]
     if trim_seconds:
         cmd.extend(["-t", str(trim_seconds)])
-    cmd.extend(["-f", "wav", "-bitexact", dst])
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    cmd.extend(["-ar", "48000", "-ac", "2", "-f", "wav", "-bitexact", dst])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
         last_line = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else f"ffmpeg exit {result.returncode}"
         raise _DecodeFailedError(f"ffmpeg: {last_line}")
@@ -245,45 +272,19 @@ def analyze_track(filepath, trim_seconds=30):
     """Analyze a single audio file for spectral quality.
 
     Runs 17 sox commands (1 reference band + 16 test slices). Non-sox
-    formats (.m4a/.aac/.alac/.wma) are decoded once to a temp WAV first.
-    Returns a TrackResult.
+    formats (.m4a/.aac/.alac/.wma) are decoded once to a temp WAV inside
+    a per-track ``TemporaryDirectory`` (auto-cleaned, not racable by other
+    uids since we own the directory). Returns a TrackResult.
     """
-    tmp_wav = None
     try:
         ext = os.path.splitext(filepath)[1].lower()
         if ext not in _SOX_NATIVE_EXTS:
-            fd, tmp_wav = tempfile.mkstemp(suffix=".wav", prefix="spectral_")
-            os.close(fd)
-            _ffmpeg_to_wav(filepath, tmp_wav, trim_seconds=trim_seconds)
-            sox_input = tmp_wav
-            sox_trim = 0  # already trimmed by ffmpeg
-        else:
-            sox_input = filepath
-            sox_trim = trim_seconds
-
-        # Reference band: 1-4kHz
-        ref_rms = _get_band_rms(sox_input, 1000, 4000, sox_trim)
-        if ref_rms is None or ref_rms < 0.000001:
-            return TrackResult(grade="genuine", hf_deficit_db=0.0)
-
-        ref_db = rms_to_db(ref_rms)
-
-        # 16 test slices from 12-20kHz
-        slices = []
-        for freq in SLICE_FREQS:
-            rms = _get_band_rms(sox_input, freq, freq + SLICE_WIDTH, sox_trim)
-            db = rms_to_db(rms) if rms is not None else DB_FLOOR
-            slices.append({"freq": freq, "db": db})
-
-        # Cliff detection
-        cliff_freq = detect_cliff(slices)
-
-        # HF deficit: avg of top 4 slices (18-20kHz) vs reference
-        hf_slices = slices[-4:]  # 18000, 18500, 19000, 19500
-        avg_hf_db = sum(s["db"] for s in hf_slices) / len(hf_slices)
-        hf_deficit = ref_db - avg_hf_db
-
-        return classify_track(hf_deficit, cliff_freq)
+            with tempfile.TemporaryDirectory(prefix="spectral_") as tmpdir:
+                tmp_wav = os.path.join(tmpdir, "audio.wav")
+                _ffmpeg_to_wav(filepath, tmp_wav, trim_seconds=trim_seconds)
+                # Already trimmed by ffmpeg; skip sox's redundant trim.
+                return _analyze_decoded(tmp_wav, sox_trim=0)
+        return _analyze_decoded(filepath, sox_trim=trim_seconds)
 
     except _DecodeFailedError as e:
         return TrackResult(grade="error", error=f"decode failed: {e}")
@@ -293,12 +294,42 @@ def analyze_track(filepath, trim_seconds=30):
         return TrackResult(grade="error", error="sox/ffmpeg timeout")
     except Exception as e:
         return TrackResult(grade="error", error=str(e))
-    finally:
-        if tmp_wav and os.path.exists(tmp_wav):
-            try:
-                os.unlink(tmp_wav)
-            except OSError:
-                pass
+
+
+def _analyze_decoded(sox_input, sox_trim):
+    """Run the 17 sox calls against a decode-ready file. Extracted from
+    analyze_track so the sox-native and ffmpeg-fallback paths share one
+    body. Reference-band None RMS now grades 'error' (was 'genuine' as the
+    silent-track early-out — see the rc=0 leg in _get_band_rms)."""
+    # Reference band: 1-4kHz. None RMS at the reference is a decode-side
+    # failure (band would have musical content); reserve the silent-track
+    # early-out for genuinely near-zero RMS only.
+    try:
+        ref_rms = _get_band_rms(sox_input, 1000, 4000, sox_trim)
+    except _DecodeFailedError:
+        raise
+    if ref_rms < 0.000001:
+        return TrackResult(grade="genuine", hf_deficit_db=0.0)
+
+    ref_db = rms_to_db(ref_rms)
+
+    slices = []
+    for freq in SLICE_FREQS:
+        # In-band slices CAN legitimately measure as silent (genuine
+        # rolloff), so a missing measurement here is just floored, not
+        # a decode failure. Different semantics from the reference band.
+        try:
+            rms = _get_band_rms(sox_input, freq, freq + SLICE_WIDTH, sox_trim)
+            db = rms_to_db(rms)
+        except _DecodeFailedError:
+            db = DB_FLOOR
+        slices.append({"freq": freq, "db": db})
+
+    cliff_freq = detect_cliff(slices)
+    hf_slices = slices[-4:]
+    avg_hf_db = sum(s["db"] for s in hf_slices) / len(hf_slices)
+    hf_deficit = ref_db - avg_hf_db
+    return classify_track(hf_deficit, cliff_freq)
 
 
 def analyze_album(folder_path, trim_seconds=30):
@@ -318,10 +349,24 @@ def analyze_album(folder_path, trim_seconds=30):
                 files.append(os.path.join(root, f))
 
     track_results = []
+    error_count = 0
     for filepath in files:
         result = analyze_track(filepath, trim_seconds)
-        if result.grade != "error":
+        if result.grade == "error":
+            error_count += 1
+        else:
             track_results.append(result)
+
+    # Fail closed when every audio file errored — empty track_results from
+    # a non-empty input list is the same silent-genuine bug class the
+    # codec fix targets, just at the album level. classify_album's
+    # empty-list branch returns 'genuine' (which is correct for "no audio
+    # files at all" — e.g. a docs-only folder), so we have to distinguish
+    # the two cases here, before delegating.
+    if files and not track_results:
+        return AlbumResult(
+            grade="error", suspect_pct=0.0, tracks=[], estimated_bitrate_kbps=None,
+        )
 
     grade, suspect_pct = classify_album(track_results)
 

--- a/lib/spectral_check.py
+++ b/lib/spectral_check.py
@@ -1,14 +1,17 @@
 """Spectral quality verification for audio files.
 
 Detects transcoded/upsampled audio using sox bandpass filtering and
-spectral gradient analysis. Works on FLAC and MP3 files.
+spectral gradient analysis. Works on FLAC, MP3, OGG, Opus, and WAV
+natively; AAC/M4A/ALAC/WMA are decoded through ffmpeg first because
+sox in our nix shell has no handler for those containers.
 
-Requires: sox in PATH.
+Requires: sox in PATH (always); ffmpeg in PATH (for AAC/ALAC/WMA).
 """
 
 import math
 import os
 import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -181,25 +184,85 @@ def classify_album(track_results):
 
 # --- Sox interaction ---
 
+# Extensions sox can decode natively in our nix shell (see `sox --help`).
+# Anything outside this set must be transcoded via ffmpeg first or sox will
+# emit "FAIL formats: no handler for file extension X" and produce no RMS.
+_SOX_NATIVE_EXTS: frozenset[str] = frozenset({
+    ".mp3", ".flac", ".ogg", ".opus", ".wav", ".aif", ".aiff", ".au",
+})
+
+
+class _DecodeFailedError(Exception):
+    """sox/ffmpeg failed to decode the file — distinct from genuine silence.
+
+    Raised by ``_get_band_rms`` when sox exits non-zero with no RMS line in
+    its stderr (e.g. "FAIL formats: no handler for file extension `m4a'"),
+    or by ``_ffmpeg_to_wav`` when ffmpeg can't open the source. The caller
+    must surface this as ``grade='error'`` rather than letting the missing
+    measurement fall through the silent-track early-out as ``'genuine'``.
+    """
+
+
 def _get_band_rms(filepath, lo_hz, hi_hz, trim_seconds=30):
-    """Get RMS amplitude of audio filtered to a frequency band via sox."""
+    """Get RMS amplitude of audio filtered to a frequency band via sox.
+
+    Returns the measured RMS (float, possibly ~0 for silent input), or None
+    if sox returned no RMS line but exited cleanly (legacy permissive path).
+    Raises ``_DecodeFailedError`` when sox exited non-zero — in that case
+    the file is undecodable and the caller MUST NOT treat the missing
+    measurement as a clean spectrum.
+    """
     cmd = ["sox", filepath, "-n"]
     if trim_seconds:
         cmd.extend(["trim", "0", str(trim_seconds)])
     cmd.extend(["sinc", "%d-%d" % (lo_hz, hi_hz), "stat"])
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    return parse_rms_from_stat(result.stderr)
+    rms = parse_rms_from_stat(result.stderr)
+    if rms is None and result.returncode != 0:
+        last_line = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else f"sox exit {result.returncode}"
+        raise _DecodeFailedError(last_line)
+    return rms
+
+
+def _ffmpeg_to_wav(src, dst, trim_seconds=30):
+    """Decode src to WAV at dst (already trimmed to trim_seconds).
+
+    One ffmpeg call per file replaces 17 ffmpeg calls (one per sox band)
+    when AAC/ALAC/WMA inputs reach analyze_track. Raises
+    ``_DecodeFailedError`` if ffmpeg can't decode.
+    """
+    cmd = ["ffmpeg", "-nostdin", "-loglevel", "error", "-y", "-i", src]
+    if trim_seconds:
+        cmd.extend(["-t", str(trim_seconds)])
+    cmd.extend(["-f", "wav", "-bitexact", dst])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        last_line = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else f"ffmpeg exit {result.returncode}"
+        raise _DecodeFailedError(f"ffmpeg: {last_line}")
 
 
 def analyze_track(filepath, trim_seconds=30):
     """Analyze a single audio file for spectral quality.
 
-    Runs 17 sox commands (1 reference band + 16 test slices).
+    Runs 17 sox commands (1 reference band + 16 test slices). Non-sox
+    formats (.m4a/.aac/.alac/.wma) are decoded once to a temp WAV first.
     Returns a TrackResult.
     """
+    tmp_wav = None
     try:
+        ext = os.path.splitext(filepath)[1].lower()
+        if ext not in _SOX_NATIVE_EXTS:
+            fd, tmp_wav = tempfile.mkstemp(suffix=".wav", prefix="spectral_")
+            os.close(fd)
+            _ffmpeg_to_wav(filepath, tmp_wav, trim_seconds=trim_seconds)
+            sox_input = tmp_wav
+            sox_trim = 0  # already trimmed by ffmpeg
+        else:
+            sox_input = filepath
+            sox_trim = trim_seconds
+
         # Reference band: 1-4kHz
-        ref_rms = _get_band_rms(filepath, 1000, 4000, trim_seconds)
+        ref_rms = _get_band_rms(sox_input, 1000, 4000, sox_trim)
         if ref_rms is None or ref_rms < 0.000001:
             return TrackResult(grade="genuine", hf_deficit_db=0.0)
 
@@ -208,7 +271,7 @@ def analyze_track(filepath, trim_seconds=30):
         # 16 test slices from 12-20kHz
         slices = []
         for freq in SLICE_FREQS:
-            rms = _get_band_rms(filepath, freq, freq + SLICE_WIDTH, trim_seconds)
+            rms = _get_band_rms(sox_input, freq, freq + SLICE_WIDTH, sox_trim)
             db = rms_to_db(rms) if rms is not None else DB_FLOOR
             slices.append({"freq": freq, "db": db})
 
@@ -222,12 +285,20 @@ def analyze_track(filepath, trim_seconds=30):
 
         return classify_track(hf_deficit, cliff_freq)
 
-    except FileNotFoundError:
-        return TrackResult(grade="error", error="sox not found")
+    except _DecodeFailedError as e:
+        return TrackResult(grade="error", error=f"decode failed: {e}")
+    except FileNotFoundError as e:
+        return TrackResult(grade="error", error=f"binary not found: {e}")
     except subprocess.TimeoutExpired:
-        return TrackResult(grade="error", error="sox timeout")
+        return TrackResult(grade="error", error="sox/ffmpeg timeout")
     except Exception as e:
         return TrackResult(grade="error", error=str(e))
+    finally:
+        if tmp_wav and os.path.exists(tmp_wav):
+            try:
+                os.unlink(tmp_wav)
+            except OSError:
+                pass
 
 
 def analyze_album(folder_path, trim_seconds=30):

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -862,6 +862,18 @@ def cmd_quality(db, args):
             is_flac=True, min_bitrate=245, is_cbr=False,
             spectral_grade="suspect", converted_count=12,
             post_conversion_min_bitrate=245)),
+        # Bill Hicks 1990 "Dangerous" shape: spoken-word lossless that
+        # spectral_check false-positives as suspect (high HF deficit
+        # against music-tuned thresholds), but the lossless_source_v0
+        # probe corroborates a genuine master. The V0-avg trust override
+        # in determine_verified_lossless flips this to verified.
+        ("Suspect FLAC + lossless_source_v0 avg=241/min=219 (V0 override)", dict(
+            is_flac=True, min_bitrate=219, is_cbr=False,
+            spectral_grade="suspect", converted_count=10,
+            post_conversion_min_bitrate=219,
+            candidate_v0_probe_avg=241,
+            candidate_v0_probe_min=219,
+            candidate_v0_probe_kind="lossless_source_v0")),
         # --- MP3 VBR downloads ---
         # avg_bitrate drives the new preimport spectral gate (issue #93):
         # VBR with avg >= cfg.mp3_vbr.excellent skips spectral entirely,

--- a/tests/test_conversion_e2e.py
+++ b/tests/test_conversion_e2e.py
@@ -195,10 +195,11 @@ class TestDetermineVerifiedLossless(unittest.TestCase):
     """Single source of truth for verified lossless derivation."""
 
     def _dvl(self, target_format=None, spectral_grade=None,
-             converted_count=0, is_transcode=False):
+             converted_count=0, is_transcode=False, v0_probe=None):
         from lib.quality import determine_verified_lossless
         return determine_verified_lossless(
-            target_format, spectral_grade, converted_count, is_transcode)
+            target_format, spectral_grade, converted_count, is_transcode,
+            v0_probe=v0_probe)
 
     # --- FLAC-on-disk path ---
 
@@ -250,6 +251,105 @@ class TestDetermineVerifiedLossless(unittest.TestCase):
 
     def test_lossless_suspect_is_not_verified(self):
         self.assertFalse(self._dvl(target_format="lossless", spectral_grade="suspect"))
+
+    # --- V0-avg trust override ---
+    # When spectral disagrees with V0 evidence (the spoken-word and
+    # sparse-HF-music false-positive case — Bill Hicks 1990 "Dangerous"
+    # being the canonical example), trust the V0 probe. A
+    # ``lossless_source_v0`` probe with avg ≥ 230kbps AND min ≥ 200kbps is
+    # strong evidence the source carried genuine HF complexity that LAME
+    # couldn't throw away — i.e. a real lossless master, not a fake-FLAC.
+    # Below those thresholds, we defer to spectral as before.
+
+    def _v0(self, kind="lossless_source_v0", avg=None, min=None, median=None):
+        from lib.quality import V0ProbeEvidence
+        return V0ProbeEvidence(
+            kind=kind, avg_bitrate_kbps=avg, min_bitrate_kbps=min,
+            median_bitrate_kbps=median,
+        )
+
+    def test_v0_override_bill_hicks_shape_verifies_despite_suspect(self):
+        """Real case: ALAC of Bill Hicks comedy. spectral=suspect (speech has
+        no HF), V0 probe avg=241/min=219 (genuine lossless source).
+        is_transcode=True (set by transcode_detection seeing 'suspect').
+        Expect: V0 override flips verified_lossless to True."""
+        self.assertTrue(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(avg=241, min=219, median=239),
+        ))
+
+    def test_v0_override_fake_flac_shape_stays_unverified(self):
+        """Fake-FLAC of 128k MP3 source: V0 probe avg=190/min=180. Below
+        either threshold → override does NOT fire → stays unverified."""
+        self.assertFalse(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(avg=190, min=180, median=185),
+        ))
+
+    def test_v0_override_min_below_floor_stays_unverified(self):
+        """Mixed album: 9 great tracks + 1 transcoded track. avg=240 passes
+        but min=110 fails the floor. One bad track must not whitelist the
+        whole album."""
+        self.assertFalse(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(avg=240, min=110, median=235),
+        ))
+
+    def test_v0_override_boundary_inclusive(self):
+        """Thresholds are inclusive: avg=230 AND min=200 must pass."""
+        self.assertTrue(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(avg=230, min=200, median=215),
+        ))
+
+    def test_v0_override_avg_just_below_threshold(self):
+        """avg=229 (below 230) → override does not fire."""
+        self.assertFalse(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(avg=229, min=210, median=220),
+        ))
+
+    def test_v0_override_wrong_probe_kind_ignored(self):
+        """Only lossless_source_v0 probes count. native_lossy_research_v0
+        and on_disk_research_v0 are research evidence, not policy input."""
+        self.assertFalse(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(kind="native_lossy_research_v0",
+                              avg=241, min=219, median=239),
+        ))
+
+    def test_v0_override_no_probe_falls_back_to_legacy(self):
+        """No V0 probe → behaves exactly as before. is_transcode wins."""
+        self.assertFalse(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=None,
+        ))
+
+    def test_v0_override_applies_to_lossless_on_disk_path(self):
+        """target_format='flac' + spectral=suspect + high V0 → override
+        flips verified to True for the keep-on-disk path too. A genuine
+        spoken-word FLAC kept on disk should be verified the same way."""
+        self.assertTrue(self._dvl(
+            target_format="flac", spectral_grade="suspect",
+            v0_probe=self._v0(avg=241, min=219, median=239),
+        ))
+
+    def test_v0_override_does_not_unfire_when_already_verified(self):
+        """Override is monotonic — it can only flip False→True. A normal
+        verified import (is_transcode=False) stays verified regardless of
+        V0 probe shape (even when V0 is missing or low)."""
+        self.assertTrue(self._dvl(
+            converted_count=10, is_transcode=False,
+            spectral_grade="genuine",
+            v0_probe=self._v0(avg=180, min=170, median=175),
+        ))
 
 
 # ============================================================================

--- a/tests/test_conversion_e2e.py
+++ b/tests/test_conversion_e2e.py
@@ -332,6 +332,15 @@ class TestDetermineVerifiedLossless(unittest.TestCase):
             v0_probe=None,
         ))
 
+    def test_v0_override_partial_probe_data_stays_unverified(self):
+        """V0 probe with avg high but min=None → override does not fire.
+        Partial probe data must not pass the floor check by accident."""
+        self.assertFalse(self._dvl(
+            converted_count=10, is_transcode=True,
+            spectral_grade="suspect",
+            v0_probe=self._v0(avg=241, min=None, median=239),
+        ))
+
     def test_v0_override_applies_to_lossless_on_disk_path(self):
         """target_format='flac' + spectral=suspect + high V0 → override
         flips verified to True for the keep-on-disk path too. A genuine

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -926,7 +926,8 @@ EXPECTED_PARAMS = {
     "verified_lossless", "verified_lossless_target",
     "target_format",
     "new_format", "cfg",
-    "candidate_v0_probe_avg", "existing_v0_probe_avg",
+    "candidate_v0_probe_avg", "candidate_v0_probe_min",
+    "existing_v0_probe_avg",
     "candidate_v0_probe_kind", "existing_v0_probe_kind",
     "supported_lossless_source",
     # Preimport gate inputs (issue #91) — keep the simulator's picture of the

--- a/tests/test_spectral_check.py
+++ b/tests/test_spectral_check.py
@@ -3,6 +3,8 @@
 import math
 import os
 import shutil
+import subprocess
+import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -328,6 +330,109 @@ class TestSpectralIntegration(unittest.TestCase):
         result = analyze_album(_fixture("09_fake_flac_128"))
         self.assertIsNotNone(result.estimated_bitrate_kbps,
                              "Album-level estimated bitrate should be set for transcodes")
+
+
+class TestDecodeFailureNotGenuine(unittest.TestCase):
+    """A sox decode failure must NOT be silently graded as genuine.
+
+    Bug discovered 2026-05-03: sox in the dev shell has no handler for
+    .m4a/.aac/.alac. Calling `sox file.m4a -n stat` exits non-zero with
+    stderr "FAIL formats: no handler for file extension `m4a'" and emits
+    no "RMS amplitude:" line. parse_rms_from_stat returned None for every
+    band, the early-out at analyze_track returned grade='genuine' with
+    hf_deficit_db=0.0 on every track, and ALAC files were silently
+    classified as verified-lossless without ever being measured.
+    """
+
+    @patch("lib.spectral_check.subprocess.run")
+    def test_decode_failure_grades_error_not_genuine(self, mock_run):
+        from lib.spectral_check import analyze_track
+        # Real sox stderr when handed an undecodable file:
+        mock_run.return_value = MagicMock(
+            stderr="sox FAIL formats: no handler for file extension `m4a'\n",
+            returncode=2,
+        )
+        result = analyze_track("/fake/path.m4a")
+        # Currently returns 'genuine' (the bug). The fix must return 'error'.
+        self.assertEqual(
+            result.grade, "error",
+            "Decode failure (no RMS line in sox stderr) must grade 'error', "
+            "not silently fall through the silent-track early-out as 'genuine'.",
+        )
+
+    @patch("lib.spectral_check.subprocess.run")
+    def test_silent_track_still_grades_genuine(self, mock_run):
+        """Guard that the failure-vs-silent fix doesn't over-broaden.
+
+        A real silent track (sox decoded fine, RMS legitimately ~0) should
+        still hit the silent-track early-out and grade 'genuine'.
+        """
+        from lib.spectral_check import analyze_track
+        mock_run.return_value = MagicMock(
+            stderr="RMS     amplitude:     0.0000001\n",
+            returncode=0,
+        )
+        result = analyze_track("/fake/silent.flac")
+        self.assertEqual(result.grade, "genuine")
+        self.assertEqual(result.hf_deficit_db, 0.0)
+
+
+HAS_FFMPEG = shutil.which("ffmpeg") is not None
+
+
+@unittest.skipUnless(HAS_SOX and HAS_FFMPEG, "needs sox + ffmpeg")
+class TestM4aFallback(unittest.TestCase):
+    """Real ALAC .m4a file must produce a real spectral measurement.
+
+    Drives the ffmpeg pipe fallback: sox can't decode m4a natively, so
+    spectral_check must route the file through `ffmpeg -i in -f wav -` and
+    feed sox via stdin. After the fix, a synthetic 1kHz tone in ALAC must
+    grade somewhere meaningful (not the all-zero default), and a fake-FLAC
+    pattern (steep cliff at 16kHz) in ALAC must be detectable.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="spectral_m4a_test_")
+        # Pure 1kHz tone, encoded as ALAC inside an .m4a container.
+        # Sox can't decode this; the fallback must.
+        cls.tone_m4a = os.path.join(cls.tmpdir, "tone.m4a")
+        subprocess.run(
+            ["ffmpeg", "-y", "-f", "lavfi",
+             "-i", "sine=frequency=1000:duration=35",
+             "-c:a", "alac", cls.tone_m4a],
+            capture_output=True, check=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def test_m4a_alac_actually_analyzed(self):
+        from lib.spectral_check import analyze_track
+        result = analyze_track(self.tone_m4a, trim_seconds=30)
+        # A pure 1kHz tone has effectively zero energy at 18-20kHz, so the
+        # measured HF deficit will be enormous (well above HF_DEFICIT_SUSPECT).
+        # The point is that we get a REAL measurement, not the default 0.0.
+        self.assertNotEqual(
+            result.grade, "error",
+            "ffmpeg fallback should let sox decode the m4a — saw error",
+        )
+        # Either we measured a real deficit (suspect) OR the tone hit some
+        # other genuine path; what we MUST NOT see is the default-0.0 grade.
+        # The default-0.0 case is grade='genuine' with hf_deficit_db == 0.0
+        # AND cliff_freq_hz is None — that's the bug fingerprint.
+        is_default_zero = (
+            result.grade == "genuine"
+            and result.hf_deficit_db == 0.0
+            and result.cliff_freq_hz is None
+        )
+        self.assertFalse(
+            is_default_zero,
+            f"m4a hit the silent-track default (grade={result.grade}, "
+            f"hf_deficit_db={result.hf_deficit_db}, cliff={result.cliff_freq_hz}) "
+            "— ffmpeg fallback is not wired up.",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_spectral_check.py
+++ b/tests/test_spectral_check.py
@@ -435,5 +435,110 @@ class TestM4aFallback(unittest.TestCase):
         )
 
 
+class TestArgvFlagConfusion(unittest.TestCase):
+    """Peer-controlled filenames starting with '-' must not be parsed as
+    sox/ffmpeg flags. Soulseek peers can name files arbitrarily; the
+    pipeline must treat the filename as data, not argv."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="spectral_dash_test_")
+        # Real FLAC tone with a leading-dash filename — what a hostile peer
+        # could ship via Soulseek. Sox CAN decode FLAC natively, so any
+        # failure here proves argv-flag confusion (not a decode failure).
+        cls.dash_flac = os.path.join(cls.tmpdir, "-evil.flac")
+        if HAS_SOX:
+            subprocess.run(
+                ["sox", "-n", "-r", "44100", "-c", "2",
+                 cls.dash_flac, "synth", "2", "sin", "1000", "vol", "0.5"],
+                check=True, capture_output=True,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    @unittest.skipUnless(HAS_SOX, "sox not available")
+    def test_leading_dash_filename_does_not_get_parsed_as_flag(self):
+        """A real FLAC named '-evil.flac' must analyze normally, not be
+        parsed as a sox flag and abort."""
+        from lib.spectral_check import analyze_track
+        result = analyze_track(self.dash_flac, trim_seconds=2)
+        self.assertNotEqual(
+            result.grade, "error",
+            f"sox parsed '-evil.flac' as a flag instead of as a path "
+            f"(error={result.error}). Need to prefix relative paths with './'.",
+        )
+
+
+class TestAlbumLevelSilentGenuineCollapse(unittest.TestCase):
+    """When every track in an album errors out, analyze_album must NOT
+    return grade='genuine'. The pre-existing behavior (drop error tracks
+    from track_results, then classify the empty list as genuine) is the
+    same bug class the codec fix targets — at the album level instead of
+    the track level. Surfaced by ce-adversarial-reviewer 2026-05-03."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="spectral_album_err_")
+        # Two undecodable files with audio extensions so analyze_album
+        # finds them but analyze_track errors on each.
+        for name in ("01-track.m4a", "02-track.m4a"):
+            with open(os.path.join(cls.tmpdir, name), "wb") as f:
+                f.write(b"not real audio")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    @unittest.skipUnless(HAS_SOX and HAS_FFMPEG, "needs sox + ffmpeg")
+    def test_all_tracks_error_grades_album_error_not_genuine(self):
+        """If every track in a non-empty album errors, the album grade
+        must be 'error', not the silent-default 'genuine'."""
+        from lib.spectral_check import analyze_album
+        result = analyze_album(self.tmpdir, trim_seconds=2)
+        self.assertEqual(
+            result.grade, "error",
+            f"All-error album silently graded {result.grade!r} — same "
+            "silent-genuine bug class the codec fix was meant to close. "
+            "Empty track_results from a non-empty file list must fail closed.",
+        )
+
+
+class TestRcZeroNoRmsLineNoLongerSilent(unittest.TestCase):
+    """Sox returncode==0 with no 'RMS amplitude:' line in stderr was the
+    'legacy permissive path' the codec PR's docstring acknowledged. After
+    review, that path is closed: any missing RMS line now surfaces as a
+    decode failure regardless of return code. Same failure-shape contract
+    as the rc!=0 path."""
+
+    @patch("lib.spectral_check.subprocess.run")
+    def test_clean_exit_no_rms_line_grades_error(self, mock_run):
+        from lib.spectral_check import analyze_track
+        mock_run.return_value = MagicMock(
+            stderr="some warning that has no RMS line\n",
+            returncode=0,
+        )
+        result = analyze_track("/fake/path.flac")
+        self.assertEqual(
+            result.grade, "error",
+            "sox returning rc=0 with no RMS line must grade 'error', not "
+            "fall through the silent-track early-out as 'genuine'.",
+        )
+
+
+class TestNaNRmsGuard(unittest.TestCase):
+    """parse_rms_from_stat must reject NaN/inf to avoid silent-genuine
+    via NaN comparisons (NaN >= 60 is False everywhere → 'genuine')."""
+
+    def test_nan_rms_returns_none(self):
+        from lib.spectral_check import parse_rms_from_stat
+        self.assertIsNone(parse_rms_from_stat("RMS     amplitude:     nan\n"))
+
+    def test_inf_rms_returns_none(self):
+        from lib.spectral_check import parse_rms_from_stat
+        self.assertIsNone(parse_rms_from_stat("RMS     amplitude:     inf\n"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two related soundness bugs surfaced by a Bill Hicks 1990 *Dangerous* ALAC import that silently graded `genuine` with `hf_deficit_db: 0.0` on every track:

1. **`lib/spectral_check.py` was blind to AAC/ALAC/M4A/WMA** — sox in our nix shell has no handler for those containers, so every band-RMS measurement returned `None`, and the early-out at `analyze_track:204` shipped `TrackResult(grade='genuine', hf_deficit_db=0.0)` on every track. Verified-lossless flowed from there. ALAC inputs bypassed spectral entirely; a fake-FLAC laundered through ALAC would have walked straight in.

2. **Music-tuned spectral thresholds false-positive on spoken-word lossless.** Speech tops out at ~3-4 kHz; the `60 dB` HF-deficit suspect threshold flags every genuine stand-up rip as a transcode. After fixing #1, ALAC of Bill Hicks would correctly grade `suspect`, then `transcode_detection` would set `is_transcode=True`, then `determine_verified_lossless` would return False, and the pipeline would reject every spoken-word lossless source forever.

## Commits

**1. `fix(spectral): decode AAC/ALAC/WMA via ffmpeg, fail loud on decode errors`** (`30739ee`)
- Route non-sox-native extensions through `ffmpeg -f wav -bitexact` to a temp WAV, then sox against the WAV (1 ffmpeg call per file, not per band).
- `_get_band_rms` raises `_DecodeFailedError` when sox exits non-zero with no RMS line. `analyze_track` maps that to `grade='error'`, preserving the silent-track `'genuine'` branch for legitimate near-zero RMS.
- RED tests: mocked `FAIL formats` stderr → assert `error` not `genuine`; real ALAC `.m4a` fixture → assert no all-zero default.

**2. `feat(quality): V0-avg trust override`** (`3494536`)
- New pure helper `v0_probe_overrides_spectral(probe)` with thresholds `V0_OVERRIDE_AVG_KBPS=230`, `V0_OVERRIDE_MIN_KBPS=200`. Only `lossless_source_v0` probes count.
- `determine_verified_lossless` accepts an optional `v0_probe`; the override flips False→True (monotonic — never True→False).
- Wired into `harness/import_one.py` (with a `[V0_OVERRIDE]` audit line to stderr) and `full_pipeline_decision` (kills two inline `verified_lossless = True` parallel-paths).
- New scenario in `pipeline-cli quality` so operators can see the override against any album.
- 9 new RED tests covering Bill Hicks shape, fake-FLAC shape, mixed albums (min floor), boundary inclusivity, wrong probe kinds, missing probe, lossless-on-disk path, monotonicity.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 2766 passed, 53 skipped, 0 failed
- [x] Pyright on `lib/spectral_check.py` (0 errors) and `lib/quality.py` (1 pre-existing error at line 2071, unrelated)
- [x] Live verification via direct simulator: pure `determine_verified_lossless` correctly returns True for Bill Hicks shape, False for fake-FLAC shape
- [ ] Post-deploy: re-run `pipeline-cli show 776` and verify a fresh ALAC download grades `genuine` with a real `hf_deficit_db` (not the all-zero default), and that `verified_lossless: true` appears in the import_result JSONB when V0 evidence corroborates

🤖 Generated with [Claude Code](https://claude.com/claude-code)