### PR TITLE
fix(enqueue): probe peer online + classify user-offline as rejected

### DIFF
--- a/docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md
+++ b/docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md
@@ -1,0 +1,61 @@
+# Peer Online Probe at Enqueue — Requirements
+
+**Date:** 2026-05-08
+**Status:** Ready for planning
+**Companion fix:** Part 1 — classify slskd `User offline` HTTPError as `rejected` rather than `unknown` in `slskd_enqueue_with_outcome` (this document is Part 2 of that work; both parts ship together).
+
+## Problem
+
+The Redis peer cache has grown large (>1000 hits/cycle). Cached directory listings remain valid for users who were online when we last browsed but have since gone offline. When Phase 2 picks one of those users as the winning match and calls `slskd.transfers.enqueue`, slskd attempts the upload, finds the peer offline, and returns an HTTP error. Today we misclassify that as an "ambiguous" outcome, leave the request in `downloading`, and time out 60+ seconds later with a misleading `all transfers vanished from slskd` log row. Concrete recurrence: 9 such `download_log` rows since 2026-05-05; the triggering case (request 2540, Mercury Rev — Deserter's Songs, user `pooyork`) is in the diagnostic transcript dated 2026-05-08.
+
+## Goal
+
+Don't enqueue against a user who is provably offline. Find out before we waste the call.
+
+## Approach
+
+Add one slskd HTTP probe immediately before each enqueue attempt. If the user is `Offline`, treat the matched candidate as a non-starter and continue the existing match-loop iteration to the next eligible (user, dir) pair. No new state, no caching, no cooldowns.
+
+## Behaviour
+
+1. After a match is selected (in `lib/enqueue.py`'s per-(user, dir) iteration, just before `_enqueue_with_claim_outcome`), call `ctx.slskd.users.status(username).presence`.
+2. If `presence == "Online"` or `presence == "Away"`, proceed with the existing enqueue flow unchanged.
+3. If `presence == "Offline"`, log at INFO (`peer offline at enqueue: skipping <user> for album <id>`), discard this candidate, and let the surrounding loop pick the next eligible (user, dir) pair. The download-ownership claim must NOT be set for an offline candidate — only the user that we actually attempt to enqueue against gets a claim.
+4. If `users.status()` raises an exception (transient slskd error, unknown user, etc.), proceed to enqueue anyway. Part 1's `user_offline → rejected` classification is the safety net: a downstream rejection still resets the claim cleanly within the same cycle.
+5. No persistence. No Redis key. No `user_cooldowns` row. Next cycle starts fresh and may re-select the same user — that is intentional and acceptable given the request volume.
+
+## Scope Boundaries
+
+**In scope:**
+- One `users.status()` call per match candidate that survives matching, located in the enqueue path between match selection and `transfers.enqueue`.
+- INFO log line on offline skip so the operator can see it in the cycle journal.
+
+**Out of scope (deliberately rejected during brainstorm):**
+- Probing every eligible user before matching — 1000+ extra API calls per cycle, ruled out.
+- Caching presence in Redis or anywhere else.
+- Any new cooldown or denylist semantics tied to offline status.
+- Touching the existing `peer_dir` / `peer_dir_neg` cache contents.
+- Surfacing presence in the web UI.
+
+## Success Criteria
+
+- A request whose top-ranked match is currently offline does not write a `download_log` row with `error_message='all transfers vanished from slskd'`. Instead, the cycle either enqueues the next eligible candidate or simply ends with no enqueue (same as today's "no match this cycle" path).
+- The Mercury Rev / pooyork class of failure stops appearing in `download_log` once Part 1 + Part 2 are deployed.
+- No measurable increase in cycle time. (One extra HTTP call per album-with-a-match is negligible compared to existing browse fan-out.)
+
+## Dependencies / Assumptions
+
+- slskd `GET /users/{username}/status` returns sub-second for users it has previously interacted with. Assumed true because slskd holds the peer connection state from prior browse calls; the directory listings we matched on came through that same channel.
+- "Away" means the peer is reachable for uploads. Treating Away as Online in this design; if real-world experience proves otherwise, narrow to `Online` only — single-line change.
+- slskd-api raises `requests.exceptions.HTTPError` for non-2xx responses (verified — `session.hooks` in `slskd_api/client.py:60`). Caller treats any `users.status()` exception as "unknown, attempt enqueue".
+
+## Test Plan
+
+- **Unit (seam):** in `tests/test_enqueue.py`, add a fake `slskd.users.status` to `FakeSlskdAPI` with configurable return value. Assert that when `presence='Offline'`, `transfers.enqueue` is never called for that user, the download-ownership claim is not set, and the loop advances to the next candidate.
+- **Unit (seam):** when `users.status` raises, `transfers.enqueue` IS called (fall-through path).
+- **Orchestration:** end-to-end through `lib.enqueue` with two ranked candidates — first offline, second online. Assert that the request transitions from `wanted` to `downloading` against the second user, and no `download_log` row records the first as failed (we never tried to enqueue them).
+- **Pyright:** `FakeSlskdAPI.users` extension should remain typed.
+
+## Open Questions
+
+None remaining for product behaviour. Implementation decisions (where exactly the probe lives in `lib/enqueue.py`'s match loop; whether `Away` warrants a config knob) belong in the planning step.

--- a/docs/plans/2026-05-08-002-fix-peer-online-probe-at-enqueue-plan.md
+++ b/docs/plans/2026-05-08-002-fix-peer-online-probe-at-enqueue-plan.md
@@ -1,0 +1,329 @@
+---
+title: Peer Online Probe at Enqueue + User-Offline Classification
+type: fix
+status: active
+date: 2026-05-08
+origin: docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md
+---
+
+# Peer Online Probe at Enqueue + User-Offline Classification
+
+## Summary
+
+Two-part fix that ships together. Part 1 stops misclassifying slskd's `User offline` HTTPError as an "ambiguous" enqueue outcome — instead we treat it as a verifiable rejection, reset the claim immediately, and write a `download_log` row in the same cycle. Part 2 layers a one-call online-status probe (`slskd.users.status(username).presence`) just before each enqueue attempt so we never even try an enqueue against a peer we know is offline. No new persistence — no Redis key, no cooldown row, no in-process state. The match loop simply advances to the next eligible (user, dir).
+
+---
+
+## Problem Frame
+
+Documented in `docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md`. Concrete recurrence: 9 `download_log` rows since 2026-05-05 with `error_message='all transfers vanished from slskd'`; the triggering case is request 2540 (Mercury Rev — Deserter's Songs, user `pooyork`) on 2026-05-08. Root cause is that the Redis peer cache (now serving 1000+ hits/cycle) returns valid directory listings for users who have since gone offline; today's "ambiguous" path leaves the row in `downloading` for 60+ seconds before timing out with a misleading vanish message.
+
+---
+
+## Requirements
+
+- R1. After Part 1 + Part 2 deploy, the user-offline failure mode no longer produces `error_message='all transfers vanished from slskd'` on `download_log`. The cycle either advances to the next eligible peer or ends with no enqueue.
+- R2. When slskd raises `HTTPError` with body `"User <name> appears to be offline"` from `transfers.enqueue`, `slskd_enqueue_with_outcome` returns `SlskdEnqueueOutcome(status="rejected")`. Other exception shapes (connection errors, generic 5xx without the offline marker, unrelated 4xx) continue to return `status="unknown"`.
+- R3. The `rejected` branch of `try_enqueue` writes a `download_log` row recording the soulseek user, filetype, and a non-misleading error message.
+- R4. Before each `transfers.enqueue` call, `try_enqueue` consults `slskd.users.status(username).presence`. If the result is `"Offline"`, the candidate is skipped without claiming download ownership; the loop advances to the next `_iter_wave_matches` yield.
+- R5. `"Online"` and `"Away"` both proceed to enqueue. If `users.status()` raises, `try_enqueue` falls through to enqueue and lets Part 1's classification handle the outcome.
+- R6. No persistence is added — no new Redis key, no `user_cooldowns` row, no `CratediggerContext` field tied to presence.
+
+---
+
+## Scope Boundaries
+
+- Probing presence for every eligible user before matching — explicitly out (one HTTP call per candidate would multiply into 1000s per cycle).
+- Caching presence results anywhere — explicitly out per origin doc.
+- New cooldown/denylist semantics tied to offline status — explicitly out.
+- Touching `peer_dir` / `peer_dir_neg` cache contents — explicitly out.
+- Web UI / CLI surface for "currently offline" — explicitly out.
+- Redirecting other existing `_leave_claim_for_poll_recovery` call sites (multi-disc partial enqueue, ambiguous network errors). Those keep current semantics; only the user-offline subset moves to `rejected`.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/download.py:slskd_enqueue_with_outcome` (≈ lines 433–499) — the single seam that converts slskd-api responses into `SlskdEnqueueOutcome`. `SlskdEnqueueOutcome` is a frozen dataclass at lines 372–377 with `status: Literal["accepted", "rejected", "unknown"]`.
+- `lib/enqueue.py:try_enqueue` (≈ lines 825–970) — the per-album match loop. The `_iter_wave_matches` generator yields `(username, match_result, wave_idx)` per matched candidate; the existing `accepted` / `rejected` / `unknown` branching lives at lines 889–943.
+- `lib/enqueue.py:_reset_claim_after_verified_no_acceptance` (line 529) calls `writer.reset_after_no_acceptance(request_id)` (defined at `lib/download_ownership.py:109`) which only flips status `downloading → wanted`. It does NOT write a `download_log`. Today the `rejected` branch in `try_enqueue` is effectively dead — slskd-api raises `HTTPError` (via `session.hooks` in `slskd_api/client.py:60`) for non-2xx, so `enqueue()` never returns falsy. After Part 1, the `rejected` branch becomes the live user-offline path and needs the log.
+- `lib/download.py:_timeout_album` (≈ lines 1815–1843) — canonical example of the "reset to wanted + write download_log + apply cooldown counter" pattern. Uses `_build_download_info(entry)` then `db.log_download(request_id, soulseek_username, filetype, outcome, error_message)`.
+- `tests/fakes.py:FakeSlskdUsers` (lines 259–315) already exposes `directory()`, `set_directory()`, `set_directory_error()`. Needs a `status()` method + `set_status()` / `set_status_error()` helpers, mirroring the directory pattern.
+- `tests/fakes.py:FakeSlskdTransfers` already supports configurable per-call errors — the same shape is what we want for `users.status`.
+- `nix/store/.../slskd_api/apis/users.py:status` returns `UserStatus = {"presence": Literal["Online", "Away", "Offline"], "isPrivileged": bool}`.
+
+### Institutional Learnings
+
+- Wire-boundary types must use `msgspec.Struct`, not `@dataclass`, when they cross JSON. The slskd `UserStatus` payload IS a wire boundary — when we add a typed wrapper around `users.status()` (if needed), it should be a `msgspec.Struct`. (`.claude/rules/code-quality.md` § "Wire-boundary types".) For Part 1, however, `SlskdEnqueueOutcome` is purely internal — staying as a `@dataclass` is correct.
+- "All scripts deploy via Nix, no manual cp" (`CLAUDE.md` § Critical rules). The fix lands by `nix flake update cratedigger-src` on doc1, then `nixos-rebuild switch` on doc2. `cratedigger.service` has `restartIfChanged = false`, so the next 5-min timer cycle picks up the new code automatically.
+- `FakePipelineDB` records `download_logs` with an `assert_log()` helper — orchestration tests should use that rather than poking internals.
+
+### External References
+
+- slskd-api `transfers.enqueue` source: `nix/store/.../slskd_api/apis/transfers.py:93-105` — HTTP POST, `response.ok` returned, but `session.hooks` raises on non-2xx so callers always see `HTTPError`.
+- slskd-api `users.status` source: `nix/store/.../slskd_api/apis/users.py:76-82` — HTTP GET, returns parsed JSON.
+
+---
+
+## Key Technical Decisions
+
+- **Detect "user offline" by HTTP body match, not status code.** slskd may use 400 / 500 / 504 across versions for `UserOfflineException`, but the response body consistently contains `"appears to be offline"` (verified in slskd journal at 2026-05-08T20:18:39). Matching on the body is more durable than matching on status code, and we keep an exception-catch fast path: only inspect the body inside the `requests.exceptions.HTTPError` branch.
+- **Probe at match-loop level, not inside `slskd_enqueue_with_outcome`.** The probe needs access to the per-candidate iteration in `try_enqueue` so the "Offline → continue to next candidate" semantics work cleanly. Pushing it into `slskd_enqueue_with_outcome` would force that helper to know about looping, which it shouldn't.
+- **Probe BEFORE `_claim_initial_download_ownership`, not after.** Claiming flips the request to `downloading`. If we probed after claiming and found offline, we'd have to undo the claim — adds a lossy reset path. Probing first means offline candidates never trigger a claim.
+- **No typed `UserStatusMessage` wrapper.** `slskd.users.status()` returns a `TypedDict` with two fields and we only read one. Adding a `msgspec.Struct` wrapper is overkill for a single use site. If the surface grows later (e.g., we start using `isPrivileged`), revisit then.
+- **`Away` counts as Online.** Per origin §"Dependencies / Assumptions" — Soulseek peers marked Away can still serve uploads. If field experience contradicts this, narrow to `Online` only — single-line change.
+- **`download_log` outcome value for the rejected path.** Use `outcome="user_offline"` rather than reusing `outcome="timeout"` so historical timeout rows remain distinguishable. The existing schema doesn't constrain `outcome` values (free text), and the web UI only renders the column verbatim.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Where exactly does the probe live in `try_enqueue`?* — between the empty-files `continue` check (≈ line 867) and `_claim_initial_download_ownership` (line 868).
+- *Does the rejected branch already write a `download_log` row?* — No. It only resets via `_reset_claim_after_verified_no_acceptance`. Plan adds the log write in U3.
+- *Do we need a new outcome enum value?* — No. `SlskdEnqueueOutcome.status` already has `"rejected"`. We're widening the conditions under which it fires, not adding a new state.
+
+### Deferred to Implementation
+
+- Exact body-match string. Plan recommends `"appears to be offline"` (case-insensitive, substring). The implementer may tighten or loosen after eyeballing live response bodies — the test scenarios pin behavior either way.
+- Whether `_reset_claim_after_verified_no_acceptance` itself should take an optional `download_log_payload` parameter, vs. having `try_enqueue` write the log inline. Implementer's call; both are acceptable.
+
+---
+
+## Implementation Units
+
+### U1. Extend `FakeSlskdUsers` with `status()` + helpers
+
+**Goal:** Provide the test surface needed for both Part 1 and Part 2 before any production code changes land.
+
+**Requirements:** Supports tests for R2, R4, R5.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `tests/fakes.py`
+- Test: `tests/test_fakes.py`
+
+**Approach:**
+- Add `status_calls: list[str]`, `_statuses: dict[str, str]`, `_status_errors: dict[str, Exception]` to `FakeSlskdUsers.__init__`.
+- Add `set_status(username, presence)`, `set_status_error(username, error)`, and `status(username)` method.
+- Default presence when not set should be `"Online"` so existing orchestration tests that don't yet care about presence remain green.
+- `status()` records the call in `status_calls`, raises configured error if any, otherwise returns `{"presence": <set or "Online">, "isPrivileged": False}` matching slskd-api's `UserStatus` TypedDict shape.
+
+**Execution note:** Test-first. Add `tests/test_fakes.py` cases that exercise the new API before wiring it into orchestration tests downstream.
+
+**Patterns to follow:**
+- Mirror the existing `set_directory` / `set_directory_error` / `directory_calls` shape on the same class (lines 259–315).
+
+**Test scenarios:**
+- Happy path: `set_status('foo', 'Online')` → `api.users.status('foo')` returns dict with `presence='Online'`. Recorded in `status_calls`.
+- Happy path: `set_status('foo', 'Offline')` → `api.users.status('foo')` returns `presence='Offline'`.
+- Happy path: `set_status('foo', 'Away')` → `api.users.status('foo')` returns `presence='Away'`.
+- Edge case: no `set_status` called → `api.users.status('whoever')` returns default `presence='Online'` (so legacy tests don't need updating).
+- Error path: `set_status_error('foo', requests.HTTPError(...))` → `api.users.status('foo')` raises that exception. Call still recorded in `status_calls` (assert ordering by inspection).
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_fakes -v"` passes.
+- Pyright clean on `tests/fakes.py`.
+
+---
+
+### U2. Classify `User offline` HTTPError as `rejected` in `slskd_enqueue_with_outcome`
+
+**Goal:** Part 1 — convert the slskd user-offline rejection from "unknown / ambiguous" to a verifiable `SlskdEnqueueOutcome(status="rejected")`. Pure-function change.
+
+**Requirements:** R2.
+
+**Dependencies:** U1 (test fakes).
+
+**Files:**
+- Modify: `lib/download.py`
+- Test: `tests/test_download.py`
+
+**Approach:**
+- Replace the bare `except Exception` at lib/download.py:442 with a tiered catch:
+  1. `except requests.exceptions.HTTPError as e:` — inspect `e.response.text` (or `e.response.json()` if structured) for `"appears to be offline"` (case-insensitive substring). On match, return `SlskdEnqueueOutcome(status="rejected")`. Otherwise return `SlskdEnqueueOutcome(status="unknown")`.
+  2. `except Exception:` — preserve current behavior, return `SlskdEnqueueOutcome(status="unknown")`.
+- Defensive: if `e.response is None` (rare), treat as `"unknown"`.
+- Keep the `logger.debug("Enqueue failed", exc_info=True)` line — diagnostic value for the non-offline branches.
+
+**Execution note:** Test-first. Add the failing tests in `tests/test_download.py` before touching `lib/download.py`.
+
+**Patterns to follow:**
+- The existing `slskd_enqueue_with_outcome` skeleton — keep the function body shape and the `enqueue` / `not enqueue` branches intact. Only the exception handler changes.
+
+**Test scenarios:**
+- Happy path: `transfers.enqueue` raises `requests.HTTPError` whose `response.text` contains `"User pooyork appears to be offline"` → `slskd_enqueue_with_outcome(...)` returns `SlskdEnqueueOutcome(status="rejected", downloads=None)`.
+- Happy path: same but `response.text` is `"user FOO appears to BE OFFLINE"` (mixed case) → still `rejected`. Confirms case-insensitive substring match.
+- Edge case: `HTTPError` whose `response.text` is `"internal server error"` (no offline marker) → `status="unknown"`.
+- Edge case: `HTTPError` with `response is None` → `status="unknown"`. Defensive guard.
+- Error path: `enqueue` raises `requests.exceptions.ConnectionError` (not HTTPError) → `status="unknown"`. Generic exception path preserved.
+- Regression: `enqueue` returns falsy (e.g., `False`) → still returns `status="rejected"` per existing line 446 (this branch may be unreachable in practice but the contract is preserved).
+- Regression: `enqueue` returns truthy + `_get_all_downloads_snapshot` reconciles all IDs → still returns `status="accepted"` with the full `downloads` list.
+
+**Verification:**
+- All new tests pass; `tests.test_download` suite stays green.
+- Pyright clean on `lib/download.py`.
+
+---
+
+### U3. Write `download_log` row when `try_enqueue` takes the `rejected` path
+
+**Goal:** Part 1 wiring — when U2 starts producing `status="rejected"` for live user-offline cases, surface the failure in `download_log` immediately rather than silently resetting to `wanted`.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `lib/enqueue.py`
+- Test: `tests/test_enqueue.py`
+
+**Approach:**
+- In `try_enqueue` at the `if outcome.status == "rejected":` branch (≈ line 907), after calling `_reset_claim_after_verified_no_acceptance`, also write a `download_log` row via the same `db.log_download(...)` call shape used by `_timeout_album`.
+- Keep the log write narrowly scoped to the user-offline-shaped reject. Field values:
+  - `request_id = claim.request_id`
+  - `soulseek_username = username` (the loop-local variable)
+  - `filetype = allowed_filetype`
+  - `outcome = "user_offline"`
+  - `error_message = "user offline at enqueue"`
+- Do NOT call `db.check_and_apply_cooldown(username)` here — origin §Out of scope explicitly excludes new cooldown semantics.
+- No change to the other call sites of `_reset_claim_after_verified_no_acceptance` (line 620, multi-disc partial cancel) — that's a different scenario and does not get a log here.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- `_timeout_album` in `lib/download.py:1815-1832` — same `db.log_download(...)` call shape.
+- `FakePipelineDB.assert_log(self, idx, **expected)` for the test assertion (`tests/fakes.py`).
+
+**Test scenarios:**
+- Happy path (orchestration): single eligible user, `FakeSlskdAPI.transfers.enqueue` raises offline-shaped `HTTPError`. After `try_enqueue` returns, request status is `wanted`, `FakePipelineDB.download_logs` has exactly one row with `outcome="user_offline"`, `soulseek_username="pooyork"`, `filetype="flac 16/44.1"`, `error_message="user offline at enqueue"`.
+- Regression: `transfers.enqueue` returns truthy + reconciles IDs → no `download_log` row written for the success path; request transitions `wanted → downloading`.
+- Regression: `transfers.enqueue` raises generic `ConnectionError` (status="unknown", ambiguous branch) → no `download_log` row written here, claim left for poll-cycle recovery as today. Confirms we didn't widen the log site.
+- Edge case: `_reset_claim_after_verified_no_acceptance` returns the "couldn't prove no acceptance" `claim.entry.files` value (verified-no-acceptance failed) → log is still written (the failure is observable; the residual claim is the system's safety net but the user deserves the log entry).
+
+**Verification:**
+- New orchestration tests pass.
+- `pipeline-cli show <id>` for a future user-offline failure shows the row with the new outcome.
+- Pyright clean on `lib/enqueue.py`.
+
+---
+
+### U4. Add `users.status` probe in `try_enqueue` match loop
+
+**Goal:** Part 2 — gate every match candidate on `slskd.users.status(username).presence` before claim + enqueue. Offline candidates skip cleanly to the next match.
+
+**Requirements:** R4, R5, R6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `lib/enqueue.py`
+- Test: `tests/test_enqueue.py`
+
+**Approach:**
+- Insert the probe between the empty-files `continue` check (≈ lib/enqueue.py:867) and `_claim_initial_download_ownership` (line 868).
+- New helper at module scope: `def _peer_is_eligible_for_enqueue(username: str, ctx: CratediggerContext) -> bool`. Calls `ctx.slskd.users.status(username)`, reads `presence`, returns `False` only when `presence == "Offline"`. Treats `"Online"` and `"Away"` as eligible. On exception, log at DEBUG with `exc_info=True` and return `True` (fall through to enqueue — Part 1's classification is the safety net, per R5).
+- In the loop: `if not _peer_is_eligible_for_enqueue(username, ctx): logger.info("peer offline at enqueue: skipping %s for album %s", username, album_id); continue`.
+- The `continue` here advances the `for ... in _iter_wave_matches(...)` loop. No claim is made, no log is written, no slskd transfer call is issued.
+- This change does NOT touch `_eligible_user_dirs` or any other earlier filter — origin explicitly rules out probing all eligible candidates.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Logging style mirrors `_log_album_browse` and other INFO lines at the same scope.
+- `cooldowns.py:get_cooled_down_users` is the existing analog of "skip a user" — but lives at the eligible-filter layer, not the per-match layer. The new probe is intentionally NOT integrated there.
+
+**Test scenarios:**
+- Happy path: single online candidate. `FakeSlskdUsers.set_status('foo', 'Online')`. `try_enqueue` calls `users.status('foo')` once, then proceeds to enqueue. Assert `users.status_calls == ['foo']` and `transfers.enqueue` was called once.
+- Happy path: single Away candidate. `set_status('foo', 'Away')`. Probe is called, treated as online, enqueue proceeds. Confirms Away → Online behavior.
+- Happy path (skip): single Offline candidate. `set_status('foo', 'Offline')`. After `try_enqueue` returns, `users.status_calls == ['foo']`, `transfers.enqueue` was NOT called, no claim was made (FakePipelineDB request status remains `wanted`), no `download_log` row written.
+- Happy path (failover): two ranked candidates. User A offline, user B online. Assert `users.status_calls == ['A', 'B']`, `transfers.enqueue` called once with B, B's claim made and persisted, A never claimed. Request status `wanted → downloading`.
+- Error path: `users.status` raises `HTTPError`. Probe falls through, `transfers.enqueue` is called as today. If enqueue then succeeds, request transitions `wanted → downloading`; if enqueue raises offline-shaped `HTTPError`, U2 + U3 take over (status="rejected" + log). Confirms R5.
+- Edge case: probe returns Offline but `_iter_wave_matches` has no further candidates. `try_enqueue` returns `EnqueueAttempt(matched=False, ...)` (or whatever the loop's exhausted-without-success path produces today). No claim, no log, request stays `wanted`.
+- Edge case: probe never sees an offline user across multiple matches → existing behavior unchanged. Verifies the probe is non-disruptive in the steady state.
+
+**Verification:**
+- New orchestration tests pass.
+- Live verification post-deploy: `pipeline-cli show <future-request>` for a user that was matched-but-skipped shows no spurious download_log row, and the request's search forensics show subsequent peers attempted.
+- Pyright clean on `lib/enqueue.py`.
+
+---
+
+### U5. Integration slice: two-user fan-out, first offline, second online
+
+**Goal:** End-to-end coverage that Part 1 + Part 2 compose correctly. Real `try_enqueue`, real `slskd_enqueue_with_outcome`, real `_reset_claim_after_verified_no_acceptance` — only the network edges (slskd, DB) are faked.
+
+**Requirements:** R1, R3, R4 (composed).
+
+**Dependencies:** U2, U3, U4.
+
+**Files:**
+- Test: `tests/test_integration_slices.py`
+
+**Approach:**
+- Slice mirrors existing `TestDispatchThroughQualityGate` shape — patch only `_get_all_downloads_snapshot` (since we're not testing the snapshot polling) and rely on real code from `try_enqueue` down.
+- Build two ranked candidates via `FakeSlskdAPI` directory data and standard search-result builders. Configure `FakeSlskdUsers.set_status('A', 'Offline')` and `set_status('B', 'Online')`. Configure `FakeSlskdAPI.transfers.enqueue` to succeed for B.
+- Run `try_enqueue(...)`. Assert:
+  - `users.status_calls` records both A and B in order.
+  - `transfers.enqueue` was called exactly once, for user B, with B's planned files.
+  - The request transitions `wanted → downloading` against B's user.
+  - No `download_log` row was written (offline skip is silent; only a hard rejection writes a log).
+- Add a sibling test where BOTH users are offline. Assert: enqueue never called, no claim made, request stays `wanted`, no `download_log` row, `EnqueueAttempt.matched` reflects the no-match outcome.
+- Add a third sibling test where probe says A is online (cache lying / status endpoint stale) but `transfers.enqueue` then raises offline-shaped `HTTPError`. Assert: U2 + U3 path runs — request returns to `wanted`, one `download_log` row with `outcome="user_offline"`. Confirms the safety-net composition.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- `tests/test_integration_slices.py:TestDispatchThroughQualityGate` for slice scaffolding.
+- `tests/helpers.py:make_ctx_with_fake_db` to wire `FakePipelineDB` into a `CratediggerContext`.
+
+**Test scenarios:**
+- *(scenarios are described in the Approach section above as the slice's three composed cases)*
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_integration_slices -v"` passes including the three new cases.
+- `bash scripts/run_tests.sh` full suite green; pyright clean.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Touches `try_enqueue` (the per-album match loop) and `slskd_enqueue_with_outcome` (the slskd seam). Other call sites of `_reset_claim_after_verified_no_acceptance` (multi-disc partial cancel at lib/enqueue.py:620, line 1174) are intentionally NOT modified.
+- **Error propagation:** When `users.status()` raises, the probe falls through to enqueue. If enqueue then succeeds, normal flow continues. If enqueue raises offline-shaped `HTTPError`, U2 reclassifies to `rejected` and U3 writes the log. Worst-case is identical to today's behavior with one extra HTTP round trip.
+- **State lifecycle risks:** Probe runs BEFORE claim, so an offline candidate never causes a `wanted → downloading` flip that needs unwinding. The existing rejected branch already handles the unwind path for the safety-net case.
+- **API surface parity:** No web/API changes. CLI `pipeline-cli show <id>` will start showing `outcome="user_offline"` rows for the user-offline failure mode going forward — that's a deliberate diagnostic improvement, not a breaking change.
+- **Integration coverage:** U5 covers the cross-layer composition. Unit tests at U2 / U4 validate the seams independently.
+- **Unchanged invariants:** `SlskdEnqueueOutcome` shape, the `accepted` / `unknown` branches of `try_enqueue`, the `_iter_wave_matches` generator contract, all peer-cache code, all cooldown code (`user_cooldowns`, `cooled_down_users`), and the web UI all stay unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| slskd's user-offline error body changes shape across versions | Substring match on `"appears to be offline"` is more durable than status-code matching. If it ever changes, U2 quietly degrades to `status="unknown"` (today's behavior) — no regression vs current state. |
+| `users.status()` is slow for never-browsed users | Per origin §Dependencies, slskd holds peer connection state from prior browse calls and the directory listing came from that channel — status is fast for any user we've already matched. The probe runs only for matched candidates, not every eligible user. |
+| `Away` peers reject uploads in practice | Single-line change to narrow probe predicate to `presence == "Online"` only. Easy to reverse if observed. |
+| Adding a `download_log` row in the rejected branch could surprise UI consumers expecting only timeout/success rows | The web UI renders `outcome` as free text. New `outcome="user_offline"` rows just appear with that label. No schema change. |
+| `users.status()` HTTP errors flood logs | Logged at DEBUG with `exc_info=True`. INFO line for the offline-skip path is a separate, intentional diagnostic. |
+
+---
+
+## Documentation / Operational Notes
+
+- No CLAUDE.md / docs update required — neither pipeline behavior nor decision architecture changes shape.
+- Deploy via the standard flow in `.claude/rules/deploy.md`: push cratedigger → `nix flake update cratedigger-src` on doc1 → `nixos-rebuild switch` doc2. `cratedigger.service` has `restartIfChanged = false`; the next 5-min timer cycle picks up the new code automatically. No DB migration.
+- Post-deploy verification: monitor `download_log` for the next 24 h. Expect: zero new `error_message='all transfers vanished from slskd'` rows attributable to peer offline-status (rare snapshot-fetch failures at poll time may still produce that message — those are unrelated and stay in scope today).
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md`
+- Diagnostic transcript: chat session dated 2026-05-08 covering request 2540 (Mercury Rev — Deserter's Songs, user `pooyork`).
+- Related code: `lib/download.py:slskd_enqueue_with_outcome`, `lib/enqueue.py:try_enqueue`, `lib/download_ownership.py:reset_after_no_acceptance`, `lib/download.py:_timeout_album`, `tests/fakes.py:FakeSlskdUsers`.
+- slskd-api source paths (read during planning): `slskd_api/apis/transfers.py:93-105`, `slskd_api/apis/users.py:76-82`, `slskd_api/client.py:60`.

--- a/lib/download.py
+++ b/lib/download.py
@@ -430,6 +430,30 @@ def slskd_download_status(downloads: list[Any], ctx: CratediggerContext,
     return ok
 
 
+def _is_user_offline_http_error(exc: BaseException) -> bool:
+    """slskd surfaces a peer-offline rejection as an HTTPError whose
+    response body contains 'appears to be offline' (verified against
+    Soulseek.UserOfflineException — see the 2026-05-08 pooyork incident).
+
+    Match on body substring rather than status code: slskd has shipped 400 /
+    500 / 504 across versions for this case, but the body string is durable.
+    Detection is structural — any exception carrying a ``.response`` with
+    a readable ``.text`` containing the marker counts. Avoiding
+    ``isinstance(requests.exceptions.HTTPError)`` keeps the helper safe
+    when ``sys.modules["requests"]`` is monkey-patched in tests.
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return False
+    try:
+        body = response.text or ""
+    except Exception:
+        return False
+    if not isinstance(body, str):
+        return False
+    return "appears to be offline" in body.lower()
+
+
 def slskd_enqueue_with_outcome(
     username: str,
     files: list[dict[str, Any]],
@@ -439,7 +463,13 @@ def slskd_enqueue_with_outcome(
     """Enqueue files for download via slskd with an explicit outcome."""
     try:
         enqueue = ctx.slskd.transfers.enqueue(username=username, files=files)
-    except Exception:
+    except Exception as exc:
+        if _is_user_offline_http_error(exc):
+            logger.info(
+                "slskd reports peer %s offline at enqueue; classifying as rejected",
+                username,
+            )
+            return SlskdEnqueueOutcome(status="rejected")
         logger.debug("Enqueue failed", exc_info=True)
         return SlskdEnqueueOutcome(status="unknown")
     if not enqueue:

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -923,6 +923,21 @@ def try_enqueue(
                         downloads=owned,
                         candidates=tuple(accumulated),
                     )
+                # Verified-no-acceptance: surface the rejection in
+                # download_log so the failure is visible immediately
+                # rather than disappearing into a silent status flip.
+                # Today the only path that produces a verified rejection
+                # is a peer-offline classification from
+                # slskd_enqueue_with_outcome (see _is_user_offline_http_error).
+                if claim.request_id is not None:
+                    db = ctx.pipeline_db_source._get_db()
+                    db.log_download(
+                        request_id=claim.request_id,
+                        soulseek_username=username,
+                        filetype=allowed_filetype,
+                        outcome="user_offline",
+                        error_message="user offline at enqueue",
+                    )
             elif claim.claimed:
                 owned = _leave_claim_for_poll_recovery(
                     claim,

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -366,6 +366,34 @@ def _planned_downloads(
     ]
 
 
+def _peer_is_online_for_enqueue(username: str, ctx: CratediggerContext) -> bool:
+    """Probe slskd's user-status endpoint just before enqueue to avoid
+    issuing a doomed enqueue against a peer who has gone offline since
+    we cached their browse data.
+
+    Returns False ONLY when slskd reports ``presence == "Offline"``.
+    ``Online`` and ``Away`` both return True (away peers can still serve
+    uploads). On any exception (transient slskd error, unknown user,
+    network blip), fall through and return True — slskd_enqueue_with_outcome
+    classifies a real peer-offline rejection via the response body.
+    """
+    try:
+        status = ctx.slskd.users.status(username)
+    except Exception:
+        logger.debug(
+            "users.status probe raised for %s; falling through to enqueue",
+            username,
+            exc_info=True,
+        )
+        return True
+    presence = ""
+    if isinstance(status, dict):
+        presence_value = status.get("presence")
+        if isinstance(presence_value, str):
+            presence = presence_value
+    return presence != "Offline"
+
+
 def _planned_grab_entry(
     album: Any,
     files: list[DownloadFile],
@@ -863,6 +891,13 @@ def try_enqueue(
                 album_name,
                 username,
                 allowed_filetype,
+            )
+            continue
+        if not _peer_is_online_for_enqueue(username, ctx):
+            logger.info(
+                "peer offline at enqueue: skipping %s for album %s",
+                username,
+                album_id,
             )
             continue
         claim = _claim_initial_download_ownership(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -265,6 +265,9 @@ class FakeSlskdUsers:
         self._directories: dict[tuple[str, str], list[Any]] = {}
         self._directory_errors: dict[tuple[str, str], Exception] = {}
         self._directory_delays: dict[tuple[str, str], float] = {}
+        self.status_calls: list[str] = []
+        self._statuses: dict[str, str] = {}
+        self._status_errors: dict[str, Exception] = {}
         # Optional concurrency probe — set to a callable taking a +/-1 delta to
         # observe in-flight count (used by fan-out concurrency-cap tests).
         self.in_flight_probe: Callable[[int], None] | None = None
@@ -313,6 +316,29 @@ class FakeSlskdUsers:
         finally:
             if self.in_flight_probe is not None:
                 self.in_flight_probe(-1)
+
+    def set_status(self, username: str, presence: str) -> None:
+        """Configure the presence returned by ``status(username)``.
+
+        ``presence`` is the slskd-api ``UserPresence`` value -- one of
+        ``"Online"``, ``"Away"``, ``"Offline"``.
+        """
+        self._statuses[username] = presence
+
+    def set_status_error(self, username: str, error: Exception) -> None:
+        """Configure ``status(username)`` to raise ``error``."""
+        self._status_errors[username] = error
+
+    def status(self, username: str) -> dict[str, Any]:
+        """Mirror slskd-api ``UsersApi.status`` shape: ``{"presence": ...,
+        "isPrivileged": False}``. Default presence is ``"Online"`` so legacy
+        tests that don't configure status stay green."""
+        self.status_calls.append(username)
+        configured_error = self._status_errors.get(username)
+        if configured_error is not None:
+            raise configured_error
+        presence = self._statuses.get(username, "Online")
+        return {"presence": presence, "isPrivileged": False}
 
 
 @dataclass

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -565,6 +565,148 @@ class TestSlskdDoEnqueue(unittest.TestCase):
         self.assertEqual(slskd.transfers.cancel_download_calls, [])
 
 
+class TestSlskdEnqueueWithOutcome(unittest.TestCase):
+    """slskd_enqueue_with_outcome must distinguish a hard 'user offline'
+    HTTP rejection (verifiable, transfers will never appear) from a
+    generic exception (transient, retry next cycle)."""
+
+    def _make_offline_http_error(self, body: str) -> Exception:
+        """Build an exception whose ``.response.text`` mirrors what slskd
+        returns when the peer is offline. We avoid constructing a real
+        ``requests.HTTPError`` here because ``test_beets_validation.py``
+        replaces ``sys.modules['requests']`` with a MagicMock at discovery
+        time, which would make a runtime ``import requests`` here yield
+        non-class types. The detector matches structurally on
+        ``.response.text``, so a synthetic shape works identically."""
+        from types import SimpleNamespace
+
+        class _FakeHTTPError(Exception):
+            pass
+
+        err = _FakeHTTPError("500 Server Error")
+        err.response = SimpleNamespace(text=body)  # type: ignore[attr-defined]
+        return err
+
+    def test_offline_http_error_body_returns_rejected(self):
+        """The canonical slskd response body 'User pooyork appears to be
+        offline' must be classified as rejected — the safety net that
+        unblocks the 60s vanish timeout."""
+        from lib.download import slskd_enqueue_with_outcome
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = self._make_offline_http_error(
+            "User pooyork appears to be offline")
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "pooyork", [{"filename": "track.flac", "size": 1}],
+                "pooyork\\Music", ctx)
+
+        self.assertEqual(outcome.status, "rejected")
+        self.assertIsNone(outcome.downloads)
+
+    def test_offline_http_error_case_insensitive(self):
+        """Body match must tolerate slskd-version body casing variants."""
+        from lib.download import slskd_enqueue_with_outcome
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = self._make_offline_http_error(
+            "User FOO Appears To BE OFFLINE")
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "foo", [{"filename": "t.flac", "size": 1}], "foo\\m", ctx)
+
+        self.assertEqual(outcome.status, "rejected")
+
+    def test_non_offline_http_error_returns_unknown(self):
+        """HTTPError without the offline marker is still unknown — the
+        request stays downloading for poll-cycle recovery."""
+        from lib.download import slskd_enqueue_with_outcome
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = self._make_offline_http_error(
+            "internal server error")
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "user1", [{"filename": "t.flac", "size": 1}], "user1\\m", ctx)
+
+        self.assertEqual(outcome.status, "unknown")
+
+    def test_http_error_with_no_response_returns_unknown(self):
+        """Defensive: HTTPError without an attached response should not
+        crash — fall through to unknown."""
+        from lib.download import slskd_enqueue_with_outcome
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = Exception("synthetic — no .response")
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "user1", [{"filename": "t.flac", "size": 1}], "user1\\m", ctx)
+
+        self.assertEqual(outcome.status, "unknown")
+
+    def test_connection_error_returns_unknown(self):
+        """Generic non-HTTPError exceptions (network drop, etc.) stay in
+        the unknown / ambiguous bucket — only the verifiable user-offline
+        body promotes to rejected."""
+        from lib.download import slskd_enqueue_with_outcome
+
+        class _ConnectionError(Exception):
+            """Synthetic stand-in. ``test_beets_validation.py`` mocks
+            ``sys.modules['requests']`` so importing real
+            ``requests.ConnectionError`` here yields a non-class type."""
+            pass
+
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_error = _ConnectionError("dropped")
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "user1", [{"filename": "t.flac", "size": 1}], "user1\\m", ctx)
+
+        self.assertEqual(outcome.status, "unknown")
+
+    def test_falsy_enqueue_response_still_returns_rejected(self):
+        """Regression guard: when slskd-api ever returns falsy (rather
+        than raising), the existing rejected branch still fires."""
+        from lib.download import slskd_enqueue_with_outcome
+        slskd = FakeSlskdAPI()
+        slskd.transfers.enqueue_result = False
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "user1", [{"filename": "t.flac", "size": 1}], "user1\\m", ctx)
+
+        self.assertEqual(outcome.status, "rejected")
+
+    def test_successful_enqueue_still_returns_accepted(self):
+        """Regression guard: the happy path is unchanged."""
+        from lib.download import slskd_enqueue_with_outcome
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "user1",
+            "directories": [{
+                "directory": "user1\\Music",
+                "files": [{"filename": "track.mp3", "id": "tid-1"}],
+            }],
+        }])
+        ctx = _make_ctx(slskd=slskd)
+
+        with patch("time.sleep"):
+            outcome = slskd_enqueue_with_outcome(
+                "user1", [{"filename": "track.mp3", "size": 5000000}],
+                "user1\\Music", ctx)
+
+        self.assertEqual(outcome.status, "accepted")
+        self.assertIsNotNone(outcome.downloads)
+        assert outcome.downloads is not None
+        self.assertEqual(outcome.downloads[0].id, "tid-1")
+
+
 class TestGrabMostWanted(unittest.TestCase):
     """grab_most_wanted enqueues and persists state, no blocking monitor."""
 

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -671,6 +671,182 @@ class TestDownloadOwnershipPreclaim(unittest.TestCase):
         self.assertEqual(db.recorded_attempts, [(1, "download")])
         self.assertIsNotNone(db.request(1)["next_retry_after"])
 
+    def test_offline_presence_skips_enqueue_without_claim(self):
+        """When ``users.status`` reports the matched peer as ``Offline``,
+        ``try_enqueue`` must skip the enqueue entirely — no claim, no
+        ``download_log`` row, no ``transfers.enqueue`` call."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[])
+        slskd.users.set_status("u00", "Offline")
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        match = _match_for("u00", "Music\\u00\\Album")
+        enqueue_mock = MagicMock()
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch("lib.enqueue.slskd_enqueue_with_outcome", enqueue_mock):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        # Probe was consulted; enqueue was never called.
+        self.assertEqual(slskd.users.status_calls, ["u00"])
+        enqueue_mock.assert_not_called()
+        # Request stayed wanted; no claim made; no log written.
+        self.assertEqual(db.request(1)["status"], "wanted")
+        self.assertIsNone(db.request(1)["active_download_state"])
+        self.assertEqual(db.download_logs, [])
+        self.assertFalse(attempt.matched)
+
+    def test_online_presence_proceeds_to_enqueue(self):
+        """``Online`` presence is a no-op — enqueue runs as before."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[])
+        slskd.users.set_status("u00", "Online")
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        match = _match_for("u00", "Music\\u00\\Album")
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(
+                     status="accepted",
+                     downloads=[DownloadFile(
+                         filename="Music\\u00\\Album\\01.flac",
+                         id="tid-1",
+                         file_dir="Music\\u00\\Album",
+                         username="u00",
+                         size=123,
+                     )],
+                 ),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertEqual(slskd.users.status_calls, ["u00"])
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+
+    def test_away_presence_treated_as_online(self):
+        """``Away`` peers can still serve uploads — proceed to enqueue."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[])
+        slskd.users.set_status("u00", "Away")
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        match = _match_for("u00", "Music\\u00\\Album")
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(
+                     status="accepted",
+                     downloads=[DownloadFile(
+                         filename="Music\\u00\\Album\\01.flac",
+                         id="tid-1",
+                         file_dir="Music\\u00\\Album",
+                         username="u00",
+                         size=123,
+                     )],
+                 ),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+
+    def test_status_exception_falls_through_to_enqueue(self):
+        """If the probe raises, fall through to enqueue. The user-offline
+        classification in ``slskd_enqueue_with_outcome`` is the safety
+        net for the actual offline case."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[])
+        slskd.users.set_status_error("u00", RuntimeError("status endpoint flaky"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        match = _match_for("u00", "Music\\u00\\Album")
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(
+                     status="accepted",
+                     downloads=[DownloadFile(
+                         filename="Music\\u00\\Album\\01.flac",
+                         id="tid-1",
+                         file_dir="Music\\u00\\Album",
+                         username="u00",
+                         size=123,
+                     )],
+                 ),
+             ):
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+
+    def test_offline_first_user_falls_through_to_online_second(self):
+        """Two ranked users: A offline, B online. Probe both; enqueue only
+        B; A never claimed."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[])
+        slskd.users.set_status("u00", "Offline")
+        slskd.users.set_status("u01", "Online")
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00", "u01"]
+        results = _make_results(users)
+
+        def match_side_effect(_tracks, _allowed_filetype, _file_dirs, ctx, *, username, **_kwargs):
+            return _match_for(username, f"Music\\{username}\\Album")
+
+        # Each user gets its own match.
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match",
+                   side_effect=lambda *a, **kw: _match_for(
+                       kw.get("username", a[3] if len(a) > 3 else "u00"),
+                       f"Music\\{kw.get('username', 'u00')}\\Album",
+                   )), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(
+                     status="accepted",
+                     downloads=[DownloadFile(
+                         filename="Music\\u01\\Album\\01.flac",
+                         id="tid-1",
+                         file_dir="Music\\u01\\Album",
+                         username="u01",
+                         size=123,
+                     )],
+                 ),
+             ) as enq:
+            attempt = try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        self.assertEqual(slskd.users.status_calls, ["u00", "u01"])
+        # enqueue called once, for u01
+        self.assertEqual(enq.call_count, 1)
+        called_username = enq.call_args.kwargs.get("username") or enq.call_args.args[0]
+        self.assertEqual(called_username, "u01")
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        # No download_log row written for the offline skip.
+        self.assertEqual(db.download_logs, [])
+
     def test_verified_no_acceptance_writes_user_offline_download_log(self):
         """When ``slskd_enqueue_with_outcome`` returns ``rejected`` and
         verification confirms no transfer landed, ``try_enqueue`` must

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -671,6 +671,94 @@ class TestDownloadOwnershipPreclaim(unittest.TestCase):
         self.assertEqual(db.recorded_attempts, [(1, "download")])
         self.assertIsNotNone(db.request(1)["next_retry_after"])
 
+    def test_verified_no_acceptance_writes_user_offline_download_log(self):
+        """When ``slskd_enqueue_with_outcome`` returns ``rejected`` and
+        verification confirms no transfer landed, ``try_enqueue`` must
+        write a ``download_log`` row recording the failed attempt — so
+        the failure is surfaced in the web UI / pipeline-cli immediately
+        rather than silently disappearing into a status flip."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(
+            cfg=cfg,
+            db=db,
+            slskd=FakeSlskdAPI(downloads=[]),
+        )
+        # Route pipeline_db_source -> same FakePipelineDB so the download_log
+        # write is observable (in production both seams connect to the same
+        # Postgres; in this fixture they're independent unless wired here).
+        ctx.pipeline_db_source._get_db.return_value = db  # type: ignore[attr-defined]
+        users = ["pooyork"]
+        results = _make_results(users)
+        file_dir = "musiclibrary\\Mercury Rev\\Deserter's Songs"
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="rejected"),
+             ):
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        # One log row, attributed to the rejected user.
+        self.assertEqual(len(db.download_logs), 1)
+        log = db.download_logs[0]
+        self.assertEqual(log.request_id, 1)
+        self.assertEqual(log.soulseek_username, "pooyork")
+        self.assertEqual(log.filetype, "flac")
+        self.assertEqual(log.outcome, "user_offline")
+        assert log.error_message is not None
+        self.assertIn("offline", log.error_message.lower())
+
+    def test_rejected_enqueue_with_visible_transfer_does_not_log(self):
+        """When the rejected outcome leaves a visible transfer (the
+        residual-claim safety net), the request stays in ``downloading``
+        and no ``download_log`` row should be written — the attempt is
+        not yet a verified failure."""
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        file_dir = "Music\\u00\\Album"
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "u00",
+            "directories": [{"directory": file_dir, "files": [
+                {"filename": "Music\\u00\\Album\\01.flac", "id": "transfer-1"},
+            ]}],
+        }])
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        users = ["u00"]
+        results = _make_results(users)
+        match = MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{"filename": "01.flac", "size": 123}],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match", return_value=match), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(status="rejected"),
+             ):
+            try_enqueue(_make_tracks(), results, "flac", ctx)
+
+        # Verified-no-acceptance failed; claim left for recovery — no log.
+        self.assertEqual(db.download_logs, [])
+
     def test_rejected_enqueue_with_visible_transfer_stays_downloading(self):
         cfg = _make_cfg(browse_top_k=20)
         db = FakePipelineDB()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1033,6 +1033,50 @@ class TestFakeSlskdAPI(unittest.TestCase):
             ("user1", "Music\\Broken"),
         ])
 
+    def test_user_status_default_is_online(self):
+        """Unset users default to Online so legacy tests stay green."""
+        slskd = FakeSlskdAPI()
+
+        result = slskd.users.status("never_set")
+
+        self.assertEqual(result["presence"], "Online")
+        self.assertEqual(slskd.users.status_calls, ["never_set"])
+
+    def test_user_status_returns_configured_presence(self):
+        slskd = FakeSlskdAPI()
+        slskd.users.set_status("alice", "Online")
+        slskd.users.set_status("bob", "Away")
+        slskd.users.set_status("carol", "Offline")
+
+        self.assertEqual(slskd.users.status("alice")["presence"], "Online")
+        self.assertEqual(slskd.users.status("bob")["presence"], "Away")
+        self.assertEqual(slskd.users.status("carol")["presence"], "Offline")
+        self.assertEqual(
+            slskd.users.status_calls, ["alice", "bob", "carol"],
+        )
+
+    def test_user_status_raises_configured_error(self):
+        slskd = FakeSlskdAPI()
+        boom = RuntimeError("slskd unreachable")
+        slskd.users.set_status_error("flaky", boom)
+
+        with self.assertRaises(RuntimeError):
+            slskd.users.status("flaky")
+        # The call is still recorded so tests can assert ordering.
+        self.assertEqual(slskd.users.status_calls, ["flaky"])
+
+    def test_user_status_payload_shape_matches_slskd_api(self):
+        """Returned dict mirrors slskd-api UserStatus TypedDict shape:
+        {presence: str, isPrivileged: bool}."""
+        slskd = FakeSlskdAPI()
+        slskd.users.set_status("alice", "Online")
+
+        result = slskd.users.status("alice")
+
+        self.assertIn("presence", result)
+        self.assertIn("isPrivileged", result)
+        self.assertIsInstance(result["isPrivileged"], bool)
+
 
 class TestFakeSlskdSearches(unittest.TestCase):
     """Self-test for the FakeSlskdSearches stub introduced in U5."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -170,6 +170,194 @@ class TestDownloadOwnershipPreclaimRecoverySlice(unittest.TestCase):
         self.assertEqual(poll_slskd.transfers.get_all_downloads_calls, [True])
 
 
+class TestPeerOnlineProbeAtEnqueueSlice(unittest.TestCase):
+    """End-to-end coverage for Part 1 (user_offline classification) +
+    Part 2 (presence probe). Real ``try_enqueue`` over real
+    ``slskd_enqueue_with_outcome`` and ``_peer_is_online_for_enqueue``.
+    Only the network edges (slskd, DB) are faked.
+
+    Reference incident: 2026-05-08 request 2540 (Mercury Rev — Deserter's
+    Songs, peer ``pooyork``) — see
+    docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md.
+    """
+
+    def _build_offline_http_error(self) -> Exception:
+        """Synthetic stand-in for slskd-api's ``requests.HTTPError`` —
+        ``test_beets_validation.py`` mocks ``sys.modules['requests']`` at
+        discovery time, so a real ``requests.HTTPError`` constructed here
+        would not be a real exception. The detector matches structurally
+        on ``.response.text``."""
+        class _FakeHTTPError(Exception):
+            pass
+
+        err = _FakeHTTPError("500 Server Error")
+        err.response = SimpleNamespace(  # type: ignore[attr-defined]
+            text="User pooyork appears to be offline",
+        )
+        return err
+
+    def _make_album(self, request_id: int):
+        return SimpleNamespace(
+            id=request_id,
+            db_request_id=request_id,
+            title="Album",
+            artist_name="Artist",
+            release_date="2024-01-01T00:00:00Z",
+            db_mb_release_id=f"mbid-{request_id}",
+            db_source="request",
+            db_search_filetype_override=None,
+            db_target_format=None,
+        )
+
+    def _setup_ctx(
+        self,
+        db: FakePipelineDB,
+        slskd: FakeSlskdAPI,
+        speeds: dict[str, int],
+    ):
+        from lib.download_ownership import DownloadOwnershipWriter
+        cfg = _download_ownership_cfg()
+        ctx = make_ctx_with_fake_db(db, cfg=cfg, slskd=slskd)
+        ctx.current_album_cache[1] = self._make_album(1)
+        ctx.user_upload_speed = speeds
+        ctx.download_ownership = DownloadOwnershipWriter(db_factory=lambda: db)
+        return ctx
+
+    def _wave_match_side_effect(self):
+        from lib.matching import MatchResult
+
+        def matcher(*args, **kwargs):
+            username = kwargs.get("username") or args[3]
+            file_dir = f"Music\\{username}\\Album"
+            return MatchResult(
+                matched=True,
+                directory={
+                    "directory": file_dir,
+                    "files": [{
+                        "filename": f"{file_dir}\\01.flac",
+                        "size": 123,
+                    }],
+                },
+                file_dir=file_dir,
+                candidates=[],
+            )
+        return matcher
+
+    def test_offline_first_then_online_second_enqueues_only_second(self):
+        from lib.enqueue import try_enqueue
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[{
+            "username": "online_peer",
+            "directories": [{
+                "directory": "Music\\online_peer\\Album",
+                "files": [{
+                    "filename": "Music\\online_peer\\Album\\01.flac",
+                    "id": "tid-1",
+                }],
+            }],
+        }])
+        slskd.users.set_status("offline_peer", "Offline")
+        slskd.users.set_status("online_peer", "Online")
+        ctx = self._setup_ctx(db, slskd, speeds={
+            "offline_peer": 10_000,
+            "online_peer": 9_000,
+        })
+        results = {
+            "offline_peer": {"flac": ["Music\\offline_peer\\Album"]},
+            "online_peer": {"flac": ["Music\\online_peer\\Album"]},
+        }
+        tracks = cast(
+            Any, [{"albumId": 1, "title": "Track 1", "mediumNumber": 1}],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match",
+                   side_effect=self._wave_match_side_effect()), \
+             patch("time.sleep"):
+            attempt = try_enqueue(tracks, results, "flac", ctx)
+
+        # Both peers probed (in upload-speed order).
+        self.assertEqual(
+            slskd.users.status_calls, ["offline_peer", "online_peer"],
+        )
+        # transfers.enqueue called exactly once, against the online peer.
+        self.assertEqual(len(slskd.transfers.enqueue_calls), 1)
+        self.assertEqual(
+            slskd.transfers.enqueue_calls[0].username, "online_peer",
+        )
+        # Request transitioned to downloading; no spurious download_log.
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        self.assertEqual(db.download_logs, [])
+
+    def test_both_peers_offline_no_enqueue_no_log_request_stays_wanted(self):
+        from lib.enqueue import try_enqueue
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI()
+        slskd.users.set_status("u00", "Offline")
+        slskd.users.set_status("u01", "Offline")
+        ctx = self._setup_ctx(db, slskd, speeds={"u00": 10_000, "u01": 9_000})
+        results = {
+            "u00": {"flac": ["Music\\u00\\Album"]},
+            "u01": {"flac": ["Music\\u01\\Album"]},
+        }
+        tracks = cast(
+            Any, [{"albumId": 1, "title": "Track 1", "mediumNumber": 1}],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match",
+                   side_effect=self._wave_match_side_effect()), \
+             patch("time.sleep"):
+            attempt = try_enqueue(tracks, results, "flac", ctx)
+
+        self.assertEqual(slskd.users.status_calls, ["u00", "u01"])
+        self.assertEqual(slskd.transfers.enqueue_calls, [])
+        self.assertFalse(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "wanted")
+        self.assertIsNone(db.request(1)["active_download_state"])
+        self.assertEqual(db.download_logs, [])
+
+    def test_probe_online_but_enqueue_user_offline_writes_log(self):
+        """Safety net: if the probe says ``Online`` (status endpoint stale)
+        but ``transfers.enqueue`` then raises a peer-offline HTTPError,
+        Part 1's classification + Part 2's log site compose so the
+        request returns to wanted with a ``user_offline`` log row."""
+        from lib.enqueue import try_enqueue
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI(downloads=[])
+        slskd.users.set_status("pooyork", "Online")
+        slskd.transfers.enqueue_error = self._build_offline_http_error()
+        ctx = self._setup_ctx(db, slskd, speeds={"pooyork": 10_000})
+        results = {"pooyork": {"flac": ["Music\\pooyork\\Album"]}}
+        tracks = cast(
+            Any, [{"albumId": 1, "title": "Track 1", "mediumNumber": 1}],
+        )
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch("lib.enqueue.check_for_match",
+                   side_effect=self._wave_match_side_effect()), \
+             patch("time.sleep"):
+            try_enqueue(tracks, results, "flac", ctx)
+
+        # Probe said Online, so we did try.
+        self.assertEqual(slskd.users.status_calls, ["pooyork"])
+        self.assertEqual(len(slskd.transfers.enqueue_calls), 1)
+        # Reset to wanted via verified-no-acceptance, with a log row.
+        self.assertEqual(db.request(1)["status"], "wanted")
+        self.assertEqual(len(db.download_logs), 1)
+        log = db.download_logs[0]
+        self.assertEqual(log.outcome, "user_offline")
+        self.assertEqual(log.soulseek_username, "pooyork")
+        self.assertEqual(log.filetype, "flac")
+
+
 class TestDispatchThroughQualityGate(unittest.TestCase):
     """Integration slice: dispatch_import_core → real parse_import_result
     → real _check_quality_gate_core → domain state assertions.


### PR DESCRIPTION
## Summary

Two-part fix for the `all transfers vanished from slskd` false-timeout class observed against request 2540 (Mercury Rev — Deserter's Songs / `pooyork`) on 2026-05-08.

- **Part 1** — `slskd_enqueue_with_outcome` now classifies slskd's user-offline `HTTPError` (response body contains `"appears to be offline"`) as `rejected` instead of `unknown`. The pre-existing `rejected` branch in `try_enqueue` now also writes a `download_log` row (`outcome="user_offline"`) so the failure is visible immediately rather than disappearing into a silent status flip and resurfacing 60+ seconds later as a misleading vanish-timeout.
- **Part 2** — A new `_peer_is_online_for_enqueue` probe sits in the `try_enqueue` match loop (between the empty-files check and the download-ownership claim). It calls `slskd.users.status(username).presence`. On `Offline` we skip the candidate without claiming and continue iterating to the next eligible (user, dir). `Online` and `Away` both proceed to enqueue. If `users.status` raises, we fall through and let Part 1's classification handle the actual peer-offline case as the safety net.

No persistence: no Redis key, no cooldown row, no in-process state. Next cycle starts fresh.

## Why this matters now

The Redis peer cache has grown large (1000+ hits/cycle). Cached directory listings remain valid for users who were online when we last browsed but have since gone offline. Without these two fixes, we waste a 60s+ poll cycle per stale-cache match and the operator sees the wrong cause in `pipeline-cli show`. There are 9 such `download_log` rows in the database since 2026-05-05 — all expected to disappear once this lands.

## Implementation units (each its own commit)

1. `docs/brainstorms/2026-05-08-peer-online-probe-at-enqueue-requirements.md` + `docs/plans/2026-05-08-002-fix-peer-online-probe-at-enqueue-plan.md`
2. `FakeSlskdUsers.status()` + `set_status` / `set_status_error` test helpers
3. `lib/download.py` — `_is_user_offline_http_error()` + tiered exception handler in `slskd_enqueue_with_outcome`
4. `lib/enqueue.py` — `download_log` row write at the rejected branch
5. `lib/enqueue.py` — `_peer_is_online_for_enqueue()` probe + match-loop call site
6. `tests/test_integration_slices.py` — three composed slices (failover, both offline, probe-online-but-enqueue-rejects)

One test-isolation gotcha discovered: `tests/test_beets_validation.py:18` mutates `sys.modules["requests"] = MagicMock()` at discovery time. Production code uses structural matching on `.response.text` (no `isinstance(requests.exceptions.HTTPError)` dependency); test fixtures use synthetic exception classes with the matching shape.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3135 tests pass, 55 skipped
- [x] `pyright lib/download.py lib/enqueue.py tests/fakes.py` — 0 errors
- [x] U2: 7 unit tests in `TestSlskdEnqueueWithOutcome` covering offline classification, case-insensitive body match, no-response defensive path, ConnectionError fall-through, regression guard for `accepted`/`rejected` happy paths
- [x] U3: 2 orchestration tests asserting `download_log.outcome="user_offline"` is written on verified-no-acceptance and NOT written when the residual-claim safety net fires
- [x] U4: 5 orchestration tests covering `Offline` skip, `Online`/`Away` proceed, `status()` exception fall-through, two-user failover
- [x] U5: 3 integration slices through real `try_enqueue` + real `slskd_enqueue_with_outcome` composition
- [ ] Post-deploy: monitor `download_log` for 24 h — expect zero new `error_message='all transfers vanished from slskd'` rows attributable to peer-offline status

## Deployment

Standard flake-update flow per `.claude/rules/deploy.md`:
- `nix flake update cratedigger-src` on doc1
- `nixos-rebuild switch` on doc2
- `cratedigger.service` has `restartIfChanged = false`; the next 5-min timer cycle picks up the new code automatically. No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)