### PR TITLE
fix(web): fallback to beets_detail on spectral_reject when typed cols are NULL

### DIFF
--- a/web/classify.py
+++ b/web/classify.py
@@ -882,6 +882,20 @@ def _rejection_verdict(entry: LogEntry) -> str:
     if scenario == "spectral_reject":
         # Spectral scenario — spectral_bitrate IS the right field here
         old_kbps = entry.existing_spectral_bitrate or entry.existing_min_bitrate
+        # New preimport_decide path (post 2026-05-16 hotfix #254) writes the
+        # bitrate numbers into beets_detail (e.g. "spectral 128kbps <= existing
+        # 192kbps") but leaves the typed spectral_bitrate / existing_spectral_*
+        # columns NULL on the row, because _route_preimport_decision_reject's
+        # synthesized DownloadInfo doesn't carry spectral facts. When the
+        # typed columns are absent but beets_detail has a real string, render
+        # that directly — the importer already wrote a good human-readable
+        # reason.
+        if (
+            entry.spectral_bitrate is None
+            and old_kbps is None
+            and entry.beets_detail
+        ):
+            return f"Spectral: {entry.beets_detail}"
         return _comparison_verdict(
             entry.spectral_bitrate, old_kbps, prefix="Spectral:")
 


### PR DESCRIPTION
## Summary

Tiny UI fix following PR #254's hotfix.

The new `preimport_decide` reject path writes bitrate numbers into `beets_detail` (e.g. `spectral 128kbps <= existing 192kbps`) but leaves the typed `spectral_bitrate` / `existing_spectral_*` / `existing_min_bitrate` columns NULL on the `download_log` row, because `_route_preimport_decision_reject`'s synthesized `DownloadInfo` doesn't carry spectral facts.

**UI consequence:** every preimport-rejected row rendered as `Spectral: unknown — not better than existing unknown` — misleading, because the actual numbers ARE on the row, just in `beets_detail`.

**Fix:** in `web/classify.py`'s `spectral_reject` branch (around line 882), when all typed spectral columns are NULL but `beets_detail` is set, render the detail text directly with the `Spectral:` prefix. The importer already wrote a good human-readable reason; the UI just had to use it.

## Production trigger

Sufjan Stevens — *Noel: Songs for Christmas, Volume I* from `cherjr`:
- Download: 128kbps MP3 (single-bitrate fixed; the V2 label in the UI was misleading)
- Existing: 192kbps MP3 in library
- `beets_detail`: `spectral 128kbps <= existing 192kbps`
- Decision: **correctly rejected** by `preimport_decide`
- UI render before this fix: `Spectral: unknown — not better than existing unknown`
- UI render after this fix: `Spectral: spectral 128kbps <= existing 192kbps`

## Followup

A backend fix that populates the typed `dl_info` columns from the persisted `AlbumQualityEvidence` row is the right long-term cleanup — it would also restore the rich `_comparison_verdict` rendering (with grade, metric labels, etc.). Tracked as follow-up; for now this UI patch is the smallest correct change to make the recents tab honest about why a row was rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)