### PR TITLE
Restore safe Wrong Matches delete controls

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -77,6 +77,10 @@ DISPATCH_CODE_REQUEUE_FAILED = "requeue_failed"
 # misuse. The legacy direct-measurement branch that previously handled
 # this case was deleted in U4 because no production path reaches it.
 DISPATCH_CODE_BAD_REQUEST = "bad_request"
+# Canonical terminal rejection from ``full_pipeline_decision_from_evidence``.
+# Consumers may react to this outcome, but must not re-run a parallel import
+# decision to prove it again.
+DISPATCH_CODE_QUALITY_PIPELINE_REJECTED = "quality_pipeline_rejected"
 
 # Scenarios whose ``path`` is the user's source data (``failed_imports/…``),
 # NOT a disposable staging directory. Used to gate ``_cleanup_staged_dir``
@@ -819,6 +823,7 @@ def _reject_import_from_evidence_decision(
     return DispatchOutcome(
         success=False,
         message=f"Rejected by persisted quality evidence: {decision}",
+        code=DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
     )
 
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -1067,9 +1067,6 @@ class PipelineDB:
         dirs = [str(path) for path in dict.fromkeys(source_dirs) if path]
         match_clauses: list[str] = ["payload->>'download_log_id' = %s::text"]
         match_params: list[Any] = [str(int(download_log_id))]
-        if request_id is not None:
-            match_clauses.append("request_id = %s")
-            match_params.append(int(request_id))
         if paths:
             match_clauses.append("payload->>'failed_path' = ANY(%s::text[])")
             match_params.append(paths)

--- a/lib/wrong_match_delete_service.py
+++ b/lib/wrong_match_delete_service.py
@@ -1,0 +1,473 @@
+"""Manual Wrong Matches source deletion service."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, cast
+
+import msgspec
+
+from lib.wrong_matches import (
+    cleanup_wrong_match_source,
+    unsafe_failed_import_path_reason,
+    validation_failed_path,
+)
+from lib.pipeline_db import (
+    ADVISORY_LOCK_NAMESPACE_WRONG_MATCH_CLEANUP,
+    wrong_match_cleanup_lock_key,
+)
+from lib.processing_paths import normalize_source_dirs
+from lib.util import resolve_failed_path
+
+OUTCOME_DELETED = "deleted"
+OUTCOME_DELETE_FAILED = "delete_failed"
+OUTCOME_SKIPPED_ACTIVE_JOB = "skipped_active_job"
+OUTCOME_SKIPPED_INVALID_ROW = "skipped_invalid_row"
+OUTCOME_SKIPPED_NOT_VISIBLE = "skipped_not_visible"
+OUTCOME_SKIPPED_LOCKED = "skipped_locked"
+OUTCOME_SKIPPED_UNSAFE_PATH = "skipped_unsafe_path"
+
+GROUP_OUTCOME_DELETED = "deleted"
+GROUP_OUTCOME_EMPTY = "empty"
+GROUP_OUTCOME_PARTIAL = "partial"
+GROUP_OUTCOME_FAILED = "failed"
+
+
+class WrongMatchDeleteResult(msgspec.Struct, frozen=True):
+    download_log_id: int
+    outcome: str
+    success: bool = False
+    request_id: int | None = None
+    entry_found: bool = False
+    visible: bool = False
+    raw_failed_path: str | None = None
+    failed_path_hint: str | None = None
+    resolved_path: str | None = None
+    deleted_path: str | None = None
+    path_missing: bool = False
+    cleared_rows: int = 0
+    skipped: bool = False
+    reason: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return cast(dict[str, object], msgspec.to_builtins(self))
+
+
+class WrongMatchDeleteSummary(msgspec.Struct, frozen=True):
+    request_id: int
+    outcome: str
+    success: bool
+    processed: int
+    deleted: int
+    deleted_paths: int
+    cleared: int
+    skipped: int
+    errors: int
+    remaining: int
+    group_empty: bool
+    results: tuple[WrongMatchDeleteResult, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return cast(dict[str, object], msgspec.to_builtins(self))
+
+
+def delete_wrong_match(
+    db: Any,
+    download_log_id: int,
+    *,
+    failed_path_hint: str | None = None,
+    source_dirs_hint: Iterable[str] = (),
+    ignore_import_job_id: int | None = None,
+    require_visible: bool = True,
+) -> WrongMatchDeleteResult:
+    """Delete and clear one Wrong Matches source without deciding importability."""
+    try:
+        return _delete_wrong_match(
+            db,
+            download_log_id,
+            failed_path_hint=failed_path_hint,
+            source_dirs_hint=source_dirs_hint,
+            ignore_import_job_id=ignore_import_job_id,
+            require_visible=require_visible,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return WrongMatchDeleteResult(
+            download_log_id=download_log_id,
+            outcome=OUTCOME_DELETE_FAILED,
+            error=f"{type(exc).__name__}: {exc}",
+            reason="operational_failure",
+        )
+
+
+def delete_wrong_match_group(
+    db: Any,
+    request_id: int,
+) -> WrongMatchDeleteSummary:
+    results: list[WrongMatchDeleteResult] = []
+    for row in list(db.get_wrong_matches()):
+        if row.get("request_id") != request_id:
+            continue
+        log_id = row.get("download_log_id")
+        if not isinstance(log_id, int) or isinstance(log_id, bool):
+            results.append(WrongMatchDeleteResult(
+                download_log_id=0,
+                request_id=request_id,
+                outcome=OUTCOME_SKIPPED_INVALID_ROW,
+                skipped=True,
+                reason="invalid_download_log_id",
+            ))
+            continue
+        if _visible_wrong_match_row(db, log_id) is None:
+            continue
+        results.append(delete_wrong_match(db, log_id, require_visible=True))
+
+    remaining = _remaining_visible_count(db, request_id)
+    deleted = sum(1 for result in results if result.success and result.cleared_rows)
+    deleted_paths = sum(1 for result in results if result.deleted_path)
+    cleared = sum(result.cleared_rows for result in results)
+    skipped = sum(1 for result in results if result.skipped)
+    errors = sum(
+        1
+        for result in results
+        if result.error or result.outcome == OUTCOME_DELETE_FAILED
+    )
+    success = (
+        (not results and remaining == 0)
+        or (errors == 0 and skipped == 0 and remaining == 0)
+    )
+    outcome = _group_outcome(
+        processed=len(results),
+        success=success,
+        errors=errors,
+        skipped=skipped,
+        remaining=remaining,
+    )
+    return WrongMatchDeleteSummary(
+        request_id=request_id,
+        outcome=outcome,
+        success=success,
+        processed=len(results),
+        deleted=deleted,
+        deleted_paths=deleted_paths,
+        cleared=cleared,
+        skipped=skipped,
+        errors=errors,
+        remaining=remaining,
+        group_empty=remaining == 0,
+        results=tuple(results),
+    )
+
+
+def _delete_wrong_match(
+    db: Any,
+    download_log_id: int,
+    *,
+    failed_path_hint: str | None,
+    source_dirs_hint: Iterable[str],
+    ignore_import_job_id: int | None,
+    require_visible: bool,
+) -> WrongMatchDeleteResult:
+    entry = db.get_download_log_entry(download_log_id)
+    if not entry:
+        return _result(
+            download_log_id,
+            OUTCOME_SKIPPED_INVALID_ROW,
+            reason="download_log_missing",
+        )
+    request_id_raw = entry.get("request_id")
+    request_id = request_id_raw if type(request_id_raw) is int else None
+    validation_result = _validation_result_dict(entry.get("validation_result"))
+    raw_failed_path = validation_failed_path(validation_result)
+    if not raw_failed_path:
+        return _result(
+            download_log_id,
+            OUTCOME_SKIPPED_INVALID_ROW,
+            request_id=request_id,
+            entry_found=True,
+            reason="failed_path_missing",
+        )
+
+    if require_visible and _visible_wrong_match_row(db, download_log_id) is None:
+        return _result(
+            download_log_id,
+            OUTCOME_SKIPPED_NOT_VISIBLE,
+            request_id=request_id,
+            entry_found=True,
+            raw_failed_path=raw_failed_path,
+            failed_path_hint=failed_path_hint,
+            skipped=True,
+            reason="wrong_match_not_visible",
+        )
+
+    candidates = _path_candidates(failed_path_hint, raw_failed_path)
+    resolved_path = _resolve_first_existing(candidates)
+    if resolved_path:
+        candidates = _path_candidates(*candidates, resolved_path)
+        unsafe_reason = unsafe_failed_import_path_reason(resolved_path)
+        if unsafe_reason:
+            return _result(
+                download_log_id,
+                OUTCOME_SKIPPED_UNSAFE_PATH,
+                request_id=request_id,
+                entry_found=True,
+                visible=True,
+                raw_failed_path=raw_failed_path,
+                failed_path_hint=failed_path_hint,
+                resolved_path=resolved_path,
+                skipped=True,
+                reason=unsafe_reason,
+                error=unsafe_reason,
+            )
+    source_dirs = _source_dirs(validation_result, source_dirs_hint)
+
+    active_jobs = _active_jobs(
+        db,
+        download_log_id=download_log_id,
+        request_id=request_id,
+        failed_paths=candidates,
+        source_dirs=source_dirs,
+        ignore_import_job_id=ignore_import_job_id,
+    )
+    if active_jobs:
+        return _result(
+            download_log_id,
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            request_id=request_id,
+            entry_found=True,
+            visible=True,
+            raw_failed_path=raw_failed_path,
+            failed_path_hint=failed_path_hint,
+            resolved_path=resolved_path,
+            skipped=True,
+            reason="active_import_job",
+        )
+
+    lock_key = wrong_match_cleanup_lock_key(
+        request_id,
+        download_log_id,
+        resolved_path or failed_path_hint or raw_failed_path,
+    )
+    with db.advisory_lock(
+        ADVISORY_LOCK_NAMESPACE_WRONG_MATCH_CLEANUP,
+        lock_key,
+    ) as acquired:
+        if not acquired:
+            return _result(
+                download_log_id,
+                OUTCOME_SKIPPED_LOCKED,
+                request_id=request_id,
+                entry_found=True,
+                visible=True,
+                raw_failed_path=raw_failed_path,
+                failed_path_hint=failed_path_hint,
+                resolved_path=resolved_path,
+                skipped=True,
+                reason="cleanup_lock_unavailable",
+            )
+        if require_visible and _visible_wrong_match_row(db, download_log_id) is None:
+            return _result(
+                download_log_id,
+                OUTCOME_SKIPPED_NOT_VISIBLE,
+                request_id=request_id,
+                entry_found=True,
+                raw_failed_path=raw_failed_path,
+                failed_path_hint=failed_path_hint,
+                resolved_path=resolved_path,
+                skipped=True,
+                reason="wrong_match_not_visible",
+            )
+        active_jobs = _active_jobs(
+            db,
+            download_log_id=download_log_id,
+            request_id=request_id,
+            failed_paths=candidates,
+            source_dirs=source_dirs,
+            ignore_import_job_id=ignore_import_job_id,
+        )
+        if active_jobs:
+            return _result(
+                download_log_id,
+                OUTCOME_SKIPPED_ACTIVE_JOB,
+                request_id=request_id,
+                entry_found=True,
+                visible=True,
+                raw_failed_path=raw_failed_path,
+                failed_path_hint=failed_path_hint,
+                resolved_path=resolved_path,
+                skipped=True,
+                reason="active_import_job",
+            )
+        cleanup = cleanup_wrong_match_source(
+            db,
+            download_log_id,
+            failed_path_hint=resolved_path or failed_path_hint,
+        )
+
+    if not cleanup.success or cleanup.error:
+        return _result(
+            download_log_id,
+            OUTCOME_DELETE_FAILED,
+            request_id=cleanup.request_id,
+            entry_found=cleanup.entry_found,
+            visible=True,
+            raw_failed_path=cleanup.raw_failed_path,
+            failed_path_hint=cleanup.failed_path_hint,
+            resolved_path=cleanup.resolved_path,
+            path_missing=cleanup.path_missing,
+            cleared_rows=cleanup.cleared_rows,
+            reason=cleanup.error or "delete_failed",
+            error=cleanup.error or "delete_failed",
+        )
+    return _result(
+        download_log_id,
+        OUTCOME_DELETED,
+        success=True,
+        request_id=cleanup.request_id,
+        entry_found=cleanup.entry_found,
+        visible=True,
+        raw_failed_path=cleanup.raw_failed_path,
+        failed_path_hint=cleanup.failed_path_hint,
+        resolved_path=cleanup.resolved_path,
+        deleted_path=cleanup.deleted_path,
+        path_missing=cleanup.path_missing,
+        cleared_rows=cleanup.cleared_rows,
+    )
+
+
+def _result(
+    download_log_id: int,
+    outcome: str,
+    *,
+    success: bool = False,
+    request_id: int | None = None,
+    entry_found: bool = False,
+    visible: bool = False,
+    raw_failed_path: str | None = None,
+    failed_path_hint: str | None = None,
+    resolved_path: str | None = None,
+    deleted_path: str | None = None,
+    path_missing: bool = False,
+    cleared_rows: int = 0,
+    skipped: bool = False,
+    reason: str | None = None,
+    error: str | None = None,
+) -> WrongMatchDeleteResult:
+    return WrongMatchDeleteResult(
+        download_log_id=download_log_id,
+        outcome=outcome,
+        success=success,
+        request_id=request_id,
+        entry_found=entry_found,
+        visible=visible,
+        raw_failed_path=raw_failed_path,
+        failed_path_hint=failed_path_hint,
+        resolved_path=resolved_path,
+        deleted_path=deleted_path,
+        path_missing=path_missing,
+        cleared_rows=cleared_rows,
+        skipped=skipped,
+        reason=reason,
+        error=error,
+    )
+
+
+def _group_outcome(
+    *,
+    processed: int,
+    success: bool,
+    errors: int,
+    skipped: int,
+    remaining: int,
+) -> str:
+    if success:
+        return GROUP_OUTCOME_DELETED if processed else GROUP_OUTCOME_EMPTY
+    if errors:
+        return GROUP_OUTCOME_FAILED
+    if skipped or remaining:
+        return GROUP_OUTCOME_PARTIAL
+    return GROUP_OUTCOME_PARTIAL
+
+
+def _visible_wrong_match_row(db: Any, download_log_id: int) -> dict[str, Any] | None:
+    for row in db.get_wrong_matches():
+        if row.get("download_log_id") == download_log_id:
+            return row
+    return None
+
+
+def _remaining_visible_count(db: Any, request_id: int) -> int:
+    return sum(1 for row in db.get_wrong_matches() if row.get("request_id") == request_id)
+
+
+def _validation_result_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _source_dirs(
+    validation_result: dict[str, Any],
+    source_dirs_hint: Iterable[str],
+) -> tuple[str, ...]:
+    raw = validation_result.get("source_dirs")
+    dirs: list[str] = []
+    if isinstance(raw, list):
+        dirs.extend(str(path) for path in raw if path)
+    dirs.extend(str(path) for path in source_dirs_hint if path)
+    return tuple(normalize_source_dirs(dirs))
+
+
+def _path_candidates(*paths: str | None) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        if not path:
+            continue
+        value = str(path)
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _resolve_first_existing(paths: Iterable[str]) -> str | None:
+    for path in paths:
+        resolved = resolve_failed_path(path)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _active_jobs(
+    db: Any,
+    *,
+    download_log_id: int,
+    request_id: int | None,
+    failed_paths: Iterable[str],
+    source_dirs: Iterable[str],
+    ignore_import_job_id: int | None,
+) -> list[Any]:
+    finder = getattr(db, "list_active_import_jobs_for_wrong_match", None)
+    if callable(finder):
+        return list(finder(
+            download_log_id=download_log_id,
+            request_id=request_id,
+            failed_paths=failed_paths,
+            source_dirs=source_dirs,
+            ignore_import_job_id=ignore_import_job_id,
+        ))
+
+    jobs = getattr(db, "list_active_import_jobs", lambda **_: [])(
+        request_id=request_id
+    )
+    if ignore_import_job_id is None:
+        return list(jobs)
+    return [job for job in jobs if getattr(job, "id", None) != ignore_import_job_id]

--- a/lib/wrong_matches.py
+++ b/lib/wrong_matches.py
@@ -8,7 +8,7 @@ import shutil
 from dataclasses import dataclass
 from typing import Any
 
-from lib.util import resolve_failed_path
+from lib.util import FAILED_IMPORT_SEARCH_DIRS, resolve_failed_path
 
 
 @dataclass(frozen=True)
@@ -129,6 +129,60 @@ def _resolved_candidates(candidates: list[str]) -> tuple[str | None, list[str]]:
     return resolved_path, candidates
 
 
+def unsafe_failed_import_path_reason(path: str) -> str | None:
+    """Return a reason when ``path`` is outside a failed_imports child dir."""
+    real_path = os.path.realpath(path)
+    for root in _failed_import_roots():
+        if _is_child_path(real_path, root):
+            return None
+    if _has_failed_imports_ancestor(real_path):
+        return None
+    return f"unsafe_failed_import_path: {path}"
+
+
+def _failed_import_roots() -> tuple[str, ...]:
+    return tuple(
+        os.path.realpath(os.path.join(base, "failed_imports"))
+        for base in FAILED_IMPORT_SEARCH_DIRS
+    )
+
+
+def _is_child_path(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath([path, root]) == root and path != root
+    except ValueError:
+        return False
+
+
+def _has_failed_imports_ancestor(path: str) -> bool:
+    parts = path.split(os.sep)
+    for index, part in enumerate(parts):
+        if part == "failed_imports" and index < len(parts) - 1:
+            return True
+    return False
+
+
+def _equivalent_failed_path_aliases(
+    db: Any,
+    request_id: int | None,
+    resolved_path: str | None,
+) -> list[str]:
+    if request_id is None or resolved_path is None:
+        return []
+    target_path = os.path.realpath(resolved_path)
+    aliases: list[str] = []
+    for row in db.get_wrong_matches():
+        if row.get("request_id") != request_id:
+            continue
+        raw_path = validation_failed_path(row.get("validation_result"))
+        if not raw_path:
+            continue
+        row_resolved = resolve_failed_path(raw_path)
+        if row_resolved and os.path.realpath(row_resolved) == target_path:
+            aliases.append(raw_path)
+    return aliases
+
+
 def dismiss_wrong_match_source(
     db: Any,
     download_log_id: int,
@@ -152,6 +206,10 @@ def dismiss_wrong_match_source(
 
     candidates = _path_candidates(failed_path_hint, raw_path)
     resolved_path, candidates = _resolved_candidates(candidates)
+    candidates = _path_candidates(
+        *candidates,
+        *_equivalent_failed_path_aliases(db, request_id, resolved_path),
+    )
 
     cleared_rows = 0
     if request_id is not None:
@@ -195,8 +253,23 @@ def cleanup_wrong_match_source(
 
     candidates = _path_candidates(failed_path_hint, raw_path)
     resolved_path, candidates = _resolved_candidates(candidates)
+    candidates = _path_candidates(
+        *candidates,
+        *_equivalent_failed_path_aliases(db, request_id, resolved_path),
+    )
 
     if resolved_path is not None:
+        unsafe_reason = unsafe_failed_import_path_reason(resolved_path)
+        if unsafe_reason:
+            return WrongMatchCleanupResult(
+                download_log_id=download_log_id,
+                entry_found=True,
+                request_id=request_id,
+                raw_failed_path=raw_path,
+                failed_path_hint=failed_path_hint,
+                resolved_path=resolved_path,
+                error=unsafe_reason,
+            )
         try:
             shutil.rmtree(resolved_path)
         except FileNotFoundError:

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -16,6 +16,7 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from lib.import_dispatch import (
+    DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
     DISPATCH_CODE_REQUEUE_FAILED,
     DISPATCH_CODE_REQUEUED_FOR_PREVIEW,
     DispatchOutcome,
@@ -68,21 +69,39 @@ def _cleanup_failed_force_import(
     if force_payload is None:
         return None
     download_log_id, failed_path_hint = force_payload
+    if outcome.code != DISPATCH_CODE_QUALITY_PIPELINE_REJECTED:
+        return {
+            "success": False,
+            "download_log_id": download_log_id,
+            "failed_path_hint": failed_path_hint,
+            "outcome": "skipped_non_quality_pipeline_failure",
+            "skipped": True,
+            "dispatch_code": outcome.code,
+            "dispatch_message": outcome.message,
+        }
     try:
-        from lib.wrong_match_cleanup_service import (
-            OUTCOME_DELETED,
-            cleanup_wrong_match,
-        )
+        from lib.wrong_match_delete_service import delete_wrong_match
 
-        result = cleanup_wrong_match(
+        # Dispatch already made the canonical import decision via
+        # full_pipeline_decision_from_evidence; this step only removes the
+        # reviewed source from Wrong Matches.
+        payload = job.payload or {}
+        source_dirs = payload.get("source_dirs")
+        result = delete_wrong_match(
             db,
             download_log_id,
             failed_path_hint=failed_path_hint,
+            source_dirs_hint=(
+                source_dirs if isinstance(source_dirs, list) else ()
+            ),
             ignore_import_job_id=job.id,
+            require_visible=False,
         )
         data = result.to_dict()
-        if result.outcome != OUTCOME_DELETED:
-            data["skipped"] = True
+        data["dispatch_code"] = outcome.code
+        data["dispatch_message"] = outcome.message
+        if result.success:
+            data["reason"] = "quality_pipeline_rejected"
         return data
     except Exception as exc:
         logger.exception(

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1473,6 +1473,118 @@ def cmd_wrong_match_triage(db, args):
     return 0
 
 
+def _print_wrong_match_delete_result(result, *, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return
+    print(f"  [{result.download_log_id}] {result.outcome}")
+    if result.reason:
+        print(f"  reason: {result.reason}")
+    if result.deleted_path:
+        print(f"  deleted_path: {result.deleted_path}")
+    if result.path_missing:
+        print("  path_missing: yes")
+    print(f"  cleared_rows: {result.cleared_rows}")
+
+
+def cmd_wrong_match_delete(db, args):
+    """Delete one visible Wrong Matches source folder."""
+    from lib.wrong_match_delete_service import (
+        OUTCOME_DELETE_FAILED,
+        OUTCOME_DELETED,
+        OUTCOME_SKIPPED_ACTIVE_JOB,
+        OUTCOME_SKIPPED_INVALID_ROW,
+        OUTCOME_SKIPPED_LOCKED,
+        OUTCOME_SKIPPED_NOT_VISIBLE,
+        OUTCOME_SKIPPED_UNSAFE_PATH,
+        delete_wrong_match,
+    )
+
+    if not args.apply:
+        print(
+            "  Refusing destructive wrong-match delete without --apply.",
+            file=sys.stderr,
+        )
+        return 2
+
+    result = delete_wrong_match(
+        db,
+        args.download_log_id,
+        require_visible=True,
+    )
+    _print_wrong_match_delete_result(result, json_output=args.json)
+    if result.outcome == OUTCOME_DELETED:
+        return 0
+    if result.outcome in (OUTCOME_SKIPPED_INVALID_ROW, OUTCOME_SKIPPED_NOT_VISIBLE):
+        return 2
+    if result.outcome == OUTCOME_SKIPPED_ACTIVE_JOB:
+        return 4
+    if result.outcome == OUTCOME_SKIPPED_UNSAFE_PATH:
+        return 3
+    if result.outcome == OUTCOME_SKIPPED_LOCKED:
+        return 5
+    if result.outcome == OUTCOME_DELETE_FAILED:
+        return 1
+    return 1
+
+
+def cmd_wrong_match_delete_group(db, args):
+    """Delete every visible Wrong Matches source folder for one request."""
+    from lib.wrong_match_delete_service import delete_wrong_match_group
+
+    if not args.apply:
+        print(
+            "  Refusing destructive wrong-match group delete without --apply.",
+            file=sys.stderr,
+        )
+        return 2
+
+    summary = delete_wrong_match_group(db, args.request_id)
+    if args.json:
+        print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))
+        return _wrong_match_delete_group_exit_code(summary)
+
+    for result in summary.results:
+        print(f"  [{result.download_log_id}] {result.outcome}")
+        if result.reason:
+            print(f"    reason: {result.reason}")
+    if summary.results:
+        print("")
+    print(f"  deleted: {summary.deleted}")
+    print(f"  deleted_paths: {summary.deleted_paths}")
+    print(f"  cleared: {summary.cleared}")
+    print(f"  skipped: {summary.skipped}")
+    print(f"  errors: {summary.errors}")
+    print(f"  remaining: {summary.remaining}")
+    return _wrong_match_delete_group_exit_code(summary)
+
+
+def _wrong_match_delete_group_exit_code(summary) -> int:
+    from lib.wrong_match_delete_service import (
+        OUTCOME_DELETE_FAILED,
+        OUTCOME_SKIPPED_ACTIVE_JOB,
+        OUTCOME_SKIPPED_INVALID_ROW,
+        OUTCOME_SKIPPED_LOCKED,
+        OUTCOME_SKIPPED_NOT_VISIBLE,
+        OUTCOME_SKIPPED_UNSAFE_PATH,
+    )
+
+    if summary.success:
+        return 0
+    outcomes = {result.outcome for result in summary.results}
+    if OUTCOME_DELETE_FAILED in outcomes:
+        return 1
+    if OUTCOME_SKIPPED_LOCKED in outcomes:
+        return 5
+    if OUTCOME_SKIPPED_ACTIVE_JOB in outcomes:
+        return 4
+    if OUTCOME_SKIPPED_UNSAFE_PATH in outcomes:
+        return 3
+    if outcomes & {OUTCOME_SKIPPED_INVALID_ROW, OUTCOME_SKIPPED_NOT_VISIBLE}:
+        return 2
+    return 1
+
+
 def cmd_search_plan_show(db, args):
     """U6: read-only `pipeline-cli search-plan show <id>`.
 
@@ -1942,6 +2054,26 @@ def main():
                           help="Allow destructive full-queue cleanup")
     p_triage.add_argument("--json", action="store_true")
 
+    # wrong-match-delete
+    p_wm_delete = sub.add_parser(
+        "wrong-match-delete",
+        help="Delete one visible Wrong Matches source folder",
+    )
+    p_wm_delete.add_argument("download_log_id", type=int)
+    p_wm_delete.add_argument("--apply", action="store_true",
+                             help="Allow destructive source deletion")
+    p_wm_delete.add_argument("--json", action="store_true")
+
+    # wrong-match-delete-group
+    p_wm_delete_group = sub.add_parser(
+        "wrong-match-delete-group",
+        help="Delete visible Wrong Matches source folders for one request",
+    )
+    p_wm_delete_group.add_argument("request_id", type=int)
+    p_wm_delete_group.add_argument("--apply", action="store_true",
+                                   help="Allow destructive source deletion")
+    p_wm_delete_group.add_argument("--json", action="store_true")
+
     # repair-spectral
     p_repair = sub.add_parser("repair-spectral",
                               help="Fix albums stuck by stale current_spectral_bitrate (#18)")
@@ -1975,6 +2107,8 @@ def main():
         "import-jobs": cmd_import_jobs,
         "import-preview": cmd_import_preview,
         "wrong-match-triage": cmd_wrong_match_triage,
+        "wrong-match-delete": cmd_wrong_match_delete,
+        "wrong-match-delete-group": cmd_wrong_match_delete_group,
         "repair-spectral": cmd_repair_spectral,
     }
     search_plan_commands = {

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -881,7 +881,6 @@ class FakePipelineDB:
             matches = (
                 payload.get("download_log_id") == download_log_id
                 or str(payload.get("download_log_id")) == str(download_log_id)
-                or (request_id is not None and row.get("request_id") == request_id)
                 or str(payload.get("failed_path") or "") in paths
                 or bool(dirs.intersection(payload_dirs))
             )

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -604,8 +604,11 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
                     candidate_import_job_id=job.id,
                 )
 
+            from lib.import_dispatch import DISPATCH_CODE_QUALITY_PIPELINE_REJECTED
+
             self.assertFalse(result.success)
             self.assertIn("Rejected by persisted quality evidence", result.message)
+            self.assertEqual(result.code, DISPATCH_CODE_QUALITY_PIPELINE_REJECTED)
             ext.run.assert_not_called()
             refreshed_id = db.get_request_current_evidence_id(42)
             self.assertIsNotNone(refreshed_id)

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -2561,7 +2561,7 @@ class TestFakeActiveImportJobForRequest(unittest.TestCase):
 
 
 class TestFakeActiveImportJobsForWrongMatch(unittest.TestCase):
-    def test_matches_by_download_log_request_path_or_source_dir(self):
+    def test_matches_by_download_log_path_or_source_dir(self):
         from lib.import_queue import IMPORT_JOB_FORCE, force_import_payload
 
         db = FakePipelineDB()
@@ -2618,7 +2618,7 @@ class TestFakeActiveImportJobsForWrongMatch(unittest.TestCase):
 
         self.assertEqual(
             {job.id for job in rows},
-            {by_log.id, by_request.id, by_path.id, by_dir.id},
+            {by_log.id, by_path.id, by_dir.id},
         )
 
 

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -12,7 +12,10 @@ from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from lib.config import CratediggerConfig
-from lib.import_dispatch import DispatchOutcome
+from lib.import_dispatch import (
+    DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
+    DispatchOutcome,
+)
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
     IMPORT_JOB_FORCE,
@@ -79,6 +82,13 @@ def _seed_current_for_request(db, request_id: int, *, mb_release_id: str,
     assert persisted is not None and persisted.id is not None
     db.set_request_current_evidence(request_id, persisted.id)
     return persisted
+
+
+def _make_failed_import_source() -> tuple[str, str]:
+    root = tempfile.mkdtemp()
+    source = os.path.join(root, "failed_imports", "Album")
+    os.makedirs(source)
+    return root, source
 
 
 class TestAutomationEvidenceReuse(unittest.TestCase):
@@ -558,20 +568,15 @@ class TestImporterWorker(unittest.TestCase):
         self.assertEqual(updated.error, "quality gate rejected")
         self.assertEqual(self._result(updated)["success"], False)
 
-    def test_failed_force_import_job_cleans_wrong_match_source(self):
+    def test_failed_force_import_quality_pipeline_reject_cleans_without_redeciding(self):
         from scripts import importer
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
             log_id = self._log_wrong_match(db, failed_path=source)
-            self._seed_cleanup_reject_evidence(
-                db,
-                log_id=log_id,
-                source_path=source,
-            )
             job = db.enqueue_import_job(
                 IMPORT_JOB_FORCE,
                 request_id=42,
@@ -588,10 +593,24 @@ class TestImporterWorker(unittest.TestCase):
 
             with patch(
                 "lib.import_dispatch.dispatch_import_from_db",
-                return_value=DispatchOutcome(False, "Pre-import gate rejected"),
-            ), self._patch_beets_album(source, min_bitrate=245):
-                updated = importer.process_claimed_job(cast(Any, db), claimed)
+                return_value=DispatchOutcome(
+                    False,
+                    "Rejected by persisted quality evidence: downgrade",
+                    code=DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
+                ),
+            ), patch(
+                "lib.wrong_match_cleanup_service.cleanup_wrong_match",
+            ) as cleanup_wrong_match:
+                with patch(
+                    "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+                    side_effect=AssertionError("cleanup must not re-decide"),
+                ), patch(
+                    "lib.quality.full_pipeline_decision_from_evidence",
+                    side_effect=AssertionError("cleanup must not re-decide"),
+                ):
+                    updated = importer.process_claimed_job(cast(Any, db), claimed)
 
+            cleanup_wrong_match.assert_not_called()
             assert updated is not None
             self.assertEqual(updated.status, "failed")
             self.assertFalse(os.path.exists(source))
@@ -600,15 +619,19 @@ class TestImporterWorker(unittest.TestCase):
             self.assertEqual(result["cleanup"]["success"], True)
             self.assertEqual(result["cleanup"]["outcome"], "deleted")
             self.assertEqual(result["cleanup"]["cleared_rows"], 1)
-            self.assertEqual(result["cleanup"]["verdict"], "confident_reject")
+            self.assertEqual(result["cleanup"]["reason"], "quality_pipeline_rejected")
+            self.assertEqual(
+                result["cleanup"]["dispatch_code"],
+                DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
+            )
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
-    def test_failed_force_import_job_skips_cleanup_when_fresh_evidence_uncertain(self):
+    def test_failed_force_import_non_pipeline_failure_preserves_wrong_match(self):
         from scripts import importer
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
@@ -642,23 +665,25 @@ class TestImporterWorker(unittest.TestCase):
 
             with patch(
                 "lib.import_dispatch.dispatch_import_from_db",
-                return_value=DispatchOutcome(False, "Pre-import gate rejected"),
-            ):
+                return_value=DispatchOutcome(False, "beets failed"),
+            ), patch(
+                "lib.wrong_match_cleanup_service.cleanup_wrong_match",
+            ) as cleanup_wrong_match:
                 updated = importer.process_claimed_job(cast(Any, db), claimed)
 
+            cleanup_wrong_match.assert_not_called()
             assert updated is not None
             self.assertEqual(updated.status, "failed")
             self.assertTrue(os.path.isdir(source))
             self.assertEqual(len(db.get_wrong_matches()), 1)
-            result = self._result(updated)
-            self.assertEqual(result["cleanup"]["success"], False)
-            self.assertTrue(result["cleanup"]["skipped"])
+            cleanup = self._result(updated)["cleanup"]
+            self.assertTrue(cleanup["skipped"])
             self.assertEqual(
-                result["cleanup"]["outcome"],
-                "skipped_candidate_evidence_missing",
+                cleanup["outcome"],
+                "skipped_non_quality_pipeline_failure",
             )
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_force_import_requeued_for_preview_does_not_mark_failed(self):
         """U2: when dispatch returns DISPATCH_CODE_REQUEUED_FOR_PREVIEW the
@@ -670,7 +695,7 @@ class TestImporterWorker(unittest.TestCase):
         from lib.import_dispatch import DISPATCH_CODE_REQUEUED_FOR_PREVIEW
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
@@ -725,7 +750,7 @@ class TestImporterWorker(unittest.TestCase):
             if updated is not None:
                 self.assertNotEqual(updated.status, "failed")
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_force_import_requeue_failed_marks_job_failed(self):
         """REL-001: when dispatch returns DISPATCH_CODE_REQUEUE_FAILED (its
@@ -742,7 +767,7 @@ class TestImporterWorker(unittest.TestCase):
         from lib.import_dispatch import DISPATCH_CODE_REQUEUE_FAILED
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
@@ -783,22 +808,17 @@ class TestImporterWorker(unittest.TestCase):
             assert updated is not None
             self.assertEqual(updated.status, "failed")
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_failed_force_import_job_clears_newer_duplicate_rejection(self):
         from scripts import importer
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
             log_id = self._log_wrong_match(db, failed_path=source, username="old")
-            self._seed_cleanup_reject_evidence(
-                db,
-                log_id=log_id,
-                source_path=source,
-            )
             job = db.enqueue_import_job(
                 IMPORT_JOB_FORCE,
                 request_id=42,
@@ -823,12 +843,16 @@ class TestImporterWorker(unittest.TestCase):
                         "failed_path": kwargs["failed_path"],
                     },
                 )
-                return DispatchOutcome(False, "Rejected: quality_downgrade")
+                return DispatchOutcome(
+                    False,
+                    "Rejected by persisted quality evidence: downgrade",
+                    code=DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
+                )
 
             with patch(
                 "lib.import_dispatch.dispatch_import_from_db",
                 side_effect=reject_again,
-            ), self._patch_beets_album(source, min_bitrate=245):
+            ):
                 updated = importer.process_claimed_job(cast(Any, db), claimed)
 
             assert updated is not None
@@ -836,13 +860,62 @@ class TestImporterWorker(unittest.TestCase):
             self.assertEqual(self._result(updated)["cleanup"]["cleared_rows"], 2)
             self.assertEqual(db.get_wrong_matches(), [])
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_failed_force_import_quality_reject_skips_cleanup_for_other_active_job(self):
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            self._mark_importable(db, job)
+            claimed = db.claim_next_import_job(worker_id="worker")
+            assert claimed is not None
+            db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=42,
+                dedupe_key=manual_import_dedupe_key(42, source),
+                payload=manual_import_payload(failed_path=source),
+            )
+
+            with patch(
+                "lib.import_dispatch.dispatch_import_from_db",
+                return_value=DispatchOutcome(
+                    False,
+                    "Rejected by persisted quality evidence: downgrade",
+                    code=DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
+                ),
+            ):
+                updated = importer.process_claimed_job(cast(Any, db), claimed)
+
+            assert updated is not None
+            self.assertEqual(updated.status, "failed")
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            cleanup = self._result(updated)["cleanup"]
+            self.assertTrue(cleanup["skipped"])
+            self.assertEqual(cleanup["outcome"], "skipped_active_job")
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_manual_import_failure_preserves_source_and_wrong_match(self):
         from scripts import importer
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             self._log_wrong_match(db, failed_path=source)
             job = db.enqueue_import_job(
@@ -867,13 +940,13 @@ class TestImporterWorker(unittest.TestCase):
             self.assertEqual(len(db.get_wrong_matches()), 1)
             self.assertNotIn("cleanup", self._result(updated))
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_deferred_force_import_preserves_source_and_wrong_match(self):
         from scripts import importer
 
         db = FakePipelineDB()
-        source = tempfile.mkdtemp()
+        root, source = _make_failed_import_source()
         try:
             log_id = self._log_wrong_match(db, failed_path=source)
             job = db.enqueue_import_job(
@@ -905,7 +978,7 @@ class TestImporterWorker(unittest.TestCase):
             self.assertEqual(len(db.get_wrong_matches()), 1)
             self.assertNotIn("cleanup", self._result(updated))
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_startup_requeues_abandoned_running_job_for_retry(self):
         from scripts import importer

--- a/tests/test_js_wrong_matches.mjs
+++ b/tests/test_js_wrong_matches.mjs
@@ -169,7 +169,8 @@ console.log('renderWrongMatches() shows threshold controls and green state');
   assert(dom.wrongMatches.innerHTML.includes('Converge (2)'), 'converge button includes count');
   assert(!dom.wrongMatches.innerHTML.includes('remove all wrong matches when converging'), 'cleanup checkbox is gone');
   assert(dom.wrongMatches.innerHTML.includes('Cleanup Wrong Matches (3)'), 'renders full-queue cleanup action');
-  assert(!dom.wrongMatches.innerHTML.includes('Delete All'), 'per-group delete-all action is gone');
+  assert(dom.wrongMatches.innerHTML.includes('Delete All (3)'), 'renders per-group delete-all action');
+  assert(dom.wrongMatches.innerHTML.includes('deleteWrongMatch(100'), 'renders per-entry delete action');
 
   __test__.setWrongMatchConvergeThreshold(42, 230);
   assert(dom.wrongMatches.innerHTML.includes('3 green'), 'threshold edit updates green count');
@@ -270,6 +271,165 @@ console.log('convergeWrongMatches() posts selected threshold and removes row in 
   assert(!calls.some(call => call.url === '/api/wrong-matches'), 'does not refetch the whole wrong-matches pane');
   assert(dom.toast.textContent.includes('Queued 2 candidates'), 'toasts converge result');
   assert(dom.wrongMatches.innerHTML.includes('No wrong matches'), 'removes the emptied group locally');
+}
+
+console.log('deleteWrongMatch() posts one row and refreshes');
+{
+  installStorage();
+  const dom = installDom();
+  __test__.renderWrongMatches(wrongMatchesData(), dom.wrongMatches);
+  const calls = [];
+  globalThis.confirm = () => true;
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (url === '/api/wrong-matches/delete') {
+      return {
+        ok: true,
+        json: async () => ({
+          status: 'ok',
+          success: true,
+          deleted_path: '/fi/a',
+          cleared_rows: 1,
+        }),
+      };
+    }
+    if (url === '/api/wrong-matches') {
+      return {
+        ok: true,
+        json: async () => ({ groups: [] }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const btn = { disabled: false, textContent: 'Delete', style: {} };
+  await __test__.deleteWrongMatch(100, btn);
+  assertEqual(calls[0].url, '/api/wrong-matches/delete', 'posts to row delete endpoint');
+  assertDeepEqual(
+    JSON.parse(calls[0].options.body),
+    { download_log_id: 100 },
+    'posts selected download log id',
+  );
+  assert(calls.some(call => call.url === '/api/wrong-matches'), 'refreshes after row delete');
+  assert(dom.toast.textContent.includes('Deleted wrong match'), 'toasts row delete result');
+}
+
+console.log('deleteWrongMatchGroup() posts request id and refreshes');
+{
+  installStorage();
+  const dom = installDom();
+  __test__.renderWrongMatches(wrongMatchesData(), dom.wrongMatches);
+  const calls = [];
+  globalThis.confirm = () => true;
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (url === '/api/wrong-matches/delete-group') {
+      return {
+        ok: true,
+        json: async () => ({
+          status: 'ok',
+          processed: 3,
+          deleted: 3,
+          skipped: 0,
+          errors: 0,
+        }),
+      };
+    }
+    if (url === '/api/wrong-matches') {
+      return {
+        ok: true,
+        json: async () => ({ groups: [] }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const btn = { disabled: false, textContent: 'Delete All (3)', style: {} };
+  await __test__.deleteWrongMatchGroup(42, btn);
+  assertEqual(calls[0].url, '/api/wrong-matches/delete-group', 'posts to group delete endpoint');
+  assertDeepEqual(
+    JSON.parse(calls[0].options.body),
+    { request_id: 42 },
+    'posts selected request id',
+  );
+  assert(calls.some(call => call.url === '/api/wrong-matches'), 'refreshes after group delete');
+  assert(dom.toast.textContent.includes('Deleted 3 candidates'), 'toasts group delete result');
+}
+
+console.log('delete controls handle cancel and failures');
+{
+  installStorage();
+  const dom = installDom();
+  __test__.renderWrongMatches(wrongMatchesData(), dom.wrongMatches);
+
+  let calls = [];
+  globalThis.confirm = () => false;
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const cancelBtn = { disabled: false, textContent: 'Delete', style: {} };
+  await __test__.deleteWrongMatch(100, cancelBtn);
+  assertEqual(calls.length, 0, 'row delete cancel does not fetch');
+  assertEqual(cancelBtn.disabled, false, 'row delete cancel leaves button enabled');
+
+  globalThis.confirm = () => true;
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (url === '/api/wrong-matches/delete') {
+      return {
+        ok: false,
+        json: async () => ({ error: 'active_import_job' }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const failBtn = { disabled: false, textContent: 'Delete', style: {} };
+  await __test__.deleteWrongMatch(100, failBtn);
+  assertEqual(failBtn.disabled, false, 'row delete API failure restores button enabled');
+  assertEqual(failBtn.textContent, 'Delete', 'row delete API failure restores button text');
+  assertEqual(dom.toast.className, 'toast error', 'row delete API failure shows error toast');
+
+  globalThis.fetch = async () => {
+    throw new Error('network down');
+  };
+  const errorBtn = { disabled: false, textContent: 'Delete', style: {} };
+  await __test__.deleteWrongMatch(100, errorBtn);
+  assertEqual(errorBtn.disabled, false, 'row delete fetch exception restores button enabled');
+  assertEqual(errorBtn.textContent, 'Delete', 'row delete fetch exception restores button text');
+
+  calls = [];
+  globalThis.confirm = () => false;
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const cancelGroupBtn = { disabled: false, textContent: 'Delete All (3)', style: {} };
+  await __test__.deleteWrongMatchGroup(42, cancelGroupBtn);
+  assertEqual(calls.length, 0, 'group delete cancel does not fetch');
+
+  globalThis.confirm = () => true;
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (url === '/api/wrong-matches/delete-group') {
+      return {
+        ok: false,
+        json: async () => ({ error: 'cleanup_lock_unavailable' }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const failGroupBtn = { disabled: false, textContent: 'Delete All (3)', style: {} };
+  await __test__.deleteWrongMatchGroup(42, failGroupBtn);
+  assertEqual(failGroupBtn.disabled, false, 'group delete API failure restores button enabled');
+  assertEqual(failGroupBtn.textContent, 'Delete All (3)', 'group delete API failure restores button text');
+  assertEqual(dom.toast.className, 'toast error', 'group delete API failure shows error toast');
+
+  globalThis.fetch = async () => {
+    throw new Error('network down');
+  };
+  const errorGroupBtn = { disabled: false, textContent: 'Delete All (3)', style: {} };
+  await __test__.deleteWrongMatchGroup(42, errorGroupBtn);
+  assertEqual(errorGroupBtn.disabled, false, 'group delete fetch exception restores button enabled');
+  assertEqual(errorGroupBtn.textContent, 'Delete All (3)', 'group delete fetch exception restores button text');
 }
 
 console.log('bulkTriageWrongMatches() posts full-queue confirmation and refreshes');

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -86,26 +86,27 @@ class TestImporterServiceContract(unittest.TestCase):
         self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
         self.assertIn("WorkingDirectory = cfg.stateDir", text)
 
-    def test_importer_service_does_not_restart_on_switch(self) -> None:
-        """The long-lived importer worker must NOT restart on nixos-rebuild
-        switch — that would kill in-flight beets mutations. The existing
-        requeue_running_import_jobs path covers crashes; deploys should not
-        manufacture them.
+    def test_importer_service_restarts_on_switch(self) -> None:
+        """Deploy should restart the importer worker.
+
+        requeue_running_import_jobs handles mid-job kills at startup; leaving a
+        worker dead after switch-to-configuration is worse than restarting it.
         """
         text = MODULE_NIX.read_text(encoding="utf-8")
-        # Find the importer service block and assert restartIfChanged=false
+        # Find the importer service block and assert restartIfChanged=true
         # appears within it (not just somewhere in the file).
         importer_block_start = text.index("systemd.services.cratedigger-importer")
         importer_block_end = text.index(
             "systemd.services.cratedigger-import-preview-worker"
         )
         importer_block = text[importer_block_start:importer_block_end]
-        self.assertIn("restartIfChanged = false", importer_block)
+        self.assertIn("restartIfChanged = true", importer_block)
 
-    def test_preview_worker_service_does_not_restart_on_switch(self) -> None:
-        """Same rationale as the importer — avoid killing in-flight
-        measurement on deploy. Recovery via requeue_stale_import_preview_jobs
-        exists but skipping the kill is cheaper.
+    def test_preview_worker_service_restarts_on_switch(self) -> None:
+        """Same rationale as the importer worker.
+
+        requeue_stale_import_preview_jobs handles mid-measurement kills at
+        startup; deploy should not leave the preview worker dead.
         """
         text = MODULE_NIX.read_text(encoding="utf-8")
         preview_block_start = text.index(
@@ -114,7 +115,7 @@ class TestImporterServiceContract(unittest.TestCase):
         # The next service definition or end of the systemd.services block
         # bounds the preview-worker block. Use a sentinel that's safe.
         preview_block = text[preview_block_start:preview_block_start + 4000]
-        self.assertIn("restartIfChanged = false", preview_block)
+        self.assertIn("restartIfChanged = true", preview_block)
 
     def test_prestart_renders_config_atomically_for_parallel_services(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -566,6 +566,199 @@ class TestCmdWrongMatchTriage(unittest.TestCase):
         self.assertEqual(payload["deleted"], 1)
 
 
+class TestCmdWrongMatchDelete(unittest.TestCase):
+    def test_delete_requires_apply(self):
+        db = MagicMock()
+        args = SimpleNamespace(download_log_id=42, apply=False, json=False)
+        stderr = io.StringIO()
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match"
+        ) as delete, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_delete(db, args)
+
+        self.assertEqual(rc, 2)
+        delete.assert_not_called()
+        self.assertIn("--apply", stderr.getvalue())
+
+    def test_delete_apply_delegates_to_service(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_DELETED,
+            WrongMatchDeleteResult,
+        )
+
+        db = MagicMock()
+        args = SimpleNamespace(download_log_id=42, apply=True, json=True)
+        result = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_DELETED,
+            success=True,
+            cleared_rows=1,
+            deleted_path="/fi/a",
+        )
+        stdout = io.StringIO()
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match",
+            return_value=result,
+        ) as delete, redirect_stdout(stdout):
+            rc = pipeline_cli.cmd_wrong_match_delete(db, args)
+
+        self.assertEqual(rc, 0)
+        delete.assert_called_once_with(db, 42, require_visible=True)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["outcome"], OUTCOME_DELETED)
+        self.assertEqual(payload["cleared_rows"], 1)
+
+    def test_delete_active_job_returns_conflict_exit_code(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            WrongMatchDeleteResult,
+        )
+
+        db = MagicMock()
+        args = SimpleNamespace(download_log_id=42, apply=True, json=True)
+        result = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_SKIPPED_ACTIVE_JOB,
+            skipped=True,
+            reason="active_import_job",
+        )
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match",
+            return_value=result,
+        ), redirect_stdout(io.StringIO()):
+            rc = pipeline_cli.cmd_wrong_match_delete(db, args)
+
+        self.assertEqual(rc, 4)
+
+    def test_delete_missing_row_returns_not_found_exit_code(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_NOT_VISIBLE,
+            WrongMatchDeleteResult,
+        )
+
+        db = MagicMock()
+        args = SimpleNamespace(download_log_id=42, apply=True, json=True)
+        result = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_SKIPPED_NOT_VISIBLE,
+            skipped=True,
+            reason="wrong_match_not_visible",
+        )
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match",
+            return_value=result,
+        ), redirect_stdout(io.StringIO()):
+            rc = pipeline_cli.cmd_wrong_match_delete(db, args)
+
+        self.assertEqual(rc, 2)
+
+    def test_delete_locked_returns_transient_exit_code(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_LOCKED,
+            WrongMatchDeleteResult,
+        )
+
+        db = MagicMock()
+        args = SimpleNamespace(download_log_id=42, apply=True, json=True)
+        result = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_SKIPPED_LOCKED,
+            skipped=True,
+            reason="cleanup_lock_unavailable",
+        )
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match",
+            return_value=result,
+        ), redirect_stdout(io.StringIO()):
+            rc = pipeline_cli.cmd_wrong_match_delete(db, args)
+
+        self.assertEqual(rc, 5)
+
+
+class TestCmdWrongMatchDeleteGroup(unittest.TestCase):
+    def test_delete_group_requires_apply(self):
+        db = MagicMock()
+        args = SimpleNamespace(request_id=42, apply=False, json=False)
+        stderr = io.StringIO()
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match_group"
+        ) as delete, redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_wrong_match_delete_group(db, args)
+
+        self.assertEqual(rc, 2)
+        delete.assert_not_called()
+        self.assertIn("--apply", stderr.getvalue())
+
+    def test_delete_group_apply_delegates_to_service(self):
+        from lib.wrong_match_delete_service import WrongMatchDeleteSummary
+
+        db = MagicMock()
+        args = SimpleNamespace(request_id=42, apply=True, json=True)
+        summary = WrongMatchDeleteSummary(
+            request_id=42,
+            outcome="deleted",
+            success=True,
+            processed=2,
+            deleted=2,
+            deleted_paths=2,
+            cleared=2,
+            skipped=0,
+            errors=0,
+            remaining=0,
+            group_empty=True,
+            results=(),
+        )
+        stdout = io.StringIO()
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match_group",
+            return_value=summary,
+        ) as delete, redirect_stdout(stdout):
+            rc = pipeline_cli.cmd_wrong_match_delete_group(db, args)
+
+        self.assertEqual(rc, 0)
+        delete.assert_called_once_with(db, 42)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["deleted"], 2)
+        self.assertEqual(payload["cleared"], 2)
+
+    def test_delete_group_active_job_returns_conflict_exit_code(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            WrongMatchDeleteResult,
+            WrongMatchDeleteSummary,
+        )
+
+        db = MagicMock()
+        args = SimpleNamespace(request_id=42, apply=True, json=True)
+        result = WrongMatchDeleteResult(
+            download_log_id=100,
+            outcome=OUTCOME_SKIPPED_ACTIVE_JOB,
+            skipped=True,
+            reason="active_import_job",
+        )
+        summary = WrongMatchDeleteSummary(
+            request_id=42,
+            outcome="partial",
+            success=False,
+            processed=1,
+            deleted=0,
+            deleted_paths=0,
+            cleared=0,
+            skipped=1,
+            errors=0,
+            remaining=1,
+            group_empty=False,
+            results=(result,),
+        )
+        with patch(
+            "lib.wrong_match_delete_service.delete_wrong_match_group",
+            return_value=summary,
+        ), redirect_stdout(io.StringIO()):
+            rc = pipeline_cli.cmd_wrong_match_delete_group(db, args)
+
+        self.assertEqual(rc, 4)
+
+
 class TestMainExitCodes(unittest.TestCase):
     def test_main_propagates_command_return_code(self):
         argv = [
@@ -583,6 +776,83 @@ class TestMainExitCodes(unittest.TestCase):
                 pipeline_cli.main()
 
         self.assertEqual(raised.exception.code, 2)
+        db.close.assert_called_once_with()
+
+    def test_main_routes_wrong_match_delete(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_DELETED,
+            WrongMatchDeleteResult,
+        )
+
+        argv = [
+            "pipeline_cli.py",
+            "--dsn",
+            "postgresql://example/test",
+            "wrong-match-delete",
+            "42",
+            "--apply",
+            "--json",
+        ]
+        db = MagicMock()
+        result = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_DELETED,
+            success=True,
+            cleared_rows=1,
+        )
+        with patch.object(sys, "argv", argv), patch(
+            "scripts.pipeline_cli.PipelineDB",
+            return_value=db,
+        ), patch(
+            "lib.wrong_match_delete_service.delete_wrong_match",
+            return_value=result,
+        ) as delete, redirect_stdout(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                pipeline_cli.main()
+
+        self.assertEqual(raised.exception.code, 0)
+        delete.assert_called_once_with(db, 42, require_visible=True)
+        db.close.assert_called_once_with()
+
+    def test_main_routes_wrong_match_delete_group(self):
+        from lib.wrong_match_delete_service import WrongMatchDeleteSummary
+
+        argv = [
+            "pipeline_cli.py",
+            "--dsn",
+            "postgresql://example/test",
+            "wrong-match-delete-group",
+            "42",
+            "--apply",
+            "--json",
+        ]
+        db = MagicMock()
+        summary = WrongMatchDeleteSummary(
+            request_id=42,
+            outcome="empty",
+            success=True,
+            processed=0,
+            deleted=0,
+            deleted_paths=0,
+            cleared=0,
+            skipped=0,
+            errors=0,
+            remaining=0,
+            group_empty=True,
+            results=(),
+        )
+        with patch.object(sys, "argv", argv), patch(
+            "scripts.pipeline_cli.PipelineDB",
+            return_value=db,
+        ), patch(
+            "lib.wrong_match_delete_service.delete_wrong_match_group",
+            return_value=summary,
+        ) as delete, redirect_stdout(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                pipeline_cli.main()
+
+        self.assertEqual(raised.exception.code, 0)
+        delete.assert_called_once_with(db, 42)
         db.close.assert_called_once_with()
 
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -4514,7 +4514,7 @@ class TestActiveImportJobsForWrongMatch(unittest.TestCase):
 
         self.assertEqual(
             {job.id for job in jobs},
-            {by_download_log.id, by_request.id, by_path.id, by_source_dir.id},
+            {by_download_log.id, by_path.id, by_source_dir.id},
         )
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -994,6 +994,8 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/import-preview",
         "/api/wrong-matches",
         "/api/wrong-matches/audio",
+        "/api/wrong-matches/delete",
+        "/api/wrong-matches/delete-group",
         "/api/wrong-matches/converge",
         "/api/wrong-matches/triage",
         "/api/wrong-matches/explorer",
@@ -5967,6 +5969,7 @@ class TestWrongMatchesContract(unittest.TestCase):
 
     def setUp(self) -> None:
         self.mock_db.get_request.return_value = copy.deepcopy(_MOCK_PIPELINE_REQUEST)
+        self.mock_db.get_wrong_matches.side_effect = None
         self.mock_db.get_wrong_matches.return_value = [copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)]
         self.mock_db.get_download_log_entry.reset_mock()
         self.mock_db.get_download_log_entry.side_effect = None
@@ -5980,6 +5983,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.mock_db.enqueue_import_job.return_value = self._job(
             77, 100, 42, "/mnt/virtio/music/slskd/failed_imports/Test")
         self.mock_db.get_download_history_batch.return_value = {}
+        self.mock_db.list_active_import_jobs_for_wrong_match.return_value = []
         # Default: treat every failed_path as existing so the group survives
         # filtering. Individual tests override this to exercise missing-file
         # and mixed-existence cases. Converge deletion is service-backed.
@@ -5987,11 +5991,23 @@ class TestWrongMatchesContract(unittest.TestCase):
             "web.routes.imports.cleanup_wrong_match",
             side_effect=lambda _db, lid: self._cleanup_result(lid),
         )
+        manual_cleanup_patch = patch(
+            "web.routes.imports.delete_wrong_match",
+            side_effect=lambda _db, lid, **_kwargs: self._manual_cleanup_result(lid),
+        )
+        manual_group_cleanup_patch = patch(
+            "web.routes.imports.delete_wrong_match_group",
+            side_effect=lambda _db, rid: self._manual_group_cleanup_result(rid),
+        )
         resolve_patch = patch("web.routes.imports.resolve_failed_path",
                               side_effect=lambda p: p if p else None)
         self.mock_cleanup = cleanup_patch.start()
+        self.mock_manual_cleanup = manual_cleanup_patch.start()
+        self.mock_manual_group_cleanup = manual_group_cleanup_patch.start()
         self.mock_resolve_failed_path = resolve_patch.start()
         self.addCleanup(cleanup_patch.stop)
+        self.addCleanup(manual_cleanup_patch.stop)
+        self.addCleanup(manual_group_cleanup_patch.stop)
         self.addCleanup(resolve_patch.stop)
 
     GROUP_REQUIRED_FIELDS = {
@@ -6014,6 +6030,17 @@ class TestWrongMatchesContract(unittest.TestCase):
         # values are None when the underlying row lacks evidence.
         "spectral_grade", "spectral_bitrate",
         "v0_probe_kind", "v0_probe_avg_bitrate",
+    }
+    DELETE_RESULT_REQUIRED_FIELDS = {
+        "status", "download_log_id", "outcome", "success", "request_id",
+        "entry_found", "visible", "raw_failed_path", "failed_path_hint",
+        "resolved_path", "deleted_path", "path_missing", "cleared_rows",
+        "skipped", "reason", "error",
+    }
+    DELETE_GROUP_REQUIRED_FIELDS = {
+        "status", "request_id", "outcome", "success", "processed", "deleted",
+        "deleted_paths", "cleared", "skipped", "errors", "remaining",
+        "group_empty", "results",
     }
 
     GROUP_FIELD_TYPES = {
@@ -6102,6 +6129,47 @@ class TestWrongMatchesContract(unittest.TestCase):
             verdict="confident_reject" if outcome == OUTCOME_DELETED else "uncertain",
             cleanup_eligible=outcome == OUTCOME_DELETED,
             cleared_rows=1 if outcome == OUTCOME_DELETED else 0,
+        )
+
+    def _manual_cleanup_result(self, log_id: int):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_DELETED,
+            WrongMatchDeleteResult,
+        )
+
+        return WrongMatchDeleteResult(
+            download_log_id=log_id,
+            outcome=OUTCOME_DELETED,
+            success=True,
+            entry_found=True,
+            visible=True,
+            request_id=42,
+            raw_failed_path="/mnt/virtio/music/slskd/failed_imports/Test",
+            resolved_path="/mnt/virtio/music/slskd/failed_imports/Test",
+            deleted_path="/mnt/virtio/music/slskd/failed_imports/Test",
+            cleared_rows=1,
+        )
+
+    def _manual_group_cleanup_result(self, request_id: int):
+        from lib.wrong_match_delete_service import WrongMatchDeleteSummary
+
+        results = (
+            self._manual_cleanup_result(100),
+            self._manual_cleanup_result(101),
+        )
+        return WrongMatchDeleteSummary(
+            request_id=request_id,
+            outcome="deleted",
+            success=True,
+            processed=2,
+            deleted=2,
+            deleted_paths=2,
+            cleared=2,
+            skipped=0,
+            errors=0,
+            remaining=0,
+            group_empty=True,
+            results=results,
         )
 
     def test_response_has_groups(self):
@@ -6667,10 +6735,144 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(entry["failed_path"],
                          "/mnt/virtio/music/slskd/failed_imports/Test")
 
-    def test_legacy_delete_routes_are_removed(self):
-        for path in (
+    def test_manual_delete_route_deletes_single_wrong_match(self):
+        status, data = self._post(
             "/api/wrong-matches/delete",
+            {"download_log_id": 42},
+        )
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self,
+            data,
+            self.DELETE_RESULT_REQUIRED_FIELDS,
+            "wrong-match delete response",
+        )
+        self.assertEqual(data["status"], "ok")
+        self.assertTrue(data["success"])
+        self.assertEqual(data["deleted_path"],
+                         "/mnt/virtio/music/slskd/failed_imports/Test")
+        self.mock_manual_cleanup.assert_called_once_with(
+            self.mock_db,
+            42,
+            require_visible=True,
+        )
+
+    def test_manual_delete_route_blocks_active_import_job(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            WrongMatchDeleteResult,
+        )
+
+        self.mock_manual_cleanup.side_effect = None
+        self.mock_manual_cleanup.return_value = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_SKIPPED_ACTIVE_JOB,
+            skipped=True,
+            reason="active_import_job",
+        )
+
+        status, data = self._post(
+            "/api/wrong-matches/delete",
+            {"download_log_id": 42},
+        )
+
+        self.assertEqual(status, 409)
+        self.assertEqual(data["error"], "active_import_job")
+        self.mock_manual_cleanup.assert_called_once_with(
+            self.mock_db,
+            42,
+            require_visible=True,
+        )
+
+    def test_manual_delete_route_reports_lock_contention_as_retryable(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_LOCKED,
+            WrongMatchDeleteResult,
+        )
+
+        self.mock_manual_cleanup.side_effect = None
+        self.mock_manual_cleanup.return_value = WrongMatchDeleteResult(
+            download_log_id=42,
+            outcome=OUTCOME_SKIPPED_LOCKED,
+            skipped=True,
+            reason="cleanup_lock_unavailable",
+        )
+
+        status, data = self._post(
+            "/api/wrong-matches/delete",
+            {"download_log_id": 42},
+        )
+
+        self.assertEqual(status, 503)
+        self.assertEqual(data["error"], "cleanup_lock_unavailable")
+
+    def test_manual_delete_group_deletes_request_rows(self):
+        status, data = self._post(
             "/api/wrong-matches/delete-group",
+            {"request_id": 42},
+        )
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self,
+            data,
+            self.DELETE_GROUP_REQUIRED_FIELDS,
+            "wrong-match delete-group response",
+        )
+        self.assertEqual(data["status"], "ok")
+        self.assertTrue(data["success"])
+        self.assertEqual(data["processed"], 2)
+        self.assertEqual(data["deleted"], 2)
+        self.assertEqual(data["cleared"], 2)
+        self.assertEqual(data["deleted_paths"], 2)
+        self.assertTrue(data["group_empty"])
+        self.mock_manual_group_cleanup.assert_called_once_with(self.mock_db, 42)
+
+    def test_manual_delete_group_reports_partial_when_rows_are_skipped(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            WrongMatchDeleteResult,
+            WrongMatchDeleteSummary,
+        )
+
+        skipped = WrongMatchDeleteResult(
+            download_log_id=100,
+            outcome=OUTCOME_SKIPPED_ACTIVE_JOB,
+            success=False,
+            request_id=42,
+            skipped=True,
+            reason="active_import_job",
+        )
+        self.mock_manual_group_cleanup.side_effect = None
+        self.mock_manual_group_cleanup.return_value = WrongMatchDeleteSummary(
+            request_id=42,
+            outcome="partial",
+            success=False,
+            processed=1,
+            deleted=0,
+            deleted_paths=0,
+            cleared=0,
+            skipped=1,
+            errors=0,
+            remaining=1,
+            group_empty=False,
+            results=(skipped,),
+        )
+
+        status, data = self._post(
+            "/api/wrong-matches/delete-group",
+            {"request_id": 42},
+        )
+
+        self.assertEqual(status, 409)
+        self.assertEqual(data["status"], "partial")
+        self.assertFalse(data["success"])
+        self.assertEqual(data["skipped"], 1)
+        self.assertEqual(data["remaining"], 1)
+
+    def test_retired_heuristic_delete_routes_are_removed(self):
+        for path in (
             "/api/wrong-matches/delete-transparent-non-flac",
             "/api/wrong-matches/delete-lossless-opus",
         ):
@@ -6737,6 +6939,13 @@ class TestWrongMatchesContract(unittest.TestCase):
             self._job(900, 42, 100, "/fi/a"),
             self._job(901, 42, 101, "/fi/b"),
         ]
+        self.mock_cleanup.side_effect = None
+
+        def cleanup_after_enqueue(_db, log_id):
+            self.assertEqual(self.mock_db.enqueue_import_job.call_count, 2)
+            return self._cleanup_result(log_id)
+
+        self.mock_cleanup.side_effect = cleanup_after_enqueue
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -43,7 +43,9 @@ def _cfg() -> types.SimpleNamespace:
 
 
 def _make_source(root: str, name: str) -> str:
-    source = os.path.join(root, name)
+    failed_root = os.path.join(root, "failed_imports")
+    os.makedirs(failed_root, exist_ok=True)
+    source = os.path.join(failed_root, name)
     os.mkdir(source)
     with open(os.path.join(source, "01.mp3"), "wb") as handle:
         handle.write(b"audio")

--- a/tests/test_wrong_matches_cleanup.py
+++ b/tests/test_wrong_matches_cleanup.py
@@ -10,6 +10,13 @@ from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
 
+def make_failed_import_source() -> tuple[str, str]:
+    root = tempfile.mkdtemp()
+    source = os.path.join(root, "failed_imports", "Album")
+    os.makedirs(source)
+    return root, source
+
+
 class TestWrongMatchCleanup(unittest.TestCase):
     def _make_db(self) -> FakePipelineDB:
         db = FakePipelineDB()
@@ -45,7 +52,7 @@ class TestWrongMatchCleanup(unittest.TestCase):
         from lib.wrong_matches import cleanup_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
+        root, source = make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
@@ -59,13 +66,13 @@ class TestWrongMatchCleanup(unittest.TestCase):
             self.assertFalse(os.path.exists(source))
             self.assertEqual(db.get_wrong_matches(), [])
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_clears_relative_and_absolute_duplicate_rows(self):
         from lib.wrong_matches import cleanup_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
+        root, source = make_failed_import_source()
         try:
             raw_path = "failed_imports/Artist - Album"
             original_id = self._log_rejected(
@@ -81,48 +88,86 @@ class TestWrongMatchCleanup(unittest.TestCase):
             self.assertFalse(os.path.exists(source))
             self.assertEqual(db.get_wrong_matches(), [])
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_clears_relative_duplicate_when_absolute_row_is_deleted(self):
+        from lib.wrong_matches import cleanup_wrong_match_source
+
+        db = self._make_db()
+        root, source = make_failed_import_source()
+        try:
+            raw_path = "failed_imports/Album"
+            self._log_rejected(db, failed_path=raw_path, username="old")
+            absolute_id = self._log_rejected(
+                db,
+                failed_path=os.path.abspath(source),
+                username="new",
+            )
+
+            def fake_resolve(path):
+                if path == raw_path and os.path.isdir(source):
+                    return os.path.abspath(source)
+                if os.path.isdir(path):
+                    return os.path.abspath(path)
+                return None
+
+            with patch("lib.wrong_matches.resolve_failed_path",
+                       side_effect=fake_resolve):
+                result = cleanup_wrong_match_source(db, absolute_id)
+
+            self.assertTrue(result.success)
+            self.assertEqual(result.cleared_rows, 2)
+            self.assertFalse(os.path.exists(source))
+            self.assertEqual(db.get_wrong_matches(), [])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_missing_directory_still_clears_stale_pointer(self):
         from lib.wrong_matches import cleanup_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
-        shutil.rmtree(source)
-        log_id = self._log_rejected(db, failed_path=source)
+        root, source = make_failed_import_source()
+        try:
+            shutil.rmtree(source)
+            log_id = self._log_rejected(db, failed_path=source)
 
-        result = cleanup_wrong_match_source(db, log_id)
+            result = cleanup_wrong_match_source(db, log_id)
 
-        self.assertTrue(result.success)
-        self.assertTrue(result.path_missing)
-        self.assertIsNone(result.deleted_path)
-        self.assertEqual(result.cleared_rows, 1)
-        self.assertEqual(db.get_wrong_matches(), [])
+            self.assertTrue(result.success)
+            self.assertTrue(result.path_missing)
+            self.assertIsNone(result.deleted_path)
+            self.assertEqual(result.cleared_rows, 1)
+            self.assertEqual(db.get_wrong_matches(), [])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_missing_directory_can_preserve_pointer_for_service_policy(self):
         from lib.wrong_matches import cleanup_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
-        shutil.rmtree(source)
-        log_id = self._log_rejected(db, failed_path=source)
+        root, source = make_failed_import_source()
+        try:
+            shutil.rmtree(source)
+            log_id = self._log_rejected(db, failed_path=source)
 
-        result = cleanup_wrong_match_source(
-            db,
-            log_id,
-            clear_missing=False,
-        )
+            result = cleanup_wrong_match_source(
+                db,
+                log_id,
+                clear_missing=False,
+            )
 
-        self.assertTrue(result.success)
-        self.assertTrue(result.path_missing)
-        self.assertEqual(result.cleared_rows, 0)
-        self.assertEqual(len(db.get_wrong_matches()), 1)
+            self.assertTrue(result.success)
+            self.assertTrue(result.path_missing)
+            self.assertEqual(result.cleared_rows, 0)
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_delete_race_still_clears_stale_pointer(self):
         from lib.wrong_matches import cleanup_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
+        root, source = make_failed_import_source()
         try:
             log_id = self._log_rejected(db, failed_path=source)
 
@@ -137,13 +182,13 @@ class TestWrongMatchCleanup(unittest.TestCase):
             self.assertEqual(result.cleared_rows, 1)
             self.assertEqual(db.get_wrong_matches(), [])
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_delete_error_reports_failure_and_keeps_pointer(self):
         from lib.wrong_matches import cleanup_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
+        root, source = make_failed_import_source()
         try:
             log_id = self._log_rejected(db, failed_path=source)
 
@@ -156,13 +201,32 @@ class TestWrongMatchCleanup(unittest.TestCase):
             self.assertEqual(result.cleared_rows, 0)
             self.assertEqual(len(db.get_wrong_matches()), 1)
         finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_cleanup_refuses_directory_outside_failed_imports(self):
+        from lib.wrong_matches import cleanup_wrong_match_source
+
+        db = self._make_db()
+        source = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_rejected(db, failed_path=source)
+
+            result = cleanup_wrong_match_source(db, log_id)
+
+            self.assertFalse(result.success)
+            self.assertIn("unsafe_failed_import_path", result.error or "")
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+        finally:
             shutil.rmtree(source, ignore_errors=True)
 
     def test_dismiss_clears_pointer_without_deleting_directory(self):
         from lib.wrong_matches import dismiss_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
+        root, source = make_failed_import_source()
         try:
             with open(os.path.join(source, "01.mp3"), "wb") as f:
                 f.write(b"audio")
@@ -176,13 +240,13 @@ class TestWrongMatchCleanup(unittest.TestCase):
             self.assertTrue(os.path.isdir(source))
             self.assertEqual(db.get_wrong_matches(), [])
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_dismiss_clears_relative_and_absolute_duplicate_rows(self):
         from lib.wrong_matches import dismiss_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
+        root, source = make_failed_import_source()
         try:
             raw_path = "failed_imports/Artist - Album"
             original_id = self._log_rejected(
@@ -198,22 +262,25 @@ class TestWrongMatchCleanup(unittest.TestCase):
             self.assertTrue(os.path.isdir(source))
             self.assertEqual(db.get_wrong_matches(), [])
         finally:
-            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_dismiss_missing_directory_still_clears_stale_pointer(self):
         from lib.wrong_matches import dismiss_wrong_match_source
 
         db = self._make_db()
-        source = tempfile.mkdtemp()
-        shutil.rmtree(source)
-        log_id = self._log_rejected(db, failed_path=source)
+        root, source = make_failed_import_source()
+        try:
+            shutil.rmtree(source)
+            log_id = self._log_rejected(db, failed_path=source)
 
-        result = dismiss_wrong_match_source(db, log_id)
+            result = dismiss_wrong_match_source(db, log_id)
 
-        self.assertTrue(result.success)
-        self.assertIsNone(result.resolved_path)
-        self.assertEqual(result.cleared_rows, 1)
-        self.assertEqual(db.get_wrong_matches(), [])
+            self.assertTrue(result.success)
+            self.assertIsNone(result.resolved_path)
+            self.assertEqual(result.cleared_rows, 1)
+            self.assertEqual(db.get_wrong_matches(), [])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_dismiss_missing_entry_reports_failure(self):
         from lib.wrong_matches import dismiss_wrong_match_source
@@ -226,6 +293,225 @@ class TestWrongMatchCleanup(unittest.TestCase):
         self.assertFalse(result.entry_found)
         self.assertEqual(result.cleared_rows, 0)
         self.assertIn("99999", result.error or "")
+
+
+class TestWrongMatchDeleteService(unittest.TestCase):
+    def _make_db(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1,
+            artist_name="Artist",
+            album_title="Album",
+            mb_release_id="mbid-1",
+            status="manual",
+        ))
+        return db
+
+    def _log_download(
+        self,
+        db: FakePipelineDB,
+        *,
+        failed_path: str,
+        outcome: str = "rejected",
+        request_id: int = 1,
+    ) -> int:
+        db.log_download(
+            request_id,
+            soulseek_username="alice",
+            outcome=outcome,
+            validation_result={
+                "scenario": "high_distance",
+                "failed_path": failed_path,
+            },
+        )
+        return db.download_logs[-1].id
+
+    def test_manual_delete_requires_visible_wrong_match_row(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_NOT_VISIBLE,
+            delete_wrong_match,
+        )
+
+        db = self._make_db()
+        root, source = make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_download(
+                db,
+                failed_path=source,
+                outcome="accepted",
+            )
+
+            result = delete_wrong_match(db, log_id, require_visible=True)
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.outcome, OUTCOME_SKIPPED_NOT_VISIBLE)
+            self.assertTrue(os.path.isdir(source))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_delete_skips_when_another_active_job_owns_same_source(self):
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            delete_wrong_match,
+        )
+
+        db = self._make_db()
+        root, source = make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_download(db, failed_path=source)
+            db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=1,
+                payload=manual_import_payload(failed_path=source),
+            )
+
+            result = delete_wrong_match(db, log_id, require_visible=True)
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.outcome, OUTCOME_SKIPPED_ACTIVE_JOB)
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_delete_ignores_current_job_but_blocks_other_matching_job(self):
+        from lib.import_queue import (
+            IMPORT_JOB_FORCE,
+            force_import_payload,
+        )
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_ACTIVE_JOB,
+            delete_wrong_match,
+        )
+
+        db = self._make_db()
+        root, source = make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_download(db, failed_path=source)
+            current = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=1,
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=1,
+                payload=force_import_payload(
+                    download_log_id=log_id + 100,
+                    failed_path=source,
+                ),
+            )
+
+            result = delete_wrong_match(
+                db,
+                log_id,
+                ignore_import_job_id=current.id,
+                require_visible=False,
+            )
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.outcome, OUTCOME_SKIPPED_ACTIVE_JOB)
+            self.assertTrue(os.path.isdir(source))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_delete_uses_cleanup_lock(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_LOCKED,
+            delete_wrong_match,
+        )
+
+        db = self._make_db()
+        db.set_advisory_lock_result(False)
+        root, source = make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_download(db, failed_path=source)
+
+            result = delete_wrong_match(db, log_id, require_visible=True)
+
+            self.assertEqual(result.outcome, OUTCOME_SKIPPED_LOCKED)
+            self.assertTrue(os.path.isdir(source))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_delete_group_deletes_current_request_rows_only(self):
+        from lib.wrong_match_delete_service import delete_wrong_match_group
+
+        db = self._make_db()
+        db.seed_request(make_request_row(
+            id=2,
+            artist_name="Other",
+            album_title="Album",
+            mb_release_id="mbid-2",
+            status="manual",
+        ))
+        root1, source1 = make_failed_import_source()
+        root2, source2 = make_failed_import_source()
+        root3, source3 = make_failed_import_source()
+        try:
+            for source in (source1, source2, source3):
+                with open(os.path.join(source, "01.mp3"), "wb") as f:
+                    f.write(b"audio")
+            self._log_download(db, failed_path=source1)
+            self._log_download(db, failed_path=source2)
+            self._log_download(db, failed_path=source3, request_id=2)
+
+            summary = delete_wrong_match_group(db, 1)
+
+            self.assertTrue(summary.success)
+            self.assertEqual(summary.outcome, "deleted")
+            self.assertEqual(summary.processed, 2)
+            self.assertEqual(summary.deleted, 2)
+            self.assertEqual(summary.deleted_paths, 2)
+            self.assertEqual(summary.cleared, 2)
+            self.assertEqual(summary.skipped, 0)
+            self.assertEqual(summary.errors, 0)
+            self.assertTrue(summary.group_empty)
+            self.assertFalse(os.path.exists(source1))
+            self.assertFalse(os.path.exists(source2))
+            self.assertTrue(os.path.isdir(source3))
+            remaining = db.get_wrong_matches()
+            self.assertEqual(len(remaining), 1)
+            self.assertEqual(remaining[0]["request_id"], 2)
+        finally:
+            shutil.rmtree(root1, ignore_errors=True)
+            shutil.rmtree(root2, ignore_errors=True)
+            shutil.rmtree(root3, ignore_errors=True)
+
+    def test_delete_refuses_directory_outside_failed_imports(self):
+        from lib.wrong_match_delete_service import (
+            OUTCOME_SKIPPED_UNSAFE_PATH,
+            delete_wrong_match,
+        )
+
+        db = self._make_db()
+        source = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            log_id = self._log_download(db, failed_path=source)
+
+            result = delete_wrong_match(db, log_id, require_visible=True)
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.outcome, OUTCOME_SKIPPED_UNSAFE_PATH)
+            self.assertIn("unsafe_failed_import_path", result.reason or "")
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -13,7 +13,7 @@ import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, render
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
-import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, reloadWrongMatchExplorer, forceImportWrongMatch, bulkTriageWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold } from './wrong-matches.js';
+import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, reloadWrongMatchExplorer, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup, bulkTriageWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold } from './wrong-matches.js';
 import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, onLabelYearFilterInput, toggleLabelIncludeSublabels, goToLabelPage } from './labels.js';
 import { toggleSearchPlanSummary, openSearchPlanDetail, closeSearchPlanDetail, searchPlanRegenerate, searchPlanAdvance, searchPlanLoadOlder, searchPlanRefreshDetail, searchPlanSubmitAdvance, searchPlanCancelAdvance } from './search_plan.js';
 import { toast } from './state.js';
@@ -145,6 +145,8 @@ Object.assign(window, {
   toggleWrongMatchEntry,
   reloadWrongMatchExplorer,
   forceImportWrongMatch,
+  deleteWrongMatch,
+  deleteWrongMatchGroup,
   bulkTriageWrongMatches,
   convergeWrongMatches,
   setWrongMatchConvergeThreshold,

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -882,6 +882,7 @@ function renderConvergeControls(g, count, thresholdMilli) {
         <span id="wm-green-count-${g.request_id}" class="badge" style="${greenCountStyle(greenCount)}">${greenCountLabel(greenCount)}</span>
       </div>
       <div style="display:flex;align-items:center;gap:6px;">
+        <button id="wm-delete-group-btn-${g.request_id}" class="p-btn delete" onclick="event.stopPropagation(); window.deleteWrongMatchGroup(${g.request_id}, this)">Delete All (${count})</button>
         <button id="wm-converge-btn-${g.request_id}" class="p-btn" style="border-color:#6a9;color:#6a9;" ${disabled ? 'disabled' : ''} onclick="event.stopPropagation(); window.convergeWrongMatches(${g.request_id}, this)">${label}</button>
       </div>
     </div>`;
@@ -1017,6 +1018,7 @@ function renderEntryDetail(e, job) {
   const active = job && (job.status === 'queued' || job.status === 'running');
   const label = active ? job.status[0].toUpperCase() + job.status.slice(1) : 'Force Import';
   html += `<button class="p-btn" style="border-color:#6a9;color:#6a9;" ${active ? 'disabled' : ''} onclick="event.stopPropagation(); window.forceImportWrongMatch(${e.download_log_id}, this)">${label}</button>`;
+  html += `<button class="p-btn delete" ${active ? 'disabled' : ''} onclick="event.stopPropagation(); window.deleteWrongMatch(${e.download_log_id}, this)">Delete</button>`;
   html += '</div>';
 
   return html;
@@ -1133,6 +1135,8 @@ export const __test__ = {
   cleanupSummaryToast,
   convergeRequestBody,
   convergeWrongMatches,
+  deleteWrongMatch,
+  deleteWrongMatchGroup,
   deleteUnmatchedOnConverge,
   formatEntryEvidence,
   greenEntries,
@@ -1222,6 +1226,76 @@ export async function forceImportWrongMatch(logId, btn) {
   } catch (e) {
     btn.textContent = 'Error';
     toast('Force import request failed', true);
+  }
+}
+
+/**
+ * Delete one wrong-match source folder and remove it from review.
+ * @param {number} logId
+ * @param {HTMLButtonElement} btn
+ */
+export async function deleteWrongMatch(logId, btn) {
+  if (!confirm('Delete this wrong-match source folder?')) return;
+  btn.disabled = true;
+  btn.textContent = 'Deleting...';
+  try {
+    const r = await fetch(`${API}/api/wrong-matches/delete`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({download_log_id: logId}),
+    });
+    const data = await r.json();
+    if (r.ok && data.status === 'ok') {
+      toast(data.path_missing ? 'Cleared missing wrong match' : 'Deleted wrong match');
+      invalidateWrongMatches();
+      await _refreshWrongMatches();
+    } else {
+      btn.disabled = false;
+      btn.textContent = 'Delete';
+      toast(data.error || data.message || 'Delete failed', true);
+    }
+  } catch (_e) {
+    btn.disabled = false;
+    btn.textContent = 'Delete';
+    toast('Delete request failed', true);
+  }
+}
+
+/**
+ * Delete every current wrong-match source folder for one release group.
+ * @param {number} requestId
+ * @param {HTMLButtonElement} btn
+ */
+export async function deleteWrongMatchGroup(requestId, btn) {
+  const group = ((_lastData && Array.isArray(_lastData.groups)) ? _lastData.groups : [])
+    .find((/** @type {any} */ g) => Number(g.request_id) === Number(requestId));
+  const count = group ? (group.pending_count || (group.entries ? group.entries.length : 0)) : 0;
+  if (!confirm(`Delete all ${count} wrong-match candidate source folders for this release?`)) return;
+
+  btn.disabled = true;
+  btn.textContent = 'Deleting...';
+  try {
+    const r = await fetch(`${API}/api/wrong-matches/delete-group`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({request_id: requestId}),
+    });
+    const data = await r.json();
+    if (r.ok && (data.status === 'ok' || data.status === 'partial')) {
+      const skipped = data.skipped ? ` · skipped ${data.skipped}` : '';
+      const errors = data.errors ? ` · errors ${data.errors}` : '';
+      toast(`Deleted ${data.deleted || 0} candidates${skipped}${errors}`);
+      invalidateWrongMatches();
+      await _refreshWrongMatches();
+    } else {
+      btn.disabled = false;
+      btn.textContent = `Delete All (${count})`;
+      toast(data.error || data.message || 'Delete all failed', true);
+    }
+  } catch (_e) {
+    btn.disabled = false;
+    btn.textContent = `Delete All (${count})`;
+    toast('Delete all request failed', true);
   }
 }
 

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -24,6 +24,16 @@ from lib.wrong_match_cleanup_service import (
     cleanup_all_wrong_matches,
     cleanup_wrong_match,
 )
+from lib.wrong_match_delete_service import (
+    OUTCOME_DELETE_FAILED as DELETE_OUTCOME_FAILED,
+    OUTCOME_SKIPPED_ACTIVE_JOB as DELETE_OUTCOME_ACTIVE_JOB,
+    OUTCOME_SKIPPED_INVALID_ROW as DELETE_OUTCOME_INVALID_ROW,
+    OUTCOME_SKIPPED_LOCKED as DELETE_OUTCOME_LOCKED,
+    OUTCOME_SKIPPED_NOT_VISIBLE as DELETE_OUTCOME_NOT_VISIBLE,
+    OUTCOME_SKIPPED_UNSAFE_PATH as DELETE_OUTCOME_UNSAFE_PATH,
+    delete_wrong_match,
+    delete_wrong_match_group,
+)
 from lib.import_preview import (
     ImportPreviewValues,
     preview_import_from_download_log,
@@ -578,6 +588,69 @@ def _delete_wrong_match_row(pdb, log_id: int):
     return cleanup_wrong_match(pdb, log_id)
 
 
+def post_wrong_match_delete(h, body: dict) -> None:
+    """Operator-triggered deletion of one visible Wrong Matches candidate."""
+    raw_id = body.get("download_log_id")
+    try:
+        log_id = int(raw_id)
+    except (TypeError, ValueError):
+        h._error("download_log_id must be an integer")
+        return
+
+    result = delete_wrong_match(_server()._db(), log_id, require_visible=True)
+    if result.success:
+        h._json({"status": "ok", **result.to_dict()})
+        return
+    if result.outcome == DELETE_OUTCOME_ACTIVE_JOB:
+        h._error("active_import_job", 409)
+        return
+    if result.outcome == DELETE_OUTCOME_LOCKED:
+        h._error(result.reason or result.outcome, 503)
+        return
+    if result.outcome in (DELETE_OUTCOME_INVALID_ROW, DELETE_OUTCOME_NOT_VISIBLE):
+        h._error(result.reason or result.outcome, 404)
+        return
+    if result.outcome == DELETE_OUTCOME_UNSAFE_PATH:
+        h._error(result.reason or result.outcome, 422)
+        return
+    h._error(result.error or result.reason or result.outcome, 500)
+
+
+def post_wrong_match_delete_group(h, body: dict) -> None:
+    """Operator-triggered deletion of all current Wrong Matches for a request."""
+    raw_id = body.get("request_id")
+    try:
+        request_id = int(raw_id)
+    except (TypeError, ValueError):
+        h._error("request_id must be an integer")
+        return
+
+    summary = delete_wrong_match_group(_server()._db(), request_id)
+    status = "ok" if summary.success else "partial"
+    h._json(
+        {"status": status, **summary.to_dict()},
+        status=_wrong_match_delete_group_http_status(summary),
+    )
+
+
+def _wrong_match_delete_group_http_status(summary) -> int:
+    """Mirror the CLI status/exit-code precedence for group delete."""
+    if summary.success:
+        return 200
+    outcomes = {result.outcome for result in summary.results}
+    if DELETE_OUTCOME_FAILED in outcomes:
+        return 500
+    if DELETE_OUTCOME_LOCKED in outcomes:
+        return 503
+    if DELETE_OUTCOME_ACTIVE_JOB in outcomes:
+        return 409
+    if DELETE_OUTCOME_UNSAFE_PATH in outcomes:
+        return 422
+    if outcomes & {DELETE_OUTCOME_INVALID_ROW, DELETE_OUTCOME_NOT_VISIBLE}:
+        return 404
+    return 409
+
+
 def post_wrong_match_converge(h, body: dict) -> None:
     """Queue acceptable candidates and delete the rest for the release."""
     request_id = body.get("request_id")
@@ -606,6 +679,7 @@ def post_wrong_match_converge(h, body: dict) -> None:
 
     selected: list[dict[str, object]] = []
     unmatched: list[dict[str, object]] = []
+    green_candidates: list[dict[str, object]] = []
     skipped: list[dict[str, object]] = []
     jobs: list[dict[str, object]] = []
     unmatched_log_ids: list[int] = []
@@ -638,39 +712,16 @@ def post_wrong_match_converge(h, body: dict) -> None:
                 })
                 remaining += 1
                 continue
-            source_username_raw = (
-                row.get("soulseek_username")
-                or vr.get("soulseek_username")
-            )
-            source_username = (
-                str(source_username_raw)
-                if source_username_raw is not None else None
-            )
-            job = pdb.enqueue_import_job(
-                IMPORT_JOB_FORCE,
-                request_id=rid,
-                dedupe_key=force_import_dedupe_key(lid),
-                payload=force_import_payload(
-                    download_log_id=lid,
-                    failed_path=resolved_path,
-                    source_username=source_username,
-                    source_dirs=source_dirs_from_validation_result(vr),
-                ),
-                message=(
-                    f"Force import queued for "
-                    f"{req['artist_name']} - {req['album_title']}"
-                ),
-            )
-            if getattr(job, "deduped", False):
-                deduped += 1
-            jobs.append(_serialize_import_job(job))
-            selected.append({
+            green_candidates.append({
                 "download_log_id": lid,
                 "distance": distance,
-                "job_id": job.id,
-                "deduped": bool(getattr(job, "deduped", False)),
+                "failed_path": resolved_path,
+                "source_username": (
+                    row.get("soulseek_username")
+                    or vr.get("soulseek_username")
+                ),
+                "source_dirs": source_dirs_from_validation_result(vr),
             })
-            remaining += 1
             continue
 
         unmatched.append({
@@ -679,7 +730,40 @@ def post_wrong_match_converge(h, body: dict) -> None:
         })
         unmatched_log_ids.append(lid)
 
-    if selected:
+    for candidate in green_candidates:
+        lid = candidate["download_log_id"]
+        source_username_raw = candidate.get("source_username")
+        source_username = (
+            str(source_username_raw)
+            if source_username_raw is not None else None
+        )
+        job = pdb.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=rid,
+            dedupe_key=force_import_dedupe_key(lid),
+            payload=force_import_payload(
+                download_log_id=lid,
+                failed_path=str(candidate["failed_path"]),
+                source_username=source_username,
+                source_dirs=list(candidate["source_dirs"]),
+            ),
+            message=(
+                f"Force import queued for "
+                f"{req['artist_name']} - {req['album_title']}"
+            ),
+        )
+        if getattr(job, "deduped", False):
+            deduped += 1
+        jobs.append(_serialize_import_job(job))
+        selected.append({
+            "download_log_id": lid,
+            "distance": candidate["distance"],
+            "job_id": job.id,
+            "deduped": bool(getattr(job, "deduped", False)),
+        })
+        remaining += 1
+
+    if green_candidates:
         for lid in unmatched_log_ids:
             result = _delete_wrong_match_row(pdb, lid)
             if result.outcome == OUTCOME_DELETED:
@@ -791,6 +875,8 @@ GET_ROUTES: dict[str, object] = {
 POST_ROUTES: dict[str, object] = {
     "/api/manual-import/import": post_manual_import,
     "/api/import-preview": post_import_preview,
+    "/api/wrong-matches/delete": post_wrong_match_delete,
+    "/api/wrong-matches/delete-group": post_wrong_match_delete_group,
     "/api/wrong-matches/converge": post_wrong_match_converge,
     "/api/wrong-matches/triage": post_wrong_match_triage,
 }


### PR DESCRIPTION
## Summary
- Restore per-row Delete and group Delete All controls for Wrong Matches.
- Route manual/failed force-import cleanup through a shared delete service that does not re-run quality decisions.
- Clear exact duplicate wrong-match rows safely with active-job, advisory-lock, path-scope, API, and CLI parity guards.
- Queue converge imports before destructive unmatched cleanup and preserve the quality-pipeline decision boundary.

## Verification
- nix-shell --run "bash scripts/run_tests.sh" (3464 tests, 56 skipped)
- Targeted route/CLI/delete/force-import tests after final parity fix
- git diff --check