### PR TITLE
fix(download): persist candidate evidence on auto-import reject

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -32,7 +32,7 @@ from lib.processing_paths import (
     stage_to_ai_root,
 )
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
-                         DownloadDecision, ValidationResult,
+                         DownloadDecision, DownloadInfo, ValidationResult,
                          decide_download_action,
                          compute_effective_override_bitrate,
                          extract_usernames,
@@ -1555,6 +1555,75 @@ def _handle_valid_result(
         return None
 
 
+def _persist_candidate_evidence_for_reject(
+    *,
+    db: Any,
+    ctx: CratediggerContext,
+    album_data: GrabListEntry,
+    dl_info: DownloadInfo,
+    bv_result: ValidationResult,
+    download_log_id: int | None,
+) -> None:
+    """Measure and persist candidate evidence on a reject row.
+
+    Called after the download_log row is written by ``_handle_rejected_result``.
+    Future Wrong Matches triage on this row looks up evidence by
+    ``owner_type='download_log_candidate', owner_id=download_log_id`` and
+    skips re-measurement when the snapshot still matches the file on disk.
+
+    Every error case here is non-fatal — the reject row is already written
+    and the request transition has already happened. The worst case is that
+    triage falls back to its own measurement path on first interaction, which
+    is the pre-fix behavior. Log a warning and move on.
+    """
+    if db is None or not isinstance(download_log_id, int) or download_log_id <= 0:
+        return
+    failed_path = bv_result.failed_path
+    if not isinstance(failed_path, str) or not failed_path:
+        return
+    try:
+        from lib.preimport import measure_preimport_state
+        from lib.quality_evidence import (
+            persist_candidate_evidence_from_measurement,
+        )
+
+        measurement = measure_preimport_state(
+            path=failed_path,
+            mb_release_id=album_data.mb_release_id or "",
+            label=f"{album_data.artist} - {album_data.title}",
+            download_filetype=dl_info.filetype or "",
+            download_min_bitrate_bps=dl_info.bitrate,
+            download_is_vbr=dl_info.is_vbr,
+            cfg=ctx.cfg,
+            db=db,
+            request_id=album_data.db_request_id,
+            propagate_download_to_existing=False,
+        )
+        result = persist_candidate_evidence_from_measurement(
+            db,
+            source_path=failed_path,
+            measurement=measurement,
+            download_log_id=download_log_id,
+        )
+        if result.status != "ready":
+            logger.warning(
+                "REJECT EVIDENCE PERSIST: status=%s detail=%r dl_id=%s — "
+                "Wrong Matches triage will fall back to re-measurement on "
+                "first interaction.",
+                result.status,
+                result.reason,
+                download_log_id,
+            )
+    except Exception:
+        logger.warning(
+            "REJECT EVIDENCE PERSIST: unexpected error persisting candidate "
+            "evidence for dl_id=%s — Wrong Matches triage will fall back to "
+            "re-measurement on first interaction.",
+            download_log_id,
+            exc_info=True,
+        )
+
+
 def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResult,
                             staged_album: StagedAlbum,
                             ctx: CratediggerContext) -> DispatchOutcome:
@@ -1587,6 +1656,26 @@ def _handle_rejected_result(album_data: GrabListEntry, bv_result: ValidationResu
         download_info=dl_info,
         search_filetype_override=backfill_override,
         cooled_down_users=ctx.cooled_down_users,
+    )
+    # Persist candidate evidence on the rejected row so Wrong Matches triage
+    # (`decide_wrong_match_cleanup → ensure_candidate_evidence_for_action`)
+    # finds it via owner_type='download_log_candidate' and returns
+    # candidate_status='reused' on first interaction. Without this, triage
+    # falls back to `_preview_for_triage` → full re-measurement (snapshot +
+    # validate_audio + spectral_analyze + V0 probe), 10-30s per album. The
+    # legacy auto-import path (this function) is the only reject seam that
+    # didn't already write evidence — the preview-worker path persists via
+    # `persist_candidate_evidence_from_measurement` in `import_preview.py`
+    # before marking `evidence_ready`. Moves the measurement cost from
+    # interactive triage to the background poll loop where it doesn't block
+    # the operator.
+    _persist_candidate_evidence_for_reject(
+        db=ctx.pipeline_db_source._get_db(),
+        ctx=ctx,
+        album_data=album_data,
+        dl_info=dl_info,
+        bv_result=bv_result,
+        download_log_id=download_log_id,
     )
     _run_post_rejection_wrong_match_triage(
         ctx,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7085,5 +7085,169 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             self.assertIn(("rejected", "audio_corrupt"), outcomes)
 
 
+class TestPersistEvidenceOnRejectSlice(unittest.TestCase):
+    """Auto-import reject persists candidate evidence so Wrong Matches triage is instant.
+
+    Pre-fix behavior: ``_handle_rejected_result`` wrote the download_log row
+    but never persisted ``album_quality_evidence`` with
+    ``owner_type='download_log_candidate'``. First Wrong Matches triage
+    interaction with that row fell back to ``_preview_for_triage`` →
+    full re-measurement (snapshot + validate_audio + spectral_analyze +
+    V0 probe), 10-30s per album.
+
+    Post-fix: ``_persist_candidate_evidence_for_reject`` runs measurement
+    once at reject time and persists the evidence row. Triage then finds
+    the row via ``ensure_candidate_evidence_for_action`` and returns
+    ``candidate_status='reused'`` without firing the preview fallback.
+    """
+
+    def test_reject_persists_candidate_evidence_for_owner_download_log(self):
+        from lib.quality import AlbumQualityEvidenceOwner
+        from lib.preimport import PreimportMeasurement
+        from lib.download import _persist_candidate_evidence_for_reject
+        from lib.import_evidence import ensure_candidate_evidence_for_action
+        from tests.helpers import make_grab_list_entry, make_download_file
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        # Seed a download_log row first so the FakePipelineDB's owner-validation
+        # check accepts the download_log_candidate evidence upsert (real PG has
+        # the same FK constraint).
+        download_log_id = db.log_download(
+            request_id=42,
+            outcome="rejected",
+            beets_scenario="high_distance",
+            beets_detail="distance 0.5 above threshold",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            failed_path = os.path.join(tmpdir, "Artist - Album")
+            os.makedirs(failed_path)
+            track_path = os.path.join(failed_path, "01 - Track.mp3")
+            with open(track_path, "wb") as f:
+                f.write(b"FAKE_MP3_DATA")
+
+            measurement = PreimportMeasurement(
+                corrupt_files=[],
+                audio_corrupt=False,
+                matched_bad_hash_id=None,
+                matched_bad_track_path=None,
+                download_spectral=SimpleNamespace(
+                    grade="suspect",
+                    bitrate_kbps=128,
+                    suspect_pct=80.0,
+                ),
+                existing_spectral=SimpleNamespace(
+                    grade="genuine",
+                    bitrate_kbps=320,
+                    suspect_pct=0.0,
+                ),
+                existing_min_bitrate=320,
+                folder_layout="flat",
+                audio_file_count=1,
+                filetype_band="mp3",
+                min_bitrate_kbps=192,
+                is_vbr=False,
+            )
+
+            ctx = SimpleNamespace(
+                cfg=SimpleNamespace(
+                    beets_harness_path=_HARNESS,
+                    beets_distance_threshold=0.15,
+                    quality_ranks=None,
+                    audio_check_mode="off",
+                    beets_directory="",
+                ),
+            )
+            album_data = make_grab_list_entry(
+                artist="Artist",
+                title="Album",
+                mb_release_id="mbid-42",
+                db_request_id=42,
+                files=[make_download_file(filename="01 - Track.mp3")],
+            )
+            dl_info = SimpleNamespace(
+                filetype="mp3",
+                bitrate=192000,
+                is_vbr=False,
+            )
+            bv_result = SimpleNamespace(
+                failed_path=failed_path,
+            )
+
+            with patch(
+                "lib.preimport.measure_preimport_state",
+                return_value=measurement,
+            ):
+                _persist_candidate_evidence_for_reject(
+                    db=db,
+                    ctx=ctx,  # type: ignore[arg-type]
+                    album_data=album_data,
+                    dl_info=dl_info,  # type: ignore[arg-type]
+                    bv_result=bv_result,  # type: ignore[arg-type]
+                    download_log_id=download_log_id,
+                )
+
+            # Evidence persisted with download_log_candidate owner.
+            owner = AlbumQualityEvidenceOwner(
+                owner_type="download_log_candidate",
+                owner_id=download_log_id,
+            )
+            evidence = db.load_album_quality_evidence(owner)
+            self.assertIsNotNone(evidence)
+            assert evidence is not None  # type narrowing for pyright
+            self.assertEqual(evidence.measurement.spectral_grade, "suspect")
+            self.assertEqual(evidence.measurement.spectral_bitrate_kbps, 128)
+            self.assertEqual(evidence.audio_file_count, 1)
+            self.assertEqual(evidence.folder_layout, "flat")
+
+            # Triage's fast-path lookup finds the row.
+            triage_result = ensure_candidate_evidence_for_action(
+                db,
+                source_path=failed_path,
+                download_log_id=download_log_id,
+            )
+            self.assertTrue(triage_result.available)
+            self.assertEqual(
+                triage_result.provenance.candidate_status,
+                "reused",
+            )
+
+    def test_persist_helper_is_defensive_when_inputs_are_missing(self):
+        """Helper must not crash when db is None, dl_id is non-int, or path is missing."""
+        from lib.download import _persist_candidate_evidence_for_reject
+        from tests.helpers import make_grab_list_entry
+
+        # None db: silent no-op.
+        _persist_candidate_evidence_for_reject(
+            db=None,
+            ctx=SimpleNamespace(cfg=SimpleNamespace()),  # type: ignore[arg-type]
+            album_data=make_grab_list_entry(artist="A", title="B"),
+            dl_info=SimpleNamespace(filetype="mp3", bitrate=192000, is_vbr=False),  # type: ignore[arg-type]
+            bv_result=SimpleNamespace(failed_path="/tmp/nonexistent"),  # type: ignore[arg-type]
+            download_log_id=1,
+        )
+
+        # MagicMock dl_id (the pre-fix bug): silent no-op.
+        _persist_candidate_evidence_for_reject(
+            db=FakePipelineDB(),
+            ctx=SimpleNamespace(cfg=SimpleNamespace()),  # type: ignore[arg-type]
+            album_data=make_grab_list_entry(artist="A", title="B"),
+            dl_info=SimpleNamespace(filetype="mp3", bitrate=192000, is_vbr=False),  # type: ignore[arg-type]
+            bv_result=SimpleNamespace(failed_path="/tmp/nonexistent"),  # type: ignore[arg-type]
+            download_log_id=MagicMock(),  # type: ignore[arg-type]
+        )
+
+        # Empty failed_path: silent no-op.
+        _persist_candidate_evidence_for_reject(
+            db=FakePipelineDB(),
+            ctx=SimpleNamespace(cfg=SimpleNamespace()),  # type: ignore[arg-type]
+            album_data=make_grab_list_entry(artist="A", title="B"),
+            dl_info=SimpleNamespace(filetype="mp3", bitrate=192000, is_vbr=False),  # type: ignore[arg-type]
+            bv_result=SimpleNamespace(failed_path=""),  # type: ignore[arg-type]
+            download_log_id=1,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Wrong Matches triage was slow (10-30s) on first interaction with newly-rejected `high_distance` rows because the legacy auto-import path in `lib/download.py::_handle_rejected_result` wrote the `download_log` row but never persisted `album_quality_evidence`. Triage then hit `decide_wrong_match_cleanup → ensure_candidate_evidence_for_action → 'missing' → fallback to _preview_for_triage`, which ran the full measurement pipeline (snapshot + validate_audio + spectral_analyze + V0 probe) **interactively** while the operator waited.

Confirmed via production DB query: 4 of 8 recent `high_distance` rejects had no candidate evidence row (the other 4 got theirs from a prior triage or force-import that already paid the cost). The user reported triage feels sluggish on these rows.

## Fix

New `_persist_candidate_evidence_for_reject` helper runs `measure_preimport_state` on the `failed_path` and calls `persist_candidate_evidence_from_measurement` with the new `download_log_id` as the evidence owner. This **moves the measurement cost from interactive triage to the background poll loop** where it doesn't block the operator. The persisted evidence row makes `ensure_candidate_evidence_for_action` return `candidate_status='reused'` on first triage interaction.

**Defensive:** `db=None`, non-int `dl_id` (test MagicMock case), missing `failed_path` all short-circuit cleanly. Any measurement exception is caught, logged as a warning with the dl_id, and the reject flow continues — triage falls back to its existing slow path in that case. The reject row + request transition are already written before the helper runs, so a measurement failure here can't strand anything.

## Test surface

`TestPersistEvidenceOnRejectSlice` (2 cases):

- Asserts evidence row exists with `owner_type='download_log_candidate'`, `owner_id=<new dl_id>`, populated with measurement facts (`spectral_grade='suspect'`, `spectral_bitrate_kbps=128`, `folder_layout='flat'`, `audio_file_count=1`) — and that `ensure_candidate_evidence_for_action` returns `candidate_status='reused'` on the same id, proving the fast path lights up.
- Defensive guards: `None` db / MagicMock dl_id / empty failed_path are all silent no-ops.

Full suite: **3432 tests, 0 failures.**

## Follow-up

The same evidence-persistence gap exists for the importer-side rejection path in `lib/import_dispatch.py::_route_preimport_decision_reject` — that path stores evidence with `owner_type='import_job_candidate'` but Wrong Matches triage looks up by `download_log_id` only. Importer-rejected rows would also benefit from a `download_log_candidate` companion row, OR triage could be extended to look up by both owners. Out of scope for this PR; tracked as separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)