### PR TITLE
fix: converge deletes via operator-authority service, not classifier

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -5999,6 +5999,14 @@ class TestWrongMatchesContract(unittest.TestCase):
         # Default: treat every failed_path as existing so the group survives
         # filtering. Individual tests override this to exercise missing-file
         # and mixed-existence cases. Converge deletion is service-backed.
+        # Regression-guard sentinel: import cleanup_wrong_match into the route
+        # module's namespace so the converge tests can assert it is NOT called.
+        # See project_converge_operator_authority memory + post_wrong_match_converge
+        # docstring — converge must route deletion through delete_wrong_match,
+        # never through cleanup_wrong_match.
+        from lib.wrong_match_cleanup_service import cleanup_wrong_match as _cwm_sentinel
+        import web.routes.imports as _imports_mod
+        _imports_mod.cleanup_wrong_match = _cwm_sentinel
         cleanup_patch = patch(
             "web.routes.imports.cleanup_wrong_match",
             side_effect=lambda _db, lid: self._cleanup_result(lid),
@@ -6021,6 +6029,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.addCleanup(manual_cleanup_patch.stop)
         self.addCleanup(manual_group_cleanup_patch.stop)
         self.addCleanup(resolve_patch.stop)
+        self.addCleanup(lambda: delattr(_imports_mod, "cleanup_wrong_match"))
 
     GROUP_REQUIRED_FIELDS = {
         "request_id", "artist", "album", "mb_release_id",
@@ -6951,13 +6960,11 @@ class TestWrongMatchesContract(unittest.TestCase):
             self._job(900, 42, 100, "/fi/a"),
             self._job(901, 42, 101, "/fi/b"),
         ]
-        self.mock_cleanup.side_effect = None
-
-        def cleanup_after_enqueue(_db, log_id):
+        def manual_delete_after_enqueue(_db, log_id, **_kwargs):
             self.assertEqual(self.mock_db.enqueue_import_job.call_count, 2)
-            return self._cleanup_result(log_id)
+            return self._manual_cleanup_result(log_id)
 
-        self.mock_cleanup.side_effect = cleanup_after_enqueue
+        self.mock_manual_cleanup.side_effect = manual_delete_after_enqueue
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,
@@ -6992,7 +6999,8 @@ class TestWrongMatchesContract(unittest.TestCase):
             self.mock_db.enqueue_import_job.call_args_list[0].kwargs["payload"]["source_dirs"],
             ["u1\\Artist\\Album"],
         )
-        self.mock_cleanup.assert_called_once_with(self.mock_db, 102)
+        self.mock_manual_cleanup.assert_called_once_with(self.mock_db, 102, require_visible=True)
+        self.mock_cleanup.assert_not_called()
 
     def test_converge_deletes_unmatched_when_legacy_client_requests_it(self):
         """Legacy true payloads still delete non-green rows while selected rows stay visible."""
@@ -7025,9 +7033,17 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(data["deleted"], 1)
         self.assertEqual(data["remaining"], 2)
         self.assertFalse(data["group_empty"])
-        self.mock_cleanup.assert_called_once_with(self.mock_db, 102)
+        self.mock_manual_cleanup.assert_called_once_with(self.mock_db, 102, require_visible=True)
+        self.mock_cleanup.assert_not_called()
 
-    def test_converge_recomputes_cleanup_and_keeps_uncertain_unmatched_candidate(self):
+    def test_converge_deletes_unmatched_unconditionally_without_classifier(self):
+        """Operator-authority contract: converge does NOT route deletion through cleanup_wrong_match.
+
+        Regression guard for the issue where unmatched rows with kept_would_import
+        or stale-evidence verdicts would silently stay visible because cleanup's
+        evidence-based classifier blocked deletion. Converge has already collected
+        operator intent; the unmatched row dies.
+        """
         self.mock_db.get_wrong_matches.return_value = [
             self._row(100, 42, "u1", "/fi/a", distance=0.167),
             self._row(102, 42, "u3", "/fi/c", distance=0.226),
@@ -7041,11 +7057,6 @@ class TestWrongMatchesContract(unittest.TestCase):
         )
         self.mock_db.enqueue_import_job.return_value = self._job(900, 42, 100, "/fi/a")
 
-        self.mock_cleanup.side_effect = None
-        self.mock_cleanup.return_value = self._cleanup_result(
-            102,
-            outcome="kept_uncertain",
-        )
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,
             "threshold_milli": 180,
@@ -7053,9 +7064,10 @@ class TestWrongMatchesContract(unittest.TestCase):
         })
 
         self.assertEqual(status, 202)
-        self.assertEqual(data["deleted"], 0)
-        self.assertEqual(data["remaining"], 2)
-        self.mock_cleanup.assert_called_once_with(self.mock_db, 102)
+        self.assertEqual(data["deleted"], 1)
+        self.assertEqual(data["remaining"], 1)
+        self.mock_manual_cleanup.assert_called_once_with(self.mock_db, 102, require_visible=True)
+        self.mock_cleanup.assert_not_called()
 
     def test_converge_skips_missing_green_files(self):
         """A green row with no surviving failed_path is not queued or dismissed."""

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -20,9 +20,7 @@ from lib.import_queue import (
 )
 from lib.util import resolve_failed_path
 from lib.wrong_match_cleanup_service import (
-    OUTCOME_DELETED,
     cleanup_all_wrong_matches,
-    cleanup_wrong_match,
 )
 from lib.wrong_match_delete_service import (
     OUTCOME_DELETE_FAILED as DELETE_OUTCOME_FAILED,
@@ -584,8 +582,15 @@ def get_wrong_match_audio(h, params: dict[str, list[str]]) -> None:
 
 
 def _delete_wrong_match_row(pdb, log_id: int):
-    """Converge helper that routes deletion through the cleanup service."""
-    return cleanup_wrong_match(pdb, log_id)
+    """Converge helper: operator-authority delete via lib/wrong_match_delete_service.
+
+    Do NOT route this through cleanup_wrong_match. Converge has already collected
+    operator intent (they picked the green candidate; everything else dies). The
+    evidence-based cleanup classifier would skip kept_would_import / stale-evidence
+    rows that converge is explicitly trying to clear. See post_wrong_match_converge
+    docstring.
+    """
+    return delete_wrong_match(pdb, log_id, require_visible=True)
 
 
 def post_wrong_match_delete(h, body: dict) -> None:
@@ -652,7 +657,25 @@ def _wrong_match_delete_group_http_status(summary) -> int:
 
 
 def post_wrong_match_converge(h, body: dict) -> None:
-    """Queue acceptable candidates and delete the rest for the release."""
+    """Queue acceptable candidates and delete the rest for the release.
+
+    ⚠ OPERATOR-AUTHORITY CONTRACT — do not route deletion through
+    cleanup_wrong_match or the evidence-based cleanup classifier.
+
+    Converge is a one-click cleanup workflow: the operator has reviewed the
+    candidates, chosen the green (acceptable-distance) ones for force-import,
+    and is explicitly asking us to remove the rest. Their judgement, not the
+    classifier's, gates the deletion. The unmatched rows are deleted via
+    lib/wrong_match_delete_service.delete_wrong_match, which preserves
+    advisory-lock + active-jobs safety but skips the candidate-evidence load,
+    the reducer, and the verified-lossless short-circuit.
+
+    Regression history: routing converge through cleanup_wrong_match caused
+    "kept_would_import" and stale-evidence rows to silently stay visible after
+    the operator hit converge — visible as a #268 follow-up bug. The fix is
+    permanent; if you find yourself reaching for cleanup_wrong_match here,
+    re-read this docstring.
+    """
     request_id = body.get("request_id")
     if request_id is None:
         h._error("Missing request_id")
@@ -766,14 +789,14 @@ def post_wrong_match_converge(h, body: dict) -> None:
     if green_candidates:
         for lid in unmatched_log_ids:
             result = _delete_wrong_match_row(pdb, lid)
-            if result.outcome == OUTCOME_DELETED:
+            if result.success:
                 deleted += 1
             else:
                 skipped.append({
                     "download_log_id": lid,
                     "reason": result.outcome,
-                    "cleanup_reason": result.reason,
-                    "cleanup_verdict": result.verdict,
+                    "delete_reason": result.reason,
+                    "delete_error": result.error,
                 })
                 remaining += 1
     else:


### PR DESCRIPTION
## Summary

The Wrong Matches **Converge** button was routing unmatched-row deletion through `cleanup_wrong_match` (the evidence-based classifier), which silently kept any row the reducer classified as `kept_would_import` or that hit a skip outcome (stale evidence, missing path, etc.). That contradicts converge's UX contract: the operator picked the green candidate, they want everything else removed.

The bug existed silently before PR #269 because cleanup was misclassifying many rows as `kept_would_import` due to missing current evidence. After #269 made the classifier accurate, the long-standing converge bug became visible.

## Fix

`_delete_wrong_match_row` in `web/routes/imports.py` now calls `delete_wrong_match` from `lib/wrong_match_delete_service` — the operator-authority deletion path that preserves advisory-lock + active-jobs safety but skips the candidate-evidence load, the reducer, and the verified-lossless short-circuit.

A prominent ⚠ docstring on `post_wrong_match_converge` documents the contract and the regression history so this can't be reintroduced.

Saved as a project memory: `project_converge_operator_authority`.

## Test plan

- [x] `test_converge_queues_green_candidates_and_deletes_unmatched` asserts `delete_wrong_match` is called and `cleanup_wrong_match` is **not**
- [x] `test_converge_deletes_unmatched_when_legacy_client_requests_it` same
- [x] New `test_converge_deletes_unmatched_unconditionally_without_classifier` — explicit regression guard
- [x] `test_converge_skips_missing_green_files`, `test_converge_reports_deduped_jobs`, `test_converge_missing_request_id_returns_error` still pass
- [x] Full suite: 3481 tests, 56 skipped, 0 failures