### PR TITLE
fix: Wrong Matches cleanup ↔ force-import parity (#268)

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -45,7 +45,7 @@ from lib.import_evidence import (
     CandidateEvidenceActionResult,
     CURRENT_STATUS_MISSING,
     ensure_candidate_evidence_for_action,
-    ensure_current_evidence_for_action,
+    load_current_evidence_for_action,
 )
 from lib.processing_paths import normalize_source_dirs
 from lib.util import (beets_subprocess_env, cleanup_disambiguation_orphans,
@@ -595,47 +595,22 @@ def _load_evidence_import_gate(
             snapshot_guard=candidate_result.provenance.snapshot_guard,
         )
 
-    try:
-        from lib.beets_db import BeetsDB
-        from lib.quality import QualityRankConfig
-
-        cfg = quality_ranks if quality_ranks is not None else QualityRankConfig.defaults()
-        with BeetsDB(library_root=beets_library_root) as beets:
-            album_info = beets.get_album_info(mb_release_id, cfg)
-        if album_info is None:
-            return EvidenceImportGate(
-                current=None,
-                candidate=candidate_result.evidence,
-                candidate_status=candidate_result.provenance.candidate_status,
-                candidate_reason=candidate_result.provenance.fallback_reason,
-                current_status=CURRENT_STATUS_MISSING,
-                current_reason="album not in beets",
-                current_fail_closed=False,
-                snapshot_guard=candidate_result.provenance.snapshot_guard,
-            )
-        current_result = ensure_current_evidence_for_action(
-            db,
-            request_id=request_id,
-            mb_release_id=mb_release_id,
-            quality_ranks=quality_ranks,
-            current_album_path=album_info.album_path,
-            album_info=album_info,
-            beets_library_root=beets_library_root,
-        )
-    except Exception as exc:
-        logger.debug(
-            "Failed to load/backfill current quality evidence for request %s",
-            request_id,
-            exc_info=True,
-        )
+    current_result = load_current_evidence_for_action(
+        db,
+        request_id=request_id,
+        mb_release_id=mb_release_id,
+        quality_ranks=quality_ranks,
+        beets_library_root=beets_library_root,
+    )
+    if current_result is None:
         return EvidenceImportGate(
             current=None,
             candidate=candidate_result.evidence,
             candidate_status=candidate_result.provenance.candidate_status,
             candidate_reason=candidate_result.provenance.fallback_reason,
-            current_status="failed",
-            current_reason=f"{type(exc).__name__}: {exc}",
-            current_fail_closed=True,
+            current_status=CURRENT_STATUS_MISSING,
+            current_reason="album not in beets",
+            current_fail_closed=False,
             snapshot_guard=candidate_result.provenance.snapshot_guard,
         )
 

--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -241,7 +241,7 @@ def load_current_evidence_for_action(
     *,
     request_id: int,
     mb_release_id: str,
-    quality_ranks: "QualityRankConfig | None" = None,
+    quality_ranks: QualityRankConfig | None = None,
     beets_library_root: str = "",
 ) -> CurrentEvidenceActionResult | None:
     """Look Beets up by MBID then load/backfill; return None if no album, fail-closed on error."""

--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -8,11 +8,12 @@ columns as mutation authority.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable
 
 import msgspec
 
-from lib.quality import AlbumQualityEvidence
+from lib.quality import AlbumQualityEvidence, QualityRankConfig
 from lib.quality_evidence import (
     EvidenceBuildResult,
     audio_snapshot_matches,
@@ -20,6 +21,8 @@ from lib.quality_evidence import (
     load_candidate_evidence_for_source,
     load_or_backfill_current_evidence,
 )
+
+logger = logging.getLogger("cratedigger")
 
 
 CANDIDATE_STATUS_REUSED = "reused"
@@ -48,6 +51,7 @@ __all__ = [
     "CurrentEvidenceActionResult",
     "ensure_candidate_evidence_for_action",
     "ensure_current_evidence_for_action",
+    "load_current_evidence_for_action",
 ]
 
 
@@ -230,6 +234,49 @@ def ensure_current_evidence_for_action(
             fail_closed=True,
         ),
     )
+
+
+def load_current_evidence_for_action(
+    db: Any,
+    *,
+    request_id: int,
+    mb_release_id: str,
+    quality_ranks: "QualityRankConfig | None" = None,
+    beets_library_root: str = "",
+) -> CurrentEvidenceActionResult | None:
+    """Look Beets up by MBID then load/backfill; return None if no album, fail-closed on error."""
+
+    cfg = quality_ranks if quality_ranks is not None else QualityRankConfig.defaults()
+    try:
+        from lib.beets_db import BeetsDB
+
+        with BeetsDB(library_root=beets_library_root) as beets:
+            album_info = beets.get_album_info(mb_release_id, cfg)
+        if album_info is None:
+            return None
+        return ensure_current_evidence_for_action(
+            db,
+            request_id=request_id,
+            mb_release_id=mb_release_id,
+            quality_ranks=cfg,
+            current_album_path=album_info.album_path,
+            album_info=album_info,
+            beets_library_root=beets_library_root,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Failed to load/backfill current quality evidence for request %s",
+            request_id,
+            exc_info=True,
+        )
+        return CurrentEvidenceActionResult(
+            evidence=None,
+            provenance=ActionEvidenceProvenance(
+                current_status=CURRENT_STATUS_FAILED,
+                fallback_reason=f"{type(exc).__name__}: {exc}",
+                fail_closed=True,
+            ),
+        )
 
 
 def _candidate_action_status(status: str) -> str:

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable
 
 import msgspec
 
+from lib.import_evidence import load_current_evidence_for_action
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_WRONG_MATCH_CLEANUP,
     wrong_match_cleanup_lock_key,
@@ -20,7 +21,6 @@ from lib.quality import (
     evidence_decision_name,
     full_pipeline_decision_from_evidence,
 )
-from lib.quality_evidence import audio_snapshot_matches
 from lib.quality_evidence import load_candidate_evidence_for_source
 from lib.util import resolve_failed_path
 from lib.wrong_matches import cleanup_wrong_match_source, validation_failed_path
@@ -34,6 +34,7 @@ OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING = "skipped_candidate_evidence_missing
 OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE = "skipped_candidate_evidence_stale"
 OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING = "skipped_current_evidence_missing"
 OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE = "skipped_current_evidence_stale"
+OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED = "skipped_current_evidence_failed"
 OUTCOME_SKIPPED_ACTIVE_JOB = "skipped_active_job"
 OUTCOME_SKIPPED_INVALID_ROW = "skipped_invalid_row"
 OUTCOME_SKIPPED_MISSING_PATH = "skipped_missing_path"
@@ -48,6 +49,7 @@ OUTCOME_KEYS: tuple[str, ...] = (
     OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
     OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
     OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE,
+    OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED,
     OUTCOME_SKIPPED_ACTIVE_JOB,
     OUTCOME_SKIPPED_INVALID_ROW,
     OUTCOME_SKIPPED_MISSING_PATH,
@@ -92,6 +94,7 @@ class WrongMatchCleanupSummary(msgspec.Struct, frozen=True):
     skipped_candidate_evidence_stale: int = 0
     skipped_current_evidence_missing: int = 0
     skipped_current_evidence_stale: int = 0
+    skipped_current_evidence_failed: int = 0
     skipped_active_job: int = 0
     skipped_invalid_row: int = 0
     skipped_missing_path: int = 0
@@ -254,20 +257,43 @@ def _cleanup_wrong_match(
             reason=candidate.reason,
         )
 
-    current = _load_current_evidence(db, request, request_id)
-    if current.outcome is not None:
-        return _result(
-            download_log_id,
-            current.outcome,
-            request_id=request_id,
-            source_path=resolved_path,
-            reason=current.reason,
-        )
-
     runtime_cfg = cfg if cfg is not None else _runtime_config()
+    mb_release_id_raw = request.get("mb_release_id")
+    mb_release_id = str(mb_release_id_raw) if mb_release_id_raw else None
+    beets_library_root = getattr(runtime_cfg, "beets_directory", "") or ""
+    current_evidence: AlbumQualityEvidence | None = None
+    if mb_release_id is not None:
+        current_result = load_current_evidence_for_action(
+            db,
+            request_id=request_id,
+            mb_release_id=mb_release_id,
+            quality_ranks=getattr(runtime_cfg, "quality_ranks", None),
+            beets_library_root=beets_library_root,
+        )
+        if current_result is not None:
+            if current_result.provenance.fail_closed:
+                return _result(
+                    download_log_id,
+                    OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED,
+                    request_id=request_id,
+                    source_path=resolved_path,
+                    reason=current_result.provenance.fallback_reason
+                    or "current_evidence_unavailable",
+                )
+            if not current_result.available:
+                return _result(
+                    download_log_id,
+                    OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
+                    request_id=request_id,
+                    source_path=resolved_path,
+                    reason=current_result.provenance.fallback_reason
+                    or "current_evidence_unavailable",
+                )
+            current_evidence = current_result.evidence
+
     decision = full_pipeline_decision_from_evidence(
         candidate.evidence,
-        current.evidence,
+        current_evidence,
         facts=AlbumQualityEvidenceDecisionFacts(
             import_mode="force",
             verified_lossless_target=getattr(
@@ -426,46 +452,6 @@ def _load_candidate_evidence(
     )
 
 
-def _load_current_evidence(
-    db: Any,
-    request: dict[str, Any],
-    request_id: int,
-) -> _LoadedEvidence:
-    current_path = request.get("imported_path")
-    current_required = bool(current_path) or request.get("status") == "imported"
-    if not current_required:
-        return _LoadedEvidence(None)
-
-    evidence_id = db.get_request_current_evidence_id(request_id)
-    if evidence_id is None:
-        return _LoadedEvidence(
-            None,
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
-            "current_evidence_fk_missing",
-        )
-    evidence = db.load_album_quality_evidence_by_id(evidence_id)
-    if evidence is None:
-        return _LoadedEvidence(
-            None,
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
-            f"current_evidence_id_{evidence_id}_missing",
-        )
-    if not current_path or not audio_snapshot_matches(str(current_path), evidence.files):
-        return _LoadedEvidence(
-            None,
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE,
-            "current_album_changed_since_evidence_capture",
-        )
-    reasons = evidence.policy_incomplete_reasons()
-    if reasons:
-        return _LoadedEvidence(
-            None,
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
-            "; ".join(reasons),
-        )
-    return _LoadedEvidence(evidence)
-
-
 def _matching_active_jobs(
     db: Any,
     *,
@@ -564,6 +550,9 @@ def _summary(
         ],
         skipped_current_evidence_stale=counts[
             OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE
+        ],
+        skipped_current_evidence_failed=counts[
+            OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED
         ],
         skipped_active_job=counts[OUTCOME_SKIPPED_ACTIVE_JOB],
         skipped_invalid_row=counts[OUTCOME_SKIPPED_INVALID_ROW],

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable
 
 import msgspec
 
-from lib.import_evidence import load_current_evidence_for_action
+from lib.import_evidence import CURRENT_STATUS_LOADED, load_current_evidence_for_action
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_WRONG_MATCH_CLEANUP,
     wrong_match_cleanup_lock_key,
@@ -126,6 +126,9 @@ def cleanup_all_wrong_matches(
     """Run cleanup over the full current Wrong Matches queue."""
     if confirm_all_wrong_matches is not True:
         raise ValueError("confirm_all_wrong_matches must be true")
+
+    if cfg is None:
+        cfg = _runtime_config()
 
     results: list[WrongMatchCleanupOutcome] = []
     for row in db.get_wrong_matches():
@@ -266,6 +269,7 @@ def _cleanup_wrong_match(
     mb_release_id = str(mb_release_id_raw) if mb_release_id_raw else None
     beets_library_root = getattr(runtime_cfg, "beets_directory", "") or ""
     current_evidence: AlbumQualityEvidence | None = None
+    current_evidence_status: str | None = None
     if mb_release_id is not None:
         current_result = load_current_evidence_for_action(
             db,
@@ -294,10 +298,18 @@ def _cleanup_wrong_match(
                     or "current_evidence_unavailable",
                 )
             current_evidence = current_result.evidence
+            current_evidence_status = current_result.provenance.current_status
 
+    # Cleanup-only policy (NOT a quality decision): when the in-Beets parent is
+    # verified-lossless AND the evidence was loaded directly from disk (not
+    # backfilled, which can preserve a stale verified_lossless_proof against
+    # changed audio), any candidate in Wrong Matches against this MBID is
+    # guaranteed to lose the upgrade gate. Short-circuit deletion. The reducer
+    # is deliberately not called -- see TestVerifiedLosslessShortCircuit.
     if (
         current_evidence is not None
         and current_evidence.verified_lossless_proof is not None
+        and current_evidence_status == CURRENT_STATUS_LOADED
     ):
         return _perform_cleanup_deletion(
             db,

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -28,6 +28,7 @@ from lib.wrong_matches import cleanup_wrong_match_source, validation_failed_path
 logger = logging.getLogger("cratedigger")
 
 OUTCOME_DELETED = "deleted"
+OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT = "deleted_verified_lossless_parent"
 OUTCOME_KEPT_WOULD_IMPORT = "kept_would_import"
 OUTCOME_KEPT_UNCERTAIN = "kept_uncertain"
 OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING = "skipped_candidate_evidence_missing"
@@ -43,6 +44,7 @@ OUTCOME_DELETE_FAILED = "delete_failed"
 
 OUTCOME_KEYS: tuple[str, ...] = (
     OUTCOME_DELETED,
+    OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT,
     OUTCOME_KEPT_WOULD_IMPORT,
     OUTCOME_KEPT_UNCERTAIN,
     OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
@@ -59,6 +61,7 @@ OUTCOME_KEYS: tuple[str, ...] = (
 
 FINAL_AUDIT_OUTCOMES: frozenset[str] = frozenset({
     OUTCOME_DELETED,
+    OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT,
     OUTCOME_KEPT_WOULD_IMPORT,
     OUTCOME_KEPT_UNCERTAIN,
     OUTCOME_DELETE_FAILED,
@@ -88,6 +91,7 @@ class WrongMatchCleanupOutcome(msgspec.Struct, frozen=True):
 class WrongMatchCleanupSummary(msgspec.Struct, frozen=True):
     processed: int = 0
     deleted: int = 0
+    deleted_verified_lossless_parent: int = 0
     kept_would_import: int = 0
     kept_uncertain: int = 0
     skipped_candidate_evidence_missing: int = 0
@@ -291,6 +295,26 @@ def _cleanup_wrong_match(
                 )
             current_evidence = current_result.evidence
 
+    if (
+        current_evidence is not None
+        and current_evidence.verified_lossless_proof is not None
+    ):
+        return _perform_cleanup_deletion(
+            db,
+            download_log_id=download_log_id,
+            request_id=request_id,
+            resolved_path=resolved_path,
+            candidates=tuple(candidates),
+            source_dirs=tuple(source_dirs),
+            ignore_import_job_id=ignore_import_job_id,
+            success_outcome=OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT,
+            reason="parent_album_verified_lossless",
+            verdict="confident_reject",
+            preview_decision="verified_lossless_parent",
+            cleanup_eligible=True,
+            decision=None,
+        )
+
     decision = full_pipeline_decision_from_evidence(
         candidate.evidence,
         current_evidence,
@@ -333,6 +357,40 @@ def _cleanup_wrong_match(
             decision=decision,
         )
 
+    return _perform_cleanup_deletion(
+        db,
+        download_log_id=download_log_id,
+        request_id=request_id,
+        resolved_path=resolved_path,
+        candidates=tuple(candidates),
+        source_dirs=tuple(source_dirs),
+        ignore_import_job_id=ignore_import_job_id,
+        success_outcome=OUTCOME_DELETED,
+        reason=reason,
+        verdict=verdict,
+        preview_decision=preview_decision,
+        cleanup_eligible=cleanup_eligible,
+        decision=decision,
+    )
+
+
+def _perform_cleanup_deletion(
+    db: Any,
+    *,
+    download_log_id: int,
+    request_id: int,
+    resolved_path: str,
+    candidates: tuple[str, ...],
+    source_dirs: tuple[str, ...],
+    ignore_import_job_id: int | None,
+    success_outcome: str,
+    reason: str | None,
+    verdict: str | None,
+    preview_decision: str | None,
+    cleanup_eligible: bool,
+    decision: dict[str, Any] | None,
+) -> WrongMatchCleanupOutcome:
+    """Acquire WMCL lock, re-check active jobs, delete the source, translate the result."""
     lock_key = wrong_match_cleanup_lock_key(
         request_id,
         download_log_id,
@@ -413,7 +471,7 @@ def _cleanup_wrong_match(
         )
     return _result(
         download_log_id,
-        OUTCOME_DELETED,
+        success_outcome,
         success=True,
         request_id=request_id,
         source_path=resolved_path,
@@ -537,6 +595,9 @@ def _summary(
     return WrongMatchCleanupSummary(
         processed=len(results),
         deleted=counts[OUTCOME_DELETED],
+        deleted_verified_lossless_parent=counts[
+            OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT
+        ],
         kept_would_import=counts[OUTCOME_KEPT_WOULD_IMPORT],
         kept_uncertain=counts[OUTCOME_KEPT_UNCERTAIN],
         skipped_candidate_evidence_missing=counts[
@@ -600,6 +661,8 @@ def _result(
 def _audit_action(outcome: str) -> str:
     if outcome == OUTCOME_DELETED:
         return "deleted_reject"
+    if outcome == OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT:
+        return "deleted_verified_lossless_parent"
     return outcome
 
 

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -718,7 +718,7 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
             with patch_dispatch_externals() as ext, \
                  _patch_beets_album(tmpdir, min_bitrate=128), \
                  patch(
-                     "lib.import_dispatch.ensure_current_evidence_for_action",
+                     "lib.import_evidence.ensure_current_evidence_for_action",
                      side_effect=RuntimeError("beets unavailable"),
                  ):
                 result = dispatch_import_core(

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -1049,5 +1049,89 @@ class TestDispatchFromDbPrecondition(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+class TestLoadEvidenceImportGateDelegation(unittest.TestCase):
+    """U2: ``_load_evidence_import_gate`` delegates current-evidence loading."""
+
+    def _candidate_result(self):
+        evidence = make_album_quality_evidence(
+            mb_release_id="mbid-candidate",
+        )
+        provenance = ActionEvidenceProvenance(
+            candidate_status="reused",
+            snapshot_guard="matched",
+        )
+        return CandidateEvidenceActionResult(
+            evidence=evidence, provenance=provenance
+        )
+
+    def test_helper_returns_none_marks_current_missing(self):
+        """Beets has no album → current_status='missing', not fail-closed."""
+        from lib.import_dispatch import _load_evidence_import_gate
+
+        db = FakePipelineDB()
+        candidate_result = self._candidate_result()
+        with patch(
+            "lib.import_dispatch.load_current_evidence_for_action",
+            return_value=None,
+        ) as mock_helper:
+            gate = _load_evidence_import_gate(
+                db,  # type: ignore[arg-type]
+                request_id=42,
+                mb_release_id="mbid-123",
+                path="/tmp/stage",
+                quality_ranks=None,
+                candidate_import_job_id=7,
+                candidate_download_log_id=None,
+                prevalidated_candidate_result=candidate_result,
+            )
+
+        mock_helper.assert_called_once()
+        self.assertIsNone(gate.current)
+        self.assertEqual(gate.current_status, "missing")
+        self.assertFalse(gate.current_fail_closed)
+        self.assertEqual(gate.current_reason, "album not in beets")
+        self.assertEqual(gate.snapshot_guard, "matched")
+        self.assertIs(gate.candidate, candidate_result.evidence)
+
+    def test_helper_fail_closed_propagates_to_gate(self):
+        """Helper fail-closed result → gate current_fail_closed=True."""
+        from lib.import_evidence import CurrentEvidenceActionResult
+        from lib.import_dispatch import _load_evidence_import_gate
+
+        db = FakePipelineDB()
+        candidate_result = self._candidate_result()
+        fail_provenance = ActionEvidenceProvenance(
+            current_status="failed",
+            snapshot_guard="not_checked",
+            fallback_reason="RuntimeError: boom",
+            fail_closed=True,
+        )
+        fail_result = CurrentEvidenceActionResult(
+            evidence=None, provenance=fail_provenance
+        )
+        with patch(
+            "lib.import_dispatch.load_current_evidence_for_action",
+            return_value=fail_result,
+        ):
+            gate = _load_evidence_import_gate(
+                db,  # type: ignore[arg-type]
+                request_id=42,
+                mb_release_id="mbid-123",
+                path="/tmp/stage",
+                quality_ranks=None,
+                candidate_import_job_id=7,
+                candidate_download_log_id=None,
+                prevalidated_candidate_result=candidate_result,
+            )
+
+        self.assertIsNone(gate.current)
+        self.assertEqual(gate.current_status, "failed")
+        self.assertTrue(gate.current_fail_closed)
+        self.assertEqual(gate.current_reason, "RuntimeError: boom")
+        # snapshot_guard always sourced from the candidate side.
+        self.assertEqual(gate.snapshot_guard, "matched")
+        self.assertIs(gate.candidate, candidate_result.evidence)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_import_evidence.py
+++ b/tests/test_import_evidence.py
@@ -10,10 +10,13 @@ from unittest.mock import patch
 
 from lib.beets_db import AlbumInfo
 from lib.import_evidence import (
+    ActionEvidenceProvenance,
+    CurrentEvidenceActionResult,
     ensure_candidate_evidence_for_action,
     ensure_current_evidence_for_action,
+    load_current_evidence_for_action,
 )
-from lib.quality import AlbumQualityEvidence
+from lib.quality import AlbumQualityEvidence, QualityRankConfig
 from lib.quality_evidence import (
     EvidenceBuildResult,
     snapshot_audio_files,
@@ -208,6 +211,145 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
         self.assertEqual(result.provenance.current_status, "missing")
         self.assertIsNone(backfill.call_args.kwargs["preloaded_evidence"])
         self.assertTrue(backfill.call_args.kwargs["preloaded"])
+
+
+class TestLoadCurrentEvidenceForAction(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = tempfile.mkdtemp()
+        self.db = FakePipelineDB()
+        self.db.seed_request(make_request_row(id=42, mb_release_id="release-1"))
+        self.album_info = AlbumInfo(
+            album_id=1,
+            track_count=1,
+            min_bitrate_kbps=240,
+            avg_bitrate_kbps=250,
+            median_bitrate_kbps=245,
+            is_cbr=False,
+            album_path=self.root,
+            format="MP3",
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _available_result(self) -> CurrentEvidenceActionResult:
+        evidence = make_album_quality_evidence(mb_release_id="release-1")
+        return CurrentEvidenceActionResult(
+            evidence=evidence,
+            provenance=ActionEvidenceProvenance(
+                current_status="loaded",
+                snapshot_guard="matched",
+            ),
+        )
+
+    def test_happy_path_returns_ensure_result_unchanged(self):
+        expected = self._available_result()
+        with patch("lib.beets_db.BeetsDB") as beets_cls, patch(
+            "lib.import_evidence.ensure_current_evidence_for_action",
+            return_value=expected,
+        ) as ensure:
+            beets_cls.return_value.__enter__.return_value.get_album_info.return_value = (
+                self.album_info
+            )
+
+            result = load_current_evidence_for_action(
+                self.db,
+                request_id=42,
+                mb_release_id="release-1",
+                quality_ranks=QualityRankConfig.defaults(),
+                beets_library_root="/tmp/beets",
+            )
+
+        self.assertIs(result, expected)
+        ensure.assert_called_once()
+        kwargs = ensure.call_args.kwargs
+        self.assertEqual(kwargs["request_id"], 42)
+        self.assertEqual(kwargs["mb_release_id"], "release-1")
+        self.assertIs(kwargs["album_info"], self.album_info)
+        self.assertEqual(kwargs["current_album_path"], self.root)
+        self.assertEqual(kwargs["beets_library_root"], "/tmp/beets")
+
+    def test_beets_absent_returns_none(self):
+        with patch("lib.beets_db.BeetsDB") as beets_cls, patch(
+            "lib.import_evidence.ensure_current_evidence_for_action"
+        ) as ensure:
+            beets_cls.return_value.__enter__.return_value.get_album_info.return_value = None
+
+            result = load_current_evidence_for_action(
+                self.db,
+                request_id=42,
+                mb_release_id="release-1",
+            )
+
+        self.assertIsNone(result)
+        ensure.assert_not_called()
+
+    def test_ensure_raises_returns_fail_closed_result(self):
+        with patch("lib.beets_db.BeetsDB") as beets_cls, patch(
+            "lib.import_evidence.ensure_current_evidence_for_action",
+            side_effect=RuntimeError("backfill failed"),
+        ):
+            beets_cls.return_value.__enter__.return_value.get_album_info.return_value = (
+                self.album_info
+            )
+
+            result = load_current_evidence_for_action(
+                self.db,
+                request_id=42,
+                mb_release_id="release-1",
+            )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIsNone(result.evidence)
+        self.assertTrue(result.provenance.fail_closed)
+        self.assertEqual(result.provenance.current_status, "failed")
+        self.assertIn("RuntimeError", result.provenance.fallback_reason or "")
+        self.assertIn("backfill failed", result.provenance.fallback_reason or "")
+
+    def test_unavailable_fail_closed_passes_through(self):
+        fail_closed = CurrentEvidenceActionResult(
+            evidence=None,
+            provenance=ActionEvidenceProvenance(
+                current_status="failed",
+                fallback_reason="snapshot drift",
+                fail_closed=True,
+            ),
+        )
+        with patch("lib.beets_db.BeetsDB") as beets_cls, patch(
+            "lib.import_evidence.ensure_current_evidence_for_action",
+            return_value=fail_closed,
+        ):
+            beets_cls.return_value.__enter__.return_value.get_album_info.return_value = (
+                self.album_info
+            )
+
+            result = load_current_evidence_for_action(
+                self.db,
+                request_id=42,
+                mb_release_id="release-1",
+            )
+
+        self.assertIs(result, fail_closed)
+
+    def test_default_quality_ranks_resolves_to_defaults(self):
+        with patch("lib.beets_db.BeetsDB") as beets_cls, patch(
+            "lib.import_evidence.ensure_current_evidence_for_action",
+            return_value=self._available_result(),
+        ) as ensure:
+            get_album_info = beets_cls.return_value.__enter__.return_value.get_album_info
+            get_album_info.return_value = self.album_info
+
+            load_current_evidence_for_action(
+                self.db,
+                request_id=42,
+                mb_release_id="release-1",
+            )
+
+        get_album_info.assert_called_once()
+        passed_cfg = get_album_info.call_args.args[1]
+        self.assertEqual(passed_cfg, QualityRankConfig.defaults())
+        self.assertEqual(ensure.call_args.kwargs["quality_ranks"], QualityRankConfig.defaults())
 
 
 if __name__ == "__main__":

--- a/tests/test_js_wrong_matches.mjs
+++ b/tests/test_js_wrong_matches.mjs
@@ -728,5 +728,46 @@ console.log('cleanupSummaryToast() reports kept, skipped, and delete failures');
   assertEqual(body, 'Deleted 2 candidates, kept 4, skipped 5', 'summarizes cleanup outcomes');
 }
 
+console.log('renderLatestImport() distinguishes absent / in-library / verified-lossless / present states');
+{
+  // 1. No latest import, album not in library — neutral copy.
+  let html = __test__.renderLatestImport(null, { in_library: false, verified_lossless: false });
+  assert(html.includes('No previous import on disk.'), 'absent: renders neutral "no previous import" copy');
+  assert(!html.includes('Album already in library'), 'absent: does not claim album in library');
+  assert(!html.includes('Verified-lossless copy in library'), 'absent: no verified-lossless copy');
+  assert(!html.includes('No successful import on disk'), 'absent: no longer uses old "No successful import on disk" copy');
+
+  // 2. No latest import, album in library, not verified lossless — distinguishes
+  //    "no cratedigger history" from "Beets already has this MBID".
+  html = __test__.renderLatestImport(null, { in_library: true, verified_lossless: false });
+  assert(html.includes('Album already in library'), 'in_library: surfaces the in-library copy');
+  assert(html.includes('must beat current quality'), 'in_library: explains upgrade gate semantics');
+  assert(!html.includes('No previous import'), 'in_library: does not claim no prior import');
+  assert(!html.includes('No successful import'), 'in_library: no longer uses old "No successful import" copy');
+  assert(!html.includes('Verified-lossless copy in library'), 'in_library: not the verified-lossless branch');
+
+  // 3. No latest import, album in library AND verified lossless — strongest copy.
+  html = __test__.renderLatestImport(null, { in_library: true, verified_lossless: true });
+  assert(html.includes('Verified-lossless copy in library'), 'verified-lossless: surfaces the verified-lossless copy');
+  assert(html.includes('auto-clean on next sweep'), 'verified-lossless: explains the cleanup behavior');
+  assert(!html.includes('Album already in library'), 'verified-lossless: does not fall back to plain in-library copy');
+  assert(!html.includes('No previous import'), 'verified-lossless: does not fall back to absent copy');
+
+  // 4. Latest import present — render existing summary regardless of in_library.
+  html = __test__.renderLatestImport(
+    {
+      outcome: 'imported',
+      created_at: '2026-05-17T00:00:00Z',
+      actual_filetype: 'flac',
+      actual_min_bitrate: 950,
+    },
+    { in_library: true, verified_lossless: false },
+  );
+  assert(html.includes('Last import: imported'), 'present: renders existing latest-import summary');
+  assert(html.includes('FLAC 950k'), 'present: renders filetype and bitrate floor');
+  assert(!html.includes('Album already in library'), 'present: in_library flag does not override the summary');
+  assert(!html.includes('No previous import'), 'present: does not render absent copy');
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_js_wrong_matches.mjs
+++ b/tests/test_js_wrong_matches.mjs
@@ -728,6 +728,20 @@ console.log('cleanupSummaryToast() reports kept, skipped, and delete failures');
   assertEqual(body, 'Deleted 2 candidates, kept 4, skipped 5', 'summarizes cleanup outcomes');
 }
 
+console.log('cleanupSummaryToast() includes verified-lossless deletes and current-evidence-failed skips');
+{
+  const body = __test__.cleanupSummaryToast({
+    deleted: 1,
+    deleted_verified_lossless_parent: 4,
+    kept_would_import: 0,
+    kept_uncertain: 0,
+    skipped_current_evidence_failed: 2,
+    skipped_active_job: 1,
+    delete_failed: 0,
+  });
+  assertEqual(body, 'Deleted 5 candidates, kept 0, skipped 3', 'includes new outcome categories in totals');
+}
+
 console.log('renderLatestImport() distinguishes absent / in-library / verified-lossless / present states');
 {
   // 1. No latest import, album not in library — neutral copy.
@@ -749,7 +763,7 @@ console.log('renderLatestImport() distinguishes absent / in-library / verified-l
   // 3. No latest import, album in library AND verified lossless — strongest copy.
   html = __test__.renderLatestImport(null, { in_library: true, verified_lossless: true });
   assert(html.includes('Verified-lossless copy in library'), 'verified-lossless: surfaces the verified-lossless copy');
-  assert(html.includes('auto-clean on next sweep'), 'verified-lossless: explains the cleanup behavior');
+  assert(html.includes('cleared on the next cleanup sweep'), 'verified-lossless: explains the cleanup behavior');
   assert(!html.includes('Album already in library'), 'verified-lossless: does not fall back to plain in-library copy');
   assert(!html.includes('No previous import'), 'verified-lossless: does not fall back to absent copy');
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1088,9 +1088,11 @@ class TestPipelineRouteContracts(_WebServerCase):
         "cleanup_eligible", "decision", "reason", "stage_chain",
     }
     WRONG_MATCH_TRIAGE_REQUIRED_FIELDS = {
-        "status", "processed", "deleted", "kept_would_import", "kept_uncertain",
+        "status", "processed", "deleted", "deleted_verified_lossless_parent",
+        "kept_would_import", "kept_uncertain",
         "skipped_candidate_evidence_missing", "skipped_candidate_evidence_stale",
         "skipped_current_evidence_missing", "skipped_current_evidence_stale",
+        "skipped_current_evidence_failed",
         "skipped_active_job", "skipped_invalid_row", "skipped_missing_path",
         "skipped_operational", "delete_failed", "results",
     }

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -10,11 +10,14 @@ import unittest
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import msgspec
+
 from lib.quality import (
     AlbumQualityEvidence,
     AlbumQualityEvidenceFile,
     AudioQualityMeasurement,
     QualityRankConfig,
+    VerifiedLosslessProof,
 )
 from lib.quality_evidence import snapshot_fingerprint
 from lib.import_evidence import (
@@ -24,6 +27,7 @@ from lib.import_evidence import (
 from lib.wrong_match_cleanup_service import (
     OUTCOME_DELETE_FAILED,
     OUTCOME_DELETED,
+    OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT,
     OUTCOME_KEPT_WOULD_IMPORT,
     OUTCOME_SKIPPED_ACTIVE_JOB,
     OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
@@ -603,6 +607,128 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         assert result.reason is not None
         self.assertIn("RuntimeError", result.reason)
         self.assertIn("boom", result.reason)
+
+    def test_verified_lossless_parent_short_circuits_to_deletion(self) -> None:
+        """Verified-lossless current → cleanup deletes without calling the reducer."""
+        source = _make_source(self.tmp, "verified-lossless-parent-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source)),
+        )
+        current = msgspec.structs.replace(
+            _evidence(source, mb_release_id="mbid-1"),
+            verified_lossless_proof=VerifiedLosslessProof(
+                proof_origin="library",
+                source="library_audit",
+                classifier="verified_lossless",
+                detail="parent_lossless_proof",
+            ),
+        )
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=current,
+                provenance=ActionEvidenceProvenance(current_status="loaded"),
+            )
+        )
+
+        cleanup = types.SimpleNamespace(
+            success=True,
+            error=None,
+            path_missing=False,
+            cleared_rows=1,
+            deleted_path=source,
+        )
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+        ) as decider, patch(
+            "lib.wrong_match_cleanup_service.cleanup_wrong_match_source",
+            return_value=cleanup,
+        ) as cleanup_call:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(
+            result.outcome,
+            OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.reason, "parent_album_verified_lossless")
+        self.assertEqual(result.verdict, "confident_reject")
+        self.assertEqual(result.preview_decision, "verified_lossless_parent")
+        self.assertTrue(result.cleanup_eligible)
+        self.assertEqual(decider.call_count, 0)
+        cleanup_call.assert_called_once()
+
+    def test_candidate_missing_bails_before_verified_lossless_check(self) -> None:
+        """Missing candidate evidence skips before the verified-lossless branch fires."""
+        source = _make_source(self.tmp, "candidate-missing-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        # NOTE: no set_download_log_candidate_evidence → candidate loader returns None.
+        current = msgspec.structs.replace(
+            _evidence(source, mb_release_id="mbid-1"),
+            verified_lossless_proof=VerifiedLosslessProof(
+                proof_origin="library",
+                source="library_audit",
+                classifier="verified_lossless",
+            ),
+        )
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=current,
+                provenance=ActionEvidenceProvenance(current_status="loaded"),
+            )
+        )
+
+        with patch(
+            "lib.wrong_match_cleanup_service.cleanup_wrong_match_source",
+        ) as cleanup_call:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(
+            result.outcome,
+            OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
+        )
+        self.mock_current_evidence_helper.assert_not_called()
+        cleanup_call.assert_not_called()
+        self.assertTrue(os.path.isdir(source))
+
+    def test_current_without_verified_lossless_reaches_reducer(self) -> None:
+        """Non-verified-lossless current evidence still flows through the reducer."""
+        source = _make_source(self.tmp, "no-verified-lossless-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source)),
+        )
+        current = _evidence(source, mb_release_id="mbid-1")
+        self.assertIsNone(current.verified_lossless_proof)
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=current,
+                provenance=ActionEvidenceProvenance(current_status="loaded"),
+            )
+        )
+
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+            wraps=__import__(
+                "lib.wrong_match_cleanup_service",
+                fromlist=["full_pipeline_decision_from_evidence"],
+            ).full_pipeline_decision_from_evidence,
+        ) as decider:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(decider.call_count, 1)
+        _candidate_arg, current_arg = decider.call_args.args[:2]
+        self.assertIs(current_arg, current)
+        # The reducer was reached, which is the contract under test. The
+        # specific outcome depends on candidate-vs-current comparison; the
+        # only outcome this test rules out is the verified-lossless short-
+        # circuit.
+        self.assertNotEqual(
+            result.outcome,
+            OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT,
+        )
 
     def test_mbid_missing_passes_current_none_to_reducer(self) -> None:
         """Request without an MBID skips the helper and feeds current=None."""

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -658,6 +658,47 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         self.assertTrue(result.cleanup_eligible)
         self.assertEqual(decider.call_count, 0)
         cleanup_call.assert_called_once()
+        self.assertEqual(len(self.db.advisory_lock_calls), 1,
+                         "verified-lossless short-circuit must acquire the WMCL advisory lock")
+
+    def test_backfilled_verified_lossless_does_not_short_circuit(self) -> None:
+        """Backfill can carry an old verified_lossless_proof against changed files; require loaded-from-disk status."""
+        source = _make_source(self.tmp, "backfilled-verified-lossless-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source)),
+        )
+        current = msgspec.structs.replace(
+            _evidence(source, mb_release_id="mbid-1"),
+            verified_lossless_proof=VerifiedLosslessProof(
+                proof_origin="library",
+                source="library_audit",
+                classifier="verified_lossless",
+            ),
+        )
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=current,
+                provenance=ActionEvidenceProvenance(current_status="backfilled"),
+            )
+        )
+
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+            wraps=__import__(
+                "lib.wrong_match_cleanup_service",
+                fromlist=["full_pipeline_decision_from_evidence"],
+            ).full_pipeline_decision_from_evidence,
+        ) as decider, patch(
+            "lib.wrong_match_cleanup_service.cleanup_wrong_match_source",
+        ) as cleanup_call:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertNotEqual(result.outcome, OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT)
+        self.assertEqual(decider.call_count, 1)
+        cleanup_call.assert_not_called()
+        self.assertTrue(os.path.isdir(source))
 
     def test_candidate_missing_bails_before_verified_lossless_check(self) -> None:
         """Missing candidate evidence skips before the verified-lossless branch fires."""

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -17,6 +17,10 @@ from lib.quality import (
     QualityRankConfig,
 )
 from lib.quality_evidence import snapshot_fingerprint
+from lib.import_evidence import (
+    ActionEvidenceProvenance,
+    CurrentEvidenceActionResult,
+)
 from lib.wrong_match_cleanup_service import (
     OUTCOME_DELETE_FAILED,
     OUTCOME_DELETED,
@@ -24,8 +28,8 @@ from lib.wrong_match_cleanup_service import (
     OUTCOME_SKIPPED_ACTIVE_JOB,
     OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
     OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+    OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED,
     OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
-    OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE,
     OUTCOME_SKIPPED_MISSING_PATH,
     OUTCOME_SKIPPED_OPERATIONAL,
     cleanup_all_wrong_matches,
@@ -134,6 +138,18 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
             status="wanted",
             mb_release_id="mbid-1",
         ))
+        # Default: Beets has no album for this MBID. Individual tests override
+        # via self._set_current_evidence_helper(...) to drive specific branches.
+        self._current_evidence_helper = lambda *_args, **_kwargs: None
+        helper_patch = patch(
+            "lib.wrong_match_cleanup_service.load_current_evidence_for_action",
+            side_effect=lambda *a, **kw: self._current_evidence_helper(*a, **kw),
+        )
+        self.addCleanup(helper_patch.stop)
+        self.mock_current_evidence_helper = helper_patch.start()
+
+    def _set_current_evidence_helper(self, fn) -> None:
+        self._current_evidence_helper = fn
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp, ignore_errors=True)
@@ -354,68 +370,28 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         cleanup_source.assert_not_called()
         self.assertTrue(os.path.isdir(source))
 
-    def test_imported_request_without_current_evidence_keeps_row(self) -> None:
-        source = _make_source(self.tmp, "missing-current-source")
+    def test_helper_unavailable_non_failclose_skips_with_missing_outcome(self) -> None:
+        """Helper signals current evidence unloadable but recoverable; skip not fail."""
+        source = _make_source(self.tmp, "helper-unavailable-source")
         log_id = _log_wrong_match(self.db, 1, source)
         self.db.set_download_log_candidate_evidence(
             log_id,
             _store_evidence(self.db, _evidence(source, audio_corrupt=True)),
         )
-        request = self.db.request(1)
-        request["status"] = "imported"
-        request["imported_path"] = _make_source(self.tmp, "current-source")
-
-        summary = cleanup_all_wrong_matches(
-            self.db,
-            confirm_all_wrong_matches=True,
-            cfg=_cfg(),
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=None,
+                provenance=ActionEvidenceProvenance(
+                    current_status="missing",
+                    fallback_reason="no current evidence found",
+                    fail_closed=False,
+                ),
+            )
         )
-
-        self.assertEqual(summary.skipped_current_evidence_missing, 1)
-        self.assertEqual(summary.results[0].outcome, OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING)
-        self.assertTrue(os.path.isdir(source))
-        self.assertIn("failed_path", self.db.download_logs[-1].validation_result)
-
-    def test_imported_request_with_missing_current_evidence_row_keeps_row(self) -> None:
-        source = _make_source(self.tmp, "missing-current-row-source")
-        log_id = _log_wrong_match(self.db, 1, source)
-        self.db.set_download_log_candidate_evidence(
-            log_id,
-            _store_evidence(self.db, _evidence(source, audio_corrupt=True)),
-        )
-        request = self.db.request(1)
-        request["status"] = "imported"
-        request["imported_path"] = _make_source(self.tmp, "current-row-source")
-        self.db.set_request_current_evidence(1, 99999)
 
         result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
 
         self.assertEqual(result.outcome, OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING)
-        self.assertTrue(os.path.isdir(source))
-        self.assertIn("failed_path", self.db.download_logs[-1].validation_result)
-
-    def test_imported_request_with_stale_current_evidence_keeps_row(self) -> None:
-        source = _make_source(self.tmp, "stale-current-source")
-        current = _make_source(self.tmp, "current-stale-source")
-        log_id = _log_wrong_match(self.db, 1, source)
-        self.db.set_download_log_candidate_evidence(
-            log_id,
-            _store_evidence(self.db, _evidence(source, audio_corrupt=True)),
-        )
-        current_evidence_id = _store_evidence(
-            self.db,
-            _evidence(current, mb_release_id="current-mbid"),
-        )
-        with open(os.path.join(current, "02.mp3"), "wb") as handle:
-            handle.write(b"changed")
-        request = self.db.request(1)
-        request["status"] = "imported"
-        request["imported_path"] = current
-        self.db.set_request_current_evidence(1, current_evidence_id)
-
-        result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
-
-        self.assertEqual(result.outcome, OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE)
         self.assertTrue(os.path.isdir(source))
         self.assertIn("failed_path", self.db.download_logs[-1].validation_result)
 
@@ -504,6 +480,158 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
     def test_bulk_requires_explicit_confirmation(self) -> None:
         with self.assertRaisesRegex(ValueError, "confirm_all_wrong_matches"):
             cleanup_all_wrong_matches(self.db, cfg=_cfg())
+
+    def test_wanted_row_uses_current_evidence_from_beets(self) -> None:
+        """Parts & Labor: wanted row whose MBID is in Beets feeds current evidence to the reducer."""
+        # Before the fix, cleanup short-circuited current=None for wanted rows
+        # (no imported_path, status != 'imported'), so the reducer never saw the
+        # parent quality and a downgrade candidate could pass as would_import.
+        source = _make_source(self.tmp, "wanted-current-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source)),
+        )
+        current = _evidence(source, mb_release_id="mbid-1")
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=current,
+                provenance=ActionEvidenceProvenance(current_status="loaded"),
+            )
+        )
+
+        cleanup = types.SimpleNamespace(
+            success=True,
+            error=None,
+            path_missing=False,
+            cleared_rows=1,
+            deleted_path=source,
+        )
+        reject_decision = {
+            "preimport_audio": None,
+            "preimport_nested": None,
+            "preimport_bad_hash": None,
+            "preimport_empty_fileset": None,
+            "stage0_spectral_gate": None,
+            "stage1_spectral": None,
+            "stage2_import": "reject",
+            "stage3_quality_gate": "reject",
+            "final_status": "wanted",
+            "imported": False,
+            "denylisted": False,
+            "keep_searching": True,
+            "target_final_format": None,
+            "verified_lossless": False,
+        }
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+            return_value=reject_decision,
+        ) as decider, patch(
+            "lib.wrong_match_cleanup_service.classify_full_pipeline_decision",
+            return_value=("confident_reject", True, "downgrade"),
+        ), patch(
+            "lib.wrong_match_cleanup_service.evidence_decision_name",
+            return_value="downgrade",
+        ), patch(
+            "lib.wrong_match_cleanup_service.cleanup_wrong_match_source",
+            return_value=cleanup,
+        ):
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(result.outcome, OUTCOME_DELETED)
+        decider.assert_called_once()
+        _candidate_arg, current_arg = decider.call_args.args[:2]
+        self.assertIs(current_arg, current)
+        self.mock_current_evidence_helper.assert_called_once()
+        helper_kwargs = self.mock_current_evidence_helper.call_args.kwargs
+        self.assertEqual(helper_kwargs["mb_release_id"], "mbid-1")
+        self.assertEqual(helper_kwargs["request_id"], 1)
+
+    def test_beets_absent_passes_current_none_to_reducer(self) -> None:
+        """Helper returns None (no Beets album) → reducer sees current=None."""
+        source = _make_source(self.tmp, "beets-absent-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source)),
+        )
+        self._set_current_evidence_helper(lambda *_a, **_kw: None)
+
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+            wraps=__import__(
+                "lib.wrong_match_cleanup_service",
+                fromlist=["full_pipeline_decision_from_evidence"],
+            ).full_pipeline_decision_from_evidence,
+        ) as decider:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(result.outcome, OUTCOME_KEPT_WOULD_IMPORT)
+        self.assertTrue(os.path.isdir(source))
+        decider.assert_called_once()
+        _candidate_arg, current_arg = decider.call_args.args[:2]
+        self.assertIsNone(current_arg)
+
+    def test_beets_present_but_fail_closed_skips(self) -> None:
+        """Helper signals current evidence unloadable; reducer never runs."""
+        source = _make_source(self.tmp, "fail-closed-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source, audio_corrupt=True)),
+        )
+        self._set_current_evidence_helper(
+            lambda *_a, **_kw: CurrentEvidenceActionResult(
+                evidence=None,
+                provenance=ActionEvidenceProvenance(
+                    current_status="failed",
+                    fallback_reason="RuntimeError: boom",
+                    fail_closed=True,
+                ),
+            )
+        )
+
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+        ) as decider:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(result.outcome, OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED)
+        self.assertTrue(os.path.isdir(source))
+        decider.assert_not_called()
+        self.assertIsNotNone(result.reason)
+        assert result.reason is not None
+        self.assertIn("RuntimeError", result.reason)
+        self.assertIn("boom", result.reason)
+
+    def test_mbid_missing_passes_current_none_to_reducer(self) -> None:
+        """Request without an MBID skips the helper and feeds current=None."""
+        self.db.seed_request(make_request_row(
+            id=2,
+            status="wanted",
+            mb_release_id=None,
+        ))
+        source = _make_source(self.tmp, "no-mbid-source")
+        log_id = _log_wrong_match(self.db, 2, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source, mb_release_id="mbid-x")),
+        )
+
+        with patch(
+            "lib.wrong_match_cleanup_service.full_pipeline_decision_from_evidence",
+            wraps=__import__(
+                "lib.wrong_match_cleanup_service",
+                fromlist=["full_pipeline_decision_from_evidence"],
+            ).full_pipeline_decision_from_evidence,
+        ) as decider:
+            result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.mock_current_evidence_helper.assert_not_called()
+        decider.assert_called_once()
+        _candidate_arg, current_arg = decider.call_args.args[:2]
+        self.assertIsNone(current_arg)
+        self.assertEqual(result.outcome, OUTCOME_KEPT_WOULD_IMPORT)
 
 
 if __name__ == "__main__":

--- a/web/classify.py
+++ b/web/classify.py
@@ -273,6 +273,8 @@ def _stage_failure_family(stage_chain: list[str]) -> str | None:
 def _wrong_match_action_label(action: str | None) -> str | None:
     if action == "deleted_reject":
         return "deleted"
+    if action == "deleted_verified_lossless_parent":
+        return "deleted: verified-lossless parent"
     if action == "delete_failed":
         return "delete failed"
     if action == "stale_path_cleared":
@@ -308,6 +310,9 @@ def _build_wrong_match_triage_summary(
                   or _humanize_token(preview_decision)
                   or _humanize_token(preview_verdict))
         return f"deleted: {detail}" if detail else "deleted"
+
+    if action == "deleted_verified_lossless_parent":
+        return "deleted: verified-lossless parent in library"
 
     if action == "kept_would_import":
         return "kept: would import"

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -792,13 +792,19 @@ function fmtTs(iso) {
  * recent success/force_import/manual_import for the release — i.e. what's
  * actually on disk — not the newest attempt. A later rejection doesn't
  * change what beets has.
- * @param {any} d
+ *
+ * When `latest_import` is absent the header distinguishes three states using
+ * the group's `in_library` / `verified_lossless` flags so the operator knows
+ * whether a new candidate has to beat anything to land.
+ *
+ * @param {any} d - latest_import payload, or null/undefined
+ * @param {{in_library?: boolean, verified_lossless?: boolean}} [group]
  * @returns {string}
  */
-function renderLatestImport(d) {
-  if (!d) return '<div style="color:#555;font-size:0.78em;padding:4px 8px;">No successful import on disk.</div>';
-  const fmtBr = d.actual_filetype ? `${String(d.actual_filetype).toUpperCase()}${d.actual_min_bitrate ? ' ' + d.actual_min_bitrate + 'k' : ''}` : '';
-  return `
+function renderLatestImport(d, group) {
+  if (d) {
+    const fmtBr = d.actual_filetype ? `${String(d.actual_filetype).toUpperCase()}${d.actual_min_bitrate ? ' ' + d.actual_min_bitrate + 'k' : ''}` : '';
+    return `
     <div style="background:#161616;border-left:3px solid #6d6;padding:6px 10px;margin:0 0 8px 0;font-size:0.78em;">
       <div style="color:#aaa;">
         <span style="color:#6d6;font-weight:600;">Last import: ${esc(d.outcome || '?')}</span>
@@ -810,6 +816,16 @@ function renderLatestImport(d) {
         ${d.beets_scenario ? ' · ' + esc(d.beets_scenario) : ''}
       </div>
     </div>`;
+  }
+  const inLibrary = !!(group && group.in_library);
+  const verifiedLossless = !!(group && group.verified_lossless);
+  if (inLibrary && verifiedLossless) {
+    return '<div style="color:#6d6;font-size:0.78em;padding:4px 8px;">Verified-lossless copy in library — Wrong Matches against this album auto-clean on next sweep.</div>';
+  }
+  if (inLibrary) {
+    return '<div style="color:#9bf;font-size:0.78em;padding:4px 8px;">Album already in library — any new candidate must beat current quality to import.</div>';
+  }
+  return '<div style="color:#555;font-size:0.78em;padding:4px 8px;">No previous import on disk.</div>';
 }
 
 /**
@@ -848,7 +864,7 @@ function renderGroup(g) {
     </div>`;
 
   const entries = (g.entries || []).map((/** @type {any} */ e) => renderEntry(e, thresholdMilli, g.request_id)).join('');
-  const latest = renderLatestImport(g.latest_import);
+  const latest = renderLatestImport(g.latest_import, g);
   const bulkActions = renderConvergeControls(g, count, thresholdMilli);
 
   return `<div id="wm-release-${g.request_id}" data-pending-count="${count}">
@@ -1143,6 +1159,7 @@ export const __test__ = {
   isConvergeGreen,
   normalizeThreshold,
   reloadWrongMatchExplorer,
+  renderLatestImport,
   renderWrongMatchExplorer,
   renderWrongMatches,
   setWrongMatchConvergeThreshold,

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -495,13 +495,15 @@ function convergeToast(data) {
  * @returns {string}
  */
 function cleanupSummaryToast(data) {
-  const deleted = Number(data?.deleted || 0);
+  const deleted = Number(data?.deleted || 0)
+    + Number(data?.deleted_verified_lossless_parent || 0);
   const kept = Number(data?.kept_would_import || 0)
     + Number(data?.kept_uncertain || 0);
   const skipped = Number(data?.skipped_candidate_evidence_missing || 0)
     + Number(data?.skipped_candidate_evidence_stale || 0)
     + Number(data?.skipped_current_evidence_missing || 0)
     + Number(data?.skipped_current_evidence_stale || 0)
+    + Number(data?.skipped_current_evidence_failed || 0)
     + Number(data?.skipped_active_job || 0)
     + Number(data?.skipped_invalid_row || 0)
     + Number(data?.skipped_missing_path || 0)
@@ -820,7 +822,7 @@ function renderLatestImport(d, group) {
   const inLibrary = !!(group && group.in_library);
   const verifiedLossless = !!(group && group.verified_lossless);
   if (inLibrary && verifiedLossless) {
-    return '<div style="color:#6d6;font-size:0.78em;padding:4px 8px;">Verified-lossless copy in library — Wrong Matches against this album auto-clean on next sweep.</div>';
+    return '<div style="color:#6d6;font-size:0.78em;padding:4px 8px;">Verified-lossless copy in library — Wrong Matches against this album are cleared on the next cleanup sweep.</div>';
   }
   if (inLibrary) {
     return '<div style="color:#9bf;font-size:0.78em;padding:4px 8px;">Album already in library — any new candidate must beat current quality to import.</div>';


### PR DESCRIPTION
## Summary

Closes #268. Wrong Matches bulk cleanup was reaching different decisions from force-import for the same candidate because it loaded current evidence with weaker inputs. This PR makes the two paths share evidence acquisition, adds a verified-lossless short-circuit that auto-cleans guaranteed-clutter rows, and fixes a misleading UI header.

## What changed

| Unit | Change |
|------|--------|
| U1 | Extract `load_current_evidence_for_action` helper in `lib/import_evidence.py` (Beets-by-MBID + `ensure_current_evidence_for_action` + fail-closed). |
| U2 | `_load_evidence_import_gate` in dispatch delegates to the helper. Pure factoring. |
| U3 | Cleanup uses the helper; `_load_current_evidence` deleted. **This is the bug fix.** New `OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED` for the fail-closed case. |
| U4 | Verified-lossless short-circuit: when in-Beets current is verified-lossless, auto-delete the Wrong Match without calling the reducer. New `OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT`. Gated on `current_status == CURRENT_STATUS_LOADED` (not backfilled — backfill can preserve a stale verified_lossless_proof). |
| U5 | Wrong Matches header distinguishes "no cratedigger history" from "album already in library" (uses existing `in_library` flag). |
| Review polish | Wire new outcomes into `cleanupSummaryToast`, `WRONG_MATCH_TRIAGE_REQUIRED_FIELDS`, `web/classify.py` action labels. Hoist `_runtime_config()` out of the per-row loop. Drop redundant quoted annotation. |

## Decision invariant

Per CLAUDE.md, `full_pipeline_decision_from_evidence` remains the single source of truth for quality decisions. The verified-lossless short-circuit is a cleanup-only policy ("guaranteed clutter") that deliberately skips the reducer; the contract test asserts `decider.call_count == 0` on that branch.

## Tests

- `tests/test_import_evidence.py` — 5 new unit tests for the helper.
- `tests/test_dispatch_from_db.py` — 2 new delegation tests for the dispatch wiring.
- `tests/test_wrong_match_cleanup_service.py` — 9 new scenarios covering the bug fix (Parts & Labor case), the verified-lossless short-circuit, the backfilled-status gate, the fail-closed branch, and the missing-MBID branch.
- `tests/test_js_wrong_matches.mjs` — 4 new render tests for the header, 1 new toast counter test.

Full suite: 3481 tests, 56 skipped, 0 failures. Pyright clean on touched files (pre-existing third-party-stub warnings remain).

## Test plan

- [x] Pure decisions covered by `tests/test_quality_decisions.py` (untouched — same reducer)
- [x] New helper unit-tested through its three return states (None / fail_closed / available)
- [x] Cleanup + dispatch parity covered by the Parts & Labor scenario test
- [x] Verified-lossless short-circuit asserts the WMCL advisory lock is acquired
- [x] Backfilled-current case pinned (must NOT short-circuit)
- [x] UI header asserts three render branches
- [ ] **Post-merge dry-run probe on live DB** — count how many rows the new code path would delete vs keep vs skip across the 722 risk-bucket rows from issue #268