### PR TITLE
fix(quality): make full pipeline the single decider; strip parallel spectral gate

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,5 +1,48 @@
 # Code Quality Standards
 
+## Quality decisions live in ONE place
+
+**`full_pipeline_decision_from_evidence`** in `lib/quality.py` (and its
+flat-kwargs simulator twin `full_pipeline_decision`) is the single source of
+truth for every quality decision: spectral, codec rank, V0 probe, provisional
+lossless, verified lossless, transcode detection, quality gate. **Never
+re-create quality decisions elsewhere.** If a code path needs to know "should
+this be imported", it must call the full pipeline — not invent its own
+narrower spectral / rank / bitrate comparison.
+
+This bit us in PR #257: U6 wired a parallel `preimport_decide` spectral branch
+upstream of the full pipeline. The narrower decider fell back to existing
+container bitrate when spectral evidence was missing on one side, rejecting
+legitimate FLAC provisional-lossless upgrades (request 4514). The fix was to
+delete the parallel decision. Don't reintroduce.
+
+**Preview produces evidence. Importer decides.** The two-worker contract:
+
+- **Preview worker** (`lib/import_preview.py`): measures, persists
+  `AlbumQualityEvidence`, marks the job `evidence_ready` or
+  `measurement_failed`. Never emits a verdict. Never decides accept/reject.
+- **Importer worker** (`lib/import_dispatch.py::dispatch_import_from_db`):
+  reads persisted evidence, decides via `full_pipeline_decision_from_evidence`.
+  Sole production caller of `preimport_decide` — which now owns ONLY
+  folder/audio-integrity facts (`audio_corrupt`, `bad_audio_hash`,
+  `nested_layout`, `empty_fileset`). Spectral, codec rank, and quality-gate
+  decisions go through the full pipeline.
+
+**The album test set is the contract.** Live-bug scenarios go in
+`tests/test_quality_classification.py::TestLiveBugReproductions` (one test
+per real-world album that exercised a quality decision). Every scenario MUST
+also be exercised through the production decider via
+`TestLiveBugReproductionsThroughEvidencePipeline` — the parity contract is
+that the simulator and the evidence pipeline produce the same outcome on the
+same album. If you change quality policy, update the album test set first;
+the live code follows.
+
+**Red flag phrases that mean you're about to re-invent the decision:** "let me
+add a quick spectral check here", "the importer needs to handle this case
+upstream", "I'll just compare bitrates before calling the pipeline", "this
+gate should reject obviously-bad candidates early". All of these are wrong.
+Call the full pipeline.
+
 ## Type Safety
 - All new dataclasses, functions, and module-level code must pass pyright with 0 errors
 - Use typed dataclasses (not dicts) for structured data crossing module boundaries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,13 +209,57 @@ If you only need the capability from one surface in this PR, expose it on both a
 
 ## Decision architecture
 
-Quality policy should stay pure where possible: facts in, decision out, no I/O,
-database, or filesystem side effects. Key entries in `lib/quality.py` include
-`spectral_import_decision`, `import_quality_decision`,
-`transcode_detection`, `quality_gate_decision`,
+**Quality decisions live in ONE place.** `full_pipeline_decision_from_evidence`
+in `lib/quality.py` (and its flat-kwargs simulator twin `full_pipeline_decision`)
+is the single source of truth for every quality decision: spectral, codec rank,
+V0 probe, provisional lossless, verified lossless, transcode detection, quality
+gate. **Never re-create quality decisions elsewhere.** If a code path needs to
+know "should this be imported", it must call the full pipeline — not invent its
+own narrower spectral / rank / bitrate comparison.
+
+This bit us once already (PR #257): U6 wired a parallel `preimport_decide`
+spectral branch in front of `full_pipeline_decision_from_evidence`. The
+narrower decider fell back to existing container bitrate when spectral evidence
+was missing on one side, rejecting legitimate FLAC provisional-lossless
+upgrades (request 4514). The fix was to delete the parallel decision and let
+the full pipeline own it. **Don't reintroduce parallel quality deciders.**
+
+**Preview produces evidence. Importer decides.** The two-worker contract:
+
+- **Preview worker** (`lib/import_preview.py`): measures via
+  `measure_preimport_state` + `run_import_one`, persists
+  `AlbumQualityEvidence`, marks the job `evidence_ready` (or
+  `measurement_failed`). Never emits a verdict. Never decides accept/reject.
+- **Importer worker** (`lib/import_dispatch.py::dispatch_import_from_db`):
+  reads persisted evidence and decides via `full_pipeline_decision_from_evidence`.
+  Sole production caller of `preimport_decide`, which now owns only
+  folder/audio-integrity facts (`audio_corrupt`, `bad_audio_hash`,
+  `nested_layout`, `empty_fileset`) — quality decisions go through the full
+  pipeline.
+
+If you find yourself writing a new function that compares spectral / bitrate
+/ codec ranks, stop. Either call `full_pipeline_decision_from_evidence` or
+extend the pure decision helpers it already composes (`spectral_import_decision`,
+`measured_import_decision`, `provisional_lossless_decision`,
+`quality_gate_decision`). The function does NOT accept container-bitrate
+fallback — spectral compares to spectral evidence only (invariant of #257).
+
+**The album test set is what defines behavior.** Live-bug scenarios go in
+`tests/test_quality_classification.py::TestLiveBugReproductions` (Bride,
+Flux, Taboo, Tyler Lambert, BoC, Heretic Pride, etc.). Every scenario MUST
+also be exercised through the production decider via
+`TestLiveBugReproductionsThroughEvidencePipeline` — the parity contract is
+that the simulator and the evidence pipeline reach the same outcome on the
+same album. If you change quality policy, update the album test set first;
+the live code follows.
+
+Pure decision helpers in `lib/quality.py`: `spectral_import_decision`,
+`import_quality_decision`, `transcode_detection`, `quality_gate_decision`,
 `determine_verified_lossless`, `dispatch_action`,
 `compute_effective_override_bitrate`, `verify_filetype`, `should_cooldown`,
-and `get_decision_tree` (feeds the web UI Decisions tab).
+`provisional_lossless_decision`, `measured_import_decision`,
+`preimport_decide` (folder/audio-integrity only), and `get_decision_tree`
+(feeds the web UI Decisions tab).
 
 The importer queue is the beets-mutating ownership boundary. Web, CLI, and the
 automation poller enqueue import jobs; `cratedigger-importer` drains them

--- a/lib/preimport.py
+++ b/lib/preimport.py
@@ -34,8 +34,7 @@ from lib.audio_hash import AudioHashError, hash_audio_content
 _BAD_HASH_SUPPORTED_EXTS: frozenset[str] = frozenset({"flac", "mp3", "m4a", "aac", "ogg", "opus"})
 from lib.pipeline_db import RequestSpectralStateUpdate
 from lib.quality import (SPECTRAL_TRANSCODE_GRADES, PreimportDecision,
-                         SpectralMeasurement, preimport_decide,
-                         spectral_import_decision)
+                         SpectralMeasurement)
 from lib.util import repair_mp3_headers, validate_audio
 
 if TYPE_CHECKING:
@@ -756,46 +755,6 @@ def run_preimport_gates(
             request_id=request_id,
             usernames=usernames,
         )
-        # Operator-visible reject log — preserved from pre-U3 behavior.
-        if decision.reason == "spectral_reject":
-            dl_bitrate = (
-                measurement.download_spectral.bitrate_kbps
-                if measurement.download_spectral is not None else None
-            )
-            effective_existing = (
-                (measurement.existing_spectral.bitrate_kbps
-                 if measurement.existing_spectral is not None else None)
-                or measurement.existing_min_bitrate or 0
-            )
-            logger.warning(
-                f"SPECTRAL REJECT: {label} "
-                f"new spectral {dl_bitrate}kbps <= existing "
-                f"{effective_existing}kbps")
-    else:
-        # Operator-visible accept log for spectral upgrades / no-exist (pre-U3
-        # behavior). Only fires when spectral actually ran.
-        ds = measurement.download_spectral
-        if ds is not None:
-            dl_bitrate = ds.bitrate_kbps
-            verdict = spectral_import_decision(
-                ds.grade, dl_bitrate,
-                (measurement.existing_spectral.bitrate_kbps
-                 if measurement.existing_spectral is not None else None),
-                existing_min_bitrate=measurement.existing_min_bitrate,
-            )
-            effective_existing = (
-                (measurement.existing_spectral.bitrate_kbps
-                 if measurement.existing_spectral is not None else None)
-                or measurement.existing_min_bitrate or 0
-            )
-            if verdict == "import_upgrade":
-                logger.info(
-                    f"SPECTRAL UPGRADE: {label} suspect at {dl_bitrate}kbps "
-                    f"but > existing {effective_existing}kbps, importing")
-            elif verdict == "import_no_exist":
-                logger.info(
-                    f"SPECTRAL: {label} suspect at {dl_bitrate}kbps "
-                    f"but no existing album, importing")
 
     return result
 
@@ -803,13 +762,20 @@ def run_preimport_gates(
 def _legacy_preimport_decision(
     measurement: PreimportMeasurement,
 ) -> PreimportDecision:
-    """Subset of ``preimport_decide`` matching pre-U3 ``run_preimport_gates`` gates.
+    """Pre-U3 ``run_preimport_gates`` decision shim — folder/audio facts only.
 
-    Only audio_corrupt → bad_audio_hash → spectral_reject. ``nested_layout``
-    and ``empty_fileset`` are intentionally excluded so this shim is bit-for-bit
+    Owns the same two reject reasons preimport_decide owns for legacy callers
+    (``audio_corrupt``, ``bad_audio_hash``). ``nested_layout`` and
+    ``empty_fileset`` are intentionally excluded so this shim is bit-for-bit
     backward compatible with pre-U3 callers (preview filters nested itself;
-    auto path never checked file count). U6 wires the full ``preimport_decide``
-    into the importer where the broader gate set is correct.
+    auto path never checked file count).
+
+    Quality decisions (spectral / codec rank / provisional lossless) are NOT
+    made here. The importer's evidence pipeline
+    (``full_pipeline_decision_from_evidence``) is the single decider for
+    quality — the same function the album test set pins. Re-litigating
+    spectral here bypasses the FLAC provisional pathway and violates
+    evidence-set parity.
     """
     if measurement.audio_corrupt:
         n = len(measurement.corrupt_files)
@@ -828,29 +794,6 @@ def _legacy_preimport_decision(
                 f"track {track}"
             ),
         )
-    ds = measurement.download_spectral
-    if ds is not None:
-        existing_cliff_bitrate = (
-            measurement.existing_spectral.bitrate_kbps
-            if measurement.existing_spectral is not None else None
-        )
-        verdict = spectral_import_decision(
-            ds.grade, ds.bitrate_kbps,
-            existing_cliff_bitrate,
-            existing_min_bitrate=measurement.existing_min_bitrate,
-        )
-        if verdict == "reject":
-            effective_existing = (
-                existing_cliff_bitrate or measurement.existing_min_bitrate or 0
-            )
-            return PreimportDecision(
-                decision="reject",
-                reason="spectral_reject",
-                detail=(
-                    f"spectral {ds.bitrate_kbps}kbps <= existing "
-                    f"{effective_existing}kbps"
-                ),
-            )
     return PreimportDecision(decision="accept")
 
 
@@ -862,13 +805,12 @@ def _apply_legacy_denylist_side_effects(
     request_id: int | None,
     usernames: set[str] | None,
 ) -> None:
-    """Denylist side effects preserved during the U3 → U6 transition.
+    """Denylist side effects for the legacy preimport gate shim.
 
-    Bad-hash and spectral-reject scenarios denylist the Soulseek users who
-    served the bad source so the search executor doesn't ask them again on the
-    next attempt. U6 moves this into the shared rejection-finalize helper;
-    until then the shim continues to do it inline to keep behavior identical
-    to pre-U3.
+    Only ``bad_audio_hash`` denylists peers from this gate — that's a
+    source-quality decision the curator/operator has already made. Spectral
+    no longer rejects here (see ``_legacy_preimport_decision``); quality-side
+    denylisting is owned by the importer's evidence-pipeline reject helper.
     """
     if db is None or request_id is None or not usernames:
         return
@@ -886,23 +828,3 @@ def _apply_legacy_denylist_side_effects(
         logger.info(
             f"  Denylisted {usernames} for request {request_id}")
         return
-    if decision.reason == "spectral_reject":
-        dl_bitrate = (
-            measurement.download_spectral.bitrate_kbps
-            if measurement.download_spectral is not None else None
-        )
-        effective_existing = (
-            (measurement.existing_spectral.bitrate_kbps
-             if measurement.existing_spectral is not None else None)
-            or measurement.existing_min_bitrate or 0
-        )
-        for username in usernames:
-            try:
-                db.add_denylist(
-                    request_id, username,
-                    f"spectral: {dl_bitrate}kbps <= existing "
-                    f"{effective_existing}kbps")
-            except Exception:
-                logger.exception(
-                    f"Failed to denylist {username} for request {request_id}")
-        logger.info(f"  Denylisted {usernames} for request {request_id}")

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2195,20 +2195,30 @@ def preimport_decide(
     cfg: "QualityRankConfig",
     existing_evidence: "AlbumQualityEvidence | None" = None,
 ) -> PreimportDecision:
-    """Decide accept/reject from a measurement + cfg + existing-album evidence.
+    """Decide accept/reject for the *pre-import folder/audio gate*.
 
     Pure function — no DB writes, no denylist mutations, no filesystem
-    side effects. Mirror of the decision branches that previously lived inline
-    inside ``lib.preimport.run_preimport_gates`` (U3 split).
+    side effects. Owns only the facts ``full_pipeline_decision_from_evidence``
+    does not model: "is this folder even usable to run a quality decision
+    against?". Quality (spectral, codec rank, V0 probe, provisional lossless,
+    verified lossless, quality-gate) is owned by
+    ``full_pipeline_decision_from_evidence`` — the same function the album
+    test set in ``tests/test_quality_classification.py`` pins.
 
-    Decision order matches the legacy gate pipeline:
+    Decision order:
       1. ``audio_corrupt`` — any decode failure → reject.
       2. ``bad_audio_hash`` — track matches a curator-reported bad hash → reject.
       3. ``nested_layout`` — audio in subdirectories → reject.
       4. ``empty_fileset`` — no audio files found → reject.
-      5. ``spectral_reject`` — ``spectral_import_decision`` says "reject" → reject.
 
-    Everything else is ``accept``.
+    Everything else is ``accept`` — even when spectral evidence is present.
+    Spectral comparisons live in ``full_pipeline_decision`` /
+    ``full_pipeline_decision_from_evidence``; routing them through this gate
+    bypasses the FLAC provisional-lossless pathway and violates evidence-set
+    parity (it would let an existing MP3 320 container with no spectral run
+    outrank a freshly measured candidate cliff). The ``existing_evidence``
+    parameter is retained for callers that still pass it; this gate ignores
+    it.
     """
     # 1. audio integrity
     if measurement.audio_corrupt:
@@ -2247,44 +2257,16 @@ def preimport_decide(
             detail="no audio files found",
         )
 
-    # 5. spectral
-    download_spectral = measurement.download_spectral
-    existing_spectral = measurement.existing_spectral
-    if download_spectral is not None:
-        dl_grade = download_spectral.grade
-        dl_bitrate = download_spectral.bitrate_kbps
-        existing_cliff_bitrate = (
-            existing_spectral.bitrate_kbps
-            if existing_spectral is not None else None
-        )
-        verdict = spectral_import_decision(
-            dl_grade,
-            dl_bitrate,
-            existing_cliff_bitrate,
-            existing_min_bitrate=measurement.existing_min_bitrate,
-        )
-        if verdict == "reject":
-            effective_existing = (
-                existing_cliff_bitrate or measurement.existing_min_bitrate or 0
-            )
-            return PreimportDecision(
-                decision="reject",
-                reason="spectral_reject",
-                detail=(
-                    f"spectral {dl_bitrate}kbps <= existing "
-                    f"{effective_existing}kbps"
-                ),
-            )
-
     return PreimportDecision(decision="accept")
 
 
-def spectral_import_decision(spectral_grade, spectral_bitrate, existing_spectral_bitrate,
-                             existing_min_bitrate=None):
+def spectral_import_decision(spectral_grade, spectral_bitrate, existing_spectral_bitrate):
     """Decide whether to import a download based on spectral analysis.
 
-    Called in process_completed_album() for non-FLAC downloads after
-    spectral analysis runs on the downloaded files.
+    Pure comparison of spectral evidence against spectral evidence. Container
+    bitrate is intentionally NOT consulted — that violates evidence-set parity
+    (absence of an existing spectral measurement is not evidence the existing
+    file is genuine, only that we haven't measured it yet).
 
     Returns one of:
         "import"          — spectral says genuine/marginal, proceed
@@ -2296,16 +2278,12 @@ def spectral_import_decision(spectral_grade, spectral_bitrate, existing_spectral
         spectral_grade:             "genuine" | "marginal" | "suspect" | "likely_transcode"
         spectral_bitrate:           estimated bitrate from cliff detection (kbps), or None
         existing_spectral_bitrate:  spectral estimate of what's already in beets (kbps), or 0/None
-        existing_min_bitrate:       container bitrate from beets (kbps), fallback when
-                                    existing files are genuine (no spectral estimate)
     """
     if spectral_grade not in ("suspect", "likely_transcode"):
         return "import"
 
     new_q = spectral_bitrate or 0
-    # Fall back to container bitrate when existing files have no spectral estimate
-    # (genuine files have no cliff → no estimated bitrate)
-    existing_q = existing_spectral_bitrate or existing_min_bitrate or 0
+    existing_q = existing_spectral_bitrate or 0
 
     if new_q and existing_q and new_q <= existing_q:
         return "reject"

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -475,22 +475,19 @@ class TestPreimportRepairsEvenWhenAudioCheckOff(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
-    """The persisted-spectral fallback must be grade-aware: a stored
-    ``current_spectral_grade='genuine', current_spectral_bitrate=96`` is
-    stale (genuine files have no cliff). Feeding that 96 kbps into
-    spectral_import_decision would let real transcodes be imported as
-    "upgrades". Matches compute_effective_override_bitrate and
-    load_quality_gate_state — only transcode grades are authoritative.
+class TestPreimportGateDoesNotDecideQuality(unittest.TestCase):
+    """The preimport gate is folder/audio-integrity only; quality decisions
+    (spectral vs container, transcode upgrade, etc.) belong to the importer's
+    evidence pipeline (``full_pipeline_decision_from_evidence``). This guards
+    against any future reintroduction of a stale-spectral or container-fallback
+    footgun inside ``run_preimport_gates``.
     """
 
-    def test_genuine_stored_spectral_ignored(self):
+    def test_likely_transcode_alone_does_not_reject_at_preimport(self):
         from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
         db = FakePipelineDB()
-        # Stored grade=genuine, bitrate=96 — a stale leftover from prior runs.
-        # Not a transcode grade, so the bitrate must NOT be used as authoritative.
         db.seed_request(make_request_row(
             id=42,
             min_bitrate=320,
@@ -503,10 +500,9 @@ class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
             album_path="/Beets/NonexistentPath")
         cfg = CratediggerConfig(audio_check_mode="off")
 
-        # Download is a suspect 192kbps transcode. If the fallback used the
-        # stored grade=genuine/bitrate=96 verbatim, 192 > 96 would wrongly
-        # import the transcode. With grade-aware handling, the 96 is ignored
-        # and decision falls back to min_bitrate=320 → reject.
+        # Even when the candidate spectrally looks like a transcode at 192kbps
+        # against an existing 320kbps album, the preimport gate must NOT reject.
+        # The importer's evidence pipeline owns that comparison.
         with patch("lib.preimport.spectral_analyze",
                    return_value=_analyze_result(
                        "likely_transcode", 192, 80.0, 5)), \
@@ -525,11 +521,11 @@ class TestFallbackIgnoresNonTranscodeStoredSpectral(unittest.TestCase):
                 propagate_download_to_existing=False,
             )
 
-        self.assertFalse(
+        self.assertTrue(
             result.valid,
-            "stale genuine stored spectral must not be used to import a 192kbps "
-            "transcode over a 320kbps on-disk album")
-        self.assertEqual(result.scenario, "spectral_reject")
+            "preimport gate must not reject on quality grounds — quality "
+            "decisions live in full_pipeline_decision_from_evidence")
+        self.assertIsNone(result.scenario)
 
 
 class TestUnknownVbrResolvesViaInspection(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -759,7 +759,17 @@ class TestSpectralPropagationSlice(unittest.TestCase):
     consistently regardless of caller.
     """
 
-    def test_suspect_download_updates_current_spectral_and_denylists(self):
+    def test_suspect_download_persists_existing_spectral_state(self):
+        """Issue #90: when run_preimport_gates measures spectral on both the
+        download and the existing album, it must persist the *existing*
+        spectral state to ``album_requests.current_spectral_*`` so subsequent
+        attempts can compare evidence-to-evidence.
+
+        Spectral comparison itself is owned by the importer's evidence
+        pipeline (``full_pipeline_decision_from_evidence``) — preimport just
+        accepts and lets the importer decide. Denylisting on quality grounds
+        is the importer's responsibility, not this gate's.
+        """
         from lib.config import CratediggerConfig
         from lib.preimport import run_preimport_gates
 
@@ -794,30 +804,32 @@ class TestSpectralPropagationSlice(unittest.TestCase):
             ],
         ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
              patch("os.path.isdir", return_value=True):
-            with self.assertLogs("cratedigger", level="WARNING") as logs:
-                result = run_preimport_gates(
-                    path="/tmp/download",
-                    mb_release_id="mbid-123",
-                    label="Test Artist - Test Album",
-                    download_filetype="mp3",
-                    download_min_bitrate_bps=320_000,
-                    download_is_vbr=False,
-                    cfg=cfg,
-                    db=db,  # type: ignore[arg-type]
-                    request_id=42,
-                    usernames={"user1"},
-                )
+            result = run_preimport_gates(
+                path="/tmp/download",
+                mb_release_id="mbid-123",
+                label="Test Artist - Test Album",
+                download_filetype="mp3",
+                download_min_bitrate_bps=320_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                db=db,  # type: ignore[arg-type]
+                request_id=42,
+                usernames={"user1"},
+            )
 
+        # Preimport accepts — quality decisions live in
+        # full_pipeline_decision_from_evidence.
+        self.assertTrue(result.valid)
+        self.assertIsNone(result.scenario)
+        self.assertEqual(len(db.denylist), 0,
+                         "preimport must not denylist on quality grounds")
+
+        # Spectral state for the *existing* album was persisted so the
+        # importer's evidence pipeline can compare spectral-to-spectral on
+        # the next attempt.
         row = db.request(42)
-        self.assertIn("SPECTRAL REJECT", "\n".join(logs.output))
         self.assertEqual(row["current_spectral_grade"], "genuine")
         self.assertEqual(row["current_spectral_bitrate"], 320)
-        self.assertFalse(result.valid)
-        self.assertEqual(result.scenario, "spectral_reject")
-        self.assertEqual(len(db.denylist), 1)
-        self.assertEqual(db.denylist[0].username, "user1")
-        self.assertIn("spectral: 128kbps <= existing 320kbps",
-                      db.denylist[0].reason or "")
 
     def test_stale_album_path_does_not_self_compare(self):
         """Issue #90: when BeetsDB returns an album whose on-disk path has
@@ -890,59 +902,6 @@ class TestSpectralPropagationSlice(unittest.TestCase):
                                 "spectral 128kbps <= existing 128kbps",
                                 "self-compare bug: download compared against "
                                 "a propagated copy of its own spectral")
-
-    def test_stale_album_path_rejects_against_container_bitrate(self):
-        """Issue #90 regression guard: when beets path is stale, the spectral
-        decision must fall back to the container's min_bitrate (320), not
-        the download's own spectral. So a suspect 128kbps download rejects
-        against 320kbps (a real comparison) and the detail string reflects
-        that — not the self-compare "128 <= 128" the old code produced.
-        """
-        from lib.config import CratediggerConfig
-        from lib.preimport import run_preimport_gates
-
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(id=42, status="downloading"))
-        beets_info = AlbumInfo(
-            album_id=1,
-            track_count=10,
-            min_bitrate_kbps=320,
-            avg_bitrate_kbps=320,
-            format="MP3",
-            is_cbr=True,
-            album_path="/Beets/Test",
-        )
-        cfg = CratediggerConfig(audio_check_mode="off")
-
-        with patch(
-            "lib.preimport.spectral_analyze",
-            return_value=SimpleNamespace(
-                grade="suspect",
-                estimated_bitrate_kbps=128,
-                suspect_pct=90.0,
-                tracks=[],
-            ),
-        ), patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)), \
-             patch("os.path.isdir", return_value=False):
-            result = run_preimport_gates(
-                path="/tmp/download",
-                mb_release_id="mbid-123",
-                label="Test Artist - Test Album",
-                download_filetype="mp3",
-                download_min_bitrate_bps=320_000,
-                download_is_vbr=False,
-                cfg=cfg,
-                db=db,  # type: ignore[arg-type]
-                request_id=42,
-                usernames={"user1"},
-                propagate_download_to_existing=True,
-            )
-
-        self.assertFalse(result.valid, "suspect 128 < container 320 should reject")
-        self.assertEqual(result.scenario, "spectral_reject")
-        self.assertEqual(result.detail, "spectral 128kbps <= existing 320kbps",
-                         "reject must compare against stale container's 320kbps, "
-                         "not a propagated copy of the download's 128kbps")
 
     def test_stale_album_path_imports_when_download_beats_container(self):
         """Issue #90 correctness: suspect download above the container
@@ -6370,12 +6329,16 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "empty_fileset"), outcomes)
 
-    def test_spectral_reject_evidence_routes_through_self_heal(self):
-        """Suspect candidate spectral with no upgrade over existing → reject.
+    def test_spectral_reject_evidence_routes_through_evidence_pipeline(self):
+        """likely_transcode candidate spectral matches existing transcode
+        spectral → ``full_pipeline_decision_from_evidence`` rejects at
+        stage1_spectral (spectral evidence vs spectral evidence). The
+        importer routes the reject through ``_reject_import_from_evidence_decision``;
+        beets never runs and the download_log records the rejection.
 
-        likely_transcode at 128kbps vs an existing transcode at the same band
-        — ``spectral_import_decision`` returns 'reject', preimport_decide
-        emits a reject(reason=spectral_reject), self-heal fires."""
+        Spectral comparison lives in the full pipeline (the same function
+        the album test set pins) — not in ``preimport_decide``, which only
+        owns folder/audio-integrity facts."""
         from lib.quality import AlbumQualityEvidenceFile
 
         db = FakePipelineDB()
@@ -6429,14 +6392,10 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertIn("spectral_reject", result.message or "")
+        # Beets subprocess NEVER ran — evidence pipeline rejected upstream.
         self.assertEqual(ext.run.call_count, 0)
-        row = db.request(45)
-        self.assertEqual(row["status"], "wanted")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "spectral_reject"), outcomes)
-        # Source-quality reject — peer denylisted (5-strikes rule applies).
-        self.assertEqual(len(db.denylist), 1)
-        self.assertEqual(db.denylist[0].username, "alice")
 
 
 # ---------------------------------------------------------------------------
@@ -6722,16 +6681,18 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
     def test_boc_geogaddi_suspect_96k_persists_evidence_and_importer_rejects(self):
         """Production BoC bug: suspect 96kbps MP3 download vs existing 192kbps.
 
+        Preview collects facts via ``measure_preimport_state`` and runs the
+        harness (which measures spectral as suspect@96kbps), then persists
+        evidence. The importer reads the persisted evidence and routes it
+        through ``full_pipeline_decision_from_evidence``. The candidate is
+        a clear codec-rank downgrade (MP3 96 vs existing MP3 192) — the
+        full pipeline returns ``downgrade`` and the importer rejects via
+        the evidence pipeline.
+
         Pre-fix: preview's legacy shim ran ``_legacy_preimport_decision``,
         returned ``spectral_reject``, early-returned without persisting,
         importer's front-gate then fired ``evidence_persist_failed`` and
         re-queued forever.
-
-        Post-fix: preview collects facts via ``measure_preimport_state``,
-        runs the harness (which also measures spectral as suspect@96kbps),
-        persists evidence, importer's ``preimport_decide`` reads the
-        persisted spectral facts and rejects with ``spectral_reject``.
-        Self-heal: request → wanted.
         """
         from lib.preimport import PreimportMeasurement
         from lib.quality import (
@@ -6864,14 +6825,15 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                 )
 
             self.assertFalse(result.success)
-            self.assertIn("spectral_reject", result.message or "")
+            # The full pipeline returns ``downgrade`` for this codec-rank
+            # comparison (MP3 96 vs MP3 192); the importer rejects via the
+            # evidence pipeline rather than reinventing the comparison.
+            self.assertIn("downgrade", result.message or "")
             # Beets NEVER ran.
             self.assertEqual(ext.run.call_count, 0)
-            # Self-heal: request → wanted.
-            self.assertEqual(db.request(42)["status"], "wanted")
-            # download_log rejection scenario.
+            # download_log rejection scenario reflects the actual decision.
             outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
-            self.assertIn(("rejected", "spectral_reject"), outcomes)
+            self.assertIn(("rejected", "downgrade"), outcomes)
 
     def test_clean_upgrade_persists_evidence_and_importer_accepts(self):
         """Happy path: suspect spectral but a clear bitrate upgrade.

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -721,6 +721,56 @@ class TestLiveBugReproductions(unittest.TestCase):
         self.assertTrue(r["keep_searching"])
 
 
+    def test_live_mountain_goats_flux_flac_source_vs_lossy_no_spectral(self):
+        """Mountain Goats - The Life of the World in Flux / AnderMachines.
+
+        Request 4514, 2026-05-16 14:47 AWST. FLAC source with a suspect
+        spectral cliff at 160 kbps (one-track cliff, 69% suspect grade).
+        Lossless-source V0 probe: avg=211, min=198, median=214 — well
+        above the V0 floor, so a strong provisional-lossless signal.
+
+        Existing in beets: MP3 320 CBR, no spectral measurement.
+
+        Pre-fix bug: the importer's ``preimport_decide`` ran a parallel
+        spectral comparison that fell back to the existing container
+        bitrate (320 kbps) when no existing spectral was measured. The
+        candidate's 160 kbps cliff was compared against 320 kbps and
+        rejected as ``spectral_reject`` — bypassing the full pipeline's
+        FLAC provisional-lossless pathway entirely.
+
+        Correct behavior: provisional_lossless_upgrade. The full pipeline
+        owns spectral, codec rank, and the provisional lossless path —
+        ``preimport_decide`` only owns folder/audio-integrity facts.
+        """
+        r = full_pipeline_decision(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="suspect",
+            spectral_bitrate=160,
+            converted_count=13,
+            post_conversion_min_bitrate=198,
+            candidate_v0_probe_avg=211,
+            candidate_v0_probe_min=198,
+            existing_min_bitrate=320,
+            existing_avg_bitrate=320,
+            existing_format="MP3",
+            existing_is_cbr=True,
+        )
+
+        self.assertEqual(r["stage0_spectral_gate"], "skipped_flac",
+                         "FLAC skips the preimport spectral gate")
+        # Stage 1 is informational; existing has no spectral → import_no_exist
+        # (NOT 'reject' — spectral compares to spectral, not container).
+        self.assertEqual(r["stage1_spectral"], "import_no_exist")
+        # Stage 2 owns the FLAC provisional-lossless pathway. The V0 probe
+        # (lossless-source min=198) outranks the suspect spectral cliff.
+        self.assertEqual(r["stage2_import"], "provisional_lossless_upgrade")
+        self.assertTrue(r["imported"])
+        self.assertTrue(r["denylisted"])
+        self.assertTrue(r["keep_searching"])
+        self.assertEqual(r["final_status"], "wanted")
+
     def test_heretic_pride_one_bad_track_infinite_requeue(self):
         """BUG: 13/14 tracks at 320kbps + 1 track at 192kbps → infinite requeue.
 
@@ -766,6 +816,256 @@ class TestLiveBugReproductions(unittest.TestCase):
         # BUG: keep_searching=True means it will try AGAIN → infinite loop
         # When fixed, system should detect same-quality loop and accept
         self.assertTrue(r2["keep_searching"])
+
+
+class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
+    """Every TestLiveBugReproductions scenario must produce the same outcome
+    when run through ``full_pipeline_decision_from_evidence`` — the function
+    the importer actually calls in production.
+
+    The simulator (``full_pipeline_decision``) and the evidence pipeline
+    (``full_pipeline_decision_from_evidence``) are two entry points into
+    the SAME decision logic. Quality decisions live in exactly one place;
+    the simulator is a thin flat-kwargs adapter. This class proves the
+    parity contract — if you can describe an album scenario with the
+    simulator, you can describe it as evidence rows, and the outcome
+    matches.
+
+    See CLAUDE.md § "Quality decisions live in one place" for the rule.
+    """
+
+    def _build_candidate(
+        self,
+        *,
+        is_flac: bool,
+        min_bitrate: int,
+        is_cbr: bool,
+        spectral_grade: str | None = None,
+        spectral_bitrate: int | None = None,
+        post_conversion_min_bitrate: int | None = None,
+        candidate_v0_probe_avg: int | None = None,
+        candidate_v0_probe_min: int | None = None,
+    ):
+        """Build an ``AlbumQualityEvidence`` candidate row matching the
+        simulator's flat-kwargs shape."""
+        from datetime import datetime, timezone
+        from lib.quality import (
+            ALBUM_QUALITY_EVIDENCE_OWNER_IMPORT_JOB_CANDIDATE,
+            AlbumQualityEvidence,
+            AlbumQualityEvidenceFile,
+            AlbumQualityEvidenceOwner,
+            AlbumQualityV0Metric,
+            AudioQualityMeasurement,
+            V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+        )
+
+        # For a FLAC source post-conversion, the candidate measurement
+        # reflects the V0 output the importer compares against.
+        if is_flac and post_conversion_min_bitrate is not None:
+            fmt = "MP3"
+            container = "flac"
+            codec = "flac"
+            storage_format = "flac"
+            measurement = AudioQualityMeasurement(
+                min_bitrate_kbps=post_conversion_min_bitrate,
+                avg_bitrate_kbps=candidate_v0_probe_avg or post_conversion_min_bitrate,
+                median_bitrate_kbps=candidate_v0_probe_avg or post_conversion_min_bitrate,
+                format=fmt,
+                is_cbr=False,
+                spectral_grade=spectral_grade,
+                spectral_bitrate_kbps=spectral_bitrate,
+                was_converted_from="flac",
+            )
+        elif is_flac:
+            container = codec = "flac"
+            storage_format = "flac"
+            measurement = AudioQualityMeasurement(
+                min_bitrate_kbps=min_bitrate or 900,
+                avg_bitrate_kbps=min_bitrate or 900,
+                median_bitrate_kbps=min_bitrate or 900,
+                format="FLAC",
+                is_cbr=False,
+                spectral_grade=spectral_grade,
+                spectral_bitrate_kbps=spectral_bitrate,
+            )
+        else:
+            container = codec = "mp3"
+            storage_format = "mp3 v0" if not is_cbr else "mp3 320"
+            measurement = AudioQualityMeasurement(
+                min_bitrate_kbps=min_bitrate,
+                avg_bitrate_kbps=min_bitrate,
+                median_bitrate_kbps=min_bitrate,
+                format="MP3",
+                is_cbr=is_cbr,
+                spectral_grade=spectral_grade,
+                spectral_bitrate_kbps=spectral_bitrate,
+            )
+
+        v0_metric = None
+        if candidate_v0_probe_avg is not None or candidate_v0_probe_min is not None:
+            v0_metric = AlbumQualityV0Metric(
+                min_bitrate_kbps=candidate_v0_probe_min,
+                avg_bitrate_kbps=candidate_v0_probe_avg,
+                median_bitrate_kbps=candidate_v0_probe_avg,
+                source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+                source_provenance="neutral_album_quality_evidence",
+            )
+
+        return AlbumQualityEvidence(
+            owner=AlbumQualityEvidenceOwner(
+                owner_type=ALBUM_QUALITY_EVIDENCE_OWNER_IMPORT_JOB_CANDIDATE,
+                owner_id=1,
+            ),
+            measurement=measurement,
+            measured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            files=[AlbumQualityEvidenceFile(
+                relative_path=f"01.{container}",
+                size_bytes=1, mtime_ns=1,
+                extension=container, container=container, codec=codec,
+            )],
+            codec=codec,
+            container=container,
+            storage_format=storage_format,
+            v0_metric=v0_metric,
+        )
+
+    def _build_current(
+        self,
+        *,
+        min_bitrate: int | None,
+        avg_bitrate: int | None = None,
+        format: str = "MP3",
+        is_cbr: bool = False,
+        spectral_grade: str | None = None,
+        spectral_bitrate: int | None = None,
+    ):
+        if min_bitrate is None:
+            return None
+        from datetime import datetime, timezone
+        from lib.quality import (
+            ALBUM_QUALITY_EVIDENCE_OWNER_REQUEST_CURRENT,
+            AlbumQualityEvidence,
+            AlbumQualityEvidenceFile,
+            AlbumQualityEvidenceOwner,
+            AudioQualityMeasurement,
+        )
+
+        container = format.lower().split()[0]
+        return AlbumQualityEvidence(
+            owner=AlbumQualityEvidenceOwner(
+                owner_type=ALBUM_QUALITY_EVIDENCE_OWNER_REQUEST_CURRENT,
+                owner_id=1,
+            ),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=min_bitrate,
+                avg_bitrate_kbps=avg_bitrate if avg_bitrate is not None else min_bitrate,
+                median_bitrate_kbps=avg_bitrate if avg_bitrate is not None else min_bitrate,
+                format=format,
+                is_cbr=is_cbr,
+                spectral_grade=spectral_grade,
+                spectral_bitrate_kbps=spectral_bitrate,
+            ),
+            measured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            files=[AlbumQualityEvidenceFile(
+                relative_path=f"01.{container}",
+                size_bytes=1, mtime_ns=1,
+                extension=container, container=container, codec=container,
+            )],
+            codec=container,
+            container=container,
+            storage_format=format.lower(),
+        )
+
+    def test_mountain_goats_flux_provisional_lossless_via_evidence(self):
+        """Request 4514 shape, but routed through the production decider."""
+        from lib.quality import (
+            AlbumQualityEvidenceDecisionFacts,
+            full_pipeline_decision_from_evidence,
+        )
+
+        candidate = self._build_candidate(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="suspect",
+            spectral_bitrate=160,
+            post_conversion_min_bitrate=198,
+            candidate_v0_probe_avg=211,
+            candidate_v0_probe_min=198,
+        )
+        current = self._build_current(
+            min_bitrate=320, avg_bitrate=320,
+            format="MP3", is_cbr=True,
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, current,
+            facts=AlbumQualityEvidenceDecisionFacts(import_mode="auto"),
+        )
+
+        self.assertEqual(r["stage2_import"], "provisional_lossless_upgrade",
+                         "evidence pipeline must reach the same decision as "
+                         "the simulator — FLAC source + V0 probe + existing "
+                         "lossy = provisional_lossless_upgrade")
+        self.assertTrue(r["imported"])
+        self.assertTrue(r["denylisted"])
+        self.assertTrue(r["keep_searching"])
+
+    def test_mountain_goats_bride_provisional_via_evidence(self):
+        """test_live_mountain_goats_bride_first_provisional_source_import
+        — same scenario through the evidence pipeline."""
+        from lib.quality import (
+            AlbumQualityEvidenceDecisionFacts,
+            full_pipeline_decision_from_evidence,
+        )
+
+        candidate = self._build_candidate(
+            is_flac=True, min_bitrate=0, is_cbr=False,
+            spectral_grade="likely_transcode",
+            post_conversion_min_bitrate=214,
+            candidate_v0_probe_avg=214,
+        )
+        current = self._build_current(
+            min_bitrate=320, avg_bitrate=320,
+            format="MP3", is_cbr=True,
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, current,
+            facts=AlbumQualityEvidenceDecisionFacts(
+                import_mode="auto",
+                verified_lossless_target="opus 128",
+            ),
+        )
+
+        self.assertEqual(r["stage2_import"], "provisional_lossless_upgrade")
+        self.assertTrue(r["imported"])
+
+    def test_heretic_pride_downgrade_via_evidence(self):
+        """test_heretic_pride second-pass downgrade case via the evidence
+        pipeline — MP3 192 vs existing MP3 192."""
+        from lib.quality import (
+            AlbumQualityEvidenceDecisionFacts,
+            full_pipeline_decision_from_evidence,
+        )
+
+        candidate = self._build_candidate(
+            is_flac=False, min_bitrate=192, is_cbr=False,
+            spectral_grade="genuine",
+        )
+        current = self._build_current(
+            min_bitrate=192, avg_bitrate=192,
+            format="MP3", is_cbr=False,
+            spectral_grade="genuine",
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, current,
+            facts=AlbumQualityEvidenceDecisionFacts(import_mode="auto"),
+        )
+
+        self.assertEqual(r["stage2_import"], "downgrade")
+        self.assertFalse(r["imported"])
 
 
 # ============================================================================

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -134,42 +134,57 @@ class TestSpectralGateTrigger(unittest.TestCase):
 
 
 class TestSpectralImportDecision(unittest.TestCase):
-    """Test pre-import spectral decision (MP3/CBR path)."""
+    """Test pre-import spectral decision (MP3/CBR path).
+
+    Spectral compares to spectral evidence only — never to container bitrate.
+    Absence of an existing spectral measurement means "we haven't measured it
+    yet", not "it's genuine". The decision returns import_no_exist when only
+    one side has spectral evidence.
+    """
 
     CASES = [
-        # desc, grade, bitrate, existing_spectral, existing_min, expected
-        ("genuine imports", "genuine", None, None, None, "import"),
-        ("genuine ignores bitrates", "genuine", 128, 256, None, "import"),
-        ("marginal imports", "marginal", 192, 256, None, "import"),
-        ("marginal no bitrates", "marginal", None, None, None, "import"),
-        ("suspect equal rejects", "suspect", 128, 128, None, "reject"),
-        ("suspect worse rejects", "suspect", 96, 128, None, "reject"),
-        ("likely transcode equal rejects", "likely_transcode", 160, 160, None, "reject"),
-        ("suspect better upgrades", "suspect", 192, 128, None, "import_upgrade"),
-        ("likely transcode better upgrades", "likely_transcode", 192, 96, None, "import_upgrade"),
-        ("suspect no existing zero", "suspect", 128, 0, None, "import_no_exist"),
-        ("suspect no existing none", "suspect", 128, None, None, "import_no_exist"),
-        ("likely transcode no existing", "likely_transcode", 96, None, None, "import_no_exist"),
-        ("suspect no new no existing", "suspect", None, None, None, "import_no_exist"),
-        ("suspect no new with existing", "suspect", None, 128, None, "import"),
-        ("fallback rejects", "likely_transcode", 96, None, 128, "reject"),
-        ("fallback upgrades", "suspect", 192, None, 128, "import_upgrade"),
-        ("spectral beats fallback", "suspect", 192, 128, 64, "import_upgrade"),
-        ("no spectral or container existing", "likely_transcode", 96, None, None, "import_no_exist"),
+        # desc, grade, bitrate, existing_spectral, expected
+        ("genuine imports", "genuine", None, None, "import"),
+        ("genuine ignores bitrates", "genuine", 128, 256, "import"),
+        ("marginal imports", "marginal", 192, 256, "import"),
+        ("marginal no bitrates", "marginal", None, None, "import"),
+        ("suspect equal rejects", "suspect", 128, 128, "reject"),
+        ("suspect worse rejects", "suspect", 96, 128, "reject"),
+        ("likely transcode equal rejects", "likely_transcode", 160, 160, "reject"),
+        ("suspect better upgrades", "suspect", 192, 128, "import_upgrade"),
+        ("likely transcode better upgrades", "likely_transcode", 192, 96, "import_upgrade"),
+        ("suspect no existing zero", "suspect", 128, 0, "import_no_exist"),
+        ("suspect no existing none", "suspect", 128, None, "import_no_exist"),
+        ("likely transcode no existing", "likely_transcode", 96, None, "import_no_exist"),
+        ("suspect no new no existing", "suspect", None, None, "import_no_exist"),
+        ("suspect no new with existing", "suspect", None, 128, "import"),
+        ("no spectral or container existing", "likely_transcode", 96, None, "import_no_exist"),
     ]
 
     def test_spectral_import_decisions(self):
-        for desc, grade, bitrate, existing_spectral, existing_min, expected in self.CASES:
+        for desc, grade, bitrate, existing_spectral, expected in self.CASES:
             with self.subTest(desc=desc):
                 self.assertEqual(
                     spectral_import_decision(
                         grade,
                         bitrate,
                         existing_spectral,
-                        existing_min_bitrate=existing_min,
                     ),
                     expected,
                 )
+
+    def test_signature_has_no_container_fallback(self):
+        """Invariant: spectral_import_decision must compare spectral to
+        spectral. The signature must not accept ``existing_min_bitrate`` —
+        that footgun produces cross-evidence comparisons (e.g. a 160kbps
+        spectral cliff being rejected by a 320kbps MP3 container nominal
+        bitrate with no spectral measured)."""
+        import inspect
+        sig = inspect.signature(spectral_import_decision)
+        self.assertNotIn(
+            "existing_min_bitrate", sig.parameters,
+            "spectral_import_decision must not accept a container-bitrate "
+            "fallback parameter — see lib/quality.py for the rationale")
 
 
 # ============================================================================
@@ -265,8 +280,55 @@ class TestPreimportDecide(unittest.TestCase):
         self.assertEqual(result.decision, "reject")
         self.assertEqual(result.reason, "empty_fileset")
 
-    def test_spectral_reject_no_upgrade(self):
-        """likely_transcode + no improvement over existing → reject."""
+    # ------------------------------------------------------------------
+    # Spectral is NOT a preimport gate.
+    #
+    # The preimport gate owns folder/audio-integrity facts only:
+    # audio_corrupt, bad_audio_hash, nested_layout, empty_fileset.
+    # Spectral, codec rank, V0 probe, provisional lossless, verified
+    # lossless, and quality-gate decisions all live in
+    # ``full_pipeline_decision_from_evidence`` (the same function the
+    # album test set in tests/test_quality_classification.py pins).
+    #
+    # Previously, preimport_decide ran its own narrower spectral
+    # comparison that fell back to ``existing_min_bitrate`` (container
+    # bitrate) when ``existing_spectral_bitrate`` was None — violating
+    # evidence-set parity ("a 320 kbps MP3 container with no spectral
+    # run on it" outranking "a freshly measured 160 kbps cliff") AND
+    # short-circuiting the provisional-lossless pathway for FLAC sources
+    # before the full pipeline could fire. Both regressions are now
+    # impossible by construction: there is no spectral branch here.
+    # ------------------------------------------------------------------
+
+    def test_spectral_suspect_with_existing_lossy_no_spectral_accepts(self):
+        """Request 4514 shape: candidate FLAC source measured suspect at
+        160kbps cliff vs existing MP3 320 container with no spectral.
+        Preimport must NOT reject — that's the full pipeline's call."""
+        from lib.quality import preimport_decide
+        m = self._measurement(
+            download_spectral=("suspect", 160),
+            existing_spectral=None,
+            existing_min_bitrate=320,
+        )
+        result = preimport_decide(m, self._cfg(), None)
+        self.assertEqual(result.decision, "accept")
+        self.assertIsNone(result.reason)
+
+    def test_spectral_likely_transcode_with_lossy_no_spectral_accepts(self):
+        """likely_transcode candidate vs existing MP3 320 container with
+        no spectral — still accept. Evidence-set parity invariant."""
+        from lib.quality import preimport_decide
+        m = self._measurement(
+            download_spectral=("likely_transcode", 128),
+            existing_spectral=None,
+            existing_min_bitrate=320,
+        )
+        result = preimport_decide(m, self._cfg(), None)
+        self.assertEqual(result.decision, "accept")
+
+    def test_spectral_likely_transcode_with_lossless_existing_accepts(self):
+        """Even with existing spectral evidence, preimport accepts —
+        the full pipeline owns the quality comparison."""
         from lib.quality import preimport_decide
         m = self._measurement(
             download_spectral=("likely_transcode", 128),
@@ -274,9 +336,7 @@ class TestPreimportDecide(unittest.TestCase):
             existing_min_bitrate=320,
         )
         result = preimport_decide(m, self._cfg(), None)
-        self.assertEqual(result.decision, "reject")
-        self.assertEqual(result.reason, "spectral_reject")
-        self.assertIn("128", result.detail or "")
+        self.assertEqual(result.decision, "accept")
 
     def test_spectral_upgrade_accepts(self):
         """suspect grade BUT bitrate improves on existing → accept."""
@@ -310,6 +370,21 @@ class TestPreimportDecide(unittest.TestCase):
         )
         result = preimport_decide(m, self._cfg(), None)
         self.assertEqual(result.decision, "accept")
+
+    def test_preimport_never_emits_spectral_reject(self):
+        """Reason taxonomy: preimport_decide must never return
+        ``reason='spectral_reject'``. Quality decisions live elsewhere."""
+        import inspect
+        from lib import quality
+        src = inspect.getsource(quality.preimport_decide)
+        self.assertNotIn(
+            "spectral_reject", src,
+            "preimport_decide must not emit spectral_reject — "
+            "spectral is owned by full_pipeline_decision_from_evidence")
+        self.assertNotIn(
+            "spectral_import_decision", src,
+            "preimport_decide must not call spectral_import_decision — "
+            "that's a quality decision, not a preimport gate")
 
     def test_decision_function_has_no_side_effect_imports(self):
         """preimport_decide is pure: no db, denylist, filesystem references."""
@@ -1053,8 +1128,7 @@ class TestSpectralContext(unittest.TestCase):
             grade="suspect", bitrate=192,
             existing_spectral_bitrate=128)
         result = spectral_import_decision(
-            ctx.grade, ctx.bitrate, ctx.existing_spectral_bitrate or 0,
-            existing_min_bitrate=ctx.existing_min_bitrate)
+            ctx.grade, ctx.bitrate, ctx.existing_spectral_bitrate or 0)
         self.assertEqual(result, "import_upgrade")
 
     def test_no_check_needed(self):


### PR DESCRIPTION
## Summary

- Quality decisions now live in **one place**: `full_pipeline_decision_from_evidence`. The parallel spectral branch in `preimport_decide` (added by U6 in #253) is deleted.
- `spectral_import_decision` no longer accepts `existing_min_bitrate` — spectral compares to spectral evidence only (evidence-set parity invariant).
- Album test set in `TestLiveBugReproductions` extended with the Mountain Goats Flux scenario, and pinned to the production decider via the new `TestLiveBugReproductionsThroughEvidencePipeline` parity class.

## The bug

Live failure on request 4514 (Mountain Goats — Life of the World in Flux):

- Preview correctly computed `provisional_lossless_upgrade` from candidate evidence (FLAC source, V0 probe min=198/avg=211, suspect spectral cliff at 160kbps).
- Importer then re-litigated via `preimport_decide`'s spectral branch: candidate spectral 160kbps was compared against existing MP3 320 **container** bitrate (no spectral measured on existing) and rejected.
- AnderMachines was denylisted for "spectral analysis rejected the source", the request was requeued.

Two invariants broken by the parallel decider:
1. Evidence-set parity — spectral must only be compared to spectral, never container.
2. FLAC takes precedence — the provisional-lossless pathway is the canonical FLAC-source decision, not preimport spectral.

## The fix

- `preimport_decide` owns only folder/audio-integrity facts (`audio_corrupt`, `bad_audio_hash`, `nested_layout`, `empty_fileset`). Spectral, codec rank, V0 probe, provisional lossless all flow through `full_pipeline_decision_from_evidence` — the same function the album test set pins.
- `_legacy_preimport_decision` (the legacy shim) matches the new contract; spectral_reject denylist side-effect removed.
- `spectral_import_decision` signature tightened — no container-bitrate fallback parameter.

## Test set

- Added `test_live_mountain_goats_flux_flac_source_vs_lossy_no_spectral` to `TestLiveBugReproductions` documenting the regression scenario.
- New `TestLiveBugReproductionsThroughEvidencePipeline` class runs each album scenario through `full_pipeline_decision_from_evidence` to pin simulator/evidence parity.
- Deleted `test_stale_album_path_rejects_against_container_bitrate` and `test_genuine_stored_spectral_ignored` — both codified the deleted bug.
- Rewrote BoC and U6 slices to assert the new (correct) rejection path via the evidence pipeline.

## Encoded invariants

Added to `CLAUDE.md` § "Decision architecture" and `.claude/rules/code-quality.md`:
- Quality decisions live in ONE place.
- Preview produces evidence. Importer decides.
- The album test set is the contract.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3439 tests, 2 failures (both pre-existing on main, not from this PR).
- [x] New `TestPreimportDecide` cases assert spectral is no longer a preimport gate (3 new tests).
- [x] `test_signature_has_no_container_fallback` guards the new `spectral_import_decision` signature.
- [x] `test_preimport_never_emits_spectral_reject` guards against future reintroduction.
- [x] `TestLiveBugReproductionsThroughEvidencePipeline` parity tests pass.
- [ ] Deploy to doc2 and verify request 4514 imports as `provisional_lossless_upgrade` on next pipeline cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)