### PR TITLE
feat(config): beets_directory option decouples absolutization from plex_path_map

### DIFF
--- a/docs/plex-primer.md
+++ b/docs/plex-primer.md
@@ -44,17 +44,31 @@ Single function: `lib/util.py::trigger_plex_scan(cfg, imported_path)`.
 - Sends `GET <plex_url>/library/sections/<id>/refresh?path=<...>&X-Plex-Token=<...>`.
 - Best-effort — failures don't block the import.
 
-The `path_map` config translates the cratedigger-side filesystem path
-(`/mnt/virtio/Music/Beets/...`) into the Plex container's path
-(`/prom_music/...`). **Beets stores paths as relative to its
-`directory:` root, so `imported_path` is normally relative.** The
-substitution handles both relative and absolute inputs and warns on
-unmappable absolute paths — see PR #236 and
-`docs/solutions/runtime-errors/plex-partial-scan-silent-200.md`.
+### How paths get to Plex
+
+Beets stores file paths as **relative** to its `directory:` root, so
+`imported_path` is normally something like `Artist/Album` (no leading
+slash). `trigger_plex_scan` runs two transforms in sequence:
+
+1. **Absolutize** if relative and `beets_directory` is set
+   (`Artist/Album` → `/mnt/virtio/Music/Beets/Artist/Album`).
+2. **Translate host → container** if `path_map` is set
+   (`/mnt/virtio/Music/Beets/Artist/Album` → `/prom_music/Artist/Album`).
+
+If both are set (this homelab), the two compose. If only `path_map` is
+set, the path_map substitution itself anchors relative paths under the
+container prefix as a fallback. If only `beets_directory` is set
+(bare-metal Plex on the same host as beets), the absolutize step is
+sufficient by itself. See PR #236 and
+`docs/solutions/runtime-errors/plex-partial-scan-silent-200.md` for the
+five-week silent-failure story behind this.
 
 ### Cratedigger config (`/var/lib/cratedigger/config.ini`)
 
 ```ini
+[Beets]
+directory = /mnt/virtio/Music/Beets
+
 [Plex]
 url = https://plex.ablz.au
 token_file = /run/cratedigger-secrets/PLEX_TOKEN
@@ -65,6 +79,21 @@ path_map = /mnt/virtio/Music/Beets:/prom_music
 `token_file` is sops-managed (`secrets/cratedigger.env` on doc1, decrypted
 into `/run/cratedigger-secrets/` at runtime via the
 `cratedigger-secrets-split` oneshot — see `docs/nixos-module.md`).
+
+### Plex on a different setup (other deployments)
+
+The path-shape concerns are configurable; nothing is hardcoded:
+
+| Deployment | Set in cratedigger config | Result |
+|------------|--------------------------|--------|
+| Plex in Docker, music mounted at a different container path | `[Beets] directory` + `[Plex] path_map = /host/beets:/container/path` | Absolutize then translate |
+| Plex on the same host as beets (bare metal, no remap) | `[Beets] directory` only | Absolutize, send absolute |
+| Plex with the same path on host and container (already absolute somehow) | `[Plex] path_map = /shared/root:/shared/root` | Idempotent translation |
+| Nothing configured | (warning logged) | Plex receives a relative path and silently no-ops |
+
+Via the Nix module, the equivalent options are
+`services.cratedigger.beetsDirectory` and
+`services.cratedigger.notifiers.plex.pathMap`.
 
 ## API Access
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -125,6 +125,16 @@ class CratediggerConfig:
     audio_check_mode: str = "normal"
     beets_tracking_file: str = ""
     verified_lossless_target: str = ""  # Target format after verified lossless (e.g. "opus 128", "mp3 v2")
+    # Absolute path to the beets library root (matches `directory:` in
+    # ~/.config/beets/config.yaml). Beets stores file paths in its SQLite
+    # DB as relative to this root, so `BeetsDB.get_album_info().album_path`
+    # is also relative. Consumers that perform host-side filesystem ops
+    # (cleanup_disambiguation_orphans) or send absolute paths to external
+    # services (trigger_plex_scan on bare-metal Plex) need to absolutize
+    # against this root. Optional — leave empty if the equivalent
+    # absolutization is provided via `plex_path_map` instead.
+    # See docs/solutions/runtime-errors/plex-partial-scan-silent-200.md.
+    beets_directory: str = ""
 
     # --- Quality Ranks (codec-aware comparison model, issue #60) ---
     quality_ranks: QualityRankConfig = field(default_factory=QualityRankConfig.defaults)
@@ -303,6 +313,9 @@ class CratediggerConfig:
             audio_check_mode=get("Beets Validation", "audio_check", "normal"),
             beets_tracking_file=get("Beets Validation", "tracking_file", ""),
             verified_lossless_target=get("Beets Validation", "verified_lossless_target", ""),
+            # Top-level `[Beets]` section (separate from `[Beets Validation]`
+            # which exists for legacy reasons). Empty string → unset.
+            beets_directory=get("Beets", "directory", ""),
             # Quality Ranks — codec-aware comparison policy. Missing section
             # yields the default QualityRankConfig (see lib/quality.py).
             quality_ranks=QualityRankConfig.from_ini(config),

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -1263,7 +1263,10 @@ def dispatch_import_core(
                     # disposable by design.
                     _cleanup_staged_dir(path)
                 if action.mark_done and ir.postflight.disambiguated and ir.postflight.imported_path:
-                    removed = cleanup_disambiguation_orphans(ir.postflight.imported_path)
+                    removed = cleanup_disambiguation_orphans(
+                        ir.postflight.imported_path,
+                        beets_directory=cfg.beets_directory if cfg is not None else "",
+                    )
                     if removed and cfg is not None:
                         trigger_meelo_clean(cfg)
         except sp.TimeoutExpired:

--- a/lib/util.py
+++ b/lib/util.py
@@ -229,7 +229,9 @@ def repair_mp3_headers(folder_path: str) -> None:
 from lib.quality import AUDIO_EXTENSIONS as _AUDIO_EXTS
 
 
-def cleanup_disambiguation_orphans(imported_path: str) -> list[str]:
+def cleanup_disambiguation_orphans(
+    imported_path: str, beets_directory: str = ""
+) -> list[str]:
     """Remove sibling directories that contain no audio files.
 
     After beets disambiguates an album path (e.g. renames '2009 - Blood Bank'
@@ -238,20 +240,24 @@ def cleanup_disambiguation_orphans(imported_path: str) -> list[str]:
     scans the parent (artist) directory and removes any sibling dirs that
     have zero audio files.
 
-    ``imported_path`` MUST be absolute. ``BeetsDB.get_album_info()`` returns
-    paths relative to the beets library root, so callers that source the
-    path from beets need to absolutize it (or accept the warn-and-skip below).
+    ``imported_path`` is absolutized against ``beets_directory`` if it's
+    relative (``BeetsDB.get_album_info()`` returns paths relative to the
+    beets library root). When ``beets_directory`` is empty and the path
+    is relative, warn-and-skip rather than silently no-op.
     Returns the list of removed directory paths.
     """
     if not os.path.isabs(imported_path):
-        # Symmetric defense with trigger_plex_scan's path_map warning: silent
-        # no-ops on a path-translation gap is exactly how PR #236 lurked for
-        # 5 weeks. See docs/solutions/runtime-errors/plex-partial-scan-silent-200.md
-        logger.warning(
-            f"cleanup_disambiguation_orphans: imported_path {imported_path!r} "
-            "is relative; cannot resolve siblings without an absolute beets root. "
-            "Skipping (no orphans removed).")
-        return []
+        if beets_directory:
+            imported_path = os.path.join(beets_directory, imported_path)
+        else:
+            # Symmetric defense with trigger_plex_scan: silent no-ops on a
+            # path-translation gap is exactly how PR #236 lurked for 5 weeks.
+            # See docs/solutions/runtime-errors/plex-partial-scan-silent-200.md
+            logger.warning(
+                f"cleanup_disambiguation_orphans: imported_path {imported_path!r} "
+                "is relative and beets_directory is unset; cannot resolve "
+                "siblings. Skipping (no orphans removed).")
+            return []
     artist_dir = os.path.dirname(imported_path)
     if not os.path.isdir(artist_dir):
         return []
@@ -536,20 +542,33 @@ def trigger_plex_scan(cfg: CratediggerConfig, imported_path: str | None = None) 
         if imported_path:
             from urllib.parse import quote
             scan_path = imported_path
+            # Step 1: absolutize relative paths via beets_directory if set.
+            # Beets stores paths relative to its library root, so this is the
+            # general-purpose mechanism for any deployment to absolutize.
+            if not os.path.isabs(scan_path) and cfg.beets_directory:
+                scan_path = os.path.join(cfg.beets_directory, scan_path)
+            # Step 2: translate host path → container path via path_map
+            # (only needed when Plex runs in a container with a different mount).
             if cfg.plex_path_map:
                 local_prefix, container_prefix = cfg.plex_path_map.split(":", 1)
                 if scan_path.startswith(local_prefix):
                     scan_path = container_prefix + scan_path[len(local_prefix):]
                 elif not os.path.isabs(scan_path):
-                    # beets stores paths relative to its library root.
-                    # Re-anchor under the container prefix so Plex resolves
-                    # them against the library section's location.
+                    # path_map is set but beets_directory wasn't (or didn't
+                    # apply). Fall back to anchoring relative paths under the
+                    # container_prefix — this is the original PR #236 fix.
                     scan_path = container_prefix.rstrip("/") + "/" + scan_path
                 else:
                     logger.warning(
                         f"PLEX: imported_path {scan_path!r} is absolute but "
                         f"outside path_map local_prefix {local_prefix!r}; "
                         "Plex may silently ignore the partial scan")
+            # Step 3: final guard — Plex won't resolve a relative path.
+            if not os.path.isabs(scan_path):
+                logger.warning(
+                    f"PLEX: imported_path {scan_path!r} is relative and no "
+                    "beets_directory or plex_path_map is configured to "
+                    "absolutize it; Plex may silently ignore the partial scan")
             url += f"&path={quote(scan_path, safe='')}"
         # Log the URL without the token for debugging
         safe_url = url.split("X-Plex-Token=")[0] + "X-Plex-Token=<redacted>"

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -168,6 +168,9 @@
     use_extension_whitelist = ${if cfg.downloadSettings.useExtensionWhitelist then "True" else "False"}
     extensions_whitelist = ${concatStringsSep "," cfg.downloadSettings.extensionsWhitelist}
 
+    [Beets]
+    directory = ${cfg.beetsDirectory}
+
     [Beets Validation]
     enabled = ${if cfg.beetsValidation.enable then "True" else "False"}
     harness_path = ${cfg.beetsValidation.harnessPath}
@@ -457,6 +460,24 @@ in {
         default = 100;
         description = "Redis command timeout for the pipeline peer cache, in milliseconds.";
       };
+    };
+
+    beetsDirectory = mkOption {
+      type = types.str;
+      default = "";
+      example = "/mnt/virtio/Music/Beets";
+      description = ''
+        Absolute path to the beets library root (matches `directory:` in
+        ~/.config/beets/config.yaml). Beets stores file paths in its SQLite
+        DB as relative to this root, so consumers that perform host-side
+        filesystem ops (cleanup_disambiguation_orphans) or send absolute
+        paths to external services (trigger_plex_scan on bare-metal Plex)
+        need to absolutize against this root.
+
+        Optional but recommended. Leave empty if you provide an equivalent
+        absolute prefix via notifiers.plex.pathMap (Docker remap form
+        `/host/beets:/container/path`).
+      '';
     };
 
     beetsValidation = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -415,6 +415,29 @@ class TestReadRuntimeConfig(unittest.TestCase):
         self.assertEqual(cfg.plex_url, "http://plex.test")
         self.assertEqual(cfg.plex_token, "test-token")
 
+    def test_beets_directory_defaults_to_empty(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".ini") as tmp:
+            tmp.write("[Slskd]\napi_key = ignored\n")
+            config_path = tmp.name
+        try:
+            cfg = read_runtime_config(config_path)
+        finally:
+            os.unlink(config_path)
+        self.assertEqual(cfg.beets_directory, "")
+
+    def test_beets_directory_read_from_config(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".ini") as tmp:
+            tmp.write(
+                "[Beets]\n"
+                "directory = /srv/music/Beets\n"
+            )
+            config_path = tmp.name
+        try:
+            cfg = read_runtime_config(config_path)
+        finally:
+            os.unlink(config_path)
+        self.assertEqual(cfg.beets_directory, "/srv/music/Beets")
+
 
 class TestReadRuntimeRankConfig(unittest.TestCase):
     def test_missing_config_returns_defaults(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -445,6 +445,36 @@ class TestCleanupDisambiguationOrphans(unittest.TestCase):
             f"Expected warning about relative path, got: {captured.output}",
         )
 
+    def test_relative_path_absolutizes_with_beets_directory(self):
+        """When beets_directory is provided, relative imported_path should be
+        absolutized against it and the function should perform real cleanup
+        (not just warn-and-skip)."""
+        from lib.util import cleanup_disambiguation_orphans
+        # Use the existing tmpdir as the synthetic beets root.
+        # self.artist_dir = <tmpdir>/Bon Iver, set by setUp.
+        imported_rel = os.path.relpath(self._make_dir(
+            "2009 - Blood Bank [2009]",
+            ["01 Blood Bank.mp3"]), self.tmpdir)
+        orphan = self._make_dir("2009 - Blood Bank", ["cover.jpg"])
+        removed = cleanup_disambiguation_orphans(
+            imported_rel, beets_directory=self.tmpdir)
+        self.assertFalse(os.path.exists(orphan))
+        self.assertEqual(removed, [orphan])
+
+    def test_relative_path_with_empty_beets_directory_still_warns(self):
+        """Empty beets_directory falls back to warn-and-skip — explicit
+        regression guard for the case where the config option is wired up
+        but left empty."""
+        from lib.util import cleanup_disambiguation_orphans
+        with self.assertLogs("cratedigger", level="WARNING") as captured:
+            removed = cleanup_disambiguation_orphans(
+                "Artist/Album", beets_directory="")
+        self.assertEqual(removed, [])
+        self.assertTrue(
+            any("relative" in m.lower() for m in captured.output),
+            f"Expected warning, got: {captured.output}",
+        )
+
     def test_ignores_files_in_artist_dir(self):
         """Files directly in the artist dir should not cause errors."""
         from lib.util import cleanup_disambiguation_orphans
@@ -550,12 +580,14 @@ class TestTriggerPlexScan(unittest.TestCase):
 
     def _make_cfg(self, url: str | None = "http://plex:32400",
                   token: str | None = "tok123", section: str | None = "3",
-                  path_map: str | None = None):
+                  path_map: str | None = None,
+                  beets_directory: str = ""):
         cfg = MagicMock()
         cfg.plex_url = url
         cfg.plex_token = token
         cfg.plex_library_section_id = section
         cfg.plex_path_map = path_map
+        cfg.beets_directory = beets_directory
         cfg.resolved_plex_token.return_value = token
         return cfg
 
@@ -668,6 +700,58 @@ class TestTriggerPlexScan(unittest.TestCase):
         # confirm we sent something rooted under /prom_music, not the raw
         # ./ prefix without anchoring.
         self.assertIn("path=%2Fprom_music%2F", req.full_url)
+
+    @patch("lib.util.urllib.request.urlopen")
+    def test_beets_directory_absolutizes_relative_path_for_bare_metal_plex(self, mock_urlopen):
+        """Bare-metal Plex (no Docker, no path_map) must still get an absolute
+        path. With cfg.beets_directory set and no path_map, the relative path
+        from beets gets joined with beets_directory before being sent."""
+        from lib.util import trigger_plex_scan
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b""
+        mock_urlopen.return_value = mock_resp
+        cfg = self._make_cfg(path_map=None,
+                             beets_directory="/srv/music")
+        trigger_plex_scan(cfg, "Artist/Album")
+        req = mock_urlopen.call_args[0][0]
+        self.assertIn("path=%2Fsrv%2Fmusic%2FArtist%2FAlbum", req.full_url)
+
+    @patch("lib.util.urllib.request.urlopen")
+    def test_beets_directory_composes_with_path_map(self, mock_urlopen):
+        """When BOTH beets_directory and path_map are set (typical Docker
+        deployment): absolutize against beets_directory FIRST, then path_map
+        translates host→container. Output should be the container path."""
+        from lib.util import trigger_plex_scan
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b""
+        mock_urlopen.return_value = mock_resp
+        cfg = self._make_cfg(path_map="/srv/music:/container/music",
+                             beets_directory="/srv/music")
+        trigger_plex_scan(cfg, "Artist/Album")
+        req = mock_urlopen.call_args[0][0]
+        self.assertIn("path=%2Fcontainer%2Fmusic%2FArtist%2FAlbum", req.full_url)
+
+    @patch("lib.util.urllib.request.urlopen")
+    def test_warns_when_relative_and_no_absolutize_config(self, mock_urlopen):
+        """Final defensive guard: relative path with NO path_map AND NO
+        beets_directory should log a warning, since Plex can't resolve it."""
+        from lib.util import trigger_plex_scan
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b""
+        mock_urlopen.return_value = mock_resp
+        cfg = self._make_cfg(path_map=None, beets_directory="")
+        with self.assertLogs("cratedigger", level="WARNING") as captured:
+            trigger_plex_scan(cfg, "Artist/Album")
+        self.assertTrue(
+            any("relative" in m.lower() for m in captured.output),
+            f"Expected warning about relative path, got: {captured.output}",
+        )
 
     @patch("lib.util.urllib.request.urlopen")
     def test_empty_imported_path_skips_path_arg(self, mock_urlopen):


### PR DESCRIPTION
## Summary

Closes the portability gap surfaced after #236/#237: deployments that don't use Docker for Plex (or whose Plex container path matches the host path) still had to abuse `plex_path_map` (e.g., `path_map = /beets/root:/beets/root`) to trigger absolutization for the relative paths beets emits.

This PR introduces a top-level `beets_directory` config option that absolutizes relative paths cleanly, and updates both consumers (`trigger_plex_scan` and `cleanup_disambiguation_orphans`) to use it.

## Behavior matrix

| Deployment | Set in config | Result |
|------------|---------------|--------|
| Plex in Docker, music at a different container path | `[Beets] directory` + `[Plex] path_map = /host/beets:/container/path` | Absolutize, then translate host→container (this homelab) |
| Plex on same host as beets (bare metal, no remap) | `[Beets] directory` only | Absolutize, send absolute |
| Plex with the same path on host and container | `[Plex] path_map = /shared/root:/shared/root` (the old idiom, still works) | Idempotent translation |
| Nothing configured | (warning logged at INFO) | Plex would silently no-op |

The two transforms compose cleanly: absolutize first, then translate. A final defensive `WARNING` fires if `scan_path` is still relative after both — closing the silent-failure loop one more time.

## Code changes

- `lib/config.py`: add `beets_directory: str = ""` field, read from `[Beets] directory` in `from_ini`. New `[Beets]` section is separate from existing `[Beets Validation]` (a misnomer, kept for back-compat).
- `lib/util.py::trigger_plex_scan`: absolutize via `cfg.beets_directory` before `path_map` translation. Final guard warns if still relative.
- `lib/util.py::cleanup_disambiguation_orphans`: accept `beets_directory: str = ""` kwarg. When set, absolutize relative inputs; when unset, fall back to the warn-and-skip from #237.
- `lib/import_dispatch.py`: pass `cfg.beets_directory` through to `cleanup_disambiguation_orphans`.
- `nix/module.nix`: new `beetsDirectory` mkOption (string, defaults to empty), rendered into `[Beets] directory` in `config.ini`.
- `docs/plex-primer.md`: portability table + composed-flow explanation.

## Tests added (7)

- `test_config.py::TestReadRuntimeConfig::test_beets_directory_defaults_to_empty`
- `test_config.py::TestReadRuntimeConfig::test_beets_directory_read_from_config`
- `test_util.py::TestCleanupDisambiguationOrphans::test_relative_path_absolutizes_with_beets_directory`
- `test_util.py::TestCleanupDisambiguationOrphans::test_relative_path_with_empty_beets_directory_still_warns`
- `test_util.py::TestTriggerPlexScan::test_beets_directory_absolutizes_relative_path_for_bare_metal_plex`
- `test_util.py::TestTriggerPlexScan::test_beets_directory_composes_with_path_map`
- `test_util.py::TestTriggerPlexScan::test_warns_when_relative_and_no_absolutize_config`

## Verification

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3170 tests pass (3163 → 3170, +7), 0 failures
- [x] `pyright lib/util.py lib/config.py` — 0 errors
- [x] `nix build .#checks.x86_64-linux.moduleVm` — passes with the new option
- [ ] Downstream wrapper (`~/nixosconfig/modules/nixos/services/cratedigger.nix`) updated to set `beetsDirectory = "/mnt/virtio/Music/Beets"` — applied locally, will be deployed alongside this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)