### PR TITLE
fix: restore recents downgrade explanations

### DIFF
--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -320,7 +320,7 @@ console.log('renderRecentsItems() escapes wrong-match triage chip fields');
     'raw triage summary is not rendered');
 }
 
-console.log('renderRecentsItems() distinguishes rejected history from actionable Wrong Matches');
+console.log('renderRecentsItems() does not mark rejected history as cleared wrong-matches');
 {
   const html = __test__.renderRecentsItems([{
     id: 15838,
@@ -335,8 +335,8 @@ console.log('renderRecentsItems() distinguishes rejected history from actionable
     summary: 'downgrade · AliceLo',
     validation_result: null,
   }]);
-  assertContains(html, 'not in Wrong Matches',
-    'rejected history row with no failed_path is marked non-actionable');
+  assertExcludes(html, 'not in Wrong Matches',
+    'ordinary rejected history row is not labelled as a wrong-match cleanup result');
 }
 
 console.log('renderRecentsItems() does not mark visible wrong-match rows as cleared');

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -650,6 +650,38 @@ class TestClassifyVerdict(unittest.TestCase):
         self.assertIn("320", result.verdict)
         self.assertIn("not", result.verdict.lower())
 
+    def test_persisted_quality_downgrade_verdict_uses_import_result(self):
+        """Auto-import rows may store the quality-pipeline decision as the
+        scenario. Recents must still show the comparison, not bare
+        "downgrade".
+        """
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="downgrade",
+            soulseek_username="CondosInQueens",
+            import_result={
+                "version": 2,
+                "exit_code": 5,
+                "decision": "downgrade",
+                "new_measurement": {
+                    "min_bitrate_kbps": 159,
+                    "avg_bitrate_kbps": 159,
+                    "spectral_bitrate_kbps": 160,
+                    "spectral_grade": "likely_transcode",
+                    "format": "MP3",
+                },
+                "existing_measurement": {
+                    "min_bitrate_kbps": 192,
+                    "avg_bitrate_kbps": 192,
+                    "format": "MP3",
+                },
+            },
+        ))
+        self.assertNotEqual(result.verdict, "downgrade")
+        self.assertIn("159", result.verdict)
+        self.assertIn("192", result.verdict)
+        self.assertIn("CondosInQueens", result.summary)
+
     def test_spectral_reject_verdict(self):
         result = classify_log_entry(_entry(
             outcome="rejected", beets_scenario="spectral_reject",

--- a/web/classify.py
+++ b/web/classify.py
@@ -846,6 +846,7 @@ def _rejection_verdict(entry: LogEntry) -> str:
 
     # Quality comparison scenarios — delegate to ImportResult when available
     if scenario in (
+        "downgrade",
         "quality_downgrade",
         "transcode_downgrade",
         "suspect_lossless_downgrade",

--- a/web/js/recents.js
+++ b/web/js/recents.js
@@ -76,7 +76,6 @@ export function renderRecentsItems(items, matchRates = null) {
       const triageChip = triageSummary
         ? `<span class="badge badge-warn" title="${esc(triageDetail)}">triage: ${esc(triageSummary)}</span>`
         : '';
-      const clearedChip = clearedWrongMatchChip(item);
 
       // Search-plan inspector button — Recents rows always render the
       // button. Use the request_id (the album_requests.id) since the
@@ -87,7 +86,7 @@ export function renderRecentsItems(items, matchRates = null) {
         <div class="r-item" style="border-left-color:${borderColor}" onclick="window.toggleDetail('dl-${item.id}', ${item.request_id})">
           <div class="p-top">
             <div>
-              <div class="p-title">${esc(item.album_title)} <span class="badge ${badgeClass}">${badge}</span>${disambigChip}${badExtChip}${triageChip}${clearedChip}</div>
+              <div class="p-title">${esc(item.album_title)} <span class="badge ${badgeClass}">${badge}</span>${disambigChip}${badExtChip}${triageChip}</div>
               <div class="p-artist">${esc(item.artist_name)}</div>
             </div>
             <div class="p-row-actions">${spBtn}<span style="font-size:0.75em;color:#666;">${time}</span></div>
@@ -108,30 +107,6 @@ function renderRecentsDateHeader(date, matchRates) {
     <span>${date}</span>
     <span class="recents-date-metrics">6h ${formatMatchRate(matchRates.matches_per_hour_6h)} match/hr · 24h ${formatMatchRate(matchRates.matches_per_hour_24h)} match/hr</span>
   </div>`;
-}
-
-function validationResultDict(raw) {
-  if (raw && typeof raw === 'object' && !Array.isArray(raw)) return raw;
-  if (typeof raw === 'string' && raw.length) {
-    try {
-      const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
-    } catch (_e) {
-      return null;
-    }
-  }
-  return null;
-}
-
-function hasFailedPath(raw) {
-  const validationResult = validationResultDict(raw);
-  return Boolean(validationResult && validationResult.failed_path);
-}
-
-function clearedWrongMatchChip(item) {
-  if (item.outcome !== 'rejected') return '';
-  if (hasFailedPath(item.validation_result)) return '';
-  return '<span class="badge badge-library" title="No failed_path remains on this rejected history row.">not in Wrong Matches</span>';
 }
 
 function queueBadge(job, index) {


### PR DESCRIPTION
## Summary
- render persisted quality-pipeline downgrade rows using the ImportResult comparison instead of a bare `downgrade` label
- remove the misleading `not in Wrong Matches` chip from normal rejected history rows

## Tests
- nix-shell --run "python3 -m unittest tests.test_web_recents -v"
- nix-shell --run "node tests/test_js_recents.mjs"
- git diff --check