### PR TITLE
fix(harness): tolerate non-UTF-8 stderr in subprocess captures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ tests/                  — 1400+ tests; fakes.py + helpers.py shared infra
 nix/                    — slskd-api build, package.nix, shell.nix, module.nix, VM check
 flake.nix               — Outputs: slskd-api, devShell, nixosModules.default, checks.moduleVm
 docs/                   — Subsystem docs referenced from this file
+docs/solutions/         — Compounding lessons from past bugs/decisions, organized by category with YAML frontmatter (module, tags, problem_type). Worth a grep when debugging in a documented area.
 .claude/rules/          — Path-scoped auto-loaded rules (code-quality, nix-shell, deploy, ...)
 ```
 

--- a/docs/solutions/runtime-errors/subprocess-text-mode-utf8-strict-decode-crash.md
+++ b/docs/solutions/runtime-errors/subprocess-text-mode-utf8-strict-decode-crash.md
@@ -1,0 +1,208 @@
+---
+title: "subprocess text mode decodes captured streams as UTF-8 strict"
+date: 2026-05-08
+category: runtime-errors
+problem_type: runtime_error
+component: harness
+severity: high
+tags:
+  - subprocess
+  - encoding
+  - ffmpeg
+  - sox
+  - flac
+  - vorbis-comments
+  - defense-in-depth
+related_pr: https://github.com/abl030/cratedigger/pull/232
+related_files:
+  - harness/import_one.py
+  - lib/spectral_check.py
+  - lib/util.py
+  - lib/import_dispatch.py
+  - lib/beets.py
+  - lib/beets_album_op.py
+  - lib/audio_hash.py
+---
+
+# subprocess text mode decodes captured streams as UTF-8 strict
+
+## Context
+
+Live trigger: request 580 (78 Saab — *Crossed Lines*), download from
+Soulseek peer `trelospatrinos`, 2026-05-08 14:23 UTC. The album was
+already in beets at 320 kbps CBR; the pipeline was searching for a
+lossless upgrade. trelospatrinos's FLAC files passed validation, audio
+integrity, and spectral analysis, then crashed at the `[CONVERT]` step
+with:
+
+```
+decision:  crash
+exit_code: 99
+error:     UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in
+           position 32388: invalid continuation byte
+```
+
+The request bounced back to `wanted` (status reset, no denylist applied
+because the peer wasn't at fault), so the same crash could repeat
+indefinitely on every cycle.
+
+## Guidance
+
+When running an external binary that operates on user-supplied data
+(audio files, files with arbitrary metadata, anything tagged in an
+unknown encoding), **always pair `text=True` with `errors="replace"`**
+on `subprocess.run` and `subprocess.Popen`:
+
+```python
+# Correct — bad bytes become U+FFFD instead of crashing the caller.
+result = subprocess.run(
+    cmd,
+    capture_output=True,
+    text=True,
+    errors="replace",   # <-- the safety net
+    timeout=300,
+)
+
+# Same applies to Popen:
+proc = subprocess.Popen(
+    cmd,
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    text=True, errors="replace",
+)
+```
+
+The fix is mechanical, but the failure mode it prevents is sneaky:
+`text=True` defaults to UTF-8 strict, and the decode happens **during
+capture inside `subprocess.run` itself**, before the function ever
+returns. A `try/except` block around the call that only catches
+`subprocess.TimeoutExpired` (the most common pattern) will not catch
+the decode error — `UnicodeDecodeError` propagates straight up from
+`_translate_newlines()` deep inside `Popen._communicate`.
+
+Prior art lived in this repo at `lib/audio_hash.py:113` — that file
+already used `stderr.decode("utf-8", errors="replace")` after capturing
+in binary mode. The pattern wasn't generalized to other sites, and
+fifteen `subprocess.run(..., text=True, ...)` calls across six files
+were left vulnerable for over a year before request 580 surfaced the
+problem.
+
+## Why this matters
+
+The decode-on-capture failure mode has three properties that combine to
+make it a high-impact, low-detection bug:
+
+1. **It's invisible in tests.** Most unit tests mock `subprocess.run`
+   with clean `MagicMock(stdout="", stderr="")` returns. The decoding
+   step is never exercised. Even integration tests that use real
+   subprocesses usually feed clean inputs that don't trip strict UTF-8.
+
+2. **It's impossible to catch with the obvious try/except.** Code that
+   already wraps the call in `try: ... except subprocess.TimeoutExpired:`
+   looks defensive, but the protection is only against one specific
+   failure mode. `UnicodeDecodeError` is raised from a completely
+   different code path inside `Popen._communicate` →
+   `_translate_newlines` → `data.decode(encoding, errors)`.
+
+3. **Real-world audio metadata is rarely clean UTF-8.** Soulseek-sourced
+   FLAC files are often tagged with non-UTF-8 encodings (CP1252 from
+   Windows rippers, Shift-JIS from Japanese sources, raw Latin-1).
+   ffmpeg/sox echo Vorbis comment values into stderr in their verbose
+   output, so any tagged file with a non-ASCII character can trigger
+   the crash. Position 32388 in the live error corresponds to a tag
+   value being dumped roughly 32 KB into ffmpeg's stream-info section.
+
+The blast radius is also worse than it looks. A single bad file from
+any peer crashes the entire import for that album, returns the request
+to `wanted` without recording a real decision, and lets the same peer
+be retried on the next cycle — the failure isn't attributed to the
+peer (no denylist write), so the loop is permanent until a different
+peer is tried or the underlying bug is fixed.
+
+## When to apply
+
+Pair `text=True` with `errors="replace"` whenever **all** of the
+following are true:
+
+- The subprocess output is captured (`capture_output=True`,
+  `stdout=PIPE`, or `stderr=PIPE`).
+- The subprocess operates on data that came from outside our trust
+  boundary — user uploads, peer downloads, scraped metadata, or any
+  binary's verbose mode that echoes file content.
+- The caller decodes the captured streams as text (`text=True` /
+  `encoding=...`).
+
+Sites in this repo that should always follow the pattern:
+
+- ffmpeg / ffprobe / sox / flac / mp3val on audio files
+- beets harness drivers (beets reads tags via mutagen and re-emits them)
+- any subprocess that runs a user-supplied script or processes a
+  user-supplied filename
+
+Sites where it's safe to rely on UTF-8 strict:
+
+- Subprocesses that only emit machine-generated output (JSON, CSV,
+  numeric stdout) and never echo user data on stderr.
+- Subprocesses operating on data we generated ourselves in this
+  process (round-tripping our own UTF-8 strings).
+
+When in doubt, add `errors="replace"`. The cost is one keyword
+argument; the consumers in this codebase already tolerate U+FFFD
+because they parse numeric values, search for known substrings, or
+truncate stderr to the last 200 characters for logging.
+
+## Examples
+
+**Crash site (request 580 reproduction):**
+
+```python
+# harness/import_one.py — convert_lossless, before
+result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+# ↑ Raises UnicodeDecodeError if ffmpeg stderr contains any non-UTF-8 byte.
+#   The surrounding `try/except subprocess.TimeoutExpired` does NOT catch it.
+```
+
+```python
+# harness/import_one.py — convert_lossless, after
+result = subprocess.run(
+    cmd, capture_output=True, text=True, errors="replace", timeout=300,
+)
+# ↑ Bad bytes become U+FFFD. ffmpeg returncode and stderr text are still
+#   inspected normally; the only difference is that bad bytes survive
+#   capture instead of crashing the caller.
+```
+
+**RED test that reproduces the failure mode** (see
+`tests/test_import_one_stages.py::TestConvertLosslessNonUtf8Stderr`):
+
+```python
+def test_convert_lossless_tolerates_non_utf8_ffmpeg_stderr(self):
+    """A fake ffmpeg shim emits 0xE2+ASCII to stderr. Pre-fix this raises
+    UnicodeDecodeError before subprocess.run returns; post-fix it returns
+    cleanly."""
+    bin_dir = tmp + "/bin"
+    write_shim(bin_dir, "ffmpeg", body=
+        'OUT="${@: -1}"\n'
+        'printf "metadata: title=caf\\xe2X end\\n" >&2\n'   # bare 0xE2
+        'printf "id3" > "$OUT"\n'
+        'exit 0\n'
+    )
+    with override_path(bin_dir):
+        converted, failed, ext = convert_lossless(album, V0_SPEC)
+    assert (converted, failed, ext) == (1, 0, "flac")
+```
+
+The test approach generalizes: drop a `#!/bin/sh` shim that emits the
+problematic bytes, prepend its directory to `PATH`, run the function
+under test. No mocks, no reliance on real ffmpeg behavior — directly
+exercises the `subprocess.run(text=True)` decode path.
+
+**Sites fixed in [PR #232](https://github.com/abl030/cratedigger/pull/232)**
+(15 sites across 6 files):
+
+- `harness/import_one.py` — 5× `subprocess.run` (ffprobe, ffmpeg) +
+  1× `subprocess.Popen` (beets harness driver)
+- `lib/spectral_check.py` — 2× (sox, ffmpeg)
+- `lib/util.py` — 4× (mp3val, ffmpeg validate, flac repair, ffmpeg retest)
+- `lib/import_dispatch.py` — 1× (import_one subprocess)
+- `lib/beets.py` — 1× (harness Popen)
+- `lib/beets_album_op.py` — 1× (`beet remove` / `beet move`)

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -524,7 +524,7 @@ def _get_folder_bitrates(folder_path,
                  "-select_streams", "a:0",
                  "-show_entries", "stream=bit_rate",
                  "-of", "csv=p=0", fpath],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True, text=True, errors="replace", timeout=30,
             )
             br_str = result.stdout.strip().rstrip(",")
             # VBR MP3s return N/A for stream bitrate — fall back to format
@@ -533,7 +533,7 @@ def _get_folder_bitrates(folder_path,
                     ["ffprobe", "-v", "error",
                      "-show_entries", "format=bit_rate",
                      "-of", "csv=p=0", fpath],
-                    capture_output=True, text=True, timeout=30,
+                    capture_output=True, text=True, errors="replace", timeout=30,
                 )
                 br_str = result.stdout.strip().rstrip(",")
             if br_str and br_str.isdigit():
@@ -580,7 +580,7 @@ def _ffprobe_audio_codec_name(fpath: str) -> str | None:
         result = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "a:0",
              "-show_entries", "stream=codec_name", "-of", "json", fpath],
-            capture_output=True, text=True, timeout=10)
+            capture_output=True, text=True, errors="replace", timeout=10)
         if result.returncode != 0:
             return None
         payload: object = json.loads(result.stdout or "{}")
@@ -686,7 +686,8 @@ def _temp_v0_probe(
             ]
             try:
                 result = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=300)
+                    cmd, capture_output=True, text=True, errors="replace",
+                    timeout=300)
             except subprocess.TimeoutExpired:
                 failed += 1
                 continue
@@ -768,8 +769,12 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
                *spec.metadata_args,
                "-y", temp_out_path]
         try:
+            # errors="replace" so non-UTF-8 bytes in ffmpeg stderr (e.g.
+            # CP1252-tagged FLAC Vorbis comments echoed in verbose output)
+            # don't raise UnicodeDecodeError during capture and crash the
+            # whole import — request 580 (78 Saab — Crossed Lines) hit this.
             result = subprocess.run(cmd, capture_output=True, text=True,
-                                    timeout=300)
+                                    errors="replace", timeout=300)
         except subprocess.TimeoutExpired:
             print(f"  [FAIL] {fname}: ffmpeg timed out after 300s",
                   file=sys.stderr)
@@ -817,7 +822,8 @@ def run_import(path, mb_release_id):
 
     proc = subprocess.Popen(
         cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, text=True, preexec_fn=os.setsid,
+        stderr=subprocess.PIPE, text=True, errors="replace",
+        preexec_fn=os.setsid,
         env=beets_subprocess_env(),
     )
     assert proc.stdin is not None

--- a/lib/beets.py
+++ b/lib/beets.py
@@ -36,7 +36,8 @@ def beets_validate(harness_path, album_path, mb_release_id, distance_threshold=0
     logger.info(f"BEETS_VALIDATE: cmd={' '.join(cmd)}")
 
     try:
-        proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, text=True,
+        proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE,
+                        text=True, errors="replace",
                         env=beets_subprocess_env())
     except Exception as e:
         result.error = f"Failed to start harness: {e}"

--- a/lib/beets_album_op.py
+++ b/lib/beets_album_op.py
@@ -191,7 +191,7 @@ def _run_beet_op(
         # ``beet move`` doesn't prompt, so the extra byte is harmless there.
         proc = sp.run(
             argv,
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True, text=True, errors="replace", timeout=timeout,
             env=beets_subprocess_env(),
             input="y\n",
         )

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -266,6 +266,7 @@ def run_import_one(
         cmd,
         capture_output=True,
         text=True,
+        errors="replace",
         timeout=timeout,
         env=beets_subprocess_env(),
     )

--- a/lib/spectral_check.py
+++ b/lib/spectral_check.py
@@ -236,7 +236,10 @@ def _get_band_rms(filepath, lo_hz, hi_hz, trim_seconds=30):
     if trim_seconds:
         cmd.extend(["trim", "0", str(trim_seconds)])
     cmd.extend(["sinc", "%d-%d" % (lo_hz, hi_hz), "stat"])
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    # errors="replace": sox echoes filename + tag bytes; non-UTF-8 metadata
+    # would otherwise raise UnicodeDecodeError during capture.
+    result = subprocess.run(cmd, capture_output=True, text=True,
+                            errors="replace", timeout=60)
     rms = parse_rms_from_stat(result.stderr)
     if rms is None:
         last_line = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else f"sox exit {result.returncode}"
@@ -262,7 +265,8 @@ def _ffmpeg_to_wav(src, dst, trim_seconds=30):
     if trim_seconds:
         cmd.extend(["-t", str(trim_seconds)])
     cmd.extend(["-ar", "48000", "-ac", "2", "-f", "wav", "-bitexact", dst])
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    result = subprocess.run(cmd, capture_output=True, text=True,
+                            errors="replace", timeout=30)
     if result.returncode != 0:
         last_line = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else f"ffmpeg exit {result.returncode}"
         raise _DecodeFailedError(f"ffmpeg: {last_line}")

--- a/lib/util.py
+++ b/lib/util.py
@@ -213,7 +213,8 @@ def repair_mp3_headers(folder_path: str) -> None:
             filepath = os.path.join(root, f)
             try:
                 result = sp.run(["mp3val", "-f", "-nb", filepath],
-                                capture_output=True, text=True, timeout=60)
+                                capture_output=True, text=True,
+                                errors="replace", timeout=60)
                 if "FIXED" in result.stdout:
                     logger.info(f"MP3VAL: fixed {f}")
             except FileNotFoundError:
@@ -293,7 +294,7 @@ def validate_audio(folder_path: str, mode: str = "normal") -> AudioValidationRes
             result = sp.run(
                 ["ffmpeg", "-v", "error", "-i", filepath,
                  "-map", "0:a", "-f", "null", "-"],
-                capture_output=True, text=True, timeout=300
+                capture_output=True, text=True, errors="replace", timeout=300
             )
             ffmpeg_returncode = result.returncode
             stderr = result.stderr.strip()
@@ -301,13 +302,15 @@ def validate_audio(folder_path: str, mode: str = "normal") -> AudioValidationRes
                 logger.info(f"AUDIO_CHECK: fixing unset MD5: {display}")
                 fix = sp.run(
                     ["flac", "-f", "--verify", filepath],
-                    capture_output=True, text=True, timeout=300,
+                    capture_output=True, text=True, errors="replace",
+                    timeout=300,
                 )
                 if fix.returncode == 0:
                     retest = sp.run(
                         ["ffmpeg", "-v", "error", "-i", filepath,
                          "-map", "0:a", "-f", "null", "-"],
-                        capture_output=True, text=True, timeout=300,
+                        capture_output=True, text=True, errors="replace",
+                        timeout=300,
                     )
                     ffmpeg_returncode = retest.returncode
                     stderr = retest.stderr.strip()

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -704,6 +704,64 @@ class TestConvertLosslessKeepSource(unittest.TestCase):
             self.assertFalse(os.path.exists(flac_path))
 
 
+class TestConvertLosslessNonUtf8Stderr(unittest.TestCase):
+    """Regression: subprocess.run(text=True) decodes stderr as UTF-8 strict by
+    default, so any non-UTF-8 byte in ffmpeg's stderr (typical when FLAC Vorbis
+    comments are CP1252-tagged) raises UnicodeDecodeError DURING capture and
+    crashes the import. Repro from request 580 (78 Saab — Crossed Lines,
+    trelospatrinos, 2026-05-08): exit_code=99,
+    `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 32388`.
+    """
+
+    def _make_shim(self, bin_dir: str, name: str, body: str) -> str:
+        """Drop a #!/bin/sh shim into bin_dir; return its path."""
+        path = os.path.join(bin_dir, name)
+        with open(path, "w") as f:
+            f.write("#!/bin/sh\n" + body)
+        os.chmod(path, 0o755)
+        return path
+
+    def test_convert_lossless_tolerates_non_utf8_ffmpeg_stderr(self):
+        """A fake ffmpeg that writes 0xE2 + ASCII to stderr must not crash convert_lossless.
+
+        Without errors='replace' on the subprocess.run capture, this raises
+        UnicodeDecodeError before subprocess.run even returns — exactly the
+        live crash on request 580.
+        """
+        import tempfile
+        from harness.import_one import convert_lossless, V0_SPEC
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bin_dir = os.path.join(tmpdir, "bin")
+            os.makedirs(bin_dir)
+            # Fake ffmpeg: take the last arg as output, create it, emit
+            # 32KB of stderr containing a bare 0xE2 byte (not a UTF-8 lead),
+            # exit 0.
+            self._make_shim(bin_dir, "ffmpeg", (
+                'OUT="${@: -1}"\n'
+                # Pad to ~32KB so the bad byte sits well into the stderr buffer.
+                'printf "%.s ffmpeg version pad pad pad pad pad pad pad pad\\n" {1..600} >&2\n'
+                # Bare 0xE2 followed by ASCII X (no UTF-8 continuation byte).
+                'printf "metadata: title=caf\\xe2X end\\n" >&2\n'
+                # Write a tiny non-empty output so convert_lossless counts it.
+                'printf "id3" > "$OUT"\n'
+                'exit 0\n'
+            ))
+            album = os.path.join(tmpdir, "album")
+            os.makedirs(album)
+            with open(os.path.join(album, "track01.flac"), "wb") as f:
+                f.write(b"fLaC")  # placeholder; only the extension matters for _is_lossless_file
+            saved_path = os.environ.get("PATH", "")
+            try:
+                os.environ["PATH"] = bin_dir + os.pathsep + saved_path
+                # Pre-fix this raises UnicodeDecodeError; post-fix it returns cleanly.
+                converted, failed, ext = convert_lossless(album, V0_SPEC)
+            finally:
+                os.environ["PATH"] = saved_path
+            self.assertEqual(converted, 1, "shim wrote a non-empty output file → counted as converted")
+            self.assertEqual(failed, 0)
+            self.assertEqual(ext, "flac")
+
+
 # ============================================================================
 # --preserve-source CLI flag — issue #111
 # ============================================================================


### PR DESCRIPTION
## Summary

- `subprocess.run(text=True)` decodes stderr as UTF-8 **strict** during capture; non-UTF-8 bytes raise `UnicodeDecodeError` before the call returns, propagating past existing `TimeoutExpired`-only try/except blocks and crashing the whole import.
- Add `errors="replace"` to every text-mode subprocess capture that runs an external binary on user-supplied audio metadata (ffmpeg, ffprobe, sox, mp3val, flac, beets, the import_one harness itself).
- Mirrors the prior-art pattern at `lib/audio_hash.py:113`. All call-sites already tolerate the U+FFFD replacement char (they parse numeric stdout or grep stderr for known substrings).

## Live repro

Request 580 (78 Saab — *Crossed Lines*), peer `trelospatrinos`, 2026-05-08:

```
decision:  crash
error:     UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 32388: invalid continuation byte
```

Crash happened in `convert_lossless` at `harness/import_one.py:771` — ffmpeg's verbose stderr included a Latin-1 byte from the FLAC's Vorbis comments, the strict UTF-8 decoder raised, the request bounced back to `wanted`, and the same peer can be retried indefinitely.

## Sites fixed (15)

- `harness/import_one.py` — 5× `subprocess.run` (ffprobe / ffmpeg) + 1× `subprocess.Popen` (beets harness driver)
- `lib/spectral_check.py` — 2× (sox, ffmpeg)
- `lib/util.py` — 4× (mp3val, ffmpeg validate, flac repair, ffmpeg retest)
- `lib/import_dispatch.py` — 1× (import_one subprocess)
- `lib/beets.py` — 1× (harness Popen)
- `lib/beets_album_op.py` — 1× (`beet remove` / `beet move`)

## Lesson captured

[docs/solutions/runtime-errors/subprocess-text-mode-utf8-strict-decode-crash.md](../blob/fix/subprocess-utf8-decode-crash/docs/solutions/runtime-errors/subprocess-text-mode-utf8-strict-decode-crash.md) records the general pattern so future sessions don't have to rediscover it: the decode happens *during* capture (so `try/except TimeoutExpired` doesn't help), it's invisible in mocked-subprocess tests, and Soulseek-sourced audio metadata is rarely clean UTF-8 in practice. CLAUDE.md now surfaces `docs/solutions/` in the Repository layout block so the lesson is discoverable.

## Test plan

- [x] RED test in `tests/test_import_one_stages.py::TestConvertLosslessNonUtf8Stderr` drops a fake `ffmpeg` shim on PATH that emits `0xE2 + ASCII` to stderr — pre-fix it reproduces the exact live error (`UnicodeDecodeError at byte 0xe2 in _translate_newlines`); post-fix it returns cleanly.
- [x] Full suite green (3150 tests, 55 skipped).
- [x] Pyright clean across all touched files.
- [ ] Deploy to doc2 and verify the next download attempt for request 580 either imports or rejects with a real decision (not `crash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)