### PR TITLE
fix: Wrong Matches — stop refetching after Force Import + group-delete partial

### DIFF
--- a/tests/test_js_wrong_matches.mjs
+++ b/tests/test_js_wrong_matches.mjs
@@ -94,9 +94,11 @@ function wrongMatchesData() {
   };
 }
 
-async function runPoll(job) {
+async function runPoll(job, logId) {
+  installStorage();
   const calls = [];
   const dom = installDom();
+  __test__.renderWrongMatches(wrongMatchesData(), dom.wrongMatches);
   globalThis.fetch = async (url) => {
     calls.push(url);
     if (String(url).startsWith('/api/import-jobs/')) {
@@ -105,40 +107,34 @@ async function runPoll(job) {
         json: async () => ({ job }),
       };
     }
-    if (url === '/api/wrong-matches') {
-      return {
-        ok: true,
-        json: async () => ({ groups: [] }),
-      };
-    }
     throw new Error(`unexpected fetch: ${url}`);
   };
   const btn = { textContent: '', style: {} };
-  await __test__.pollImportJob(17, btn);
+  await __test__.pollImportJob(17, btn, logId);
   return { calls, dom, btn };
 }
 
-console.log('_pollImportJob() refreshes after completed jobs');
+console.log('_pollImportJob() removes row in place after completed jobs — no full refresh');
 {
   const { calls, dom, btn } = await runPoll({
     status: 'completed',
     message: 'Import completed',
-  });
+  }, 100);
   assertEqual(btn.textContent, 'Imported', 'button shows imported');
-  assert(calls.includes('/api/wrong-matches'), 'refreshes wrong matches after completion');
-  assert(dom.wrongMatches.innerHTML.includes('No wrong matches'), 'renders refreshed empty state');
+  assert(!calls.includes('/api/wrong-matches'),
+    'does NOT refetch the queue on completion (in-place removal)');
   assertEqual(dom.toast.className, 'toast', 'completion toast is not an error');
 }
 
-console.log('_pollImportJob() refreshes after failed jobs');
+console.log('_pollImportJob() leaves row visible after failed jobs — no full refresh');
 {
   const { calls, dom, btn } = await runPoll({
     status: 'failed',
     message: 'Pre-import gate rejected',
-  });
+  }, 100);
   assertEqual(btn.textContent, 'Failed', 'button shows failed');
-  assert(calls.includes('/api/wrong-matches'), 'refreshes wrong matches after failure');
-  assert(dom.wrongMatches.innerHTML.includes('No wrong matches'), 'renders refreshed empty state');
+  assert(!calls.includes('/api/wrong-matches'),
+    'does NOT refetch the queue on failure (ambiguous source state)');
   assertEqual(dom.toast.className, 'toast error', 'failure toast is an error');
 }
 

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -1191,8 +1191,11 @@ export async function refreshWrongMatches(btn) {
  * Poll a queued import job until it reaches a terminal state.
  * @param {number} jobId
  * @param {HTMLButtonElement} btn
+ * @param {number=} logId — the download_log row the import targets; used to
+ *   surgically remove the row from the queue on completion. When omitted,
+ *   completion just toasts and updates the button without touching the DOM.
  */
-async function _pollImportJob(jobId, btn) {
+async function _pollImportJob(jobId, btn, logId) {
   for (let i = 0; i < 240; i++) {
     await new Promise(resolve => setTimeout(resolve, 2000));
     try {
@@ -1210,7 +1213,11 @@ async function _pollImportJob(jobId, btn) {
         btn.style.color = '#6d6';
         toast(job.message || 'Import completed');
         invalidateWrongMatches();
-        await _refreshWrongMatches();
+        // Import succeeded → row leaves the Wrong Matches queue. Surgical
+        // remove preserves scroll position and surrounding expanded state.
+        if (Number.isFinite(logId)) {
+          removeWrongMatchEntry(Number(logId));
+        }
         return;
       }
       if (job.status === 'failed') {
@@ -1218,7 +1225,11 @@ async function _pollImportJob(jobId, btn) {
         btn.style.color = '#f88';
         toast(job.message || job.error || 'Import failed', true);
         invalidateWrongMatches();
-        await _refreshWrongMatches();
+        // Don't refetch: failed imports may have cleaned up the source folder
+        // (confident_reject) OR left it intact (transient failure). Either way
+        // the row state is ambiguous; operator can hit Refresh if they want
+        // to reconcile. Refetching on every failed import was the jarring
+        // post-Force-Import refresh.
         return;
       }
     } catch (_e) {
@@ -1331,7 +1342,7 @@ export async function forceImportWrongMatch(logId, btn) {
       btn.style.color = '#9bf';
       toast(`Queued import: ${data.artist} - ${data.album}`);
       if (data.job_id) {
-        await _pollImportJob(data.job_id, btn);
+        await _pollImportJob(data.job_id, btn, logId);
       }
     } else {
       btn.textContent = 'Failed';
@@ -1404,7 +1415,13 @@ export async function deleteWrongMatchGroup(requestId, btn) {
       if (data.status === 'ok' || (data.remaining === 0)) {
         removeWrongMatchGroup(requestId);
       } else {
-        await _refreshWrongMatches();
+        // Partial outcome: remove the rows that actually deleted, leave the
+        // skipped/errored rows visible so the operator can see what failed.
+        for (const result of (data.results || [])) {
+          if (result && result.success && Number.isFinite(Number(result.download_log_id))) {
+            removeWrongMatchEntry(result.download_log_id);
+          }
+        }
       }
     } else {
       btn.disabled = false;


### PR DESCRIPTION
## Summary

Two refreshes survived #273 and were re-rendering the queue after operator actions:

1. **Force Import completion / failure poll** (`_pollImportJob`). Both terminal states called `_refreshWrongMatches`. Now:
   - **Completed** → surgical `removeWrongMatchEntry(logId)`. The threaded `logId` came in via `forceImportWrongMatch`.
   - **Failed** → no refetch. The source folder state is ambiguous (transient failure leaves it; `confident_reject` cleans it up), so leave the row visible and let the operator hit Refresh.

2. **Group delete `partial` branch**. When some rows skipped/errored, the function fell back to a full refresh. Now iterates the per-row `results` and surgically removes only the rows that actually deleted; skipped/errored rows stay visible.

## Test plan

- [x] `node tests/test_js_wrong_matches.mjs` — 123 passing. Both `_pollImportJob` tests rewritten to assert no-refetch.