### PR TITLE
feat(web): wrong-matches beets-distance overlay in Replace picker

### DIFF
--- a/lib/beets_distance.py
+++ b/lib/beets_distance.py
@@ -46,6 +46,18 @@ from typing import Callable, Optional, Protocol, Sequence
 
 import msgspec
 
+# Eager beets imports. Lazy-loading was tempting (the module is heavy
+# and quality_evidence/measurement do the same), but a sibling
+# ``tests/test_web_server.py`` adds ``tests/../lib`` to sys.path early
+# in the test session, which then shadows the upstream ``beets``
+# package whenever we lazily ``from beets import library`` later. By
+# importing eagerly here we lock in the right module at this file's
+# load time, before any test fixture can prepend lib/ to sys.path.
+from beets import library as _beets_library  # noqa: E402
+from beets.autotag import distance as _beets_distance_mod  # noqa: E402
+from beets.autotag import hooks as _beets_hooks  # noqa: E402
+from beets.autotag import match as _beets_match_mod  # noqa: E402
+
 
 log = logging.getLogger(__name__)
 
@@ -188,10 +200,8 @@ def _fingerprint_file(path: str) -> Optional[_AudioFileFingerprint]:
     deliberately don't raise: a single corrupt sidecar file shouldn't
     fail the whole picker query.
     """
-    from beets import library
-
     try:
-        item = library.Item.from_path(path)
+        item = _beets_library.Item.from_path(path)
     except Exception as exc:  # noqa: BLE001 — beets raises a mediafile mess
         log.warning("beets_distance: tag read failed for %s: %s", path, exc)
         return None
@@ -278,15 +288,13 @@ def _build_album_info(mb_release: dict, mbid: str):
     helpers skip the missing comparison (no penalty for unknowable
     fields — appropriate for picker-time triage).
     """
-    from beets.autotag import hooks
-
     tracks = []
     artist_name = mb_release.get("artist_name") or ""
     artist_id = mb_release.get("artist_id")
     for t in mb_release.get("tracks") or []:
         # MB pre-gap tracks ride as track_number=0; beets'
         # ``assign_items`` is fine with that.
-        tracks.append(hooks.TrackInfo(
+        tracks.append(_beets_hooks.TrackInfo(
             title=t.get("title") or "",
             track_id=None,
             artist=artist_name,
@@ -299,7 +307,7 @@ def _build_album_info(mb_release: dict, mbid: str):
 
     year = mb_release.get("year")
     rg_id = mb_release.get("release_group_id")
-    return hooks.AlbumInfo(
+    return _beets_hooks.AlbumInfo(
         tracks=tracks,
         album=mb_release.get("title") or "",
         album_id=mbid,
@@ -320,11 +328,9 @@ def _build_items(fingerprints: Sequence[_AudioFileFingerprint]):
     fingerprint cache — beets ``library.Item`` is a dict-like, so we
     just splat the fields in and skip the MediaFile roundtrip.
     """
-    from beets import library
-
     items = []
     for fp in fingerprints:
-        item = library.Item(
+        item = _beets_library.Item(
             path=fp.path.encode("utf-8"),
             title=fp.title,
             artist=fp.artist,
@@ -497,13 +503,11 @@ def compute_beets_distance(
 
     # 8. Hand to beets for the actual distance compute.
     try:
-        from beets.autotag import distance as distance_mod
-        from beets.autotag import match as match_mod
-
         album_info = _build_album_info(mb_release, mbid)
         items = _build_items(fingerprints)
-        mapping, extra_items, extra_tracks = match_mod.assign_items(items, album_info.tracks)
-        dist = distance_mod.distance(items, album_info, mapping)
+        mapping, extra_items, extra_tracks = _beets_match_mod.assign_items(
+            items, album_info.tracks)
+        dist = _beets_distance_mod.distance(items, album_info, mapping)
     except Exception as exc:  # noqa: BLE001 — beets bugs shouldn't 500 us
         return _result(
             "distance_failed",

--- a/lib/beets_distance.py
+++ b/lib/beets_distance.py
@@ -1,0 +1,588 @@
+"""Standalone beets-distance computation for the Replace picker.
+
+Given a ``download_log_id`` and a candidate MBID, return the beets match
+distance between the audio files at the download_log's failed_path and
+the MBID's MusicBrainz release. This is the same distance metric the
+beets importer uses, computed without booting the harness, the importer
+plugin chain, or any MB roundtrip beyond the one cached fetch.
+
+Guardrail (R1): the candidate MBID **must** belong to the same release
+group as the download_log's request. We refuse otherwise. The replace
+picker only ever needs to compare alternative pressings of the same
+album, and an MBID from an unrelated release group is almost certainly
+an operator slip — failing fast keeps the API hard to misuse.
+
+Speed: the dominant cost is reading tags off N audio files via beets'
+``Item.from_path``. We cache a JSON-serialisable fingerprint of each
+file's tag fields keyed by ``(absolute_path, mtime, size)``; subsequent
+calls reconstruct lightweight ``Item`` instances from the cache and
+never touch the filesystem again. MB releases are fetched through the
+existing web/mb.py memoiser (24h TTL). The distance compute itself is
+microseconds once both sides are in memory.
+
+The module surface is a pure service function plus its typed result:
+
+    compute_beets_distance(
+        download_log_id: int,
+        mbid: str,
+        *,
+        pdb: PipelineDB,
+        mb_get_release: Callable[[str], dict],
+        cache: BeetsDistanceCache | None = None,
+    ) -> BeetsDistanceResult
+
+Callers (web route + pipeline-cli) wrap the result into HTTP status
+codes / shell exit codes the same way ``mbid_replace_service`` and
+``search_plan_service`` do — see the CLI ⇄ API symmetry rule in
+``.claude/rules/code-quality.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Callable, Optional, Protocol, Sequence
+
+import msgspec
+
+
+log = logging.getLogger(__name__)
+
+
+# === Outcomes ===========================================================
+
+# Public outcome string set. Tests pin against these — adding a new
+# outcome is a contract change and must be reflected at the route /
+# CLI / frontend boundaries.
+OUTCOMES = (
+    "ok",
+    "download_log_not_found",
+    "request_not_found",
+    "folder_missing",
+    "no_audio",
+    "mb_lookup_failed",
+    "mb_no_release_group",
+    "wrong_release_group",
+    "distance_failed",
+)
+
+
+class BeetsDistanceResult(msgspec.Struct, kw_only=True):
+    """Typed result of a single distance computation.
+
+    Crosses the wire (HTTP response + CLI JSON output) so this is a
+    ``msgspec.Struct`` per the wire-boundary rule. Optional fields stay
+    ``None`` when the outcome is not ``ok``; ``error_message`` carries
+    the human-readable reason for any non-``ok`` outcome.
+    """
+
+    outcome: str
+    distance: Optional[float] = None
+    matched_tracks: Optional[int] = None
+    total_local_tracks: Optional[int] = None
+    total_mb_tracks: Optional[int] = None
+    extra_local_tracks: Optional[int] = None
+    extra_mb_tracks: Optional[int] = None
+    # Per-component distance breakdown — same names beets emits, useful
+    # when an operator wants to know "why is this 0.42?".
+    components: Optional[dict[str, float]] = None
+    # RG IDs for guardrail traceability. Always populated when we got
+    # far enough to look them up; ``None`` otherwise.
+    request_release_group_id: Optional[str] = None
+    candidate_release_group_id: Optional[str] = None
+    candidate_mbid: Optional[str] = None
+    download_log_id: Optional[int] = None
+    request_id: Optional[int] = None
+    folder_path: Optional[str] = None
+    error_message: Optional[str] = None
+    # Latency observability — useful in tests + the eventual UI.
+    duration_ms: Optional[int] = None
+
+
+# === Cache protocol =====================================================
+
+
+class BeetsDistanceCache(Protocol):
+    """Minimal key-value cache protocol the service depends on.
+
+    Implementations adapt Redis or any in-process dict. Production
+    wires this to the existing Redis client in ``web/_cache.py``; tests
+    pass a ``DictCache`` (see below) or ``None`` for "no caching".
+    """
+
+    def get(self, key: str) -> Optional[bytes]: ...
+    def set(self, key: str, value: bytes, ttl_seconds: int) -> None: ...
+
+
+class DictCache:
+    """In-memory ``BeetsDistanceCache`` for tests + single-process runs."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self._store.get(key)
+
+    def set(self, key: str, value: bytes, ttl_seconds: int) -> None:
+        self._store[key] = value
+
+
+# Reasonable defaults — folder reads are dominated by tag IO so a long
+# TTL is fine; files are keyed by ``(path, mtime, size)`` so any real
+# change invalidates the cache automatically.
+_FOLDER_CACHE_TTL_S = 7 * 24 * 60 * 60
+
+
+# === Audio-file fingerprint (JSON-safe) =================================
+
+
+class _AudioFileFingerprint(msgspec.Struct):
+    """Subset of beets ``Item`` fields needed to compute distance.
+
+    Kept narrow on purpose — broadening this without intent leads to
+    cache size creep and slow first-reads. Add fields only when distance
+    actually reads them.
+    """
+
+    path: str
+    mtime: float
+    size: int
+    title: str
+    artist: str
+    album: str
+    albumartist: str
+    track: int
+    tracktotal: int
+    disc: int
+    disctotal: int
+    length: float
+    format: str
+    media: str
+
+
+def _audio_files_under(folder: str) -> list[str]:
+    """Return absolute paths to audio files under ``folder``.
+
+    Sorts for deterministic ordering — beets distance is order-
+    insensitive but stable ordering makes the cache key stable, the
+    test assertions stable, and the per-track distance breakdown
+    consistent across runs.
+    """
+    from lib.measurement import AUDIO_EXTS
+
+    out: list[str] = []
+    for root, _dirs, files in os.walk(folder):
+        for f in files:
+            ext = f.rsplit(".", 1)[-1].lower() if "." in f else ""
+            if ext in AUDIO_EXTS:
+                out.append(os.path.join(root, f))
+    out.sort()
+    return out
+
+
+def _fingerprint_file(path: str) -> Optional[_AudioFileFingerprint]:
+    """Read tags via beets ``Item.from_path`` and project to fingerprint.
+
+    Returns ``None`` if the file can't be read — caller skips it. We
+    deliberately don't raise: a single corrupt sidecar file shouldn't
+    fail the whole picker query.
+    """
+    from beets import library
+
+    try:
+        item = library.Item.from_path(path)
+    except Exception as exc:  # noqa: BLE001 — beets raises a mediafile mess
+        log.warning("beets_distance: tag read failed for %s: %s", path, exc)
+        return None
+
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+
+    # Beets Item exposes tag fields as attributes (LightFlavoredDict).
+    return _AudioFileFingerprint(
+        path=path,
+        mtime=st.st_mtime,
+        size=st.st_size,
+        title=str(item.get("title", "") or ""),
+        artist=str(item.get("artist", "") or ""),
+        album=str(item.get("album", "") or ""),
+        albumartist=str(item.get("albumartist", "") or ""),
+        track=int(item.get("track", 0) or 0),
+        tracktotal=int(item.get("tracktotal", 0) or 0),
+        disc=int(item.get("disc", 0) or 0),
+        disctotal=int(item.get("disctotal", 0) or 0),
+        length=float(item.get("length", 0.0) or 0.0),
+        format=str(item.get("format", "") or ""),
+        media=str(item.get("media", "") or ""),
+    )
+
+
+def _read_folder_fingerprints(
+    folder: str,
+    cache: Optional[BeetsDistanceCache],
+) -> list[_AudioFileFingerprint]:
+    """Read fingerprints for every audio file under ``folder``.
+
+    Per-file cache keyed by ``(path, mtime, size)``: if any of those
+    change the cache misses and the file is re-read. We don't cache the
+    folder-level list because the same folder can gain or lose files
+    without any individual file's stats changing — the os.walk is cheap
+    relative to tag reads.
+    """
+    fps: list[_AudioFileFingerprint] = []
+    for path in _audio_files_under(folder):
+        try:
+            st = os.stat(path)
+        except OSError:
+            continue
+        cached: Optional[_AudioFileFingerprint] = None
+        if cache is not None:
+            blob = cache.get(_file_cache_key(path, st.st_mtime, st.st_size))
+            if blob:
+                try:
+                    cached = msgspec.json.decode(blob, type=_AudioFileFingerprint)
+                except msgspec.ValidationError:
+                    cached = None
+        if cached is not None and cached.mtime == st.st_mtime and cached.size == st.st_size:
+            fps.append(cached)
+            continue
+        fp = _fingerprint_file(path)
+        if fp is None:
+            continue
+        fps.append(fp)
+        if cache is not None:
+            cache.set(
+                _file_cache_key(path, st.st_mtime, st.st_size),
+                msgspec.json.encode(fp),
+                _FOLDER_CACHE_TTL_S,
+            )
+    return fps
+
+
+def _file_cache_key(path: str, mtime: float, size: int) -> str:
+    # mtime as int-seconds is enough resolution and keeps the key short.
+    return f"beets-distance:fp:{path}:{int(mtime)}:{size}"
+
+
+# === MB → AlbumInfo / TrackInfo conversion ==============================
+
+
+def _build_album_info(mb_release: dict, mbid: str):
+    """Construct a beets ``AlbumInfo`` from the local MB mirror's JSON.
+
+    Only fields beets ``distance()`` actually reads are populated.
+    Anything not in the MB payload stays ``None`` and beets' distance
+    helpers skip the missing comparison (no penalty for unknowable
+    fields — appropriate for picker-time triage).
+    """
+    from beets.autotag import hooks
+
+    tracks = []
+    artist_name = mb_release.get("artist_name") or ""
+    artist_id = mb_release.get("artist_id")
+    for t in mb_release.get("tracks") or []:
+        # MB pre-gap tracks ride as track_number=0; beets'
+        # ``assign_items`` is fine with that.
+        tracks.append(hooks.TrackInfo(
+            title=t.get("title") or "",
+            track_id=None,
+            artist=artist_name,
+            artist_id=artist_id,
+            length=t.get("length_seconds"),
+            index=t.get("track_number") or None,
+            medium=t.get("disc_number") or 1,
+            medium_index=t.get("track_number") or None,
+        ))
+
+    year = mb_release.get("year")
+    rg_id = mb_release.get("release_group_id")
+    return hooks.AlbumInfo(
+        tracks=tracks,
+        album=mb_release.get("title") or "",
+        album_id=mbid,
+        artist=artist_name,
+        artist_id=artist_id,
+        releasegroup_id=rg_id,
+        year=year if isinstance(year, int) else None,
+        country=mb_release.get("country") or None,
+        albumstatus=mb_release.get("status") or None,
+        va=False,
+    )
+
+
+def _build_items(fingerprints: Sequence[_AudioFileFingerprint]):
+    """Construct in-memory beets ``Item`` instances from fingerprints.
+
+    Reconstructing rather than re-reading is the whole point of the
+    fingerprint cache — beets ``library.Item`` is a dict-like, so we
+    just splat the fields in and skip the MediaFile roundtrip.
+    """
+    from beets import library
+
+    items = []
+    for fp in fingerprints:
+        item = library.Item(
+            path=fp.path.encode("utf-8"),
+            title=fp.title,
+            artist=fp.artist,
+            album=fp.album,
+            albumartist=fp.albumartist,
+            track=fp.track,
+            tracktotal=fp.tracktotal,
+            disc=fp.disc,
+            disctotal=fp.disctotal,
+            length=fp.length,
+            format=fp.format,
+            media=fp.media,
+        )
+        items.append(item)
+    return items
+
+
+# === Service entrypoint =================================================
+
+
+def compute_beets_distance(
+    download_log_id: int,
+    mbid: str,
+    *,
+    pdb,  # lib.pipeline_db.PipelineDB — duck-typed for test fakes
+    mb_get_release: Callable[[str], Optional[dict]],
+    cache: Optional[BeetsDistanceCache] = None,
+    resolve_failed_path: Optional[Callable[[str], Optional[str]]] = None,
+) -> BeetsDistanceResult:
+    """Compute beets match distance for one ``(download_log_id, mbid)``.
+
+    Service-layer entrypoint. Pure of HTTP/CLI concerns; callers map the
+    typed result onto status codes / exit codes (CLI ⇄ API symmetry).
+
+    Guardrails before any heavy work:
+      1. download_log row must exist;
+      2. request row for that log must exist;
+      3. MB release for ``mbid`` must be fetchable;
+      4. MB release must belong to a release group;
+      5. that release group MUST equal the request's release group.
+
+    Only after all five does the function touch the filesystem.
+    """
+    started = time.monotonic()
+
+    # 1. Load the download_log entry.
+    log_row = pdb.get_download_log_entry(download_log_id)
+    if not log_row:
+        return _result(
+            "download_log_not_found",
+            error=f"download_log #{download_log_id} not found",
+            download_log_id=download_log_id,
+            candidate_mbid=mbid,
+            started=started,
+        )
+
+    # 2. Load the request for its release group.
+    request_id = log_row.get("request_id")
+    if not isinstance(request_id, int):
+        return _result(
+            "request_not_found",
+            error="download_log row has no request_id",
+            download_log_id=download_log_id,
+            candidate_mbid=mbid,
+            started=started,
+        )
+    req = pdb.get_request(request_id)
+    if not req:
+        return _result(
+            "request_not_found",
+            error=f"request #{request_id} not found",
+            download_log_id=download_log_id,
+            request_id=request_id,
+            candidate_mbid=mbid,
+            started=started,
+        )
+    request_rg = req.get("mb_release_group_id")
+
+    # 3. Fetch MB release for the candidate mbid.
+    try:
+        mb_release = mb_get_release(mbid)
+    except Exception as exc:  # noqa: BLE001 — upstream errors vary
+        return _result(
+            "mb_lookup_failed",
+            error=f"MB lookup for {mbid} failed: {exc}",
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_mbid=mbid,
+            started=started,
+        )
+    if not mb_release:
+        return _result(
+            "mb_lookup_failed",
+            error=f"MB lookup for {mbid} returned empty",
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_mbid=mbid,
+            started=started,
+        )
+    candidate_rg = mb_release.get("release_group_id")
+
+    # 4. MB release must have a release group (legacy / non-MB rows fail here).
+    if not candidate_rg:
+        return _result(
+            "mb_no_release_group",
+            error=f"MB release {mbid} has no release_group_id",
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_mbid=mbid,
+            started=started,
+        )
+
+    # 5. Guardrail — refuse cross-RG distance queries.
+    if request_rg and request_rg != candidate_rg:
+        return _result(
+            "wrong_release_group",
+            error=(
+                f"MBID {mbid} is in release group {candidate_rg}, "
+                f"which differs from request #{request_id}'s release "
+                f"group {request_rg}"
+            ),
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_release_group_id=candidate_rg,
+            candidate_mbid=mbid,
+            started=started,
+        )
+
+    # 6. Resolve the on-disk path for the rejected download.
+    vr = log_row.get("validation_result") or {}
+    failed_path = (vr.get("failed_path") if isinstance(vr, dict) else None) or ""
+    resolver = resolve_failed_path
+    if resolver is None:
+        from lib.util import resolve_failed_path as default_resolver
+        resolver = default_resolver
+    resolved = resolver(str(failed_path)) if failed_path else None
+    if not resolved:
+        return _result(
+            "folder_missing",
+            error=(
+                f"download_log #{download_log_id} failed_path "
+                f"{failed_path!r} does not exist on disk"
+            ),
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_release_group_id=candidate_rg,
+            candidate_mbid=mbid,
+            started=started,
+        )
+
+    # 7. Read (or cache-hit) audio fingerprints.
+    fingerprints = _read_folder_fingerprints(resolved, cache)
+    if not fingerprints:
+        return _result(
+            "no_audio",
+            error=f"no readable audio files under {resolved}",
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_release_group_id=candidate_rg,
+            candidate_mbid=mbid,
+            folder_path=resolved,
+            started=started,
+        )
+
+    # 8. Hand to beets for the actual distance compute.
+    try:
+        from beets.autotag import distance as distance_mod
+        from beets.autotag import match as match_mod
+
+        album_info = _build_album_info(mb_release, mbid)
+        items = _build_items(fingerprints)
+        mapping, extra_items, extra_tracks = match_mod.assign_items(items, album_info.tracks)
+        dist = distance_mod.distance(items, album_info, mapping)
+    except Exception as exc:  # noqa: BLE001 — beets bugs shouldn't 500 us
+        return _result(
+            "distance_failed",
+            error=f"beets distance failed: {exc}",
+            download_log_id=download_log_id,
+            request_id=request_id,
+            request_release_group_id=request_rg,
+            candidate_release_group_id=candidate_rg,
+            candidate_mbid=mbid,
+            folder_path=resolved,
+            total_local_tracks=len(fingerprints),
+            total_mb_tracks=len(mb_release.get("tracks") or []),
+            started=started,
+        )
+
+    # 9. Extract per-component scores so the caller can show "why 0.42?"
+    components: dict[str, float] = {}
+    try:
+        for k, v in dist.items():
+            try:
+                components[str(k)] = float(v)
+            except (TypeError, ValueError):
+                continue
+    except Exception:  # noqa: BLE001 — Distance API varies across beets versions
+        components = {}
+
+    return _result(
+        "ok",
+        distance=float(dist.distance),
+        matched_tracks=len(mapping),
+        total_local_tracks=len(items),
+        total_mb_tracks=len(album_info.tracks),
+        extra_local_tracks=len(extra_items),
+        extra_mb_tracks=len(extra_tracks),
+        components=components,
+        download_log_id=download_log_id,
+        request_id=request_id,
+        request_release_group_id=request_rg,
+        candidate_release_group_id=candidate_rg,
+        candidate_mbid=mbid,
+        folder_path=resolved,
+        started=started,
+    )
+
+
+def _result(
+    outcome: str,
+    *,
+    distance: Optional[float] = None,
+    matched_tracks: Optional[int] = None,
+    total_local_tracks: Optional[int] = None,
+    total_mb_tracks: Optional[int] = None,
+    extra_local_tracks: Optional[int] = None,
+    extra_mb_tracks: Optional[int] = None,
+    components: Optional[dict[str, float]] = None,
+    request_release_group_id: Optional[str] = None,
+    candidate_release_group_id: Optional[str] = None,
+    candidate_mbid: Optional[str] = None,
+    download_log_id: Optional[int] = None,
+    request_id: Optional[int] = None,
+    folder_path: Optional[str] = None,
+    error: Optional[str] = None,
+    started: float,
+) -> BeetsDistanceResult:
+    return BeetsDistanceResult(
+        outcome=outcome,
+        distance=distance,
+        matched_tracks=matched_tracks,
+        total_local_tracks=total_local_tracks,
+        total_mb_tracks=total_mb_tracks,
+        extra_local_tracks=extra_local_tracks,
+        extra_mb_tracks=extra_mb_tracks,
+        components=components,
+        request_release_group_id=request_release_group_id,
+        candidate_release_group_id=candidate_release_group_id,
+        candidate_mbid=candidate_mbid,
+        download_log_id=download_log_id,
+        request_id=request_id,
+        folder_path=folder_path,
+        error_message=error,
+        duration_ms=int((time.monotonic() - started) * 1000),
+    )

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1798,6 +1798,91 @@ def cmd_replace(db, args):
     return 1
 
 
+def cmd_beets_distance(db, args):
+    """Real beets-distance between a download_log's failed_path and an MBID.
+
+    Counterpart of ``GET /api/beets-distance/<download_log_id>/<mbid>``.
+    Both surfaces wrap ``lib.beets_distance.compute_beets_distance`` —
+    keep them in sync (see ``CLAUDE.md`` § "CLI ⇄ API surface
+    symmetry").
+
+    Exit codes:
+      * 0 — ``ok``
+      * 2 — ``download_log_not_found``, ``request_not_found``
+      * 3 — ``mb_no_release_group``, ``wrong_release_group`` (semantic
+            input violations, including the cross-RG guardrail)
+      * 4 — ``folder_missing``, ``no_audio`` (the artifacts we wanted
+            to compare are gone)
+      * 5 — ``mb_lookup_failed`` (transient MB-mirror failure)
+      * 1 — ``distance_failed`` / unknown outcome
+    """
+    from lib.beets_distance import compute_beets_distance
+    from web import mb as mb_api
+
+    result = compute_beets_distance(
+        int(args.download_log_id),
+        args.mbid,
+        pdb=db,
+        mb_get_release=lambda m: mb_api.get_release(m, fresh=False),
+        cache=None,
+    )
+
+    payload = {
+        "outcome": result.outcome,
+        "distance": result.distance,
+        "matched_tracks": result.matched_tracks,
+        "total_local_tracks": result.total_local_tracks,
+        "total_mb_tracks": result.total_mb_tracks,
+        "extra_local_tracks": result.extra_local_tracks,
+        "extra_mb_tracks": result.extra_mb_tracks,
+        "components": result.components,
+        "request_release_group_id": result.request_release_group_id,
+        "candidate_release_group_id": result.candidate_release_group_id,
+        "candidate_mbid": result.candidate_mbid,
+        "download_log_id": result.download_log_id,
+        "request_id": result.request_id,
+        "folder_path": result.folder_path,
+        "error_message": result.error_message,
+        "duration_ms": result.duration_ms,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+    else:
+        print(f"  download_log_id:        {result.download_log_id}")
+        print(f"  request_id:             {result.request_id}")
+        print(f"  candidate_mbid:         {result.candidate_mbid}")
+        print(f"  outcome:                {result.outcome}")
+        if result.distance is not None:
+            print(f"  distance:               {result.distance:.4f}")
+        if result.matched_tracks is not None:
+            print(f"  matched tracks:         "
+                  f"{result.matched_tracks} / {result.total_mb_tracks} "
+                  f"({result.total_local_tracks} local)")
+        if result.components:
+            print("  components:")
+            for k, v in sorted(result.components.items()):
+                print(f"    {k:<24} {v:.4f}")
+        if result.folder_path:
+            print(f"  folder:                 {result.folder_path}")
+        if result.duration_ms is not None:
+            print(f"  latency:                {result.duration_ms} ms")
+        if result.error_message:
+            print(f"  error:                  {result.error_message}")
+
+    if result.outcome == "ok":
+        return 0
+    if result.outcome in ("download_log_not_found", "request_not_found"):
+        return 2
+    if result.outcome in ("mb_no_release_group", "wrong_release_group"):
+        return 3
+    if result.outcome in ("folder_missing", "no_audio"):
+        return 4
+    if result.outcome == "mb_lookup_failed":
+        return 5
+    return 1
+
+
 def cmd_search_plan_advance(db, args):
     """Forward-only operator advance of the search-plan cursor.
 
@@ -2177,6 +2262,18 @@ def main():
     p_replace.add_argument("--json", action="store_true",
                            help="Print structured JSON instead of text")
 
+    # beets-distance
+    p_bd = sub.add_parser(
+        "beets-distance",
+        help="Real beets-distance between a download_log's audio and an MBID "
+             "(refuses if MBID is outside the request's release group)")
+    p_bd.add_argument("download_log_id", type=int,
+                      help="download_log row id (see `pipeline-cli show <req>`)")
+    p_bd.add_argument("mbid",
+                      help="Candidate MB release UUID")
+    p_bd.add_argument("--json", action="store_true",
+                      help="Print structured JSON instead of text")
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -2208,6 +2305,7 @@ def main():
         "wrong-match-delete-group": cmd_wrong_match_delete_group,
         "repair-spectral": cmd_repair_spectral,
         "replace": cmd_replace,
+        "beets-distance": cmd_beets_distance,
     }
     search_plan_commands = {
         "show": cmd_search_plan_show,

--- a/tests/test_beets_distance.py
+++ b/tests/test_beets_distance.py
@@ -342,9 +342,13 @@ class TestBeetsDistanceIntegrationSlice(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         # Read the fixture's real length once so MB tracks line up
-        # with whatever the on-disk file actually decodes to.
-        from beets import library
-        item = library.Item.from_path(FIXTURE_FLAC)
+        # with whatever the on-disk file actually decodes to. Import
+        # via ``lib.beets_distance`` which holds an eager reference to
+        # the upstream ``beets.library`` module — guards against the
+        # sys.path leak where other tests inject ``tests/../lib`` and
+        # shadow the real ``beets`` package.
+        from lib.beets_distance import _beets_library
+        item = _beets_library.Item.from_path(FIXTURE_FLAC)
         cls.fixture_length = float(item.get("length") or 1.0)
 
     def _build_request_and_mb(self, *, artist: str, album: str, titles: list[str]):

--- a/tests/test_beets_distance.py
+++ b/tests/test_beets_distance.py
@@ -1,0 +1,494 @@
+"""Tests for ``lib.beets_distance.compute_beets_distance``.
+
+Covers the outcome matrix end-to-end. Filesystem-touching paths use a
+temp directory + a real audio fixture (copied from
+``tests/fixtures/audio_hash``) tagged via ``music_tag``; non-FS paths
+use a tiny stub DB so we exercise the real service logic without
+mocking the function under test.
+
+The integration slice in ``TestBeetsDistanceIntegrationSlice`` is the
+authoritative coverage of the happy path — it runs the real beets
+distance computation against real on-disk files and asserts the result
+is in a sane range and that the cache fast-path returns the same
+number on a second call (mtime-stable).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+from typing import Optional
+
+import music_tag
+
+from lib.beets_distance import (
+    BeetsDistanceCache,
+    BeetsDistanceResult,
+    DictCache,
+    OUTCOMES,
+    compute_beets_distance,
+)
+
+
+FIXTURE_FLAC = os.path.join(
+    os.path.dirname(__file__), "fixtures", "audio_hash", "sine_440.flac")
+
+
+class _StubPDB:
+    """Tiny ``PipelineDB`` stand-in for the service tests.
+
+    Only the two methods ``compute_beets_distance`` touches are
+    implemented; ``FakePipelineDB`` in ``tests/fakes.py`` is overkill
+    for a 1-call read path and would couple this test file to its
+    unrelated schema.
+    """
+
+    def __init__(
+        self,
+        *,
+        download_log_entry: Optional[dict] = None,
+        request: Optional[dict] = None,
+    ) -> None:
+        self._dl = download_log_entry
+        self._request = request
+
+    def get_download_log_entry(self, log_id):
+        if self._dl is None:
+            return None
+        if self._dl.get("id") != log_id:
+            return None
+        return dict(self._dl)
+
+    def get_request(self, request_id):
+        if self._request is None or self._request.get("id") != request_id:
+            return None
+        return dict(self._request)
+
+
+def _ok_mb_release(
+    *,
+    mbid: str = "rel-aaa",
+    rg: str = "rg-shared",
+    artist: str = "Dr. Octagon",
+    album: str = "Dr. Octagonecologyst",
+    tracks: Optional[list[dict]] = None,
+):
+    return {
+        "id": mbid,
+        "title": album,
+        "artist_name": artist,
+        "artist_id": "artist-1",
+        "release_group_id": rg,
+        "date": "1996-05-07",
+        "year": 1996,
+        "country": "US",
+        "status": "Official",
+        "tracks": tracks if tracks is not None else [
+            {"disc_number": 1, "track_number": 1, "title": "Intro", "length_seconds": 60.0},
+            {"disc_number": 1, "track_number": 2, "title": "3000",  "length_seconds": 180.0},
+        ],
+    }
+
+
+# ============================================================================
+# Outcome-matrix tests — DB/MB/disk are stubbed, every branch is one subTest.
+# ============================================================================
+
+
+class TestComputeBeetsDistanceOutcomes(unittest.TestCase):
+    """Every outcome in ``OUTCOMES`` reachable from a single subTest table.
+
+    Each row drives ``compute_beets_distance`` to exactly one outcome.
+    ``ok`` is exercised by the integration slice further down (it needs
+    a real audio file).
+    """
+
+    def test_outcome_set_is_stable(self) -> None:
+        """Adding/removing an outcome is a wire-contract change — pin it."""
+        self.assertEqual(
+            set(OUTCOMES),
+            {
+                "ok",
+                "download_log_not_found",
+                "request_not_found",
+                "folder_missing",
+                "no_audio",
+                "mb_lookup_failed",
+                "mb_no_release_group",
+                "wrong_release_group",
+                "distance_failed",
+            },
+        )
+
+    def test_download_log_not_found(self) -> None:
+        pdb = _StubPDB()  # no download_log
+        r = compute_beets_distance(
+            42, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid),
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "download_log_not_found")
+        self.assertIsNone(r.distance)
+        self.assertEqual(r.download_log_id, 42)
+        self.assertEqual(r.candidate_mbid, "rel-x")
+
+    def test_request_not_found_when_log_has_no_request(self) -> None:
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": None},
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid),
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "request_not_found")
+
+    def test_request_not_found_when_request_missing(self) -> None:
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 99},
+            request=None,
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid),
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "request_not_found")
+
+    def test_mb_lookup_failed_when_returns_empty(self) -> None:
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7},
+            request={"id": 7, "mb_release_group_id": "rg-shared"},
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: None,
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "mb_lookup_failed")
+        self.assertEqual(r.request_release_group_id, "rg-shared")
+
+    def test_mb_lookup_failed_on_exception(self) -> None:
+        def _boom(mbid):
+            raise RuntimeError("MB mirror down")
+
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7},
+            request={"id": 7, "mb_release_group_id": "rg-shared"},
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=_boom,
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "mb_lookup_failed")
+        assert r.error_message is not None
+        self.assertIn("MB mirror down", r.error_message)
+
+    def test_mb_no_release_group(self) -> None:
+        mb = _ok_mb_release(mbid="rel-x")
+        mb["release_group_id"] = None
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7},
+            request={"id": 7, "mb_release_group_id": "rg-shared"},
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: mb,
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "mb_no_release_group")
+
+    def test_wrong_release_group_guardrail(self) -> None:
+        """The sanity-stop: candidate MBID in a different RG → refuse."""
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7,
+                                "validation_result": {"failed_path": "/whatever"}},
+            request={"id": 7, "mb_release_group_id": "rg-source"},
+        )
+        r = compute_beets_distance(
+            1, "rel-alien",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid, rg="rg-other"),
+            resolve_failed_path=lambda p: p,
+        )
+        self.assertEqual(r.outcome, "wrong_release_group")
+        self.assertEqual(r.request_release_group_id, "rg-source")
+        self.assertEqual(r.candidate_release_group_id, "rg-other")
+        # Guardrail must fire BEFORE filesystem access.
+        # (We never resolved a path — fingerprints/distance never ran.)
+        self.assertIsNone(r.folder_path)
+        self.assertIsNone(r.distance)
+
+    def test_wrong_release_group_passes_when_request_rg_is_null(self) -> None:
+        """If the request has no RG (legacy row), we can't refuse — fall through.
+
+        Documenting the asymmetry: the guardrail only fires when *both*
+        sides know their release group. A null request RG drops us into
+        the rest of the pipeline, which will fail later (folder_missing
+        or no_audio) but on a different signal.
+        """
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7,
+                                "validation_result": {"failed_path": "/missing"}},
+            request={"id": 7, "mb_release_group_id": None},
+        )
+        r = compute_beets_distance(
+            1, "rel-alien",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid, rg="rg-other"),
+            resolve_failed_path=lambda p: None,  # file not on disk
+        )
+        self.assertEqual(r.outcome, "folder_missing")  # not wrong_release_group
+        self.assertEqual(r.candidate_release_group_id, "rg-other")
+
+    def test_folder_missing(self) -> None:
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7,
+                                "validation_result": {"failed_path": "/not/there"}},
+            request={"id": 7, "mb_release_group_id": "rg-shared"},
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid),
+            resolve_failed_path=lambda p: None,
+        )
+        self.assertEqual(r.outcome, "folder_missing")
+
+    def test_folder_missing_when_validation_result_absent(self) -> None:
+        pdb = _StubPDB(
+            download_log_entry={"id": 1, "request_id": 7,
+                                "validation_result": None},
+            request={"id": 7, "mb_release_group_id": "rg-shared"},
+        )
+        r = compute_beets_distance(
+            1, "rel-x",
+            pdb=pdb,
+            mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid),
+            resolve_failed_path=lambda p: None,
+        )
+        self.assertEqual(r.outcome, "folder_missing")
+
+    def test_no_audio_when_folder_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pdb = _StubPDB(
+                download_log_entry={"id": 1, "request_id": 7,
+                                    "validation_result": {"failed_path": tmp}},
+                request={"id": 7, "mb_release_group_id": "rg-shared"},
+            )
+            r = compute_beets_distance(
+                1, "rel-x",
+                pdb=pdb,
+                mb_get_release=lambda mbid: _ok_mb_release(mbid=mbid),
+                resolve_failed_path=lambda p: p,
+            )
+            self.assertEqual(r.outcome, "no_audio")
+            self.assertEqual(r.folder_path, tmp)
+
+
+# ============================================================================
+# Integration slice — real beets distance against real on-disk audio.
+# ============================================================================
+
+
+def _make_tagged_folder(
+    target_dir: str,
+    tracks: list[dict],
+) -> None:
+    """Copy the sine fixture N times into ``target_dir`` and apply tags.
+
+    Each ``tracks[i]`` dict supplies the tag fields. We use FLAC because
+    the fixture set already contains a FLAC; sine_440.mp3 would work
+    too. Length is fixed (the fixture is ~1s) — distance compares to
+    ``length_seconds`` on the MB side, so we set the MB lengths to
+    match the fixture for a clean ``ok``.
+    """
+    for i, t in enumerate(tracks):
+        dest = os.path.join(target_dir, f"{i + 1:02d} - {t['title']}.flac")
+        shutil.copyfile(FIXTURE_FLAC, dest)
+        f = music_tag.load_file(dest)
+        assert f is not None
+        f["artist"] = t["artist"]
+        f["album"] = t["album"]
+        f["albumartist"] = t.get("albumartist", t["artist"])
+        f["title"] = t["title"]
+        f["tracknumber"] = t["track"]
+        f["totaltracks"] = len(tracks)
+        f["discnumber"] = t.get("disc", 1)
+        f.save()
+
+
+class TestBeetsDistanceIntegrationSlice(unittest.TestCase):
+    """Drive the real beets distance pipeline end-to-end.
+
+    The fixture FLACs are ~1 s; we tag them with realistic metadata
+    and point MB-side TrackInfo lengths at the fixture's true length
+    so a clean tag set produces a small distance. Then we mutate the
+    tags and confirm the distance grows. That's enough signal to
+    prove the real beets distance call is plumbed correctly without
+    coupling to specific numeric values that the beets default
+    weights can shift between versions.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Read the fixture's real length once so MB tracks line up
+        # with whatever the on-disk file actually decodes to.
+        from beets import library
+        item = library.Item.from_path(FIXTURE_FLAC)
+        cls.fixture_length = float(item.get("length") or 1.0)
+
+    def _build_request_and_mb(self, *, artist: str, album: str, titles: list[str]):
+        tracks = [
+            {
+                "disc_number": 1,
+                "track_number": i + 1,
+                "title": title,
+                "length_seconds": self.fixture_length,
+            }
+            for i, title in enumerate(titles)
+        ]
+        mb = {
+            "id": "rel-aaa",
+            "title": album,
+            "artist_name": artist,
+            "artist_id": "artist-1",
+            "release_group_id": "rg-shared",
+            "year": 2020,
+            "date": "2020-01-01",
+            "country": "US",
+            "status": "Official",
+            "tracks": tracks,
+        }
+        return mb
+
+    def _run_compute(
+        self,
+        *,
+        folder: str,
+        mb: dict,
+        cache: Optional[BeetsDistanceCache] = None,
+    ) -> BeetsDistanceResult:
+        pdb = _StubPDB(
+            download_log_entry={
+                "id": 100,
+                "request_id": 7,
+                "validation_result": {"failed_path": folder},
+            },
+            request={"id": 7, "mb_release_group_id": "rg-shared"},
+        )
+        return compute_beets_distance(
+            100, "rel-aaa",
+            pdb=pdb,
+            mb_get_release=lambda mbid: mb,
+            resolve_failed_path=lambda p: p,
+            cache=cache,
+        )
+
+    def test_clean_match_is_low_distance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_tagged_folder(tmp, [
+                {"title": "Intro",  "artist": "Dr. Octagon", "album": "Dr. Octagonecologyst", "track": 1},
+                {"title": "3000",   "artist": "Dr. Octagon", "album": "Dr. Octagonecologyst", "track": 2},
+            ])
+            mb = self._build_request_and_mb(
+                artist="Dr. Octagon",
+                album="Dr. Octagonecologyst",
+                titles=["Intro", "3000"],
+            )
+            r = self._run_compute(folder=tmp, mb=mb)
+
+            self.assertEqual(r.outcome, "ok", msg=r.error_message)
+            assert r.distance is not None
+            self.assertGreaterEqual(r.distance, 0.0)
+            self.assertLess(r.distance, 0.5, msg="clean tag match should score < 0.5")
+            self.assertEqual(r.matched_tracks, 2)
+            self.assertEqual(r.total_local_tracks, 2)
+            self.assertEqual(r.total_mb_tracks, 2)
+            assert r.duration_ms is not None
+            # First-read latency: tag IO + beets fit. Generous ceiling
+            # so the test doesn't flake on slow CI; the cached-fast-path
+            # test below pins what "fast" actually means.
+            self.assertLess(r.duration_ms, 10_000)
+
+    def test_wrong_album_metadata_is_higher_distance(self) -> None:
+        """Sanity: mistagged folder vs. correct MB → distance grows."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_tagged_folder(tmp, [
+                {"title": "Nothing Like It",  "artist": "Other Person", "album": "Wrong Album", "track": 1},
+                {"title": "Some Other Song",  "artist": "Other Person", "album": "Wrong Album", "track": 2},
+            ])
+            mb = self._build_request_and_mb(
+                artist="Dr. Octagon",
+                album="Dr. Octagonecologyst",
+                titles=["Intro", "3000"],
+            )
+            r = self._run_compute(folder=tmp, mb=mb)
+            self.assertEqual(r.outcome, "ok", msg=r.error_message)
+            assert r.distance is not None
+            self.assertGreater(r.distance, 0.3,
+                msg="mismatched album metadata should score > 0.3")
+
+    def test_cache_makes_second_call_fast(self) -> None:
+        """Same folder, same MB → second compute reuses cached fingerprints.
+
+        First call: tag IO across N files (slow).
+        Second call: cache hit, no FS reads beyond os.walk + stat.
+
+        We don't assert a hard wall-clock bound — flaky on shared
+        hardware. Instead we assert (a) the cache picked up entries,
+        and (b) the second call returns the same distance bit-for-bit
+        (proves we round-tripped through the cache without drift).
+        """
+        cache = DictCache()
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_tagged_folder(tmp, [
+                {"title": "Intro",  "artist": "Dr. Octagon", "album": "Dr. Octagonecologyst", "track": 1},
+                {"title": "3000",   "artist": "Dr. Octagon", "album": "Dr. Octagonecologyst", "track": 2},
+            ])
+            mb = self._build_request_and_mb(
+                artist="Dr. Octagon",
+                album="Dr. Octagonecologyst",
+                titles=["Intro", "3000"],
+            )
+            r1 = self._run_compute(folder=tmp, mb=mb, cache=cache)
+            self.assertEqual(r1.outcome, "ok")
+            # Two files → two cache entries.
+            self.assertEqual(len(cache._store), 2)
+            r2 = self._run_compute(folder=tmp, mb=mb, cache=cache)
+            self.assertEqual(r2.outcome, "ok")
+            self.assertEqual(r1.distance, r2.distance,
+                msg="cached fingerprint round-trip must reproduce the same distance")
+
+    def test_distance_result_serializes_to_json(self) -> None:
+        """Wire-boundary smoke test: result encodes via msgspec without error."""
+        import msgspec
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_tagged_folder(tmp, [
+                {"title": "Intro",  "artist": "Dr. Octagon", "album": "Dr. Octagonecologyst", "track": 1},
+            ])
+            mb = self._build_request_and_mb(
+                artist="Dr. Octagon",
+                album="Dr. Octagonecologyst",
+                titles=["Intro"],
+            )
+            r = self._run_compute(folder=tmp, mb=mb)
+            self.assertEqual(r.outcome, "ok", msg=r.error_message)
+            blob = msgspec.json.encode(r)
+            self.assertIn(b'"outcome":"ok"', blob)
+            # Round-trip back to a struct of the same shape.
+            r2 = msgspec.json.decode(blob, type=BeetsDistanceResult)
+            self.assertEqual(r2.distance, r.distance)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -695,6 +695,9 @@ import {
   renderTracklist,
   renderSourcePanel,
   formatLength,
+  pickBestDistance,
+  formatDistanceBadge,
+  runWithConcurrency,
   esc as replaceEsc,
 } from '../web/js/replace_picker.js';
 
@@ -818,6 +821,78 @@ assert(loadedPanel.includes('2:00'), 'renderSourcePanel renders track duration')
 
 const errorPanel = renderSourcePanel({ label: 'X', tracks: null, error: 'HTTP 500' });
 assert(errorPanel.includes('HTTP 500'), 'renderSourcePanel renders error message');
+
+// pickBestDistance — picks the lowest-distance ok result; null when none scored
+assertEqual(pickBestDistance([]), null, 'pickBestDistance [] → null');
+assertEqual(
+  pickBestDistance([
+    { outcome: 'fetch_failed' },
+    { outcome: 'wrong_release_group' },
+  ]),
+  null,
+  'pickBestDistance all-errors → null',
+);
+const best = pickBestDistance([
+  { outcome: 'ok', distance: 0.21, matched_tracks: 10, total_mb_tracks: 12 },
+  { outcome: 'ok', distance: 0.07, matched_tracks: 12, total_mb_tracks: 12 },
+  { outcome: 'no_audio' },
+]);
+assertEqual(best?.distance, 0.07, 'pickBestDistance picks lowest');
+assertEqual(best?.matched_tracks, 12, 'pickBestDistance carries metadata');
+
+// formatDistanceBadge — empty for null, formatted otherwise
+assertEqual(formatDistanceBadge(null), '', 'formatDistanceBadge null → empty');
+assertEqual(
+  formatDistanceBadge({ outcome: 'ok', distance: 0.0712,
+                         matched_tracks: 12, total_mb_tracks: 12 }),
+  'best 0.07 (12/12)',
+  'formatDistanceBadge ok result',
+);
+assertEqual(
+  formatDistanceBadge({ outcome: 'ok', distance: 0.42,
+                         matched_tracks: 8, total_mb_tracks: 12 }),
+  'best 0.42 (8/12)',
+  'formatDistanceBadge partial match',
+);
+assertEqual(
+  formatDistanceBadge({ outcome: 'ok', distance: 0.0 }),
+  'best 0.00',
+  'formatDistanceBadge no track-count metadata → distance only',
+);
+
+// runWithConcurrency — caps in-flight workers; preserves input order
+{
+  const order = [];
+  let inFlight = 0;
+  let peak = 0;
+  const items = [1, 2, 3, 4, 5, 6, 7, 8];
+  const results = await runWithConcurrency(items, 3, async (item) => {
+    inFlight++; peak = Math.max(peak, inFlight);
+    await new Promise((r) => setTimeout(r, 5 + Math.random() * 5));
+    inFlight--;
+    order.push(item);
+    return item * 10;
+  });
+  assertEqual(results.length, items.length,
+    'runWithConcurrency preserves count');
+  for (let i = 0; i < items.length; i++) {
+    assertEqual(results[i], items[i] * 10,
+      `runWithConcurrency preserves index ${i}`);
+  }
+  assert(peak <= 3,
+    `runWithConcurrency caps in-flight workers (peak=${peak})`);
+}
+{
+  // limit larger than item count — still completes correctly
+  const results = await runWithConcurrency([1, 2], 99, async (n) => n + 100);
+  assertEqual(results[0], 101, 'runWithConcurrency oversize limit ok [0]');
+  assertEqual(results[1], 102, 'runWithConcurrency oversize limit ok [1]');
+}
+{
+  // empty input — resolves immediately
+  const results = await runWithConcurrency([], 4, async () => 'never-called');
+  assertEqual(results.length, 0, 'runWithConcurrency [] → []');
+}
 
 assertEqual(replaceEsc('<script>'), '&lt;script&gt;', 'esc escapes <');
 assertEqual(replaceEsc('a&b'), 'a&amp;b', 'esc escapes &');

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -692,6 +692,9 @@ import {
   renderConfirmDialog,
   renderStandardHeader,
   renderInvertedHeader,
+  renderTracklist,
+  renderSourcePanel,
+  formatLength,
   esc as replaceEsc,
 } from '../web/js/replace_picker.js';
 
@@ -706,12 +709,23 @@ const sample = [
   { id: 'bbb', title: 'Pressing B', date: '2021-05-01', country: 'JP', track_count: 13, format: 'LP' },
 ];
 const pressingsHtml = renderPressingsList(sample, 'aaa');
-assert(pressingsHtml.includes('data-mbid="aaa"'), 'renderPressingsList includes current as data-mbid');
-assert(pressingsHtml.includes('disabled'), 'renderPressingsList marks current pressing disabled');
+assert(pressingsHtml.includes('data-expand-mbid="aaa"'),
+  'renderPressingsList wires current pressing as expandable row');
+assert(/data-expand-mbid="aaa"[^>]*disabled|disabled[^>]*data-expand-mbid="aaa"/.test(pressingsHtml),
+  'renderPressingsList marks current pressing disabled');
 assert(pressingsHtml.includes('current pressing'), 'renderPressingsList labels current pressing');
-assert(pressingsHtml.includes('data-mbid="bbb"'), 'renderPressingsList includes sibling');
-assert(!/<button[^>]*data-mbid="bbb"[^>]*disabled/.test(pressingsHtml),
+assert(pressingsHtml.includes('data-expand-mbid="bbb"'), 'renderPressingsList includes sibling');
+assert(!/<button[^>]*data-expand-mbid="bbb"[^>]*disabled/.test(pressingsHtml),
   'renderPressingsList does not disable non-current siblings');
+assert(pressingsHtml.includes('data-mbid="bbb"') &&
+  /replace-picker-confirm[^>]*data-mbid="bbb"/.test(pressingsHtml),
+  'renderPressingsList renders pick-button for non-current pressing');
+assert(!/replace-picker-confirm[^>]*data-mbid="aaa"/.test(pressingsHtml),
+  'renderPressingsList omits pick-button for current pressing');
+assert(!pressingsHtml.includes('aaa</small>') && !pressingsHtml.includes('bbb</small>'),
+  'renderPressingsList does not expose MBID to operator (visual-noise cleanup)');
+assert(/2020.*US.*CD.*12t/.test(pressingsHtml) || pressingsHtml.includes('US · 2020 · CD · 12t'),
+  'renderPressingsList renders meta in country·year·format·Nt order');
 
 assertEqual(
   renderRequestsList([]).includes('No active requests'),
@@ -721,8 +735,14 @@ assertEqual(
 const reqHtml = renderRequestsList([
   { id: 42, mb_release_id: 'old-uuid', status: 'wanted', artist_name: 'Pet Grief', album_title: 'X' },
 ]);
-assert(reqHtml.includes('data-rid="42"'), 'renderRequestsList carries id');
+assert(reqHtml.includes('data-rid="42"'), 'renderRequestsList carries id (pick button)');
 assert(reqHtml.includes('Pet Grief'), 'renderRequestsList includes artist');
+assert(reqHtml.includes('data-expand-mbid="old-uuid"'),
+  'renderRequestsList row expands by MBID');
+assert(reqHtml.includes('data-tracks-for="old-uuid"'),
+  'renderRequestsList renders lazy tracklist container per row');
+assert(!/<small[^>]*>[^<]*old-uuid/.test(reqHtml),
+  'renderRequestsList hides the MBID from the operator');
 
 const dlg = renderConfirmDialog({
   sourceRequestId: 4194,
@@ -740,6 +760,64 @@ assert(renderStandardHeader('Pet Grief — Old').includes('Switch'),
   'renderStandardHeader carries "Switch" verb');
 assert(renderInvertedHeader('Pet Grief — New').includes('replace an existing request'),
   'renderInvertedHeader carries inverted-mode verb');
+
+// Tracklist container is rendered hidden until row.open
+assert(pressingsHtml.includes('data-tracks-for="aaa"'),
+  'renderPressingsList renders tracklist container per row');
+
+// formatLength
+assertEqual(formatLength(0), '0:00', 'formatLength 0 → 0:00');
+assertEqual(formatLength(7), '0:07', 'formatLength <60s pads seconds');
+assertEqual(formatLength(63), '1:03', 'formatLength 63s → 1:03');
+assertEqual(formatLength(263.4), '4:23', 'formatLength rounds');
+assertEqual(formatLength(null), '', 'formatLength null → empty');
+assertEqual(formatLength(undefined), '', 'formatLength undefined → empty');
+assertEqual(formatLength(NaN), '', 'formatLength NaN → empty');
+
+// renderTracklist
+assert(renderTracklist([]).includes('No tracks'),
+  'renderTracklist empty → friendly message');
+const tlHtml = renderTracklist([
+  { disc_number: 1, track_number: 1, title: 'Aaa', length_seconds: 200 },
+  { disc_number: 1, track_number: 2, title: 'Bbb <em>', length_seconds: 263.4 },
+]);
+assert(tlHtml.includes('Aaa'), 'renderTracklist includes title');
+assert(tlHtml.includes('4:23'), 'renderTracklist formats track length');
+assert(tlHtml.includes('&lt;em&gt;'), 'renderTracklist escapes titles');
+assert(!/Disc 1/.test(tlHtml), 'renderTracklist hides disc header for single-disc');
+
+const multiDiscHtml = renderTracklist([
+  { disc_number: 1, track_number: 1, title: 'A', length_seconds: 60 },
+  { disc_number: 2, track_number: 1, title: 'B', length_seconds: 60 },
+]);
+assert(multiDiscHtml.includes('Disc 1') && multiDiscHtml.includes('Disc 2'),
+  'renderTracklist shows disc headers for multi-disc');
+
+// renderSourcePanel
+const loadingPanel = renderSourcePanel({
+  label: 'Pet Grief — Old',
+  meta: 'US · 2020 · CD · 12t',
+  tracks: null,
+  loading: true,
+});
+assert(loadingPanel.includes('Current request:'),
+  'renderSourcePanel labels the panel "Current request:"');
+assert(loadingPanel.includes('Pet Grief — Old'), 'renderSourcePanel includes the label');
+assert(loadingPanel.includes('US · 2020 · CD · 12t'),
+  'renderSourcePanel renders meta line on summary');
+assert(loadingPanel.includes('Loading'), 'renderSourcePanel loading state shows placeholder');
+assert(loadingPanel.includes('replace-picker-source-body'),
+  'renderSourcePanel exposes the body container for lazy fill');
+
+const loadedPanel = renderSourcePanel({
+  label: 'X',
+  tracks: [{ disc_number: 1, track_number: 1, title: 'Z', length_seconds: 120 }],
+});
+assert(loadedPanel.includes('Z'), 'renderSourcePanel renders tracks when loaded');
+assert(loadedPanel.includes('2:00'), 'renderSourcePanel renders track duration');
+
+const errorPanel = renderSourcePanel({ label: 'X', tracks: null, error: 'HTTP 500' });
+assert(errorPanel.includes('HTTP 500'), 'renderSourcePanel renders error message');
 
 assertEqual(replaceEsc('<script>'), '&lt;script&gt;', 'esc escapes <');
 assertEqual(replaceEsc('a&b'), 'a&amp;b', 'esc escapes &');

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2188,6 +2188,92 @@ class TestCmdReplace(unittest.TestCase):
         self.assertEqual(cm.exception.code, 2)
 
 
+class TestCmdBeetsDistance(unittest.TestCase):
+    """``pipeline-cli beets-distance`` wraps
+    ``lib.beets_distance.compute_beets_distance``. Counterpart of
+    ``GET /api/beets-distance/<download_log_id>/<mbid>``. Service-layer
+    correctness lives in ``tests.test_beets_distance``; here we pin the
+    exit-code mapping per the CLI ⇄ API symmetry rule."""
+
+    UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    def _run(self, *, outcome, json_out=False, **result_kwargs):
+        from lib.beets_distance import BeetsDistanceResult
+        result = BeetsDistanceResult(outcome=outcome, **result_kwargs)
+        args = SimpleNamespace(
+            download_log_id=100, mbid=self.UUID, json=json_out,
+        )
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            with patch(
+                "lib.beets_distance.compute_beets_distance",
+                return_value=result,
+            ):
+                rc = pipeline_cli.cmd_beets_distance(MagicMock(), args)
+        return rc, stdout.getvalue()
+
+    def test_exit_0_on_ok(self):
+        rc, out = self._run(
+            outcome="ok",
+            distance=0.07,
+            matched_tracks=12,
+            total_local_tracks=12,
+            total_mb_tracks=12,
+            duration_ms=8,
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("0.0700", out)
+        self.assertIn("12 / 12", out)
+
+    def test_exit_2_on_not_found_branches(self):
+        for outcome in ("download_log_not_found", "request_not_found"):
+            with self.subTest(outcome=outcome):
+                rc, _ = self._run(outcome=outcome,
+                                  error_message="not found")
+                self.assertEqual(rc, 2)
+
+    def test_exit_3_on_semantic_violations(self):
+        """Cross-RG guardrail + missing-RG both surface as exit 3."""
+        for outcome in ("wrong_release_group", "mb_no_release_group"):
+            with self.subTest(outcome=outcome):
+                rc, _ = self._run(outcome=outcome,
+                                  error_message="bad MBID")
+                self.assertEqual(rc, 3)
+
+    def test_exit_4_on_missing_artifacts(self):
+        for outcome in ("folder_missing", "no_audio"):
+            with self.subTest(outcome=outcome):
+                rc, _ = self._run(outcome=outcome,
+                                  error_message="gone")
+                self.assertEqual(rc, 4)
+
+    def test_exit_5_on_transient(self):
+        rc, _ = self._run(outcome="mb_lookup_failed",
+                          error_message="MB mirror down")
+        self.assertEqual(rc, 5)
+
+    def test_exit_1_on_distance_failed(self):
+        rc, _ = self._run(outcome="distance_failed",
+                          error_message="beets blew up")
+        self.assertEqual(rc, 1)
+
+    def test_json_output_carries_full_payload(self):
+        rc, out = self._run(
+            outcome="ok",
+            distance=0.07,
+            matched_tracks=12,
+            total_local_tracks=12,
+            total_mb_tracks=12,
+            components={"album": 0.0, "artist": 0.05},
+            json_out=True,
+        )
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["outcome"], "ok")
+        self.assertAlmostEqual(payload["distance"], 0.07, places=4)
+        self.assertEqual(payload["components"]["album"], 0.0)
+
+
 class TestCmdSearchPlanHistory(unittest.TestCase):
     """``pipeline-cli search-plan history`` wraps
     ``SearchPlanService.history_for_request``. Counterpart of the API

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -994,6 +994,7 @@ class TestRouteContractAudit(unittest.TestCase):
         r"^/api/pipeline/(\d+)/replace$",
         r"^/api/pipeline/(\d+)/resolve-rg$",
         r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$",
+        r"^/api/beets-distance/(\d+)/([a-f0-9-]{36})$",
         "/api/pipeline/active-rgs",
         "/api/pipeline/add",
         "/api/pipeline/update",
@@ -8542,6 +8543,183 @@ class TestClientDisconnectHandling(unittest.TestCase):
         self.assertEqual(len(errors), 0,
             f"Normal POST must not produce ERROR logs, got: "
             f"{[r.getMessage() for r in errors]}")
+
+
+class TestBeetsDistanceRouteContract(_WebServerCase):
+    """Contract for ``GET /api/beets-distance/<download_log_id>/<mbid>``.
+
+    Service-layer correctness is covered by ``tests.test_beets_distance``.
+    Here we pin the HTTP wrapper: every ``BeetsDistanceResult.outcome``
+    maps to the documented status code, every required response field
+    is present, and the route is registered (the
+    ``TestRouteContractAudit`` guard catches missing classification).
+
+    The service function is patched at its import site
+    (``web.routes.pipeline.compute_beets_distance``-equivalent — actually
+    imported lazily inside the handler so we patch the module
+    attribute) and we drive each outcome through the wrapper. The real
+    beets distance pipeline is not exercised in this class; the
+    integration slice in ``tests.test_beets_distance`` is the
+    authority on that.
+    """
+
+    REQUIRED_FIELDS = {
+        "outcome",
+        "distance",
+        "matched_tracks",
+        "total_local_tracks",
+        "total_mb_tracks",
+        "extra_local_tracks",
+        "extra_mb_tracks",
+        "components",
+        "request_release_group_id",
+        "candidate_release_group_id",
+        "candidate_mbid",
+        "download_log_id",
+        "request_id",
+        "folder_path",
+        "error_message",
+        "duration_ms",
+    }
+
+    UUID_A = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    UUID_B = "12345678-1234-1234-1234-123456789abc"
+
+    def setUp(self) -> None:
+        self.mock_db.reset_mock()
+        from lib.beets_distance import BeetsDistanceResult
+        self._Result = BeetsDistanceResult
+
+    def _patch_service(self, **kwargs):
+        from unittest.mock import patch as _patch
+        return _patch(
+            "lib.beets_distance.compute_beets_distance",
+            return_value=self._Result(**kwargs),
+        )
+
+    def test_ok_returns_200_with_distance_and_required_fields(self):
+        with self._patch_service(
+            outcome="ok",
+            distance=0.07,
+            matched_tracks=12,
+            total_local_tracks=12,
+            total_mb_tracks=12,
+            extra_local_tracks=0,
+            extra_mb_tracks=0,
+            components={"album": 0.0, "artist": 0.0},
+            request_release_group_id="rg-1",
+            candidate_release_group_id="rg-1",
+            candidate_mbid=self.UUID_A,
+            download_log_id=100,
+            request_id=7,
+            folder_path="/tmp/x",
+            duration_ms=8,
+        ):
+            status, data = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.REQUIRED_FIELDS,
+                                "beets-distance ok response")
+        self.assertEqual(data["outcome"], "ok")
+        self.assertAlmostEqual(data["distance"], 0.07, places=4)
+        self.assertEqual(data["matched_tracks"], 12)
+
+    def test_download_log_not_found_returns_404(self):
+        with self._patch_service(
+            outcome="download_log_not_found",
+            download_log_id=999,
+            candidate_mbid=self.UUID_A,
+            error_message="download_log #999 not found",
+        ):
+            status, _ = self._get(f"/api/beets-distance/999/{self.UUID_A}")
+        self.assertEqual(status, 404)
+
+    def test_request_not_found_returns_404(self):
+        with self._patch_service(
+            outcome="request_not_found",
+            download_log_id=100,
+            candidate_mbid=self.UUID_A,
+            error_message="request #7 not found",
+        ):
+            status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 404)
+
+    def test_wrong_release_group_returns_422(self):
+        """The cross-RG guardrail surfaces as 422 (semantic violation)."""
+        with self._patch_service(
+            outcome="wrong_release_group",
+            download_log_id=100,
+            request_id=7,
+            request_release_group_id="rg-source",
+            candidate_release_group_id="rg-other",
+            candidate_mbid=self.UUID_A,
+            error_message="MBID is in a different release group",
+        ):
+            status, data = self._get(
+                f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 422)
+        self.assertEqual(data["outcome"], "wrong_release_group")
+
+    def test_mb_no_release_group_returns_422(self):
+        with self._patch_service(
+            outcome="mb_no_release_group",
+            download_log_id=100,
+            candidate_mbid=self.UUID_A,
+            error_message="MB release has no release_group_id",
+        ):
+            status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 422)
+
+    def test_folder_missing_returns_410(self):
+        with self._patch_service(
+            outcome="folder_missing",
+            download_log_id=100,
+            candidate_mbid=self.UUID_A,
+            error_message="failed_path is gone",
+        ):
+            status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 410)
+
+    def test_no_audio_returns_410(self):
+        with self._patch_service(
+            outcome="no_audio",
+            download_log_id=100,
+            candidate_mbid=self.UUID_A,
+            folder_path="/tmp/empty",
+            error_message="no readable audio files",
+        ):
+            status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 410)
+
+    def test_mb_lookup_failed_returns_503(self):
+        with self._patch_service(
+            outcome="mb_lookup_failed",
+            download_log_id=100,
+            candidate_mbid=self.UUID_A,
+            error_message="MB mirror unreachable",
+        ):
+            status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 503)
+
+    def test_distance_failed_returns_500(self):
+        with self._patch_service(
+            outcome="distance_failed",
+            download_log_id=100,
+            candidate_mbid=self.UUID_A,
+            error_message="beets blew up",
+        ):
+            status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
+        self.assertEqual(status, 500)
+
+    def test_route_pattern_requires_uuid_shape(self):
+        """The route pattern only matches MBID UUIDs — a malformed
+        MBID (e.g. a Discogs numeric id) doesn't even hit the handler.
+
+        This is a route-table contract: keep the regex strict so we
+        never accidentally compute a distance against a non-MB id.
+        """
+        # Numeric id (Discogs-shaped) — pattern shouldn't match.
+        status, _ = self._get("/api/beets-distance/100/2048516")
+        self.assertEqual(status, 404)
 
 
 if __name__ == "__main__":

--- a/web/index.html
+++ b/web/index.html
@@ -351,6 +351,37 @@
   .confirm-box h3 { color: #f66; margin-bottom: 12px; }
   .confirm-box p { color: #aaa; margin-bottom: 16px; font-size: 0.9em; }
   .confirm-box .actions { display: flex; gap: 8px; justify-content: center; }
+
+  /* Replace picker — matches .p-item / .p-detail visual language */
+  .replace-picker-shell { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 8px; padding: 20px; max-width: 720px; width: 90vw; max-height: 85vh; overflow-y: auto; text-align: left; color: #ccc; }
+  .replace-picker-shell h2 { color: #ccd; margin: 0 0 6px; font-size: 1.05em; font-weight: 500; }
+  .replace-picker-shell > p { color: #888; font-size: 0.85em; margin-bottom: 12px; }
+  .replace-picker-shell code { color: #aac; background: #14141a; padding: 0 4px; border-radius: 3px; font-size: 0.85em; }
+  .replace-picker-list { list-style: none; padding: 0; margin: 0; }
+  .replace-picker-row { margin-bottom: 4px; }
+  .replace-picker-pick { padding: 10px 12px; background: #1e1e1e; border-left: 3px solid #444; border-right: none; border-top: none; border-bottom: none; border-radius: 0 6px 6px 0; cursor: pointer; color: #ccc; font: inherit; text-align: left; width: 100%; display: block; }
+  .replace-picker-pick:hover { background: #252525; }
+  .replace-picker-row.open .replace-picker-pick { border-radius: 0 6px 0 0; border-left-color: #6a9; background: #232a25; color: #cdc; }
+  .replace-picker-pick small { color: #777; font-size: 0.75em; }
+  .replace-picker-pick:disabled { cursor: default; opacity: 0.55; }
+  .replace-picker-pick:disabled:hover { background: #1e1e1e; }
+  .replace-picker-detail { background: #191919; padding: 10px 12px; margin: 0 0 4px 0; border-radius: 0 0 6px 6px; display: none; border-left: 3px solid #333; }
+  .replace-picker-row.open .replace-picker-detail { display: block; border-left-color: #6a9; }
+  .replace-picker-detail-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 10px; padding-top: 8px; border-top: 1px solid #232323; }
+  .replace-picker-confirm { background: #2a5a2a; color: #8d8; border: none; border-radius: 6px; padding: 6px 14px; cursor: pointer; font-size: 0.85em; font-weight: 500; }
+  .replace-picker-confirm:hover { background: #3a6a3a; }
+  .replace-picker-tracks { list-style: none; padding: 0; margin: 0; font-size: 0.82em; color: #bbb; }
+  .replace-picker-tracks li { padding: 1px 0; display: flex; gap: 8px; align-items: baseline; }
+  .replace-picker-tnum { color: #666; min-width: 28px; text-align: right; font-variant-numeric: tabular-nums; }
+  .replace-picker-dur { color: #666; margin-left: auto; font-variant-numeric: tabular-nums; }
+  .replace-picker-disc { color: #888; font-size: 0.8em; margin: 6px 0 2px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .replace-picker-source { background: #191919; border-left: 3px solid #6a9; border-radius: 0 6px 6px 0; padding: 10px 12px; margin: 8px 0 14px; }
+  .replace-picker-source summary { cursor: pointer; color: #cdc; font-size: 0.9em; list-style: none; outline: none; }
+  .replace-picker-source summary::-webkit-details-marker { display: none; }
+  .replace-picker-source summary::before { content: '▾ '; color: #6a9; font-size: 0.85em; }
+  .replace-picker-source:not([open]) summary::before { content: '▸ '; }
+  .replace-picker-source-body { margin-top: 8px; max-height: 240px; overflow-y: auto; }
+  .replace-picker-cancel-bar { display: flex; justify-content: flex-end; margin-top: 12px; }
   .loading { color: #666; padding: 20px; text-align: center; }
   .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); padding: 12px 24px; background: #2a5a2a; color: #8d8; border-radius: 8px; font-size: 14px; z-index: 100; display: none; }
   .toast.error { background: #5a2a2a; color: #d88; }

--- a/web/index.html
+++ b/web/index.html
@@ -382,6 +382,7 @@
   .replace-picker-source:not([open]) summary::before { content: '▸ '; }
   .replace-picker-source-body { margin-top: 8px; max-height: 240px; overflow-y: auto; }
   .replace-picker-cancel-bar { display: flex; justify-content: flex-end; margin-top: 12px; }
+  .replace-picker-distance { color: #6a9; font-weight: 500; font-variant-numeric: tabular-nums; }
   .loading { color: #666; padding: 20px; text-align: center; }
   .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); padding: 12px 24px; background: #2a5a2a; color: #8d8; border-radius: 8px; font-size: 14px; z-index: 100; display: none; }
   .toast.error { background: #5a2a2a; color: #d88; }

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -469,6 +469,13 @@ async function runStandard(options, showOverlay, close) {
   // Lazy-fill the "current request" tracklist. Failure here is non-fatal —
   // the picker still works without the reference panel.
   loadSourceTracklist(modal, sourceMbid, sourceLabel).catch(() => {});
+  // Fan out beets-distance lookups against the source request's
+  // wrong-matches folders. Decorates each pressing row's meta line as
+  // results arrive. Silent no-op when the request has no wrong-matches
+  // entries — the picker looks identical to the non-distance UI.
+  loadDistances(modal, options.sourceRequestId, releases).catch((err) => {
+    console.warn('replace-picker distance overlay failed:', err);
+  });
 }
 
 /**
@@ -481,6 +488,95 @@ async function runStandard(options, showOverlay, close) {
  * @type {Map<string, Promise<{ tracks: TracklistTrack[] }>>}
  */
 const tracklistCache = new Map();
+
+/* --------------------------------------------------------------------------
+ * Beets-distance overlay — pure helpers
+ *
+ * The picker decorates each pressing row with the best beets-distance against
+ * the source request's wrong-matches folders. Pure helpers below are tested
+ * via tests/test_js_util.mjs; DOM glue further down lives in `loadDistances`.
+ * ------------------------------------------------------------------------ */
+
+/**
+ * @typedef {Object} BeetsDistanceResult
+ * @property {string} outcome
+ * @property {number|null} [distance]
+ * @property {number|null} [matched_tracks]
+ * @property {number|null} [total_local_tracks]
+ * @property {number|null} [total_mb_tracks]
+ * @property {string|null} [folder_path]
+ * @property {number|null} [download_log_id]
+ */
+
+/**
+ * Pick the lowest-distance "ok" result from a list. Returns null if none
+ * of the inputs scored — keeps the caller branch-free (no distance UI
+ * if every download errored, was wrong-RG-guarded, etc.).
+ *
+ * @param {BeetsDistanceResult[]} results
+ * @returns {BeetsDistanceResult|null}
+ */
+export function pickBestDistance(results) {
+  let best = null;
+  for (const r of results) {
+    if (!r || r.outcome !== 'ok' || typeof r.distance !== 'number') continue;
+    if (best === null || r.distance < /** @type {number} */ (best.distance)) {
+      best = r;
+    }
+  }
+  return best;
+}
+
+/**
+ * Format a distance badge for the pressing-row meta line: `best 0.07 (12/12)`.
+ *
+ * Distance only — no folder path, that's a different surface (the
+ * expanded-row breakdown will carry the per-download details). Returns
+ * an empty string for null so callers can concatenate unconditionally.
+ *
+ * @param {BeetsDistanceResult|null} best
+ * @returns {string}
+ */
+export function formatDistanceBadge(best) {
+  if (best === null) return '';
+  if (typeof best.distance !== 'number') return '';
+  const matched = best.matched_tracks;
+  const total = best.total_mb_tracks;
+  const ratio = (typeof matched === 'number' && typeof total === 'number')
+    ? ` (${matched}/${total})`
+    : '';
+  return `best ${best.distance.toFixed(2)}${ratio}`;
+}
+
+/**
+ * Run an async worker over a list of inputs with a concurrency cap.
+ *
+ * Used to fan out N×M `/api/beets-distance` calls without blowing past
+ * the browser's per-origin connection limit. Resolves to the worker
+ * results in input order (failed workers resolve to whatever the
+ * worker returns on error — typically a struct with `outcome: 'error'`).
+ *
+ * @template T, R
+ * @param {T[]} items
+ * @param {number} limit
+ * @param {(item: T, index: number) => Promise<R>} worker
+ * @returns {Promise<R[]>}
+ */
+export async function runWithConcurrency(items, limit, worker) {
+  /** @type {R[]} */
+  const results = new Array(items.length);
+  let cursor = 0;
+  const lanes = Math.max(1, Math.min(limit, items.length));
+  async function lane() {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: lanes }, () => lane()));
+  return results;
+}
 
 /**
  * @param {string} mbid
@@ -579,6 +675,127 @@ function cssEscape(s) {
     return CSS.escape(s);
   }
   return s.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+/**
+ * Maximum concurrent ``/api/beets-distance`` requests. Cap at six,
+ * which matches the browser's typical per-origin keep-alive limit —
+ * past that, requests just queue behind the limit anyway and we'd
+ * waste server-side parallelism waiting for the next free socket.
+ */
+const DISTANCE_CONCURRENCY = 6;
+
+/**
+ * Fetch the source request's wrong-matches folders, compute beets-distance
+ * against every candidate pressing, and decorate the picker rows with the
+ * best result per pressing as each pressing's column resolves.
+ *
+ * Silent no-op when:
+ *   - the request has zero wrong-matches entries on disk, or
+ *   - every distance call fails (no signal to show).
+ *
+ * Failure mode for the operator: the distance badge just doesn't appear.
+ * The picker remains fully usable; the badge is additive, not load-bearing.
+ *
+ * @param {HTMLElement} modal
+ * @param {number} sourceRequestId
+ * @param {ReleaseGroupSibling[]} releases
+ */
+async function loadDistances(modal, sourceRequestId, releases) {
+  // 1. Find this request's wrong-matches entries → their download_log_ids.
+  let downloadLogIds;
+  try {
+    const res = await fetch('/api/wrong-matches');
+    if (!res.ok) return;
+    const body = await res.json();
+    const groups = body.groups || [];
+    const ourGroup = groups.find((g) => g.request_id === sourceRequestId);
+    if (!ourGroup) return;
+    const entries = ourGroup.entries || [];
+    downloadLogIds = entries
+      .map((e) => e.download_log_id)
+      .filter((id) => typeof id === 'number');
+  } catch (err) {
+    console.warn('replace-picker: wrong-matches fetch failed:', err);
+    return;
+  }
+  if (downloadLogIds.length === 0) return;
+
+  // 2. Build the (pressing, download_log_id) work list. Disabled rows
+  //    (the current pressing) are skipped — there is no point telling
+  //    the operator how well their existing downloads match the
+  //    pressing they're trying to switch *away* from.
+  /** @type {{mbid: string, logId: number}[]} */
+  const work = [];
+  for (const r of releases) {
+    const row = modal.querySelector(`.replace-picker-row[data-mbid-row="${cssEscape(r.id)}"]`);
+    const pickBtn = row && row.querySelector('button.replace-picker-pick');
+    if (pickBtn && /** @type {HTMLButtonElement} */ (pickBtn).disabled) continue;
+    for (const logId of downloadLogIds) {
+      work.push({ mbid: r.id, logId });
+    }
+  }
+  if (work.length === 0) return;
+
+  // 3. Per-pressing accumulator: as results stream in we recompute the
+  //    best score for that MBID and rewrite its row's badge. This keeps
+  //    the UI feeling fast even when the last download is still
+  //    crunching — early best-distances appear immediately.
+  /** @type {Map<string, BeetsDistanceResult[]>} */
+  const perPressing = new Map();
+  for (const r of releases) perPressing.set(r.id, []);
+
+  await runWithConcurrency(work, DISTANCE_CONCURRENCY, async ({ mbid, logId }) => {
+    /** @type {BeetsDistanceResult} */
+    let result;
+    try {
+      const res = await fetch(`/api/beets-distance/${logId}/${encodeURIComponent(mbid)}`);
+      result = /** @type {BeetsDistanceResult} */ (await res.json());
+    } catch (err) {
+      result = { outcome: 'fetch_failed' };
+    }
+    const bucket = perPressing.get(mbid);
+    if (bucket) {
+      bucket.push(result);
+      paintDistanceBadge(modal, mbid, pickBestDistance(bucket));
+    }
+    return result;
+  });
+}
+
+/**
+ * Rewrite the distance-badge span for one pressing row.
+ *
+ * The badge sits inside the row's `<small>` meta line as
+ * ``<span class="replace-picker-distance">…</span>``. We create the
+ * span on first paint and update its text on subsequent paints —
+ * cheaper than rebuilding the row's innerHTML each time a result
+ * lands.
+ *
+ * @param {HTMLElement} modal
+ * @param {string} mbid
+ * @param {BeetsDistanceResult|null} best
+ */
+function paintDistanceBadge(modal, mbid, best) {
+  const row = modal.querySelector(
+    `.replace-picker-row[data-mbid-row="${cssEscape(mbid)}"]`);
+  if (!row) return;
+  const meta = row.querySelector('button.replace-picker-pick small');
+  if (!meta) return;
+  let badge = /** @type {HTMLSpanElement|null} */ (
+    meta.querySelector('.replace-picker-distance'));
+  const text = formatDistanceBadge(best);
+  if (!text) {
+    if (badge) badge.remove();
+    return;
+  }
+  if (!badge) {
+    badge = document.createElement('span');
+    badge.className = 'replace-picker-distance';
+    meta.appendChild(document.createTextNode(' · '));
+    meta.appendChild(badge);
+  }
+  badge.textContent = text;
 }
 
 /**

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -86,7 +86,27 @@ export function esc(s) {
 }
 
 /**
+ * Build the meta line for a release row — matches the format used by
+ * analysis.js pressing rows: `country · year · format · Nt`. Empty
+ * fields drop out.
+ *
+ * @param {{ date?: string, country?: string, format?: string, track_count?: number }} r
+ * @returns {string}
+ */
+export function pressingMeta(r) {
+  const year = r.date ? r.date.slice(0, 4) : '';
+  return [r.country, year, r.format, r.track_count ? `${r.track_count}t` : '']
+    .filter((x) => !!x)
+    .join(' · ');
+}
+
+/**
  * Render the "pressings in this release group" list (standard mode).
+ *
+ * Each row is click-to-expand. The MB tracklist is lazy-fetched on the
+ * first expand; the "Use this pressing" button lives inside the expanded
+ * detail panel so the row click never accidentally fires the destructive
+ * confirm flow.
  *
  * @param {ReleaseGroupSibling[]} releases
  * @param {string} sourceMbid       // current pressing — disabled in the list
@@ -98,24 +118,125 @@ export function renderPressingsList(releases, sourceMbid) {
   }
   const rows = releases.map((r) => {
     const isCurrent = r.id === sourceMbid;
-    const year = r.date ? r.date.slice(0, 4) : '';
-    const meta = [year, r.country, r.format, r.track_count ? `${r.track_count}tk` : '']
-      .filter((x) => !!x)
-      .join(' · ');
     const disabledAttr = isCurrent ? ' disabled' : '';
     const labelSuffix = isCurrent ? ' (current pressing)' : '';
-    return `<li>
-      <button class="btn"${disabledAttr} data-mbid="${esc(r.id)}">
+    const meta = pressingMeta(r);
+    const pickLabel = isCurrent
+      ? ''
+      : `<button class="replace-picker-confirm" data-mbid="${esc(r.id)}">Use this pressing</button>`;
+    return `<li class="replace-picker-row" data-mbid-row="${esc(r.id)}">
+      <button class="replace-picker-pick"${disabledAttr} data-expand-mbid="${esc(r.id)}" aria-expanded="false">
         <strong>${esc(r.title)}</strong>${labelSuffix}<br>
-        <small style="color:#888;">${esc(meta)} · ${esc(r.id)}</small>
+        <small>${esc(meta)}</small>
       </button>
+      <div class="replace-picker-detail" data-tracks-for="${esc(r.id)}"></div>
+      <div class="replace-picker-detail-actions-slot" data-actions-for="${esc(r.id)}" hidden>
+        <div class="replace-picker-detail-actions">${pickLabel}</div>
+      </div>
     </li>`;
   });
-  return `<ul style="list-style:none;padding:0;">${rows.join('')}</ul>`;
+  return `<ul class="replace-picker-list">${rows.join('')}</ul>`;
+}
+
+/**
+ * Format seconds → "m:ss". Returns empty string for null/undefined/NaN.
+ *
+ * @param {number|null|undefined} secs
+ * @returns {string}
+ */
+export function formatLength(secs) {
+  if (secs === null || secs === undefined || Number.isNaN(secs)) return '';
+  const total = Math.round(Number(secs));
+  if (!Number.isFinite(total) || total < 0) return '';
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * @typedef {Object} TracklistTrack
+ * @property {number} [disc_number]
+ * @property {number} [track_number]
+ * @property {string} [title]
+ * @property {number|null} [length_seconds]
+ */
+
+/**
+ * Render a compact tracklist. Disc headers only appear when there is
+ * more than one disc — keeps the visual quiet for the common single-disc
+ * case.
+ *
+ * @param {TracklistTrack[]} tracks
+ * @returns {string}
+ */
+export function renderTracklist(tracks) {
+  if (!tracks || !tracks.length) {
+    return '<p style="color:#888;margin:8px 0;">No tracks listed.</p>';
+  }
+  const discs = new Set(tracks.map((t) => t.disc_number || 1));
+  const multiDisc = discs.size > 1;
+  const byDisc = new Map();
+  for (const t of tracks) {
+    const d = t.disc_number || 1;
+    if (!byDisc.has(d)) byDisc.set(d, []);
+    byDisc.get(d).push(t);
+  }
+  const parts = [];
+  const sortedDiscs = [...byDisc.keys()].sort((a, b) => a - b);
+  for (const d of sortedDiscs) {
+    if (multiDisc) parts.push(`<div class="replace-picker-disc">Disc ${d}</div>`);
+    const items = byDisc.get(d).map((t) => {
+      const num = t.track_number || '';
+      const dur = formatLength(t.length_seconds);
+      const durHtml = dur ? `<span class="replace-picker-dur">${esc(dur)}</span>` : '';
+      return `<li><span class="replace-picker-tnum">${esc(String(num))}.</span> ${esc(t.title || '')} ${durHtml}</li>`;
+    });
+    parts.push(`<ol class="replace-picker-tracks">${items.join('')}</ol>`);
+  }
+  return parts.join('');
+}
+
+/**
+ * Render the pinned "current request" tracklist panel — the source
+ * request in standard mode, the target MBID in inverted mode. Shown
+ * once at the top of the picker so the operator always has the
+ * reference visible while expanding candidate pressings below. The
+ * summary line carries the same meta tags (country · year · format ·
+ * Nt) as the rows below so visual comparison is direct.
+ *
+ * @param {{
+ *   label: string,
+ *   meta?: string,
+ *   tracks: TracklistTrack[]|null,
+ *   loading?: boolean,
+ *   error?: string,
+ * }} args
+ * @returns {string}
+ */
+export function renderSourcePanel(args) {
+  let body;
+  if (args.error) {
+    body = `<p style="color:#f66;margin:4px 0;">${esc(args.error)}</p>`;
+  } else if (args.loading || args.tracks === null) {
+    body = '<p style="color:#888;margin:4px 0;">Loading tracklist…</p>';
+  } else {
+    body = renderTracklist(args.tracks);
+  }
+  const metaHtml = args.meta
+    ? `<br><small style="color:#888;">${esc(args.meta)}</small>`
+    : '';
+  return `<details class="replace-picker-source" open>
+    <summary><strong>Current request:</strong> ${esc(args.label)}${metaHtml}</summary>
+    <div class="replace-picker-source-body">${body}</div>
+  </details>`;
 }
 
 /**
  * Render the inverted-mode "which existing request to replace?" list.
+ *
+ * Same click-to-expand pattern as the standard-mode pressings list: the
+ * row is the disclosure, the "Use this request" button lives inside the
+ * expanded detail panel.
  *
  * @param {ExistingRequest[]} requests
  * @returns {string}
@@ -125,13 +246,19 @@ export function renderRequestsList(requests) {
     return '<p style="color:#888;">No active requests exist in this release group.</p>';
   }
   const rows = requests.map((r) => `
-    <li>
-      <button class="btn" data-rid="${r.id}">
+    <li class="replace-picker-row" data-mbid-row="${esc(r.mb_release_id)}">
+      <button class="replace-picker-pick" data-expand-mbid="${esc(r.mb_release_id)}" aria-expanded="false">
         <strong>#${r.id}</strong> · ${esc(r.artist_name)} — ${esc(r.album_title)}<br>
-        <small style="color:#888;">${esc(r.mb_release_id)} (status=${esc(r.status)})</small>
+        <small>status: ${esc(r.status)}</small>
       </button>
+      <div class="replace-picker-detail" data-tracks-for="${esc(r.mb_release_id)}"></div>
+      <div class="replace-picker-detail-actions-slot" data-actions-for="${esc(r.mb_release_id)}" hidden>
+        <div class="replace-picker-detail-actions">
+          <button class="replace-picker-confirm" data-rid="${r.id}">Use this request</button>
+        </div>
+      </div>
     </li>`);
-  return `<ul style="list-style:none;padding:0;">${rows.join('')}</ul>`;
+  return `<ul class="replace-picker-list">${rows.join('')}</ul>`;
 }
 
 /**
@@ -225,7 +352,7 @@ export async function openReplacePicker(options) {
     }
 
     function showOverlay(/** @type {string} */ inner) {
-      modal.innerHTML = `<div class="confirm-overlay"><div class="confirm-box" style="max-width:640px;text-align:left;">${inner}</div></div>`;
+      modal.innerHTML = `<div class="confirm-overlay"><div class="replace-picker-shell">${inner}</div></div>`;
       modal.style.display = '';
       const overlay = modal.querySelector('.confirm-overlay');
       if (overlay) {
@@ -298,7 +425,12 @@ async function runStandard(options, showOverlay, close) {
     const detail = await fetch(`/api/pipeline/${options.sourceRequestId}`);
     if (detail.ok) {
       const drow = await detail.json();
-      sourceMbid = drow.mb_release_id || '';
+      // The pipeline detail endpoint wraps the row under `request` —
+      // a flat read returned `undefined`, leaving sourceMbid blank
+      // (which the picker silently tolerated because it only drove the
+      // "disable current pressing" visual). Fixed when we started
+      // depending on it for the reference tracklist.
+      sourceMbid = (drow.request && drow.request.mb_release_id) || drow.mb_release_id || '';
     }
   } catch (err) {
     showOverlay(`${renderStandardHeader(options.sourceLabel || '')}
@@ -308,25 +440,165 @@ async function runStandard(options, showOverlay, close) {
     return;
   }
 
-  showOverlay(`${renderStandardHeader(options.sourceLabel || `request #${options.sourceRequestId}`)}
+  const sourceLabel = options.sourceLabel || `request #${options.sourceRequestId}`;
+  const sourcePressing = releases.find((r) => r.id === sourceMbid) || null;
+  const sourceMeta = sourcePressing ? pressingMeta(sourcePressing) : '';
+  const sourcePanel = renderSourcePanel({
+    label: sourceLabel,
+    meta: sourceMeta,
+    tracks: null,
+    loading: true,
+  });
+  showOverlay(`${renderStandardHeader(sourceLabel)}
+    ${sourcePanel}
     ${renderPressingsList(releases, sourceMbid)}
-    <div class="actions" style="margin-top:12px;">
+    <div class="replace-picker-cancel-bar">
       <button class="btn" id="replace-picker-cancel">Cancel</button>
     </div>`);
 
   bindCancel(close);
   const modal = document.getElementById('replace-picker-modal');
   if (!modal) return;
-  modal.querySelectorAll('button[data-mbid]').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const targetMbid = btn.getAttribute('data-mbid') || '';
-      await runConfirm({
-        sourceRequestId: options.sourceRequestId,
-        targetMbid,
-        targetLabel: btn.textContent || targetMbid,
-      }, showOverlay, close);
+  wireRows(modal, async (targetMbid, rowLabel) => {
+    await runConfirm({
+      sourceRequestId: options.sourceRequestId,
+      targetMbid,
+      targetLabel: rowLabel,
+    }, showOverlay, close);
+  });
+  // Lazy-fill the "current request" tracklist. Failure here is non-fatal —
+  // the picker still works without the reference panel.
+  loadSourceTracklist(modal, sourceMbid, sourceLabel).catch(() => {});
+}
+
+/**
+ * Module-scoped cache for fetched MB releases — keyed by MBID. Drops on
+ * picker close because the modal HTML is wiped, not because the cache
+ * itself clears, so re-opening the picker against the same RG will
+ * re-fetch. That's fine: /api/release/<mbid> is Redis-cached server-side
+ * (24h TTL), so the second open is still effectively instant.
+ *
+ * @type {Map<string, Promise<{ tracks: TracklistTrack[] }>>}
+ */
+const tracklistCache = new Map();
+
+/**
+ * @param {string} mbid
+ * @returns {Promise<{ tracks: TracklistTrack[] }>}
+ */
+function fetchTracklist(mbid) {
+  const cached = tracklistCache.get(mbid);
+  if (cached) return cached;
+  const p = fetch(`/api/release/${encodeURIComponent(mbid)}`)
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = await res.json();
+      return { tracks: body.tracks || [] };
+    });
+  tracklistCache.set(mbid, p);
+  // If the fetch rejects, drop the cache entry so retries are possible.
+  p.catch(() => tracklistCache.delete(mbid));
+  return p;
+}
+
+/**
+ * Wire row-click expansion + confirm-button click for every picker row
+ * inside `root`.
+ *
+ * Row click toggles the tracklist + action panel. The first expansion
+ * lazy-fetches `/api/release/<mbid>` and renders the tracklist; later
+ * expansions just toggle visibility. The pick button (rendered inside
+ * the expanded panel) calls `onPick` with the row's MBID, its label,
+ * and the optional `data-rid` (inverted-mode existing-request id).
+ *
+ * @param {HTMLElement|Document} root
+ * @param {(mbid: string, label: string, rid: string | null) => void | Promise<void>} onPick
+ */
+function wireRows(root, onPick) {
+  root.querySelectorAll('.replace-picker-row').forEach((row) => {
+    const pickBtn = /** @type {HTMLButtonElement|null} */ (
+      row.querySelector('button.replace-picker-pick[data-expand-mbid]')
+    );
+    if (!pickBtn || pickBtn.disabled) return;
+    const mbid = pickBtn.getAttribute('data-expand-mbid') || '';
+    const panel = /** @type {HTMLElement|null} */ (
+      row.querySelector(`.replace-picker-detail[data-tracks-for="${cssEscape(mbid)}"]`)
+    );
+    const actionsSlot = /** @type {HTMLElement|null} */ (
+      row.querySelector(`.replace-picker-detail-actions-slot[data-actions-for="${cssEscape(mbid)}"]`)
+    );
+    if (!panel) return;
+
+    pickBtn.addEventListener('click', async (event) => {
+      event.stopPropagation();
+      const expanded = pickBtn.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        row.classList.remove('open');
+        pickBtn.setAttribute('aria-expanded', 'false');
+        if (actionsSlot) actionsSlot.hidden = true;
+        return;
+      }
+      row.classList.add('open');
+      pickBtn.setAttribute('aria-expanded', 'true');
+      if (actionsSlot) actionsSlot.hidden = false;
+      if (!panel.dataset.loaded) {
+        panel.innerHTML = '<p style="color:#888;margin:4px 0;">Loading tracklist…</p>';
+        try {
+          const { tracks } = await fetchTracklist(mbid);
+          panel.innerHTML = renderTracklist(tracks);
+          panel.dataset.loaded = '1';
+        } catch (err) {
+          panel.innerHTML = `<p style="color:#f66;margin:4px 0;">Failed to load: ${esc(String(err))}</p>`;
+        }
+      }
+    });
+
+    const confirmBtn = /** @type {HTMLButtonElement|null} */ (
+      row.querySelector('button.replace-picker-confirm')
+    );
+    if (!confirmBtn) return;
+    confirmBtn.addEventListener('click', async (event) => {
+      event.stopPropagation();
+      const label = (pickBtn.textContent || '').trim().split('\n')[0] || mbid;
+      const rid = confirmBtn.getAttribute('data-rid');
+      await onPick(mbid, label, rid);
     });
   });
+}
+
+/**
+ * Minimal CSS.escape replacement — picker MBIDs are UUIDs so the only
+ * character classes we need to handle are `[0-9a-f-]`, but we guard
+ * defensively anyway.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function cssEscape(s) {
+  if (typeof CSS !== 'undefined' && CSS && typeof CSS.escape === 'function') {
+    return CSS.escape(s);
+  }
+  return s.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+/**
+ * @param {HTMLElement} modal
+ * @param {string} sourceMbid
+ * @param {string} sourceLabel
+ */
+async function loadSourceTracklist(modal, sourceMbid, sourceLabel) {
+  const body = modal.querySelector('.replace-picker-source-body');
+  if (!body) return;
+  if (!sourceMbid) {
+    body.innerHTML = '<p style="color:#888;margin:4px 0;">No reference MBID for this request.</p>';
+    return;
+  }
+  try {
+    const { tracks } = await fetchTracklist(sourceMbid);
+    body.innerHTML = renderTracklist(tracks);
+  } catch (err) {
+    body.innerHTML = `<p style="color:#f66;margin:4px 0;">Failed to load reference tracklist: ${esc(String(err))}</p>`;
+  }
 }
 
 /**
@@ -404,24 +676,32 @@ async function runInverted(options, showOverlay, close) {
     return;
   }
 
-  showOverlay(`${renderInvertedHeader(options.targetLabel || options.targetMbid)}
+  const targetLabel = options.targetLabel || options.targetMbid;
+  const sourcePanel = renderSourcePanel({
+    label: targetLabel,
+    meta: '',
+    tracks: null,
+    loading: true,
+  });
+  showOverlay(`${renderInvertedHeader(targetLabel)}
+    ${sourcePanel}
     ${renderRequestsList(requests)}
-    <div class="actions" style="margin-top:12px;">
+    <div class="replace-picker-cancel-bar">
       <button class="btn" id="replace-picker-cancel">Cancel</button>
     </div>`);
   bindCancel(close);
   const modal = document.getElementById('replace-picker-modal');
   if (!modal) return;
-  modal.querySelectorAll('button[data-rid]').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const rid = Number(btn.getAttribute('data-rid'));
-      await runConfirm({
-        sourceRequestId: rid,
-        targetMbid: options.targetMbid,
-        targetLabel: options.targetLabel || options.targetMbid,
-      }, showOverlay, close);
-    });
+  wireRows(modal, async (_rowMbid, _rowLabel, ridAttr) => {
+    const rid = Number(ridAttr);
+    if (!Number.isFinite(rid)) return;
+    await runConfirm({
+      sourceRequestId: rid,
+      targetMbid: options.targetMbid,
+      targetLabel: options.targetLabel || options.targetMbid,
+    }, showOverlay, close);
   });
+  loadSourceTracklist(modal, options.targetMbid, targetLabel).catch(() => {});
 }
 
 /**

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1869,6 +1869,103 @@ def post_pipeline_delete(h, body: dict) -> None:
 
 # ── Route tables ─────────────────────────────────────────────────
 
+class _RedisFingerprintCache:
+    """Adapt ``web/cache.py``'s Redis client to the ``BeetsDistanceCache`` protocol.
+
+    Our fingerprints are msgspec-encoded bytes, while ``web/cache.py``
+    targets JSON-serialisable dicts/lists — so we bypass the JSON
+    wrapping and talk to the Redis client directly. Falls back to a
+    no-op cache when Redis is unavailable so single-call dev shells
+    still work (just without the cached fast-path).
+    """
+
+    def __init__(self) -> None:
+        from web import cache as _cache_mod
+        self._redis = getattr(_cache_mod, "_redis", None)
+
+    def get(self, key: str):
+        if self._redis is None:
+            return None
+        try:
+            raw = self._redis.get(key)  # type: ignore[union-attr]
+        except Exception:
+            return None
+        if raw is None:
+            return None
+        # web/cache.py initialises Redis with ``decode_responses=True``,
+        # so ``get`` returns str. msgspec.json.decode handles bytes;
+        # encoding is cheap.
+        if isinstance(raw, str):
+            return raw.encode("utf-8")
+        return raw
+
+    def set(self, key: str, value: bytes, ttl_seconds: int) -> None:
+        if self._redis is None:
+            return
+        try:
+            self._redis.setex(key, ttl_seconds, value)  # type: ignore[union-attr]
+        except Exception:
+            pass
+
+
+_BEETS_DISTANCE_OUTCOME_STATUS: dict[str, int] = {
+    "ok": 200,
+    "download_log_not_found": 404,
+    "request_not_found": 404,
+    "folder_missing": 410,
+    "no_audio": 410,
+    "mb_lookup_failed": 503,
+    "mb_no_release_group": 422,
+    "wrong_release_group": 422,
+    "distance_failed": 500,
+}
+
+
+def get_beets_distance(
+    h, params: dict[str, list[str]],
+    download_log_id_str: str, mbid: str,
+) -> None:
+    """``GET /api/beets-distance/<download_log_id>/<mbid>``.
+
+    Real beets match distance for one ``(download_log_id, mbid)``
+    pair. The service does the heavy lifting (see
+    ``lib/beets_distance.compute_beets_distance``); this handler is a
+    thin adapter that maps the typed ``BeetsDistanceResult`` outcomes
+    to HTTP status codes per the CLI ⇄ API symmetry rule.
+
+    Status-code mapping:
+      * 200 — ``ok`` (distance is in ``response.distance``)
+      * 404 — ``download_log_not_found`` / ``request_not_found``
+      * 410 — ``folder_missing`` / ``no_audio`` (the data the caller
+              wanted to compare against is gone)
+      * 422 — ``mb_no_release_group`` / ``wrong_release_group``
+              (semantic input violations — including the
+              cross-release-group guardrail)
+      * 503 — ``mb_lookup_failed`` (MB mirror transient)
+      * 500 — ``distance_failed`` (unexpected beets error)
+    """
+    from lib.beets_distance import compute_beets_distance
+
+    try:
+        download_log_id = int(download_log_id_str)
+    except (TypeError, ValueError):
+        h._error("Invalid download_log_id")
+        return
+
+    s = _server()
+    result = compute_beets_distance(
+        download_log_id,
+        mbid,
+        pdb=s._db(),
+        mb_get_release=lambda m: mb_api.get_release(m, fresh=False),
+        cache=_RedisFingerprintCache(),
+    )
+
+    status = _BEETS_DISTANCE_OUTCOME_STATUS.get(result.outcome, 500)
+    payload = msgspec.to_builtins(result)
+    h._json(payload, status=status)
+
+
 GET_ROUTES: dict[str, object] = {
     "/api/pipeline/log": get_pipeline_log,
     "/api/pipeline/status": get_pipeline_status,
@@ -1884,6 +1981,10 @@ GET_ROUTES: dict[str, object] = {
 }
 
 GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
+    # /api/beets-distance/<download_log_id>/<mbid> — real beets distance
+    # for one (download_log_id, mbid) pair. See get_beets_distance above.
+    (re.compile(r"^/api/beets-distance/(\d+)/([a-f0-9-]{36})$"),
+     get_beets_distance),
     (re.compile(r"^/api/pipeline/(\d+)$"), get_pipeline_detail),
     (re.compile(r"^/api/pipeline/(\d+)/search-plan$"),
      get_pipeline_search_plan),


### PR DESCRIPTION
## Summary
- Each pressing row in the Replace picker carries a `best 0.07 (12/12)` green badge computed via `GET /api/beets-distance/<dl>/<mbid>` against the source request's wrong-matches folders.
- Source-agnostic: data always comes from the source request's wrong-matches, regardless of where Replace was clicked from.
- Silent no-op when the request has no wrong-matches or when individual calls fail. Picker remains fully usable.
- Fan-out capped at 6 concurrent requests (browser per-origin keep-alive). N×M ≈ 100 for Dr. Octagon; warm cache total ≈ 100·5ms / 6 ≈ 80ms.

## Stacked on
- #284 (Replace picker UX cleanup)
- #285 (beets-distance API + CLI + route)

Merge in order: #285 → #284 → this. Or merge into a single integration branch if you prefer.

## Test plan
- [x] `node tests/test_js_util.mjs` — 288 pass
- [ ] Deploy + reopen Replace picker on Dr. Octagon (request with many wrong-matches folders); confirm each pressing shows its best distance and the JP-cassette pressing scores lowest if soulseek is serving that copy
- [ ] Reopen Replace picker on a request with zero wrong-matches; confirm no distance badges appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)