### PR TITLE
fix(recents): mark cleared wrong-match rejects

### DIFF
--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -175,6 +175,30 @@ console.log('renderImportQueueItems() prefers terminal import messages over stal
     'stale preview message hidden for terminal rows');
 }
 
+console.log('renderImportQueueItems() surfaces failed force-import source cleanup');
+{
+  const html = __test__.renderImportQueueItems([{
+    id: 40636,
+    job_type: 'force_import',
+    status: 'failed',
+    preview_status: 'evidence_ready',
+    artist_name: 'Parts & Labor',
+    album_title: 'Escapers Two',
+    message: 'Rejected by persisted quality evidence: downgrade',
+    result: {
+      cleanup: {
+        success: true,
+        outcome: 'deleted',
+        deleted_path: '/mnt/virtio/music/slskd/failed_imports/Parts & Labor - Escapers Two (2007)',
+      },
+    },
+  }]);
+  assertContains(html, 'source deleted',
+    'cleanup-success chip rendered on failed force-import row');
+  assertContains(html, 'Parts &amp; Labor - Escapers Two',
+    'cleanup path is escaped in chip hover text');
+}
+
 console.log('renderDownloadingItems() shows current file progress and user');
 {
   const html = __test__.renderDownloadingItems([{
@@ -294,6 +318,46 @@ console.log('renderRecentsItems() escapes wrong-match triage chip fields');
     'triage detail is escaped');
   assertExcludes(html, '<img src=x>',
     'raw triage summary is not rendered');
+}
+
+console.log('renderRecentsItems() distinguishes rejected history from actionable Wrong Matches');
+{
+  const html = __test__.renderRecentsItems([{
+    id: 15838,
+    request_id: 2762,
+    outcome: 'rejected',
+    created_at: '2026-05-16T16:19:59+00:00',
+    album_title: 'Escapers Two',
+    artist_name: 'Parts & Labor',
+    badge: 'Rejected',
+    badge_class: 'badge-rejected',
+    border_color: '#a33',
+    summary: 'downgrade · AliceLo',
+    validation_result: null,
+  }]);
+  assertContains(html, 'not in Wrong Matches',
+    'rejected history row with no failed_path is marked non-actionable');
+}
+
+console.log('renderRecentsItems() does not mark visible wrong-match rows as cleared');
+{
+  const html = __test__.renderRecentsItems([{
+    id: 14534,
+    request_id: 2762,
+    outcome: 'rejected',
+    created_at: '2026-05-15T08:02:42+00:00',
+    album_title: 'Escapers Two',
+    artist_name: 'Parts & Labor',
+    badge: 'Rejected',
+    badge_class: 'badge-rejected',
+    border_color: '#a33',
+    summary: 'Wrong match (dist 0.167) · AliceLo',
+    validation_result: {
+      failed_path: '/mnt/virtio/music/slskd/failed_imports/Parts & Labor - Escapers Two (2007)',
+    },
+  }]);
+  assertExcludes(html, 'not in Wrong Matches',
+    'actionable row with failed_path does not get cleared chip');
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/web/js/recents.js
+++ b/web/js/recents.js
@@ -76,6 +76,7 @@ export function renderRecentsItems(items, matchRates = null) {
       const triageChip = triageSummary
         ? `<span class="badge badge-warn" title="${esc(triageDetail)}">triage: ${esc(triageSummary)}</span>`
         : '';
+      const clearedChip = clearedWrongMatchChip(item);
 
       // Search-plan inspector button — Recents rows always render the
       // button. Use the request_id (the album_requests.id) since the
@@ -86,7 +87,7 @@ export function renderRecentsItems(items, matchRates = null) {
         <div class="r-item" style="border-left-color:${borderColor}" onclick="window.toggleDetail('dl-${item.id}', ${item.request_id})">
           <div class="p-top">
             <div>
-              <div class="p-title">${esc(item.album_title)} <span class="badge ${badgeClass}">${badge}</span>${disambigChip}${badExtChip}${triageChip}</div>
+              <div class="p-title">${esc(item.album_title)} <span class="badge ${badgeClass}">${badge}</span>${disambigChip}${badExtChip}${triageChip}${clearedChip}</div>
               <div class="p-artist">${esc(item.artist_name)}</div>
             </div>
             <div class="p-row-actions">${spBtn}<span style="font-size:0.75em;color:#666;">${time}</span></div>
@@ -107,6 +108,30 @@ function renderRecentsDateHeader(date, matchRates) {
     <span>${date}</span>
     <span class="recents-date-metrics">6h ${formatMatchRate(matchRates.matches_per_hour_6h)} match/hr · 24h ${formatMatchRate(matchRates.matches_per_hour_24h)} match/hr</span>
   </div>`;
+}
+
+function validationResultDict(raw) {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) return raw;
+  if (typeof raw === 'string' && raw.length) {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+    } catch (_e) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function hasFailedPath(raw) {
+  const validationResult = validationResultDict(raw);
+  return Boolean(validationResult && validationResult.failed_path);
+}
+
+function clearedWrongMatchChip(item) {
+  if (item.outcome !== 'rejected') return '';
+  if (hasFailedPath(item.validation_result)) return '';
+  return '<span class="badge badge-library" title="No failed_path remains on this rejected history row.">not in Wrong Matches</span>';
 }
 
 function queueBadge(job, index) {
@@ -144,6 +169,22 @@ function queueMessage(job) {
   return job.preview_message || job.message || job.preview_error || job.error || '';
 }
 
+function jobCleanupChip(job) {
+  const cleanup = job && job.result && typeof job.result === 'object'
+    ? job.result.cleanup
+    : null;
+  if (!cleanup || typeof cleanup !== 'object') return '';
+  if (cleanup.outcome === 'deleted' && cleanup.success) {
+    const path = cleanup.deleted_path || cleanup.resolved_path || '';
+    return `<span class="badge badge-library" title="${esc(path)}">source deleted</span>`;
+  }
+  if (cleanup.skipped || cleanup.outcome) {
+    const reason = cleanup.reason || cleanup.error || cleanup.outcome || 'cleanup skipped';
+    return `<span class="badge badge-warn" title="${esc(reason)}">cleanup: ${esc(cleanup.outcome || 'skipped')}</span>`;
+  }
+  return '';
+}
+
 /**
  * Render import queue timeline rows.
  * @param {Array<Object>} jobs
@@ -164,6 +205,7 @@ export function renderImportQueueItems(jobs) {
       job.preview_status ? `preview: ${job.preview_status}` : '',
       job.status ? `import: ${job.status}` : '',
     ].filter(Boolean).join(' · ');
+    const cleanupChip = jobCleanupChip(job);
     // Search-plan inspector button — Recents queue rows render the
     // button when the import job is bound to a pipeline request. Orphan
     // imports (job.request_id null) get nothing — the conditional in
@@ -173,7 +215,7 @@ export function renderImportQueueItems(jobs) {
       <div class="r-item" style="border-left-color:${queueBorderColor(job)}">
         <div class="p-top">
           <div>
-            <div class="p-title">${esc(title)} <span class="badge ${badgeClass}">${esc(badge)}</span></div>
+            <div class="p-title">${esc(title)} <span class="badge ${badgeClass}">${esc(badge)}</span>${cleanupChip}</div>
             <div class="p-artist">${esc(artist)}</div>
           </div>
           <div class="p-row-actions">${spBtn}<span style="font-size:0.75em;color:#666;">#${job.id}</span></div>


### PR DESCRIPTION
## Summary
- show a `not in Wrong Matches` chip on rejected Recents history rows with no remaining `failed_path`
- show a `source deleted` chip on failed import-queue rows when wrong-match cleanup succeeded
- cover both states in the Recents JS unit test

## Verification
- `node tests/test_js_recents.mjs`
- `nix-shell --run "node tests/test_js_recents.mjs"`
- `git diff --check`