### PR TITLE
feat(web): expandable tracklists + reference panel in Replace picker (#281)

### DIFF
--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -692,6 +692,9 @@ import {
   renderConfirmDialog,
   renderStandardHeader,
   renderInvertedHeader,
+  renderTracklist,
+  renderSourcePanel,
+  formatLength,
   esc as replaceEsc,
 } from '../web/js/replace_picker.js';
 
@@ -706,12 +709,23 @@ const sample = [
   { id: 'bbb', title: 'Pressing B', date: '2021-05-01', country: 'JP', track_count: 13, format: 'LP' },
 ];
 const pressingsHtml = renderPressingsList(sample, 'aaa');
-assert(pressingsHtml.includes('data-mbid="aaa"'), 'renderPressingsList includes current as data-mbid');
-assert(pressingsHtml.includes('disabled'), 'renderPressingsList marks current pressing disabled');
+assert(pressingsHtml.includes('data-expand-mbid="aaa"'),
+  'renderPressingsList wires current pressing as expandable row');
+assert(/data-expand-mbid="aaa"[^>]*disabled|disabled[^>]*data-expand-mbid="aaa"/.test(pressingsHtml),
+  'renderPressingsList marks current pressing disabled');
 assert(pressingsHtml.includes('current pressing'), 'renderPressingsList labels current pressing');
-assert(pressingsHtml.includes('data-mbid="bbb"'), 'renderPressingsList includes sibling');
-assert(!/<button[^>]*data-mbid="bbb"[^>]*disabled/.test(pressingsHtml),
+assert(pressingsHtml.includes('data-expand-mbid="bbb"'), 'renderPressingsList includes sibling');
+assert(!/<button[^>]*data-expand-mbid="bbb"[^>]*disabled/.test(pressingsHtml),
   'renderPressingsList does not disable non-current siblings');
+assert(pressingsHtml.includes('data-mbid="bbb"') &&
+  /replace-picker-confirm[^>]*data-mbid="bbb"/.test(pressingsHtml),
+  'renderPressingsList renders pick-button for non-current pressing');
+assert(!/replace-picker-confirm[^>]*data-mbid="aaa"/.test(pressingsHtml),
+  'renderPressingsList omits pick-button for current pressing');
+assert(!pressingsHtml.includes('aaa</small>') && !pressingsHtml.includes('bbb</small>'),
+  'renderPressingsList does not expose MBID to operator (visual-noise cleanup)');
+assert(/2020.*US.*CD.*12t/.test(pressingsHtml) || pressingsHtml.includes('US · 2020 · CD · 12t'),
+  'renderPressingsList renders meta in country·year·format·Nt order');
 
 assertEqual(
   renderRequestsList([]).includes('No active requests'),
@@ -721,8 +735,14 @@ assertEqual(
 const reqHtml = renderRequestsList([
   { id: 42, mb_release_id: 'old-uuid', status: 'wanted', artist_name: 'Pet Grief', album_title: 'X' },
 ]);
-assert(reqHtml.includes('data-rid="42"'), 'renderRequestsList carries id');
+assert(reqHtml.includes('data-rid="42"'), 'renderRequestsList carries id (pick button)');
 assert(reqHtml.includes('Pet Grief'), 'renderRequestsList includes artist');
+assert(reqHtml.includes('data-expand-mbid="old-uuid"'),
+  'renderRequestsList row expands by MBID');
+assert(reqHtml.includes('data-tracks-for="old-uuid"'),
+  'renderRequestsList renders lazy tracklist container per row');
+assert(!/<small[^>]*>[^<]*old-uuid/.test(reqHtml),
+  'renderRequestsList hides the MBID from the operator');
 
 const dlg = renderConfirmDialog({
   sourceRequestId: 4194,
@@ -740,6 +760,64 @@ assert(renderStandardHeader('Pet Grief — Old').includes('Switch'),
   'renderStandardHeader carries "Switch" verb');
 assert(renderInvertedHeader('Pet Grief — New').includes('replace an existing request'),
   'renderInvertedHeader carries inverted-mode verb');
+
+// Tracklist container is rendered hidden until row.open
+assert(pressingsHtml.includes('data-tracks-for="aaa"'),
+  'renderPressingsList renders tracklist container per row');
+
+// formatLength
+assertEqual(formatLength(0), '0:00', 'formatLength 0 → 0:00');
+assertEqual(formatLength(7), '0:07', 'formatLength <60s pads seconds');
+assertEqual(formatLength(63), '1:03', 'formatLength 63s → 1:03');
+assertEqual(formatLength(263.4), '4:23', 'formatLength rounds');
+assertEqual(formatLength(null), '', 'formatLength null → empty');
+assertEqual(formatLength(undefined), '', 'formatLength undefined → empty');
+assertEqual(formatLength(NaN), '', 'formatLength NaN → empty');
+
+// renderTracklist
+assert(renderTracklist([]).includes('No tracks'),
+  'renderTracklist empty → friendly message');
+const tlHtml = renderTracklist([
+  { disc_number: 1, track_number: 1, title: 'Aaa', length_seconds: 200 },
+  { disc_number: 1, track_number: 2, title: 'Bbb <em>', length_seconds: 263.4 },
+]);
+assert(tlHtml.includes('Aaa'), 'renderTracklist includes title');
+assert(tlHtml.includes('4:23'), 'renderTracklist formats track length');
+assert(tlHtml.includes('&lt;em&gt;'), 'renderTracklist escapes titles');
+assert(!/Disc 1/.test(tlHtml), 'renderTracklist hides disc header for single-disc');
+
+const multiDiscHtml = renderTracklist([
+  { disc_number: 1, track_number: 1, title: 'A', length_seconds: 60 },
+  { disc_number: 2, track_number: 1, title: 'B', length_seconds: 60 },
+]);
+assert(multiDiscHtml.includes('Disc 1') && multiDiscHtml.includes('Disc 2'),
+  'renderTracklist shows disc headers for multi-disc');
+
+// renderSourcePanel
+const loadingPanel = renderSourcePanel({
+  label: 'Pet Grief — Old',
+  meta: 'US · 2020 · CD · 12t',
+  tracks: null,
+  loading: true,
+});
+assert(loadingPanel.includes('Current request:'),
+  'renderSourcePanel labels the panel "Current request:"');
+assert(loadingPanel.includes('Pet Grief — Old'), 'renderSourcePanel includes the label');
+assert(loadingPanel.includes('US · 2020 · CD · 12t'),
+  'renderSourcePanel renders meta line on summary');
+assert(loadingPanel.includes('Loading'), 'renderSourcePanel loading state shows placeholder');
+assert(loadingPanel.includes('replace-picker-source-body'),
+  'renderSourcePanel exposes the body container for lazy fill');
+
+const loadedPanel = renderSourcePanel({
+  label: 'X',
+  tracks: [{ disc_number: 1, track_number: 1, title: 'Z', length_seconds: 120 }],
+});
+assert(loadedPanel.includes('Z'), 'renderSourcePanel renders tracks when loaded');
+assert(loadedPanel.includes('2:00'), 'renderSourcePanel renders track duration');
+
+const errorPanel = renderSourcePanel({ label: 'X', tracks: null, error: 'HTTP 500' });
+assert(errorPanel.includes('HTTP 500'), 'renderSourcePanel renders error message');
 
 assertEqual(replaceEsc('<script>'), '&lt;script&gt;', 'esc escapes <');
 assertEqual(replaceEsc('a&b'), 'a&amp;b', 'esc escapes &');

--- a/web/index.html
+++ b/web/index.html
@@ -351,6 +351,37 @@
   .confirm-box h3 { color: #f66; margin-bottom: 12px; }
   .confirm-box p { color: #aaa; margin-bottom: 16px; font-size: 0.9em; }
   .confirm-box .actions { display: flex; gap: 8px; justify-content: center; }
+
+  /* Replace picker — matches .p-item / .p-detail visual language */
+  .replace-picker-shell { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 8px; padding: 20px; max-width: 720px; width: 90vw; max-height: 85vh; overflow-y: auto; text-align: left; color: #ccc; }
+  .replace-picker-shell h2 { color: #ccd; margin: 0 0 6px; font-size: 1.05em; font-weight: 500; }
+  .replace-picker-shell > p { color: #888; font-size: 0.85em; margin-bottom: 12px; }
+  .replace-picker-shell code { color: #aac; background: #14141a; padding: 0 4px; border-radius: 3px; font-size: 0.85em; }
+  .replace-picker-list { list-style: none; padding: 0; margin: 0; }
+  .replace-picker-row { margin-bottom: 4px; }
+  .replace-picker-pick { padding: 10px 12px; background: #1e1e1e; border-left: 3px solid #444; border-right: none; border-top: none; border-bottom: none; border-radius: 0 6px 6px 0; cursor: pointer; color: #ccc; font: inherit; text-align: left; width: 100%; display: block; }
+  .replace-picker-pick:hover { background: #252525; }
+  .replace-picker-row.open .replace-picker-pick { border-radius: 0 6px 0 0; border-left-color: #6a9; background: #232a25; color: #cdc; }
+  .replace-picker-pick small { color: #777; font-size: 0.75em; }
+  .replace-picker-pick:disabled { cursor: default; opacity: 0.55; }
+  .replace-picker-pick:disabled:hover { background: #1e1e1e; }
+  .replace-picker-detail { background: #191919; padding: 10px 12px; margin: 0 0 4px 0; border-radius: 0 0 6px 6px; display: none; border-left: 3px solid #333; }
+  .replace-picker-row.open .replace-picker-detail { display: block; border-left-color: #6a9; }
+  .replace-picker-detail-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 10px; padding-top: 8px; border-top: 1px solid #232323; }
+  .replace-picker-confirm { background: #2a5a2a; color: #8d8; border: none; border-radius: 6px; padding: 6px 14px; cursor: pointer; font-size: 0.85em; font-weight: 500; }
+  .replace-picker-confirm:hover { background: #3a6a3a; }
+  .replace-picker-tracks { list-style: none; padding: 0; margin: 0; font-size: 0.82em; color: #bbb; }
+  .replace-picker-tracks li { padding: 1px 0; display: flex; gap: 8px; align-items: baseline; }
+  .replace-picker-tnum { color: #666; min-width: 28px; text-align: right; font-variant-numeric: tabular-nums; }
+  .replace-picker-dur { color: #666; margin-left: auto; font-variant-numeric: tabular-nums; }
+  .replace-picker-disc { color: #888; font-size: 0.8em; margin: 6px 0 2px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .replace-picker-source { background: #191919; border-left: 3px solid #6a9; border-radius: 0 6px 6px 0; padding: 10px 12px; margin: 8px 0 14px; }
+  .replace-picker-source summary { cursor: pointer; color: #cdc; font-size: 0.9em; list-style: none; outline: none; }
+  .replace-picker-source summary::-webkit-details-marker { display: none; }
+  .replace-picker-source summary::before { content: '▾ '; color: #6a9; font-size: 0.85em; }
+  .replace-picker-source:not([open]) summary::before { content: '▸ '; }
+  .replace-picker-source-body { margin-top: 8px; max-height: 240px; overflow-y: auto; }
+  .replace-picker-cancel-bar { display: flex; justify-content: flex-end; margin-top: 12px; }
   .loading { color: #666; padding: 20px; text-align: center; }
   .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); padding: 12px 24px; background: #2a5a2a; color: #8d8; border-radius: 8px; font-size: 14px; z-index: 100; display: none; }
   .toast.error { background: #5a2a2a; color: #d88; }

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -86,7 +86,27 @@ export function esc(s) {
 }
 
 /**
+ * Build the meta line for a release row — matches the format used by
+ * analysis.js pressing rows: `country · year · format · Nt`. Empty
+ * fields drop out.
+ *
+ * @param {{ date?: string, country?: string, format?: string, track_count?: number }} r
+ * @returns {string}
+ */
+export function pressingMeta(r) {
+  const year = r.date ? r.date.slice(0, 4) : '';
+  return [r.country, year, r.format, r.track_count ? `${r.track_count}t` : '']
+    .filter((x) => !!x)
+    .join(' · ');
+}
+
+/**
  * Render the "pressings in this release group" list (standard mode).
+ *
+ * Each row is click-to-expand. The MB tracklist is lazy-fetched on the
+ * first expand; the "Use this pressing" button lives inside the expanded
+ * detail panel so the row click never accidentally fires the destructive
+ * confirm flow.
  *
  * @param {ReleaseGroupSibling[]} releases
  * @param {string} sourceMbid       // current pressing — disabled in the list
@@ -98,24 +118,125 @@ export function renderPressingsList(releases, sourceMbid) {
   }
   const rows = releases.map((r) => {
     const isCurrent = r.id === sourceMbid;
-    const year = r.date ? r.date.slice(0, 4) : '';
-    const meta = [year, r.country, r.format, r.track_count ? `${r.track_count}tk` : '']
-      .filter((x) => !!x)
-      .join(' · ');
     const disabledAttr = isCurrent ? ' disabled' : '';
     const labelSuffix = isCurrent ? ' (current pressing)' : '';
-    return `<li>
-      <button class="btn"${disabledAttr} data-mbid="${esc(r.id)}">
+    const meta = pressingMeta(r);
+    const pickLabel = isCurrent
+      ? ''
+      : `<button class="replace-picker-confirm" data-mbid="${esc(r.id)}">Use this pressing</button>`;
+    return `<li class="replace-picker-row" data-mbid-row="${esc(r.id)}">
+      <button class="replace-picker-pick"${disabledAttr} data-expand-mbid="${esc(r.id)}" aria-expanded="false">
         <strong>${esc(r.title)}</strong>${labelSuffix}<br>
-        <small style="color:#888;">${esc(meta)} · ${esc(r.id)}</small>
+        <small>${esc(meta)}</small>
       </button>
+      <div class="replace-picker-detail" data-tracks-for="${esc(r.id)}"></div>
+      <div class="replace-picker-detail-actions-slot" data-actions-for="${esc(r.id)}" hidden>
+        <div class="replace-picker-detail-actions">${pickLabel}</div>
+      </div>
     </li>`;
   });
-  return `<ul style="list-style:none;padding:0;">${rows.join('')}</ul>`;
+  return `<ul class="replace-picker-list">${rows.join('')}</ul>`;
+}
+
+/**
+ * Format seconds → "m:ss". Returns empty string for null/undefined/NaN.
+ *
+ * @param {number|null|undefined} secs
+ * @returns {string}
+ */
+export function formatLength(secs) {
+  if (secs === null || secs === undefined || Number.isNaN(secs)) return '';
+  const total = Math.round(Number(secs));
+  if (!Number.isFinite(total) || total < 0) return '';
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * @typedef {Object} TracklistTrack
+ * @property {number} [disc_number]
+ * @property {number} [track_number]
+ * @property {string} [title]
+ * @property {number|null} [length_seconds]
+ */
+
+/**
+ * Render a compact tracklist. Disc headers only appear when there is
+ * more than one disc — keeps the visual quiet for the common single-disc
+ * case.
+ *
+ * @param {TracklistTrack[]} tracks
+ * @returns {string}
+ */
+export function renderTracklist(tracks) {
+  if (!tracks || !tracks.length) {
+    return '<p style="color:#888;margin:8px 0;">No tracks listed.</p>';
+  }
+  const discs = new Set(tracks.map((t) => t.disc_number || 1));
+  const multiDisc = discs.size > 1;
+  const byDisc = new Map();
+  for (const t of tracks) {
+    const d = t.disc_number || 1;
+    if (!byDisc.has(d)) byDisc.set(d, []);
+    byDisc.get(d).push(t);
+  }
+  const parts = [];
+  const sortedDiscs = [...byDisc.keys()].sort((a, b) => a - b);
+  for (const d of sortedDiscs) {
+    if (multiDisc) parts.push(`<div class="replace-picker-disc">Disc ${d}</div>`);
+    const items = byDisc.get(d).map((t) => {
+      const num = t.track_number || '';
+      const dur = formatLength(t.length_seconds);
+      const durHtml = dur ? `<span class="replace-picker-dur">${esc(dur)}</span>` : '';
+      return `<li><span class="replace-picker-tnum">${esc(String(num))}.</span> ${esc(t.title || '')} ${durHtml}</li>`;
+    });
+    parts.push(`<ol class="replace-picker-tracks">${items.join('')}</ol>`);
+  }
+  return parts.join('');
+}
+
+/**
+ * Render the pinned "current request" tracklist panel — the source
+ * request in standard mode, the target MBID in inverted mode. Shown
+ * once at the top of the picker so the operator always has the
+ * reference visible while expanding candidate pressings below. The
+ * summary line carries the same meta tags (country · year · format ·
+ * Nt) as the rows below so visual comparison is direct.
+ *
+ * @param {{
+ *   label: string,
+ *   meta?: string,
+ *   tracks: TracklistTrack[]|null,
+ *   loading?: boolean,
+ *   error?: string,
+ * }} args
+ * @returns {string}
+ */
+export function renderSourcePanel(args) {
+  let body;
+  if (args.error) {
+    body = `<p style="color:#f66;margin:4px 0;">${esc(args.error)}</p>`;
+  } else if (args.loading || args.tracks === null) {
+    body = '<p style="color:#888;margin:4px 0;">Loading tracklist…</p>';
+  } else {
+    body = renderTracklist(args.tracks);
+  }
+  const metaHtml = args.meta
+    ? `<br><small style="color:#888;">${esc(args.meta)}</small>`
+    : '';
+  return `<details class="replace-picker-source" open>
+    <summary><strong>Current request:</strong> ${esc(args.label)}${metaHtml}</summary>
+    <div class="replace-picker-source-body">${body}</div>
+  </details>`;
 }
 
 /**
  * Render the inverted-mode "which existing request to replace?" list.
+ *
+ * Same click-to-expand pattern as the standard-mode pressings list: the
+ * row is the disclosure, the "Use this request" button lives inside the
+ * expanded detail panel.
  *
  * @param {ExistingRequest[]} requests
  * @returns {string}
@@ -125,13 +246,19 @@ export function renderRequestsList(requests) {
     return '<p style="color:#888;">No active requests exist in this release group.</p>';
   }
   const rows = requests.map((r) => `
-    <li>
-      <button class="btn" data-rid="${r.id}">
+    <li class="replace-picker-row" data-mbid-row="${esc(r.mb_release_id)}">
+      <button class="replace-picker-pick" data-expand-mbid="${esc(r.mb_release_id)}" aria-expanded="false">
         <strong>#${r.id}</strong> · ${esc(r.artist_name)} — ${esc(r.album_title)}<br>
-        <small style="color:#888;">${esc(r.mb_release_id)} (status=${esc(r.status)})</small>
+        <small>status: ${esc(r.status)}</small>
       </button>
+      <div class="replace-picker-detail" data-tracks-for="${esc(r.mb_release_id)}"></div>
+      <div class="replace-picker-detail-actions-slot" data-actions-for="${esc(r.mb_release_id)}" hidden>
+        <div class="replace-picker-detail-actions">
+          <button class="replace-picker-confirm" data-rid="${r.id}">Use this request</button>
+        </div>
+      </div>
     </li>`);
-  return `<ul style="list-style:none;padding:0;">${rows.join('')}</ul>`;
+  return `<ul class="replace-picker-list">${rows.join('')}</ul>`;
 }
 
 /**
@@ -225,7 +352,7 @@ export async function openReplacePicker(options) {
     }
 
     function showOverlay(/** @type {string} */ inner) {
-      modal.innerHTML = `<div class="confirm-overlay"><div class="confirm-box" style="max-width:640px;text-align:left;">${inner}</div></div>`;
+      modal.innerHTML = `<div class="confirm-overlay"><div class="replace-picker-shell">${inner}</div></div>`;
       modal.style.display = '';
       const overlay = modal.querySelector('.confirm-overlay');
       if (overlay) {
@@ -298,7 +425,12 @@ async function runStandard(options, showOverlay, close) {
     const detail = await fetch(`/api/pipeline/${options.sourceRequestId}`);
     if (detail.ok) {
       const drow = await detail.json();
-      sourceMbid = drow.mb_release_id || '';
+      // The pipeline detail endpoint wraps the row under `request` —
+      // a flat read returned `undefined`, leaving sourceMbid blank
+      // (which the picker silently tolerated because it only drove the
+      // "disable current pressing" visual). Fixed when we started
+      // depending on it for the reference tracklist.
+      sourceMbid = (drow.request && drow.request.mb_release_id) || drow.mb_release_id || '';
     }
   } catch (err) {
     showOverlay(`${renderStandardHeader(options.sourceLabel || '')}
@@ -308,25 +440,165 @@ async function runStandard(options, showOverlay, close) {
     return;
   }
 
-  showOverlay(`${renderStandardHeader(options.sourceLabel || `request #${options.sourceRequestId}`)}
+  const sourceLabel = options.sourceLabel || `request #${options.sourceRequestId}`;
+  const sourcePressing = releases.find((r) => r.id === sourceMbid) || null;
+  const sourceMeta = sourcePressing ? pressingMeta(sourcePressing) : '';
+  const sourcePanel = renderSourcePanel({
+    label: sourceLabel,
+    meta: sourceMeta,
+    tracks: null,
+    loading: true,
+  });
+  showOverlay(`${renderStandardHeader(sourceLabel)}
+    ${sourcePanel}
     ${renderPressingsList(releases, sourceMbid)}
-    <div class="actions" style="margin-top:12px;">
+    <div class="replace-picker-cancel-bar">
       <button class="btn" id="replace-picker-cancel">Cancel</button>
     </div>`);
 
   bindCancel(close);
   const modal = document.getElementById('replace-picker-modal');
   if (!modal) return;
-  modal.querySelectorAll('button[data-mbid]').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const targetMbid = btn.getAttribute('data-mbid') || '';
-      await runConfirm({
-        sourceRequestId: options.sourceRequestId,
-        targetMbid,
-        targetLabel: btn.textContent || targetMbid,
-      }, showOverlay, close);
+  wireRows(modal, async (targetMbid, rowLabel) => {
+    await runConfirm({
+      sourceRequestId: options.sourceRequestId,
+      targetMbid,
+      targetLabel: rowLabel,
+    }, showOverlay, close);
+  });
+  // Lazy-fill the "current request" tracklist. Failure here is non-fatal —
+  // the picker still works without the reference panel.
+  loadSourceTracklist(modal, sourceMbid, sourceLabel).catch(() => {});
+}
+
+/**
+ * Module-scoped cache for fetched MB releases — keyed by MBID. Drops on
+ * picker close because the modal HTML is wiped, not because the cache
+ * itself clears, so re-opening the picker against the same RG will
+ * re-fetch. That's fine: /api/release/<mbid> is Redis-cached server-side
+ * (24h TTL), so the second open is still effectively instant.
+ *
+ * @type {Map<string, Promise<{ tracks: TracklistTrack[] }>>}
+ */
+const tracklistCache = new Map();
+
+/**
+ * @param {string} mbid
+ * @returns {Promise<{ tracks: TracklistTrack[] }>}
+ */
+function fetchTracklist(mbid) {
+  const cached = tracklistCache.get(mbid);
+  if (cached) return cached;
+  const p = fetch(`/api/release/${encodeURIComponent(mbid)}`)
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = await res.json();
+      return { tracks: body.tracks || [] };
+    });
+  tracklistCache.set(mbid, p);
+  // If the fetch rejects, drop the cache entry so retries are possible.
+  p.catch(() => tracklistCache.delete(mbid));
+  return p;
+}
+
+/**
+ * Wire row-click expansion + confirm-button click for every picker row
+ * inside `root`.
+ *
+ * Row click toggles the tracklist + action panel. The first expansion
+ * lazy-fetches `/api/release/<mbid>` and renders the tracklist; later
+ * expansions just toggle visibility. The pick button (rendered inside
+ * the expanded panel) calls `onPick` with the row's MBID, its label,
+ * and the optional `data-rid` (inverted-mode existing-request id).
+ *
+ * @param {HTMLElement|Document} root
+ * @param {(mbid: string, label: string, rid: string | null) => void | Promise<void>} onPick
+ */
+function wireRows(root, onPick) {
+  root.querySelectorAll('.replace-picker-row').forEach((row) => {
+    const pickBtn = /** @type {HTMLButtonElement|null} */ (
+      row.querySelector('button.replace-picker-pick[data-expand-mbid]')
+    );
+    if (!pickBtn || pickBtn.disabled) return;
+    const mbid = pickBtn.getAttribute('data-expand-mbid') || '';
+    const panel = /** @type {HTMLElement|null} */ (
+      row.querySelector(`.replace-picker-detail[data-tracks-for="${cssEscape(mbid)}"]`)
+    );
+    const actionsSlot = /** @type {HTMLElement|null} */ (
+      row.querySelector(`.replace-picker-detail-actions-slot[data-actions-for="${cssEscape(mbid)}"]`)
+    );
+    if (!panel) return;
+
+    pickBtn.addEventListener('click', async (event) => {
+      event.stopPropagation();
+      const expanded = pickBtn.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        row.classList.remove('open');
+        pickBtn.setAttribute('aria-expanded', 'false');
+        if (actionsSlot) actionsSlot.hidden = true;
+        return;
+      }
+      row.classList.add('open');
+      pickBtn.setAttribute('aria-expanded', 'true');
+      if (actionsSlot) actionsSlot.hidden = false;
+      if (!panel.dataset.loaded) {
+        panel.innerHTML = '<p style="color:#888;margin:4px 0;">Loading tracklist…</p>';
+        try {
+          const { tracks } = await fetchTracklist(mbid);
+          panel.innerHTML = renderTracklist(tracks);
+          panel.dataset.loaded = '1';
+        } catch (err) {
+          panel.innerHTML = `<p style="color:#f66;margin:4px 0;">Failed to load: ${esc(String(err))}</p>`;
+        }
+      }
+    });
+
+    const confirmBtn = /** @type {HTMLButtonElement|null} */ (
+      row.querySelector('button.replace-picker-confirm')
+    );
+    if (!confirmBtn) return;
+    confirmBtn.addEventListener('click', async (event) => {
+      event.stopPropagation();
+      const label = (pickBtn.textContent || '').trim().split('\n')[0] || mbid;
+      const rid = confirmBtn.getAttribute('data-rid');
+      await onPick(mbid, label, rid);
     });
   });
+}
+
+/**
+ * Minimal CSS.escape replacement — picker MBIDs are UUIDs so the only
+ * character classes we need to handle are `[0-9a-f-]`, but we guard
+ * defensively anyway.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function cssEscape(s) {
+  if (typeof CSS !== 'undefined' && CSS && typeof CSS.escape === 'function') {
+    return CSS.escape(s);
+  }
+  return s.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+/**
+ * @param {HTMLElement} modal
+ * @param {string} sourceMbid
+ * @param {string} sourceLabel
+ */
+async function loadSourceTracklist(modal, sourceMbid, sourceLabel) {
+  const body = modal.querySelector('.replace-picker-source-body');
+  if (!body) return;
+  if (!sourceMbid) {
+    body.innerHTML = '<p style="color:#888;margin:4px 0;">No reference MBID for this request.</p>';
+    return;
+  }
+  try {
+    const { tracks } = await fetchTracklist(sourceMbid);
+    body.innerHTML = renderTracklist(tracks);
+  } catch (err) {
+    body.innerHTML = `<p style="color:#f66;margin:4px 0;">Failed to load reference tracklist: ${esc(String(err))}</p>`;
+  }
 }
 
 /**
@@ -404,24 +676,32 @@ async function runInverted(options, showOverlay, close) {
     return;
   }
 
-  showOverlay(`${renderInvertedHeader(options.targetLabel || options.targetMbid)}
+  const targetLabel = options.targetLabel || options.targetMbid;
+  const sourcePanel = renderSourcePanel({
+    label: targetLabel,
+    meta: '',
+    tracks: null,
+    loading: true,
+  });
+  showOverlay(`${renderInvertedHeader(targetLabel)}
+    ${sourcePanel}
     ${renderRequestsList(requests)}
-    <div class="actions" style="margin-top:12px;">
+    <div class="replace-picker-cancel-bar">
       <button class="btn" id="replace-picker-cancel">Cancel</button>
     </div>`);
   bindCancel(close);
   const modal = document.getElementById('replace-picker-modal');
   if (!modal) return;
-  modal.querySelectorAll('button[data-rid]').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const rid = Number(btn.getAttribute('data-rid'));
-      await runConfirm({
-        sourceRequestId: rid,
-        targetMbid: options.targetMbid,
-        targetLabel: options.targetLabel || options.targetMbid,
-      }, showOverlay, close);
-    });
+  wireRows(modal, async (_rowMbid, _rowLabel, ridAttr) => {
+    const rid = Number(ridAttr);
+    if (!Number.isFinite(rid)) return;
+    await runConfirm({
+      sourceRequestId: rid,
+      targetMbid: options.targetMbid,
+      targetLabel: options.targetLabel || options.targetMbid,
+    }, showOverlay, close);
   });
+  loadSourceTracklist(modal, options.targetMbid, targetLabel).catch(() => {});
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace picker rows match existing `.p-item` visual language: dark neutral shell, green left-border highlight on the open row, click-to-expand (no chevron), pick button inside the expanded detail.
- Pinned **Current request:** panel at top with `country · year · format · Nt` meta + lazy tracklist.
- Tracklists lazy-fetched from `/api/release/<mbid>` (Redis-cached server-side), memoised per-picker.
- Latent bug fixed: source MBID lookup read `drow.mb_release_id` but `/api/pipeline/<id>` wraps the row under `request`.

Closes #281 partially — distance-overlay follow-up coming in a separate PR.

## Test plan
- [x] `node tests/test_js_util.mjs` — 267 passed
- [ ] Open picker from Wrong-matches (standard mode) → reference panel + tracklists render
- [ ] Open picker from Browse search (inverted mode) → same behaviour, existing-request rows expand
- [ ] Click row → tracklist loads; click again → collapses; click pick button inside → confirm dialog (red destructive vibe preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)