### PR TITLE
fix(search): decouple find_download from search refill

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -10,6 +10,7 @@ import time
 from typing import Any, Sequence, TYPE_CHECKING, TypedDict
 
 import slskd_api
+from lib.slskd_client import SLSKD_HTTP_TIMEOUT_S, configure_slskd_http_pool
 
 if TYPE_CHECKING:
     from album_source import DatabaseSource
@@ -77,13 +78,28 @@ pipeline_db_source: "DatabaseSource" = None  # type: ignore[assignment]  # Set i
 # All matching/search functions receive ctx explicitly.
 _module_ctx: Any = None  # CratediggerContext — set in main()
 
+
+def _create_slskd_client(client_cfg: CratediggerConfig) -> slskd_api.SlskdClient:
+    """Create the slskd client and configure its HTTP connection pool."""
+    client = slskd_api.SlskdClient(
+        host=client_cfg.slskd_host_url,
+        api_key=client_cfg.resolved_slskd_api_key(),
+        url_base=client_cfg.slskd_url_base,
+        timeout=SLSKD_HTTP_TIMEOUT_S,
+    )
+    configure_slskd_http_pool(client, client_cfg)
+    return client
+
 from lib.browse import (
     _browse_directories,
     _browse_one,
     download_filter,
     rank_candidate_dirs,
+    shutdown_browse_coordinator,
 )
 from lib.enqueue import (
+    FindDownloadResult,
+    FindDownloadOwnerPathError,
     _get_denied_users,
     _get_user_dirs,
     _prefixed_directory_files,
@@ -91,6 +107,7 @@ from lib.enqueue import (
     choose_release,
     find_download,
     get_album_tracks,
+    prepare_find_download_context,
     release_trackcount_mode,
     try_enqueue,
     try_multi_enqueue,
@@ -639,62 +656,83 @@ def _log_search_result(album, result, ctx) -> None:
         db.reset_search_attempts(request_id)
 
 
-def _apply_find_download_result(album, result, find_result, failed_grab) -> None:
+def _apply_find_download_result(
+    album,
+    result,
+    find_result,
+    failed_grab,
+    grab_list=None,
+    ctx=None,
+) -> None:
     """Translate matching/enqueue outcome into search_log telemetry."""
     # Forensic capture: copy the per-(user, dir, filetype) score list off the
     # find_download result onto the SearchResult so `_log_search_result` can
     # persist the top-20 to `search_log.candidates`.
     result.candidates = tuple(find_result.candidates)
+    if ctx is not None and getattr(find_result, "metrics", None) is not None:
+        metrics = find_result.metrics
+        ctx.browse_time_s += metrics.browse_time_s
+        ctx.match_time_s += metrics.match_time_s
+        ctx.peers_browsed += metrics.peers_browsed
+        ctx.peers_browsed_lazy += metrics.peers_browsed_lazy
+        ctx.fanout_waves += metrics.fanout_waves
+    elif getattr(find_result, "metrics", None) is not None:
+        raise AssertionError("find_download metrics require owner context merge")
     if find_result.outcome == "found":
         result.outcome = "found"
+        if grab_list is None:
+            raise AssertionError("found find_download result requires grab_list merge")
+        if find_result.grab_entry is None:
+            raise AssertionError("found find_download result requires grab entry")
+        grab_list[find_result.grab_entry.album_id] = find_result.grab_entry
         return
     result.outcome = "error" if find_result.outcome == "enqueue_failed" else "no_match"
     failed_grab.append(album)
 
 
 def search_and_queue(albums, ctx):
-    if cfg.parallel_searches > 1 and len(albums) > 1:
+    if ctx.cfg.parallel_searches > 1 and len(albums) > 1:
         return _search_and_queue_parallel(albums, ctx)
     grab_list = {}
     failed_grab = []
     failed_search = []
     total = len(albums)
-    for i, album in enumerate(albums, 1):
-        logger.info(f"Album {i}/{total}: {album.artist_name} - {album.title}")
-        result = search_for_album(album, ctx)
-        if result.success:
-            find_result = find_download(album, grab_list, ctx)
-            _apply_find_download_result(album, result, find_result, failed_grab)
-        else:
-            failed_search.append(album)
-        _log_search_result(album, result, ctx)
-    return grab_list, failed_search, failed_grab
+    try:
+        for i, album in enumerate(albums, 1):
+            logger.info(f"Album {i}/{total}: {album.artist_name} - {album.title}")
+            result = search_for_album(album, ctx)
+            if result.success:
+                find_ctx = prepare_find_download_context(album, ctx, result)
+                find_result = find_download(album, find_ctx)
+                _apply_find_download_result(
+                    album, result, find_result, failed_grab, grab_list, ctx,
+                )
+            else:
+                failed_search.append(album)
+            _log_search_result(album, result, ctx)
+        return grab_list, failed_search, failed_grab
+    finally:
+        shutdown_browse_coordinator(ctx)
 
 
 def _search_and_queue_parallel(albums, ctx):
-    """Pipeline searches with result processing: always 2 searches in flight.
+    """Pipeline searches and hand successful results to find_download workers.
 
     slskd constraints (from source code):
     - SemaphoreSlim(1,1) on POST /searches: one submission at a time
     - maximumConcurrentSearches=2 in Soulseek.NET: only 2 active on network
 
-    We keep 2 searches running on the network at all times. When one completes,
-    we process its results (browse dirs, match tracks, enqueue) AND submit the
-    next search — so network wait and result processing overlap.
-
-    Timeline:
-      search_1 ─────────> process_1    search_5 ──────> process_5 ...
-      search_2 ─────────> process_2    search_6 ──────> ...
-        search_3 ─────────> process_3
-        search_4 ─────────> process_4
+    Completed searches queue find_download work and immediately refill the
+    search slot, so browse/match/enqueue no longer blocks search collection.
     """
-    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
 
     # Pipeline depth — number of search-collection futures in flight at once.
     # Configurable via cfg.search_max_inflight (issue #198 U4). Submission
     # stays sequential through the existing 429-retry loop; only the
     # collect-side concurrency increases.
-    max_inflight = ctx.cfg.search_max_inflight
+    search_cfg = ctx.cfg
+    max_inflight = search_cfg.search_max_inflight
 
     grab_list: dict[Any, Any] = {}
     failed_grab: list[Any] = []
@@ -724,7 +762,7 @@ def _search_and_queue_parallel(albums, ctx):
         while album_queue:
             album = album_queue.pop(0)
             db = ctx.pipeline_db_source._get_db()
-            variant, base_query = _select_variant_for_album(album, cfg, db)
+            variant, base_query = _select_variant_for_album(album, search_cfg, db)
 
             if variant.kind == "exhausted":
                 # Variant ladder exhausted — emit a SearchResult inline, no
@@ -756,7 +794,7 @@ def _search_and_queue_parallel(albums, ctx):
                 failed_search.append(album)
                 continue
 
-            submit_result = _submit_search(album, variant, cfg, slskd)
+            submit_result = _submit_search(album, variant, search_cfg, ctx.slskd)
             if submit_result is None:
                 # slskd round-trip failed — preserve variant_tag in the log.
                 sr = SearchResult(
@@ -771,63 +809,178 @@ def _search_and_queue_parallel(albums, ctx):
 
             search_id, query, album_id, variant_tag = submit_result
             future = pool.submit(
-                _collect_search_results, search_id, query, album_id, cfg, slskd,
+                _collect_search_results, search_id, query, album_id, search_cfg, ctx.slskd,
                 variant_tag,
             )
             return (future, album)
         return None
 
-    with ThreadPoolExecutor(max_workers=max_inflight) as pool:
-        # Seed the pipeline with initial searches
-        inflight: dict[Any, Any] = {}
-        for _ in range(min(max_inflight, len(album_queue))):
-            submitted = _submit_next()
-            if submitted:
-                future, album = submitted
-                inflight[future] = album
+    find_pool: ThreadPoolExecutor | None = None
+    find_inflight: dict[Any, tuple[Any, Any]] = {}
+    find_merge_time_s = 0.0
 
-        # Process completions and refill the pipeline
-        while inflight:
-            for future in as_completed(inflight):
-                album = inflight.pop(future)
-                try:
-                    result = future.result()
-                except Exception:
-                    logger.exception(f"Search collection crashed for {album.title}")
-                    from lib.search import SearchResult
-                    sr = SearchResult(album_id=album.id, success=False, outcome="error")
-                    _log_search_result(album, sr, ctx)
-                    failed_search.append(album)
-                else:
-                    done_count = len(grab_list) + len(failed_grab) + len(failed_search)
-                    logger.info(
-                        f"Search {done_count + 1}/{total} done: {result.query} "
-                        f"({result.result_count if result.result_count is not None else 'n/a'} results, "
-                        f"{result.elapsed_s:.1f}s)"
-                    )
-                    if result.success:
-                        _merge_search_result(result, ctx)
-                        find_result = find_download(album, grab_list, ctx)
-                        _apply_find_download_result(album, result, find_result, failed_grab)
-                    else:
-                        failed_search.append(album)
-                    _log_search_result(album, result, ctx)
+    def _submit_find_download(album, result) -> None:
+        nonlocal find_pool
+        if find_pool is None:
+            find_pool = ThreadPoolExecutor(
+                max_workers=max(1, total),
+                thread_name_prefix="find-download",
+            )
+        find_ctx = prepare_find_download_context(album, ctx, result)
+        future = find_pool.submit(find_download, album, find_ctx)
+        find_inflight[future] = (album, result)
+        ctx.find_download_queued += 1
 
-                # Refill: submit next search to keep pipeline full
+    def _apply_find_future(future, *, log_search: bool = True) -> None:
+        album, result = find_inflight.pop(future)
+        try:
+            find_result = future.result()
+        except Exception:
+            logger.exception(f"find_download crashed for {album.title}")
+            find_result = FindDownloadResult(outcome="enqueue_failed")
+        _apply_find_download_result(
+            album, result, find_result, failed_grab, grab_list, ctx,
+        )
+        ctx.find_download_completed += 1
+        if log_search:
+            try:
+                _log_search_result(album, result, ctx)
+            except Exception:
+                logger.exception(
+                    "Failed to log search result after find_download for %s",
+                    getattr(album, "title", album),
+                )
+
+    def _drain_completed_find() -> None:
+        nonlocal find_merge_time_s
+        if not find_inflight:
+            return
+        done, _pending = wait(
+            list(find_inflight),
+            timeout=0,
+            return_when=FIRST_COMPLETED,
+        )
+        if not done:
+            return
+        drain_start = time.time()
+        for future in done:
+            _apply_find_future(future)
+        elapsed = time.time() - drain_start
+        find_merge_time_s += elapsed
+        ctx.find_download_drain_time_s += elapsed
+
+    def _drain_find_after_owner_exception() -> None:
+        nonlocal find_pool, find_merge_time_s
+        logger.exception(
+            "Search pipeline owner path crashed; draining submitted "
+            "find_download work before returning partial results"
+        )
+        if find_pool is not None:
+            find_pool.shutdown(wait=True, cancel_futures=True)
+            find_pool = None
+        if not find_inflight:
+            return
+        drain_start = time.time()
+        for future in as_completed(list(find_inflight)):
+            try:
+                _apply_find_future(future, log_search=False)
+            except Exception:
+                logger.exception("Failed to merge find_download result after owner crash")
+        elapsed = time.time() - drain_start
+        find_merge_time_s += elapsed
+        ctx.find_download_drain_time_s += elapsed
+
+    try:
+        with ThreadPoolExecutor(max_workers=max_inflight) as pool:
+            # Seed the pipeline with initial searches
+            inflight: dict[Any, Any] = {}
+            for _ in range(min(max_inflight, len(album_queue))):
                 submitted = _submit_next()
                 if submitted:
-                    new_future, new_album = submitted
-                    inflight[new_future] = new_album
+                    future, album = submitted
+                    inflight[future] = album
 
-                # Break out of the as_completed loop to re-enter with updated dict
-                break
+            # Process completions and refill the pipeline
+            while inflight:
+                for future in as_completed(inflight):
+                    album = inflight.pop(future)
+                    try:
+                        result = future.result()
+                    except Exception:
+                        logger.exception(f"Search collection crashed for {album.title}")
+                        from lib.search import SearchResult
+                        sr = SearchResult(album_id=album.id, success=False, outcome="error")
+                        _log_search_result(album, sr, ctx)
+                        failed_search.append(album)
+                    else:
+                        done_count = (
+                            len(grab_list)
+                            + len(failed_grab)
+                            + len(failed_search)
+                            + len(find_inflight)
+                        )
+                        logger.info(
+                            f"Search {done_count + 1}/{total} done: {result.query} "
+                            f"({result.result_count if result.result_count is not None else 'n/a'} results, "
+                            f"{result.elapsed_s:.1f}s)"
+                        )
+                        if result.success:
+                            _merge_search_result(result, ctx)
+                            try:
+                                _submit_find_download(album, result)
+                            except Exception:
+                                logger.exception(
+                                    f"find_download submission failed for {album.title}"
+                                )
+                                find_result = FindDownloadResult(outcome="enqueue_failed")
+                                _apply_find_download_result(
+                                    album, result, find_result, failed_grab, grab_list, ctx,
+                                )
+                                _log_search_result(album, result, ctx)
+                        else:
+                            failed_search.append(album)
+                            _log_search_result(album, result, ctx)
+
+                    # Refill: submit next search to keep pipeline full before
+                    # doing any opportunistic find-result merge work.
+                    submitted = _submit_next()
+                    if submitted:
+                        new_future, new_album = submitted
+                        inflight[new_future] = new_album
+                    _drain_completed_find()
+
+                    # Break out of the as_completed loop to re-enter with updated dict
+                    break
+    except Exception:
+        owner_exc = sys.exception()
+        _drain_find_after_owner_exception()
+        shutdown_browse_coordinator(ctx, wait=True, cancel_futures=True)
+        raise FindDownloadOwnerPathError(
+            "Search pipeline owner path failed after find_download work was queued; "
+            "submitted side effects were drained before aborting the cycle"
+        ) from owner_exc
 
     wall_elapsed = time.time() - wall_start
     # U1 instrumentation (issue #198 R13): credit the search phase wall time
     # to the per-cycle accumulator so the cycle summary can split it from
     # browse/match. Includes both submit (network round-trip) and collect
     # (poll + result merge) since both are gated by slskd's pipeline depth.
-    ctx.search_time_s += wall_elapsed
+    ctx.search_time_s += max(0.0, wall_elapsed - find_merge_time_s)
+
+    try:
+        if find_inflight:
+            find_drain_start = time.time()
+            for future in as_completed(list(find_inflight)):
+                try:
+                    _apply_find_future(future)
+                except Exception:
+                    logger.exception("Failed to merge find_download result")
+            ctx.find_download_drain_time_s += time.time() - find_drain_start
+    finally:
+        if find_pool is not None:
+            find_pool.shutdown(wait=True)
+        shutdown_browse_coordinator(ctx)
+
     logger.info(f"Pipelined search complete: {total} albums in {wall_elapsed:.1f}s "
                 f"(found={len(grab_list)}, no_match={len(failed_grab)}, "
                 f"no_results={len(failed_search)})")
@@ -949,7 +1102,7 @@ def main():
         if cfg.meelo_url:
             logger.info(f"Meelo post-import scan ENABLED: {cfg.meelo_url}")
 
-        slskd = slskd_api.SlskdClient(host=cfg.slskd_host_url, api_key=cfg.resolved_slskd_api_key(), url_base=cfg.slskd_url_base)
+        slskd = _create_slskd_client(cfg)
 
         # Build context with fresh caches for this cycle
         from lib.context import CratediggerContext

--- a/docs/brainstorms/find-download-concurrency-requirements.md
+++ b/docs/brainstorms/find-download-concurrency-requirements.md
@@ -1,0 +1,163 @@
+---
+date: 2026-05-04
+topic: find-download-concurrency
+issue: 217
+---
+
+# Find Download Concurrency — Remove Main-Thread Search Pipeline Blocking
+
+## Summary
+
+Completed searches should hand their results to concurrent `find_download` work immediately, then refill search slots without waiting for browse, match, or enqueue to finish. Browse pressure stays bounded by one true global browse limit, and the slskd HTTP connection pool is sized from that limit so concurrency is real rather than connection churn.
+
+---
+
+## Problem Frame
+
+Issue #198 fixed the original serial browse fan-out problem inside a single album's enqueue path, and issue #213 fixed the stuck-search failure mode with a per-search progress watchdog. The remaining #217 trace shows a different bottleneck: once a search completes, the main search loop runs `find_download` synchronously before it submits the next search. During that time, search collector slots are idle even though more wanted albums are available.
+
+This did not dominate in the older pipeline because each completed search carried a much smaller candidate surface. The search-escalation work and #198 tuning intentionally widened that surface: higher response limits, higher file limits, and more productive un-wildcarded/escalated queries now feed many more peer directories into `find_download`. The serial architecture was tolerable when each album was cheap; it is exposed now that each album can require substantial browse-and-match work.
+
+Production logs also show repeated `Connection pool is full, discarding connection: localhost. Connection pool size: 10` warnings. The configured browse worker capacity is 32, but the slskd Python client inherits requests' default HTTP pool size of 10 unless cratedigger configures it. That mismatch means concurrency above 10 creates disposable connections and noisy logs rather than clean reusable capacity.
+
+---
+
+## Actors
+
+- A1. Search pipeline: submits searches, collects slskd results, records search outcomes, and keeps the cycle moving.
+- A2. `find_download` worker: browses candidate peer directories, scores matches, and enqueues a matched download when found.
+- A3. Browse coordinator: enforces total browse concurrency and owns safe shared access to cached directory data.
+- A4. slskd HTTP client: carries search, browse, transfer, and cancel API calls to the local slskd service.
+- A5. Operator: reads cycle logs and throughput metrics to decide whether the pipeline is healthy.
+
+---
+
+## Key Flows
+
+- F1. Search completion hands off to `find_download`
+  - **Trigger:** A search collector finishes with usable peer results for an album.
+  - **Actors:** A1, A2
+  - **Steps:** The search result is merged into the album's match input, a `find_download` job is queued, and the search pipeline immediately attempts to submit the next wanted album.
+  - **Outcome:** Search slots are not blocked by browse, match, or enqueue work for a prior album.
+  - **Covered by:** R1, R2, R3, R4
+
+- F2. Concurrent `find_download` jobs share browse capacity
+  - **Trigger:** Multiple completed searches are ready for `find_download` work in the same cycle.
+  - **Actors:** A2, A3, A4
+  - **Steps:** Each `find_download` job proceeds independently, but every uncached slskd directory browse passes through one shared browse capacity limit before hitting slskd.
+  - **Outcome:** Completed albums can progress concurrently without multiplying browse pressure by album count.
+  - **Covered by:** R5, R6, R7, R8
+
+- F3. Completed `find_download` results are merged and logged
+  - **Trigger:** A `find_download` job returns found, no-match, or enqueue-failed.
+  - **Actors:** A1, A2
+  - **Steps:** The search pipeline merges the job's result into the cycle's found/failed collections, copies candidate forensics onto the corresponding search result, and logs the final search outcome.
+  - **Outcome:** Existing search-log semantics and download queue behavior are preserved while work runs concurrently.
+  - **Covered by:** R9, R10, R11
+
+---
+
+## Requirements
+
+**Search pipeline handoff**
+
+- R1. A successful search completion must not run `find_download` inline on the search pipeline's main completion path.
+- R2. A successful search completion must queue `find_download` work and then immediately make the search slot eligible to submit the next wanted album.
+- R3. Search collection concurrency and `find_download` concurrency must be decoupled: the existing search-side in-flight setting continues to control search collection only.
+- R4. There must be no separate `find_download_concurrency` cap. The number of active `find_download` jobs may grow with completed successful searches in the current cycle.
+
+**Global browse capacity**
+
+- R5. Browse capacity must be global across the process, not local to one album or one `find_download` call.
+- R6. `browse_global_max_workers` remains the browse capacity control, with the current default of 32.
+- R7. When multiple `find_download` jobs run concurrently, `browse_global_max_workers=32` must mean at most 32 slskd directory browse calls in flight total.
+- R8. Concurrent `find_download` jobs must share cached directory results so one worker's successful browse can be reused by later workers in the same cycle and by persisted cache saves.
+
+**slskd HTTP connection pool**
+
+- R9. The slskd HTTP connection pool size must be configured automatically from the concurrency settings instead of relying on requests' default pool size of 10.
+- R10. The configured HTTP pool must be large enough for the global browse limit plus search and transfer headroom.
+- R11. When demand exceeds the configured HTTP pool, cratedigger should backpressure rather than create and discard excess localhost connections.
+- R12. Repeated `Connection pool is full, discarding connection` warnings during normal browse fan-out are a regression signal after this work lands.
+
+**Worker isolation and result merging**
+
+- R13. `find_download` workers must not mutate the cycle's final result collections directly.
+- R14. Per-album matching state must be isolated so concurrent `find_download` jobs cannot clear or pollute each other's negative-match decisions.
+- R15. Shared cache and broken-peer state must be accessed through a safe shared mechanism, not ad hoc concurrent mutation of the full cycle context.
+- R16. Search outcome logging must remain anchored to the matching/enqueue result from the corresponding album, including candidate forensic data.
+- R17. Concurrent enqueue side effects are allowed to remain inside `find_download`; this issue must not split candidate selection from transfer enqueue.
+
+**Instrumentation and observability**
+
+- R18. Cycle logs must make it possible to distinguish search collection time, `find_download` drain time, browse time, and local match/scoring time.
+- R19. Logs or metrics must expose enough concurrency evidence to verify that search slots refill while earlier `find_download` jobs are still running.
+- R20. The cycle summary must retain existing browse, match, peer-count, fan-out, and watchdog observability, with any new fields added only where they clarify the new concurrent flow.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3.** Given four search collector slots are in use and one search completes successfully, when its result is handed to `find_download`, the search pipeline submits or attempts to submit the next wanted album before that `find_download` job finishes.
+- AE2. **Covers R4, R5, R7.** Given sixteen searches complete quickly and all require cold directory browse work, when their `find_download` jobs run, the system may have sixteen active jobs but no more than 32 total slskd directory browse calls in flight.
+- AE3. **Covers R8, R14, R15.** Given two concurrent `find_download` jobs encounter the same user directory, when one job browses and caches the directory successfully, the other job can reuse the cached directory without corrupting either album's per-album negative-match state.
+- AE4. **Covers R9, R10, R11, R12.** Given `browse_global_max_workers=32` and normal search/enqueue headroom, when a large fan-out cycle runs, the slskd HTTP client has a pool sized from that concurrency and does not emit repeated default-pool-size warnings.
+- AE5. **Covers R16, R17.** Given a concurrent `find_download` job finds and enqueues a match, when the job completes, the corresponding search log row records `found` with its candidate forensics, and the download appears in the same downstream polling flow as before.
+
+---
+
+## Success Criteria
+
+- Search pipeline idle gaps caused by synchronous `find_download` processing disappear from production traces.
+- For a #217-shaped cycle, wall time moves materially toward search time plus bounded `find_download` drain time rather than search time plus the sum of every album's serial `find_download` time.
+- Daily search throughput recovers toward the pre-regression baseline from the #198/#213 discussion without reducing search thoroughness.
+- Match, import, and enqueue success rates do not regress because of concurrent processing.
+- Normal production logs stop emitting repeated slskd HTTP connection-pool warnings during browse fan-out.
+- A downstream planner can design the implementation without inventing the core behavior: search handoff, unlimited active `find_download` jobs, true global browse capacity, HTTP pool sizing, worker isolation, concurrent enqueue, and observability are all decided here.
+
+---
+
+## Scope Boundaries
+
+- Do not reintroduce per-cycle gates, browse-wave deadlines, or wall-clock caps to make cycles look bounded.
+- Do not reduce `search_response_limit` or `search_file_limit` to shrink the candidate surface and hide the bottleneck.
+- Do not change search ladder behavior, query variants, or strict matching policy.
+- Do not tune search-side in-flight depth as part of this issue.
+- Do not add a separate `find_download_concurrency` configuration knob.
+- Do not split `find_download` into candidate selection plus serialized enqueue for this issue.
+- Do not treat connection-pool warnings as harmless expected noise after the HTTP pool is sized from concurrency.
+
+---
+
+## Key Decisions
+
+- `find_download` is the concurrent work unit: this matches the current mental model of "match" while preserving the fact that the function also browses and enqueues.
+- No `find_download_concurrency` cap: active work should be limited by available completed searches and by shared downstream resources, not by another album-count knob.
+- Browse pressure is the real scarce resource: concurrency control belongs around total slskd directory browse calls.
+- Keep browse capacity at 32: the current production setting remains the capacity target; the HTTP client must be brought up to match it instead of lowering the browse cap to the client default.
+- Size the slskd HTTP pool automatically: a configured browse limit higher than 10 must not rely on requests' default connection pool.
+- Allow concurrent enqueue: serializing enqueue would add a new bottleneck before there is evidence that slskd transfer enqueue requires it.
+
+---
+
+## Dependencies / Assumptions
+
+- The slskd browse endpoint can tolerate the existing configured browse capacity of 32 when the HTTP client pool is sized accordingly.
+- requests' default pool size of 10 is the source of the observed connection-pool warnings, not a slskd server-side concurrency limit.
+- `find_download` is mostly waiting on browse and slskd API work rather than CPU-bound local scoring, so concurrent jobs should improve wall time.
+- Existing download polling can handle concurrent enqueues because it already reconstructs and monitors active downloads from persisted state.
+- Some shared state must remain shared because directory browse results are intentionally cached across albums and cycles; the requirement is to narrow and coordinate that sharing, not eliminate cache sharing entirely.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*(none)*
+
+### Deferred to Planning
+
+- [Affects R8, R15][Technical] What is the smallest safe shared cache mechanism: locks around the current cache maps, a dedicated browse/cache coordinator object, or centralizing writes on one owner thread?
+- [Affects R9, R10, R11][Technical] What exact HTTP pool sizing formula should be used for search and transfer headroom beyond `browse_global_max_workers`?
+- [Affects R18, R19, R20][Technical] Which new timing fields best expose `find_download` queue/drain behavior without bloating the cycle summary?

--- a/docs/plans/2026-05-04-002-fix-find-download-concurrency-plan.md
+++ b/docs/plans/2026-05-04-002-fix-find-download-concurrency-plan.md
@@ -1,0 +1,488 @@
+---
+title: "fix: Parallelize find_download without multiplying browse pressure"
+type: fix
+status: completed
+date: 2026-05-04
+origin: docs/brainstorms/find-download-concurrency-requirements.md
+---
+
+# fix: Parallelize find_download without multiplying browse pressure
+
+## Summary
+
+Decouple search collection from `find_download` by handing completed searches to cycle-sized `find_download` workers while the search pipeline immediately refills search slots. The implementation freezes worker inputs, introduces one process-wide browse/cache coordination boundary, and gives worker threads configured slskd clients so 32 browse workers do not churn a default 10-connection pool.
+
+---
+
+## Problem Frame
+
+Issue #217 shows the search pipeline idling while the main thread runs `find_download` synchronously after each completed search. The wider search surface introduced by the #198/#213 arc makes each `find_download` call much heavier than it was in the older serial design, so the main-thread handoff point has become the current throughput gate.
+
+---
+
+## Requirements
+
+- R1. Successful search completions queue `find_download` work and refill search slots without waiting for browse, match, or enqueue to finish. (Origin R1-R4, F1, AE1)
+- R2. Active `find_download` jobs are not limited by a new configuration knob; the cycle batch size is the natural ceiling. (Origin R4)
+- R3. Browse capacity is global across all active `find_download` jobs, with the existing default capacity of 32 preserved. (Origin R5-R8, F2, AE2, AE3)
+- R4. The slskd HTTP connection pool is sized from browse capacity plus headroom and backpressures instead of discarding excess localhost connections. (Origin R9-R12, AE4)
+- R5. Workers isolate per-album matching state and return mergeable results; final collections and search-log outcomes remain owned by the search pipeline. (Origin R13-R17, F3, AE5)
+- R6. Cycle observability distinguishes search collection, `find_download` queue/drain behavior, browse time, and local match/scoring time. (Origin R18-R20)
+
+**Origin actors:** A1 search pipeline, A2 `find_download` worker, A3 browse coordinator, A4 slskd HTTP client, A5 operator.
+
+**Origin flows:** F1 search completion handoff, F2 concurrent `find_download` jobs share browse capacity, F3 completed `find_download` results are merged and logged.
+
+**Origin acceptance examples:** AE1-AE5.
+
+---
+
+## Scope Boundaries
+
+- Do not reintroduce per-cycle gates, browse-wave deadlines, search-poll wall-clock caps, or other deadline mechanisms rolled back during #198/#213.
+- Do not reduce `search_response_limit`, `search_file_limit`, search ladder breadth, or matching strictness to hide the larger candidate surface.
+- Do not tune search-side in-flight depth beyond preserving existing `search_max_inflight` semantics.
+- Do not add a separate `find_download_concurrency` configuration knob.
+- Do not split candidate selection from transfer enqueue; enqueue remains inside `find_download` for this issue.
+- Do not make broad pipeline DB, import, or download polling refactors beyond the ownership changes needed to make `find_download` safe to run concurrently.
+
+### Deferred to Follow-Up Work
+
+- Search-side in-flight tuning above 4: measure only after `find_download` no longer blocks search-slot refill.
+- Persisted cache storage changes such as Redis or DB-backed folder cache: tracked separately from #217.
+- SignalR or push-based slskd search state collection: unrelated to `find_download` serialization.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `cratedigger.py`: `_search_and_queue_parallel` currently merges each successful search, calls `find_download` inline, applies/logs the result, and only then submits the next search.
+- `lib/enqueue.py`: `find_download`, `_try_filetype`, `try_enqueue`, `try_multi_enqueue`, and `_iter_wave_matches` contain the browse/match/enqueue path. Today `FindDownloadResult` carries outcome and candidates while `grab_list` is mutated through a caller-owned dictionary.
+- `lib/browse.py`: `_fanout_browse_users` creates a new `ThreadPoolExecutor` for each wave, so concurrent albums would multiply `browse_global_max_workers` unless the browse boundary changes.
+- `lib/matching.py`: `check_for_match` still has a lazy browse fallback and mutates shared `negative_matches`, `folder_cache`, `_folder_cache_ts`, `broken_user`, and timing counters through `ctx`.
+- `lib/context.py`: per-cycle state is centralized on `CratediggerContext`; this worked while `find_download` was serial but needs narrower ownership under concurrency.
+- `lib/cycle_summary.py`: cycle summary already emits browse, match, search, cache, peer, fan-out, and watchdog counters.
+- `lib/download.py`: `slskd_do_enqueue` remains inside `find_download` and polls slskd transfer snapshots after enqueue.
+- `album_source.py` and `lib/pipeline_db.py`: `DatabaseSource._get_db()` caches one `PipelineDB` backed by one psycopg connection, so worker threads must not call the main context's pipeline DB source.
+- `tests/test_browse.py`: existing concurrency-probe pattern for directory browse caps.
+- `tests/test_enqueue_fanout.py`: wave-shape, cached-entry, cooldown/denylist, enqueue-failure, and multi-disc cache-reuse coverage.
+- `tests/test_search_max_inflight.py`: existing pipeline-log contract style for search-side in-flight settings.
+- `tests/test_integration_slices.py`: end-to-end slices for search result processing, `find_download`, search logging, and watchdog behavior.
+
+### Institutional Learnings
+
+- `docs/plans/2026-05-01-001-feat-browse-fanout-and-pipeline-depth-plan.md`: the top update supersedes the earlier wave-deadline/cycle-budget design. The fan-out primitive survived, but client-side caps starved legitimate work.
+- `docs/slskd-internals.md` and `docs/parallel-search.md`: slskd search creation is serialized and active searches queue internally, while browse is not throttled the same way. This plan keeps search submission sequential and browse separately bounded.
+- `docs/solutions/architecture/multiplexed-postgres-client-and-set-local-incompatibility.md`: shared clients and session-scoped state need clear ownership; pools reduce blast radius only when their sizing and use are explicit.
+- `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`: helper-level tests need at least one cross-layer slice for confidence when the changed behavior is a helper/service integration.
+
+### External References
+
+- No web research used. Local package inspection showed `slskd-api` constructs one shared `requests.Session` with adapters that do not override requests' default pool size of 10. The API objects expose that session, so cratedigger can configure adapters without forking the package, but the implementation must still define thread ownership for slskd client instances.
+
+---
+
+## Key Technical Decisions
+
+- Cycle-sized `find_download` executor: use the current cycle's album count as the executor capacity rather than introducing a new `find_download_concurrency` knob. Guard the empty-album case so no executor is created with zero workers.
+- Main-thread result merge: `find_download` workers return result objects that the search pipeline merges. This preserves ownership of `grab_list`, failure lists, search logging, and candidate forensics.
+- Frozen worker input: each `find_download` worker receives a snapshot of the album's search results, upload speeds, directory audio counts, tracks, denied users, cooled-down users, album metadata, and per-album negative/broken-user state. Workers must not read live `ctx.search_cache`, `ctx.user_upload_speed`, `ctx.search_dir_audio_count`, `ctx.negative_matches`, `ctx.current_album_cache`, or the main pipeline DB source.
+- Mandatory DB prefetch or explicit thread ownership: tracks and denied users should be prefetched on the owner thread before queueing work. If implementation cannot avoid worker DB reads, the worker must receive an explicit fresh DB/thread-local factory that closes after use; it must not call the main `ctx.pipeline_db_source._get_db()`.
+- Process-wide browse/cache boundary: route both primary fan-out and lazy fallback browsing through the same process-scoped browse coordinator or equivalent shared boundary, so total directory calls honor `browse_global_max_workers` across every `find_download` path in the process.
+- Single-flight directory browse: the browse/cache boundary must deduplicate simultaneous cold misses for the same `(user, dir)` so follower workers reuse the first in-flight browse instead of issuing duplicate slskd calls.
+- slskd client ownership is explicit: use a small provider/boundary for configured slskd clients rather than casually sharing one mutable `requests.Session` across all worker roles. Thread-local configured clients are preferred if package behavior permits; otherwise the plan must introduce an explicit locked/shared-client contract and capacity semaphores.
+- HTTP capacity follows concurrency: configured HTTP capacity must be at least `browse_global_max_workers + search_max_inflight + page_size + phase1/admin slack`. Use blocking behavior plus observable wait/backpressure logging so overload becomes visible rather than just quiet.
+- Concurrent enqueue stays in `find_download`: transfer enqueue is not serialized separately unless production evidence later shows it needs its own limiter.
+- Side-effect-aware enqueue failures: after slskd accepts an enqueue, later polling/reconciliation errors must not leave untracked transfers behind. Workers must either return enough partial transfer information for the owner to track/reconcile, or cancel/reconcile before logging a failure.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should `find_download` get a separate concurrency knob? No. Active work is capped by cycle batch size; browse pressure is capped globally.
+- Should enqueue be serialized outside `find_download`? No. It remains concurrent inside the worker path for this issue.
+- Should browse capacity drop from 32 to requests' default pool size of 10? No. Keep capacity at 32 and size the HTTP pool to match.
+
+### Deferred to Implementation
+
+- Exact shape of the browse/cache boundary internals: a dedicated coordinator object, locks around existing maps, or a hybrid wrapper can be chosen during implementation, as long as it is process-scoped, single-flights duplicate cold misses, and preserves persisted cache writes.
+- Final names of worker result/state helper types: choose names that fit local conventions once the refactor touches real call sites.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Search as Search pipeline
+    participant SearchPool as search collectors
+    participant FindPool as cycle-sized find_download workers
+    participant Browse as process-wide browse/cache boundary
+    participant Slskd as configured slskd client provider
+
+    Search->>SearchPool: submit search collection up to search_max_inflight
+    SearchPool-->>Search: completed SearchResult
+    Search->>Search: merge search caches and prefetch worker inputs
+    Search->>FindPool: queue find_download job
+    Search->>SearchPool: immediately submit next wanted album
+    FindPool->>Browse: request uncached directory browses through single-flight cache
+    Browse->>Slskd: at most browse_global_max_workers directory calls total
+    FindPool-->>Search: FindDownload result + optional GrabListEntry + metrics
+    Search->>Search: merge grab/failed lists and log search outcome
+```
+
+The important ordering is search refill before `find_download` completion. The important resource bound is total browse calls, not number of albums currently in `find_download`, and duplicate workers asking for the same cold directory should share one browse.
+
+---
+
+## Implementation Units
+
+- U1. **Configure slskd client ownership and HTTP capacity**
+
+**Goal:** Remove the mismatch between 32 browse workers and requests' default 10-connection pool while making slskd client/session ownership explicit for worker threads.
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `cratedigger.py`
+- Create: `lib/slskd_client.py`
+- Test: `tests/test_slskd_http_pool.py`
+
+**Approach:**
+- Add a small local provider/helper that creates or configures slskd clients with adapters sized from existing config values rather than adding a user-facing knob.
+- Prefer thread-local configured slskd clients for worker threads if package behavior permits; otherwise define an explicit shared-client ownership contract with capacity semaphores for browse and transfer calls.
+- Configure HTTP capacity with a deterministic lower bound: `browse_global_max_workers + search_max_inflight + page_size + phase1/admin slack`.
+- Use blocking pool behavior so accidental over-subscription waits instead of creating and discarding excess localhost connections.
+- Make real-client configuration mandatory in production: fake-client tolerance is acceptable for tests, but failure to configure an actual `SlskdClient` should log loudly enough to fail deployment verification.
+- Expose or log configured HTTP capacity and any observable wait/backpressure signal so warning absence is not the only health check.
+
+**Execution note:** Implement test-first with a fake requests session/adapter surface before wiring the helper into startup.
+
+**Patterns to follow:**
+- `lib/config.py` parse-time clamping for existing concurrency knobs.
+- `cratedigger.py` startup checks that log operator-visible configuration issues without preventing healthy startup.
+
+**Test scenarios:**
+- Happy path: given `browse_global_max_workers=32`, `search_max_inflight=4`, and `page_size=10`, configuring a fake slskd client sets HTTP and HTTPS capacity to at least browse capacity plus deterministic headroom.
+- Contract: given the installed `slskd_api.SlskdClient` shape, the helper discovers and configures the real requests session without making network calls.
+- Happy path: configured adapters use blocking behavior, not only a larger pool size.
+- Edge case: given a fake slskd client with no accessible requests session, configuration returns without crashing and emits a diagnostic log.
+- Edge case: given `browse_global_max_workers=1`, the derived pool size remains at least one plus headroom.
+- Integration: several found workers can enter transfer enqueue polling concurrently without starving browse/search client capacity in the test harness.
+- Integration: startup path constructs the slskd client and invokes the pool configuration helper exactly once.
+
+**Verification:**
+- Local tests prove adapter sizing is derived from config and applied to the real installed client shape.
+- Production verification should show the configured HTTP capacity in logs and no repeated `Connection pool is full, discarding connection` warnings during normal fan-out cycles after deploy.
+
+---
+
+- U2. **Make find_download return mergeable results**
+
+**Goal:** Stop `find_download` from mutating final cycle collections so workers can run independently and main-thread merge remains authoritative.
+
+**Requirements:** R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/enqueue.py`
+- Modify: `cratedigger.py`
+- Test: `tests/test_grab_list.py`
+- Test: `tests/test_integration.py`
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Widen the `FindDownloadResult` concept so a found result carries the `GrabListEntry` it produced instead of writing directly into the caller's `grab_list`.
+- Preserve existing candidate-forensics behavior: `_apply_find_download_result` still copies candidates to the corresponding `SearchResult`.
+- Keep the serial path behavior equivalent by merging the returned entry into `grab_list` at the call site.
+- Update existing tests that assert `find_download` output shape and `_apply_find_download_result` mapping.
+
+**Execution note:** Add characterization tests around current serial behavior before changing ownership. The first green state should preserve behavior without enabling concurrency yet.
+
+**Patterns to follow:**
+- `lib.grab_list.GrabListEntry` construction in `_try_filetype`.
+- Existing `_apply_find_download_result` seam in `cratedigger.py`.
+
+**Test scenarios:**
+- Happy path: a found single-disc album returns a result containing a `GrabListEntry`, and the caller merges it into `grab_list`.
+- Happy path: a found multi-disc album returns one merged `GrabListEntry` with all disk metadata preserved.
+- Error path: enqueue failure returns the same outcome and candidates as before, with no partial `grab_list` write.
+- Error path: if slskd accepts an enqueue but later transfer-ID reconciliation fails or raises, the result is side-effect-aware: it either returns trackable partial transfer information or cancels/reconciles before the owner logs failure.
+- Integration: existing search-forensics slice still logs top candidates after the ownership change.
+
+**Verification:**
+- Serial `search_and_queue` behavior remains unchanged from the caller's perspective.
+- No feature-bearing path depends on `find_download` writing directly to an external dict.
+- Post-enqueue failures cannot silently orphan untracked transfers that would be duplicated on a later search.
+
+---
+
+- U3. **Isolate worker-local album and match state**
+
+**Goal:** Remove shared per-album mutable state from the `find_download` path before enabling concurrent workers.
+
+**Requirements:** R5
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `lib/enqueue.py`
+- Modify: `lib/matching.py`
+- Modify: `lib/context.py`
+- Test: `tests/test_matching.py`
+- Test: `tests/test_enqueue_fanout.py`
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Introduce a frozen worker input/view for everything a `find_download` job is allowed to observe from the search pipeline.
+- Snapshot the album's search-result entries, upload speeds, directory audio counts, album metadata, tracks, denied users, cooled-down users, search override settings, and per-album negative/broken-user state before queueing work.
+- Workers must not read live `ctx.search_cache`, `ctx.user_upload_speed`, `ctx.search_dir_audio_count`, `ctx.negative_matches`, `ctx.current_album_cache`, or the main `ctx.pipeline_db_source`.
+- Prefetch track and denylist data on the owner thread by default. A worker-owned DB path is allowed only if it receives an explicit fresh DB/thread-local factory and closes it after use.
+- Treat `broken_user` as album-local match state rather than shared global state unless implementation proves a more precise keyed error record is safe.
+- Keep shared read-only config and configured slskd client access available through a lightweight worker view.
+- Preserve cooldown and denylist filtering semantics from the worker snapshot.
+- Move worker-local browse/match/peer/fanout metric accumulation into this boundary so enabling concurrent workers later does not introduce concurrent writes to shared counters.
+
+**Execution note:** Treat this as a behavior-preserving refactor; add concurrency-shaped tests even before the pipeline starts running jobs in parallel.
+
+**Patterns to follow:**
+- Existing small dataclasses in `lib/enqueue.py` for return shapes.
+- `main()` Phase 1 pattern where a separate DB source is used when work crosses threads.
+
+**Test scenarios:**
+- Happy path: two independent worker inputs can evaluate different albums without clearing each other's negative matches or broken-user state.
+- Edge case: multi-disc matching still clears negative matches per disc within one album without affecting another album.
+- Edge case: denied users, cooled-down users, upload-speed ranking, and directory audio-count prefilters are applied from worker-owned snapshots.
+- Edge case: mutating the main context's search cache, upload speeds, dir counts, cooldowns, or denied users after worker submission does not change that worker's result.
+- Error path: one album's browse failure for a user does not cause another concurrent album to skip a successful directory from that same user.
+- Error path: a spy main pipeline DB source fails the test if a worker calls `_get_db()` through the shared source.
+- Integration: two `find_download` calls run concurrently in a test harness and produce independent candidate lists/outcomes.
+- Metrics: worker-local browse/match/fanout counters are returned for owner-thread merge and are not written directly to shared context fields.
+
+**Verification:**
+- No concurrent worker path mutates `ctx.negative_matches`, `ctx.broken_user`, or relies on `ctx.current_album_cache` for album lookup.
+- DB-backed track and denylist data are prefetched on the main thread unless an explicit fresh DB/thread-local factory is passed to and closed by the worker.
+- Worker metrics are mergeable data, not direct shared-counter mutation.
+
+---
+
+- U4. **Introduce a true global browse/cache boundary**
+
+**Goal:** Make `browse_global_max_workers=32` mean 32 total directory browse calls across all active `find_download` jobs in the process, with single-flight reuse for duplicate cold directory misses.
+
+**Requirements:** R3, R5
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `lib/browse.py`
+- Modify: `lib/enqueue.py`
+- Modify: `lib/matching.py`
+- Modify: `lib/context.py`
+- Test: `tests/test_browse.py`
+- Test: `tests/test_enqueue_fanout.py`
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Replace per-wave executor ownership with a process-wide/shared-context browse/cache boundary used by every `find_download` path in the process.
+- Route primary fan-out and lazy fallback directory browse through the same boundary.
+- Protect shared directory cache, cache timestamps, in-flight browse registry, and browse counters through that boundary.
+- Implement single-flight behavior keyed by `(user, dir)`: one worker reserves and performs a cold browse while followers wait for and reuse the same result.
+- Write successful browse results and timestamps into the existing cache structures that `lib/cache.py` persists, not worker-local copies.
+- Keep album-level broken-user/negative-match decisions worker-local; the shared boundary may record per-directory browse errors only if those records cannot cause unrelated albums to false no-match.
+- Preserve existing top-K/lazy-tail behavior and cached-entry skipping.
+- Keep browse exceptions isolated to the relevant user/dir and preserve broken-user semantics.
+
+**Execution note:** Start with a failing concurrency-cap test using the existing `FakeSlskdUsers.in_flight_probe`.
+
+**Patterns to follow:**
+- `tests/test_browse.py` in-flight probe for verifying concurrency caps.
+- Existing pre-created bucket invariant from `_fanout_browse_users`, but generalized beyond one wave call.
+
+**Test scenarios:**
+- Covers AE2. Given multiple concurrent album jobs with cold directories, peak fake slskd directory calls never exceeds `browse_global_max_workers`.
+- Covers AE3. Given two jobs request the same uncached user/dir concurrently, fake slskd receives one directory call and both jobs observe the shared result.
+- Covers AE3. Given two jobs request the same uncached user/dir and the first browse fails, the failure does not create a shared album-level broken-user decision that prevents a later successful browse path for another album.
+- Happy path: cached entries are skipped from browse work under concurrent jobs.
+- Happy path: concurrent browse writes land in the existing `folder_cache` and `_folder_cache_ts` maps so the normal persisted cache save path can write them.
+- Error path: one user's browse exceptions do not poison unrelated users or albums.
+- Edge case: lazy fallback browse uses the same global capacity as wave fan-out.
+
+**Verification:**
+- The old per-wave fan-out tests still pass.
+- New cross-album tests prove the cap is global, not multiplied by active albums.
+- Cache persistence tests or integration checks prove concurrent browse results remain visible to the existing save/load path.
+
+---
+
+- U5. **Decouple search futures from find_download futures**
+
+**Goal:** Rework `_search_and_queue_parallel` so completed searches queue `find_download` jobs and refill search slots immediately, then drain `find_download` results for merge/logging.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- Modify: `cratedigger.py`
+- Test: `tests/test_search_max_inflight.py`
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Maintain separate collections for search futures and `find_download` futures.
+- On successful search completion, merge search-result cache data needed for ranking/forensics, prepare worker inputs, queue a `find_download` job, and submit the next search before waiting for that job.
+- Use a cycle-sized executor for `find_download` jobs so there is no separate user-facing concurrency cap.
+- Keep `_log_search_result` on the owner path after the corresponding `find_download` result has produced the final outcome.
+- Preserve inline handling for non-search cases such as empty query, search error, or exhausted variant ladder.
+- Do not create a `find_download` executor when there are no albums or no successful searches that need it.
+- Record search collection timing separately from find-drain timing; search collection ends when the last search future completes, not when all find jobs drain.
+- Merge worker-local metric bundles on the owner path exactly once when each find future completes.
+
+**Execution note:** Add a RED orchestration test for the #217 failure shape: a blocked `find_download` must not prevent the next search submission.
+
+**Patterns to follow:**
+- Existing `_search_and_queue_parallel` submit/collect/refill loop.
+- `tests/test_search_max_inflight.py` log-based contract style.
+
+**Test scenarios:**
+- Covers AE1. Given one completed search and a blocked `find_download`, the next search is submitted before the blocked job returns.
+- Happy path: found, no-match, no-results, exhausted, empty-query, and search-error outcomes land in the same returned `grab_list`, `failed_search`, and `failed_grab` categories as before.
+- Error path: a `find_download` worker exception logs an error for that album, records a safe search outcome, and does not kill unrelated in-flight search or find jobs.
+- Error path: a post-enqueue worker failure returns side-effect-aware data or performs cleanup so no untracked transfer continues silently.
+- Edge case: no successful searches means the find executor drains no jobs and the function returns promptly.
+- Edge case: empty album input does not create an executor with zero workers.
+- Metrics: blocked `find_download` drain does not continue increasing `search_time_s` after search collection is complete.
+- Integration: a cycle with several successful searches shows overlapping find jobs and final search logs tied to the correct album/request.
+
+**Verification:**
+- Search slots are refilled independently from `find_download` completion.
+- Existing search-result logging semantics and return shape remain compatible with `grab_most_wanted`.
+
+---
+
+- U6. **Expose find_download drain observability**
+
+**Goal:** Keep cycle logs useful under concurrency and add just enough evidence to verify the new handoff behavior in production.
+
+**Requirements:** R6
+
+**Dependencies:** U4, U5
+
+**Files:**
+- Modify: `lib/context.py`
+- Modify: `lib/cycle_summary.py`
+- Modify: `lib/browse.py`
+- Modify: `lib/matching.py`
+- Modify: `cratedigger.py`
+- Test: `tests/test_cycle_summary.py`
+- Test: `tests/test_cycle_watchdog_counter.py`
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Add compact cycle-summary fields for `find_download` queued/completed/drain timing if they materially help distinguish search collection from find drain.
+- Preserve existing summary field names so current journal queries remain useful.
+- Define timing semantics explicitly: search collection wall time excludes find-drain wait; find drain wall time covers queued-to-drained find work; summed worker browse/match times are cumulative worker seconds.
+- Log enough lifecycle evidence to show search refill happens while previous find jobs are still active, without adding noisy per-directory logs.
+
+**Patterns to follow:**
+- `lib/cycle_summary.py` key=value summary style.
+- Existing watchdog counter merge via `_log_search_result`.
+
+**Test scenarios:**
+- Happy path: cycle summary includes existing browse/match/search/cache/watchdog fields after the new fields are added.
+- Happy path: a worker-local metric bundle from U3/U5 appears in context totals exactly once per completed `find_download` job.
+- Edge case: a worker exception still contributes any available timing and does not double-count.
+- Edge case: `search_time_s` does not include blocked find-drain wait after the last search future completes.
+- Integration: an orchestration test can assert find queued/completed evidence without scraping order-dependent logs.
+
+**Verification:**
+- Cycle summary remains grep-friendly.
+- Production validation can compare `search_time_s`, browse/match totals, and new find-drain fields for #217-shaped cycles.
+
+---
+
+- U7. **End-to-end regression and production verification**
+
+**Goal:** Prove the changed pipeline preserves acquisition behavior while removing the #217 serialization bottleneck.
+
+**Requirements:** R1-R6
+
+**Dependencies:** U1, U2, U3, U4, U5, U6
+
+**Files:**
+- Modify: `tests/test_integration_slices.py`
+- Modify: `tests/test_slskd_live.py`
+
+**Approach:**
+- Add or extend an integration slice that exercises search completion, concurrent `find_download`, candidate forensics, and final search logging together.
+- Add live slskd coverage only where it can validate behavior fakes cannot prove, especially HTTP pool/backpressure and browse concurrency assumptions.
+
+**Patterns to follow:**
+- Existing env-gated live slskd tests in `tests/test_slskd_live.py`.
+- Existing issue-specific integration slices in `tests/test_integration_slices.py`.
+
+**Test scenarios:**
+- Integration: several fake searches complete quickly, several find jobs overlap, final returned `grab_list` and search logs map to the correct albums.
+- Integration: a no-match-heavy cycle drains all find jobs and leaves requests in the same failure categories as before.
+- Error path: one find job fails while other search/find jobs complete normally.
+- Error path: enqueue accepted followed by transfer polling failure leaves no orphaned untracked transfer and no duplicate future enqueue path.
+- Live/env-gated: configured HTTP pool size avoids repeated connection-pool churn during a controlled burst of browse calls.
+
+**Verification:**
+- Targeted unit and integration tests pass.
+- Full suite and pyright pass before merge.
+- Post-deploy journal review confirms search slots refill while find jobs drain and connection-pool warnings are absent or rare enough to investigate as exceptions.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `grab_most_wanted` remains the owner of persistence after `search_and_queue` returns. `search_and_queue` still returns `grab_list`, `failed_search`, and `failed_grab`, but the parallel path internally drains both search and find futures before returning.
+- **Error propagation:** Search collection errors remain search failures. `find_download` errors become album-local enqueue/match failures and must not cancel unrelated search or find futures. Post-enqueue failures are handled specially because slskd may already have accepted transfers.
+- **State lifecycle risks:** `folder_cache` is intentionally shared and persisted, but per-album negative matches are not. Worker result merging must be exactly-once to avoid duplicate downloads or duplicate failure accounting.
+- **API surface parity:** The serial `search_and_queue` path should either reuse the new result merge behavior or stay behaviorally equivalent. CLI/web request status flows should not observe a different contract.
+- **Integration coverage:** Unit tests can prove concurrency caps and ownership seams; integration slices are required to prove search logging, candidate forensics, and `grab_list` return behavior remain coherent together.
+- **Unchanged invariants:** Search POST submission stays sequential; search ladder, response/file limits, strict matching, cooldowns, denylist filtering, and download polling semantics remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Shared mutable state race creates wrong candidates or duplicate downloads | Move per-album state worker-local; main thread merges final collections; shared cache access goes through one boundary with tests. |
+| Browse capacity is accidentally multiplied by active albums | Add cross-album concurrency tests using fake slskd in-flight probes; route lazy fallback and fan-out through the same boundary. |
+| HTTP pool sizing removes warnings but hides overload by blocking in an unexpected path | Use a deterministic lower-bound formula, log configured capacity/backpressure, and validate with targeted tests plus production journal review. |
+| Shared slskd client session behaves poorly under threaded use | Prefer thread-local configured clients through a provider; otherwise add an explicit shared-client contract with capacity semaphores and tests against the real package shape. |
+| Worker thread shares non-thread-safe DB connection | Prefetch track and denylist data before queueing work; if impossible, pass an explicit fresh DB/thread-local factory and test that workers do not call the main source. |
+| Refactor changes search-log outcomes or candidate forensics | Keep `_apply_find_download_result` and `_log_search_result` as owner-path seams; extend existing integration slices. |
+| Concurrent enqueue creates slskd transfer contention or orphaned transfers | Keep enqueue concurrent per requirements, make post-enqueue failures side-effect-aware, and observe transfer enqueue failures/import throughput after deploy. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update issue #217 or the PR body with before/after cycle traces showing search refill behavior and connection-pool warning status.
+- Post-deploy verification should inspect `journalctl -u cratedigger` for cycle summary fields, connection-pool warnings, search throughput, and download/import outcomes.
+- Conditional docs: update `docs/slskd-internals.md` only if implementation or verification changes the documented understanding of slskd/client concurrency behavior.
+- If slskd HTTP pool sizing requires changing the local `slskd-api` package rather than configuring clients externally, document the reason and keep the package patch scoped.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/find-download-concurrency-requirements.md](../brainstorms/find-download-concurrency-requirements.md)
+- Related issue: #217
+- Related context: #198, #213
+- Related docs: `docs/slskd-internals.md`, `docs/parallel-search.md`
+- Related plans: `docs/plans/2026-05-01-001-feat-browse-fanout-and-pipeline-depth-plan.md`, `docs/plans/2026-05-04-001-fix-search-watchdog-and-cycle-gate-removal-plan.md`
+- Related learnings: `docs/solutions/architecture/multiplexed-postgres-client-and-set-local-incompatibility.md`, `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`

--- a/lib/browse.py
+++ b/lib/browse.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -14,6 +15,164 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("cratedigger")
+
+
+class BrowseCoordinator:
+    """Shared browse/cache boundary with global capacity and single-flight."""
+
+    def __init__(self, ctx: CratediggerContext, max_workers: int) -> None:
+        self._ctx = ctx
+        self._max_workers = max(1, int(max_workers))
+        self._executor = ThreadPoolExecutor(
+            max_workers=self._max_workers,
+            thread_name_prefix="browse",
+        )
+        self._lock = threading.RLock()
+        self._inflight: dict[tuple[str, str], Future[Any | None]] = {}
+
+    @property
+    def max_workers(self) -> int:
+        return self._max_workers
+
+    def cache_directory(
+        self,
+        username: str,
+        file_dir: str,
+        directory: Any,
+    ) -> None:
+        with self._lock:
+            _cache_browsed_directory(self._ctx, username, file_dir, directory)
+
+    def ensure_user(self, username: str) -> None:
+        with self._lock:
+            _ensure_cache_user(self._ctx, username)
+
+    def browse_many(
+        self,
+        work_items: list[tuple[str, str]],
+        slskd_client: Any,
+    ) -> dict[tuple[str, str], Any]:
+        """Browse uncached directories with process-wide capacity."""
+        if not work_items:
+            return {}
+
+        futures: dict[tuple[str, str], Future[Any | None]] = {}
+        with self._lock:
+            for user, file_dir in work_items:
+                self._ctx.folder_cache.setdefault(user, {})
+                self._ctx._folder_cache_ts.setdefault(user, {})
+                cached = self._ctx.folder_cache[user].get(file_dir)
+                if cached is not None:
+                    future: Future[Any | None] = Future()
+                    future.set_result(cached)
+                    futures[(user, file_dir)] = future
+                    continue
+                key = (user, file_dir)
+                existing_future = self._inflight.get(key)
+                if existing_future is None:
+                    browse_future = self._executor.submit(
+                        self._browse_and_cache, user, file_dir, slskd_client,
+                    )
+                    self._inflight[key] = browse_future
+                else:
+                    browse_future = existing_future
+                futures[key] = browse_future
+
+        results: dict[tuple[str, str], Any] = {}
+        for key, future in futures.items():
+            result = future.result()
+            if result is not None:
+                results[key] = result
+        return results
+
+    def shutdown(self, *, wait: bool = True, cancel_futures: bool = False) -> None:
+        self._executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    def _browse_and_cache(
+        self,
+        username: str,
+        file_dir: str,
+        slskd_client: Any,
+    ) -> Any | None:
+        _file_dir, result = _browse_one(username, file_dir, slskd_client)
+        with self._lock:
+            if result is not None:
+                _cache_browsed_directory(self._ctx, username, file_dir, result)
+            self._inflight.pop((username, file_dir), None)
+        return result
+
+
+def get_browse_coordinator(
+    ctx: CratediggerContext,
+    max_workers: int,
+) -> BrowseCoordinator:
+    requested_workers = max(1, int(max_workers))
+    lock = getattr(ctx, "browse_coordinator_lock", None)
+    if lock is None:
+        lock = threading.Lock()
+        ctx.browse_coordinator_lock = lock
+    with lock:
+        coordinator = getattr(ctx, "browse_coordinator", None)
+        if coordinator is None:
+            coordinator = BrowseCoordinator(ctx, requested_workers)
+            ctx.browse_coordinator = coordinator
+        elif coordinator.max_workers != requested_workers:
+            raise ValueError(
+                "BrowseCoordinator already initialised with "
+                f"max_workers={coordinator.max_workers}; requested {max_workers}"
+            )
+        return coordinator
+
+
+def shutdown_browse_coordinator(
+    ctx: CratediggerContext,
+    *,
+    wait: bool = True,
+    cancel_futures: bool = False,
+) -> None:
+    coordinator = getattr(ctx, "browse_coordinator", None)
+    if isinstance(coordinator, BrowseCoordinator):
+        coordinator.shutdown(wait=wait, cancel_futures=cancel_futures)
+        ctx.browse_coordinator = None
+
+
+def _cache_browsed_directory(
+    ctx: CratediggerContext,
+    username: str,
+    file_dir: str,
+    directory: Any,
+) -> None:
+    _ensure_cache_user(ctx, username)
+    ctx.folder_cache[username][file_dir] = directory
+    ctx._folder_cache_ts[username][file_dir] = time.time()
+
+
+def _ensure_cache_user(ctx: CratediggerContext, username: str) -> None:
+    ctx.folder_cache.setdefault(username, {})
+    ctx._folder_cache_ts.setdefault(username, {})
+
+
+def ensure_cache_user(ctx: CratediggerContext, username: str) -> None:
+    """Ensure shared browse cache buckets exist without overwriting entries."""
+    coordinator = getattr(ctx, "browse_coordinator", None)
+    if isinstance(coordinator, BrowseCoordinator):
+        coordinator.ensure_user(username)
+    else:
+        _ensure_cache_user(ctx, username)
+
+
+def cache_browsed_directory(
+    ctx: CratediggerContext,
+    username: str,
+    file_dir: str,
+    directory: Any,
+) -> None:
+    """Store a browsed directory through the shared browse boundary."""
+    coordinator = getattr(ctx, "browse_coordinator", None)
+    if isinstance(coordinator, BrowseCoordinator):
+        coordinator.cache_directory(username, file_dir, directory)
+    else:
+        _cache_browsed_directory(ctx, username, file_dir, directory)
 
 
 def download_filter(
@@ -138,9 +297,9 @@ def _fanout_browse_users(
 ) -> None:
     """Bounded parallel browse fan-out across (user, dir) pairs.
 
-    Submits each `(username, file_dir)` browse to a bounded
-    ThreadPoolExecutor and writes successful results into
-    `ctx.folder_cache[user][dir]` and `ctx._folder_cache_ts[user][dir]`.
+    Routes each `(username, file_dir)` browse through the shared
+    BrowseCoordinator so concurrent find_download jobs share one global
+    browse capacity and duplicate cold directory misses are single-flighted.
 
     No client-side wave deadline — slskd's per-peer TCP read timeout
     (~30–60 s) is the only authority on when a hung peer is abandoned.
@@ -148,28 +307,26 @@ def _fanout_browse_users(
     real peers had a chance to respond and were starving the pipeline (see
     2026-05-02 regression).
 
-    Thread-safety: workers only return tuples — the calling thread is the
-    sole writer to `ctx.folder_cache`. The Step 1 pre-create is therefore
-    not a race fix; it makes "all dirs failed for this user" observable to
-    callers (the inner dict exists but is empty).
+    Thread-safety: BrowseCoordinator owns writes to `ctx.folder_cache` and
+    `ctx._folder_cache_ts`; callers observe "all dirs failed for this user"
+    via an empty pre-created inner dict.
     """
     if not work_items:
         return
 
-    # Step 1: pre-create user buckets so callers can observe "every dir
-    # failed for this user" via an empty inner dict.
-    for user, _file_dir in work_items:
-        ctx.folder_cache.setdefault(user, {})
-        ctx._folder_cache_ts.setdefault(user, {})
+    get_browse_coordinator(ctx, max_workers).browse_many(work_items, slskd_client)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {
-            pool.submit(_browse_one, user, file_dir, slskd_client): (user, file_dir)
-            for (user, file_dir) in work_items
-        }
-        for fut in as_completed(futures):
-            user, file_dir = futures[fut]
-            _file_dir, result = fut.result()
-            if result is not None:
-                ctx.folder_cache[user][file_dir] = result
-                ctx._folder_cache_ts[user][file_dir] = time.time()
+
+def _browse_directories_for_ctx(
+    dirs_to_browse: list[str],
+    username: str,
+    ctx: CratediggerContext,
+    max_workers: int,
+) -> dict[str, Any]:
+    """Browse one user's directories through the shared context boundary."""
+    work = [(username, d) for d in dirs_to_browse]
+    browsed = get_browse_coordinator(ctx, max_workers).browse_many(work, ctx.slskd)
+    return {
+        file_dir: directory
+        for (_username, file_dir), directory in browsed.items()
+    }

--- a/lib/context.py
+++ b/lib/context.py
@@ -8,6 +8,7 @@ as their first parameter instead of reading globals.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import threading
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -34,6 +35,7 @@ class CratediggerContext:
     current_album_cache: dict[int, Any] = field(default_factory=dict)
     denied_users_cache: dict[int, set[str]] = field(default_factory=dict)
     cooled_down_users: set[str] = field(default_factory=set)
+    prefetched_album_tracks: dict[int, list[Any]] = field(default_factory=dict)
 
     # --- Cache timestamps (epoch floats, for per-entry TTL eviction) ---
     _folder_cache_ts: dict[str, dict[str, float]] = field(default_factory=dict)
@@ -64,3 +66,15 @@ class CratediggerContext:
     # `cycle_max_runtime_s` cycle-entry gate. Healthy steady-state is 0–1
     # per cycle; >3 sustained warrants investigation.
     cycle_searches_watchdog_killed: int = 0
+
+    # --- Per-cycle find_download pipeline counters (issue #217). ---
+    find_download_queued: int = 0
+    find_download_completed: int = 0
+    find_download_drain_time_s: float = 0.0
+
+    # --- Shared browse boundary ---
+    # Lazily initialised by lib.browse so tests that directly pass max_workers
+    # to the fan-out primitive keep their local cap. Worker contexts share this
+    # object with the owner context to make browse_global_max_workers global.
+    browse_coordinator: Any = None
+    browse_coordinator_lock: threading.Lock = field(default_factory=threading.Lock)

--- a/lib/cycle_summary.py
+++ b/lib/cycle_summary.py
@@ -29,5 +29,8 @@ def format_cycle_summary(ctx: CratediggerContext, elapsed_s: float) -> str:
         f"peers_browsed_lazy={ctx.peers_browsed_lazy} "
         f"fanout_waves={ctx.fanout_waves} "
         f"cycle_searches_watchdog_killed={ctx.cycle_searches_watchdog_killed} "
+        f"find_download_queued={ctx.find_download_queued} "
+        f"find_download_completed={ctx.find_download_completed} "
+        f"find_download_drain_time_s={ctx.find_download_drain_time_s:.1f} "
         f"cycle_total_s={elapsed_s:.1f}"
     )

--- a/lib/download.py
+++ b/lib/download.py
@@ -428,24 +428,34 @@ def slskd_do_enqueue(username: str, files: list[dict[str, Any]],
         ):
             break
 
-    if download_list is None:
-        return None
-
     downloads: list[DownloadFile] = []
     for file in files:
-        transfer_id = match_transfer_id(
-            download_list,
-            file["filename"],
-            username=username,
-        )
-        if transfer_id is not None:
-            downloads.append(DownloadFile(
-                filename=file["filename"],
-                id=transfer_id,
-                file_dir=file_dir,
+        transfer_id = (
+            match_transfer_id(
+                download_list,
+                file["filename"],
                 username=username,
-                size=file["size"],
-            ))
+            )
+            if download_list is not None
+            else None
+        )
+        downloads.append(DownloadFile(
+            filename=file["filename"],
+            id=transfer_id or "",
+            file_dir=file_dir,
+            username=username,
+            size=file["size"],
+        ))
+
+    reconciled = sum(1 for download in downloads if download.id)
+    if reconciled != len(downloads):
+        logger.warning(
+            "slskd accepted enqueue for %s but only reconciled %s/%s "
+            "transfer IDs; tracking filenames for next-cycle rederivation",
+            username,
+            reconciled,
+            len(downloads),
+        )
     return downloads
 
 

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, cast
 
-from lib.browse import _fanout_browse_users, download_filter
+from lib.browse import _fanout_browse_users, download_filter, get_browse_coordinator
 from lib.download import cancel_and_delete, slskd_do_enqueue
 from lib.grab_list import GrabListEntry
 from lib.matching import MatchResult, check_for_match, get_album_by_id
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
     from cratedigger import SlskdDirectory, TrackRecord
     from lib.config import CratediggerConfig
     from lib.context import CratediggerContext
+    from lib.search import SearchResult
 
 
 logger = logging.getLogger("cratedigger")
@@ -39,6 +41,25 @@ class EnqueueAttempt:
 
 
 @dataclass(frozen=True)
+class FindDownloadMetrics:
+    browse_time_s: float = 0.0
+    match_time_s: float = 0.0
+    peers_browsed: int = 0
+    peers_browsed_lazy: int = 0
+    fanout_waves: int = 0
+
+    @classmethod
+    def from_context(cls, ctx: CratediggerContext) -> "FindDownloadMetrics":
+        return cls(
+            browse_time_s=ctx.browse_time_s,
+            match_time_s=ctx.match_time_s,
+            peers_browsed=ctx.peers_browsed,
+            peers_browsed_lazy=ctx.peers_browsed_lazy,
+            fanout_waves=ctx.fanout_waves,
+        )
+
+
+@dataclass(frozen=True)
 class FindDownloadResult:
     """Final outcome of matching + enqueue for one album.
 
@@ -50,7 +71,105 @@ class FindDownloadResult:
     """
 
     outcome: Literal["found", "no_match", "enqueue_failed"]
+    grab_entry: GrabListEntry | None = None
     candidates: tuple[CandidateScore, ...] = ()
+    metrics: FindDownloadMetrics | None = None
+
+
+class _WorkerPipelineDBSource:
+    """Sentinel DB source for worker contexts.
+
+    Track and denylist data must be prefetched before worker execution. If a
+    worker reaches this source, the caller forgot to snapshot an input.
+    """
+
+    def _get_db(self) -> None:
+        raise AssertionError("find_download worker attempted owner DB access")
+
+    def get_tracks(self, album: Any) -> list[Any]:
+        raise AssertionError("find_download worker attempted owner DB access")
+
+
+class FindDownloadOwnerPathError(RuntimeError):
+    """Owner-thread orchestration failed after find_download work was queued."""
+
+
+def prepare_find_download_context(
+    album: Any,
+    ctx: CratediggerContext,
+    search_result: "SearchResult | None" = None,
+) -> CratediggerContext:
+    """Build a worker-local context for one album's find_download run."""
+    album_id = album.id
+    request_id = abs(album_id)
+    tracks = get_album_tracks(album, ctx)
+    denied_users = _get_denied_users(album_id, ctx)
+    coordinator = get_browse_coordinator(
+        ctx, ctx.cfg.browse_global_max_workers,
+    )
+    search_cache = copy.deepcopy(
+        search_result.cache_entries
+        if search_result is not None
+        else ctx.search_cache.get(album_id, {})
+    )
+    users = set(search_cache)
+    user_upload_speed = {
+        user: speed
+        for user, speed in (
+            getattr(search_result, "upload_speeds", None) or ctx.user_upload_speed
+        ).items()
+        if user in users
+    }
+    dir_count_source = (
+        getattr(search_result, "dir_audio_counts", None)
+        or ctx.search_dir_audio_count
+    )
+    search_dir_audio_count: dict[str, dict[str, int]] = {}
+    for user, filetypes in search_cache.items():
+        source_counts = dir_count_source.get(user, {})
+        wanted_dirs = {
+            file_dir
+            for dirs in filetypes.values()
+            for file_dir in dirs
+        }
+        selected = {
+            file_dir: source_counts[file_dir]
+            for file_dir in wanted_dirs
+            if file_dir in source_counts
+        }
+        if selected:
+            search_dir_audio_count[user] = selected
+
+    from lib.context import CratediggerContext
+
+    return CratediggerContext(
+        cfg=ctx.cfg,
+        slskd=ctx.slskd,
+        pipeline_db_source=cast(Any, _WorkerPipelineDBSource()),
+        search_cache={album_id: search_cache},
+        folder_cache=ctx.folder_cache,
+        user_upload_speed=user_upload_speed,
+        search_dir_audio_count=search_dir_audio_count,
+        current_album_cache={album_id: album},
+        denied_users_cache={request_id: set(denied_users)},
+        cooled_down_users=set(ctx.cooled_down_users),
+        _folder_cache_ts=ctx._folder_cache_ts,
+        prefetched_album_tracks={album_id: list(tracks)},
+        browse_coordinator=coordinator,
+        browse_coordinator_lock=ctx.browse_coordinator_lock,
+    )
+
+
+def _with_metrics(
+    result: FindDownloadResult,
+    ctx: CratediggerContext,
+) -> FindDownloadResult:
+    return FindDownloadResult(
+        outcome=result.outcome,
+        grab_entry=result.grab_entry,
+        candidates=result.candidates,
+        metrics=FindDownloadMetrics.from_context(ctx),
+    )
 
 
 def release_trackcount_mode(releases: list[Any]) -> Any:
@@ -153,6 +272,8 @@ def _get_denied_users(album_id: int, ctx: CratediggerContext) -> set[str]:
     try:
         db = ctx.pipeline_db_source._get_db()
         denied.update(e["username"] for e in db.get_denylisted_users(request_id))
+    except AssertionError:
+        raise
     except Exception:
         pass
     ctx.denied_users_cache[request_id] = denied
@@ -191,6 +312,8 @@ def _prefixed_directory_files(
 
 def get_album_tracks(album: Any, ctx: CratediggerContext) -> list[TrackRecord]:
     """Get tracks for an album from the pipeline DB source."""
+    if album.id in ctx.prefetched_album_tracks:
+        return cast("list[TrackRecord]", ctx.prefetched_album_tracks[album.id])
     return cast("list[TrackRecord]", ctx.pipeline_db_source.get_tracks(album))
 
 
@@ -259,8 +382,8 @@ def _iter_wave_matches(
     deadlines were starving the pipeline (see 2026-05-02 regression).
 
     Side effects: appends per-dir ``CandidateScore`` entries into
-    ``accumulated`` (caller-owned), bumps ``ctx.fanout_waves`` and
-    ``ctx.peers_browsed``.
+    ``accumulated`` (caller-owned), bumps primary fan-out browse timing and
+    ``ctx.fanout_waves`` / ``ctx.peers_browsed``.
 
     Caller is responsible for stopping iteration (``break``) once a match is
     enqueued; the generator stops fan-out work as soon as iteration stops.
@@ -281,11 +404,14 @@ def _iter_wave_matches(
 
         if work:
             t0 = time.monotonic()
-            _fanout_browse_users(
-                work, ctx.slskd, ctx,
-                max_workers=cfg.browse_global_max_workers,
-            )
-            elapsed = time.monotonic() - t0
+            try:
+                _fanout_browse_users(
+                    work, ctx.slskd, ctx,
+                    max_workers=cfg.browse_global_max_workers,
+                )
+            finally:
+                elapsed = time.monotonic() - t0
+                ctx.browse_time_s += elapsed
             ctx.fanout_waves += 1
             ctx.peers_browsed += len(work)
             n_returned = sum(
@@ -486,7 +612,6 @@ def _try_filetype(
     album: Any,
     results: dict[str, dict[str, list[str]]],
     allowed_filetype: str,
-    grab_list: dict[int, GrabListEntry],
     ctx: CratediggerContext,
 ) -> FindDownloadResult:
     """Try to match and enqueue an album at a specific filetype quality."""
@@ -520,7 +645,7 @@ def _try_filetype(
 
         if attempt.matched:
             assert attempt.downloads is not None
-            grab_list[album_id] = GrabListEntry(
+            grab_entry = GrabListEntry(
                 album_id=album_id,
                 files=attempt.downloads,
                 filetype=allowed_filetype,
@@ -534,7 +659,9 @@ def _try_filetype(
                 db_target_format=album.db_target_format,
             )
             return FindDownloadResult(
-                outcome="found", candidates=tuple(accumulated),
+                outcome="found",
+                grab_entry=grab_entry,
+                candidates=tuple(accumulated),
             )
 
         if attempt.enqueue_failed:
@@ -558,7 +685,6 @@ def _try_filetype(
 
 def find_download(
     album: Any,
-    grab_list: dict[int, GrabListEntry],
     ctx: CratediggerContext,
 ) -> FindDownloadResult:
     """Walk search results and enqueue the best matching download."""
@@ -585,12 +711,14 @@ def find_download(
     accumulated: list[CandidateScore] = []
     for allowed_filetype in filetypes_to_try:
         logger.info(f"Checking for Quality: {allowed_filetype}")
-        result = _try_filetype(album, results, allowed_filetype, grab_list, ctx)
+        result = _try_filetype(album, results, allowed_filetype, ctx)
         accumulated.extend(result.candidates)
         if result.outcome == "found":
-            return FindDownloadResult(
-                outcome="found", candidates=tuple(accumulated),
-            )
+            return _with_metrics(FindDownloadResult(
+                outcome="found",
+                grab_entry=result.grab_entry,
+                candidates=tuple(accumulated),
+            ), ctx)
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
 
@@ -602,16 +730,18 @@ def find_download(
             f"No match at preferred quality for {artist_name} - {album.title}, "
             f"trying catch-all (any audio format)"
         )
-        result = _try_filetype(album, results, "*", grab_list, ctx)
+        result = _try_filetype(album, results, "*", ctx)
         accumulated.extend(result.candidates)
         if result.outcome == "found":
-            return FindDownloadResult(
-                outcome="found", candidates=tuple(accumulated),
-            )
+            return _with_metrics(FindDownloadResult(
+                outcome="found",
+                grab_entry=result.grab_entry,
+                candidates=tuple(accumulated),
+            ), ctx)
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
 
-    return FindDownloadResult(
+    return _with_metrics(FindDownloadResult(
         outcome="enqueue_failed" if had_enqueue_failure else "no_match",
         candidates=tuple(accumulated),
-    )
+    ), ctx)

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -8,9 +8,16 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Sequence, TYPE_CHECKING
 
-from lib.browse import _browse_directories, rank_candidate_dirs
+from lib.browse import (
+    _browse_directories_for_ctx,
+    cache_browsed_directory,
+    ensure_cache_user,
+    rank_candidate_dirs,
+)
 from lib.quality import CandidateScore
 from lib.util import _track_titles_cross_check
+
+_browse_directories = _browse_directories_for_ctx
 
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
@@ -294,8 +301,7 @@ def check_for_match(
     if not dirs_to_try:
         return MatchResult(matched=False, directory={}, file_dir="", candidates=candidates)
 
-    if username not in ctx.folder_cache:
-        ctx.folder_cache[username] = {}
+    ensure_cache_user(ctx, username)
 
     uncached = [d for d in dirs_to_try if d not in ctx.folder_cache[username]]
     if uncached:
@@ -312,8 +318,8 @@ def check_for_match(
             browsed = _browse_directories(
                 uncached,
                 username,
-                ctx.slskd,
-                ctx.cfg.browse_parallelism,
+                ctx,
+                ctx.cfg.browse_global_max_workers,
             )
         finally:
             ctx.browse_time_s += time.monotonic() - browse_t0
@@ -324,8 +330,7 @@ def check_for_match(
             # distinguish primary fan-out load from residual lazy retries.
             ctx.peers_browsed_lazy += len(uncached)
         for d, result in browsed.items():
-            ctx.folder_cache[username][d] = result
-            ctx._folder_cache_ts.setdefault(username, {})[d] = time.time()
+            cache_browsed_directory(ctx, username, d, result)
 
         if not browsed and len(uncached) == len(dirs_to_try):
             ctx.broken_user.append(username)

--- a/lib/slskd_client.py
+++ b/lib/slskd_client.py
@@ -1,0 +1,120 @@
+"""slskd client configuration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+
+from lib.config import CratediggerConfig
+
+
+logger = logging.getLogger("cratedigger")
+
+SLSKD_HTTP_POOL_ADMIN_SLACK = 4
+SLSKD_HTTP_TIMEOUT_S = 120.0
+
+
+@dataclass(frozen=True)
+class SlskdHttpPoolConfigResult:
+    pool_size: int
+    sessions_configured: int
+    configured: bool
+
+
+def derive_slskd_http_pool_size(cfg: CratediggerConfig) -> int:
+    """Return the minimum requests pool size for the configured pipeline width."""
+    return max(
+        1,
+        int(cfg.browse_global_max_workers)
+        + int(cfg.search_max_inflight)
+        + int(cfg.page_size)
+        + SLSKD_HTTP_POOL_ADMIN_SLACK,
+    )
+
+
+def _iter_sessions(slskd_client: Any) -> list[Any]:
+    """Discover unique requests.Session-like objects exposed by slskd-api."""
+    sessions: list[Any] = []
+    seen: set[int] = set()
+    for obj in [slskd_client, *vars(slskd_client).values()] if hasattr(slskd_client, "__dict__") else [slskd_client]:
+        session = getattr(obj, "session", None)
+        if session is None or not hasattr(session, "adapters"):
+            continue
+        ident = id(session)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        sessions.append(session)
+    return sessions
+
+
+def _adapter_for_pool(
+    existing: Any,
+    pool_size: int,
+) -> HTTPAdapter:
+    """Build a replacement adapter while preserving slskd-api timeout behavior."""
+    adapter_cls: Any = existing.__class__ if existing is not None else HTTPAdapter
+    kwargs: dict[str, Any] = {
+        "pool_connections": pool_size,
+        "pool_maxsize": pool_size,
+        "pool_block": True,
+    }
+    timeout = getattr(existing, "timeout", None)
+    if timeout is not None:
+        try:
+            return adapter_cls(timeout=timeout, **kwargs)
+        except TypeError:
+            logger.debug(
+                "slskd HTTP adapter %s does not accept timeout; falling back",
+                adapter_cls,
+            )
+    try:
+        return adapter_cls(**kwargs)
+    except TypeError:
+        return HTTPAdapter(**kwargs)
+
+
+def configure_slskd_http_pool(
+    slskd_client: Any,
+    cfg: CratediggerConfig,
+) -> SlskdHttpPoolConfigResult:
+    """Configure requests connection pools on a slskd-api client.
+
+    The installed `slskd_api.SlskdClient` exposes one shared requests session
+    through each API object. This helper configures every discovered unique
+    session so the 32-way browse path does not hit requests' default pool of
+    10 and churn localhost connections.
+    """
+    pool_size = derive_slskd_http_pool_size(cfg)
+    sessions = _iter_sessions(slskd_client)
+    if not sessions:
+        logger.warning(
+            "Could not configure slskd HTTP pool: no requests session found "
+            "on %s",
+            type(slskd_client).__name__,
+        )
+        return SlskdHttpPoolConfigResult(
+            pool_size=pool_size,
+            sessions_configured=0,
+            configured=False,
+        )
+
+    for session in sessions:
+        for prefix in ("http://", "https://"):
+            existing = session.adapters.get(prefix)
+            session.mount(prefix, _adapter_for_pool(existing, pool_size))
+
+    logger.info(
+        "Configured slskd HTTP pool: pool_size=%s sessions=%s pool_block=true",
+        pool_size,
+        len(sessions),
+    )
+    return SlskdHttpPoolConfigResult(
+        pool_size=pool_size,
+        sessions_configured=len(sessions),
+        configured=True,
+    )

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -21,10 +21,11 @@ from __future__ import annotations
 
 import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock
 
-from lib.browse import _fanout_browse_users
+from lib.browse import _fanout_browse_users, get_browse_coordinator
 from lib.context import CratediggerContext
 from tests.fakes import FakeSlskdAPI
 
@@ -140,6 +141,81 @@ class TestFanoutBrowseConcurrencyCap(unittest.TestCase):
         self.assertLessEqual(peak, 4, f"max_workers=4 cap was violated; peak={peak}")
         # All 50 work items completed (no client deadline anymore).
         self.assertEqual(len(ctx.folder_cache), 50)
+
+    def test_cap_is_global_across_concurrent_fanout_callers(self):
+        slskd = FakeSlskdAPI()
+        peak = 0
+        in_flight = 0
+        lock = threading.Lock()
+
+        def probe(delta: int) -> None:
+            nonlocal peak, in_flight
+            with lock:
+                in_flight += delta
+                peak = max(peak, in_flight)
+
+        slskd.users.in_flight_probe = probe
+        work_a = []
+        work_b = []
+        for i in range(20):
+            user = f"u{i}"
+            directory = f"d{i}"
+            slskd.users.set_directory(user, directory, [_make_directory(directory)])
+            slskd.users.set_directory_delay(user, directory, 0.05)
+            (work_a if i % 2 == 0 else work_b).append((user, directory))
+
+        ctx = _make_ctx(slskd)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(_fanout_browse_users, work_a, slskd, ctx, 4)
+            second = pool.submit(_fanout_browse_users, work_b, slskd, ctx, 4)
+            first.result()
+            second.result()
+
+        self.assertLessEqual(peak, 4, f"global browse cap was violated; peak={peak}")
+        self.assertEqual(len(slskd.users.directory_calls), 20)
+
+    def test_duplicate_cold_directory_is_single_flighted(self):
+        slskd = FakeSlskdAPI()
+        slskd.users.set_directory("user1", "Album", [_make_directory("Album")])
+        slskd.users.set_directory_delay("user1", "Album", 0.05)
+        ctx = _make_ctx(slskd)
+        work = [("user1", "Album")]
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(_fanout_browse_users, work, slskd, ctx, 4)
+            second = pool.submit(_fanout_browse_users, work, slskd, ctx, 4)
+            first.result()
+            second.result()
+
+        self.assertEqual(slskd.users.directory_calls, [("user1", "Album")])
+        self.assertIn("Album", ctx.folder_cache["user1"])
+
+    def test_reusing_coordinator_with_different_capacity_fails_loudly(self):
+        slskd = FakeSlskdAPI()
+        ctx = _make_ctx(slskd)
+
+        get_browse_coordinator(ctx, 4)
+
+        with self.assertRaises(ValueError):
+            get_browse_coordinator(ctx, 8)
+
+    def test_first_time_coordinator_creation_is_single(self):
+        slskd = FakeSlskdAPI()
+        ctx = _make_ctx(slskd)
+        coordinators = []
+
+        def get_one():
+            coordinators.append(get_browse_coordinator(ctx, 4))
+
+        threads = [threading.Thread(target=get_one) for _ in range(20)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual({id(coordinator) for coordinator in coordinators}, {
+            id(ctx.browse_coordinator),
+        })
 
 
 class TestFanoutBrowseRaceRegression(unittest.TestCase):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -26,6 +26,7 @@ class TestCratediggerContext(unittest.TestCase):
         self.assertIsInstance(ctx.folder_cache, dict)
         self.assertIsInstance(ctx.user_upload_speed, dict)
         self.assertIsInstance(ctx.broken_user, list)
+        self.assertIsNotNone(ctx.browse_coordinator_lock)
         self.assertEqual(len(ctx.search_cache), 0)
         self.assertEqual(len(ctx.broken_user), 0)
 
@@ -54,6 +55,7 @@ class TestCratediggerContext(unittest.TestCase):
         self.assertEqual(len(ctx2.search_cache), 0)
         self.assertEqual(len(ctx2.broken_user), 0)
         self.assertEqual(len(ctx2.user_upload_speed), 0)
+        self.assertIsNot(ctx1.browse_coordinator_lock, ctx2.browse_coordinator_lock)
 
 
 if __name__ == "__main__":

--- a/tests/test_cycle_summary.py
+++ b/tests/test_cycle_summary.py
@@ -150,6 +150,9 @@ class TestFormatCycleSummary(unittest.TestCase):
         "peers_browsed=",
         "peers_browsed_lazy=",
         "fanout_waves=",
+        "find_download_queued=",
+        "find_download_completed=",
+        "find_download_drain_time_s=",
         "cycle_total_s=",
     )
 
@@ -167,6 +170,9 @@ class TestFormatCycleSummary(unittest.TestCase):
         ctx.peers_browsed = 42
         ctx.peers_browsed_lazy = 5
         ctx.fanout_waves = 2
+        ctx.find_download_queued = 3
+        ctx.find_download_completed = 2
+        ctx.find_download_drain_time_s = 8.9
         line = format_cycle_summary(ctx, elapsed_s=99.9)
         self.assertIn("browse_time_s=12.3", line)
         self.assertIn("match_time_s=4.5", line)
@@ -174,6 +180,9 @@ class TestFormatCycleSummary(unittest.TestCase):
         self.assertIn("peers_browsed=42", line)
         self.assertIn("peers_browsed_lazy=5", line)
         self.assertIn("fanout_waves=2", line)
+        self.assertIn("find_download_queued=3", line)
+        self.assertIn("find_download_completed=2", line)
+        self.assertIn("find_download_drain_time_s=8.9", line)
         self.assertIn("cycle_total_s=99.9", line)
 
     def test_summary_is_single_line(self):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -512,8 +512,8 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         # Should have polled twice
         self.assertEqual(len(slskd.transfers.get_all_downloads_calls), 2)
 
-    def test_enqueue_timeout_returns_partial(self):
-        """Transfer IDs never appear — should return whatever we have after timeout."""
+    def test_enqueue_timeout_tracks_files_without_transfer_ids(self):
+        """Transfer IDs never appear — accepted enqueue is tracked for re-derivation."""
         from lib.download import slskd_do_enqueue
         # Never returns the transfer ID
         slskd = FakeSlskdAPI(downloads=[{
@@ -524,10 +524,38 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         files = [{"filename": "track.mp3", "size": 5000000}]
         with patch("time.sleep"):
             result = slskd_do_enqueue("user1", files, "user1\\Music", ctx)
-        # Should return empty list (no files matched), not None
         self.assertIsNotNone(result)
         assert result is not None
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].filename, "track.mp3")
+        self.assertEqual(result[0].id, "")
+
+    def test_enqueue_partial_transfer_reconciliation_tracks_every_file(self):
+        """Accepted enqueue with partial IDs still tracks every requested file."""
+        from lib.download import slskd_do_enqueue
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "user1",
+            "directories": [{
+                "directory": "user1\\Music",
+                "files": [{"filename": "track1.mp3", "id": "new-id"}],
+            }],
+        }])
+        ctx = _make_ctx(slskd=slskd)
+        files = [
+            {"filename": "track1.mp3", "size": 5000000},
+            {"filename": "track2.mp3", "size": 5000000},
+        ]
+        with patch("time.sleep"):
+            result = slskd_do_enqueue("user1", files, "user1\\Music", ctx)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual([download.filename for download in result], [
+            "track1.mp3",
+            "track2.mp3",
+        ])
+        self.assertEqual([download.id for download in result], ["new-id", ""])
+        self.assertEqual(slskd.transfers.cancel_download_calls, [])
 
 
 class TestGrabMostWanted(unittest.TestCase):

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -27,7 +27,13 @@ from unittest.mock import MagicMock, patch
 from cratedigger import TrackRecord
 from lib.config import CratediggerConfig
 from lib.context import CratediggerContext
-from lib.enqueue import try_enqueue, try_multi_enqueue
+from lib.enqueue import (
+    _WorkerPipelineDBSource,
+    get_album_tracks,
+    prepare_find_download_context,
+    try_enqueue,
+    try_multi_enqueue,
+)
 from lib.matching import MatchResult
 
 
@@ -245,6 +251,30 @@ class TestWaveShape(unittest.TestCase):
         work_users = {u for (u, _d) in work}
         self.assertEqual(work_users, set(users[2:]))
 
+    def test_primary_fanout_browse_time_is_recorded(self):
+        cfg = _make_cfg(browse_top_k=20)
+        users = _ranked_users(2)
+        ctx = _make_ctx(cfg, user_upload_speed=_upload_speeds(users))
+        results = _make_results(users)
+
+        def fake_fanout(work, slskd, ctx, max_workers):
+            import time
+
+            time.sleep(0.001)
+            for user, file_dir in work:
+                ctx.folder_cache.setdefault(user, {})[file_dir] = {
+                    "directory": file_dir,
+                    "files": [],
+                }
+
+        with patch("lib.enqueue._fanout_browse_users", side_effect=fake_fanout), \
+             patch("lib.enqueue.check_for_match", return_value=_nomatch()):
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertGreater(ctx.browse_time_s, 0.0)
+        self.assertEqual(ctx.fanout_waves, 1)
+        self.assertEqual(ctx.peers_browsed, 2)
+
 
 # ---------------------------------------------------------------------------
 # Per-cycle scope of broken_user
@@ -257,6 +287,69 @@ class TestBrokenUserPerCycle(unittest.TestCase):
         cfg = _make_cfg()
         ctx = CratediggerContext(cfg=cfg, slskd=MagicMock(), pipeline_db_source=MagicMock())
         self.assertEqual(ctx.broken_user, [])
+
+
+class TestFindDownloadWorkerContext(unittest.TestCase):
+    def test_worker_context_snapshots_inputs_and_prefetches_db_data(self):
+        cfg = _make_cfg()
+        source = MagicMock()
+        db = MagicMock()
+        db.get_denylisted_users.return_value = [{"username": "blocked"}]
+        source._get_db.return_value = db
+        source.get_tracks.return_value = [
+            {"albumId": 1, "title": "Track 1", "mediumNumber": 1},
+        ]
+        ctx = CratediggerContext(
+            cfg=cfg,
+            slskd=MagicMock(),
+            pipeline_db_source=source,
+            search_cache={1: {"fast": {"flac": ["dirA"]}}},
+            user_upload_speed={"fast": 100},
+            search_dir_audio_count={"fast": {"dirA": 1}},
+            cooled_down_users={"cooled"},
+        )
+        album = MagicMock(id=1, db_request_id=1)
+
+        search_result = MagicMock(
+            cache_entries={"fast": {"flac": ["dirA"]}},
+            upload_speeds={"fast": 100},
+            dir_audio_counts={"fast": {"dirA": 1}},
+        )
+
+        worker_ctx = prepare_find_download_context(album, ctx, search_result)
+
+        ctx.search_cache[1]["fast"]["flac"].append("dirB")
+        ctx.user_upload_speed["fast"] = 1
+        ctx.search_dir_audio_count["fast"]["dirA"] = 99
+        ctx.cooled_down_users.add("late")
+
+        self.assertEqual(worker_ctx.search_cache[1]["fast"]["flac"], ["dirA"])
+        self.assertEqual(worker_ctx.user_upload_speed["fast"], 100)
+        self.assertEqual(worker_ctx.search_dir_audio_count["fast"]["dirA"], 1)
+        self.assertEqual(worker_ctx.cooled_down_users, {"cooled"})
+        self.assertEqual(worker_ctx.denied_users_cache[1], {"blocked"})
+        self.assertIs(worker_ctx.folder_cache, ctx.folder_cache)
+        self.assertIs(worker_ctx.browse_coordinator, ctx.browse_coordinator)
+
+        source.get_tracks.reset_mock()
+        self.assertEqual(get_album_tracks(album, worker_ctx), [
+            {"albumId": 1, "title": "Track 1", "mediumNumber": 1},
+        ])
+        source.get_tracks.assert_not_called()
+        with self.assertRaises(AssertionError):
+            worker_ctx.pipeline_db_source._get_db()
+
+    def test_worker_db_sentinel_is_not_swallowed_by_denylist_lookup(self):
+        from lib.enqueue import _get_denied_users
+
+        ctx = CratediggerContext(
+            cfg=_make_cfg(),
+            slskd=MagicMock(),
+            pipeline_db_source=_WorkerPipelineDBSource(),  # type: ignore[arg-type]
+        )
+
+        with self.assertRaises(AssertionError):
+            _get_denied_users(1, ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2634,9 +2634,11 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
             result = self._cratedigger.search_for_album(album, ctx)
             grab_list: dict[Any, Any] = {}
             from lib.enqueue import find_download
-            find_result = find_download(album, grab_list, ctx)
+            find_result = find_download(album, ctx)
+            self.assertEqual(grab_list, {})
             self._cratedigger._apply_find_download_result(
-                album, result, find_result, [])
+                album, result, find_result, [], grab_list, ctx)
+            self.assertIn(album.id, grab_list)
             self._cratedigger._log_search_result(album, result, ctx)
 
         # responseLimit was forwarded to slskd at the wire boundary.
@@ -2890,9 +2892,9 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         grab_list: dict[Any, Any] = {}
         from lib.enqueue import find_download
         with patch("lib.enqueue.slskd_do_enqueue", return_value=[MagicMock()]):
-            find_result = find_download(album, grab_list, ctx)
+            find_result = find_download(album, ctx)
         self._cratedigger._apply_find_download_result(
-            album, result, find_result, [])
+            album, result, find_result, [], grab_list, ctx)
         self._cratedigger._log_search_result(album, result, ctx)
 
         # Same blob shape regardless of MB-vs-Discogs origin.

--- a/tests/test_search_max_inflight.py
+++ b/tests/test_search_max_inflight.py
@@ -12,13 +12,26 @@ with `cfg.search_max_inflight` (default 4). These tests pin:
 from __future__ import annotations
 
 import configparser
+import json
 import logging
+import threading
+import time
 import unittest
 from dataclasses import replace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import cratedigger
 from lib.config import CratediggerConfig
+from lib.context import CratediggerContext
+from lib.enqueue import (
+    FindDownloadMetrics,
+    FindDownloadOwnerPathError,
+    FindDownloadResult,
+)
+from lib.grab_list import DownloadFile, GrabListEntry
+from lib.quality import CandidateScore
+from lib.search import SearchResult, SearchVariant
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
 
 
 def _empty_cfg(**overrides) -> CratediggerConfig:
@@ -69,6 +82,344 @@ class TestSearchMaxInflightPipelineLog(unittest.TestCase):
         cfg = _empty_cfg(search_max_inflight=1)
         line = self._run_with(cfg)
         self.assertIn("1 in flight", line)
+
+
+class TestFindDownloadDoesNotBlockSearchRefill(unittest.TestCase):
+    def test_blocked_find_download_does_not_prevent_next_search_submit(self):
+        cfg = _empty_cfg(search_max_inflight=1)
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [101, 102]
+        source = MagicMock()
+        source._get_db.return_value = MagicMock()
+        ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=source)
+        albums = [
+            MagicMock(id=1, artist_name="Artist", title="One"),
+            MagicMock(id=2, artist_name="Artist", title="Two"),
+        ]
+        first_find_started = threading.Event()
+        release_first_find = threading.Event()
+
+        def variant_for(album, _cfg, _db):
+            return (
+                SearchVariant(
+                    kind="default",
+                    query=f"Artist {album.title}",
+                    tag="default",
+                    slice_index=None,
+                ),
+                f"Artist {album.title}",
+            )
+
+        def collect(_search_id, query, album_id, _cfg, _slskd, variant_tag):
+            return SearchResult(
+                album_id=album_id,
+                success=True,
+                cache_entries={},
+                upload_speeds={},
+                dir_audio_counts={},
+                query=query,
+                result_count=1,
+                elapsed_s=0.01,
+                variant_tag=variant_tag,
+            )
+
+        def find(album, _worker_ctx):
+            if album.id == 1:
+                first_find_started.set()
+                self.assertTrue(release_first_find.wait(timeout=2))
+            return FindDownloadResult(outcome="no_match")
+
+        def run_pipeline():
+            with patch.object(
+                cratedigger, "_select_variant_for_album", side_effect=variant_for,
+            ), patch.object(
+                cratedigger, "_collect_search_results", side_effect=collect,
+            ), patch.object(
+                cratedigger,
+                "prepare_find_download_context",
+                side_effect=lambda album, ctx, result=None: ctx,
+            ), patch.object(
+                cratedigger, "find_download", side_effect=find,
+            ):
+                return cratedigger._search_and_queue_parallel(albums, ctx)
+
+        thread = threading.Thread(target=run_pipeline)
+        thread.start()
+        try:
+            self.assertTrue(first_find_started.wait(timeout=2))
+            deadline = time.monotonic() + 2
+            while (
+                len(slskd.searches.search_text_calls) < 2
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+            self.assertEqual(
+                len(slskd.searches.search_text_calls),
+                2,
+                "second search should be submitted while first find_download is blocked",
+            )
+        finally:
+            release_first_find.set()
+            thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+
+    def test_parallel_find_download_results_merge_and_log_on_owner_thread(self):
+        cfg = _empty_cfg(search_max_inflight=1)
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [201, 202]
+        db = FakePipelineDB()
+        rid_found = db.add_request(
+            artist_name="Artist",
+            album_title="Found",
+            source="request",
+            mb_release_id="mbid-found",
+        )
+        rid_miss = db.add_request(
+            artist_name="Artist",
+            album_title="Miss",
+            source="request",
+            mb_release_id="mbid-miss",
+        )
+        source = MagicMock()
+        source._get_db.return_value = db
+        ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=source)
+        albums = [
+            MagicMock(
+                id=-rid_found,
+                db_request_id=rid_found,
+                artist_name="Artist",
+                title="Found",
+            ),
+            MagicMock(
+                id=-rid_miss,
+                db_request_id=rid_miss,
+                artist_name="Artist",
+                title="Miss",
+            ),
+        ]
+        score_found = CandidateScore(
+            username="peer1",
+            dir="Music\\Found",
+            filetype="flac",
+            matched_tracks=2,
+            total_tracks=2,
+            avg_ratio=1.0,
+            missing_titles=[],
+            file_count=2,
+        )
+        score_miss = CandidateScore(
+            username="peer2",
+            dir="Music\\Miss",
+            filetype="flac",
+            matched_tracks=0,
+            total_tracks=2,
+            avg_ratio=0.0,
+            missing_titles=[],
+            file_count=1,
+        )
+        grab_entry = GrabListEntry(
+            album_id=-rid_found,
+            files=[
+                DownloadFile(
+                    filename="Music\\Found\\01.flac",
+                    id="transfer-1",
+                    file_dir="Music\\Found",
+                    username="peer1",
+                    size=123,
+                ),
+            ],
+            filetype="flac",
+            title="Found",
+            artist="Artist",
+            year="1991",
+            mb_release_id="mbid-found",
+            db_request_id=rid_found,
+            db_source="request",
+        )
+
+        def variant_for(album, _cfg, _db):
+            return (
+                SearchVariant(
+                    kind="default",
+                    query=f"Artist {album.title}",
+                    tag="default",
+                    slice_index=None,
+                ),
+                f"Artist {album.title}",
+            )
+
+        def collect(_search_id, query, album_id, _cfg, _slskd, variant_tag):
+            return SearchResult(
+                album_id=album_id,
+                success=True,
+                cache_entries={},
+                upload_speeds={},
+                dir_audio_counts={},
+                query=query,
+                result_count=1,
+                elapsed_s=0.01,
+                variant_tag=variant_tag,
+                final_state="Completed",
+            )
+
+        def find(album, _worker_ctx):
+            if album.id == -rid_found:
+                return FindDownloadResult(
+                    outcome="found",
+                    grab_entry=grab_entry,
+                    candidates=(score_found,),
+                    metrics=FindDownloadMetrics(
+                        browse_time_s=1.5,
+                        match_time_s=0.25,
+                        peers_browsed=3,
+                        peers_browsed_lazy=1,
+                        fanout_waves=2,
+                    ),
+                )
+            return FindDownloadResult(
+                outcome="no_match",
+                candidates=(score_miss,),
+                metrics=FindDownloadMetrics(
+                    browse_time_s=0.5,
+                    match_time_s=0.75,
+                    peers_browsed=4,
+                    peers_browsed_lazy=0,
+                    fanout_waves=1,
+                ),
+            )
+
+        with patch.object(
+            cratedigger, "_select_variant_for_album", side_effect=variant_for,
+        ), patch.object(
+            cratedigger, "_collect_search_results", side_effect=collect,
+        ), patch.object(
+            cratedigger,
+            "prepare_find_download_context",
+            side_effect=lambda album, ctx, result=None: ctx,
+        ), patch.object(
+            cratedigger, "find_download", side_effect=find,
+        ):
+            grab_list, failed_search, failed_grab = cratedigger._search_and_queue_parallel(
+                albums,
+                ctx,
+            )
+
+        self.assertEqual(list(grab_list), [-rid_found])
+        self.assertIs(grab_list[-rid_found], grab_entry)
+        self.assertEqual(failed_search, [])
+        self.assertEqual(failed_grab, [albums[1]])
+        self.assertEqual(ctx.find_download_queued, 2)
+        self.assertEqual(ctx.find_download_completed, 2)
+        self.assertEqual(ctx.browse_time_s, 2.0)
+        self.assertEqual(ctx.match_time_s, 1.0)
+        self.assertEqual(ctx.peers_browsed, 7)
+        self.assertEqual(ctx.peers_browsed_lazy, 1)
+        self.assertEqual(ctx.fanout_waves, 3)
+
+        logs_by_request = {row.request_id: row for row in db.search_logs}
+        self.assertEqual(logs_by_request[rid_found].outcome, "found")
+        self.assertEqual(logs_by_request[rid_miss].outcome, "no_match")
+        found_candidates = json.loads(logs_by_request[rid_found].candidates or "[]")
+        miss_candidates = json.loads(logs_by_request[rid_miss].candidates or "[]")
+        self.assertEqual(found_candidates[0]["username"], "peer1")
+        self.assertEqual(miss_candidates[0]["username"], "peer2")
+
+    def test_owner_exception_after_find_submit_returns_partial_grab(self):
+        cfg = _empty_cfg(search_max_inflight=1)
+        slskd = FakeSlskdAPI()
+        slskd.searches.search_text_id_sequence = [301]
+        db = FakePipelineDB()
+        rid_found = db.add_request(
+            artist_name="Artist",
+            album_title="Found",
+            source="request",
+            mb_release_id="mbid-found",
+        )
+        rid_crash = db.add_request(
+            artist_name="Artist",
+            album_title="Crash",
+            source="request",
+            mb_release_id="mbid-crash",
+        )
+        source = MagicMock()
+        source._get_db.return_value = db
+        ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=source)
+        albums = [
+            MagicMock(
+                id=-rid_found,
+                db_request_id=rid_found,
+                artist_name="Artist",
+                title="Found",
+            ),
+            MagicMock(
+                id=-rid_crash,
+                db_request_id=rid_crash,
+                artist_name="Artist",
+                title="Crash",
+            ),
+        ]
+        grab_entry = GrabListEntry(
+            album_id=-rid_found,
+            files=[
+                DownloadFile(
+                    filename="Music\\Found\\01.flac",
+                    id="transfer-1",
+                    file_dir="Music\\Found",
+                    username="peer1",
+                    size=123,
+                ),
+            ],
+            filetype="flac",
+            title="Found",
+            artist="Artist",
+            year="1991",
+            mb_release_id="mbid-found",
+            db_request_id=rid_found,
+            db_source="request",
+        )
+
+        def variant_for(album, _cfg, _db):
+            if album.id == -rid_crash:
+                raise RuntimeError("owner path failed after worker submit")
+            return (
+                SearchVariant(
+                    kind="default",
+                    query=f"Artist {album.title}",
+                    tag="default",
+                    slice_index=None,
+                ),
+                f"Artist {album.title}",
+            )
+
+        def collect(_search_id, query, album_id, _cfg, _slskd, variant_tag):
+            return SearchResult(
+                album_id=album_id,
+                success=True,
+                query=query,
+                result_count=1,
+                elapsed_s=0.01,
+                variant_tag=variant_tag,
+            )
+
+        def find(_album, _worker_ctx):
+            return FindDownloadResult(
+                outcome="found",
+                grab_entry=grab_entry,
+                metrics=FindDownloadMetrics(),
+            )
+
+        with patch.object(
+            cratedigger, "_select_variant_for_album", side_effect=variant_for,
+        ), patch.object(
+            cratedigger, "_collect_search_results", side_effect=collect,
+        ), patch.object(
+            cratedigger,
+            "prepare_find_download_context",
+            side_effect=lambda album, ctx, result=None: ctx,
+        ), patch.object(
+            cratedigger, "find_download", side_effect=find,
+        ), self.assertRaises(FindDownloadOwnerPathError):
+            cratedigger._search_and_queue_parallel(albums, ctx)
 
 
 if __name__ == "__main__":

--- a/tests/test_slskd_http_pool.py
+++ b/tests/test_slskd_http_pool.py
@@ -1,0 +1,140 @@
+"""slskd HTTP pool sizing tests."""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from dataclasses import replace
+
+import requests
+
+import cratedigger
+from lib.config import CratediggerConfig
+from lib.slskd_client import (
+    SLSKD_HTTP_TIMEOUT_S,
+    SLSKD_HTTP_POOL_ADMIN_SLACK,
+    configure_slskd_http_pool,
+    derive_slskd_http_pool_size,
+)
+from unittest.mock import MagicMock, Mock, patch
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.adapters: dict[str, requests.adapters.HTTPAdapter] = {}
+        self.mounted: list[tuple[str, requests.adapters.HTTPAdapter]] = []
+
+    def mount(self, prefix: str, adapter: requests.adapters.HTTPAdapter) -> None:
+        self.adapters[prefix] = adapter
+        self.mounted.append((prefix, adapter))
+
+
+class FakeApi:
+    def __init__(self, session: FakeSession) -> None:
+        self.session = session
+
+
+class FakeSlskdClient:
+    def __init__(self) -> None:
+        self._session = FakeSession()
+        self.users = FakeApi(self._session)
+        self.searches = FakeApi(self._session)
+        self.transfers = FakeApi(self._session)
+
+
+def _cfg(**overrides):
+    cfg = CratediggerConfig()
+    if overrides:
+        cfg = replace(cfg, **overrides)
+    return cfg
+
+
+class TestSlskdHttpPoolSizing(unittest.TestCase):
+    def test_pool_size_is_derived_from_concurrency_values(self):
+        cfg = _cfg(
+            browse_global_max_workers=32,
+            search_max_inflight=4,
+            page_size=10,
+        )
+
+        self.assertEqual(
+            derive_slskd_http_pool_size(cfg),
+            32 + 4 + 10 + SLSKD_HTTP_POOL_ADMIN_SLACK,
+        )
+
+    def test_configures_http_and_https_adapters_with_blocking_pool(self):
+        client = FakeSlskdClient()
+        cfg = _cfg(browse_global_max_workers=32, search_max_inflight=4, page_size=10)
+
+        result = configure_slskd_http_pool(client, cfg)
+
+        self.assertTrue(result.configured)
+        self.assertEqual(result.sessions_configured, 1)
+        self.assertGreaterEqual(result.pool_size, 46)
+        for prefix in ("http://", "https://"):
+            adapter = client._session.adapters[prefix]
+            self.assertEqual(adapter._pool_connections, result.pool_size)
+            self.assertEqual(adapter._pool_maxsize, result.pool_size)
+            self.assertTrue(adapter._pool_block)
+
+    def test_minimal_concurrency_still_gets_headroom(self):
+        cfg = _cfg(browse_global_max_workers=1, search_max_inflight=1, page_size=1)
+
+        self.assertEqual(
+            derive_slskd_http_pool_size(cfg),
+            1 + 1 + 1 + SLSKD_HTTP_POOL_ADMIN_SLACK,
+        )
+
+    def test_missing_session_logs_diagnostic_without_crashing(self):
+        with self.assertLogs("cratedigger", level=logging.WARNING) as captured:
+            result = configure_slskd_http_pool(object(), _cfg())
+
+        self.assertFalse(result.configured)
+        self.assertEqual(result.sessions_configured, 0)
+        self.assertIn("Could not configure slskd HTTP pool", captured.output[0])
+
+    def test_installed_slskd_client_shape_is_configurable_without_network(self):
+        from tests import conftest
+
+        slskd_api = conftest._real_slskd_api
+        if slskd_api is None or isinstance(slskd_api, Mock):  # pragma: no cover
+            raise unittest.SkipTest("real slskd_api unavailable")
+
+        client = slskd_api.SlskdClient(
+            host="http://localhost:5030",
+            api_key="test-key",
+        )
+        result = configure_slskd_http_pool(client, _cfg())
+
+        self.assertTrue(result.configured)
+        self.assertGreaterEqual(result.sessions_configured, 1)
+        adapter = client.users.session.adapters["http://"]
+        self.assertEqual(adapter._pool_maxsize, result.pool_size)
+        self.assertTrue(adapter._pool_block)
+        self.assertTrue(hasattr(adapter, "timeout"))
+
+    def test_cratedigger_client_factory_configures_pool_once(self):
+        cfg = _cfg(
+            slskd_host_url="http://slskd.example",
+            slskd_api_key="secret",
+            slskd_url_base="/base",
+        )
+        client = MagicMock()
+
+        with patch.object(cratedigger.slskd_api, "SlskdClient", return_value=client) as cls, \
+             patch.object(cratedigger, "configure_slskd_http_pool") as configure:
+            result = cratedigger._create_slskd_client(cfg)
+
+        self.assertIs(result, client)
+        cls.assert_called_once_with(
+            host="http://slskd.example",
+            api_key="secret",
+            url_base="/base",
+            timeout=SLSKD_HTTP_TIMEOUT_S,
+        )
+        configure.assert_called_once_with(client, cfg)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
## Summary
- queue successful search results into cycle-sized find_download workers so search slots refill before browse/match/enqueue completes
- add a shared BrowseCoordinator with global browse capacity, single-flight cold directory misses, explicit shutdown, and safe cache ownership
- configure slskd HTTP pool size from browse/search/page concurrency with blocking adapters and a bounded client timeout
- make find_download return owner-mergeable results/metrics and track accepted enqueues even when transfer IDs are re-derived next cycle

Closes #217.

## Verification
- nix-shell --run "bash scripts/run_tests.sh"
  - JS syntax OK
  - JS unit tests: 204 passed + 118 passed
  - Python: 2805 tests OK, skipped 54
- changed-file pyright passed before final full suite