### PR TITLE
feat(search-plan): operator-driven cursor advance via CLI + API

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -87,6 +87,20 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
 - Never construct `CratediggerConfig` with positional/keyword args for a subset of fields. Always use `CratediggerConfig.from_ini()` with the runtime config file. Partial configs silently diverge when new config fields are added.
 - Before adding a new function that "does roughly what X does but simpler," check if X can be called with an adapter. The adapter may be ugly — that's a signal to improve X's interface, not to duplicate X.
 
+## CLI ⇄ API Surface Symmetry
+- Every operator action must exist on **both** `pipeline-cli` and the web API. Adding only one is a contract drift waiting to happen — operators expect parity and will trip when it isn't there.
+- Both surfaces wrap the same service-layer method (e.g. `SearchPlanService.advance_for_request`). The CLI subcommand and the HTTP handler are thin adapters with matched outcome → exit-code / outcome → status-code mappings. Never duplicate logic across the two; route everything through the service.
+- Reference layout (worked example: `search-plan advance` in PR for the cursor-advance feature):
+  - `lib/<thing>_service.py` — service method + typed `Result` dataclass (one outcome string per branch)
+  - `lib/pipeline_db.py` — atomic mutation with `FOR UPDATE` row lock
+  - `scripts/pipeline_cli.py` — CLI subcommand wrapping the service
+  - `web/routes/<thing>.py` — HTTP endpoint wrapping the service
+  - `tests/test_<thing>_service.py` — authoritative coverage of every outcome branch
+  - `tests/test_pipeline_cli.py` — CLI wrapper test (exit-code mapping)
+  - `tests/test_web_server.py` — API contract test (status-code mapping) + entry in `TestRouteContractAudit.CLASSIFIED_ROUTES`
+- Status/exit-code convention to match: `200/0` success, `400/3` input validation (API only — CLI argparse covers this), `404/2` not found, `409/4` wrong state, `422/3` semantic violation, `503/5` transient/retryable.
+- See `CLAUDE.md` § "CLI ⇄ API surface symmetry" for the full pattern table.
+
 ## New Work Checklist (read this first)
 
 Before writing any new code, decide which test types you owe and what infrastructure you'll reuse:
@@ -95,7 +109,8 @@ Before writing any new code, decide which test types you owe and what infrastruc
 |------------------|-----------|-------------------------|
 | A new pure decision function in `lib/quality.py` | A subTest table covering every branch | `tests/test_quality_decisions.py` patterns |
 | A new dispatch / orchestration path | An orchestration test asserting domain state + an integration slice | `FakePipelineDB`, `patch_dispatch_externals()`, `tests/test_integration_slices.py` |
-| A new web API endpoint | A contract test with `REQUIRED_FIELDS` AND an entry in `TestRouteContractAudit.CLASSIFIED_ROUTES` | `_WebServerCase`, `_assert_required_fields`, `tests/test_web_server.py` |
+| A new web API endpoint | A contract test with `REQUIRED_FIELDS` AND an entry in `TestRouteContractAudit.CLASSIFIED_ROUTES` AND a paired `pipeline-cli` subcommand (CLI ⇄ API symmetry) | `_WebServerCase`, `_assert_required_fields`, `tests/test_web_server.py`, `scripts/pipeline_cli.py` |
+| A new operator action (CLI subcommand or API endpoint) | A service-layer method with a typed `Result`, BOTH a CLI subcommand AND an API endpoint, exit-code and status-code tests for each | `tests/test_<service>.py` for the authoritative coverage; CLI/API tests check the wrapper only |
 | A new slskd interaction | An orchestration test using `FakeSlskdAPI` | `FakeSlskdAPI` from `tests/fakes.py` |
 | A new typed dataclass | A pure test of construction + serialization, and a builder in `tests/helpers.py` if it crosses test boundaries | `tests/helpers.py` |
 | A new `PipelineDB` method | An equivalent stub on `FakePipelineDB`, with a self-test in `tests/test_fakes.py` | `tests/fakes.py`, `tests/test_fakes.py` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,33 @@ Web UI (music.ablz.au)               CLI
 
 Schema fields, JSONB audit blobs, search_log outcomes, and the force-import flow live in `docs/pipeline-db-schema.md`.
 
+## CLI ⇄ API surface symmetry
+
+Operator capabilities should appear on **both** `pipeline-cli` and the web API. When you add an operator action to one, add it to the other in the same PR. Both surfaces wrap the same service-layer method (e.g. `SearchPlanService.advance_for_request`); the CLI command and the HTTP endpoint are thin adapters with matching exit-code/status-code mappings.
+
+Why: operators frequently start in the web UI, escalate to CLI when they want a script, or vice versa. A capability that exists in only one surface is a trap — the team learns to expect parity, then trips when it isn't there. A drifted contract (CLI returns one shape, API returns another) is worse than no parity, because tests usually catch only one side.
+
+Concrete pattern (see `search-plan advance` for a worked example):
+
+| Layer | File | Responsibility |
+|-------|------|----------------|
+| Service | `lib/<thing>_service.py` | Holds logic; returns a typed `Result` dataclass |
+| DB | `lib/pipeline_db.py` | Atomic mutations + `FOR UPDATE` row locks |
+| CLI | `scripts/pipeline_cli.py` | Wraps service; maps `Result.outcome` to exit code |
+| API | `web/routes/<thing>.py` | Wraps service; maps `Result.outcome` to HTTP status |
+| Tests | `tests/test_<thing>_service.py` + `tests/test_pipeline_cli.py` + `tests/test_web_server.py` | Service tests are authoritative; CLI + API tests check the wrapper mapping |
+| Audit | `tests/test_web_server.py::TestRouteContractAudit::CLASSIFIED_ROUTES` | Every new route must be added — guard test fails otherwise |
+
+Status/exit code mapping should follow the existing convention:
+- 200 / exit 0 — success
+- 400 / exit 3 — input validation error (API only — CLI argparse catches this)
+- 404 / exit 2 — not found
+- 409 / exit 4 — wrong state (e.g. no active plan when one is required)
+- 422 / exit 3 — semantic validation error (e.g. forward-only violated)
+- 503 / exit 5 — transient (lock contention, retry)
+
+If you only need the capability from one surface in this PR, expose it on both anyway. The cost of adding the second surface is small; the cost of explaining "why is X CLI-only?" to a future operator is larger.
+
 ## Decision architecture
 
 Quality policy should stay pure where possible: facts in, decision out, no I/O,

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -4019,6 +4019,77 @@ class PipelineDB:
             cycle_count=int(row["plan_cycle_count"]),
         )
 
+    def advance_search_plan_cursor(
+        self,
+        request_id: int,
+        *,
+        target_ordinal: int,
+        plan_item_count: int,
+    ) -> tuple[int, int, int]:
+        """Operator-driven forward-only advance of ``next_plan_ordinal``.
+
+        Used by ``SearchPlanService.advance_for_request`` (via CLI / web
+        API). Forward-only by design — backward intent should go through
+        ``regenerate``. Returns ``(active_plan_id, previous_ordinal,
+        new_ordinal)`` on success.
+
+        Validates inside the row lock so concurrent
+        ``record_consumed_search_attempt`` (executor cursor advance) can't
+        race past the operator: SELECT ... FOR UPDATE pins ``album_requests``
+        for the duration of the check + UPDATE.
+
+        Raises ``ValueError`` for: missing request, no active plan,
+        ``target_ordinal`` outside ``[0, plan_item_count)``, or
+        ``target_ordinal <= current_ordinal`` (forward-only). Service-layer
+        callers translate these into structured outcomes; the DB layer's
+        job is just to keep the invariant.
+        """
+        if plan_item_count <= 0:
+            raise ValueError(
+                f"plan_item_count must be > 0 (got {plan_item_count})")
+        if target_ordinal < 0 or target_ordinal >= plan_item_count:
+            raise ValueError(
+                f"target_ordinal {target_ordinal} out of range "
+                f"[0, {plan_item_count})")
+        self._ensure_conn()
+        old_autocommit = self.conn.autocommit
+        self.conn.autocommit = False
+        try:
+            with self.conn.cursor(
+                cursor_factory=psycopg2.extras.RealDictCursor,
+            ) as cur:
+                cur.execute(
+                    "SELECT active_plan_id, next_plan_ordinal "
+                    "FROM album_requests WHERE id = %s FOR UPDATE",
+                    (request_id,),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise ValueError(f"request {request_id} not found")
+                active_plan_id = row["active_plan_id"]
+                if active_plan_id is None:
+                    raise ValueError(
+                        f"request {request_id} has no active plan")
+                previous_ordinal = int(row["next_plan_ordinal"])
+                if target_ordinal <= previous_ordinal:
+                    raise ValueError(
+                        f"target_ordinal {target_ordinal} must be greater "
+                        f"than current next_plan_ordinal {previous_ordinal} "
+                        "(advance is forward-only; use regenerate for "
+                        "backward intent)")
+                cur.execute(
+                    "UPDATE album_requests SET next_plan_ordinal = %s, "
+                    "updated_at = NOW() WHERE id = %s",
+                    (target_ordinal, request_id),
+                )
+            self.conn.commit()
+            return (int(active_plan_id), previous_ordinal, target_ordinal)
+        except Exception:
+            self.conn.rollback()
+            raise
+        finally:
+            self.conn.autocommit = old_autocommit
+
     def is_request_plan_current(
         self,
         request_id: int,

--- a/lib/search_plan_service.py
+++ b/lib/search_plan_service.py
@@ -76,6 +76,10 @@ RESULT_NOOP_ACTIVE_PLAN_EXISTS = "noop_active_plan_exists"
 RESULT_FAILED_DETERMINISTIC = "failed_deterministic"
 RESULT_FAILED_TRANSIENT = "failed_transient"
 RESULT_REQUEST_NOT_FOUND = "request_not_found"
+# advance_for_request outcomes (forward-only cursor mutation, no plan write).
+RESULT_ADVANCED = "advanced"
+RESULT_NO_ACTIVE_PLAN = "no_active_plan"
+RESULT_INVALID_TARGET = "invalid_target"
 
 # Sanitisation cap for persisted error/provenance strings. 4 KB is well
 # above any expected exception string but bounds JSONB blob growth so a
@@ -230,6 +234,28 @@ class ServiceResult:
     is_supersede: bool = False
 
 
+@dataclass(frozen=True)
+class AdvanceResult:
+    """Outcome of a single ``advance_for_request`` call.
+
+    Distinct from ``ServiceResult`` because cursor advance does not
+    persist a plan and reports its own set of outcomes
+    (``RESULT_ADVANCED``, ``RESULT_NO_ACTIVE_PLAN``, ``RESULT_INVALID_TARGET``,
+    ``RESULT_REQUEST_NOT_FOUND``). ``previous_ordinal`` and ``new_ordinal``
+    are populated on the success path so CLI / API can render a clear
+    "cursor: 1 → 7" line.
+    """
+
+    outcome: str
+    request_id: int
+    plan_id: int | None = None
+    previous_ordinal: int | None = None
+    new_ordinal: int | None = None
+    new_strategy: str | None = None
+    new_query: str | None = None
+    error_message: str | None = None
+
+
 class SearchPlanService:
     """Shared plan generation/persistence service.
 
@@ -318,6 +344,143 @@ class SearchPlanService:
                 request_id, regenerate=regenerate,
                 prepend_artist=prepend,
             )
+
+    def advance_for_request(
+        self,
+        request_id: int,
+        *,
+        to_ordinal: int | None = None,
+        to_strategy: str | None = None,
+    ) -> "AdvanceResult":
+        """Forward-only cursor advance for an operator's active plan.
+
+        Resolves the target ordinal from either ``to_ordinal`` (explicit)
+        or ``to_strategy`` (prefix match against ``strategy`` of plan items
+        at or after the current cursor). Exactly one must be set.
+
+        Designed for cases like self-titled releases where the dedup
+        collapses 5 default-strategy slots into the same query, leaving
+        track searches stranded behind retries. ``advance --to-strategy
+        track`` jumps the cursor to the first track-strategy slot so the
+        next cycle exercises a useful query.
+
+        Forward-only: backward intent should go through ``regenerate``.
+        Held under the PLAN advisory lock so concurrent regeneration
+        cannot replace the plan we're advancing within. Forward-stale
+        completions from in-flight executors are still detected by
+        ``record_consumed_search_attempt``'s row-level cursor check.
+
+        Outcomes:
+          * ``RESULT_ADVANCED`` — cursor moved; ``previous_ordinal`` /
+            ``new_ordinal`` / ``new_strategy`` / ``new_query`` populated.
+          * ``RESULT_REQUEST_NOT_FOUND`` — no such request id.
+          * ``RESULT_NO_ACTIVE_PLAN`` — request exists but has no active
+            plan (request never got past add-time, or last attempt failed
+            deterministically).
+          * ``RESULT_INVALID_TARGET`` — ordinal out of range, would go
+            backward, or no plan item matches the strategy prefix.
+        """
+        if (to_ordinal is None) == (to_strategy is None):
+            return AdvanceResult(
+                outcome=RESULT_INVALID_TARGET,
+                request_id=request_id,
+                error_message=(
+                    "exactly one of to_ordinal or to_strategy must be "
+                    "provided"),
+            )
+        with self.db.advisory_lock(
+            ADVISORY_LOCK_NAMESPACE_PLAN, request_id,
+        ) as acquired:
+            if not acquired:
+                return AdvanceResult(
+                    outcome=RESULT_FAILED_TRANSIENT,
+                    request_id=request_id,
+                    error_message="another writer holds the plan lock",
+                )
+            row = self.db.get_request(request_id)
+            if row is None:
+                return AdvanceResult(
+                    outcome=RESULT_REQUEST_NOT_FOUND,
+                    request_id=request_id,
+                    error_message=f"request {request_id} not found",
+                )
+            active = self.db.get_active_search_plan(request_id)
+            if active is None:
+                return AdvanceResult(
+                    outcome=RESULT_NO_ACTIVE_PLAN,
+                    request_id=request_id,
+                    error_message=(
+                        f"request {request_id} has no active plan; "
+                        "regenerate first"),
+                )
+            current = active.next_ordinal
+            target = self._resolve_advance_target(
+                items=active.items, current_ordinal=current,
+                to_ordinal=to_ordinal, to_strategy=to_strategy,
+            )
+            if isinstance(target, str):
+                # Resolution returned an error message.
+                return AdvanceResult(
+                    outcome=RESULT_INVALID_TARGET,
+                    request_id=request_id,
+                    plan_id=active.plan.id,
+                    previous_ordinal=current,
+                    error_message=target,
+                )
+            try:
+                _, prev, new = self.db.advance_search_plan_cursor(
+                    request_id, target_ordinal=target,
+                    plan_item_count=len(active.items),
+                )
+            except ValueError as e:
+                return AdvanceResult(
+                    outcome=RESULT_INVALID_TARGET,
+                    request_id=request_id,
+                    plan_id=active.plan.id,
+                    previous_ordinal=current,
+                    error_message=str(e),
+                )
+            new_item = active.items[new]
+            return AdvanceResult(
+                outcome=RESULT_ADVANCED,
+                request_id=request_id,
+                plan_id=active.plan.id,
+                previous_ordinal=prev,
+                new_ordinal=new,
+                new_strategy=new_item.strategy,
+                new_query=new_item.query,
+            )
+
+    @staticmethod
+    def _resolve_advance_target(
+        *,
+        items: list[Any],
+        current_ordinal: int,
+        to_ordinal: int | None,
+        to_strategy: str | None,
+    ) -> int | str:
+        """Return the absolute target ordinal, or an error string."""
+        if to_ordinal is not None:
+            if to_ordinal < 0 or to_ordinal >= len(items):
+                return (
+                    f"to_ordinal {to_ordinal} out of range "
+                    f"[0, {len(items)})")
+            if to_ordinal <= current_ordinal:
+                return (
+                    f"to_ordinal {to_ordinal} must be greater than "
+                    f"current cursor {current_ordinal} "
+                    "(advance is forward-only)")
+            return to_ordinal
+        # to_strategy: first item past current cursor whose strategy
+        # starts with the given prefix.
+        assert to_strategy is not None
+        for item in items:
+            if (item.ordinal > current_ordinal
+                    and item.strategy.startswith(to_strategy)):
+                return int(item.ordinal)
+        return (
+            f"no plan item past cursor {current_ordinal} has strategy "
+            f"prefix {to_strategy!r}")
 
     def _generate_for_request_locked(
         self,

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1656,6 +1656,81 @@ def cmd_search_plan_regenerate(db, args):
     return 1
 
 
+def cmd_search_plan_advance(db, args):
+    """Forward-only operator advance of the search-plan cursor.
+
+    Counterpart of ``POST /api/pipeline/<id>/search-plan/advance``. Both
+    surfaces wrap ``SearchPlanService.advance_for_request`` — keep them
+    in sync (see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
+
+    Exit codes:
+      * 0 — ``RESULT_ADVANCED``
+      * 2 — ``RESULT_REQUEST_NOT_FOUND``
+      * 3 — ``RESULT_INVALID_TARGET`` (out of range, would go backward,
+        no slot matches strategy, or both/neither flag given)
+      * 4 — ``RESULT_NO_ACTIVE_PLAN``
+      * 5 — ``RESULT_FAILED_TRANSIENT`` (lock contention)
+    """
+    from lib.config import read_runtime_config
+    from lib.search_plan_service import (
+        RESULT_ADVANCED,
+        RESULT_FAILED_TRANSIENT,
+        RESULT_INVALID_TARGET,
+        RESULT_NO_ACTIVE_PLAN,
+        RESULT_REQUEST_NOT_FOUND,
+        SearchPlanService,
+    )
+
+    cfg = read_runtime_config()
+    svc = SearchPlanService(db, cfg)
+    result = svc.advance_for_request(
+        int(args.id),
+        to_ordinal=args.to_ordinal,
+        to_strategy=args.to_strategy,
+    )
+    payload = {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "plan_id": result.plan_id,
+        "previous_ordinal": result.previous_ordinal,
+        "new_ordinal": result.new_ordinal,
+        "new_strategy": result.new_strategy,
+        "new_query": result.new_query,
+        "error_message": result.error_message,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+    else:
+        print(f"  Request ID:        {payload['request_id']}")
+        print(f"  Outcome:           {result.outcome}")
+        if result.plan_id is not None:
+            print(f"  Plan id:           {result.plan_id}")
+        if (result.previous_ordinal is not None
+                and result.new_ordinal is not None):
+            print(
+                f"  Cursor:            {result.previous_ordinal} → "
+                f"{result.new_ordinal}")
+        if result.new_strategy is not None:
+            print(f"  New slot strategy: {result.new_strategy}")
+        if result.new_query is not None:
+            print(f"  New slot query:    {result.new_query}")
+        if result.error_message:
+            print(f"  Error message:     {result.error_message}")
+
+    if result.outcome == RESULT_ADVANCED:
+        return 0
+    if result.outcome == RESULT_REQUEST_NOT_FOUND:
+        return 2
+    if result.outcome == RESULT_INVALID_TARGET:
+        return 3
+    if result.outcome == RESULT_NO_ACTIVE_PLAN:
+        return 4
+    if result.outcome == RESULT_FAILED_TRANSIENT:
+        return 5
+    return 1
+
+
 def main():
     parser = argparse.ArgumentParser(description="Pipeline CLI — manage download pipeline DB")
     parser.add_argument("--dsn", default=DEFAULT_DSN, help="PostgreSQL connection string")
@@ -1721,6 +1796,22 @@ def main():
                              "generated queries")
     p_sp_regen.add_argument("--json", action="store_true",
                              help="Print structured JSON instead of text")
+    p_sp_advance = sp_sub.add_parser(
+        "advance",
+        help="Forward-only operator advance of the cursor (e.g. skip "
+             "collapsed default-strategy slots on a self-titled release)")
+    p_sp_advance.add_argument("id", type=int, help="Request ID")
+    sp_target = p_sp_advance.add_mutually_exclusive_group(required=True)
+    sp_target.add_argument(
+        "--to-ordinal", type=int, dest="to_ordinal",
+        help="Absolute target ordinal in [0, plan_item_count)")
+    sp_target.add_argument(
+        "--to-strategy", dest="to_strategy",
+        help="Strategy prefix; advance to the first plan item past the "
+             "current cursor whose strategy starts with this string "
+             "(e.g. `track`, `unwild_year`)")
+    p_sp_advance.add_argument("--json", action="store_true",
+                              help="Print structured JSON instead of text")
 
     # quality
     p_quality = sub.add_parser("quality", help="Show quality state and simulate decisions")
@@ -1867,6 +1958,7 @@ def main():
     search_plan_commands = {
         "show": cmd_search_plan_show,
         "regenerate": cmd_search_plan_regenerate,
+        "advance": cmd_search_plan_advance,
     }
     try:
         if args.command == "search-plan":

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2928,6 +2928,43 @@ class FakePipelineDB:
             return False
         return True
 
+    def advance_search_plan_cursor(
+        self,
+        request_id: int,
+        *,
+        target_ordinal: int,
+        plan_item_count: int,
+    ) -> tuple[int, int, int]:
+        """Mirror of ``PipelineDB.advance_search_plan_cursor``.
+
+        Forward-only operator-driven cursor advance. Validates inputs the
+        same way the real method does, raising ``ValueError`` for missing
+        request, no active plan, out-of-range target, or backward intent.
+        """
+        if plan_item_count <= 0:
+            raise ValueError(
+                f"plan_item_count must be > 0 (got {plan_item_count})")
+        if target_ordinal < 0 or target_ordinal >= plan_item_count:
+            raise ValueError(
+                f"target_ordinal {target_ordinal} out of range "
+                f"[0, {plan_item_count})")
+        row = self._requests.get(request_id)
+        if row is None:
+            raise ValueError(f"request {request_id} not found")
+        active_plan_id = row.get("active_plan_id")
+        if active_plan_id is None:
+            raise ValueError(
+                f"request {request_id} has no active plan")
+        previous_ordinal = int(row.get("next_plan_ordinal") or 0)
+        if target_ordinal <= previous_ordinal:
+            raise ValueError(
+                f"target_ordinal {target_ordinal} must be greater than "
+                f"current next_plan_ordinal {previous_ordinal} "
+                "(advance is forward-only; use regenerate for backward "
+                "intent)")
+        row["next_plan_ordinal"] = target_ordinal
+        return (int(active_plan_id), previous_ordinal, target_ordinal)
+
     def list_wanted_for_plan_reconciliation(
         self,
     ) -> list[WantedReconciliationCandidate]:

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1894,5 +1894,107 @@ class TestStaleCompletionRacingRegeneration(unittest.TestCase):
         self.assertEqual(stale_rows[0]["plan_id"], plan_a_id)
 
 
+class TestCmdSearchPlanAdvance(unittest.TestCase):
+    """``pipeline-cli search-plan advance`` wraps
+    ``SearchPlanService.advance_for_request``. Counterpart of the API
+    endpoint ``POST /api/pipeline/<id>/search-plan/advance`` — both must
+    stay in sync; see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry"."""
+
+    def _seed_plan(self):
+        from tests.fakes import FakePipelineDB
+        from lib.pipeline_db import SearchPlanItemInput
+        from lib.search import SEARCH_PLAN_GENERATOR_ID
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="David Bowie", album_title="David Bowie",
+            source="request", year=1967, status="wanted",
+        )
+        items = [
+            SearchPlanItemInput(
+                ordinal=i, strategy="default",
+                query="*avid *owie", canonical_query_key="*avid *owie")
+            for i in range(5)
+        ]
+        items.append(SearchPlanItemInput(
+            ordinal=5, strategy="track_0", query="Love Till Tuesday",
+            canonical_query_key="love till tuesday"))
+        db.create_successful_search_plan(
+            request_id=rid, generator_id=SEARCH_PLAN_GENERATOR_ID,
+            items=items, set_active=True,
+        )
+        return db, rid
+
+    def _run(self, db, rid, *, to_ordinal=None, to_strategy=None,
+             json_out=False):
+        args = SimpleNamespace(
+            id=rid, to_ordinal=to_ordinal, to_strategy=to_strategy,
+            json=json_out,
+        )
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            with patch("lib.config.read_runtime_config") as mock_cfg:
+                from lib.config import CratediggerConfig
+                import configparser
+                cp = configparser.RawConfigParser()
+                cp.read_string("[General]\n")
+                mock_cfg.return_value = CratediggerConfig.from_ini(cp)
+                rc = pipeline_cli.cmd_search_plan_advance(db, args)
+        return rc, stdout.getvalue()
+
+    def test_advance_to_ordinal_succeeds_and_moves_cursor(self):
+        db, rid = self._seed_plan()
+        rc, out = self._run(db, rid, to_ordinal=5)
+        self.assertEqual(rc, 0)
+        active = db.get_active_search_plan(rid)
+        assert active is not None
+        self.assertEqual(active.next_ordinal, 5)
+        self.assertIn("track_0", out)
+
+    def test_advance_to_strategy_jumps_past_collapsed_default_slots(self):
+        """The motivating use case: self-titled releases collapse into 5
+        identical default-strategy slots; --to-strategy track skips them."""
+        db, rid = self._seed_plan()
+        rc, out = self._run(db, rid, to_strategy="track")
+        self.assertEqual(rc, 0)
+        active = db.get_active_search_plan(rid)
+        assert active is not None
+        self.assertEqual(active.next_ordinal, 5)
+        self.assertIn("Cursor:", out)
+        self.assertIn("0 → 5", out)
+
+    def test_advance_returns_2_when_request_not_found(self):
+        from tests.fakes import FakePipelineDB
+        rc, out = self._run(FakePipelineDB(), 9999, to_ordinal=1)
+        self.assertEqual(rc, 2)
+        self.assertIn("request_not_found", out)
+
+    def test_advance_returns_3_on_invalid_target(self):
+        db, rid = self._seed_plan()
+        rc, out = self._run(db, rid, to_ordinal=99)
+        self.assertEqual(rc, 3)
+        self.assertIn("invalid_target", out)
+
+    def test_advance_returns_4_when_no_active_plan(self):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="X", album_title="Y",
+            source="request", year=2020, status="wanted",
+        )
+        rc, out = self._run(db, rid, to_ordinal=1)
+        self.assertEqual(rc, 4)
+        self.assertIn("no_active_plan", out)
+
+    def test_advance_json_output_carries_full_payload(self):
+        db, rid = self._seed_plan()
+        rc, out = self._run(db, rid, to_ordinal=5, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["outcome"], "advanced")
+        self.assertEqual(payload["new_ordinal"], 5)
+        self.assertEqual(payload["new_strategy"], "track_0")
+        self.assertEqual(payload["new_query"], "Love Till Tuesday")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_search_plan_service.py
+++ b/tests/test_search_plan_service.py
@@ -843,5 +843,142 @@ class TestAdvisoryLockBoundary(unittest.TestCase):
         self.assertEqual(db.search_plans, {})
 
 
+class TestSearchPlanServiceAdvance(unittest.TestCase):
+    """Operator-driven cursor advance — counterpart of regenerate, used to
+    skip past collapsed default-strategy slots on self-titled releases.
+
+    The CLI (``pipeline-cli search-plan advance``) and web API (``POST
+    /api/pipeline/<id>/search-plan/advance``) are thin wrappers over
+    ``SearchPlanService.advance_for_request``; coverage here protects both
+    surfaces. See ``CLAUDE.md`` § "CLI ⇄ API surface symmetry"."""
+
+    def setUp(self):
+        self.db = FakePipelineDB()
+        self.cfg = CratediggerConfig()
+        self.svc = SearchPlanService(self.db, self.cfg)
+
+    def _seed_plan_with_items(self) -> int:
+        """Seed a Bowie-style plan: 5 default + 1 unwild + 1 unwild_year +
+        2 track_X items. Returns the request id (10)."""
+        _seed_request(self.db, id=10,
+                       artist_name="David Bowie",
+                       album_title="David Bowie", year=1967)
+        from lib.pipeline_db import SearchPlanItemInput
+        items = [
+            SearchPlanItemInput(ordinal=i, strategy="default",
+                                query="*avid *owie",
+                                canonical_query_key="*avid *owie")
+            for i in range(5)
+        ]
+        items.append(SearchPlanItemInput(
+            ordinal=5, strategy="unwild", query="David Bowie",
+            canonical_query_key="david bowie"))
+        items.append(SearchPlanItemInput(
+            ordinal=6, strategy="unwild_year", query="David Bowie 1967",
+            canonical_query_key="david bowie 1967"))
+        items.append(SearchPlanItemInput(
+            ordinal=7, strategy="track_0", query="Love Till Tuesday",
+            canonical_query_key="love till tuesday"))
+        items.append(SearchPlanItemInput(
+            ordinal=8, strategy="track_1", query="Maids Bond Street",
+            canonical_query_key="maids bond street"))
+        plan = self.db.create_successful_search_plan(
+            request_id=10, generator_id=SEARCH_PLAN_GENERATOR_ID,
+            items=items)
+        return plan
+
+    def test_advance_to_ordinal_moves_cursor_forward(self):
+        """Happy path: explicit ordinal advance updates cursor and reports
+        the new slot."""
+        from lib.search_plan_service import RESULT_ADVANCED
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(10, to_ordinal=7)
+        self.assertEqual(result.outcome, RESULT_ADVANCED)
+        self.assertEqual(result.previous_ordinal, 0)
+        self.assertEqual(result.new_ordinal, 7)
+        self.assertEqual(result.new_strategy, "track_0")
+        self.assertEqual(result.new_query, "Love Till Tuesday")
+        active = self.db.get_active_search_plan(10)
+        assert active is not None
+        self.assertEqual(active.next_ordinal, 7)
+
+    def test_advance_to_strategy_finds_first_matching_slot(self):
+        """``--to-strategy track`` jumps to the first ``track_*`` slot past
+        the cursor — the motivating use case for self-titled releases."""
+        from lib.search_plan_service import RESULT_ADVANCED
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(10, to_strategy="track")
+        self.assertEqual(result.outcome, RESULT_ADVANCED)
+        self.assertEqual(result.new_ordinal, 7)
+        self.assertEqual(result.new_strategy, "track_0")
+
+    def test_advance_to_strategy_unwild_year_exact(self):
+        """Strategy prefix matches exact strategy names too."""
+        from lib.search_plan_service import RESULT_ADVANCED
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(10, to_strategy="unwild_year")
+        self.assertEqual(result.outcome, RESULT_ADVANCED)
+        self.assertEqual(result.new_ordinal, 6)
+        self.assertEqual(result.new_strategy, "unwild_year")
+
+    def test_advance_backward_is_rejected(self):
+        """Forward-only: target <= current cursor returns INVALID_TARGET."""
+        from lib.search_plan_service import RESULT_INVALID_TARGET
+        self._seed_plan_with_items()
+        # First advance to 5 so cursor isn't at 0
+        self.svc.advance_for_request(10, to_ordinal=5)
+        result = self.svc.advance_for_request(10, to_ordinal=3)
+        self.assertEqual(result.outcome, RESULT_INVALID_TARGET)
+        self.assertIsNotNone(result.error_message)
+        # Cursor unchanged.
+        active = self.db.get_active_search_plan(10)
+        assert active is not None
+        self.assertEqual(active.next_ordinal, 5)
+
+    def test_advance_to_same_ordinal_is_rejected(self):
+        """target == current is also forward-only-violating."""
+        from lib.search_plan_service import RESULT_INVALID_TARGET
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(10, to_ordinal=0)
+        self.assertEqual(result.outcome, RESULT_INVALID_TARGET)
+
+    def test_advance_to_out_of_range_ordinal(self):
+        from lib.search_plan_service import RESULT_INVALID_TARGET
+        self._seed_plan_with_items()  # 9 items, indices 0..8
+        result = self.svc.advance_for_request(10, to_ordinal=99)
+        self.assertEqual(result.outcome, RESULT_INVALID_TARGET)
+
+    def test_advance_to_strategy_no_match(self):
+        from lib.search_plan_service import RESULT_INVALID_TARGET
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(10, to_strategy="nonexistent")
+        self.assertEqual(result.outcome, RESULT_INVALID_TARGET)
+
+    def test_advance_no_active_plan(self):
+        """Request exists but has no active plan → NO_ACTIVE_PLAN."""
+        from lib.search_plan_service import RESULT_NO_ACTIVE_PLAN
+        _seed_request(self.db, id=20, artist_name="X", album_title="Y")
+        result = self.svc.advance_for_request(20, to_ordinal=1)
+        self.assertEqual(result.outcome, RESULT_NO_ACTIVE_PLAN)
+
+    def test_advance_request_not_found(self):
+        from lib.search_plan_service import RESULT_REQUEST_NOT_FOUND
+        result = self.svc.advance_for_request(9999, to_ordinal=1)
+        self.assertEqual(result.outcome, RESULT_REQUEST_NOT_FOUND)
+
+    def test_advance_neither_target_provided(self):
+        from lib.search_plan_service import RESULT_INVALID_TARGET
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(10)
+        self.assertEqual(result.outcome, RESULT_INVALID_TARGET)
+
+    def test_advance_both_targets_provided(self):
+        from lib.search_plan_service import RESULT_INVALID_TARGET
+        self._seed_plan_with_items()
+        result = self.svc.advance_for_request(
+            10, to_ordinal=7, to_strategy="track")
+        self.assertEqual(result.outcome, RESULT_INVALID_TARGET)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -938,6 +938,7 @@ class TestRouteContractAudit(unittest.TestCase):
         r"^/api/pipeline/(\d+)$",
         r"^/api/pipeline/(\d+)/search-plan$",
         r"^/api/pipeline/(\d+)/search-plan/regenerate$",
+        r"^/api/pipeline/(\d+)/search-plan/advance$",
         "/api/pipeline/add",
         "/api/pipeline/update",
         "/api/pipeline/upgrade",
@@ -2207,6 +2208,165 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
         self.assertEqual(status, 400)
         self.assertEqual(data["error"], "prepend_artist must be a boolean")
         mock_gen.assert_not_called()
+
+
+class TestPipelineSearchPlanAdvanceContract(_WebServerCase):
+    """Contract for ``POST /api/pipeline/<id>/search-plan/advance``.
+
+    The endpoint wraps ``SearchPlanService.advance_for_request``. Both
+    the CLI (``pipeline-cli search-plan advance``) and the API live or
+    die on the same service contract — see ``CLAUDE.md`` § "CLI ⇄ API
+    surface symmetry"; touching one without the other is a contract
+    drift waiting to happen.
+
+    Status-code mapping mirrors the CLI exit codes:
+      * 200 — RESULT_ADVANCED
+      * 400 — body validation failure
+      * 404 — RESULT_REQUEST_NOT_FOUND
+      * 409 — RESULT_NO_ACTIVE_PLAN
+      * 422 — RESULT_INVALID_TARGET
+      * 503 — RESULT_FAILED_TRANSIENT
+    """
+
+    ADVANCE_REQUIRED_FIELDS = {
+        "request_id", "outcome", "plan_id", "previous_ordinal",
+        "new_ordinal", "new_strategy", "new_query", "error_message",
+    }
+
+    def setUp(self) -> None:
+        from lib.config import CratediggerConfig
+        import configparser
+        cp = configparser.RawConfigParser()
+        cp.read_string("[General]\n")
+        self._cfg_patcher = patch(
+            "lib.config.read_runtime_config",
+            return_value=CratediggerConfig.from_ini(cp),
+        )
+        self._cfg_patcher.start()
+
+    def tearDown(self) -> None:
+        self._cfg_patcher.stop()
+
+    def _patch_service(self, **result_kwargs):
+        from unittest.mock import patch as _patch
+        from lib.search_plan_service import AdvanceResult
+        return _patch(
+            "lib.search_plan_service.SearchPlanService.advance_for_request",
+            return_value=AdvanceResult(**result_kwargs),
+        )
+
+    def test_advance_success_returns_200_with_required_fields(self):
+        with self._patch_service(
+                outcome="advanced", request_id=100, plan_id=42,
+                previous_ordinal=1, new_ordinal=7,
+                new_strategy="track_0", new_query="Love Till Tuesday"):
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_ordinal": 7})
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.ADVANCE_REQUIRED_FIELDS,
+                                "search-plan advance response")
+        self.assertEqual(data["outcome"], "advanced")
+        self.assertEqual(data["new_ordinal"], 7)
+        self.assertEqual(data["new_strategy"], "track_0")
+
+    def test_advance_request_not_found_returns_404(self):
+        with self._patch_service(
+                outcome="request_not_found", request_id=9999,
+                error_message="request 9999 not found"):
+            status, data = self._post(
+                "/api/pipeline/9999/search-plan/advance",
+                {"to_ordinal": 7})
+        self.assertEqual(status, 404)
+        _assert_required_fields(self, data, self.ADVANCE_REQUIRED_FIELDS,
+                                "404 advance response")
+        self.assertIn("error", data)
+
+    def test_advance_no_active_plan_returns_409(self):
+        with self._patch_service(
+                outcome="no_active_plan", request_id=100,
+                error_message="request 100 has no active plan"):
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_ordinal": 1})
+        self.assertEqual(status, 409)
+        self.assertEqual(data["outcome"], "no_active_plan")
+        self.assertIn("error", data)
+
+    def test_advance_invalid_target_returns_422(self):
+        with self._patch_service(
+                outcome="invalid_target", request_id=100, plan_id=42,
+                previous_ordinal=5, error_message="target 3 must be > 5"):
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_ordinal": 3})
+        self.assertEqual(status, 422)
+        self.assertEqual(data["outcome"], "invalid_target")
+        self.assertIn("error", data)
+
+    def test_advance_lock_contention_returns_503(self):
+        with self._patch_service(
+                outcome="failed_transient", request_id=100,
+                error_message="another writer holds the plan lock"):
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_ordinal": 1})
+        self.assertEqual(status, 503)
+        self.assertEqual(data["outcome"], "failed_transient")
+        self.assertIn("error", data)
+
+    def test_advance_passes_to_strategy_to_service(self):
+        from unittest.mock import patch as _patch
+        from lib.search_plan_service import AdvanceResult
+        with _patch(
+            "lib.search_plan_service.SearchPlanService.advance_for_request",
+            return_value=AdvanceResult(
+                outcome="advanced", request_id=100, plan_id=1,
+                previous_ordinal=0, new_ordinal=7,
+                new_strategy="track_0", new_query="X"),
+        ) as mock_adv:
+            status, _ = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_strategy": "track"})
+        self.assertEqual(status, 200)
+        mock_adv.assert_called_once()
+        kwargs = mock_adv.call_args.kwargs
+        self.assertEqual(kwargs.get("to_strategy"), "track")
+        self.assertIsNone(kwargs.get("to_ordinal"))
+
+    def test_advance_rejects_missing_target(self):
+        from unittest.mock import patch as _patch
+        with _patch(
+            "lib.search_plan_service.SearchPlanService.advance_for_request",
+        ) as mock_adv:
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance", {})
+        self.assertEqual(status, 400)
+        self.assertIn("to_ordinal", data["error"])
+        mock_adv.assert_not_called()
+
+    def test_advance_rejects_both_targets(self):
+        from unittest.mock import patch as _patch
+        with _patch(
+            "lib.search_plan_service.SearchPlanService.advance_for_request",
+        ) as mock_adv:
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_ordinal": 1, "to_strategy": "track"})
+        self.assertEqual(status, 400)
+        mock_adv.assert_not_called()
+
+    def test_advance_rejects_non_int_ordinal(self):
+        from unittest.mock import patch as _patch
+        with _patch(
+            "lib.search_plan_service.SearchPlanService.advance_for_request",
+        ) as mock_adv:
+            status, data = self._post(
+                "/api/pipeline/100/search-plan/advance",
+                {"to_ordinal": "seven"})
+        self.assertEqual(status, 400)
+        self.assertIn("integer", data["error"])
+        mock_adv.assert_not_called()
 
 
 def _kwargs_to_query(kwargs: dict) -> str:

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -578,6 +578,104 @@ def post_pipeline_search_plan_regenerate(
     h._json(payload)
 
 
+def post_pipeline_search_plan_advance(
+    h, body: dict, req_id_str: str,
+) -> None:
+    """``POST /api/pipeline/<id>/search-plan/advance``.
+
+    Forward-only operator advance of the search-plan cursor. Counterpart
+    of ``pipeline-cli search-plan advance``. Both surfaces wrap
+    ``SearchPlanService.advance_for_request`` — keep them in sync (see
+    ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
+
+    Body: exactly one of
+      * ``{"to_ordinal": <int>}`` — absolute target ordinal
+      * ``{"to_strategy": <str>}`` — first slot past cursor whose strategy
+        starts with this prefix
+
+    Status-code mapping mirrors the CLI exit codes:
+      * 200 — ``RESULT_ADVANCED``
+      * 400 — body validation failure (missing/extra keys, wrong type)
+      * 404 — ``RESULT_REQUEST_NOT_FOUND``
+      * 409 — ``RESULT_NO_ACTIVE_PLAN`` (request needs ``regenerate`` first)
+      * 422 — ``RESULT_INVALID_TARGET`` (out of range, backward, no slot
+        matches strategy)
+      * 503 — ``RESULT_FAILED_TRANSIENT`` (lock contention)
+    """
+    from lib.config import read_runtime_config
+    from lib.search_plan_service import (
+        RESULT_ADVANCED,
+        RESULT_FAILED_TRANSIENT,
+        RESULT_INVALID_TARGET,
+        RESULT_NO_ACTIVE_PLAN,
+        RESULT_REQUEST_NOT_FOUND,
+        SearchPlanService,
+    )
+    try:
+        request_id = int(req_id_str)
+    except (TypeError, ValueError):
+        h._error("Invalid request id")
+        return
+    body = body or {}
+    if not isinstance(body, dict):
+        h._json({"error": "body must be a JSON object"}, status=400)
+        return
+    to_ordinal = body.get("to_ordinal")
+    to_strategy = body.get("to_strategy")
+    if (to_ordinal is None) == (to_strategy is None):
+        h._json({
+            "error": "exactly one of to_ordinal or to_strategy is required",
+        }, status=400)
+        return
+    if to_ordinal is not None and not isinstance(to_ordinal, int):
+        h._json({"error": "to_ordinal must be an integer"}, status=400)
+        return
+    if to_strategy is not None and not isinstance(to_strategy, str):
+        h._json({"error": "to_strategy must be a string"}, status=400)
+        return
+
+    db = _server()._db()
+    cfg = read_runtime_config()
+    svc = SearchPlanService(db, cfg)
+    result = svc.advance_for_request(
+        request_id, to_ordinal=to_ordinal, to_strategy=to_strategy,
+    )
+    payload: dict[str, object] = {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "plan_id": result.plan_id,
+        "previous_ordinal": result.previous_ordinal,
+        "new_ordinal": result.new_ordinal,
+        "new_strategy": result.new_strategy,
+        "new_query": result.new_query,
+        "error_message": result.error_message,
+    }
+    if result.outcome == RESULT_ADVANCED:
+        h._json(payload)
+        return
+    if result.outcome == RESULT_REQUEST_NOT_FOUND:
+        payload["error"] = result.error_message or "Not found"
+        h._json(payload, status=404)
+        return
+    if result.outcome == RESULT_NO_ACTIVE_PLAN:
+        payload["error"] = (
+            result.error_message or "No active plan; regenerate first")
+        h._json(payload, status=409)
+        return
+    if result.outcome == RESULT_INVALID_TARGET:
+        payload["error"] = (
+            result.error_message or "Invalid advance target")
+        h._json(payload, status=422)
+        return
+    if result.outcome == RESULT_FAILED_TRANSIENT:
+        payload["error"] = (
+            result.error_message or "Plan lock contention; retry")
+        h._json(payload, status=503)
+        return
+    # Defensive: any unknown outcome string is a bug.
+    h._error(f"Unknown advance outcome: {result.outcome}", 500)
+
+
 def _serialize_import_job(job) -> dict[str, object]:
     if hasattr(job, "to_json_dict"):
         return job.to_json_dict()
@@ -1348,4 +1446,6 @@ POST_ROUTES: dict[str, object] = {
 POST_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/pipeline/(\d+)/search-plan/regenerate$"),
      post_pipeline_search_plan_regenerate),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/advance$"),
+     post_pipeline_search_plan_advance),
 ]


### PR DESCRIPTION
## Summary

Adds \`pipeline-cli search-plan advance <id>\` and \`POST /api/pipeline/<id>/search-plan/advance\` for forward-only cursor advance on an active search plan.

Concrete motivation: request #2566 (David Bowie self-titled, 1967) — the dedup collapses artist + album into a single \`*avid *owie\` query, so 5 of the 10 plan slots are identical retries with the track-search slots stranded behind them. Operators currently need raw SQL (\`UPDATE album_requests SET next_plan_ordinal=...\`) to skip ahead. This adds a proper interface.

## Surfaces

| | CLI | API |
|---|---|---|
| Invoke | \`pipeline-cli search-plan advance 2566 --to-strategy track\` | \`POST /api/pipeline/2566/search-plan/advance\` body \`{\"to_strategy\": \"track\"}\` |
| Resolve modes | \`--to-ordinal N\` or \`--to-strategy PREFIX\` (first slot past cursor matching prefix) | Same; body has \`to_ordinal\` xor \`to_strategy\` |
| Success | exit 0, prints \`Cursor: 0 → 7\` and the new slot's strategy/query | 200, full payload |
| Forward-only violated | exit 3 (invalid_target) | 422 |
| Out-of-range | exit 3 | 422 |
| No active plan | exit 4 (regenerate first) | 409 |
| Request not found | exit 2 | 404 |
| Lock contention | exit 5 | 503 |

Both wrap a new \`SearchPlanService.advance_for_request\` method that takes the per-request PLAN advisory lock (same as regenerate) and dispatches through \`PipelineDB.advance_search_plan_cursor\`, which validates inside a \`SELECT ... FOR UPDATE\` so concurrent executors and operators serialise on the row.

## CLI ⇄ API symmetry

Documented in CLAUDE.md and \`.claude/rules/code-quality.md\` as a first-class principle: **every operator action must exist on both surfaces, both wrapping the same service method.** New code-quality checklist row: a new web API endpoint owes a paired CLI subcommand, and vice versa. The pattern table covers the layered split: service (logic + Result dataclass) → DB (atomic mutation) → CLI/API (thin adapters with matched outcome → exit-code/status-code mappings).

## Tests (26 new)

- \`tests/test_search_plan_service.TestSearchPlanServiceAdvance\` — 11 cases covering every outcome branch (forward-only, both/neither target, strategy resolution, no-active-plan, request-not-found, out-of-range, ordinal of identical strategies)
- \`tests/test_pipeline_cli.TestCmdSearchPlanAdvance\` — 6 cases covering every exit code
- \`tests/test_web_server.TestPipelineSearchPlanAdvanceContract\` — 9 cases covering every status-code plus body validation (missing target, both targets, non-int ordinal)
- Route audit (\`CLASSIFIED_ROUTES\`) updated
- \`FakePipelineDB.advance_search_plan_cursor\` mirrors the real method's validation

## Verification

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3196 tests pass (3170 → 3196, +26), 0 failures
- [x] \`pyright lib/pipeline_db.py lib/search_plan_service.py web/routes/pipeline.py scripts/pipeline_cli.py\` — 0 errors, 0 warnings
- [x] Manual repro of original problem: \`pipeline-cli search-plan show 2566\` confirms 10-slot plan with 5 collapsed default slots
- [ ] After merge: \`/deploy\`. Tomorrow's cycle on #2566 will exercise the track searches now that I bumped the cursor manually; future self-titled releases get the proper CLI/API path

## Out of scope (filed as follow-up)

The deeper fix for self-titled releases — making \`generate_search_plan\` emit fewer collapsed default-strategy slots when the artist/album dedup is degenerate — needs more thought. User's instinct: pull entropy from year or a track when the artist+album token space is too small. Issue forthcoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)