### PR TITLE
fix: keep recents triage labels visible

### DIFF
--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -79,6 +79,16 @@ console.log('renderRecentsCounts() stays focused on history filters');
   assertExcludes(html, 'match/hr', 'match rates are not rendered in count cards');
 }
 
+console.log('recentsLogUrl() requests enough history for triage labels');
+{
+  state.recentsFilter = 'all';
+  assertContains(__test__.recentsLogUrl(), '/api/pipeline/log?limit=500',
+    'all recents requests the expanded bounded history window');
+  state.recentsFilter = 'rejected';
+  assertContains(__test__.recentsLogUrl(), '/api/pipeline/log?outcome=rejected&limit=500',
+    'filtered recents keeps outcome filter and expanded limit');
+}
+
 console.log('renderRecentsItems() shows match rates beside the first date header');
 {
   const html = __test__.renderRecentsItems([

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -607,6 +607,16 @@ class TestServerEndpoints(unittest.TestCase):
         self.assertEqual(status, 200)
         self.mock_db.get_log.assert_called_with(limit=50, outcome_filter="rejected")
 
+    def test_pipeline_log_limit_param(self):
+        status, data = self._get("/api/pipeline/log?outcome=rejected&limit=300")
+        self.assertEqual(status, 200)
+        self.mock_db.get_log.assert_called_with(limit=300, outcome_filter="rejected")
+
+    def test_pipeline_log_limit_param_is_capped(self):
+        status, data = self._get("/api/pipeline/log?limit=5000")
+        self.assertEqual(status, 200)
+        self.mock_db.get_log.assert_called_with(limit=500, outcome_filter=None)
+
     def test_pipeline_log_filter_invalid_ignored(self):
         status, data = self._get("/api/pipeline/log?outcome=badvalue")
         self.assertEqual(status, 200)

--- a/web/js/recents.js
+++ b/web/js/recents.js
@@ -4,6 +4,8 @@ import { awstDate, awstTime, esc } from './util.js';
 import { toggleDetail } from './pipeline.js';
 import { renderSearchPlanButton } from './search_plan.js';
 
+const RECENTS_HISTORY_LIMIT = 500;
+
 /**
  * Set the recents filter and reload.
  * @param {string} f
@@ -29,6 +31,13 @@ function renderRecentsSubnav() {
     <button class="p-btn ${state.recentsSub === 'queue' ? 'active-status' : ''}" onclick="window.setRecentsSub('queue')">Queue</button>
     <button class="p-btn subtab-refresh" onclick="window.loadRecents()">Refresh</button>
   </div>`;
+}
+
+function recentsLogUrl() {
+  const params = new URLSearchParams();
+  if (state.recentsFilter !== 'all') params.set('outcome', state.recentsFilter);
+  params.set('limit', String(RECENTS_HISTORY_LIMIT));
+  return `${API}/api/pipeline/log?${params.toString()}`;
 }
 
 /**
@@ -433,8 +442,7 @@ export async function loadRecents() {
   }
   el.innerHTML = renderRecentsSubnav() + '<div class="loading">Loading...</div>';
   try {
-    const filterParam = state.recentsFilter === 'all' ? '' : `?outcome=${state.recentsFilter}`;
-    const r = await fetch(`${API}/api/pipeline/log${filterParam}`);
+    const r = await fetch(recentsLogUrl());
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const data = await r.json();
     const items = data.log || [];
@@ -453,6 +461,7 @@ export async function loadRecents() {
 export const __test__ = {
   hasMatchRates,
   matchRatesFromDashboardWindows,
+  recentsLogUrl,
   renderDownloadingItems,
   renderImportQueueItems,
   renderRecentsCounts,

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -39,6 +39,9 @@ from web import discogs as discogs_api
 from web import cache as cache_api
 from web.wrong_match_file_service import source_dirs_from_validation_result
 
+DEFAULT_PIPELINE_LOG_LIMIT = 50
+MAX_PIPELINE_LOG_LIMIT = 500
+
 
 def _generate_plan_after_add(req_id, *, artist_name, album_title, year,
                               tracks, source):
@@ -75,6 +78,16 @@ def _server():
     from web import server
     return server
 
+
+def _pipeline_log_limit(params: dict[str, list[str]]) -> int:
+    raw = params.get("limit", [str(DEFAULT_PIPELINE_LOG_LIMIT)])[0]
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_PIPELINE_LOG_LIMIT
+    return max(1, min(limit, MAX_PIPELINE_LOG_LIMIT))
+
+
 # ── GET handlers ─────────────────────────────────────────────────
 
 
@@ -82,7 +95,10 @@ def get_pipeline_log(h, params: dict[str, list[str]]) -> None:
     outcome_filter = params.get("outcome", [None])[0]
     if outcome_filter not in (None, "imported", "rejected"):
         outcome_filter = None
-    entries = _server()._db().get_log(limit=50, outcome_filter=outcome_filter)
+    entries = _server()._db().get_log(
+        limit=_pipeline_log_limit(params),
+        outcome_filter=outcome_filter,
+    )
     mbids = list(set(e["mb_release_id"] for e in entries if e.get("mb_release_id")))
     beets_info = _server().check_beets_library_detail(mbids) if mbids else {}
     result = []


### PR DESCRIPTION
## Summary
- add a capped `limit` parameter to `/api/pipeline/log`
- have the Recents history tab request 500 rows so recently triaged Wrong Matches do not immediately fall out of the feed
- keep the existing triage-chip rendering unchanged

## Tests
- nix-shell --run "python3 -m unittest tests.test_web_server.TestServerEndpoints.test_pipeline_log_filter_imported tests.test_web_server.TestServerEndpoints.test_pipeline_log_filter_rejected tests.test_web_server.TestServerEndpoints.test_pipeline_log_limit_param tests.test_web_server.TestServerEndpoints.test_pipeline_log_limit_param_is_capped tests.test_web_server.TestServerEndpoints.test_pipeline_log_filter_invalid_ignored -v"
- nix-shell --run "node tests/test_js_recents.mjs"
- git diff --check