### PR TITLE
feat: propagate lossless-source evidence on transcoded imports + narrow search on lossless-source lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,22 +276,44 @@ them via `import_jobs.candidate_evidence_id`,
 cross-walk via `request_id` → measure as last resort). Evidence is never
 deleted unless the files actually change.
 
-**Evidence survives the candidate → library transition.** After a
-successful import, `propagate_candidate_evidence_to_current` (U10) inherits
-the candidate's full measurement payload (spectral grade, V0 lineage,
-bad-audio-hash matches, verified_lossless_proof) onto the library evidence
-row, for **both** renamed-only and transcoded imports (FLAC → V0/Opus).
-These fields describe the upstream source audio at import time, not the
-on-disk file. For transcoded imports the on-disk file has a different
-spectrum and codec, but the propagated fields remain accurate descriptions
-of the source that produced it — which is what wrong-match cleanup triage
-compares future candidates against.
+**Evidence survives the candidate → library transition (lossless-source
+gated).** After a successful import, `propagate_candidate_evidence_to_current`
+(U10) inherits the candidate's measurement payload onto the library
+evidence row. `verified_lossless_proof`, `verified_lossless`, and
+`was_converted_from` propagate in **all** cases. `spectral_grade`,
+`spectral_bitrate_kbps`, `v0_metric`, and `matched_bad_audio_hash_*`
+propagate when the import is renamed-only OR when the candidate source
+codec is lossless (FLAC / ALAC / WAV) — `LOSSLESS_CODECS` in `lib/quality.py`
+is the canonical set. Non-lossless transcoded imports (MP3 → Opus etc.)
+strip those fields onto NULL because a lossy source's spectral / V0
+lineage is not meaningfully comparable against future candidates and
+storing it on the library row would mislead triage.
 
-Known wart: library rows imported before this policy reversal landed
-(2026-05-17) have NULL spectral / V0 / bad-hash fields. They keep the old
-behaviour — wrong-match triage cannot reject same-source duplicates against
-them — until each row is re-imported or force-imported. Forward-only by
-design; no backfill. See `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`.
+For lossless-source-transcoded library rows, the propagated fields
+describe the upstream source audio at import time, not the on-disk
+file. Wrong-match cleanup triage compares future candidates against
+this evidence to reject same-source duplicates.
+
+**Search narrowing companion.** When `lossless_source_locked` fires —
+in the importer (`lib/import_dispatch.py`) or wrong-match cleanup
+triage (`lib/wrong_match_cleanup_service.py`) — the request's
+`search_filetype_override` is narrowed to `"lossless"` via
+`narrow_override_on_lossless_source_lock` (`lib/quality.py`). Future
+search cycles only ask Soulseek for lossless tiers, so the lock
+doesn't fire repeatedly against new peers serving the same lossy
+file. No plan-generator change is needed — `generate_search_plan`
+produces query strategies, and the filetype filter is applied
+downstream in `enqueue.py::effective_search_tiers` from the request's
+override column.
+
+Known wart: library rows imported before this policy landed (2026-05-17)
+have NULL spectral / V0 / bad-hash fields and may have lossy
+`search_filetype_override` values. They keep the old behaviour —
+wrong-match triage cannot reject same-source duplicates against them
+and the search-narrowing only fires on new `lossless_source_locked`
+events — until each row is re-imported or force-imported. Forward-only
+by design; no backfill. See
+`docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`.
 
 Pure decision helpers in `lib/quality.py`: `spectral_import_decision`,
 `import_quality_decision`, `transcode_detection`, `quality_gate_decision`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,10 +279,19 @@ deleted unless the files actually change.
 **Evidence survives the candidate → library transition.** After a
 successful import, `propagate_candidate_evidence_to_current` (U10) inherits
 the candidate's full measurement payload (spectral grade, V0 lineage,
-bad-audio-hash matches, verified_lossless_proof) for renamed-only imports.
-Transcoded imports (FLAC → V0) inherit only `verified_lossless_proof`;
-spectral and V0 fields refer to the source audio and stay NULL on the
-library row until something later measures them.
+bad-audio-hash matches, verified_lossless_proof) onto the library evidence
+row, for **both** renamed-only and transcoded imports (FLAC → V0/Opus).
+These fields describe the upstream source audio at import time, not the
+on-disk file. For transcoded imports the on-disk file has a different
+spectrum and codec, but the propagated fields remain accurate descriptions
+of the source that produced it — which is what wrong-match cleanup triage
+compares future candidates against.
+
+Known wart: library rows imported before this policy reversal landed
+(2026-05-17) have NULL spectral / V0 / bad-hash fields. They keep the old
+behaviour — wrong-match triage cannot reject same-source duplicates against
+them — until each row is re-imported or force-imported. Forward-only by
+design; no backfill. See `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`.
 
 Pure decision helpers in `lib/quality.py`: `spectral_import_decision`,
 `import_quality_decision`, `transcode_detection`, `quality_gate_decision`,

--- a/docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
+++ b/docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
@@ -1,0 +1,226 @@
+---
+date: 2026-05-17
+topic: propagate-source-evidence-on-transcode
+---
+
+# Propagate Source-Side Evidence on Transcoded Imports
+
+## Problem Frame
+
+`propagate_candidate_evidence_to_current` (lib/quality_evidence.py:795) writes the
+library-side `album_quality_evidence` row after an import succeeds. For
+**renamed-only** imports it propagates the candidate's full measurement payload
+(spectral grade, V0 lineage, bad-audio-hash matches, verified-lossless proof).
+For **transcoded** imports (FLAC → V0 / Opus) it propagates only
+`verified_lossless_proof`; spectral, V0 lineage, and bad-audio-hash fields are
+zeroed.
+
+The original reasoning was "spectral/V0 describe source audio that's gone after
+transcode." That reasoning is internally inconsistent: `verified_lossless_proof`
+also describes the source's provenance, and we keep it across transcode because
+lineage matters. The current rule effectively says **proof-of-good survives
+transcode; proof-of-compromised does not**.
+
+The asymmetry produces a concrete bug. Live reproducer: request 3779 (Lil Wayne
+— *Da Drought 3*). A transcoded-FLAC import landed at 16:06; a second
+identical-quality FLAC arrived at 18:32. Wrong-match cleanup triage called
+`full_pipeline_decision_from_evidence` against the library row, found the
+on-disk evidence had NULL spectral/V0 fields, fell through to
+`provisional_lossless_upgrade` → `kept_would_import`, and the folder stayed in
+the queue for manual review even though the operator had already imported an
+identical source 31 minutes earlier.
+
+## Scope
+
+Reverse the propagation asymmetry so transcoded imports also carry the
+source-side evidence fields forward to the library row, for **all** transcoded
+imports (not gated on source codec). Forward-only — existing library rows are
+not backfilled.
+
+## Requirements
+
+**Propagation policy**
+
+- R1. `propagate_candidate_evidence_to_current` must propagate `spectral_grade`
+  and `spectral_bitrate_kbps` from the candidate measurement to the library
+  measurement on transcoded imports.
+- R2. It must propagate `v0_source_lineage` and the
+  `v0_min_bitrate_kbps` / `v0_avg_bitrate_kbps` / `v0_median_bitrate_kbps` trio
+  from the candidate evidence to the library evidence on transcoded imports.
+- R3. It must propagate `matched_bad_audio_hash_id` and
+  `matched_bad_audio_hash_path` from the candidate evidence to the library
+  evidence on transcoded imports.
+- R4. The docstring at lib/quality_evidence.py:825-847 must be updated to
+  reflect the reversed rule and re-state the lineage semantic: these fields now
+  describe the upstream source audio at import time, not the on-disk file.
+
+**Semantic contract**
+
+- R5. `current_spectral_grade` / `current_spectral_bitrate` on `album_requests`
+  (mirrored from the library evidence row by `lib/import_service.py`) now
+  describe the source the library row was made from, not the file on disk. Any
+  downstream consumer that assumed "file at source_path" semantics inherits the
+  new contract; no consumer requires special-casing today.
+- R6. Source-replacement must overwrite stale evidence. When a clean
+  lossless-source candidate is force-imported over a previously-transcoded
+  library row, the new candidate's evidence propagation must overwrite the
+  stale `likely_transcode` / `lossless_source` fields with the new candidate's
+  values. (This is the existing behaviour of the upsert + propagation pair; the
+  requirement is to verify, not to change.)
+
+**Forward-only**
+
+- R7. No backfill of existing transcoded library rows. They retain their
+  current NULL spectral/V0/bad-hash fields until the album is re-imported or
+  force-imported, at which point the new policy applies.
+- R8. The asymmetry between pre-change and post-change library rows is an
+  accepted known wart. Wrong-match triage continues to return
+  `kept_would_import` against pre-change transcoded library rows until they
+  are touched.
+
+## Acceptance Examples
+
+- **AE1. Same-source duplicate is rejected by triage** (covers R1, R2).
+  Given a transcoded-FLAC library row imported under the new policy with
+  `spectral_grade=likely_transcode`, `spectral_bitrate=128`,
+  `v0_source_lineage=lossless_source`, `v0_avg=215`, and a new candidate
+  arrives with the same source-side evidence,
+  `full_pipeline_decision_from_evidence(import_mode="force")` must return a
+  reject-class decision (e.g. `lossless_source_not_better`,
+  `suspect_lossless_downgrade`) rather than `provisional_lossless_upgrade`.
+  Wrong-match cleanup triage classifies the outcome as `confident_reject` and
+  the folder becomes cleanup-eligible.
+
+- **AE2. Lossy candidate against transcoded-FLAC row is locked out** (covers
+  R2). Given the same library row as AE1, a lossy MP3 V0 candidate must
+  trigger `lossless_source_locked` at the provisional-lossless gate
+  (lib/quality.py:2341-2357), producing `confident_reject` and cleanup
+  eligibility. This is a behaviour change relative to today's NULL
+  v0_source_lineage — the lock fires where previously the candidate fell
+  through to `provisional_lossless_upgrade`.
+
+- **AE3. Bad-rip hash propagates** (covers R3). Given a candidate evidence
+  row with a non-NULL `matched_bad_audio_hash_id` that imports as a transcoded
+  FLAC → V0, the resulting library evidence row must carry the same
+  `matched_bad_audio_hash_id` and `matched_bad_audio_hash_path`. A subsequent
+  candidate matching the same bad-audio-hash must be detected against the
+  library row.
+
+- **AE4. Source-replacement overwrites** (covers R6). Given a library row
+  with `spectral_grade=likely_transcode` (propagated from a compromised
+  source), when a clean genuine FLAC force-imports over it, the resulting
+  library evidence row must reflect `spectral_grade=genuine` (or the new
+  source's actual grade), not the stale `likely_transcode`.
+
+- **AE5. Renamed-only path unchanged** (regression guard). Given a
+  lossless-stored-as-lossless import (FLAC kept as FLAC), the propagated
+  library row must carry the same evidence fields as today. No behaviour
+  change on the rename-only path.
+
+## Test Obligations
+
+Per `.claude/rules/code-quality.md` taxonomy:
+
+- **Pure tests** (`tests/test_quality_evidence.py` or equivalent): assert
+  field-by-field propagation for transcoded imports — spectral, V0 trio, bad
+  hash — and a regression assertion that rename-only behaviour is unchanged.
+- **Live-bug reproduction** in
+  `tests/test_quality_classification.py::TestLiveBugReproductions`: the
+  Lil Wayne — *Da Drought 3* (request 3779) scenario as AE1, plus its parity
+  exercise through `TestLiveBugReproductionsThroughEvidencePipeline`.
+- **Integration slice** in `tests/test_integration_slices.py`: round-trip
+  through `propagate_candidate_evidence_to_current` then a triage call against
+  the resulting library row, asserting the `kept_would_import` → reject
+  transition.
+- **Search-planner regression**: extend an existing
+  `compute_effective_override_bitrate` test to cover the case where a
+  transcoded library row now carries a `spectral_grade=likely_transcode` /
+  `spectral_bitrate=128` pair, asserting the MP3 V0 override drops from
+  container (~225) to spectral (128) — matching today's rename-only behaviour.
+
+## Scope Boundaries
+
+- Do not backfill existing transcoded library rows.
+- Do not narrow search-plan tiers based on `v0_source_lineage=lossless_source`.
+  That follow-up is the natural shape of the buckets work (see
+  `docs/brainstorms/quality-bucket-system-requirements.md` — once buckets are
+  in, search asks only for `verified`-bucket candidates when the existing row
+  is `verified`, which dissolves the wasted-search window noted below).
+- Do not change `full_pipeline_decision_from_evidence` or any pure decider in
+  `lib/quality.py`. The deciders already do the right thing when both sides
+  have comparable evidence; this change just makes the library side carry the
+  evidence forward.
+- Do not change UI copy or wrong-match triage display labels. The audit row
+  already carries `verdict`, `preview_decision`, and `stage_chain` — these
+  will surface the new outcomes (e.g. `lossless_source_locked`) without
+  additional plumbing.
+
+## Key Decisions
+
+- **Symmetric over scoped.** Propagate the source-side fields for all
+  transcoded imports, not just lossless-source candidates. The asymmetry is
+  rename-only vs transcoded, not lossless vs lossy; the symmetric fix is the
+  coherent one.
+- **Forward-only over backfill.** Backfill via the candidate-evidence FK
+  chain (`download_log.candidate_evidence_id` → `album_quality_evidence`) was
+  considered. Rejected for this change because (a) the bug is operator-
+  visible only on new wrong-matches, (b) backfill compounds risk on the
+  search-planner semantic shift, (c) organic re-touch over time closes the
+  asymmetry without a sweep. Revisit if false-positive triage keeps remain
+  noisy after a few weeks.
+- **Lossless-source lock is accepted, not loosened.** The propagation change
+  causes `lossless_source_locked` to fire on transcoded-from-FLAC library
+  rows for any lossy candidate. That is the intended behaviour under both the
+  current spectral-distrust posture and the future bucket model — a transcoded
+  copy of a lossless source still has lossless lineage, and only another
+  lossless source can override that lineage.
+
+## Dependencies / Assumptions
+
+- The current `provisional_lossless_decision` already returns
+  `lossless_source_locked` correctly when `existing_probe` is a comparable
+  lossless-source V0 probe (lib/quality.py:2341-2357). No deciders change.
+- `lib/import_service.py:135-136` already writes `spectral_grade` from the
+  library measurement back to `album_requests.current_spectral_grade`. The
+  new fields flow through this existing path without additional plumbing.
+- `compute_effective_override_bitrate` (lib/quality.py:2821) already
+  consumes `spectral_grade` correctly via `SPECTRAL_TRANSCODE_GRADES`. Its
+  behaviour change for transcoded library rows is the same shift that already
+  happens for rename-only library rows today; this change makes the two paths
+  consistent.
+
+## Known Consequence: Temporary Wasted-Search Window
+
+Until the buckets work narrows search tiers based on existing-bucket, search
+will continue to ask Soulseek for lossy candidates against transcoded-FLAC
+library rows. Those candidates come back, hit triage, get
+`lossless_source_locked`, and get cleanup-deleted. Net: more slskd churn and
+more wrong-matches queue entries that auto-delete. No different files on disk.
+
+This window closes when search-plan tier selection moves to the bucket model
+(`docs/brainstorms/quality-bucket-system-requirements.md` R1, R6).
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R1, R2, R3][Technical] Identify the outer-row construction site in
+  `propagate_candidate_evidence_to_current` for `v0_source_lineage`, the v0
+  bitrate trio, and the bad-audio-hash pair; current docstring suggests the
+  inner `AudioQualityMeasurement` build at lib/quality_evidence.py:879-894
+  handles spectral but the v0/bad-hash fields live on the outer
+  `AlbumQualityEvidence` row.
+- [Affects R6][Technical] Confirm via test that the
+  `upsert_album_quality_evidence` + `propagate` flow overwrites stale fields
+  on source-replacement rather than preserving them via partial update.
+
+## Next Steps
+
+→ Use `/ce-plan` for structured implementation planning. The change is small
+   enough (one function plus tests) that planning will be light; the main
+   planning work is the test matrix in §Test Obligations and the outer-row vs
+   inner-measurement field-location question in §Deferred to Planning.

--- a/docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
+++ b/docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
@@ -3,224 +3,314 @@ date: 2026-05-17
 topic: propagate-source-evidence-on-transcode
 ---
 
-# Propagate Source-Side Evidence on Transcoded Imports
+# Propagate Source-Side Evidence on Lossless-Source Transcoded Imports + Narrow Search on Lossless-Source Lock
 
 ## Problem Frame
 
-`propagate_candidate_evidence_to_current` (lib/quality_evidence.py:795) writes the
-library-side `album_quality_evidence` row after an import succeeds. For
-**renamed-only** imports it propagates the candidate's full measurement payload
-(spectral grade, V0 lineage, bad-audio-hash matches, verified-lossless proof).
-For **transcoded** imports (FLAC → V0 / Opus) it propagates only
-`verified_lossless_proof`; spectral, V0 lineage, and bad-audio-hash fields are
-zeroed.
+Two coupled gaps in the current pipeline:
 
-The original reasoning was "spectral/V0 describe source audio that's gone after
-transcode." That reasoning is internally inconsistent: `verified_lossless_proof`
-also describes the source's provenance, and we keep it across transcode because
-lineage matters. The current rule effectively says **proof-of-good survives
-transcode; proof-of-compromised does not**.
+1. **`propagate_candidate_evidence_to_current` strips spectral / V0 / bad-hash
+   fields on every transcoded import**, including the FLAC → V0/Opus case
+   where the source is lossless and its source-side evidence is meaningful for
+   future candidates. The function only preserves `verified_lossless_proof`.
+2. **`lossless_source_locked` rejections don't narrow the search plan.** Even
+   though triage classifies a lossy candidate against a lossless-source
+   library row as `confident_reject`, the search planner keeps asking
+   Soulseek for the same album with no filetype filter on the next cycle.
+   New peers serve the same lossy file, it's downloaded, rejected again,
+   indefinitely.
 
-The asymmetry produces a concrete bug. Live reproducer: request 3779 (Lil Wayne
-— *Da Drought 3*). A transcoded-FLAC import landed at 16:06; a second
+Both gaps are visible in the live reproducer: request 3779 (Lil Wayne —
+*Da Drought 3*). A transcoded-FLAC import landed at 16:06 UTC; a second
 identical-quality FLAC arrived at 18:32. Wrong-match cleanup triage called
-`full_pipeline_decision_from_evidence` against the library row, found the
-on-disk evidence had NULL spectral/V0 fields, fell through to
-`provisional_lossless_upgrade` → `kept_would_import`, and the folder stayed in
-the queue for manual review even though the operator had already imported an
-identical source 31 minutes earlier.
+`full_pipeline_decision_from_evidence(import_mode="force")`, found the
+on-disk evidence row had NULL `spectral_grade` / `v0_metric` /
+`matched_bad_audio_hash_id`, fell through to `provisional_lossless_upgrade` →
+`kept_would_import`. Even if propagation had been correct, the search planner
+would still keep asking for the album with no filetype narrowing — the lock
+would fire repeatedly until peer cooldowns burn out.
+
+The two changes belong in the same PR because they are the same architectural
+intent: **once a library row carries lossless-source evidence, the system
+should both (a) recognize that evidence on the next candidate, and (b) stop
+searching for non-lossless candidates that can never override it.** Shipping
+(a) without (b) creates a wasted-cycle window.
+
+This is consistent with the direction in
+`docs/brainstorms/quality-bucket-system-requirements.md` — under buckets, the
+lock dissolves into bucket-comparison and the search narrowing is just
+"search same-bucket-or-above." This PR is the transitional step that mimics
+that behavior inside the current spectral system without waiting for the
+full buckets rewrite.
 
 ## Scope
 
-Reverse the propagation asymmetry so transcoded imports also carry the
-source-side evidence fields forward to the library row, for **all** transcoded
-imports (not gated on source codec). Forward-only — existing library rows are
-not backfilled.
+**In scope:**
+- Gate `propagate_candidate_evidence_to_current` source-side propagation on
+  whether the candidate source is a lossless codec. Lossless-source
+  transcodes propagate spectral / V0 / bad-hash; non-lossless transcodes
+  keep today's strip behavior.
+- When `lossless_source_locked` fires (importer worker AND wrong-match
+  cleanup triage), narrow the request's `search_filetype_override` to
+  `"lossless"` so future cycles only ask for lossless candidates.
+
+**Out of scope:**
+- No backfill of existing transcoded library rows.
+- No decider changes in `lib/quality.py` (the existing
+  `provisional_lossless_decision` already handles the lock correctly given
+  the right inputs).
+- No UI / copy / triage-display changes.
+- No `import_service.py` changes; downstream `current_spectral_*` flow
+  inherits the narrower policy naturally.
+- No force-import-bypass-the-lock affordance. Operator escape hatches stay
+  as-is (bad-rip ban + manual evidence deletion).
+- No new CLI / web API surface; this is automated pipeline behavior, not an
+  operator action.
 
 ## Requirements
 
-**Propagation policy**
+**Propagation policy (lossless-source gated)**
 
-- R1. `propagate_candidate_evidence_to_current` must propagate `spectral_grade`
-  and `spectral_bitrate_kbps` from the candidate measurement to the library
-  measurement on transcoded imports.
-- R2. It must propagate `v0_source_lineage` and the
-  `v0_min_bitrate_kbps` / `v0_avg_bitrate_kbps` / `v0_median_bitrate_kbps` trio
-  from the candidate evidence to the library evidence on transcoded imports.
-- R3. It must propagate `matched_bad_audio_hash_id` and
-  `matched_bad_audio_hash_path` from the candidate evidence to the library
-  evidence on transcoded imports.
-- R4. The docstring at lib/quality_evidence.py:825-847 must be updated to
-  reflect the reversed rule and re-state the lineage semantic: these fields now
-  describe the upstream source audio at import time, not the on-disk file.
+- R1. `propagate_candidate_evidence_to_current` must propagate
+  `spectral_grade`, `spectral_bitrate_kbps`, `v0_metric`,
+  `matched_bad_audio_hash_id`, and `matched_bad_audio_hash_path` from the
+  candidate to the library evidence row when the candidate is a lossless
+  source (codec in `LOSSLESS_CODECS = {"flac", "alac", "wav"}`).
+- R2. For non-lossless transcoded imports (e.g., MP3 → Opus), the function
+  must continue to strip those fields onto NULL — the source's spectral /
+  V0 lineage is not meaningfully comparable across future candidates and
+  storing it provides no decision value.
+- R3. For renamed-only imports (any source codec), the function must
+  continue to propagate all source-side fields — today's behavior unchanged.
+- R4. `verified_lossless_proof` and `verified_lossless` continue to
+  propagate in all cases — today's behavior unchanged.
+- R5. The function's `target_format` parameter is unused after the gate is
+  re-shaped; remove it from the signature.
+
+**Search narrowing (lossless-source lock → lossless-only override)**
+
+- R6. A new pure helper in `lib/quality.py` —
+  `narrow_override_on_lossless_source_lock(current: str | None) -> str | None`
+  — must return `"lossless"` when the lock fires unless the current override
+  is already `"lossless"` (idempotent narrowing returns `None`).
+- R7. The importer-side `lossless_source_locked` rejection in
+  `lib/import_dispatch.py` must call this helper and pass the narrowed
+  override through `_record_rejection_and_maybe_requeue` (precedent: the
+  `downgrade` branch immediately above already does this with
+  `narrow_override_on_downgrade`).
+- R8. The wrong-match cleanup triage path in
+  `lib/wrong_match_cleanup_service.py` must call this helper when a
+  deletion completes with `preview_decision == "lossless_source_locked"`
+  and persist the narrowed override on the request row.
+- R9. Search-plan persistence is unaffected — `generate_search_plan`
+  (`lib/search.py`) produces query strategies, not filetype slices. The
+  filetype filter is applied downstream in
+  `enqueue.py::effective_search_tiers` from the request's
+  `search_filetype_override` column. No plan invalidation or
+  `SEARCH_PLAN_GENERATOR_ID` bump needed.
 
 **Semantic contract**
 
-- R5. `current_spectral_grade` / `current_spectral_bitrate` on `album_requests`
-  (mirrored from the library evidence row by `lib/import_service.py`) now
-  describe the source the library row was made from, not the file on disk. Any
-  downstream consumer that assumed "file at source_path" semantics inherits the
-  new contract; no consumer requires special-casing today.
-- R6. Source-replacement must overwrite stale evidence. When a clean
-  lossless-source candidate is force-imported over a previously-transcoded
-  library row, the new candidate's evidence propagation must overwrite the
-  stale `likely_transcode` / `lossless_source` fields with the new candidate's
-  values. (This is the existing behaviour of the upsert + propagation pair; the
-  requirement is to verify, not to change.)
+- R10. `current_spectral_grade` / `current_spectral_bitrate` on
+  `album_requests` (mirrored from the library row by
+  `lib/import_service.py`) inherit the narrower propagation rule naturally.
+  For lossless-source transcoded library rows, these now describe the
+  upstream source. For non-lossless transcoded library rows, they remain
+  NULL as today.
+- R11. Source-replacement (a clean lossless-source candidate force-imports
+  over a previously-transcoded lossless-source library row) overwrites the
+  stale fields via the existing `upsert_album_quality_evidence` ON CONFLICT
+  DO UPDATE behavior. No new code; the requirement is verified via test.
 
 **Forward-only**
 
-- R7. No backfill of existing transcoded library rows. They retain their
-  current NULL spectral/V0/bad-hash fields until the album is re-imported or
-  force-imported, at which point the new policy applies.
-- R8. The asymmetry between pre-change and post-change library rows is an
+- R12. No backfill of existing transcoded library rows. They retain their
+  current NULL spectral / V0 / bad-hash fields until the album is
+  re-imported or force-imported.
+- R13. The asymmetry between pre-change and post-change library rows is an
   accepted known wart. Wrong-match triage continues to return
   `kept_would_import` against pre-change transcoded library rows until they
   are touched.
 
 ## Acceptance Examples
 
-- **AE1. Same-source duplicate is rejected by triage** (covers R1, R2).
-  Given a transcoded-FLAC library row imported under the new policy with
-  `spectral_grade=likely_transcode`, `spectral_bitrate=128`,
-  `v0_source_lineage=lossless_source`, `v0_avg=215`, and a new candidate
-  arrives with the same source-side evidence,
-  `full_pipeline_decision_from_evidence(import_mode="force")` must return a
-  reject-class decision (e.g. `lossless_source_not_better`,
-  `suspect_lossless_downgrade`) rather than `provisional_lossless_upgrade`.
-  Wrong-match cleanup triage classifies the outcome as `confident_reject` and
-  the folder becomes cleanup-eligible.
+- **AE1. Lossless-source duplicate is rejected by triage AND search
+  narrows** (covers R1, R7, R8). Given a transcoded-FLAC library row
+  imported under the new policy with `spectral_grade=likely_transcode`,
+  `v0_metric` carrying `lossless_source` lineage at avg 215 / min 184, when
+  a second identical-quality FLAC arrives:
+    - `full_pipeline_decision_from_evidence(import_mode="force")` returns
+      `suspect_lossless_downgrade` (or a sibling reject-class decision).
+    - Wrong-match cleanup triage classifies the outcome as
+      `confident_reject` and the folder becomes cleanup-eligible.
+    - After cleanup deletion, the request's `search_filetype_override` is
+      `"lossless"`.
 
-- **AE2. Lossy candidate against transcoded-FLAC row is locked out** (covers
-  R2). Given the same library row as AE1, a lossy MP3 V0 candidate must
-  trigger `lossless_source_locked` at the provisional-lossless gate
-  (lib/quality.py:2341-2357), producing `confident_reject` and cleanup
-  eligibility. This is a behaviour change relative to today's NULL
-  v0_source_lineage — the lock fires where previously the candidate fell
-  through to `provisional_lossless_upgrade`.
+- **AE2. Lossy candidate against lossless-source library row triggers
+  `lossless_source_locked` AND narrows search** (covers R7, R8). Given the
+  same library row as AE1, a lossy MP3 V0 candidate must hit
+  `provisional_lossless_decision`'s lock branch
+  (`lib/quality.py:2341-2357`), produce `confident_reject` + cleanup
+  eligibility, and the cleanup must persist
+  `search_filetype_override="lossless"` on the request. The next search
+  cycle for that request only asks for lossless tiers.
 
-- **AE3. Bad-rip hash propagates** (covers R3). Given a candidate evidence
-  row with a non-NULL `matched_bad_audio_hash_id` that imports as a transcoded
+- **AE3. Bad-rip hash propagates on lossless-source transcoded import**
+  (covers R1). Given a lossless-source candidate evidence row with a
+  non-NULL `matched_bad_audio_hash_id` that imports as a transcoded
   FLAC → V0, the resulting library evidence row must carry the same
-  `matched_bad_audio_hash_id` and `matched_bad_audio_hash_path`. A subsequent
-  candidate matching the same bad-audio-hash must be detected against the
-  library row.
+  `matched_bad_audio_hash_id` and `matched_bad_audio_hash_path`. A
+  subsequent candidate matching the same bad-audio-hash is detected against
+  the library row.
 
-- **AE4. Source-replacement overwrites** (covers R6). Given a library row
-  with `spectral_grade=likely_transcode` (propagated from a compromised
-  source), when a clean genuine FLAC force-imports over it, the resulting
-  library evidence row must reflect `spectral_grade=genuine` (or the new
-  source's actual grade), not the stale `likely_transcode`.
+- **AE4. Source-replacement overwrites stale propagated evidence** (covers
+  R11). Given a lossless-source-transcoded library row with
+  `spectral_grade=likely_transcode`, when a clean genuine FLAC force-imports
+  over it, the resulting library evidence row reflects
+  `spectral_grade=genuine` and the new candidate's V0 metric and verified
+  lossless proof. No stale values survive the upsert.
 
-- **AE5. Renamed-only path unchanged** (regression guard). Given a
-  lossless-stored-as-lossless import (FLAC kept as FLAC), the propagated
-  library row must carry the same evidence fields as today. No behaviour
-  change on the rename-only path.
+- **AE5. Non-lossless-source transcoded import does NOT propagate
+  source-side evidence** (covers R2). Given an MP3 source candidate that
+  imports as a transcoded MP3 → Opus (e.g., a low-bitrate MP3 the user
+  asked the pipeline to re-encode to Opus), the resulting library evidence
+  row's `spectral_grade`, `v0_metric`, `matched_bad_audio_hash_id`, and
+  `matched_bad_audio_hash_path` must be NULL. Behavior unchanged from
+  today.
+
+- **AE6. Renamed-only path unchanged** (covers R3). Given a
+  lossless-stored-as-lossless import (FLAC kept as FLAC) and any
+  renamed-only import where source codec equals library codec, the
+  propagated library row must carry the same evidence fields as today.
+  Behavior unchanged.
+
+- **AE7. Idempotent narrowing** (covers R6). Given a request whose
+  `search_filetype_override` is already `"lossless"`, when
+  `lossless_source_locked` fires again, the narrowing helper returns
+  `None` (no-op) and the override stays `"lossless"`.
+
+## Key Decisions
+
+- **Lossless-source-gated, not symmetric.** The earlier framing of
+  "propagate everything for all transcoded imports symmetrically" was
+  scope creep. The user-stated intent is narrower: propagate source-side
+  evidence specifically when the source is lossless, because that's the
+  only case where the source-side spectral / V0 lineage is meaningfully
+  comparable against future candidates.
+- **Search narrowing is in scope, not deferred.** The propagation reversal
+  alone creates a wasted-cycle window (lock fires → cleanup deletes →
+  search re-asks → repeat). Closing that window with
+  `search_filetype_override="lossless"` is the companion change that makes
+  the propagation policy actually pay off. Without it, the lock is half a
+  system.
+- **`narrow_override_on_lossless_source_lock` is a pure helper at two call
+  sites, not a decider change.** The deciders in `lib/quality.py` already
+  return `lossless_source_locked` correctly; the new helper is rejection-
+  side handling at the orchestration layer.
+- **Forward-only over backfill.** Existing transcoded library rows are not
+  retroactively populated. Same reasoning as before — organic re-touch
+  closes the gap over time; backfill compounds risk on the search-planner
+  semantic shift.
+- **Aligned with the bucket model's trajectory.** Per
+  `docs/brainstorms/quality-bucket-system-requirements.md` R15, spectral
+  is being demoted to a bucket-modifier signal. This PR doesn't entrench
+  the spectral system; it makes the spectral-era lock plus search-narrowing
+  match the behavior the bucket model will produce naturally
+  ("only grind up quality within the bucket or above where we are").
 
 ## Test Obligations
 
 Per `.claude/rules/code-quality.md` taxonomy:
 
-- **Pure tests** (`tests/test_quality_evidence.py` or equivalent): assert
-  field-by-field propagation for transcoded imports — spectral, V0 trio, bad
-  hash — and a regression assertion that rename-only behaviour is unchanged.
+- **Pure tests** in `tests/test_quality_decisions.py`: new test class for
+  `narrow_override_on_lossless_source_lock` covering R6 cases (None input,
+  "lossless" input, lossy override input).
+- **Pure / structural test** in `tests/test_quality_evidence.py` or a
+  parametric extension of existing propagation tests: the lossless-source
+  gate behaves as specified for the four cases — renamed-only lossless,
+  renamed-only lossy, transcoded lossless source, transcoded lossy source.
 - **Live-bug reproduction** in
-  `tests/test_quality_classification.py::TestLiveBugReproductions`: the
-  Lil Wayne — *Da Drought 3* (request 3779) scenario as AE1, plus its parity
-  exercise through `TestLiveBugReproductionsThroughEvidencePipeline`.
-- **Integration slice** in `tests/test_integration_slices.py`: round-trip
-  through `propagate_candidate_evidence_to_current` then a triage call against
-  the resulting library row, asserting the `kept_would_import` → reject
-  transition.
-- **Search-planner regression**: extend an existing
-  `compute_effective_override_bitrate` test to cover the case where a
-  transcoded library row now carries a `spectral_grade=likely_transcode` /
-  `spectral_bitrate=128` pair, asserting the MP3 V0 override drops from
-  container (~225) to spectral (128) — matching today's rename-only behaviour.
+  `tests/test_quality_classification.py::TestLiveBugReproductions` +
+  `TestLiveBugReproductionsThroughEvidencePipeline`: the Lil Wayne
+  (request 3779) FLAC-source same-source-duplicate scenario, with parity
+  assertion that simulator and evidence-pipeline reach the same decision.
+- **Integration slice** in `tests/test_integration_slices.py`: end-to-end
+  propagate → wrong-match cleanup triage → assert (a) outcome is
+  `OUTCOME_DELETED`, (b) the request's `search_filetype_override` ends up
+  as `"lossless"`.
+- **Orchestration test** for importer-side rejection in
+  `lib/import_dispatch.py`: when `lossless_source_locked` fires during
+  import, the request's `search_filetype_override` ends up as
+  `"lossless"`. Reuses the `FakePipelineDB` pattern from existing dispatch
+  tests.
+- **Negative test** for AE5: a non-lossless source transcoded import does
+  NOT propagate spectral / V0 / bad-hash to the library row.
 
 ## Scope Boundaries
 
-- Do not backfill existing transcoded library rows.
-- Do not narrow search-plan tiers based on `v0_source_lineage=lossless_source`.
-  That follow-up is the natural shape of the buckets work (see
-  `docs/brainstorms/quality-bucket-system-requirements.md` — once buckets are
-  in, search asks only for `verified`-bucket candidates when the existing row
-  is `verified`, which dissolves the wasted-search window noted below).
-- Do not change `full_pipeline_decision_from_evidence` or any pure decider in
-  `lib/quality.py`. The deciders already do the right thing when both sides
-  have comparable evidence; this change just makes the library side carry the
-  evidence forward.
-- Do not change UI copy or wrong-match triage display labels. The audit row
-  already carries `verdict`, `preview_decision`, and `stage_chain` — these
-  will surface the new outcomes (e.g. `lossless_source_locked`) without
-  additional plumbing.
+- Do not backfill existing transcoded library rows (R12).
+- Do not change `full_pipeline_decision_from_evidence` or any pure decider
+  in `lib/quality.py`.
+- Do not change UI / copy / triage-display.
+- Do not add a force-import-bypass-the-lock affordance.
+- Do not bump `SEARCH_PLAN_GENERATOR_ID` — plan output unchanged.
 
-## Key Decisions
+### Deferred to Follow-Up Work
 
-- **Symmetric over scoped.** Propagate the source-side fields for all
-  transcoded imports, not just lossless-source candidates. The asymmetry is
-  rename-only vs transcoded, not lossless vs lossy; the symmetric fix is the
-  coherent one.
-- **Forward-only over backfill.** Backfill via the candidate-evidence FK
-  chain (`download_log.candidate_evidence_id` → `album_quality_evidence`) was
-  considered. Rejected for this change because (a) the bug is operator-
-  visible only on new wrong-matches, (b) backfill compounds risk on the
-  search-planner semantic shift, (c) organic re-touch over time closes the
-  asymmetry without a sweep. Revisit if false-positive triage keeps remain
-  noisy after a few weeks.
-- **Lossless-source lock is accepted, not loosened.** The propagation change
-  causes `lossless_source_locked` to fire on transcoded-from-FLAC library
-  rows for any lossy candidate. That is the intended behaviour under both the
-  current spectral-distrust posture and the future bucket model — a transcoded
-  copy of a lossless source still has lossless lineage, and only another
-  lossless source can override that lineage.
+- **Bucket-aware search-plan tier ordering** (the broader buckets work).
+  This PR narrows the override at the lock site; the buckets brainstorm
+  generalizes "search same-bucket-or-above" as the primary mechanism.
+  When buckets land, the lock and the helper introduced here are likely
+  obsolete in favor of pure bucket comparison.
+- **Bad-rip ban evidence cleanup**
+  (`lib/release_cleanup.py::clear_on_disk_quality_fields` doesn't null
+  `current_evidence_id`). Sharpened by this PR but pre-existing and
+  separate from the propagation/narrowing intent.
+- **Force-import override of `lossless_source_locked`.** Operator escape
+  hatch from the lock — needs a design decision (always bypass on force?
+  explicit "unlock-source" CLI action?). Not in this PR.
 
 ## Dependencies / Assumptions
 
-- The current `provisional_lossless_decision` already returns
-  `lossless_source_locked` correctly when `existing_probe` is a comparable
-  lossless-source V0 probe (lib/quality.py:2341-2357). No deciders change.
-- `lib/import_service.py:135-136` already writes `spectral_grade` from the
-  library measurement back to `album_requests.current_spectral_grade`. The
-  new fields flow through this existing path without additional plumbing.
-- `compute_effective_override_bitrate` (lib/quality.py:2821) already
-  consumes `spectral_grade` correctly via `SPECTRAL_TRANSCODE_GRADES`. Its
-  behaviour change for transcoded library rows is the same shift that already
-  happens for rename-only library rows today; this change makes the two paths
-  consistent.
-
-## Known Consequence: Temporary Wasted-Search Window
-
-Until the buckets work narrows search tiers based on existing-bucket, search
-will continue to ask Soulseek for lossy candidates against transcoded-FLAC
-library rows. Those candidates come back, hit triage, get
-`lossless_source_locked`, and get cleanup-deleted. Net: more slskd churn and
-more wrong-matches queue entries that auto-delete. No different files on disk.
-
-This window closes when search-plan tier selection moves to the bucket model
-(`docs/brainstorms/quality-bucket-system-requirements.md` R1, R6).
+- `lib/quality.py::LOSSLESS_CODECS = frozenset({"flac", "alac", "wav"})`
+  is the right gating set.
+- `provisional_lossless_decision` already returns `lossless_source_locked`
+  correctly when `existing_probe` is a comparable lossless-source V0 probe
+  (`lib/quality.py:2341-2357`). No decider changes.
+- `_record_rejection_and_maybe_requeue` in `lib/import_dispatch.py`
+  already accepts a `search_filetype_override` argument that flows through
+  to the request row update. No new transition plumbing needed.
+- `db.set_request_*` patterns exist in `lib/pipeline_db.py` for updating
+  the override column; specific method name to be confirmed during
+  implementation.
+- `generate_search_plan` in `lib/search.py` produces query strategies only;
+  the filetype filter is applied downstream in `enqueue.py`, so updating
+  the request's override takes effect on the next cycle without plan
+  regeneration.
+- `compute_effective_override_bitrate` (`lib/quality.py:2821`) already
+  consumes `spectral_grade` correctly. Its behavior shift for lossless-
+  source transcoded library rows is intentional and matches today's
+  rename-only behavior.
 
 ## Outstanding Questions
 
 ### Resolve Before Planning
 
-- None.
+- None — research at the end of the planning bootstrap confirmed the call
+  sites and the helper shape.
 
 ### Deferred to Planning
 
-- [Affects R1, R2, R3][Technical] Identify the outer-row construction site in
-  `propagate_candidate_evidence_to_current` for `v0_source_lineage`, the v0
-  bitrate trio, and the bad-audio-hash pair; current docstring suggests the
-  inner `AudioQualityMeasurement` build at lib/quality_evidence.py:879-894
-  handles spectral but the v0/bad-hash fields live on the outer
-  `AlbumQualityEvidence` row.
-- [Affects R6][Technical] Confirm via test that the
-  `upsert_album_quality_evidence` + `propagate` flow overwrites stale fields
-  on source-replacement rather than preserving them via partial update.
+- The exact method name / signature for persisting the narrowed override
+  on the request row from `lib/wrong_match_cleanup_service.py` (does an
+  existing transition helper already cover this, or does it need a small
+  new wrapper?).
+- Whether the `is_transcode` detection block can be partially preserved
+  (since the gate is now `is_transcode AND NOT source_is_lossless`) or
+  re-derived inline.
 
 ## Next Steps
 
-→ Use `/ce-plan` for structured implementation planning. The change is small
-   enough (one function plus tests) that planning will be light; the main
-   planning work is the test matrix in §Test Obligations and the outer-row vs
-   inner-measurement field-location question in §Deferred to Planning.
+→ `/ce-plan` updates the existing plan file in place against this corrected
+   scope. Then strict-TDD execution of the new units; the previous PR
+   commits get rewound or amended to match.

--- a/docs/plans/2026-05-17-002-feat-propagate-source-evidence-on-transcode-plan.md
+++ b/docs/plans/2026-05-17-002-feat-propagate-source-evidence-on-transcode-plan.md
@@ -1,0 +1,693 @@
+---
+title: "feat: propagate source-side evidence on transcoded imports"
+date: 2026-05-17
+deepened: 2026-05-17
+type: feat
+status: active
+origin: docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
+---
+
+# feat: Propagate Source-Side Evidence on Transcoded Imports
+
+## Summary
+
+Reverse the propagation asymmetry in `propagate_candidate_evidence_to_current`
+(`lib/quality_evidence.py:795`). Today, transcoded imports (FLAC → V0 / Opus)
+zero the library row's `spectral_grade`, `spectral_bitrate_kbps`, `v0_metric`,
+`matched_bad_audio_hash_id`, and `matched_bad_audio_hash_path` while propagating
+only `verified_lossless_proof`. After this change, all five fields propagate
+symmetrically with the rename-only path. Forward-only; no backfill of existing
+transcoded library rows. See origin: `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`.
+
+---
+
+## Problem Frame
+
+Live reproducer: request 3779 (Lil Wayne — *Da Drought 3*), MBID
+`244322cc-51ba-4f35-b072-f7c5888fb5ce`. A transcoded-FLAC import landed at
+16:06 UTC; a second identical-quality FLAC arrived at 18:32. Wrong-match
+cleanup triage (`lib/wrong_match_cleanup_service.py:330`) called
+`full_pipeline_decision_from_evidence(import_mode="force")`, found the on-disk
+evidence row had NULL `spectral_grade` / `v0_metric` / `matched_bad_audio_hash_id`,
+and fell through to `provisional_lossless_upgrade` → `kept_would_import`. The
+operator had already imported an identical source 31 minutes earlier; triage
+should have classified the new candidate as `confident_reject` and cleanup-
+deleted the wrong-match folder.
+
+Root cause: `propagate_candidate_evidence_to_current` strips source-side
+evidence on transcoded imports, leaving the library row blind to its own
+provenance. The triage decider has comparable evidence on the candidate side
+and nothing on the library side, so it cannot reject.
+
+The brainstorm establishes the asymmetry as internally inconsistent —
+`verified_lossless_proof` also describes the upstream source, but survives
+transcode because lineage matters. The current rule conflates "describes source
+audio" with "proof-of-good survives, proof-of-compromised does not." Reversing
+makes the policy coherent.
+
+---
+
+## Requirements Trace
+
+From `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`:
+
+| Origin ID | Description | Addressed by |
+|-----------|-------------|--------------|
+| R1 | Propagate `spectral_grade` / `spectral_bitrate_kbps` on transcoded imports | U5 |
+| R2 | Propagate `v0_metric` (single struct holding lineage + bitrate trio) on transcoded imports | U5 |
+| R3 | Propagate `matched_bad_audio_hash_id` / `matched_bad_audio_hash_path` on transcoded imports | U5 |
+| R4 | Update docstring at lib/quality_evidence.py:825-847 to reflect reversed rule | U5 + U7 |
+| R5 | `current_spectral_grade` on `album_requests` inherits new semantic; no special-casing needed | Verified in research; no work |
+| R6 | Source-replacement overwrites stale propagated evidence | U4 (regression coverage) |
+| R7 | No backfill of existing transcoded library rows | Out-of-scope by decision |
+| R8 | Pre-change rows remain NULL — accepted known wart | Documented in U7 |
+| AE1 | Same-source duplicate is rejected by triage | U2 (parity) + U3 (round-trip) |
+| AE2 | Lossy candidate against transcoded-FLAC row is locked out by `lossless_source_locked` | U2 (parity) + U3 (round-trip) |
+| AE3 | Bad-rip hash propagates and matches future candidates | U1 (existing fixture has hash=99 ready to flip) |
+| AE4 | Source-replacement overwrites stale evidence | U4 |
+| AE5 | Renamed-only path unchanged | Regression guard via existing `test_renamed_only_flac_propagates_full_measurement_payload` |
+| Search-planner regression | `compute_effective_override_bitrate` for transcoded library rows with spectral | U6 |
+
+---
+
+## Implementation Units
+
+### U1. Flip TestU10 transcoded-evidence propagation assertions (test-first RED)
+
+**Goal:** Convert the existing assertion that transcoded imports drop spectral
+/ V0 / bad-hash into an assertion that they now propagate. Becomes the RED
+baseline for U5's production change.
+
+**Requirements:** AE3 (bad-rip hash by virtue of the fixture's existing
+`matched_bad_audio_hash_id=99`), AE5 (sibling rename-only test untouched as
+regression guard).
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_integration_slices.py` (modify `TestU10PostImportEvidencePropagation`)
+
+**Approach:**
+- Rename `test_transcoded_flac_to_v0_drops_spectral_and_v0_keeps_proof` →
+  `test_transcoded_flac_to_v0_propagates_source_evidence`.
+- Flip the five `assertIsNone` checks at the bottom of the test
+  (`new_evidence.measurement.spectral_grade`,
+  `new_evidence.measurement.spectral_bitrate_kbps`, `new_evidence.v0_metric`,
+  `new_evidence.matched_bad_audio_hash_id`,
+  `new_evidence.matched_bad_audio_hash_path`) to `assertEqual` against the
+  candidate's seeded values. Keep `verified_lossless_proof` assertion as-is
+  (already propagates).
+- Leave `test_renamed_only_flac_propagates_full_measurement_payload`
+  untouched — it stays as the AE5 regression guard.
+
+**Execution note:** Write the assertion flip first. Run the test, watch it
+fail (RED). U5 turns it green. Do not modify production code in this unit.
+
+**Patterns to follow:** Mirror the existing sibling test's assertion shape —
+the `_build_candidate_evidence` helpers in `TestU10PostImportEvidencePropagation`
+already produce the right fixture; only the assertions change.
+
+**Test scenarios:**
+- Covers AE3. Transcoded FLAC → V0 with candidate
+  `spectral_grade="genuine"`, `spectral_bitrate_kbps=850`,
+  `v0_metric.source_lineage="lossless_source"`, `v0_metric.avg_bitrate_kbps=850`,
+  `matched_bad_audio_hash_id=99`,
+  `matched_bad_audio_hash_path="/some/known/bad.flac"`. After propagation,
+  the library row's `measurement.spectral_grade`, `measurement.spectral_bitrate_kbps`,
+  `v0_metric` (full struct equality), `matched_bad_audio_hash_id`,
+  `matched_bad_audio_hash_path` must equal the candidate's values.
+- Regression: `verified_lossless_proof` still propagates (no change).
+- Regression: `measurement.min_bitrate_kbps` / `avg_bitrate_kbps` / `format`
+  still describe the *library copy* (V0 output), not the candidate (FLAC
+  source) — these are re-derived from `album_info`, not propagated.
+
+**Verification:** Running
+`nix-shell --run "python3 -m unittest tests.test_integration_slices.TestU10PostImportEvidencePropagation.test_transcoded_flac_to_v0_propagates_source_evidence -v"`
+must fail with `AssertionError: None != ...` on each of the five propagated
+fields before U5; pass after U5.
+
+---
+
+### U2. Add Lil Wayne live-bug scenario — simulator + evidence-pipeline parity (test-first RED)
+
+**Goal:** Encode the live bug (request 3779, MBID
+`244322cc-51ba-4f35-b072-f7c5888fb5ce`) as a permanent regression test.
+Establishes the parity contract: the simulator decider and the
+evidence-pipeline decider must reach the same outcome on the same album.
+
+**Requirements:** AE1, AE2 (at decision level).
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_quality_classification.py` (extend `TestLiveBugReproductions`
+  and `TestLiveBugReproductionsThroughEvidencePipeline`)
+
+**Approach:**
+- Add one test method to `TestLiveBugReproductions` named
+  `test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_simulator`.
+  Build the candidate facts to match the live row: FLAC container, spectral
+  `likely_transcode`, spectral_bitrate `128`, v0 probe `lossless_source` avg
+  `215` min `184`. Existing library facts match the transcoded-FLAC import:
+  format `Opus`, codec `opus`, min `100`, avg `119`, plus the now-propagated
+  source-side fields (`spectral_grade=likely_transcode`,
+  `spectral_bitrate=128`, `v0_source_lineage=lossless_source`, `v0_avg=215`).
+  Call `full_pipeline_decision(...)` with `import_mode="force"`. Expected
+  outcome: reject-class decision (e.g. `suspect_lossless_downgrade` or
+  `lossless_source_not_better`); NOT `provisional_lossless_upgrade`.
+- Add the parity sibling to `TestLiveBugReproductionsThroughEvidencePipeline`
+  named `test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_evidence`.
+  Use `_build_candidate(...)` and `_build_current(...)` to construct
+  `AlbumQualityEvidence` rows matching the same facts; call
+  `full_pipeline_decision_from_evidence(candidate_evidence, current_evidence,
+  facts=AlbumQualityEvidenceDecisionFacts(import_mode="force"), cfg=...)`.
+  Assert the same decision and that `classify_full_pipeline_decision(decision)`
+  returns `verdict="confident_reject"`.
+- Both tests must reference the live row in the docstring with MBID, request
+  ID, and date for future archaeology.
+
+**Execution note:** The simulator test may already pass today — `full_pipeline_decision`
+takes flat kwargs and will decide correctly when given the propagated
+evidence. The evidence-pipeline test is the RED test: today, no plausible
+`_build_current(...)` would carry the source-side fields (because propagation
+never wrote them), so the test will encode the *intended* state and fail
+until U5 makes the production path produce that state. Document this asymmetry
+in the test docstring.
+
+**Patterns to follow:** Mirror `test_mountain_goats_bride_provisional_via_evidence`
+(parity sibling pattern) and `test_live_mountain_goats_flux_flac_source_vs_lossy_no_spectral`
+(simulator scenario shape). Use the existing `_build_candidate` / `_build_current`
+helpers; do not hand-roll `AlbumQualityEvidence` rows.
+
+**Test scenarios:**
+- Covers AE1. Simulator: transcoded-FLAC library row (propagated source
+  evidence) + identical-source FLAC candidate → reject-class decision,
+  `confident_reject` verdict.
+- Covers AE1. Evidence pipeline parity: same inputs through
+  `full_pipeline_decision_from_evidence(import_mode="force")` →
+  same decision, `confident_reject` verdict.
+- Covers AE2. Same library row but lossy MP3 V0 candidate (in the same
+  parity-test or a sibling) → `lossless_source_locked` decision,
+  `confident_reject` verdict, `cleanup_eligible=True`.
+
+**Verification:** The simulator test passes immediately (decider already
+handles the inputs correctly); the evidence-pipeline test fails RED
+before U5 and passes after U5. The parity assertion (both classes return
+the same outcome) catches future drift.
+
+---
+
+### U3. Integration slice: propagate → wrong-match triage round-trip (test-first RED)
+
+**Goal:** Prove AE1 end-to-end at the orchestration level — propagate
+transcoded-FLAC evidence on import, then exercise the real
+`cleanup_wrong_match` call path against an identical-source wrong-match
+candidate, and assert the triage outcome flips from `kept_would_import` to
+`deleted` (`confident_reject` + cleanup eligible).
+
+**Requirements:** AE1 (orchestration level).
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_integration_slices.py` (new test class
+  `TestWrongMatchTriageRejectsSameSourceDuplicate` adjacent to
+  `TestWrongMatchCleanupFKChainAvoidsRemeasurement`)
+
+**Approach:**
+- Reuse the `_seed(source)`, `_evidence_for(source_dir, mb_release_id)`, and
+  `_patch_cfg()` builders from
+  `TestWrongMatchCleanupFKChainAvoidsRemeasurement` (or extract them into
+  module-level helpers if duplication starts hurting).
+- Stage two source dirs on disk: a `transcoded_origin` dir representing the
+  first FLAC import, and a `duplicate_source` dir representing the identical
+  second arrival. Build matching `AlbumQualityEvidence` rows for both with
+  `spectral_grade="likely_transcode"`, `spectral_bitrate_kbps=128`,
+  `v0_metric` with `source_lineage="lossless_source"` and `avg=215`.
+- Simulate the first import by calling
+  `_refresh_current_evidence_after_import(...)` with the transcoded-origin
+  candidate evidence and an `album_info` for a V0 library copy. Verify the
+  resulting library evidence row carries the propagated source fields
+  (sanity check; the real assertion is downstream).
+- Seed a `download_log` row marking the duplicate-source folder as
+  `rejected` (mirroring the live row 16682).
+- Call `cleanup_wrong_match(db, download_log_id)` with the seeded log id.
+- Assert outcome: `WrongMatchCleanupOutcome.outcome == OUTCOME_DELETED`,
+  `verdict == "confident_reject"`, `cleanup_eligible == True`,
+  `preview_decision` is a reject decision name (e.g. `suspect_lossless_downgrade`
+  or `lossless_source_locked`).
+
+**Execution note:** Test will be RED before U5 — without propagation, the
+library row's source-side fields stay NULL, triage returns
+`OUTCOME_KEPT_WOULD_IMPORT`, and the assertion against `OUTCOME_DELETED`
+fails. Document this in the test docstring.
+
+**Patterns to follow:**
+- `TestWrongMatchCleanupFKChainAvoidsRemeasurement` for the
+  seed/evidence/cfg-patch pattern.
+- `TestU10PostImportEvidencePropagation` for staging audio dirs and calling
+  `_refresh_current_evidence_after_import`.
+- `FakePipelineDB` from `tests/fakes.py` for the stateful DB.
+
+**Test scenarios:**
+- Covers AE1. Two-source scenario: propagate evidence for the first
+  transcoded import, then call cleanup triage on the duplicate-source
+  wrong-match → `OUTCOME_DELETED`, `confident_reject`, `cleanup_eligible`.
+- Negative regression: same setup but skip the propagation step (or use a
+  bare candidate evidence with NULL source-side fields) → still
+  `OUTCOME_KEPT_WOULD_IMPORT`. Demonstrates the propagation IS the load-
+  bearing input, not some other gate.
+
+**Verification:** Test fails RED before U5 with
+`AssertionError: 'kept_would_import' != 'deleted'`; passes after U5.
+
+---
+
+### U4. Source-replacement overwrite slice (regression coverage)
+
+**Goal:** Document and pin behaviour for AE4 — when a clean lossless-source
+candidate force-imports over a previously-transcoded library row, the new
+candidate's evidence overwrites the stale propagated fields.
+
+**Requirements:** AE4, R6.
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_integration_slices.py` (new test method in
+  `TestU10PostImportEvidencePropagation` or a sibling class)
+
+**Approach:**
+- Stage one library dir. Propagate evidence from a first candidate with
+  compromised source (`spectral_grade="likely_transcode"`,
+  `spectral_bitrate=128`, `v0_metric.source_lineage="lossless_source"`,
+  `v0_avg=215`). Verify the library row reflects these values.
+- Propagate evidence from a second candidate with clean genuine source
+  (`spectral_grade="genuine"`, `spectral_bitrate=900`,
+  `v0_metric.source_lineage="lossless_source"`, `v0_avg=900`,
+  `verified_lossless_proof` populated) over the same MBID + snapshot
+  fingerprint.
+- Assert the library row's `measurement.spectral_grade == "genuine"` (not
+  `"likely_transcode"`), `measurement.spectral_bitrate_kbps == 900`,
+  `v0_metric.source_lineage == "lossless_source"` with `avg == 900`,
+  `verified_lossless_proof IS NOT None`. No stale values survive.
+
+**Execution note:** This unit may pass before U5 if the second candidate
+also exercises the existing rename-only path (which propagates everything).
+The unit explicitly tests the transcoded → transcoded replacement case to
+exercise the new policy. If it passes immediately under U5 because
+`upsert_album_quality_evidence` uses `ON CONFLICT DO UPDATE` and the upsert
+overwrites by `(mb_release_id, snapshot_fingerprint)`, that is the
+documented success criterion — the test serves as regression coverage,
+not RED→GREEN.
+
+**Patterns to follow:** Reuse `TestU10PostImportEvidencePropagation`'s
+audio-staging and `_refresh_current_evidence_after_import` patterns.
+
+**Test scenarios:**
+- Covers AE4. Sequential propagation: compromised source first, clean
+  source second → library row reflects the second.
+- Edge case: the snapshot fingerprint changes between propagations
+  (different file set) → both rows coexist as separate
+  `album_quality_evidence` rows; the request's `current_evidence_id`
+  points at the second. (Optional; only add if `_refresh_current_evidence_after_import`
+  exposes this transition cleanly.)
+
+**Verification:** Test passes after U5; documents the upsert semantic.
+
+---
+
+### U5. Reverse propagation policy in lib/quality_evidence.py (production change — GREEN)
+
+**Goal:** Remove the `is_transcode` conditionals that zero the source-side
+fields on the library row. Update the function docstring to reflect the
+reversed rule and re-state the semantic shift.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Dependencies:** U1, U2, U3 (all must be RED before this lands).
+
+**Files:**
+- `lib/quality_evidence.py` (modify `propagate_candidate_evidence_to_current`,
+  lines 795-923)
+
+**Approach:**
+- **Inner measurement (lines 886-891).** Remove the `None if is_transcode
+  else ...` conditionals on `spectral_grade` and `spectral_bitrate_kbps`.
+  After the change, both fields always equal `candidate_measurement.spectral_grade`
+  / `candidate_measurement.spectral_bitrate_kbps`.
+- **Outer row (line 911).** Remove the `None if is_transcode else ...`
+  conditional on `v0_metric`. After the change, `v0_metric` always equals
+  `candidate_evidence.v0_metric` (a single `AlbumQualityV0Metric` struct
+  holding lineage + min/avg/median).
+- **Outer row (lines 917-918, 920-921).** Remove the `None if is_transcode
+  else ...` conditionals on `matched_bad_audio_hash_id` and
+  `matched_bad_audio_hash_path`. After the change, both always equal the
+  candidate's values.
+- **`is_transcode` flag and its inputs.** Verified at plan time: the
+  detection block at lines 858-877 (and the locals `source_codec`,
+  `library_codec`, `effective_target`, `effective_target_lc` that feed it)
+  is referenced ONLY by the five conditionals being removed. After the
+  conditional removals, the entire detection block plus its input locals
+  become dead code and must be deleted in the same change. No downstream
+  call path consumes `is_transcode` from this function.
+- **Docstring (lines 825-847).** Rewrite the "Field policy" bullet that
+  starts "Propagated when renamed-only, NULL when transcoded:" to instead
+  describe the new unified rule: "Propagated in both renamed-only and
+  transcoded cases — these describe the upstream source audio at import
+  time, not the on-disk file. For transcoded imports, the on-disk file
+  has a different spectrum and codec, but the propagated fields remain
+  accurate descriptions of the source that produced it." Update the
+  surrounding paragraphs to remove the now-obsolete reasoning.
+
+**Execution note:** This is the GREEN unit. Once it lands, U1's flipped
+assertions, U2's evidence-pipeline parity test, U3's triage round-trip,
+and U4's source-replacement test all turn green. The simulator side of U2
+was already green.
+
+**Patterns to follow:** The rename-only path. After the change, transcoded
+and rename-only branches differ only in whether `measurement.format` /
+`measurement.min_bitrate_kbps` etc. come from `album_info` (always re-derived
+from the library snapshot, for both cases) — the source-side fields no
+longer branch on `is_transcode`.
+
+**Test scenarios:** None added in this unit (production change). All test
+coverage lives in U1-U4. Verification is "the previously-RED tests turn
+GREEN."
+
+**Verification:**
+- `nix-shell --run "python3 -m unittest tests.test_integration_slices.TestU10PostImportEvidencePropagation -v"`
+  passes (both U1's flipped test and U4's source-replacement test).
+- `nix-shell --run "python3 -m unittest tests.test_quality_classification.TestLiveBugReproductionsThroughEvidencePipeline -v"`
+  passes (including U2's parity test).
+- New `TestWrongMatchTriageRejectsSameSourceDuplicate` from U3 passes.
+- `nix-shell --run "bash scripts/run_tests.sh"` full suite passes — no
+  regressions in adjacent decider tests.
+- Pyright on `lib/quality_evidence.py` is clean.
+
+---
+
+### U6. Extend `TestComputeEffectiveOverrideBitrate.CASES` for transcoded library rows with spectral (search-planner coverage)
+
+**Goal:** Pin the search-planner's override-min-bitrate behaviour for the
+new world where transcoded library rows can carry `spectral_grade` /
+`spectral_bitrate_kbps`. Documents the semantic shift noted in the
+brainstorm's "Known Consequence: Temporary Wasted-Search Window" section.
+
+**Requirements:** Search-planner regression (brainstorm Test Obligations
+section, last bullet).
+
+**Dependencies:** None (pure function test; independent of U5).
+
+**Files:**
+- `tests/test_quality_decisions.py` (extend `TestComputeEffectiveOverrideBitrate.CASES`)
+
+**Approach:**
+- Add subTest rows to the existing `CASES` table covering both transcoded-
+  output container bitrates:
+  - Opus V2 transcoded library row: `container_bitrate=100`,
+    `spectral_bitrate=128`, `spectral_grade="likely_transcode"`,
+    expected `100` (min wins; unchanged behaviour).
+  - MP3 V0 transcoded library row: `container_bitrate=225`,
+    `spectral_bitrate=128`, `spectral_grade="likely_transcode"`,
+    expected `128` (spectral wins; semantic shift visible).
+- The descriptions on the new rows should reference "transcoded library
+  row" so the intent is obvious from the subTest label.
+
+**Patterns to follow:** `TestComputeEffectiveOverrideBitrate.CASES` rows
+already cover the (container, spectral, grade) decision matrix exhaustively;
+add to the table, do not invent a new pattern.
+
+**Test scenarios:**
+- New: Opus V2 transcoded row with spectral=128/likely_transcode → 100
+  (container min wins).
+- New: MP3 V0 transcoded row with spectral=128/likely_transcode → 128
+  (spectral min wins, demonstrating the semantic shift).
+- Existing rows unchanged.
+
+**Verification:**
+`nix-shell --run "python3 -m unittest tests.test_quality_decisions.TestComputeEffectiveOverrideBitrate -v"`
+passes; new rows visible in subTest output.
+
+---
+
+### U7. Update CLAUDE.md and acknowledge known wart
+
+**Goal:** Update the living docs to reflect the reversed propagation policy
+and document the accepted asymmetry between pre-change and post-change
+transcoded library rows.
+
+**Requirements:** R4 (extends docstring updates from U5 to project-level docs),
+R8 (documents the accepted known wart).
+
+**Dependencies:** U5 (docs follow the code change in the same PR but trail
+it in the unit list for readability).
+
+**Files:**
+- `CLAUDE.md` (lines 280-285, "Evidence survives the candidate → library
+  transition" paragraph in § "Decision architecture")
+
+**Approach:**
+- Rewrite the paragraph at CLAUDE.md:278-285 to describe the new rule:
+  > After a successful import, `propagate_candidate_evidence_to_current` (U10)
+  > inherits the candidate's full measurement payload (spectral grade, V0
+  > lineage, bad-audio-hash matches, verified-lossless proof) onto the
+  > library evidence row, for **both** renamed-only and transcoded imports.
+  > These fields describe the upstream source audio at import time, not the
+  > on-disk file. For transcoded imports the on-disk file has a different
+  > spectrum and codec, but the propagated fields remain accurate
+  > descriptions of the source that produced it.
+- Add a one-sentence "Known wart" follow-up paragraph:
+  > Library rows imported before this policy change have NULL
+  > spectral/V0/bad-hash fields. They retain the old behaviour (wrong-match
+  > triage cannot reject same-source duplicates against them) until they
+  > are re-imported or force-imported. Forward-only by design; no backfill.
+- No update needed in `.claude/rules/code-quality.md` (its "Quality
+  decisions live in ONE place" section covers decision purity, not
+  propagation policy — confirmed via grep during research).
+- No update needed in `docs/pipeline-db-schema.md` (no mentions of the
+  propagation policy — confirmed via grep).
+- The lib/quality_evidence.py docstring update is owned by U5; this unit
+  is project-level docs only.
+
+**Patterns to follow:** Match the surrounding tone of CLAUDE.md's
+"Decision architecture" section — concise, opinionated, with a clear
+"never re-create decisions elsewhere" frame.
+
+**Test scenarios:** Test expectation: none — docs-only change.
+
+**Verification:**
+- `grep -n "inherit only\|stay NULL\|NULL when transcoded" CLAUDE.md` returns
+  no results after the update.
+- `grep -n "Propagated in both" CLAUDE.md` shows the new wording.
+- Manual read of the updated paragraph to confirm tone matches the section.
+
+---
+
+## Sequencing
+
+```
+U1  (RED: flip TestU10 transcoded assertions)
+U2  (RED: Lil Wayne live-bug, simulator + evidence-pipeline parity)
+U3  (RED: propagate → triage round-trip slice)
+U4  (regression coverage: source-replacement overwrite)
+U6  (search-planner coverage: compute_effective_override_bitrate CASES)
+                    │
+                    ▼
+U5  (GREEN: production change — lib/quality_evidence.py + docstring)
+                    │
+                    ▼
+U7  (docs: CLAUDE.md policy paragraph)
+```
+
+U1, U2, U3, U4, U6 are independent and can be written in any order or in
+parallel. U5 must come after the RED test units to honour the strict-TDD
+posture (RED visible before GREEN). U7 follows U5 in the unit list for
+review readability but could technically land in the same commit; the
+implementer's call.
+
+---
+
+## Key Technical Decisions
+
+- **Symmetric over scoped.** Propagate source-side fields for all transcoded
+  imports, not just lossless-source candidates. The asymmetry being fixed is
+  rename-only vs transcoded, not lossless vs lossy — the symmetric fix is the
+  coherent one. See origin: brainstorm § Key Decisions #1.
+- **Forward-only over backfill.** Existing transcoded library rows are not
+  retroactively populated. The bug is operator-visible only on new
+  wrong-matches; organic re-touch closes the asymmetry over time;
+  `migrations/021_evidence_canonical_rekey.sql` provides a clean atomic-
+  backfill precedent if operator pain warrants revisiting. See origin:
+  brainstorm § Key Decisions #2.
+- **One production change unit, one docs unit.** Splitting the policy code
+  change from the project-level docs change makes the policy shift
+  auditable in a single commit and the docs propagation reviewable in a
+  separate one. The function docstring belongs with the code (in U5)
+  because it describes function-local behaviour; CLAUDE.md belongs with
+  the docs unit (U7) because it describes project-level architecture.
+- **Test-first per unit.** U1, U2, U3 are RED tests written before U5
+  flips them green. U4 is regression coverage that may pass immediately
+  after U5 via `ON CONFLICT DO UPDATE`. U6 is pure-function coverage
+  independent of propagation. The plan structures tests as separate units
+  so each commit makes its intent visible (RED-then-GREEN over fewer-
+  larger-commits per user TDD preference).
+- **Reuse existing builders.** All test units lean on existing infrastructure
+  — `TestU10PostImportEvidencePropagation`'s audio-staging helpers,
+  `TestLiveBugReproductionsThroughEvidencePipeline._build_candidate` /
+  `_build_current`, `TestWrongMatchCleanupFKChainAvoidsRemeasurement`'s
+  `_seed` / `_evidence_for` / `_patch_cfg`, `FakePipelineDB` from
+  `tests/fakes.py`, `make_album_quality_evidence` from `tests/helpers.py`.
+  No new builders; no hand-rolled msgspec.Struct construction.
+
+---
+
+## Test Strategy
+
+- **Pure tests** for `compute_effective_override_bitrate` (U6) — subTest
+  table extension.
+- **Integration slices** for propagation (U1 — flip existing; U4 —
+  source-replacement) and for the end-to-end triage round-trip (U3).
+- **Parity tests** for the live bug (U2) — simulator and evidence pipeline
+  must agree.
+- **Regression guards** are explicit: `test_renamed_only_flac_propagates_full_measurement_payload`
+  (untouched, guards AE5); existing `TestComputeEffectiveOverrideBitrate.CASES`
+  rows (untouched, guards rename-only override behaviour); full test suite
+  must pass after U5.
+
+Per `.claude/rules/code-quality.md`, no new bespoke harnesses; all test
+infrastructure already exists.
+
+---
+
+## System-Wide Impact
+
+- **Decision layer (`lib/quality.py`).** No changes. Existing deciders
+  (`provisional_lossless_decision`, `spectral_import_decision`,
+  `full_pipeline_decision_from_evidence`) already handle the propagated
+  evidence shapes correctly — they were written assuming evidence might
+  be present on both sides; the current bug is that the library side was
+  artificially empty.
+- **Importer worker (`lib/import_dispatch.py`).** No changes. The importer
+  reads persisted evidence and decides via the unchanged pipeline.
+- **Preview worker (`lib/import_preview.py`).** No changes. Preview produces
+  candidate evidence; the propagation policy reversal only affects how
+  candidate evidence flows to the library row after import.
+- **Search planner (`lib/download.py:1575-1610`).** Behavioural shift for
+  newly-imported transcoded albums: `compute_effective_override_bitrate`
+  will start returning the source spectral cliff for MP3 V0 transcoded
+  library rows (e.g. drops from container ~225 to spectral 128). For
+  Opus V2 transcoded rows, behaviour is unchanged (`min(100, 128) = 100`).
+  Net effect: searches become slightly more permissive for new transcoded
+  albums; resulting lossy candidates get locked out at triage by the new
+  `lossless_source_locked` firing. Wasted slskd churn; no different files
+  on disk. Closes when the bucket model lands and search tiers narrow
+  based on existing-bucket (see `docs/brainstorms/quality-bucket-system-requirements.md`).
+- **Wrong-match cleanup triage (`lib/wrong_match_cleanup_service.py`).**
+  Intended behavioural shift: lossy candidates against transcoded-FLAC
+  library rows now classify as `confident_reject` (via
+  `lossless_source_locked`) and become cleanup-eligible. Same-source FLAC
+  duplicates against transcoded-FLAC library rows likewise classify as
+  reject (via `suspect_lossless_downgrade` or equivalent). Result: cleaner
+  wrong-matches queue for new transcoded imports.
+- **Web UI.** No changes. The Wrong Matches view consumes triage audit
+  rows via `download_log.validation_result`; new outcomes (e.g.
+  `lossless_source_locked`) already render via
+  `_wrong_match_action_label` (`web/classify.py:273-290`) without
+  additional plumbing.
+- **Pipeline DB schema.** No changes. Forward-only; no migrations.
+- **Operator workflows.** No CLI changes; no API changes; no config
+  changes. The CLI ⇄ API surface symmetry rule (§ CLAUDE.md) does not
+  apply — this is an internal policy reversal, not a new operator action.
+
+---
+
+## Scope Boundaries
+
+In scope:
+- Five `is_transcode` conditional removals in
+  `propagate_candidate_evidence_to_current`.
+- Docstring updates at lib/quality_evidence.py:825-847 and CLAUDE.md:278-285.
+- Test additions per U1-U4, U6.
+- No-op verification of `verified_lossless_proof` propagation (already
+  works; explicitly tested by existing assertions in U1's flipped test).
+
+Out of scope:
+- No backfill of existing transcoded library rows (Key Decision #2).
+- No changes to `full_pipeline_decision_from_evidence` or any pure decider
+  in `lib/quality.py`.
+- No changes to `import_service.py` or how `current_spectral_grade` flows
+  from library evidence back to `album_requests` (existing path inherits
+  the new semantic naturally; no special-casing).
+- No UI / copy / triage-display changes.
+- No `.claude/rules/code-quality.md` updates (decision purity rules
+  unchanged).
+
+### Deferred to Follow-Up Work
+
+- **Search-plan tier narrowing on `lossless_source` lineage.** Once a
+  library row carries `v0_source_lineage="lossless_source"`, the search
+  plan could narrow to lossless tiers only, since any lossy candidate
+  will be locked out downstream. This is the natural shape of the bucket
+  work (see `docs/brainstorms/quality-bucket-system-requirements.md` R1,
+  R6) and absorbs the temporary wasted-search window from this change.
+  Not bundled into this PR.
+- **FK-chain backfill for existing transcoded library rows.** If the
+  organic re-touch rate proves too slow and false-positive triage keeps
+  remain operationally noisy, walk `album_requests.current_evidence_id` →
+  `download_log.candidate_evidence_id` and propagate the prior candidate's
+  source-side fields to the library row. Deferred behind operator
+  observation; revisit only if pain warrants.
+
+---
+
+## Risks and Mitigations
+
+- **Risk: U2's simulator test passes immediately, masking incomplete RED
+  baseline.** Mitigation: U2's docstring explicitly notes the simulator vs
+  evidence-pipeline asymmetry. The evidence-pipeline parity test is the
+  load-bearing RED; the simulator side documents the expected outcome
+  shape.
+- **Risk: `is_transcode` flag still referenced after conditional removals.**
+  Mitigation: U5 includes an explicit local read of lines 858-877 to
+  decide whether to delete the detection or preserve it with a comment.
+- **Risk: `lossless_source_locked` firing more aggressively breaks a
+  workflow we forgot.** Mitigation: U3's integration slice exercises the
+  full triage path against a real wrong-match row, and the full test suite
+  must pass after U5. Adjacent decider tests in `tests/test_quality_decisions.py`
+  exercise `provisional_lossless_decision` directly and will catch
+  unintended changes to the lock branch.
+- **Risk: Search-planner override drop (225 → 128) on MP3 V0 transcoded
+  rows causes excessive slskd churn.** Mitigation: brainstorm classifies
+  this as a known-acceptable temporary window. U6 documents the shift
+  with subTest rows. If the churn proves operationally painful, the
+  follow-up "search-plan tier narrowing" work in `Deferred to Follow-Up Work`
+  closes it.
+- **Risk: Pre-change transcoded library rows generate ongoing false-
+  positive triage keeps.** Mitigation: documented as R8 known wart in
+  brainstorm and U7. If pain warrants, FK-chain backfill in
+  `Deferred to Follow-Up Work` resolves it.
+
+---
+
+## Verification Checklist
+
+Before merging:
+- [ ] U1 test (`test_transcoded_flac_to_v0_propagates_source_evidence`) fails
+  with `AssertionError` on each of the five propagated fields before U5;
+  passes after.
+- [ ] U2 evidence-pipeline test fails RED before U5; passes after; parity
+  with the simulator test holds.
+- [ ] U3 round-trip test fails RED before U5 with
+  `'kept_would_import' != 'deleted'`; passes after.
+- [ ] U4 source-replacement test passes after U5; documents the upsert
+  overwrite semantic.
+- [ ] U6 subTest rows visible in test output; pass.
+- [ ] `nix-shell --run "bash scripts/run_tests.sh"` full suite passes; no
+  unrelated regressions.
+- [ ] Pyright clean on `lib/quality_evidence.py`,
+  `tests/test_integration_slices.py`,
+  `tests/test_quality_classification.py`,
+  `tests/test_quality_decisions.py`.
+- [ ] CLAUDE.md grep confirms old wording removed, new wording present.
+- [ ] Pre-commit hook (`scripts/pre-commit`) passes.

--- a/docs/plans/2026-05-17-002-feat-propagate-source-evidence-on-transcode-plan.md
+++ b/docs/plans/2026-05-17-002-feat-propagate-source-evidence-on-transcode-plan.md
@@ -1,49 +1,84 @@
 ---
-title: "feat: propagate source-side evidence on transcoded imports"
+title: "feat: propagate lossless-source evidence on transcoded imports + narrow search on lossless-source lock"
 date: 2026-05-17
 deepened: 2026-05-17
+rescoped: 2026-05-17
 type: feat
 status: active
 origin: docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
 ---
 
-# feat: Propagate Source-Side Evidence on Transcoded Imports
+# feat: Propagate Lossless-Source Evidence on Transcoded Imports + Narrow Search on Lossless-Source Lock
 
 ## Summary
 
-Reverse the propagation asymmetry in `propagate_candidate_evidence_to_current`
-(`lib/quality_evidence.py:795`). Today, transcoded imports (FLAC → V0 / Opus)
-zero the library row's `spectral_grade`, `spectral_bitrate_kbps`, `v0_metric`,
-`matched_bad_audio_hash_id`, and `matched_bad_audio_hash_path` while propagating
-only `verified_lossless_proof`. After this change, all five fields propagate
-symmetrically with the rename-only path. Forward-only; no backfill of existing
-transcoded library rows. See origin: `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`.
+Two coupled changes shipped together:
+
+1. **Narrow the propagation policy in
+   `lib/quality_evidence.py::propagate_candidate_evidence_to_current`** to
+   carry source-side evidence (spectral, V0, bad-hash) forward onto the
+   library row **only when the candidate source is lossless** (FLAC / ALAC /
+   WAV). Renamed-only behavior unchanged. Non-lossless transcodes
+   (MP3 → Opus etc.) continue to strip source-side fields onto NULL.
+2. **Add `narrow_override_on_lossless_source_lock` and wire it into both
+   the importer rejection path and the wrong-match cleanup triage path**
+   so that whenever `lossless_source_locked` fires, the request's
+   `search_filetype_override` is set to `"lossless"`. Future search cycles
+   only ask Soulseek for lossless candidates that can actually win against
+   the existing lossless-source library row.
+
+Forward-only; no backfill. Fixes live bug request 3779 Lil Wayne — Da
+Drought 3 AND closes the wasted-search-cycle window the first version of
+this plan left open.
+
+This file replaces an earlier broader version of the plan that proposed
+symmetric propagation for all transcoded imports and deferred the search
+narrowing. See origin brainstorm for the rescope rationale; see git
+history for the previous shape's commits.
+
+---
+
+## Rescope Notes (read before editing)
+
+This plan was originally written against a broader scope ("symmetric
+propagation for all transcoded imports; defer search narrowing to the
+buckets work"). That scope diverged from the user's actual ask
+("propagate evidence in lossless scenarios only; narrow search when
+lossless_source-locked"). 8 commits already landed on the branch under
+the old scope; the unit list below reflects the **corrected target
+state**, not the historical sequencing.
+
+The corrective work goes on top of the existing commits as new commits
+(no rebase). Tests that pin behavior the rescope changes need to be
+adjusted; some tests will be tightened, none deleted wholesale.
 
 ---
 
 ## Problem Frame
 
-Live reproducer: request 3779 (Lil Wayne — *Da Drought 3*), MBID
-`244322cc-51ba-4f35-b072-f7c5888fb5ce`. A transcoded-FLAC import landed at
-16:06 UTC; a second identical-quality FLAC arrived at 18:32. Wrong-match
-cleanup triage (`lib/wrong_match_cleanup_service.py:330`) called
-`full_pipeline_decision_from_evidence(import_mode="force")`, found the on-disk
-evidence row had NULL `spectral_grade` / `v0_metric` / `matched_bad_audio_hash_id`,
-and fell through to `provisional_lossless_upgrade` → `kept_would_import`. The
-operator had already imported an identical source 31 minutes earlier; triage
-should have classified the new candidate as `confident_reject` and cleanup-
-deleted the wrong-match folder.
+**Gap 1 (propagation):** Today's
+`propagate_candidate_evidence_to_current` zeros spectral / V0 / bad-hash
+on every transcoded import. For the lossless-source case (FLAC → V0/Opus)
+the source-side evidence is meaningful for future candidates and should
+survive transcode; this is the gap the live bug exposed.
 
-Root cause: `propagate_candidate_evidence_to_current` strips source-side
-evidence on transcoded imports, leaving the library row blind to its own
-provenance. The triage decider has comparable evidence on the candidate side
-and nothing on the library side, so it cannot reject.
+**Gap 2 (search narrowing):** Even after Gap 1 is fixed, the
+`lossless_source_locked` rejection doesn't narrow the request's search
+plan. Future cycles re-ask for the same album with no filetype filter,
+download the same lossy candidate from a new peer, hit the lock again,
+auto-delete, repeat. The lock without narrowing is half a system.
 
-The brainstorm establishes the asymmetry as internally inconsistent —
-`verified_lossless_proof` also describes the upstream source, but survives
-transcode because lineage matters. The current rule conflates "describes source
-audio" with "proof-of-good survives, proof-of-compromised does not." Reversing
-makes the policy coherent.
+Live reproducer: request 3779 (Lil Wayne — *Da Drought 3*),
+MBID `244322cc-51ba-4f35-b072-f7c5888fb5ce`. Transcoded-FLAC import at
+16:06 UTC; identical-quality FLAC at 18:32. Today triage classifies
+`kept_would_import` (Gap 1). After Gap 1 fix alone, triage would reject
+correctly but each future cycle would re-find lossy candidates and
+re-lock — Gap 2.
+
+This PR closes both gaps in tandem because they are the same
+architectural intent: a library row's lossless-source lineage should both
+(a) be recognized on the next candidate, and (b) constrain what future
+candidates are even searched for.
 
 ---
 
@@ -53,641 +88,608 @@ From `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-require
 
 | Origin ID | Description | Addressed by |
 |-----------|-------------|--------------|
-| R1 | Propagate `spectral_grade` / `spectral_bitrate_kbps` on transcoded imports | U5 |
-| R2 | Propagate `v0_metric` (single struct holding lineage + bitrate trio) on transcoded imports | U5 |
-| R3 | Propagate `matched_bad_audio_hash_id` / `matched_bad_audio_hash_path` on transcoded imports | U5 |
-| R4 | Update docstring at lib/quality_evidence.py:825-847 to reflect reversed rule | U5 + U7 |
-| R5 | `current_spectral_grade` on `album_requests` inherits new semantic; no special-casing needed | Verified in research; no work |
-| R6 | Source-replacement overwrites stale propagated evidence | U4 (regression coverage) |
-| R7 | No backfill of existing transcoded library rows | Out-of-scope by decision |
-| R8 | Pre-change rows remain NULL — accepted known wart | Documented in U7 |
-| AE1 | Same-source duplicate is rejected by triage | U2 (parity) + U3 (round-trip) |
-| AE2 | Lossy candidate against transcoded-FLAC row is locked out by `lossless_source_locked` | U2 (parity) + U3 (round-trip) |
-| AE3 | Bad-rip hash propagates and matches future candidates | U1 (existing fixture has hash=99 ready to flip) |
-| AE4 | Source-replacement overwrites stale evidence | U4 |
-| AE5 | Renamed-only path unchanged | Regression guard via existing `test_renamed_only_flac_propagates_full_measurement_payload` |
-| Search-planner regression | `compute_effective_override_bitrate` for transcoded library rows with spectral | U6 |
+| R1 | Propagate spectral/V0/bad-hash when source is lossless | U8 |
+| R2 | Strip on non-lossless transcoded imports (unchanged) | U8 + U1 negative test |
+| R3 | Renamed-only path unchanged | U8 (unchanged code path) + AE6 regression guard |
+| R4 | verified_lossless_proof propagates always (unchanged) | No change; existing tests pin |
+| R5 | Remove unused `target_format` param | U8 |
+| R6 | New `narrow_override_on_lossless_source_lock` helper | U9 |
+| R7 | Wire helper into importer-side rejection | U10 |
+| R8 | Wire helper into wrong-match cleanup triage | U11 |
+| R9 | No plan invalidation needed | Verified during research |
+| R10 | current_spectral_grade inherits narrower rule naturally | No code change |
+| R11 | Source-replacement overwrites via ON CONFLICT (existing) | U7 regression coverage |
+| R12 | No backfill | Out-of-scope by decision |
+| R13 | Pre-change rows remain NULL — accepted known wart | Documented in U12 |
+| AE1 | Same-source duplicate rejected by triage AND search narrows | U4 + U6 |
+| AE2 | Lossy candidate against lossless-source row → lock fires + narrows | U3 + U4 |
+| AE3 | Bad-rip hash propagates on lossless-source transcoded import | U1 |
+| AE4 | Source-replacement overwrites stale propagated evidence | U7 |
+| AE5 | Non-lossless source transcoded import strips source-side evidence | U1 negative case |
+| AE6 | Renamed-only path unchanged | Existing `test_renamed_only_flac_propagates_full_measurement_payload` |
+| AE7 | Idempotent narrowing | U2 |
 
 ---
 
 ## Implementation Units
 
-### U1. Flip TestU10 transcoded-evidence propagation assertions (test-first RED)
+### U1. Adjust TestU10 transcoded propagation tests for lossless-source gate
 
-**Goal:** Convert the existing assertion that transcoded imports drop spectral
-/ V0 / bad-hash into an assertion that they now propagate. Becomes the RED
-baseline for U5's production change.
+**Goal:** The existing flipped test (`test_transcoded_flac_to_v0_propagates_source_evidence`)
+still pins the correct lossless-source case. Add a new negative test
+that pins the non-lossless-source case (MP3 → Opus): source-side fields
+must stay NULL.
 
-**Requirements:** AE3 (bad-rip hash by virtue of the fixture's existing
-`matched_bad_audio_hash_id=99`), AE5 (sibling rename-only test untouched as
-regression guard).
-
-**Dependencies:** None.
-
-**Files:**
-- `tests/test_integration_slices.py` (modify `TestU10PostImportEvidencePropagation`)
-
-**Approach:**
-- Rename `test_transcoded_flac_to_v0_drops_spectral_and_v0_keeps_proof` →
-  `test_transcoded_flac_to_v0_propagates_source_evidence`.
-- Flip the five `assertIsNone` checks at the bottom of the test
-  (`new_evidence.measurement.spectral_grade`,
-  `new_evidence.measurement.spectral_bitrate_kbps`, `new_evidence.v0_metric`,
-  `new_evidence.matched_bad_audio_hash_id`,
-  `new_evidence.matched_bad_audio_hash_path`) to `assertEqual` against the
-  candidate's seeded values. Keep `verified_lossless_proof` assertion as-is
-  (already propagates).
-- Leave `test_renamed_only_flac_propagates_full_measurement_payload`
-  untouched — it stays as the AE5 regression guard.
-
-**Execution note:** Write the assertion flip first. Run the test, watch it
-fail (RED). U5 turns it green. Do not modify production code in this unit.
-
-**Patterns to follow:** Mirror the existing sibling test's assertion shape —
-the `_build_candidate_evidence` helpers in `TestU10PostImportEvidencePropagation`
-already produce the right fixture; only the assertions change.
-
-**Test scenarios:**
-- Covers AE3. Transcoded FLAC → V0 with candidate
-  `spectral_grade="genuine"`, `spectral_bitrate_kbps=850`,
-  `v0_metric.source_lineage="lossless_source"`, `v0_metric.avg_bitrate_kbps=850`,
-  `matched_bad_audio_hash_id=99`,
-  `matched_bad_audio_hash_path="/some/known/bad.flac"`. After propagation,
-  the library row's `measurement.spectral_grade`, `measurement.spectral_bitrate_kbps`,
-  `v0_metric` (full struct equality), `matched_bad_audio_hash_id`,
-  `matched_bad_audio_hash_path` must equal the candidate's values.
-- Regression: `verified_lossless_proof` still propagates (no change).
-- Regression: `measurement.min_bitrate_kbps` / `avg_bitrate_kbps` / `format`
-  still describe the *library copy* (V0 output), not the candidate (FLAC
-  source) — these are re-derived from `album_info`, not propagated.
-
-**Verification:** Running
-`nix-shell --run "python3 -m unittest tests.test_integration_slices.TestU10PostImportEvidencePropagation.test_transcoded_flac_to_v0_propagates_source_evidence -v"`
-must fail with `AssertionError: None != ...` on each of the five propagated
-fields before U5; pass after U5.
-
----
-
-### U2. Add Lil Wayne live-bug scenario — simulator + evidence-pipeline parity (test-first RED)
-
-**Goal:** Encode the live bug (request 3779, MBID
-`244322cc-51ba-4f35-b072-f7c5888fb5ce`) as a permanent regression test.
-Establishes the parity contract: the simulator decider and the
-evidence-pipeline decider must reach the same outcome on the same album.
-
-**Requirements:** AE1, AE2 (at decision level).
+**Requirements:** AE3 (bad-hash propagates on lossless-source case; existing
+fixture has matched_bad_audio_hash_id=99), AE5 (non-lossless strip).
 
 **Dependencies:** None.
 
 **Files:**
-- `tests/test_quality_classification.py` (extend `TestLiveBugReproductions`
-  and `TestLiveBugReproductionsThroughEvidencePipeline`)
+- `tests/test_integration_slices.py` (`TestU10PostImportEvidencePropagation`)
 
 **Approach:**
-- Add one test method to `TestLiveBugReproductions` named
-  `test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_simulator`.
-  Build the candidate facts to match the live row: FLAC container, spectral
-  `likely_transcode`, spectral_bitrate `128`, v0 probe `lossless_source` avg
-  `215` min `184`. Existing library facts match the transcoded-FLAC import:
-  format `Opus`, codec `opus`, min `100`, avg `119`, plus the now-propagated
-  source-side fields (`spectral_grade=likely_transcode`,
-  `spectral_bitrate=128`, `v0_source_lineage=lossless_source`, `v0_avg=215`).
-  Call `full_pipeline_decision(...)` with `import_mode="force"`. Expected
-  outcome: reject-class decision (e.g. `suspect_lossless_downgrade` or
-  `lossless_source_not_better`); NOT `provisional_lossless_upgrade`.
-- Add the parity sibling to `TestLiveBugReproductionsThroughEvidencePipeline`
-  named `test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_evidence`.
-  Use `_build_candidate(...)` and `_build_current(...)` to construct
-  `AlbumQualityEvidence` rows matching the same facts; call
-  `full_pipeline_decision_from_evidence(candidate_evidence, current_evidence,
-  facts=AlbumQualityEvidenceDecisionFacts(import_mode="force"), cfg=...)`.
-  Assert the same decision and that `classify_full_pipeline_decision(decision)`
-  returns `verdict="confident_reject"`.
-- Both tests must reference the live row in the docstring with MBID, request
-  ID, and date for future archaeology.
+- Keep the renamed `test_transcoded_flac_to_v0_propagates_source_evidence`
+  as-is — it exercises the FLAC source → V0 library case which is
+  lossless-source-gated.
+- Add new test `test_transcoded_mp3_to_opus_strips_source_evidence` (or
+  similar). Mirrors the existing transcoded test fixture but with
+  `candidate_evidence.codec="mp3"`, `container="mp3"`, `storage_format="mp3 v0"`.
+  Library copy is Opus. Asserts the resulting library row's
+  `measurement.spectral_grade`, `measurement.spectral_bitrate_kbps`,
+  `v0_metric`, `matched_bad_audio_hash_id`, and
+  `matched_bad_audio_hash_path` are ALL NULL.
 
-**Execution note:** The simulator test may already pass today — `full_pipeline_decision`
-takes flat kwargs and will decide correctly when given the propagated
-evidence. The evidence-pipeline test is the RED test: today, no plausible
-`_build_current(...)` would carry the source-side fields (because propagation
-never wrote them), so the test will encode the *intended* state and fail
-until U5 makes the production path produce that state. Document this asymmetry
-in the test docstring.
+**Execution note:** Write the test first — it should fail RED before U8
+lands (current code propagates the fields symmetrically), pass after U8
+re-gates on source_is_lossless.
 
-**Patterns to follow:** Mirror `test_mountain_goats_bride_provisional_via_evidence`
-(parity sibling pattern) and `test_live_mountain_goats_flux_flac_source_vs_lossy_no_spectral`
-(simulator scenario shape). Use the existing `_build_candidate` / `_build_current`
-helpers; do not hand-roll `AlbumQualityEvidence` rows.
+**Patterns to follow:** Existing
+`test_transcoded_flac_to_v0_propagates_source_evidence` is the template;
+only the candidate codec and matching assertions change.
 
 **Test scenarios:**
-- Covers AE1. Simulator: transcoded-FLAC library row (propagated source
-  evidence) + identical-source FLAC candidate → reject-class decision,
-  `confident_reject` verdict.
-- Covers AE1. Evidence pipeline parity: same inputs through
-  `full_pipeline_decision_from_evidence(import_mode="force")` →
-  same decision, `confident_reject` verdict.
-- Covers AE2. Same library row but lossy MP3 V0 candidate (in the same
-  parity-test or a sibling) → `lossless_source_locked` decision,
-  `confident_reject` verdict, `cleanup_eligible=True`.
+- New: MP3 source transcoded to Opus → all source-side fields NULL on
+  library row. Verifies AE5.
+- Regression: existing FLAC → Opus propagation test still passes after U8.
+- Regression: renamed-only test still passes after U8.
 
-**Verification:** The simulator test passes immediately (decider already
-handles the inputs correctly); the evidence-pipeline test fails RED
-before U5 and passes after U5. The parity assertion (both classes return
-the same outcome) catches future drift.
+**Verification:** New test fails RED before U8; passes after. Existing
+tests unaffected.
 
 ---
 
-### U3. Integration slice: propagate → wrong-match triage round-trip (test-first RED)
+### U2. Pure tests for `narrow_override_on_lossless_source_lock`
 
-**Goal:** Prove AE1 end-to-end at the orchestration level — propagate
-transcoded-FLAC evidence on import, then exercise the real
-`cleanup_wrong_match` call path against an identical-source wrong-match
-candidate, and assert the triage outcome flips from `kept_would_import` to
-`deleted` (`confident_reject` + cleanup eligible).
+**Goal:** Pin the helper's behavior at every input case.
 
-**Requirements:** AE1 (orchestration level).
+**Requirements:** R6, AE7.
 
 **Dependencies:** None.
 
 **Files:**
-- `tests/test_integration_slices.py` (new test class
-  `TestWrongMatchTriageRejectsSameSourceDuplicate` adjacent to
-  `TestWrongMatchCleanupFKChainAvoidsRemeasurement`)
+- `tests/test_quality_decisions.py` (new test class
+  `TestNarrowOverrideOnLosslessSourceLock`)
 
 **Approach:**
-- Reuse the `_seed(source)`, `_evidence_for(source_dir, mb_release_id)`, and
-  `_patch_cfg()` builders from
-  `TestWrongMatchCleanupFKChainAvoidsRemeasurement` (or extract them into
-  module-level helpers if duplication starts hurting).
-- Stage two source dirs on disk: a `transcoded_origin` dir representing the
-  first FLAC import, and a `duplicate_source` dir representing the identical
-  second arrival. Build matching `AlbumQualityEvidence` rows for both with
-  `spectral_grade="likely_transcode"`, `spectral_bitrate_kbps=128`,
-  `v0_metric` with `source_lineage="lossless_source"` and `avg=215`.
-- Simulate the first import by calling
-  `_refresh_current_evidence_after_import(...)` with the transcoded-origin
-  candidate evidence and an `album_info` for a V0 library copy. Verify the
-  resulting library evidence row carries the propagated source fields
-  (sanity check; the real assertion is downstream).
-- Seed a `download_log` row marking the duplicate-source folder as
-  `rejected` (mirroring the live row 16682).
-- Call `cleanup_wrong_match(db, download_log_id)` with the seeded log id.
-- Assert outcome: `WrongMatchCleanupOutcome.outcome == OUTCOME_DELETED`,
-  `verdict == "confident_reject"`, `cleanup_eligible == True`,
-  `preview_decision` is a reject decision name (e.g. `suspect_lossless_downgrade`
-  or `lossless_source_locked`).
-
-**Execution note:** Test will be RED before U5 — without propagation, the
-library row's source-side fields stay NULL, triage returns
-`OUTCOME_KEPT_WOULD_IMPORT`, and the assertion against `OUTCOME_DELETED`
-fails. Document this in the test docstring.
-
-**Patterns to follow:**
-- `TestWrongMatchCleanupFKChainAvoidsRemeasurement` for the
-  seed/evidence/cfg-patch pattern.
-- `TestU10PostImportEvidencePropagation` for staging audio dirs and calling
-  `_refresh_current_evidence_after_import`.
-- `FakePipelineDB` from `tests/fakes.py` for the stateful DB.
+- subTest table with rows:
+  - `(None, "lossless")` — no override → narrow to lossless
+  - `("mp3 v0", "lossless")` — lossy override → narrow to lossless
+  - `("mp3 320", "lossless")` — lossy override → narrow to lossless
+  - `("lossless,mp3 v0,mp3 320", "lossless")` — full ladder → narrow to lossless
+  - `("lossless", None)` — already narrowest → no-op (returns None)
+- Pattern: match `TestComputeEffectiveOverrideBitrate`'s subTest CASES
+  table shape.
 
 **Test scenarios:**
-- Covers AE1. Two-source scenario: propagate evidence for the first
-  transcoded import, then call cleanup triage on the duplicate-source
-  wrong-match → `OUTCOME_DELETED`, `confident_reject`, `cleanup_eligible`.
-- Negative regression: same setup but skip the propagation step (or use a
-  bare candidate evidence with NULL source-side fields) → still
-  `OUTCOME_KEPT_WOULD_IMPORT`. Demonstrates the propagation IS the load-
-  bearing input, not some other gate.
+- Each row above; assertion shape:
+  `assertEqual(narrow_override_on_lossless_source_lock(current), expected)`.
 
-**Verification:** Test fails RED before U5 with
-`AssertionError: 'kept_would_import' != 'deleted'`; passes after U5.
+**Verification:** All subTest cases pass after U9 lands.
 
 ---
 
-### U4. Source-replacement overwrite slice (regression coverage)
+### U3. Importer-side rejection narrows override (orchestration test)
 
-**Goal:** Document and pin behaviour for AE4 — when a clean lossless-source
-candidate force-imports over a previously-transcoded library row, the new
-candidate's evidence overwrites the stale propagated fields.
+**Goal:** When `dispatch_import_from_db` (or its dispatch core) decides
+`lossless_source_locked`, the request's `search_filetype_override` ends
+up as `"lossless"` after the rejection is recorded.
 
-**Requirements:** AE4, R6.
+**Requirements:** R7, AE2.
 
 **Dependencies:** None.
 
 **Files:**
-- `tests/test_integration_slices.py` (new test method in
-  `TestU10PostImportEvidencePropagation` or a sibling class)
+- `tests/test_dispatch_core.py` (or `tests/test_integration_slices.py` if
+  the existing dispatch-core scaffolding is too tied to other flows)
 
 **Approach:**
-- Stage one library dir. Propagate evidence from a first candidate with
-  compromised source (`spectral_grade="likely_transcode"`,
-  `spectral_bitrate=128`, `v0_metric.source_lineage="lossless_source"`,
-  `v0_avg=215`). Verify the library row reflects these values.
-- Propagate evidence from a second candidate with clean genuine source
-  (`spectral_grade="genuine"`, `spectral_bitrate=900`,
-  `v0_metric.source_lineage="lossless_source"`, `v0_avg=900`,
-  `verified_lossless_proof` populated) over the same MBID + snapshot
-  fingerprint.
-- Assert the library row's `measurement.spectral_grade == "genuine"` (not
-  `"likely_transcode"`), `measurement.spectral_bitrate_kbps == 900`,
-  `v0_metric.source_lineage == "lossless_source"` with `avg == 900`,
-  `verified_lossless_proof IS NOT None`. No stale values survive.
+- Use `FakePipelineDB` with a seeded request whose
+  `search_filetype_override` is initially `"mp3 v0,mp3 320"` (or None).
+- Drive the dispatch path with a lossy candidate (`dl_info`) that
+  produces an `ImportResult` with `decision="lossless_source_locked"`.
+  Mock the `import_one.py` subprocess to return the canned result, or
+  use the existing dispatch-core fakes.
+- Assert post-call: `db.request(request_id)["search_filetype_override"]`
+  equals `"lossless"`.
 
-**Execution note:** This unit may pass before U5 if the second candidate
-also exercises the existing rename-only path (which propagates everything).
-The unit explicitly tests the transcoded → transcoded replacement case to
-exercise the new policy. If it passes immediately under U5 because
-`upsert_album_quality_evidence` uses `ON CONFLICT DO UPDATE` and the upsert
-overwrites by `(mb_release_id, snapshot_fingerprint)`, that is the
-documented success criterion — the test serves as regression coverage,
-not RED→GREEN.
+**Execution note:** Test will be RED before U10 lands.
 
-**Patterns to follow:** Reuse `TestU10PostImportEvidencePropagation`'s
-audio-staging and `_refresh_current_evidence_after_import` patterns.
+**Patterns to follow:** Existing downgrade-narrowing orchestration tests
+in test_dispatch_core.py (around the `downgrade` branch's
+`narrow_override_on_downgrade` call); mirror their shape.
 
 **Test scenarios:**
-- Covers AE4. Sequential propagation: compromised source first, clean
-  source second → library row reflects the second.
-- Edge case: the snapshot fingerprint changes between propagations
-  (different file set) → both rows coexist as separate
-  `album_quality_evidence` rows; the request's `current_evidence_id`
-  points at the second. (Optional; only add if `_refresh_current_evidence_after_import`
-  exposes this transition cleanly.)
+- Happy path: lossy candidate + lossless-source library evidence
+  → `lossless_source_locked` → override becomes `"lossless"`.
+- Idempotent: if override is already `"lossless"`, stays
+  `"lossless"` (no spurious DB write).
 
-**Verification:** Test passes after U5; documents the upsert semantic.
+**Verification:** Test fails RED before U10; passes after.
 
 ---
 
-### U5. Reverse propagation policy in lib/quality_evidence.py (production change — GREEN)
+### U4. Lil Wayne parity tests (simulator + evidence pipeline)
 
-**Goal:** Remove the `is_transcode` conditionals that zero the source-side
-fields on the library row. Update the function docstring to reflect the
-reversed rule and re-state the semantic shift.
+**Goal:** Pin the Lil Wayne (request 3779) FLAC-source same-source
+duplicate scenario as a regression test in both
+`TestLiveBugReproductions` and
+`TestLiveBugReproductionsThroughEvidencePipeline`. Encode the parity
+contract: simulator and evidence pipeline must reach the same decision.
 
-**Requirements:** R1, R2, R3, R4.
+**Requirements:** AE1 at the decision level.
 
-**Dependencies:** U1, U2, U3 (all must be RED before this lands).
+**Dependencies:** None.
 
 **Files:**
-- `lib/quality_evidence.py` (modify `propagate_candidate_evidence_to_current`,
-  lines 795-923)
+- `tests/test_quality_classification.py`
 
 **Approach:**
-- **Inner measurement (lines 886-891).** Remove the `None if is_transcode
-  else ...` conditionals on `spectral_grade` and `spectral_bitrate_kbps`.
-  After the change, both fields always equal `candidate_measurement.spectral_grade`
-  / `candidate_measurement.spectral_bitrate_kbps`.
-- **Outer row (line 911).** Remove the `None if is_transcode else ...`
-  conditional on `v0_metric`. After the change, `v0_metric` always equals
-  `candidate_evidence.v0_metric` (a single `AlbumQualityV0Metric` struct
-  holding lineage + min/avg/median).
-- **Outer row (lines 917-918, 920-921).** Remove the `None if is_transcode
-  else ...` conditionals on `matched_bad_audio_hash_id` and
-  `matched_bad_audio_hash_path`. After the change, both always equal the
-  candidate's values.
-- **`is_transcode` flag and its inputs.** Verified at plan time: the
-  detection block at lines 858-877 (and the locals `source_codec`,
-  `library_codec`, `effective_target`, `effective_target_lc` that feed it)
-  is referenced ONLY by the five conditionals being removed. After the
-  conditional removals, the entire detection block plus its input locals
-  become dead code and must be deleted in the same change. No downstream
-  call path consumes `is_transcode` from this function.
-- **Docstring (lines 825-847).** Rewrite the "Field policy" bullet that
-  starts "Propagated when renamed-only, NULL when transcoded:" to instead
-  describe the new unified rule: "Propagated in both renamed-only and
-  transcoded cases — these describe the upstream source audio at import
-  time, not the on-disk file. For transcoded imports, the on-disk file
-  has a different spectrum and codec, but the propagated fields remain
-  accurate descriptions of the source that produced it." Update the
-  surrounding paragraphs to remove the now-obsolete reasoning.
+- Existing tests from the prior plan version (already in branch history
+  on commit be30928) cover this. Inspect and verify they still match the
+  corrected scope — both candidate and existing-library inputs are FLAC,
+  which is the lossless-source case.
+- Strengthen the parity assertion: explicitly assert
+  `simulator_result["stage2_import"] ==
+  evidence_result["stage2_import"]`, not just hardcoded equality to
+  `"suspect_lossless_downgrade"` on each side independently. Pin the
+  parity contract, not the literal decision name.
 
-**Execution note:** This is the GREEN unit. Once it lands, U1's flipped
-assertions, U2's evidence-pipeline parity test, U3's triage round-trip,
-and U4's source-replacement test all turn green. The simulator side of U2
-was already green.
+**Test scenarios:**
+- Same as the existing tests; assertion strengthening only.
 
-**Patterns to follow:** The rename-only path. After the change, transcoded
-and rename-only branches differ only in whether `measurement.format` /
-`measurement.min_bitrate_kbps` etc. come from `album_info` (always re-derived
-from the library snapshot, for both cases) — the source-side fields no
-longer branch on `is_transcode`.
+**Verification:** Both tests pass; parity assertion fails if a future
+change makes the two deciders diverge.
 
-**Test scenarios:** None added in this unit (production change). All test
-coverage lives in U1-U4. Verification is "the previously-RED tests turn
-GREEN."
+---
+
+### U5. Wrong-match triage → search narrowing integration slice
+
+**Goal:** Extend the existing
+`TestWrongMatchTriageRejectsSameSourceDuplicate` (added in commit
+770ccd8) so that after triage deletes the wrong-match folder, the
+request's `search_filetype_override` is `"lossless"`.
+
+**Requirements:** R8, AE1, AE2.
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_integration_slices.py`
+  (`TestWrongMatchTriageRejectsSameSourceDuplicate`)
+
+**Approach:**
+- Add an assertion after the existing OUTCOME_DELETED assertion:
+  `self.assertEqual(db.request(request_id)["search_filetype_override"],
+  "lossless")`.
+- Also extend the negative regression sibling test to assert the
+  override is unchanged (None or whatever it was seeded with) in the
+  no-propagation path.
+
+**Execution note:** New assertion fails RED before U11 lands.
+
+**Test scenarios:**
+- Happy path: propagation + triage deletion → override is `"lossless"`.
+- Negative: no propagation → override unchanged (regression).
+
+**Verification:** Test fails RED before U11; passes after.
+
+---
+
+### U6. AE2 lossy-candidate triage round-trip (NEW — addresses prior P0)
+
+**Goal:** Add a slice that exercises the lossy MP3 V0 candidate vs
+lossless-source library row case end-to-end through triage. This is the
+test the previous reviewer flagged as missing (P0 in the prior code
+review).
+
+**Requirements:** AE2 explicitly.
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_integration_slices.py` (extend
+  `TestWrongMatchTriageRejectsSameSourceDuplicate` or sibling class)
+
+**Approach:**
+- Seed the same lossless-source library row from U5/U6 of the existing
+  test.
+- Seed a wrong-match download_log with a lossy MP3 V0 candidate
+  (`codec="mp3"`, no v0_metric).
+- Call `cleanup_wrong_match`.
+- Assert: outcome is `OUTCOME_DELETED`, `preview_decision ==
+  "lossless_source_locked"`, `verdict == "confident_reject"`, and the
+  request's `search_filetype_override` is `"lossless"`.
+
+**Test scenarios:**
+- Lossy MP3 V0 candidate vs lossless-source library row →
+  `lossless_source_locked` → DELETED + override narrowed.
+
+**Verification:** Test passes after U8 + U11 land (depends on both
+propagation gate behaving correctly so the library row has the V0
+probe, AND the cleanup wiring narrowing).
+
+---
+
+### U7. Source-replacement overwrite slice (regression coverage)
+
+**Goal:** Pin the AE4 behavior — when a clean lossless-source candidate
+force-imports over a previously-transcoded lossless-source library row,
+the new candidate's evidence overwrites the stale fields via the
+existing `upsert_album_quality_evidence` ON CONFLICT.
+
+**Requirements:** AE4, R11.
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/test_integration_slices.py` (existing
+  `test_source_replacement_overwrites_stale_propagated_evidence`)
+
+**Approach:**
+- The test from commit 57639d2 already covers this. Verify it still
+  matches the corrected scope (both candidates are FLAC, so within the
+  lossless-source gate). No changes expected.
+
+**Verification:** Test passes; no change required.
+
+---
+
+### U8. Production change: re-gate propagation on lossless source
+
+**Goal:** Replace today's "always strip on transcode" policy with
+"strip on transcode UNLESS source is lossless." Remove the unused
+`target_format` parameter and the dead `is_transcode` detection block
+where appropriate.
+
+**Requirements:** R1, R2, R3, R4, R5.
+
+**Dependencies:** U1.
+
+**Files:**
+- `lib/quality_evidence.py::propagate_candidate_evidence_to_current`
+
+**Approach:**
+- Re-introduce a minimal `is_transcode` detection (source codec vs
+  library codec, since `target_format` param is gone). Add a
+  `source_is_lossless` check: `(candidate_evidence.codec or "").lower()
+  in LOSSLESS_CODECS`.
+- Combine: `strip_source_fields = is_transcode and not source_is_lossless`.
+- Apply the gate to the 5 fields:
+  - `measurement.spectral_grade`
+  - `measurement.spectral_bitrate_kbps`
+  - `v0_metric`
+  - `matched_bad_audio_hash_id`
+  - `matched_bad_audio_hash_path`
+- Leave `verified_lossless`, `verified_lossless_proof`,
+  `was_converted_from` propagating unchanged.
+- Update the function docstring to describe the lossless-source gate
+  precisely.
+
+**Execution note:** Production GREEN unit. Unblocks U1's negative case
+(MP3 → Opus strip) and keeps U1's positive case (FLAC → Opus propagate)
+passing.
+
+**Patterns to follow:** Today's stripped-conditional pattern that the
+earlier rewrite removed; restore selectively with the
+`source_is_lossless` check.
+
+**Test scenarios:** None added in this unit. Verification is U1, U7, and
+U2's tests all behaving correctly.
 
 **Verification:**
-- `nix-shell --run "python3 -m unittest tests.test_integration_slices.TestU10PostImportEvidencePropagation -v"`
-  passes (both U1's flipped test and U4's source-replacement test).
-- `nix-shell --run "python3 -m unittest tests.test_quality_classification.TestLiveBugReproductionsThroughEvidencePipeline -v"`
-  passes (including U2's parity test).
-- New `TestWrongMatchTriageRejectsSameSourceDuplicate` from U3 passes.
-- `nix-shell --run "bash scripts/run_tests.sh"` full suite passes — no
-  regressions in adjacent decider tests.
-- Pyright on `lib/quality_evidence.py` is clean.
+- U1's new MP3 → Opus negative case passes (strip).
+- U1's existing FLAC → Opus positive case passes (propagate).
+- Existing renamed-only test passes (unchanged).
+- `nix-shell --run "bash scripts/run_tests.sh"` full suite passes.
+- Pyright clean on `lib/quality_evidence.py`.
 
 ---
 
-### U6. Extend `TestComputeEffectiveOverrideBitrate.CASES` for transcoded library rows with spectral (search-planner coverage)
+### U9. Add `narrow_override_on_lossless_source_lock` helper
 
-**Goal:** Pin the search-planner's override-min-bitrate behaviour for the
-new world where transcoded library rows can carry `spectral_grade` /
-`spectral_bitrate_kbps`. Documents the semantic shift noted in the
-brainstorm's "Known Consequence: Temporary Wasted-Search Window" section.
+**Goal:** Pure helper that returns `"lossless"` unless the override is
+already `"lossless"` (in which case returns `None` for idempotent no-op).
 
-**Requirements:** Search-planner regression (brainstorm Test Obligations
-section, last bullet).
+**Requirements:** R6, AE7.
 
-**Dependencies:** None (pure function test; independent of U5).
+**Dependencies:** None.
 
 **Files:**
-- `tests/test_quality_decisions.py` (extend `TestComputeEffectiveOverrideBitrate.CASES`)
+- `lib/quality.py` (add helper near `narrow_override_on_downgrade`,
+  `rejection_backfill_override`)
 
 **Approach:**
-- Add subTest rows to the existing `CASES` table covering both transcoded-
-  output container bitrates:
-  - Opus V2 transcoded library row: `container_bitrate=100`,
-    `spectral_bitrate=128`, `spectral_grade="likely_transcode"`,
-    expected `100` (min wins; unchanged behaviour).
-  - MP3 V0 transcoded library row: `container_bitrate=225`,
-    `spectral_bitrate=128`, `spectral_grade="likely_transcode"`,
-    expected `128` (spectral wins; semantic shift visible).
-- The descriptions on the new rows should reference "transcoded library
-  row" so the intent is obvious from the subTest label.
+- Function shape:
+  ```
+  def narrow_override_on_lossless_source_lock(current: str | None) -> str | None:
+      if current == QUALITY_LOSSLESS:
+          return None
+      return QUALITY_LOSSLESS
+  ```
+- Tiny docstring referencing the brainstorm and the call sites that
+  use it.
 
-**Patterns to follow:** `TestComputeEffectiveOverrideBitrate.CASES` rows
-already cover the (container, spectral, grade) decision matrix exhaustively;
-add to the table, do not invent a new pattern.
+**Patterns to follow:** `narrow_override_on_downgrade` is the precedent
+in shape and naming.
 
-**Test scenarios:**
-- New: Opus V2 transcoded row with spectral=128/likely_transcode → 100
-  (container min wins).
-- New: MP3 V0 transcoded row with spectral=128/likely_transcode → 128
-  (spectral min wins, demonstrating the semantic shift).
-- Existing rows unchanged.
+**Test scenarios:** Owned by U2.
 
-**Verification:**
-`nix-shell --run "python3 -m unittest tests.test_quality_decisions.TestComputeEffectiveOverrideBitrate -v"`
-passes; new rows visible in subTest output.
+**Verification:** U2's subTest cases all pass.
 
 ---
 
-### U7. Update CLAUDE.md and acknowledge known wart
+### U10. Wire helper into importer-side rejection
 
-**Goal:** Update the living docs to reflect the reversed propagation policy
-and document the accepted asymmetry between pre-change and post-change
-transcoded library rows.
+**Goal:** When `dispatch_import_from_db` (importer worker) processes a
+`lossless_source_locked` rejection, narrow the request's
+`search_filetype_override` to `"lossless"`.
 
-**Requirements:** R4 (extends docstring updates from U5 to project-level docs),
-R8 (documents the accepted known wart).
+**Requirements:** R7.
 
-**Dependencies:** U5 (docs follow the code change in the same PR but trail
-it in the unit list for readability).
+**Dependencies:** U9.
 
 **Files:**
-- `CLAUDE.md` (lines 280-285, "Evidence survives the candidate → library
-  transition" paragraph in § "Decision architecture")
+- `lib/import_dispatch.py` (the `lossless_source_locked` rejection
+  branch around lines 1846-1858, plus a narrowing block analogous to
+  the existing downgrade branch at 1906-1939)
 
 **Approach:**
-- Rewrite the paragraph at CLAUDE.md:278-285 to describe the new rule:
-  > After a successful import, `propagate_candidate_evidence_to_current` (U10)
-  > inherits the candidate's full measurement payload (spectral grade, V0
-  > lineage, bad-audio-hash matches, verified-lossless proof) onto the
-  > library evidence row, for **both** renamed-only and transcoded imports.
-  > These fields describe the upstream source audio at import time, not the
-  > on-disk file. For transcoded imports the on-disk file has a different
-  > spectrum and codec, but the propagated fields remain accurate
-  > descriptions of the source that produced it.
-- Add a one-sentence "Known wart" follow-up paragraph:
-  > Library rows imported before this policy change have NULL
-  > spectral/V0/bad-hash fields. They retain the old behaviour (wrong-match
-  > triage cannot reject same-source duplicates against them) until they
-  > are re-imported or force-imported. Forward-only by design; no backfill.
-- No update needed in `.claude/rules/code-quality.md` (its "Quality
-  decisions live in ONE place" section covers decision purity, not
-  propagation policy — confirmed via grep during research).
-- No update needed in `docs/pipeline-db-schema.md` (no mentions of the
-  propagation policy — confirmed via grep).
-- The lib/quality_evidence.py docstring update is owned by U5; this unit
-  is project-level docs only.
+- In the `elif decision == "lossless_source_locked":` branch, compute:
+  ```
+  current_override = req_row.get("search_filetype_override")
+                     if req_row else None
+  narrowed_override = narrow_override_on_lossless_source_lock(
+      current_override)
+  ```
+  (where `req_row = db.get_request(request_id)`).
+- Ensure `narrowed_override` flows into the existing
+  `_record_rejection_and_maybe_requeue(...,
+  search_filetype_override=narrowed_override, ...)` call.
+- Log the narrowing for parity with the downgrade-branch logging
+  ("Narrowed search_filetype_override 'X' -> 'lossless' after
+  lossless_source_locked").
 
-**Patterns to follow:** Match the surrounding tone of CLAUDE.md's
-"Decision architecture" section — concise, opinionated, with a clear
-"never re-create decisions elsewhere" frame.
+**Execution note:** Production unit. Unblocks U3's test going GREEN.
 
-**Test scenarios:** Test expectation: none — docs-only change.
+**Patterns to follow:** The `downgrade` branch at lines 1906-1939 is the
+exact precedent.
 
-**Verification:**
-- `grep -n "inherit only\|stay NULL\|NULL when transcoded" CLAUDE.md` returns
-  no results after the update.
-- `grep -n "Propagated in both" CLAUDE.md` shows the new wording.
-- Manual read of the updated paragraph to confirm tone matches the section.
+**Test scenarios:** Owned by U3.
+
+**Verification:** U3 passes; full suite passes.
+
+---
+
+### U11. Wire helper into wrong-match cleanup triage
+
+**Goal:** When `cleanup_wrong_match` deletes a folder with
+`preview_decision == "lossless_source_locked"`, also narrow the request's
+`search_filetype_override` to `"lossless"`.
+
+**Requirements:** R8.
+
+**Dependencies:** U9.
+
+**Files:**
+- `lib/wrong_match_cleanup_service.py` (likely
+  `_perform_cleanup_deletion` or `_cleanup_wrong_match`)
+
+**Approach:**
+- After the successful deletion path (where outcome would be
+  `OUTCOME_DELETED`), if `preview_decision == "lossless_source_locked"`:
+  - Look up the current override on the request row.
+  - Call `narrow_override_on_lossless_source_lock(current_override)`.
+  - Persist the narrowed override via the appropriate
+    `db.set_request_*` method (or a small wrapper if no exact match
+    exists — TBD during implementation; check `lib/pipeline_db.py` for
+    the right entry point).
+- Audit: include the narrowed override in the cleanup audit payload
+  so the Recents tab can show "search narrowed to lossless" if useful.
+
+**Execution note:** Production unit. Unblocks U5 and U6 going GREEN.
+
+**Patterns to follow:** Existing `cleanup_wrong_match` already persists
+audit data via `db.record_wrong_match_triage(...)`; the override update
+is a small additional step.
+
+**Test scenarios:** Owned by U5 (FLAC same-source case) and U6 (lossy
+MP3 case).
+
+**Verification:** U5 and U6 pass; full suite passes.
+
+---
+
+### U12. Update CLAUDE.md and lib/quality_evidence.py docstring
+
+**Goal:** Update the living docs to reflect the corrected (narrower)
+propagation policy and the new search-narrowing behavior.
+
+**Requirements:** Companion to U8 and U10-U11.
+
+**Dependencies:** U8, U9, U10, U11.
+
+**Files:**
+- `CLAUDE.md` (the "Evidence survives the candidate → library transition"
+  paragraph, currently in the post-U7 state from the earlier work)
+- `lib/quality_evidence.py` (function docstring)
+
+**Approach:**
+- Rewrite the CLAUDE.md paragraph to describe:
+  - Propagation rule: full payload for renamed-only; lossless-source-only
+    for transcoded; non-lossless transcodes strip.
+  - Search-narrowing companion: lossless_source_locked → override
+    becomes "lossless" so search stops asking for non-lossless candidates.
+  - Known wart paragraph stays (pre-change rows still NULL).
+- Update the function docstring to match the gate's actual behavior
+  and remove the symmetric-propagation framing introduced earlier.
+- Also fix the stale docstring at
+  `lib/import_dispatch.py:645-648` (the `_refresh_current_evidence_after_import`
+  wrapper) which the project-standards reviewer flagged.
+- Fix the stale class docstring at
+  `tests/test_integration_slices.py:7367-7376`
+  (`TestU10PostImportEvidencePropagation`) which still says "stay NULL".
+
+**Test scenarios:** None — docs-only.
+
+**Verification:** `grep -n "stay NULL\|inherit only" CLAUDE.md
+lib/quality_evidence.py lib/import_dispatch.py
+tests/test_integration_slices.py` returns no results.
 
 ---
 
 ## Sequencing
 
 ```
-U1  (RED: flip TestU10 transcoded assertions)
-U2  (RED: Lil Wayne live-bug, simulator + evidence-pipeline parity)
-U3  (RED: propagate → triage round-trip slice)
-U4  (regression coverage: source-replacement overwrite)
-U6  (search-planner coverage: compute_effective_override_bitrate CASES)
-                    │
-                    ▼
-U5  (GREEN: production change — lib/quality_evidence.py + docstring)
-                    │
-                    ▼
-U7  (docs: CLAUDE.md policy paragraph)
+U1 (RED: TestU10 negative MP3 case)
+U2 (pure: narrow helper subTest cases)
+U3 (RED: importer-side narrowing test)
+U4 (parity test strengthening)
+U5 (RED: triage slice narrowing assertion)
+U6 (RED: AE2 lossy candidate slice)
+U7 (regression coverage check)
+              │
+              ▼
+U8 (GREEN: propagation gate re-introduction)
+U9 (GREEN: narrow helper)
+              │
+              ▼
+U10 (GREEN: importer wiring)
+U11 (GREEN: triage wiring)
+              │
+              ▼
+U12 (docs: CLAUDE.md + docstrings)
 ```
 
-U1, U2, U3, U4, U6 are independent and can be written in any order or in
-parallel. U5 must come after the RED test units to honour the strict-TDD
-posture (RED visible before GREEN). U7 follows U5 in the unit list for
-review readability but could technically land in the same commit; the
-implementer's call.
+U1-U7 are RED-first / regression-coverage units. U8 and U9 unblock most
+of them; U10 unblocks U3; U11 unblocks U5 and U6. U12 lands docs after
+behavior is verified.
 
 ---
 
 ## Key Technical Decisions
 
-- **Symmetric over scoped.** Propagate source-side fields for all transcoded
-  imports, not just lossless-source candidates. The asymmetry being fixed is
-  rename-only vs transcoded, not lossless vs lossy — the symmetric fix is the
-  coherent one. See origin: brainstorm § Key Decisions #1.
-- **Forward-only over backfill.** Existing transcoded library rows are not
-  retroactively populated. The bug is operator-visible only on new
-  wrong-matches; organic re-touch closes the asymmetry over time;
-  `migrations/021_evidence_canonical_rekey.sql` provides a clean atomic-
-  backfill precedent if operator pain warrants revisiting. See origin:
-  brainstorm § Key Decisions #2.
-- **One production change unit, one docs unit.** Splitting the policy code
-  change from the project-level docs change makes the policy shift
-  auditable in a single commit and the docs propagation reviewable in a
-  separate one. The function docstring belongs with the code (in U5)
-  because it describes function-local behaviour; CLAUDE.md belongs with
-  the docs unit (U7) because it describes project-level architecture.
-- **Test-first per unit.** U1, U2, U3 are RED tests written before U5
-  flips them green. U4 is regression coverage that may pass immediately
-  after U5 via `ON CONFLICT DO UPDATE`. U6 is pure-function coverage
-  independent of propagation. The plan structures tests as separate units
-  so each commit makes its intent visible (RED-then-GREEN over fewer-
-  larger-commits per user TDD preference).
-- **Reuse existing builders.** All test units lean on existing infrastructure
-  — `TestU10PostImportEvidencePropagation`'s audio-staging helpers,
-  `TestLiveBugReproductionsThroughEvidencePipeline._build_candidate` /
-  `_build_current`, `TestWrongMatchCleanupFKChainAvoidsRemeasurement`'s
-  `_seed` / `_evidence_for` / `_patch_cfg`, `FakePipelineDB` from
-  `tests/fakes.py`, `make_album_quality_evidence` from `tests/helpers.py`.
-  No new builders; no hand-rolled msgspec.Struct construction.
-
----
-
-## Test Strategy
-
-- **Pure tests** for `compute_effective_override_bitrate` (U6) — subTest
-  table extension.
-- **Integration slices** for propagation (U1 — flip existing; U4 —
-  source-replacement) and for the end-to-end triage round-trip (U3).
-- **Parity tests** for the live bug (U2) — simulator and evidence pipeline
-  must agree.
-- **Regression guards** are explicit: `test_renamed_only_flac_propagates_full_measurement_payload`
-  (untouched, guards AE5); existing `TestComputeEffectiveOverrideBitrate.CASES`
-  rows (untouched, guards rename-only override behaviour); full test suite
-  must pass after U5.
-
-Per `.claude/rules/code-quality.md`, no new bespoke harnesses; all test
-infrastructure already exists.
-
----
-
-## System-Wide Impact
-
-- **Decision layer (`lib/quality.py`).** No changes. Existing deciders
-  (`provisional_lossless_decision`, `spectral_import_decision`,
-  `full_pipeline_decision_from_evidence`) already handle the propagated
-  evidence shapes correctly — they were written assuming evidence might
-  be present on both sides; the current bug is that the library side was
-  artificially empty.
-- **Importer worker (`lib/import_dispatch.py`).** No changes. The importer
-  reads persisted evidence and decides via the unchanged pipeline.
-- **Preview worker (`lib/import_preview.py`).** No changes. Preview produces
-  candidate evidence; the propagation policy reversal only affects how
-  candidate evidence flows to the library row after import.
-- **Search planner (`lib/download.py:1575-1610`).** Behavioural shift for
-  newly-imported transcoded albums: `compute_effective_override_bitrate`
-  will start returning the source spectral cliff for MP3 V0 transcoded
-  library rows (e.g. drops from container ~225 to spectral 128). For
-  Opus V2 transcoded rows, behaviour is unchanged (`min(100, 128) = 100`).
-  Net effect: searches become slightly more permissive for new transcoded
-  albums; resulting lossy candidates get locked out at triage by the new
-  `lossless_source_locked` firing. Wasted slskd churn; no different files
-  on disk. Closes when the bucket model lands and search tiers narrow
-  based on existing-bucket (see `docs/brainstorms/quality-bucket-system-requirements.md`).
-- **Wrong-match cleanup triage (`lib/wrong_match_cleanup_service.py`).**
-  Intended behavioural shift: lossy candidates against transcoded-FLAC
-  library rows now classify as `confident_reject` (via
-  `lossless_source_locked`) and become cleanup-eligible. Same-source FLAC
-  duplicates against transcoded-FLAC library rows likewise classify as
-  reject (via `suspect_lossless_downgrade` or equivalent). Result: cleaner
-  wrong-matches queue for new transcoded imports.
-- **Web UI.** No changes. The Wrong Matches view consumes triage audit
-  rows via `download_log.validation_result`; new outcomes (e.g.
-  `lossless_source_locked`) already render via
-  `_wrong_match_action_label` (`web/classify.py:273-290`) without
-  additional plumbing.
-- **Pipeline DB schema.** No changes. Forward-only; no migrations.
-- **Operator workflows.** No CLI changes; no API changes; no config
-  changes. The CLI ⇄ API surface symmetry rule (§ CLAUDE.md) does not
-  apply — this is an internal policy reversal, not a new operator action.
+- **Lossless-source-gated, not symmetric.** The earlier symmetric scope
+  was scope creep; the user's actual intent is narrower. The gate is
+  `candidate_evidence.codec in LOSSLESS_CODECS` (= `{"flac", "alac",
+  "wav"}`).
+- **Search narrowing is in scope, not deferred.** A standalone helper
+  (`narrow_override_on_lossless_source_lock`) wired into two sites
+  (importer + triage) closes the wasted-cycle window the propagation
+  change would otherwise create.
+- **No `SEARCH_PLAN_GENERATOR_ID` bump.** Research confirmed
+  `generate_search_plan` produces query strategies only; filetype
+  filtering happens downstream in `enqueue.py::effective_search_tiers`
+  via the request's `search_filetype_override`. Updating that column
+  takes effect on the next cycle without plan regeneration.
+- **Reuse existing infrastructure.** All test units extend existing
+  builders (`FakePipelineDB`, `_build_candidate`/`_build_current`,
+  TestU10 audio-staging) and the production code follows the existing
+  downgrade-narrowing pattern.
+- **Forward-only over backfill.** Existing transcoded rows stay NULL.
 
 ---
 
 ## Scope Boundaries
 
 In scope:
-- Five `is_transcode` conditional removals in
-  `propagate_candidate_evidence_to_current`.
-- Docstring updates at lib/quality_evidence.py:825-847 and CLAUDE.md:278-285.
-- Test additions per U1-U4, U6.
-- No-op verification of `verified_lossless_proof` propagation (already
-  works; explicitly tested by existing assertions in U1's flipped test).
+- Lossless-source gate in `propagate_candidate_evidence_to_current`.
+- `narrow_override_on_lossless_source_lock` helper + two call sites.
+- Docstring + CLAUDE.md updates.
+- Test additions per U1-U7.
 
 Out of scope:
-- No backfill of existing transcoded library rows (Key Decision #2).
-- No changes to `full_pipeline_decision_from_evidence` or any pure decider
-  in `lib/quality.py`.
-- No changes to `import_service.py` or how `current_spectral_grade` flows
-  from library evidence back to `album_requests` (existing path inherits
-  the new semantic naturally; no special-casing).
-- No UI / copy / triage-display changes.
-- No `.claude/rules/code-quality.md` updates (decision purity rules
-  unchanged).
+- No backfill of existing transcoded library rows.
+- No changes to `full_pipeline_decision_from_evidence` or any pure
+  decider.
+- No force-import-bypass-the-lock affordance.
+- No UI / copy / triage-display changes (beyond the optional audit
+  payload extension in U11).
+- No new CLI / web API surface.
 
 ### Deferred to Follow-Up Work
 
-- **Search-plan tier narrowing on `lossless_source` lineage.** Once a
-  library row carries `v0_source_lineage="lossless_source"`, the search
-  plan could narrow to lossless tiers only, since any lossy candidate
-  will be locked out downstream. This is the natural shape of the bucket
-  work (see `docs/brainstorms/quality-bucket-system-requirements.md` R1,
-  R6) and absorbs the temporary wasted-search window from this change.
-  Not bundled into this PR.
-- **FK-chain backfill for existing transcoded library rows.** If the
-  organic re-touch rate proves too slow and false-positive triage keeps
-  remain operationally noisy, walk `album_requests.current_evidence_id` →
-  `download_log.candidate_evidence_id` and propagate the prior candidate's
-  source-side fields to the library row. Deferred behind operator
-  observation; revisit only if pain warrants.
+- **Bucket-aware search-plan tier ordering** (the full buckets work).
+  This PR mimics the bucket behavior at the lock site only; the bucket
+  rewrite generalizes it.
+- **Bad-rip ban evidence cleanup**
+  (`clear_on_disk_quality_fields` doesn't null `current_evidence_id`).
+  Pre-existing wart sharpened by this PR but separate from the
+  propagation/narrowing intent.
+- **Force-import override of `lossless_source_locked`.** Operator
+  escape hatch from the lock — needs a design decision.
+
+---
+
+## Branch History Strategy
+
+8 commits from the previous (over-scoped) shape are already on the
+branch (`feat/propagate-source-evidence-on-transcode`). The corrective
+work goes on top as new commits — do not rebase or rewrite history.
+Rationale: the evolution is real and the audit trail is part of the
+honesty of the PR. The PR description will explain the rescope explicitly.
+
+Each new commit's message references the corrected unit (e.g.,
+`test(u1-fix): add negative MP3-source case after rescope`,
+`feat(u8-fix): re-gate propagation on lossless source`, etc.) so the
+delta from the earlier shape is searchable.
 
 ---
 
 ## Risks and Mitigations
 
-- **Risk: U2's simulator test passes immediately, masking incomplete RED
-  baseline.** Mitigation: U2's docstring explicitly notes the simulator vs
-  evidence-pipeline asymmetry. The evidence-pipeline parity test is the
-  load-bearing RED; the simulator side documents the expected outcome
-  shape.
-- **Risk: `is_transcode` flag still referenced after conditional removals.**
-  Mitigation: U5 includes an explicit local read of lines 858-877 to
-  decide whether to delete the detection or preserve it with a comment.
-- **Risk: `lossless_source_locked` firing more aggressively breaks a
-  workflow we forgot.** Mitigation: U3's integration slice exercises the
-  full triage path against a real wrong-match row, and the full test suite
-  must pass after U5. Adjacent decider tests in `tests/test_quality_decisions.py`
-  exercise `provisional_lossless_decision` directly and will catch
-  unintended changes to the lock branch.
-- **Risk: Search-planner override drop (225 → 128) on MP3 V0 transcoded
-  rows causes excessive slskd churn.** Mitigation: brainstorm classifies
-  this as a known-acceptable temporary window. U6 documents the shift
-  with subTest rows. If the churn proves operationally painful, the
-  follow-up "search-plan tier narrowing" work in `Deferred to Follow-Up Work`
-  closes it.
-- **Risk: Pre-change transcoded library rows generate ongoing false-
-  positive triage keeps.** Mitigation: documented as R8 known wart in
-  brainstorm and U7. If pain warrants, FK-chain backfill in
-  `Deferred to Follow-Up Work` resolves it.
+- **Risk: gating logic accidentally re-strips renamed-only lossless
+  cases (FLAC → FLAC).** Mitigation: U1 keeps the existing
+  `test_renamed_only_flac_propagates_full_measurement_payload` and the
+  existing renamed-only FLAC test as a regression guard.
+- **Risk: `search_filetype_override = "lossless"` interacts badly with
+  user-driven re-queue paths.** Mitigation: `resolve_user_requeue_override`
+  (`lib/quality.py:84`) already preserves stricter overrides on user
+  requeue. The narrowing aligns with that contract.
+- **Risk: the wrong-match cleanup triage write of
+  `search_filetype_override` races with the importer's update on the
+  same request.** Mitigation: both update paths are guarded by
+  advisory locks per the existing architecture; verify during
+  implementation, add a test if a race is observable.
 
 ---
 
 ## Verification Checklist
 
 Before merging:
-- [ ] U1 test (`test_transcoded_flac_to_v0_propagates_source_evidence`) fails
-  with `AssertionError` on each of the five propagated fields before U5;
-  passes after.
-- [ ] U2 evidence-pipeline test fails RED before U5; passes after; parity
-  with the simulator test holds.
-- [ ] U3 round-trip test fails RED before U5 with
-  `'kept_would_import' != 'deleted'`; passes after.
-- [ ] U4 source-replacement test passes after U5; documents the upsert
-  overwrite semantic.
-- [ ] U6 subTest rows visible in test output; pass.
-- [ ] `nix-shell --run "bash scripts/run_tests.sh"` full suite passes; no
-  unrelated regressions.
-- [ ] Pyright clean on `lib/quality_evidence.py`,
-  `tests/test_integration_slices.py`,
-  `tests/test_quality_classification.py`,
-  `tests/test_quality_decisions.py`.
+- [ ] U1 negative test (MP3 → Opus strips) fails RED before U8; passes after.
+- [ ] U1 positive test (FLAC → Opus propagates) passes throughout.
+- [ ] U2 subTest cases for narrowing helper all pass.
+- [ ] U3 importer-narrowing test fails RED before U10; passes after.
+- [ ] U4 parity tests assert simulator/evidence equality (not just
+  hardcoded strings on each side).
+- [ ] U5 triage slice asserts override narrowing.
+- [ ] U6 AE2 lossy-candidate slice passes.
+- [ ] U7 source-replacement test still passes.
+- [ ] `nix-shell --run "bash scripts/run_tests.sh"` full suite passes;
+  no unrelated regressions.
+- [ ] Pyright clean on touched files.
 - [ ] CLAUDE.md grep confirms old wording removed, new wording present.
+- [ ] Stale docstrings at `lib/import_dispatch.py:645-648` and
+  `tests/test_integration_slices.py:7367-7376` updated.
 - [ ] Pre-commit hook (`scripts/pre-commit`) passes.

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -32,6 +32,7 @@ from lib.quality import (parse_import_result, DispatchAction, DownloadInfo,
                          extract_usernames, is_comparable_lossless_source_probe,
                          full_pipeline_decision_from_evidence,
                          narrow_override_on_downgrade,
+                         narrow_override_on_lossless_source_lock,
                          override_bitrate_from_current_evidence,
                          rejection_backfill_override)
 from lib.quality_evidence import (
@@ -1937,6 +1938,26 @@ def dispatch_import_core(
                         except Exception:
                             logger.debug(
                                 "Failed to inspect search_filetype_override before downgrade reset")
+
+                    elif decision == "lossless_source_locked":
+                        # R7 / AE2: once the library row carries a comparable
+                        # lossless-source V0 probe, no lossy candidate can
+                        # override it. Narrow the search to lossless-only so
+                        # future cycles stop re-finding lossy candidates that
+                        # would just hit the lock again. See
+                        # docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md
+                        try:
+                            req_row = db.get_request(request_id)
+                            current_override = (
+                                req_row.get("search_filetype_override")
+                                if req_row else None
+                            )
+                            narrowed_override = narrow_override_on_lossless_source_lock(
+                                current_override)
+                        except Exception:
+                            logger.debug(
+                                "Failed to inspect search_filetype_override"
+                                " before lossless_source_locked narrow")
 
                     _record_rejection_and_maybe_requeue(
                         db, request_id, dl_info,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -640,13 +640,12 @@ def _refresh_current_evidence_after_import(
     """Persist current evidence for the just-imported Beets album.
 
     When ``source_candidate`` is supplied (the normal post-U10 path), the new
-    library-side evidence row is built by propagating the candidate's full
+    library-side evidence row is built by propagating the candidate's
     measurement payload — see
-    :func:`lib.quality_evidence.propagate_candidate_evidence_to_current`.
-    Renamed-only imports inherit spectral grade, V0 lineage, and
-    bad-audio-hash matches; transcoded imports inherit only the verified-
-    lossless proof. Bitrate/format always re-derive from ``album_info``
-    (dual-check against the candidate measurement).
+    :func:`lib.quality_evidence.propagate_candidate_evidence_to_current`
+    for the lossless-source gate that governs which fields propagate.
+    Bitrate/format always re-derive from ``album_info`` (dual-check
+    against the candidate measurement).
 
     When ``source_candidate`` is ``None`` (rare — legacy callers, an evidence
     record that vanished, or non-post-import callers reusing this helper),

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2896,6 +2896,34 @@ def narrow_override_on_downgrade(search_filetype_override: str | None,
     return ",".join(narrowed)
 
 
+def narrow_override_on_lossless_source_lock(
+    current: str | None,
+) -> str | None:
+    """Narrow ``search_filetype_override`` to lossless-only when the
+    ``lossless_source_locked`` decision fires.
+
+    Once a library row carries a comparable lossless-source V0 probe,
+    no lossy candidate can override it -- the lock catches every lossy
+    candidate at triage and routes it to ``confident_reject`` with
+    cleanup eligibility. Without this narrowing, the search planner
+    keeps asking Soulseek for the album with no filetype filter, peer
+    after peer serves the same lossy file, each download is locked-out
+    and auto-deleted. This helper closes that wasted-cycle window by
+    pinning the search to lossless tiers.
+
+    Returns:
+        ``"lossless"`` when the override needs to change to lossless-only.
+        ``None`` when the override is already ``"lossless"`` (no-op).
+
+    Called from both the importer rejection branch
+    (``lib.import_dispatch``) and the wrong-match cleanup triage
+    (``lib.wrong_match_cleanup_service``).
+    """
+    if current == QUALITY_LOSSLESS:
+        return None
+    return QUALITY_LOSSLESS
+
+
 def rejection_backfill_override(
     *,
     is_cbr: bool,

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from lib.quality import (
+    LOSSLESS_CODECS,
     V0_PROBE_LOSSLESS_SOURCE,
     V0_PROBE_NATIVE_LOSSY_RESEARCH,
     V0_PROBE_ON_DISK_RESEARCH,
@@ -821,18 +822,22 @@ def propagate_candidate_evidence_to_current(
       the library path — for renamed-only this is the same audio as the
       candidate's measurement (a dual-check that catches drift); for
       transcoded imports this describes the V0/Opus output.
-    * Propagated symmetrically for both renamed-only AND transcoded
-      imports: ``spectral_grade``, ``spectral_bitrate_kbps`` (on the inner
-      measurement); ``v0_metric``, ``matched_bad_audio_hash_id``,
-      ``matched_bad_audio_hash_path`` (on the outer evidence row);
-      ``verified_lossless`` and ``verified_lossless_proof`` (on both).
-      These fields describe the upstream source audio at import time, not
-      the on-disk file. For transcoded imports the on-disk file has a
-      different spectrum and codec, but the propagated fields remain
-      accurate descriptions of the source that produced it — which is
-      what wrong-match triage compares future candidates against. Also
-      ``was_converted_from`` (source format before conversion) propagates
-      as-is.
+    * **Propagated when renamed-only OR when the source is a lossless
+      codec (FLAC / ALAC / WAV); stripped on non-lossless transcoded
+      imports:** ``spectral_grade``, ``spectral_bitrate_kbps`` (on the
+      inner measurement); ``v0_metric``, ``matched_bad_audio_hash_id``,
+      ``matched_bad_audio_hash_path`` (on the outer evidence row). The
+      gate is lossless-source-only because the source-side spectral / V0
+      lineage is only meaningfully comparable against future candidates
+      when the source audio was lossless to begin with. For non-lossless
+      transcoded imports (MP3 → Opus etc.) the source-side fields
+      describe lossy audio that has no comparable role in subsequent
+      candidate comparisons; storing them on the library row provides
+      no decision value and would mislead future triage.
+    * Propagated in ALL cases (unchanged): ``verified_lossless``,
+      ``verified_lossless_proof``, ``was_converted_from``. Verified
+      lineage survives transcode by definition; a V0 transcoded from a
+      verified-lossless FLAC is still verified-lossless by lineage.
     """
 
     album_path = getattr(album_info, "album_path", "")
@@ -843,6 +848,20 @@ def propagate_candidate_evidence_to_current(
     if not files:
         return EvidenceBuildResult(None, "empty_fileset", "no audio files found")
 
+    # Lossless-source gate: source-side fields propagate when the source
+    # codec is lossless (FLAC/ALAC/WAV) OR when the import is renamed-only
+    # (same codec in / out). Strip otherwise. See `docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md`.
+    source_codec = (candidate_evidence.codec or "").lower() or None
+    library_codec_from_files = files[0].codec
+    library_codec = (library_codec_from_files or "").lower() or None
+    is_transcode = (
+        source_codec is not None
+        and library_codec is not None
+        and source_codec != library_codec
+    )
+    source_is_lossless = source_codec in LOSSLESS_CODECS if source_codec else False
+    strip_source_fields = is_transcode and not source_is_lossless
+
     candidate_measurement = candidate_evidence.measurement
     measurement = AudioQualityMeasurement(
         min_bitrate_kbps=getattr(album_info, "min_bitrate_kbps", None),
@@ -850,14 +869,18 @@ def propagate_candidate_evidence_to_current(
         median_bitrate_kbps=getattr(album_info, "median_bitrate_kbps", None),
         format=getattr(album_info, "format", None) or None,
         is_cbr=bool(getattr(album_info, "is_cbr", False)),
-        spectral_grade=candidate_measurement.spectral_grade,
-        spectral_bitrate_kbps=candidate_measurement.spectral_bitrate_kbps,
+        spectral_grade=(
+            None if strip_source_fields else candidate_measurement.spectral_grade
+        ),
+        spectral_bitrate_kbps=(
+            None if strip_source_fields
+            else candidate_measurement.spectral_bitrate_kbps
+        ),
         verified_lossless=candidate_measurement.verified_lossless,
         was_converted_from=candidate_measurement.was_converted_from,
     )
 
     library_filetype_band = derive_filetype_band(files)
-    library_codec_from_files = files[0].codec
     library_container_from_files = files[0].container
 
     evidence = AlbumQualityEvidence(
@@ -871,14 +894,20 @@ def propagate_candidate_evidence_to_current(
         container=library_container_from_files,
         storage_format=measurement.format,
         target_format=None,
-        v0_metric=candidate_evidence.v0_metric,
+        v0_metric=None if strip_source_fields else candidate_evidence.v0_metric,
         verified_lossless_proof=candidate_evidence.verified_lossless_proof,
         audio_corrupt=any(not file.decode_ok for file in files),
         folder_layout=derive_folder_layout(files),
         audio_file_count=len(files),
         filetype_band=library_filetype_band,
-        matched_bad_audio_hash_id=candidate_evidence.matched_bad_audio_hash_id,
-        matched_bad_audio_hash_path=candidate_evidence.matched_bad_audio_hash_path,
+        matched_bad_audio_hash_id=(
+            None if strip_source_fields
+            else candidate_evidence.matched_bad_audio_hash_id
+        ),
+        matched_bad_audio_hash_path=(
+            None if strip_source_fields
+            else candidate_evidence.matched_bad_audio_hash_path
+        ),
     )
     errors = evidence.storage_validation_errors()
     if errors:

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -798,7 +798,6 @@ def propagate_candidate_evidence_to_current(
     request_id: int,
     candidate_evidence: AlbumQualityEvidence,
     album_info: Any,
-    target_format: str | None = None,
     measured_at: datetime | None = None,
 ) -> EvidenceBuildResult:
     """Build new library-side evidence by propagating candidate measurement payload.
@@ -806,21 +805,9 @@ def propagate_candidate_evidence_to_current(
     Post-import propagation path (U10). The candidate evidence row that the
     importer worked on already paid for expensive measurements (spectral
     analysis, V0 lineage, bad-audio-hash matches, verified-lossless proof).
-    After the file rename to the library path, the candidate and library
-    rows describe audio that is bit-equal in the non-transcoded case and
-    semantically related in the transcoded case. This helper builds the
-    new library-side evidence row without re-measuring — see
+    After the file rename or transcode to the library path, this helper
+    builds the new library-side evidence row without re-measuring — see
     ``CLAUDE.md`` § "Decision architecture" and the U10 design doc.
-
-    Detection:
-
-    * The candidate's persisted ``codec`` (lowercased) is the source codec.
-    * The library copy's ``album_info.format`` (lowercased, "flac"/"mp3"/etc)
-      is the library codec.
-    * ``target_format`` (or the candidate's persisted ``target_format``) is
-      the planned target format if a conversion was configured.
-    * Transcode = ``(target_format and target_format != source_codec)`` OR
-      ``(library_codec != source_codec)``.
 
     Field policy:
 
@@ -833,18 +820,19 @@ def propagate_candidate_evidence_to_current(
       Beets's per-track bitrate measurements describe the on-disk files at
       the library path — for renamed-only this is the same audio as the
       candidate's measurement (a dual-check that catches drift); for
-      transcoded imports this describes the V0 output.
-    * Propagated when renamed-only, NULL when transcoded: ``spectral_grade``,
-      ``spectral_bitrate_kbps`` (on the inner measurement); ``v0_metric``,
-      ``matched_bad_audio_hash_id``, ``matched_bad_audio_hash_path`` (on
-      the outer evidence row). These describe the source audio's frequency
-      content / lineage / hash; under transcode the V0 output has a
-      different spectrum and no V0 lineage relative to itself.
-    * Propagated in BOTH cases: ``verified_lossless`` and
-      ``verified_lossless_proof``. These classify the source's provenance
-      and survive transcode — a V0 transcoded from a verified-lossless FLAC
-      is still verified-lossless by lineage. Also ``was_converted_from``
-      (source format before conversion) propagates as-is.
+      transcoded imports this describes the V0/Opus output.
+    * Propagated symmetrically for both renamed-only AND transcoded
+      imports: ``spectral_grade``, ``spectral_bitrate_kbps`` (on the inner
+      measurement); ``v0_metric``, ``matched_bad_audio_hash_id``,
+      ``matched_bad_audio_hash_path`` (on the outer evidence row);
+      ``verified_lossless`` and ``verified_lossless_proof`` (on both).
+      These fields describe the upstream source audio at import time, not
+      the on-disk file. For transcoded imports the on-disk file has a
+      different spectrum and codec, but the propagated fields remain
+      accurate descriptions of the source that produced it — which is
+      what wrong-match triage compares future candidates against. Also
+      ``was_converted_from`` (source format before conversion) propagates
+      as-is.
     """
 
     album_path = getattr(album_info, "album_path", "")
@@ -855,27 +843,6 @@ def propagate_candidate_evidence_to_current(
     if not files:
         return EvidenceBuildResult(None, "empty_fileset", "no audio files found")
 
-    source_codec = (candidate_evidence.codec or "").lower() or None
-    library_codec = (getattr(album_info, "format", None) or "").lower() or None
-    effective_target = (
-        (target_format or candidate_evidence.target_format) or None
-    )
-    effective_target_lc = effective_target.lower() if effective_target else None
-    if (
-        effective_target_lc is not None
-        and source_codec is not None
-        and effective_target_lc != source_codec
-    ):
-        is_transcode = True
-    elif (
-        library_codec is not None
-        and source_codec is not None
-        and library_codec != source_codec
-    ):
-        is_transcode = True
-    else:
-        is_transcode = False
-
     candidate_measurement = candidate_evidence.measurement
     measurement = AudioQualityMeasurement(
         min_bitrate_kbps=getattr(album_info, "min_bitrate_kbps", None),
@@ -883,12 +850,8 @@ def propagate_candidate_evidence_to_current(
         median_bitrate_kbps=getattr(album_info, "median_bitrate_kbps", None),
         format=getattr(album_info, "format", None) or None,
         is_cbr=bool(getattr(album_info, "is_cbr", False)),
-        spectral_grade=(
-            None if is_transcode else candidate_measurement.spectral_grade
-        ),
-        spectral_bitrate_kbps=(
-            None if is_transcode else candidate_measurement.spectral_bitrate_kbps
-        ),
+        spectral_grade=candidate_measurement.spectral_grade,
+        spectral_bitrate_kbps=candidate_measurement.spectral_bitrate_kbps,
         verified_lossless=candidate_measurement.verified_lossless,
         was_converted_from=candidate_measurement.was_converted_from,
     )
@@ -908,18 +871,14 @@ def propagate_candidate_evidence_to_current(
         container=library_container_from_files,
         storage_format=measurement.format,
         target_format=None,
-        v0_metric=(None if is_transcode else candidate_evidence.v0_metric),
+        v0_metric=candidate_evidence.v0_metric,
         verified_lossless_proof=candidate_evidence.verified_lossless_proof,
         audio_corrupt=any(not file.decode_ok for file in files),
         folder_layout=derive_folder_layout(files),
         audio_file_count=len(files),
         filetype_band=library_filetype_band,
-        matched_bad_audio_hash_id=(
-            None if is_transcode else candidate_evidence.matched_bad_audio_hash_id
-        ),
-        matched_bad_audio_hash_path=(
-            None if is_transcode else candidate_evidence.matched_bad_audio_hash_path
-        ),
+        matched_bad_audio_hash_id=candidate_evidence.matched_bad_audio_hash_id,
+        matched_bad_audio_hash_path=candidate_evidence.matched_bad_audio_hash_path,
     )
     errors = evidence.storage_validation_errors()
     if errors:

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -20,6 +20,7 @@ from lib.quality import (
     classify_full_pipeline_decision,
     evidence_decision_name,
     full_pipeline_decision_from_evidence,
+    narrow_override_on_lossless_source_lock,
 )
 from lib.quality_evidence import load_candidate_evidence_for_source
 from lib.util import resolve_failed_path
@@ -481,6 +482,37 @@ def _perform_cleanup_deletion(
             cleared_rows=cleanup.cleared_rows,
             path_missing=True,
         )
+
+    # R8 / AE2: when the cleanup fired because of `lossless_source_locked`,
+    # narrow the request's search_filetype_override to "lossless" so the
+    # next search cycle stops asking Soulseek for lossy candidates that
+    # will only hit the lock again. The narrowing is no-op when the
+    # override is already "lossless" (helper returns None).
+    if preview_decision == "lossless_source_locked":
+        try:
+            request_row = db.get_request(request_id)
+            current_override = (
+                request_row.get("search_filetype_override")
+                if request_row else None
+            )
+            narrowed = narrow_override_on_lossless_source_lock(current_override)
+            if narrowed is not None:
+                db.update_request_fields(
+                    request_id, search_filetype_override=narrowed,
+                )
+                logger.info(
+                    "wrong_match_cleanup: narrowed search_filetype_override"
+                    " from %r to %r after lossless_source_locked"
+                    " (request_id=%s)",
+                    current_override, narrowed, request_id,
+                )
+        except Exception:
+            logger.exception(
+                "wrong_match_cleanup: failed to narrow search_filetype_override"
+                " after lossless_source_locked (request_id=%s)",
+                request_id,
+            )
+
     return _result(
         download_log_id,
         success_outcome,

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -796,6 +796,42 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
         r = self._dispatch(ir=ir, requeue_on_failure=False)
         self.assertNotEqual(r["db"].request(42)["status"], "wanted")
 
+    # --- lossless_source_locked + search-narrowing (R7, AE2) ---
+
+    def test_lossless_source_locked_narrows_search_filetype_override(self):
+        """R7 / AE2: when a lossy candidate hits lossless_source_locked
+        during importer dispatch, the request's search_filetype_override
+        narrows to 'lossless' so future cycles only ask for lossless
+        candidates that can actually win against the existing
+        lossless-source library row.
+
+        Without this narrowing, the search planner keeps re-asking
+        Soulseek with no filetype filter, each new peer serves the
+        same lossy file, and the lock fires repeatedly. The narrowing
+        closes that wasted-cycle window.
+        """
+        ir = make_import_result(decision="lossless_source_locked")
+        r = self._dispatch(
+            ir=ir,
+            request_overrides={
+                "search_filetype_override": "lossless,mp3 v0,mp3 320",
+            },
+        )
+        self.assertEqual(
+            r["db"].request(42)["search_filetype_override"], "lossless")
+
+    def test_lossless_source_locked_narrowing_is_idempotent(self):
+        """AE7: when the override is already 'lossless', the lock
+        firing again is a no-op (no spurious DB write that would churn
+        change tracking or audit logs)."""
+        ir = make_import_result(decision="lossless_source_locked")
+        r = self._dispatch(
+            ir=ir,
+            request_overrides={"search_filetype_override": "lossless"},
+        )
+        self.assertEqual(
+            r["db"].request(42)["search_filetype_override"], "lossless")
+
 
 class TestDispatchCoreSeams(unittest.TestCase):
     """Seam tests — assert subprocess argv construction."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7667,6 +7667,129 @@ class TestU10PostImportEvidencePropagation(unittest.TestCase):
             self.assertEqual(new_evidence.codec, "mp3")
             self.assertEqual(new_evidence.container, "mp3")
 
+    def test_transcoded_mp3_to_opus_strips_source_evidence(self):
+        """AE5: non-lossless-source transcoded import does NOT propagate
+        source-side evidence.
+
+        MP3 source → Opus library: the candidate's spectral_grade /
+        spectral_bitrate / v0_metric / matched_bad_audio_hash_* must NOT
+        appear on the library evidence row. The source-side fields
+        describe the MP3 source which is not a comparable lossless
+        anchor for future candidates; storing them provides no decision
+        value. Verified_lossless / verified_lossless_proof still
+        propagate (always have).
+
+        This is the negative sibling of
+        ``test_transcoded_flac_to_v0_propagates_source_evidence`` and
+        the regression guard for the lossless-source gate in
+        ``propagate_candidate_evidence_to_current`` (rescoped 2026-05-17).
+        """
+        from lib.import_dispatch import _refresh_current_evidence_after_import
+        from lib.quality import AlbumQualityV0Metric
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=145, mb_release_id="mbid-mp3-opus"))
+
+        with tempfile.TemporaryDirectory() as source_dir, \
+                tempfile.TemporaryDirectory() as library_dir:
+            self._stage_audio(source_dir, filenames=["01 - source.mp3"])
+            self._stage_audio(library_dir, filenames=["01 - Library.opus"])
+
+            from lib.quality_evidence import snapshot_audio_files
+            candidate_files = snapshot_audio_files(source_dir)
+            # Candidate carries source-side fields just like the FLAC
+            # case — the gate must strip them because the source is
+            # lossy, not because they are absent on the candidate.
+            v0_metric = AlbumQualityV0Metric(
+                min_bitrate_kbps=180,
+                avg_bitrate_kbps=210,
+                median_bitrate_kbps=205,
+                source_lineage="native_lossy_research",
+                source_provenance="native_lossy_research",
+            )
+            candidate_measurement = AudioQualityMeasurement(
+                min_bitrate_kbps=192,
+                avg_bitrate_kbps=192,
+                median_bitrate_kbps=192,
+                format="MP3",
+                is_cbr=True,
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=192,
+                verified_lossless=False,
+                was_converted_from="mp3",
+            )
+            from lib.quality import AlbumQualityEvidence
+            from datetime import datetime, timezone
+            from lib.quality_evidence import snapshot_fingerprint
+            candidate_evidence = AlbumQualityEvidence(
+                mb_release_id="mbid-mp3-opus",
+                snapshot_fingerprint=snapshot_fingerprint(candidate_files),
+                source_path=source_dir,
+                measurement=candidate_measurement,
+                measured_at=datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc),
+                files=candidate_files,
+                codec="mp3",
+                container="mp3",
+                storage_format="mp3 320",
+                target_format="opus",
+                v0_metric=v0_metric,
+                verified_lossless_proof=None,
+                audio_corrupt=False,
+                folder_layout="flat",
+                audio_file_count=len(candidate_files),
+                filetype_band="mp3 320",
+                matched_bad_audio_hash_id=77,
+                matched_bad_audio_hash_path="/some/known/bad.mp3",
+            )
+            db.upsert_album_quality_evidence(candidate_evidence)
+            persisted_candidate = db.find_album_quality_evidence(
+                mb_release_id="mbid-mp3-opus",
+                snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
+            )
+            assert persisted_candidate is not None
+
+            beets_info = AlbumInfo(
+                album_id=4,
+                track_count=1,
+                min_bitrate_kbps=119,
+                avg_bitrate_kbps=128,
+                median_bitrate_kbps=125,
+                is_cbr=False,
+                album_path=library_dir,
+                format="Opus",
+            )
+            with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                _refresh_current_evidence_after_import(
+                    db,  # type: ignore[arg-type]
+                    request_id=145,
+                    mb_release_id="mbid-mp3-opus",
+                    quality_ranks=None,
+                    source_candidate=persisted_candidate,
+                    import_result=make_import_result(
+                        decision="import", new_min_bitrate=119,
+                    ),
+                )
+
+            request_row = db.request(145)
+            new_evidence_id = request_row["current_evidence_id"]
+            self.assertIsNotNone(new_evidence_id)
+            new_evidence = db.load_album_quality_evidence_by_id(new_evidence_id)
+            assert new_evidence is not None
+
+            # Non-lossless-source transcode: source-side fields are
+            # stripped onto NULL. The MP3 source's spectral grade and
+            # bad-hash match describe audio that has no comparable role
+            # in future candidate comparisons.
+            self.assertIsNone(new_evidence.measurement.spectral_grade)
+            self.assertIsNone(new_evidence.measurement.spectral_bitrate_kbps)
+            self.assertIsNone(new_evidence.v0_metric)
+            self.assertIsNone(new_evidence.matched_bad_audio_hash_id)
+            self.assertIsNone(new_evidence.matched_bad_audio_hash_path)
+
+            # Bitrate / format reflect the Opus output from album_info.
+            self.assertEqual(new_evidence.measurement.format, "Opus")
+            self.assertEqual(new_evidence.codec, "opus")
+
     def test_source_replacement_overwrites_stale_propagated_evidence(self):
         """U4 / AE4: when a clean lossless-source candidate force-imports
         over a previously-transcoded library row that propagated

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -6974,6 +6974,395 @@ class TestWrongMatchCleanupFKChainAvoidsRemeasurement(unittest.TestCase):
             _shutil.rmtree(source, ignore_errors=True)
 
 
+class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
+    """U3: AE1 end-to-end — propagate transcoded-FLAC evidence to the library
+    row, then trigger ``cleanup_wrong_match`` against an identical-source FLAC
+    sitting in the Wrong Matches queue. After U5 lands, triage must classify
+    the duplicate as ``confident_reject`` (``suspect_lossless_downgrade``) and
+    delete the folder. Before U5, the library row has NULL spectral / V0
+    fields and triage falls through to ``provisional_lossless_upgrade`` →
+    ``kept_would_import`` — this test is the RED baseline that flips to GREEN
+    when U5 reverses the propagation policy.
+
+    Live reproducer: request 3779 (Lil Wayne — *Da Drought 3*, MBID
+    ``244322cc-51ba-4f35-b072-f7c5888fb5ce``), download_log row 16682
+    (2026-05-17 18:32 UTC, 31 minutes after the original transcoded-FLAC
+    import landed at 16:06 UTC).
+    """
+
+    MB_RELEASE_ID = "mbid-lil-wayne-da-drought-3"
+
+    def _stage_audio(self, tmpdir: str, *, filenames: list[str]) -> None:
+        for fname in filenames:
+            with open(os.path.join(tmpdir, fname), "wb") as handle:
+                handle.write(b"audio-bytes-" + fname.encode("utf-8"))
+
+    def _build_transcoded_source_evidence(
+        self,
+        source_dir: str,
+        *,
+        mb_release_id: str,
+    ):
+        """Construct candidate evidence matching the live transcoded-FLAC
+        source: spectral ``likely_transcode`` at 128 kbps, V0 probe with
+        ``lossless_source`` lineage and 215 kbps avg. Files on disk are
+        snapshot-fingerprinted so freshness checks pass.
+        """
+        from datetime import datetime, timezone
+        from lib.quality import (
+            AlbumQualityEvidence,
+            AlbumQualityV0Metric,
+            AudioQualityMeasurement,
+        )
+        from lib.quality_evidence import snapshot_audio_files, snapshot_fingerprint
+
+        files = snapshot_audio_files(source_dir)
+        v0_metric = AlbumQualityV0Metric(
+            min_bitrate_kbps=184,
+            avg_bitrate_kbps=215,
+            median_bitrate_kbps=210,
+            source_lineage="lossless_source",
+            source_provenance="lossless_source",
+            proof_provenance="lossless-source probe",
+        )
+        measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=820,
+            avg_bitrate_kbps=850,
+            median_bitrate_kbps=845,
+            format="flac",
+            is_cbr=False,
+            spectral_grade="likely_transcode",
+            spectral_bitrate_kbps=128,
+            verified_lossless=False,
+        )
+        return AlbumQualityEvidence(
+            mb_release_id=mb_release_id,
+            snapshot_fingerprint=snapshot_fingerprint(files),
+            source_path=source_dir,
+            measurement=measurement,
+            measured_at=datetime(2026, 5, 17, 16, 0, 0, tzinfo=timezone.utc),
+            files=files,
+            codec="flac",
+            container="flac",
+            storage_format="flac",
+            target_format="mp3",
+            v0_metric=v0_metric,
+            verified_lossless_proof=None,
+            audio_corrupt=False,
+            folder_layout="flat",
+            audio_file_count=len(files),
+            filetype_band="lossless",
+        )
+
+    def _patch_cfg(self):
+        """Pin runtime config so cleanup sees ``quality_ranks`` without disk."""
+        from lib.quality import QualityRankConfig
+        from types import SimpleNamespace as _SN
+        cfg = _SN(
+            quality_ranks=QualityRankConfig.defaults(),
+            verified_lossless_target="",
+            beets_directory="",
+        )
+        return patch("lib.config.read_runtime_config", return_value=cfg)
+
+    def _seed_duplicate_wrong_match(
+        self,
+        db: FakePipelineDB,
+        *,
+        request_id: int,
+        duplicate_source_dir: str,
+        candidate_evidence_id: int,
+    ) -> int:
+        db.log_download(
+            request_id,
+            outcome="rejected",
+            beets_scenario="high_distance",
+            soulseek_username="testuser",
+            validation_result={
+                "scenario": "wrong_match",
+                "failed_path": duplicate_source_dir,
+                "source_dirs": [duplicate_source_dir],
+            },
+        )
+        log_id = db.download_logs[-1].id
+        db.set_download_log_candidate_evidence(log_id, candidate_evidence_id)
+        return log_id
+
+    def _make_failed_imports_dir(self, parent: str, name: str) -> str:
+        """Create a ``failed_imports/<name>`` subdir so the cleanup-deletion
+        safety check (``unsafe_failed_import_path_reason``) accepts the path.
+        """
+        failed_imports = os.path.join(parent, "failed_imports")
+        os.makedirs(failed_imports, exist_ok=True)
+        target = os.path.join(failed_imports, name)
+        os.makedirs(target, exist_ok=True)
+        return target
+
+    def _propagate_first_import(
+        self,
+        db: FakePipelineDB,
+        *,
+        request_id: int,
+        mb_release_id: str,
+        source_dir: str,
+        library_dir: str,
+    ):
+        """Stand in for the first transcoded-FLAC import: build candidate
+        evidence for the source, then call the real
+        ``_refresh_current_evidence_after_import`` (the propagation entry
+        point) so the library evidence row reflects production policy.
+        Returns the resulting library evidence row.
+        """
+        from lib.import_dispatch import _refresh_current_evidence_after_import
+
+        candidate = self._build_transcoded_source_evidence(
+            source_dir, mb_release_id=mb_release_id,
+        )
+        db.upsert_album_quality_evidence(candidate)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=mb_release_id,
+            snapshot_fingerprint=candidate.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+
+        # Library copy is the V0 transcode output — different codec/bitrate
+        # from the source. Mirrors the live row's on-disk shape.
+        beets_info = AlbumInfo(
+            album_id=1,
+            track_count=len(persisted.files),
+            min_bitrate_kbps=100,
+            avg_bitrate_kbps=119,
+            median_bitrate_kbps=115,
+            is_cbr=False,
+            album_path=library_dir,
+            format="Opus",
+        )
+        with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+            _refresh_current_evidence_after_import(
+                db,  # type: ignore[arg-type]
+                request_id=request_id,
+                mb_release_id=mb_release_id,
+                quality_ranks=None,
+                source_candidate=persisted,
+                import_result=make_import_result(
+                    decision="import", new_min_bitrate=100,
+                ),
+            )
+
+        request_row = db.request(request_id)
+        new_evidence_id = request_row["current_evidence_id"]
+        assert new_evidence_id is not None
+        library_evidence = db.load_album_quality_evidence_by_id(new_evidence_id)
+        assert library_evidence is not None
+        return library_evidence, beets_info
+
+    def test_propagation_lets_triage_reject_same_source_duplicate(self) -> None:
+        """End-to-end RED test for U3 / AE1.
+
+        1. Propagate transcoded-FLAC evidence on the first import (library
+           row inherits source-side ``likely_transcode`` / ``lossless_source``
+           fields under the new policy).
+        2. Seed an identical-source FLAC as a wrong-match candidate.
+        3. ``cleanup_wrong_match`` must classify the duplicate as
+           ``confident_reject`` + cleanup-eligible and delete the folder.
+
+        RED before U5: library evidence has NULL spectral / V0 fields, the
+        decider falls through to ``provisional_lossless_upgrade``, and
+        ``OUTCOME_KEPT_WOULD_IMPORT`` fires instead of ``OUTCOME_DELETED``.
+        """
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_DELETED,
+            cleanup_wrong_match,
+        )
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=3779,
+            status="manual",
+            mb_release_id=self.MB_RELEASE_ID,
+        ))
+
+        with tempfile.TemporaryDirectory() as origin_dir, \
+                tempfile.TemporaryDirectory() as library_dir, \
+                tempfile.TemporaryDirectory() as dup_parent:
+
+            # The first transcoded-FLAC source (already imported earlier).
+            self._stage_audio(origin_dir, filenames=["01 - Track.flac"])
+            # The library-side V0 copy that was written by that import.
+            self._stage_audio(library_dir, filenames=["01 - Track.opus"])
+            # The duplicate FLAC sitting in the Wrong Matches queue. Must
+            # live under a ``failed_imports`` directory so the cleanup
+            # deletion safety check accepts the path.
+            duplicate_source_dir = self._make_failed_imports_dir(
+                dup_parent, "Lil Wayne - Da Drought 3 (duplicate)",
+            )
+            self._stage_audio(duplicate_source_dir, filenames=["01 - Track.flac"])
+
+            # Simulate the first import's propagation. After U5, the library
+            # evidence carries the propagated source-side fields.
+            library_evidence, _ = self._propagate_first_import(
+                db,
+                request_id=3779,
+                mb_release_id=self.MB_RELEASE_ID,
+                source_dir=origin_dir,
+                library_dir=library_dir,
+            )
+
+            # Sanity check: propagation actually landed before we test
+            # triage. This flips to passing once U5 reverses the policy;
+            # today it fails first, which is the correct RED signal.
+            self.assertEqual(
+                library_evidence.measurement.spectral_grade,
+                "likely_transcode",
+                "U5 propagation policy must carry source spectral_grade "
+                "to the library row; without it triage cannot reject.",
+            )
+            self.assertIsNotNone(
+                library_evidence.v0_metric,
+                "U5 propagation policy must carry source v0_metric to the "
+                "library row; without it the lossless-source lineage is lost.",
+            )
+            assert library_evidence.v0_metric is not None
+            self.assertEqual(
+                library_evidence.v0_metric.source_lineage,
+                "lossless_source",
+            )
+
+            # Seed the duplicate-source wrong-match row + its candidate
+            # evidence, then exercise the real cleanup path.
+            dup_candidate = self._build_transcoded_source_evidence(
+                duplicate_source_dir, mb_release_id=self.MB_RELEASE_ID,
+            )
+            db.upsert_album_quality_evidence(dup_candidate)
+            persisted_dup = db.find_album_quality_evidence(
+                mb_release_id=self.MB_RELEASE_ID,
+                snapshot_fingerprint=dup_candidate.snapshot_fingerprint,
+            )
+            assert persisted_dup is not None and persisted_dup.id is not None
+
+            log_id = self._seed_duplicate_wrong_match(
+                db,
+                request_id=3779,
+                duplicate_source_dir=duplicate_source_dir,
+                candidate_evidence_id=persisted_dup.id,
+            )
+
+            # The cleanup path re-reads current evidence via Beets; keep
+            # the mocked BeetsDB returning the same library album_info so
+            # ``ensure_current_evidence_for_action`` resolves to the
+            # propagated row.
+            beets_info = AlbumInfo(
+                album_id=1,
+                track_count=len(library_evidence.files),
+                min_bitrate_kbps=100,
+                avg_bitrate_kbps=119,
+                median_bitrate_kbps=115,
+                is_cbr=False,
+                album_path=library_dir,
+                format="Opus",
+            )
+
+            with self._patch_cfg(), \
+                    patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                result = cleanup_wrong_match(db, log_id)
+
+            # Load-bearing assertions. RED today: outcome is
+            # OUTCOME_KEPT_WOULD_IMPORT because the library row's NULL
+            # source-side fields force provisional_lossless_upgrade.
+            self.assertEqual(
+                result.outcome,
+                OUTCOME_DELETED,
+                f"expected triage to reject same-source duplicate; "
+                f"got outcome={result.outcome!r} "
+                f"verdict={result.verdict!r} "
+                f"preview_decision={result.preview_decision!r}",
+            )
+            self.assertEqual(result.verdict, "confident_reject")
+            self.assertTrue(result.cleanup_eligible)
+            self.assertTrue(result.success)
+            # The decider should land on a lossless-aware reject branch.
+            # Under U2 work this is ``suspect_lossless_downgrade``; if the
+            # decider chooses ``lossless_source_locked`` or
+            # ``lossless_source_not_better``, that is still a valid
+            # confident_reject outcome.
+            self.assertIn(
+                result.preview_decision,
+                {
+                    "suspect_lossless_downgrade",
+                    "lossless_source_locked",
+                    "lossless_source_not_better",
+                },
+                f"unexpected reject decision: {result.preview_decision!r}",
+            )
+
+    def test_without_propagation_triage_still_keeps_would_import(self) -> None:
+        """Negative regression sibling: skip the propagation step entirely
+        and confirm the result is ``OUTCOME_KEPT_WOULD_IMPORT``. Pinpoints
+        propagation as the load-bearing input for the RED→GREEN signal in
+        the main test — without it, the decider falls through to
+        ``provisional_lossless_upgrade`` and triage keeps the folder.
+
+        This test PASSES today (pre-U5) and should continue to pass — it
+        documents the failure mode the main test is RED against.
+        """
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_KEPT_WOULD_IMPORT,
+            cleanup_wrong_match,
+        )
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=3780,
+            status="manual",
+            mb_release_id=self.MB_RELEASE_ID,
+        ))
+
+        with tempfile.TemporaryDirectory() as library_dir, \
+                tempfile.TemporaryDirectory() as dup_parent:
+            self._stage_audio(library_dir, filenames=["01 - Track.opus"])
+            duplicate_source_dir = self._make_failed_imports_dir(
+                dup_parent, "Lil Wayne - Da Drought 3 (no-propagation)",
+            )
+            self._stage_audio(duplicate_source_dir, filenames=["01 - Track.flac"])
+
+            # No propagation step — the library evidence row will be
+            # backfilled from album_info during the cleanup call, which
+            # produces a bare row with NULL spectral / V0 fields.
+            dup_candidate = self._build_transcoded_source_evidence(
+                duplicate_source_dir, mb_release_id=self.MB_RELEASE_ID,
+            )
+            db.upsert_album_quality_evidence(dup_candidate)
+            persisted_dup = db.find_album_quality_evidence(
+                mb_release_id=self.MB_RELEASE_ID,
+                snapshot_fingerprint=dup_candidate.snapshot_fingerprint,
+            )
+            assert persisted_dup is not None and persisted_dup.id is not None
+
+            log_id = self._seed_duplicate_wrong_match(
+                db,
+                request_id=3780,
+                duplicate_source_dir=duplicate_source_dir,
+                candidate_evidence_id=persisted_dup.id,
+            )
+
+            beets_info = AlbumInfo(
+                album_id=2,
+                track_count=1,
+                min_bitrate_kbps=100,
+                avg_bitrate_kbps=119,
+                median_bitrate_kbps=115,
+                is_cbr=False,
+                album_path=library_dir,
+                format="Opus",
+            )
+            with self._patch_cfg(), \
+                    patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                result = cleanup_wrong_match(db, log_id)
+
+            self.assertEqual(result.outcome, OUTCOME_KEPT_WOULD_IMPORT)
+            self.assertEqual(result.verdict, "would_import")
+
+
 class TestU10PostImportEvidencePropagation(unittest.TestCase):
     """U10: ``_refresh_current_evidence_after_import`` propagates the candidate
     measurement payload into the new library evidence row.

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7667,6 +7667,230 @@ class TestU10PostImportEvidencePropagation(unittest.TestCase):
             self.assertEqual(new_evidence.codec, "mp3")
             self.assertEqual(new_evidence.container, "mp3")
 
+    def test_source_replacement_overwrites_stale_propagated_evidence(self):
+        """U4 / AE4: when a clean lossless-source candidate force-imports
+        over a previously-transcoded library row that propagated
+        ``likely_transcode`` / ``lossless_source`` source evidence, the
+        new candidate's evidence must overwrite the stale fields.
+
+        Two propagations against the same library snapshot fingerprint:
+        the first carries compromised source evidence
+        (``likely_transcode``, V0 avg 215); the second carries clean
+        genuine source evidence (``genuine``, V0 avg 900, verified
+        lossless proof). The library evidence row must reflect the
+        second after upsert ``ON CONFLICT DO UPDATE``.
+
+        RED today on the intermediate sanity check that the FIRST
+        propagation actually wrote ``likely_transcode`` to the library
+        row — U5 propagation policy must land first.
+        """
+        from datetime import datetime, timezone
+        from lib.import_dispatch import _refresh_current_evidence_after_import
+        from lib.quality import (
+            AlbumQualityEvidence,
+            AlbumQualityV0Metric,
+            AudioQualityMeasurement,
+            VerifiedLosslessProof,
+        )
+        from lib.quality_evidence import snapshot_audio_files, snapshot_fingerprint
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=44, mb_release_id="mbid-replace"))
+
+        with tempfile.TemporaryDirectory() as compromised_source_dir, \
+                tempfile.TemporaryDirectory() as clean_source_dir, \
+                tempfile.TemporaryDirectory() as library_dir:
+            # Stage audio for both source dirs and the library copy. The
+            # library dir's bytes do not change between the two propagations
+            # — that's the whole point of source-replacement: same album
+            # path, fresh source audio. Identical library snapshot
+            # fingerprint forces the upsert to hit the ON CONFLICT branch.
+            self._stage_audio(
+                compromised_source_dir, filenames=["01 - compromised.flac"],
+            )
+            self._stage_audio(
+                clean_source_dir, filenames=["01 - clean.flac"],
+            )
+            self._stage_audio(library_dir, filenames=["01 - Library.mp3"])
+
+            # --- First propagation: compromised source ---
+            compromised_files = snapshot_audio_files(compromised_source_dir)
+            compromised_candidate = AlbumQualityEvidence(
+                mb_release_id="mbid-replace",
+                snapshot_fingerprint=snapshot_fingerprint(compromised_files),
+                source_path=compromised_source_dir,
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=820,
+                    avg_bitrate_kbps=850,
+                    median_bitrate_kbps=845,
+                    format="flac",
+                    is_cbr=False,
+                    spectral_grade="likely_transcode",
+                    spectral_bitrate_kbps=128,
+                    was_converted_from="flac",
+                ),
+                measured_at=datetime(2026, 5, 17, 14, 0, 0, tzinfo=timezone.utc),
+                files=compromised_files,
+                codec="flac",
+                container="flac",
+                storage_format="flac",
+                target_format="mp3",
+                v0_metric=AlbumQualityV0Metric(
+                    min_bitrate_kbps=184,
+                    avg_bitrate_kbps=215,
+                    median_bitrate_kbps=210,
+                    source_lineage="lossless_source",
+                    source_provenance="lossless_source",
+                ),
+                verified_lossless_proof=None,
+                audio_corrupt=False,
+                folder_layout="flat",
+                audio_file_count=len(compromised_files),
+                filetype_band="lossless",
+            )
+            db.upsert_album_quality_evidence(compromised_candidate)
+            persisted_compromised = db.find_album_quality_evidence(
+                mb_release_id="mbid-replace",
+                snapshot_fingerprint=compromised_candidate.snapshot_fingerprint,
+            )
+            assert persisted_compromised is not None
+
+            beets_info = AlbumInfo(
+                album_id=3,
+                track_count=1,
+                min_bitrate_kbps=100,
+                avg_bitrate_kbps=119,
+                median_bitrate_kbps=115,
+                is_cbr=False,
+                album_path=library_dir,
+                format="MP3",
+            )
+            with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                _refresh_current_evidence_after_import(
+                    db,  # type: ignore[arg-type]
+                    request_id=44,
+                    mb_release_id="mbid-replace",
+                    quality_ranks=None,
+                    source_candidate=persisted_compromised,
+                    import_result=make_import_result(
+                        decision="import", new_min_bitrate=100,
+                    ),
+                )
+
+            # Sanity: the first propagation wrote the compromised fields
+            # onto the library row. Fails RED before U5 — propagation
+            # policy must propagate spectral on transcoded imports for
+            # source-replacement to have anything to overwrite.
+            first_evidence_id = db.request(44)["current_evidence_id"]
+            self.assertIsNotNone(first_evidence_id)
+            first_evidence = db.load_album_quality_evidence_by_id(
+                first_evidence_id,
+            )
+            assert first_evidence is not None
+            self.assertEqual(
+                first_evidence.measurement.spectral_grade,
+                "likely_transcode",
+                "U5 propagation policy must carry compromised "
+                "spectral_grade to the library row before "
+                "source-replacement has anything to overwrite.",
+            )
+            self.assertIsNotNone(first_evidence.v0_metric)
+            assert first_evidence.v0_metric is not None
+            self.assertEqual(first_evidence.v0_metric.avg_bitrate_kbps, 215)
+
+            # --- Second propagation: clean genuine source over the same
+            # library snapshot. Library fingerprint unchanged → ON CONFLICT
+            # DO UPDATE in upsert_album_quality_evidence overwrites the
+            # library evidence row in place.
+            clean_files = snapshot_audio_files(clean_source_dir)
+            clean_candidate = AlbumQualityEvidence(
+                mb_release_id="mbid-replace",
+                snapshot_fingerprint=snapshot_fingerprint(clean_files),
+                source_path=clean_source_dir,
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=900,
+                    avg_bitrate_kbps=940,
+                    median_bitrate_kbps=935,
+                    format="flac",
+                    is_cbr=False,
+                    spectral_grade="genuine",
+                    spectral_bitrate_kbps=940,
+                    verified_lossless=True,
+                    was_converted_from="flac",
+                ),
+                measured_at=datetime(2026, 5, 17, 15, 0, 0, tzinfo=timezone.utc),
+                files=clean_files,
+                codec="flac",
+                container="flac",
+                storage_format="flac",
+                target_format="mp3",
+                v0_metric=AlbumQualityV0Metric(
+                    min_bitrate_kbps=880,
+                    avg_bitrate_kbps=900,
+                    median_bitrate_kbps=895,
+                    source_lineage="lossless_source",
+                    source_provenance="lossless_source",
+                ),
+                verified_lossless_proof=VerifiedLosslessProof(
+                    proof_origin="import_result",
+                    source="flac",
+                    classifier="spectral_verified_lossless",
+                    detail="genuine",
+                ),
+                audio_corrupt=False,
+                folder_layout="flat",
+                audio_file_count=len(clean_files),
+                filetype_band="lossless",
+            )
+            db.upsert_album_quality_evidence(clean_candidate)
+            persisted_clean = db.find_album_quality_evidence(
+                mb_release_id="mbid-replace",
+                snapshot_fingerprint=clean_candidate.snapshot_fingerprint,
+            )
+            assert persisted_clean is not None
+
+            with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                _refresh_current_evidence_after_import(
+                    db,  # type: ignore[arg-type]
+                    request_id=44,
+                    mb_release_id="mbid-replace",
+                    quality_ranks=None,
+                    source_candidate=persisted_clean,
+                    import_result=make_import_result(
+                        decision="import", new_min_bitrate=100,
+                    ),
+                )
+
+            # Load the library row again and assert the clean candidate's
+            # evidence overwrote the compromised fields — no stale values
+            # survive the upsert.
+            second_evidence_id = db.request(44)["current_evidence_id"]
+            self.assertIsNotNone(second_evidence_id)
+            second_evidence = db.load_album_quality_evidence_by_id(
+                second_evidence_id,
+            )
+            assert second_evidence is not None
+            self.assertEqual(
+                second_evidence.measurement.spectral_grade, "genuine",
+                "Source-replacement must overwrite stale likely_transcode "
+                "spectral_grade with the new candidate's genuine grade.",
+            )
+            self.assertEqual(
+                second_evidence.measurement.spectral_bitrate_kbps, 940,
+            )
+            self.assertIsNotNone(second_evidence.v0_metric)
+            assert second_evidence.v0_metric is not None
+            self.assertEqual(
+                second_evidence.v0_metric.avg_bitrate_kbps, 900,
+                "Source-replacement must overwrite stale V0 avg with "
+                "the new candidate's value.",
+            )
+            self.assertEqual(
+                second_evidence.v0_metric.source_lineage, "lossless_source",
+            )
+            self.assertTrue(second_evidence.measurement.verified_lossless)
+            self.assertIsNotNone(second_evidence.verified_lossless_proof)
+
     def test_source_candidate_none_falls_back_to_legacy_backfill(self):
         """When ``source_candidate is None`` the helper falls back to the
         pre-U10 ``backfill_current_evidence_from_album_info`` path. The

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7506,13 +7506,25 @@ class TestU10PostImportEvidencePropagation(unittest.TestCase):
     """U10: ``_refresh_current_evidence_after_import`` propagates the candidate
     measurement payload into the new library evidence row.
 
-    Renamed-only imports (same codec) inherit spectral grade, V0 lineage,
-    bad-audio-hash matches, and verified-lossless proof. Transcoded imports
-    (different codec) inherit ONLY ``verified_lossless`` /
-    ``verified_lossless_proof``; spectral and V0 fields stay NULL. The
-    candidate evidence row is preserved as the audit trail for the import
-    job, and ``album_requests.current_evidence_id`` is updated to the new
-    library evidence row.
+    Propagation is governed by a lossless-source gate (see
+    ``lib/quality_evidence.py::propagate_candidate_evidence_to_current``):
+
+    * Renamed-only imports (same codec in / out): the full source-side
+      payload propagates — spectral grade, V0 lineage, bad-audio-hash
+      matches, verified-lossless proof.
+    * Transcoded imports with a lossless source (FLAC/ALAC/WAV → V0/Opus):
+      the full payload propagates too. The source-side fields describe
+      the upstream lossless audio and remain comparable for future
+      candidates against this MBID.
+    * Transcoded imports with a lossy source (MP3 → Opus etc.): only
+      ``verified_lossless`` / ``verified_lossless_proof`` /
+      ``was_converted_from`` propagate. The source-side spectral / V0 /
+      bad-hash fields stay NULL because a lossy source has no
+      meaningfully comparable lineage to future candidates.
+
+    The candidate evidence row is preserved as the audit trail for the
+    import job, and ``album_requests.current_evidence_id`` is updated to
+    the new library evidence row.
     """
 
     def _stage_audio(self, tmpdir: str, *, filenames: list[str]) -> None:

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7142,11 +7142,13 @@ class TestU10PostImportEvidencePropagation(unittest.TestCase):
                 audio_snapshot_matches(library_dir, new_evidence.files)
             )
 
-    def test_transcoded_flac_to_v0_drops_spectral_and_v0_keeps_proof(self):
+    def test_transcoded_flac_to_v0_propagates_source_evidence(self):
         """FLAC source → V0 library: spectral grade, V0 lineage, and bad-hash
-        matches stay NULL on the library row (they describe source audio).
-        ``verified_lossless`` / ``verified_lossless_proof`` carry forward.
-        Bitrate/format reflect the V0 output from ``album_info``.
+        matches propagate forward symmetrically with the rename-only path.
+        They describe the upstream source audio at import time, not the
+        on-disk V0 file. ``verified_lossless`` / ``verified_lossless_proof``
+        also carry forward (unchanged). Bitrate/format reflect the V0
+        output from ``album_info``.
         """
         from lib.import_dispatch import _refresh_current_evidence_after_import
         from lib.quality import (
@@ -7247,12 +7249,18 @@ class TestU10PostImportEvidencePropagation(unittest.TestCase):
             new_evidence = db.load_album_quality_evidence_by_id(new_evidence_id)
             assert new_evidence is not None
 
-            # Transcoded: spectral + V0 lineage + bad-hash do NOT propagate.
-            self.assertIsNone(new_evidence.measurement.spectral_grade)
-            self.assertIsNone(new_evidence.measurement.spectral_bitrate_kbps)
-            self.assertIsNone(new_evidence.v0_metric)
-            self.assertIsNone(new_evidence.matched_bad_audio_hash_id)
-            self.assertIsNone(new_evidence.matched_bad_audio_hash_path)
+            # Transcoded: spectral + V0 lineage + bad-hash propagate from
+            # the candidate. These fields describe the upstream source
+            # audio at import time; they remain accurate even after the
+            # source is transcoded to a different codec.
+            self.assertEqual(new_evidence.measurement.spectral_grade, "genuine")
+            self.assertEqual(new_evidence.measurement.spectral_bitrate_kbps, 850)
+            self.assertEqual(new_evidence.v0_metric, v0_metric)
+            self.assertEqual(new_evidence.matched_bad_audio_hash_id, 99)
+            self.assertEqual(
+                new_evidence.matched_bad_audio_hash_path,
+                "/some/known/bad.flac",
+            )
 
             # But verified-lossless proof carries forward.
             self.assertTrue(new_evidence.measurement.verified_lossless)

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7362,6 +7362,145 @@ class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
             self.assertEqual(result.outcome, OUTCOME_KEPT_WOULD_IMPORT)
             self.assertEqual(result.verdict, "would_import")
 
+    def test_lossy_candidate_against_lossless_source_locks_and_narrows(self) -> None:
+        """AE2: a lossy MP3 V0 candidate vs lossless-source library row →
+        ``lossless_source_locked`` → ``OUTCOME_DELETED`` + the request's
+        ``search_filetype_override`` is narrowed to ``"lossless"``.
+
+        This is the load-bearing test for the search-narrowing
+        behavior. The Lil Wayne sibling test above exercises the
+        FLAC-vs-FLAC same-source case (decision
+        ``suspect_lossless_downgrade``) which does NOT fire the lock and
+        should NOT narrow. This test exercises the lossy-candidate
+        path which IS the lock, and asserts both the rejection and
+        the narrowing land.
+        """
+        from datetime import datetime, timezone
+        from lib.quality import AlbumQualityEvidence
+        from lib.quality_evidence import (
+            snapshot_audio_files,
+            snapshot_fingerprint,
+        )
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_DELETED,
+            cleanup_wrong_match,
+        )
+
+        db = FakePipelineDB()
+        # Seed the request with a full upgrade-tier override; narrowing
+        # must compress it to "lossless".
+        db.seed_request(make_request_row(
+            id=3781,
+            status="manual",
+            mb_release_id=self.MB_RELEASE_ID,
+            search_filetype_override="lossless,mp3 v0,mp3 320",
+        ))
+
+        with tempfile.TemporaryDirectory() as origin_dir, \
+                tempfile.TemporaryDirectory() as library_dir, \
+                tempfile.TemporaryDirectory() as dup_parent:
+
+            # First import (lossless-source FLAC → Opus library copy)
+            # establishes a lossless_source V0 probe on the library row.
+            self._stage_audio(origin_dir, filenames=["01 - Track.flac"])
+            self._stage_audio(library_dir, filenames=["01 - Track.opus"])
+            self._propagate_first_import(
+                db,
+                request_id=3781,
+                mb_release_id=self.MB_RELEASE_ID,
+                source_dir=origin_dir,
+                library_dir=library_dir,
+            )
+
+            # Build a LOSSY MP3 V0 candidate in the wrong-matches queue.
+            # No v0_metric, no spectral lineage — a clean lossy file
+            # that would normally pass the gate against a non-lossless
+            # existing, but cannot override the recorded lossless_source
+            # V0 probe.
+            duplicate_source_dir = self._make_failed_imports_dir(
+                dup_parent, "Lil Wayne - Da Drought 3 (lossy MP3 V0)",
+            )
+            self._stage_audio(
+                duplicate_source_dir, filenames=["01 - Track.mp3"],
+            )
+            dup_files = snapshot_audio_files(duplicate_source_dir)
+            dup_candidate = AlbumQualityEvidence(
+                mb_release_id=self.MB_RELEASE_ID,
+                snapshot_fingerprint=snapshot_fingerprint(dup_files),
+                source_path=duplicate_source_dir,
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=240,
+                    avg_bitrate_kbps=245,
+                    median_bitrate_kbps=243,
+                    format="MP3",
+                    is_cbr=False,
+                ),
+                measured_at=datetime(2026, 5, 17, 19, 0, 0, tzinfo=timezone.utc),
+                files=dup_files,
+                codec="mp3",
+                container="mp3",
+                storage_format="mp3 v0",
+                target_format="opus",
+                v0_metric=None,
+                verified_lossless_proof=None,
+                audio_corrupt=False,
+                folder_layout="flat",
+                audio_file_count=len(dup_files),
+                filetype_band="mp3 v0",
+            )
+            db.upsert_album_quality_evidence(dup_candidate)
+            persisted_dup = db.find_album_quality_evidence(
+                mb_release_id=self.MB_RELEASE_ID,
+                snapshot_fingerprint=dup_candidate.snapshot_fingerprint,
+            )
+            assert persisted_dup is not None and persisted_dup.id is not None
+
+            log_id = self._seed_duplicate_wrong_match(
+                db,
+                request_id=3781,
+                duplicate_source_dir=duplicate_source_dir,
+                candidate_evidence_id=persisted_dup.id,
+            )
+
+            beets_info = AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=100,
+                avg_bitrate_kbps=119,
+                median_bitrate_kbps=115,
+                is_cbr=False,
+                album_path=library_dir,
+                format="Opus",
+            )
+            with self._patch_cfg(), \
+                    patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                result = cleanup_wrong_match(db, log_id)
+
+            # Decision: lossless_source_locked.
+            self.assertEqual(
+                result.outcome,
+                OUTCOME_DELETED,
+                f"expected lock + deletion; got outcome={result.outcome!r} "
+                f"verdict={result.verdict!r} "
+                f"preview_decision={result.preview_decision!r}",
+            )
+            self.assertEqual(result.verdict, "confident_reject")
+            self.assertEqual(
+                result.preview_decision, "lossless_source_locked",
+            )
+            self.assertTrue(result.cleanup_eligible)
+            self.assertTrue(result.success)
+
+            # Search narrowing: the request's override compressed from
+            # full upgrade ladder to lossless-only. RED before U11.
+            self.assertEqual(
+                db.request(3781)["search_filetype_override"], "lossless",
+                "lossless_source_locked cleanup must narrow the search "
+                "override to lossless-only so future cycles stop "
+                "asking Soulseek for lossy candidates that will hit "
+                "the lock and waste bandwidth.",
+            )
+
 
 class TestU10PostImportEvidencePropagation(unittest.TestCase):
     """U10: ``_refresh_current_evidence_after_import`` propagates the candidate

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -1214,7 +1214,57 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
             facts=AlbumQualityEvidenceDecisionFacts(import_mode="force"),
         )
 
-        # Parity assertion: same decision as the simulator sibling.
+        # --- Parity contract -------------------------------------------------
+        # Run the simulator with the same album facts and assert it reaches
+        # the same outcome through the flat-kwargs decider. This is the
+        # load-bearing parity assertion — it fails if the two entry points
+        # ever diverge on this album, regardless of what the literal decision
+        # name happens to be. The hardcoded check below pins the current
+        # value (suspect_lossless_downgrade); the parity check guards
+        # against future drift between the simulator and evidence pipeline.
+        sim = full_pipeline_decision(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            converted_count=13,
+            post_conversion_min_bitrate=184,
+            candidate_v0_probe_avg=215,
+            candidate_v0_probe_min=184,
+            existing_min_bitrate=100,
+            existing_avg_bitrate=119,
+            existing_format="Opus",
+            existing_is_cbr=False,
+            existing_spectral_grade="likely_transcode",
+            existing_spectral_bitrate=128,
+            existing_v0_probe_avg=215,
+            import_mode="force",
+        )
+        self.assertEqual(
+            r["stage2_import"], sim["stage2_import"],
+            "Parity contract violated: simulator and evidence pipeline "
+            "reached different stage2_import decisions on the same album "
+            f"(simulator={sim['stage2_import']!r}, "
+            f"evidence={r['stage2_import']!r})",
+        )
+        self.assertEqual(
+            r["imported"], sim["imported"],
+            "Parity contract violated: imported flag differs",
+        )
+        self.assertEqual(
+            r["denylisted"], sim["denylisted"],
+            "Parity contract violated: denylisted flag differs",
+        )
+        self.assertEqual(
+            r["keep_searching"], sim["keep_searching"],
+            "Parity contract violated: keep_searching flag differs",
+        )
+
+        # Literal value pin (sibling of the simulator test's hardcoded
+        # assertion). Both deciders currently land on suspect_lossless_downgrade
+        # for this album; if either side moves to a different reject branch,
+        # update both tests together.
         self.assertEqual(r["stage2_import"], "suspect_lossless_downgrade")
 
         verdict, cleanup_eligible, _reason = classify_full_pipeline_decision(r)

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -33,7 +33,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from lib.spectral_check import analyze_album, AlbumResult
 from lib.quality import (quality_gate_decision, full_pipeline_decision,
                          spectral_import_decision, import_quality_decision,
-                         transcode_detection, QUALITY_MIN_BITRATE_KBPS)
+                         transcode_detection, QUALITY_MIN_BITRATE_KBPS,
+                         AlbumQualityV0Metric)
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "albums")
 
@@ -771,6 +772,68 @@ class TestLiveBugReproductions(unittest.TestCase):
         self.assertTrue(r["keep_searching"])
         self.assertEqual(r["final_status"], "wanted")
 
+    def test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_simulator(self):
+        """Lil Wayne - Da Drought 3 / mymedia.
+
+        Request 3779, MBID ``244322cc-51ba-4f35-b072-f7c5888fb5ce``, 2026-05-17.
+        Live download_log rows: 16564 (force-imported predecessor at 08:06 UTC,
+        transcoded FLAC → Opus V2) and 16682 (rejected duplicate at 18:32 UTC).
+
+        Live bug: wrong-match cleanup triage classified the second candidate
+        as ``kept_would_import`` because the on-disk library evidence row had
+        NULL spectral / V0 fields. The library row exists (the first import
+        succeeded and produced an Opus copy), but ``propagate_candidate_evidence_to_current``
+        used to strip source-side evidence on transcoded imports — so triage
+        had comparable evidence on the candidate side and nothing on the
+        library side, and fell through to ``provisional_lossless_upgrade``.
+
+        Correct behaviour (post-U5 propagation policy): triage sees that the
+        library row was produced from a comparable lossless source (likely_transcode
+        FLAC, spectral=128, V0 probe avg=215 min=184) and rejects the new
+        candidate as a same-source duplicate via the provisional-lossless
+        gate (``lossless_source_not_better``). ``import_mode="force"``
+        mirrors what ``cleanup_wrong_match`` actually calls
+        (lib/wrong_match_cleanup_service.py:330-343).
+
+        This is the simulator side of the parity contract — the sibling
+        ``test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_evidence``
+        in ``TestLiveBugReproductionsThroughEvidencePipeline`` must reach
+        the same outcome through the evidence pipeline.
+        """
+        r = full_pipeline_decision(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            converted_count=13,
+            post_conversion_min_bitrate=184,
+            candidate_v0_probe_avg=215,
+            candidate_v0_probe_min=184,
+            # Existing-side facts mirror what the library row will look like
+            # post-U5: the previous transcoded FLAC → Opus import propagated
+            # source spectral + V0 onto the library evidence row, so triage
+            # now sees comparable evidence on both sides.
+            existing_min_bitrate=100,
+            existing_avg_bitrate=119,
+            existing_format="Opus",
+            existing_is_cbr=False,
+            existing_spectral_grade="likely_transcode",
+            existing_spectral_bitrate=128,
+            existing_v0_probe_avg=215,
+            import_mode="force",
+        )
+
+        # Provisional-lossless gate: same-source comparable evidence on both
+        # sides — the candidate's likely_transcode spectral grade + lossless-
+        # source V0 probe matches the library row's propagated provenance,
+        # so the gate rejects the duplicate as ``suspect_lossless_downgrade``
+        # rather than upgrading.
+        self.assertEqual(r["stage2_import"], "suspect_lossless_downgrade")
+        self.assertFalse(r["imported"])
+        self.assertTrue(r["denylisted"])
+        self.assertTrue(r["keep_searching"])
+
     def test_heretic_pride_one_bad_track_infinite_requeue(self):
         """BUG: 13/14 tracks at 320kbps + 1 track at 192kbps → infinite requeue.
 
@@ -955,6 +1018,9 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
         spectral_grade: str | None = None,
         spectral_bitrate: int | None = None,
         mb_release_id: str = "mbid-parity-candidate",
+        v0_metric: AlbumQualityV0Metric | None = None,
+        matched_bad_audio_hash_id: int | None = None,
+        matched_bad_audio_hash_path: str | None = None,
     ):
         if min_bitrate is None:
             return None
@@ -991,6 +1057,9 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
             storage_format=format.lower(),
             audio_file_count=len(files),
             filetype_band=format.lower(),
+            v0_metric=v0_metric,
+            matched_bad_audio_hash_id=matched_bad_audio_hash_id,
+            matched_bad_audio_hash_path=matched_bad_audio_hash_path,
         )
 
     def test_mountain_goats_flux_provisional_lossless_via_evidence(self):
@@ -1083,6 +1152,74 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
 
         self.assertEqual(r["stage2_import"], "downgrade")
         self.assertFalse(r["imported"])
+
+    def test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_evidence(self):
+        """Parity sibling of
+        ``TestLiveBugReproductions.test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_simulator``.
+
+        Request 3779, MBID ``244322cc-51ba-4f35-b072-f7c5888fb5ce``, 2026-05-17.
+        Encodes the post-U5 expectation: the library evidence row for the
+        previously-transcoded FLAC → Opus import carries the propagated
+        source-side spectral + V0 evidence, so triage rejects the second
+        identical-source candidate as a same-source duplicate.
+
+        Parity contract: the simulator and the evidence pipeline must
+        reach the same ``stage2_import`` decision on the same album, and
+        ``classify_full_pipeline_decision`` must mark the outcome
+        ``confident_reject`` with ``cleanup_eligible=True`` so the
+        wrong-match folder becomes eligible for cleanup.
+
+        Today (pre-U5) the library row has NULL spectral / V0 because
+        ``propagate_candidate_evidence_to_current`` strips source-side
+        evidence on transcoded imports. The current evidence row is being
+        synthesized here as the post-U5 shape, so this test will fail
+        RED until U5 makes the production path produce that state.
+        """
+        from lib.quality import (
+            AlbumQualityEvidenceDecisionFacts,
+            AlbumQualityV0Metric,
+            V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+            classify_full_pipeline_decision,
+            full_pipeline_decision_from_evidence,
+        )
+
+        candidate = self._build_candidate(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            post_conversion_min_bitrate=184,
+            candidate_v0_probe_avg=215,
+            candidate_v0_probe_min=184,
+        )
+        current = self._build_current(
+            min_bitrate=100,
+            avg_bitrate=119,
+            format="Opus",
+            is_cbr=False,
+            spectral_grade="likely_transcode",
+            spectral_bitrate=128,
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=184,
+                avg_bitrate_kbps=215,
+                median_bitrate_kbps=215,
+                source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+                source_provenance="neutral_album_quality_evidence",
+            ),
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, current,
+            facts=AlbumQualityEvidenceDecisionFacts(import_mode="force"),
+        )
+
+        # Parity assertion: same decision as the simulator sibling.
+        self.assertEqual(r["stage2_import"], "suspect_lossless_downgrade")
+
+        verdict, cleanup_eligible, _reason = classify_full_pipeline_decision(r)
+        self.assertEqual(verdict, "confident_reject")
+        self.assertTrue(cleanup_eligible)
 
 
 class TestFourFactPreimportRejects(unittest.TestCase):

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -2282,6 +2282,13 @@ class TestComputeEffectiveOverrideBitrate(unittest.TestCase):
         ("both None, genuine",                           None, None, "genuine",        None),
         ("both None, suspect",                           None, None, "suspect",        None),
         ("both None, grade None",                        None, None, None,             None),
+        # U6: transcoded-from-FLAC library rows now carry source spectral
+        # post-U5. compute_effective_override_bitrate's behaviour for the
+        # OPUS V2 case is unchanged (min(100, 128) = 100); the MP3 V0 case
+        # shifts from container (~225) to spectral (128) — searches become
+        # more permissive in line with the source's actual quality cliff.
+        ("transcoded opus v2 row, lossless_source spectral", 100, 128, "likely_transcode", 100),
+        ("transcoded mp3 v0 row, lossless_source spectral",  225, 128, "likely_transcode", 128),
     ]
 
     def test_grade_aware_table(self):

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -2506,6 +2506,37 @@ class TestNarrowOverrideOnDowngrade(unittest.TestCase):
         self.assertEqual(result, "lossless,mp3 v0")
 
 
+class TestNarrowOverrideOnLosslessSourceLock(unittest.TestCase):
+    """Test narrowing search_filetype_override to lossless-only after the
+    ``lossless_source_locked`` decision fires.
+
+    Pure helper; deterministic on its single argument. See origin:
+    ``docs/brainstorms/2026-05-17-propagate-source-evidence-on-transcode-requirements.md``
+    R6 and AE7.
+    """
+
+    # (description, current_override, expected)
+    CASES = [
+        ("none → lossless", None, "lossless"),
+        ("mp3 v0 → lossless", "mp3 v0", "lossless"),
+        ("mp3 320 → lossless", "mp3 320", "lossless"),
+        ("full ladder → lossless", "lossless,mp3 v0,mp3 320", "lossless"),
+        ("already lossless → None (idempotent)", "lossless", None),
+        ("empty string → lossless", "", "lossless"),
+    ]
+
+    def test_narrow_table(self):
+        from lib.quality import narrow_override_on_lossless_source_lock
+        for desc, current, expected in self.CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    narrow_override_on_lossless_source_lock(current),
+                    expected,
+                    f"{desc}: narrow_override_on_lossless_source_lock"
+                    f"({current!r}) expected {expected!r}",
+                )
+
+
 class TestRejectionBackfillOverride(unittest.TestCase):
     """Tests for rejection_backfill_override — breaks CBR 320 download loops.
 


### PR DESCRIPTION
## Summary

Two coupled changes shipped together that fix request 3779 (Lil Wayne — *Da Drought 3*) and close the wasted-cycle window the bug exposed.

**1. Propagation policy in `lib/quality_evidence.py::propagate_candidate_evidence_to_current`** now carries source-side evidence (spectral, V0 lineage, bad-hash) forward onto the library row **only when the candidate source is a lossless codec** (FLAC / ALAC / WAV). Renamed-only behaviour unchanged. Non-lossless transcodes (MP3 → Opus etc.) continue to strip source-side fields onto NULL.

**2. `narrow_override_on_lossless_source_lock`** is a new pure helper in `lib/quality.py`, wired into both the importer-side rejection path (`lib/import_dispatch.py`) and the wrong-match cleanup triage path (`lib/wrong_match_cleanup_service.py`). Whenever `lossless_source_locked` fires, the request's `search_filetype_override` is set to `"lossless"`. Future search cycles only ask Soulseek for lossless candidates that can actually win against the existing lossless-source library row.

Forward-only; no backfill of existing transcoded library rows.

## Why both halves matter

The Lil Wayne bug: a transcoded-FLAC import landed at 16:06 UTC, an identical-quality FLAC arrived at 18:32, and triage classified the duplicate as `kept_would_import` because the on-disk library row had NULL spectral/V0 (the old propagation policy stripped them on transcode).

Fixing propagation alone leaves a wasted-cycle window: even after triage correctly rejects, the search planner keeps asking Soulseek with no filetype filter, each new peer serves the same lossy file, the lock fires repeatedly, the wrong-matches queue churns. The companion search-narrowing closes that window.

This is consistent with the direction in `docs/brainstorms/quality-bucket-system-requirements.md` — under buckets, the lock dissolves into bucket comparison and the search narrowing is just "search same-bucket-or-above." This PR is the transitional step that mimics that behavior inside the current spectral system without waiting for the full buckets rewrite.

## Branch history

16 commits in two phases. The first 8 commits (`5220955..f87f812`) implemented an over-scoped version (symmetric propagation for *all* transcoded imports; search narrowing deferred). Phase 2 (`39a7124..2c32f98`) rescoped to the actual user ask:

- `39a7124` brainstorm + plan rewrite to lossless-source-gated + search narrowing
- `3169b19` U1: MP3-source negative test (RED)
- `0b2ba09` U8: re-gate propagation on lossless source (GREEN)
- `4f6ed49` U2+U9: narrow helper + pure tests
- `59c08ed` U3+U10: importer-side narrowing
- `696725e` U5+U6+U11: triage-side narrowing
- `92d6fd6` U4: strengthen Lil Wayne parity assertion
- `2c32f98` U12: CLAUDE.md + docstring cleanup

History preserved deliberately so the evolution is auditable.

## Test plan

- [x] Full test suite (3499 tests, 56 skipped) passes under `nix-shell --run "bash scripts/run_tests.sh"`
- [x] New tests cover all 7 acceptance examples (AE1-AE7) plus the `narrow_override_on_lossless_source_lock` helper
- [x] Lil Wayne (request 3779) live-bug scenario pinned in both `TestLiveBugReproductions` (simulator) and `TestLiveBugReproductionsThroughEvidencePipeline` (evidence pipeline) with a strengthened parity assertion that asserts both deciders reach the same outcome
- [x] AE2 lossy-candidate test specifically pins `lossless_source_locked` + override narrowing end-to-end
- [x] Negative test (MP3 → Opus transcode strips source-side evidence) pins the gate against accidental widening
- [x] Pyright clean on all touched files (one pre-existing unrelated error remains in `_matching_active_jobs`)

## Deploy notes

No schema migration. No new CLI / API surface. No UI changes. Forward-only — pre-2026-05-17 library rows keep their NULL spectral/V0 fields until each is re-imported or force-imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)