### PR TITLE
fix(harness): downmix to stereo on every lossless conversion

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -695,6 +695,7 @@ def _temp_v0_probe(
             out_path = os.path.join(temp_dir, f"{index:03d}-{base}.mp3")
             cmd = [
                 "ffmpeg", "-i", src_path,
+                "-ac", "2",
                 "-c:a", V0_SPEC.codec, *V0_SPEC.codec_args,
                 *V0_SPEC.metadata_args,
                 "-y", out_path,
@@ -734,20 +735,53 @@ def _remove_lossless_files(folder: str) -> None:
             os.remove(os.path.join(folder, fname))
 
 
+def _probe_source_channels(path: str) -> int | None:
+    """Read the channel count from an audio file via mutagen.
+
+    Returns the integer channel count or ``None`` if the probe fails. Used
+    to detect multichannel sources before convert_lossless / _temp_v0_probe
+    invoke ffmpeg — libopus rejects ``5.1(side)`` outright (the Mott
+    /r3852 bug), and even codecs that auto-downmix (libmp3lame) silently
+    discard surround content. We always downmix to stereo on output; this
+    probe lets us log the source layout as a breadcrumb.
+    """
+    try:
+        from mutagen import File as _MutagenFile  # type: ignore[import-untyped,attr-defined]  # pyright: ignore[reportPrivateImportUsage]
+    except ImportError:
+        return None
+    try:
+        mf = _MutagenFile(path)
+    except Exception:
+        return None
+    if mf is None:
+        return None
+    channels = getattr(getattr(mf, "info", None), "channels", None)
+    if isinstance(channels, int) and channels > 0:
+        return channels
+    return None
+
+
 def convert_lossless(album_path: str, spec: ConversionSpec,
                      dry_run: bool = False,
                      keep_source: bool = False,
                      lossless_files: list[str] | None = None
-                     ) -> tuple[int, int, str | None]:
+                     ) -> tuple[int, int, str | None, int | None]:
     """Convert all lossless files using the given ConversionSpec.
 
     Single conversion function — replaces both convert_lossless_to_v0()
     and convert_lossless_to_opus(). The spec carries ffmpeg args, output
     extension, and metadata handling.
 
-    Returns (converted, failed, original_filetype) where original_filetype
-    is the extension of the first source file (e.g. "flac", "m4a", "wav"),
-    or None if no lossless files were found.
+    Returns ``(converted, failed, original_filetype, source_channels)``:
+
+    * ``original_filetype`` — extension of the first source file
+      (``"flac"``, ``"m4a"``, ``"wav"``).
+    * ``source_channels`` — channel count of the first source file as read
+      by mutagen, or ``None`` if the probe failed or the source list was
+      empty. ``> 2`` means the ffmpeg cmd downmixed to stereo via ``-ac
+      2``; we always emit stereo because libopus rejects ``5.1(side)``
+      outright (Mott /r3852) and the library is stereo-only by user
+      policy.
 
     When keep_source=True, original lossless files are preserved (used when
     a second conversion pass will run from the originals). If the target uses
@@ -759,9 +793,16 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
     else:
         lossless_files = sorted(lossless_files)
     if not lossless_files:
-        return 0, 0, None
+        return 0, 0, None, None
 
     original_ext = os.path.splitext(lossless_files[0])[1].lstrip(".").lower()
+    source_channels = _probe_source_channels(
+        os.path.join(album_path, lossless_files[0]))
+    if source_channels is not None and source_channels > 2:
+        _log(
+            f"  [DOWNMIX] {source_channels}ch source → stereo "
+            f"(target={spec.label})"
+        )
 
     converted = 0
     failed = 0
@@ -783,7 +824,13 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
             converted += 1
             continue
 
+        # ``-ac 2`` forces stereo on every output. libopus rejects
+        # ``5.1(side)`` with mapping family -1 *and* 1, and the library
+        # is stereo-only by user policy — downmix universally. Codecs
+        # that already auto-downmix (libmp3lame, aac) ignore the
+        # redundant flag.
         cmd = ["ffmpeg", "-i", src_path,
+               "-ac", "2",
                "-c:a", spec.codec, *spec.codec_args,
                *spec.metadata_args,
                "-y", temp_out_path]
@@ -821,7 +868,7 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
                 os.remove(src_path)
             converted += 1
 
-    return converted, failed, original_ext
+    return converted, failed, original_ext, source_channels
 
 
 # ---------------------------------------------------------------------------
@@ -1157,12 +1204,13 @@ def _materialize_quality_evidence_action(
             _log("[EVIDENCE] Normalizing non-FLAC lossless for Beets import")
             stage_start = time.monotonic()
             try:
-                converted, failed, original_ext = convert_lossless(
+                converted, failed, original_ext, source_channels = convert_lossless(
                     work_path, FLAC_SPEC, lossless_files=lossless_files)
             finally:
                 _log_timing("evidence_lossless_normalization", stage_start)
             r.conversion.converted = converted
             r.conversion.failed = failed
+            r.conversion.source_channels = source_channels
             if failed > 0:
                 raise RuntimeError(f"{failed} FLAC normalizations failed")
             if converted > 0:
@@ -1179,7 +1227,7 @@ def _materialize_quality_evidence_action(
     _log(f"[EVIDENCE] Materializing lossless source → {target_spec.label}")
     stage_start = time.monotonic()
     try:
-        converted, failed, original_ext = convert_lossless(
+        converted, failed, original_ext, source_channels = convert_lossless(
             work_path,
             target_spec,
             keep_source=True,
@@ -1189,6 +1237,7 @@ def _materialize_quality_evidence_action(
         _log_timing("evidence_materialization", stage_start)
     r.conversion.converted = converted
     r.conversion.failed = failed
+    r.conversion.source_channels = source_channels
     if failed > 0:
         raise RuntimeError(f"{failed} {target_spec.label} conversions failed")
     _remove_lossless_files(work_path)
@@ -1563,13 +1612,14 @@ def main():
         _log(f"[CONVERT] {work_path}")
         stage_start = time.monotonic()
         try:
-            converted, failed, original_ext = convert_lossless(
+            converted, failed, original_ext, source_channels = convert_lossless(
                 work_path, V0_SPEC,
                 keep_source=keep_v0_source)
         finally:
             _log_timing("primary_conversion", stage_start)
         r.conversion.converted = converted
         r.conversion.failed = failed
+        r.conversion.source_channels = source_channels
         if converted > 0:
             r.conversion.was_converted = True
             r.conversion.original_filetype = original_ext or "flac"
@@ -1615,12 +1665,13 @@ def main():
             _log(f"[NORMALIZE] Converting non-FLAC lossless → FLAC")
             stage_start = time.monotonic()
             try:
-                converted, failed, original_ext = convert_lossless(
+                converted, failed, original_ext, source_channels = convert_lossless(
                     work_path, FLAC_SPEC)
             finally:
                 _log_timing("lossless_normalization", stage_start)
             r.conversion.converted = converted
             r.conversion.failed = failed
+            r.conversion.source_channels = source_channels
             if converted > 0:
                 r.conversion.was_converted = True
                 r.conversion.original_filetype = original_ext
@@ -1870,8 +1921,13 @@ def main():
         if target_spec.extension == V0_SPEC.extension:
             _remove_files_by_ext(work_path, "." + V0_SPEC.extension)
         try:
-            target_converted, target_failed, _ = convert_lossless(
+            target_converted, target_failed, _, target_source_channels = convert_lossless(
                 work_path, target_spec, keep_source=True)
+            if (
+                target_source_channels is not None
+                and r.conversion.source_channels is None
+            ):
+                r.conversion.source_channels = target_source_channels
             if target_failed > 0:
                 r.exit_code = 1
                 r.decision = "target_conversion_failed"

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1712,6 +1712,11 @@ class ConversionInfo(msgspec.Struct):
     post_conversion_min_bitrate: Optional[int] = None  # min bitrate after lossless→V0
     is_transcode: bool = False  # True if FLAC was actually a transcode
     final_format: Optional[str] = None  # e.g. "opus 128", "mp3 v2", "aac 128"
+    # Source channel count read off the first source file before conversion.
+    # ``> 2`` means the ffmpeg invocation downmixed multichannel → stereo;
+    # 5.1(side) FLAC otherwise breaks libopus outright (Mott / r3852). None
+    # for legacy rows or when the probe fails.
+    source_channels: Optional[int] = None
 
 
 class SpectralDetail(msgspec.Struct):

--- a/tests/test_conversion_e2e.py
+++ b/tests/test_conversion_e2e.py
@@ -486,7 +486,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
-            converted, failed, orig_ext = convert_lossless(album, V0_SPEC)
+            converted, failed, orig_ext, _ = convert_lossless(album, V0_SPEC)
             self.assertEqual(converted, 2)
             self.assertEqual(failed, 0)
             self.assertEqual(orig_ext, "flac")
@@ -505,7 +505,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=12000)
-            converted, failed, orig_ext = convert_lossless(album, V0_SPEC)
+            converted, failed, orig_ext, _ = convert_lossless(album, V0_SPEC)
             self.assertEqual(converted, 2)
             self.assertEqual(failed, 0)
             for f in os.listdir(album):
@@ -531,7 +531,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
-            converted, failed, orig_ext = convert_lossless(album, spec)
+            converted, failed, orig_ext, _ = convert_lossless(album, spec)
             self.assertEqual(converted, 2)
             self.assertEqual(failed, 0)
             exts = self._count_by_ext(album)
@@ -545,7 +545,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
-            converted, failed, _ = convert_lossless(album, spec)
+            converted, failed, _, _ = convert_lossless(album, spec)
             self.assertEqual(converted, 2)
             exts = self._count_by_ext(album)
             self.assertEqual(exts.get(".mp3", 0), 2)
@@ -558,7 +558,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
-            converted, failed, _ = convert_lossless(album, spec)
+            converted, failed, _, _ = convert_lossless(album, spec)
             self.assertEqual(converted, 2)
             exts = self._count_by_ext(album)
             self.assertEqual(exts.get(".m4a", 0), 2)
@@ -583,11 +583,11 @@ class TestConvertLosslessE2E(unittest.TestCase):
                 capture_output=True, check=True, timeout=30,
             )
 
-            converted, failed, _ = convert_lossless(album, V0_SPEC, keep_source=True)
+            converted, failed, _, _ = convert_lossless(album, V0_SPEC, keep_source=True)
             self.assertEqual((converted, failed), (1, 0))
 
             target_spec = parse_verified_lossless_target("aac 128")
-            converted, failed, _ = convert_lossless(album, target_spec, keep_source=True)
+            converted, failed, _, _ = convert_lossless(album, target_spec, keep_source=True)
             self.assertEqual((converted, failed), (1, 0))
 
             _remove_files_by_ext(album, "." + V0_SPEC.extension)
@@ -608,7 +608,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
                 ["ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
                  "-y", wav],
                 capture_output=True, check=True, timeout=30)
-            converted, failed, orig_ext = convert_lossless(album, FLAC_SPEC)
+            converted, failed, orig_ext, _ = convert_lossless(album, FLAC_SPEC)
             self.assertEqual(converted, 1)
             self.assertEqual(failed, 0)
             self.assertEqual(orig_ext, "wav")
@@ -627,7 +627,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
                 ["ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
                  "-c:a", "alac", "-y", src],
                 capture_output=True, check=True, timeout=30)
-            converted, failed, orig_ext = convert_lossless(album, FLAC_SPEC)
+            converted, failed, orig_ext, _ = convert_lossless(album, FLAC_SPEC)
             self.assertEqual(converted, 1)
             self.assertEqual(orig_ext, "m4a")
             exts = self._count_by_ext(album)
@@ -647,7 +647,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=1, cutoff_hz=15500)
-            converted, failed, _ = convert_lossless(album, FLAC_SPEC)
+            converted, failed, _, _ = convert_lossless(album, FLAC_SPEC)
             self.assertEqual(converted, 1)  # re-compresses via temp file
             exts = self._count_by_ext(album)
             self.assertEqual(exts.get(".flac", 0), 1)
@@ -659,7 +659,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
             # Create a fake mp3
             with open(os.path.join(d, "track.mp3"), "w") as f:
                 f.write("not real")
-            converted, failed, orig_ext = convert_lossless(d, V0_SPEC)
+            converted, failed, orig_ext, _ = convert_lossless(d, V0_SPEC)
             self.assertEqual(converted, 0)
             self.assertEqual(failed, 0)
             self.assertIsNone(orig_ext)
@@ -670,7 +670,7 @@ class TestConvertLosslessE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=1, cutoff_hz=15500)
-            converted, failed, _ = convert_lossless(album, V0_SPEC, dry_run=True)
+            converted, failed, _, _ = convert_lossless(album, V0_SPEC, dry_run=True)
             self.assertEqual(converted, 1)
             exts = self._count_by_ext(album)
             self.assertNotIn(".mp3", exts, "Dry run should not create files")
@@ -697,7 +697,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=15500)
-            converted, failed, _ = convert_lossless(album, V0_SPEC)
+            converted, failed, _, _ = convert_lossless(album, V0_SPEC)
 
             # Measure V0 bitrate
             min_br = None
@@ -724,7 +724,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             album = os.path.join(d, "album")
             make_test_album(album, track_count=2, cutoff_hz=12000)
-            converted, failed, _ = convert_lossless(album, V0_SPEC)
+            converted, failed, _, _ = convert_lossless(album, V0_SPEC)
 
             min_br = None
             for f in os.listdir(album):
@@ -752,7 +752,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
             make_test_album(album, track_count=2, cutoff_hz=15500)
 
             # Step 1: V0 verification (keep source for second pass)
-            converted, _, _ = convert_lossless(album, V0_SPEC, keep_source=True)
+            converted, _, _, _ = convert_lossless(album, V0_SPEC, keep_source=True)
 
             # Measure V0 for verification
             v0_bitrates = []
@@ -771,7 +771,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
 
             # Step 3: Convert FLAC → Opus (from originals, not V0)
             spec = parse_verified_lossless_target("opus 128")
-            opus_converted, opus_failed, _ = convert_lossless(album, spec)
+            opus_converted, opus_failed, _, _ = convert_lossless(album, spec)
             self.assertEqual(opus_converted, 2)
 
             # Step 4: Clean up V0 (ephemeral) + FLAC (consumed)
@@ -797,7 +797,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
             make_test_album(album, track_count=2, cutoff_hz=12000)
 
             # V0 verification (keep source because target was configured)
-            converted, _, _ = convert_lossless(album, V0_SPEC, keep_source=True)
+            converted, _, _, _ = convert_lossless(album, V0_SPEC, keep_source=True)
 
             v0_min = None
             for f in os.listdir(album):
@@ -849,7 +849,7 @@ class TestConversionPipelineE2E(unittest.TestCase):
             _remove_files_by_ext(album, "." + V0_SPEC.extension)
 
             # Step 3: Convert FLAC → MP3 V2
-            converted, failed, _ = convert_lossless(album, target_spec,
+            converted, failed, _, _ = convert_lossless(album, target_spec,
                                                     keep_source=True)
             self.assertEqual(converted, 2)
             self.assertEqual(failed, 0)

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -733,10 +733,11 @@ class TestConvertLosslessKeepSource(unittest.TestCase):
                  "-y", flac_path],
                 capture_output=True, timeout=30)
             self.assertTrue(os.path.exists(flac_path))
-            converted, failed, ext = convert_lossless(tmpdir, V0_SPEC,
-                                                      keep_source=True)
+            converted, failed, ext, channels = convert_lossless(
+                tmpdir, V0_SPEC, keep_source=True)
             self.assertEqual(converted, 1)
             self.assertEqual(failed, 0)
+            self.assertEqual(channels, 1, "sine source is mono")
             self.assertTrue(os.path.exists(flac_path))
             mp3_path = os.path.join(tmpdir, "track01.mp3")
             self.assertTrue(os.path.exists(mp3_path))
@@ -751,9 +752,122 @@ class TestConvertLosslessKeepSource(unittest.TestCase):
                 ["ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
                  "-y", flac_path],
                 capture_output=True, timeout=30)
-            converted, failed, ext = convert_lossless(tmpdir, V0_SPEC)
+            converted, failed, ext, _channels = convert_lossless(tmpdir, V0_SPEC)
             self.assertEqual(converted, 1)
             self.assertFalse(os.path.exists(flac_path))
+
+
+class TestConvertLosslessMultichannelDownmix(unittest.TestCase):
+    """Multichannel FLAC sources must downmix to stereo on every target.
+
+    Live bug: Mott the Hoople — All the Young Dudes (request 3852, evidence
+    2424). The candidate FLAC files were ``5.1(side)`` 24-bit; libopus
+    rejects that channel layout outright (``Invalid channel layout
+    5.1(side) for specified mapping family -1``) and every per-file
+    ffmpeg invocation failed with "Nothing was written into output file".
+    Two force-import attempts both surfaced
+    ``quality_evidence_action_failed`` because ``convert_lossless`` raised
+    "10 opus 128 conversions failed" before beets ever ran.
+
+    Policy: the library is stereo-only by user requirement, so every
+    output is forced to ``-ac 2`` regardless of source layout. We also
+    record the source channel count on ``ConversionInfo.source_channels``
+    so the breadcrumb is queryable from ``download_log.import_result``.
+    """
+
+    def _make_5_1_flac(self, dst: str, duration_s: float = 0.5) -> None:
+        """Synthesize a 5.1(side) FLAC at dst using ffmpeg's lavfi source."""
+        # Six discrete sines panned across the 5.1(side) layout. The
+        # ``channelmap=channel_layout=5.1(side)`` filter is what makes
+        # libopus reject the file without ``-ac 2``.
+        cmd = [
+            "ffmpeg", "-y",
+            "-f", "lavfi", "-i", f"sine=frequency=200:duration={duration_s}",
+            "-f", "lavfi", "-i", f"sine=frequency=300:duration={duration_s}",
+            "-f", "lavfi", "-i", f"sine=frequency=400:duration={duration_s}",
+            "-f", "lavfi", "-i", f"sine=frequency=500:duration={duration_s}",
+            "-f", "lavfi", "-i", f"sine=frequency=600:duration={duration_s}",
+            "-f", "lavfi", "-i", f"sine=frequency=700:duration={duration_s}",
+            "-filter_complex",
+            "[0:a][1:a][2:a][3:a][4:a][5:a]"
+            "amerge=inputs=6,channelmap=channel_layout=5.1(side)[a]",
+            "-map", "[a]",
+            "-c:a", "flac",
+            dst,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            raise unittest.SkipTest(
+                f"ffmpeg cannot synthesize 5.1(side) FLAC fixture "
+                f"(rc={result.returncode}): {result.stderr[-300:]}"
+            )
+
+    def test_5_1_flac_converts_to_opus_via_stereo_downmix(self):
+        """Pre-fix: libopus rejects 5.1(side) → 10 OPUS conversions failed.
+
+        Post-fix: ``-ac 2`` downmixes to stereo so libopus accepts the
+        stream, the conversion succeeds, and the 6-channel breadcrumb is
+        recorded.
+        """
+        from harness.import_one import (
+            convert_lossless, parse_verified_lossless_target,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "track01.flac")
+            self._make_5_1_flac(src)
+            opus_128 = parse_verified_lossless_target("opus 128")
+            converted, failed, ext, channels = convert_lossless(
+                tmpdir, opus_128, keep_source=True)
+            self.assertEqual(failed, 0, "5.1 → opus 128 must not fail")
+            self.assertEqual(converted, 1)
+            self.assertEqual(ext, "flac")
+            self.assertEqual(channels, 6,
+                             "source_channels must record the 5.1 layout")
+            self.assertTrue(os.path.exists(
+                os.path.join(tmpdir, "track01.opus")))
+
+    def test_5_1_flac_converts_to_v0_mp3_via_stereo_downmix(self):
+        """libmp3lame already auto-downmixes, but the breadcrumb must still
+        fire so the operator can see 5.1 sources in download_log even when
+        the conversion would have silently succeeded.
+        """
+        from harness.import_one import convert_lossless, V0_SPEC
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "track01.flac")
+            self._make_5_1_flac(src)
+            converted, failed, ext, channels = convert_lossless(
+                tmpdir, V0_SPEC, keep_source=True)
+            self.assertEqual(failed, 0)
+            self.assertEqual(converted, 1)
+            self.assertEqual(ext, "flac")
+            self.assertEqual(channels, 6)
+
+    def test_stereo_source_records_two_channels(self):
+        """The breadcrumb is populated for every source, not just multichannel."""
+        from harness.import_one import (
+            convert_lossless, parse_verified_lossless_target,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "track01.flac")
+            cmd = [
+                "ffmpeg", "-y",
+                "-f", "lavfi", "-i", "sine=frequency=440:duration=0.5",
+                "-f", "lavfi", "-i", "sine=frequency=660:duration=0.5",
+                "-filter_complex", "[0:a][1:a]amerge=inputs=2[a]",
+                "-map", "[a]", "-c:a", "flac",
+                src,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True,
+                                    timeout=30)
+            if result.returncode != 0:
+                raise unittest.SkipTest(
+                    f"ffmpeg stereo fixture failed: {result.stderr[-300:]}")
+            opus_128 = parse_verified_lossless_target("opus 128")
+            converted, failed, _ext, channels = convert_lossless(
+                tmpdir, opus_128, keep_source=True)
+            self.assertEqual(failed, 0)
+            self.assertEqual(converted, 1)
+            self.assertEqual(channels, 2)
 
 
 class TestConvertLosslessNonUtf8Stderr(unittest.TestCase):
@@ -806,7 +920,7 @@ class TestConvertLosslessNonUtf8Stderr(unittest.TestCase):
             try:
                 os.environ["PATH"] = bin_dir + os.pathsep + saved_path
                 # Pre-fix this raises UnicodeDecodeError; post-fix it returns cleanly.
-                converted, failed, ext = convert_lossless(album, V0_SPEC)
+                converted, failed, ext, _channels = convert_lossless(album, V0_SPEC)
             finally:
                 os.environ["PATH"] = saved_path
             self.assertEqual(converted, 1, "shim wrote a non-empty output file → counted as converted")
@@ -1150,7 +1264,7 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
             result = ImportResult()
 
             with patch("harness.import_one.convert_lossless",
-                       return_value=(1, 0, "flac")) as convert:
+                       return_value=(1, 0, "flac", 2)) as convert:
                 quality_is_transcode = (
                     import_one._materialize_quality_evidence_action(
                         work_path=album,
@@ -1181,7 +1295,7 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
             result = ImportResult()
 
             with patch("harness.import_one.convert_lossless",
-                       return_value=(1, 0, "flac")) as convert:
+                       return_value=(1, 0, "flac", 2)) as convert:
                 quality_is_transcode = (
                     import_one._materialize_quality_evidence_action(
                         work_path=album,
@@ -1215,7 +1329,7 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
             result = ImportResult()
 
             with patch("harness.import_one.convert_lossless",
-                       return_value=(0, 0, "flac")):
+                       return_value=(0, 0, "flac", 2)):
                 import_one._materialize_quality_evidence_action(
                     work_path=album,
                     payload=payload,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1473,7 +1473,7 @@ class TestPreserveSourceSlice(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             flac_path = self._make_flac(tmpdir, "01.flac")
 
-            converted, failed, _ = convert_lossless(
+            converted, failed, _, _ = convert_lossless(
                 tmpdir, V0_SPEC, keep_source=True)
 
             self.assertEqual((converted, failed), (1, 0))
@@ -1493,7 +1493,7 @@ class TestPreserveSourceSlice(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             flac_path = self._make_flac(tmpdir, "01.flac")
 
-            converted, failed, _ = convert_lossless(
+            converted, failed, _, _ = convert_lossless(
                 tmpdir, V0_SPEC, keep_source=True)
             self.assertEqual((converted, failed), (1, 0))
             self.assertTrue(os.path.exists(flac_path))
@@ -1562,7 +1562,7 @@ class TestPreserveSourceSlice(unittest.TestCase):
                                         _remove_files_by_ext)
         with tempfile.TemporaryDirectory() as tmpdir:
             flac_path = self._make_flac(tmpdir, "01.flac")
-            converted, _, _ = convert_lossless(
+            converted, _, _, _ = convert_lossless(
                 tmpdir, V0_SPEC, keep_source=True)
             self.assertEqual(converted, 1)
             mp3_path = os.path.join(tmpdir, "01.mp3")
@@ -1596,12 +1596,12 @@ class TestPreserveSourceSlice(unittest.TestCase):
 
             # First attempt: V0 conversion with keep_source=True (both
             # FLAC and MP3 now exist).
-            converted1, _, _ = convert_lossless(
+            converted1, _, _, _ = convert_lossless(
                 tmpdir, V0_SPEC, keep_source=True)
             self.assertEqual(converted1, 1)
 
             # Second attempt: output MP3 exists — convert_lossless skips.
-            converted2, _, _ = convert_lossless(
+            converted2, _, _, _ = convert_lossless(
                 tmpdir, V0_SPEC, keep_source=True)
             self.assertEqual(converted2, 0,
                              "V0 MP3 already exists — convert_lossless "


### PR DESCRIPTION
## Summary
- 5.1(side) FLAC source material broke force-import: libopus rejects the layout outright (`Invalid channel layout 5.1(side) for specified mapping family -1`), every per-file ffmpeg invocation in `convert_lossless` failed in ~0.3s, and the RuntimeError surfaced as `quality_evidence_action_failed` for the whole album. Reproduced on Mott the Hoople — All the Young Dudes (`request 3852`, `evidence 2424`); two force-import attempts both failed identically.
- libmp3lame on the V0 probe path auto-downmixes silently, so only the OPUS target tripped the wall. The library is stereo-only by user policy, so the fix is universal: add `-ac 2` to every ffmpeg cmd in `convert_lossless` and `_temp_v0_probe`. Codecs that already auto-downmix ignore the redundant flag.
- Probe source channel count via mutagen before the conversion loop, log `[DOWNMIX] Nch source → stereo (target=…)` when N > 2, and persist the count on `ConversionInfo.source_channels` so the breadcrumb flows through `download_log.import_result` JSONB for SQL queryability.

## Audit
Every ffmpeg call site in production code was checked for the same class of bug:

| Call site | Codec | Behavior | Action |
|---|---|---|---|
| `harness/import_one.py::convert_lossless` (FLAC/V0/MP3/AAC/OPUS targets) | mixed | **Fails on libopus** | Patched (`-ac 2` + breadcrumb) |
| `harness/import_one.py::_temp_v0_probe` (V0 probe encoder) | libmp3lame | auto-downmixed | Patched for consistency |
| `lib/spectral_check.py::_ffmpeg_to_wav` | wav | Already `-ac 2` | None |
| `lib/audio_hash.py::_hash_flac_pcm` / `_hash_lossy_container` | passthrough | Correctly preserves channels (hash stability) | None |

## API change
`convert_lossless` return type widened from `(converted, failed, ext)` to `(converted, failed, ext, source_channels)`. All 6 production callers + test fixtures updated in this PR.

## Test plan
- [x] Full suite passes (`nix-shell --run "bash scripts/run_tests.sh"`): 3489 tests OK, 56 skipped, 0 failures.
- [x] pyright clean on `harness/import_one.py`, `lib/quality.py`, all touched test files.
- [x] New `TestConvertLosslessMultichannelDownmix` synthesizes a real 5.1(side) FLAC via lavfi + channelmap and exercises OPUS 128 / V0 MP3 / stereo branches.
- [x] Direct ffmpeg verification on the live problem file (`/mnt/virtio/music/slskd/failed_imports/Mott the Hoople - All the Young Dudes (1990)_1/(1) Sweet Jane.flac`) — pre-fix cmd fails in 0.3s, post-fix cmd produces a 4.3 MB Opus 128 file.

## Follow-up (not addressed here)
The Mott source directory contains a 1.27 GB single-file whole-album FLAC alongside the 9 per-track FLACs. After this lands, conversion will succeed but beets track-matching may still skew because the 10th "track" is the whole album. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)