### PR TITLE
fix: Replace button wiring for legacy null-RG rows + library tab

### DIFF
--- a/scripts/backfill_release_groups.py
+++ b/scripts/backfill_release_groups.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""One-shot backfill: populate ``album_requests.mb_release_group_id``
+for legacy rows where it is NULL.
+
+Rationale: rows added before the RG field was populated have NULL
+``mb_release_group_id``. The Replace operator action (and other
+RG-keyed surfaces) used to gate UI affordances on this column being
+truthy, hiding the button entirely for ~4001 legacy rows. The picker
+now lazy-resolves at click-time via
+``POST /api/pipeline/<id>/resolve-rg``, so this backfill is *not*
+required for correctness — it's an optimisation that converts the
+first-click latency from "MB lookup + UPDATE" to "cache-served".
+
+Safe to run on production:
+- Read-only side effects: a 24h MB-mirror cache fill plus the
+  UPDATE on a single nullable column. Idempotent and resumable
+  (the WHERE clause naturally skips already-backfilled rows).
+- Numeric Discogs ids are skipped (no MB release-group concept).
+- MB-mirror 404 / lookup failure leaves the row NULL and moves on.
+
+Usage:
+    nix-shell --run "python3 scripts/backfill_release_groups.py [--limit N]"
+
+Environment:
+    PIPELINE_DB_DSN  — defaults to
+                       postgresql://cratedigger@localhost/cratedigger
+                       In production set via the sops-managed
+                       /run/secrets/cratedigger-pgpass on doc2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import sys
+import uuid
+from urllib.error import URLError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lib.pipeline_db import PipelineDB
+from web import mb as mb_api
+
+
+logger = logging.getLogger("backfill_release_groups")
+
+
+# MB-mirror transient errors that should NOT mark the row as
+# permanently un-resolvable. We just log and move on; a future run can
+# retry. Mirrors lib.mbid_replace_service._TRANSIENT_LOOKUP_EXCEPTIONS.
+_TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    URLError, TimeoutError, socket.timeout, ConnectionError,
+    json.JSONDecodeError,
+)
+
+
+def _is_mb_uuid(value: str | None) -> bool:
+    """``True`` iff ``value`` is a UUID-shaped string. Numeric Discogs
+    ids fail this check and are skipped — they have no MB
+    release-group concept."""
+    if not value:
+        return False
+    try:
+        uuid.UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return False
+    return True
+
+
+def _rows_to_backfill(db: PipelineDB, limit: int | None) -> list[dict]:
+    sql = (
+        "SELECT id, mb_release_id, source "
+        "FROM album_requests "
+        "WHERE mb_release_group_id IS NULL "
+        "AND mb_release_id IS NOT NULL "
+        "ORDER BY id"
+    )
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+    cur = db._execute(sql)
+    return list(cur.fetchall())
+
+
+def backfill(db: PipelineDB, *, limit: int | None = None) -> dict[str, int]:
+    """Walk all eligible rows and backfill RG. Returns a summary dict."""
+    rows = _rows_to_backfill(db, limit)
+    total = len(rows)
+    updated = 0
+    skipped_non_uuid = 0
+    skipped_no_rg = 0
+    errored_transient = 0
+    errored_other = 0
+
+    logger.info("Found %d row(s) to scan", total)
+
+    for i, row in enumerate(rows, start=1):
+        rid = int(row["id"])
+        mb_release_id = row.get("mb_release_id")
+        source = row.get("source")
+
+        if not _is_mb_uuid(mb_release_id):
+            logger.info(
+                "skip id=%d mb_release_id=%r source=%s "
+                "(non-MB id; no release-group concept)",
+                rid, mb_release_id, source,
+            )
+            skipped_non_uuid += 1
+        else:
+            try:
+                data = mb_api.get_release(mb_release_id, fresh=False)
+            except _TRANSIENT_EXCEPTIONS as exc:
+                logger.warning(
+                    "transient MB error id=%d mb_release_id=%s: %s",
+                    rid, mb_release_id, exc,
+                )
+                errored_transient += 1
+                data = None
+            except Exception as exc:  # noqa: BLE001
+                # 404 from the mirror (release deleted upstream),
+                # malformed payload, anything else — log + leave NULL.
+                logger.warning(
+                    "lookup failed id=%d mb_release_id=%s: %s",
+                    rid, mb_release_id, exc,
+                )
+                errored_other += 1
+                data = None
+
+            if data is not None:
+                rg_id = data.get("release_group_id") if isinstance(data, dict) else None
+                if not rg_id:
+                    logger.info(
+                        "no RG id=%d mb_release_id=%s "
+                        "(MB returned no release_group_id)",
+                        rid, mb_release_id,
+                    )
+                    skipped_no_rg += 1
+                else:
+                    db.update_request_fields(rid, mb_release_group_id=rg_id)
+                    updated += 1
+
+        if i % 100 == 0:
+            logger.info(
+                "progress: scanned=%d updated=%d skipped=%d errored=%d",
+                i, updated,
+                skipped_non_uuid + skipped_no_rg,
+                errored_transient + errored_other,
+            )
+
+    return {
+        "scanned": total,
+        "updated": updated,
+        "skipped_non_uuid": skipped_non_uuid,
+        "skipped_no_rg": skipped_no_rg,
+        "errored_transient": errored_transient,
+        "errored_other": errored_other,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill mb_release_group_id for legacy album_requests rows",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Only process the first N rows (debug / smoke test)",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Verbose per-row logging",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    db = PipelineDB()
+    summary = backfill(db, limit=args.limit)
+    print()
+    print("=" * 60)
+    print("Backfill summary:")
+    for key, val in summary.items():
+        print(f"  {key:24s} {val}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -783,6 +783,40 @@ assert(invDisabled.includes('disabled'),
 assert(!invDisabled.includes('window.openReplacePicker'),
   'renderReplaceButton inverted disabled does not wire onclick');
 
+// Null-RG handling: legacy rows have releaseGroupId=null. The picker
+// lazy-resolves. The button must still render, with an explicit JS
+// ``null`` literal in the onclick payload so the picker can detect the
+// missing RG.
+const stdNullRg = renderReplaceButton({
+  mode: 'standard',
+  sourceRequestId: 4194,
+  releaseGroupId: null,
+  sourceLabel: 'Pet Grief — Old',
+}, { stopPropagation: true });
+assert(stdNullRg.includes('window.openReplacePicker'),
+  'renderReplaceButton standard renders with null releaseGroupId');
+assert(stdNullRg.includes('releaseGroupId: null'),
+  'renderReplaceButton standard encodes null RG as JS null literal');
+
+const invNullRg = renderReplaceButton({
+  mode: 'inverted',
+  targetMbid: 'new-mbid',
+  releaseGroupId: null,
+  targetLabel: 'Pet Grief — New',
+}, { enabled: true });
+assert(invNullRg.includes('window.openReplacePicker'),
+  'renderReplaceButton inverted renders with null releaseGroupId');
+assert(invNullRg.includes('releaseGroupId: null'),
+  'renderReplaceButton inverted encodes null RG as JS null literal');
+
+// Standard mode without sourceRequestId still returns empty.
+const stdNoSource = renderReplaceButton({
+  mode: 'standard',
+  releaseGroupId: 'rg-1',
+});
+assertEqual(stdNoSource, '',
+  'renderReplaceButton standard returns empty without sourceRequestId');
+
 // Active-RG Set lookup — U9 enable logic
 const activeRgSet = new Set(['rg-1', 'rg-2']);
 assertEqual(activeRgSet.has('rg-1'), true, 'active-RG Set hit');

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -992,6 +992,7 @@ class TestRouteContractAudit(unittest.TestCase):
         r"^/api/pipeline/(\d+)/search-plan/regenerate$",
         r"^/api/pipeline/(\d+)/search-plan/advance$",
         r"^/api/pipeline/(\d+)/replace$",
+        r"^/api/pipeline/(\d+)/resolve-rg$",
         r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$",
         "/api/pipeline/active-rgs",
         "/api/pipeline/add",
@@ -2833,6 +2834,163 @@ class TestPipelineReplaceContract(_WebServerCase):
         status, data = self._get("/api/pipeline/active-rgs")
         self.assertEqual(status, 200)
         self.assertEqual(data["release_group_ids"], [])
+
+
+class TestPipelineResolveRgContract(_WebServerCase):
+    """Contract for ``POST /api/pipeline/<id>/resolve-rg``.
+
+    Lazy-backfill ``mb_release_group_id`` for legacy rows. The Replace
+    picker calls this in standard mode when the row has a null RG so the
+    sibling-fetch can proceed.
+
+    Status-code mapping:
+      * 200 — ``status='resolved'`` (RG found or already set)
+      * 404 — request not found
+      * 422 — non-UUID release id (Discogs) or MB returned no RG
+      * 503 — transient MB-mirror failure
+    """
+
+    RESOLVE_RG_REQUIRED_FIELDS = {
+        "request_id", "mb_release_group_id", "status",
+    }
+
+    def setUp(self) -> None:
+        # _WebServerCase shares ``mock_db`` across tests in the class via
+        # setUpClass; reset call counts here so per-test assertions don't
+        # see stale calls from earlier tests in the same class.
+        self.mock_db.reset_mock()
+
+    def test_resolve_rg_already_set_returns_200(self):
+        """Idempotent: row already has a RG → return it untouched
+        and do NOT hit the MB mirror or write to the DB."""
+        self.mock_db.get_request.return_value = {
+            "id": 42,
+            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "mb_release_group_id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
+        }
+        with patch("web.mb.get_release") as mock_mb:
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg already-set response",
+        )
+        self.assertEqual(data["status"], "resolved")
+        self.assertEqual(
+            data["mb_release_group_id"],
+            "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
+        )
+        mock_mb.assert_not_called()
+        self.mock_db.update_request_fields.assert_not_called()
+
+    def test_resolve_rg_lazy_backfill_happy_path_returns_200(self):
+        """Row has no RG → MB lookup → UPDATE row → 200."""
+        self.mock_db.get_request.return_value = {
+            "id": 42,
+            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "mb_release_group_id": None,
+        }
+        with patch(
+            "web.mb.get_release",
+            return_value={"release_group_id": "rrrr-rrrr-rrrr"},
+        ) as mock_mb:
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg happy-path response",
+        )
+        self.assertEqual(data["status"], "resolved")
+        self.assertEqual(
+            data["mb_release_group_id"], "rrrr-rrrr-rrrr",
+        )
+        mock_mb.assert_called_once_with(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", fresh=False,
+        )
+        self.mock_db.update_request_fields.assert_called_once_with(
+            42, mb_release_group_id="rrrr-rrrr-rrrr",
+        )
+
+    def test_resolve_rg_not_found_returns_404(self):
+        self.mock_db.get_request.return_value = None
+        with patch("web.mb.get_release") as mock_mb:
+            status, data = self._post(
+                "/api/pipeline/9999/resolve-rg", {},
+            )
+        self.assertEqual(status, 404)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg not-found response",
+        )
+        self.assertEqual(data["status"], "not_found")
+        self.assertIsNone(data["mb_release_group_id"])
+        mock_mb.assert_not_called()
+
+    def test_resolve_rg_no_release_group_returns_422(self):
+        """MB returns a payload but no release_group_id (e.g. mirror
+        anomaly, or a release whose RG is missing upstream)."""
+        self.mock_db.get_request.return_value = {
+            "id": 42,
+            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "mb_release_group_id": None,
+        }
+        with patch(
+            "web.mb.get_release",
+            return_value={"release_group_id": None},
+        ):
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 422)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg 422 response",
+        )
+        self.assertEqual(data["status"], "no_release_group")
+        self.mock_db.update_request_fields.assert_not_called()
+
+    def test_resolve_rg_discogs_release_id_returns_422(self):
+        """Numeric Discogs release id → 422 short-circuit, no MB hit."""
+        self.mock_db.get_request.return_value = {
+            "id": 42,
+            "mb_release_id": "12345",
+            "mb_release_group_id": None,
+        }
+        with patch("web.mb.get_release") as mock_mb:
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 422)
+        self.assertEqual(data["status"], "non_mb_release_id")
+        mock_mb.assert_not_called()
+        self.mock_db.update_request_fields.assert_not_called()
+
+    def test_resolve_rg_transient_returns_503(self):
+        """Network blip / timeout → 503 retryable."""
+        from urllib.error import URLError
+        self.mock_db.get_request.return_value = {
+            "id": 42,
+            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "mb_release_group_id": None,
+        }
+        with patch(
+            "web.mb.get_release",
+            side_effect=URLError("connection refused"),
+        ):
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 503)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg 503 response",
+        )
+        self.assertEqual(data["status"], "transient")
+        self.mock_db.update_request_fields.assert_not_called()
 
 
 class TestPipelineSearchPlanHistoryContract(_WebServerCase):

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -269,24 +269,52 @@ export async function loadReleaseGroup(id, el, opts = {}) {
       // release has an active pipeline request (see release_action_state.js
       // for the pipelineStore lookup).
       const spBtn = renderSearchPlanButton({ pipelineId: actionState.pipelineId });
-      // Inverted-mode Replace button. Hidden when the row IS the active
-      // request (acquireKind === 'remove_request' — there's nothing to
-      // replace into itself) and on the Discogs path (no MB
-      // release-group id available). Enabled only when an existing
-      // non-replaced row already targets a sibling MBID in the same RG.
-      const rgForReplace = rel.release_group_id || parentRgId;
+      // Replace button — two variants:
+      //
+      //   - ``isCurrent`` (acquireKind === 'remove_request'): this row
+      //     IS the active/imported request. Standard mode — clicking
+      //     opens the picker on this request's release group so the
+      //     operator can switch to a sibling pressing.
+      //
+      //   - Otherwise: inverted mode. Clicking asks the operator which
+      //     active request in this RG should be replaced with the
+      //     clicked row's MBID. Enabled only when an existing
+      //     non-replaced row already targets a sibling MBID in the same
+      //     RG (``hasActiveRg``).
+      //
+      // ``releaseGroupId`` may be null for legacy rows; the picker
+      // lazy-resolves it via ``POST /api/pipeline/<id>/resolve-rg``
+      // (standard) or ``GET /api/release/<mbid>`` (inverted) before
+      // fetching siblings.
+      const rgForReplace = rel.release_group_id || parentRgId || null;
       const isCurrent = actionState.acquireKind === 'remove_request';
-      const replaceBtn = (!isCurrent && rgForReplace) ? renderReplaceButton({
-        mode: 'inverted',
-        targetMbid: rel.id,
-        releaseGroupId: rgForReplace,
-        targetLabel: `${state.browseArtist?.name || ''} — ${rel.title || ''}`,
-      }, {
-        className: 'btn',
-        style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
-        enabled: hasActiveRg(rgForReplace),
-        stopPropagation: true,
-      }) : '';
+      let replaceBtn = '';
+      if (isCurrent) {
+        if (actionState.pipelineId) {
+          replaceBtn = renderReplaceButton({
+            mode: 'standard',
+            sourceRequestId: actionState.pipelineId,
+            releaseGroupId: rgForReplace,
+            sourceLabel: `${state.browseArtist?.name || ''} — ${rel.title || ''}`,
+          }, {
+            className: 'btn',
+            style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
+            stopPropagation: true,
+          });
+        }
+      } else {
+        replaceBtn = renderReplaceButton({
+          mode: 'inverted',
+          targetMbid: rel.id,
+          releaseGroupId: rgForReplace,
+          targetLabel: `${state.browseArtist?.name || ''} — ${rel.title || ''}`,
+        }, {
+          className: 'btn',
+          style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
+          enabled: hasActiveRg(rgForReplace),
+          stopPropagation: true,
+        });
+      }
       return `
         <div class="release" data-release-id="${rel.id}" onclick="event.stopPropagation(); window.toggleReleaseDetail('${rel.id}')">
           <div class="release-info">

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -963,13 +963,14 @@ export async function toggleDetail(elId, requestId) {
     });
     // Replace button — only shown when the row is not itself a frozen
     // audit row (R30 / scope boundary "re-replacing a replaced row is
-    // not supported") and the row has a release group to anchor the
-    // picker on.
-    if (req.status !== 'replaced' && req.mb_release_group_id) {
+    // not supported"). ``mb_release_group_id`` may be null on legacy
+    // rows; the picker lazy-resolves via
+    // ``POST /api/pipeline/<id>/resolve-rg`` before fetching siblings.
+    if (req.status !== 'replaced') {
       html += renderReplaceButton({
         mode: 'standard',
         sourceRequestId: id,
-        releaseGroupId: req.mb_release_group_id,
+        releaseGroupId: req.mb_release_group_id || null,
         sourceLabel: `${req.artist_name || ''} — ${req.album_title || ''}`,
       }, { className: 'p-btn', stopPropagation: true });
     }

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -175,7 +175,7 @@ export function renderBadRipButton(state, opts = {}) {
  * @param {'standard'|'inverted'} args.mode
  * @param {number} [args.sourceRequestId]  // standard mode
  * @param {string} [args.targetMbid]       // inverted mode
- * @param {string} args.releaseGroupId
+ * @param {string|null} [args.releaseGroupId]  // null → picker lazy-resolves
  * @param {string} [args.sourceLabel]
  * @param {string} [args.targetLabel]
  * @param {Object} [opts]
@@ -193,17 +193,21 @@ export function renderReplaceButton(args, opts = {}) {
   const stopPropagation = opts.stopPropagation ? 'event.stopPropagation(); ' : '';
 
   if (args.mode === 'standard') {
-    if (!args.sourceRequestId || !args.releaseGroupId) return '';
+    if (!args.sourceRequestId) return '';
+    // ``releaseGroupId`` may be null on legacy rows; the picker
+    // lazy-resolves via POST /api/pipeline/<id>/resolve-rg before
+    // fetching siblings. Encode an explicit JS ``null`` literal so the
+    // picker's ``in`` checks behave correctly.
     const sourceArg = jsArg(args.sourceLabel || '');
-    const rgArg = jsArg(args.releaseGroupId);
+    const rgArg = args.releaseGroupId ? jsArg(args.releaseGroupId) : 'null';
     return `<button class="${className}"${style} onclick="${stopPropagation}window.openReplacePicker({sourceRequestId: ${args.sourceRequestId}, releaseGroupId: ${rgArg}, sourceLabel: ${sourceArg}})">${label}</button>`;
   }
 
   // Inverted mode.
-  if (!args.targetMbid || !args.releaseGroupId) return '';
+  if (!args.targetMbid) return '';
   const enabled = opts.enabled !== false;
   const mbidArg = jsArg(args.targetMbid);
-  const rgArg = jsArg(args.releaseGroupId);
+  const rgArg = args.releaseGroupId ? jsArg(args.releaseGroupId) : 'null';
   const targetArg = jsArg(args.targetLabel || '');
   if (!enabled) {
     return `<button class="${className}"${style} disabled title="No existing request in this release group">${label}</button>`;

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -28,7 +28,7 @@
 /**
  * @typedef {Object} ReplacePickerOptionsStandard
  * @property {number} sourceRequestId
- * @property {string} releaseGroupId
+ * @property {string|null} [releaseGroupId]  // null → lazy-resolve via resolve-rg
  * @property {string} [sourceLabel]  // "Pet Grief — Old Pressing"
  * @property {string} [source]       // calling-tab identifier for telemetry
  */
@@ -36,7 +36,7 @@
 /**
  * @typedef {Object} ReplacePickerOptionsInverted
  * @property {string} targetMbid
- * @property {string} releaseGroupId
+ * @property {string|null} [releaseGroupId]  // null → lazy-resolve via /api/release/<mbid>
  * @property {string} [targetLabel]  // "Pet Grief — New Pressing (2025, JP)"
  * @property {string} [source]
  */
@@ -251,13 +251,43 @@ export async function openReplacePicker(options) {
  * @param {(r: ReplacePickerResult) => void} close
  */
 async function runStandard(options, showOverlay, close) {
+  // Lazy-resolve release group id for legacy null-RG rows. The endpoint
+  // both returns the RG and persists it back to the album_requests row
+  // so the next click is fast.
+  let releaseGroupId = options.releaseGroupId || null;
+  if (!releaseGroupId) {
+    showOverlay(`${renderStandardHeader(options.sourceLabel || `request #${options.sourceRequestId}`)}
+      <p>Resolving release group…</p>`);
+    try {
+      const res = await fetch(
+        `/api/pipeline/${options.sourceRequestId}/resolve-rg`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+      const body = await res.json();
+      if (!res.ok || !body.mb_release_group_id) {
+        const msg = body.error || `HTTP ${res.status}`;
+        showOverlay(`${renderStandardHeader(options.sourceLabel || '')}
+          <p style="color:#f66;">Failed to resolve release group: ${esc(String(msg))}</p>
+          <div class="actions"><button class="btn" id="replace-picker-cancel">Close</button></div>`);
+        bindCancel(close);
+        return;
+      }
+      releaseGroupId = body.mb_release_group_id;
+    } catch (err) {
+      showOverlay(`${renderStandardHeader(options.sourceLabel || '')}
+        <p style="color:#f66;">Failed to resolve release group: ${esc(String(err))}</p>
+        <div class="actions"><button class="btn" id="replace-picker-cancel">Close</button></div>`);
+      bindCancel(close);
+      return;
+    }
+  }
+
   showOverlay(`${renderStandardHeader(options.sourceLabel || `request #${options.sourceRequestId}`)}
     <p>Loading pressings…</p>`);
 
   let releases;
   let sourceMbid = '';
   try {
-    const res = await fetch(`/api/release-group/${encodeURIComponent(options.releaseGroupId)}`);
+    const res = await fetch(`/api/release-group/${encodeURIComponent(releaseGroupId)}`);
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
@@ -305,13 +335,45 @@ async function runStandard(options, showOverlay, close) {
  * @param {(r: ReplacePickerResult) => void} close
  */
 async function runInverted(options, showOverlay, close) {
+  // Lazy-resolve release group id for legacy null-RG rows by hitting
+  // the existing /api/release/<mbid> route (the response carries
+  // ``release_group_id``). We don't persist the result anywhere — the
+  // active-requests fetch below is the only consumer.
+  let releaseGroupId = options.releaseGroupId || null;
+  if (!releaseGroupId) {
+    showOverlay(`${renderInvertedHeader(options.targetLabel || options.targetMbid)}
+      <p>Resolving release group…</p>`);
+    try {
+      const res = await fetch(`/api/release/${encodeURIComponent(options.targetMbid)}`);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const body = await res.json();
+      const rg = body.release_group_id;
+      if (!rg) {
+        showOverlay(`${renderInvertedHeader(options.targetLabel || '')}
+          <p style="color:#f66;">Target MBID has no release group on the MB mirror.</p>
+          <div class="actions"><button class="btn" id="replace-picker-cancel">Close</button></div>`);
+        bindCancel(close);
+        return;
+      }
+      releaseGroupId = rg;
+    } catch (err) {
+      showOverlay(`${renderInvertedHeader(options.targetLabel || '')}
+        <p style="color:#f66;">Failed to resolve release group: ${esc(String(err))}</p>
+        <div class="actions"><button class="btn" id="replace-picker-cancel">Close</button></div>`);
+      bindCancel(close);
+      return;
+    }
+  }
+
   showOverlay(`${renderInvertedHeader(options.targetLabel || options.targetMbid)}
     <p>Loading active requests…</p>`);
 
   let requests = [];
   try {
     const res = await fetch(
-      `/api/pipeline/requests-by-rg/${encodeURIComponent(options.releaseGroupId)}`);
+      `/api/pipeline/requests-by-rg/${encodeURIComponent(releaseGroupId)}`);
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -976,12 +976,12 @@ function renderConvergeControls(g, count, thresholdMilli) {
       <div style="display:flex;align-items:center;gap:6px;">
         <button id="wm-delete-group-btn-${g.request_id}" class="p-btn delete" onclick="event.stopPropagation(); window.deleteWrongMatchGroup(${g.request_id}, this)">Delete All (${count})</button>
         <button id="wm-converge-btn-${g.request_id}" class="p-btn" style="border-color:#6a9;color:#6a9;" ${disabled ? 'disabled' : ''} onclick="event.stopPropagation(); window.convergeWrongMatches(${g.request_id}, this)">${label}</button>
-        ${g.mb_release_group_id ? renderReplaceButton({
+        ${renderReplaceButton({
           mode: 'standard',
           sourceRequestId: g.request_id,
-          releaseGroupId: g.mb_release_group_id,
+          releaseGroupId: g.mb_release_group_id || null,
           sourceLabel: `${g.artist || ''} — ${g.album || ''}`,
-        }, { className: 'p-btn', stopPropagation: true }) : ''}
+        }, { className: 'p-btn', stopPropagation: true })}
       </div>
     </div>`;
 }

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -809,6 +809,135 @@ def post_pipeline_search_plan_advance(
     h._error(f"Unknown advance outcome: {result.outcome}", 500)
 
 
+def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
+    """``POST /api/pipeline/<id>/resolve-rg``.
+
+    Lazy-backfill ``album_requests.mb_release_group_id`` for a single
+    legacy row that was added before the RG field was populated.
+
+    Used by ``web/js/replace_picker.js`` standard-mode when the row has
+    a null RG — the picker calls this endpoint, persists the resolved
+    RG back to the row, then continues into the sibling fetch.
+
+    The persisted side-effect is intentionally idempotent: if the row
+    already has a non-null RG the route returns it untouched (no
+    redundant MB hit because ``get_release(fresh=False)`` is cache-served).
+
+    Status-code mapping:
+      * 200 — ``status='resolved'`` (RG found; row updated or already set)
+      * 404 — request id does not exist
+      * 422 — MB lookup returned no release_group_id (e.g. the row's
+              ``mb_release_id`` is a numeric Discogs id, or the upstream
+              MB release has no RG attached)
+      * 503 — transient MB-mirror error (timeout, network, malformed
+              JSON) — retryable
+    """
+    try:
+        request_id = int(req_id_str)
+    except (TypeError, ValueError):
+        h._error("Invalid request id")
+        return
+
+    db = _server()._db()
+    row = db.get_request(request_id)
+    if row is None:
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "not_found",
+            "error": f"request {request_id} not found",
+        }, status=404)
+        return
+
+    existing_rg = row.get("mb_release_group_id")
+    if existing_rg:
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": existing_rg,
+            "status": "resolved",
+        })
+        return
+
+    mb_release_id = row.get("mb_release_id")
+    if not mb_release_id:
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "missing_release_id",
+            "error": (
+                f"request {request_id} has no mb_release_id to resolve"
+            ),
+        }, status=422)
+        return
+
+    # MB release ids are UUIDs; numeric ids are Discogs and have no
+    # release-group concept here. Surface 422 so the picker can show a
+    # clean error rather than letting the mirror return 404 / 500.
+    try:
+        import uuid as _uuid
+        _uuid.UUID(str(mb_release_id))
+    except (ValueError, TypeError, AttributeError):
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "non_mb_release_id",
+            "error": (
+                f"request {request_id}.mb_release_id "
+                f"{mb_release_id!r} is not a MusicBrainz UUID"
+            ),
+        }, status=422)
+        return
+
+    # MB-mirror transient errors (network, JSON decode) are retryable.
+    # See ``lib/mbid_replace_service.py::_TRANSIENT_LOOKUP_EXCEPTIONS``
+    # for the rationale and the same exception set.
+    import socket as _socket
+    from urllib.error import URLError
+    transient: tuple[type[BaseException], ...] = (
+        URLError, TimeoutError, _socket.timeout, ConnectionError,
+        json.JSONDecodeError,
+    )
+    try:
+        data = mb_api.get_release(mb_release_id, fresh=False)
+    except transient as exc:
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "transient",
+            "error": f"MB lookup failed (transient): {exc}",
+        }, status=503)
+        return
+    except Exception as exc:  # noqa: BLE001
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "lookup_failed",
+            "error": (
+                f"MB lookup for {mb_release_id} failed: {exc}"
+            ),
+        }, status=422)
+        return
+
+    rg_id = (data or {}).get("release_group_id") if isinstance(data, dict) else None
+    if not rg_id:
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "no_release_group",
+            "error": (
+                f"MB release {mb_release_id} has no release_group_id"
+            ),
+        }, status=422)
+        return
+
+    db.update_request_fields(request_id, mb_release_group_id=rg_id)
+    h._json({
+        "request_id": request_id,
+        "mb_release_group_id": rg_id,
+        "status": "resolved",
+    })
+
+
 def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
     """``POST /api/pipeline/<id>/replace``.
 
@@ -1783,4 +1912,6 @@ POST_PATTERNS: list[tuple[re.Pattern[str], object]] = [
      post_pipeline_search_plan_advance),
     (re.compile(r"^/api/pipeline/(\d+)/replace$"),
      post_pipeline_replace),
+    (re.compile(r"^/api/pipeline/(\d+)/resolve-rg$"),
+     post_pipeline_resolve_rg),
 ]


### PR DESCRIPTION
## Summary

Fixes three UI wiring bugs in the Replace operator action shipped in #279:

1. **Wrong Matches tab** — `web/js/wrong-matches.js` gated the button on `mb_release_group_id` being truthy. NULL on the **4001 legacy rows** in production, so the button never rendered.
2. **Pipeline tab** — `web/js/pipeline.js` had the same null-RG gate. Same problem.
3. **Library tab** (`web/js/discography.js`) — standard-mode button never wired on the active/imported row. Only inverted-mode buttons on sibling pressings. Library-tab Replace was effectively missing entirely.

Root cause: the original implementation gated the button render on `mb_release_group_id` truthy at the UI layer, ignoring that the service has lazy-backfill for legacy rows. Since the UI never invoked the service for null-RG rows, the lazy-backfill never fired and legacy rows were permanently un-replaceable.

This also fixes a "finish what you start" gap: `web/js/discography.js` was only wired in inverted mode, leaving the most important library-tab surface (the active album row) without a Replace affordance.

## Fixes

- **`feat(replace): /api/pipeline/<id>/resolve-rg endpoint for lazy RG backfill`** (`08fbbbd`)
  - New `POST /api/pipeline/<request_id>/resolve-rg` route. Loads the request, calls `mb_api.get_release(..., fresh=False)`, returns the canonical release-group ID, AND updates `album_requests.mb_release_group_id` so future renders just work.
  - Status mappings: 200 (`resolved`), 404 (request not found), 422 (MBID doesn't resolve), 503 (MB mirror transient).
  - `TestPipelineResolveRgContract` covers all four. Audit registry entry added.
- **`fix(replace): wire library-mode standard Replace button on discography active row`** (`3aac26e`)
  - When `isCurrent === true` (active/imported row), render STANDARD-mode button with `sourceRequestId: actionState.pipelineId`.
  - Sibling rows continue rendering inverted-mode as before.
- **`fix(replace): render Replace button for legacy null-RG rows + picker lazy-resolves`** (`e0ae70d`)
  - Dropped the `mb_release_group_id` truthy gate from `wrong-matches.js` and `pipeline.js`.
  - `replace_picker.js` lazy-resolves on open: standard mode hits the new `/resolve-rg` endpoint; inverted mode hits the existing `GET /api/release/<mbid>` (reuses what's already exposed). Shows a "Resolving release group…" intermediate state.
- **`chore(replace): one-shot backfill script for legacy mb_release_group_id`** (`770f36d`)
  - `scripts/backfill_release_groups.py` — idempotent, resumable, `--limit`/`--verbose`. Run via `nix-shell --run "python3 scripts/backfill_release_groups.py"`. Cleans up the 4001 legacy rows in one pass.

## Test plan

- [x] Full suite: **3596 ran, 0 failures, 56 skipped, OK**. New `TestPipelineResolveRgContract` (6 cases) + JS unit tests for null-RG render paths (238 passed).
- [x] Pyright clean inside `nix-shell` on touched files (3 pre-existing errors on main verified unchanged).
- [ ] **Manual dogfood after merge**:
  1. Deploy.
  2. Run the backfill: `ssh doc2 'nix-shell --run "python3 /nix/store/.../cratedigger-src/scripts/backfill_release_groups.py"'` (path varies; use the deployed flake output).
  3. Open Wrong Matches tab — Replace button should now appear on Pet Grief 4194 + other rows.
  4. Open Pipeline tab — Replace button on every non-replaced row.
  5. Open Browse → an artist's discography → the active imported row should have a standard-mode Replace button.
  6. Click Replace on Pet Grief 4194 → picker shows release-group siblings → pick `18056805-...` → confirm → end-to-end self-heal.

## Related

- Follows up #279 — same Replace operator action, same dogfood case.
- Issue #278 still tracks the broader slskd-orphan convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — caught and addressed during post-merge dogfood verification.