### PR TITLE
fix(rejection): populate dl_info columns for evidence-decision rejects

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -671,6 +671,7 @@ def _reject_import_from_evidence_decision(
     db: "PipelineDB",
     request_id: int,
     dl_info: DownloadInfo,
+    import_result: ImportResult,
     distance: float,
     decision: str,
     detail: str,
@@ -682,8 +683,18 @@ def _reject_import_from_evidence_decision(
     source_path_cleanup_scenario: str,
     cooled_down_users: set[str] | None,
 ) -> DispatchOutcome:
-    """Record a persisted-evidence rejection before beets can mutate files."""
+    """Record a persisted-evidence rejection before beets can mutate files.
 
+    Threads ``import_result`` through ``_populate_dl_info_from_import_result``
+    so the same top-level ``download_log`` columns the post-import reject
+    path populates (``bitrate``, ``actual_filetype``, ``spectral_grade``,
+    ``existing_min_bitrate``, ``v0_probe_*``, etc.) get filled here too.
+    Without this, the Recents UI rendered evidence-decision rejections
+    as just ``"downgrade · username"`` because every quality column
+    came back NULL — see ``TestRejectImportFromEvidenceDecision``.
+    """
+
+    _populate_dl_info_from_import_result(dl_info, import_result)
     action = dispatch_action(decision)
     _record_rejection_and_maybe_requeue(
         db,
@@ -1384,7 +1395,7 @@ def dispatch_import_core(
                         "import-time persisted evidence rejected candidate "
                         f"(decision={decision})"
                     )
-                    dl_info.import_result = ImportResult(
+                    evidence_import_result = ImportResult(
                         decision=decision,
                         new_measurement=evidence_gate.candidate.measurement,
                         existing_measurement=(
@@ -1396,15 +1407,12 @@ def dispatch_import_core(
                             evidence_gate.candidate.v0_metric
                         ),
                         existing_v0_probe=existing_v0_probe,
-                    ).to_json()
-                    dl_info.v0_probe = lossless_source_v0_probe_from_metric(
-                        evidence_gate.candidate.v0_metric
                     )
-                    dl_info.existing_v0_probe = existing_v0_probe
                     return _reject_import_from_evidence_decision(
                         db=db,
                         request_id=request_id,
                         dl_info=dl_info,
+                        import_result=evidence_import_result,
                         distance=distance,
                         decision=decision,
                         detail=detail,

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -300,6 +300,83 @@ class TestRecordRejectionAndRequeueSeam(unittest.TestCase):
         self.assertIsNone(row["beets_scenario"])
 
 
+class TestRejectImportFromEvidenceDecision(unittest.TestCase):
+    """Evidence-decision rejections must populate download_log columns.
+
+    Bug: ``_reject_import_from_evidence_decision`` built ``ImportResult``
+    JSON for the JSONB column but skipped
+    ``_populate_dl_info_from_import_result``, so every top-level
+    quality column landed NULL. The Recents UI rendered just
+    ``"downgrade · username"`` instead of the full quality verdict.
+
+    Live reproducer: download_log id 14570 — Faux Pas - Entropy Begins
+    at Home, decision=downgrade, new=127kbps mp3 likely_transcode,
+    existing=192kbps mp3 cbr. JSONB had everything; columns were all
+    NULL.
+    """
+
+    def test_evidence_rejection_populates_download_log_columns(self) -> None:
+        from lib.import_dispatch import _reject_import_from_evidence_decision
+        from lib.quality import AudioQualityMeasurement, ImportResult
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        dl_info = DownloadInfo(filetype="mp3", username="user1")
+        ir = ImportResult(
+            decision="downgrade",
+            new_measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=127,
+                avg_bitrate_kbps=127,
+                median_bitrate_kbps=128,
+                format="MP3",
+                spectral_grade="likely_transcode",
+                spectral_bitrate_kbps=128,
+            ),
+            existing_measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=192,
+                avg_bitrate_kbps=192,
+                median_bitrate_kbps=192,
+                format="MP3",
+                is_cbr=True,
+            ),
+        )
+
+        with patch_dispatch_externals():
+            _reject_import_from_evidence_decision(
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                dl_info=dl_info,
+                import_result=ir,
+                distance=0.1279,
+                decision="downgrade",
+                detail="import-time persisted evidence rejected candidate",
+                requeue_on_failure=True,
+                validation_result=None,
+                staged_path="/tmp/cratedigger-evidence-reject-test",
+                scenario="downgrade",
+                files=None,
+                source_path_cleanup_scenario="downgrade",
+                cooled_down_users=None,
+            )
+
+        self.assertEqual(len(db.download_logs), 1)
+        log = db.download_logs[0]
+        self.assertEqual(log.outcome, "rejected")
+        self.assertEqual(log.beets_scenario, "downgrade")
+        self.assertEqual(log.beets_distance, 0.1279)
+        # Top-level quality columns the UI reads.
+        self.assertEqual(log.extra["actual_filetype"], "mp3")
+        self.assertEqual(log.extra["slskd_filetype"], "mp3")
+        self.assertEqual(log.extra["bitrate"], 127_000)
+        self.assertEqual(log.extra["actual_min_bitrate"], 127)
+        self.assertEqual(log.extra["spectral_grade"], "likely_transcode")
+        self.assertEqual(log.extra["spectral_bitrate"], 128)
+        self.assertEqual(log.extra["existing_min_bitrate"], 192)
+        self.assertEqual(log.extra["existing_spectral_bitrate"], None)
+        # The full ImportResult is still serialized into the JSONB.
+        self.assertIsNotNone(log.import_result)
+
+
 class TestDispatchImport(unittest.TestCase):
     """Orchestration tests — assert domain state via FakePipelineDB."""
 


### PR DESCRIPTION
## Summary

Evidence-decision rejections (`downgrade`, `transcode_downgrade`, `suspect_lossless_*`, `lossless_source_locked`, etc.) were stored with all top-level quality columns NULL. Recents UI rendered just `"downgrade · username"` instead of the full quality verdict, even though the `import_result` JSONB carried everything (e.g. `new=127kbps mp3 likely_transcode <= existing=192kbps mp3 cbr`).

Live reproducer: download_log id 14570 — Faux Pas - Entropy Begins at Home.

## Fix

`_reject_import_from_evidence_decision` now takes the constructed `ImportResult` as an argument and calls `_populate_dl_info_from_import_result` at the top. Same helper the post-import reject path already uses — both paths now produce identical column shape.

The call site shrinks: the ad-hoc field-by-field stamping on `dl_info` is gone.

## Test plan

- [x] RED: `tests/test_import_dispatch.py::TestRejectImportFromEvidenceDecision::test_evidence_rejection_populates_download_log_columns` — fails with `TypeError` before the fix (no `import_result` param), then asserts every UI-relevant column is populated after
- [x] Full suite 3364 tests pass; pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)