### PR TITLE
fix(download): preclaim slskd ownership

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -1152,7 +1152,13 @@ def main():
 
         # Build context with fresh caches for this cycle
         from lib.context import CratediggerContext
-        _module_ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=pipeline_db_source)
+        from lib.download_ownership import DownloadOwnershipWriter
+        _module_ctx = CratediggerContext(
+            cfg=cfg,
+            slskd=slskd,
+            pipeline_db_source=pipeline_db_source,
+            download_ownership=DownloadOwnershipWriter(cfg.pipeline_db_dsn),
+        )
         from lib.peer_cache import connect_from_config
         _module_ctx.peer_cache = connect_from_config(cfg)
 

--- a/docs/plans/2026-05-05-003-fix-download-ownership-persistence-plan.md
+++ b/docs/plans/2026-05-05-003-fix-download-ownership-persistence-plan.md
@@ -1,0 +1,393 @@
+---
+title: "fix: Claim download ownership before slskd enqueue"
+type: fix
+status: active
+date: 2026-05-05
+deepened: 2026-05-05
+---
+
+# fix: Claim download ownership before slskd enqueue
+
+## Summary
+
+Move the `wanted` to `downloading` ownership write ahead of the external slskd enqueue side effect so a process restart cannot leave accepted transfers unowned by the pipeline DB. The implementation should persist a planned active download witness before enqueue, then reset it only after verifying that slskd accepted no work.
+
+---
+
+## Problem Frame
+
+Issue #219 reports a restart seam introduced by the async search/enqueue pipeline: slskd can accept transfers inside `find_download`, but Cratedigger currently waits until `search_and_queue` returns and `grab_most_wanted` loops the final grab list before writing `status='downloading'`. A kill in that gap leaves slskd downloading while the request remains `wanted`, allowing the next cycle to enqueue duplicate work.
+
+---
+
+## Requirements
+
+- R1. Before an initial request enqueue can create slskd transfers, the request must transition to `downloading` with planned `active_download_state`; end-of-cycle aggregation must not be the first ownership write.
+- R2. The persisted `active_download_state` payload must use one canonical shape: filetype, enqueued/progress timestamps, one entry per planned file with source user, full filename, source `file_dir`, size, disk metadata, retry/progress fields, and a `current_path` key whose initial value is `null` until local processing starts.
+- R3. If slskd definitely rejects the enqueue before accepting any transfer, the request must return to retryable `wanted` through the existing retry/backoff behavior.
+- R4. If enqueue outcome is ambiguous, cancellation cannot be verified, transfer-ID lookup fails, multi-disc enqueue fails, owner-thread merge fails, or cycle completion fails, the row must not become fresh `wanted` while accepted transfers may still exist. The only valid post-enqueue outcomes are: owned as `downloading`, verified no accepted transfer/cancelled then retryable, or left `downloading` as unsafe-unresolved for poll/timeout/operator recovery.
+- R5. Restart regression coverage must prove that a process stop at the dangerous seams, including after the slskd call returns but before normal worker completion, resumes through persisted DB state instead of treating the request as fresh `wanted`.
+- R6. Request status writes must continue to flow through the shared `lib.transitions` transition seam.
+
+---
+
+## Scope Boundaries
+
+- Do not change the systemd timer, unit restart policy, or deploy cadence from the #198/#217 rollout.
+- Do not refactor search, browse fan-out, match scoring, Redis folder cache, or slskd lifecycle management beyond what is needed to persist download ownership at enqueue time.
+- Do not introduce new request statuses or change the existing request lifecycle. The existing automatic retry transition `downloading -> wanted` remains valid when no accepted transfer exists or accepted transfers have been verified cancelled.
+- Do not build a general orphan-transfer reconciliation tool; this plan closes the forward path that creates the orphan.
+- Do not make broad DB connection-pooling changes. Any worker DB access should be a narrow ownership-write seam, not a general permission for `find_download` workers to use owner DB state.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/download.py`: `slskd_do_enqueue` calls `ctx.slskd.transfers.enqueue`, then polls `get_all_downloads` for up to 10 seconds to recover transfer IDs. It already returns `DownloadFile` entries with empty IDs when slskd accepted the enqueue but ID reconciliation is incomplete, and retry re-enqueue inside `poll_active_downloads` also uses this low-level helper.
+- `lib/download.py`: `build_active_download_state` serializes `GrabListEntry` data into the JSON shape consumed by `poll_active_downloads`.
+- `lib/download.py`: `grab_most_wanted` currently persists `downloading` after `search_and_queue` returns; this is the ownership gap to remove or neutralize.
+- `lib/download.py`: `poll_active_downloads` reconstructs entries from `active_download_state`, re-derives transfer IDs from the bulk slskd snapshot, and can continue with empty persisted IDs as long as username and filename data are present.
+- `lib/enqueue.py`: `try_enqueue` and `try_multi_enqueue` call `slskd_do_enqueue`; `_try_filetype` builds the `GrabListEntry` after a match and successful enqueue.
+- `lib/enqueue.py`: `prepare_find_download_context` intentionally installs `_WorkerPipelineDBSource` so match workers cannot accidentally use the owner thread's cached DB connection.
+- `lib/transitions.py`: `RequestTransition.to_downloading`, `finalize_request`, and transition validation are the required state-transition seam.
+- `tests/test_request_finalization.py`: AST contract coverage rejects direct request status writes outside the transition seam.
+- `tests/test_download.py`: `TestGrabMostWanted`, `TestBuildActiveDownloadState`, and `poll_active_downloads` tests cover the existing delayed persist and resume behavior.
+- `tests/test_search_max_inflight.py`: covers parallel `find_download` worker orchestration, owner-path exceptions, merge behavior, and logging.
+- `tests/test_enqueue_fanout.py`: covers single-disc, multi-disc, fan-out, and enqueue-failure paths.
+
+### Institutional Learnings
+
+- `docs/advisory-locks.md` documents a similar crash-window fix: persist a precise witness before crossing a process boundary so the next cycle can distinguish safe retry from unsafe duplicate work. This plan applies the same ownership principle to slskd transfer acceptance.
+- No `docs/solutions/` entry directly targets slskd enqueue ownership. The closest testing guidance is `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`: cross-boundary behavior needs at least one integration slice, not only mocked helper tests.
+
+### External References
+
+- No external research used. The issue is local pipeline reliability work with strong existing code patterns.
+
+---
+
+## Key Technical Decisions
+
+- Pre-claim before slskd enqueue: slskd and PostgreSQL cannot be updated atomically, so the robust invariant is that a planned `downloading` witness exists before the external enqueue call can create transfers. A same-process no-acceptance outcome can reset the row; a crash leaves a conservative `downloading` row rather than an unowned transfer.
+- Keep `slskd_do_enqueue` a low-level slskd seam: initial request enqueue paths may wrap or split it only after claiming ownership, but poller retry re-enqueues must not trigger new request ownership writes.
+- Use a narrow per-call ownership writer: `find_download` workers must not call the owner context's cached `DatabaseSource._get_db()`. The first implementation should pass a dedicated collaborator into worker contexts that constructs its own `PipelineDB` from the configured DSN for the ownership claim, guarded enrichment, and verified reset operations, then closes it in `finally`.
+- Provisional planned state is valid state: transfer IDs may be empty because `poll_active_downloads` re-derives them from username and filename. The canonical initial payload includes `current_path: null`; local current-path updates begin only once processing/staging starts.
+- Preserve the transition seam and make success observable: the new ownership write must use a transition-layer helper that returns success/failure for `wanted -> downloading`; it must not infer success from warning logs or call `db.set_downloading` directly outside `lib.transitions`.
+- Guard all post-claim state changes: enrichment after ID reconciliation and reset-after-no-acceptance must return success/failure and must only apply while the row is still in the expected status.
+- Make later aggregation idempotent or obsolete: after immediate persistence lands, `grab_most_wanted` should no longer be the first writer of `downloading`; it should either stop writing ownership entirely or only update non-status state when the row is already owned.
+- Treat partial multi-disc acceptance as owned work: after all disc sources are selected, materialize the full planned file list with disk metadata before the first enqueue. Persist that full planned state before any disc enqueue. If a later disc fails in the same process, transition back to retryable `wanted` only after proving no accepted transfers remain; otherwise keep the request `downloading`.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be handled by a repair script that finds orphans after restart? No. Issue #219 asks to prevent new orphan creation by persisting ownership at enqueue acceptance time.
+- Should the fix wait for transfer IDs before persisting? No. Waiting for ID reconciliation preserves a real kill window; existing polling can re-derive IDs from filenames and usernames.
+- Should ownership be written only after slskd acceptance? No. That still leaves a kill window between the external side effect and the DB write. The plan intentionally pre-claims `downloading` and resets only after verified no-acceptance/cancellation.
+- Should match workers gain general DB access? No. The existing sentinel is a useful guard. Add only the narrow ownership-write path needed by this bug.
+
+### Deferred to Implementation
+
+- Exact helper names for the transition-layer ownership result and context collaborator.
+- Whether a same-process multi-disc cleanup failure should immediately log a download attempt before leaving the row `downloading`, or leave attempt accounting to existing timeout/operator recovery.
+- Exact log wording for ownership persistence, guard rejection, verified cancellation, and unsafe-unresolved outcomes.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Worker as find_download worker
+    participant Slskd as slskd transfers
+    participant Owner as ownership writer
+    participant DB as pipeline DB
+    participant Poll as next poll_active_downloads
+
+    Worker->>Owner: persist planned active state
+    Owner->>DB: wanted -> downloading + active_download_state
+    DB-->>Owner: ownership success/failure
+    Worker->>Slskd: enqueue matched files
+    Slskd-->>Worker: accepted, rejected, or ambiguous
+    Worker->>Slskd: reconcile transfer IDs
+    Worker-->>Worker: return found result for normal owner-thread merge
+    Note over Worker,DB: If the process dies after enqueue, DB already owns the planned transfer set.
+    Poll->>DB: read downloading rows
+    Poll->>Slskd: re-derive IDs from persisted username+filename
+```
+
+The important ordering is planned ownership before external enqueue before reconciliation. The persisted state can be enriched later, but it must exist before slskd can start work, any slow polling, worker return, owner-thread merge, or end-of-cycle aggregation. If enqueue returns rejected or ambiguous, the code must prove no accepted transfer exists before resetting to `wanted`; otherwise the row stays `downloading`.
+
+---
+
+## Implementation Units
+
+- U1. **Add a worker-safe download ownership writer**
+
+**Goal:** Provide one explicit way for enqueue code running in a `find_download` worker to mark a request `downloading` without using the owner thread's cached DB connection or bypassing transition contracts.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `album_source.py`
+- Modify: `lib/context.py`
+- Modify: `lib/download.py`
+- Modify: `lib/enqueue.py`
+- Modify: `lib/pipeline_db.py`
+- Modify: `lib/transitions.py`
+- Test: `tests/test_download.py`
+- Test: `tests/test_pipeline_db.py`
+- Test: `tests/test_request_finalization.py`
+- Test: `tests/test_transitions.py`
+
+**Approach:**
+- Add a transition-layer ownership helper that returns `True` only when the guarded `wanted -> downloading` write actually applies. Existing callers can keep using `finalize_request`, but the enqueue ownership path needs an observable result.
+- Add a narrow ownership persistence collaborator that receives a request identifier and active download state payload, opens its own `PipelineDB` connection from the configured DSN, writes through the transition-layer helper, and closes the connection.
+- Give the collaborator three explicit operations: claim planned ownership, guarded active-state enrichment while still `downloading`, and verified reset to retryable `wanted` after no-acceptance/verified-cancelled outcomes.
+- Wire worker contexts so they can use this collaborator while `_WorkerPipelineDBSource` continues to reject general DB reads.
+- Keep the boundary small: no track reads, no denylist reads, no search logging, no import writes, and no direct status-update calls.
+- Make guard rejection explicit. If the row is no longer `wanted`, the enqueue path must stop before calling slskd rather than assuming ownership succeeded or continuing to the next peer.
+
+**Execution note:** Start with a failing test that proves a worker context can persist `downloading` through the new boundary while still failing if it tries to use general DB access.
+
+**Patterns to follow:**
+- `lib.transitions.RequestTransition.to_downloading`, transition validation, and the existing `finalize_request` pattern.
+- `_WorkerPipelineDBSource` in `lib/enqueue.py` for preserving worker DB boundaries.
+- `FakePipelineDB.status_history` and transition tests in `tests/test_download.py` / `tests/test_transitions.py`.
+
+**Test scenarios:**
+- Happy path: given a wanted request and a worker-safe ownership writer, persisting active state records one `downloading` transition and stores non-empty `active_download_state`.
+- Happy path: the transition-layer ownership helper returns `True` when `PipelineDB.set_downloading` applies the guarded write.
+- Happy path: guarded active-state enrichment updates only a row that is still `downloading`.
+- Contract: the ownership writer routes through `lib.transitions`; the direct status-write AST guard in `tests/test_request_finalization.py` remains green.
+- Edge case: worker code that attempts generic DB reads still hits `_WorkerPipelineDBSource`, proving the new seam did not reopen general worker DB access.
+- Error path: if the status guard rejects `wanted -> downloading`, the transition-layer helper returns `False`, the writer reports non-ownership, and the caller stops before invoking slskd.
+- Error path: guarded active-state enrichment returns failure and does not rewrite state when the row has moved to `wanted`, `manual`, or `imported`.
+- Error path: if the ownership write raises before slskd enqueue, the writer closes its DB connection, reports the failure to the caller, and slskd is not called.
+
+**Verification:**
+- Worker enqueue paths have an explicit safe way to persist ownership.
+- No new production status writes bypass `lib.transitions`.
+
+---
+
+- U2. **Persist planned ownership before initial slskd enqueue**
+
+**Goal:** Close the kill window between slskd acceptance and DB ownership for single-disc downloads by claiming the planned transfer set before the external enqueue call.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `lib/download.py`
+- Modify: `lib/enqueue.py`
+- Test: `tests/test_download.py`
+- Test: `tests/test_enqueue_fanout.py`
+
+**Approach:**
+- Build planned active state from the matched album/request context and file payload before calling `transfers.enqueue`.
+- Claim `downloading` with that planned state before the external enqueue call. If the claim fails, do not call slskd.
+- Do not make the ownership write unconditional inside every `slskd_do_enqueue` call. Either split initial enqueue from retry enqueue, or pass an explicit initial-ownership collaborator only from request enqueue paths so poller retry re-enqueues remain pure slskd operations.
+- Keep ID reconciliation as an enrichment step: when IDs are found, update the active state or returned `GrabListEntry` as needed, but do not depend on IDs for initial ownership.
+- If slskd definitely rejects the enqueue before accepting work, verify no matching transfer exists and transition back to retryable `wanted` through existing retry semantics.
+- If the enqueue result is false, raises, or cannot be trusted, query the bulk transfer snapshot for the requested username and filenames before deciding the request has no accepted transfer. If the snapshot cannot prove no transfer exists, leave the row `downloading`.
+- Treat cleanup as a proven-outcome operation: reset to `wanted` only after accepted transfers are verified absent or verified cancelled. Empty transfer IDs, failed snapshots, or failed cancels leave the row `downloading` rather than retryable.
+
+**Execution note:** Add the restart-seam regression before changing the enqueue flow: inject stops after the ownership claim and after the slskd call returns, and assert the DB row is already `downloading`.
+
+**Patterns to follow:**
+- `slskd_do_enqueue` currently returns empty IDs when accepted transfers cannot be reconciled.
+- `poll_active_downloads` / `rederive_transfer_ids` already tolerate empty persisted IDs.
+- `build_active_download_state` is the canonical JSON state builder.
+
+**Test scenarios:**
+- Happy path: a single-disc initial enqueue claims `downloading` before the fake slskd enqueue method is called.
+- Happy path: accepted enqueue with missing transfer IDs persists planned state containing username, filename, source `file_dir`, size, filetype, timestamps, disk fields, retry/progress fields, and `current_path: null`; next poll can re-derive IDs from a fake slskd snapshot.
+- Error path: `transfers.enqueue` returns false and a bulk snapshot proves no matching transfer exists; the row transitions back to retryable `wanted`.
+- Error path: `transfers.enqueue` raises and a bulk snapshot finds a matching transfer; the row stays `downloading`.
+- Error path: `transfers.enqueue` raises and the bulk snapshot itself fails; the row stays `downloading` as unsafe-unresolved.
+- Error path: ownership claim guard fails before enqueue; slskd is not called and the album attempt stops.
+- Error path: verified cancellation is required before reset; missing transfer IDs plus failed re-derivation/cancel leaves the row `downloading`.
+- Race path: row changes away from `downloading` before ID enrichment; guarded enrichment fails without rewriting active state.
+- Restart seam: inject a process-stop exception after the slskd call returns but before normal `find_download` return; the DB row remains `downloading` with planned active state.
+- Regression: poller retry re-enqueue of failed files does not call the request ownership writer.
+
+**Verification:**
+- The first durable DB write happens before the external slskd enqueue call.
+- Existing enqueue-failure telemetry classifies only verified no-acceptance failures as retryable failures.
+
+---
+
+- U3. **Handle multi-disc and partial-acceptance ownership**
+
+**Goal:** Ensure multi-disc enqueue cannot orphan a subset of accepted disc transfers if a later disc fails or the process dies mid-sequence.
+
+**Requirements:** R2, R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `lib/enqueue.py`
+- Modify: `lib/download.py`
+- Test: `tests/test_enqueue_fanout.py`
+- Test: `tests/test_download.py`
+
+**Approach:**
+- After all disc sources are selected, build the full planned file list with disk metadata before any disc is enqueued.
+- Persist the full planned active state before the first disc enqueue, even though later disc transfer IDs may still be empty or not yet accepted.
+- Keep active state coherent enough for `poll_active_downloads`: disk metadata, source user, file directory, filename, size, and retry counters must survive restart.
+- When final multi-disc success reconciles additional transfer IDs or status details after the planned write, update `active_download_state` through the guarded enrichment operation so the row tracks the latest complete file set.
+- If a later disc fails in the same process, attempt to re-derive IDs and cancel accepted transfers. When no accepted transfer exists or cancellation is verified, transition the request back to retryable `wanted`; when absence/cancellation cannot be proven, keep the full planned state owned as `downloading` for poll/timeout handling.
+
+**Execution note:** Characterize current multi-disc failure behavior first, especially the branch that cancels `all_downloads` after one disc accepted and a later enqueue fails.
+
+**Patterns to follow:**
+- `try_multi_enqueue` existing `cancel_and_delete(all_downloads, ctx)` cleanup on partial failure.
+- `DownloadFile.disk_no` / `disk_count` propagation in successful multi-disc paths.
+- `active_download_state` retry and disk metadata tests in `tests/test_download.py`.
+
+**Test scenarios:**
+- Happy path: a multi-disc enqueue accepted for all discs persists a final state containing every disc's files and disk metadata.
+- Edge case: disc 1 accepted, disc 2 pending, process stops; DB state owns the full planned album so the next poll does not treat disc 1 as a complete album or re-search as fresh `wanted`.
+- Error path: disc 1 accepted, disc 2 rejected, transfer IDs initially missing, re-derivation finds IDs, cancellation succeeds; the request transitions back to retryable `wanted` and no accepted transfer remains unowned.
+- Error path: disc 1 accepted, disc 2 rejected, transfer IDs cannot be re-derived or cancellation cannot be verified; the request stays `downloading` with the full planned state instead of silently reverting to `wanted`.
+- Race path: a manual/imported/reset transition happens before final multi-disc enrichment; guarded enrichment fails and does not overwrite the newer state.
+- Integration: `poll_active_downloads` can reconstruct a full planned state after partial acceptance and either observe active transfers, retry missing transfers, or time them out through existing handling.
+
+**Verification:**
+- No accepted multi-disc transfer can exist in slskd while the request remains `wanted` without active state.
+- Existing successful multi-disc result shape remains compatible with normal owner-thread merge and search logging.
+
+---
+
+- U4. **Remove delayed ownership as the primary writer**
+
+**Goal:** Make `grab_most_wanted` compatible with immediate ownership persistence so later aggregation cannot be the first or only state write.
+
+**Requirements:** R1, R3, R6
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `lib/download.py`
+- Modify: `cratedigger.py`
+- Test: `tests/test_download.py`
+- Test: `tests/test_search_max_inflight.py`
+
+**Approach:**
+- Stop relying on the final `grab_list` loop in `grab_most_wanted` to transition found downloads to `downloading`.
+- Preserve `grab_most_wanted` return counts and logging semantics for found, failed-search, and failed-grab outcomes.
+- Ensure parallel `find_download` owner-path exception handling no longer needs to drain worker results before DB ownership is safe; draining can still matter for logging, metrics, and partial results.
+- Avoid duplicate warning noise from attempting a second guarded `wanted -> downloading` transition after the row is already `downloading`.
+
+**Execution note:** Update the existing `TestGrabMostWanted` tests to assert the new ownership location instead of only the end-of-cycle effect.
+
+**Patterns to follow:**
+- Existing `grab_most_wanted` no-blocking behavior test.
+- `tests/test_search_max_inflight.py` owner-path exception coverage.
+- Cycle summary counters should remain metrics-only and not become part of ownership correctness.
+
+**Test scenarios:**
+- Happy path: `grab_most_wanted` returns the same count for found downloads when ownership was already persisted by enqueue code.
+- Edge case: owner-thread merge is delayed or raises after worker enqueue acceptance; DB ownership is already durable.
+- Error path: found result reaches `grab_most_wanted` for a row already `downloading`; no duplicate transition warning is emitted.
+- Regression: a verified no-acceptance enqueue failure still increments the failed-grab/search failure path and leaves the request retryable.
+- Regression: a worker crash after ownership persistence but before owner-thread merge leaves the request `downloading`, not `wanted`.
+
+**Verification:**
+- End-of-cycle aggregation is no longer a restart-safety requirement.
+- Existing search logging and cycle summaries remain understandable after the ownership move.
+
+---
+
+- U5. **Add restart-resume integration coverage**
+
+**Goal:** Prove the complete issue #219 lifecycle: accepted slskd work survives process death as a DB-owned active download and resumes through the poller on the next run.
+
+**Requirements:** R2, R5
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- Modify: `tests/test_download.py`
+- Modify: `tests/test_integration_slices.py`
+- Modify: `tests/fakes.py`
+- Test: `tests/test_download.py`
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Add a focused seam test that simulates planned ownership, slskd accepting enqueue, then raises before transfer-ID reconciliation or normal cycle completion.
+- Use a sentinel that is not swallowed by broad `except Exception` blocks when modeling process stop; the test should prove persistence happened before normal cleanup/merge code can run.
+- Add an integration slice that seeds the resulting DB row into a fresh context and runs `poll_active_downloads` against a fake slskd snapshot.
+- Extend fakes only as needed to record enqueue acceptance, active state writes, and bulk transfer snapshots; avoid adding behavior that production does not have.
+- Keep the test at the boundary the bug lives on: slskd acceptance, DB state, restart, and poll resume.
+
+**Execution note:** This unit should be test-first and should fail on current `main` because current persistence happens after `search_and_queue` returns.
+
+**Patterns to follow:**
+- `FakeSlskdAPI` transfer snapshots and enqueue calls in `tests/fakes.py`.
+- `TestGrabMostWanted` and `poll_active_downloads` fixtures in `tests/test_download.py`.
+- Existing integration slices that reconstruct `active_download_state` and validate current-path recovery.
+
+**Test scenarios:**
+- Integration: enqueue accepted, process-stop exception fires before normal cycle completion, fresh context polls the persisted `downloading` row and matches transfers by username and filename.
+- Integration: process-stop exception fires immediately after the fake slskd call returns and before ID reconciliation; fresh context still sees `downloading`.
+- Integration: accepted enqueue with transfer IDs still missing in persisted state resumes because the poller re-derives IDs from the bulk slskd snapshot.
+- Error path: verified no-acceptance enqueue failure returns the row to `wanted` and eligible for existing retry/backoff behavior.
+- Error path: ambiguous enqueue failure leaves the row `downloading` unless the test proves no matching slskd transfer exists.
+- Edge case: status guard rejects because another process already moved the request out of `wanted`; slskd is not called for the stale worker.
+- Regression: retry re-enqueue inside `poll_active_downloads` does not call the initial-ownership seam.
+
+**Verification:**
+- The regression test models the issue's kill seam directly.
+- A fresh post-restart poll path uses DB state rather than the original in-memory `grab_list`.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The affected flow is search result -> `find_download` -> request ownership claim -> slskd enqueue -> `poll_active_downloads`. Import dispatch, web UI add flows, and quality decisions should not change.
+- **Error propagation:** Verified no-acceptance slskd failures remain enqueue/search failures. Ambiguous outcomes remain `downloading` unless the implementation proves no transfer exists or verifies cancellation.
+- **State lifecycle risks:** The critical risk is a partial side effect: slskd accepts files but DB ownership is absent. The mitigation is a durable planned ownership claim before the external enqueue call, plus guarded reset only after verified no-acceptance or verified cancellation.
+- **API surface parity:** CLI/web request creation and pipeline status display continue to use the same `wanted` and `downloading` statuses.
+- **Integration coverage:** Unit tests alone are insufficient; the plan requires a restart-style slice where a fresh context resumes from persisted `active_download_state`.
+- **Unchanged invariants:** Request status writes still route through `lib.transitions`; `PipelineDB.set_downloading` remains guarded to `status='wanted'`; `poll_active_downloads` remains the only owner of ongoing download monitoring.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Worker code accidentally reuses the owner DB connection | Add a per-call ownership writer that opens/closes its own `PipelineDB` and keep `_WorkerPipelineDBSource` as the general DB sentinel. |
+| Transfer IDs are unavailable at the first durable write | Persist username and filename data before enqueue; rely on existing transfer-ID re-derivation in `poll_active_downloads`. |
+| Multi-disc partial enqueue creates ambiguous ownership | Materialize and persist full planned state before first enqueue, and reset only after verified no-acceptance or verified cancellation. |
+| Duplicate transition attempts create noisy warnings | Remove or neutralize the delayed `grab_most_wanted` transition once immediate persistence owns the state. |
+| DB write fails or guard rejects before slskd enqueue | Do not call slskd; stop the album attempt and report enqueue failure. |
+| Enqueue result is ambiguous or cancellation cannot be verified | Leave the row `downloading` as unsafe-unresolved so the next poll/operator path owns recovery; do not return it to fresh `wanted`. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update inline comments near `grab_most_wanted` and the initial enqueue path so future changes understand that DB ownership is claimed before slskd enqueue. Keep `slskd_do_enqueue` comments clear that poller retry calls do not create new request ownership.
+- No migration is expected; `active_download_state` and `status='downloading'` already exist.
+- No deployment choreography change is expected. Normal verification should include a cycle log showing ownership claimed before initial slskd enqueue and retained or reset according to the verified outcome.
+
+---
+
+## Sources & References
+
+- Related issue: #219
+- Related rollout context: #198, #217
+- Related code: `lib/download.py`, `lib/enqueue.py`, `cratedigger.py`, `lib/transitions.py`, `tests/test_download.py`, `tests/test_search_max_inflight.py`, `tests/test_enqueue_fanout.py`
+- Related docs: `docs/advisory-locks.md`, `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`

--- a/docs/plans/2026-05-05-004-fix-download-ownership-review-remediation-plan.md
+++ b/docs/plans/2026-05-05-004-fix-download-ownership-review-remediation-plan.md
@@ -1,0 +1,250 @@
+---
+title: "fix: Harden download ownership preclaim recovery"
+type: fix
+status: active
+date: 2026-05-05
+origin: docs/plans/2026-05-05-003-fix-download-ownership-persistence-plan.md
+---
+
+# fix: Harden download ownership preclaim recovery
+
+## Summary
+
+Close the remaining review findings in the download ownership preclaim work by making every reset prove that slskd accepted no work, fencing poll recovery to the current claim, canonicalizing the initial state shape, and adding the missing contract coverage around the new DB and transition seams.
+
+---
+
+## Problem Frame
+
+The first implementation moves ownership before slskd enqueue, but code review found that some reset and recovery paths are still optimistic. A false/rejected enqueue result, same-cycle poll overlap, stale terminal slskd snapshots, or unverified cancellation can still clear ownership while transfers may exist.
+
+---
+
+## Requirements
+
+- R1. A claimed request may reset from `downloading` to `wanted` only after a fresh slskd snapshot proves every planned transfer is absent, or after accepted transfers are verifiably cancelled.
+- R2. Ambiguous, stale, failed-snapshot, failed-cancel, same-cycle, and unverified outcomes must leave the request `downloading` with enough planned state for poll recovery.
+- R3. Poll recovery must not attach a new ownership claim to slskd terminal transfers older than the persisted `enqueued_at`.
+- R4. Initial planned `active_download_state` must use the canonical shape, including `current_path: null` until local processing starts, while readers remain compatible with legacy missing keys.
+- R5. Verified no-acceptance resets must use retry/backoff accounting through the transition seam.
+- R6. New status-mutating DB helpers and fake DB stubs must be covered by direct contract tests and the direct-status-write guard.
+
+---
+
+## Scope Boundaries
+
+- Do not introduce a new request status or a general orphan-reconciliation tool.
+- Do not redesign slskd polling or retry re-enqueue semantics beyond the current ownership claim.
+- Do not broaden worker DB access beyond the existing narrow ownership writer.
+- Do not make CLI/operator UX changes in this pass; structured operator evidence can follow after the safety fixes land.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/enqueue.py` owns the preclaim, single-disc enqueue, multi-disc enqueue, reset, and partial-failure recovery branches.
+- `lib/download.py` owns `cancel_and_delete`, `rederive_transfer_ids`, and `poll_active_downloads` resume behavior.
+- `lib/quality.py` owns `ActiveDownloadState.to_json()` and legacy-compatible parsing.
+- `lib/download_ownership.py` is the narrow worker-safe writer that routes status changes through `lib.transitions`.
+- `lib/pipeline_db.py`, `tests/fakes.py`, `tests/test_pipeline_db.py`, `tests/test_fakes.py`, and `tests/test_request_finalization.py` are the DB seam contract surface.
+
+### Institutional Learnings
+
+- `docs/advisory-locks.md` establishes the witness-before-side-effect pattern: retry only after the DB can distinguish safe retry from unsafe duplicate work.
+- `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md` warns that mocked helper tests miss cross-boundary behavior; this fix needs at least one fresh-context poll/restart slice.
+
+### External References
+
+- None. This is local pipeline reliability work.
+
+---
+
+## Key Technical Decisions
+
+- Treat `SlskdEnqueueOutcome(status="rejected")` as "not accepted by the direct call", not as durable proof that no transfer exists. The reset path must independently prove absence using the same username/filename planned state.
+- Use the persisted `enqueued_at` as the claim boundary. Poll and recovery helpers may ignore stale terminal records older than that boundary when they are deciding whether the current claim owns a transfer.
+- Keep `current_path` explicit in the JSON payload with `null`. This separates canonical planned rows from legacy missing-key rows while preserving reader compatibility.
+- Verified no-acceptance remains a retryable download attempt. It should increment download attempts and set backoff just like other automatic `downloading -> wanted` paths.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should rejected enqueue reset immediately? No. Reset only after a snapshot proves absence.
+- Should poll use the timestamp fence globally? Yes, for rows reconstructed from persisted active state so the current claim cannot bind to old terminal transfers.
+- Should cancellation success rely on the absence of exceptions? No. A falsey cancel result or a still-present transfer leaves ownership in place.
+
+### Deferred to Implementation
+
+- Exact helper names for verified absence and post-cancel verification.
+- Whether the same-cycle poll guard uses a small age grace or the same timestamp-fenced absence proof. The implementation should pick the least invasive option that prevents fresh preclaim resets.
+
+---
+
+## Implementation Units
+
+- U1. **Prove no-acceptance before reset**
+
+**Goal:** Replace direct rejected-outcome resets with verified absence checks for single-disc and multi-disc paths.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/enqueue.py`
+- Test: `tests/test_enqueue_fanout.py`
+
+**Approach:**
+- Add a helper that re-derives planned transfer IDs from a fresh bulk snapshot using `claim.enqueued_at`.
+- Reset to `wanted` only when the snapshot succeeds and no planned transfer is present.
+- On snapshot failure or any matching transfer, persist/keep the planned state and return the owned downloads for poll recovery.
+- Use the helper for single-disc rejected outcomes and multi-disc first-disc rejected outcomes.
+
+**Execution note:** Test-first: add a rejected outcome with a matching transfer in the fake slskd snapshot before changing the reset branch.
+
+**Patterns to follow:**
+- `rederive_transfer_ids` and `_leave_claim_for_poll_recovery` in `lib/download.py` / `lib/enqueue.py`.
+- `test_ambiguous_enqueue_failure_stays_downloading_for_poll_recovery` in `tests/test_enqueue_fanout.py`.
+
+**Test scenarios:**
+- Error path: rejected single-disc outcome plus matching snapshot leaves the row `downloading`.
+- Happy path: rejected single-disc outcome plus empty snapshot resets to `wanted`.
+- Error path: rejected first-disc multi-disc outcome plus matching snapshot leaves the row `downloading`.
+- Error path: rejected outcome plus snapshot failure leaves the row `downloading`.
+
+**Verification:**
+- No reset branch treats `rejected` alone as proof of no side effect.
+
+---
+
+- U2. **Verify partial multi-disc cancellation**
+
+**Goal:** Ensure partial multi-disc failure clears ownership only after accepted transfers are actually cancelled or absent.
+
+**Requirements:** R1, R2
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `lib/download.py`
+- Modify: `lib/enqueue.py`
+- Modify: `tests/fakes.py`
+- Test: `tests/test_enqueue_fanout.py`
+
+**Approach:**
+- Make `cancel_and_delete` treat a falsey `cancel_download` result as failure.
+- After cancelling accepted files, verify via a post-cancel snapshot that every planned transfer is absent or terminal-cancelled after the claim boundary.
+- If verification fails, persist the planned/enriched state and leave the row `downloading`.
+
+**Execution note:** Characterize the current falsey-cancel behavior first so the regression is pinned.
+
+**Patterns to follow:**
+- `_handle_claimed_partial_failure` in `lib/enqueue.py`.
+- `FakeSlskdTransfers.cancel_download` in `tests/fakes.py`.
+
+**Test scenarios:**
+- Error path: accepted first disc, rejected second disc, cancel returns false leaves `downloading`.
+- Error path: accepted first disc, rejected second disc, post-cancel snapshot still shows an active transfer leaves `downloading`.
+- Happy path: accepted first disc, rejected second disc, cancel succeeds and post-cancel snapshot proves absence resets to `wanted`.
+
+**Verification:**
+- Partial multi-disc cleanup has a proven outcome before clearing `active_download_state`.
+
+---
+
+- U3. **Fence poll recovery and fresh preclaims**
+
+**Goal:** Prevent poll recovery from using stale terminal transfers or immediately timing out a fresh preclaim before slskd can register transfers.
+
+**Requirements:** R2, R3
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `lib/download.py`
+- Test: `tests/test_download.py`
+- Test: `tests/test_enqueue_fanout.py`
+
+**Approach:**
+- Pass `not_before=state.enqueued_at` when poll re-derives transfer IDs from persisted state.
+- Add a small same-cycle/fresh-claim guard so rows with no visible transfer immediately after claim are skipped for a later poll rather than reset to `wanted`.
+- Keep legacy completed-transfer behavior where it is still valid for older rows; the timestamp fence should distinguish current claims from stale records.
+
+**Test scenarios:**
+- Error path: persisted planned row plus stale terminal snapshot older than `enqueued_at` does not bind the stale transfer.
+- Race path: fresh planned row with an empty snapshot remains `downloading` instead of resetting to `wanted`.
+- Integration: accepted enqueue with missing IDs, fresh context, and a later poll snapshot re-derives IDs from persisted planned state.
+
+**Verification:**
+- Poll recovery honors the ownership claim boundary.
+
+---
+
+- U4. **Canonical state, retry accounting, and seam coverage**
+
+**Goal:** Bring serialization, retry/backoff behavior, DB contracts, and transition guard tests in line with the new ownership seam.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/quality.py`
+- Modify: `lib/download_ownership.py`
+- Modify: `tests/test_download.py`
+- Modify: `tests/test_enqueue_fanout.py`
+- Modify: `tests/test_pipeline_db.py`
+- Modify: `tests/test_fakes.py`
+- Modify: `tests/test_request_finalization.py`
+
+**Approach:**
+- Serialize `current_path` even when it is `None`; keep `from_dict` tolerant of missing legacy keys.
+- Pass `attempt_type="download"` on verified no-acceptance reset.
+- Add real/fake DB tests for guarded reset and guarded state update behavior.
+- Extend the AST direct-write guard to include `reset_downloading_to_wanted`.
+
+**Test scenarios:**
+- Happy path: initial planned state JSON contains `current_path: null`.
+- Happy path: verified no-acceptance increments download attempts and sets retry/backoff metadata.
+- Contract: `reset_downloading_to_wanted` succeeds only from `downloading`, clears active state, preserves counters, and returns bool.
+- Contract: `update_download_state_if_downloading` updates only `downloading` rows and returns bool.
+- Contract: direct `reset_downloading_to_wanted` calls outside `lib.transitions` are rejected by the AST guard.
+
+**Verification:**
+- The JSON contract and status seam are enforced by tests, not just code review.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Phase 2 preclaim writes can now be observed by Phase 1 poll in the same process, so poll must treat very fresh planned rows conservatively.
+- **Error propagation:** Failed snapshots, failed cancels, and guard races should flow to `downloading` recovery, not retryable `wanted`.
+- **State lifecycle risks:** The main risk is clearing `active_download_state` too early; every reset path must be proven.
+- **API surface parity:** `slskd_do_enqueue` remains the low-level helper for retry re-enqueue and should not trigger ownership writes.
+- **Integration coverage:** Unit tests must be backed by at least one fresh-context poll/recovery slice.
+- **Unchanged invariants:** Request status writes still flow through `lib.transitions`; no migrations or new statuses are introduced.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Snapshot verification is too conservative and leaves more rows `downloading` | Prefer conservative ownership over duplicate/orphan transfers; existing poll/timeout/operator recovery owns follow-up |
+| Timestamp filtering breaks valid completed-transfer processing | Apply the fence to current persisted claims and keep tests for terminal snapshot handling |
+| Additional tests slow the suite | Keep new cases focused in existing modules and run the full suite once at the end |
+
+---
+
+## Sources & References
+
+- Origin document: `docs/plans/2026-05-05-003-fix-download-ownership-persistence-plan.md`
+- Related issue: #219
+- Related code: `lib/enqueue.py`, `lib/download.py`, `lib/quality.py`, `lib/download_ownership.py`, `lib/pipeline_db.py`, `lib/transitions.py`
+- Related learning: `docs/advisory-locks.md`
+- Related learning: `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`

--- a/lib/context.py
+++ b/lib/context.py
@@ -24,6 +24,7 @@ class CratediggerContext:
     cfg: CratediggerConfig
     slskd: Any  # slskd_api.SlskdClient — Any to avoid import
     pipeline_db_source: DatabaseSource
+    download_ownership: Any = None
 
     # --- Runtime caches (reset each cycle) ---
     search_cache: dict[int, Any] = field(default_factory=dict)

--- a/lib/download.py
+++ b/lib/download.py
@@ -11,8 +11,9 @@ import os
 import re
 import shutil
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, Literal, TYPE_CHECKING
 
 import music_tag
 
@@ -352,19 +353,39 @@ def _canonical_import_folder_path(
 
 # === slskd transfer helpers ===
 
-def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> None:
-    """Cancel downloads and remove their directories."""
+
+@dataclass(frozen=True)
+class SlskdEnqueueOutcome:
+    """Structured result for one slskd enqueue request."""
+
+    status: Literal["accepted", "rejected", "unknown"]
+    downloads: list[DownloadFile] | None = None
+
+def cancel_and_delete(files: list[Any], ctx: CratediggerContext) -> bool:
+    """Cancel downloads and remove their directories.
+
+    Returns whether every requested transfer had an ID and cancel call
+    completed. Callers that only need best-effort cleanup can ignore it.
+    """
+    ok = True
     for file in files:
         if not file.id:
+            ok = False
             continue  # Transfer vanished or never assigned — skip cancel
         try:
-            ctx.slskd.transfers.cancel_download(username=file.username, id=file.id)
+            if not ctx.slskd.transfers.cancel_download(
+                username=file.username,
+                id=file.id,
+            ):
+                ok = False
         except Exception:
+            ok = False
             logger.warning(f"Failed to cancel download {file.filename} for {file.username}",
                            exc_info=True)
         delete_dir = slskd_local_folder(file.file_dir, ctx.cfg.slskd_download_dir)
         if os.path.isdir(delete_dir):
             shutil.rmtree(delete_dir)
+    return ok
 
 
 def slskd_download_status(downloads: list[Any], ctx: CratediggerContext,
@@ -394,16 +415,20 @@ def slskd_download_status(downloads: list[Any], ctx: CratediggerContext,
     return ok
 
 
-def slskd_do_enqueue(username: str, files: list[dict[str, Any]],
-                     file_dir: str, ctx: CratediggerContext) -> list[DownloadFile] | None:
-    """Enqueue files for download via slskd. Returns DownloadFile list or None."""
+def slskd_enqueue_with_outcome(
+    username: str,
+    files: list[dict[str, Any]],
+    file_dir: str,
+    ctx: CratediggerContext,
+) -> SlskdEnqueueOutcome:
+    """Enqueue files for download via slskd with an explicit outcome."""
     try:
         enqueue = ctx.slskd.transfers.enqueue(username=username, files=files)
     except Exception:
         logger.debug("Enqueue failed", exc_info=True)
-        return None
+        return SlskdEnqueueOutcome(status="unknown")
     if not enqueue:
-        return None
+        return SlskdEnqueueOutcome(status="rejected")
 
     # Poll for transfer IDs — slskd needs time to register the enqueue.
     # Typically resolves in 1-2s; max 10s before giving up.
@@ -456,7 +481,16 @@ def slskd_do_enqueue(username: str, files: list[dict[str, Any]],
             reconciled,
             len(downloads),
         )
-    return downloads
+    return SlskdEnqueueOutcome(status="accepted", downloads=downloads)
+
+
+def slskd_do_enqueue(username: str, files: list[dict[str, Any]],
+                     file_dir: str, ctx: CratediggerContext) -> list[DownloadFile] | None:
+    """Enqueue files for download via slskd. Returns DownloadFile list or None."""
+    outcome = slskd_enqueue_with_outcome(username, files, file_dir, ctx)
+    if outcome.status != "accepted":
+        return None
+    return outcome.downloads
 
 
 def downloads_all_done(downloads: list[Any]) -> tuple[bool, list[Any] | None, int]:
@@ -1335,6 +1369,15 @@ def _parse_transfer_timestamp(value: Any) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
+def _transfer_latest_timestamp(transfer: dict[str, Any]) -> datetime:
+    return max(
+        _parse_transfer_timestamp(transfer.get("endedAt")),
+        _parse_transfer_timestamp(transfer.get("startedAt")),
+        _parse_transfer_timestamp(transfer.get("enqueuedAt")),
+        _parse_transfer_timestamp(transfer.get("requestedAt")),
+    )
+
+
 def _transfer_priority(transfer: dict[str, Any]) -> tuple[int, int, datetime]:
     """Rank duplicate transfer snapshots for the same username+filename.
 
@@ -1345,13 +1388,24 @@ def _transfer_priority(transfer: dict[str, Any]) -> tuple[int, int, datetime]:
     state = str(transfer.get("state", ""))
     is_terminal = state.startswith("Completed,")
     is_success = state == "Completed, Succeeded"
-    latest_ts = max(
-        _parse_transfer_timestamp(transfer.get("endedAt")),
-        _parse_transfer_timestamp(transfer.get("startedAt")),
-        _parse_transfer_timestamp(transfer.get("enqueuedAt")),
-        _parse_transfer_timestamp(transfer.get("requestedAt")),
-    )
+    latest_ts = _transfer_latest_timestamp(transfer)
     return (0 if is_terminal else 1, 1 if is_success else 0, latest_ts)
+
+
+def _is_terminal_transfer_before(
+    transfer: dict[str, Any],
+    not_before: str | None,
+) -> bool:
+    if not_before is None:
+        return False
+    state = str(transfer.get("state", ""))
+    if not state.startswith("Completed,"):
+        return False
+    threshold = _parse_transfer_timestamp(not_before)
+    latest_ts = _transfer_latest_timestamp(transfer)
+    if latest_ts == datetime.min.replace(tzinfo=timezone.utc):
+        return False
+    return latest_ts < threshold
 
 
 def match_transfer(
@@ -1405,6 +1459,7 @@ def rederive_transfer_ids(
     slskd_client: Any,
     *,
     snapshot: list[dict[str, Any]] | None = None,
+    not_before: str | None = None,
 ) -> bool:
     """Re-derive slskd transfer IDs for all files in a GrabListEntry.
 
@@ -1423,6 +1478,11 @@ def rederive_transfer_ids(
 
     for f in entry.files:
         transfer = match_transfer(downloads, f.filename, username=f.username)
+        if transfer is not None and _is_terminal_transfer_before(
+            transfer,
+            not_before,
+        ):
+            transfer = None
         if transfer is not None:
             f.id = transfer.get("id", "")
             state = str(transfer.get("state", ""))
@@ -1918,14 +1978,32 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
             continue
 
         # Re-derive transfer IDs from pre-fetched snapshot
-        if not rederive_transfer_ids(entry, ctx.slskd, snapshot=cycle_snapshot):
+        if not rederive_transfer_ids(
+            entry,
+            ctx.slskd,
+            snapshot=cycle_snapshot,
+            not_before=state.enqueued_at,
+        ):
             logger.warning(f"API error re-deriving transfers for {entry.artist} - {entry.title} "
                            f"— will retry next cycle")
             continue
 
+        enqueued_at = datetime.fromisoformat(state.enqueued_at)
+        if enqueued_at.tzinfo is None:
+            enqueued_at = enqueued_at.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        elapsed_seconds = (now - enqueued_at).total_seconds()
+
         # Check if all transfers have vanished (slskd restart, user offline)
         all_vanished = all(f.id == "" for f in entry.files)
         if all_vanished:
+            if elapsed_seconds < 60:
+                logger.info(
+                    "Request %s has fresh planned ownership but no visible "
+                    "slskd transfers yet; deferring vanished-transfer reset",
+                    request_id,
+                )
+                continue
             _timeout_album(entry, request_id, "all transfers vanished from slskd", ctx)
             continue
 
@@ -1935,10 +2013,6 @@ def poll_active_downloads(ctx: CratediggerContext) -> None:
                 f.status = {"state": "Completed, Errored"}
 
         # Track total album age separately from stall/progress timing.
-        enqueued_at = datetime.fromisoformat(state.enqueued_at)
-        now = datetime.now(timezone.utc)
-        elapsed_seconds = (now - enqueued_at).total_seconds()
-
         # Poll live status only for transfers that are still active in slskd.
         files_requiring_status = [
             f for f in entry.files
@@ -2055,9 +2129,11 @@ def grab_most_wanted(albums: list[Any],
         entry = grab_list[album_id]
         logger.info(f"Album: {entry.title} Artist: {entry.artist}")
 
-        # Persist download state to DB
+        # Legacy/test fallback: production find_download workers claim
+        # ownership before the slskd enqueue. Keep this only for callers that
+        # do not provide the worker-safe ownership collaborator.
         request_id = entry.db_request_id
-        if request_id:
+        if request_id and getattr(ctx, "download_ownership", None) is None:
             state = build_active_download_state(entry)
             db = ctx.pipeline_db_source._get_db()
             transitions.finalize_request(

--- a/lib/download_ownership.py
+++ b/lib/download_ownership.py
@@ -1,0 +1,101 @@
+"""Worker-safe ownership writes for newly enqueued downloads."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from lib import transitions
+
+logger = logging.getLogger("cratedigger")
+
+
+class DownloadOwnershipWriter:
+    """Persist download ownership using a fresh DB handle per operation.
+
+    find_download workers intentionally cannot use the owner thread's cached
+    DatabaseSource connection. This collaborator gives workers a narrow write
+    surface for the status/state transition that makes an accepted slskd enqueue
+    durable before the cycle can crash.
+    """
+
+    def __init__(
+        self,
+        dsn: str | None = None,
+        *,
+        db_factory: Callable[[], Any] | None = None,
+        close_after_use: bool | None = None,
+    ) -> None:
+        self.dsn = dsn
+        self._db_factory = db_factory
+        self._close_after_use = (
+            db_factory is None if close_after_use is None else close_after_use
+        )
+
+    def _open_db(self) -> Any:
+        if self._db_factory is not None:
+            return self._db_factory()
+        from lib.pipeline_db import PipelineDB
+
+        return PipelineDB(self.dsn)
+
+    def _close_db(self, db: Any) -> None:
+        if not self._close_after_use:
+            return
+        close = getattr(db, "close", None)
+        if close is not None:
+            close()
+
+    def claim_downloading(self, request_id: int, state_json: str) -> bool:
+        """Guarded wanted -> downloading claim with planned download state."""
+        db = self._open_db()
+        try:
+            return transitions.finalize_request(
+                db,
+                request_id,
+                transitions.RequestTransition.to_downloading(
+                    from_status="wanted",
+                    state_json=state_json,
+                ),
+            )
+        finally:
+            self._close_db(db)
+
+    def reset_after_no_acceptance(self, request_id: int) -> bool:
+        """Guarded downloading -> wanted reset for verified no-acceptance."""
+        db = self._open_db()
+        try:
+            return transitions.finalize_request(
+                db,
+                request_id,
+                transitions.RequestTransition.to_wanted(
+                    from_status="downloading",
+                    attempt_type="download",
+                ),
+            )
+        finally:
+            self._close_db(db)
+
+    def update_state_if_downloading(
+        self,
+        request_id: int,
+        state_json: str,
+    ) -> bool:
+        """Guard active_download_state enrichment after slskd returns IDs."""
+        db = self._open_db()
+        try:
+            update = getattr(db, "update_download_state_if_downloading", None)
+            if update is None:
+                row = db.get_request(request_id)
+                if not row or row.get("status") != "downloading":
+                    logger.warning(
+                        "download ownership state update blocked for request %s: "
+                        "request is no longer downloading",
+                        request_id,
+                    )
+                    return False
+                db.update_download_state(request_id, state_json)
+                return True
+            return bool(update(request_id, state_json))
+        finally:
+            self._close_db(db)

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, cast
 
 from lib.browse import _fanout_browse_users, download_filter, get_browse_coordinator
-from lib.download import cancel_and_delete, slskd_do_enqueue
-from lib.grab_list import GrabListEntry
+from lib.download import (
+    SlskdEnqueueOutcome,
+    build_active_download_state,
+    cancel_and_delete,
+    rederive_transfer_ids,
+    slskd_do_enqueue,
+    slskd_enqueue_with_outcome,
+)
+from lib.grab_list import DownloadFile, GrabListEntry
 from lib.matching import MatchResult, check_for_match, get_album_by_id
 from lib.quality import CandidateScore
 
@@ -163,6 +170,7 @@ def prepare_find_download_context(
         cooled_down_users=set(ctx.cooled_down_users),
         prefetched_album_tracks={album_id: list(tracks)},
         peer_cache=peer_cache,
+        download_ownership=ctx.download_ownership,
         browse_coordinator=coordinator,
         browse_coordinator_lock=ctx.browse_coordinator_lock,
     )
@@ -316,6 +324,329 @@ def _prefixed_directory_files(
         {**file, "filename": file_dir + "\\" + file["filename"]}
         for file in directory["files"]
     ]
+
+
+@dataclass(frozen=True)
+class DownloadOwnershipClaim:
+    entry: GrabListEntry
+    request_id: int | None
+    attempted: bool
+    claimed: bool
+    enqueued_at: str | None = None
+
+
+def _album_request_id(album: Any) -> int | None:
+    request_id = getattr(album, "db_request_id", None)
+    if isinstance(request_id, bool) or not isinstance(request_id, int):
+        return None
+    return request_id if request_id > 0 else None
+
+
+def _planned_downloads(
+    *,
+    username: str,
+    file_dir: str,
+    files: Sequence[dict[str, Any]],
+) -> list[DownloadFile]:
+    return [
+        DownloadFile(
+            filename=str(file["filename"]),
+            id="",
+            file_dir=file_dir,
+            username=username,
+            size=int(file.get("size") or 0),
+        )
+        for file in files
+    ]
+
+
+def _planned_grab_entry(
+    album: Any,
+    files: list[DownloadFile],
+    allowed_filetype: str,
+) -> GrabListEntry:
+    release_date = str(getattr(album, "release_date", "") or "")
+    return GrabListEntry(
+        album_id=int(getattr(album, "id", 0) or 0),
+        files=files,
+        filetype=allowed_filetype,
+        title=str(getattr(album, "title", "")),
+        artist=str(getattr(album, "artist_name", "")),
+        year=release_date[:4],
+        mb_release_id=str(getattr(album, "db_mb_release_id", "") or ""),
+        db_request_id=_album_request_id(album),
+        db_source=getattr(album, "db_source", None),
+        db_search_filetype_override=getattr(
+            album, "db_search_filetype_override", None),
+        db_target_format=getattr(album, "db_target_format", None),
+    )
+
+
+def _state_json_for_entry(
+    entry: GrabListEntry,
+    *,
+    enqueued_at: str | None = None,
+) -> str:
+    return build_active_download_state(
+        entry,
+        enqueued_at=enqueued_at,
+        last_progress_at=enqueued_at,
+    ).to_json()
+
+
+def _claim_initial_download_ownership(
+    album: Any,
+    files: list[DownloadFile],
+    allowed_filetype: str,
+    ctx: CratediggerContext,
+) -> DownloadOwnershipClaim:
+    entry = _planned_grab_entry(album, files, allowed_filetype)
+    request_id = entry.db_request_id
+    writer = getattr(ctx, "download_ownership", None)
+    if writer is None or request_id is None:
+        return DownloadOwnershipClaim(
+            entry=entry,
+            request_id=request_id,
+            attempted=False,
+            claimed=False,
+        )
+
+    state = build_active_download_state(entry)
+    claimed = bool(writer.claim_downloading(
+        request_id,
+        state.to_json(),
+    ))
+    if not claimed:
+        logger.info(
+            "Skipped slskd enqueue for request %s because ownership claim "
+            "was blocked; request is no longer wanted",
+            request_id,
+        )
+    return DownloadOwnershipClaim(
+        entry=entry,
+        request_id=request_id,
+        attempted=True,
+        claimed=claimed,
+        enqueued_at=state.enqueued_at,
+    )
+
+
+def _entry_with_files(
+    entry: GrabListEntry,
+    files: list[DownloadFile],
+) -> GrabListEntry:
+    return replace(entry, files=files)
+
+
+def _copy_download_observations(
+    planned: list[DownloadFile],
+    observed: Sequence[Any],
+) -> None:
+    by_key = {
+        (download.username, download.filename): download
+        for download in planned
+    }
+    for source in observed:
+        target = by_key.get((source.username, source.filename))
+        if target is None:
+            continue
+        target.id = source.id
+        target.status = getattr(source, "status", None)
+        target.retry = getattr(source, "retry", None)
+        target.bytes_transferred = getattr(source, "bytes_transferred", None)
+        target.last_state = getattr(source, "last_state", None)
+
+
+def _clear_download_observations(files: Sequence[DownloadFile]) -> None:
+    for file in files:
+        file.id = ""
+        file.status = None
+        file.retry = None
+        file.bytes_transferred = None
+        file.last_state = None
+
+
+def _visible_transfer_files(files: Sequence[DownloadFile]) -> list[DownloadFile]:
+    return [
+        file for file in files
+        if file.id or file.status is not None
+    ]
+
+
+def _visible_claim_transfers(
+    claim: DownloadOwnershipClaim,
+    ctx: CratediggerContext,
+) -> tuple[bool, list[DownloadFile]]:
+    verification_entry = copy.deepcopy(claim.entry)
+    _clear_download_observations(verification_entry.files)
+    snapshot_ok = rederive_transfer_ids(
+        verification_entry,
+        ctx.slskd,
+        not_before=claim.enqueued_at,
+    )
+    if not snapshot_ok:
+        return False, []
+
+    visible = _visible_transfer_files(verification_entry.files)
+    if visible:
+        _copy_download_observations(claim.entry.files, verification_entry.files)
+    return True, visible
+
+
+def _persist_claimed_download_state(
+    claim: DownloadOwnershipClaim,
+    files: list[DownloadFile],
+    ctx: CratediggerContext,
+) -> bool:
+    if not claim.claimed or claim.request_id is None:
+        return True
+    writer = getattr(ctx, "download_ownership", None)
+    if writer is None:
+        return True
+    entry = _entry_with_files(claim.entry, files)
+    updated = bool(writer.update_state_if_downloading(
+        claim.request_id,
+        _state_json_for_entry(entry, enqueued_at=claim.enqueued_at),
+    ))
+    if not updated:
+        logger.warning(
+            "Accepted slskd enqueue for request %s, but the guarded "
+            "active_download_state update was blocked; cancelling transfer",
+            claim.request_id,
+        )
+    return updated
+
+
+def _reset_claim_after_verified_no_acceptance(
+    claim: DownloadOwnershipClaim,
+    ctx: CratediggerContext,
+    *,
+    reason: str,
+) -> list[DownloadFile] | None:
+    if not claim.claimed or claim.request_id is None:
+        return None
+    writer = getattr(ctx, "download_ownership", None)
+    if writer is None:
+        return None
+
+    snapshot_ok, visible = _visible_claim_transfers(claim, ctx)
+    if snapshot_ok and not visible:
+        writer.reset_after_no_acceptance(claim.request_id)
+        return None
+
+    writer.update_state_if_downloading(
+        claim.request_id,
+        _state_json_for_entry(claim.entry, enqueued_at=claim.enqueued_at),
+    )
+    logger.warning(
+        "%s for request %s could not prove no slskd transfer exists; "
+        "leaving planned download ownership for recovery",
+        reason,
+        claim.request_id,
+    )
+    return claim.entry.files
+
+
+def _leave_claim_for_poll_recovery(
+    claim: DownloadOwnershipClaim,
+    ctx: CratediggerContext,
+    *,
+    reason: str,
+) -> list[DownloadFile] | None:
+    if not claim.claimed or claim.request_id is None:
+        return None
+    writer = getattr(ctx, "download_ownership", None)
+    if writer is not None:
+        writer.update_state_if_downloading(
+            claim.request_id,
+            _state_json_for_entry(claim.entry, enqueued_at=claim.enqueued_at),
+        )
+
+    logger.warning(
+        "%s for request %s; "
+        "leaving planned download ownership for the next poll cycle",
+        reason,
+        claim.request_id,
+    )
+    return claim.entry.files
+
+
+def _handle_claimed_partial_failure(
+    claim: DownloadOwnershipClaim,
+    accepted: list[DownloadFile],
+    ctx: CratediggerContext,
+) -> list[DownloadFile] | None:
+    if not claim.claimed or claim.request_id is None:
+        return None
+    writer = getattr(ctx, "download_ownership", None)
+    if writer is None:
+        return None
+
+    _copy_download_observations(claim.entry.files, accepted)
+    _visible_claim_transfers(claim, ctx)
+    accepted_by_key = {
+        (download.username, download.filename)
+        for download in accepted
+    }
+    accepted_planned = [
+        download for download in claim.entry.files
+        if (download.username, download.filename) in accepted_by_key
+    ]
+    if any(not download.id for download in accepted_planned):
+        writer.update_state_if_downloading(
+            claim.request_id,
+            _state_json_for_entry(claim.entry, enqueued_at=claim.enqueued_at),
+        )
+        logger.warning(
+            "Partial multi-disc enqueue for request %s could not be verified "
+            "as cancelled because accepted transfers lack IDs; leaving "
+            "request downloading for recovery",
+            claim.request_id,
+        )
+        return claim.entry.files
+    files_to_cancel = [download for download in claim.entry.files if download.id]
+    cancelled = cancel_and_delete(files_to_cancel, ctx)
+    post_cancel_snapshot_ok, visible_after_cancel = _visible_claim_transfers(claim, ctx)
+    if cancelled and post_cancel_snapshot_ok and not visible_after_cancel:
+        writer.reset_after_no_acceptance(claim.request_id)
+        return None
+
+    writer.update_state_if_downloading(
+        claim.request_id,
+        _state_json_for_entry(claim.entry, enqueued_at=claim.enqueued_at),
+    )
+    logger.warning(
+        "Partial multi-disc enqueue for request %s could not be verified as "
+        "cancelled; leaving request downloading for recovery",
+        claim.request_id,
+    )
+    return claim.entry.files
+
+
+def _enqueue_with_claim_outcome(
+    *,
+    claim: DownloadOwnershipClaim,
+    username: str,
+    files: list[dict[str, Any]],
+    file_dir: str,
+    ctx: CratediggerContext,
+) -> SlskdEnqueueOutcome:
+    if claim.claimed:
+        return slskd_enqueue_with_outcome(
+            username=username,
+            files=files,
+            file_dir=file_dir,
+            ctx=ctx,
+        )
+    downloads = slskd_do_enqueue(
+        username=username,
+        files=files,
+        file_dir=file_dir,
+        ctx=ctx,
+    )
+    if downloads is None:
+        return SlskdEnqueueOutcome(status="unknown")
+    return SlskdEnqueueOutcome(status="accepted", downloads=downloads)
 
 
 def get_album_tracks(album: Any, ctx: CratediggerContext) -> list[TrackRecord]:
@@ -515,14 +846,33 @@ def try_enqueue(
             match_wave = wave_idx
         directory = download_filter(allowed_filetype, match_result.directory, ctx.cfg)
         files_to_enqueue = _prefixed_directory_files(directory, match_result.file_dir)
+        claim = _claim_initial_download_ownership(
+            album,
+            _planned_downloads(
+                username=username,
+                file_dir=match_result.file_dir,
+                files=files_to_enqueue,
+            ),
+            allowed_filetype,
+            ctx,
+        )
+        if claim.attempted and not claim.claimed:
+            had_enqueue_failure = True
+            break
         try:
-            downloads = slskd_do_enqueue(
+            outcome = _enqueue_with_claim_outcome(
+                claim=claim,
                 username=username,
                 files=files_to_enqueue,
                 file_dir=match_result.file_dir,
                 ctx=ctx,
             )
-            if downloads is not None:
+            if outcome.status == "accepted" and outcome.downloads is not None:
+                downloads = outcome.downloads
+                if not _persist_claimed_download_state(claim, downloads, ctx):
+                    cancel_and_delete(downloads, ctx)
+                    had_enqueue_failure = True
+                    break
                 _log_album_browse(
                     artist_name, album_name, allowed_filetype, "single",
                     matched=True, match_wave=match_wave,
@@ -535,12 +885,67 @@ def try_enqueue(
                     downloads=downloads,
                     candidates=tuple(accumulated),
                 )
+            if outcome.status == "rejected":
+                owned = _reset_claim_after_verified_no_acceptance(
+                    claim,
+                    ctx,
+                    reason="slskd rejected enqueue",
+                )
+                if owned is not None:
+                    _log_album_browse(
+                        artist_name, album_name, allowed_filetype, "single",
+                        matched=True, match_wave=match_wave,
+                        eligible=len(eligible),
+                        peers=ctx.peers_browsed - peers_before,
+                        waves=ctx.fanout_waves - waves_before,
+                    )
+                    return EnqueueAttempt(
+                        matched=True,
+                        downloads=owned,
+                        candidates=tuple(accumulated),
+                    )
+            elif claim.claimed:
+                owned = _leave_claim_for_poll_recovery(
+                    claim,
+                    ctx,
+                    reason="slskd enqueue outcome was ambiguous",
+                )
+                _log_album_browse(
+                    artist_name, album_name, allowed_filetype, "single",
+                    matched=True, match_wave=match_wave,
+                    eligible=len(eligible),
+                    peers=ctx.peers_browsed - peers_before,
+                    waves=ctx.fanout_waves - waves_before,
+                )
+                return EnqueueAttempt(
+                    matched=True,
+                    downloads=owned,
+                    candidates=tuple(accumulated),
+                )
             had_enqueue_failure = True
             logger.info(
                 f"Failed to enqueue download to slskd for "
                 f"{artist_name} - {album_name} from {username}"
             )
         except Exception as e:
+            if claim.claimed:
+                owned = _leave_claim_for_poll_recovery(
+                    claim,
+                    ctx,
+                    reason="slskd enqueue raised after ownership claim",
+                )
+                _log_album_browse(
+                    artist_name, album_name, allowed_filetype, "single",
+                    matched=True, match_wave=match_wave,
+                    eligible=len(eligible),
+                    peers=ctx.peers_browsed - peers_before,
+                    waves=ctx.fanout_waves - waves_before,
+                )
+                return EnqueueAttempt(
+                    matched=True,
+                    downloads=owned,
+                    candidates=tuple(accumulated),
+                )
             had_enqueue_failure = True
             logger.warning(f"Exception enqueueing tracks: {e}")
             logger.info(
@@ -631,19 +1036,47 @@ def try_multi_enqueue(
         disk["source"] = (username, directory, match_result.file_dir)
         count_found += 1
     if count_found == total:
+        planned_downloads: list[DownloadFile] = []
+        for disk in split_release:
+            username, directory, file_dir = disk["source"]
+            files_to_enqueue = _prefixed_directory_files(directory, file_dir)
+            disk_planned = _planned_downloads(
+                username=username,
+                file_dir=file_dir,
+                files=files_to_enqueue,
+            )
+            for file in disk_planned:
+                file.disk_no = disk["disk_no"]
+                file.disk_count = disk["disk_count"]
+            planned_downloads.extend(disk_planned)
+        claim = _claim_initial_download_ownership(
+            album,
+            planned_downloads,
+            allowed_filetype,
+            ctx,
+        )
+        if claim.attempted and not claim.claimed:
+            return EnqueueAttempt(
+                matched=False,
+                enqueue_failed=True,
+                candidates=tuple(accumulated),
+            )
+
         all_downloads = []
         enqueued = 0
         for disk in split_release:
             username, directory, file_dir = disk["source"]
             files_to_enqueue = _prefixed_directory_files(directory, file_dir)
             try:
-                downloads = slskd_do_enqueue(
+                outcome = _enqueue_with_claim_outcome(
+                    claim=claim,
                     username=username,
                     files=files_to_enqueue,
                     file_dir=file_dir,
                     ctx=ctx,
                 )
-                if downloads is not None:
+                if outcome.status == "accepted" and outcome.downloads is not None:
+                    downloads = outcome.downloads
                     for file in downloads:
                         file.disk_no = disk["disk_no"]
                         file.disk_count = disk["disk_count"]
@@ -655,7 +1088,53 @@ def try_multi_enqueue(
                         f"{artist_name} - {album_name} from {username}"
                     )
                     if len(all_downloads) > 0:
-                        cancel_and_delete(all_downloads, ctx)
+                        if outcome.status == "rejected":
+                            recovered = _handle_claimed_partial_failure(
+                                claim, all_downloads, ctx,
+                            )
+                            if recovered is not None:
+                                return EnqueueAttempt(
+                                    matched=True,
+                                    downloads=recovered,
+                                    candidates=tuple(accumulated),
+                                )
+                        elif claim.claimed:
+                            owned = _leave_claim_for_poll_recovery(
+                                claim,
+                                ctx,
+                                reason="multi-disc enqueue outcome was ambiguous",
+                            )
+                            return EnqueueAttempt(
+                                matched=True,
+                                downloads=owned,
+                                candidates=tuple(accumulated),
+                            )
+                        if not claim.claimed:
+                            cancel_and_delete(all_downloads, ctx)
+                    else:
+                        if outcome.status == "rejected":
+                            owned = _reset_claim_after_verified_no_acceptance(
+                                claim,
+                                ctx,
+                                reason="slskd rejected first multi-disc enqueue",
+                            )
+                            if owned is not None:
+                                return EnqueueAttempt(
+                                    matched=True,
+                                    downloads=owned,
+                                    candidates=tuple(accumulated),
+                                )
+                        elif claim.claimed:
+                            owned = _leave_claim_for_poll_recovery(
+                                claim,
+                                ctx,
+                                reason="slskd enqueue outcome was ambiguous",
+                            )
+                            return EnqueueAttempt(
+                                matched=True,
+                                downloads=owned,
+                                candidates=tuple(accumulated),
+                            )
                     return EnqueueAttempt(
                         matched=False,
                         enqueue_failed=True,
@@ -668,20 +1147,59 @@ def try_multi_enqueue(
                     f"{artist_name} - {album_name} from {username}"
                 )
                 if len(all_downloads) > 0:
-                    cancel_and_delete(all_downloads, ctx)
+                    if claim.claimed:
+                        owned = _leave_claim_for_poll_recovery(
+                            claim,
+                            ctx,
+                            reason="multi-disc enqueue raised after ownership claim",
+                        )
+                        return EnqueueAttempt(
+                            matched=True,
+                            downloads=owned,
+                            candidates=tuple(accumulated),
+                        )
+                    if not claim.claimed:
+                        cancel_and_delete(all_downloads, ctx)
+                else:
+                    if claim.claimed:
+                        owned = _leave_claim_for_poll_recovery(
+                            claim,
+                            ctx,
+                            reason="slskd enqueue raised after ownership claim",
+                        )
+                        return EnqueueAttempt(
+                            matched=True,
+                            downloads=owned,
+                            candidates=tuple(accumulated),
+                        )
                 return EnqueueAttempt(
                     matched=False,
                     enqueue_failed=True,
                     candidates=tuple(accumulated),
                 )
         if enqueued == total:
+            if not _persist_claimed_download_state(claim, all_downloads, ctx):
+                cancel_and_delete(all_downloads, ctx)
+                return EnqueueAttempt(
+                    matched=False,
+                    enqueue_failed=True,
+                    candidates=tuple(accumulated),
+                )
             return EnqueueAttempt(
                 matched=True,
                 downloads=all_downloads,
                 candidates=tuple(accumulated),
             )
         if len(all_downloads) > 0:
-            cancel_and_delete(all_downloads, ctx)
+            recovered = _handle_claimed_partial_failure(claim, all_downloads, ctx)
+            if recovered is not None:
+                return EnqueueAttempt(
+                    matched=True,
+                    downloads=recovered,
+                    candidates=tuple(accumulated),
+                )
+            if not claim.claimed:
+                cancel_and_delete(all_downloads, ctx)
         return EnqueueAttempt(
             matched=False,
             enqueue_failed=True,

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -1006,6 +1006,41 @@ class PipelineDB:
         )
         self.conn.commit()
 
+    def reset_downloading_to_wanted(
+        self,
+        request_id: int,
+        **fields: Any,
+    ) -> bool:
+        """Reset a still-downloading request to wanted.
+
+        This is the guarded automatic failure path: stale workers must not
+        requeue rows that an operator or another phase already moved elsewhere.
+        Retry counters are preserved so automatic backoff keeps growing.
+        """
+        now = datetime.now(timezone.utc)
+        sets = [
+            "status = 'wanted'",
+            "active_download_state = NULL",
+            "manual_reason = NULL",
+            "updated_at = %s",
+        ]
+        params: list[object] = [now]
+        if "search_filetype_override" in fields:
+            sets.append("search_filetype_override = %s")
+            params.append(fields["search_filetype_override"])
+        if "min_bitrate" in fields:
+            sets.append("prev_min_bitrate = COALESCE(min_bitrate, prev_min_bitrate)")
+            sets.append("min_bitrate = %s")
+            params.append(fields["min_bitrate"])
+        params.append(request_id)
+        cur = self._execute(
+            f"UPDATE album_requests SET {', '.join(sets)} "
+            "WHERE id = %s AND status = 'downloading'",
+            params,
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
     def reset_search_attempts(self, request_id: int) -> None:
         """Reset ``search_attempts`` to 0; leave status/backoff/other counters alone.
 
@@ -1121,6 +1156,23 @@ class PipelineDB:
             WHERE id = %s
         """, (state_json, now, request_id))
         self.conn.commit()
+
+    def update_download_state_if_downloading(
+        self,
+        request_id: int,
+        state_json: str,
+    ) -> bool:
+        """Rewrite active_download_state only while the request is downloading."""
+        now = datetime.now(timezone.utc)
+        cur = self._execute("""
+            UPDATE album_requests
+            SET active_download_state = %s::jsonb,
+                updated_at = %s
+            WHERE id = %s
+              AND status = 'downloading'
+        """, (state_json, now, request_id))
+        self.conn.commit()
+        return cur.rowcount > 0
 
     def update_download_state_current_path(
         self,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -593,8 +593,7 @@ class ActiveDownloadState:
             data["import_subprocess_started_at"] = (
                 self.import_subprocess_started_at
             )
-        if self.current_path is not None:
-            data["current_path"] = self.current_path
+        data["current_path"] = self.current_path
         return json.dumps(data)
 
     @staticmethod
@@ -2084,7 +2083,9 @@ def provisional_lossless_decision(
             stage_chain=[f"stage2_provisional:{decision}"],
         )
 
-    candidate_avg = candidate.candidate_probe.avg_bitrate_kbps
+    candidate_probe = candidate.candidate_probe
+    assert candidate_probe is not None
+    candidate_avg = candidate_probe.avg_bitrate_kbps
     assert candidate_avg is not None
     existing_probe = (
         candidate.existing_probe

--- a/lib/transitions.py
+++ b/lib/transitions.py
@@ -294,7 +294,7 @@ def finalize_request(
     db: "PipelineDB",
     request_id: int,
     transition: RequestTransition,
-) -> None:
+) -> bool:
     """Apply one validated request-state transition command."""
 
     _validate_transition_fields(transition.target_status, transition.fields)
@@ -305,7 +305,7 @@ def finalize_request(
     if transition.attempt_type is not None:
         transition_kwargs["attempt_type"] = transition.attempt_type
 
-    apply_transition(
+    return apply_transition(
         db,
         request_id,
         transition.target_status,
@@ -375,7 +375,7 @@ def apply_transition(
     request_id: int,
     to_status: str,
     **extra: Any,
-) -> None:
+) -> bool:
     """Execute a validated state transition.
 
     This is the single entry point for all album_requests status mutations.
@@ -406,7 +406,7 @@ def apply_transition(
         row = db.get_request(request_id)
         if row is None:
             logger.warning(f"apply_transition: request {request_id} not found")
-            return
+            return False
         current = row["status"]
         assert isinstance(current, str)
         from_status = current
@@ -428,28 +428,40 @@ def apply_transition(
             logger.warning(
                 f"apply_transition: status guard prevented {from_status!r} -> "
                 f"'downloading' for request {request_id} (album no longer wanted)")
-        return
+            return False
+        return True
 
     # → wanted with counter reset: use reset_to_wanted
     if to_status == "wanted" and fx.clear_retry_counters:
         cast(Any, db.reset_to_wanted)(request_id, **transition_fields)
         if fx.record_attempt and attempt_type:
             db.record_attempt(request_id, attempt_type)
-        return
+        return True
 
     # downloading → wanted: clear active download state, preserve retry counters,
     # then record the failed automatic attempt so backoff can continue growing.
     if from_status == "downloading" and to_status == "wanted":
-        cast(Any, db.reset_to_wanted)(
-            request_id,
-            clear_retry_counters=False,
-            **transition_fields,
-        )
+        reset = getattr(db, "reset_downloading_to_wanted", None)
+        if reset is None:
+            cast(Any, db.reset_to_wanted)(
+                request_id,
+                clear_retry_counters=False,
+                **transition_fields,
+            )
+            reset_ok = True
+        else:
+            reset_ok = bool(reset(request_id, **transition_fields))
+        if not reset_ok:
+            logger.warning(
+                f"apply_transition: status guard prevented 'downloading' -> "
+                f"'wanted' for request {request_id}")
+            return False
         if attempt_type:
             db.record_attempt(request_id, attempt_type)
-        return
+        return True
 
     # All other transitions: use update_status
     all_extra: dict[str, object] = dict(extra)
     all_extra.update(transition_fields)
     db.update_status(request_id, to_status, **all_extra)
+    return True

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -153,6 +153,7 @@ class FakeSlskdTransfers:
         self.get_all_downloads_error: Exception | None = None
         self.get_download_error: Exception | None = None
         self.cancel_download_error: Exception | None = None
+        self.cancel_download_result = True
 
     def enqueue(self, username: str, files: list[dict[str, Any]]) -> bool:
         self.enqueue_calls.append(EnqueueCall(username, copy.deepcopy(files)))
@@ -184,6 +185,9 @@ class FakeSlskdTransfers:
         self.cancel_download_calls.append(CancelDownloadCall(username, id))
         if self.cancel_download_error is not None:
             raise self.cancel_download_error
+        if not self.cancel_download_result:
+            return False
+        self._api.remove_transfer(username=username, id=id)
         return True
 
 
@@ -483,6 +487,16 @@ class FakeSlskdAPI:
                     if transfer.get("id") == transfer_id:
                         return copy.deepcopy(transfer)
         return None
+
+    def remove_transfer(self, *, username: str, id: str) -> None:
+        for group in self._downloads:
+            if group.get("username") not in (None, "", username):
+                continue
+            for directory in group.get("directories", []):
+                directory["files"] = [
+                    transfer for transfer in directory.get("files", [])
+                    if transfer.get("id") != id
+                ]
 
     def _find_or_create_group(self, username: str) -> dict[str, Any]:
         for group in self._downloads:
@@ -1155,6 +1169,29 @@ class FakePipelineDB:
             row["min_bitrate"] = fields["min_bitrate"]
         self.status_history.append((request_id, "wanted"))
 
+    def reset_downloading_to_wanted(
+        self,
+        request_id: int,
+        **fields: Any,
+    ) -> bool:
+        row = self._requests.get(request_id)
+        if row is None or row["status"] != "downloading":
+            return False
+        now = _utcnow()
+        row["status"] = "wanted"
+        row["active_download_state"] = None
+        row["manual_reason"] = None
+        row["updated_at"] = now
+        if "search_filetype_override" in fields:
+            row["search_filetype_override"] = fields["search_filetype_override"]
+        if "min_bitrate" in fields:
+            current_min_bitrate = row.get("min_bitrate")
+            if current_min_bitrate is not None:
+                row["prev_min_bitrate"] = current_min_bitrate
+            row["min_bitrate"] = fields["min_bitrate"]
+        self.status_history.append((request_id, "wanted"))
+        return True
+
     def set_manual(
         self,
         request_id: int,
@@ -1212,6 +1249,17 @@ class FakePipelineDB:
             except json.JSONDecodeError:
                 row["active_download_state"] = state_json
             row["updated_at"] = _utcnow()
+
+    def update_download_state_if_downloading(
+        self,
+        request_id: int,
+        state_json: str,
+    ) -> bool:
+        row = self._requests.get(request_id)
+        if row is None or row["status"] != "downloading":
+            return False
+        self.update_download_state(request_id, state_json)
+        return True
 
     def update_download_state_current_path(
         self,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -934,6 +934,47 @@ class TestRederiveTransferIds(unittest.TestCase):
         assert status is not None
         self.assertEqual(status["state"], "Completed, Succeeded")
 
+    def test_not_before_ignores_stale_terminal_transfer(self):
+        from lib.download import rederive_transfer_ids
+        from lib.grab_list import GrabListEntry, DownloadFile
+        entry = GrabListEntry(
+            album_id=1,
+            files=[
+                DownloadFile(
+                    filename="user1\\Album\\01.flac",
+                    id="",
+                    file_dir="user1\\Album",
+                    username="user1",
+                    size=1000,
+                ),
+            ],
+            filetype="flac",
+            title="T",
+            artist="A",
+            year="2020",
+            mb_release_id="mbid",
+        )
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "user1",
+            "directories": [{"directory": "user1\\Album", "files": [
+                {
+                    "filename": "user1\\Album\\01.flac",
+                    "id": "old-completed",
+                    "state": "Completed, Succeeded",
+                    "endedAt": "2026-05-05T01:00:00+00:00",
+                },
+            ]}],
+        }])
+
+        rederive_transfer_ids(
+            entry,
+            slskd,
+            not_before="2026-05-05T02:00:00+00:00",
+        )
+
+        self.assertEqual(entry.files[0].id, "")
+        self.assertIsNone(entry.files[0].status)
+
 
 class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
     """Test process_completed_album return ownership."""
@@ -2387,7 +2428,16 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_active_transfer_vanished_all(self):
         """slskd returns no matching transfers → treat as timeout."""
         from lib.download import poll_active_downloads
-        row = self._make_downloading_row()
+        row = self._make_downloading_row(state_dict={
+            "filetype": "flac",
+            "enqueued_at": (
+                datetime.now(timezone.utc) - timedelta(minutes=2)
+            ).isoformat(),
+            "files": [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ],
+        })
         ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
@@ -2401,10 +2451,34 @@ class TestPollActiveDownloads(unittest.TestCase):
         fake_db.assert_log(self, 0, outcome="timeout")
         self.assertEqual(fake_db.request(1)["status"], "wanted")
 
+    def test_poll_active_fresh_preclaim_with_empty_snapshot_stays_downloading(self):
+        """A same-cycle preclaim should not be reset before slskd registers transfers."""
+        from lib.download import poll_active_downloads
+        row = self._make_downloading_row()
+        ctx, fake_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": []}],
+            }],
+        )
+
+        poll_active_downloads(ctx)
+
+        self.assertEqual(fake_db.download_logs, [])
+        self.assertEqual(fake_db.request(1)["status"], "downloading")
+
     def test_poll_active_completed_removed_transfer_uses_snapshot_status(self):
         """Completed transfers from includeRemoved=true should enqueue, not timeout."""
         from lib.download import poll_active_downloads
-        row = self._make_downloading_row()
+        row = self._make_downloading_row(state_dict={
+            "filetype": "flac",
+            "enqueued_at": "2026-04-03T20:00:00+00:00",
+            "files": [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ],
+        })
         ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
             slskd_downloads=[{
@@ -2428,6 +2502,39 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.download_logs, [])
         self.assertEqual(fake_db.request(1)["status"], "downloading")
         self.assertEqual(len(fake_db.list_import_jobs()), 1)
+
+    def test_poll_ignores_stale_terminal_transfer_before_claim(self):
+        """A new claim must not bind to an older includeRemoved terminal transfer."""
+        from lib.download import poll_active_downloads
+        now = datetime.now(timezone.utc)
+        row = self._make_downloading_row(state_dict={
+            "filetype": "flac",
+            "enqueued_at": (now - timedelta(minutes=2)).isoformat(),
+            "files": [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ],
+        })
+        ctx, fake_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "old-done-id",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                    "endedAt": (now - timedelta(hours=1)).isoformat(),
+                }]}],
+            }],
+        )
+
+        with patch("lib.download.cancel_and_delete"):
+            poll_active_downloads(ctx)
+
+        fake_db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
+        self.assertEqual(fake_db.list_import_jobs(), [])
 
     def test_poll_active_in_progress(self):
         """Files still downloading with fresh state transition → persist progress snapshot."""

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -20,6 +20,7 @@ These tests pin:
 from __future__ import annotations
 
 import configparser
+import json
 import unittest
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -35,7 +36,12 @@ from lib.enqueue import (
     try_enqueue,
     try_multi_enqueue,
 )
+from lib.download import SlskdEnqueueOutcome
+from lib.download_ownership import DownloadOwnershipWriter
+from lib.grab_list import DownloadFile
 from lib.matching import MatchResult
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
+from tests.helpers import make_request_row
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +102,33 @@ def _make_tracks() -> list[TrackRecord]:
         "list[TrackRecord]",
         [{"albumId": 1, "title": "Track 1", "mediumNumber": 1}],
     )
+
+
+def _album_with_request(request_id: int = 1) -> MagicMock:
+    return MagicMock(
+        id=request_id,
+        db_request_id=request_id,
+        title="Album",
+        artist_name="Artist",
+        release_date="2024-01-01T00:00:00Z",
+        db_mb_release_id=f"mbid-{request_id}",
+        db_source="request",
+        db_search_filetype_override=None,
+        db_target_format=None,
+    )
+
+
+def _ctx_with_download_ownership(
+    *,
+    cfg: CratediggerConfig,
+    db: FakePipelineDB,
+    slskd: FakeSlskdAPI | None = None,
+) -> CratediggerContext:
+    ctx = _make_ctx(cfg, user_upload_speed={"u00": 10_000, "u01": 9_999})
+    ctx.slskd = slskd if slskd is not None else FakeSlskdAPI()
+    ctx.current_album_cache[1] = _album_with_request(1)
+    ctx.download_ownership = DownloadOwnershipWriter(db_factory=lambda: db)
+    return ctx
 
 
 def _ranked_users(n: int) -> list[str]:
@@ -435,6 +468,581 @@ class TestEnqueueFailureTracking(unittest.TestCase):
 
         self.assertFalse(attempt.matched)
         self.assertTrue(attempt.enqueue_failed)
+
+
+class TestDownloadOwnershipPreclaim(unittest.TestCase):
+    def test_claims_downloading_before_slskd_enqueue(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db)
+        users = ["u00"]
+        results = _make_results(users)
+        file_dir = "Music\\u00\\Album"
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        def fake_enqueue(*, username, files, file_dir, ctx):
+            row = db.request(1)
+            self.assertEqual(row["status"], "downloading")
+            state = json.loads(row["active_download_state"])
+            self.assertEqual(state["filetype"], "flac")
+            self.assertEqual(state["files"][0]["username"], "u00")
+            self.assertEqual(
+                state["files"][0]["filename"],
+                "Music\\u00\\Album\\01.flac",
+            )
+            self.assertIn("current_path", state)
+            self.assertIsNone(state["current_path"])
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id="transfer-1",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", side_effect=fake_enqueue):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.status_history, [(1, "downloading")])
+        self.assertEqual(db.request(1)["status"], "downloading")
+
+    def test_process_death_after_claim_leaves_planned_state_owned(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db)
+        users = ["u00"]
+        results = _make_results(users)
+        file_dir = "Music\\u00\\Album"
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        row = db.request(1)
+        self.assertEqual(row["status"], "downloading")
+        state = json.loads(row["active_download_state"])
+        self.assertEqual(state["files"][0]["filename"], "Music\\u00\\Album\\01.flac")
+
+    def test_verified_no_acceptance_resets_to_wanted(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(
+            cfg=cfg,
+            db=db,
+            slskd=FakeSlskdAPI(downloads=[]),
+        )
+        users = ["u00"]
+        results = _make_results(users)
+        file_dir = "Music\\u00\\Album"
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="rejected"),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        self.assertTrue(attempt.enqueue_failed)
+        self.assertEqual(db.request(1)["status"], "wanted")
+        self.assertIsNone(db.request(1)["active_download_state"])
+        self.assertEqual(db.status_history, [(1, "downloading"), (1, "wanted")])
+        self.assertEqual(db.recorded_attempts, [(1, "download")])
+        self.assertIsNotNone(db.request(1)["next_retry_after"])
+
+    def test_rejected_enqueue_with_visible_transfer_stays_downloading(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        file_dir = "Music\\u00\\Album"
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "u00",
+            "directories": [{"directory": file_dir, "files": [
+                {"filename": "Music\\u00\\Album\\01.flac", "id": "transfer-1"},
+            ]}],
+        }])
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="rejected"),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        state_raw = db.request(1)["active_download_state"]
+        state = json.loads(state_raw) if isinstance(state_raw, str) else state_raw
+        self.assertEqual(state["files"][0]["username"], "u00")
+        self.assertEqual(state["files"][0]["filename"], "Music\\u00\\Album\\01.flac")
+        self.assertEqual(db.status_history, [(1, "downloading")])
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [True])
+
+    def test_rejected_enqueue_snapshot_failure_stays_downloading(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI()
+        slskd.transfers.get_all_downloads_error = RuntimeError("snapshot down")
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        file_dir = "Music\\u00\\Album"
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="rejected"),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        self.assertEqual(db.status_history, [(1, "downloading")])
+
+    def test_ambiguous_enqueue_failure_stays_downloading_for_poll_recovery(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db)
+        users = ["u00"]
+        results = _make_results(users)
+        file_dir = "Music\\u00\\Album"
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="unknown"),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        state_raw = db.request(1)["active_download_state"]
+        state = json.loads(state_raw) if isinstance(state_raw, str) else state_raw
+        self.assertEqual(state["files"][0]["username"], "u00")
+
+    def test_multi_disc_claim_contains_all_discs_before_first_enqueue(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db)
+        users = ["u00", "u01"]
+        results = _make_results(users)
+        release = MagicMock()
+        release.media = [MagicMock(medium_number=1), MagicMock(medium_number=2)]
+        tracks = cast(
+            "list[TrackRecord]",
+            [
+                {"albumId": 1, "title": "Disc1 Track", "mediumNumber": 1},
+                {"albumId": 1, "title": "Disc2 Track", "mediumNumber": 2},
+            ],
+        )
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            disc_no = tracks[0]["mediumNumber"]
+            if disc_no == 1 and username == "u00":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d1.flac", "size": 111}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            if disc_no == 2 and username == "u01":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d2.flac", "size": 222}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            return _nomatch()
+
+        enqueue_calls = 0
+
+        def fake_enqueue(*, username, files, file_dir, ctx):
+            nonlocal enqueue_calls
+            enqueue_calls += 1
+            if enqueue_calls == 1:
+                state = json.loads(db.request(1)["active_download_state"])
+                self.assertEqual(len(state["files"]), 2)
+                self.assertEqual(
+                    [(f["username"], f["disk_no"], f["disk_count"])
+                     for f in state["files"]],
+                    [("u00", 1, 2), ("u01", 2, 2)],
+                )
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id=f"transfer-{enqueue_calls}",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", side_effect=fake_enqueue):
+            attempt = try_multi_enqueue(release, tracks, results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.status_history, [(1, "downloading")])
+
+    def test_multi_disc_partial_failure_resets_after_verified_cancel(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI()
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00", "u01"]
+        results = _make_results(users)
+        release = MagicMock()
+        release.media = [MagicMock(medium_number=1), MagicMock(medium_number=2)]
+        tracks = cast(
+            "list[TrackRecord]",
+            [
+                {"albumId": 1, "title": "Disc1 Track", "mediumNumber": 1},
+                {"albumId": 1, "title": "Disc2 Track", "mediumNumber": 2},
+            ],
+        )
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            disc_no = tracks[0]["mediumNumber"]
+            if disc_no == 1 and username == "u00":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d1.flac", "size": 111}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            if disc_no == 2 and username == "u01":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d2.flac", "size": 222}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            return _nomatch()
+
+        enqueue_calls = 0
+
+        def fake_enqueue(*, username, files, file_dir, ctx):
+            nonlocal enqueue_calls
+            enqueue_calls += 1
+            if enqueue_calls == 2:
+                return SlskdEnqueueOutcome(status="rejected")
+            slskd.add_transfer(
+                username=username,
+                directory=file_dir,
+                filename=files[0]["filename"],
+                id="transfer-1",
+            )
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id="transfer-1",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", side_effect=fake_enqueue):
+            attempt = try_multi_enqueue(release, tracks, results, "flac", ctx)
+
+        self.assertFalse(attempt.matched)
+        self.assertTrue(attempt.enqueue_failed)
+        self.assertEqual(db.request(1)["status"], "wanted")
+        self.assertEqual(db.status_history, [(1, "downloading"), (1, "wanted")])
+        self.assertEqual(
+            [(call.username, call.id) for call in slskd.transfers.cancel_download_calls],
+            [("u00", "transfer-1")],
+        )
+
+    def test_multi_disc_first_rejected_with_visible_transfer_stays_owned(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        file_dir = "Music\\u00\\Album"
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "u00",
+            "directories": [{"directory": file_dir, "files": [
+                {"filename": "Music\\u00\\Album\\d1.flac", "id": "transfer-1"},
+            ]}],
+        }])
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        release = MagicMock()
+        release.media = [MagicMock(medium_number=1)]
+        tracks = cast(
+            "list[TrackRecord]",
+            [{"albumId": 1, "title": "Disc1 Track", "mediumNumber": 1}],
+        )
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            return MatchResult(
+                matched=True,
+                directory={
+                    "directory": file_dir,
+                    "files": [{"filename": "d1.flac", "size": 111}],
+                },
+                file_dir=file_dir,
+                candidates=[],
+            )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="rejected"),
+             ):
+            attempt = try_multi_enqueue(release, tracks, results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        self.assertEqual(db.status_history, [(1, "downloading")])
+
+    def test_multi_disc_partial_failure_cancel_false_stays_owned(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI()
+        slskd.transfers.cancel_download_result = False
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00", "u01"]
+        results = _make_results(users)
+        release = MagicMock()
+        release.media = [MagicMock(medium_number=1), MagicMock(medium_number=2)]
+        tracks = cast(
+            "list[TrackRecord]",
+            [
+                {"albumId": 1, "title": "Disc1 Track", "mediumNumber": 1},
+                {"albumId": 1, "title": "Disc2 Track", "mediumNumber": 2},
+            ],
+        )
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            disc_no = tracks[0]["mediumNumber"]
+            if disc_no == 1 and username == "u00":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d1.flac", "size": 111}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            if disc_no == 2 and username == "u01":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d2.flac", "size": 222}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            return _nomatch()
+
+        enqueue_calls = 0
+
+        def fake_enqueue(*, username, files, file_dir, ctx):
+            nonlocal enqueue_calls
+            enqueue_calls += 1
+            if enqueue_calls == 2:
+                return SlskdEnqueueOutcome(status="rejected")
+            slskd.add_transfer(
+                username=username,
+                directory=file_dir,
+                filename=files[0]["filename"],
+                id="transfer-1",
+            )
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id="transfer-1",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", side_effect=fake_enqueue):
+            attempt = try_multi_enqueue(release, tracks, results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        self.assertEqual(db.status_history, [(1, "downloading")])
+        self.assertEqual(
+            [(call.username, call.id) for call in slskd.transfers.cancel_download_calls],
+            [("u00", "transfer-1")],
+        )
+
+    def test_multi_disc_partial_failure_without_transfer_ids_stays_owned(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db)
+        users = ["u00", "u01"]
+        results = _make_results(users)
+        release = MagicMock()
+        release.media = [MagicMock(medium_number=1), MagicMock(medium_number=2)]
+        tracks = cast(
+            "list[TrackRecord]",
+            [
+                {"albumId": 1, "title": "Disc1 Track", "mediumNumber": 1},
+                {"albumId": 1, "title": "Disc2 Track", "mediumNumber": 2},
+            ],
+        )
+
+        def fake_match(tracks, allowed_filetype, file_dirs, username, ctx):
+            disc_no = tracks[0]["mediumNumber"]
+            if disc_no == 1 and username == "u00":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d1.flac", "size": 111}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            if disc_no == 2 and username == "u01":
+                file_dir = file_dirs[0]
+                return MatchResult(
+                    matched=True,
+                    directory={
+                        "directory": file_dir,
+                        "files": [{"filename": "d2.flac", "size": 222}],
+                    },
+                    file_dir=file_dir,
+                    candidates=[],
+                )
+            return _nomatch()
+
+        enqueue_calls = 0
+
+        def fake_enqueue(*, username, files, file_dir, ctx):
+            nonlocal enqueue_calls
+            enqueue_calls += 1
+            if enqueue_calls == 2:
+                return SlskdEnqueueOutcome(status="rejected")
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id="",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", side_effect=fake_match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", side_effect=fake_enqueue):
+            attempt = try_multi_enqueue(release, tracks, results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        state_raw = db.request(1)["active_download_state"]
+        state = json.loads(state_raw) if isinstance(state_raw, str) else state_raw
+        self.assertEqual(len(state["files"]), 2)
+        self.assertEqual(db.status_history, [(1, "downloading")])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -64,6 +64,49 @@ class TestFakePipelineDB(unittest.TestCase):
             [(42, '{"filetype":"flac"}')],
         )
 
+    def test_update_download_state_if_downloading_guards_status(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        db.seed_request(make_request_row(
+            id=43,
+            status="wanted",
+            active_download_state={"filetype": "old"},
+        ))
+
+        updated = db.update_download_state_if_downloading(
+            42,
+            '{"filetype":"flac"}',
+        )
+        blocked = db.update_download_state_if_downloading(
+            43,
+            '{"filetype":"mp3"}',
+        )
+
+        self.assertTrue(updated)
+        self.assertFalse(blocked)
+        self.assertEqual(db.request(42)["active_download_state"], {"filetype": "flac"})
+        self.assertEqual(db.request(43)["active_download_state"], {"filetype": "old"})
+
+    def test_reset_downloading_to_wanted_guards_status_and_preserves_counters(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            status="downloading",
+            active_download_state={"filetype": "flac"},
+            download_attempts=3,
+        ))
+        db.seed_request(make_request_row(id=43, status="wanted"))
+
+        reset = db.reset_downloading_to_wanted(42)
+        blocked = db.reset_downloading_to_wanted(43)
+
+        self.assertTrue(reset)
+        self.assertFalse(blocked)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        self.assertIsNone(db.request(42)["active_download_state"])
+        self.assertEqual(db.request(42)["download_attempts"], 3)
+        self.assertEqual(db.status_history, [(42, "wanted")])
+
     def test_update_download_state_current_path_rewrites_nested_path(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -1374,6 +1374,7 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(state.filetype, "flac")
         self.assertEqual(state.enqueued_at, "2026-04-03T12:00:00+00:00")
         self.assertEqual(state.files, [])
+        self.assertIsNone(json.loads(state.to_json())["current_path"])
 
     def test_active_download_state_enqueued_at_iso(self):
         """Verify ISO8601 datetime format."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9,6 +9,7 @@ and _check_quality_gate_core run for real, not patched.
 """
 
 import os
+import configparser
 from contextlib import contextmanager
 import tempfile
 from typing import Any, cast
@@ -28,8 +29,9 @@ from lib.quality import (
     ImportResult,
     PostflightInfo,
 )
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
 from tests.helpers import (
+    make_ctx_with_fake_db,
     make_import_result,
     make_request_row,
     patch_dispatch_externals,
@@ -37,6 +39,25 @@ from tests.helpers import (
 
 
 _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"
+
+
+def _download_ownership_cfg() -> CratediggerConfig:
+    ini = configparser.ConfigParser()
+    ini["Search Settings"] = {
+        "minimum_filename_match_ratio": "0.5",
+        "ignored_users": "",
+        "allowed_filetypes": "flac",
+        "browse_parallelism": "4",
+        "browse_top_k": "20",
+        "browse_global_max_workers": "4",
+    }
+    ini["Slskd"] = {
+        "download_dir": "/tmp/test_downloads",
+    }
+    ini["Beets Validation"] = {
+        "staging_dir": "/tmp/staging",
+    }
+    return CratediggerConfig.from_ini(ini)
 
 
 def _make_stdout(ir: ImportResult) -> str:
@@ -52,6 +73,101 @@ def _mock_beets_db(beets_info):
     mock_cls.return_value.__enter__ = MagicMock(return_value=mock_beets_instance)
     mock_cls.return_value.__exit__ = MagicMock(return_value=False)
     return mock_cls
+
+
+class TestDownloadOwnershipPreclaimRecoverySlice(unittest.TestCase):
+    """Cross-boundary slice for enqueue preclaim -> fresh poll recovery."""
+
+    def test_preclaimed_missing_transfer_id_recovers_in_fresh_poll_context(self):
+        from lib.download import SlskdEnqueueOutcome, poll_active_downloads
+        from lib.download_ownership import DownloadOwnershipWriter
+        from lib.enqueue import try_enqueue
+        from lib.grab_list import DownloadFile
+        from lib.matching import MatchResult
+
+        cfg = _download_ownership_cfg()
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1,
+            status="wanted",
+            artist_name="Artist",
+            album_title="Album",
+            mb_release_id="mbid-1",
+        ))
+        album = SimpleNamespace(
+            id=1,
+            db_request_id=1,
+            title="Album",
+            artist_name="Artist",
+            release_date="2024-01-01T00:00:00Z",
+            db_mb_release_id="mbid-1",
+            db_source="request",
+            db_search_filetype_override=None,
+            db_target_format=None,
+        )
+        enqueue_ctx = make_ctx_with_fake_db(db, cfg=cfg, slskd=FakeSlskdAPI())
+        enqueue_ctx.current_album_cache[1] = album
+        enqueue_ctx.user_upload_speed = {"u00": 1000}
+        enqueue_ctx.download_ownership = DownloadOwnershipWriter(
+            db_factory=lambda: db,
+        )
+        file_dir = "Music\\u00\\Album"
+        tracks = cast(
+            Any,
+            [{"albumId": 1, "title": "Track 1", "mediumNumber": 1}],
+        )
+        results = {"u00": {"flac": [file_dir]}}
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        def accepted_without_id(*, username, files, file_dir, ctx):
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id="",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 side_effect=accepted_without_id,
+             ):
+            attempt = try_enqueue(tracks, results, "flac", enqueue_ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        planned_state = db.request(1)["active_download_state"]
+        self.assertIsNone(planned_state["current_path"])
+
+        poll_slskd = FakeSlskdAPI(downloads=[{
+            "username": "u00",
+            "directories": [{"directory": file_dir, "files": [{
+                "filename": "Music\\u00\\Album\\01.flac",
+                "id": "transfer-1",
+                "state": "InProgress",
+                "bytesTransferred": 10,
+            }]}],
+        }])
+        poll_ctx = make_ctx_with_fake_db(db, cfg=cfg, slskd=poll_slskd)
+
+        poll_active_downloads(poll_ctx)
+
+        self.assertEqual(db.request(1)["status"], "downloading")
+        recovered_state = db.request(1)["active_download_state"]
+        self.assertEqual(recovered_state["files"][0]["bytes_transferred"], 10)
+        self.assertEqual(poll_slskd.transfers.get_all_downloads_calls, [True])
 
 
 class TestDispatchThroughQualityGate(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -2101,6 +2101,89 @@ class TestDownloadingStatus(unittest.TestCase):
         assert ads is not None
         self.assertEqual(ads["processing_started_at"], "2026-04-03T12:05:00+00:00")
 
+    def test_update_download_state_if_downloading_success_and_guard(self):
+        req_id = self.db.add_request(
+            mb_release_id="udsifd-ok",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        blocked_id = self.db.add_request(
+            mb_release_id="udsifd-blocked",
+            artist_name="C",
+            album_title="D",
+            source="request",
+        )
+        original_state = json.dumps({
+            "filetype": "flac",
+            "enqueued_at": "2026-04-03T12:00:00+00:00",
+            "files": [],
+        })
+        self.db.set_downloading(req_id, original_state)
+        self.db.set_downloading(blocked_id, original_state)
+        self.db.update_status(blocked_id, "imported")
+
+        updated = self.db.update_download_state_if_downloading(
+            req_id,
+            json.dumps({
+                "filetype": "mp3 v0",
+                "enqueued_at": "2026-04-03T12:01:00+00:00",
+                "files": [],
+            }),
+        )
+        blocked = self.db.update_download_state_if_downloading(
+            blocked_id,
+            json.dumps({
+                "filetype": "mp3 320",
+                "enqueued_at": "2026-04-03T12:02:00+00:00",
+                "files": [],
+            }),
+        )
+
+        self.assertTrue(updated)
+        self.assertFalse(blocked)
+        req = self.db.get_request(req_id)
+        blocked_req = self.db.get_request(blocked_id)
+        assert req is not None
+        assert blocked_req is not None
+        self.assertEqual(req["active_download_state"]["filetype"], "mp3 v0")
+        self.assertIsNone(blocked_req["active_download_state"])
+
+    def test_reset_downloading_to_wanted_success_and_guard(self):
+        req_id = self.db.add_request(
+            mb_release_id="rdtw-ok",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        blocked_id = self.db.add_request(
+            mb_release_id="rdtw-blocked",
+            artist_name="C",
+            album_title="D",
+            source="request",
+        )
+        state_json = json.dumps({
+            "filetype": "flac",
+            "enqueued_at": "2026-04-03T12:00:00+00:00",
+            "files": [],
+        })
+        self.db.set_downloading(req_id, state_json)
+        self.db.record_attempt(req_id, "download")
+
+        reset = self.db.reset_downloading_to_wanted(req_id)
+        blocked = self.db.reset_downloading_to_wanted(blocked_id)
+
+        self.assertTrue(reset)
+        self.assertFalse(blocked)
+        req = self.db.get_request(req_id)
+        blocked_req = self.db.get_request(blocked_id)
+        assert req is not None
+        assert blocked_req is not None
+        self.assertEqual(req["status"], "wanted")
+        self.assertIsNone(req["active_download_state"])
+        self.assertEqual(req["download_attempts"], 1)
+        self.assertEqual(blocked_req["status"], "wanted")
+
     def test_update_download_state_current_path(self):
         """update_download_state_current_path() rewrites only the path field."""
         req_id = self.db.add_request(

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -143,6 +143,7 @@ class _RequestStatusWriteVisitor(ast.NodeVisitor):
 
         if func_name in {
             "apply_transition",
+            "reset_downloading_to_wanted",
             "reset_to_wanted",
             "set_downloading",
             "update_status",
@@ -315,6 +316,18 @@ class TestRequestStatusWriteVisitor(unittest.TestCase):
 
     def test_rejects_direct_set_downloading_call(self) -> None:
         tree = ast.parse('db.set_downloading(42, "{}")\n')
+        visitor = _RequestStatusWriteVisitor(
+            "lib/download.py",
+            _module_string_constants(tree),
+            _transition_aliases(tree),
+        )
+
+        visitor.visit(tree)
+
+        self.assertEqual(len(visitor.offending), 1)
+
+    def test_rejects_direct_reset_downloading_to_wanted_call(self) -> None:
+        tree = ast.parse("db.reset_downloading_to_wanted(42)\n")
         visitor = _RequestStatusWriteVisitor(
             "lib/download.py",
             _module_string_constants(tree),

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -158,11 +158,22 @@ class TestApplyTransition(unittest.TestCase):
 
     def test_downloading_to_wanted_calls_reset(self):
         db = self._make_db("downloading")
+        db.reset_downloading_to_wanted.return_value = True
         apply_transition(db, 1, "wanted", from_status="downloading",
                          search_filetype_override="flac", attempt_type="download")
-        db.reset_to_wanted.assert_called_once_with(
-            1, clear_retry_counters=False, search_filetype_override="flac")
+        db.reset_downloading_to_wanted.assert_called_once_with(
+            1, search_filetype_override="flac")
+        db.reset_to_wanted.assert_not_called()
         db.record_attempt.assert_called_once_with(1, "download")
+
+    def test_downloading_to_wanted_guard_failure_skips_attempt_record(self):
+        db = self._make_db("downloading")
+        db.reset_downloading_to_wanted.return_value = False
+        result = apply_transition(
+            db, 1, "wanted", from_status="downloading",
+            attempt_type="download")
+        self.assertFalse(result)
+        db.record_attempt.assert_not_called()
 
     def test_imported_to_wanted_calls_reset(self):
         db = self._make_db("imported")


### PR DESCRIPTION
## Summary

Fixes issue #219 by claiming download ownership before the initial slskd enqueue side effect. The request now has a planned `downloading` witness before slskd can accept transfers, so a restart cannot leave accepted downloads owned only by slskd while the DB row remains `wanted`.

The reset paths are deliberately conservative: a claimed request only returns to `wanted` after a fresh snapshot proves no planned transfer exists, or after accepted transfers are cancelled and verified absent. Ambiguous snapshots, failed cancels, missing transfer IDs, and fresh same-cycle preclaims stay `downloading` for poll recovery instead of risking duplicate enqueue.

Follow-up simplification issue: #221

## What Changed

- Added a narrow worker-safe download ownership writer that routes status changes through `lib.transitions`.
- Preclaims planned active download state before single-disc and multi-disc slskd enqueue.
- Hardened rejected/partial enqueue cleanup to verify no accepted work before reset.
- Fenced poll transfer re-derivation to the persisted `enqueued_at` claim boundary.
- Kept fresh preclaims from being immediately timed out before slskd registers transfers.
- Canonicalized planned active state serialization with `current_path: null`.
- Added real DB, fake DB, enqueue, poll, transition, AST guard, and integration regression coverage.
- Added implementation and review-remediation plan docs under `docs/plans/`.

## Verification

- `nix-shell --run "pyright cratedigger.py lib/context.py lib/download.py lib/enqueue.py lib/pipeline_db.py lib/quality.py lib/transitions.py lib/download_ownership.py tests/fakes.py tests/test_download.py tests/test_enqueue_fanout.py tests/test_fakes.py tests/test_import_result.py tests/test_integration_slices.py tests/test_pipeline_db.py tests/test_request_finalization.py tests/test_transitions.py"`
- `nix-shell --run "python3 -m unittest discover tests -q"` - 2,856 tests passed, 55 skipped
- `git diff --check`

🤖 Generated with [Compound Engineering](https://compound.engineering)