### PR TITLE
fix(nix): include beets in cratedigger production pythonEnv

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,18 +3,23 @@
 let
   slskd-api = pkgs.callPackage ./slskd-api.nix { };
 
-  # Production python deps. Deliberately does NOT include beets — cratedigger
-  # invokes beets out-of-process via harness/run_beets_harness.sh, which
-  # uses whatever `beet` the deployment environment provides (so the
-  # consumer's plugins + MB host config + library DB all just work).
-  # Putting `beet` in our pythonEnv would shadow the consumer's binary
-  # via PATH and cause silent validation failures.
+  # Production python deps. Includes beets only as a Python library —
+  # ``lib/beets_distance.py`` calls ``beets.autotag.distance`` directly
+  # from cratedigger-web to compute Replace-picker distance scores. The
+  # consumer's ``beet`` CLI is still the source of truth for import:
+  # ``harness/run_beets_harness.sh`` invokes it explicitly with its own
+  # PATH + plugin config, and the systemd unit doesn't put the Nix
+  # ``beet`` binary on the cratedigger user's shell PATH. So adding the
+  # library here does NOT shadow the consumer's binary at import time.
+  # If we ever spawn ``beet`` from the cratedigger process itself, that
+  # invariant breaks and this needs revisiting.
   pythonPackages = ps: [
     ps.psycopg2
     ps.music-tag
     ps.msgspec
     ps.redis     # web UI cache (graceful no-op if redis server is down, but the module must be importable)
     ps.zstandard # peer cache compresses msgpack directory payloads before writing Redis bytes
+    ps.beets     # beets.autotag.distance for /api/beets-distance — library import only
     slskd-api
   ];
 in {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -3,11 +3,13 @@
 let
   cratedigger = import ./package.nix { inherit pkgs; };
 
-  # Dev-only python env: production deps + beets so
-  # harness/beets_harness.py is importable for tests. Production
-  # pythonEnv deliberately excludes beets — see nix/package.nix.
+  # Dev env: production deps. ``ps.beets`` was previously listed
+  # again here because the production env excluded it; now that
+  # ``lib.beets_distance`` makes beets a first-class library
+  # dependency it's already in ``pythonPackages``, so the dev shell
+  # inherits it without duplication.
   testPythonEnv = pkgs.python3.withPackages (ps:
-    cratedigger.pythonPackages ps ++ [ps.beets]
+    cratedigger.pythonPackages ps
   );
 in
 pkgs.mkShell {


### PR DESCRIPTION
Fixes the 500 ModuleNotFoundError: No module named 'beets' that PR #285 hit in prod. See commit body. After this, deploy + retry GET /api/beets-distance/... should land cleanly.