### PR TITLE
fix(quality): unblock importer queue and triage labels

### DIFF
--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -121,10 +121,28 @@ class AlbumInfo:
 class BeetsDB:
     """Read-only connection to the beets SQLite library database."""
 
-    def __init__(self, db_path: str = DEFAULT_BEETS_DB) -> None:
+    def __init__(
+        self,
+        db_path: str = DEFAULT_BEETS_DB,
+        *,
+        library_root: str = "",
+    ) -> None:
+        """Open the library DB.
+
+        ``library_root`` is the absolute filesystem path that beets'
+        ``items.path`` values are stored relative to (matches the
+        ``directory:`` setting in the beets config). When set,
+        :meth:`get_album_info` returns an absolute ``album_path``;
+        otherwise it returns whatever beets stored, which in production
+        is a path relative to ``library_root`` and breaks any consumer
+        that does host-side filesystem ops (see
+        ``evidence_from_album_info`` → ``snapshot_audio_files`` →
+        bogus ``empty_fileset / "no audio files found"``).
+        """
         if not os.path.exists(db_path):
             raise FileNotFoundError(f"Beets DB not found: {db_path}")
         self._conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        self._library_root = library_root
 
     def close(self) -> None:
         self._conn.close()
@@ -373,8 +391,13 @@ class BeetsDB:
         is_cbr = len(set(bitrates)) == 1
         track_count = len(rows)
 
-        # Album path = directory of first track
+        # Album path = directory of first track. Beets stores items.path
+        # relative to the library root in production; absolutize so
+        # downstream FS consumers (snapshot_audio_files, spectral_analyze,
+        # os.path.isdir checks) work regardless of cwd.
         first_path = self._decode_path(rows[0][1])
+        if self._library_root and not os.path.isabs(first_path):
+            first_path = os.path.join(self._library_root, first_path)
         album_path = os.path.dirname(first_path)
 
         # Reduce multi-format albums via cfg.mixed_format_precedence.

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -542,6 +542,7 @@ def _load_evidence_import_gate(
     candidate_import_job_id: int | None,
     candidate_download_log_id: int | None,
     prevalidated_candidate_result: CandidateEvidenceActionResult | None = None,
+    beets_library_root: str = "",
 ) -> EvidenceImportGate:
     """Load persisted evidence for import-time quality authority."""
 
@@ -569,7 +570,7 @@ def _load_evidence_import_gate(
         from lib.quality import QualityRankConfig
 
         cfg = quality_ranks if quality_ranks is not None else QualityRankConfig.defaults()
-        with BeetsDB() as beets:
+        with BeetsDB(library_root=beets_library_root) as beets:
             album_info = beets.get_album_info(mb_release_id, cfg)
         if album_info is None:
             return EvidenceImportGate(
@@ -589,6 +590,7 @@ def _load_evidence_import_gate(
             quality_ranks=quality_ranks,
             current_album_path=album_info.album_path,
             album_info=album_info,
+            beets_library_root=beets_library_root,
         )
     except Exception as exc:
         logger.debug(
@@ -1310,6 +1312,7 @@ def dispatch_import_core(
                 candidate_import_job_id=candidate_import_job_id,
                 candidate_download_log_id=candidate_download_log_id,
                 prevalidated_candidate_result=prevalidated_candidate_result,
+                beets_library_root=getattr(cfg, "beets_directory", "") if cfg is not None else "",
             )
             existing_v0_probe = lossless_source_v0_probe_from_metric(
                 evidence_gate.current.v0_metric

--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -125,6 +125,7 @@ def ensure_current_evidence_for_action(
     current_album_path: str | None = None,
     album_info: Any = None,
     backfill_builder: CurrentEvidenceBackfillBuilder | None = None,
+    beets_library_root: str = "",
 ) -> CurrentEvidenceActionResult:
     """Load or backfill current Beets evidence with action provenance."""
 
@@ -183,6 +184,7 @@ def ensure_current_evidence_for_action(
                 quality_ranks=quality_ranks,
                 preloaded_evidence=None if existing_snapshot_stale else existing,
                 preloaded=True,
+                beets_library_root=beets_library_root,
             )
     except Exception as exc:
         return CurrentEvidenceActionResult(

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -413,6 +413,7 @@ def preview_import_from_path(
                     request_id=request_id,
                     mb_release_id=mbid,
                     quality_ranks=cfg.quality_ranks,
+                    beets_library_root=getattr(cfg, "beets_directory", ""),
                 )
                 current_evidence = current_result.evidence
             except Exception:

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -223,7 +223,7 @@ def _analyze_existing(
     existing_min: int | None = None
     existing_spectral: SpectralMeasurement | None = None
     try:
-        with BeetsDB() as beets:
+        with BeetsDB(library_root=getattr(cfg, "beets_directory", "")) as beets:
             existing_info = beets.get_album_info(
                 mb_release_id, cfg.quality_ranks)
         if existing_info:

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -138,18 +138,53 @@ def snapshot_audio_files(root: str) -> list[AlbumQualityEvidenceFile]:
     return sorted(files, key=lambda f: f.relative_path)
 
 
+def _snapshot_match_key(
+    file: AlbumQualityEvidenceFile,
+) -> tuple[str, int, str, str, str | None]:
+    """Stable identity tuple for snapshot equality.
+
+    Excludes ``mtime_ns`` because:
+    * ``process_completed_album`` writes ID3 tags to source files via
+      ``music_tag.save()`` AFTER preview snapshots them. Tagging bumps
+      mtime even when the audio bytes are unchanged. With strict mtime
+      equality the importer requeues every job to preview as
+      ``"candidate source changed since evidence capture"`` and the
+      queue never drains — see issue audit-2026-05-15.
+    * virtiofs has been observed to return slightly different
+      ``st_mtime_ns`` between back-to-back ``stat`` calls on the same
+      file. Strict equality is fragile under that flake.
+
+    Size + path + extension/container/codec is sufficient to detect any
+    content change that matters here. ``mtime_ns`` stays in the
+    persisted struct as a forensic field but does not gate freshness.
+    """
+    return (
+        file.relative_path,
+        file.size_bytes,
+        file.extension,
+        file.container,
+        file.codec,
+    )
+
+
 def audio_snapshot_matches(
     root: str,
     files: list[AlbumQualityEvidenceFile],
 ) -> bool:
-    """Return whether ``root`` still has the recorded active audio snapshot."""
+    """Return whether ``root`` still has the recorded active audio snapshot.
+
+    Compares on stable identity (path/size/codec) only. See
+    :func:`_snapshot_match_key` for why ``mtime_ns`` is excluded.
+    """
 
     try:
         current = snapshot_audio_files(root)
     except OSError:
         return False
     expected = sorted(files, key=lambda f: f.relative_path)
-    return current == expected
+    return [_snapshot_match_key(f) for f in current] == [
+        _snapshot_match_key(f) for f in expected
+    ]
 
 
 def neutral_v0_metric_from_probe(
@@ -494,6 +529,7 @@ def load_or_backfill_current_evidence(
     quality_ranks: Any = None,
     preloaded_evidence: AlbumQualityEvidence | None = None,
     preloaded: bool = False,
+    beets_library_root: str = "",
 ) -> EvidenceBuildResult:
     """Load current Beets evidence, backfilling when absent or incomplete."""
 
@@ -512,7 +548,7 @@ def load_or_backfill_current_evidence(
             return EvidenceBuildResult(existing, "ready")
 
     cfg = quality_ranks if quality_ranks is not None else QualityRankConfig.defaults()
-    with BeetsDB() as beets:
+    with BeetsDB(library_root=beets_library_root) as beets:
         album_info = beets.get_album_info(mb_release_id, cfg)
     if album_info is None:
         return EvidenceBuildResult(None, "empty_current", "album not in beets")

--- a/lib/wrong_match_cleanup_decision.py
+++ b/lib/wrong_match_cleanup_decision.py
@@ -146,7 +146,7 @@ def decide_wrong_match_cleanup(
             if quality_ranks is not None
             else QualityRankConfig.defaults()
         )
-        with BeetsDB() as beets:
+        with BeetsDB(library_root=getattr(cfg, "beets_directory", "")) as beets:
             album_info = beets.get_album_info(mb_release_id, rank_cfg)
     except Exception:
         logger.debug(
@@ -165,6 +165,7 @@ def decide_wrong_match_cleanup(
             quality_ranks=getattr(cfg, "quality_ranks", None),
             current_album_path=album_info.album_path,
             album_info=album_info,
+            beets_library_root=getattr(cfg, "beets_directory", ""),
         )
         if current_result.evidence is None:
             return _uncertain(

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -710,6 +710,62 @@ class TestGetAlbumInfo(unittest.TestCase):
         self.assertEqual(info.album_path, "/music/Artist/Album")
         self.assertEqual(info.format, "MP3")
 
+    def test_relative_paths_absolutized_against_library_root(self) -> None:
+        """Real beets stores items.path relative to the library root.
+
+        Without absolutizing, downstream consumers like
+        ``snapshot_audio_files`` (called from
+        ``evidence_from_album_info``) test ``os.path.isdir`` against the
+        relative path from the importer's cwd, get False, and emit
+        ``empty_fileset / "no audio files found"`` even when the album
+        has files on disk. Surfaced as ``"kept: no audio files found"``
+        triage labels in the Wrong Matches UI.
+        """
+        _insert_album(self.db_path, 7, "rel-1", [
+            # Stored relative — exactly what production beets emits when
+            # `library: relative_to_lib: yes` (or similar) is set.
+            (192000, "Infinity Shred/2009 - Album/01.mp3"),
+            (192000, "Infinity Shred/2009 - Album/02.mp3"),
+        ])
+        with BeetsDB(self.db_path,
+                     library_root="/mnt/virtio/Music/Beets") as db:
+            info = db.get_album_info("rel-1", self.cfg)
+        assert info is not None
+        self.assertTrue(
+            os.path.isabs(info.album_path),
+            f"album_path must be absolute when library_root is set, "
+            f"got {info.album_path!r}",
+        )
+        self.assertEqual(
+            info.album_path,
+            "/mnt/virtio/Music/Beets/Infinity Shred/2009 - Album",
+        )
+
+    def test_absolute_paths_pass_through_with_library_root(self) -> None:
+        """An already-absolute beets path is returned untouched."""
+        _insert_album(self.db_path, 8, "abs-1", [
+            (320000, "/music/Foo/Bar/01.mp3"),
+        ])
+        with BeetsDB(self.db_path,
+                     library_root="/mnt/virtio/Music/Beets") as db:
+            info = db.get_album_info("abs-1", self.cfg)
+        assert info is not None
+        self.assertEqual(info.album_path, "/music/Foo/Bar")
+
+    def test_relative_paths_unchanged_without_library_root(self) -> None:
+        """Backwards compat: no library_root means no absolutization.
+
+        Existing call sites that don't pass ``library_root`` keep the
+        old contract — they still get whatever beets stored.
+        """
+        _insert_album(self.db_path, 9, "rel-2", [
+            (192000, "Artist/Album/01.mp3"),
+        ])
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("rel-2", self.cfg)
+        assert info is not None
+        self.assertEqual(info.album_path, "Artist/Album")
+
     def test_vbr_album(self) -> None:
         _insert_album(self.db_path, 2, "def-456", [
             (245000, "/music/A/B/01.mp3"),

--- a/tests/test_quality_evidence.py
+++ b/tests/test_quality_evidence.py
@@ -18,9 +18,11 @@ from lib.quality import (
     VerifiedLosslessProof,
 )
 from lib.quality_evidence import (
+    audio_snapshot_matches,
     backfill_current_evidence_from_album_info,
     evidence_from_import_result,
     request_current_owner,
+    snapshot_audio_files,
 )
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_album_quality_evidence, make_request_row
@@ -311,6 +313,79 @@ class TestQualityEvidenceConstruction(unittest.TestCase):
         self.assertFalse(result.available)
         self.assertEqual(result.status, "incomplete")
         self.assertIn("duplicate snapshot relative_path", result.reason or "")
+
+
+class TestAudioSnapshotMatches(unittest.TestCase):
+    """Snapshot equality must ignore mtime_ns.
+
+    Real failure: ``process_completed_album`` writes ID3 tags to the
+    source files via ``music_tag.save()`` AFTER the preview worker has
+    already snapshotted them. The ``save()`` rewrites mtimes by
+    nanoseconds, the strict struct equality fails, the importer
+    requeues the job to preview as ``"candidate source changed since
+    evidence capture"``, preview re-runs, importer re-tags, infinite
+    loop. The queue grows but never drains.
+
+    virtiofs adds a second source of mtime jitter — the same file's
+    ``stat().st_mtime_ns`` can flicker by a few ns between reads. Any
+    fix must also make the snapshot resilient to that.
+
+    Comparison key is (relative_path, size_bytes, extension, container,
+    codec). mtime_ns stays in the struct as a forensic field but does
+    not participate in equality.
+    """
+
+    def setUp(self) -> None:
+        self.root = tempfile.mkdtemp()
+        with open(os.path.join(self.root, "01.mp3"), "wb") as f:
+            f.write(b"track 1 audio content")
+        with open(os.path.join(self.root, "02.mp3"), "wb") as f:
+            f.write(b"track 2 audio content")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_snapshot_matches_after_mtime_only_change(self):
+        """Touching a file (size unchanged) must not invalidate the snapshot."""
+        captured = snapshot_audio_files(self.root)
+        # Simulate music_tag.save() rewriting the file in place: mtime
+        # advances even if the byte content (and so size) is identical.
+        for entry in os.listdir(self.root):
+            full = os.path.join(self.root, entry)
+            stat = os.stat(full)
+            os.utime(full, ns=(stat.st_atime_ns, stat.st_mtime_ns + 5_000_000))
+
+        self.assertTrue(
+            audio_snapshot_matches(self.root, captured),
+            "mtime-only changes must not be treated as a source mismatch — "
+            "this caused the importer→preview infinite loop",
+        )
+
+    def test_snapshot_mismatch_when_size_differs(self):
+        """A real content change (size delta) must still be detected."""
+        captured = snapshot_audio_files(self.root)
+        with open(os.path.join(self.root, "01.mp3"), "ab") as f:
+            f.write(b"appended bytes")
+
+        self.assertFalse(audio_snapshot_matches(self.root, captured))
+
+    def test_snapshot_mismatch_when_file_removed(self):
+        captured = snapshot_audio_files(self.root)
+        os.remove(os.path.join(self.root, "02.mp3"))
+
+        self.assertFalse(audio_snapshot_matches(self.root, captured))
+
+    def test_snapshot_mismatch_when_file_added(self):
+        captured = snapshot_audio_files(self.root)
+        with open(os.path.join(self.root, "03.mp3"), "wb") as f:
+            f.write(b"new track")
+
+        self.assertFalse(audio_snapshot_matches(self.root, captured))
+
+    def test_snapshot_matches_unchanged_files(self):
+        """Sanity: an unchanged tree always matches."""
+        captured = snapshot_audio_files(self.root)
+        self.assertTrue(audio_snapshot_matches(self.root, captured))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two distinct bugs in the candidate-evidence guard layer surfaced together when the cratedigger pipeline restarted today.

### Bug A — importer→preview infinite loop (queue not draining)

`process_completed_album` writes ID3 tags via `music_tag.save()` BEFORE the candidate-evidence freshness check. `save()` rewrites mtime even when audio bytes are unchanged. `audio_snapshot_matches` compared the persisted struct by full equality including `mtime_ns`. Result: every importer claim → tag → mtime change → "candidate source changed since evidence capture" → requeue to preview → preview rerun → claim → tag → loop. Observed 11 jobs in 60 seconds, all stuck in this loop.

virtiofs adds independent mtime jitter — the same fix protects against that.

**Fix:** `audio_snapshot_matches` compares on `(relative_path, size_bytes, extension, container, codec)`. `mtime_ns` stays in the struct as a forensic field.

### Bug B — "kept: no audio files found" triage labels

`BeetsDB.get_album_info()` returned `album_path` as a relative path because beets stores `items.path` relative to the library root. `evidence_from_album_info` then called `snapshot_audio_files(relative_path)` which tested `os.path.isdir` from the importer's cwd, got False, returned empty, emitted `empty_fileset / "no audio files found"`. UI rendered that on rejections where the failure was in locating the *current beets album*, not the rejected candidate.

Affected ~15 of last 2 days' rejections.

**Fix:** `BeetsDB.__init__(library_root="")` — when set, `get_album_info` joins relative paths with the library root. Callers that do host-side FS ops on the returned path now pass `cfg.beets_directory`. Also incidentally repairs a long-standing latent bug in `preimport._existing_min_and_spectral` where spectral-on-existing was silently no-oping for relative paths.

## Test plan

- [x] RED reproduction in `tests/test_quality_evidence.py::TestAudioSnapshotMatches::test_snapshot_matches_after_mtime_only_change` — fails before fix
- [x] RED reproduction in `tests/test_beets_db.py::TestGetAlbumInfo::test_relative_paths_absolutized_against_library_root` — fails before fix
- [x] Both pass after fix; full suite 3363 tests pass; pyright clean
- [x] Regression guards: size/file-add/file-remove still detected; absolute paths pass through unchanged; backwards compat preserved when `library_root` not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)