### PR TITLE
fix(nix): TimeoutStartSec replaces RuntimeMaxSec on Type=oneshot service

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -717,7 +717,7 @@ def _search_and_queue_parallel(albums, ctx):
         Issue #212 removed the cycle-entry deadline gate. Bounded runtime
         comes from two layers now: the per-search progress watchdog inside
         `_collect_search_results` (90s no-progress kill) and the systemd
-        unit's `RuntimeMaxSec=1h` defense-in-depth.
+        unit's `TimeoutStartSec=1h` defense-in-depth.
         """
         from lib.search import SearchResult
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -800,7 +800,14 @@ in {
         # the next cycle. Cycle-boundary checkpointing already tolerates
         # a forced kill — the importer service owns beets writes
         # independently and is unaffected.
-        RuntimeMaxSec = "1h";
+        #
+        # `RuntimeMaxSec` does NOT apply to Type=oneshot — systemd warns
+        # `RuntimeMaxSec= has no effect in combination with Type=oneshot.
+        # Ignoring.` and the defense-in-depth silently disappears. For a
+        # oneshot, the entire service runtime IS the start phase, so
+        # `TimeoutStartSec` is the right knob. It SIGTERMs (then SIGKILLs
+        # after `TimeoutStopSec`) the ExecStart process at the cap.
+        TimeoutStartSec = "1h";
       };
     };
 


### PR DESCRIPTION
Production followup to #213. Deploy surfaced:

\`\`\`
cratedigger.service: RuntimeMaxSec= has no effect in combination with Type=oneshot. Ignoring.
\`\`\`

systemd silently drops \`RuntimeMaxSec\` on \`Type=oneshot\` — the entire service runtime IS the start phase, so \`TimeoutStartSec\` is the right knob. Without this, the R13 defense-in-depth from #212 was silently disabled.

Refs #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)