### PR TITLE
fix: unwedge auto-import retries + log full harness stderr

### DIFF
--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -175,13 +175,32 @@ expects them and the next cycle simply re-enters with the same
 
 If the process dies after moving into `beets_staging_dir`, the persisted
 staging root tells the next poll whether the row is on the
-`auto-import/` or `post-validation/` branch. `auto-import/` retries are
-blocked for manual recovery because an import subprocess may already
-have started; `post-validation/` retries re-enter normally because
+`auto-import/` or `post-validation/` branch. The
+`active_download_state.import_subprocess_started_at` flag distinguishes
+two cases for `auto-import/` retries:
+
+- **Flag is `None`** — files were moved to the staged path but
+  `import_one.py` was never launched. Beets has not been touched. The
+  resume guard permits retry: the next cycle re-enters
+  `process_completed_album`, runs `beets_validate` against the staged
+  files, and dispatches as normal.
+- **Flag is set** — `dispatch_import_core` set this stamp immediately
+  before launching `run_import_one(...)`. The subprocess may have
+  written to beets before crashing, so retry is unsafe and would risk
+  a double-import. The guard blocks; manual recovery is required.
+
+`post-validation/` retries re-enter normally regardless because
 `StagedAlbum.move_to(...)` is idempotent when the album is already at
-the staged destination. For blocked auto-import rows,
+the staged destination. For blocked auto-import rows (flag set),
 operator recovery should inspect the staged path and either finish the
 import manually or reset the request explicitly.
+
+The 2026-05-04 wedge (5788 failed import_jobs, 3 albums stuck in
+`downloading` since Apr 27) was caused by the absence of this flag:
+the original guard fired regardless of whether the subprocess had
+launched, trapping rows after a crash that occurred between the staged
+move and the subprocess spawn. The flag is the necessary witness that
+makes the guard precise.
 
 To list candidate blocked rows, query for `status='downloading'` entries
 whose persisted `current_path` already points at your staging root:

--- a/lib/beets.py
+++ b/lib/beets.py
@@ -159,7 +159,11 @@ def beets_validate(harness_path, album_path, mb_release_id, distance_threshold=0
             proc.kill()
 
     if stderr_out:
-        logger.warning(f"BEETS_VALIDATE: stderr: {stderr_out[:500]}")
+        # Log the full stderr — truncating loses the actual exception line
+        # at the bottom of a Python traceback. The 2026-05-04 Psilodump
+        # ``library.Library()`` crash had its root cause hidden behind a
+        # 500-char slice. journald handles multi-line records fine.
+        logger.warning("BEETS_VALIDATE: stderr:\n%s", stderr_out)
     if not got_choose_match:
         logger.warning(f"BEETS_VALIDATE: harness never sent choose_match!")
 

--- a/lib/download.py
+++ b/lib/download.py
@@ -502,6 +502,61 @@ def _log_post_move_resume_blocked(
     )
 
 
+def _import_subprocess_already_started(
+    db: Any,
+    request_id: int | None,
+) -> bool:
+    """Did a previous attempt actually launch ``import_one.py`` for this row?
+
+    The auto-import resume guard blocks retries when files live at the
+    request-scoped staged path because a prior subprocess may have
+    started writing to beets. That guard is correct only when a
+    subprocess actually started — files-at-staged is a necessary but not
+    sufficient signal. The 2026-05-04 wedge accumulated 5788 failed
+    importer jobs because the guard fired even when the subprocess had
+    never launched (crash window between staged-move and subprocess
+    spawn). See ``docs/advisory-locks.md``.
+
+    With the ``import_subprocess_started_at`` flag set in
+    ``ActiveDownloadState`` immediately before ``run_import_one(...)``,
+    this helper returns ``True`` only when the flag is set: the
+    necessary AND sufficient evidence that the subprocess could have
+    written to beets.
+
+    Returns ``True`` (block) if state is unreachable — fail safe; the
+    operator can still recover manually. Returns ``False`` (permit
+    retry) only on positive evidence the subprocess never launched.
+    """
+    if request_id is None or db is None:
+        return True
+    try:
+        row = db.get_request(request_id)
+    except Exception:
+        logger.debug(
+            "Failed to read active_download_state for resume guard",
+            exc_info=True,
+        )
+        return True
+    if not row:
+        return True
+    raw_state = row.get("active_download_state")
+    if not raw_state:
+        return False
+    try:
+        state = (
+            ActiveDownloadState.from_dict(raw_state)
+            if isinstance(raw_state, dict)
+            else ActiveDownloadState.from_json(str(raw_state))
+        )
+    except Exception:
+        logger.debug(
+            "Failed to parse active_download_state for resume guard",
+            exc_info=True,
+        )
+        return True
+    return state.import_subprocess_started_at is not None
+
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -539,8 +594,13 @@ def _materialize_processing_dir(
     )
 
     if current_path_location.kind != "canonical":
+        subprocess_started = _import_subprocess_already_started(
+            db, request_id)
         if not os.path.isdir(staged_album.current_path):
-            if current_path_location.blocks_post_move_retry:
+            if (
+                current_path_location.blocks_post_move_retry
+                and subprocess_started
+            ):
                 _log_post_move_resume_blocked(
                     album_data,
                     current_path=staged_album.current_path,
@@ -563,7 +623,10 @@ def _materialize_processing_dir(
             if not os.path.isfile(import_path):
                 missing_paths.append(import_path)
         if missing_paths:
-            if current_path_location.blocks_post_move_retry:
+            if (
+                current_path_location.blocks_post_move_retry
+                and subprocess_started
+            ):
                 _log_post_move_resume_blocked(
                     album_data,
                     current_path=staged_album.current_path,
@@ -580,7 +643,10 @@ def _materialize_processing_dir(
                 ", ".join(missing_paths),
             )
             return False
-        if current_path_location.blocks_auto_import_dispatch:
+        if (
+            current_path_location.blocks_auto_import_dispatch
+            and _import_subprocess_already_started(db, request_id)
+        ):
             detail = (
                 "already lives at the request-scoped auto-import staged "
                 "path. Automatic retry is disabled to avoid duplicate "
@@ -968,6 +1034,12 @@ def _handle_valid_result(album_data: GrabListEntry, bv_result: ValidationResult,
     if (
         will_auto_import
         and current_path_location.blocks_auto_import_dispatch
+        and _import_subprocess_already_started(
+            ctx.pipeline_db_source._get_db()
+            if ctx.pipeline_db_source is not None
+            else None,
+            request_id,
+        )
     ):
         _log_post_move_resume_blocked(
             album_data,
@@ -1175,12 +1247,17 @@ def build_active_download_state(
     enqueued_at: str | None = None,
     last_progress_at: str | None = None,
     processing_started_at: str | None = None,
+    import_subprocess_started_at: str | None = None,
     current_path: str | None = None,
 ) -> ActiveDownloadState:
     """Build an ActiveDownloadState from a GrabListEntry.
 
     Callers can pass the original enqueued_at/processing_started_at when
-    persisting updated retry state across polling cycles.
+    persisting updated retry state across polling cycles. The
+    ``import_subprocess_started_at`` flag is preserved through state
+    rebuilds so cycle-based retry persistence cannot accidentally clear
+    the resume guard's witness — only ``clear_download_state`` (terminal
+    transitions) wipes it. See ``docs/advisory-locks.md``.
     """
     enqueued_at_value = enqueued_at or datetime.now(timezone.utc).isoformat()
     files = [
@@ -1203,6 +1280,7 @@ def build_active_download_state(
         last_progress_at=last_progress_at or enqueued_at_value,
         files=files,
         processing_started_at=processing_started_at,
+        import_subprocess_started_at=import_subprocess_started_at,
         current_path=(
             current_path
             if current_path is not None
@@ -1444,6 +1522,9 @@ def _persist_updated_download_state(
             enqueued_at=state.enqueued_at,
             last_progress_at=state.last_progress_at,
             processing_started_at=state.processing_started_at,
+            import_subprocess_started_at=(
+                state.import_subprocess_started_at
+            ),
             current_path=entry.import_folder,
         ).to_json(),
     )
@@ -1637,12 +1718,13 @@ def _processing_path_ready_for_importer(
         staging_dir=ctx.cfg.beets_staging_dir,
         slskd_download_dir=ctx.cfg.slskd_download_dir,
     )
+    subprocess_started = state.import_subprocess_started_at is not None
     if not os.path.isdir(state.current_path):
         # The canonical processing folder may not exist yet. The importer
         # materializes it from the completed slskd files as its first step.
         if current_path_location.kind == "canonical":
             return True
-        if current_path_location.blocks_post_move_retry:
+        if current_path_location.blocks_post_move_retry and subprocess_started:
             _log_post_move_resume_blocked(
                 entry,
                 current_path=state.current_path,
@@ -1676,7 +1758,7 @@ def _processing_path_ready_for_importer(
     if not missing_paths:
         return True
 
-    if current_path_location.blocks_post_move_retry:
+    if current_path_location.blocks_post_move_retry and subprocess_started:
         _log_post_move_resume_blocked(
             entry,
             current_path=state.current_path,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess as sp
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Sequence, TYPE_CHECKING
 
 from lib import transitions
@@ -897,6 +898,29 @@ def dispatch_import_core(
                 request_row = None
             existing_v0_probe = _current_lossless_v0_probe_from_request(
                 request_row)
+            # Mark the subprocess as launching on the auto-import path
+            # so the resume guard can distinguish "never started" from
+            # "may have written to beets" if this process crashes
+            # before recording the result. The DB-side method is a
+            # no-op when ``active_download_state`` is NULL (force /
+            # manual paths), so calling unconditionally would also be
+            # safe — we still gate to make the intent explicit.
+            # See ``docs/advisory-locks.md`` and
+            # ``lib/download.py::_import_subprocess_already_started``.
+            if scenario not in FORCE_MANUAL_SCENARIOS:
+                try:
+                    db.mark_import_subprocess_started(
+                        request_id,
+                        datetime.now(timezone.utc).isoformat(),
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to stamp import_subprocess_started_at "
+                        "for request %s; continuing with subprocess "
+                        "launch (resume guard may fail-open until "
+                        "completion)",
+                        request_id,
+                    )
             # Force/manual import operates on the user's only copy of the source
             # material (typically failed_imports/…). Tell the harness to keep
             # lossless originals intact until the quality decision — on

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -1130,6 +1130,37 @@ class PipelineDB:
         """, (current_path, now, request_id))
         self.conn.commit()
 
+    def mark_import_subprocess_started(
+        self,
+        request_id: int,
+        timestamp: str,
+    ) -> None:
+        """Stamp ``active_download_state.import_subprocess_started_at``.
+
+        Called immediately before launching ``import_one.py`` on the
+        auto-import path so the resume guard can later distinguish
+        "subprocess never launched" (safe to retry) from "subprocess
+        may have written to beets" (manual recovery required). No-op
+        when ``active_download_state`` is NULL — force/manual paths
+        operate on a different ownership boundary
+        (``failed_imports/...``) and don't carry this state.
+        See ``docs/advisory-locks.md``.
+        """
+        now = datetime.now(timezone.utc)
+        self._execute("""
+            UPDATE album_requests
+            SET active_download_state = jsonb_set(
+                    active_download_state,
+                    '{import_subprocess_started_at}',
+                    to_jsonb(%s::text),
+                    true
+                ),
+                updated_at = %s
+            WHERE id = %s
+              AND active_download_state IS NOT NULL
+        """, (timestamp, now, request_id))
+        self.conn.commit()
+
     def get_downloading(self) -> list[dict[str, Any]]:
         """Get all albums currently being downloaded."""
         cur = self._execute(

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -570,6 +570,13 @@ class ActiveDownloadState:
     files: list[ActiveDownloadFileState]
     last_progress_at: str | None = None
     processing_started_at: str | None = None
+    # Set immediately before ``run_import_one(...)`` is invoked on the
+    # auto-import path. Distinguishes "files moved to staged path but
+    # subprocess never launched" (None — safe to retry) from "subprocess
+    # may already have written to beets" (set — manual recovery required).
+    # See ``docs/advisory-locks.md`` and the resume-block guards in
+    # ``lib/download.py::_log_post_move_resume_blocked``.
+    import_subprocess_started_at: str | None = None
     current_path: str | None = None
 
     def to_json(self) -> str:
@@ -582,6 +589,10 @@ class ActiveDownloadState:
             data["last_progress_at"] = self.last_progress_at
         if self.processing_started_at is not None:
             data["processing_started_at"] = self.processing_started_at
+        if self.import_subprocess_started_at is not None:
+            data["import_subprocess_started_at"] = (
+                self.import_subprocess_started_at
+            )
         if self.current_path is not None:
             data["current_path"] = self.current_path
         return json.dumps(data)
@@ -602,6 +613,11 @@ class ActiveDownloadState:
             processing_started_at=(
                 str(d["processing_started_at"])
                 if d.get("processing_started_at") is not None
+                else None
+            ),
+            import_subprocess_started_at=(
+                str(d["import_subprocess_started_at"])
+                if d.get("import_subprocess_started_at") is not None
                 else None
             ),
             current_path=(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -446,6 +446,7 @@ class FakePipelineDB:
         self.status_history: list[tuple[int, str]] = []
         self.update_download_state_calls: list[tuple[int, str]] = []
         self.update_download_state_current_path_calls: list[tuple[int, str | None]] = []
+        self.mark_import_subprocess_started_calls: list[tuple[int, str]] = []
         self.clear_download_state_calls: list[int] = []
         self.advisory_lock_calls: list[tuple[int, int]] = []
         self.closed = False
@@ -1141,6 +1142,33 @@ class FakePipelineDB:
             state["current_path"] = current_path
             row["active_download_state"] = state
             row["updated_at"] = _utcnow()
+
+    def mark_import_subprocess_started(
+        self,
+        request_id: int,
+        timestamp: str,
+    ) -> None:
+        """Stamp ``import_subprocess_started_at`` on the active download
+        state. No-op when the row has no ``active_download_state``
+        (force/manual paths). See ``docs/advisory-locks.md``.
+        """
+        self.mark_import_subprocess_started_calls.append(
+            (request_id, timestamp),
+        )
+        row = self._requests.get(request_id)
+        if not row or row.get("active_download_state") is None:
+            return
+        state = row.get("active_download_state")
+        if isinstance(state, str):
+            try:
+                state = json.loads(state)
+            except json.JSONDecodeError:
+                return
+        if not isinstance(state, dict):
+            return
+        state["import_subprocess_started_at"] = timestamp
+        row["active_download_state"] = state
+        row["updated_at"] = _utcnow()
 
     def log_download(self, request_id: int,
                      soulseek_username: str | None = None,

--- a/tests/test_beets_validation.py
+++ b/tests/test_beets_validation.py
@@ -165,6 +165,53 @@ class TestBeetsValidate(unittest.TestCase):
         self.assertIn("Failed to start harness", result.error)
 
     @patch("lib.beets.sp.Popen")
+    def test_long_stderr_logged_in_full(self, mock_popen):
+        """A multi-frame Python traceback in harness stderr must be logged
+        in full, not silently truncated. Without the full text, operators
+        cannot diagnose ``library.Library()`` crashes (or any other harness
+        startup failure) from journald — this is the exact condition that
+        hid the 2026-05-04 Psilodump crash root cause.
+        """
+        # Real-world traceback from harness library.Library() crash is
+        # 1500-2500 chars. Any truncation below this hides the actual
+        # cause, which appears in the deepest frames.
+        long_stderr = (
+            "Traceback (most recent call last):\n"
+            + "\n".join(
+                f'  File "/nix/store/abc{i:04d}-python3-3.13.12-env/lib/'
+                f'python3.13/site-packages/beets/library.py", line {i}, '
+                f'in __init__\n    self._connect()  # frame {i}'
+                for i in range(20)
+            )
+            + "\nsqlite3.OperationalError: database is locked\n"
+        )
+        self.assertGreater(len(long_stderr), 500,
+                           "test fixture must exceed the old [:500] slice")
+
+        mbid = "12345678-1234-1234-1234-123456789abc"
+        proc = MagicMock()
+        proc.stdout = iter([])  # harness crashed before sending any JSON
+        proc.stderr.read.return_value = long_stderr
+        proc.stdin = MagicMock()
+        proc.wait.return_value = 1
+        mock_popen.return_value = proc
+
+        with self.assertLogs("cratedigger", level="WARNING") as cm:
+            beets_validate(self.HARNESS, "/test/album", mbid, 0.15)
+
+        stderr_logs = [r for r in cm.output if "stderr" in r]
+        self.assertTrue(stderr_logs,
+                        "no stderr log line was emitted")
+        joined = "\n".join(stderr_logs)
+        # The deepest frames carry the actual cause; assert the FULL
+        # traceback is present, not just the first ~500 chars.
+        self.assertIn("frame 19", joined,
+                      "deep stack frame missing — stderr was truncated")
+        self.assertIn("sqlite3.OperationalError: database is locked",
+                      joined,
+                      "the actual exception line was truncated away")
+
+    @patch("lib.beets.sp.Popen")
     def test_launches_harness_with_beets_subprocess_env(self, mock_popen):
         """Regression guard: the harness subprocess MUST receive the beets
         env (HOME override). When cratedigger runs as the systemd service (root,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3107,7 +3107,13 @@ class TestPollActiveDownloads(unittest.TestCase):
             )
 
     def test_poll_post_move_staged_path_with_missing_file_leaves_row_downloading(self):
-        """Missing files under a staged current_path must block, not requeue."""
+        """Missing files under a staged current_path must block, not requeue —
+        but only when the prior attempt actually launched the import
+        subprocess (``import_subprocess_started_at`` is set). If the
+        subprocess never started, the staged-but-missing-files state is
+        a stale crash residue and resetting to ``wanted`` for re-search
+        is safe. See ``docs/advisory-locks.md``.
+        """
         from lib.download import poll_active_downloads
         from lib.processing_paths import stage_to_ai_path
         import tempfile
@@ -3126,6 +3132,7 @@ class TestPollActiveDownloads(unittest.TestCase):
                 "filetype": "flac",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
+                "import_subprocess_started_at": _utc_now_iso(),
                 "current_path": resumed_path,
                 "files": [
                     {"username": "user1", "filename": "user1\\Music\\01.flac",
@@ -3148,7 +3155,11 @@ class TestPollActiveDownloads(unittest.TestCase):
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     def test_poll_post_move_auto_import_path_with_missing_dir_leaves_row_downloading(self):
-        """Missing auto-import staging dirs must block, not requeue."""
+        """Missing auto-import staging dir must block when subprocess
+        already started (beets may have consumed the dir). When
+        ``import_subprocess_started_at`` is None, the dir vanishing is
+        treated as a normal crash residue — reset to ``wanted``.
+        """
         from lib.download import poll_active_downloads
         from lib.processing_paths import stage_to_ai_path
         import tempfile
@@ -3166,6 +3177,7 @@ class TestPollActiveDownloads(unittest.TestCase):
                 "filetype": "flac",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
+                "import_subprocess_started_at": _utc_now_iso(),
                 "current_path": resumed_path,
                 "files": [
                     {"username": "user1", "filename": "user1\\Music\\01.flac",
@@ -3186,6 +3198,51 @@ class TestPollActiveDownloads(unittest.TestCase):
                 resumed_path,
             )
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
+
+    def test_poll_post_move_staged_missing_file_resets_when_subprocess_never_started(self):
+        """Counterpart: when ``import_subprocess_started_at`` is None,
+        a missing file at the staged path is just stale residue from a
+        crash before subprocess launch. Reset to ``wanted`` so the
+        request can be re-searched. This is the recovery path the
+        2026-05-04 wedge was missing.
+        """
+        from lib.download import poll_active_downloads
+        from lib.processing_paths import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=True,
+            )
+            os.makedirs(resumed_path)
+            # No file present at the bound import path — file is missing.
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                # NO ``import_subprocess_started_at`` — subprocess
+                # never launched. This is the legacy wedge shape.
+                "current_path": resumed_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.beets_staging_dir = staging_root
+
+            poll_active_downloads(ctx)
+
+            self.assertEqual(
+                fake_db.request(1)["status"], "wanted",
+                "Subprocess never launched + missing files = stale "
+                "crash residue; must reset to wanted, not block forever.",
+            )
 
     def test_poll_no_redownload_window(self):
         """Album stays 'downloading' while queued for importer."""

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -1291,6 +1291,7 @@ class TestActiveDownloadState(unittest.TestCase):
             enqueued_at="2026-04-03T12:00:00+00:00",
             last_progress_at="2026-04-03T12:01:00+00:00",
             processing_started_at="2026-04-03T12:02:00+00:00",
+            import_subprocess_started_at="2026-04-03T12:04:00+00:00",
             current_path="/tmp/staged/user1/Album",
             files=[
                 ActiveDownloadFileState(
@@ -1306,6 +1307,8 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(restored.enqueued_at, original.enqueued_at)
         self.assertEqual(restored.last_progress_at, original.last_progress_at)
         self.assertEqual(restored.processing_started_at, original.processing_started_at)
+        self.assertEqual(restored.import_subprocess_started_at,
+                         original.import_subprocess_started_at)
         self.assertEqual(restored.current_path, original.current_path)
         self.assertEqual(len(restored.files), 1)
         self.assertEqual(restored.files[0].username, "user1")
@@ -1314,6 +1317,32 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(restored.files[0].retry_count, 5)
         self.assertEqual(restored.files[0].bytes_transferred, 8192)
         self.assertEqual(restored.files[0].last_state, "InProgress")
+
+    def test_active_download_state_import_subprocess_started_at_optional(self):
+        """The new flag is optional and absent by default — legacy DB rows
+        whose JSONB predates the field round-trip cleanly with the field
+        as None. This is the load-bearing property that makes the
+        2026-05-04 wedged-row recovery work: rows wedged before this fix
+        have ``import_subprocess_started_at`` absent, so the resume guard
+        permits retry. See ``lib/download.py::_log_post_move_resume_blocked``
+        callers and ``docs/advisory-locks.md``.
+        """
+        from lib.quality import ActiveDownloadState
+        legacy_raw = json.dumps({
+            "filetype": "flac",
+            "enqueued_at": "2026-04-27T13:36:28+00:00",
+            "processing_started_at": "2026-04-27T14:00:38+00:00",
+            "current_path": (
+                "/mnt/virtio/Music/Incoming/auto-import/MxPx/"
+                "Plans Within Plans [request-1984]"
+            ),
+            "files": [],
+        })
+        state = ActiveDownloadState.from_json(legacy_raw)
+        self.assertIsNone(state.import_subprocess_started_at)
+        # And re-serialising an unset flag must not introduce a null
+        # field that would diverge JSONB equality with legacy rows.
+        self.assertNotIn("import_subprocess_started_at", state.to_json())
 
     def test_active_download_file_state_fields(self):
         """Verify per-file fields present."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -3218,5 +3218,352 @@ class TestSearchExhaustionResetsCounterSlice(unittest.TestCase):
         self.assertIn(rid, wanted_ids)
 
 
+class TestImportSubprocessStartedFlag(unittest.TestCase):
+    """``dispatch_import_core`` must mark
+    ``ActiveDownloadState.import_subprocess_started_at`` immediately
+    before launching ``run_import_one`` on the auto-import path. The
+    flag is the witness the resume guard checks to decide whether the
+    subprocess might have written to beets — without setting it here,
+    the guard never blocks a real recovery situation, and the wedge
+    fix becomes a one-way ratchet that loses the safety property.
+    """
+
+    def test_flag_set_before_subprocess_launch_on_auto_import(self):
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import ActiveDownloadState
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="downloading",
+            mb_release_id="mbid-123",
+        ))
+        # Seed the state the auto path would have produced before
+        # reaching this dispatch call.
+        existing = ActiveDownloadState(
+            filetype="flac",
+            enqueued_at="2026-05-04T10:00:00+00:00",
+            files=[],
+            processing_started_at="2026-05-04T10:01:00+00:00",
+            current_path="/tmp/staged/Test/Album",
+        )
+        db.update_download_state(42, existing.to_json())
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
+            is_cbr=True, album_path="/Beets/Test")
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+        dl_info = DownloadInfo(username="user1")
+        stdout = _make_stdout(ir)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+
+                # Capture the persisted state at the moment
+                # ``run_import_one`` (= ``ext.run``) is invoked.
+                captured: dict[str, ActiveDownloadState | None] = {
+                    "at_subprocess": None,
+                }
+
+                def _record_state(*_args: Any, **_kwargs: Any):
+                    raw = db.request(42)["active_download_state"]
+                    if raw is None:
+                        captured["at_subprocess"] = None
+                    else:
+                        captured["at_subprocess"] = (
+                            ActiveDownloadState.from_dict(raw)
+                            if isinstance(raw, dict)
+                            else ActiveDownloadState.from_json(str(raw))
+                        )
+                    return MagicMock(returncode=0, stdout=stdout, stderr="")
+
+                ext.run.side_effect = _record_state
+
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id="mbid-123",
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="auto_import",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=cfg,
+                )
+
+        state_at_subprocess = captured["at_subprocess"]
+        self.assertIsNotNone(
+            state_at_subprocess,
+            "active_download_state was None when subprocess launched — "
+            "the auto path must preserve state through dispatch.",
+        )
+        assert state_at_subprocess is not None
+        self.assertIsNotNone(
+            state_at_subprocess.import_subprocess_started_at,
+            "import_subprocess_started_at must be set BEFORE "
+            "run_import_one launches; otherwise a crash mid-subprocess "
+            "would leave the resume guard unable to distinguish "
+            "'subprocess never ran' from 'subprocess wrote to beets'.",
+        )
+
+    def test_flag_not_touched_on_force_import_path(self):
+        """Force/manual paths operate on ``failed_imports/...`` and do
+        not own ``active_download_state``. Mutating the flag here would
+        be cross-cutting state corruption — the request row that
+        eventually owns ``active_download_state`` for the same MBID
+        must not be polluted by an unrelated force-import.
+        """
+        from lib.import_dispatch import dispatch_import_core
+        from lib.quality import ActiveDownloadState
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="manual",
+            mb_release_id="mbid-123",
+        ))
+        existing = ActiveDownloadState(
+            filetype="flac",
+            enqueued_at="2026-05-04T10:00:00+00:00",
+            files=[],
+            processing_started_at=None,
+            import_subprocess_started_at=None,
+        )
+        db.update_download_state(42, existing.to_json())
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
+            is_cbr=True, album_path="/Beets/Test")
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+        dl_info = DownloadInfo(username="user1")
+        stdout = _make_stdout(ir)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch_dispatch_externals() as ext, \
+                 patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id="mbid-123",
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    force=True,
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=dl_info,
+                    distance=0.05,
+                    scenario="force_import",
+                    files=[MagicMock(username="user1",
+                                     filename="01 - Track.mp3")],
+                    cfg=cfg,
+                )
+
+        raw = db.request(42)["active_download_state"]
+        if raw is None:
+            return  # Force/manual cleared the state — also acceptable.
+        state = (
+            ActiveDownloadState.from_dict(raw)
+            if isinstance(raw, dict)
+            else ActiveDownloadState.from_json(str(raw))
+        )
+        self.assertIsNone(
+            state.import_subprocess_started_at,
+            "Force-import path must not flip the auto-path resume flag.",
+        )
+
+
+class TestPostMoveResumeBlockGuard(unittest.TestCase):
+    """The wedge from 2026-05-04: requests stuck in ``downloading`` for
+    a week because a previous attempt left files at the request-scoped
+    auto-import staged path but never launched ``import_one.py``. The
+    resume guard couldn't distinguish "subprocess never ran" from
+    "subprocess may have started" and blocked retry forever — every
+    cycle requeued an importer job that failed in <50ms with
+    ``POST-MOVE RESUME BLOCKED``. 5788 failed jobs accumulated.
+
+    Fix: ``ActiveDownloadState.import_subprocess_started_at`` flag is
+    set immediately before ``run_import_one(...)`` on the auto path. The
+    resume guard now permits retry when the flag is None (subprocess
+    never launched, safe) and blocks when set (subprocess may have
+    written to beets, manual recovery required).
+
+    Tests pin the relaxed guard so future refactors can't reintroduce
+    the trap.
+    """
+
+    def _make_state(self, *, current_path: str,
+                    import_subprocess_started_at: str | None):
+        from lib.quality import ActiveDownloadState
+        return ActiveDownloadState(
+            filetype="flac",
+            enqueued_at="2026-04-27T13:36:28+00:00",
+            files=[],
+            last_progress_at="2026-04-27T14:00:38+00:00",
+            processing_started_at="2026-04-27T14:00:38+00:00",
+            import_subprocess_started_at=import_subprocess_started_at,
+            current_path=current_path,
+        )
+
+    def _setup_wedged_request(self, tmpdir: str, *,
+                              import_subprocess_started_at: str | None):
+        """Build a wedge-shaped state: files at the auto-import staged
+        path, ``processing_started_at`` set. Caller decides whether the
+        ``import_subprocess_started_at`` flag is set (block) or not (retry).
+        """
+        from lib.processing_paths import stage_to_ai_path
+        from tests.helpers import (
+            make_ctx_with_fake_db,
+            make_download_file,
+            make_grab_list_entry,
+        )
+
+        request_id = 1984
+        artist = "MxPx"
+        title = "Plans Within Plans"
+        staging_dir = os.path.join(tmpdir, "staging")
+        slskd_dir = os.path.join(tmpdir, "slskd")
+        os.makedirs(staging_dir)
+        os.makedirs(slskd_dir)
+        staged_path = stage_to_ai_path(
+            artist=artist,
+            title=title,
+            staging_dir=staging_dir,
+            request_id=request_id,
+            auto_import=True,
+        )
+        os.makedirs(staged_path)
+        # The wedge requires both: dir present AND tracked files present
+        # at their bind-target locations. Otherwise the guard at line
+        # 1644-1690 (missing dir / missing files) fires for a different
+        # reason. We construct a single tracked file so the test
+        # confirms the dispatch guard, not the missing-files guard.
+        track_path = os.path.join(staged_path, "01 - Aces Up.flac")
+        with open(track_path, "w") as fp:
+            fp.write("fake audio")
+
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+            beets_validation_enabled=True,
+            beets_distance_threshold=0.15,
+            beets_staging_dir=staging_dir,
+            slskd_download_dir=slskd_dir,
+            beets_tracking_file=os.path.join(tmpdir, "beets-tracking.jsonl"),
+        )
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=request_id,
+            status="downloading",
+            artist_name=artist,
+            album_title=title,
+            year=2012,
+            mb_release_id="2c5a5a0b-095d-434b-af15-b23e6fbc5ad9",
+        ))
+        ctx = make_ctx_with_fake_db(db, cfg=cfg)
+        entry = make_grab_list_entry(
+            album_id=request_id,
+            files=[make_download_file(
+                filename="user1\\Music\\01 - Aces Up.flac",
+                file_dir="user1\\Music",
+            )],
+            artist=artist,
+            title=title,
+            year="2012",
+            mb_release_id="2c5a5a0b-095d-434b-af15-b23e6fbc5ad9",
+            db_source="request",
+            db_request_id=request_id,
+        )
+        # Bind the import paths so the file actually lives where
+        # `_processing_path_ready_for_importer` will look for it.
+        from lib.staged_album import StagedAlbum
+        sa = StagedAlbum.from_entry(entry, default_path=staged_path)
+        sa.bind_import_paths(entry.files)
+        # Ensure the bound destination exists.
+        for file in entry.files:
+            dst = file.import_path
+            assert dst is not None
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst):
+                with open(dst, "w") as fp:
+                    fp.write("fake audio")
+        state = self._make_state(
+            current_path=staged_path,
+            import_subprocess_started_at=import_subprocess_started_at,
+        )
+        # Persist state into the FakePipelineDB so guards that read
+        # back via ``db.get_request`` see the same flag the test built.
+        db.update_download_state(request_id, state.to_json())
+        return entry, request_id, state, db, ctx, staged_path
+
+    def test_legacy_wedge_permits_retry(self):
+        """Legacy state (``processing_started_at`` set, no
+        ``import_subprocess_started_at``): the wedge guard MUST permit
+        retry. This is the recovery path for the 3 albums wedged on
+        2026-05-04 — the fix unwedges them automatically on the next
+        cycle.
+
+        Exercises ``_materialize_processing_dir`` (the actual fire site
+        seen in production logs at ``lib/download.py:583``).
+        """
+        from lib.download import _materialize_processing_dir
+        from lib.staged_album import StagedAlbum
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            entry, _, _, _, ctx, staged_path = self._setup_wedged_request(
+                tmpdir, import_subprocess_started_at=None)
+            staged_album = StagedAlbum.from_entry(
+                entry, default_path=staged_path)
+            result = _materialize_processing_dir(
+                entry, staged_album, ctx)
+
+        self.assertIs(
+            result, True,
+            "Legacy wedged row (subprocess never launched) must "
+            "materialize the existing files for retry. Returning None "
+            "perpetuates the 2026-05-04 wedge: every cycle requeues a "
+            "job that fails in <50ms with POST-MOVE RESUME BLOCKED.",
+        )
+        # And ``import_folder`` must be wired to the staged path so the
+        # downstream tag-write/beets-validate sequence picks the files up.
+        self.assertEqual(entry.import_folder, staged_path)
+
+    def test_subprocess_started_blocks_retry(self):
+        """Once ``import_subprocess_started_at`` is set, the wedge guard
+        MUST still block: the subprocess may have written to beets, so
+        retry is unsafe and operator recovery is required. This is the
+        original safety property the structural fix preserves.
+        """
+        from lib.download import _materialize_processing_dir
+        from lib.staged_album import StagedAlbum
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            entry, _, _, _, ctx, staged_path = self._setup_wedged_request(
+                tmpdir,
+                import_subprocess_started_at="2026-04-27T14:00:39+00:00")
+            staged_album = StagedAlbum.from_entry(
+                entry, default_path=staged_path)
+            result = _materialize_processing_dir(
+                entry, staged_album, ctx)
+
+        self.assertIsNone(
+            result,
+            "Subprocess-started wedge must be blocked — beets may have "
+            "started writing; an auto retry would risk a double-import.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two independent bugs surfaced by the 2026-05-04 wedge investigation:

- **`fix(download)`** — Adds `ActiveDownloadState.import_subprocess_started_at`, stamped just before `run_import_one(...)` on the auto-import path. The four resume guards in `lib/download.py` now relax when the flag is None: files-at-staged-path with no subprocess witness ⇒ safe to retry. Previously the guard fired on a state combination that couldn't distinguish "subprocess never launched" from "subprocess wrote to beets", trapping rows after a crash and accumulating 5788 failed `import_jobs` over a week. The fix auto-recovers existing wedged rows on the next poll cycle (legacy state has the field absent ≡ None ≡ retry permitted).
- **`fix(beets)`** — Removes the `[:500]` slice on `BEETS_VALIDATE: stderr`. Multi-frame Python tracebacks were truncated mid-path, hiding root-cause exception lines. The 2026-05-04 Psilodump `library.Library()` crash was unrecoverable from the journal.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 2779 tests pass
- [x] `TestActiveDownloadState` — flag round-trips through to_json/from_dict; legacy rows (field absent) preserve None
- [x] `TestImportSubprocessStartedFlag` — flag is set before `run_import_one` on auto path; not touched on force/manual
- [x] `TestPostMoveResumeBlockGuard` — wedge with flag=None permits retry; flag set still blocks
- [x] `TestPollActiveDownloads` — missing-dir/missing-files at staged path now resets to wanted when subprocess never launched, blocks when it did
- [x] `TestBeetsValidate.test_long_stderr_logged_in_full` — 20-frame stderr captured in full
- [ ] Deploy to doc2 — verify the 3 wedged albums (1984/1034/2045) self-recover on the next cycle (status flips out of `downloading`, no new failed `import_jobs` queued for them)
- [ ] Confirm `pipeline-cli show <id>` of an in-flight auto-import shows `import_subprocess_started_at` in the JSONB once `dispatch_import_core` reaches `run_import_one`

🤖 Generated with [Claude Code](https://claude.com/claude-code)