### PR TITLE
fix: kill cratedigger-web wedge with minimal Python patch (#233)

### DIFF
--- a/cratedigger.py
+++ b/cratedigger.py
@@ -1603,19 +1603,6 @@ def main():
             logger.warning(f"Failed to persist peer-dir observations: {e}")
 
     finally:
-        # Bust web UI cache so freshly imported albums appear immediately
-        try:
-            import urllib.request
-            req = urllib.request.Request(
-                "http://localhost:8085/api/cache/invalidate",
-                data=b'{"groups": ["pipeline", "library"]}',
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=2)
-        except Exception:
-            pass  # web UI may be down — that's fine
-
         # Clean up pipeline DB connection
         if pipeline_db_source is not None:
             try:

--- a/docs/brainstorms/2026-05-09-cratedigger-web-rust-rewrite-requirements.md
+++ b/docs/brainstorms/2026-05-09-cratedigger-web-rust-rewrite-requirements.md
@@ -1,0 +1,184 @@
+---
+date: 2026-05-09
+topic: cratedigger-web-rust-rewrite
+supersedes: 2026-05-09-web-stack-bottle-waitress-requirements.md
+status: superseded
+superseded_by: ../solutions/web-rewrite-deferred-pending-runtime-redesign.md
+---
+
+# Cratedigger-Web — Rewrite in Rust (axum + sqlx)
+
+> **Superseded.** ce-doc-review on this doc surfaced a P0 finding (feasibility persona): R11's "all 52 routes ported" silently included ~4,000 LOC of pipeline business logic that web POST handlers orchestrate from `lib/*` (`manual_import`, `import_queue`, `wrong_match_triage`, `import_preview`, `search_plan_service`, `audio_hash`, `release_cleanup`, etc.). The web layer is not the autonomous facade this doc treated it as; carving it out into a separate language requires either re-deriving the lib code (forgets accumulated bug-fixes from many incidents) or designing a new IPC boundary (new design + maintenance + cross-language debugging). Neither is a "rewrite the web layer" project — both are cratedigger-runtime-redesign projects with the web rewrite as a beneficiary. The active decision lives at `docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md`: apply a minimal Python patch to kill the current wedge; defer any rewrite to be part of a future cratedigger runtime redesign (cycle-driven → static / event-driven). This doc is retained for context only — the wedge-impossibility design exploration, the axum + sqlx + rusqlite + fred research, and the parallel-run bake-in shape are useful prior art for the future rewrite when its preconditions hold.
+
+## Summary
+
+Rewrite `cratedigger-web` from Python (stdlib `http.server`) to Rust (axum 0.8 + tokio + sqlx for PostgreSQL + rusqlite for the beets read-only sqlite + fred for Redis + reqwest with rustls for MB/Discogs proxying + tracing + crane for the Nix build). The pipeline (`cratedigger.py` and the importer worker) stays in Python — beets is Python and that's not changing. The two processes communicate only via shared PostgreSQL, shared sqlite (read-only), shared Redis, and shared filesystem; no direct IPC. The 52 routes ship in one all-at-once binary, parallel-deployed alongside the Python service on a different port for a 1-week bake-in before cut-over. A small Python stop-gap patch ships first to stop the wedge while the rewrite is in progress.
+
+---
+
+## Problem Frame
+
+`cratedigger-web` wedged silently for ~9 hours on 2026-05-08 (issue #233). systemd reported `active (running)`, the listener still accepted TCP, but every HTTP request hung forever until manual `systemctl restart`. Forensics traced the wedge to a sustained reconnect storm: the cratedigger main loop's end-of-cycle `POST /api/cache/invalidate` (`cratedigger.py:1610`) closes the socket mid-body before the server finishes writing the response, the `do_POST` catch-all treats the resulting `BrokenPipeError` as a database error and unconditionally tears down + reopens the psycopg2 connection, and ~3 unnecessary reconnects per minute compound until the single-threaded server thread blocks indefinitely in `poll()`. Sibling issue #227 had been tracking the BrokenPipe count climbing as a leading indicator.
+
+The first attempt at a fix migrated to Bottle + waitress (`docs/brainstorms/2026-05-09-web-stack-bottle-waitress-requirements.md`). The ce-doc-review pass on that doc surfaced two structural problems with the design:
+
+1. waitress has **no per-request timeout** — only `channel_timeout` for idle clients. The Key Decisions rationale that "waitress's request timeout makes the wedge unreachable" was factually wrong.
+2. The per-thread psycopg2 connection model needed real engineering — connection-on-thread-exit cleanup, dead-connection detection beyond `conn.closed`, advisory_lock invariant inversion, autocommit enforcement — none of which the Bottle migration trivially solved.
+
+Reconsidering the framework choice opened a wider question: why stay in Python for the web layer at all? The web UI doesn't touch beets directly; it reads `beets-library.db` as a sqlite file. The beets-as-Python constraint lives in `cratedigger.py`, not here. Going Rust replaces "engineer wedge-resistant request handling" with "use the standard tokio + tower middleware that gives wedge-impossible request handling as a property of the runtime."
+
+The cost is a meaningful rewrite (~52 routes, 3 weeks focused). The benefit is that wedging stops being a class of failure that exists, plus end-to-end type safety (sqlx compile-time SQL validation, serde JSON contracts, rustc enforcing extractor types) that Python + pyright cannot match.
+
+---
+
+## Requirements
+
+**Stack and runtime**
+
+- R1. The web service is a single Rust binary, deployed via Nix on doc2. Built with `crane` (current consensus 2026 nixpkgs Rust integration). systemd unit stays `Type=simple` + `Restart=on-failure` + `RestartSec=5`.
+- R2. The web framework is **axum 0.8**. The async runtime is **tokio** (multi-threaded). The middleware layer is **tower-http** for `TimeoutLayer`, `TraceLayer`, `CorsLayer`, `ConcurrencyLimitLayer`, and `ServeDir` for static files.
+- R3. **PostgreSQL access uses `sqlx`** (with `postgres`, `runtime-tokio`, `tls-rustls`, `macros`, `migrate`, `json`, `time`, `uuid` features). Compile-time SQL validation via `query!`/`query_as!` macros, with offline-mode `.sqlx/` directory committed to the repo so Nix builds work without DB access (`SQLX_OFFLINE=true` in the build environment).
+- R4. **Beets `library.db` access uses `rusqlite`** (read-only mode, WAL-aware, `busy_timeout(5s)`), wrapped in `tokio::task::spawn_blocking`. Pool size 4 via `r2d2`/`r2d2_sqlite`. Not `sqlx::Sqlite` — sqlx's single-shared-connection model composes badly with WAL + an external writer (beets touches the file occasionally).
+- R5. **Redis access uses `fred`** with `enable-rustls`. Built-in pool with native reconnection handling (matters when Redis flaps during a `nixos-rebuild switch`).
+- R6. **HTTP client for MB/Discogs mirror proxying uses `reqwest`** with `rustls-tls`, no OpenSSL transitive dep. Per-client timeouts: `timeout(10s)`, `connect_timeout(2s)`, `pool_idle_timeout(60s)`. One `reqwest::Client` in `AppState`, cheaply cloned per request.
+
+**Concurrency and wedge-impossibility properties**
+
+- R7. **Per-request timeout is enforced by the runtime**, not by application code. `tower_http::timeout::TimeoutLayer::new(Duration::from_secs(30))` as an outer layer aborts the request future at the timeout. PG `statement_timeout` is set on the pool connect options (20s) as a defence-in-depth lower bound. Both are configured; neither relies on the other being missing.
+- R8. **Pool exhaustion is bounded by middleware, not by infinite queueing.** `tower::limit::ConcurrencyLimitLayer::new(40)` caps inflight requests before they reach the pool. `sqlx::PgPool::max_connections(20)` + `acquire_timeout(5s)` caps the database side. Excess requests get `503` fast, not infinite queue.
+- R9. **No global mutable state.** `AppState` is constructed once in `main`, `Arc`-shared via the `State<Arc<AppState>>` extractor. No re-implementation of `_try_reconnect_db` — sqlx's pool detects broken connections, evicts them, and opens new ones on next acquire. Application code maps `sqlx::Error::Io` to a 503 via `AppError::IntoResponse`.
+- R10. **Handler panics are contained.** tokio's task runtime catches panics; axum returns a 500 to the affected client; other tasks are unaffected. Application code uses `?` on a single `AppError` enum (built with `thiserror`) — no `unwrap`/`expect` on user input.
+
+**Routes and route porting**
+
+- R11. **All 52 existing routes are ported with functional parity.** Browse (12), labels (2), library (4), imports (12), pipeline (22). No new endpoints, no UI behaviour changes, no auth. The cratedigger main loop's `POST /api/cache/invalidate` call (`cratedigger.py:1610`) is deleted; the corresponding route is not implemented in Rust.
+- R12. **JSON field naming is snake_case** end-to-end. Every public-facing struct carries `#[serde(rename_all = "snake_case")]` (the existing JS expects snake_case; rustc cannot catch a mismatch).
+- R13. **Static assets** (`web/index.html`, `web/js/*.js`, any CSS) are served via `tower_http::services::ServeDir` mounted at `/`. No build step, no npm — the existing vanilla-JS frontend ships unchanged.
+- R14. **Audio file Range streaming** (`/api/wrong-matches/audio/{id}` and any other range routes) uses a hand-rolled handler (~80 lines) backed by `tokio::fs::File` + `seek` + `tokio_util::io::ReaderStream`. Required behaviour preserved from the existing Python handler: `Accept-Ranges: bytes`, `Content-Range` on 206 and 416, suffix-range support (`bytes=-N`), explicit single-range-only (multi-range rejected with 416), `Cache-Control: no-cache`, `Access-Control-Allow-Origin: *` (load-bearing for the dev tunnel proxy). Reference: `axum-range` source.
+- R15. **CORS policy** preserves today's `Access-Control-Allow-Origin: *` plus `OPTIONS` handling. Implemented via `tower_http::cors::CorsLayer::permissive()` on `/api/*` routes (or stricter if planning identifies a tightening opportunity).
+
+**Local-dev, test, and observability**
+
+- R16. **Local-dev iteration loop** is `cargo watch -x run` inside `nix develop`. Cold compile of the full stack is 3-5 minutes (one-time pain); incremental compile is 5-15 seconds. The existing `scripts/web_dev_server.py` workflow is replaced — the Rust binary serves both production and dev. The `--data prod-api` proxy mode (currently used to point a local frontend at a remote backend) is reimplemented as a CLI flag on the Rust binary.
+- R17. **Test discipline** — four layers, each with first-class Rust tooling:
+  - **Unit tests** — colocated `#[cfg(test)] mod tests` per module. Pure logic only.
+  - **Route-level tests** — call `app.clone().oneshot(Request)` directly via `tower::ServiceExt`. No port binding, no HTTP transport. The contract-test concept (assert response shape includes required fields) is preserved, but stronger: deserialize as the typed response struct and let the compiler enforce the contract.
+  - **DB integration tests** — `sqlx::test` macro creates a per-test database via PG template, runs migrations, hands the test a `PgPool`, drops at end. Requires a Postgres for testing (already available; existing `migrations/NNN_name.sql` files run unchanged).
+  - **HTTP client mocking** — `wiremock-rs` for MB/Discogs mirror proxy tests.
+- R18. **Route audit** — preserve the `TestRouteContractAudit` discipline that fails fast if a new route ships unclassified. Implemented as a manual `const ROUTES: &[(Method, &str)]` registry that's both the source of registration AND the source of audit truth, OR via wrapping the `Router` to expose registered paths for introspection. Either approach is acceptable; planning picks one.
+- R19. **Wedge-class regression test** — a test asserts that a client closing the socket mid-response produces no journald traceback, no DB reconnect, no second body-write attempt, and the worker thread is immediately available for the next request. Implementation: raw `TcpStream` from a test, send headers + partial body, close, then assert another concurrent `reqwest` GET to a different endpoint completes normally.
+- R20. **Observability** is `tracing` + `tracing-subscriber` with `EnvFilter` (RUST_LOG) and JSON formatter to stdout. journald reads JSON from stdout; `journalctl -o json | jq` works for free. `tower_http::trace::TraceLayer` gives per-request span (method, path, status, latency).
+
+**Cut-over**
+
+- R21. **Parallel-run bake-in.** The Rust binary deploys on a new port (e.g. `:8086`) alongside the Python service on `:8085`. A diff harness (small standalone script) hits both with the same request and compares JSON responses for a representative set of routes. Runs for at least 1 week. Once diffs are zero or expected (e.g. behaviour-changes the new design intends), the cut-over flips `music.ablz.au` to the Rust binary's port and the Python service is removed.
+- R22. **Stop-gap Python patch ships first**, before the rewrite work begins, as a separate small PR against the current Python stack:
+  - Delete the end-of-cycle `urlopen` to `/api/cache/invalidate` in `cratedigger.py:1610`.
+  - Catch `BrokenPipeError` / `ConnectionResetError` / `ConnectionAbortedError` at the response layer of `web/server.py:do_GET`/`do_POST`; single-line warning; no DB reconnect; no second body-write.
+  - The existing `_try_reconnect_db()` only fires on `psycopg2.OperationalError`, not on the catch-all.
+  - Optional: switch from `HTTPServer` to `ThreadingHTTPServer` so a single slow request doesn't block all routes (low risk, two-line change, but verify no route depends on single-threading first).
+  - Total: ~50 lines, an afternoon's work, kills the wedge while the Rust rewrite is in progress. No need for a separate brainstorm — ships as a `ce-debug` fix.
+
+**Documentation and rule updates**
+
+- R23. **`.claude/rules/web.md` is rewritten** to replace "stdlib `http.server`, vanilla JS, no build step, no npm" with the new stack: "axum + sqlx + rusqlite + fred web service in Rust, vanilla JS frontend (no npm, no build step), routes in `src/routes/*.rs`". CLAUDE.md's Web UI bullet is updated correspondingly. Lands as part of the Rust rewrite PR.
+- R24. **`docs/solutions/`** gains an entry capturing the wedge → ce-doc-review → Rust pivot story for future agents. Lessons: (a) the Bottle+waitress decision was a recommendation made on a wrong assumption (waitress's timeout primitive); (b) ce-doc-review caught it before implementation; (c) framework choice should be re-pressure-tested after a researched ecosystem report.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R7, R9, R10, R19.** A client sends a `POST /api/library/<existing real route>`, reads the status line + headers, then closes the socket before the body finishes streaming. Server-side: no traceback in journald, no DB reconnect, no `download_log` row, the worker that handled the request is immediately available. A concurrent `GET /api/pipeline/dashboard` from a different client completes normally with no degradation.
+- AE2. **Covers R7, R8, R9.** A handler invokes `pool.fetch_one(...).await?` and PostgreSQL has been restarted out from under the connection. sqlx's pool detects the broken connection, evicts it, returns `Error::Io` to the handler. The handler maps to `AppError`, returns 503. The next request to the same handler acquires a fresh connection from the pool and succeeds. No global reconnect path was traversed.
+- AE3. **Covers R11, R22.** After R22 ships, the cratedigger main loop completes a cycle. The end-of-cycle `finally` block does not POST to the web service. journald shows zero `BrokenPipeError` lines from the cycle.
+- AE4. **Covers R14.** The Wrong Matches UI plays an audio file via the dev-server tunnel (`scripts/web_dev_server.py --data prod-api` or its Rust equivalent). The handler responds 206 with correct `Content-Range`, suffix-range support works, multi-range requests are rejected with 416 + `Content-Range: bytes */<size>`, `Access-Control-Allow-Origin: *` is present, audio plays end-to-end with seeking.
+- AE5. **Covers R21.** During the bake-in week, a diff harness queries `/api/pipeline/all` and 5 representative `/api/browse/*` and `/api/library/*` routes against both the Python (`:8085`) and Rust (`:8086`) services. Expected behaviour-changes (e.g. removed routes per R11) are explicitly excluded from the diff. Remaining diffs are zero on at least 50 consecutive runs before cut-over.
+
+---
+
+## Success Criteria
+
+- After cut-over: BrokenPipe count in `journalctl -u cratedigger-web` over a 24-hour window is < 5 (today's baseline is 2,355). The end-of-cycle POST is gone (R22) and disconnect handling is structural (R10).
+- After cut-over: zero `cratedigger-web` wedge incidents for 30 days under normal traffic and dashboard polling. A wedge is defined as the service reporting `active` while every HTTP request hangs > 30s.
+- A pathological request (mid-body close, stalled downstream call, deliberately slow handler) takes out at most one in-flight request — never the service. Verified by AE1 against the staging instance.
+- The Rust binary boots in < 100ms cold (sqlx pool eager-init excluded). Dashboard latency is < 100ms warm, < 500ms cold (same as today's post-#230 numbers, not a regression).
+- A downstream agent picking up `ce-plan` against this doc can name the cargo crates, the AppState shape, the route module layout, the systemd unit deltas, and the bake-in cut-over plan without inventing product behaviour, scope, or success criteria.
+
+---
+
+## Scope Boundaries
+
+- Auth or login. UI stays unauthenticated; LAN-only by design.
+- Frontend changes of any kind. Vanilla JS, no npm, no build pipeline, no SSR. Existing `web/js/*.js` ships unchanged.
+- Migrating other services. The pipeline (`cratedigger.service`), the importer worker (`cratedigger-importer.service`), and the migrator (`cratedigger-db-migrate.service`) all stay Python. Only the web service is rewritten.
+- Database schema changes. None needed. Existing `migrations/NNN_name.sql` files run via `sqlx::migrate!` macro at startup with the same ordering and idempotency guarantees as the Python migrator.
+- New observability surfaces (Prometheus, structured logs, request tracing). `tracing` to journald is the baseline; revisit if specific signals become operationally needed.
+- New runtime dependencies beyond the recommended cargo set in this doc. Auxiliary axum plugins, alternative DB drivers, alternative HTTP clients are out of scope. The route layer remains thin Rust over sqlx + rusqlite.
+- A separate signal-based watchdog. tokio's runtime + `TimeoutLayer` is the watchdog.
+- Type-state encoding of domain invariants (e.g. a beautiful `AlbumRequest<Wanted, Validated, Imported>` state machine). Existing string-status enum semantics ship unchanged via a `#[derive(Debug, Display, FromStr)]` enum. Keep the rewrite small.
+- Async ORM. No `diesel-async`, no `sea-orm`. Raw SQL via sqlx is the chosen ergonomic.
+- A dashboard caching wrapper (the residual #227 Q1 work). Tracked separately as a follow-on once the Rust web service is stable; deliberately not bundled with the rewrite. The Q1 cache wrapper is a different concern (perf optimization with explicit invalidation contract) and would muddy the rewrite's success-signal attribution.
+
+---
+
+## Key Decisions
+
+- **axum 0.8 over actix-web, rocket, poem, salvo.** Owned by the tokio team, default modern choice, cleanest tower middleware composition, native testing story (`Router` is a `Service`, callable in tests without port binding). actix-web wins benchmarks but uses its own actor model rather than pure tower; for a 50-RPS homelab service the framework choice is dominated by ergonomics and ecosystem, not by raw throughput. rocket's cadence is sluggish; poem's ecosystem is smaller.
+- **sqlx over tokio-postgres + deadpool.** Compile-time SQL validation via `query!`/`query_as!` is the type-safety win that motivated the rewrite. Offline mode (`.sqlx/` directory) makes Nix builds work without runtime DB access. Trade-off: sqlx macros can't handle dynamic `IN (...)` lists — use `ANY($1)` against an array parameter or `UNNEST` for those.
+- **rusqlite over sqlx::Sqlite for the beets DB.** Read-only access to a file an external process (beets) writes occasionally needs explicit WAL handling, `SQLITE_OPEN_READ_ONLY`, and `busy_timeout`. rusqlite gives that with no surprises. Wrap calls in `spawn_blocking` so they don't park the executor.
+- **fred over redis-rs for Redis.** Built-in async pool with reconnection handling. Matters because Redis flaps during `nixos-rebuild switch` on doc2.
+- **reqwest with rustls, no OpenSSL.** Drops the C dep transitively; pure-Rust crypto; trivial Nix build.
+- **crane over buildRustPackage / naersk for the Nix integration.** Fine-grained dep caching, current 2026 consensus, well-maintained, integrates cleanly with `rust-overlay` for toolchain pinning and with `cargo sqlx prepare` for offline mode.
+- **All 52 routes in one PR, parallel-run bake-in.** A staged migration would require maintaining two services and two route registries simultaneously. Instead, ship the Rust binary on a new port, run both for a week, diff with a harness, cut over. The Python service is the rollback target during the bake-in window.
+- **Stop-gap Python patch ships first as a separate PR.** Eliminates the wedge while the rewrite is in progress. ~50 lines, an afternoon. No reason to make the user suffer the wedge for 3 weeks.
+- **Pipeline stays Python.** beets is Python; `cratedigger.py` invokes the beets harness via subprocess. The rewrite is scoped to the web UI only. Polyglot codebase is accepted (clean process split, no IPC except via shared DB/Redis/disk).
+- **No dashboard cache wrapper in this PR.** The Q1 follow-up from #227 is a perf optimization with its own design questions (cache invalidation contract, freshness window, IPC from importer to web cache). Bundling it with the rewrite muddied the original Bottle+waitress doc and would muddy this one. Tracked as separate follow-up.
+
+---
+
+## Dependencies / Assumptions
+
+- **Rust toolchain available via nixpkgs / rust-overlay.** Stable channel, recent (1.85+ for `let-else` and other niceties). Verified before implementation begins.
+- **All recommended crates available on crates.io and pinned in `Cargo.lock`.** axum 0.8, sqlx 0.8, rusqlite 0.32, fred 9, reqwest 0.12, tower 0.5, tower-http 0.6, tracing 0.1, tracing-subscriber 0.3, thiserror 1, time 0.3, serde 1, serde_json 1, wiremock 0.6 (dev). Versions chosen for Apr 2026 ecosystem state per the research report; planning re-validates against current `cargo search` output.
+- **The existing `migrations/NNN_name.sql` files are sqlx-compatible.** They use plain SQL (no Python-specific syntax). `sqlx::migrate!` uses the same NNN ordering convention. Verified before implementation begins.
+- **PostgreSQL `max_connections` (default 100) accommodates the new pool.** With Rust web's pool max 20 + Python pipeline's connections + importer worker's connections + dev sessions, total stays well under 100.
+- **PostgreSQL hostname/credentials** stay the same. The new binary reads `PIPELINE_DB_DSN` from systemd environment exactly like the Python service today.
+- **`scripts/web_dev_server.py`'s proxy mode** has a Rust equivalent. The current proxy mode (`--data prod-api`) is implemented as a CLI flag on the Rust binary that mounts a `reqwest`-backed proxy handler at `/api/*`, otherwise serves local static files. This collapses the dev server into a single binary mode rather than a separate Python tool.
+- **`cache.invalidate_groups` Python helper has no real internal callers** beyond the deleted HTTP endpoint. Verified during ce-doc-review on the prior brainstorm — the function is dead code post-R22. The Python pipeline's web/cache.py module is removed once the cut-over completes.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- [Affects R17][User decision] What's the test-data strategy for `sqlx::test` macros — does the per-test database get migrations + a shared seed-data fixture (faster, seeds drift), or migrations + per-test inserts (slower, isolated)? The existing Python tests use `tests/fakes.py` `FakePipelineDB` for stateful collaborators; sqlx::test against a real PG is a different model and worth picking explicitly.
+- [Affects R21][User decision] How long does the parallel-run bake-in last? "At least 1 week" is the floor; the user may want longer (2-4 weeks) for a curated music collection where data-correctness regressions could go unnoticed for days.
+
+### Deferred to Planning
+
+- [Affects R2][Technical] Worker thread count for tokio's runtime — default is `num_cpus`, doc2 has N cores. Is the default fine, or should it be capped to avoid contention with the importer worker on the same host? Likely default-is-fine; verify during planning.
+- [Affects R3][Technical] sqlx pool sizing: `max_connections(20)` is a starting point. Tune during bake-in based on observed concurrent request count + query latency.
+- [Affects R7, R8][Technical] TimeoutLayer + ConcurrencyLimitLayer values: 30s timeout, 40 inflight. Reasonable starting points; verify against observed behaviour during bake-in.
+- [Affects R11][Technical] The two existing Python regex routes (`_FUNC_GET_PATTERNS`, `_FUNC_POST_PATTERNS`) need axum-equivalent path patterns. axum 0.8's `{param}` and `{*rest}` syntax handles most cases; one or two routes might need a custom `FromRequest` extractor. Verify each translates cleanly.
+- [Affects R14][Technical] Audio Range handler can either be inlined (~80 lines) or pulled in via the `axum-range` crate. Inlining is the recommended default per the research report (the dependency surface is small, the logic is readable). Decide during planning.
+- [Affects R16][Technical] Should the dev server's `--data prod-api` proxy mode use a separate axum app or a runtime flag on the production app? Both work; runtime flag is one process, separate app is cleaner. Decide during planning.
+- [Affects R18][Technical] Route audit pattern: manual `const ROUTES` registry vs `Router` introspection. Decide during planning based on which is more ergonomic against axum 0.8's type system.
+- [Affects R20][Technical] Does `tracing-subscriber`'s JSON formatter give the per-field structure journald wants, or is `tracing-journald` (explicit journald sink) materially better? Default to JSON-to-stdout; revisit if structured-field queries become important.
+- [Affects R22][Technical] Pre-flight check before deploying the stop-gap patch: confirm no other in-process Python code calls `_try_reconnect_db()` outside `do_GET`/`do_POST` catch-alls. Quick grep, but worth doing before the patch lands.
+
+---
+
+## Effort Estimate
+
+Per the Rust ecosystem research report (intermediate Rust dev):
+
+- **Phase 1 — scaffolding** (1-2 days): cargo workspace, axum skeleton, AppState, error type, tracing, sqlx pool, rusqlite handle, fred client, reqwest client, basic Nix flake with crane, one `/health` route end-to-end.
+- **Phase 2 — port routes** (1-2 weeks focused, 50-80 hours total): 52 routes. Average ~1 hr/route once patterns are established. Audio streaming and search-plan ops are the slow ones; simple GETs are 30 min.
+- **Phase 3 — tests** (3-5 days): port contract tests, add `sqlx::test` integration tests, `wiremock` for proxy routes, route audit equivalent.
+- **Phase 4 — Nix integration** (1-2 days): crane build with `SQLX_OFFLINE=true`, systemd unit, deploy to doc2, verify.
+- **Phase 5 — bake-in** (1+ week): parallel-run, diff-harness, cut-over.
+
+**Total: ~3 weeks focused full-time, or 4-6 weeks evening/weekend.** Phase 2 dominates and has the highest variance.
+
+The R22 stop-gap is a separate ~half-day of work that ships independently before Phase 1 begins.

--- a/docs/brainstorms/2026-05-09-web-stack-bottle-waitress-requirements.md
+++ b/docs/brainstorms/2026-05-09-web-stack-bottle-waitress-requirements.md
@@ -1,0 +1,137 @@
+---
+date: 2026-05-09
+topic: web-stack-bottle-waitress
+status: superseded
+superseded_by: 2026-05-09-cratedigger-web-rust-rewrite-requirements.md
+---
+
+# Cratedigger-Web — Migrate to Bottle + Waitress
+
+> **Superseded — both this and its successor.** During ce-doc-review, kieran-python found that R3's "waitress enforces request timeouts" claim was factually wrong (waitress has no per-request timeout primitive — only `channel_timeout` for idle clients). That undercut the Key Decisions rationale for picking waitress over gunicorn. Direction pivoted to a Rust rewrite (`2026-05-09-cratedigger-web-rust-rewrite-requirements.md`), which was in turn killed by ce-doc-review when the feasibility persona surfaced ~4,000 LOC of pipeline-lib coupling that POST handlers orchestrate (audio hashing, beets removal, search-plan generation, importer-queue interaction). The web layer is not a clean architectural seam, and no framework migration of just this layer is tractable today. The active decision is captured at `docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md` — apply a minimal Python patch to kill the wedge; defer any rewrite to be part of a larger cratedigger runtime redesign. This doc is retained for context only.
+
+---
+
+
+## Summary
+
+Replace the homegrown stdlib `http.server` web stack with a Bottle WSGI app hosted under waitress. Worker-thread isolation, per-thread psycopg2 connections, and a real exception model arrive as properties of the host instead of being engineered by hand. All ~52 routes are ported in one PR; the wedge-era defensive scaffolding (`_try_reconnect_db`, the catch-all `do_GET`/`do_POST` exception handlers, the bespoke `_FUNC_*` route registration tables, and the no-op `POST /api/cache/invalidate` round-trip) is deleted as part of the migration. Frontend stays vanilla JS, no npm, no build step.
+
+---
+
+## Problem Frame
+
+`cratedigger-web` is the operator's only entry point into the curated music collection — `music.ablz.au`. On 2026-05-08 it wedged silently for ~9 hours: systemd reported `active (running)`, the listener still accepted TCP, but every HTTP request hung forever. Recovery required `systemctl restart`. Ad-hoc forensics in #233 traced the wedge to a sustained reconnect storm: the cratedigger main loop's end-of-cycle `POST /api/cache/invalidate` (cratedigger.py:1610) closes the socket mid-body before the server finishes writing the response, the `do_POST` catch-all treats the resulting `BrokenPipeError` as a database error and unconditionally tears down + reopens the psycopg2 connection, ~3 unnecessary reconnects per minute compound until the single-threaded server thread blocks indefinitely in `poll()`. Sibling issue #227 had been tracking the same BrokenPipe count climbing as a leading indicator — its 2026-05-09 update confirmed the alarm fires regardless of dashboard latency.
+
+Three structural choices in the current design are jointly load-bearing for this failure mode and cannot be patched in isolation:
+
+1. The web service is a single-threaded `http.server` — one stalled request blocks every other request.
+2. The catch-all in `do_GET`/`do_POST` runs `_try_reconnect_db()` on every caught exception, conflating client-disconnect errors with database errors.
+3. The psycopg2 connection is a process-wide global, so reconnecting it under load mid-request is the only available recovery primitive — and that primitive is what the storm abuses.
+
+Each of these exists for a reasonable reason: stdlib only, simple deployment, one connection per process. Together they make a wedge inevitable under sustained client-disconnect traffic. The literal "stdlib `http.server`, no npm, no build step" rule in `.claude/rules/web.md` was originally a complexity-allergy guardrail, but the wedge has demonstrated that maintaining a hand-rolled request lifecycle costs more than the dependency it was meant to avoid.
+
+---
+
+## Requirements
+
+**Hosting and concurrency**
+
+- R1. The web service runs as a WSGI application hosted by `waitress` (pure-Python, no fork). Worker-thread count is small (4-8), enough that one slow request cannot head-of-line all others but small enough that psycopg2 connection count stays bounded.
+- R2. Each waitress worker thread holds its own psycopg2 connection, lazily initialised on first use within that thread. There is no process-global `db` singleton.
+- R3. Request timeouts are enforced by waitress, not by application code. No new signal-based watchdog is added.
+- R4. The systemd unit (`cratedigger-web.service`) keeps `Type=simple` + `Restart=on-failure`. `ExecStart` invokes `waitress-serve` (or equivalent) against the WSGI app entry point; `python web/server.py` as a direct entry point is removed.
+
+**Routing and request handling**
+
+- R5. Routes are registered as Bottle decorators on the route functions in `web/routes/*.py`. The `_FUNC_GET_ROUTES` / `_FUNC_POST_ROUTES` / `_FUNC_GET_PATTERNS` / `_FUNC_POST_PATTERNS` registration tables in `web/server.py` are deleted.
+- R6. The `Handler(BaseHTTPRequestHandler)` class with its `do_GET` / `do_POST` switchboard and inline JSON helpers (`_json`, `_html`, `_static_js`, `_error`) is deleted; equivalents live in Bottle / waitress.
+- R7. Every route currently registered in `web/routes/` (browse, labels, library, imports, pipeline — 52 routes total) is ported with functional parity. No endpoints are added, removed (other than R8), renamed, or have their JSON contracts changed.
+- R8. The `POST /api/cache/invalidate` endpoint is removed entirely on the server side. The corresponding `urlopen` call in the cratedigger main loop's end-of-cycle `finally` block (cratedigger.py:1610) is also removed. `cache.invalidate_groups()` itself remains a callable internal API in `web/cache.py`.
+- R9. The Bottle app must serve the existing static assets (`web/index.html`, `web/js/*.js`) with the same paths, content-types, and cache headers as today.
+- R10. Range requests on audio endpoints (used by the Wrong Matches audio player) continue to work end-to-end, including through the local-dev tunnel proxy.
+
+**Exception handling**
+
+- R11. Client-disconnect errors (`BrokenPipeError`, `ConnectionResetError`, `ConnectionAbortedError` and their WSGI-layer equivalents) are recognised distinctly from database errors. They produce no traceback in journald, no DB reconnect, and no second body-write attempt.
+- R12. `_try_reconnect_db()` is removed entirely. Recovery from a stale or broken DB connection is the worker process's responsibility — a handler that hits `psycopg2.OperationalError` may either let the worker crash (waitress restarts the thread) or open a fresh connection on the next request via the lazy-init in R2.
+- R13. A real `psycopg2.OperationalError` raised inside a route handler still surfaces as an HTTP 500 to the client and a single ERROR-level log line server-side. No 30-line traceback chain.
+
+**Local-dev parity**
+
+- R14. `scripts/web_dev_server.py` continues to host the same routes as the production service, against the same data sources (`--data live-db` and `--data prod-api` modes). It uses the same Bottle app entry point and the same WSGI host (or an equivalent local single-process option), so behaviour observed in dev matches production.
+
+**Operator-visible perf cleanup**
+
+- R15. `web/routes/pipeline.py::get_pipeline_dashboard` is wrapped in the existing `cache_api.cached(group="pipeline", ttl=300)` decorator (Q1 follow-up from #227). No other dashboard logic changes; this is a pure caching addition that closes the residual #227 work while the route layer is being touched.
+
+**Test coverage**
+
+- R16. `TestRouteContractAudit` continues to pass — every route registered with the new framework is classified in `CLASSIFIED_ROUTES`, and the audit fails fast if a new route ships unclassified.
+- R17. The contract tests in `tests/test_web_server.py` continue to assert the same `REQUIRED_FIELDS` for every endpoint they cover. The `_WebServerCase` harness is rebased on the new app (it already runs the real server on a random port; the host changes from `HTTPServer` to whatever the production app uses).
+- R18. A new test class covers the pathology specifically: a client closes the socket mid-body during a POST. Assertions: no DB reconnect, no `log.exception` traceback, no second body-write attempt, only a single WARNING-level log line.
+- R19. A regression-guard test confirms a real `psycopg2.OperationalError` raised inside a handler still produces a 500, still logs a single ERROR line, and does not silently swallow the failure.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R3, R11, R18.** A client opens a TCP connection to the web service, sends a `POST /api/library/foo` request, reads the status line + response headers, then closes the socket before the body finishes streaming. Server-side: no traceback in journald, no DB reconnect, no entry in any `download_log` table, and the worker thread that handled the request is immediately available for the next request. Other in-flight requests (e.g. a `GET /api/pipeline/dashboard` from a separate client) complete normally.
+- AE2. **Covers R1, R12.** A request handler invokes `db.execute(...)` and the connection is found to be dead (e.g. PostgreSQL was restarted). The handler raises `psycopg2.OperationalError`. Waitress returns a 500 to the client. The next request to the same worker thread opens a fresh psycopg2 connection via the R2 lazy-init and succeeds. No reconnect-on-every-exception storm is possible because no catch-all reconnect path exists.
+- AE3. **Covers R8.** The cratedigger main loop completes a cycle. Its end-of-cycle `finally` block does not POST to the web service. The web service receives no inbound request; no BrokenPipeError is logged; no DB reconnect is performed.
+- AE4. **Covers R10.** The Wrong Matches UI plays an audio file via the dev-server tunnel (`scripts/web_dev_server.py --data prod-api` proxying to a `live-db` backend on doc2). Range header is forwarded; seeking works; the audio plays end-to-end.
+
+---
+
+## Success Criteria
+
+- After deploy: BrokenPipe count in `journalctl -u cratedigger-web` over a 24-hour window is < 5 (today's baseline is 2,355). The end-of-cycle POST is gone, so the only surviving sources are real client-side timeouts.
+- After deploy: no `cratedigger-web` wedge incident occurs for 30 days under normal cratedigger main-loop traffic and dashboard polling. A wedge is defined as the service reporting `active` while every HTTP request hangs > 30s.
+- A pathological request (mid-body close, stalled downstream call, deliberately slow handler) takes out at most one waitress worker thread, not the whole UI. Verified with a deliberate stall test against a staging instance.
+- `_try_reconnect_db`, the `_FUNC_*` registration tables, the `Handler` class, and the `POST /api/cache/invalidate` endpoint do not appear in `web/server.py` or its replacement after the migration. `git grep` returns no matches.
+- A downstream agent picking up `ce-plan` against this doc can specify the WSGI app entry point, the Bottle route mapping pattern, and the waitress invocation in the systemd unit without inventing product behaviour, scope, or success criteria.
+
+---
+
+## Scope Boundaries
+
+- Auth or login. The UI stays unauthenticated; LAN-only by design.
+- Frontend changes of any kind. Vanilla JS, no npm, no build pipeline, no SSR.
+- Switching to async hosting (asyncio, starlette, uvicorn, hypercorn). A future option only if scale demands it; not warranted at current load.
+- A separate signal-based per-request watchdog. Waitress's built-in request timeout + worker-thread isolation is the watchdog.
+- BeetsDB sqlite reconfiguration (per-request open, connection pool, etc.). Worker-thread isolation handles a stall implicitly. Out of scope here; revisit if a sqlite stall is ever observed.
+- Migrating other services. The `cratedigger.service` oneshot is touched only to remove its end-of-cycle POST; the importer worker (`cratedigger-importer`) and the migrator (`cratedigger-db-migrate`) are unchanged.
+- Database schema changes. None needed.
+- New observability (Prometheus, structured logs, request tracing). Existing journald-based logs are sufficient; revisit if the wedge alarm pattern needs to be replaced with a more direct signal.
+- New runtime dependencies beyond `bottle` and `waitress`. Bottle plugins, ORM layers, request-helper packages, or other ecosystem additions are out of scope. The route layer remains thin Python over psycopg2.
+
+---
+
+## Key Decisions
+
+- **Bottle over Flask.** Bottle is a single-file framework with no dependencies of its own; Flask pulls in Werkzeug, Jinja2, click, itsdangerous. For a thin route layer that already has its own template story (none — the UI is vanilla JS) and its own JSON conventions, Bottle is closer to the project's "minimize complexity" ethos. Trade-off accepted: smaller ecosystem, but the route layer doesn't need ecosystem.
+- **Waitress over gunicorn.** Waitress is pure-Python and uses a thread pool, not pre-forked workers. For a homelab single-machine deployment with low RPS, pre-fork process isolation (gunicorn's main differentiator) is overkill, and the pure-Python install is one less moving piece. Trade-off accepted: a wedged thread is less isolated than a wedged worker process — but waitress's request timeout + the deletion of the catch-all reconnect makes the wedge unreachable, not merely contained.
+- **Migrate all 52 routes in one PR, not staged.** A half-migrated state (some routes on `http.server`, some on Bottle) would require two route-registration paths, two exception models, and two test harnesses simultaneously. The all-at-once migration is mechanical (route bodies don't change, only their decoration and error semantics), and the contract test suite + `TestRouteContractAudit` enforce equivalence at PR-time.
+- **Delete `_try_reconnect_db` rather than keep it for the new model.** Under per-thread connections + waitress worker recycling, a stale connection is recovered by the next request's lazy-init or by a worker recycle. The reconnect-in-place primitive is what enabled the storm; removing it makes the storm structurally impossible.
+- **Fold the Q1 dashboard cache wrapper from #227 into this PR.** The route layer is being touched anyway and the wrapper is a one-decorator addition. Scoping it out would mean a separate small PR against a freshly migrated route module — strictly more cost.
+
+---
+
+## Dependencies / Assumptions
+
+- **Bottle and waitress are available in nixpkgs.** Both are well-maintained and in the standard Python ecosystem; their absence would be surprising. Verified before implementation begins.
+- **`scripts/web_dev_server.py` shares a single WSGI app entry point with production.** The current dev server reuses `web/server.py`'s handler classes; the new design assumes the WSGI app is constructable in-process by both production (under waitress) and dev (under whatever single-process host the dev server picks). This keeps dev-vs-prod behaviour parity, which the local-dev workflow in CLAUDE.md depends on.
+- **Per-thread psycopg2 connections do not exhaust PostgreSQL's `max_connections`.** With 4-8 waitress threads and `max_connections = 100` on the nspawn PostgreSQL container (default), there is ample headroom. If multiple `cratedigger-web` workers ever ran (not currently planned), this would need re-evaluation.
+- **The cratedigger main loop's end-of-cycle POST has no other consumer.** Removing R8's `urlopen` call breaks no external system. Verified in dialogue against issue #101's note that the endpoint has been a no-op since that issue.
+- **`cache.invalidate_groups()` retained for internal callers.** Kept in `web/cache.py` because other in-process code paths may still want to invalidate cache groups; only the HTTP route and the cratedigger.py round-trip caller go away.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R5][Technical] Bottle's default exception model: does the `@app.error(500)` hook need explicit suppression for the disconnect classes in R11, or does WSGI's protocol naturally short-circuit body writes after a closed-socket signal? Verify against the waitress source during planning.
+- [Affects R2][Technical] Where does the per-thread connection live — `threading.local()` on the app object, a `bottle.request`-scoped attribute, or a small connection registry keyed by `threading.get_ident()`? Mechanism choice doesn't change the requirement; pick during planning based on Bottle conventions.
+- [Affects R4][Technical] Does the systemd unit invoke `waitress-serve` directly, or wrap it in a thin Python entry point that constructs the app and hands it to `waitress.serve(...)` programmatically? The latter gives slightly more control over thread count, listen address, and graceful shutdown signals.
+- [Affects R7][Needs research] Two routes use regex patterns rather than literal paths (`_FUNC_GET_PATTERNS`, `_FUNC_POST_PATTERNS`). Bottle supports both `<param>` placeholders and `<param:re:pattern>` regex captures; confirm during planning that every existing pattern translates cleanly.
+- [Affects R14][Technical] `scripts/web_dev_server.py` currently runs the stdlib server with custom mounting for the `--data prod-api` proxy mode. Decide during planning whether the proxy mode also runs through waitress (single host pattern) or stays on a stdlib server (different host for the proxy use case). The requirement is parity of behaviour observed by the operator; the host choice is a planning detail.

--- a/docs/plans/2026-05-09-001-fix-cratedigger-web-wedge-minimal-patch-plan.md
+++ b/docs/plans/2026-05-09-001-fix-cratedigger-web-wedge-minimal-patch-plan.md
@@ -1,0 +1,267 @@
+---
+title: "fix: minimal Python patch to kill the cratedigger-web wedge (#233)"
+type: fix
+status: active
+date: 2026-05-09
+origin: docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md
+---
+
+# fix: minimal Python patch to kill the cratedigger-web wedge (#233)
+
+## Summary
+
+Kill the active `cratedigger-web` wedge (issue #233) with the smallest possible Python patch on the existing stdlib `http.server` stack. Delete the end-of-cycle no-op POST in `cratedigger.py` that triggers the storm, narrow the `do_GET`/`do_POST` catch-all in `web/server.py` to skip `_try_reconnect_db()` on client-disconnect errors, add a RED/GREEN regression test that exercises a mid-body socket close via raw socket, and (conditional on a quick audit) switch `HTTPServer` to `ThreadingHTTPServer` so a single slow request can't head-of-line every other route. No framework migration, no Rust, no architectural change.
+
+---
+
+## Problem Frame
+
+Deferred all framework / language redesign per `docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md` — the web layer is too coupled to pipeline lib code for a clean carve-out today. This plan ships the minimum needed to stop the active operational pain (the BrokenPipe storm and 9-hour silent wedge from #233) on the existing stack while the larger architectural questions stay deferred.
+
+---
+
+## Requirements
+
+- R1. The cratedigger main loop no longer POSTs to `/api/cache/invalidate` at end of cycle (the storm trigger is gone).
+- R2. A client closing its socket mid-response on either GET or POST does not trigger `_try_reconnect_db()`, does not produce a multi-line `log.exception` traceback, and does not attempt a second body-write back to the dead socket.
+- R3. Real exceptions inside route handlers (e.g. `psycopg2.OperationalError`) still hit the existing catch-all path: traceback logged, DB reconnect attempted, 500 returned. The narrowing must NOT change behaviour for legitimate handler errors.
+- R4. After deploy, BrokenPipe lines in `journalctl -u cratedigger-web` drop from the ~2,355/24h baseline (per #233's 2026-05-08 sample) to <5/24h.
+- R5. *(Conditional)* If a quick audit confirms `web/server.py` and `web/routes/*.py` route handlers do not share per-request mutable state in race-prone ways, the listener is upgraded from `HTTPServer` to `ThreadingHTTPServer`. If the audit reveals shared mutable state, this requirement is consciously deferred — flag it explicitly in the verification notes for ce-work.
+
+---
+
+## Scope Boundaries
+
+- No framework migration. The doc explicitly defers Bottle, Flask, gunicorn, waitress, axum, and every other framework swap (see origin).
+- No Rust work.
+- No Q1 dashboard cache wrapper from #227.
+- No rewrite of the `_try_reconnect_db()` design itself. We narrow what reaches it; the function's body and its callers' broader semantics stay as-is.
+- No removal of `_FUNC_GET_ROUTES` / `_FUNC_POST_ROUTES` registration tables, no rewrite of `Handler` class, no changes to route bodies.
+- No new observability surfaces (Prometheus, structured logs, request tracing).
+
+### Deferred to Follow-Up Work
+
+- Future cratedigger runtime redesign (cycle-driven → static / event-driven), at which point the web rewrite becomes a tractable carve-out (see origin).
+- Q1 dashboard cache wrapper from #227 (orthogonal perf optimization, separate ce-plan when relevant).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`cratedigger.py:1605-1617`** — the end-of-cycle `finally` block constructs `urllib.request.Request("http://localhost:8085/api/cache/invalidate", …)`, calls `urlopen(req, timeout=2)`, swallows any exception via `except Exception: pass`. The endpoint has been a documented no-op since #101 (see `web/server.py:282-298`). Deletion is dead-code removal.
+- **`web/server.py:50-65`** — `_try_reconnect_db()` does `db.conn.close()` followed by `PipelineDB(_db_dsn)`. Survives unchanged.
+- **`web/server.py:299-329`** — `do_GET` body, including the existing `except Exception as e: log.exception(...); _try_reconnect_db(); self._error(str(e), 500)` catch-all at lines 326-329.
+- **`web/server.py:331-365`** — `do_POST` body with the equivalent catch-all at lines 362-365.
+- **`web/server.py:245-252`** — `_json` writes the response body via `self.wfile.write(body)` AFTER `send_response`/`end_headers`. This is the line that raises `BrokenPipeError` when the client has already closed.
+- **`web/server.py:18, 415`** — current listener is `HTTPServer(("0.0.0.0", args.port), Handler)`. The drop-in replacement is `ThreadingHTTPServer` from the same `http.server` module — no other API changes.
+- **`tests/test_web_server.py:97-130`** — `_WebServerCase` harness creates a real `HTTPServer` on a random port via `_make_server()`, exposes `_get(path)` and `_post(path, body)` helpers via `urllib.request.urlopen`. Reuse for happy-path and real-error tests; for the mid-body-close test we need a separate raw-socket harness because `urlopen` doesn't support "send partial body then close."
+- **`tests/test_web_server.py:911-982`** — `TestRouteContractAudit` introspects `Handler._FUNC_GET_ROUTES` etc. Unchanged by this plan; ensures any new behaviour is route-classified.
+
+### Institutional Learnings
+
+- **`docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md`** — origin. Captures the reasoning chain that led to deferring all framework migrations.
+- The same doc records the lesson that the existing catch-all is too broad: it conflates DB errors with network errors, which is exactly the mechanism this plan narrows.
+
+### External References
+
+- None. This is a stdlib `http.server` patch with no external library involvement.
+
+---
+
+## Key Technical Decisions
+
+- **Add a typed `except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)` clause BEFORE the existing `except Exception` rather than rewriting the catch-all.** Smallest possible diff. Keeps the existing `_try_reconnect_db` behaviour for real exceptions intact (R3 regression-guard). The narrower clause runs first in Python's `except` matching order, so disconnect errors never reach the catch-all.
+- **Use `log.warning(...)` (single-line) for disconnect errors, NOT `log.exception(...)`.** The existing catch-all uses `log.exception` which emits a full traceback; for a normal client disconnect the traceback is noise and is what produces the 30-line journald-flood pattern documented in #233.
+- **Do not call `self._error(str(e), 500)` in the disconnect handler.** The socket is already dead; trying to write a 500 body produces a second `BrokenPipeError` that propagates up to `socketserver._handle_request_noblock`, which is exactly the chained-traceback pattern the wedge produces. The handler returns silently after the warning log.
+- **Test the mid-body-close via a raw `socket.create_connection` + `sendall` + `close` pattern, not via `urlopen`.** `urllib.request` has no API for "send headers + partial body, then close" — it always sends a complete request. The new test uses `socket` directly to write request bytes and close at a controlled point. Pattern reference: similar raw-socket testing exists in stdlib's own `test_httpservers.py` for `BaseHTTPRequestHandler` cases.
+- **U3 (`ThreadingHTTPServer` swap) is optional and gated on an audit.** The audit reads `web/server.py`, `web/routes/*.py`, and any module-level state they touch (`srv.db`, `_beets`, `cache.*`) to confirm none is mutated within a request handler in a way that would race under threads. If the audit clears, the swap is a two-line change. If it doesn't, the swap is deferred and ce-work flags a follow-up issue. The wedge fix (U1+U2) does NOT depend on this swap landing.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How to inject a mid-body socket close in tests?** Use `socket.create_connection` against the real test server (already running on a random port via `_WebServerCase`-style setup), `sendall` headers + `Content-Length: <large>`, then close before the body completes. The handler reads partial body via `self.rfile.read(length)`, attempts to JSON-decode, hits a partial-read or write the response, and `wfile.write` raises `BrokenPipeError`. Resolution: add a small raw-socket helper to a new test class; do not modify the existing `_WebServerCase` harness.
+- **Where does the disconnect handler return from?** From inside `do_GET`/`do_POST`. The handler returns normally; `socketserver` then closes the connection on its end. No further action needed.
+- **Do we need to log anything about the disconnect at all?** Yes — single WARNING line at low frequency to detect a future flood. `log.warning("Client disconnect on %s %s: %s", method, path, type(e).__name__)`. No traceback.
+
+### Deferred to Implementation
+
+- **Exact wording of the warning log line.** Implementer picks. Suggested format above is a starting point; ce-work may adjust for consistency with surrounding log calls.
+- **Whether to add a third `except` clause for `OSError` with errno 32 (EPIPE) on platforms where `BrokenPipeError` doesn't fire.** Linux is the only deployment target; on Linux `BrokenPipeError` is a subclass of `OSError` and fires reliably. Not adding a fallback unless the test suite reveals one is needed.
+- **U3 audit findings.** Whether the `ThreadingHTTPServer` swap actually lands depends on what the audit reveals. If it lands, ce-work updates U3's verification notes; if it's deferred, ce-work flags a follow-up issue.
+
+---
+
+## Implementation Units
+
+### U1. Remove the end-of-cycle cache-invalidate POST
+
+**Goal:** Delete the storm trigger. The `cratedigger.py:1605-1617` `finally` block POSTs to a no-op endpoint every cycle and never reads the response body — every invocation produces a `BrokenPipeError` on the server side. The endpoint has been a documented no-op since #101.
+
+**Requirements:** R1, R4 (R4 is the after-deploy verification; this unit removes the storm source).
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `cratedigger.py`
+
+**Approach:**
+- Delete the entire `try` block at `cratedigger.py:1605-1617` that imports `urllib.request`, constructs the `Request`, and calls `urlopen(req, timeout=2)`. Including the comment lines and the `except Exception: pass` guard.
+- The remaining `finally` body (cleaning up the pipeline DB connection at lines 1619-1624 and removing the lock file at lines 1625-1627) is unchanged.
+- No new code added. This is a pure deletion.
+
+**Patterns to follow:**
+- The pipeline's other end-of-cycle cleanup (the `pipeline_db_source.close()` in the same `finally` block) is the pattern: best-effort, swallow failures, don't reach out across process boundaries.
+
+**Test scenarios:**
+- Test expectation: none — pure removal of dead code that has no caller-observable behaviour. The endpoint it called is a documented no-op; no test in the suite asserts the POST is made. Verification is "after deploy, journald shows no `POST /api/cache/invalidate` lines per cycle."
+
+**Verification:**
+- `git grep "/api/cache/invalidate"` in `cratedigger.py` returns no matches after the change.
+- Running the full test suite (`nix-shell --run "bash scripts/run_tests.sh"`) passes — no test depends on this POST being made.
+- After deploy, `ssh doc2 'sudo journalctl -u cratedigger --since "10 min ago" | grep -c cache/invalidate'` returns 0.
+
+---
+
+### U2. Narrow the do_GET/do_POST catch-all to skip reconnect on client-disconnect
+
+**Goal:** Add a typed `except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)` clause before the existing catch-all in both `do_GET` and `do_POST`. Disconnect errors get a single WARNING log line and a clean return; they do not fire `_try_reconnect_db()` and do not attempt a second body-write to the dead socket.
+
+**Requirements:** R2, R3.
+
+**Dependencies:** None — independent of U1, but ships in the same PR.
+
+**Execution note:** Test-first per `.claude/rules/code-quality.md`. Write the failing test that asserts no reconnect on mid-body close, watch it fail (RED) because today's code reconnects unconditionally, then implement the narrowing and watch it pass (GREEN). Add the regression-guard tests for the unchanged real-error path before considering the unit complete.
+
+**Files:**
+- Modify: `web/server.py` (specifically lines 299-329 for `do_GET` and lines 331-365 for `do_POST`)
+- Test: `tests/test_web_server.py` (new test class — see test scenarios below)
+
+**Approach:**
+- In `do_GET`, before the existing `except Exception as e:` at line 326, add:
+  - `except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError) as e:` clause
+  - Body: single `log.warning("Client disconnect on GET %s: %s", path, type(e).__name__)` line, then return.
+  - No call to `_try_reconnect_db()`. No call to `self._error(...)`.
+- Same change in `do_POST` at line 362.
+- The existing `except Exception` block remains unchanged for real exceptions (R3 regression-guard).
+- Total diff is roughly 8-10 lines added across two functions.
+
+**Patterns to follow:**
+- Existing `log.warning` calls in `web/server.py` (e.g. logger.warning patterns elsewhere in the codebase) for format string style.
+- Python exception-clause-ordering convention: more specific clauses before more general ones. The new clause is more specific than `except Exception` and runs first.
+
+**Test scenarios:**
+
+*New test class in `tests/test_web_server.py` — separate from `_WebServerCase` because raw-socket testing requires a different setup. Suggested name: `TestClientDisconnectHandling`.*
+
+- **Happy path (regression guard for unchanged behaviour):**
+  - `Happy path:` A normal `_post("/api/pipeline/status", {})` against the existing `_WebServerCase` harness — no disconnect, server returns 200 or 4xx, no `_try_reconnect_db` calls observed (assert via `mock` patch on `web.server._try_reconnect_db`).
+  - `Happy path:` A normal `_get("/api/pipeline/all")` — same assertions.
+
+- **Wedge regression (the new test, RED-first):**
+  - `Wedge regression:` Open a raw socket via `socket.create_connection(("127.0.0.1", port))`. Send `POST /api/pipeline/set-intent HTTP/1.1\r\nHost: ...\r\nContent-Type: application/json\r\nContent-Length: 1024\r\n\r\n` followed by ~10 bytes of partial body, then close the socket. Assert: `_try_reconnect_db` mock is NOT called; the test's log capture (via `self.assertLogs("cratedigger-web", level="WARNING")` or equivalent) shows exactly one WARNING line containing "Client disconnect" and zero `log.exception`-style records (i.e., no record at ERROR with `exc_info` set); the server stays up and a subsequent normal request completes.
+  - `Wedge regression:` Same pattern on a GET — open raw socket, send `GET /api/pipeline/log HTTP/1.1\r\n\r\n`, immediately close after status line might be partially written. Same assertions.
+
+- **Real DB error path (regression guard for R3):**
+  - `Error path:` Patch the route handler to raise `psycopg2.OperationalError("simulated PG outage")`. Make a normal `_post(...)` request. Assert: `_try_reconnect_db` IS called (mock invocation count == 1); `log.exception`-style record IS present (ERROR level with `exc_info`); response status is 500.
+  - `Error path:` Same pattern via GET.
+
+- **Real other-exception path (regression guard for unchanged behaviour):**
+  - `Error path:` Patch the route handler to raise `ValueError("simulated bug")`. Make a `_post` request. Assert: `_try_reconnect_db` IS called; ERROR-level log record present; response status 500. (Existing behaviour: the broad catch-all reconnects on any exception, which is wider than ideal but is explicitly out of scope per Scope Boundaries — narrowing it further is deferred to a future cleanup. This test pins down "we did not accidentally narrow more than we intended.")
+
+**Verification:**
+- All four test categories above pass under `nix-shell --run "python3 -m unittest tests.test_web_server -v"`.
+- `pyright web/server.py tests/test_web_server.py` reports 0 new errors on the changed files.
+- The pre-commit pyright hook passes on staged files.
+
+---
+
+### U3. *(Conditional)* Audit shared mutable state and switch HTTPServer → ThreadingHTTPServer
+
+**Goal:** Prevent a single slow request from head-of-lining all other routes. The wedge fix (U1+U2) eliminates the storm; a slow downstream call (psycopg2 reconnect race, sqlite virtiofs hitch, MB mirror hang) can still wedge the single thread. ThreadingHTTPServer is a stdlib drop-in that gives one-thread-per-request isolation. **This unit lands only if the audit confirms it's safe.**
+
+**Requirements:** R5.
+
+**Dependencies:** U1, U2 — those land first; the audit and swap follow on the same PR if the audit clears.
+
+**Files:**
+- Modify: `web/server.py:18` (import) and `web/server.py:415` (instantiation)
+- Audit-only (no edits unless issue surfaces): `web/server.py` module-level state, `web/routes/*.py` for any per-request mutation of process globals.
+
+**Approach:**
+- **Audit step (no edits yet):**
+  1. Search `web/server.py` for module-level mutable state that route handlers touch: `db` (PipelineDB instance — psycopg2 conn is shared; psycopg2 connection objects are NOT thread-safe — this is the load-bearing concern), `_beets` (BeetsDB sqlite handle), `beets_db_path`, `_db_dsn`, anything in `web.cache`.
+  2. For each: determine whether route handlers mutate it (write) vs read it (call methods). psycopg2 connection's `cursor()` and query methods are NOT thread-safe even for read; they hold internal protocol state.
+  3. **Expected finding:** psycopg2 `db.conn` is shared and not thread-safe. Even read-only queries from two threads concurrently can corrupt the protocol state. **This is likely a blocker for the swap.** If so, defer U3 explicitly, document the finding in the PR description, and flag a follow-up issue: "ThreadingHTTPServer swap requires per-thread psycopg2 connection management — out of scope for the wedge-fix PR."
+  4. If by some chance the audit reveals the connection IS protected (e.g. by an existing lock — it isn't today), the swap can land. This is unlikely.
+
+- **Conditional swap (only if audit clears, which is unlikely):**
+  - Change `from http.server import HTTPServer, BaseHTTPRequestHandler` to `from http.server import HTTPServer, ThreadingHTTPServer, BaseHTTPRequestHandler`.
+  - Change `server = HTTPServer((...), Handler)` at line 415 to `server = ThreadingHTTPServer((...), Handler)`.
+  - Add a brief comment near the instantiation noting the threading model.
+
+**Patterns to follow:**
+- Stdlib's `http.server.ThreadingHTTPServer` itself — it's a one-line `class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer): daemon_threads = True` in the cpython source. No surprises.
+
+**Test scenarios:**
+- **If U3 lands (audit clears):**
+  - `Integration:` two slow handlers in parallel — patch one route to sleep 2 seconds; make two concurrent requests via `threading.Thread`; assert both complete in roughly 2 seconds total (not 4). Verifies threading is actually serving requests in parallel.
+  - `Regression:` the existing test suite still passes — most importantly the `TestRouteContractAudit` and the `TestPipelineRouteContracts` tests, which assert response shapes are unchanged.
+- **If U3 is deferred:**
+  - Test expectation: none — no code change shipped.
+  - Verification is the audit notes themselves, captured in the PR description.
+
+**Verification:**
+- **If U3 lands:** the parallel-slow-handler test passes; the full test suite passes; `pyright` clean; after deploy, `ssh doc2 'sudo systemctl status cratedigger-web'` shows the service running normally.
+- **If U3 is deferred:** PR description includes a one-paragraph audit summary explaining what shared mutable state exists, why threading would be unsafe today, and a follow-up issue link/number for the future per-thread connection design. ce-work creates the follow-up issue and pastes its URL into the PR description.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Only `web/server.py`'s `do_GET`/`do_POST` and `cratedigger.py`'s end-of-cycle `finally` block are touched. No middleware, no observers, no other entry points. The `_try_reconnect_db()` function is unchanged in body and call sites — only the set of exceptions that reach it is narrower.
+- **Error propagation:** Disconnect errors are now caught and silently dropped with a warning. Real exceptions still propagate through the existing catch-all. No exception class that today reaches `_try_reconnect_db` stops reaching it (only `BrokenPipeError` / `ConnectionResetError` / `ConnectionAbortedError` are intercepted earlier).
+- **State lifecycle risks:** None. The patch removes a no-op IPC call (U1) and adds a typed exception handler (U2). No state machines change. No DB writes change. No filesystem changes.
+- **API surface parity:** No routes added, removed, or changed. JSON contracts unchanged. `TestRouteContractAudit` continues to pass with no `CLASSIFIED_ROUTES` updates needed.
+- **Integration coverage:** The new `TestClientDisconnectHandling` tests cover the cross-layer scenario (raw socket → `BaseHTTPRequestHandler` → `do_GET`/`do_POST` → `_json` → `wfile.write` → `BrokenPipeError` → new typed handler). Mocks alone wouldn't prove this — need the real HTTPServer + real socket transport.
+- **Unchanged invariants:** `_try_reconnect_db()`'s body and call sites are unchanged. The `Handler` class structure, `_FUNC_*_ROUTES` registration tables, and route-body code in `web/routes/*.py` are all untouched. `cratedigger.service`'s 5-min systemd timer still triggers cycles. The cratedigger main loop still finishes its cycle cleanly (the deleted POST was best-effort wrapped in `try/except Exception: pass` — its absence is invisible).
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The new disconnect handler swallows errors that were previously useful for debugging (e.g. a real network problem that today shows up as a traceback). | Single WARNING log line per disconnect preserves observability. If the BrokenPipe count climbs again post-deploy, journald shows the WARNING lines and the source path — enough to triage. |
+| The raw-socket test is flaky in CI (timing-dependent). | The test asserts on observable side effects (`_try_reconnect_db` mock call count, log records) rather than on timing. Use `socket.SHUT_RDWR` + small `time.sleep(0.05)` to ensure the server has attempted the body write before the assertion runs. If still flaky, add a retry decorator. |
+| U3's audit reveals psycopg2 thread-safety blocker (expected). | Plan already accommodates: defer U3, ship U1+U2 alone (the wedge fix), file follow-up. The audit is cheap (~30 min of code reading). |
+| The narrowed exception clauses miss a disconnect path on a non-Linux platform. | Deploy target is Linux only (NixOS doc2). Don't add cross-platform fallbacks unless the test suite reveals one is needed. |
+| U2's RED test passes accidentally before the fix lands (false negative). | RED-first discipline: run the test against unmodified code first; assert it fails on the `_try_reconnect_db` mock count. Only proceed to GREEN once RED is verified. |
+| Deploy-window asymmetry: between cratedigger-web restart and next cratedigger.service tick, an in-flight cycle may POST to the now-removed endpoint. | The existing `try: urlopen(...) except Exception: pass` swallows the resulting 404 silently. Benign. Documented here so a journald reader doesn't chase it. |
+
+---
+
+## Documentation / Operational Notes
+
+- **Deploy via the standard nix flake flow per `.claude/rules/deploy.md`:** push code → `nix flake update cratedigger-src` on doc1 → `nixos-rebuild switch` on doc2. `cratedigger-web.service` restarts on switch (per its `restartIfChanged` default); `cratedigger.service` does not restart (per its `restartIfChanged = false`) but the next 5-min timer tick picks up the new code.
+- **Post-deploy verification (R4):** `ssh doc2 'sudo journalctl -u cratedigger-web --since "1 hour ago" | grep -c BrokenPipeError'` should return ≤2 within an hour of deploy, and `--since "24 hours ago"` should return <5 after a full day. If the count stays elevated, U2's narrowing didn't take effect — investigate.
+- **Spot-check that U1's deletion took effect:** `ssh doc2 'sudo journalctl -u cratedigger --since "10 min ago" | grep cache/invalidate'` should return nothing after a cycle has run.
+- **No CLAUDE.md or `.claude/rules/web.md` updates required.** Both still describe the current stack accurately. The architectural rule rewrite is part of the deferred future Rust rewrite, not this patch.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md](../solutions/web-rewrite-deferred-pending-runtime-redesign.md)
+- Issue #233 — original wedge incident with full forensics (run `gh issue view 233` for details).
+- Issue #227 — sibling perf issue that surfaced the BrokenPipe alarm pattern.
+- `cratedigger.py:1605-1617` — the storm trigger.
+- `web/server.py:50-65` — `_try_reconnect_db()`.
+- `web/server.py:299-329, 331-365` — `do_GET` / `do_POST` catch-alls.
+- `web/server.py:245-252` — `_json()` write site that raises `BrokenPipeError`.
+- `tests/test_web_server.py:97-130` — `_WebServerCase` test harness pattern to extend.
+- Superseded brainstorms (retained for context): `docs/brainstorms/2026-05-09-web-stack-bottle-waitress-requirements.md`, `docs/brainstorms/2026-05-09-cratedigger-web-rust-rewrite-requirements.md`.

--- a/docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md
+++ b/docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md
@@ -1,0 +1,131 @@
+---
+date: 2026-05-09
+module: web
+tags: architecture, rust, refactor, deferred, design-decision
+problem_type: design-decision
+---
+
+# Web rewrite is deferred — `web/` is not a clean architectural seam yet
+
+## TL;DR
+
+Two attempts to rewrite `cratedigger-web` (Bottle + waitress; then Rust) both failed at the requirements-doc stage for the same underlying reason: **`web/routes/*.py` is not a clean architectural seam.** POST handlers orchestrate ~4,000 LOC of pipeline business logic from `lib/*` (`manual_import`, `import_queue`, `wrong_match_triage`, `import_preview`, `search_plan_service`, `audio_hash`, `release_cleanup`, `library_delete_service`, `spectral_check`, `wrong_matches`). Carving the web layer into a separate language requires either re-deriving all of that lib code (forgets accumulated bug-fixes from many incidents) or designing a new IPC surface (new design + maintenance burden + cross-language debugging). Neither is a "rewrite the web layer" project — both are cratedigger-runtime-redesign projects with the web rewrite as a beneficiary.
+
+**Decision:** apply the minimal Python patch to kill the current wedge (issue #233). Defer any framework or language migration until the cratedigger runtime is redesigned (cycle-driven → static / event-driven), at which point the web layer's seams will be in cleaner places and a Rust rewrite becomes a tractable carve-out.
+
+## What triggered this
+
+Issue #233: `cratedigger-web` wedged silently for ~9 hours on 2026-05-08. systemd reported `active (running)`, the listener still accepted TCP, but every HTTP request hung forever until manual restart. ce-debug traced the root cause to the `cratedigger.py:1610` end-of-cycle `POST /api/cache/invalidate` (no-op since #101) closing its socket mid-body, the `do_POST` catch-all in `web/server.py` treating the resulting `BrokenPipeError` as a database error and unconditionally tearing down + reopening the psycopg2 connection, and ~3 unnecessary reconnects per minute compounding until the single-threaded server thread blocked indefinitely in `poll()`. Sibling issue #227 had been tracking the BrokenPipe count climbing as a leading indicator.
+
+The clean fix story was: replace the homegrown `http.server` + global psycopg2 + unconditional reconnect with something that has these properties as runtime guarantees rather than as engineered behaviour. That story turned out to be more complicated than it looked.
+
+## Attempt 1: Bottle + waitress (Python WSGI)
+
+Captured at `docs/brainstorms/2026-05-09-web-stack-bottle-waitress-requirements.md` (now superseded).
+
+The pitch: keep Python, swap the homegrown stdlib server for a real WSGI app on a worker server. Worker isolation + per-request timeouts + per-thread psycopg2 connections via standard library mechanisms instead of `_try_reconnect_db()`.
+
+**Killed by ce-doc-review** (kieran-python persona): R3 stated "Request timeouts are enforced by waitress, not by application code." This is **factually wrong** — waitress has no per-request timeout primitive, only `channel_timeout` for idle clients. The Key Decisions rationale for picking waitress over gunicorn (*"waitress's request timeout makes the wedge unreachable"*) rested on a capability that doesn't exist.
+
+**Lesson:** when picking infrastructure, verify the specific capability you're depending on actually exists in the version you're picking. Don't trust framing claims from your own memory or from one source. Cost of being wrong: an entire requirements doc that the planner would have built against a phantom feature.
+
+The prior-art ce-doc-review on this attempt also surfaced ~156 handler-coupled call sites across `web/routes/*.py` (`h._json`, `h._error`, `h.send_header`, `h.wfile.write`, `h.headers.get`, `h.rfile.read`) — even within Python the migration wasn't "mechanical decoration," it was a route-body rewrite for every endpoint.
+
+## Attempt 2: Full Rust rewrite (axum + sqlx + rusqlite + fred)
+
+Captured at `docs/brainstorms/2026-05-09-cratedigger-web-rust-rewrite-requirements.md` (now superseded).
+
+The pitch: leave Python for the pipeline (beets-locked) but rewrite the web layer in Rust. Wedging stops being a class of failure (tokio + tower middleware give per-request timeouts, panic isolation, and pool-managed connections as runtime properties). End-to-end type safety via sqlx compile-time SQL validation + serde JSON contracts. A research sub-agent confirmed `axum 0.8 + sqlx + rusqlite + fred + tracing + crane` as the consensus 2026 stack.
+
+**Killed by ce-doc-review** (feasibility persona, P0 finding): the doc treated "52 routes" as if they were thin "query DB, format JSON" handlers. Reality from `web/routes/*.py`:
+
+- POST handlers call into ~3,900 LOC of pipeline lib code: `manual_import`, `import_queue`, `wrong_match_triage`, `import_preview`, `search_plan_service`, `audio_hash`, `release_cleanup`, `library_delete_service`, `artist_compare`, `artist_releases`, `spectral_check`, `wrong_matches`.
+- Endpoints like `post_pipeline_ban_source`, `post_pipeline_force_import`, `post_wrong_match_converge`, `post_pipeline_search_plan_regenerate` aren't thin routing — they orchestrate audio hashing, beets removal via subprocess, advisory locks, importer-job race-checks, search-plan generation.
+- The Decisions tab additionally exposes pure functions from `lib/quality.py` (`dispatch_action`, `get_decision_tree`, `quality_gate_decision`) — same coupling.
+
+A clean Rust web layer requires picking one of:
+
+- **Port the lib code** (~4,000 LOC of business logic) → doubles the rewrite scope; re-derives subtle behaviour (the lib code carries scars from many incidents — Palo Santo data loss, Lucksmiths MBID drift, the cooldown logic, spectral verification quirks, bad-rip detection, the wedge itself); forgets accumulated bug-fixes by re-implementing from scratch.
+- **IPC back to Python** for the heavy POST handlers → new design surface, new service to deploy, debugging crosses a language boundary, latency added per request.
+- **Hybrid** — Rust for GETs, IPC for POSTs → captures most of the wins without re-deriving the lib, but the conceptual split is real ongoing tax.
+
+None of these are a "rewrite the web layer" project. They're all "cratedigger architecture redesign" projects with a web rewrite as a side effect.
+
+**Lesson:** before committing to a language/framework migration on a piece of a codebase, audit what that piece actually depends on. The web layer isn't autonomous — it's a thin facade in front of pipeline business logic. The seam between "web concerns" and "pipeline concerns" is in the wrong place to support a clean carve-out.
+
+## The deeper observation: cratedigger isn't yet shaped for cleanly-carved services
+
+Today's cratedigger architecture is **cycle-driven**:
+
+- `cratedigger.service` runs every 5 minutes via systemd timer, importing all of `lib/*` synchronously into one Python process for the cycle's duration.
+- `cratedigger-web.service` is a long-running stdlib HTTP server in a different process that reaches into the same `lib/*` for its POST handlers.
+- `cratedigger-importer.service` is a third process that drains the import queue, also reaching into `lib/*`.
+
+All three processes are essentially Python scripts that share `lib/*` by import. There's no IPC contract between them — the contract IS the shared Python codebase. That works fine until you try to carve one process into a different language: the import-graph dependency becomes the migration boundary, and the migration boundary turns out to be ~4,000 LOC.
+
+A **static / event-driven** architecture would push the seams in different places:
+
+- Pipeline state changes happen via PG `NOTIFY` channels or a queue rather than 5-min cycles.
+- The importer worker is a long-running daemon that owns its corner of the lib (the import-relevant parts); other processes interact with it via well-defined commands (RPC, queue, or HTTP).
+- The web layer becomes genuinely thin: it queries the pipeline DB, it issues commands to the importer daemon, it doesn't import lib code directly.
+- `lib/*` decomposes naturally into "shared utilities," "importer-owned business logic," and "search/decision pure functions exposed via a stable interface."
+
+In that architecture, the web layer is a clean carve-out target — Rust or otherwise. Today's web layer is not.
+
+## The decision
+
+1. **Apply the minimal Python patch** to kill the current wedge. ce-plan handles the implementation. Specifically:
+   - Delete the end-of-cycle `urlopen` to `/api/cache/invalidate` in `cratedigger.py:1605-1617` (the source of the storm).
+   - In `web/server.py`'s `do_GET` and `do_POST` catch-alls (lines 326-329 and 362-365), recognise client-disconnect errors (`BrokenPipeError`, `ConnectionResetError`, `ConnectionAbortedError`) **before** the existing `_try_reconnect_db()` call. Single-line warning; no reconnect; no second body-write attempt.
+   - The `_try_reconnect_db()` call survives unchanged — it still fires on real exceptions (which the catch-all is too broad about, but that's a separate cleanup not required to kill the wedge).
+   - Optional but cheap: switch from `HTTPServer` to `ThreadingHTTPServer` so a single slow request doesn't block all routes. Two-line change. Verify per-request handlers don't share mutable state first.
+
+2. **Defer the framework/language migration.** Re-evaluate when:
+   - The cratedigger runtime is being redesigned for other reasons (cycle-driven → static / event-driven). The redesign is the larger project; the web rewrite rides along.
+   - OR a second wedge-class incident occurs that the minimal patch doesn't prevent. That would be evidence the structural concern is real, not theoretical.
+
+3. **Capture this learning** so future-self / future-Claude doesn't re-derive it. (This document.)
+
+## What a future Rust rewrite would need to be true
+
+For a Rust rewrite of the web layer to be a clean carve-out, all of these need to hold:
+
+- **The web layer's responsibilities are bounded.** It queries data and issues commands; it doesn't orchestrate business logic by importing pipeline modules.
+- **The boundary between web and pipeline is an IPC contract**, not a shared Python codebase. PG NOTIFY, JSON-RPC over Unix socket, or HTTP between services — pick one and stick to it.
+- **`lib/quality.py`'s pure decision functions are exposed via that contract**, not by Python import. Either the importer daemon hosts them and the web service queries via RPC, or they're a tiny library re-implemented in both languages with a shared test corpus that proves equivalence.
+- **The audio hashing / beets removal / search-plan generation logic** is owned by a long-running daemon in Python, not invoked synchronously from the web layer.
+
+When those preconditions hold, the web rewrite becomes the kind of project the Rust ecosystem is well-suited for: a thin axum + sqlx service that's mostly type-safe SQL queries and JSON serialization. Until then, the rewrite is a Trojan horse for the larger architectural change, and pretending otherwise produces requirements docs that ce-doc-review correctly rejects.
+
+## Adjacent ideation (for a future brainstorm)
+
+A separate brainstorm worth running, when the time is right, is **"cratedigger as a static / event-driven service rather than a cycle-driven script."** Open questions for that brainstorm:
+
+- What replaces the 5-min systemd timer? (PG `LISTEN`/`NOTIFY` per state transition? Long-running daemon with internal scheduler? Both?)
+- Where does the importer worker's responsibility end and the pipeline's begin under the new model?
+- Is the harness (`harness/beets_harness.py`) hosted by the daemon or invoked per-import?
+- What does the test taxonomy look like when there are no cycles to anchor "orchestration" tests against?
+- How does the web layer interact with the new model?
+- What's the migration path from the cycle-driven service to the static one — can they coexist for a deploy window?
+
+That brainstorm is the right place to surface a Rust rewrite as a downstream consequence, not as the framing.
+
+## What got reviewed and what was learned about the review process
+
+Both attempts were saved by ce-doc-review:
+
+- The Bottle+waitress doc would have shipped a 50-route migration built against a non-existent waitress feature. The kieran-python persona caught it in round 1 because that persona reads framework documentation, not just brainstorm prose.
+- The Rust doc would have committed 3 weeks of focused work to a project whose scope was 2-3x the estimate. The feasibility persona caught it by actually counting LOC in the lib modules the web routes import, rather than trusting the doc's "thin route" framing.
+
+**Lesson for future brainstorms:** when proposing a carve-out / migration / rewrite, the brainstorm dialogue should explicitly enumerate the imports / call-sites the carved-out piece depends on. The current `ce-brainstorm` flow doesn't force this — `ce-doc-review` catches it after-the-fact. Worth adding "what does this piece actually depend on?" as an explicit Phase 1.2 probe for migration-shaped proposals.
+
+## Cross-references
+
+- Issue #233 — original wedge incident with full forensics
+- Issue #227 — sibling perf issue that surfaced the BrokenPipe alarm
+- `docs/brainstorms/2026-05-09-web-stack-bottle-waitress-requirements.md` — superseded; the Bottle+waitress attempt
+- `docs/brainstorms/2026-05-09-cratedigger-web-rust-rewrite-requirements.md` — superseded; the Rust attempt
+- `cratedigger.py:1605-1617` — the end-of-cycle POST that triggers the storm
+- `web/server.py:50-65` — `_try_reconnect_db()`
+- `web/server.py:326-329, 362-365` — the catch-alls that fire it unconditionally
+- `lib/pipeline_db.py:838-839` — the `advisory_lock` docstring that documents today's "single-threaded HTTPServer already serialises within its own session" assumption

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -8,6 +8,7 @@ verifying response codes, JSON structure, and error handling.
 import copy
 from datetime import datetime, timezone
 import json
+import logging
 import os
 import sys
 import tempfile
@@ -7322,6 +7323,198 @@ class TestFuzzyShimRemoved(unittest.TestCase):
             "check_beets_by_artist_album was deleted in issue #123 "
             "— the fuzzy artist+album shim must not return.",
         )
+
+
+class TestClientDisconnectHandling(unittest.TestCase):
+    """Issue #233 wedge regression: client closes mid-response.
+
+    Before this fix, a BrokenPipeError raised inside do_GET/do_POST
+    (typically from _json's wfile.write to a closed socket) reached
+    the bare ``except Exception`` catch-all, which unconditionally
+    called _try_reconnect_db() and tried to write a 500 body back to
+    the dead socket — causing a second BrokenPipeError, a 30-line
+    chained traceback in journald, and a costly DB reconnect.
+    Sustained client-disconnect traffic (cratedigger.py's end-of-cycle
+    POST that closed mid-body, see U1) compounded reconnects until the
+    single-threaded server wedged in poll().
+
+    U2's fix: a typed ``except (BrokenPipeError, ConnectionResetError,
+    ConnectionAbortedError)`` clause sits before the existing catch-all
+    in both do_GET and do_POST. Disconnect errors get a single WARNING
+    log line and a clean return — no DB reconnect, no second body-write.
+
+    These tests inject the exception via ``mock_db.<method>.side_effect``
+    rather than via raw-socket mid-body close. The mechanism is the same
+    code path (typed except clause inside do_POST's try block); the
+    side_effect approach is deterministic where raw-socket timing is
+    flaky on localhost. R3 regression-guard tests confirm the existing
+    catch-all still fires for real handler errors.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server, cls.port, cls.mock_db = _make_server()
+        cls.base = f"http://127.0.0.1:{cls.port}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def setUp(self):
+        # Ensure each test starts with a clean side_effect.
+        self.mock_db.update_request_fields.side_effect = None
+        self.mock_db.update_request_fields.return_value = None
+
+    def _post(self, path, body):
+        url = f"{self.base}{path}"
+        data = json.dumps(body).encode()
+        req = Request(url, data=data, headers={"Content-Type": "application/json"})
+        try:
+            resp = urlopen(req, timeout=2)
+            return resp.status, json.loads(resp.read())
+        except HTTPError as e:
+            return e.code, json.loads(e.read())
+        except Exception:
+            # Connection-level failures (which is exactly what the wedge
+            # produces server-side) surface client-side as URLError or
+            # similar. Tests assert on server-side observable state, not
+            # on the client response.
+            return None, None
+
+    def _assert_no_reconnect_no_traceback(self, mock_reconnect, log_records, kind):
+        """Shared assertions for the disconnect-class tests."""
+        # The narrowed clause caught the disconnect — no reconnect attempted.
+        self.assertEqual(
+            mock_reconnect.call_count, 0,
+            f"{kind} must not trigger _try_reconnect_db",
+        )
+        # A single WARNING-level record about the disconnect.
+        warnings = [r for r in log_records if r.levelname == "WARNING"]
+        self.assertGreaterEqual(
+            len(warnings), 1,
+            f"Expected at least one WARNING log line for {kind}, "
+            f"got records: {[(r.levelname, r.getMessage()) for r in log_records]}",
+        )
+        self.assertTrue(
+            any("Client disconnect" in r.getMessage() for r in warnings),
+            f"Expected 'Client disconnect' in WARNING for {kind}, got: "
+            f"{[r.getMessage() for r in warnings]}",
+        )
+        # No log.exception (ERROR with exc_info) — that's the 30-line
+        # traceback pattern the wedge produced.
+        errors_with_exc = [
+            r for r in log_records
+            if r.levelname == "ERROR" and r.exc_info is not None
+        ]
+        self.assertEqual(
+            len(errors_with_exc), 0,
+            f"Disconnect ({kind}) must not emit a traceback "
+            f"(would be the journald-flood signature). Found: "
+            f"{[r.getMessage() for r in errors_with_exc]}",
+        )
+
+    @patch("web.server._try_reconnect_db")
+    def test_brokenpipe_during_post_does_not_trigger_reconnect(self, mock_reconnect):
+        """Wedge regression: BrokenPipeError reaches the typed except
+        clause first, never the catch-all that reconnects."""
+        self.mock_db.update_request_fields.side_effect = BrokenPipeError(32, "Broken pipe")
+        with self.assertLogs("cratedigger-web", level="WARNING") as cm:
+            self._post("/api/pipeline/set-intent",
+                       {"id": 100, "intent": "default"})
+        self._assert_no_reconnect_no_traceback(mock_reconnect, cm.records, "BrokenPipeError")
+
+    @patch("web.server._try_reconnect_db")
+    def test_connection_reset_during_post_does_not_trigger_reconnect(self, mock_reconnect):
+        """Sibling disconnect class — same handling expected."""
+        self.mock_db.update_request_fields.side_effect = ConnectionResetError(104, "Connection reset by peer")
+        with self.assertLogs("cratedigger-web", level="WARNING") as cm:
+            self._post("/api/pipeline/set-intent",
+                       {"id": 100, "intent": "default"})
+        self._assert_no_reconnect_no_traceback(mock_reconnect, cm.records, "ConnectionResetError")
+
+    @patch("web.server._try_reconnect_db")
+    def test_connection_aborted_during_post_does_not_trigger_reconnect(self, mock_reconnect):
+        """Sibling disconnect class — same handling expected."""
+        self.mock_db.update_request_fields.side_effect = ConnectionAbortedError(103, "Software caused connection abort")
+        with self.assertLogs("cratedigger-web", level="WARNING") as cm:
+            self._post("/api/pipeline/set-intent",
+                       {"id": 100, "intent": "default"})
+        self._assert_no_reconnect_no_traceback(mock_reconnect, cm.records, "ConnectionAbortedError")
+
+    @patch("web.server._try_reconnect_db")
+    def test_real_db_error_still_triggers_reconnect(self, mock_reconnect):
+        """R3 regression guard: psycopg2.OperationalError must still hit
+        the catch-all and trigger _try_reconnect_db. The narrowing must
+        not change behaviour for real DB errors."""
+        import psycopg2
+        self.mock_db.update_request_fields.side_effect = psycopg2.OperationalError("simulated PG outage")
+        with self.assertLogs("cratedigger-web", level="ERROR") as cm:
+            status, _ = self._post("/api/pipeline/set-intent",
+                                   {"id": 100, "intent": "default"})
+        # Real DB error → catch-all fires → reconnect attempted.
+        self.assertEqual(
+            mock_reconnect.call_count, 1,
+            "Real psycopg2.OperationalError must still trigger _try_reconnect_db",
+        )
+        # log.exception emits ERROR with exc_info — that's the existing behaviour.
+        errors_with_exc = [
+            r for r in cm.records
+            if r.levelname == "ERROR" and r.exc_info is not None
+        ]
+        self.assertGreaterEqual(
+            len(errors_with_exc), 1,
+            "Real DB error must produce a log.exception traceback for diagnosis",
+        )
+        # Server returns 500.
+        self.assertEqual(status, 500)
+
+    @patch("web.server._try_reconnect_db")
+    def test_other_exception_in_handler_still_triggers_reconnect(self, mock_reconnect):
+        """Unchanged-behaviour regression guard: a real handler bug
+        (e.g. ValueError) still hits the catch-all. Narrowing this
+        further (so non-DB exceptions skip the reconnect) is explicitly
+        out of scope per the plan — see follow-up #234."""
+        self.mock_db.update_request_fields.side_effect = ValueError("simulated handler bug")
+        with self.assertLogs("cratedigger-web", level="ERROR") as cm:
+            status, _ = self._post("/api/pipeline/set-intent",
+                                   {"id": 100, "intent": "default"})
+        self.assertEqual(
+            mock_reconnect.call_count, 1,
+            "Existing broad catch-all behaviour preserved: any non-disconnect "
+            "exception still triggers _try_reconnect_db. Narrowing is deferred to #234.",
+        )
+        errors_with_exc = [
+            r for r in cm.records
+            if r.levelname == "ERROR" and r.exc_info is not None
+        ]
+        self.assertGreaterEqual(len(errors_with_exc), 1)
+        self.assertEqual(status, 500)
+
+    @patch("web.server._try_reconnect_db")
+    def test_normal_post_no_reconnect_no_warning(self, mock_reconnect):
+        """Happy path regression guard: a successful POST does not
+        trigger any reconnect or disconnect-warning side effects."""
+        # mock_db.set_intent_for_request returns True by default per setUp.
+        # Use assertNoLogs (Python 3.10+) to assert no WARNING/ERROR records.
+        # Some logger setups still emit INFO; we only care that no WARNING
+        # for "Client disconnect" appears and no ERROR is emitted.
+        with self.assertLogs("cratedigger-web", level="DEBUG") as cm:
+            # assertLogs requires at least one record; a trivial DEBUG log
+            # ensures the context manager is satisfied even on a quiet path.
+            logging.getLogger("cratedigger-web").debug("test marker: normal POST path")
+            status, _ = self._post("/api/pipeline/set-intent",
+                                   {"id": 100, "intent": "default"})
+        self.assertEqual(mock_reconnect.call_count, 0)
+        disconnect_warnings = [
+            r for r in cm.records
+            if r.levelname == "WARNING" and "Client disconnect" in r.getMessage()
+        ]
+        self.assertEqual(len(disconnect_warnings), 0,
+            "Normal POST must not emit a disconnect WARNING")
+        errors = [r for r in cm.records if r.levelname == "ERROR"]
+        self.assertEqual(len(errors), 0,
+            f"Normal POST must not produce ERROR logs, got: "
+            f"{[r.getMessage() for r in errors]}")
 
 
 if __name__ == "__main__":

--- a/web/server.py
+++ b/web/server.py
@@ -323,6 +323,14 @@ class Handler(BaseHTTPRequestHandler):
                     fn(self, params, *m.groups())  # type: ignore[operator]
                     return
             self._error("Not found", 404)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError) as e:
+            # Issue #233: client closed mid-response. The original wedge cause
+            # was the broad `except Exception` below firing _try_reconnect_db
+            # on every disconnect, which compounded into a reconnect storm
+            # under sustained client-disconnect traffic. Catch the disconnect
+            # classes here first — single warning line, no DB churn, no second
+            # body-write attempt to a dead socket.
+            log.warning("Client disconnect on GET %s: %s", path, type(e).__name__)
         except Exception as e:
             log.exception("GET %s failed", path)
             _try_reconnect_db()
@@ -336,7 +344,10 @@ class Handler(BaseHTTPRequestHandler):
             # Cache invalidation endpoint — kept for backwards compat with
             # cratedigger's main-loop POST at end of every cycle. Post-#101
             # there's nothing to invalidate at the `web:` namespace, so
-            # this is a best-effort no-op.
+            # this is a best-effort no-op. NOTE: The cratedigger-side caller
+            # was deleted in this PR; this handler stays in place to absorb
+            # the deploy-window asymmetry (in-flight cycles may POST during
+            # the swap). Tracked for cleanup in #234.
             if path == "/api/cache/invalidate":
                 length = int(self.headers.get("Content-Length", 0))
                 body = json.loads(self.rfile.read(length)) if length else {}
@@ -359,6 +370,12 @@ class Handler(BaseHTTPRequestHandler):
                     fn(self, body, *m.groups())  # type: ignore[operator]
                     return
             self._error("Not found", 404)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError) as e:
+            # Issue #233: see do_GET above. The function-level except covers
+            # both the cache-invalidate short-circuit and the dispatch path —
+            # they share this outer try block, so any disconnect on either is
+            # handled here.
+            log.warning("Client disconnect on POST %s: %s", path, type(e).__name__)
         except Exception as e:
             log.exception("POST %s failed", path)
             _try_reconnect_db()


### PR DESCRIPTION
## Summary

Fixes #233 (cratedigger-web silently wedged for 9 hours on 2026-05-08) with the smallest possible Python patch on the existing stdlib \`http.server\` stack — no framework migration, no Rust, no architectural change. Three commits map 1:1 to the plan's three implementation units.

Architectural framing for why we are NOT rewriting the web layer right now lives at \`docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md\`. TL;DR: \`web/routes/*.py\` POST handlers orchestrate ~4,000 LOC of pipeline lib code, so no clean web-only carve-out exists today. Defer to a future cratedigger runtime redesign (cycle-driven → static / event-driven).

## What changes

### U1 — \`fix(cratedigger)\` — delete the end-of-cycle cache-invalidate POST

\`cratedigger.py:1605-1617\` posted to \`/api/cache/invalidate\` every cycle via \`urlopen(req, timeout=2)\` and never read the response body. urlopen closed the socket when scope exited, while the server was still mid-write — every invocation produced a server-side BrokenPipeError. The endpoint has been a documented no-op since #101 (no \`web:\` cache keys exist to invalidate). Pure dead-code removal.

### U2 — \`fix(web)\` — narrow do_GET/do_POST catch-all to skip reconnect on disconnect

The bare \`except Exception\` catch-all called \`_try_reconnect_db()\` on every caught exception, including BrokenPipeError. The reconnect storm wedged the single thread in poll(). This PR adds a typed \`except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)\` clause before the existing catch-all in both \`do_GET\` and \`do_POST\`. Disconnect errors now produce a single WARNING log line, no DB reconnect, no second body-write attempt.

The function-level \`except\` in \`do_POST\` covers both the legacy \`/api/cache/invalidate\` short-circuit and the dispatch path (they share the outer try block). The cache-invalidate handler stays in place to absorb the deploy-window asymmetry — cleanup tracked in #234.

### U3 — \`ThreadingHTTPServer\` swap — DEFERRED per audit

A focused read-only sub-agent audit confirmed the expected blocker: ThreadingHTTPServer is **NOT SAFE** to land alongside this fix. Concrete blockers:

1. \`web/server.py:67\` — \`db: PipelineDB | None = None\` is a single shared psycopg2 connection. psycopg2 documents that connection objects (and cursors created from them) are not thread-safe — protocol bytes will interleave on the wire even for read-only queries.
2. \`lib/beets_db.py:127\` — \`sqlite3.connect(...)\` opens the beets handle without \`check_same_thread=False\`. Threaded use raises \`ProgrammingError: SQLite objects created in a thread can only be used in that same thread.\`
3. \`lib/pipeline_db.py:837-839\` — \`advisory_lock\` docstring explicitly relies on the assumption that "the web server (single-threaded HTTPServer) already serialises within its own session." Threading silently breaks the mutual-exclusion guarantee.
4. \`web/server.py:50-65\` — \`_try_reconnect_db()\` rebinds the module-global \`db\` from request threads with no lock; concurrent requests would observe a closed conn.
5. \`scripts/web_dev_server.py:20,80\` — already declares \`class DevHTTPServer(ThreadingHTTPServer)\` and monkey-patches \`web_server._try_reconnect_db\`. **This is a latent bug today, masked only by single-developer use.**

What would have to change before ThreadingHTTPServer is safe: per-thread psycopg2 connection (e.g. \`threading.local()\` or \`psycopg2.pool.ThreadedConnectionPool\`); reopen \`BeetsDB\` with \`check_same_thread=False\`; update \`advisory_lock\` to acknowledge that single-session serialisation no longer holds; replace \`_try_reconnect_db\` 's module-global mutation with pool-managed reconnect. All four landings together.

This is exactly the design surface the deferred Rust rewrite would address structurally. Tracked in #234 and in \`docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md\`.

## Tests

New \`TestClientDisconnectHandling\` class in \`tests/test_web_server.py\` (6 tests, RED-then-GREEN):

- 3 disconnect-class tests (\`BrokenPipeError\`, \`ConnectionResetError\`, \`ConnectionAbortedError\`) assert no \`_try_reconnect_db\`, single WARNING line, no \`log.exception\` traceback.
- 2 regression-guard tests (\`psycopg2.OperationalError\`, \`ValueError\`) confirm the existing catch-all behaviour is unchanged for real handler errors. Narrowing the catch-all further (so non-DB exceptions skip reconnect) is deliberately deferred to #234.
- 1 happy-path guard confirms a normal POST emits no disconnect WARNING and no ERROR.

The exception is injected via \`mock_db.update_request_fields.side_effect\` rather than raw-socket mid-body close — same code path inside \`do_POST\`'s try block, deterministic where raw-socket timing is flaky on localhost.

Full suite: **3,156 tests, 55 skipped, 0 failures.**

## Test plan

- [x] Full unittest suite passes (\`nix-shell --run \"bash scripts/run_tests.sh\"\`)
- [x] New \`TestClientDisconnectHandling\` class passes
- [x] No new pyright errors on touched files (existing \`# type: ignore[operator]\` warnings on the dispatch code are pre-existing)
- [ ] After deploy: \`ssh doc2 'sudo journalctl -u cratedigger-web --since \"24 hours ago\" | grep -B1 BrokenPipeError | grep -c \"^Traceback\"'\` returns < 5. **Note: grep for the traceback signature, not bare \`BrokenPipeError\`** — the new typed except clause emits a single WARNING line containing \`type(e).__name__\` (i.e., the literal string "BrokenPipeError"), so a naive \`grep -c BrokenPipeError\` would count those WARNING lines too. The 30-line traceback flood (the journald-flood signature from #233) is what we need to confirm is gone.
- [ ] After deploy: \`ssh doc2 'sudo journalctl -u cratedigger --since \"10 min ago\" | grep cache/invalidate'\` returns nothing (confirms U1 took effect).
- [ ] No wedge incident for 30 days under normal traffic.

## What this does NOT fix

Per the plan and the doc-review, several items remain open and are tracked in **#234**:

- Per-request socket/read timeouts on Beets sqlite + Redis (a virtiofs hitch or Redis hang still holds the single thread).
- Per-request watchdog that crashes the process via \`os._exit\` after N seconds.
- Narrowing the bare \`except Exception\` further (a real handler bug like ValueError still triggers an unnecessary DB reconnect).

The Q1 dashboard cache wrapper from #227 also remains separately open (perf optimization, unrelated to the wedge).

The fundamental "head-of-line blocking from a single slow request" risk persists until the cratedigger runtime redesign captured in \`docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md\` happens. This patch fixes the SPECIFIC wedge from #233, not the wedge CLASS.

## Deploy

Standard nix flake flow per \`.claude/rules/deploy.md\`:

\`\`\`bash
# After merge:
ssh doc1 'cd ~/nixosconfig && nix flake update cratedigger-src && git add flake.lock && git commit -m \"cratedigger: web wedge fix\" && git push'
ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
\`\`\`

\`cratedigger-web.service\` restarts on switch; \`cratedigger.service\` does not (per \`restartIfChanged = false\`) but the next 5-min timer tick picks up the new code.

## References

- Closes #233
- Related #227 (sibling perf issue; this PR addresses the BrokenPipe-storm angle only)
- Followup #234 (sqlite/Redis timeouts + watchdog + catch-all narrowing + ThreadingHTTPServer prerequisites)
- Plan: \`docs/plans/2026-05-09-001-fix-cratedigger-web-wedge-minimal-patch-plan.md\`
- Architectural framing: \`docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md\`
- Superseded brainstorms (kept as journey records): the Bottle+waitress and Rust attempts in \`docs/brainstorms/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)