### PR TITLE
feat: search-plan entropy and matcher pre-filter

### DIFF
--- a/album_source.py
+++ b/album_source.py
@@ -58,11 +58,11 @@ class AlbumRecord:
     db_mb_release_id: str
     db_search_filetype_override: str | None
     db_target_format: str | None
-    # U3 / R9 — release-group's first-release year, populated from the
-    # local MB mirror at enqueue time (U4) or deploy-time backfill (U3).
-    # NULL for pre-backfill rows, Discogs-only rows, and rows missing
-    # ``mb_release_group_id``. The generator (U5) emits a year-suffixed
-    # slot when this differs from ``release_date``'s year.
+    # Release-group's first-release year, populated from the local MB
+    # mirror at enqueue time or via the deploy-time backfill. NULL for
+    # pre-backfill rows, Discogs-only rows, and rows missing
+    # ``mb_release_group_id``. The generator emits a year-suffixed slot
+    # when this differs from ``release_date``'s year.
     db_release_group_year: int | None = None
 
     @staticmethod

--- a/album_source.py
+++ b/album_source.py
@@ -58,6 +58,12 @@ class AlbumRecord:
     db_mb_release_id: str
     db_search_filetype_override: str | None
     db_target_format: str | None
+    # U3 / R9 — release-group's first-release year, populated from the
+    # local MB mirror at enqueue time (U4) or deploy-time backfill (U3).
+    # NULL for pre-backfill rows, Discogs-only rows, and rows missing
+    # ``mb_release_group_id``. The generator (U5) emits a year-suffixed
+    # slot when this differs from ``release_date``'s year.
+    db_release_group_year: int | None = None
 
     @staticmethod
     def from_db_row(row: dict[str, object], tracks: list[dict[str, object]]) -> AlbumRecord:
@@ -123,6 +129,8 @@ class AlbumRecord:
         assert isinstance(search_filetype_override, (str, type(None)))
         target_format = row.get("target_format")
         assert isinstance(target_format, (str, type(None)))
+        release_group_year = row.get("release_group_year")
+        assert isinstance(release_group_year, (int, type(None)))
 
         return AlbumRecord(
             id=row_id * -1,
@@ -137,6 +145,7 @@ class AlbumRecord:
             db_mb_release_id=mb_release_id or "",
             db_search_filetype_override=search_filetype_override,
             db_target_format=target_format,
+            db_release_group_year=release_group_year,
         )
 
 

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -181,7 +181,7 @@ from lib.matching import (
     check_ratio,
     get_album_by_id,
 )
-from lib.quality import top_candidates
+from lib.quality import top_candidates, top_candidates_with_skip_split
 
 
 def filter_list(albums: Sequence[Any], filter_cfg: CratediggerConfig) -> list[Any] | None:
@@ -860,7 +860,10 @@ def _log_search_result(album, result, ctx) -> None:
     # a candidate concept" (error, timeout, empty_query — those write NULL).
     OUTCOMES_WITH_CANDIDATE_CONCEPT = ("no_results", "no_match", "found")
     if result.candidates:
-        top: list | None = top_candidates(result.candidates)
+        # U2 of search-plan-entropy: split into scored + up to 5
+        # pre-filter-skip samples so the blob keeps room for both
+        # without exceeding the historical top-20 cap.
+        top: list | None = top_candidates_with_skip_split(result.candidates)
     elif outcome in OUTCOMES_WITH_CANDIDATE_CONCEPT:
         top = []
     else:
@@ -911,6 +914,9 @@ def _log_search_result(album, result, ctx) -> None:
                     peers_browsed=result.peers_browsed,
                     peers_browsed_lazy=result.peers_browsed_lazy,
                     fanout_waves=result.fanout_waves,
+                    pre_filter_skip_count=getattr(
+                        result, "pre_filter_skip_count", 0,
+                    ),
                     apply_scheduler_attempt=True,
                     scheduler_success=scheduler_success,
                 )
@@ -947,6 +953,9 @@ def _log_search_result(album, result, ctx) -> None:
                 elapsed_s=result.elapsed_s or None,
                 final_state=result.final_state,
                 apply_scheduler_attempt=True,
+                pre_filter_skip_count=getattr(
+                    result, "pre_filter_skip_count", 0,
+                ),
             )
         )
     except Exception:
@@ -1008,6 +1017,9 @@ def _apply_find_download_result(
     # find_download result onto the SearchResult so `_log_search_result` can
     # persist the top-20 to `search_log.candidates`.
     result.candidates = tuple(find_result.candidates)
+    # U2 of search-plan-entropy: aggregate pre-filter skip count from the
+    # find_download walk gets persisted on search_log.pre_filter_skip_count.
+    result.pre_filter_skip_count = find_result.pre_filter_skip_count
     if ctx is not None and getattr(find_result, "metrics", None) is not None:
         metrics = find_result.metrics
         result.browse_time_s = metrics.browse_time_s

--- a/cratedigger.py
+++ b/cratedigger.py
@@ -181,7 +181,7 @@ from lib.matching import (
     check_ratio,
     get_album_by_id,
 )
-from lib.quality import top_candidates, top_candidates_with_skip_split
+from lib.quality import top_candidates_with_skip_split
 
 
 def filter_list(albums: Sequence[Any], filter_cfg: CratediggerConfig) -> list[Any] | None:
@@ -914,9 +914,7 @@ def _log_search_result(album, result, ctx) -> None:
                     peers_browsed=result.peers_browsed,
                     peers_browsed_lazy=result.peers_browsed_lazy,
                     fanout_waves=result.fanout_waves,
-                    pre_filter_skip_count=getattr(
-                        result, "pre_filter_skip_count", 0,
-                    ),
+                    pre_filter_skip_count=result.pre_filter_skip_count,
                     apply_scheduler_attempt=True,
                     scheduler_success=scheduler_success,
                 )
@@ -953,9 +951,7 @@ def _log_search_result(album, result, ctx) -> None:
                 elapsed_s=result.elapsed_s or None,
                 final_state=result.final_state,
                 apply_scheduler_attempt=True,
-                pre_filter_skip_count=getattr(
-                    result, "pre_filter_skip_count", 0,
-                ),
+                pre_filter_skip_count=result.pre_filter_skip_count,
             )
         )
     except Exception:
@@ -1017,8 +1013,8 @@ def _apply_find_download_result(
     # find_download result onto the SearchResult so `_log_search_result` can
     # persist the top-20 to `search_log.candidates`.
     result.candidates = tuple(find_result.candidates)
-    # U2 of search-plan-entropy: aggregate pre-filter skip count from the
-    # find_download walk gets persisted on search_log.pre_filter_skip_count.
+    # Aggregate pre-filter skip count from the find_download walk gets
+    # persisted on ``search_log.pre_filter_skip_count``.
     result.pre_filter_skip_count = find_result.pre_filter_skip_count
     if ctx is not None and getattr(find_result, "metrics", None) is not None:
         metrics = find_result.metrics

--- a/docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md
+++ b/docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md
@@ -1,0 +1,401 @@
+---
+date: 2026-05-19
+topic: search-plan-entropy-and-matcher-prefilter
+---
+
+# Search Plan Entropy and Matcher Pre-filter
+
+## Summary
+
+Restructure the search-plan generator to produce per-album entropy that
+actually finds music, and reshape a matcher pre-filter that today fires
+asymmetrically and silently discards legitimate track-fallback results.
+Investment in the matcher's permissiveness also seeds the Redis browse
+cache with more peer-folder data, which is the substrate for the future
+cross-pressing matcher (out of scope here; explicitly enabled by the
+choices in this doc).
+
+---
+
+## Problem Frame
+
+The persisted search-plan system (rolled out 2026-05-08) is running cleanly
+— ~20k searches/7d, plans persist, cursor advances — but a hard read of the
+data shows ~600 / 20k searches saturating at slskd's
+`ResponseLimitReached` (1000 user cap) or `FileLimitReached` (50,000 file
+cap). The saturation rate alone (3%) is unalarming. What is alarming is the
+per-request distribution: a small set of curated requests are
+**continuously** saturating with zero downloads.
+
+Concrete starving cases (14d window):
+- Radiohead — Kid A: 43 search attempts, 25 saturated, **0 found**, status
+  still `wanted`. Has existing 128kbps MP3 in beets; pipeline cannot
+  upgrade.
+- Bon Iver — 22, a Million: 47 attempts, 23 saturated, 0 found.
+- Willow — Willow (self-titled, 2007): 37 attempts, 18 saturated, 0 found.
+- Mountains — Mountains Mountains Mountains: 8 attempts, 10 saturated,
+  2 found, none imported.
+- Darren Hanlon — I Will Love You at All: 43 attempts, 6 saturated, 0
+  found.
+
+Manual slskd probes prove every one of these albums is **on the network in
+sufficient quantity to find**:
+- Kid A FLAC: 422 unique Kid A directories across 8+ users carrying the
+  2021 Mnesia box (34 tracks), and many users carrying the original 2000
+  release.
+- Bon Iver 22 a Million with literal title: 138 responses, no saturation.
+- Willow self-titled: literal first-track query "When the Sea Called Our
+  Names" returned **exactly 2 responses, both pointing at the correct
+  album folder** on cpm4 and special_user. A direct browse of those
+  users confirmed both serve the full 4-track Willow (2007) - Willow
+  directory (MP3 only — the album is genuinely scarce in lossless, but
+  the matcher would have rejected it on quality grounds, not by silently
+  skipping it).
+- Darren Hanlon: literal title returned **one** response, a perfect
+  10-track FLAC match.
+
+Demographic confirmation: **100% of requests in the pipeline want
+lossless** (3716 with default config, 215 lossless-only, 269+ requests
+with lossless as the top tier in a multi-tier override). Zero requests
+exclude FLAC. There is no cohort for whom format-hint slots are
+inappropriate.
+
+So the pipeline is not failing because the network is empty. It is failing
+because:
+
+1. **The generator emits low-entropy queries that saturate.** Five of ten
+   plan slots are the same default query repeated. Short-token drop strips
+   the most distinguishing characters of short-titled albums ("Kid A" →
+   `*adiohead Kid`, "22, a Million" → `*on *ver Million`). Self-titled
+   albums collapse to one token (`*illow`, `*ountains`). Title-only track
+   fallbacks drop the artist and match every soundtrack on Soulseek.
+
+2. **The matcher pre-filter fires asymmetrically and silently discards
+   track-fallback results.** A pre-filter in `check_for_match` rejects any
+   candidate dir where `abs(search_count - track_num) > 2`. Track-fallback
+   queries by definition return one file per user (the matching track),
+   so for any album with ≥4 tracks the pre-filter unconditionally skips
+   and **negative-caches** every user. Three Willow track searches in
+   the DB returned 2 / 4 / 6 results and **zero candidates evaluated
+   each time**. The strategy slot fires; the matcher never looks at the
+   data. The pre-filter's true purpose is junk-dir guarding ("user has a
+   dump folder with 5000 files, don't browse it for a 4-track album"),
+   not tight-fit filtering. The bidirectional comparison was always
+   over-strict.
+
+3. **Format/year context is under-used as entropy.** Adding the literal
+   string "FLAC" or the original release year to a wildcarded query
+   collapsed saturated 1000-response results to 138–200. Year is currently
+   one slot in ten and uses the MB release year (sometimes a reissue
+   year), not the release-group year users actually file by. Kid A is
+   filed by Soulseek users overwhelmingly as 2000 (original release);
+   our request carries 2008 (US reissue), so `Radiohead Kid 2008`
+   returns ~6 results while `Radiohead Kid 2000` returns hundreds.
+
+The observability we built in the persisted-plan rollout
+(`final_state`, `candidates` JSONB, per-slot stats in
+`search-plan show`) is what made this investigation possible — that
+infrastructure is keeping its end of the bargain. The generator and
+matcher are not.
+
+---
+
+## Requirements
+
+**Matcher pre-filter — bleed-stop**
+
+- R1. The `check_for_match` pre-filter at `lib/matching.py` must flip
+  from bidirectional (`abs(search_count - track_num) > 2`) to
+  asymmetric (`search_count > 2 * track_num`). This single-line change
+  preserves the optimisation's true value (don't waste a browse on a
+  user whose dir clearly contains too much stuff to be the album) while
+  killing the false-positive case (don't skip a user just because the
+  search returned only the matching track, not the whole folder). The
+  `cached_codecs <= 1` guard stays — it protects multi-codec dirs from
+  being skipped. As a bonus dividend, this change also bypasses the
+  pre-filter for track-fallback queries automatically (`search_count = 1`
+  is well below `2 * track_num` for any multi-track album), so no
+  variant context needs to be threaded into the matcher.
+- R2. **Dissolved.** Investigation confirmed
+  `ctx.negative_matches` is a per-cycle in-memory `set` on
+  `CratediggerContext`, wiped fresh every 5-minute cycle. No permanent
+  leak exists; no cache-cleanup work is needed. The brainstorm's
+  original wipe-vs-scope question is moot.
+- R3. Search forensics must distinguish "matcher pre-filter skipped"
+  from "matcher scored, rejected" — but bounded against storage growth.
+  Shape: add `pre_filter_skip_count INTEGER` as a dedicated column on
+  `search_log` (aggregable, ~4 bytes/row), and allow up to ~5 flagged
+  skip rows to ride alongside scored candidates inside the existing
+  candidates JSONB blob (samples for inspection, not exhaustive lists).
+  Operators investigating "is the pre-filter doing real work?" use the
+  scalar; operators investigating "why was peer X skipped?" use the
+  sample. Reconstructing the full skip list from a single search is not
+  a goal — peers are still browsable, the next cycle would capture
+  them fresh.
+
+**Generator — entropy structure**
+
+- R4. The five-slot default repetition must be replaced. Each of those
+  slots should be a distinct strategy (literal-title, format-hint,
+  release-group-year, track-with-artist, etc.), not the same query
+  five times. One default slot is sufficient.
+- R5. Remove the short-token drop entirely. The current rule strips
+  tokens ≤ 2 chars unconditionally, destroying the most distinguishing
+  characters of short-titled albums ("A" in "Kid A", "22" in "22, a
+  Million", "Why" in "So Why?"). Replace with: rank tokens by
+  distinctiveness and cap total token count only — never drop a token
+  because it is short. The historical rationale ("Soulseek drops short
+  tokens") is false; the original AFI failure was an artist-name issue,
+  not a length issue.
+- R6. Add a "literal full title, no wildcarding" strategy as a
+  first-class plan slot. Empirical evidence: this strategy is
+  dramatically more focused than the wildcarded default for ≥4 of the 6
+  albums probed.
+- R7. Add format-hint strategy slots (`literal-title + FLAC`,
+  `literal-title + lossless`) as unconditional members of the plan
+  rotation. **No conditional logic, no log lookback, no statefulness in
+  the generator.** Every request in the pipeline wants lossless (zero
+  requests exclude FLAC); format-hint slots are appropriate for every
+  request. For niche releases where one slot returns zero, the parallel
+  agnostic slot catches the single available peer; the cost is bounded
+  at one slot per cycle per niche release. The generator stays a pure
+  function of the snapshot.
+- R8. Track-fallback queries must prepend the artist name. Title-only
+  track queries produce convincing false positives (e.g. Kid A's "Motion
+  Picture Soundtrack" matches a Matador OST 10/14 tracks). Artist token
+  is the disambiguating signal.
+- R9. Persist release-group year on `album_requests` and use it in the
+  generator. Specifics:
+    - Add `release_group_year INTEGER NULL` column on `album_requests`.
+    - Backfill on deploy by fetching release-group metadata from the
+      local MB mirror for every request with `mb_release_group_id IS
+      NOT NULL AND release_group_year IS NULL`. ~4000 requests, all
+      local I/O. Never defer cheap backfills.
+    - Enqueue path fetches release-group year going forward, so new
+      requests land with it populated.
+    - Generator emits a conditional extra year-anchored slot **only**
+      when `year IS NOT NULL AND release_group_year IS NOT NULL AND
+      release_group_year != year`. When years match, no extra slot
+      (would be a duplicate of `unwild_year`). Plan size grows by
+      exactly 1 for reissues; unchanged for everything else.
+
+**Self-titled / collision cases**
+
+- R10. When `normalize(artist_name) == normalize(album_title)` OR one
+  is a token-subset of the other (catches Willow / Willow,
+  Mountains / Mountains Mountains Mountains, etc.), detect the request
+  as self-titled and route through a dedicated strategy mix. The
+  default wildcarded query for these collapses to a single token
+  (`*illow`, `*ountains`) and is structurally unable to disambiguate.
+- R11. The self-titled strategy mix must include at least one slot
+  that does not rely on artist+title overlap. At minimum: `artist + year`
+  and `artist + first-track-title`. The Willow probe showed
+  track-name-with-artist is the working path; the generator must emit it.
+
+**Observability — close the loop**
+
+- R12. Ship the data and CLI surface for saturation telemetry; defer
+  the dashboard UI to the existing
+  `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md`.
+  Specifically:
+    - The `pre_filter_skip_count` column from R3 lands.
+    - A new aggregator method on `PipelineDB` exposes per-request
+      saturation rate (rows where `final_state LIKE '%LimitReached%'`
+      / total rows) for a request over a window.
+    - A `pipeline-cli search-plan saturation <id>` subcommand surfaces
+      saturation rate, pre-filter skip count, and starving-cohort
+      membership for the operator.
+    - CLI ⇄ API symmetry: same data is exposed via the request's
+      existing JSON endpoint so the future dashboard UI work has the
+      data ready.
+
+**Simulator — Simulator-First TDD for the generator**
+
+- R13. Add a `pipeline-cli search-plan dry-run <request_id>`
+  subcommand that loads the request's snapshot, runs the new generator
+  against it without persisting, and prints the resulting plan items.
+  Lets operators (and the deploy process) validate new generator output
+  against starving albums before bumping `SEARCH_PLAN_GENERATOR_ID`
+  for real. Matches the "Simulator-First TDD" pattern from
+  `.claude/rules/code-quality.md`. Pure read; no side effects on the
+  active plan or request.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1.** Given a request whose `album_tracks` row count is
+  4, when the matcher's pre-filter sees a user with `search_count = 1`
+  (typical for a track-fallback query result), it does NOT skip the
+  user — `1 > 2 * 4` is false. The user's dir is browsed and the full
+  album is evaluated by `album_match`. The same request's matcher,
+  given a user with `search_count = 50` from a junk dir, still skips
+  pre-browse — `50 > 8`.
+- AE2. **Covers R4, R5, R6, R8.** Given Radiohead Kid A request 1868
+  with a freshly-regenerated plan under the new generator, when one
+  cycle of the plan runs, the executor emits at least one query
+  containing the literal token "A" preserved, at least one query
+  containing a format hint, at least one track-fallback query that
+  prepends "Radiohead", and **no** five-fold repetition of the same
+  canonical query key.
+- AE3. **Covers R7.** Given Darren Hanlon — I Will Love You at All
+  (request 1640, niche release with 1 lossless peer on the network),
+  when one cycle of the new plan runs, both the format-hinted slots
+  (`Hanlon I Will Love You at All FLAC`) and the format-agnostic
+  literal-title slot fire. The agnostic slot returns the 1 peer and the
+  matcher evaluates it; the format-hinted slots may return zero
+  results without harm. Both slots execute regardless of the request's
+  prior cycle history — no conditional gating.
+- AE4. **Covers R9.** Given a request where `year = 2008` and
+  `release_group_year = 2000` (Kid A reissue), when the generator runs,
+  the plan contains both an `unwild_year` slot anchored on 2008 and a
+  separate slot anchored on 2000. Given a request where year and
+  release-group year match, the plan size is unchanged from current
+  behaviour — no duplicate slot.
+- AE5. **Covers R10, R11.** Given Willow request 2125 (artist = "Willow",
+  title = "Willow"), the generator detects self-titled, and the
+  emitted plan contains at least one `artist + first-track-title` slot
+  ("Willow When the Sea Called Our Names" or similar) that does NOT
+  collapse to a single wildcarded token.
+- AE6. **Covers R13.** Given any request id, when an operator runs
+  `pipeline-cli search-plan dry-run <id>`, the new generator's plan
+  items are printed to stdout without writing to `search_plans` or
+  `plan_items` or affecting the request's `active_plan_id` cursor.
+
+---
+
+## Success Criteria
+
+- The currently-starving cohort (≥ 5 saturated searches + 0 finds in 14d)
+  drops by at least 50% within two weeks of deploy. Radiohead Kid A and
+  Bon Iver 22 a Million specifically reach `imported` or surface real
+  candidates with measurable beets distance.
+- Zero search_log rows where `outcome='no_match'` AND `variant LIKE 'track%'`
+  AND `result_count > 0` AND `candidates = '[]'` in the 14d following
+  deploy. (Today: 100% of such rows are empty.)
+- Operators can identify a starving request and its failure mode from
+  `pipeline-cli show <id>` alone — generator-emitted queries, slskd
+  `final_state`, AND pre-filter skip count are all visible.
+- `pipeline-cli search-plan dry-run` produces materially different
+  plans for at least Radiohead Kid A, Bon Iver 22 a Million, Willow
+  self-titled, and Darren Hanlon I Will Love You at All before deploy
+  — confirming the generator changes are reaching the right releases.
+- No regression in the conversion rate of normal (non-saturated,
+  non-track-fallback) searches.
+- Redis browse cache coverage increases — the asymmetric pre-filter's
+  more permissive shape feeds more peer-folder data into the cache,
+  which seeds the future cross-pressing matcher.
+
+---
+
+## Scope Boundaries
+
+- Not in scope: rebuilding the `album_match` filename-similarity scoring.
+  R1 fixes the pre-filter; the downstream ratio/cross-check logic is left
+  alone unless a starving case proves it also broken.
+- Not in scope: a new query-DSL or generator framework. Changes layer on
+  `lib/search.py::generate_search_plan` in place, bumping
+  `SEARCH_PLAN_GENERATOR_ID` to invalidate old plans.
+- Not in scope: the cross-pressing matcher itself. The asymmetric
+  pre-filter (R1) and persisted `release_group_year` (R9) are
+  investments that make that future system possible, but its design and
+  implementation belong in their own brainstorm.
+- Not in scope: catalog-mining / "find every Radiohead release this user
+  has" browse strategy. The pipeline is request-driven; this work
+  improves per-request search.
+- Not in scope: changing slskd's `responseLimit` / `fileLimit` config.
+  Saturation is the symptom; raising limits would not help focus.
+- Not in scope: pipeline-level retry/cooldown policy on starving
+  requests. R12 surfaces the data; a separate brainstorm can decide
+  what to do with chronically-starving requests.
+- Not in scope: the per-request dashboard UI for saturation/skip
+  visualisation. R12 ships the data + CLI; UI lives in
+  `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md`.
+- Not in scope: bonus-track and multi-disc handling. The matcher's
+  per-folder strict-count gate still rejects 14-track 2-disc albums
+  stored as `/CD1/` + `/CD2/` and 13-track albums with a bonus track in
+  the same folder. Known limitations, separate problems.
+- Not in scope: the Willow self-titled "genuinely rare in lossless on
+  Soulseek" case. R10 + R11 give it a fighting chance via track-name
+  + artist queries; if no FLAC exists in the network, the pipeline
+  correctly stays in `wanted`. Acceptable behaviour.
+
+---
+
+## Key Decisions
+
+- **Forward-only via plan-generator ID bump.** Bumping
+  `SEARCH_PLAN_GENERATOR_ID` invalidates existing plans for affected
+  requests on the next cycle. No backfill, no migration of old plan
+  rows. Matches the repo's "request is source of truth, everything
+  else is derived" invariant.
+- **Matcher fix lands before or with generator changes, never after.**
+  Shipping new track-fallback variants while the pre-filter still
+  silently discards them would waste a deploy and obscure whether the
+  generator changes helped. Order matters.
+- **Pre-filter is asymmetric, not variant-aware.** A single-line code
+  change (bidirectional → `search_count > 2 * track_num`) is preferred
+  over plumbing variant context through `find_download` into the
+  matcher. The matcher stays unaware of search strategy; the threshold
+  doubles the album's track count rather than fitting it tightly.
+  Bonus: track-fallback bug fixed without special-casing.
+- **`2n` over `n+2`.** The pre-filter's purpose is "junk-dir guard",
+  not "tight-fit filter". `2n` captures more peer-folder data into
+  Redis (cached for 7 days, ~3 searches/release/day cadence means first
+  cycle pays the browse cost, subsequent cycles cheap), which is the
+  substrate for the future cross-pressing matcher.
+- **Format hints are universal, not conditional.** 100% of pipeline
+  requests want lossless; no cohort exists for whom format-hint slots
+  are inappropriate. The generator stays pure (no log lookback, no
+  state). Niche releases get one or two slots that return zero — bounded
+  cost.
+- **Wildcarding stays.** Empirically necessary for catalog-style
+  searches on artists where Soulseek's index doesn't return literal
+  matches (the original Beatles → `*eatles` rationale still holds). We
+  are not removing wildcarding; we are removing **wildcarding combined
+  with token-dropping that destroys entropy**.
+- **Release-group year is data, not derivation.** Persist
+  `release_group_year` as a real column and backfill on deploy. Don't
+  defer cheap backfills. Conditional extra slot when years differ; no
+  extra slot when they match (avoid the same wasteful repetition
+  pattern we are killing in R4).
+- **R3 forensic encoding: scalar count + sample in JSONB.** A dedicated
+  `INTEGER` column for aggregable skip count; a small (~5 row) sample
+  flagged inside the existing candidates JSONB for inspection.
+  Resolves the storage-growth-vs-debuggability tension by capping per-row
+  forensic size.
+- **JSONB is the right shape for forensic samples** (consumed wholesale,
+  not queried by inner fields). The broader question of "should
+  cratedigger migrate away from JSONB more aggressively" is its own
+  conversation — out of scope here.
+
+---
+
+## Dependencies / Assumptions
+
+- Depends on the persisted search-plan infrastructure already in place
+  (`lib/search.py::generate_search_plan`,
+  `lib/search_plan_service.SearchPlanService`,
+  `SEARCH_PLAN_GENERATOR_ID` constant).
+- Depends on the `search_log.final_state` and `candidates` JSONB columns
+  rolled out in migrations 010 + 014.
+- Depends on the 7-day Redis browse cache (
+  `docs/plans/2026-05-05-001-feat-peer-cache-redis-migration-plan.md`) —
+  the `2n` pre-filter shape is acceptable cost only because cached
+  browses make subsequent cycles cheap.
+- Assumes slskd's `ResponseLimitReached` / `FileLimitReached` state
+  strings are stable across the slskd-api versions we ship.
+- **Assumption to verify during implementation:** the MB mirror's
+  release-group fetch path exposes the first-release year directly. If
+  it instead requires "list all releases in this release-group, take
+  min(year)", the backfill query is slightly more elaborate but still
+  cheap (all local mirror I/O). Either way the implementation is
+  bounded.
+
+---
+
+## Outstanding Questions
+
+All planning-time questions from the original brainstorm have been
+resolved through dialogue. No blockers remain. The implementation plan
+is at `docs/plans/2026-05-19-NNN-feat-search-plan-entropy-and-matcher-prefilter-plan.md`.

--- a/docs/plans/2026-05-19-001-feat-search-plan-entropy-and-matcher-prefilter-plan.md
+++ b/docs/plans/2026-05-19-001-feat-search-plan-entropy-and-matcher-prefilter-plan.md
@@ -1,0 +1,581 @@
+---
+title: feat: Search plan entropy and matcher pre-filter
+type: feat
+status: active
+date: 2026-05-19
+origin: docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md
+---
+
+# feat: Search plan entropy and matcher pre-filter
+
+## Summary
+
+Flip the matcher pre-filter at `lib/matching.py::check_for_match` from
+bidirectional to asymmetric (one-line change), persist `release_group_year`
+on `album_requests` with a deploy-time backfill, restructure
+`lib/search.py::generate_search_plan` to kill default-slot repetition and
+the short-token drop while adding literal-title / format-hint /
+track-with-artist / release-group-year / self-titled strategy slots, and
+ship a dry-run simulator CLI + saturation telemetry plumbing. Bump
+`SEARCH_PLAN_GENERATOR_ID` to invalidate all existing plans on next cycle.
+
+---
+
+## Problem Frame
+
+See origin: `docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md`.
+A small cohort of curated requests (Radiohead Kid A, Bon Iver 22 a Million,
+Willow self-titled, Mountains, Darren Hanlon) are continuously saturating
+slskd or returning zero matches despite the albums being demonstrably
+findable on the network. Root causes are the matcher pre-filter silently
+skipping track-fallback results and the generator emitting low-entropy
+queries. Plan order matters: the matcher fix lands before or with the
+generator changes — shipping new variants while the pre-filter still
+discards them would waste a deploy.
+
+---
+
+## Requirements
+
+Carried from origin (`docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md`):
+
+- R1. Asymmetric pre-filter (`search_count > 2 * track_num`), codec guard preserved.
+- R2. Dissolved (per-cycle cache; no leak).
+- R3. Forensic encoding: `pre_filter_skip_count INTEGER` column + ≤5 flagged sample rows in candidates JSONB.
+- R4. Replace 5-slot default repetition with distinct strategies.
+- R5. Remove short-token drop entirely.
+- R6. Add literal-full-title strategy slot.
+- R7. Format-hint slots universal (no conditional gating).
+- R8. Track-fallback queries prepend artist.
+- R9. Persist `release_group_year`, backfill on deploy, conditional extra slot when years differ.
+- R10. Detect self-titled via `normalize(artist) == normalize(title)` OR token-subset.
+- R11. Self-titled strategy mix includes artist + first-track-title and artist + year.
+- R12. Ship pre_filter_skip_count column + saturation aggregator + `pipeline-cli search-plan saturation`; defer dashboard UI to `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md`.
+- R13. `pipeline-cli search-plan dry-run <id>` runs new generator without persisting.
+
+**Origin acceptance examples:** AE1 (R1), AE2 (R4/R5/R6/R8), AE3 (R7), AE4 (R9), AE5 (R10/R11), AE6 (R13).
+
+---
+
+## Scope Boundaries
+
+- Not rebuilding `album_match` filename-similarity scoring. R1 fixes the pre-filter only.
+- Not introducing a new query DSL or generator framework. Changes layer on `lib/search.py::generate_search_plan` in place.
+- Not building the cross-pressing matcher. R1 (asymmetric `2n`) and R9 (release_group_year) are investments that enable it; design and implementation belong in their own brainstorm.
+- Not implementing the dashboard UI for saturation/skip visualisation. R12 ships data + CLI; UI lives in `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md`.
+- Not changing slskd's `responseLimit` / `fileLimit` config. Saturation is the symptom; raising limits would not help focus.
+- Not addressing bonus-track / multi-disc handling. The matcher's per-folder strict-count gate still rejects those cases. Separate known limitations.
+- Not adding pipeline-level retry/cooldown policy on starving requests. R12 surfaces the data; what to do with chronically-starving requests is a separate decision.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/matching.py::check_for_match` (lines 308–517) — pre-filter at lines 350–356; negative-cache write at line 355; second strict-count gate at line 451.
+- `lib/matching.py::album_track_num` — only counts audio files matching configured specs; junk (jpg/nfo/m3u/cue/log) is correctly ignored at both gates.
+- `lib/context.py:34-35` — `search_dir_audio_count` and `negative_matches` (per-cycle; reset each context).
+- `cratedigger.py:203 _build_search_cache` and `cratedigger.py:738` — both paths populate `dir_audio_counts`. Only files passing `filetype_matches` increment the count.
+- `lib/search.py::generate_search_plan` (lines 749–1002) — current generator. `SEARCH_PLAN_GENERATOR_ID` at line 35.
+- `lib/search.py::build_query`, `cap_tokens`, `strip_short_tokens`, `wildcard_artist_tokens` — composition helpers.
+- `lib/search.py:802` — `_has_dropped_low_entropy` populates plan provenance for dropped tokens.
+- `lib/search_plan_service.SearchPlanService` — plan lifecycle, regeneration entry points.
+- `lib/pipeline_db.py::log_search` (line 3210) — search-log row insert; `candidates` is msgspec-encoded JSON.
+- `lib/quality.CandidateScore` — wire-boundary `msgspec.Struct` for forensics; flag field would be added here.
+- `lib/enqueue.py:400-416 _planned_grab_entry` — extracts `year=release_date[:4]` from release object; this is where release_group_year fetch is added.
+- `lib/pipeline_db.py` request CRUD — new column accessor methods.
+- `web/mb.py` (or equivalent MB-mirror client) — used by enqueue for release fetch; release-group fetch path may need a sibling method.
+- `scripts/pipeline_cli.py` — CLI subcommand registration; existing `search-plan show/regenerate` patterns to follow.
+- `web/routes/pipeline.py` — `get_pipeline_log` (line 94) and per-request endpoints for adding saturation aggregator.
+- `tests/test_matching.py` — existing pre-filter / album_match tests (no current track-fallback coverage).
+- `tests/test_search.py` — query-helper tests (`strip_short_tokens`, `wildcard_artist_tokens`).
+- `tests/test_search_plan_service.py` — plan-generation tests.
+- `tests/fakes.py::FakePipelineDB` — `log_search` (line 2945), `search_logs` list, `SearchLogRow` mock; needs accessor for new column.
+- `tests/test_web_server.py::TestRouteContractAudit.CLASSIFIED_ROUTES` — every new route must be added here or the audit fails.
+
+### Institutional Learnings
+
+- `docs/brainstorms/2026-05-08-persisted-search-plans-requirements.md` — `SEARCH_PLAN_GENERATOR_ID` bump protocol, forward-only invalidation, `test_generator_id_constant_is_pinned` guard. The U5 generator changes constitute a generator-output change; bump is required.
+- `docs/persisted-search-plans-rollout.md` — operational shape of plan invalidation, 580+ plans regenerated cleanly. This change will invalidate all current plans on next cycle; the cycle's compute spike is bounded by the existing wave caps.
+- `docs/plans/2026-05-05-001-feat-peer-cache-redis-migration-plan.md` — 7-day Redis browse cache is the substrate that makes the `2n` pre-filter shape affordable. Without it, the change would have meaningful first-cycle browse load impact.
+- `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md` — R12 ships data + CLI; that dashboard brainstorm consumes the data when it's next iterated.
+- `CLAUDE.md` § "CLI ⇄ API surface symmetry" — R12 and R13 must expose both CLI and API surfaces wrapping the same service-layer method. Audit via `TestRouteContractAudit.CLASSIFIED_ROUTES`.
+- `.claude/rules/code-quality.md` § "Pipeline Decision Debugging — Simulator-First TDD" — R13 (`dry-run` CLI) is the search-plan analog of `pipeline-cli quality`. Use it during development to validate generator output against starving albums before committing to the GENERATOR_ID bump.
+- `.claude/rules/code-quality.md` § "Wire-boundary types" — `CandidateScore` is the existing `msgspec.Struct` at the forensics boundary; the new `pre_filter_skip: bool` field lands there.
+- `.claude/rules/code-quality.md` § "API Contract Tests" — every new route gets a `REQUIRED_FIELDS` set and an entry in `CLASSIFIED_ROUTES`. Mock rows must use production-shaped types (datetime, UUID, typed structs).
+
+### External References
+
+No external research warranted. This is internal pipeline infrastructure built on well-trodden patterns; no third-party libraries, security/payments boundaries, or unfamiliar protocols involved.
+
+---
+
+## Key Technical Decisions
+
+- **Pre-filter is asymmetric, not variant-aware.** A single-line change (`search_count > 2 * track_num`) is preferred over plumbing variant context through `find_download → check_for_match`. The matcher stays unaware of search strategy; the threshold doubles the album's track count rather than fitting it tightly. Bonus: track-fallback bug fixed without special-casing.
+- **`2n` over `n+2`.** The pre-filter is a junk-dir guard, not a tight-fit filter. `2n` captures more peer-folder data into the 7-day Redis browse cache, which is the substrate for the future cross-pressing matcher. First-cycle browse cost is bounded by existing wave caps; subsequent cycles are cache hits.
+- **R3 encoding: scalar count + sampled JSONB.** `pre_filter_skip_count INTEGER` is queryable and aggregable; ~5 flagged sample rows ride alongside scored candidates inside the existing candidates JSONB blob for inspection. Per-row forensic size remains bounded.
+- **`release_group_year` is a real column, backfilled on deploy.** The data is cheap (~4000 requests × local MB mirror call). Never defer cheap backfills. Conditional extra slot only when `year != release_group_year` (avoid the same wasteful repetition pattern killed in R4).
+- **Format hints universal, not conditional.** 100% of pipeline requests want lossless (DB query confirmed; zero exclude FLAC). No state, no log lookback, generator stays pure of runtime data.
+- **Wildcarding stays.** Empirically necessary for catalog-style searches (Beatles → `*eatles`); we are removing wildcarding-combined-with-token-drop, not wildcarding itself.
+- **Single GENERATOR_ID bump for U5.** All generator-output changes ride one ID bump. Bumping mid-implementation would generate intermediate plans that get invalidated on the next bump.
+- **Simulator (U6) lands before generator output is committed.** The dry-run CLI is the validation surface used during U5 development; landing the CLI shell first gives U5 development a feedback loop.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Pre-filter shape (`2n` vs `n+2` vs rip vs variant-thread)** — resolved: asymmetric `2n` with codec guard preserved.
+- **R3 encoding (new outcome enum vs JSONB flag vs separate column)** — resolved: count column + flagged JSONB samples.
+- **R7 format-hint conditionality (log-lookback vs regen-flag vs unconditional)** — resolved: unconditional (100% of requests want lossless).
+- **R9 release-group year availability** — resolved: not currently fetched; add column + backfill + generator usage.
+- **R10 self-titled detection rule** — resolved: `normalize(artist) == normalize(title)` OR token-subset.
+- **R12 dashboard scope** — resolved: ship data + CLI only; defer UI to the 2026-05-09 dashboard brainstorm.
+
+### Deferred to Implementation
+
+- **MB mirror release-group fetch shape** — verify during U3 whether the mirror exposes first-release year directly on the release-group fetch path, or whether it requires `min(release_year)` over the release-group's release list. Either path is bounded; backfill is local I/O. Fall back to derived `min(year)` if no direct field exists.
+- **Candidates JSONB top-N split** — current cap is top-20 scored. With U2 adding ≤5 skip samples, the right split is likely 15 scored + 5 skipped, but the exact partition can be tuned during U2 implementation based on observed shapes.
+- **Self-titled token-subset edge cases** — Mountains / Mountains Mountains Mountains is the model case. Need to confirm during U5 implementation that "Self / Self" doesn't accidentally match unrelated albums via subset (it shouldn't — token-subset requires the smaller token set to be a proper subset of the larger).
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Generator output shape, post-restructure.** The new plan slot mix for a typical request (year known, release_group_year populated and different):
+
+| Slot | Strategy | Example query (Kid A, year=2008, rg_year=2000) |
+|------|----------|------------------------------------------------|
+| 1 | `default` (wildcarded, no short-token drop) | `*adiohead Kid A` |
+| 2 | `literal` (no wildcard, no drop, no year) | `Radiohead Kid A` |
+| 3 | `literal_flac` | `Radiohead Kid A FLAC` |
+| 4 | `literal_lossless` | `Radiohead Kid A lossless` |
+| 5 | `unwild_year` (release year) | `Radiohead Kid A 2008` |
+| 6 | `unwild_rg_year` (conditional: differs from year) | `Radiohead Kid A 2000` |
+| 7 | `track_0_artist` (artist + first track) | `Radiohead Everything In Its Right Place` |
+| 8 | `track_1_artist` | `Radiohead Kid A` (if a track title matches the album title, semi-redundant — fine) |
+| 9 | `track_2_artist` | `Radiohead The National Anthem` |
+
+For matched-year requests, slot 6 is omitted (8 slots). For self-titled requests (R10/R11), the slot mix substitutes:
+
+| Slot | Strategy | Example (Willow, year=2007, rg_year=2007) |
+|------|----------|--------------------------------------------|
+| 1 | `selftitled_artist_track_0` | `Willow And Finally I Can Breathe` |
+| 2 | `selftitled_artist_track_0_flac` | `Willow And Finally I Can Breathe FLAC` |
+| 3 | `selftitled_artist_year` | `Willow 2007` |
+| 4-6 | `track_N_artist` | `Willow When the Sea Called Our Names`, etc. |
+
+The exact slot count is variable but bounded — 8 to 10 slots for normal requests, 6 to 8 for self-titled. The persisted-plan storage already supports variable size (`plan_items` table with ordinal; no fixed schema constraint).
+
+**Asymmetric pre-filter shape.** The change in `check_for_match`:
+
+```text
+# before
+if len(cached_codecs) <= 1 and abs(search_count - track_num) > 2:
+
+# after
+if len(cached_codecs) <= 1 and search_count > 2 * track_num:
+```
+
+That is the entire matcher behavior change. The codec guard's purpose is unchanged (avoid skipping multi-codec dirs). The post-browse strict-count gate at line 451 (`tracks_info["count"] != track_num`) continues to enforce exact-fit before scoring.
+
+---
+
+## Implementation Units
+
+### U1. Asymmetric pre-filter flip
+
+**Goal:** Replace the bidirectional pre-filter in `check_for_match` with `search_count > 2 * track_num`. This is the matcher bug fix and is also the bonus dividend that makes track-fallback queries reachable (no variant plumbing needed).
+
+**Requirements:** R1.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `lib/matching.py` (single condition at line ~350)
+- Test: `tests/test_matching.py`
+
+**Approach:**
+- The change is one-line: `abs(search_count - track_num) > 2` → `search_count > 2 * track_num`.
+- The `cached_codecs <= 1` guard stays in place.
+- The `ctx.negative_matches.add(neg_key)` write stays as-is — its scope (per-cycle, in-memory) is already correct.
+
+**Execution note:** Write the failing test scenarios first (track-fallback case with `search_count=1, track_num=4` currently rejected; with the new asymmetric rule it must reach `album_track_num`). Add the bug-repro scenario before flipping the condition.
+
+**Patterns to follow:** `tests/test_matching.py` existing per-scenario test structure.
+
+**Test scenarios:**
+- Happy path: `search_count=4, track_num=4` (default-query whole-album case) — passes pre-filter, browse + score proceeds.
+- Edge case (the bug fix): `search_count=1, track_num=4` (track-fallback case) — under old rule skipped; under new rule passes pre-filter, dir is browsed and scored.
+- Happy path: `search_count=8, track_num=4` (whole album with bonus disc maybe) — passes (1 ≤ 8 ≤ 8, exactly at boundary, just barely permitted: `8 > 8` is false).
+- Edge case: `search_count=9, track_num=4` (just over `2n`) — skipped pre-filter, negative-cache entry written.
+- Junk-dir case: `search_count=50, track_num=4` (large dump folder) — skipped pre-filter, negative-cache entry written. (This is the case the pre-filter must continue to catch.)
+- Codec-guard case: `search_count=50, track_num=4, cached_codecs=3` (multi-codec dir) — NOT skipped (codec guard bypasses the pre-filter).
+- Covers AE1.
+
+**Verification:**
+- Pyright clean on `lib/matching.py`.
+- All `tests/test_matching.py` tests pass; new track-fallback test passes.
+- Spot-check via `pipeline-cli show 2125` after deploy: at least one Willow track-fallback row has non-empty `candidates`.
+
+---
+
+### U2. Pre-filter skip telemetry
+
+**Goal:** Add `pre_filter_skip_count INTEGER` column on `search_log` for aggregable counts, and extend `CandidateScore` with a `pre_filter_skip: bool` flag so up to ~5 sample skipped rows can ride inside the existing candidates JSONB blob.
+
+**Requirements:** R3.
+
+**Dependencies:** None (independent of U1, though they land together for operator value).
+
+**Files:**
+- Create: `migrations/025_search_log_pre_filter_skip_count.sql`
+- Modify: `lib/quality.py` (add `pre_filter_skip: bool = False` field to `CandidateScore`)
+- Modify: `lib/matching.py::check_for_match` — when the pre-filter rejects a dir, append a flagged `CandidateScore` (with `pre_filter_skip=True`, `matched_tracks=0`) up to a per-search cap (~5) AND increment a local skip counter
+- Modify: `lib/pipeline_db.py::log_search` — accept and persist `pre_filter_skip_count`
+- Modify: `lib/search.py::SearchResult` — carry `pre_filter_skip_count: int` field
+- Modify: `cratedigger.py::_log_search_result` — pass the count through
+- Modify: `tests/fakes.py::FakePipelineDB::log_search` — record the new field
+- Modify: `tests/fakes.py::FakePipelineDB` `SearchLogRow` (or equivalent) — expose new field
+- Test: `tests/test_matching.py`, `tests/test_pipeline_db.py`
+
+**Approach:**
+- Migration: `ALTER TABLE search_log ADD COLUMN pre_filter_skip_count INTEGER NOT NULL DEFAULT 0`.
+- `CandidateScore` extension: new optional `pre_filter_skip: bool = False` field. Defaults preserve existing wire shape; new field only set when the matcher records a skip.
+- In `check_for_match`: track skips with a local counter; emit at most ~5 flagged `CandidateScore` rows into `candidates` (skip rows count against the overall top-N cap; prefer keeping scored rows when capacity is contested). Cap can be tuned during implementation.
+- `SearchResult` and `log_search` carry the count through.
+- Adjust the existing candidates top-N cap to `15 scored + 5 skipped` (or similar split) — exact partition decided during implementation based on observed shapes.
+
+**Execution note:** Write a contract test asserting that a known pre-filter-skip case produces both the count and at least one flagged candidate row before changing the matcher.
+
+**Technical design:** *Directional guidance only.* The `pre_filter_skip` flag lives on `CandidateScore`; rendering layers (`pipeline-cli show`) can show flagged rows with a distinct prefix.
+
+**Patterns to follow:**
+- Migration pattern: `migrations/024_backfill_v0_metric_from_measurement.sql` for shape.
+- Field-on-struct extension: see `ImportResult`/`ValidationResult` extensions in prior migrations.
+- `log_search` signature evolution: existing `final_state` precedent.
+- `tests/test_pipeline_db.py` test patterns for column reads/writes.
+
+**Test scenarios:**
+- Happy path: a search where all dirs pass pre-filter — `pre_filter_skip_count = 0`, no flagged candidate rows.
+- Happy path: a search where 17 dirs are skipped via pre-filter — `pre_filter_skip_count = 17`, candidates JSONB contains up to 5 flagged skip rows.
+- Edge case: skip count higher than the sample cap — count is accurate; sample rows are capped at ~5; no overflow.
+- Round-trip: msgspec encode → decode of `CandidateScore` with `pre_filter_skip=True` preserves the field.
+- Migration test in `tests/test_migrator.py`: after migration 025, `search_log.pre_filter_skip_count` exists with `DEFAULT 0` and pre-existing rows have value 0.
+- `FakePipelineDB.log_search` records the field for downstream tests.
+
+**Verification:**
+- Pyright clean.
+- All tests pass.
+- Post-deploy, `pipeline-cli query "SELECT MAX(pre_filter_skip_count) FROM search_log WHERE created_at > NOW() - INTERVAL '1 hour'"` returns a non-zero value (real pre-filter skips are happening).
+
+---
+
+### U3. `release_group_year` column + deploy-time backfill
+
+**Goal:** Add `release_group_year INTEGER NULL` to `album_requests` and ship a backfill that populates it from the local MB mirror for every request with `mb_release_group_id IS NOT NULL`. Backfill runs as part of the deploy (via the existing `cratedigger-db-migrate` oneshot pattern, or a separate one-shot script invoked on deploy — implementation choice).
+
+**Requirements:** R9 (data layer).
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `migrations/026_album_requests_release_group_year.sql`
+- Create: `scripts/backfill_release_group_year.py` (or similar — one-shot script invoked on deploy)
+- Modify: `lib/pipeline_db.py` — `request_by_id`, `update_request_*` methods need new column awareness
+- Modify: `lib/album_source.py::AlbumRecord` — add `release_group_year: int | None` field
+- Modify: `web/mb.py` (or wherever MB-mirror client lives) — verify or add a release-group-year fetch helper
+- Modify: `tests/fakes.py::FakePipelineDB` — expose `release_group_year` on request rows
+- Test: `tests/test_migrator.py`, `tests/test_pipeline_db.py`, new `tests/test_backfill_release_group_year.py`
+
+**Approach:**
+- Migration adds the column with NULL default.
+- Backfill script iterates `album_requests WHERE mb_release_group_id IS NOT NULL AND release_group_year IS NULL`, fetches each release-group's first-release year from the local MB mirror, updates the row. Batch in transactions of ~500 for safety.
+- During U3 implementation, **verify the MB mirror's release-group fetch path** — if it exposes the year directly, use that; if not, fall back to `min(year)` over the release-group's release list.
+- The backfill is idempotent — re-runnable if it fails partway.
+
+**Execution note:** Write the backfill against a known reissue (e.g. request id 1868 Kid A) and assert the expected `release_group_year=2000` outcome before running it broadly.
+
+**Patterns to follow:**
+- Migration patterns: `migrations/024_backfill_v0_metric_from_measurement.sql` (which combines schema change with backfill SQL).
+- Deploy-time backfill: `cratedigger-db-migrate.service` runs migrations before app services start (per `CLAUDE.md` § Database migrations).
+- MB mirror client: existing patterns in `web/mb.py` for release lookups.
+
+**Test scenarios:**
+- Migration test: after migration 026 applies, `release_group_year` column exists, NULL default, pre-existing rows have NULL.
+- Backfill happy path: a request with `mb_release_group_id='21501'` (Kid A's release group) gets `release_group_year=2000` populated.
+- Backfill idempotency: running twice produces same result (the WHERE clause filters out already-populated rows).
+- Backfill resilience: if MB mirror returns 404 for a release-group, the row is left NULL (not deleted, not failed-hard) and logged.
+- Backfill batching: a batch of 500 requests commits atomically; failures in one batch don't leak into the next.
+- `FakePipelineDB` returns `release_group_year` field correctly for downstream test consumers.
+
+**Verification:**
+- Pyright clean.
+- All tests pass.
+- Post-deploy: `pipeline-cli query "SELECT COUNT(*) FROM album_requests WHERE mb_release_group_id IS NOT NULL AND release_group_year IS NULL"` returns 0 (or close to it — accounting for MB mirror 404s).
+- Spot-check on Kid A request 1868: `release_group_year = 2000`.
+
+---
+
+### U4. Enqueue path fetches `release_group_year`
+
+**Goal:** When a new request is added (web add, CLI add), populate `release_group_year` from the MB mirror at enqueue time so new requests land with the column already filled.
+
+**Requirements:** R9 (ongoing data flow).
+
+**Dependencies:** U3 (column must exist).
+
+**Files:**
+- Modify: `lib/enqueue.py::_planned_grab_entry` (line 400+) — add release-group fetch alongside the existing release fetch
+- Modify: web request-add route (`web/routes/`) and `scripts/pipeline_cli.py` add subcommand — pass `release_group_year` through to enqueue
+- Test: `tests/test_enqueue.py`, `tests/test_web_server.py`, `tests/test_pipeline_cli.py`
+
+**Approach:**
+- Reuse the MB-mirror release-group fetch helper from U3.
+- Extract release-group year at enqueue time and persist on the new request row.
+- If the MB mirror lookup fails or no release-group is found, leave `release_group_year` NULL and continue — the generator handles NULL gracefully (no extra slot).
+
+**Execution note:** None — straightforward extension of existing enqueue logic.
+
+**Patterns to follow:**
+- `lib/enqueue.py::_planned_grab_entry` existing structure for fetching MB metadata at enqueue.
+- Error-tolerant MB lookup pattern (don't fail-hard on a single bad lookup).
+
+**Test scenarios:**
+- Happy path: new request with reissue MB release → `release_group_year` populated and differs from `year`.
+- Happy path: new request with original-release MB release → `release_group_year == year`.
+- Edge case: MB mirror returns 404 for the release-group → request created with `release_group_year=NULL`, no error.
+- Integration: a full add-from-web flow creates the row with the column populated.
+
+**Verification:**
+- All enqueue tests pass.
+- Web add of a known reissue produces a row with the expected `release_group_year`.
+
+---
+
+### U5. Generator restructure
+
+**Goal:** Rewrite `lib/search.py::generate_search_plan` to (a) remove the 5-slot default repetition, (b) remove the short-token drop, (c) add literal-full-title slot, (d) add unconditional format-hint slots (FLAC + lossless), (e) prepend artist to track-fallback queries, (f) emit conditional release-group-year slot, (g) detect self-titled and route through dedicated mix. Bump `SEARCH_PLAN_GENERATOR_ID`.
+
+**Requirements:** R4, R5, R6, R7, R8, R9 (generator side), R10, R11.
+
+**Dependencies:** U3 (uses `release_group_year` column).
+
+**Files:**
+- Modify: `lib/search.py::generate_search_plan` and supporting helpers
+- Modify: `lib/search.py::SEARCH_PLAN_GENERATOR_ID` constant (bump)
+- Modify: `lib/search.py::ReleaseSnapshot` — add `release_group_year: int | None` field
+- Modify: `lib/search.py` — remove `strip_short_tokens` from the default-slot pipeline (the function may stay for other callers if any; verify during implementation)
+- Modify: `lib/search.py` — add `wildcard_artist_tokens` invocation to track-fallback queries (R8)
+- Modify: `lib/search_plan_service.py` — if `ReleaseSnapshot` construction lives here, thread `release_group_year` through
+- Modify: snapshot signature: extending `ReleaseSnapshot` with `release_group_year` changes the snapshot fingerprint — this triggers automatic plan regeneration via the existing fingerprint-change pathway. No extra invalidation work needed beyond the GENERATOR_ID bump
+- Test: `tests/test_search.py`, `tests/test_search_plan_service.py`
+
+**Approach:**
+- The generator's input snapshot grows by one field (`release_group_year`). Output structure stays the same (`SearchPlan` with `plan_items` list).
+- Slot construction becomes a series of helper calls:
+  1. `_default_slot` (wildcarded artist+title, capped token count, NO short-token drop)
+  2. `_literal_slot` (no wildcard, no drop, no year)
+  3. `_literal_flac_slot`
+  4. `_literal_lossless_slot`
+  5. `_unwild_year_slot` (existing, preserved)
+  6. `_unwild_rg_year_slot` (conditional: `release_group_year is not None and release_group_year != year`)
+  7. Track-fallback slots: `_track_with_artist_slot(track_idx, artist)` for up to 3 tracks
+- Self-titled detection: a helper `_is_self_titled(artist, title)` returns True when `normalize(artist) == normalize(title)` OR `normalize_tokens(artist) ⊂ normalize_tokens(title)` (or reverse). When True, the generator emits the dedicated self-titled mix instead of the default mix.
+- `SEARCH_PLAN_GENERATOR_ID` bumps to a new value (e.g. `"search-plan/2026-05-19-1"`).
+- Plan-provenance: `dropped_low_entropy_tokens` is no longer populated (the drop no longer happens); provenance carries `selftitled: True` when detected and `release_group_year: <int>` when used.
+
+**Execution note:** Write tests first. The new generator's output is a precise function of inputs — extensive table-driven tests for each strategy slot, edge cases (numeric tokens, comma-bearing titles, self-titled, missing year, missing release_group_year, single-track albums), and full snapshot-to-plan integration. The simulator from U6 is the primary validation surface during development.
+
+**Technical design:** *Directional only — see High-Level Technical Design above for the slot mix table.*
+
+**Patterns to follow:**
+- Existing `generate_search_plan` structure (per-strategy candidate construction → dedupe → ordinal assignment).
+- `test_generator_id_constant_is_pinned` test pattern (the GENERATOR_ID bump must be deliberate; the pinning test guards against accidental changes).
+- `_per_track_candidates` existing helper.
+
+**Test scenarios:**
+- Happy path Kid A-shape: artist `Radiohead`, title `Kid A`, year `2008`, release_group_year `2000`, 14 tracks → plan contains literal title with "A" preserved, FLAC/lossless slots, year + release_group_year slots, artist-prepended track slots, NO 5x default repetition.
+- Happy path Willow-shape (self-titled): artist `Willow`, title `Willow`, year `2007`, release_group_year `2007`, 4 tracks → self-titled detected, plan contains artist+first-track and artist+year slots, NO `*illow`-collapsed default.
+- Happy path Mountains-shape: artist `Mountains`, title `Mountains Mountains Mountains` → token-subset self-titled detected, dedicated mix emitted.
+- Happy path Hanlon-shape (niche, normal): artist `Darren Hanlon`, title `I Will Love You at All`, year `2010`, release_group_year `2010` → standard mix, no rg_year slot (years match), format-hint slots present (will return zero in production for this album, but generator emits them unconditionally).
+- Happy path Bon Iver-shape (numeric title): title `22, a Million` → "22" preserved in slots, "a" preserved (no short-token drop).
+- Edge case: missing year → no `unwild_year` slot, no `unwild_rg_year` slot.
+- Edge case: missing release_group_year → no `unwild_rg_year` slot.
+- Edge case: year == release_group_year → no `unwild_rg_year` slot (avoid duplicate).
+- Edge case: fewer than 3 tracks → fewer track-fallback slots.
+- Edge case: GENERATOR_ID test — pinned to the new value; bumping is deliberate.
+- Plan deduplication: if two strategies produce the same canonical query key, dedupe keeps the higher-priority slot.
+- Self-titled detection negative case: `Willow / Willow Tree` should NOT detect as self-titled (token-subset only fires when one set is a strict subset of the other with non-trivial overlap).
+- Provenance: `selftitled: True` and `release_group_year: <int>` flags populate plan provenance when applicable.
+- Covers AE2, AE4 (year-side), AE5.
+
+**Verification:**
+- Pyright clean.
+- All search tests pass.
+- `tests/test_search_plan_service.py::test_generator_id_constant_is_pinned` passes against the new pinned value.
+- `pipeline-cli search-plan dry-run` (from U6) on requests 1868, 455, 2125, 3018, 1640 produces plans materially different from current production.
+
+---
+
+### U6. Simulator dry-run CLI
+
+**Goal:** Add `pipeline-cli search-plan dry-run <request_id>` that loads the request's snapshot, runs `generate_search_plan` against the current code, and prints the resulting plan items without persisting or affecting `active_plan_id`.
+
+**Requirements:** R13.
+
+**Dependencies:** U5 (the simulator wraps the new generator — but the CLI shell can land first as a thin wrapper around the current generator and gain its real value when U5 lands).
+
+**Files:**
+- Modify: `scripts/pipeline_cli.py` — add `search-plan dry-run` subcommand
+- Modify: `lib/search_plan_service.py` — add `dry_run_for_request(request_id) -> SearchPlan` method (read-only, no DB writes)
+- Modify: `web/routes/pipeline.py` — add `GET /api/search-plan/<id>/dry-run` endpoint for CLI⇄API symmetry
+- Modify: `tests/test_web_server.py::TestRouteContractAudit.CLASSIFIED_ROUTES` — add the new route
+- Test: `tests/test_pipeline_cli.py`, `tests/test_search_plan_service.py`, `tests/test_web_server.py`
+
+**Approach:**
+- The service-layer method reads the request row + tracks, constructs the `ReleaseSnapshot`, calls `generate_search_plan`, and returns the `SearchPlan` (in-memory only, never persisted).
+- CLI subcommand prints plan items in the same format as `search-plan show`.
+- API endpoint returns the same shape as `search-plan show` for the active plan.
+- No state mutation. No `active_plan_id` change. No `search_plans` or `plan_items` row inserts.
+
+**Execution note:** Write the contract test first — `_assert_required_fields(self, payload, REQUIRED_FIELDS, "dry-run")` ensures the response shape is stable.
+
+**Patterns to follow:**
+- `scripts/pipeline_cli.py` existing `search-plan show` subcommand for CLI shape.
+- `lib/search_plan_service.SearchPlanService` existing read-only methods.
+- `web/routes/pipeline.py` existing GET endpoints + `_assert_required_fields` test pattern.
+- `tests/test_web_server.py::TestRouteContractAudit.CLASSIFIED_ROUTES` — every new route must be added or the audit fails.
+- `tests/test_pipeline_cli.py` exit-code mapping for the CLI subcommand.
+
+**Test scenarios:**
+- Happy path: `dry-run <request_id>` for a request with all metadata present → CLI prints the generator's slot list; no DB writes occur.
+- Happy path: API endpoint returns JSON shape matching `REQUIRED_FIELDS` (items list, generator_id, provenance).
+- Edge case: request id not found → CLI exits 2 (not_found); API returns 404.
+- Edge case: request exists but has no tracks → CLI prints plan with no track-fallback slots; no error.
+- Integration: dry-run for request 1868 (Kid A) shows the new generator's plan side-by-side with the active plan's `search-plan show` output.
+- `TestRouteContractAudit` passes with the new route classified.
+- Covers AE6.
+
+**Verification:**
+- Pyright clean.
+- All tests pass; `TestRouteContractAudit` doesn't fail.
+- Manual: `pipeline-cli search-plan dry-run 1868` produces a plan that contains literal-title slot, format-hint slots, artist-prepended tracks, and (post-U3 backfill) a release_group_year slot (2000 ≠ 2008).
+
+---
+
+### U7. Saturation telemetry CLI/API
+
+**Goal:** Add an aggregator method on `PipelineDB` that returns per-request saturation rate (rows where `final_state LIKE '%LimitReached%'` / total rows in a window) and total `pre_filter_skip_count` (from U2). Expose via `pipeline-cli search-plan saturation <id>` and a parallel API endpoint.
+
+**Requirements:** R12.
+
+**Dependencies:** U2 (uses `pre_filter_skip_count` column).
+
+**Files:**
+- Modify: `lib/pipeline_db.py` — add `get_saturation_summary(request_id, window_days=14) -> SaturationSummary` method
+- Modify: `lib/search_plan_service.py` (or new service file) — service-layer wrapper around the DB method
+- Modify: `scripts/pipeline_cli.py` — add `search-plan saturation` subcommand
+- Modify: `web/routes/pipeline.py` — add `GET /api/search-plan/<id>/saturation` endpoint
+- Modify: `tests/test_web_server.py::TestRouteContractAudit.CLASSIFIED_ROUTES` — add the new route
+- Modify: `tests/fakes.py::FakePipelineDB` — add `get_saturation_summary` stub
+- Test: `tests/test_pipeline_db.py`, `tests/test_pipeline_cli.py`, `tests/test_search_plan_service.py`, `tests/test_web_server.py`
+
+**Approach:**
+- `SaturationSummary` is a typed dataclass: `total_searches: int`, `saturated_searches: int`, `saturation_rate: float`, `total_pre_filter_skips: int`, `window_days: int`.
+- Single SQL query aggregates over `search_log` for the request in the window.
+- CLI subcommand prints a human-readable summary; API returns JSON.
+- This is the data layer for the future dashboard work; the dashboard brainstorm at `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md` consumes these endpoints when next iterated.
+
+**Execution note:** Write the contract test with `REQUIRED_FIELDS = {"total_searches", "saturated_searches", "saturation_rate", "total_pre_filter_skips", "window_days"}` first.
+
+**Patterns to follow:**
+- `lib/pipeline_db.py` existing aggregator method patterns.
+- CLI⇄API symmetry per `CLAUDE.md`: thin CLI wrapper + thin API handler around a single service-layer method.
+- Production-shaped mock rows in contract tests per `.claude/rules/code-quality.md` (timestamps as `datetime.datetime`, UUIDs as `uuid.UUID`).
+- `TestRouteContractAudit.CLASSIFIED_ROUTES` registration.
+
+**Test scenarios:**
+- Happy path: request with 30 searches in window, 10 saturated, 50 pre-filter skips → returns `total_searches=30, saturated_searches=10, saturation_rate=0.333, total_pre_filter_skips=50, window_days=14`.
+- Edge case: request with no searches in window → returns zeros, saturation_rate=0.0 (not NaN).
+- Edge case: request id not found → CLI exits 2; API returns 404.
+- Window parameter respected: `window_days=7` filters correctly.
+- Production-shaped mock: contract test populates rows with `datetime.datetime` timestamps and `uuid.UUID` IDs, not synthetic str/int.
+- `TestRouteContractAudit` passes with new route classified.
+- CLI exit codes match the convention (0 success, 2 not_found).
+
+**Verification:**
+- Pyright clean.
+- All tests pass.
+- Manual: `pipeline-cli search-plan saturation 1868` returns Kid A's saturation rate (currently very high; expected to drop post-deploy).
+- Manual: `pipeline-cli search-plan saturation 1640` returns Darren Hanlon's saturation rate (lower; this is the niche case).
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - U1 changes `check_for_match` behavior for every search that produces results. Affects `cratedigger.py::_collect_search_results`, `find_download`, and downstream forensics.
+  - U5 invalidates every active search plan on the next cycle (via GENERATOR_ID bump). The `cratedigger.service` 5-min timer regenerates them on first encounter.
+  - U7's new endpoint is consumed by the future dashboard work but otherwise has no production caller.
+- **Error propagation:**
+  - U3 backfill: errors per-row (e.g. MB mirror 404) log and continue; rows left NULL. The backfill never aborts the deploy.
+  - U4 enqueue: MB mirror lookup failure leaves `release_group_year=NULL` on the new request; generator handles NULL gracefully (no extra slot).
+  - U5 generator: pure function over snapshot; failures bubble up to `SearchPlanService` which handles plan-generation failures via existing patterns (transient errors retried; deterministic errors marked sticky).
+- **State lifecycle risks:**
+  - **Plan invalidation spike on deploy.** All active plans get regenerated on first encounter post-`SEARCH_PLAN_GENERATOR_ID` bump. The 5-min cycle's existing wave caps bound the spike. Worth monitoring journalctl for the first 1-2 cycles post-deploy.
+  - **Browse load spike on first cycle for currently-saturated requests.** With the asymmetric `2n` pre-filter, more peers per request get browsed on first cycle. Subsequent cycles hit the 7-day Redis cache and are cheap. Bounded by `browse_top_k` wave cap.
+  - **Backfill duration on deploy.** ~4000 requests × MB mirror call. All local I/O. Estimated 5-10 min wall clock. Runs as part of `cratedigger-db-migrate.service` (or invoked immediately after).
+- **API surface parity:**
+  - U6 and U7 ship CLI subcommands AND API endpoints per `CLAUDE.md` § CLI ⇄ API surface symmetry.
+  - Both new routes registered in `TestRouteContractAudit.CLASSIFIED_ROUTES`.
+- **Integration coverage:**
+  - Slice test in `tests/test_integration_slices.py`: end-to-end "request enters pipeline → generator emits new plan → matcher applies asymmetric pre-filter → forensics record skips" to validate the full chain.
+- **Unchanged invariants:**
+  - The post-browse strict-count gate (`tracks_info["count"] != track_num`) at `lib/matching.py:451` is unchanged. The asymmetric pre-filter relaxation does NOT relax exact-fit at scoring time.
+  - `negative_matches` cache scope (per-cycle) is unchanged.
+  - `album_match` filename-similarity scoring is unchanged.
+  - `search_log` outcome enum is unchanged (no new outcomes — skips are recorded via the count column + flagged candidates, not a new outcome value).
+  - Quality-decision pipeline (`full_pipeline_decision_from_evidence`) is unchanged.
+  - The persisted search-plan model (snapshot signature, cursor, cycle wrap) is unchanged; new snapshot field (`release_group_year`) is additive.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Browse load spike on first post-deploy cycle for currently-saturated requests | Med | Med | Existing `browse_top_k` wave cap bounds per-cycle browse work; 7-day Redis cache makes subsequent cycles cheap. Monitor journalctl for first 1-2 cycles post-deploy. |
+| MB mirror does not expose release-group year directly | Med | Low | Fall back to `min(year)` over the release-group's release list; both paths are bounded local I/O. Implementation choice in U3. |
+| Backfill takes longer than expected and delays cratedigger service startup | Low | Med | Make backfill a separate one-shot unit that runs alongside (not before) `cratedigger.service`. Service starts even if backfill is in-flight; generator handles NULL `release_group_year` gracefully. |
+| Generator regenerates 4000+ plans on next cycle producing transient compute spike | High (expected) | Low | This is the designed behavior of GENERATOR_ID bumps. Past bumps (2026-05-08) handled 580+ plans cleanly. Wave caps bound per-cycle work. |
+| Self-titled token-subset detection produces false positives | Low | Low | Token-subset detection requires the smaller token set to be a strict subset of the larger AND non-trivially short. Edge cases caught by test scenarios. Operators can override via existing `search_filetype_override` mechanism if needed. |
+| New `pre_filter_skip_count` column grows search_log row size meaningfully | Very Low | Very Low | INTEGER column is 4 bytes. ~1M rows/year = 4 MB. Negligible. |
+| Candidates JSONB size increases beyond ~20 rows post-flagging | Low | Low | Cap at ~15 scored + ~5 skipped = 20 total, matches current behavior. Exact partition tunable during U2. |
+| Plan size variability (new conditional rg_year slot) breaks downstream consumers expecting fixed-size plans | Low | Low | Plan size is already variable today (requests without year skip `unwild_year`; requests with fewer tracks emit fewer track slots). No fixed-size consumer exists. |
+
+---
+
+## Documentation / Operational Notes
+
+- Bump `SEARCH_PLAN_GENERATOR_ID` to `"search-plan/2026-05-19-1"` (or similar dated value).
+- Update `docs/persisted-search-plans-rollout.md` post-deploy with notes on the generator-ID bump and observed plan regeneration cycle.
+- Add a brief note to `docs/musicbrainz-mirror.md` documenting the release-group year fetch path used by U3 + U4.
+- Post-deploy: run `pipeline-cli search-plan dry-run` on the starving cohort (1868, 455, 2125, 3018, 1640) and capture the output as evidence the generator changes reached them.
+- Monitor `journalctl -u cratedigger -f` for the first 1-2 post-deploy cycles to confirm the browse load spike is bounded.
+- Two weeks post-deploy: re-run the starving-cohort SQL query from the brainstorm and verify the cohort has shrunk by ≥50%.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md`
+- Related brainstorms: `docs/brainstorms/2026-05-08-persisted-search-plans-requirements.md`, `docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md`
+- Related plans: `docs/plans/2026-05-05-001-feat-peer-cache-redis-migration-plan.md` (the 7-day Redis browse cache underpinning the `2n` decision)
+- Related code: `lib/matching.py::check_for_match`, `lib/search.py::generate_search_plan`, `lib/search_plan_service.SearchPlanService`, `lib/enqueue.py::_planned_grab_entry`
+- Related rules: `.claude/rules/code-quality.md` (CLI ⇄ API symmetry, Simulator-First TDD, Wire-boundary types, API Contract Tests), `CLAUDE.md` (DB migrations, deploy flow)

--- a/docs/plans/2026-05-19-001-feat-search-plan-entropy-and-matcher-prefilter-plan.md
+++ b/docs/plans/2026-05-19-001-feat-search-plan-entropy-and-matcher-prefilter-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Search plan entropy and matcher pre-filter
 type: feat
-status: active
+status: completed
 date: 2026-05-19
 origin: docs/brainstorms/2026-05-19-search-plan-entropy-requirements.md
 ---

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -40,11 +40,10 @@ class EnqueueAttempt:
     sub-count gate failures and cross-check rejections. U5 will surface this
     list in the persisted `search_log.candidates` JSONB blob.
 
-    ``pre_filter_skip_count`` (U2 of search-plan-entropy): aggregate count
-    of dirs the asymmetric pre-filter rejected before browse across every
-    ``check_for_match`` call that contributed to this attempt. Plumbed up
-    to ``FindDownloadResult`` and persisted on ``search_log`` so operators
-    can aggregate skip pressure per request.
+    ``pre_filter_skip_count`` aggregates dirs the asymmetric pre-filter
+    rejected before browse across every ``check_for_match`` call this
+    attempt contributed to; persisted on ``search_log`` for skip-pressure
+    telemetry.
     """
 
     matched: bool
@@ -94,10 +93,8 @@ class FindDownloadResult:
     grab_entry: GrabListEntry | None = None
     candidates: tuple[CandidateScore, ...] = ()
     metrics: FindDownloadMetrics | None = None
-    # U2 of search-plan-entropy: aggregate pre-filter skip count across
-    # every (filetype, disc, wave) ``check_for_match`` call this
-    # find_download walk contributed to. ``_apply_find_download_result``
-    # copies this onto ``SearchResult.pre_filter_skip_count``.
+    # Aggregate pre-filter skip count across every (filetype, disc,
+    # wave) ``check_for_match`` call this walk contributed to.
     pre_filter_skip_count: int = 0
 
 

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -39,12 +39,19 @@ class EnqueueAttempt:
     `check_for_match` for every dir touched during this attempt — including
     sub-count gate failures and cross-check rejections. U5 will surface this
     list in the persisted `search_log.candidates` JSONB blob.
+
+    ``pre_filter_skip_count`` (U2 of search-plan-entropy): aggregate count
+    of dirs the asymmetric pre-filter rejected before browse across every
+    ``check_for_match`` call that contributed to this attempt. Plumbed up
+    to ``FindDownloadResult`` and persisted on ``search_log`` so operators
+    can aggregate skip pressure per request.
     """
 
     matched: bool
     downloads: list[Any] | None = None
     enqueue_failed: bool = False
     candidates: tuple[CandidateScore, ...] = ()
+    pre_filter_skip_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -87,6 +94,11 @@ class FindDownloadResult:
     grab_entry: GrabListEntry | None = None
     candidates: tuple[CandidateScore, ...] = ()
     metrics: FindDownloadMetrics | None = None
+    # U2 of search-plan-entropy: aggregate pre-filter skip count across
+    # every (filetype, disc, wave) ``check_for_match`` call this
+    # find_download walk contributed to. ``_apply_find_download_result``
+    # copies this onto ``SearchResult.pre_filter_skip_count``.
+    pre_filter_skip_count: int = 0
 
 
 class _WorkerPipelineDBSource:
@@ -191,6 +203,7 @@ def _with_metrics(
         grab_entry=result.grab_entry,
         candidates=result.candidates,
         metrics=FindDownloadMetrics.from_context(ctx),
+        pre_filter_skip_count=result.pre_filter_skip_count,
     )
 
 
@@ -771,6 +784,7 @@ def _iter_wave_matches(
     allowed_filetype: str,
     ctx: CratediggerContext,
     accumulated: list[CandidateScore],
+    pre_filter_skips: list[int] | None = None,
 ) -> Iterator[tuple[str, MatchResult, int]]:
     """Yield ``(username, match_result, wave_index)`` for every dir match.
 
@@ -846,6 +860,8 @@ def _iter_wave_matches(
                 tracks, allowed_filetype, file_dirs, username, ctx,
             )
             accumulated.extend(match_result.candidates)
+            if pre_filter_skips is not None:
+                pre_filter_skips[0] += match_result.pre_filter_skip_count
             if match_result.matched:
                 yield username, match_result, wave_idx
 
@@ -875,9 +891,11 @@ def try_enqueue(
 
     had_enqueue_failure = False
     accumulated: list[CandidateScore] = []
+    pre_filter_skips: list[int] = [0]
     match_wave: int | None = None
     for username, match_result, wave_idx in _iter_wave_matches(
         all_tracks, eligible, user_dirs, allowed_filetype, ctx, accumulated,
+        pre_filter_skips,
     ):
         if match_wave is None:
             match_wave = wave_idx
@@ -938,6 +956,7 @@ def try_enqueue(
                     matched=True,
                     downloads=downloads,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
             if outcome.status == "rejected":
                 owned = _reset_claim_after_verified_no_acceptance(
@@ -957,6 +976,7 @@ def try_enqueue(
                         matched=True,
                         downloads=owned,
                         candidates=tuple(accumulated),
+                        pre_filter_skip_count=pre_filter_skips[0],
                     )
                 # Verified-no-acceptance: surface the rejection in
                 # download_log so the failure is visible immediately
@@ -990,6 +1010,7 @@ def try_enqueue(
                     matched=True,
                     downloads=owned,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
             had_enqueue_failure = True
             logger.info(
@@ -1014,6 +1035,7 @@ def try_enqueue(
                     matched=True,
                     downloads=owned,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
             had_enqueue_failure = True
             logger.warning(f"Exception enqueueing tracks: {e}")
@@ -1033,6 +1055,7 @@ def try_enqueue(
         matched=False,
         enqueue_failed=had_enqueue_failure,
         candidates=tuple(accumulated),
+        pre_filter_skip_count=pre_filter_skips[0],
     )
 
 
@@ -1069,6 +1092,7 @@ def try_multi_enqueue(
     artist_name = album.artist_name
     eligible, user_dirs = _eligible_user_dirs(results, allowed_filetype, album_id, ctx)
     accumulated: list[CandidateScore] = []
+    pre_filter_skips: list[int] = [0]
     for disk in split_release:
         ctx.negative_matches.clear()
         peers_before = ctx.peers_browsed
@@ -1076,7 +1100,7 @@ def try_multi_enqueue(
         first_match = next(
             _iter_wave_matches(
                 disk["tracks"], eligible, user_dirs, allowed_filetype, ctx,
-                accumulated,
+                accumulated, pre_filter_skips,
             ),
             None,
         )
@@ -1089,7 +1113,11 @@ def try_multi_enqueue(
                 peers=ctx.peers_browsed - peers_before,
                 waves=ctx.fanout_waves - waves_before,
             )
-            return EnqueueAttempt(matched=False, candidates=tuple(accumulated))
+            return EnqueueAttempt(
+                matched=False,
+                candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skips[0],
+            )
         username, match_result, match_wave = first_match
         directory = download_filter(
             allowed_filetype, match_result.directory, ctx.cfg,
@@ -1117,6 +1145,7 @@ def try_multi_enqueue(
             return EnqueueAttempt(
                 matched=False,
                 candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skips[0],
             )
         _log_album_browse(
             artist_name, album_name, allowed_filetype,
@@ -1147,6 +1176,7 @@ def try_multi_enqueue(
                 return EnqueueAttempt(
                     matched=False,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
             disk_planned = _planned_downloads(
                 username=username,
@@ -1168,6 +1198,7 @@ def try_multi_enqueue(
                 matched=False,
                 enqueue_failed=True,
                 candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skips[0],
             )
 
         all_downloads = []
@@ -1205,6 +1236,7 @@ def try_multi_enqueue(
                                     matched=True,
                                     downloads=recovered,
                                     candidates=tuple(accumulated),
+                                    pre_filter_skip_count=pre_filter_skips[0],
                                 )
                         elif claim.claimed:
                             owned = _leave_claim_for_poll_recovery(
@@ -1216,6 +1248,7 @@ def try_multi_enqueue(
                                 matched=True,
                                 downloads=owned,
                                 candidates=tuple(accumulated),
+                                pre_filter_skip_count=pre_filter_skips[0],
                             )
                         if not claim.claimed:
                             cancel_and_delete(all_downloads, ctx)
@@ -1231,6 +1264,7 @@ def try_multi_enqueue(
                                     matched=True,
                                     downloads=owned,
                                     candidates=tuple(accumulated),
+                                    pre_filter_skip_count=pre_filter_skips[0],
                                 )
                         elif claim.claimed:
                             owned = _leave_claim_for_poll_recovery(
@@ -1242,11 +1276,13 @@ def try_multi_enqueue(
                                 matched=True,
                                 downloads=owned,
                                 candidates=tuple(accumulated),
+                                pre_filter_skip_count=pre_filter_skips[0],
                             )
                     return EnqueueAttempt(
                         matched=False,
                         enqueue_failed=True,
                         candidates=tuple(accumulated),
+                        pre_filter_skip_count=pre_filter_skips[0],
                     )
             except Exception:
                 logger.exception("Exception enqueueing tracks")
@@ -1265,6 +1301,7 @@ def try_multi_enqueue(
                             matched=True,
                             downloads=owned,
                             candidates=tuple(accumulated),
+                            pre_filter_skip_count=pre_filter_skips[0],
                         )
                     if not claim.claimed:
                         cancel_and_delete(all_downloads, ctx)
@@ -1279,11 +1316,13 @@ def try_multi_enqueue(
                             matched=True,
                             downloads=owned,
                             candidates=tuple(accumulated),
+                            pre_filter_skip_count=pre_filter_skips[0],
                         )
                 return EnqueueAttempt(
                     matched=False,
                     enqueue_failed=True,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
         if enqueued == total:
             if not _persist_claimed_download_state(claim, all_downloads, ctx):
@@ -1292,11 +1331,13 @@ def try_multi_enqueue(
                     matched=False,
                     enqueue_failed=True,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
             return EnqueueAttempt(
                 matched=True,
                 downloads=all_downloads,
                 candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skips[0],
             )
         if len(all_downloads) > 0:
             recovered = _handle_claimed_partial_failure(claim, all_downloads, ctx)
@@ -1305,6 +1346,7 @@ def try_multi_enqueue(
                     matched=True,
                     downloads=recovered,
                     candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
                 )
             if not claim.claimed:
                 cancel_and_delete(all_downloads, ctx)
@@ -1312,9 +1354,14 @@ def try_multi_enqueue(
             matched=False,
             enqueue_failed=True,
             candidates=tuple(accumulated),
+            pre_filter_skip_count=pre_filter_skips[0],
         )
 
-    return EnqueueAttempt(matched=False, candidates=tuple(accumulated))
+    return EnqueueAttempt(
+        matched=False,
+        candidates=tuple(accumulated),
+        pre_filter_skip_count=pre_filter_skips[0],
+    )
 
 
 def _try_filetype(
@@ -1330,6 +1377,7 @@ def _try_filetype(
     has_monitored = any(r.monitored for r in releases)
     had_enqueue_failure = False
     accumulated: list[CandidateScore] = []
+    pre_filter_skip_count_total = 0
 
     for _ in range(len(releases)):
         if not releases:
@@ -1346,11 +1394,13 @@ def _try_filetype(
 
         attempt = try_enqueue(all_tracks, results, allowed_filetype, ctx)
         accumulated.extend(attempt.candidates)
+        pre_filter_skip_count_total += attempt.pre_filter_skip_count
         if not attempt.matched and len(release.media) > 1:
             attempt = try_multi_enqueue(
                 release, all_tracks, results, allowed_filetype, ctx
             )
             accumulated.extend(attempt.candidates)
+            pre_filter_skip_count_total += attempt.pre_filter_skip_count
 
         if attempt.matched:
             assert attempt.downloads is not None
@@ -1371,6 +1421,7 @@ def _try_filetype(
                 outcome="found",
                 grab_entry=grab_entry,
                 candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skip_count_total,
             )
 
         if attempt.enqueue_failed:
@@ -1389,6 +1440,7 @@ def _try_filetype(
     return FindDownloadResult(
         outcome="enqueue_failed" if had_enqueue_failure else "no_match",
         candidates=tuple(accumulated),
+        pre_filter_skip_count=pre_filter_skip_count_total,
     )
 
 
@@ -1418,15 +1470,18 @@ def find_download(
 
     had_enqueue_failure = False
     accumulated: list[CandidateScore] = []
+    pre_filter_skip_count_total = 0
     for allowed_filetype in filetypes_to_try:
         logger.info(f"Checking for Quality: {allowed_filetype}")
         result = _try_filetype(album, results, allowed_filetype, ctx)
         accumulated.extend(result.candidates)
+        pre_filter_skip_count_total += result.pre_filter_skip_count
         if result.outcome == "found":
             return _with_metrics(FindDownloadResult(
                 outcome="found",
                 grab_entry=result.grab_entry,
                 candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skip_count_total,
             ), ctx)
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
@@ -1441,11 +1496,13 @@ def find_download(
         )
         result = _try_filetype(album, results, "*", ctx)
         accumulated.extend(result.candidates)
+        pre_filter_skip_count_total += result.pre_filter_skip_count
         if result.outcome == "found":
             return _with_metrics(FindDownloadResult(
                 outcome="found",
                 grab_entry=result.grab_entry,
                 candidates=tuple(accumulated),
+                pre_filter_skip_count=pre_filter_skip_count_total,
             ), ctx)
         if result.outcome == "enqueue_failed":
             had_enqueue_failure = True
@@ -1453,4 +1510,5 @@ def find_download(
     return _with_metrics(FindDownloadResult(
         outcome="enqueue_failed" if had_enqueue_failure else "no_match",
         candidates=tuple(accumulated),
+        pre_filter_skip_count=pre_filter_skip_count_total,
     ), ctx)

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -29,14 +29,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("cratedigger")
 
 
-# U2 of search-plan-entropy: per-search cap on the number of flagged
-# pre-filter-skip CandidateScore rows emitted into the forensic
-# candidates blob. The aggregable scalar count
-# (``MatchResult.pre_filter_skip_count``) is always accurate; the
-# sample rows are bounded so the JSONB blob does not blow out for
-# pathological junk-peer searches (hundreds of skipped dirs from one
-# noisy user). 5 chosen so a search can still keep ~15 scored
-# candidates inside the existing top-20 candidates cap when contested.
+# Cap on flagged pre-filter-skip sample rows per search — bounds the
+# JSONB blob for noisy peers. The aggregate count is always accurate
+# (``MatchResult.pre_filter_skip_count``); only the sample is capped.
 PRE_FILTER_SKIP_SAMPLE_CAP = 5
 
 
@@ -98,13 +93,9 @@ class MatchResult:
     directory: Any
     file_dir: str
     candidates: list[CandidateScore] = field(default_factory=list)
-    # U2 of search-plan-entropy: count of dirs the asymmetric pre-filter
-    # rejected before browse (``search_count > 2 * track_num`` for
-    # single-codec dirs). Sums one per pre-filter skip; the candidates
-    # list also carries up to ``PRE_FILTER_SKIP_SAMPLE_CAP`` flagged
-    # sample rows so operators can see which (user, dir) tuples are
-    # noisy. The count is the authoritative total -- sample rows are a
-    # subset.
+    # Authoritative count of dirs rejected by the asymmetric pre-filter
+    # before browse; sample rows in ``candidates`` are bounded by
+    # ``PRE_FILTER_SKIP_SAMPLE_CAP``.
     pre_filter_skip_count: int = 0
 
 

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -29,6 +29,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger("cratedigger")
 
 
+# U2 of search-plan-entropy: per-search cap on the number of flagged
+# pre-filter-skip CandidateScore rows emitted into the forensic
+# candidates blob. The aggregable scalar count
+# (``MatchResult.pre_filter_skip_count``) is always accurate; the
+# sample rows are bounded so the JSONB blob does not blow out for
+# pathological junk-peer searches (hundreds of skipped dirs from one
+# noisy user). 5 chosen so a search can still keep ~15 scored
+# candidates inside the existing top-20 candidates cap when contested.
+PRE_FILTER_SKIP_SAMPLE_CAP = 5
+
+
 # ---------------------------------------------------------------------------
 # Structured return types (U2 of search-escalation-and-forensics)
 # ---------------------------------------------------------------------------
@@ -87,6 +98,14 @@ class MatchResult:
     directory: Any
     file_dir: str
     candidates: list[CandidateScore] = field(default_factory=list)
+    # U2 of search-plan-entropy: count of dirs the asymmetric pre-filter
+    # rejected before browse (``search_count > 2 * track_num`` for
+    # single-codec dirs). Sums one per pre-filter skip; the candidates
+    # list also carries up to ``PRE_FILTER_SKIP_SAMPLE_CAP`` flagged
+    # sample rows so operators can see which (user, dir) tuples are
+    # noisy. The count is the authoritative total -- sample rows are a
+    # subset.
+    pre_filter_skip_count: int = 0
 
 
 def get_album_by_id(album_id: int, ctx: CratediggerContext) -> Any:
@@ -323,6 +342,8 @@ def check_for_match(
     `search_log.candidates` for forensic introspection.
     """
     candidates: list[CandidateScore] = []
+    pre_filter_skip_count = 0
+    pre_filter_skip_samples_emitted = 0
     logger.debug(f"Current broken users {ctx.broken_user}")
     if username in ctx.broken_user:
         return MatchResult(matched=False, directory={}, file_dir="", candidates=candidates)
@@ -353,12 +374,30 @@ def check_for_match(
                     f"audio files, need {track_num} tracks"
                 )
                 ctx.negative_matches.add(neg_key)
+                # U2: telemetry — always count, sample up to the cap.
+                pre_filter_skip_count += 1
+                if pre_filter_skip_samples_emitted < PRE_FILTER_SKIP_SAMPLE_CAP:
+                    candidates.append(CandidateScore(
+                        username=username,
+                        dir=file_dir,
+                        filetype=allowed_filetype,
+                        matched_tracks=0,
+                        total_tracks=track_num,
+                        avg_ratio=0.0,
+                        missing_titles=[],
+                        file_count=search_count,
+                        pre_filter_skip=True,
+                    ))
+                    pre_filter_skip_samples_emitted += 1
                 continue
 
         dirs_to_try.append(file_dir)
 
     if not dirs_to_try:
-        return MatchResult(matched=False, directory={}, file_dir="", candidates=candidates)
+        return MatchResult(
+            matched=False, directory={}, file_dir="", candidates=candidates,
+            pre_filter_skip_count=pre_filter_skip_count,
+        )
 
     peer_cache_negative_skips = getattr(ctx, "peer_cache_negative_skips", set())
     if peer_cache_negative_skips:
@@ -369,6 +408,7 @@ def check_for_match(
         if not dirs_to_try:
             return MatchResult(
                 matched=False, directory={}, file_dir="", candidates=candidates,
+                pre_filter_skip_count=pre_filter_skip_count,
             )
 
     ensure_cache_user(ctx, username)
@@ -429,6 +469,7 @@ def check_for_match(
             logger.debug(f"All browses failed for {username}, marked as broken")
             return MatchResult(
                 matched=False, directory={}, file_dir="", candidates=candidates,
+                pre_filter_skip_count=pre_filter_skip_count,
             )
 
     # U1 instrumentation: time the local matching/scoring loop separately
@@ -502,6 +543,7 @@ def check_for_match(
                         ),
                         file_dir=file_dir,
                         candidates=candidates,
+                        pre_filter_skip_count=pre_filter_skip_count,
                     )
                 logger.warning(
                     f"Track title cross-check FAILED for user {username}, "
@@ -511,6 +553,7 @@ def check_for_match(
 
         return MatchResult(
             matched=False, directory={}, file_dir="", candidates=candidates,
+            pre_filter_skip_count=pre_filter_skip_count,
         )
     finally:
         ctx.match_time_s += time.monotonic() - match_t0

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -347,7 +347,7 @@ def check_for_match(
             cached_codecs = _search_cache_concrete_codecs_for_dir(
                 ctx, album_id, username, file_dir,
             )
-            if len(cached_codecs) <= 1 and abs(search_count - track_num) > 2:
+            if len(cached_codecs) <= 1 and search_count > 2 * track_num:
                 logger.debug(
                     f"Pre-filter skip: {username} {file_dir} has {search_count} "
                     f"audio files, need {track_num} tracks"

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -639,6 +639,40 @@ class SearchLogHistoryPage:
 
 
 @dataclass(frozen=True)
+class SaturationSummary:
+    """U7: aggregate saturation/forensic counts for one request over a window.
+
+    Returned by ``PipelineDB.get_saturation_summary``. A search counts as
+    "saturated" when its ``final_state`` contains ``LimitReached`` (e.g.
+    ``Completed, ResponseLimitReached`` or ``Completed, FileLimitReached``)
+    — slskd hit its response/file ceiling before the search naturally
+    finished, so the result set is a truncated head sample rather than
+    the full picture. High saturation rates indicate the queries are too
+    generic for the album the operator is trying to find.
+
+    ``total_pre_filter_skips`` rolls up the U2 ``pre_filter_skip_count``
+    column — how many candidate peer dirs the asymmetric matcher
+    pre-filter rejected before browse over the same window.
+
+    ``saturation_rate`` is ``saturated_searches / total_searches`` with
+    an explicit ``0.0`` fallback when ``total_searches == 0`` (NOT NaN
+    — callers serialise this to JSON and NaN would break the
+    contract). Computed in Python after the aggregate fetch.
+
+    The summary is the data layer for the future search-plan dashboard
+    (see ``docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md``);
+    today it ships via ``pipeline-cli search-plan saturation`` and
+    ``GET /api/pipeline/<id>/search-plan/saturation``.
+    """
+
+    total_searches: int
+    saturated_searches: int
+    saturation_rate: float
+    total_pre_filter_skips: int
+    window_days: int
+
+
+@dataclass(frozen=True)
 class RequestV0ProbeStateUpdate:
     """Typed update for current comparable lossless-source V0 probe state."""
 
@@ -3346,6 +3380,72 @@ class PipelineDB:
             ORDER BY id DESC
         """, (request_id,))
         return [dict(r) for r in cur.fetchall()]
+
+    def get_saturation_summary(
+        self, request_id: int, *, window_days: int = 14,
+    ) -> "SaturationSummary":
+        """U7: saturation rate + pre-filter skip total for one request.
+
+        Aggregates ``search_log`` rows for ``request_id`` whose
+        ``created_at`` falls inside the last ``window_days`` days.
+        Returns a :class:`SaturationSummary` with:
+
+        * ``total_searches`` — count of rows in window
+        * ``saturated_searches`` — rows whose ``final_state`` matches
+          ``%LimitReached%`` (slskd hit its response/file ceiling)
+        * ``saturation_rate`` — ratio in ``[0.0, 1.0]``; ``0.0`` when
+          ``total_searches == 0`` (explicit, NOT NaN — the value is
+          serialised to JSON downstream)
+        * ``total_pre_filter_skips`` — sum of the U2
+          ``pre_filter_skip_count`` column over the same window
+        * ``window_days`` — echoed back so callers don't need to
+          remember which window they asked for
+
+        ``window_days`` is a non-negative int. The route handler and
+        CLI both bound it before calling (negative or huge values are
+        operator errors); the DB layer trusts the caller. ``0`` reduces
+        the SQL to an empty window and returns all zeros — that's a
+        defensible read (operator asked for the past zero days).
+
+        Returns an empty summary (all zeros, ``saturation_rate=0.0``)
+        when the request has no logged searches in window. This method
+        does NOT consult ``album_requests`` — the caller decides
+        whether to translate "no rows" into a 404 by looking up the
+        request row separately. See the service-layer
+        ``SearchPlanService.saturation_for_request`` for that mapping.
+        """
+        cur = self._execute("""
+            SELECT
+              COUNT(*) AS total_searches,
+              COUNT(*) FILTER (WHERE final_state LIKE %s)
+                AS saturated_searches,
+              COALESCE(SUM(pre_filter_skip_count), 0)
+                AS total_pre_filter_skips
+            FROM search_log
+            WHERE request_id = %s
+              AND created_at > NOW() - make_interval(days => %s)
+        """, ("%LimitReached%", request_id, int(window_days)))
+        row = cur.fetchone()
+        if row is None:
+            # Defensive — aggregate queries always return one row, but
+            # keep the type-checker happy and the helper total.
+            return SaturationSummary(
+                total_searches=0,
+                saturated_searches=0,
+                saturation_rate=0.0,
+                total_pre_filter_skips=0,
+                window_days=int(window_days),
+            )
+        total = int(row["total_searches"] or 0)
+        saturated = int(row["saturated_searches"] or 0)
+        rate = (saturated / total) if total > 0 else 0.0
+        return SaturationSummary(
+            total_searches=total,
+            saturated_searches=saturated,
+            saturation_rate=rate,
+            total_pre_filter_skips=int(row["total_pre_filter_skips"] or 0),
+            window_days=int(window_days),
+        )
 
     def get_legacy_search_log_summary(
         self, request_id: int, *, limit: int,

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -555,10 +555,10 @@ class ConsumedAttemptInput:
     peers_browsed: int = 0
     peers_browsed_lazy: int = 0
     fanout_waves: int = 0
-    # U2 of search-plan-entropy: count of dirs the asymmetric pre-filter
-    # rejected before browse during this search's find_download walk.
-    # Persisted on search_log.pre_filter_skip_count for per-search
-    # aggregation. Default 0 keeps every existing caller / test compatible.
+    # Count of dirs the asymmetric pre-filter rejected before browse
+    # during this search's find_download walk; persisted on
+    # ``search_log.pre_filter_skip_count``. Default 0 keeps existing
+    # callers compatible.
     pre_filter_skip_count: int = 0
     # Plan-item count required by wrap detection. The executor reads it
     # from the active plan it executed; passing it explicitly avoids a
@@ -599,10 +599,9 @@ class NonConsumingAttemptInput:
     final_state: str | None = None
     error_message: str | None = None
     apply_scheduler_attempt: bool = True
-    # U2 of search-plan-entropy: pre-filter skip count for the failed
-    # attempt. Almost always 0 for pre-attempt failures because the
-    # matcher never ran, but plumbed through so the column is
-    # consistently populated across all log_search write paths.
+    # Pre-filter skip count for the failed attempt. Almost always 0
+    # because the matcher rarely runs on pre-attempt failures, but
+    # plumbed through so the column is consistently populated.
     pre_filter_skip_count: int = 0
 
 

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -555,6 +555,11 @@ class ConsumedAttemptInput:
     peers_browsed: int = 0
     peers_browsed_lazy: int = 0
     fanout_waves: int = 0
+    # U2 of search-plan-entropy: count of dirs the asymmetric pre-filter
+    # rejected before browse during this search's find_download walk.
+    # Persisted on search_log.pre_filter_skip_count for per-search
+    # aggregation. Default 0 keeps every existing caller / test compatible.
+    pre_filter_skip_count: int = 0
     # Plan-item count required by wrap detection. The executor reads it
     # from the active plan it executed; passing it explicitly avoids a
     # second SELECT inside the transaction.
@@ -594,6 +599,11 @@ class NonConsumingAttemptInput:
     final_state: str | None = None
     error_message: str | None = None
     apply_scheduler_attempt: bool = True
+    # U2 of search-plan-entropy: pre-filter skip count for the failed
+    # attempt. Almost always 0 for pre-attempt failures because the
+    # matcher never ran, but plumbed through so the column is
+    # consistently populated across all log_search write paths.
+    pre_filter_skip_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -3218,7 +3228,8 @@ class PipelineDB:
                    match_time_s: float = 0.0,
                    peers_browsed: int = 0,
                    peers_browsed_lazy: int = 0,
-                   fanout_waves: int = 0) -> None:
+                   fanout_waves: int = 0,
+                   pre_filter_skip_count: int = 0) -> None:
         """Record one search attempt for an album request.
 
         ``candidates`` is the top-N forensic ``CandidateScore`` list (already
@@ -3227,6 +3238,11 @@ class PipelineDB:
         NULL — error / submission-failure rows have no scoring data to
         report. See ``.claude/rules/code-quality.md`` § Wire-boundary types
         for the symmetric encode/decode contract.
+
+        ``pre_filter_skip_count`` (U2 of search-plan-entropy) is the
+        aggregate count of dirs the matcher's asymmetric pre-filter
+        rejected before browse. NOT NULL on the column; default 0 keeps
+        pre-attempt / error rows uniformly populated.
         """
         candidates_json: str | None = None
         if candidates is not None:
@@ -3236,12 +3252,14 @@ class PipelineDB:
             INSERT INTO search_log (
                 request_id, query, result_count, elapsed_s, outcome,
                 candidates, variant, final_state, browse_time_s, match_time_s,
-                peers_browsed, peers_browsed_lazy, fanout_waves
+                peers_browsed, peers_browsed_lazy, fanout_waves,
+                pre_filter_skip_count
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """, (request_id, query, result_count, elapsed_s, outcome,
               candidates_json, variant, final_state, browse_time_s, match_time_s,
-              peers_browsed, peers_browsed_lazy, fanout_waves))
+              peers_browsed, peers_browsed_lazy, fanout_waves,
+              pre_filter_skip_count))
         self.conn.commit()
 
     def get_search_history(self, request_id: int) -> list[dict[str, object]]:
@@ -5553,7 +5571,8 @@ class PipelineDB:
                         plan_repeat_group, plan_generator_id,
                         execution_stage, attempt_consumed,
                         cursor_update_status, stale_reason,
-                        plan_cycle_snapshot
+                        plan_cycle_snapshot,
+                        pre_filter_skip_count
                     ) VALUES (
                         %s, %s, %s, %s, %s,
                         %s, %s, %s,
@@ -5564,6 +5583,7 @@ class PipelineDB:
                         %s, %s,
                         %s, %s,
                         %s, %s,
+                        %s,
                         %s
                     )
                     RETURNING id
@@ -5594,6 +5614,7 @@ class PipelineDB:
                         cursor_update_status,
                         stale_reason,
                         attempt.cycle_count_snapshot,
+                        attempt.pre_filter_skip_count,
                     ),
                 )
                 log_row = cur.fetchone()
@@ -5712,7 +5733,8 @@ class PipelineDB:
                         plan_strategy, plan_canonical_query_key,
                         plan_repeat_group, plan_generator_id,
                         execution_stage, attempt_consumed,
-                        cursor_update_status, plan_cycle_snapshot
+                        cursor_update_status, plan_cycle_snapshot,
+                        pre_filter_skip_count
                     ) VALUES (
                         %s, %s, %s, %s, %s,
                         %s,
@@ -5720,7 +5742,8 @@ class PipelineDB:
                         %s, %s,
                         %s, %s,
                         %s, %s,
-                        %s, %s
+                        %s, %s,
+                        %s
                     )
                     RETURNING id
                     """,
@@ -5742,6 +5765,7 @@ class PipelineDB:
                         False,  # attempt_consumed
                         CURSOR_UPDATE_UNCHANGED,
                         cycle_snapshot,
+                        attempt.pre_filter_skip_count,
                     ),
                 )
                 log_row = cur.fetchone()

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -1570,19 +1570,24 @@ class PipelineDB:
                     mb_artist_id=None, discogs_release_id=None,
                     year=None, country=None, format=None,
                     source_path=None, reasoning=None,
-                    status="wanted"):
+                    status="wanted",
+                    release_group_year=None):
         now = datetime.now(timezone.utc)
         cur = self._execute("""
             INSERT INTO album_requests (
                 mb_release_id, mb_release_group_id, mb_artist_id, discogs_release_id,
-                artist_name, album_title, year, country, format,
+                artist_name, album_title, year, release_group_year,
+                country, format,
                 source, source_path, reasoning, status,
                 created_at, updated_at
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
             RETURNING id
         """, (
             mb_release_id, mb_release_group_id, mb_artist_id, discogs_release_id,
-            artist_name, album_title, year, country, format,
+            artist_name, album_title, year, release_group_year,
+            country, format,
             source, source_path, reasoning, status,
             now, now,
         ))
@@ -1926,6 +1931,54 @@ class PipelineDB:
     ) -> None:
         """Write spectral state pairs together, including explicit NULLs."""
         self.update_request_fields(request_id, **update.as_update_fields())
+
+    def get_requests_missing_release_group_year(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List requests that need ``release_group_year`` populated.
+
+        Returns the rows where ``mb_release_group_id IS NOT NULL`` and
+        ``release_group_year IS NULL``. Used by the U3 deploy backfill
+        script (``scripts/backfill_release_group_year.py``); the WHERE
+        clause is what makes the backfill idempotent — re-running skips
+        rows that already have a value.
+
+        ``limit`` is honoured so the backfill can process in deterministic
+        chunks and test setups can constrain the result set.
+        """
+        sql = (
+            "SELECT id, mb_release_group_id, artist_name, album_title "
+            "FROM album_requests "
+            "WHERE mb_release_group_id IS NOT NULL "
+            "  AND release_group_year IS NULL "
+            "ORDER BY id"
+        )
+        params: tuple[object, ...] = ()
+        if limit is not None:
+            sql += " LIMIT %s"
+            params = (limit,)
+        cur = self._execute(sql, params)
+        return [dict(r) for r in cur.fetchall()]
+
+    def set_release_group_year(
+        self,
+        request_id: int,
+        year: int | None,
+    ) -> None:
+        """Set ``album_requests.release_group_year`` (U3 / R9).
+
+        ``year`` may be ``None`` (column reset to NULL) or an int (the
+        release-group's first-release year as returned by the MB mirror).
+        Used by the U3 deploy backfill and by U4's enqueue path. Thin
+        wrapper around ``update_request_fields`` — exists so call sites
+        carry the column name as part of the method, which makes the
+        backfill / enqueue intent grep-able.
+        """
+        self.update_request_fields(
+            request_id, release_group_year=year,
+        )
 
     def update_v0_probe_state(
         self,

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -504,16 +504,10 @@ def top_candidates_with_skip_split(
 ) -> list[CandidateScore]:
     """Return scored top-N + sampled pre-filter-skip rows.
 
-    Splits the candidate list into scored (matched_tracks > 0 OR not a
-    pre-filter skip) and pre-filter-skip subsets, returns up to
-    ``scored_limit`` of the former (ranked the same way ``top_candidates``
-    ranks them) and up to ``skip_limit`` of the latter (preserving input
-    order, which mirrors matcher visit order — first N peers the matcher
-    rejected, not a random sample).
-
-    Total returned ≤ ``scored_limit + skip_limit``. Scored rows always
-    come first, then skip rows. Default split (15 + 5 = 20) matches the
-    pre-U2 forensic candidates cap so blob size does not balloon.
+    Splits ``candidates`` into scored vs pre-filter-skip; ranks scored
+    via ``top_candidates``, preserves visit order for the skip sample.
+    Default 15 + 5 keeps the JSONB blob the same size as the pre-split
+    cap of 20.
     """
     scored = [c for c in candidates if not c.pre_filter_skip]
     skipped = [c for c in candidates if c.pre_filter_skip]

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -441,6 +441,17 @@ class CandidateScore(msgspec.Struct):
     variant is the cheap zero-score record (``matched_tracks=0``,
     ``avg_ratio=0.0``, ``missing_titles=[]``) so the forensic blob still
     captures peers that had a sub-count audio file count.
+
+    ``pre_filter_skip`` (U2 of search-plan-entropy): True for the
+    sampled flagged rows ``check_for_match`` emits when the asymmetric
+    pre-filter (``search_count > 2 * track_num``) rejected the dir
+    before any browse. Sample rows carry ``matched_tracks=0``,
+    ``avg_ratio=0.0``, ``missing_titles=[]`` and the cached
+    ``file_count`` from the search response so operators can see
+    which peers are noisy. Defaults to ``False`` so historic blobs
+    decode unchanged (msgspec strict decode tolerates missing fields
+    only when a default is declared — symmetric encode keeps the field
+    on every row, including ``False`` on scored / sub-count rows).
     """
     username: str
     dir: str
@@ -450,6 +461,7 @@ class CandidateScore(msgspec.Struct):
     avg_ratio: float
     missing_titles: list[str]
     file_count: int
+    pre_filter_skip: bool = False
 
 
 def top_candidates(
@@ -470,12 +482,45 @@ def top_candidates(
     Sorting by matched_tracks first surfaces the closest peers; avg_ratio is
     the secondary tiebreak so a 24/26 dir with high ratio beats a 24/26 dir
     with low ratio.
+
+    U2 of search-plan-entropy: ``pre_filter_skip`` flagged rows
+    (``matched_tracks=0``, ``avg_ratio=0.0``) sink to the bottom of
+    this ordering naturally. Callers that want a guaranteed mix of
+    scored + skip-sample rows should split the input first
+    (see ``top_candidates_with_skip_split``).
     """
     return sorted(
         candidates,
         key=lambda c: (c.matched_tracks, c.avg_ratio),
         reverse=True,
     )[:limit]
+
+
+def top_candidates_with_skip_split(
+    candidates: Sequence[CandidateScore],
+    *,
+    scored_limit: int = 15,
+    skip_limit: int = 5,
+) -> list[CandidateScore]:
+    """Return scored top-N + sampled pre-filter-skip rows.
+
+    Splits the candidate list into scored (matched_tracks > 0 OR not a
+    pre-filter skip) and pre-filter-skip subsets, returns up to
+    ``scored_limit`` of the former (ranked the same way ``top_candidates``
+    ranks them) and up to ``skip_limit`` of the latter (preserving input
+    order, which mirrors matcher visit order — first N peers the matcher
+    rejected, not a random sample).
+
+    Total returned ≤ ``scored_limit + skip_limit``. Scored rows always
+    come first, then skip rows. Default split (15 + 5 = 20) matches the
+    pre-U2 forensic candidates cap so blob size does not balloon.
+    """
+    scored = [c for c in candidates if not c.pre_filter_skip]
+    skipped = [c for c in candidates if c.pre_filter_skip]
+    return (
+        top_candidates(scored, limit=scored_limit)
+        + list(skipped[:skip_limit])
+    )
 
 
 @dataclass

--- a/lib/release_snapshot.py
+++ b/lib/release_snapshot.py
@@ -134,6 +134,33 @@ def _track_titles_from_tracks(tracks: list[dict[str, Any]]) -> tuple[str, ...]:
     return tuple(s[2] for s in sortable)
 
 
+def _release_group_year_from_value(value: object) -> int | None:
+    """Normalise the ``release_group_year`` column / payload to ``int | None``.
+
+    The DB column is INTEGER NULL; CLI / web add paths pass a Python
+    int or None. Strings are accepted defensively (some test fixtures
+    use strings) and parsed as a 4-digit year. Non-positive ints / bad
+    strings collapse to None so the generator's ``unwild_rg_year``
+    skip path fires.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            n = int(s[:4])
+        except ValueError:
+            return None
+        return n if n > 0 else None
+    return None
+
+
 def snapshot_from_request_row(
     row: dict[str, Any],
     tracks: list[dict[str, Any]],
@@ -155,6 +182,7 @@ def snapshot_from_request_row(
         title = str(title)
     year = year_from_value(row.get("year"))
     redownload = bool(row.get("source") == "redownload")
+    rg_year = _release_group_year_from_value(row.get("release_group_year"))
     return ReleaseSnapshot(
         artist_name=artist,
         title=title,
@@ -162,6 +190,7 @@ def snapshot_from_request_row(
         track_titles=_track_titles_from_tracks(tracks),
         redownload=redownload,
         prepend_artist=prepend_artist,
+        release_group_year=rg_year,
     )
 
 
@@ -173,6 +202,7 @@ def snapshot_from_add_payload(
     tracks: list[dict[str, Any]],
     source: str,
     prepend_artist: bool = False,
+    release_group_year: object = None,
 ) -> ReleaseSnapshot:
     """Build a `ReleaseSnapshot` from add-time metadata.
 
@@ -180,6 +210,11 @@ def snapshot_from_add_payload(
     release dict + tracks list before calling `set_tracks`. Pass those
     same values through here so add-time generation sees identical
     inputs to a startup-time regeneration of the same release.
+
+    ``release_group_year`` is the first-release year of the MB release
+    group (U5 R9). When known AND different from ``year``, the
+    generator emits an extra ``unwild_rg_year`` slot so reissues find
+    their original-pressing peers on Soulseek.
     """
     return ReleaseSnapshot(
         artist_name=artist_name or "",
@@ -188,4 +223,5 @@ def snapshot_from_add_payload(
         track_titles=_track_titles_from_tracks(tracks),
         redownload=(source == "redownload"),
         prepend_artist=prepend_artist,
+        release_group_year=_release_group_year_from_value(release_group_year),
     )

--- a/lib/search.py
+++ b/lib/search.py
@@ -58,6 +58,11 @@ class SearchResult:
     # Forensic capture persisted to search_log: candidates JSONB (top-20
     # match scores from find_download), variant tag, slskd terminal state.
     candidates: tuple[CandidateScore, ...] = ()
+    # U2 of search-plan-entropy: aggregate count of dirs the asymmetric
+    # pre-filter rejected before browse during this search's
+    # find_download walk. Persisted on search_log.pre_filter_skip_count
+    # for per-search aggregation.
+    pre_filter_skip_count: int = 0
     variant_tag: str | None = None
     final_state: str | None = None
     # Per-search browse/match cost copied from FindDownloadMetrics. These are

--- a/lib/search.py
+++ b/lib/search.py
@@ -58,10 +58,9 @@ class SearchResult:
     # Forensic capture persisted to search_log: candidates JSONB (top-20
     # match scores from find_download), variant tag, slskd terminal state.
     candidates: tuple[CandidateScore, ...] = ()
-    # U2 of search-plan-entropy: aggregate count of dirs the asymmetric
-    # pre-filter rejected before browse during this search's
-    # find_download walk. Persisted on search_log.pre_filter_skip_count
-    # for per-search aggregation.
+    # Aggregate count of dirs the asymmetric pre-filter rejected before
+    # browse during this search; persisted on
+    # ``search_log.pre_filter_skip_count`` for per-search aggregation.
     pre_filter_skip_count: int = 0
     variant_tag: str | None = None
     final_state: str | None = None
@@ -582,6 +581,12 @@ _STRATEGY_UNWILD = "unwild"
 _STRATEGY_UNWILD_YEAR = "unwild_year"
 _STRATEGY_UNWILD_RG_YEAR = "unwild_rg_year"
 _STRATEGY_SELFTITLED_ARTIST_TRACK_PREFIX = "selftitled_artist_track_"
+_STRATEGY_SELFTITLED_ARTIST_TRACK_0 = (
+    f"{_STRATEGY_SELFTITLED_ARTIST_TRACK_PREFIX}0"
+)
+_STRATEGY_SELFTITLED_ARTIST_TRACK_0_FLAC = (
+    f"{_STRATEGY_SELFTITLED_ARTIST_TRACK_0}_flac"
+)
 _STRATEGY_SELFTITLED_ARTIST_YEAR = "selftitled_artist_year"
 
 
@@ -625,10 +630,10 @@ class ReleaseSnapshot:
     track_titles: tuple[str, ...]
     redownload: bool = False
     prepend_artist: bool = False
-    # U5 of search-plan-entropy: release-group year (first release year of
-    # the MB release group). When known AND different from `year`, the
-    # generator emits an extra `unwild_rg_year` slot so reissues find their
-    # original-pressing peers on Soulseek. NULL means no extra slot.
+    # First-release year of the MB release group. When known and
+    # different from ``year``, the generator emits an extra
+    # ``unwild_rg_year`` slot so reissues find original-pressing peers
+    # on Soulseek. NULL means no extra slot.
     release_group_year: int | None = None
 
 
@@ -852,73 +857,30 @@ def _is_self_titled(artist_name: str, title: str) -> bool:
     return bool(a) and a == t
 
 
-def _build_default_query(
+def _build_query(
     artist: str,
     title: str,
     *,
     prepend_artist: bool,
-) -> str | None:
-    """Build the default slot query: wildcarded artist + title, no short drop.
-
-    U5 of search-plan-entropy:
-      * No `strip_short_tokens` call — short tokens survive into the
-        query (capped only by token count, longest-first).
-      * Low-entropy normalization still applies ("the/you/from/and"
-        dropped).
-      * Artist tokens wildcarded for ban bypass.
-      * Title tokens that duplicate the wildcarded artist tokens
-        (case-insensitive on the un-wildcarded form) are dropped.
-    """
-    clean_artist = strip_special_chars(artist)
-    clean_title = strip_special_chars(title)
-
-    artist_tokens = clean_artist.split()
-    title_tokens = clean_title.split()
-
-    artist_tokens = _normalize_query_tokens(
-        artist_tokens, preserve_all_low_entropy=True,
-    )
-    title_tokens = _normalize_query_tokens(title_tokens)
-
-    artist_lower = {t.lower() for t in artist_tokens}
-    title_tokens = [t for t in title_tokens if t.lower() not in artist_lower]
-
-    if clean_artist.lower() in ("various artists", "various"):
-        artist_tokens = []
-
-    artist_tokens = wildcard_artist_tokens(artist_tokens)
-
-    if prepend_artist and artist_tokens:
-        all_tokens = artist_tokens + title_tokens
-    else:
-        all_tokens = title_tokens
-
-    if not all_tokens:
-        return None
-
-    all_tokens = cap_tokens(all_tokens, MAX_SEARCH_TOKENS)
-    return " ".join(all_tokens)
-
-
-def _build_literal_query(
-    artist: str,
-    title: str,
-    *,
-    prepend_artist: bool,
+    wildcard: bool,
     max_tokens: int = MAX_SEARCH_TOKENS,
 ) -> str | None:
-    """Build the literal slot query: artist + title, no wildcard, no short drop.
+    """Build a slot query from artist + title.
 
-    Used directly for the ``literal`` slot and as the body for the
-    format-hint and year-anchored slots (``literal_flac``,
-    ``literal_lossless``, ``unwild_year``, ``unwild_rg_year``).
+    Shared pipeline for the ``default`` slot (wildcard=True), the
+    ``literal`` slot, and the bodies of format-hint and year-anchored
+    slots (``literal_flac``, ``literal_lossless``, ``unwild_year``,
+    ``unwild_rg_year``) (wildcard=False):
 
-    Pipeline:
       * Strip special chars.
-      * Low-entropy normalization on both sides (``the/you/from/and``).
-      * Drop title tokens that duplicate artist tokens (case-insensitive).
-      * Drop artist for Various Artists.
-      * Cap to `max_tokens` longest-first.
+      * Low-entropy normalization ("the/you/from/and" dropped) on both
+        sides.
+      * Drop title tokens that duplicate artist tokens
+        (case-insensitive on the un-wildcarded form).
+      * ``Various Artists`` → no artist tokens.
+      * When ``wildcard=True``, artist tokens are wildcarded for ban
+        bypass.
+      * Cap longest-first to ``max_tokens``.
     """
     clean_artist = strip_special_chars(artist)
     clean_title = strip_special_chars(title)
@@ -936,6 +898,9 @@ def _build_literal_query(
 
     if clean_artist.lower() in ("various artists", "various"):
         artist_tokens = []
+
+    if wildcard:
+        artist_tokens = wildcard_artist_tokens(artist_tokens)
 
     if prepend_artist and artist_tokens:
         all_tokens = artist_tokens + title_tokens
@@ -1040,8 +1005,8 @@ def _generate_normal_plan(
     candidates: list[_Candidate] = []
 
     # 1. Default slot — wildcarded artist + title, no short-token drop.
-    default_query = _build_default_query(
-        artist, title, prepend_artist=prepend_artist,
+    default_query = _build_query(
+        artist, title, prepend_artist=prepend_artist, wildcard=True,
     )
     if default_query:
         candidates.append(_Candidate(
@@ -1059,14 +1024,15 @@ def _generate_normal_plan(
         ))
 
     # 2. Literal slot — un-wildcarded, no short-token drop, no year.
-    literal_query = _build_literal_query(
-        artist, title, prepend_artist=prepend_artist,
+    literal_query = _build_query(
+        artist, title, prepend_artist=prepend_artist, wildcard=False,
     )
     # Body capped at MAX_SEARCH_TOKENS - 1 so format-hint slots can
     # append their hint token without losing it to the slskd 4-token cap.
-    literal_body_for_hint = _build_literal_query(
+    literal_body_for_hint = _build_query(
         artist, title,
         prepend_artist=prepend_artist,
+        wildcard=False,
         max_tokens=MAX_SEARCH_TOKENS - 1,
     )
 
@@ -1128,55 +1094,34 @@ def _generate_normal_plan(
             omit_reason=reason,
         ))
 
-    # 6. unwild_rg_year slot — only when rg_year is known AND differs
-    #    from release `year`. When they match we omit (avoid duplicate
-    #    of the unwild_year slot).
-    if (
-        year_known
-        and rg_year is not None
-        and int(rg_year) > 0
-        and str(rg_year) != (year[:4] if year else "")
-        and literal_query
-    ):
-        rg_year_str = f"{int(rg_year):04d}"
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_RG_YEAR,
-            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
-            query=f"{literal_query} {rg_year_str}",
-            omit_reason=None,
-            extra_provenance={"release_group_year": int(rg_year)},
-        ))
-    elif rg_year is None:
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_RG_YEAR,
-            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
-            query=None,
-            omit_reason="release_group_year_unknown",
-        ))
+    # 6. unwild_rg_year slot — emit a query only when rg_year is known,
+    #    year is known, the two differ, and the literal body exists.
+    #    Otherwise emit one omission with a precise reason.
+    rg_query: str | None = None
+    rg_omit_reason: str | None = None
+    rg_provenance: dict[str, Any] = (
+        {"release_group_year": int(rg_year)}
+        if rg_year is not None else {}
+    )
+    if rg_year is None:
+        rg_omit_reason = "release_group_year_unknown"
     elif not year_known:
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_RG_YEAR,
-            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
-            query=None,
-            omit_reason="year_unknown",
-            extra_provenance={"release_group_year": int(rg_year)},
-        ))
+        rg_omit_reason = "year_unknown"
     elif str(rg_year) == (year[:4] if year else ""):
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_RG_YEAR,
-            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
-            query=None,
-            omit_reason="release_group_year_matches_year",
-            extra_provenance={"release_group_year": int(rg_year)},
-        ))
+        rg_omit_reason = "release_group_year_matches_year"
+    elif not literal_query:
+        rg_omit_reason = "empty_literal_query"
+    elif int(rg_year) <= 0:
+        rg_omit_reason = "release_group_year_unknown"
     else:
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_RG_YEAR,
-            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
-            query=None,
-            omit_reason="empty_literal_query",
-            extra_provenance={"release_group_year": int(rg_year)},
-        ))
+        rg_query = f"{literal_query} {int(rg_year):04d}"
+    candidates.append(_Candidate(
+        strategy=_STRATEGY_UNWILD_RG_YEAR,
+        repeat_group=_STRATEGY_UNWILD_RG_YEAR,
+        query=rg_query,
+        omit_reason=rg_omit_reason,
+        extra_provenance=rg_provenance,
+    ))
 
     # 7. Per-track slots — artist-prepended (R8). Multi-track only.
     per_track_pairs = _per_track_candidates(
@@ -1229,19 +1174,18 @@ def _generate_selftitled_plan(
             break
 
     # 1. selftitled_artist_track_0
-    strat1 = f"{_STRATEGY_SELFTITLED_ARTIST_TRACK_PREFIX}0"
     if first_track_query is not None and first_track_idx is not None:
         candidates.append(_Candidate(
-            strategy=strat1,
-            repeat_group=strat1,
+            strategy=_STRATEGY_SELFTITLED_ARTIST_TRACK_0,
+            repeat_group=_STRATEGY_SELFTITLED_ARTIST_TRACK_0,
             query=first_track_query,
             omit_reason=None,
             extra_provenance={"source_track_index": first_track_idx},
         ))
     else:
         candidates.append(_Candidate(
-            strategy=strat1,
-            repeat_group=strat1,
+            strategy=_STRATEGY_SELFTITLED_ARTIST_TRACK_0,
+            repeat_group=_STRATEGY_SELFTITLED_ARTIST_TRACK_0,
             query=None,
             omit_reason=(
                 "no_runnable_track_queries" if track_titles
@@ -1250,11 +1194,10 @@ def _generate_selftitled_plan(
         ))
 
     # 2. selftitled_artist_track_0_flac
-    strat1_flac = f"{strat1}_flac"
     if first_track_query_body is not None and first_track_idx is not None:
         candidates.append(_Candidate(
-            strategy=strat1_flac,
-            repeat_group=strat1_flac,
+            strategy=_STRATEGY_SELFTITLED_ARTIST_TRACK_0_FLAC,
+            repeat_group=_STRATEGY_SELFTITLED_ARTIST_TRACK_0_FLAC,
             query=f"{first_track_query_body} {_FORMAT_HINT_FLAC}",
             omit_reason=None,
             extra_provenance={
@@ -1264,8 +1207,8 @@ def _generate_selftitled_plan(
         ))
     else:
         candidates.append(_Candidate(
-            strategy=strat1_flac,
-            repeat_group=strat1_flac,
+            strategy=_STRATEGY_SELFTITLED_ARTIST_TRACK_0_FLAC,
+            repeat_group=_STRATEGY_SELFTITLED_ARTIST_TRACK_0_FLAC,
             query=None,
             omit_reason=(
                 "no_runnable_track_queries" if track_titles

--- a/lib/search.py
+++ b/lib/search.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 # strategy ladder, repeat-group identity, dedupe behavior, provenance shape)
 # MUST bump this string. The plan-generation service and startup
 # reconciliation read it to decide whether a stored plan is current.
-SEARCH_PLAN_GENERATOR_ID = "search-plan/2026-05-08-1"
+SEARCH_PLAN_GENERATOR_ID = "search-plan/2026-05-19-1"
 
 
 @dataclass
@@ -565,14 +565,34 @@ def select_variant(
 # ---------------------------------------------------------------------------
 
 
-# Strategy labels used on plan items. Aligned with current `select_variant()`
-# tags so search-log forensics stay readable across the cutover.
+# Strategy labels used on plan items. Aligned with `select_variant()` tags
+# where they overlap so search-log forensics stay readable across the
+# generator-output transitions. U5 of search-plan-entropy added:
+#   * literal           — un-wildcarded artist+title, no short-token drop
+#   * literal_flac      — literal + " FLAC" format hint
+#   * literal_lossless  — literal + " lossless" format hint
+#   * unwild_rg_year    — un-wildcarded + release-group year (reissue path)
+#   * track_<idx>_artist — artist prepended to per-track fallback query
+#   * selftitled_*      — dedicated mix for self-titled releases
 _STRATEGY_DEFAULT = "default"
+_STRATEGY_LITERAL = "literal"
+_STRATEGY_LITERAL_FLAC = "literal_flac"
+_STRATEGY_LITERAL_LOSSLESS = "literal_lossless"
 _STRATEGY_UNWILD = "unwild"
 _STRATEGY_UNWILD_YEAR = "unwild_year"
+_STRATEGY_UNWILD_RG_YEAR = "unwild_rg_year"
+_STRATEGY_SELFTITLED_ARTIST_TRACK_PREFIX = "selftitled_artist_track_"
+_STRATEGY_SELFTITLED_ARTIST_YEAR = "selftitled_artist_year"
 
 
 MAX_TRACK_SLOTS_PER_PLAN = 3
+# Format-hint tokens appended to the un-wildcarded literal query to bait
+# peers who file their lossless rips with the format tag in the directory
+# name. Tokens stay literal — no wildcarding, no short-token drop, no
+# low-entropy normalization. Soulseek's distributed search caps at 4
+# tokens, so we pre-cap the body to MAX_SEARCH_TOKENS-1 to make room.
+_FORMAT_HINT_FLAC = "FLAC"
+_FORMAT_HINT_LOSSLESS = "lossless"
 
 
 # Plan-status values. String literals so they round-trip cleanly through
@@ -605,6 +625,11 @@ class ReleaseSnapshot:
     track_titles: tuple[str, ...]
     redownload: bool = False
     prepend_artist: bool = False
+    # U5 of search-plan-entropy: release-group year (first release year of
+    # the MB release group). When known AND different from `year`, the
+    # generator emits an extra `unwild_rg_year` slot so reissues find their
+    # original-pressing peers on Soulseek. NULL means no extra slot.
+    release_group_year: int | None = None
 
 
 @dataclass(frozen=True)
@@ -713,34 +738,86 @@ def _has_dropped_low_entropy(*token_lists: list[str]) -> set[str]:
 def _per_track_candidates(
     track_titles: list[str],
     artist_name: str,
+    *,
+    prepend_artist: bool = True,
 ) -> list[tuple[int, str]]:
     """Return runnable per-track queries paired with source-track index.
 
-    Mirrors `_per_track_queries()` semantics — same cleaning, same enrichment,
-    same low-entropy drops, same case-insensitive dedupe — but preserves the
-    source-track index so the generator can rank stably by token count then
-    char count then original track order.
+    Cleaning + low-entropy normalization + case-insensitive dedupe as
+    before. U5 of search-plan-entropy (R8) prepends artist tokens to the
+    track query so a bare track title can't collapse to "Distinct Word"
+    that matches a million unrelated peers. The artist tokens are
+    *wildcarded* via ``wildcard_artist_tokens`` to bypass server-side bans
+    consistently with the default/literal strategies.
+
+    Single-token track titles still fall back to ``_longest_artist_token``
+    enrichment when ``prepend_artist=False`` (legacy call path) or when
+    the artist name has no wildcardable tokens (``Various Artists`` →
+    empty after the wildcard filter; the legacy fallback supplies a
+    distinctive artist token).
+
+    No short-token drop anywhere in this pipeline — distinctiveness is
+    enforced by ``cap_tokens`` (longest-first) and by the prepended
+    artist providing entropy. Numeric / one-character tokens like "A"
+    and "22" survive into queries.
     """
     seen_lower: set[str] = set()
     out: list[tuple[int, str]] = []
+
+    # Prepare prepended artist tokens once. Wildcarded for ban bypass,
+    # mirroring how the default/literal album-level slots treat artist
+    # tokens. Empty when prepend_artist=False or artist has no
+    # wildcardable content.
+    artist_prepend_tokens: list[str] = []
+    if prepend_artist:
+        clean_artist = strip_special_chars(artist_name)
+        if clean_artist.lower() not in ("various artists", "various"):
+            raw_artist_tokens = clean_artist.split()
+            normalized = _normalize_query_tokens(
+                raw_artist_tokens,
+                preserve_all_low_entropy=True,
+            )
+            artist_prepend_tokens = wildcard_artist_tokens(normalized)
+
     for src_idx, title in enumerate(track_titles):
         cleaned = strip_special_chars(title)
         tokens = cleaned.split()
-        tokens = strip_short_tokens(tokens)
+        # NO short-token drop here (U5 R5): titles like "Get Up" or
+        # numeric tracks ("22") were being stripped, collapsing to
+        # nothing or to broken fragments.
         tokens = _normalize_query_tokens(tokens)
         if not tokens:
             continue
-        tokens = cap_tokens(tokens)
-        if len(tokens) == 1:
-            artist_token = _longest_artist_token(
-                artist_name,
-                excluded_tokens={tokens[0].lower()},
-            )
-            if artist_token:
-                tokens = tokens + [artist_token]
-            else:
+
+        if artist_prepend_tokens:
+            # Drop title tokens that duplicate (case-insensitive) any
+            # artist token already in the prefix — avoids "Wiggles Wiggles
+            # Song" double-up.
+            artist_keys = {t.lower().lstrip("*") for t in artist_prepend_tokens}
+            tokens = [
+                t for t in tokens
+                if t.lower() not in artist_keys
+            ]
+            if not tokens:
+                # All title tokens were already in the artist prefix.
+                # Skip — query collapses to bare artist name.
                 continue
-        query = " ".join(tokens)
+            combined = artist_prepend_tokens + tokens
+            combined = cap_tokens(combined)
+            query = " ".join(combined)
+        else:
+            tokens = cap_tokens(tokens)
+            if len(tokens) == 1:
+                artist_token = _longest_artist_token(
+                    artist_name,
+                    excluded_tokens={tokens[0].lower()},
+                )
+                if artist_token:
+                    tokens = tokens + [artist_token]
+                else:
+                    continue
+            query = " ".join(tokens)
+
         if not query:
             continue
         key = query.lower()
@@ -748,6 +825,554 @@ def _per_track_candidates(
             continue
         seen_lower.add(key)
         out.append((src_idx, query))
+    return out
+
+
+def _normalize_token_set(text: str) -> set[str]:
+    """Lowercase + dedupe tokens from a cleaned string. Empty on empty."""
+    cleaned = strip_special_chars(text)
+    return {t.lower() for t in cleaned.split() if t}
+
+
+def _is_self_titled(artist_name: str, title: str) -> bool:
+    """Self-titled detection (U5 R10).
+
+    True iff the case-insensitive deduped token sets of artist and title
+    are equal and non-empty. Catches:
+
+      * Exact match: ``Willow / Willow`` → both {willow}.
+      * Repetition: ``Mountains / Mountains Mountains Mountains`` →
+        both {mountains} after dedupe.
+
+    Does NOT match ``Willow / Willow Tree`` (title carries extra tokens
+    that disambiguate it from the self-titled release).
+    """
+    a = _normalize_token_set(artist_name)
+    t = _normalize_token_set(title)
+    return bool(a) and a == t
+
+
+def _build_default_query(
+    artist: str,
+    title: str,
+    *,
+    prepend_artist: bool,
+) -> str | None:
+    """Build the default slot query: wildcarded artist + title, no short drop.
+
+    U5 of search-plan-entropy:
+      * No `strip_short_tokens` call — short tokens survive into the
+        query (capped only by token count, longest-first).
+      * Low-entropy normalization still applies ("the/you/from/and"
+        dropped).
+      * Artist tokens wildcarded for ban bypass.
+      * Title tokens that duplicate the wildcarded artist tokens
+        (case-insensitive on the un-wildcarded form) are dropped.
+    """
+    clean_artist = strip_special_chars(artist)
+    clean_title = strip_special_chars(title)
+
+    artist_tokens = clean_artist.split()
+    title_tokens = clean_title.split()
+
+    artist_tokens = _normalize_query_tokens(
+        artist_tokens, preserve_all_low_entropy=True,
+    )
+    title_tokens = _normalize_query_tokens(title_tokens)
+
+    artist_lower = {t.lower() for t in artist_tokens}
+    title_tokens = [t for t in title_tokens if t.lower() not in artist_lower]
+
+    if clean_artist.lower() in ("various artists", "various"):
+        artist_tokens = []
+
+    artist_tokens = wildcard_artist_tokens(artist_tokens)
+
+    if prepend_artist and artist_tokens:
+        all_tokens = artist_tokens + title_tokens
+    else:
+        all_tokens = title_tokens
+
+    if not all_tokens:
+        return None
+
+    all_tokens = cap_tokens(all_tokens, MAX_SEARCH_TOKENS)
+    return " ".join(all_tokens)
+
+
+def _build_literal_query(
+    artist: str,
+    title: str,
+    *,
+    prepend_artist: bool,
+    max_tokens: int = MAX_SEARCH_TOKENS,
+) -> str | None:
+    """Build the literal slot query: artist + title, no wildcard, no short drop.
+
+    Used directly for the ``literal`` slot and as the body for the
+    format-hint and year-anchored slots (``literal_flac``,
+    ``literal_lossless``, ``unwild_year``, ``unwild_rg_year``).
+
+    Pipeline:
+      * Strip special chars.
+      * Low-entropy normalization on both sides (``the/you/from/and``).
+      * Drop title tokens that duplicate artist tokens (case-insensitive).
+      * Drop artist for Various Artists.
+      * Cap to `max_tokens` longest-first.
+    """
+    clean_artist = strip_special_chars(artist)
+    clean_title = strip_special_chars(title)
+
+    artist_tokens = clean_artist.split()
+    title_tokens = clean_title.split()
+
+    artist_tokens = _normalize_query_tokens(
+        artist_tokens, preserve_all_low_entropy=True,
+    )
+    title_tokens = _normalize_query_tokens(title_tokens)
+
+    artist_lower = {t.lower() for t in artist_tokens}
+    title_tokens = [t for t in title_tokens if t.lower() not in artist_lower]
+
+    if clean_artist.lower() in ("various artists", "various"):
+        artist_tokens = []
+
+    if prepend_artist and artist_tokens:
+        all_tokens = artist_tokens + title_tokens
+    else:
+        all_tokens = title_tokens
+
+    if not all_tokens:
+        return None
+
+    all_tokens = cap_tokens(all_tokens, max_tokens)
+    return " ".join(all_tokens)
+
+
+def _literal_artist_tokens(artist: str) -> list[str]:
+    """Literal (un-wildcarded) artist tokens used by selftitled mix."""
+    clean_artist = strip_special_chars(artist)
+    if clean_artist.lower() in ("various artists", "various"):
+        return []
+    tokens = clean_artist.split()
+    return _normalize_query_tokens(tokens, preserve_all_low_entropy=True)
+
+
+def _selftitled_track_query(
+    artist: str,
+    track_title: str,
+    *,
+    max_tokens: int = MAX_SEARCH_TOKENS,
+) -> str | None:
+    """Build a ``<artist> <track-title>`` query for the selftitled mix.
+
+    Artist tokens are kept LITERAL (no wildcard) — the selftitled mix
+    leans on the track-title's distinctiveness rather than on bypassing
+    server bans, and a literal artist + literal track title is the
+    highest-recall shape for niche self-titled releases.
+    """
+    artist_tokens = _literal_artist_tokens(artist)
+    cleaned = strip_special_chars(track_title)
+    title_tokens = _normalize_query_tokens(cleaned.split())
+    if not title_tokens:
+        return None
+    # Drop title tokens that duplicate artist tokens
+    artist_keys = {t.lower() for t in artist_tokens}
+    title_tokens = [t for t in title_tokens if t.lower() not in artist_keys]
+    if not title_tokens:
+        return None
+    if artist_tokens:
+        combined = artist_tokens + title_tokens
+    else:
+        combined = title_tokens
+    combined = cap_tokens(combined, max_tokens)
+    if not combined:
+        return None
+    return " ".join(combined)
+
+
+def _selftitled_artist_year_query(
+    artist: str,
+    year: str | None,
+) -> str | None:
+    """Build ``<artist> <year>`` for the selftitled mix. None if no year."""
+    if not _year_is_known(year):
+        return None
+    assert year is not None
+    artist_tokens = _literal_artist_tokens(artist)
+    if not artist_tokens:
+        return None
+    combined = artist_tokens + [year[:4]]
+    combined = cap_tokens(combined, MAX_SEARCH_TOKENS)
+    if not combined:
+        return None
+    return " ".join(combined)
+
+
+def _append_format_hint(literal_body: str | None, hint: str) -> str | None:
+    """Append a literal format hint token to a pre-built literal body.
+
+    Body is expected to already be capped at MAX_SEARCH_TOKENS - 1
+    (caller's responsibility) so the hint is preserved. Returns None
+    when the body is None or empty.
+    """
+    if not literal_body:
+        return None
+    return f"{literal_body} {hint}"
+
+
+def _generate_normal_plan(
+    snapshot: ReleaseSnapshot,
+    config: SearchPlanConfig,
+) -> tuple[list["_Candidate"], list[dict[str, Any]]]:
+    """Build the candidate ladder for a non-self-titled request.
+
+    Returns ``(candidates, track_omissions)``. Caller folds them into
+    runnable items via the shared dedupe pass in ``generate_search_plan``.
+    """
+    artist = snapshot.artist_name
+    title = snapshot.title
+    year = snapshot.year
+    rg_year = snapshot.release_group_year
+    track_titles = list(snapshot.track_titles)
+    prepend_artist = snapshot.prepend_artist
+
+    candidates: list[_Candidate] = []
+
+    # 1. Default slot — wildcarded artist + title, no short-token drop.
+    default_query = _build_default_query(
+        artist, title, prepend_artist=prepend_artist,
+    )
+    if default_query:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_DEFAULT,
+            repeat_group=_STRATEGY_DEFAULT,
+            query=default_query,
+            omit_reason=None,
+        ))
+    else:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_DEFAULT,
+            repeat_group=_STRATEGY_DEFAULT,
+            query=None,
+            omit_reason="empty_default_query",
+        ))
+
+    # 2. Literal slot — un-wildcarded, no short-token drop, no year.
+    literal_query = _build_literal_query(
+        artist, title, prepend_artist=prepend_artist,
+    )
+    # Body capped at MAX_SEARCH_TOKENS - 1 so format-hint slots can
+    # append their hint token without losing it to the slskd 4-token cap.
+    literal_body_for_hint = _build_literal_query(
+        artist, title,
+        prepend_artist=prepend_artist,
+        max_tokens=MAX_SEARCH_TOKENS - 1,
+    )
+
+    if literal_query:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_LITERAL,
+            repeat_group=_STRATEGY_LITERAL,
+            query=literal_query,
+            omit_reason=None,
+        ))
+    else:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_LITERAL,
+            repeat_group=_STRATEGY_LITERAL,
+            query=None,
+            omit_reason="empty_literal_query",
+        ))
+
+    # 3 + 4. Format-hint slots — unconditional (R7).
+    for hint_strategy, hint_token in (
+        (_STRATEGY_LITERAL_FLAC, _FORMAT_HINT_FLAC),
+        (_STRATEGY_LITERAL_LOSSLESS, _FORMAT_HINT_LOSSLESS),
+    ):
+        hint_query = _append_format_hint(literal_body_for_hint, hint_token)
+        if hint_query:
+            candidates.append(_Candidate(
+                strategy=hint_strategy,
+                repeat_group=hint_strategy,
+                query=hint_query,
+                omit_reason=None,
+                extra_provenance={"format_hint": hint_token},
+            ))
+        else:
+            candidates.append(_Candidate(
+                strategy=hint_strategy,
+                repeat_group=hint_strategy,
+                query=None,
+                omit_reason="empty_literal_query",
+                extra_provenance={"format_hint": hint_token},
+            ))
+
+    # 5. unwild_year slot — when release `year` is known.
+    year_known = _year_is_known(year)
+    if year_known and literal_query:
+        assert year is not None
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_YEAR,
+            repeat_group=_STRATEGY_UNWILD_YEAR,
+            query=f"{literal_query} {year[:4]}",
+            omit_reason=None,
+            extra_provenance={"year": year[:4]},
+        ))
+    else:
+        reason = "year_unknown" if not year_known else "empty_literal_query"
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_YEAR,
+            repeat_group=_STRATEGY_UNWILD_YEAR,
+            query=None,
+            omit_reason=reason,
+        ))
+
+    # 6. unwild_rg_year slot — only when rg_year is known AND differs
+    #    from release `year`. When they match we omit (avoid duplicate
+    #    of the unwild_year slot).
+    if (
+        year_known
+        and rg_year is not None
+        and int(rg_year) > 0
+        and str(rg_year) != (year[:4] if year else "")
+        and literal_query
+    ):
+        rg_year_str = f"{int(rg_year):04d}"
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_RG_YEAR,
+            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
+            query=f"{literal_query} {rg_year_str}",
+            omit_reason=None,
+            extra_provenance={"release_group_year": int(rg_year)},
+        ))
+    elif rg_year is None:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_RG_YEAR,
+            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
+            query=None,
+            omit_reason="release_group_year_unknown",
+        ))
+    elif not year_known:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_RG_YEAR,
+            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
+            query=None,
+            omit_reason="year_unknown",
+            extra_provenance={"release_group_year": int(rg_year)},
+        ))
+    elif str(rg_year) == (year[:4] if year else ""):
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_RG_YEAR,
+            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
+            query=None,
+            omit_reason="release_group_year_matches_year",
+            extra_provenance={"release_group_year": int(rg_year)},
+        ))
+    else:
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_UNWILD_RG_YEAR,
+            repeat_group=_STRATEGY_UNWILD_RG_YEAR,
+            query=None,
+            omit_reason="empty_literal_query",
+            extra_provenance={"release_group_year": int(rg_year)},
+        ))
+
+    # 7. Per-track slots — artist-prepended (R8). Multi-track only.
+    per_track_pairs = _per_track_candidates(
+        track_titles, artist, prepend_artist=True,
+    )
+    track_omissions: list[dict[str, Any]] = []
+    track_candidates = _build_track_candidates(
+        track_titles, per_track_pairs, config.max_track_slots,
+        track_omissions, slot_label_suffix="_artist",
+    )
+    candidates.extend(track_candidates)
+
+    return candidates, track_omissions
+
+
+def _generate_selftitled_plan(
+    snapshot: ReleaseSnapshot,
+    config: SearchPlanConfig,
+) -> tuple[list["_Candidate"], list[dict[str, Any]]]:
+    """Build the dedicated candidate ladder for self-titled releases (R11).
+
+    The default/literal slots are skipped — they collapse to bare artist
+    name and saturate slskd. Instead the mix substitutes:
+
+      1. ``selftitled_artist_track_0`` — artist + first track (literal).
+      2. ``selftitled_artist_track_0_flac`` — same, with FLAC suffix.
+      3. ``selftitled_artist_year`` — artist + release year (literal).
+      4-N. ``track_<idx>_artist`` — artist-prepended per-track slots
+            (wildcarded artist) up to ``max_track_slots`` ranked tracks.
+    """
+    artist = snapshot.artist_name
+    year = snapshot.year
+    track_titles = list(snapshot.track_titles)
+
+    candidates: list[_Candidate] = []
+
+    # Pick first track that yields a runnable selftitled query.
+    first_track_idx: int | None = None
+    first_track_query: str | None = None
+    first_track_query_body: str | None = None
+    for src_idx, title in enumerate(track_titles):
+        body = _selftitled_track_query(
+            artist, title, max_tokens=MAX_SEARCH_TOKENS - 1,
+        )
+        full = _selftitled_track_query(artist, title)
+        if full:
+            first_track_idx = src_idx
+            first_track_query = full
+            first_track_query_body = body
+            break
+
+    # 1. selftitled_artist_track_0
+    strat1 = f"{_STRATEGY_SELFTITLED_ARTIST_TRACK_PREFIX}0"
+    if first_track_query is not None and first_track_idx is not None:
+        candidates.append(_Candidate(
+            strategy=strat1,
+            repeat_group=strat1,
+            query=first_track_query,
+            omit_reason=None,
+            extra_provenance={"source_track_index": first_track_idx},
+        ))
+    else:
+        candidates.append(_Candidate(
+            strategy=strat1,
+            repeat_group=strat1,
+            query=None,
+            omit_reason=(
+                "no_runnable_track_queries" if track_titles
+                else "no_tracks"
+            ),
+        ))
+
+    # 2. selftitled_artist_track_0_flac
+    strat1_flac = f"{strat1}_flac"
+    if first_track_query_body is not None and first_track_idx is not None:
+        candidates.append(_Candidate(
+            strategy=strat1_flac,
+            repeat_group=strat1_flac,
+            query=f"{first_track_query_body} {_FORMAT_HINT_FLAC}",
+            omit_reason=None,
+            extra_provenance={
+                "source_track_index": first_track_idx,
+                "format_hint": _FORMAT_HINT_FLAC,
+            },
+        ))
+    else:
+        candidates.append(_Candidate(
+            strategy=strat1_flac,
+            repeat_group=strat1_flac,
+            query=None,
+            omit_reason=(
+                "no_runnable_track_queries" if track_titles
+                else "no_tracks"
+            ),
+            extra_provenance={"format_hint": _FORMAT_HINT_FLAC},
+        ))
+
+    # 3. selftitled_artist_year
+    ay_query = _selftitled_artist_year_query(artist, year)
+    if ay_query:
+        assert year is not None
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_SELFTITLED_ARTIST_YEAR,
+            repeat_group=_STRATEGY_SELFTITLED_ARTIST_YEAR,
+            query=ay_query,
+            omit_reason=None,
+            extra_provenance={"year": year[:4]},
+        ))
+    else:
+        reason = "year_unknown" if not _year_is_known(year) else "empty_artist"
+        candidates.append(_Candidate(
+            strategy=_STRATEGY_SELFTITLED_ARTIST_YEAR,
+            repeat_group=_STRATEGY_SELFTITLED_ARTIST_YEAR,
+            query=None,
+            omit_reason=reason,
+        ))
+
+    # 4. track_<idx>_artist slots — same shape as the normal mix.
+    per_track_pairs = _per_track_candidates(
+        track_titles, artist, prepend_artist=True,
+    )
+    track_omissions: list[dict[str, Any]] = []
+    track_candidates = _build_track_candidates(
+        track_titles, per_track_pairs, config.max_track_slots,
+        track_omissions, slot_label_suffix="_artist",
+    )
+    candidates.extend(track_candidates)
+
+    return candidates, track_omissions
+
+
+def _build_track_candidates(
+    track_titles: list[str],
+    per_track_pairs: list[tuple[int, str]],
+    max_track_slots: int,
+    track_omissions: list[dict[str, Any]],
+    *,
+    slot_label_suffix: str,
+) -> list["_Candidate"]:
+    """Rank per-track pairs and emit up to ``max_track_slots`` candidates.
+
+    Ranking: useful-token count desc, char count desc, source-track
+    index asc. Mirrors the legacy ordering so search-log forensics
+    stay comparable across the U5 transition.
+
+    ``slot_label_suffix`` is appended to the ``track_<idx>`` strategy
+    label (e.g. ``"_artist"`` → ``track_0_artist``) so the new
+    artist-prepended slots are distinguishable from the legacy
+    track-only labels in search-log forensics.
+    """
+    if len(track_titles) <= 1:
+        if track_titles:
+            track_omissions.append({
+                "strategy": "track_*",
+                "reason": "single_track_album",
+            })
+        return []
+    if not per_track_pairs:
+        track_omissions.append({
+            "strategy": "track_*",
+            "reason": "no_runnable_track_queries",
+        })
+        return []
+
+    ranked = sorted(
+        per_track_pairs,
+        key=lambda pair: (
+            -len(pair[1].split()),
+            -len(pair[1]),
+            pair[0],
+        ),
+    )
+    chosen = ranked[:max_track_slots]
+    omitted = ranked[max_track_slots:]
+    for src_idx, q in omitted:
+        track_omissions.append({
+            "strategy": "track_excess",
+            "reason": "exceeded_max_track_slots",
+            "source_track_index": src_idx,
+            "query": q,
+            "canonical_query_key": _canonical_query_key(q),
+        })
+
+    out: list[_Candidate] = []
+    for plan_track_idx, (src_idx, q) in enumerate(chosen):
+        label = f"track_{plan_track_idx}{slot_label_suffix}"
+        out.append(_Candidate(
+            strategy=label,
+            repeat_group=label,
+            query=q,
+            omit_reason=None,
+            extra_provenance={
+                "source_track_index": src_idx,
+                "track_slot_index": plan_track_idx,
+            },
+        ))
     return out
 
 
@@ -760,45 +1385,55 @@ def generate_search_plan(
     Pure function: same input → same output. No I/O. The result is the
     materialized executor schedule for the release, in slot order.
 
-    Slot ordering:
-      1. `escalation_threshold` repeated `default` slots (intentional repeats,
-         shared `repeat_group`, distinct ordinals).
-      2. One `unwild` slot.
-      3. One `unwild_year` slot ONLY when year is known
-         (per `_year_is_known()`).
-      4. Up to `max_track_slots` track slots (default 3) drawn from the
-         per-track candidates ranked by:
-           a. useful-token count desc
-           b. character count desc
-           c. source-track index asc
-         Multi-track albums only — single-track and zero-track inputs skip
-         the track tier entirely.
+    U5 of search-plan-entropy (2026-05-19) restructured the slot mix.
+    Normal request (year known, release_group_year populated and
+    differs from year, multi-track):
 
-    Cross-strategy dedupe: when a non-default candidate produces the same
-    canonical query as an earlier slot, the earlier one wins and the loser
-    is recorded in plan-level provenance with the ordinal it would have had.
-    Repeated-default slots are NOT deduped against each other — they share
-    intentional repeat-group identity.
+      1. default              wildcarded artist+title, no short-drop
+      2. literal              un-wildcarded artist+title, no year
+      3. literal_flac         literal + " FLAC"
+      4. literal_lossless     literal + " lossless"
+      5. unwild_year          literal + " <year>"
+      6. unwild_rg_year       literal + " <rg_year>" (conditional)
+      7-9. track_<idx>_artist artist-prepended per-track fallback
 
-    Generation failure: when artist/title is unrunnable AND no per-track
-    candidate is runnable, returns `PLAN_STATUS_GENERATION_FAILED` with
-    populated provenance, NOT an empty success plan.
+    Self-titled requests (R10/R11) skip the album-level default/literal
+    slots — they collapse to bare artist name and waste slskd cycles
+    — and emit a dedicated mix:
+
+      1. selftitled_artist_track_0       artist + first track (literal)
+      2. selftitled_artist_track_0_flac  + " FLAC"
+      3. selftitled_artist_year          artist + year (literal)
+      4-N. track_<idx>_artist            artist-prepended per-track
+
+    The ``escalation_threshold`` config field is preserved for backwards
+    compatibility with persisted ``SearchPlanConfig`` values but no
+    longer controls slot count — U5 removed the five-slot default
+    repetition (R4).
+
+    Cross-strategy dedupe: when a candidate produces the same canonical
+    query as an earlier emitted slot, the earlier one wins and the
+    loser is recorded in plan-level provenance with the ordinal it
+    would have had.
+
+    Generation failure: when no candidate is runnable, returns
+    ``PLAN_STATUS_GENERATION_FAILED`` with populated provenance, NOT
+    an empty success plan.
     """
     artist = snapshot.artist_name
     title = snapshot.title
     year = snapshot.year
     track_titles = list(snapshot.track_titles)
-    prepend_artist = snapshot.prepend_artist
+    rg_year = snapshot.release_group_year
 
-    # --- Build the candidate ladder up front ----------------------------
-    # We construct candidates for every potential slot, runnable or not, so
-    # provenance can carry the omission reason. Collapse to runnable items
-    # at the end.
+    # Self-titled detection (R10). When True we route to a dedicated
+    # ladder; otherwise the normal mix.
+    selftitled = _is_self_titled(artist, title)
 
-    # Track which low-entropy tokens were ever present in raw inputs, so the
-    # plan can record the drop set even though the drop happens inside
-    # _normalize_query_tokens. We tokenise on whitespace post-strip-special
-    # to mirror the helper pipeline.
+    # Track low-entropy drops across raw inputs for plan provenance.
+    # The drop itself happens inside _normalize_query_tokens, but
+    # recording it once at the plan level keeps the provenance
+    # contract stable for operators.
     all_input_tokens: list[list[str]] = []
     all_input_tokens.append(strip_special_chars(artist).split())
     all_input_tokens.append(strip_special_chars(title).split())
@@ -806,131 +1441,20 @@ def generate_search_plan(
         all_input_tokens.append(strip_special_chars(t).split())
     dropped_low_entropy = _has_dropped_low_entropy(*all_input_tokens)
 
-    base_query = build_query(artist, title, prepend_artist=prepend_artist)
-    base_query_unwild = build_query(
-        artist, title, prepend_artist=prepend_artist, wildcard_artist=False,
-    )
-
-    candidates: list[_Candidate] = []
-
-    # 1. Repeated default slots
-    threshold = max(0, config.escalation_threshold)
-    for repeat_idx in range(threshold):
-        if base_query:
-            candidates.append(_Candidate(
-                strategy=_STRATEGY_DEFAULT,
-                repeat_group=_STRATEGY_DEFAULT,
-                query=base_query,
-                omit_reason=None,
-                extra_provenance={"repeat_index": repeat_idx},
-            ))
-        else:
-            candidates.append(_Candidate(
-                strategy=_STRATEGY_DEFAULT,
-                repeat_group=_STRATEGY_DEFAULT,
-                query=None,
-                omit_reason="empty_base_query",
-                extra_provenance={"repeat_index": repeat_idx},
-            ))
-
-    # 2. Unwild slot
-    if base_query_unwild:
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD,
-            repeat_group=_STRATEGY_UNWILD,
-            query=base_query_unwild,
-            omit_reason=None,
-        ))
-    else:
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD,
-            repeat_group=_STRATEGY_UNWILD,
-            query=None,
-            omit_reason="empty_unwild_query",
-        ))
-
-    # 3. Unwild_year slot — only when year is known
-    year_known = _year_is_known(year)
-    if year_known and base_query_unwild:
-        # year_known guarantees year is not None and 4-digit-prefixed.
-        assert year is not None  # type checker
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_YEAR,
-            repeat_group=_STRATEGY_UNWILD_YEAR,
-            query=f"{base_query_unwild} {year[:4]}",
-            omit_reason=None,
-            extra_provenance={"year": year[:4]},
-        ))
-    else:
-        reason = "year_unknown" if not year_known else "empty_unwild_query"
-        candidates.append(_Candidate(
-            strategy=_STRATEGY_UNWILD_YEAR,
-            repeat_group=_STRATEGY_UNWILD_YEAR,
-            query=None,
-            omit_reason=reason,
-        ))
-
-    # 4. Track candidates — multi-track albums only
-    per_track_pairs = _per_track_candidates(track_titles, artist)
-    track_omissions: list[dict[str, Any]] = []
-
-    if len(track_titles) <= 1:
-        # Don't emit any track slots; record the structural skip once.
-        if track_titles:
-            track_omissions.append({
-                "strategy": "track_*",
-                "reason": "single_track_album",
-            })
-    elif not per_track_pairs:
-        track_omissions.append({
-            "strategy": "track_*",
-            "reason": "no_runnable_track_queries",
-        })
-    else:
-        # Rank by token count desc, char count desc, source index asc.
-        # Source index is the natural tiebreaker for stable ordering.
-        ranked = sorted(
-            per_track_pairs,
-            key=lambda pair: (
-                -len(pair[1].split()),
-                -len(pair[1]),
-                pair[0],
-            ),
+    if selftitled:
+        candidates, track_omissions = _generate_selftitled_plan(
+            snapshot, config,
         )
-        chosen = ranked[: config.max_track_slots]
-        omitted = ranked[config.max_track_slots:]
-        # Record omitted track candidates for plan-level provenance.
-        for src_idx, q in omitted:
-            track_omissions.append({
-                "strategy": "track_excess",
-                "reason": "exceeded_max_track_slots",
-                "source_track_index": src_idx,
-                "query": q,
-                "canonical_query_key": _canonical_query_key(q),
-            })
-        # The track slot index is the *plan-side* ordinal among track slots
-        # (0..max_track_slots-1), not the source-track-index. This matches
-        # the existing `track_<idx>` strategy label semantics where idx is
-        # an executor cycle position.
-        for plan_track_idx, (src_idx, q) in enumerate(chosen):
-            candidates.append(_Candidate(
-                strategy=f"track_{plan_track_idx}",
-                repeat_group=f"track_{plan_track_idx}",
-                query=q,
-                omit_reason=None,
-                extra_provenance={
-                    "source_track_index": src_idx,
-                    "track_slot_index": plan_track_idx,
-                },
-            ))
+    else:
+        candidates, track_omissions = _generate_normal_plan(
+            snapshot, config,
+        )
 
     # --- Resolve candidates into runnable items + provenance ------------
     runnable: list[SearchPlanItem] = []
     omitted_candidates: list[dict[str, Any]] = []
     dedupe_losers: list[dict[str, Any]] = []
-    # Map canonical_query_key -> (winner_strategy, winner_ordinal). Default
-    # slots are tracked by their shared repeat_group so multiple default
-    # slots are NOT considered duplicates of each other.
+    # Map canonical_query_key -> (winner_strategy, winner_ordinal).
     seen_keys: dict[str, tuple[str, int]] = {}
 
     next_ordinal = 0
@@ -943,9 +1467,8 @@ def generate_search_plan(
             })
             continue
         key = _canonical_query_key(cand.query)
-        is_default_repeat = cand.repeat_group == _STRATEGY_DEFAULT
         prior = seen_keys.get(key)
-        if prior is not None and not is_default_repeat:
+        if prior is not None:
             # Cross-strategy duplicate. Keep earlier slot, record loser.
             winner_strategy, _ = prior
             dedupe_losers.append({
@@ -965,22 +1488,20 @@ def generate_search_plan(
             provenance=dict(cand.extra_provenance),
         )
         runnable.append(item)
-        # Only record default key once — repeated defaults share identity but
-        # do NOT block other strategies that produce the same key (rare but
-        # possible if title equals artist token).
-        if not is_default_repeat or key not in seen_keys:
-            seen_keys[key] = (cand.strategy, next_ordinal)
+        seen_keys[key] = (cand.strategy, next_ordinal)
         next_ordinal += 1
 
     omitted_candidates.extend(track_omissions)
 
-    snapshot_signature = {
+    snapshot_signature: dict[str, Any] = {
         "artist_name": artist,
         "title": title,
         "year": year,
         "track_count": len(track_titles),
         "redownload": snapshot.redownload,
     }
+    if rg_year is not None:
+        snapshot_signature["release_group_year"] = int(rg_year)
 
     base_provenance: dict[str, Any] = {
         "omitted_candidates": omitted_candidates,
@@ -988,6 +1509,10 @@ def generate_search_plan(
         "dropped_low_entropy_tokens": sorted(dropped_low_entropy),
         "snapshot_signature": snapshot_signature,
     }
+    if selftitled:
+        base_provenance["selftitled"] = True
+    if rg_year is not None:
+        base_provenance["release_group_year"] = int(rg_year)
 
     if not runnable:
         return SearchPlan(

--- a/lib/search_plan_service.py
+++ b/lib/search_plan_service.py
@@ -1153,6 +1153,19 @@ class SearchPlanService:
         )
 
 
+def _envelope(result: Any) -> dict[str, Any]:
+    """Common ``{request_id, outcome, error_message}`` envelope.
+
+    Shared by every payload helper (dry-run, saturation, ...) so the
+    CLI ⇄ API surface emits the same three keys regardless of outcome.
+    """
+    return {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "error_message": result.error_message,
+    }
+
+
 def dry_run_payload(
     result: "DryRunResult",
     *,
@@ -1202,13 +1215,11 @@ def dry_run_payload(
             "source": request_row.get("source"),
         }
     return {
-        "request_id": result.request_id,
-        "outcome": result.outcome,
+        **_envelope(result),
         "current_generator_id": current_generator_id,
         "request": request_payload,
         "plan": plan_payload,
         "would_supersede_active": bool(has_active_plan),
-        "error_message": result.error_message,
     }
 
 
@@ -1238,14 +1249,12 @@ def saturation_payload(result: "SaturationResult") -> dict[str, Any]:
         skips = 0
         window = int(result.window_days)
     return {
-        "request_id": result.request_id,
-        "outcome": result.outcome,
+        **_envelope(result),
         "total_searches": total,
         "saturated_searches": saturated,
         "saturation_rate": rate,
         "total_pre_filter_skips": skips,
         "window_days": window,
-        "error_message": result.error_message,
     }
 
 

--- a/lib/search_plan_service.py
+++ b/lib/search_plan_service.py
@@ -322,6 +322,7 @@ class SearchPlanService:
         tracks: list[dict[str, Any]],
         source: str = "request",
         prepend_artist: bool | None = None,
+        release_group_year: object = None,
     ) -> ServiceResult:
         """Generate a plan for a freshly-added request.
 
@@ -345,6 +346,7 @@ class SearchPlanService:
                 tracks=tracks,
                 source=source,
                 prepend_artist=prepend,
+                release_group_year=release_group_year,
             )
             return self._persist(request_id, snapshot, regenerate=False)
 
@@ -959,7 +961,7 @@ def _metadata_snapshot_from_snapshot(
     snapshot: ReleaseSnapshot,
 ) -> dict[str, Any]:
     """JSON-friendly metadata snapshot for `search_plans.metadata_snapshot`."""
-    return {
+    out: dict[str, Any] = {
         "artist_name": snapshot.artist_name,
         "album_title": snapshot.title,
         "year": snapshot.year,
@@ -967,6 +969,9 @@ def _metadata_snapshot_from_snapshot(
         "redownload": snapshot.redownload,
         "prepend_artist": snapshot.prepend_artist,
     }
+    if snapshot.release_group_year is not None:
+        out["release_group_year"] = int(snapshot.release_group_year)
+    return out
 
 
 def _metadata_snapshot_from_row(
@@ -978,10 +983,14 @@ def _metadata_snapshot_from_row(
     Used on resolver-failure paths so the failed-plan row still carries
     enough context to debug what was attempted.
     """
-    return {
+    out: dict[str, Any] = {
         "artist_name": row.get("artist_name"),
         "album_title": row.get("album_title"),
         "year": row.get("year"),
         "track_count": len(tracks),
         "redownload": row.get("source") == "redownload",
     }
+    rg_year = row.get("release_group_year")
+    if rg_year is not None:
+        out["release_group_year"] = rg_year
+    return out

--- a/lib/search_plan_service.py
+++ b/lib/search_plan_service.py
@@ -37,6 +37,7 @@ from lib.config import CratediggerConfig
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_PLAN,
     PLAN_STATUS_ACTIVE,
+    SaturationSummary,
     SearchPlanItemInput,
 )
 from lib.release_snapshot import (
@@ -86,6 +87,17 @@ RESULT_HISTORY_PAGE_INPUT_INVALID = "input_invalid"
 # dry_run_for_request outcomes (U6 — read-only generator simulation).
 RESULT_DRY_RUN_SUCCESS = "success"
 RESULT_DRY_RUN_GENERATION_FAILED = "generation_failed"
+# saturation_for_request outcomes (U7 — read-only telemetry aggregate).
+RESULT_SATURATION_SUCCESS = "success"
+RESULT_SATURATION_INPUT_INVALID = "input_invalid"
+
+# Saturation telemetry window bounds (U7). Operators can ask for any
+# window in [1, 90] days; defaults to 14 days matching the brainstorm.
+# The CLI / route both clamp before calling the service so the DB layer
+# stays a thin adapter.
+SATURATION_WINDOW_MIN_DAYS = 1
+SATURATION_WINDOW_MAX_DAYS = 90
+SATURATION_WINDOW_DEFAULT_DAYS = 14
 
 # Bounds for the paginated history endpoint. The route handler and CLI
 # both consult these so the cap stays consistent across surfaces.
@@ -299,6 +311,37 @@ class DryRunResult:
     plan: SearchPlan | None = None
     snapshot: ReleaseSnapshot | None = None
     metadata_snapshot: dict[str, Any] | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class SaturationResult:
+    """Outcome of one ``saturation_for_request`` call (U7).
+
+    Read-only aggregator: wraps
+    :class:`lib.pipeline_db.SaturationSummary` with a service-layer
+    outcome string so the CLI / API surfaces can map onto the standard
+    exit-code / status-code convention without coupling to the DB
+    dataclass directly.
+
+    ``outcome`` is one of:
+      * ``RESULT_SATURATION_SUCCESS`` — request exists; ``summary`` is
+        populated (it may contain all-zero fields if the window has no
+        searches, which is a valid "found but quiet" state).
+      * ``RESULT_REQUEST_NOT_FOUND`` — no row for ``request_id`` in
+        ``album_requests``; ``summary`` is ``None``. We check the
+        request row separately from the aggregate so zeros from a real
+        request never collide with "request id doesn't exist at all".
+      * ``RESULT_SATURATION_INPUT_INVALID`` — ``window_days`` is out of
+        the supported ``[SATURATION_WINDOW_MIN_DAYS,
+        SATURATION_WINDOW_MAX_DAYS]`` range; ``error_message`` carries
+        the offending value.
+    """
+
+    outcome: str
+    request_id: int
+    window_days: int
+    summary: "SaturationSummary | None" = None
     error_message: str | None = None
 
 
@@ -650,6 +693,68 @@ class SearchPlanService:
             plan=plan,
             snapshot=snapshot,
             metadata_snapshot=metadata_snapshot,
+        )
+
+    def saturation_for_request(
+        self,
+        request_id: int,
+        *,
+        window_days: int = SATURATION_WINDOW_DEFAULT_DAYS,
+    ) -> "SaturationResult":
+        """U7 read-only telemetry aggregate over the request's search_log.
+
+        Wraps :meth:`PipelineDB.get_saturation_summary` with the
+        not-found semantics the operator surfaces expect:
+
+        * The request row is checked first. If it does not exist, the
+          outcome is ``RESULT_REQUEST_NOT_FOUND`` and the route /
+          CLI map that to 404 / exit 2.
+        * If the request exists but has no logged searches in window,
+          the outcome is ``RESULT_SATURATION_SUCCESS`` with all-zero
+          counts — a valid "found but quiet" state. We deliberately do
+          NOT collapse this onto 404; the operator asked "how saturated
+          is request X?" and the truthful answer is "not at all".
+        * ``window_days`` is validated against
+          ``[SATURATION_WINDOW_MIN_DAYS, SATURATION_WINDOW_MAX_DAYS]``;
+          out-of-range values return ``RESULT_SATURATION_INPUT_INVALID``
+          which CLI argparse normally prevents but the API surface
+          relies on for its 400 response.
+
+        Counterpart of ``pipeline-cli search-plan saturation <id>`` and
+        ``GET /api/pipeline/<id>/search-plan/saturation``. Both
+        surfaces wrap this method (see ``CLAUDE.md`` § "CLI ⇄ API
+        surface symmetry").
+        """
+        if (
+            window_days < SATURATION_WINDOW_MIN_DAYS
+            or window_days > SATURATION_WINDOW_MAX_DAYS
+        ):
+            return SaturationResult(
+                outcome=RESULT_SATURATION_INPUT_INVALID,
+                request_id=request_id,
+                window_days=int(window_days),
+                error_message=(
+                    f"window_days must be in "
+                    f"[{SATURATION_WINDOW_MIN_DAYS}, "
+                    f"{SATURATION_WINDOW_MAX_DAYS}]; got {window_days}"
+                ),
+            )
+        row = self.db.get_request(request_id)
+        if row is None:
+            return SaturationResult(
+                outcome=RESULT_REQUEST_NOT_FOUND,
+                request_id=request_id,
+                window_days=int(window_days),
+                error_message=f"request {request_id} not found",
+            )
+        summary = self.db.get_saturation_summary(
+            request_id, window_days=int(window_days),
+        )
+        return SaturationResult(
+            outcome=RESULT_SATURATION_SUCCESS,
+            request_id=request_id,
+            window_days=int(window_days),
+            summary=summary,
         )
 
     @staticmethod
@@ -1103,6 +1208,43 @@ def dry_run_payload(
         "request": request_payload,
         "plan": plan_payload,
         "would_supersede_active": bool(has_active_plan),
+        "error_message": result.error_message,
+    }
+
+
+def saturation_payload(result: "SaturationResult") -> dict[str, Any]:
+    """JSON-serialisable payload for U7 saturation CLI + API responses.
+
+    The wire shape is always the five summary fields at the top level
+    so a client can read ``data["saturation_rate"]`` directly without
+    branching on outcome. When the summary is missing (request not
+    found, invalid window) the counts are zero-filled and the
+    ``outcome`` field signals the failure mode. ``error_message`` is
+    populated on every non-success path. Single helper so the CLI
+    ``--json`` mode and the API endpoint emit the same dict tree (CLI
+    ⇄ API symmetry).
+    """
+    summary = result.summary
+    if summary is not None:
+        total = int(summary.total_searches)
+        saturated = int(summary.saturated_searches)
+        rate = float(summary.saturation_rate)
+        skips = int(summary.total_pre_filter_skips)
+        window = int(summary.window_days)
+    else:
+        total = 0
+        saturated = 0
+        rate = 0.0
+        skips = 0
+        window = int(result.window_days)
+    return {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "total_searches": total,
+        "saturated_searches": saturated,
+        "saturation_rate": rate,
+        "total_pre_filter_skips": skips,
+        "window_days": window,
         "error_message": result.error_message,
     }
 

--- a/lib/search_plan_service.py
+++ b/lib/search_plan_service.py
@@ -83,6 +83,9 @@ RESULT_INVALID_TARGET = "invalid_target"
 # history_for_request outcomes (read-only paginated search_log slice).
 RESULT_HISTORY_PAGE_SUCCESS = "success"
 RESULT_HISTORY_PAGE_INPUT_INVALID = "input_invalid"
+# dry_run_for_request outcomes (U6 — read-only generator simulation).
+RESULT_DRY_RUN_SUCCESS = "success"
+RESULT_DRY_RUN_GENERATION_FAILED = "generation_failed"
 
 # Bounds for the paginated history endpoint. The route handler and CLI
 # both consult these so the cap stays consistent across surfaces.
@@ -265,6 +268,37 @@ class SearchLogHistoryPageResult:
     request_id: int
     rows: list[dict[str, Any]]
     next_before_id: int | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class DryRunResult:
+    """Outcome of one ``dry_run_for_request`` call (U6).
+
+    Read-only simulator: the service constructs the same
+    ``ReleaseSnapshot`` startup/regeneration would build, runs
+    ``generate_search_plan`` against the current code, and returns the
+    in-memory ``SearchPlan`` plus a JSON-friendly view. No
+    ``search_plans`` / ``plan_items`` rows are written and the
+    request's ``active_plan_id`` is untouched.
+
+    ``outcome`` is one of:
+      * ``RESULT_DRY_RUN_SUCCESS`` — generator produced a non-empty plan.
+      * ``RESULT_DRY_RUN_GENERATION_FAILED`` — generator returned
+        ``PLAN_STATUS_GENERATION_FAILED`` (no runnable query / metadata
+        incomplete); ``plan`` is populated but ``items`` is empty.
+      * ``RESULT_REQUEST_NOT_FOUND`` — no row for ``request_id``.
+
+    ``plan`` is the live ``SearchPlan`` object. ``snapshot`` is the
+    ``ReleaseSnapshot`` fed to the generator (useful for operators
+    debugging snapshot inputs vs generator outputs).
+    """
+
+    outcome: str
+    request_id: int
+    plan: SearchPlan | None = None
+    snapshot: ReleaseSnapshot | None = None
+    metadata_snapshot: dict[str, Any] | None = None
     error_message: str | None = None
 
 
@@ -549,6 +583,73 @@ class SearchPlanService:
             request_id=request_id,
             rows=page.rows,
             next_before_id=page.next_before_id,
+        )
+
+    def dry_run_for_request(
+        self,
+        request_id: int,
+        *,
+        prepend_artist: bool | None = None,
+    ) -> "DryRunResult":
+        """U6 read-only simulator: run the generator without persisting.
+
+        Loads the request row + persisted tracks, constructs the same
+        ``ReleaseSnapshot`` that startup / explicit regeneration would
+        build, and invokes ``generate_search_plan`` against the current
+        code. Nothing is written: no ``search_plans`` / ``plan_items``
+        row is created, no ``active_plan_id`` mutation, no advisory
+        lock taken (no concurrent mutation to protect against).
+
+        Counterpart of ``pipeline-cli search-plan dry-run <id>`` and
+        ``GET /api/pipeline/<id>/search-plan/dry-run``.
+
+        Outcomes:
+          * ``RESULT_DRY_RUN_SUCCESS`` — generator emitted a plan with
+            non-empty items.
+          * ``RESULT_DRY_RUN_GENERATION_FAILED`` — generator returned
+            ``PLAN_STATUS_GENERATION_FAILED``; ``plan`` is populated so
+            callers can inspect ``failure_reason`` / ``provenance``.
+          * ``RESULT_REQUEST_NOT_FOUND`` — no row for ``request_id``.
+
+        The simulator deliberately does NOT call the ``TrackResolver``:
+        dry-run reads what's persisted today so operators can see what
+        the next cycle's generator would produce against the current
+        persisted state. If tracks are missing in the DB the snapshot
+        is built without them — same way the generator would see them
+        at startup before any resolver hydration.
+        """
+        prepend = self._resolve_prepend_artist(prepend_artist)
+        row = self.db.get_request(request_id)
+        if row is None:
+            return DryRunResult(
+                outcome=RESULT_REQUEST_NOT_FOUND,
+                request_id=request_id,
+                error_message=f"request {request_id} not found",
+            )
+        try:
+            tracks = self.db.get_tracks(request_id) or []
+        except Exception:  # noqa: BLE001
+            tracks = []
+        snapshot = snapshot_from_request_row(
+            row, tracks, prepend_artist=prepend,
+        )
+        plan = generate_search_plan(snapshot, self.plan_config)
+        metadata_snapshot = _metadata_snapshot_from_snapshot(snapshot)
+        if plan.status == PLAN_STATUS_GENERATION_FAILED:
+            return DryRunResult(
+                outcome=RESULT_DRY_RUN_GENERATION_FAILED,
+                request_id=request_id,
+                plan=plan,
+                snapshot=snapshot,
+                metadata_snapshot=metadata_snapshot,
+                error_message=plan.failure_reason,
+            )
+        return DryRunResult(
+            outcome=RESULT_DRY_RUN_SUCCESS,
+            request_id=request_id,
+            plan=plan,
+            snapshot=snapshot,
+            metadata_snapshot=metadata_snapshot,
         )
 
     @staticmethod
@@ -945,6 +1046,65 @@ class SearchPlanService:
             failure_class=failure_class,
             error_message=sanitized_msg,
         )
+
+
+def dry_run_payload(
+    result: "DryRunResult",
+    *,
+    current_generator_id: str,
+    request_row: dict[str, Any] | None,
+    has_active_plan: bool,
+) -> dict[str, Any]:
+    """JSON-serialisable payload for U6 dry-run CLI + API responses.
+
+    Single helper so the CLI ``--json`` mode and the API endpoint emit
+    the same dict tree (CLI ⇄ API symmetry).
+    """
+    plan_payload: dict[str, Any] | None = None
+    if result.plan is not None:
+        items_payload: list[dict[str, Any]] = []
+        for it in result.plan.items:
+            items_payload.append({
+                "ordinal": it.ordinal,
+                "strategy": it.strategy,
+                "query": it.query,
+                "canonical_query_key": it.canonical_query_key,
+                "repeat_group": it.repeat_group,
+                "provenance": dict(it.provenance) if it.provenance else {},
+            })
+        plan_payload = {
+            "generator_id": result.plan.generator_id,
+            "status": result.plan.status,
+            "items": items_payload,
+            "provenance": (
+                dict(result.plan.provenance)
+                if result.plan.provenance else {}
+            ),
+            "failure_reason": result.plan.failure_reason,
+            "metadata_snapshot": result.metadata_snapshot,
+        }
+    request_payload: dict[str, Any] | None = None
+    if request_row is not None:
+        request_payload = {
+            "id": request_row.get("id"),
+            "status": request_row.get("status"),
+            "artist_name": request_row.get("artist_name"),
+            "album_title": request_row.get("album_title"),
+            "mb_release_id": request_row.get("mb_release_id"),
+            "discogs_release_id": request_row.get("discogs_release_id"),
+            "year": request_row.get("year"),
+            "release_group_year": request_row.get("release_group_year"),
+            "source": request_row.get("source"),
+        }
+    return {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "current_generator_id": current_generator_id,
+        "request": request_payload,
+        "plan": plan_payload,
+        "would_supersede_active": bool(has_active_plan),
+        "error_message": result.error_message,
+    }
 
 
 def _within_retry_window(created_at: datetime | None) -> bool:

--- a/lib/util.py
+++ b/lib/util.py
@@ -36,6 +36,23 @@ class AudioValidationResult:
     failed_files: list[tuple[str, str]] = field(default_factory=list)
 
 
+def parse_mb_first_release_year(data: dict[str, Any]) -> int | None:
+    """Parse the 4-digit year from an MB release-group ``first-release-date``.
+
+    Shared by ``web/mb.py::get_release_group_year`` and
+    ``scripts/pipeline_cli.py::fetch_mb_release_group_year`` — each owns
+    its own transport + 404 handling; only the parse is common.
+    Returns ``None`` for missing/short/non-numeric prefixes.
+    """
+    date = data.get("first-release-date", "")
+    if not isinstance(date, str) or len(date) < 4:
+        return None
+    try:
+        return int(date[:4])
+    except ValueError:
+        return None
+
+
 # === Subprocess env for beets ===
 
 

--- a/migrations/025_search_log_pre_filter_skip_count.sql
+++ b/migrations/025_search_log_pre_filter_skip_count.sql
@@ -1,0 +1,33 @@
+-- 025_search_log_pre_filter_skip_count.sql
+--
+-- U2 of the search-plan-entropy plan: pre-filter skip telemetry.
+--
+-- ``lib/matching.py::check_for_match`` skips peer dirs whose cached
+-- audio-file count exceeds the asymmetric pre-filter threshold
+-- (``search_count > 2 * track_num``, U1). Those skips are the dominant
+-- explanation for "this album exists on Soulseek but never matches"
+-- starvation cases — but until now they were invisible:
+--
+--   * No row was written to ``search_log`` for the skipped dir.
+--   * The dir never appeared in the candidates JSONB blob.
+--
+-- This migration adds an aggregable scalar count column. The producer
+-- writes the total number of dirs the pre-filter skipped for that
+-- search (sum across all (user, dir) pairs touched by the matcher).
+-- Combined with the ≤5 flagged ``pre_filter_skip=True`` ``CandidateScore``
+-- sample rows that ride alongside scored candidates inside the existing
+-- ``search_log.candidates`` JSONB blob, operators can:
+--
+--   * ``SELECT MAX(pre_filter_skip_count) FROM search_log WHERE ...`` to
+--     find the worst-skip searches over a window.
+--   * Inspect a sample of skipped (user, dir, file_count) tuples per row
+--     via the candidates blob to understand which peers are noisy.
+--
+-- Pre-existing rows default to ``0`` — historical search_log rows did
+-- not carry skip counts and we don't backfill: the data was not
+-- captured at the time and the future writes carry it cleanly. The
+-- column is NOT NULL so all forward queries can assume a number rather
+-- than guarding against NULL.
+
+ALTER TABLE search_log
+    ADD COLUMN pre_filter_skip_count INTEGER NOT NULL DEFAULT 0;

--- a/migrations/025_search_log_pre_filter_skip_count.sql
+++ b/migrations/025_search_log_pre_filter_skip_count.sql
@@ -1,33 +1,10 @@
 -- 025_search_log_pre_filter_skip_count.sql
 --
--- U2 of the search-plan-entropy plan: pre-filter skip telemetry.
---
--- ``lib/matching.py::check_for_match`` skips peer dirs whose cached
--- audio-file count exceeds the asymmetric pre-filter threshold
--- (``search_count > 2 * track_num``, U1). Those skips are the dominant
--- explanation for "this album exists on Soulseek but never matches"
--- starvation cases — but until now they were invisible:
---
---   * No row was written to ``search_log`` for the skipped dir.
---   * The dir never appeared in the candidates JSONB blob.
---
--- This migration adds an aggregable scalar count column. The producer
--- writes the total number of dirs the pre-filter skipped for that
--- search (sum across all (user, dir) pairs touched by the matcher).
--- Combined with the ≤5 flagged ``pre_filter_skip=True`` ``CandidateScore``
--- sample rows that ride alongside scored candidates inside the existing
--- ``search_log.candidates`` JSONB blob, operators can:
---
---   * ``SELECT MAX(pre_filter_skip_count) FROM search_log WHERE ...`` to
---     find the worst-skip searches over a window.
---   * Inspect a sample of skipped (user, dir, file_count) tuples per row
---     via the candidates blob to understand which peers are noisy.
---
--- Pre-existing rows default to ``0`` — historical search_log rows did
--- not carry skip counts and we don't backfill: the data was not
--- captured at the time and the future writes carry it cleanly. The
--- column is NOT NULL so all forward queries can assume a number rather
--- than guarding against NULL.
+-- Aggregable scalar count of pre-filter-skipped dirs per search_log
+-- row. Companion to the ≤5 sample CandidateScore rows in the candidates
+-- JSONB blob. Default 0 — no backfill (historical rows did not capture
+-- this; column is NOT NULL so forward queries can skip NULL guards).
+-- See ``docs/brainstorms/`` for the full search-plan-entropy plan.
 
 ALTER TABLE search_log
     ADD COLUMN pre_filter_skip_count INTEGER NOT NULL DEFAULT 0;

--- a/migrations/026_album_requests_release_group_year.sql
+++ b/migrations/026_album_requests_release_group_year.sql
@@ -1,0 +1,25 @@
+-- 026_album_requests_release_group_year.sql
+--
+-- U3 of the search-plan-entropy plan: persist the release-group's first
+-- release year alongside the per-release ``year`` already on
+-- ``album_requests``. R9 (data layer).
+--
+-- ``year`` reflects the specific pressing the operator queued (e.g. a
+-- 2008 Kid A reissue). The release-group's first-release year (e.g.
+-- 2000 for the original Kid A) is what most Soulseek folder names use,
+-- so the generator wants both values: it emits a year-suffixed query
+-- per distinct year. When the two values match, the conditional slot
+-- is dropped to avoid the kind of low-entropy slot repetition U5 kills
+-- elsewhere.
+--
+-- Nullable: many requests will not have a populated
+-- ``mb_release_group_id`` (legacy rows pre-dating the column, Discogs-
+-- only rows, manual/imported rows). The generator skips the
+-- release-group-year slot when this column is NULL.
+--
+-- Backfill is handled by ``scripts/backfill_release_group_year.py`` —
+-- run as part of the U3 deploy. Forward-only ALTER here; the script
+-- fills the column from the local MB mirror in idempotent batches.
+
+ALTER TABLE album_requests
+    ADD COLUMN release_group_year INTEGER NULL;

--- a/scripts/backfill_release_group_year.py
+++ b/scripts/backfill_release_group_year.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Backfill ``album_requests.release_group_year`` from the local MB mirror.
+
+U3 / R9 of the search-plan-entropy plan. The migration
+``026_album_requests_release_group_year.sql`` adds the column as
+nullable. This script populates it for every request that has an
+``mb_release_group_id`` but no ``release_group_year``, by fetching the
+release-group's ``first-release-date`` from the local MB mirror
+(``web/mb.py::get_release_group_year``) and parsing the year prefix.
+
+MB mirror response shape (verified 2026-05-19 against the local mirror
+at 192.168.1.35:5200): ``GET /ws/2/release-group/<mbid>?fmt=json``
+returns ``{"first-release-date": "YYYY-MM-DD", ...}`` directly on the
+release-group document. No need to paginate child releases and derive
+``min(release.date)`` — one round-trip per request.
+
+Idempotency: the ``WHERE release_group_year IS NULL`` filter on
+``get_requests_missing_release_group_year`` means re-running the script
+skips rows already populated. A 404 from the mirror leaves the row
+NULL (logged but not failed) so a future re-run can retry.
+
+Batching: requests are processed in chunks of ``BATCH_SIZE``. Each
+chunk fetches its rows up front, then ``set_release_group_year`` is
+called per row. The script logs a counter every batch. A SIGINT
+between batches loses at most the in-flight chunk; everything before
+is persisted.
+
+Usage:
+    nix-shell --run "python3 scripts/backfill_release_group_year.py"
+    nix-shell --run "python3 scripts/backfill_release_group_year.py --dry-run"
+    nix-shell --run "python3 scripts/backfill_release_group_year.py --limit 100"
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from typing import Callable
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+logger = logging.getLogger("backfill_release_group_year")
+
+BATCH_SIZE = 500
+RATE_LIMIT_SECONDS = 0.05  # 50ms between MB mirror calls — cheap local I/O
+
+
+# Result counters — surfaced in the final summary and (post-deploy) in
+# the systemd unit log so operators can confirm convergence.
+class BackfillCounters:
+    def __init__(self) -> None:
+        self.fetched: int = 0
+        self.populated: int = 0
+        self.not_found: int = 0  # mirror 404 — row stays NULL
+        self.no_date: int = 0    # mirror returned no parseable year
+        self.errors: int = 0     # unexpected exception per row
+
+
+def run_backfill(
+    *,
+    db,
+    fetch_year: Callable[[str], int | None],
+    batch_size: int = BATCH_SIZE,
+    limit: int | None = None,
+    dry_run: bool = False,
+    sleep_seconds: float = RATE_LIMIT_SECONDS,
+) -> BackfillCounters:
+    """Iterate requests needing ``release_group_year`` and populate them.
+
+    ``db`` may be a ``PipelineDB`` or a ``FakePipelineDB`` — both
+    expose ``get_requests_missing_release_group_year`` and
+    ``set_release_group_year``.
+
+    ``fetch_year`` is injected (rather than imported) so tests can pass
+    a stub mapping ``rg_mbid -> int | None``. Production passes
+    ``web.mb.get_release_group_year``.
+
+    Returns a populated ``BackfillCounters`` summary.
+    """
+    counters = BackfillCounters()
+    remaining = limit
+
+    while True:
+        chunk_size = batch_size
+        if remaining is not None:
+            if remaining <= 0:
+                break
+            chunk_size = min(batch_size, remaining)
+
+        rows = db.get_requests_missing_release_group_year(limit=chunk_size)
+        if not rows:
+            break
+
+        for row in rows:
+            counters.fetched += 1
+            rg_mbid = row["mb_release_group_id"]
+            label = f"id={row['id']} {row['artist_name']} - {row['album_title']}"
+            try:
+                year = fetch_year(rg_mbid)
+            except Exception:
+                counters.errors += 1
+                logger.exception(
+                    "release-group-year fetch failed for %s rg=%s",
+                    label, rg_mbid,
+                )
+                # Leave the row NULL — next run will retry. Do not raise:
+                # one bad release-group must not abort the whole backfill.
+                year = None
+                if sleep_seconds:
+                    time.sleep(sleep_seconds)
+                continue
+
+            if year is None:
+                # Distinguish "MB mirror returned 404 / no first-release-date"
+                # from real exceptions above. The bucket is informational —
+                # both leave the row NULL.
+                counters.no_date += 1
+                logger.info(
+                    "release-group %s has no first-release year for %s; "
+                    "leaving release_group_year NULL", rg_mbid, label,
+                )
+                if sleep_seconds:
+                    time.sleep(sleep_seconds)
+                continue
+
+            counters.populated += 1
+            if not dry_run:
+                db.set_release_group_year(row["id"], year)
+            logger.info("%s -> release_group_year=%d", label, year)
+
+            if sleep_seconds:
+                time.sleep(sleep_seconds)
+
+        if remaining is not None:
+            remaining -= len(rows)
+
+        # If the chunk was smaller than the requested size, the WHERE
+        # clause is exhausted (or the limit was reached). Either way,
+        # the next iteration would return zero rows — break early.
+        if len(rows) < chunk_size:
+            break
+
+    return counters
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    description = (__doc__ or "").splitlines()[0] if __doc__ else "backfill"
+    p = argparse.ArgumentParser(description=description)
+    p.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "PIPELINE_DB_DSN",
+            "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
+        ),
+        help="PostgreSQL DSN for the pipeline DB",
+    )
+    p.add_argument(
+        "--limit", type=int, default=None,
+        help="Process at most this many rows total (debug/staging)",
+    )
+    p.add_argument(
+        "--batch-size", type=int, default=BATCH_SIZE,
+        help=f"Rows fetched per chunk (default {BATCH_SIZE})",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Fetch + classify but do not write back to the DB",
+    )
+    p.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="DEBUG-level logging",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    from lib.pipeline_db import PipelineDB
+    from web.mb import get_release_group_year
+
+    db = PipelineDB(args.dsn)
+    try:
+        counters = run_backfill(
+            db=db,
+            fetch_year=get_release_group_year,
+            batch_size=args.batch_size,
+            limit=args.limit,
+            dry_run=args.dry_run,
+        )
+    finally:
+        db.close()
+
+    logger.info(
+        "backfill complete: fetched=%d populated=%d no_date=%d errors=%d (dry_run=%s)",
+        counters.fetched, counters.populated, counters.no_date,
+        counters.errors, args.dry_run,
+    )
+    # Exit non-zero only if every fetched row errored — partial errors
+    # are expected (some release-groups have no date) and should not
+    # fail the deploy.
+    if counters.fetched > 0 and counters.errors == counters.fetched:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_release_group_year.py
+++ b/scripts/backfill_release_group_year.py
@@ -47,7 +47,7 @@ if REPO_ROOT not in sys.path:
 logger = logging.getLogger("backfill_release_group_year")
 
 BATCH_SIZE = 500
-RATE_LIMIT_SECONDS = 0.05  # 50ms between MB mirror calls — cheap local I/O
+RATE_LIMIT_SECONDS = 0.0  # local mirror — no throttle by default
 
 
 # Result counters — surfaced in the final summary and (post-deploy) in

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -234,13 +234,17 @@ def _build_search_plan_service(db):
 
 
 def _generate_plan_after_add(db, req_id, *, artist_name, album_title, year,
-                              tracks, source):
+                              tracks, source, release_group_year=None):
     """Run plan generation for a freshly-added request.
 
     Failures are non-fatal: a deterministic / transient failure is
     recorded as a `search_plans` row and the CLI prints a one-liner so
     the operator knows the request is wanted-but-not-searchable until
     repaired.
+
+    ``release_group_year`` (U5 of search-plan-entropy) feeds the
+    generator's conditional ``unwild_rg_year`` slot. ``None`` is fine
+    — the generator handles it gracefully.
     """
     from lib.search_plan_service import (
         RESULT_FAILED_DETERMINISTIC,
@@ -256,6 +260,7 @@ def _generate_plan_after_add(db, req_id, *, artist_name, album_title, year,
         year=year,
         tracks=tracks,
         source=source,
+        release_group_year=release_group_year,
     )
     if result.outcome == RESULT_SUCCESS:
         print(f"  Plan: active id={result.plan_id}")
@@ -317,6 +322,7 @@ def _cmd_add_mb(db, mbid, source):
         year=year,
         tracks=tracks,
         source=source,
+        release_group_year=rg_year,
     )
 
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -131,6 +131,39 @@ def fetch_mb_release(mb_release_id):
         return None
 
 
+def fetch_mb_release_group_year(rg_mbid):
+    """Return the release-group's first-release year as an int, or None.
+
+    U4 enqueue-time companion to ``fetch_mb_release``. Returns ``None``
+    on 404 / unparseable date / network blip — callers persist NULL on
+    the new ``release_group_year`` column rather than failing the add.
+    Mirrors ``web/mb.py::get_release_group_year`` but goes through
+    ``urllib`` directly so the CLI stays decoupled from the Redis-backed
+    web client.
+    """
+    url = f"{MB_API}/release-group/{rg_mbid}?fmt=json"
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", "pipeline-cli/1.0")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        print(f"  [WARN] MB release-group fetch: {e}", file=sys.stderr)
+        return None
+    except urllib.error.URLError as e:
+        print(f"  [WARN] MB release-group fetch: {e}", file=sys.stderr)
+        return None
+    date = data.get("first-release-date", "")
+    if not isinstance(date, str) or len(date) < 4:
+        return None
+    try:
+        return int(date[:4])
+    except ValueError:
+        return None
+
+
 def tracks_from_mb_release(release_data):
     """Extract track list from MB API release response.
 
@@ -254,6 +287,12 @@ def _cmd_add_mb(db, mbid, source):
     if release.get("date"):
         year = int(release["date"][:4]) if len(release["date"]) >= 4 else None
 
+    # U4: persist release-group year so the generator (U5) can emit a
+    # year-anchored slot matching how users on Soulseek file reissues.
+    # ``fetch_mb_release_group_year`` is 404/error tolerant; column
+    # accepts NULL.
+    rg_year = fetch_mb_release_group_year(rg_id) if rg_id else None
+
     req_id = db.add_request(
         mb_release_id=mbid,
         mb_release_group_id=rg_id,
@@ -261,6 +300,7 @@ def _cmd_add_mb(db, mbid, source):
         artist_name=artist_name,
         album_title=release.get("title", "Unknown"),
         year=year,
+        release_group_year=rg_year,
         country=release.get("country"),
         source=source,
     )

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -2048,6 +2048,77 @@ def cmd_search_plan_dry_run(db, args):
     return 1
 
 
+def cmd_search_plan_saturation(db, args):
+    """U7: ``pipeline-cli search-plan saturation <request_id>``.
+
+    Read-only telemetry aggregator: reports the saturation rate (rows
+    whose ``final_state`` contains ``LimitReached``) and total
+    ``pre_filter_skip_count`` over the last ``--window-days`` (default
+    14) of ``search_log`` rows. Counterpart of
+    ``GET /api/pipeline/<id>/search-plan/saturation``; both surfaces
+    wrap ``SearchPlanService.saturation_for_request`` — keep them in
+    sync (see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
+
+    Exit codes:
+      * 0 — ``RESULT_SATURATION_SUCCESS`` (zeros are still success —
+        the request exists, the window is just quiet)
+      * 2 — ``RESULT_REQUEST_NOT_FOUND``
+      * 3 — ``RESULT_SATURATION_INPUT_INVALID`` (argparse normally
+        bounds this; the branch is defensive parity with the API's
+        400)
+    """
+    from lib.config import read_runtime_config
+    from lib.search_plan_service import (
+        RESULT_REQUEST_NOT_FOUND,
+        RESULT_SATURATION_INPUT_INVALID,
+        RESULT_SATURATION_SUCCESS,
+        SATURATION_WINDOW_DEFAULT_DAYS,
+        SearchPlanService,
+        saturation_payload,
+    )
+
+    cfg = read_runtime_config()
+    svc = SearchPlanService(db, cfg)
+    # ``None`` means "argparse default" (operator omitted the flag);
+    # treat 0 / negative as explicit and let the service flag them
+    # invalid so the operator sees the failure rather than silently
+    # widening to 14.
+    raw_window = getattr(args, "window_days", None)
+    window_days = int(
+        raw_window if raw_window is not None
+        else SATURATION_WINDOW_DEFAULT_DAYS)
+    result = svc.saturation_for_request(
+        int(args.id), window_days=window_days,
+    )
+    payload = saturation_payload(result)
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+    else:
+        print(f"  Request ID:             {payload['request_id']}")
+        print(f"  Outcome:                {payload['outcome']}")
+        print(f"  Window (days):          {payload['window_days']}")
+        print(f"  Total searches:         {payload['total_searches']}")
+        print(f"  Saturated searches:     {payload['saturated_searches']}")
+        # Render the rate as a percentage with one decimal so the
+        # number is human-readable at a glance.
+        rate_pct = 100.0 * float(payload['saturation_rate'])
+        print(f"  Saturation rate:        {rate_pct:.1f}%")
+        print(
+            f"  Pre-filter skips total: {payload['total_pre_filter_skips']}")
+        if payload.get("error_message"):
+            print(f"  Error message:          {payload['error_message']}")
+
+    if result.outcome == RESULT_SATURATION_SUCCESS:
+        return 0
+    if result.outcome == RESULT_REQUEST_NOT_FOUND:
+        return 2
+    if result.outcome == RESULT_SATURATION_INPUT_INVALID:
+        return 3
+    return 1
+
+
 def cmd_search_plan_advance(db, args):
     """Forward-only operator advance of the search-plan cursor.
 
@@ -2307,6 +2378,17 @@ def main():
                               "generated queries")
     p_sp_dry_run.add_argument("--json", action="store_true",
                               help="Print structured JSON instead of text")
+    p_sp_saturation = sp_sub.add_parser(
+        "saturation",
+        help="Show per-request saturation rate + pre-filter skip total "
+             "over the recent search_log window (U7 telemetry)")
+    p_sp_saturation.add_argument("id", type=int, help="Request ID")
+    p_sp_saturation.add_argument(
+        "--window-days", type=int, default=None, dest="window_days",
+        help="Window in days; defaults to 14; valid range [1, 90]")
+    p_sp_saturation.add_argument(
+        "--json", action="store_true",
+        help="Print structured JSON instead of text")
     p_sp_history = sp_sub.add_parser(
         "history",
         help="Cursor-paginated read of one request's search_log rows "
@@ -2489,6 +2571,7 @@ def main():
         "advance": cmd_search_plan_advance,
         "history": cmd_search_plan_history,
         "dry-run": cmd_search_plan_dry_run,
+        "saturation": cmd_search_plan_saturation,
     }
     try:
         if args.command == "search-plan":

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -60,7 +60,10 @@ from lib.import_queue import (
 from lib.pipeline_db import PipelineDB, DEFAULT_DSN
 from lib.import_preview import ImportPreviewValues
 from lib.release_identity import detect_release_source, normalize_release_id
-from lib.util import resolve_failed_path as _shared_resolve_failed_path
+from lib.util import (
+    parse_mb_first_release_year,
+    resolve_failed_path as _shared_resolve_failed_path,
+)
 
 MB_API = "http://192.168.1.35:5200/ws/2"
 SPECTRAL_GRADE_CHOICES = ("genuine", "marginal", "suspect", "likely_transcode")
@@ -155,13 +158,7 @@ def fetch_mb_release_group_year(rg_mbid):
     except urllib.error.URLError as e:
         print(f"  [WARN] MB release-group fetch: {e}", file=sys.stderr)
         return None
-    date = data.get("first-release-date", "")
-    if not isinstance(date, str) or len(date) < 4:
-        return None
-    try:
-        return int(date[:4])
-    except ValueError:
-        return None
+    return parse_mb_first_release_year(data)
 
 
 def tracks_from_mb_release(release_data):
@@ -233,6 +230,46 @@ def _build_search_plan_service(db):
     return SearchPlanService(db, read_runtime_config())
 
 
+def _search_plan_exit_code(outcome: str) -> int:
+    """CLI ⇄ API exit-code mapping for search-plan read/advance subcommands.
+
+    Per CLAUDE.md § "CLI ⇄ API surface symmetry":
+    0=success, 2=not_found, 3=input_validation, 4=wrong_state, 5=transient.
+
+    Covers the outcome strings emitted by ``dry_run_for_request``,
+    ``saturation_for_request``, ``advance_for_request`` and
+    ``history_for_request``. Regenerate has its own ladder
+    (``failed_transient`` → 4 there, predating this convention).
+    """
+    from lib.search_plan_service import (
+        RESULT_ADVANCED,
+        RESULT_DRY_RUN_GENERATION_FAILED,
+        RESULT_DRY_RUN_SUCCESS,
+        RESULT_FAILED_TRANSIENT,
+        RESULT_HISTORY_PAGE_INPUT_INVALID,
+        RESULT_HISTORY_PAGE_SUCCESS,
+        RESULT_INVALID_TARGET,
+        RESULT_NO_ACTIVE_PLAN,
+        RESULT_REQUEST_NOT_FOUND,
+        RESULT_SATURATION_INPUT_INVALID,
+        RESULT_SATURATION_SUCCESS,
+    )
+    mapping: dict[str, int] = {
+        RESULT_DRY_RUN_SUCCESS: 0,
+        RESULT_DRY_RUN_GENERATION_FAILED: 0,
+        RESULT_SATURATION_SUCCESS: 0,
+        RESULT_ADVANCED: 0,
+        RESULT_HISTORY_PAGE_SUCCESS: 0,
+        RESULT_REQUEST_NOT_FOUND: 2,
+        RESULT_SATURATION_INPUT_INVALID: 3,
+        RESULT_INVALID_TARGET: 3,
+        RESULT_HISTORY_PAGE_INPUT_INVALID: 3,
+        RESULT_NO_ACTIVE_PLAN: 4,
+        RESULT_FAILED_TRANSIENT: 5,
+    }
+    return mapping.get(outcome, 1)
+
+
 def _generate_plan_after_add(db, req_id, *, artist_name, album_title, year,
                               tracks, source, release_group_year=None):
     """Run plan generation for a freshly-added request.
@@ -292,7 +329,7 @@ def _cmd_add_mb(db, mbid, source):
     if release.get("date"):
         year = int(release["date"][:4]) if len(release["date"]) >= 4 else None
 
-    # U4: persist release-group year so the generator (U5) can emit a
+    # Persist release-group year so the generator can emit a
     # year-anchored slot matching how users on Soulseek file reissues.
     # ``fetch_mb_release_group_year`` is 404/error tolerant; column
     # accepts NULL.
@@ -1954,9 +1991,6 @@ def cmd_search_plan_dry_run(db, args):
     """
     from lib.config import read_runtime_config
     from lib.search_plan_service import (
-        RESULT_DRY_RUN_GENERATION_FAILED,
-        RESULT_DRY_RUN_SUCCESS,
-        RESULT_REQUEST_NOT_FOUND,
         SearchPlanService,
         dry_run_payload,
     )
@@ -2039,13 +2073,7 @@ def cmd_search_plan_dry_run(db, args):
                     else:
                         print(f"    {key}: {value}")
 
-    if result.outcome == RESULT_DRY_RUN_SUCCESS:
-        return 0
-    if result.outcome == RESULT_DRY_RUN_GENERATION_FAILED:
-        return 0
-    if result.outcome == RESULT_REQUEST_NOT_FOUND:
-        return 2
-    return 1
+    return _search_plan_exit_code(result.outcome)
 
 
 def cmd_search_plan_saturation(db, args):
@@ -2069,9 +2097,6 @@ def cmd_search_plan_saturation(db, args):
     """
     from lib.config import read_runtime_config
     from lib.search_plan_service import (
-        RESULT_REQUEST_NOT_FOUND,
-        RESULT_SATURATION_INPUT_INVALID,
-        RESULT_SATURATION_SUCCESS,
         SATURATION_WINDOW_DEFAULT_DAYS,
         SearchPlanService,
         saturation_payload,
@@ -2110,13 +2135,7 @@ def cmd_search_plan_saturation(db, args):
         if payload.get("error_message"):
             print(f"  Error message:          {payload['error_message']}")
 
-    if result.outcome == RESULT_SATURATION_SUCCESS:
-        return 0
-    if result.outcome == RESULT_REQUEST_NOT_FOUND:
-        return 2
-    if result.outcome == RESULT_SATURATION_INPUT_INVALID:
-        return 3
-    return 1
+    return _search_plan_exit_code(result.outcome)
 
 
 def cmd_search_plan_advance(db, args):
@@ -2136,11 +2155,6 @@ def cmd_search_plan_advance(db, args):
     """
     from lib.config import read_runtime_config
     from lib.search_plan_service import (
-        RESULT_ADVANCED,
-        RESULT_FAILED_TRANSIENT,
-        RESULT_INVALID_TARGET,
-        RESULT_NO_ACTIVE_PLAN,
-        RESULT_REQUEST_NOT_FOUND,
         SearchPlanService,
     )
 
@@ -2181,17 +2195,7 @@ def cmd_search_plan_advance(db, args):
         if result.error_message:
             print(f"  Error message:     {result.error_message}")
 
-    if result.outcome == RESULT_ADVANCED:
-        return 0
-    if result.outcome == RESULT_REQUEST_NOT_FOUND:
-        return 2
-    if result.outcome == RESULT_INVALID_TARGET:
-        return 3
-    if result.outcome == RESULT_NO_ACTIVE_PLAN:
-        return 4
-    if result.outcome == RESULT_FAILED_TRANSIENT:
-        return 5
-    return 1
+    return _search_plan_exit_code(result.outcome)
 
 
 def cmd_search_plan_history(db, args):
@@ -2214,9 +2218,7 @@ def cmd_search_plan_history(db, args):
     from lib.config import read_runtime_config
     from lib.search_plan_service import (
         HISTORY_PAGE_DEFAULT_LIMIT,
-        RESULT_HISTORY_PAGE_INPUT_INVALID,
         RESULT_HISTORY_PAGE_SUCCESS,
-        RESULT_REQUEST_NOT_FOUND,
         SearchPlanService,
     )
 
@@ -2277,13 +2279,7 @@ def cmd_search_plan_history(db, args):
         if result.error_message:
             print(f"  Error message:     {result.error_message}")
 
-    if result.outcome == RESULT_HISTORY_PAGE_SUCCESS:
-        return 0
-    if result.outcome == RESULT_REQUEST_NOT_FOUND:
-        return 2
-    if result.outcome == RESULT_HISTORY_PAGE_INPUT_INVALID:
-        return 3
-    return 1
+    return _search_plan_exit_code(result.outcome)
 
 
 def main():

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1929,6 +1929,125 @@ def cmd_beets_distance(db, args):
     return 1
 
 
+def cmd_search_plan_dry_run(db, args):
+    """U6: ``pipeline-cli search-plan dry-run <request_id>``.
+
+    Read-only simulator: runs the current generator against the
+    request's persisted snapshot and prints the slot list without
+    writing anything. Counterpart of ``GET /api/pipeline/<id>/search-plan/dry-run``.
+    Both surfaces wrap ``SearchPlanService.dry_run_for_request`` — keep
+    them in sync (see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
+
+    Use this during generator development (see
+    ``.claude/rules/code-quality.md`` § "Pipeline Decision Debugging
+    — Simulator-First TDD") to validate that the next cycle's
+    generator output matches expectations before bumping
+    ``SEARCH_PLAN_GENERATOR_ID``.
+
+    Exit codes:
+      * 0 — ``RESULT_DRY_RUN_SUCCESS`` or
+        ``RESULT_DRY_RUN_GENERATION_FAILED`` (generator returned a
+        deterministic generation failure — informational, not a CLI
+        error; the operator still wants to see ``failure_reason`` and
+        provenance).
+      * 2 — ``RESULT_REQUEST_NOT_FOUND``.
+    """
+    from lib.config import read_runtime_config
+    from lib.search_plan_service import (
+        RESULT_DRY_RUN_GENERATION_FAILED,
+        RESULT_DRY_RUN_SUCCESS,
+        RESULT_REQUEST_NOT_FOUND,
+        SearchPlanService,
+        dry_run_payload,
+    )
+
+    cfg = read_runtime_config()
+    svc = SearchPlanService(db, cfg)
+    result = svc.dry_run_for_request(
+        int(args.id),
+        prepend_artist=bool(getattr(args, "prepend_artist", False)),
+    )
+    row = db.get_request(int(args.id))
+    has_active = False
+    if row is not None:
+        try:
+            active = db.get_active_search_plan(int(args.id))
+            has_active = active is not None
+        except Exception:  # noqa: BLE001
+            has_active = False
+    payload = dry_run_payload(
+        result,
+        current_generator_id=svc.generator_id,
+        request_row=row,
+        has_active_plan=has_active,
+    )
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+    else:
+        print(f"  Request ID:             {payload['request_id']}")
+        print(f"  Outcome:                {payload['outcome']}")
+        print(
+            f"  Current generator id:   {payload['current_generator_id']}")
+        if payload["request"] is not None:
+            req = payload["request"]
+            print(f"  Artist:                 {req.get('artist_name')}")
+            print(f"  Album:                  {req.get('album_title')}")
+            print(f"  Status:                 {req.get('status')}")
+            print(f"  Year:                   {req.get('year') or '-'}")
+            rg = req.get("release_group_year")
+            print(f"  Release-group year:     {rg if rg is not None else '-'}")
+            print(
+                f"  Would supersede active: "
+                f"{'yes' if payload['would_supersede_active'] else 'no'}")
+        plan = payload["plan"]
+        if plan is None:
+            print(f"  Plan:                   (none)")
+            if result.error_message:
+                print(f"  Error message:          {result.error_message}")
+        else:
+            print(f"  Plan generator_id:      {plan['generator_id']}")
+            print(f"  Plan status:            {plan['status']}")
+            if plan["failure_reason"]:
+                print(
+                    f"  Plan failure_reason:    {plan['failure_reason']}")
+            items = plan["items"]
+            print(f"  Plan items ({len(items)}):")
+            for it in items:
+                head = (
+                    f"    [{it['ordinal']:>2}] strategy={it['strategy']}"
+                    f"  query={it['query']!r}")
+                if it.get("canonical_query_key"):
+                    head += f"  key={it['canonical_query_key']}"
+                if it.get("repeat_group"):
+                    head += f"  repeat={it['repeat_group']}"
+                print(head)
+                prov = it.get("provenance") or {}
+                for key, value in prov.items():
+                    print(f"          provenance.{key}: {value}")
+            prov_plan = plan.get("provenance") or {}
+            if prov_plan:
+                print(f"  Plan provenance:")
+                for key, value in prov_plan.items():
+                    if isinstance(value, list):
+                        print(f"    {key}: {len(value)} item(s)")
+                        for entry in value[:5]:
+                            print(f"      - {entry}")
+                        if len(value) > 5:
+                            print(f"      ... +{len(value) - 5} more")
+                    else:
+                        print(f"    {key}: {value}")
+
+    if result.outcome == RESULT_DRY_RUN_SUCCESS:
+        return 0
+    if result.outcome == RESULT_DRY_RUN_GENERATION_FAILED:
+        return 0
+    if result.outcome == RESULT_REQUEST_NOT_FOUND:
+        return 2
+    return 1
+
+
 def cmd_search_plan_advance(db, args):
     """Forward-only operator advance of the search-plan cursor.
 
@@ -2177,6 +2296,17 @@ def main():
              "(e.g. `track`, `unwild_year`)")
     p_sp_advance.add_argument("--json", action="store_true",
                               help="Print structured JSON instead of text")
+    p_sp_dry_run = sp_sub.add_parser(
+        "dry-run",
+        help="Run the generator against the request's snapshot without "
+             "persisting (U6 simulator)")
+    p_sp_dry_run.add_argument("id", type=int, help="Request ID")
+    p_sp_dry_run.add_argument("--prepend-artist", action="store_true",
+                              dest="prepend_artist",
+                              help="Prepend artist name to album title in "
+                              "generated queries")
+    p_sp_dry_run.add_argument("--json", action="store_true",
+                              help="Print structured JSON instead of text")
     p_sp_history = sp_sub.add_parser(
         "history",
         help="Cursor-paginated read of one request's search_log rows "
@@ -2358,6 +2488,7 @@ def main():
         "regenerate": cmd_search_plan_regenerate,
         "advance": cmd_search_plan_advance,
         "history": cmd_search_plan_history,
+        "dry-run": cmd_search_plan_dry_run,
     }
     try:
         if args.command == "search-plan":

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1958,6 +1958,39 @@ class FakePipelineDB:
             row.update(fields)
             row["updated_at"] = _utcnow()
 
+    def set_release_group_year(
+        self,
+        request_id: int,
+        year: int | None,
+    ) -> None:
+        """In-memory mirror of ``PipelineDB.set_release_group_year``."""
+        self.update_request_fields(request_id, release_group_year=year)
+
+    def get_requests_missing_release_group_year(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """In-memory mirror of
+        ``PipelineDB.get_requests_missing_release_group_year``.
+        """
+        out: list[dict[str, Any]] = []
+        for rid in sorted(self._requests.keys()):
+            row = self._requests[rid]
+            if not row.get("mb_release_group_id"):
+                continue
+            if row.get("release_group_year") is not None:
+                continue
+            out.append({
+                "id": row["id"],
+                "mb_release_group_id": row["mb_release_group_id"],
+                "artist_name": row["artist_name"],
+                "album_title": row["album_title"],
+            })
+            if limit is not None and len(out) >= limit:
+                break
+        return out
+
     # --- Session lifecycle ---
 
     def close(self) -> None:
@@ -1975,7 +2008,8 @@ class FakePipelineDB:
                     format: str | None = None,
                     source_path: str | None = None,
                     reasoning: str | None = None,
-                    status: str = "wanted") -> int:
+                    status: str = "wanted",
+                    release_group_year: int | None = None) -> int:
         """Insert an album_requests row.
 
         Seeds the full ``album_requests`` column set (matching
@@ -1996,6 +2030,9 @@ class FakePipelineDB:
             "artist_name": artist_name,
             "album_title": album_title,
             "year": year,
+            # U3 / R9 — release-group's first-release year. Populated by
+            # the deploy-time backfill or U4's enqueue path; nullable.
+            "release_group_year": release_group_year,
             "country": country,
             "format": format,
             "source": source,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -26,7 +26,7 @@ _PERTH_TZ = ZoneInfo("Australia/Perth")
 
 if TYPE_CHECKING:
     from lib.quality import CandidateScore
-    from lib.pipeline_db import SearchLogHistoryPage
+    from lib.pipeline_db import SaturationSummary, SearchLogHistoryPage
 
 from lib.import_queue import (
     ImportJob,
@@ -3076,6 +3076,43 @@ class FakePipelineDB:
             assert isinstance(extra_id, int)
             next_before_id = extra_id
         return _Page(rows=rows, next_before_id=next_before_id)
+
+    def get_saturation_summary(
+        self, request_id: int, *, window_days: int = 14,
+    ) -> "SaturationSummary":
+        """U7 mirror of ``PipelineDB.get_saturation_summary``.
+
+        Replicates the SQL aggregate against ``self.search_logs``:
+        rows whose ``final_state`` contains ``LimitReached`` count as
+        saturated; ``pre_filter_skip_count`` is summed. The window cut
+        uses Python ``datetime`` arithmetic so tests can rewind
+        ``SearchLogRow.created_at`` deterministically.
+
+        ``saturation_rate`` is ``0.0`` (not NaN) when the window
+        contains no rows — same explicit fallback the real DB returns.
+        """
+        from lib.pipeline_db import SaturationSummary as _SatSummary
+        cutoff = _utcnow() - timedelta(days=int(window_days))
+        total = 0
+        saturated = 0
+        skips = 0
+        for entry in self.search_logs:
+            if entry.request_id != request_id:
+                continue
+            if entry.created_at <= cutoff:
+                continue
+            total += 1
+            if entry.final_state is not None and "LimitReached" in entry.final_state:
+                saturated += 1
+            skips += int(entry.pre_filter_skip_count or 0)
+        rate = (saturated / total) if total > 0 else 0.0
+        return _SatSummary(
+            total_searches=total,
+            saturated_searches=saturated,
+            saturation_rate=rate,
+            total_pre_filter_skips=skips,
+            window_days=int(window_days),
+        )
 
     def get_legacy_search_log_summary(
         self, request_id: int, *, limit: int,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -162,6 +162,10 @@ class SearchLogRow:
     cursor_update_status: str | None = None
     stale_reason: str | None = None
     plan_cycle_snapshot: int | None = None
+    # U2 of search-plan-entropy: pre-filter skip count. NOT NULL on
+    # the real column with default 0; mirror that here so test asserts
+    # never see None on the field.
+    pre_filter_skip_count: int = 0
 
 
 @dataclass
@@ -2953,7 +2957,8 @@ class FakePipelineDB:
                    match_time_s: float = 0.0,
                    peers_browsed: int = 0,
                    peers_browsed_lazy: int = 0,
-                   fanout_waves: int = 0) -> None:
+                   fanout_waves: int = 0,
+                   pre_filter_skip_count: int = 0) -> None:
         """Mirror PipelineDB.log_search wire boundary.
 
         ``candidates`` is encoded via ``msgspec.json.encode`` (same as the
@@ -2981,6 +2986,7 @@ class FakePipelineDB:
             peers_browsed=peers_browsed,
             peers_browsed_lazy=peers_browsed_lazy,
             fanout_waves=fanout_waves,
+            pre_filter_skip_count=pre_filter_skip_count,
         ))
 
     def get_search_history(self,
@@ -3114,6 +3120,7 @@ class FakePipelineDB:
             "cursor_update_status": entry.cursor_update_status,
             "stale_reason": entry.stale_reason,
             "plan_cycle_snapshot": entry.plan_cycle_snapshot,
+            "pre_filter_skip_count": entry.pre_filter_skip_count,
         }
 
     # --- User cooldowns ---
@@ -3734,6 +3741,7 @@ class FakePipelineDB:
                 cursor_update_status=cursor_update_status,
                 stale_reason=stale_reason,
                 plan_cycle_snapshot=attempt.cycle_count_snapshot,
+                pre_filter_skip_count=attempt.pre_filter_skip_count,
             ))
 
             now = _utcnow()
@@ -3803,6 +3811,7 @@ class FakePipelineDB:
             attempt_consumed=False,
             cursor_update_status=CURSOR_UPDATE_UNCHANGED,
             plan_cycle_snapshot=cycle_snapshot,
+            pre_filter_skip_count=attempt.pre_filter_skip_count,
         ))
         if attempt.apply_scheduler_attempt:
             now = _utcnow()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,6 +51,8 @@ def make_request_row(**overrides: Any) -> dict[str, Any]:
         "artist_name": "Test Artist",
         "album_title": "Test Album",
         "year": 2024,
+        # Migration 026 — release-group's first-release year (U3 / R9).
+        "release_group_year": None,
         "country": "US",
         "format": None,
         "source": "request",

--- a/tests/test_backfill_release_group_year.py
+++ b/tests/test_backfill_release_group_year.py
@@ -1,0 +1,316 @@
+"""Tests for ``scripts/backfill_release_group_year.py``.
+
+U3 / R9 of the search-plan-entropy plan. The backfill is a one-shot
+deploy-time script that populates ``album_requests.release_group_year``
+from the local MB mirror. Tests use ``FakePipelineDB`` + a stub
+``fetch_year`` callable; nothing hits the real mirror.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.backfill_release_group_year import (  # noqa: E402
+    BackfillCounters,
+    run_backfill,
+)
+from tests.fakes import FakePipelineDB  # noqa: E402
+
+
+def _seed(db: FakePipelineDB, **fields: Any) -> int:
+    """Seed a request row with sane defaults; return its id."""
+    defaults: dict[str, Any] = {
+        "artist_name": "Test Artist",
+        "album_title": "Test Album",
+        "source": "request",
+        "mb_release_id": None,
+        "mb_release_group_id": None,
+        "year": None,
+    }
+    defaults.update(fields)
+    return db.add_request(**defaults)
+
+
+class TestBackfillHappyPath(unittest.TestCase):
+    """The Kid A scenario: row has mb_release_group_id, mirror returns
+    a year, the column gets populated."""
+
+    def test_populates_release_group_year_from_mirror(self):
+        db = FakePipelineDB()
+        rid = _seed(
+            db,
+            artist_name="Radiohead",
+            album_title="Kid A",
+            mb_release_group_id="kid-a-rg-mbid",
+            year=2008,  # the 2008 reissue
+        )
+
+        def fetch(rg_mbid: str) -> int | None:
+            self.assertEqual(rg_mbid, "kid-a-rg-mbid")
+            return 2000  # the original Kid A first-release year
+
+        counters = run_backfill(
+            db=db, fetch_year=fetch, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.populated, 1)
+        self.assertEqual(counters.fetched, 1)
+        self.assertEqual(counters.no_date, 0)
+        self.assertEqual(counters.errors, 0)
+
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertEqual(row["release_group_year"], 2000)
+
+    def test_skips_rows_without_release_group_id(self):
+        """Discogs-only / legacy rows without an MB release-group are
+        not visible to the backfill query, so the fetcher is never
+        called for them.
+        """
+        db = FakePipelineDB()
+        rid = _seed(
+            db, artist_name="A", album_title="B",
+            discogs_release_id="12345",  # no mb_release_group_id
+        )
+
+        calls: list[str] = []
+
+        def fetch(rg_mbid: str) -> int | None:
+            calls.append(rg_mbid)
+            return 1999
+
+        counters = run_backfill(
+            db=db, fetch_year=fetch, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.fetched, 0)
+        self.assertEqual(counters.populated, 0)
+        self.assertEqual(calls, [])
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertIsNone(row["release_group_year"])
+
+    def test_dry_run_does_not_write(self):
+        db = FakePipelineDB()
+        rid = _seed(
+            db, artist_name="X", album_title="Y",
+            mb_release_group_id="rg-1",
+        )
+
+        counters = run_backfill(
+            db=db, fetch_year=lambda _: 1995,
+            dry_run=True, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.populated, 1)
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertIsNone(row["release_group_year"])
+
+
+class TestBackfillIdempotency(unittest.TestCase):
+    """Re-running the backfill must not re-fetch rows that already have
+    a populated ``release_group_year``."""
+
+    def test_second_run_is_a_noop(self):
+        db = FakePipelineDB()
+        _seed(
+            db, artist_name="A", album_title="B",
+            mb_release_group_id="rg-idem",
+        )
+
+        calls: list[str] = []
+
+        def fetch(rg_mbid: str) -> int | None:
+            calls.append(rg_mbid)
+            return 1980
+
+        first = run_backfill(db=db, fetch_year=fetch, sleep_seconds=0)
+        second = run_backfill(db=db, fetch_year=fetch, sleep_seconds=0)
+
+        self.assertEqual(first.populated, 1)
+        self.assertEqual(first.fetched, 1)
+        self.assertEqual(second.populated, 0)
+        self.assertEqual(second.fetched, 0)
+        # The mirror was hit exactly once across both runs.
+        self.assertEqual(calls, ["rg-idem"])
+
+
+class TestBackfillResilience(unittest.TestCase):
+    """Per-row failures must not abort the whole batch. The MB mirror
+    can return 404 (release-group missing) or no parseable date — both
+    must leave the row NULL and the backfill must keep going."""
+
+    def test_mirror_404_leaves_row_null(self):
+        db = FakePipelineDB()
+        rid_a = _seed(
+            db, artist_name="A", album_title="B",
+            mb_release_group_id="rg-found",
+        )
+        rid_b = _seed(
+            db, artist_name="C", album_title="D",
+            mb_release_group_id="rg-404",
+        )
+        rid_c = _seed(
+            db, artist_name="E", album_title="F",
+            mb_release_group_id="rg-also-found",
+        )
+
+        def fetch(rg_mbid: str) -> int | None:
+            if rg_mbid == "rg-404":
+                return None  # simulate 404 / no date
+            return 1972 if rg_mbid == "rg-found" else 1985
+
+        counters = run_backfill(
+            db=db, fetch_year=fetch, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.fetched, 3)
+        self.assertEqual(counters.populated, 2)
+        self.assertEqual(counters.no_date, 1)
+        self.assertEqual(counters.errors, 0)
+
+        a, b, c = (db.get_request(r) for r in (rid_a, rid_b, rid_c))
+        assert a is not None and b is not None and c is not None
+        self.assertEqual(a["release_group_year"], 1972)
+        self.assertIsNone(b["release_group_year"])
+        self.assertEqual(c["release_group_year"], 1985)
+
+    def test_unexpected_exception_per_row_is_recorded_and_continues(self):
+        db = FakePipelineDB()
+        rid_a = _seed(
+            db, artist_name="A", album_title="B",
+            mb_release_group_id="rg-good",
+        )
+        rid_b = _seed(
+            db, artist_name="C", album_title="D",
+            mb_release_group_id="rg-explode",
+        )
+        rid_c = _seed(
+            db, artist_name="E", album_title="F",
+            mb_release_group_id="rg-also-good",
+        )
+
+        def fetch(rg_mbid: str) -> int | None:
+            if rg_mbid == "rg-explode":
+                raise RuntimeError("mirror exploded")
+            return 1999
+
+        counters = run_backfill(
+            db=db, fetch_year=fetch, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.fetched, 3)
+        self.assertEqual(counters.populated, 2)
+        self.assertEqual(counters.errors, 1)
+
+        b = db.get_request(rid_b)
+        assert b is not None
+        self.assertIsNone(b["release_group_year"])
+        # The neighbouring rows still got populated.
+        a = db.get_request(rid_a)
+        c = db.get_request(rid_c)
+        assert a is not None and c is not None
+        self.assertEqual(a["release_group_year"], 1999)
+        self.assertEqual(c["release_group_year"], 1999)
+
+
+class TestBackfillBatching(unittest.TestCase):
+    """The script processes rows in chunks. A chunk's failures must not
+    leak into the next chunk — every populated row is committed before
+    the next batch starts (FakePipelineDB writes are synchronous, so we
+    assert post-batch state after each call)."""
+
+    def test_processes_more_rows_than_one_batch(self):
+        db = FakePipelineDB()
+        rids = [
+            _seed(
+                db, artist_name=f"A{i}", album_title=f"Album {i}",
+                mb_release_group_id=f"rg-{i}",
+            )
+            for i in range(7)
+        ]
+
+        def fetch(rg_mbid: str) -> int | None:
+            # Encode the year as 2000 + the request's index.
+            return 2000 + int(rg_mbid.split("-")[1])
+
+        counters = run_backfill(
+            db=db, fetch_year=fetch, batch_size=3, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.fetched, 7)
+        self.assertEqual(counters.populated, 7)
+        for i, rid in enumerate(rids):
+            row = db.get_request(rid)
+            assert row is not None
+            self.assertEqual(row["release_group_year"], 2000 + i)
+
+    def test_limit_caps_total_processed(self):
+        db = FakePipelineDB()
+        for i in range(10):
+            _seed(
+                db, artist_name=f"A{i}", album_title=f"X{i}",
+                mb_release_group_id=f"rg-{i}",
+            )
+
+        counters = run_backfill(
+            db=db, fetch_year=lambda _: 1990,
+            batch_size=4, limit=5, sleep_seconds=0,
+        )
+
+        self.assertEqual(counters.fetched, 5)
+        self.assertEqual(counters.populated, 5)
+
+
+class TestFakePipelineDBExposesField(unittest.TestCase):
+    """Downstream consumers (web UI, generator, AlbumRecord builder)
+    will read ``release_group_year`` off rows returned by
+    ``FakePipelineDB.get_request``. Smoke-test that the field is present
+    and writable via ``set_release_group_year`` + ``add_request``."""
+
+    def test_default_value_is_none(self):
+        db = FakePipelineDB()
+        rid = _seed(db, artist_name="A", album_title="B",
+                    mb_release_group_id="rg-default-test")
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertIn("release_group_year", row)
+        self.assertIsNone(row["release_group_year"])
+
+    def test_add_request_accepts_explicit_release_group_year(self):
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="A", album_title="B", source="request",
+            mb_release_group_id="rg-1", release_group_year=1973,
+        )
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertEqual(row["release_group_year"], 1973)
+
+    def test_set_release_group_year_writes(self):
+        db = FakePipelineDB()
+        rid = _seed(db, artist_name="A", album_title="B",
+                    mb_release_group_id="rg-set-test")
+        db.set_release_group_year(rid, 1969)
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertEqual(row["release_group_year"], 1969)
+
+
+class TestBackfillCountersInit(unittest.TestCase):
+    def test_counters_start_at_zero(self):
+        c = BackfillCounters()
+        self.assertEqual(c.fetched, 0)
+        self.assertEqual(c.populated, 0)
+        self.assertEqual(c.no_date, 0)
+        self.assertEqual(c.errors, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1319,11 +1319,20 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         cratedigger.slskd = self._orig_slskd
         cratedigger.pipeline_db_source = self._orig_pdb
 
-    def test_dir_with_wrong_count_skipped_before_browse(self):
-        """Directory with 3 audio files should be skipped when we need 12 tracks."""
-        # Search metadata says this dir has 3 audio files
+    def test_dir_with_junk_count_skipped_before_browse(self):
+        """Junk-dir guard: ``search_count > 2 * track_num`` skips pre-browse.
+
+        Asymmetric pre-filter (U1, 2026-05-19): the old bidirectional
+        ``abs(search_count - track_num) > 2`` was over-strict and silently
+        discarded track-fallback results (search_count=1 vs track_num=4).
+        The new rule only skips when the dir has way too many audio files
+        to plausibly be the album — a 12-track album request seeing 50
+        audio files matching its query is almost certainly a junk dump,
+        and we save the network roundtrip.
+        """
+        # 50 audio files for a 12-track album → 50 > 2*12 = 24 → skip.
         self.ctx.search_dir_audio_count = {
-            "user1": {"Music\\Album": 3}
+            "user1": {"Music\\Album": 50}
         }
         self.ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
 
@@ -1333,8 +1342,46 @@ class TestSearchResultPreFiltering(unittest.TestCase):
         # Should NOT have called slskd.users.directory — skipped before browse
         self.assertEqual(self.slskd.users.directory_calls, [])
 
+    def test_track_fallback_dir_not_skipped(self):
+        """Track-fallback search (search_count=1) must reach the browse step.
+
+        Bug fix dividend (U1, 2026-05-19): under the old bidirectional rule
+        the 1-file response from a track-name query was always skipped
+        and negative-cached. The asymmetric rule lets it through.
+        """
+        # 1 audio file for a 12-track album → 1 > 24 is false → browse.
+        self.ctx.search_dir_audio_count = {
+            "user1": {"Music\\Album": 1}
+        }
+        self.slskd.users.set_directory("user1", "Music\\Album", [
+            make_directory("Music\\Album", [
+                {"filename": f"0{i} - Track {i}.flac", "size": 100}
+                for i in range(12)
+            ])
+        ])
+        self.ctx.current_album_cache[1] = MagicMock(
+            title="Album", artist_name="Artist")
+
+        tracks: list[cratedigger.TrackRecord] = [
+            {"albumId": 1, "title": f"Track {i}", "mediumNumber": 1}
+            for i in range(12)
+        ]  # type: ignore[misc]
+        cratedigger.check_for_match(
+            tracks, "flac", ["Music\\Album"], "user1", self.ctx)
+
+        # SHOULD have browsed — search_count=1 is below the 2*track_num guard.
+        self.assertEqual(
+            self.slskd.users.directory_calls,
+            [("user1", "Music\\Album")],
+        )
+
     def test_dir_with_close_count_not_skipped(self):
-        """Directory with 13 audio files should NOT be skipped for 12 tracks (tolerance +-2)."""
+        """Directory with 13 audio files should NOT be skipped for 12 tracks.
+
+        Under the asymmetric pre-filter (U1, 2026-05-19) the cutoff is
+        ``search_count > 2 * track_num`` (i.e. >24 for a 12-track album).
+        13 sails through.
+        """
         self.ctx.search_dir_audio_count = {
             "user1": {"Music\\Album": 13}
         }

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -3255,7 +3255,15 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         self.assertEqual(row.candidates, "[]")
 
     def test_top_20_truncation_when_many_candidates(self):
-        """JSONB blob caps at top-20 by (matched_tracks, avg_ratio) DESC."""
+        """JSONB blob caps at top-15 scored + up to 5 pre-filter-skip samples.
+
+        Under U2 the cap split changed from top-20 scored to a 15-scored +
+        5-skip-sample blend so per-row forensic storage stays bounded as
+        the asymmetric pre-filter (U1) lets more peers through. Scored
+        candidates with no `pre_filter_skip=True` flag take the first 15
+        slots; this scenario feeds 30 scored candidates and asserts the
+        15 highest by (matched_tracks, avg_ratio) DESC land.
+        """
         import json
         from lib.quality import CandidateScore
         from lib.search import SearchResult
@@ -3305,10 +3313,13 @@ class TestSearchForensicsCaptureSlice(unittest.TestCase):
         row = db.search_logs[0]
         assert row.candidates is not None
         decoded = json.loads(row.candidates)
-        self.assertEqual(len(decoded), 20, "must truncate to top 20")
+        self.assertEqual(len(decoded), 15, "must truncate to top 15 scored")
         # The very top entry has matched_tracks=30 (i=0 in the source list).
         self.assertEqual(decoded[0]["matched_tracks"], 30)
-        self.assertEqual(decoded[-1]["matched_tracks"], 11)
+        # Last scored kept is matched_tracks=16 (i=14, 30-14=16).
+        self.assertEqual(decoded[-1]["matched_tracks"], 16)
+        # No pre-filter-skip rows in this scenario — all 30 inputs are scored.
+        self.assertTrue(all(not c.get("pre_filter_skip") for c in decoded))
 
     def test_discogs_source_request_produces_same_blob_shape(self):
         """A Discogs-source request flows through the same forensic capture."""

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -608,5 +608,204 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
         self.assertEqual(candidates[0].file_count, 3)
 
 
+# ---------------------------------------------------------------------------
+# Asymmetric pre-filter (U1 of search-plan-entropy plan)
+#
+# The pre-filter rule is `search_count > 2 * track_num` — junk-dir guard only,
+# not a tight-fit filter. This lets track-fallback queries (search_count=1
+# vs track_num=4) reach `album_track_num` so the dir can be browsed and
+# scored. The codec guard (`cached_codecs <= 1`) still bypasses the
+# pre-filter so multi-codec dirs are never skipped on count alone.
+# ---------------------------------------------------------------------------
+
+class TestCheckForMatchAsymmetricPreFilter(unittest.TestCase):
+    """The pre-filter only skips dirs whose audio count exceeds 2 * track_num.
+
+    Track-fallback queries (one track in the search response) MUST reach the
+    browse + score path; the bidirectional `abs() > 2` rule used to silently
+    skip them.
+    """
+
+    def setUp(self) -> None:
+        self.cfg = _make_cfg()
+        self.ctx = _make_ctx(self.cfg, album_id=1, album_title="Cool Album")
+        self.username = "user1"
+        # 4-track album — the canonical scenario from the plan.
+        self.tracks = [
+            _track(1, "Alpha"),
+            _track(1, "Bravo"),
+            _track(1, "Charlie"),
+            _track(1, "Delta"),
+        ]
+        self.full_files = [
+            _file("Alpha.flac"),
+            _file("Bravo.flac"),
+            _file("Charlie.flac"),
+            _file("Delta.flac"),
+        ]
+
+    def _set_browse(self, file_dir: str, files: list[SlskdFile]) -> None:
+        self.ctx.folder_cache.setdefault(self.username, {})[file_dir] = {
+            "directory": file_dir,
+            "files": files,
+        }
+
+    def _set_search_count(self, file_dir: str, count: int) -> None:
+        """Populate search_dir_audio_count and search_cache so the pre-filter
+        actually consults the cached count for this dir."""
+        self.ctx.search_dir_audio_count = {
+            self.username: {file_dir: count},
+        }
+        self.ctx.search_cache = {
+            1: {
+                self.username: {
+                    "flac": [file_dir],
+                },
+            },
+        }
+
+    @staticmethod
+    def _matched(result: Any) -> bool:
+        return result.matched if hasattr(result, "matched") else result[0]
+
+    @staticmethod
+    def _candidates(result: Any) -> list[CandidateScore]:
+        if hasattr(result, "candidates"):
+            return result.candidates
+        return result[3]
+
+    def test_search_count_equals_track_num_passes_prefilter(self) -> None:
+        """Happy path: search_count=4, track_num=4 — passes pre-filter,
+        browse + score proceeds, dir matches."""
+        self._set_search_count("dirA", 4)
+        self._set_browse("dirA", self.full_files)
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+
+        self.assertTrue(self._matched(result))
+        self.assertNotIn(
+            (self.username, "dirA", 4, "flac"),
+            self.ctx.negative_matches,
+        )
+
+    def test_track_fallback_search_count_one_passes_prefilter(self) -> None:
+        """The bug fix: track-fallback queries return one file but the album
+        has many tracks. Under the old `abs() > 2` rule this was skipped;
+        under the new `2n` rule it must reach the browse + score path."""
+        self._set_search_count("dirA", 1)
+        # Files match the full album — the dir on the peer IS the album,
+        # the search response just only had one file in it.
+        self._set_browse("dirA", self.full_files)
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+
+        self.assertTrue(self._matched(result))
+        self.assertNotIn(
+            (self.username, "dirA", 4, "flac"),
+            self.ctx.negative_matches,
+        )
+
+    def test_search_count_at_2n_boundary_passes_prefilter(self) -> None:
+        """Boundary: search_count=8, track_num=4 — `8 > 8` is false, so the
+        pre-filter does NOT skip. The dir is browsed; the post-browse strict
+        -count gate at line 451 then writes its own negative_matches entry
+        because 8 != 4. We verify the pre-filter passed by checking that
+        a CandidateScore was recorded (pre-filter skips produce zero
+        candidates; the strict-count gate produces a cheap one)."""
+        self._set_search_count("dirA", 8)
+        # Dir actually contains the 4 tracks plus 4 extras — the post-browse
+        # strict-count gate will fail (8 != 4), but the pre-filter must pass.
+        self._set_browse("dirA", self.full_files + [
+            _file("Bonus1.flac"),
+            _file("Bonus2.flac"),
+            _file("Bonus3.flac"),
+            _file("Bonus4.flac"),
+        ])
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+
+        # Pre-filter did NOT skip — at least one candidate was recorded.
+        # (A pre-filter skip produces zero candidates per
+        # test_search_count_just_over_2n_is_skipped.)
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        # The candidate is the cheap one from the strict-count gate
+        # (file_count=8 != track_num=4 → matched_tracks=0).
+        self.assertEqual(candidates[0].file_count, 8)
+        self.assertEqual(candidates[0].matched_tracks, 0)
+
+    def test_search_count_just_over_2n_is_skipped(self) -> None:
+        """Edge case: search_count=9, track_num=4 — `9 > 8`, dir is skipped,
+        negative-cache entry written, no candidates recorded."""
+        self._set_search_count("dirA", 9)
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+
+        self.assertFalse(self._matched(result))
+        self.assertEqual(self._candidates(result), [])
+        self.assertIn(
+            (self.username, "dirA", 4, "flac"),
+            self.ctx.negative_matches,
+        )
+        # Pre-filter rejected without ever browsing this user.
+        self.assertNotIn(self.username, self.ctx.folder_cache)
+
+    def test_junk_dir_well_over_2n_is_skipped(self) -> None:
+        """Junk-dir case: search_count=50, track_num=4 — large dump folder.
+        Pre-filter must continue to catch this case."""
+        self._set_search_count("dirJunk", 50)
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirJunk"], self.username, self.ctx,
+        )
+
+        self.assertFalse(self._matched(result))
+        self.assertEqual(self._candidates(result), [])
+        self.assertIn(
+            (self.username, "dirJunk", 4, "flac"),
+            self.ctx.negative_matches,
+        )
+        self.assertNotIn(self.username, self.ctx.folder_cache)
+
+    def test_codec_guard_bypasses_prefilter_on_large_dir(self) -> None:
+        """Codec-guard case: search_count=50, track_num=4 BUT the dir is
+        present in the search_cache under multiple concrete codecs — the
+        `len(cached_codecs) <= 1` guard bypasses the pre-filter so the
+        multi-codec dir is browsed and scored."""
+        # Multi-codec presence: both "flac" and "mp3" tiers contain dirMulti.
+        self.ctx.search_dir_audio_count = {
+            self.username: {"dirMulti": 50},
+        }
+        self.ctx.search_cache = {
+            1: {
+                self.username: {
+                    "flac": ["dirMulti"],
+                    "mp3": ["dirMulti"],
+                },
+            },
+        }
+        self._set_browse("dirMulti", self.full_files)
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirMulti"], self.username, self.ctx,
+        )
+
+        # Pre-filter did NOT add a negative_matches entry — codec guard fired.
+        self.assertNotIn(
+            (self.username, "dirMulti", 4, "flac"),
+            self.ctx.negative_matches,
+        )
+        # And the dir was actually browsed + scored.
+        self.assertTrue(self._matched(result))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -421,7 +421,15 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
         )
 
         self.assertFalse(self._matched(result))
-        self.assertEqual(self._candidates(result), [])
+        # U2 of search-plan-entropy: pre-filter skips now emit a flagged
+        # sample CandidateScore for forensic visibility (one per skip up
+        # to ``PRE_FILTER_SKIP_SAMPLE_CAP``).
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0].pre_filter_skip)
+        self.assertEqual(candidates[0].file_count, 30)
+        self.assertEqual(candidates[0].matched_tracks, 0)
+        self.assertEqual(result.pre_filter_skip_count, 1)
         self.assertIn(
             (self.username, "dirLong", 2, "mp3 v0"),
             self.ctx.negative_matches,
@@ -742,7 +750,7 @@ class TestCheckForMatchAsymmetricPreFilter(unittest.TestCase):
 
     def test_search_count_just_over_2n_is_skipped(self) -> None:
         """Edge case: search_count=9, track_num=4 — `9 > 8`, dir is skipped,
-        negative-cache entry written, no candidates recorded."""
+        negative-cache entry written, U2 emits a flagged skip sample."""
         self._set_search_count("dirA", 9)
 
         result = check_for_match(
@@ -750,7 +758,14 @@ class TestCheckForMatchAsymmetricPreFilter(unittest.TestCase):
         )
 
         self.assertFalse(self._matched(result))
-        self.assertEqual(self._candidates(result), [])
+        # U2 of search-plan-entropy: pre-filter skip is recorded as both
+        # a scalar counter and a flagged sample CandidateScore row.
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0].pre_filter_skip)
+        self.assertEqual(candidates[0].file_count, 9)
+        self.assertEqual(candidates[0].matched_tracks, 0)
+        self.assertEqual(result.pre_filter_skip_count, 1)
         self.assertIn(
             (self.username, "dirA", 4, "flac"),
             self.ctx.negative_matches,
@@ -760,7 +775,7 @@ class TestCheckForMatchAsymmetricPreFilter(unittest.TestCase):
 
     def test_junk_dir_well_over_2n_is_skipped(self) -> None:
         """Junk-dir case: search_count=50, track_num=4 — large dump folder.
-        Pre-filter must continue to catch this case."""
+        Pre-filter must continue to catch this case (and U2 records it)."""
         self._set_search_count("dirJunk", 50)
 
         result = check_for_match(
@@ -768,7 +783,11 @@ class TestCheckForMatchAsymmetricPreFilter(unittest.TestCase):
         )
 
         self.assertFalse(self._matched(result))
-        self.assertEqual(self._candidates(result), [])
+        candidates = self._candidates(result)
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0].pre_filter_skip)
+        self.assertEqual(candidates[0].file_count, 50)
+        self.assertEqual(result.pre_filter_skip_count, 1)
         self.assertIn(
             (self.username, "dirJunk", 4, "flac"),
             self.ctx.negative_matches,
@@ -805,6 +824,159 @@ class TestCheckForMatchAsymmetricPreFilter(unittest.TestCase):
         )
         # And the dir was actually browsed + scored.
         self.assertTrue(self._matched(result))
+
+
+# ---------------------------------------------------------------------------
+# U2 of search-plan-entropy: pre-filter skip telemetry.
+#
+# Asserts the contract: ``check_for_match`` returns
+# ``MatchResult.pre_filter_skip_count`` as the authoritative scalar count
+# of dirs the asymmetric pre-filter rejected, and emits up to
+# ``PRE_FILTER_SKIP_SAMPLE_CAP`` flagged ``CandidateScore`` sample rows
+# inside the ``candidates`` list for forensic visibility.
+# ---------------------------------------------------------------------------
+
+class TestCheckForMatchPreFilterSkipTelemetry(unittest.TestCase):
+    """U2 contract: ``pre_filter_skip_count`` aggregates ALL skips,
+    sample rows are capped, and happy paths emit zero skip telemetry."""
+
+    def setUp(self) -> None:
+        self.cfg = _make_cfg()
+        self.ctx = _make_ctx(self.cfg, album_id=1, album_title="Cool Album")
+        self.username = "user1"
+        self.tracks = [
+            _track(1, "Alpha"),
+            _track(1, "Bravo"),
+            _track(1, "Charlie"),
+            _track(1, "Delta"),
+        ]
+        self.full_files = [
+            _file("Alpha.flac"),
+            _file("Bravo.flac"),
+            _file("Charlie.flac"),
+            _file("Delta.flac"),
+        ]
+
+    def _set_browse(self, file_dir: str, files: list[SlskdFile]) -> None:
+        self.ctx.folder_cache.setdefault(self.username, {})[file_dir] = {
+            "directory": file_dir,
+            "files": files,
+        }
+
+    def test_happy_path_no_skips_zero_count_no_samples(self) -> None:
+        """All dirs pass pre-filter → count=0, no flagged samples."""
+        # Single dir, search_count == track_num: passes pre-filter.
+        self.ctx.search_dir_audio_count = {self.username: {"dirA": 4}}
+        self.ctx.search_cache = {
+            1: {self.username: {"flac": ["dirA"]}},
+        }
+        self._set_browse("dirA", self.full_files)
+
+        result = check_for_match(
+            self.tracks, "flac", ["dirA"], self.username, self.ctx,
+        )
+
+        self.assertEqual(result.pre_filter_skip_count, 0)
+        # The one CandidateScore is from the post-browse match path,
+        # NOT a pre-filter skip sample.
+        self.assertEqual(len(result.candidates), 1)
+        self.assertFalse(result.candidates[0].pre_filter_skip)
+
+    def test_skip_count_above_sample_cap_truncates_samples(self) -> None:
+        """17 skipped dirs → count=17 but only ``PRE_FILTER_SKIP_SAMPLE_CAP``
+        flagged sample rows. The scalar count is authoritative, the
+        candidates list is bounded so the JSONB blob stays small even for
+        pathological junk-peer searches."""
+        from lib.matching import PRE_FILTER_SKIP_SAMPLE_CAP
+
+        # 17 dirs, all over the 2*track_num=8 threshold.
+        dir_names = [f"dir{i}" for i in range(17)]
+        self.ctx.search_dir_audio_count = {
+            self.username: {d: 100 for d in dir_names},
+        }
+        self.ctx.search_cache = {
+            1: {self.username: {"flac": dir_names}},
+        }
+
+        result = check_for_match(
+            self.tracks, "flac", dir_names, self.username, self.ctx,
+        )
+
+        self.assertFalse(result.matched)
+        # Authoritative count: every skip is counted exactly once.
+        self.assertEqual(result.pre_filter_skip_count, 17)
+        # Sample rows: bounded by the cap. All entries are flagged.
+        self.assertEqual(len(result.candidates), PRE_FILTER_SKIP_SAMPLE_CAP)
+        self.assertTrue(all(c.pre_filter_skip for c in result.candidates))
+        # Each sample row carries the cached file_count from the search
+        # response so operators can see the noisy peer's profile.
+        self.assertTrue(all(c.file_count == 100 for c in result.candidates))
+
+    def test_skip_count_exactly_at_cap_emits_all_samples(self) -> None:
+        """Exactly ``PRE_FILTER_SKIP_SAMPLE_CAP`` skips → count and samples
+        match. Boundary check that the cap is inclusive."""
+        from lib.matching import PRE_FILTER_SKIP_SAMPLE_CAP
+
+        dir_names = [f"dir{i}" for i in range(PRE_FILTER_SKIP_SAMPLE_CAP)]
+        self.ctx.search_dir_audio_count = {
+            self.username: {d: 100 for d in dir_names},
+        }
+        self.ctx.search_cache = {
+            1: {self.username: {"flac": dir_names}},
+        }
+
+        result = check_for_match(
+            self.tracks, "flac", dir_names, self.username, self.ctx,
+        )
+
+        self.assertEqual(result.pre_filter_skip_count, PRE_FILTER_SKIP_SAMPLE_CAP)
+        self.assertEqual(len(result.candidates), PRE_FILTER_SKIP_SAMPLE_CAP)
+        self.assertTrue(all(c.pre_filter_skip for c in result.candidates))
+
+
+class TestCandidateScorePreFilterRoundTrip(unittest.TestCase):
+    """Wire-boundary parity: a flagged ``CandidateScore`` survives msgspec
+    encode → decode. This is the regression guard for the JSONB blob.
+
+    Per ``.claude/rules/code-quality.md`` § Wire-boundary types: every
+    Struct field needs at least one RED-style assertion that it survives
+    the round-trip with the value the producer would have written.
+    """
+
+    def test_pre_filter_skip_true_survives_json_round_trip(self) -> None:
+        import msgspec
+
+        flagged = CandidateScore(
+            username="alice",
+            dir="Music/Albums/Foo",
+            filetype="flac",
+            matched_tracks=0,
+            total_tracks=12,
+            avg_ratio=0.0,
+            missing_titles=[],
+            file_count=200,
+            pre_filter_skip=True,
+        )
+        encoded = msgspec.json.encode(flagged)
+        decoded = msgspec.json.decode(encoded, type=CandidateScore)
+        self.assertTrue(decoded.pre_filter_skip)
+        self.assertEqual(decoded.file_count, 200)
+        self.assertEqual(decoded.username, "alice")
+
+    def test_pre_filter_skip_default_false_when_field_omitted(self) -> None:
+        """Historic JSONB blobs written before U2 do not carry the new
+        field. Decoding must tolerate the omission and default to False."""
+        import msgspec
+
+        # Legacy on-wire shape: no pre_filter_skip key.
+        legacy_json = (
+            b'{"username":"bob","dir":"x","filetype":"flac",'
+            b'"matched_tracks":4,"total_tracks":4,"avg_ratio":0.95,'
+            b'"missing_titles":[],"file_count":4}'
+        )
+        decoded = msgspec.json.decode(legacy_json, type=CandidateScore)
+        self.assertFalse(decoded.pre_filter_skip)
+        self.assertEqual(decoded.matched_tracks, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -1765,5 +1765,92 @@ class TestSearchLogPreFilterSkipCountSchema(unittest.TestCase):
         self.assertEqual(len(rows), 1)
 
 
+@requires_postgres
+class TestAlbumRequestsReleaseGroupYearSchema(unittest.TestCase):
+    """Migration 026 adds ``album_requests.release_group_year``
+    (INTEGER, NULL). U3 of search-plan-entropy / R9 (data layer). The
+    column is nullable because many requests have no
+    ``mb_release_group_id`` (legacy / Discogs / manual rows) — the
+    backfill skips those, the generator handles NULL gracefully.
+    """
+
+    def _query(self, sql: str, params: tuple = ()):
+        conn = psycopg2.connect(TEST_DSN)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+    def _exec(self, sql: str, params: tuple = ()):
+        conn = psycopg2.connect(TEST_DSN)
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+        finally:
+            conn.close()
+
+    def test_column_exists_nullable_with_no_default(self):
+        rows = self._query("""
+            SELECT column_name, is_nullable, column_default, data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'album_requests'
+              AND column_name = 'release_group_year'
+        """)
+        self.assertEqual(len(rows), 1)
+        col, is_nullable, default, dtype = rows[0]
+        self.assertEqual(col, "release_group_year")
+        self.assertEqual(is_nullable, "YES")
+        self.assertIsNone(default)
+        self.assertEqual(dtype, "integer")
+
+    def test_existing_row_defaults_to_null_on_insert_without_value(self):
+        rid = self._query("""
+            INSERT INTO album_requests (mb_release_id, artist_name, album_title, source)
+            VALUES ('rg-year-default-test', 'A', 'B', 'request')
+            RETURNING id
+        """)[0][0]
+        try:
+            rows = self._query(
+                "SELECT release_group_year FROM album_requests "
+                "WHERE id = %s",
+                (rid,),
+            )
+            self.assertIsNone(rows[0][0])
+        finally:
+            self._exec(
+                "DELETE FROM album_requests WHERE id = %s", (rid,),
+            )
+
+    def test_writable_when_explicitly_set(self):
+        rid = self._query("""
+            INSERT INTO album_requests (
+                mb_release_id, mb_release_group_id, artist_name,
+                album_title, source, release_group_year
+            )
+            VALUES ('rg-year-set-test', 'rg-test-uuid', 'A', 'B', 'request', 2000)
+            RETURNING id
+        """)[0][0]
+        try:
+            rows = self._query(
+                "SELECT release_group_year FROM album_requests "
+                "WHERE id = %s",
+                (rid,),
+            )
+            self.assertEqual(rows[0][0], 2000)
+        finally:
+            self._exec(
+                "DELETE FROM album_requests WHERE id = %s", (rid,),
+            )
+
+    def test_records_applied_version_026(self):
+        rows = self._query("""
+            SELECT version FROM schema_migrations
+            WHERE version = 26
+        """)
+        self.assertEqual(len(rows), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -1695,5 +1695,75 @@ class TestBackfillV0MetricFromMeasurementSchema(unittest.TestCase):
             self._cleanup_request(rid)
 
 
+class TestSearchLogPreFilterSkipCountSchema(unittest.TestCase):
+    """Migration 025 adds ``search_log.pre_filter_skip_count`` (NOT NULL,
+    default 0). U2 of search-plan-entropy. Pre-existing rows must default
+    to 0 because the data was never captured at the time, and we
+    intentionally do not backfill — forward-only by design.
+    """
+
+    def _query(self, sql: str, params: tuple = ()):
+        conn = psycopg2.connect(TEST_DSN)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+    def _exec(self, sql: str, params: tuple = ()):
+        conn = psycopg2.connect(TEST_DSN)
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+        finally:
+            conn.close()
+
+    def test_column_exists_with_default_zero(self):
+        rows = self._query("""
+            SELECT column_name, is_nullable, column_default, data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'search_log'
+              AND column_name = 'pre_filter_skip_count'
+        """)
+        self.assertEqual(len(rows), 1)
+        col, is_nullable, default, dtype = rows[0]
+        self.assertEqual(col, "pre_filter_skip_count")
+        self.assertEqual(is_nullable, "NO")
+        # Default is the SQL literal ``0``.
+        assert default is not None
+        self.assertIn("0", str(default))
+        self.assertEqual(dtype, "integer")
+
+    def test_existing_row_defaults_to_zero_on_insert_without_value(self):
+        rid = self._query("""
+            INSERT INTO album_requests (mb_release_id, artist_name, album_title, source)
+            VALUES ('pre-filter-skip-test', 'A', 'B', 'request')
+            RETURNING id
+        """)[0][0]
+        try:
+            self._exec("""
+                INSERT INTO search_log (request_id, query, outcome)
+                VALUES (%s, 'q', 'no_match')
+            """, (rid,))
+            rows = self._query(
+                "SELECT pre_filter_skip_count FROM search_log "
+                "WHERE request_id = %s",
+                (rid,),
+            )
+            self.assertEqual(rows[0][0], 0)
+        finally:
+            self._exec(
+                "DELETE FROM album_requests WHERE id = %s", (rid,),
+            )
+
+    def test_records_applied_version_025(self):
+        rows = self._query("""
+            SELECT version FROM schema_migrations
+            WHERE version = 25
+        """)
+        self.assertEqual(len(rows), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1979,6 +1979,148 @@ class TestCmdSearchPlanRegenerate(unittest.TestCase):
         self.assertEqual(active.plan.id, old_plan_id)
 
 
+class TestCmdSearchPlanDryRun(unittest.TestCase):
+    """U6: ``pipeline-cli search-plan dry-run`` wraps
+    ``SearchPlanService.dry_run_for_request`` — read-only generator
+    simulator. Mirrors the same exit-code convention as ``search-plan
+    show``: success = 0, request_not_found = 2.
+    """
+
+    def _seed_request(
+        self, *, status: str = "wanted",
+        artist: str = "Radiohead", title: str = "Kid A",
+        year: int = 2008, release_group_year: int | None = 2000,
+        tracks: list[dict] | None = None,
+    ):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name=artist, album_title=title,
+            source="request", year=year, status=status,
+        )
+        if release_group_year is not None:
+            db._requests[rid]["release_group_year"] = release_group_year
+        if tracks is None:
+            tracks = [
+                {"track_number": 1, "title": "Everything In Its Right Place"},
+                {"track_number": 2, "title": "Kid A"},
+                {"track_number": 3, "title": "The National Anthem"},
+            ]
+        if tracks:
+            db.set_tracks(rid, tracks)
+        return db, rid
+
+    def _run(self, db, rid, *, json_out: bool = False, prepend: bool = False):
+        args = SimpleNamespace(
+            id=rid, json=json_out, prepend_artist=prepend)
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            with patch("lib.config.read_runtime_config") as mock_cfg:
+                from lib.config import CratediggerConfig
+                import configparser
+                cp = configparser.RawConfigParser()
+                cp.read_string("[General]\n")
+                mock_cfg.return_value = CratediggerConfig.from_ini(cp)
+                rc = pipeline_cli.cmd_search_plan_dry_run(db, args)
+        return rc, stdout.getvalue()
+
+    def test_dry_run_happy_path_prints_plan_items_without_persisting(self):
+        db, rid = self._seed_request()
+        plans_before = len(db.search_plans)
+        items_before = len(db.search_plan_items)
+        rc, out = self._run(db, rid)
+        self.assertEqual(rc, 0)
+        self.assertIn("Outcome:", out)
+        self.assertIn("success", out)
+        self.assertIn("Plan items", out)
+        # Persistence invariant: dry-run never writes plan rows.
+        self.assertEqual(len(db.search_plans), plans_before)
+        self.assertEqual(len(db.search_plan_items), items_before)
+        # Request row's active_plan_id is untouched.
+        self.assertIsNone(db._requests[rid]["active_plan_id"])
+
+    def test_dry_run_json_returns_full_payload(self):
+        db, rid = self._seed_request()
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        for key in ("request_id", "outcome", "current_generator_id",
+                    "request", "plan", "would_supersede_active",
+                    "error_message"):
+            self.assertIn(key, payload)
+        self.assertEqual(payload["request_id"], rid)
+        self.assertEqual(payload["outcome"], "success")
+        self.assertIsNotNone(payload["plan"])
+        # release_group_year reflected in request payload (U5 input).
+        self.assertEqual(
+            payload["request"]["release_group_year"], 2000)
+        # Plan items shape is the documented contract.
+        self.assertGreater(len(payload["plan"]["items"]), 0)
+        item = payload["plan"]["items"][0]
+        for key in ("ordinal", "strategy", "query",
+                    "canonical_query_key", "repeat_group", "provenance"):
+            self.assertIn(key, item)
+
+    def test_dry_run_missing_request_returns_2(self):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        rc, out = self._run(db, 9999)
+        self.assertEqual(rc, 2)
+        self.assertIn("request_not_found", out)
+
+    def test_dry_run_missing_request_json_is_structured(self):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        rc, out = self._run(db, 9999, json_out=True)
+        self.assertEqual(rc, 2)
+        payload = json.loads(out)
+        self.assertEqual(payload["outcome"], "request_not_found")
+        self.assertEqual(payload["request_id"], 9999)
+        self.assertIsNone(payload["plan"])
+        self.assertIsNone(payload["request"])
+
+    def test_dry_run_request_with_no_tracks_succeeds_no_track_slots(self):
+        db, rid = self._seed_request(tracks=[])
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["outcome"], "success")
+        # No track-fallback slots when the request has zero tracks.
+        strategies = [
+            it["strategy"] for it in payload["plan"]["items"]
+        ]
+        self.assertFalse(
+            any(s.startswith("track_") for s in strategies),
+            f"unexpected track slots: {strategies}")
+
+    def test_dry_run_flags_active_plan_would_be_superseded(self):
+        from lib.pipeline_db import SearchPlanItemInput
+        from lib.search import SEARCH_PLAN_GENERATOR_ID
+        db, rid = self._seed_request()
+        db.create_successful_search_plan(
+            request_id=rid, generator_id=SEARCH_PLAN_GENERATOR_ID,
+            items=[SearchPlanItemInput(
+                ordinal=0, strategy="default", query="prior",
+                canonical_query_key="k0")],
+            set_active=True,
+        )
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertTrue(payload["would_supersede_active"])
+
+    def test_dry_run_uses_current_generator_id(self):
+        from lib.search import SEARCH_PLAN_GENERATOR_ID
+        db, rid = self._seed_request()
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(
+            payload["current_generator_id"], SEARCH_PLAN_GENERATOR_ID)
+        self.assertEqual(
+            payload["plan"]["generator_id"], SEARCH_PLAN_GENERATOR_ID)
+
+
 class TestStaleCompletionRacingRegeneration(unittest.TestCase):
     """U8: a stale plan-A completion arriving after regeneration must
     log against plan A but never advance plan B's cursor. Integration

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -6,6 +6,7 @@ import os
 import sys
 import tempfile
 import unittest
+import urllib.error
 from contextlib import redirect_stderr, redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -99,6 +100,67 @@ class TestCmdAdd(unittest.TestCase):
         args = MagicMock(mbid="44438bf9-26d9-4460-9b4f-1a1b015e37a1", source="request")
         pipeline_cli.cmd_add(self.db, args)
         mock_fetch.assert_not_called()
+
+    @patch("scripts.pipeline_cli.fetch_mb_release_group_year")
+    @patch("scripts.pipeline_cli.fetch_mb_release")
+    def test_add_with_mbid_persists_release_group_year_reissue(
+        self, mock_fetch, mock_fetch_rgy,
+    ):
+        """U4: reissue MB release → release_group_year populated and
+        differs from the per-release year."""
+        mock_fetch.return_value = SAMPLE_MB_RELEASE  # date=2014, rg=rg-uuid
+        mock_fetch_rgy.return_value = 2008
+        args = MagicMock(
+            mbid="44438bf9-26d9-4460-9b4f-1a1b015e37a1", source="request",
+        )
+        pipeline_cli.cmd_add(self.db, args)
+
+        req = self.db.get_request_by_mb_release_id(
+            "44438bf9-26d9-4460-9b4f-1a1b015e37a1")
+        assert req is not None
+        self.assertEqual(req["year"], 2014)
+        self.assertEqual(req["release_group_year"], 2008)
+        mock_fetch_rgy.assert_called_once_with("rg-uuid")
+
+    @patch("scripts.pipeline_cli.fetch_mb_release_group_year")
+    @patch("scripts.pipeline_cli.fetch_mb_release")
+    def test_add_with_mbid_persists_release_group_year_original(
+        self, mock_fetch, mock_fetch_rgy,
+    ):
+        """U4: original release MB release → release_group_year matches
+        the per-release year."""
+        mock_fetch.return_value = SAMPLE_MB_RELEASE  # date=2014
+        mock_fetch_rgy.return_value = 2014
+        args = MagicMock(
+            mbid="44438bf9-26d9-4460-9b4f-1a1b015e37a1", source="request",
+        )
+        pipeline_cli.cmd_add(self.db, args)
+
+        req = self.db.get_request_by_mb_release_id(
+            "44438bf9-26d9-4460-9b4f-1a1b015e37a1")
+        assert req is not None
+        self.assertEqual(req["year"], 2014)
+        self.assertEqual(req["release_group_year"], 2014)
+
+    @patch("scripts.pipeline_cli.fetch_mb_release_group_year")
+    @patch("scripts.pipeline_cli.fetch_mb_release")
+    def test_add_with_mbid_release_group_404_leaves_column_null(
+        self, mock_fetch, mock_fetch_rgy,
+    ):
+        """U4: 404 / missing release-group → ``release_group_year`` is
+        NULL on the new row, no error raised."""
+        mock_fetch.return_value = SAMPLE_MB_RELEASE
+        mock_fetch_rgy.return_value = None
+        args = MagicMock(
+            mbid="44438bf9-26d9-4460-9b4f-1a1b015e37a1", source="request",
+        )
+        pipeline_cli.cmd_add(self.db, args)
+
+        req = self.db.get_request_by_mb_release_id(
+            "44438bf9-26d9-4460-9b4f-1a1b015e37a1")
+        assert req is not None
+        self.assertEqual(req["year"], 2014)
+        self.assertIsNone(req["release_group_year"])
 
 
 class TestCmdAddPlanGenerationFakeDB(unittest.TestCase):
@@ -2392,6 +2454,78 @@ class TestCmdSearchPlanHistory(unittest.TestCase):
         self.assertIn("request_id", payload)
         self.assertIn("rows", payload)
         self.assertIn("next_before_id", payload)
+
+
+class TestFetchMbReleaseGroupYear(unittest.TestCase):
+    """U4 pure-function coverage of the MB release-group-year client.
+
+    Mirrors the contract of ``web/mb.py::get_release_group_year``: 404
+    → None, unparseable / missing date → None, otherwise the 4-digit
+    year prefix as an int.
+    """
+
+    def _fake_urlopen(self, payload: dict):
+        """Build a context-manager fake whose ``read()`` returns
+        ``json.dumps(payload).encode()``."""
+
+        class _Resp:
+            def __init__(self, body: bytes) -> None:
+                self._body = body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return self._body
+
+        return lambda req, timeout=15: _Resp(json.dumps(payload).encode())
+
+    @patch("scripts.pipeline_cli.urllib.request.urlopen")
+    def test_returns_year_from_first_release_date(self, mock_urlopen):
+        mock_urlopen.side_effect = self._fake_urlopen(
+            {"first-release-date": "2000-10-02"})
+        self.assertEqual(
+            pipeline_cli.fetch_mb_release_group_year("rg-x"), 2000)
+
+    @patch("scripts.pipeline_cli.urllib.request.urlopen")
+    def test_returns_none_when_date_missing(self, mock_urlopen):
+        mock_urlopen.side_effect = self._fake_urlopen({})
+        self.assertIsNone(
+            pipeline_cli.fetch_mb_release_group_year("rg-x"))
+
+    @patch("scripts.pipeline_cli.urllib.request.urlopen")
+    def test_returns_none_when_date_short(self, mock_urlopen):
+        mock_urlopen.side_effect = self._fake_urlopen(
+            {"first-release-date": "200"})
+        self.assertIsNone(
+            pipeline_cli.fetch_mb_release_group_year("rg-x"))
+
+    @patch("scripts.pipeline_cli.urllib.request.urlopen")
+    def test_returns_none_on_404(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "http://mb/x", 404, "Not Found", {}, None,  # type: ignore[arg-type]
+        )
+        self.assertIsNone(
+            pipeline_cli.fetch_mb_release_group_year("rg-x"))
+
+    @patch("scripts.pipeline_cli.urllib.request.urlopen")
+    def test_returns_none_on_other_http_error(self, mock_urlopen):
+        """500/503/etc. also fall back to None — caller persists NULL
+        rather than blocking the add."""
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "http://mb/x", 503, "Service Unavailable", {}, None,  # type: ignore[arg-type]
+        )
+        self.assertIsNone(
+            pipeline_cli.fetch_mb_release_group_year("rg-x"))
+
+    @patch("scripts.pipeline_cli.urllib.request.urlopen")
+    def test_returns_none_on_url_error(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+        self.assertIsNone(
+            pipeline_cli.fetch_mb_release_group_year("rg-x"))
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2121,6 +2121,123 @@ class TestCmdSearchPlanDryRun(unittest.TestCase):
             payload["plan"]["generator_id"], SEARCH_PLAN_GENERATOR_ID)
 
 
+class TestCmdSearchPlanSaturation(unittest.TestCase):
+    """U7: ``pipeline-cli search-plan saturation`` wraps
+    ``SearchPlanService.saturation_for_request``. Exit-code convention:
+    success = 0 (even when window is empty — found-but-quiet is still
+    success), request_not_found = 2, input_invalid = 3.
+    """
+
+    def _seed(self, *, rid: int = 1):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=rid, artist_name="Radiohead", album_title="Kid A",
+            source="request",
+        ))
+        return db, rid
+
+    def _run(self, db, rid, *, json_out: bool = False,
+             window_days: int | None = None):
+        args = SimpleNamespace(
+            id=rid, json=json_out, window_days=window_days)
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            with patch("lib.config.read_runtime_config") as mock_cfg:
+                from lib.config import CratediggerConfig
+                import configparser
+                cp = configparser.RawConfigParser()
+                cp.read_string("[General]\n")
+                mock_cfg.return_value = CratediggerConfig.from_ini(cp)
+                rc = pipeline_cli.cmd_search_plan_saturation(db, args)
+        return rc, stdout.getvalue()
+
+    def test_happy_path_prints_human_summary(self):
+        db, rid = self._seed()
+        for i in range(10):
+            final_state = (
+                "Completed, ResponseLimitReached" if i < 3
+                else "Completed")
+            db.log_search(request_id=rid, query=f"q{i}",
+                          outcome="found", final_state=final_state,
+                          pre_filter_skip_count=4)
+        rc, out = self._run(db, rid)
+        self.assertEqual(rc, 0)
+        self.assertIn("Outcome:", out)
+        self.assertIn("success", out)
+        self.assertIn("Total searches:", out)
+        self.assertIn("10", out)
+        self.assertIn("Saturated searches:", out)
+        self.assertIn("Saturation rate:", out)
+        # Pre-filter skip total surfaces in human view.
+        self.assertIn("Pre-filter skips total:", out)
+        self.assertIn("40", out)
+
+    def test_json_returns_full_payload(self):
+        db, rid = self._seed()
+        db.log_search(request_id=rid, query="q",
+                      outcome="found",
+                      final_state="Completed, FileLimitReached",
+                      pre_filter_skip_count=3)
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        for key in ("request_id", "outcome", "total_searches",
+                    "saturated_searches", "saturation_rate",
+                    "total_pre_filter_skips", "window_days",
+                    "error_message"):
+            self.assertIn(key, payload)
+        self.assertEqual(payload["request_id"], rid)
+        self.assertEqual(payload["outcome"], "success")
+        self.assertEqual(payload["total_searches"], 1)
+        self.assertEqual(payload["saturated_searches"], 1)
+        self.assertEqual(payload["saturation_rate"], 1.0)
+        self.assertEqual(payload["total_pre_filter_skips"], 3)
+        self.assertEqual(payload["window_days"], 14)
+
+    def test_empty_window_exits_0_with_zeros(self):
+        # Found-but-quiet — exit 0, all zeros, NOT 404.
+        db, rid = self._seed()
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["outcome"], "success")
+        self.assertEqual(payload["total_searches"], 0)
+        self.assertEqual(payload["saturation_rate"], 0.0)
+
+    def test_missing_request_returns_2(self):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        rc, out = self._run(db, 9999)
+        self.assertEqual(rc, 2)
+        self.assertIn("request_not_found", out)
+
+    def test_missing_request_json_is_structured(self):
+        from tests.fakes import FakePipelineDB
+        db = FakePipelineDB()
+        rc, out = self._run(db, 9999, json_out=True)
+        self.assertEqual(rc, 2)
+        payload = json.loads(out)
+        self.assertEqual(payload["outcome"], "request_not_found")
+        # All summary fields zero-filled so clients can read without
+        # branching on outcome.
+        self.assertEqual(payload["total_searches"], 0)
+        self.assertEqual(payload["saturation_rate"], 0.0)
+
+    def test_invalid_window_days_returns_3(self):
+        db, rid = self._seed()
+        rc, out = self._run(db, rid, window_days=0)
+        self.assertEqual(rc, 3)
+        self.assertIn("input_invalid", out)
+
+    def test_window_days_default_is_14(self):
+        db, rid = self._seed()
+        rc, out = self._run(db, rid, json_out=True)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["window_days"], 14)
+
+
 class TestStaleCompletionRacingRegeneration(unittest.TestCase):
     """U8: a stale plan-A completion arriving after regeneration must
     log against plan A but never advance plan B's cursor. Integration

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -2509,6 +2509,86 @@ class TestClearOnDiskQualityFields(unittest.TestCase):
 
 
 @requires_postgres
+class TestReleaseGroupYearColumn(unittest.TestCase):
+    """U3 / R9 — ``album_requests.release_group_year`` column wiring.
+
+    The migration is verified in ``tests/test_migrator.py``. These tests
+    cover ``PipelineDB.set_release_group_year`` and
+    ``get_requests_missing_release_group_year`` against real PostgreSQL.
+    """
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_get_request_round_trips_release_group_year(self):
+        rid = self.db.add_request(
+            mb_release_id="rg-year-roundtrip",
+            mb_release_group_id="rg-uuid-1",
+            artist_name="A", album_title="B", source="request",
+        )
+        req = self.db.get_request(rid)
+        assert req is not None
+        # Default is NULL — the column has no default in the migration.
+        self.assertIsNone(req["release_group_year"])
+
+        self.db.set_release_group_year(rid, 2000)
+        req2 = self.db.get_request(rid)
+        assert req2 is not None
+        self.assertEqual(req2["release_group_year"], 2000)
+
+    def test_set_to_none_clears_the_column(self):
+        rid = self.db.add_request(
+            mb_release_id="rg-year-clear",
+            mb_release_group_id="rg-uuid-clear",
+            artist_name="A", album_title="B", source="request",
+        )
+        self.db.set_release_group_year(rid, 1980)
+        self.db.set_release_group_year(rid, None)
+        req = self.db.get_request(rid)
+        assert req is not None
+        self.assertIsNone(req["release_group_year"])
+
+    def test_get_requests_missing_release_group_year_filters_correctly(self):
+        # Has RG, no year → returned.
+        needs = self.db.add_request(
+            mb_release_id="needs-year",
+            mb_release_group_id="rg-needs",
+            artist_name="A", album_title="B", source="request",
+        )
+        # Has RG and year → excluded.
+        has = self.db.add_request(
+            mb_release_id="has-year",
+            mb_release_group_id="rg-has",
+            artist_name="A", album_title="B", source="request",
+        )
+        self.db.set_release_group_year(has, 1999)
+        # No RG → excluded (the generator's RG slot wouldn't fire either).
+        no_rg = self.db.add_request(
+            discogs_release_id="555",
+            artist_name="A", album_title="B", source="request",
+        )
+
+        rows = self.db.get_requests_missing_release_group_year()
+        ids = {r["id"] for r in rows}
+        self.assertIn(needs, ids)
+        self.assertNotIn(has, ids)
+        self.assertNotIn(no_rg, ids)
+
+    def test_missing_year_query_respects_limit(self):
+        for i in range(5):
+            self.db.add_request(
+                mb_release_id=f"rg-limit-{i}",
+                mb_release_group_id=f"rg-limit-uuid-{i}",
+                artist_name="A", album_title="B", source="request",
+            )
+        rows = self.db.get_requests_missing_release_group_year(limit=2)
+        self.assertEqual(len(rows), 2)
+
+
+@requires_postgres
 class TestApplyTransitionDB(unittest.TestCase):
     """DB-backed contract tests for apply_transition preserve semantics."""
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1476,6 +1476,137 @@ class TestSearchLog(unittest.TestCase):
 
 
 @requires_postgres
+class TestGetSaturationSummary(unittest.TestCase):
+    """U7: ``PipelineDB.get_saturation_summary`` aggregates one request's
+    search_log rows in the recent window. Saturation = rows whose
+    ``final_state`` matches ``%LimitReached%`` (slskd hit response /
+    file ceiling). ``total_pre_filter_skips`` rolls up the U2 column.
+
+    ``saturation_rate`` is computed in Python so the explicit ``0.0``
+    fallback survives the empty-window case (NaN would break JSON
+    serialisation downstream).
+    """
+
+    def setUp(self):
+        self.db = make_db()
+        self.req_id = self.db.add_request(
+            mb_release_id="saturation-uuid",
+            artist_name="A", album_title="B", source="request",
+        )
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_empty_request_returns_zeros(self):
+        summary = self.db.get_saturation_summary(self.req_id, window_days=14)
+        self.assertEqual(summary.total_searches, 0)
+        self.assertEqual(summary.saturated_searches, 0)
+        # Critical invariant: 0.0, not NaN.
+        self.assertEqual(summary.saturation_rate, 0.0)
+        self.assertEqual(summary.total_pre_filter_skips, 0)
+        self.assertEqual(summary.window_days, 14)
+
+    def test_counts_only_saturated_final_states(self):
+        # Only rows whose final_state contains "LimitReached" count
+        # as saturated. The slskd state strings are comma-joined so
+        # the match must be a substring, not equality.
+        for state in (
+            "Completed, ResponseLimitReached",
+            "Completed, FileLimitReached",
+            "Completed",  # not saturated
+            "Cancelled",  # not saturated
+            None,         # not saturated
+        ):
+            self.db.log_search(
+                request_id=self.req_id, query="q", outcome="found",
+                final_state=state,
+            )
+        summary = self.db.get_saturation_summary(self.req_id, window_days=14)
+        self.assertEqual(summary.total_searches, 5)
+        self.assertEqual(summary.saturated_searches, 2)
+        self.assertAlmostEqual(summary.saturation_rate, 2 / 5)
+
+    def test_sums_pre_filter_skip_count(self):
+        for skip in (4, 1, 0, 8):
+            self.db.log_search(
+                request_id=self.req_id, query="q", outcome="found",
+                final_state="Completed", pre_filter_skip_count=skip,
+            )
+        summary = self.db.get_saturation_summary(self.req_id, window_days=14)
+        self.assertEqual(summary.total_searches, 4)
+        self.assertEqual(summary.saturated_searches, 0)
+        self.assertEqual(summary.total_pre_filter_skips, 13)
+
+    def test_window_days_filters_old_rows(self):
+        # Insert two recent rows, then backdate a third via direct SQL
+        # so we can test the window cut without sleeping.
+        self.db.log_search(
+            request_id=self.req_id, query="recent_a",
+            outcome="found",
+            final_state="Completed, ResponseLimitReached",
+            pre_filter_skip_count=2,
+        )
+        self.db.log_search(
+            request_id=self.req_id, query="recent_b",
+            outcome="found", final_state="Completed",
+            pre_filter_skip_count=1,
+        )
+        self.db.log_search(
+            request_id=self.req_id, query="old",
+            outcome="found",
+            final_state="Completed, FileLimitReached",
+            pre_filter_skip_count=10,
+        )
+        # Backdate the most recent row 10 days into the past.
+        self.db._execute(
+            "UPDATE search_log SET created_at = NOW() - INTERVAL '10 days' "
+            "WHERE query = %s",
+            ("old",),
+        )
+        # 7-day window: old row out, two recent rows in.
+        seven = self.db.get_saturation_summary(self.req_id, window_days=7)
+        self.assertEqual(seven.total_searches, 2)
+        self.assertEqual(seven.saturated_searches, 1)
+        self.assertEqual(seven.total_pre_filter_skips, 3)
+        self.assertEqual(seven.window_days, 7)
+        # 14-day window: all three rows are in scope.
+        fourteen = self.db.get_saturation_summary(
+            self.req_id, window_days=14)
+        self.assertEqual(fourteen.total_searches, 3)
+        self.assertEqual(fourteen.saturated_searches, 2)
+        self.assertEqual(fourteen.total_pre_filter_skips, 13)
+
+    def test_isolates_by_request_id(self):
+        # Rows for a different request must not bleed into this
+        # request's saturation roll-up.
+        other = self.db.add_request(
+            mb_release_id="other-uuid",
+            artist_name="X", album_title="Y", source="request",
+        )
+        self.db.log_search(
+            request_id=other, query="other",
+            outcome="found",
+            final_state="Completed, ResponseLimitReached",
+            pre_filter_skip_count=99,
+        )
+        self.db.log_search(
+            request_id=self.req_id, query="mine",
+            outcome="found", final_state="Completed",
+            pre_filter_skip_count=2,
+        )
+        summary = self.db.get_saturation_summary(self.req_id, window_days=14)
+        self.assertEqual(summary.total_searches, 1)
+        self.assertEqual(summary.saturated_searches, 0)
+        self.assertEqual(summary.total_pre_filter_skips, 2)
+
+    def test_window_days_echoes_back(self):
+        # The summary echoes window_days so callers don't have to
+        # remember what they asked for.
+        summary = self.db.get_saturation_summary(self.req_id, window_days=30)
+        self.assertEqual(summary.window_days, 30)
+
+
+@requires_postgres
 class TestGetSearchHistoryPage(unittest.TestCase):
     """U1: cursor-style pagination for ``GET /search-plan/history``.
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1433,6 +1433,26 @@ class TestSearchLog(unittest.TestCase):
         self.assertEqual(history[0]["variant"], "v1_year")
         self.assertEqual(history[0]["final_state"], "TimedOut")
 
+    def test_log_search_persists_pre_filter_skip_count(self):
+        """U2 of search-plan-entropy: ``pre_filter_skip_count`` writes to
+        the dedicated column. NOT NULL with default 0; this asserts the
+        explicit non-zero path actually round-trips, AND that omitting
+        the kwarg defaults to 0 in the persisted row."""
+        # Explicit non-zero round-trip.
+        self.db.log_search(
+            request_id=self.req_id, query="q", outcome="no_match",
+            candidates=None, pre_filter_skip_count=42,
+        )
+        # Default (kwarg omitted) writes 0.
+        self.db.log_search(
+            request_id=self.req_id, query="q2", outcome="found",
+            candidates=None,
+        )
+        history = self.db.get_search_history(self.req_id)
+        # history is newest-first; index 0 == second insert (default).
+        self.assertEqual(history[0]["pre_filter_skip_count"], 0)
+        self.assertEqual(history[1]["pre_filter_skip_count"], 42)
+
     def test_log_search_candidates_decode_rejects_wrong_type(self):
         """Wire-boundary regression: msgspec.convert raises on type drift.
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -809,22 +809,27 @@ class TestSelectVariant(unittest.TestCase):
                 self.assertEqual(v.slice_index, idx)
 
 class TestGenerateSearchPlan(unittest.TestCase):
-    """Pure search-plan generator (U2 — persisted search plans).
+    """Pure search-plan generator (U5 of search-plan-entropy).
 
     Asserts full plan output, strategy ordering, canonical query keys,
     repeat groups, omitted candidates, dedupe provenance, low-entropy
-    drop recording, generation-failure path, and the generator id
-    constant.
+    drop recording, generation-failure path, self-titled mix, the
+    conditional release-group-year slot, and the generator id constant.
     """
 
-    WIGGLES_TITLES = (
-        "Get Ready to Wiggle",
-        "Rock-A-Bye Your Bear",
-        "Dorothy the Dinosaur",
-        "Mischief the Monkey",
+    KID_A_TITLES = (
+        "Everything in Its Right Place",
+        "Kid A",
+        "The National Anthem",
+        "How to Disappear Completely",
+        "Treefingers",
+        "Optimistic",
     )
 
     def _cfg(self, threshold: int = 5, max_track_slots: int = 3) -> SearchPlanConfig:
+        # ``escalation_threshold`` is preserved on SearchPlanConfig for
+        # backwards-compat but U5 collapsed default repetition to a single
+        # slot; the threshold value no longer affects slot count.
         return SearchPlanConfig(
             escalation_threshold=threshold,
             max_track_slots=max_track_slots,
@@ -833,12 +838,13 @@ class TestGenerateSearchPlan(unittest.TestCase):
     def _snapshot(
         self,
         *,
-        artist: str = "The Wiggles",
-        title: str = "The Wiggles",
-        year: str | None = "1991",
-        track_titles: tuple[str, ...] = WIGGLES_TITLES,
+        artist: str = "Radiohead",
+        title: str = "Kid A",
+        year: str | None = "2008",
+        track_titles: tuple[str, ...] = KID_A_TITLES,
         redownload: bool = False,
         prepend_artist: bool = True,
+        release_group_year: int | None = 2000,
     ) -> ReleaseSnapshot:
         return ReleaseSnapshot(
             artist_name=artist,
@@ -847,118 +853,354 @@ class TestGenerateSearchPlan(unittest.TestCase):
             track_titles=track_titles,
             redownload=redownload,
             prepend_artist=prepend_artist,
+            release_group_year=release_group_year,
         )
 
-    # --- happy path: typical multi-track release with year -----------------
+    # --- happy path: typical multi-track release with year + rg_year ---
 
     def test_typical_release_emits_full_ladder(self):
-        plan = generate_search_plan(self._snapshot(), self._cfg(threshold=5))
+        plan = generate_search_plan(self._snapshot(), self._cfg())
 
         self.assertIsInstance(plan, SearchPlan)
         self.assertEqual(plan.status, PLAN_STATUS_SUCCESS)
         self.assertIsNone(plan.failure_reason)
         self.assertEqual(plan.generator_id, SEARCH_PLAN_GENERATOR_ID)
 
-        # 5 default + 1 unwild + 1 unwild_year + 3 track = 10 slots
-        self.assertEqual(len(plan.items), 10)
-
-        # Slot ordering and strategies
+        # 1 default + 1 literal + 1 literal_flac + 1 literal_lossless
+        # + 1 unwild_year + 1 unwild_rg_year + 3 track = 9 slots
         strategies = [it.strategy for it in plan.items]
         self.assertEqual(strategies, [
-            "default", "default", "default", "default", "default",
-            "unwild",
+            "default",
+            "literal",
+            "literal_flac",
+            "literal_lossless",
             "unwild_year",
-            "track_0", "track_1", "track_2",
+            "unwild_rg_year",
+            "track_0_artist",
+            "track_1_artist",
+            "track_2_artist",
         ])
 
-        # Ordinals are 0..9 contiguous
-        self.assertEqual([it.ordinal for it in plan.items], list(range(10)))
-
-        # Default repeats share repeat group; non-defaults have own group
+        # Ordinals contiguous from 0
         self.assertEqual(
-            [it.repeat_group for it in plan.items[:5]],
-            ["default"] * 5,
+            [it.ordinal for it in plan.items],
+            list(range(len(plan.items))),
         )
-        self.assertEqual(plan.items[5].repeat_group, "unwild")
-        self.assertEqual(plan.items[6].repeat_group, "unwild_year")
-        self.assertEqual(plan.items[7].repeat_group, "track_0")
 
-        # All items have non-empty queries and canonical keys
+        # Repeat group equals strategy for every non-default slot, and
+        # each slot's repeat group is its own (no more shared default
+        # repeat group).
+        for it in plan.items:
+            self.assertEqual(it.repeat_group, it.strategy)
+
+        # All items runnable + canonical keys consistent.
         for it in plan.items:
             self.assertTrue(it.query)
-            self.assertEqual(it.canonical_query_key, " ".join(it.query.lower().split()))
+            self.assertEqual(
+                it.canonical_query_key,
+                " ".join(it.query.lower().split()),
+            )
 
-        # Repeated-default queries are identical and share canonical key
-        default_keys = {it.canonical_query_key for it in plan.items[:5]}
-        self.assertEqual(len(default_keys), 1)
+        # Concrete query shapes for Radiohead / Kid A / 2008 / rg=2000.
+        by_strategy = {it.strategy: it.query for it in plan.items}
+        self.assertEqual(by_strategy["default"], "*adiohead Kid A")
+        self.assertEqual(by_strategy["literal"], "Radiohead Kid A")
+        self.assertEqual(by_strategy["literal_flac"], "Radiohead Kid A FLAC")
+        self.assertEqual(
+            by_strategy["literal_lossless"], "Radiohead Kid A lossless",
+        )
+        self.assertEqual(by_strategy["unwild_year"], "Radiohead Kid A 2008")
+        self.assertEqual(by_strategy["unwild_rg_year"], "Radiohead Kid A 2000")
+        # Artist-prepended track slots — wildcarded artist token.
+        self.assertTrue(
+            by_strategy["track_0_artist"].startswith("*adiohead "),
+            by_strategy["track_0_artist"],
+        )
 
-        # Default = wildcarded base; unwild = un-wildcarded.
-        self.assertEqual(plan.items[0].query, "*iggles")
-        self.assertEqual(plan.items[5].query, "Wiggles")
-        self.assertEqual(plan.items[6].query, "Wiggles 1991")
-
-    def test_repeated_default_repeat_index_in_provenance(self):
-        plan = generate_search_plan(self._snapshot(), self._cfg(threshold=3))
-        # First three slots are defaults with repeat_index 0/1/2
-        repeat_indexes = [
-            it.provenance.get("repeat_index") for it in plan.items[:3]
+    def test_no_more_five_slot_default_repetition(self):
+        """U5 R4: the five-slot default repetition is gone — one default only."""
+        plan = generate_search_plan(self._snapshot(), self._cfg(threshold=5))
+        default_slots = [
+            it for it in plan.items if it.strategy == "default"
         ]
-        self.assertEqual(repeat_indexes, [0, 1, 2])
+        self.assertEqual(len(default_slots), 1)
+        # ``repeat_index`` provenance no longer recorded (no repetition).
+        self.assertNotIn("repeat_index", default_slots[0].provenance)
 
     # --- year unknown ------------------------------------------------------
 
     def test_unknown_year_skips_unwild_year_and_records_omission(self):
         plan = generate_search_plan(
-            self._snapshot(year=None), self._cfg(threshold=2),
+            self._snapshot(year=None, release_group_year=None),
+            self._cfg(),
         )
         self.assertEqual(plan.status, PLAN_STATUS_SUCCESS)
         strategies = [it.strategy for it in plan.items]
-        # 2 default + 1 unwild + 3 track. unwild_year omitted.
-        self.assertEqual(strategies, [
-            "default", "default", "unwild",
-            "track_0", "track_1", "track_2",
-        ])
+        self.assertNotIn("unwild_year", strategies)
+        self.assertNotIn("unwild_rg_year", strategies)
         omitted = plan.provenance["omitted_candidates"]
-        unwild_year_omits = [o for o in omitted if o["strategy"] == "unwild_year"]
+        unwild_year_omits = [
+            o for o in omitted if o["strategy"] == "unwild_year"
+        ]
         self.assertEqual(len(unwild_year_omits), 1)
         self.assertEqual(unwild_year_omits[0]["reason"], "year_unknown")
 
     def test_year_0000_treated_as_unknown(self):
         plan = generate_search_plan(
-            self._snapshot(year="0000"), self._cfg(threshold=1),
+            self._snapshot(year="0000"), self._cfg(),
         )
         strategies = [it.strategy for it in plan.items]
         self.assertNotIn("unwild_year", strategies)
+
+    # --- release-group year ----------------------------------------------
+
+    def test_rg_year_slot_emitted_when_differs_from_year(self):
+        plan = generate_search_plan(
+            self._snapshot(year="2008", release_group_year=2000),
+            self._cfg(),
+        )
+        strategies = [it.strategy for it in plan.items]
+        self.assertIn("unwild_rg_year", strategies)
+        by_strategy = {it.strategy: it.query for it in plan.items}
+        self.assertEqual(by_strategy["unwild_rg_year"], "Radiohead Kid A 2000")
+        # Provenance carries rg_year for debuggability.
+        rg_item = next(it for it in plan.items
+                       if it.strategy == "unwild_rg_year")
+        self.assertEqual(rg_item.provenance.get("release_group_year"), 2000)
+        # Plan-level provenance records rg_year too.
+        self.assertEqual(plan.provenance.get("release_group_year"), 2000)
+
+    def test_rg_year_slot_omitted_when_matches_year(self):
+        plan = generate_search_plan(
+            self._snapshot(year="2010", release_group_year=2010),
+            self._cfg(),
+        )
+        strategies = [it.strategy for it in plan.items]
+        self.assertNotIn("unwild_rg_year", strategies)
+        omitted = plan.provenance["omitted_candidates"]
+        self.assertTrue(
+            any(o["strategy"] == "unwild_rg_year"
+                and o["reason"] == "release_group_year_matches_year"
+                for o in omitted),
+            f"missing rg_year matches omission: {omitted!r}",
+        )
+
+    def test_rg_year_slot_omitted_when_rg_year_missing(self):
+        plan = generate_search_plan(
+            self._snapshot(release_group_year=None),
+            self._cfg(),
+        )
+        strategies = [it.strategy for it in plan.items]
+        self.assertNotIn("unwild_rg_year", strategies)
+        omitted = plan.provenance["omitted_candidates"]
+        self.assertTrue(
+            any(o["strategy"] == "unwild_rg_year"
+                and o["reason"] == "release_group_year_unknown"
+                for o in omitted),
+        )
+        self.assertNotIn("release_group_year", plan.provenance)
+
+    def test_rg_year_slot_omitted_when_year_unknown(self):
+        plan = generate_search_plan(
+            self._snapshot(year=None, release_group_year=2000),
+            self._cfg(),
+        )
+        strategies = [it.strategy for it in plan.items]
+        self.assertNotIn("unwild_rg_year", strategies)
+
+    # --- format-hint slots unconditional ---------------------------------
+
+    def test_format_hint_slots_present_when_years_match(self):
+        plan = generate_search_plan(
+            self._snapshot(
+                artist="Darren Hanlon",
+                title="I Will Love You at All",
+                year="2010",
+                release_group_year=2010,
+            ),
+            self._cfg(),
+        )
+        strategies = [it.strategy for it in plan.items]
+        self.assertIn("literal_flac", strategies)
+        self.assertIn("literal_lossless", strategies)
+        self.assertNotIn("unwild_rg_year", strategies)
+
+    # --- short-token drop removed ----------------------------------------
+
+    def test_short_tokens_preserved_in_title(self):
+        """Kid A's 'A' must survive; previously short-drop removed it."""
+        plan = generate_search_plan(self._snapshot(), self._cfg())
+        by_strategy = {it.strategy: it.query for it in plan.items}
+        # Literal slot preserves the bare 'A'.
+        self.assertIn(" A", by_strategy["literal"])
+        self.assertEqual(by_strategy["literal"], "Radiohead Kid A")
+
+    def test_short_tokens_preserved_for_bon_iver_numeric(self):
+        plan = generate_search_plan(
+            self._snapshot(
+                artist="Bon Iver",
+                title="22, a Million",
+                track_titles=(),
+                year="2016",
+                release_group_year=2016,
+            ),
+            self._cfg(),
+        )
+        by_strategy = {it.strategy: it.query for it in plan.items}
+        # 22 (2 chars) and a (1 char) must both survive the post-clean
+        # pipeline. The order is preserved (source order), cap=4.
+        self.assertEqual(by_strategy["default"], "*on *ver 22 Million")
+        # Literal slot keeps the same body shape (un-wildcarded).
+        self.assertEqual(by_strategy["literal"], "Bon Iver 22 Million")
+
+    # --- self-titled detection -------------------------------------------
+
+    def test_selftitled_release_uses_dedicated_mix(self):
+        plan = generate_search_plan(
+            ReleaseSnapshot(
+                artist_name="Willow",
+                title="Willow",
+                year="2007",
+                track_titles=(
+                    "And Finally I Can Breathe",
+                    "When the Sea Called Our Names",
+                    "Stay Forever",
+                    "Going Going Gone",
+                ),
+                prepend_artist=True,
+                release_group_year=2007,
+            ),
+            self._cfg(),
+        )
+        self.assertEqual(plan.status, PLAN_STATUS_SUCCESS)
+        strategies = [it.strategy for it in plan.items]
+        # No default / literal / literal_flac / unwild_year slots — they
+        # would collapse to bare artist for self-titled releases.
+        for s in ("default", "literal", "literal_flac",
+                  "literal_lossless", "unwild_year", "unwild_rg_year"):
+            self.assertNotIn(s, strategies)
+        # Dedicated selftitled slots emitted.
+        self.assertIn("selftitled_artist_track_0", strategies)
+        self.assertIn("selftitled_artist_track_0_flac", strategies)
+        self.assertIn("selftitled_artist_year", strategies)
+        # Concrete queries.
+        by_strategy = {it.strategy: it.query for it in plan.items}
+        # First selftitled track query = literal artist + literal track,
+        # capped to MAX_SEARCH_TOKENS (longest first). "And"/"I" survive
+        # short-drop removal but cap may drop them.
+        self.assertTrue(
+            by_strategy["selftitled_artist_track_0"].startswith("Willow"),
+            by_strategy["selftitled_artist_track_0"],
+        )
+        self.assertIn("FLAC", by_strategy["selftitled_artist_track_0_flac"])
+        self.assertEqual(by_strategy["selftitled_artist_year"], "Willow 2007")
+        # Provenance flag set.
+        self.assertTrue(plan.provenance.get("selftitled"))
+
+    def test_selftitled_token_subset_mountains_case(self):
+        """Mountains / Mountains Mountains Mountains → both normalize to {mountains}."""
+        plan = generate_search_plan(
+            ReleaseSnapshot(
+                artist_name="Mountains",
+                title="Mountains Mountains Mountains",
+                year="2009",
+                track_titles=(
+                    "Bountiful Spreading",
+                    "Telescope",
+                    "Sheets Two",
+                ),
+                prepend_artist=True,
+                release_group_year=2009,
+            ),
+            self._cfg(),
+        )
+        self.assertTrue(plan.provenance.get("selftitled"))
+        strategies = [it.strategy for it in plan.items]
+        self.assertNotIn("default", strategies)
+        self.assertIn("selftitled_artist_track_0", strategies)
+
+    def test_selftitled_negative_willow_tree(self):
+        """Willow / Willow Tree → title has 'tree'; NOT self-titled."""
+        plan = generate_search_plan(
+            ReleaseSnapshot(
+                artist_name="Willow",
+                title="Willow Tree",
+                year="2007",
+                track_titles=("Branches", "Roots", "Leaves"),
+                prepend_artist=True,
+                release_group_year=2007,
+            ),
+            self._cfg(),
+        )
+        self.assertFalse(plan.provenance.get("selftitled"))
+        strategies = [it.strategy for it in plan.items]
+        self.assertIn("default", strategies)
+        self.assertIn("literal", strategies)
+
+    def test_selftitled_case_insensitive(self):
+        plan = generate_search_plan(
+            ReleaseSnapshot(
+                artist_name="WILLOW",
+                title="Willow",
+                year="2007",
+                track_titles=("Sample A", "Sample B"),
+                prepend_artist=True,
+            ),
+            self._cfg(),
+        )
+        self.assertTrue(plan.provenance.get("selftitled"))
 
     # --- single-track album skips track tier ------------------------------
 
     def test_single_track_album_has_no_track_slots(self):
         plan = generate_search_plan(
             self._snapshot(track_titles=("Lonely Track",)),
-            self._cfg(threshold=2),
+            self._cfg(),
         )
         self.assertEqual(plan.status, PLAN_STATUS_SUCCESS)
         strategies = [it.strategy for it in plan.items]
-        self.assertEqual(strategies, ["default", "default", "unwild", "unwild_year"])
-        # Skip recorded in provenance
+        # No track_* slots for single-track albums.
+        self.assertFalse(any(s.startswith("track_") for s in strategies))
+        # Album-level slots still present.
+        self.assertIn("default", strategies)
+        self.assertIn("literal", strategies)
+        # Skip recorded in provenance.
         omitted = plan.provenance["omitted_candidates"]
         self.assertTrue(
-            any(o["strategy"] == "track_*" and o["reason"] == "single_track_album"
+            any(o["strategy"] == "track_*"
+                and o["reason"] == "single_track_album"
                 for o in omitted),
             f"missing single_track_album omission: {omitted!r}",
         )
+
+    def test_fewer_than_three_tracks_emits_fewer_track_slots(self):
+        plan = generate_search_plan(
+            self._snapshot(
+                track_titles=("First Song Title", "Second Track Name"),
+            ),
+            self._cfg(),
+        )
+        track_slots = [
+            it for it in plan.items if it.strategy.startswith("track_")
+        ]
+        self.assertEqual(len(track_slots), 2)
 
     # --- empty tracklist still emits album-level slots --------------------
 
     def test_empty_tracklist_still_emits_album_slots(self):
         plan = generate_search_plan(
             self._snapshot(track_titles=()),
-            self._cfg(threshold=1),
+            self._cfg(),
         )
         self.assertEqual(plan.status, PLAN_STATUS_SUCCESS)
         strategies = [it.strategy for it in plan.items]
-        self.assertEqual(strategies, ["default", "unwild", "unwild_year"])
-        # No track-tier omission record (no tracks at all)
+        self.assertIn("default", strategies)
+        self.assertIn("literal", strategies)
+        self.assertIn("literal_flac", strategies)
+        self.assertIn("literal_lossless", strategies)
+        self.assertIn("unwild_year", strategies)
+        # No track slots and no track-tier omission record for empty.
+        self.assertFalse(any(s.startswith("track_") for s in strategies))
         omitted = plan.provenance["omitted_candidates"]
         self.assertFalse(
             any(o.get("strategy") == "track_*" for o in omitted),
@@ -1022,45 +1264,34 @@ class TestGenerateSearchPlan(unittest.TestCase):
     # --- cross-strategy dedupe: keep first, record loser -----------------
 
     def test_cross_strategy_duplicate_keeps_first_records_loser(self):
-        # When wildcarded and un-wildcarded queries coincide (e.g. an artist
-        # with no wildcardable tokens), unwild_year still differs because of
-        # the year suffix. To force a same-key collision across strategies,
-        # use a release where the unwild and the unwild_year base differ
-        # only by year, but force a track query that collides with the
-        # default base.
-        #
-        # Simpler construction: two strategies with identical canonical
-        # query. We exploit the fact that build_query returns the same string
-        # for an artist with no wildcardable content. Use a Various-Artists
-        # release whose title is a single distinct token; then a track named
-        # exactly that single title produces the same canonical query.
+        # Various Artists collapses to no wildcardable artist tokens, so
+        # the default slot is just "Compilation"; the literal slot is
+        # also "Compilation" — identical canonical key. The literal slot
+        # is deduped against the default slot.
         plan = generate_search_plan(
             ReleaseSnapshot(
                 artist_name="Various Artists",
                 title="Compilation",
                 year="2010",
                 track_titles=(
-                    "Compilation",  # collides with default canonical key
                     "Other Track Title Here",
                     "Yet Another Distinct Track",
                 ),
                 prepend_artist=True,
+                release_group_year=2010,
             ),
-            self._cfg(threshold=1),
+            self._cfg(),
         )
-        # default = "Compilation"; unwild = "Compilation"; identical canonical key
-        # so unwild is deduped against default.
+        # default = "Compilation"; literal = "Compilation"; identical
+        # canonical key so literal is deduped against default.
         self.assertEqual(plan.items[0].strategy, "default")
         self.assertEqual(plan.items[0].canonical_query_key, "compilation")
         strategies = [it.strategy for it in plan.items]
-        # unwild MUST be deduped (it'd be identical to "compilation")
-        self.assertNotIn("unwild", strategies)
-        # The dedupe loser is recorded in provenance with the ordinal it
-        # would have taken (1 — immediately after the single default).
+        self.assertNotIn("literal", strategies)
         losers = plan.provenance["dedupe_losers"]
         self.assertTrue(
             any(L["winner_strategy"] == "default"
-                and L["loser_strategy"] == "unwild"
+                and L["loser_strategy"] == "literal"
                 and L["canonical_query_key"] == "compilation"
                 and L["would_have_been_ordinal"] == 1
                 for L in losers),
@@ -1071,13 +1302,14 @@ class TestGenerateSearchPlan(unittest.TestCase):
 
     def test_track_ranking_ties_break_by_source_order(self):
         # All four tracks have identical useful-token count AND identical
-        # char count after cleaning, so the tiebreaker is source-track order.
-        # Two tokens of length 5 + space = 11 chars each.
+        # char count after cleaning. Artist prepending adds the same
+        # tokens to every track, so the relative rank stays source-order.
         plan = generate_search_plan(
             self._snapshot(
                 artist="Dallas Crane",
                 title="Album",
                 year=None,
+                release_group_year=None,
                 track_titles=(
                     "Alpha Sigma",   # 11 chars, 2 tokens
                     "Bravo Delta",   # 11 chars, 2 tokens
@@ -1085,56 +1317,61 @@ class TestGenerateSearchPlan(unittest.TestCase):
                     "Golfa Hotel",   # 11 chars, 2 tokens
                 ),
             ),
-            self._cfg(threshold=1, max_track_slots=3),
+            self._cfg(max_track_slots=3),
         )
-        track_items = [it for it in plan.items if it.strategy.startswith("track_")]
-        # Sanity: same token count, same char count → source-order
-        for it in track_items:
-            self.assertEqual(len(it.query.split()), 2)
-            self.assertEqual(len(it.query), 11)
+        track_items = [
+            it for it in plan.items if it.strategy.startswith("track_")
+        ]
         self.assertEqual(len(track_items), 3)
-        self.assertEqual(track_items[0].query, "Alpha Sigma")
-        self.assertEqual(track_items[1].query, "Bravo Delta")
-        self.assertEqual(track_items[2].query, "Echo1 Foxxx")
-        # source_track_index recorded in provenance
+        # Each query is "<*allas> <*rane> <Tok> <Tok>" capped to 4 tokens.
+        for it in track_items:
+            self.assertEqual(len(it.query.split()), 4)
+            self.assertTrue(it.query.startswith("*allas *rane "))
+        # First three tracks survive source-order ranking; fourth is
+        # bumped to omitted_candidates as excess.
         self.assertEqual(track_items[0].provenance["source_track_index"], 0)
         self.assertEqual(track_items[1].provenance["source_track_index"], 1)
         self.assertEqual(track_items[2].provenance["source_track_index"], 2)
-        # The fourth track must appear in plan-level omissions.
         omitted = plan.provenance["omitted_candidates"]
-        excess = [o for o in omitted if o.get("strategy") == "track_excess"]
+        excess = [
+            o for o in omitted if o.get("strategy") == "track_excess"
+        ]
         self.assertEqual(len(excess), 1)
         self.assertEqual(excess[0]["source_track_index"], 3)
-        self.assertEqual(excess[0]["query"], "Golfa Hotel")
 
     def test_track_ranking_orders_by_useful_tokens_then_chars(self):
-        # Make tracks with different post-clean shapes to exercise the rank
-        # order: useful-token count desc, then char count desc, then source
-        # index asc. No artist enrichment happens here — every cleaned track
-        # has >=2 tokens — so the ranking inputs are predictable.
+        # Ranking is computed on the post-prepend query (artist tokens
+        # consume slots equally for every track, so cap drops happen on
+        # the title side). Among queries tied on token count, the
+        # longest char count wins; ties break by source order.
         plan = generate_search_plan(
             self._snapshot(
                 artist="Some Artist",
                 title="Album",
                 year=None,
+                release_group_year=None,
                 track_titles=(
-                    "Aaa Bbbbbbb",                  # 2 tokens, 11 chars
-                    "One Two Three Four Tokens",    # 4 tokens (capped from 5)
-                    "Aaaaa Bbbbbbbbbbb",            # 2 tokens, 17 chars
-                    "One Two",                      # 2 tokens, 7 chars
+                    "Aaaaa Bbbbbbb",                # 2 title tokens → 4 after prepend
+                    "One Two Three Four Tokens",    # 5 cleaned title tokens
+                    "Aaaaa Bbbbbbbbbbb",            # 2 title tokens, longest body
+                    "Six Seven",                    # 2 title tokens, shortest body
                 ),
             ),
-            self._cfg(threshold=1, max_track_slots=3),
+            self._cfg(max_track_slots=3),
         )
-        track_items = [it for it in plan.items if it.strategy.startswith("track_")]
+        track_items = [
+            it for it in plan.items if it.strategy.startswith("track_")
+        ]
         self.assertEqual(len(track_items), 3)
-        # First slot is the 4-token query (most useful tokens).
-        self.assertEqual(track_items[0].provenance["source_track_index"], 1)
-        self.assertEqual(len(track_items[0].query.split()), 4)
-        # Among 2-token queries, the longer wins on char count, then ties
-        # break by source index. 17-char wins, then 11-char wins.
-        self.assertEqual(track_items[1].provenance["source_track_index"], 2)
-        self.assertEqual(track_items[2].provenance["source_track_index"], 0)
+        # All four post-prepend queries cap to 4 tokens (artist prepend
+        # consumes 2 slots). Char-count tiebreaker picks longest first.
+        # "*ome *rtist Aaaaa Bbbbbbbbbbb" is the longest (idx=2).
+        self.assertEqual(track_items[0].provenance["source_track_index"], 2)
+        # idx=0 "*ome *rtist Aaaaa Bbbbbbb" is next-longest.
+        self.assertEqual(track_items[1].provenance["source_track_index"], 0)
+        # Among remaining, idx=1 ("One Two Three Four Tokens") with
+        # artist prepend caps to 4 tokens with non-trivial body.
+        self.assertEqual(track_items[2].provenance["source_track_index"], 1)
 
     # --- generation failure: no runnable query ---------------------------
 
@@ -1163,9 +1400,11 @@ class TestGenerateSearchPlan(unittest.TestCase):
         self.assertFalse(sig["redownload"])
 
     def test_unrunnable_album_with_runnable_track_still_succeeds(self):
-        # Empty artist+title but two distinct track candidates with multi-token
-        # queries → multi-track album, track tier produces runnable items so
-        # the plan succeeds even without album-level slots.
+        # Empty artist+title but two distinct track candidates with
+        # multi-token queries → multi-track album, track tier produces
+        # runnable items so the plan succeeds even without album-level
+        # slots. Empty artist also collapses the artist-prepend prefix
+        # in per-track candidates, so the track queries are bare titles.
         plan = generate_search_plan(
             ReleaseSnapshot(
                 artist_name="",
@@ -1174,22 +1413,24 @@ class TestGenerateSearchPlan(unittest.TestCase):
                 track_titles=("Distinct Track Title", "Another Real Song"),
                 prepend_artist=True,
             ),
-            self._cfg(threshold=2),
+            self._cfg(),
         )
         self.assertEqual(plan.status, PLAN_STATUS_SUCCESS)
-        # Only track slots; default and unwild candidates omitted.
+        # Only track slots; album-level candidates all omitted.
         strategies = [it.strategy for it in plan.items]
-        self.assertEqual(strategies, ["track_0", "track_1"])
+        self.assertEqual(strategies, ["track_0_artist", "track_1_artist"])
         omitted = plan.provenance["omitted_candidates"]
         self.assertTrue(
-            any(o["strategy"] == "default" and o["reason"] == "empty_base_query"
+            any(o["strategy"] == "default"
+                and o["reason"] == "empty_default_query"
                 for o in omitted),
             f"missing default empty omission: {omitted!r}",
         )
         self.assertTrue(
-            any(o["strategy"] == "unwild" and o["reason"] == "empty_unwild_query"
+            any(o["strategy"] == "literal"
+                and o["reason"] == "empty_literal_query"
                 for o in omitted),
-            f"missing unwild empty omission: {omitted!r}",
+            f"missing literal empty omission: {omitted!r}",
         )
 
     # --- redownload flag preserved in snapshot signature -----------------
@@ -1206,28 +1447,33 @@ class TestGenerateSearchPlan(unittest.TestCase):
     def test_generator_id_constant_is_pinned(self):
         """Changing generator output requires bumping `SEARCH_PLAN_GENERATOR_ID`.
 
-        This explicit assertion is the contract: if the generator's behavior
-        changes (token rules, ladder, repeat groups, dedupe, provenance
-        shape), the test author MUST also bump the id constant. U3
-        (service) and U4 (reconciliation) read this constant — drift
-        breaks the persisted plan currentness check.
+        This explicit assertion is the contract: if the generator's
+        behavior changes (token rules, ladder, repeat groups, dedupe,
+        provenance shape), the test author MUST also bump the id
+        constant. The service layer and reconciliation read this
+        constant — drift breaks the persisted plan currentness check.
         """
         # Snapshot output of a known release. Bumping any of these
         # expectations should require the id below to change too.
-        plan = generate_search_plan(self._snapshot(), self._cfg(threshold=2))
-        self.assertEqual(plan.generator_id, "search-plan/2026-05-08-1")
+        plan = generate_search_plan(self._snapshot(), self._cfg())
+        self.assertEqual(plan.generator_id, "search-plan/2026-05-19-1")
         self.assertEqual(plan.generator_id, SEARCH_PLAN_GENERATOR_ID)
-        # Pin the slot ladder shape and queries.
+        # Pin the slot ladder shape and queries for Radiohead / Kid A /
+        # year=2008 / rg_year=2000.
         self.assertEqual(
             [(it.strategy, it.query) for it in plan.items],
             [
-                ("default", "*iggles"),
-                ("default", "*iggles"),
-                ("unwild", "Wiggles"),
-                ("unwild_year", "Wiggles 1991"),
-                ("track_0", "Rock-A-Bye Your Bear"),
-                ("track_1", "Get Ready Wiggle"),
-                ("track_2", "Dorothy Dinosaur"),
+                ("default", "*adiohead Kid A"),
+                ("literal", "Radiohead Kid A"),
+                ("literal_flac", "Radiohead Kid A FLAC"),
+                ("literal_lossless", "Radiohead Kid A lossless"),
+                ("unwild_year", "Radiohead Kid A 2008"),
+                ("unwild_rg_year", "Radiohead Kid A 2000"),
+                ("track_0_artist",
+                 "*adiohead How Disappear Completely"),
+                ("track_1_artist",
+                 "*adiohead Everything Right Place"),
+                ("track_2_artist", "*adiohead National Anthem"),
             ],
         )
 

--- a/tests/test_search_plan_service.py
+++ b/tests/test_search_plan_service.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -1022,6 +1023,192 @@ class TestSearchPlanServiceDryRun(unittest.TestCase):
         assert result.plan is not None
         self.assertEqual(
             result.plan.generator_id, SEARCH_PLAN_GENERATOR_ID)
+
+
+class TestSearchPlanServiceSaturation(unittest.TestCase):
+    """U7 service contract: ``SearchPlanService.saturation_for_request``.
+
+    Read-only telemetry aggregator. The method wraps
+    ``PipelineDB.get_saturation_summary`` and adds the explicit "request
+    exists at all?" 404 check so empty windows do not collide with
+    deleted requests. Both ``pipeline-cli search-plan saturation`` and
+    ``GET /api/pipeline/<id>/search-plan/saturation`` go through this
+    method — keep the outcome / exit-code mapping symmetric.
+    """
+
+    def setUp(self):
+        self.db = FakePipelineDB()
+        self.cfg = CratediggerConfig()
+        self.svc = SearchPlanService(self.db, self.cfg)
+
+    def _seed(self, rid: int = 1) -> int:
+        row = make_request_row(id=rid, artist_name="Radiohead",
+                               album_title="Kid A")
+        self.db.seed_request(row)
+        return rid
+
+    def test_happy_path_returns_typed_summary(self):
+        # Plan AE: 30 searches in window, 10 saturated, 50 pre-filter
+        # skips → saturation_rate=10/30, total_pre_filter_skips=50.
+        # Distribute 50 skips across 30 rows as 20 rows of 2 + 10 rows
+        # of 1 = 50; deterministic and easy to read.
+        from lib.search_plan_service import RESULT_SATURATION_SUCCESS
+        rid = self._seed(rid=1)
+        for i in range(30):
+            final_state = (
+                "Completed, ResponseLimitReached" if i < 10
+                else "Completed")
+            skip = 2 if i < 20 else 1
+            self.db.log_search(
+                request_id=rid, query=f"q{i}",
+                result_count=5, outcome="found",
+                final_state=final_state,
+                pre_filter_skip_count=skip,
+            )
+        result = self.svc.saturation_for_request(rid, window_days=14)
+        self.assertEqual(result.outcome, RESULT_SATURATION_SUCCESS)
+        self.assertEqual(result.request_id, rid)
+        self.assertIsNotNone(result.summary)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_searches, 30)
+        self.assertEqual(result.summary.saturated_searches, 10)
+        self.assertAlmostEqual(result.summary.saturation_rate, 10 / 30)
+        self.assertEqual(result.summary.total_pre_filter_skips, 50)
+        self.assertEqual(result.summary.window_days, 14)
+
+    def test_empty_window_is_success_with_zeros_not_404(self):
+        # Request exists but has no logged searches in window. This is
+        # "found but quiet" — outcome MUST be SUCCESS with zero counts,
+        # NOT REQUEST_NOT_FOUND. Operators ask "how saturated is X?"
+        # and the truthful answer for a quiet request is "not at all".
+        from lib.search_plan_service import RESULT_SATURATION_SUCCESS
+        rid = self._seed(rid=2)
+        result = self.svc.saturation_for_request(rid, window_days=14)
+        self.assertEqual(result.outcome, RESULT_SATURATION_SUCCESS)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_searches, 0)
+        self.assertEqual(result.summary.saturated_searches, 0)
+        # Crucial: 0.0, not NaN. NaN would break JSON serialisation.
+        self.assertEqual(result.summary.saturation_rate, 0.0)
+        self.assertEqual(result.summary.total_pre_filter_skips, 0)
+
+    def test_request_not_found_returns_404_outcome(self):
+        from lib.search_plan_service import RESULT_REQUEST_NOT_FOUND
+        result = self.svc.saturation_for_request(9999, window_days=14)
+        self.assertEqual(result.outcome, RESULT_REQUEST_NOT_FOUND)
+        self.assertEqual(result.request_id, 9999)
+        self.assertIsNone(result.summary)
+        self.assertIsNotNone(result.error_message)
+
+    def test_window_days_parameter_filters_rows(self):
+        from lib.search_plan_service import RESULT_SATURATION_SUCCESS
+        rid = self._seed(rid=3)
+        # Two recent rows + one row older than 7 days.
+        self.db.log_search(request_id=rid, query="recent_a",
+                           outcome="found",
+                           final_state="Completed, FileLimitReached")
+        self.db.log_search(request_id=rid, query="recent_b",
+                           outcome="found",
+                           final_state="Completed")
+        # Backdate the third row to 10 days ago.
+        old = self.db.search_logs[-1]
+        self.db.log_search(request_id=rid, query="old",
+                           outcome="found",
+                           final_state="Completed, ResponseLimitReached")
+        self.db.search_logs[-1].created_at = (
+            old.created_at - timedelta(days=10))
+        # Window of 7 days: the old row falls outside.
+        result = self.svc.saturation_for_request(rid, window_days=7)
+        self.assertEqual(result.outcome, RESULT_SATURATION_SUCCESS)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_searches, 2)
+        self.assertEqual(result.summary.saturated_searches, 1)
+        self.assertEqual(result.summary.window_days, 7)
+        # Window of 14 days: all three rows are in scope.
+        result14 = self.svc.saturation_for_request(rid, window_days=14)
+        assert result14.summary is not None
+        self.assertEqual(result14.summary.total_searches, 3)
+        self.assertEqual(result14.summary.saturated_searches, 2)
+
+    def test_window_days_input_validation_below_min(self):
+        from lib.search_plan_service import RESULT_SATURATION_INPUT_INVALID
+        rid = self._seed(rid=4)
+        result = self.svc.saturation_for_request(rid, window_days=0)
+        self.assertEqual(result.outcome, RESULT_SATURATION_INPUT_INVALID)
+        self.assertIsNone(result.summary)
+        self.assertIsNotNone(result.error_message)
+
+    def test_window_days_input_validation_above_max(self):
+        from lib.search_plan_service import RESULT_SATURATION_INPUT_INVALID
+        rid = self._seed(rid=5)
+        result = self.svc.saturation_for_request(rid, window_days=10000)
+        self.assertEqual(result.outcome, RESULT_SATURATION_INPUT_INVALID)
+        self.assertIsNotNone(result.error_message)
+
+    def test_saturated_match_is_substring_not_exact(self):
+        # Production final_state values include the slskd-prefixed
+        # "Completed, ResponseLimitReached" / "Completed, FileLimitReached".
+        # The aggregator must match on substring, not equality.
+        from lib.search_plan_service import RESULT_SATURATION_SUCCESS
+        rid = self._seed(rid=6)
+        for state in (
+            "Completed, ResponseLimitReached",
+            "Completed, FileLimitReached",
+            "Completed",  # not saturated
+            "Cancelled",  # not saturated
+        ):
+            self.db.log_search(request_id=rid, query="q",
+                               outcome="found", final_state=state)
+        result = self.svc.saturation_for_request(rid, window_days=14)
+        self.assertEqual(result.outcome, RESULT_SATURATION_SUCCESS)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_searches, 4)
+        self.assertEqual(result.summary.saturated_searches, 2)
+
+    def test_takes_no_advisory_lock(self):
+        rid = self._seed(rid=7)
+        before = list(self.db.advisory_lock_calls)
+        self.svc.saturation_for_request(rid, window_days=14)
+        self.assertEqual(self.db.advisory_lock_calls, before)
+
+    def test_payload_helper_round_trips_summary_fields(self):
+        from lib.search_plan_service import (
+            RESULT_SATURATION_SUCCESS, saturation_payload,
+        )
+        rid = self._seed(rid=8)
+        self.db.log_search(request_id=rid, query="q1", outcome="found",
+                           final_state="Completed, ResponseLimitReached",
+                           pre_filter_skip_count=4)
+        self.db.log_search(request_id=rid, query="q2", outcome="found",
+                           final_state="Completed",
+                           pre_filter_skip_count=2)
+        result = self.svc.saturation_for_request(rid, window_days=14)
+        self.assertEqual(result.outcome, RESULT_SATURATION_SUCCESS)
+        payload = saturation_payload(result)
+        for key in ("request_id", "outcome", "total_searches",
+                    "saturated_searches", "saturation_rate",
+                    "total_pre_filter_skips", "window_days",
+                    "error_message"):
+            self.assertIn(key, payload)
+        self.assertEqual(payload["total_searches"], 2)
+        self.assertEqual(payload["saturated_searches"], 1)
+        self.assertAlmostEqual(payload["saturation_rate"], 0.5)
+        self.assertEqual(payload["total_pre_filter_skips"], 6)
+        self.assertEqual(payload["window_days"], 14)
+        self.assertIsNone(payload["error_message"])
+
+    def test_payload_helper_zeros_on_not_found(self):
+        from lib.search_plan_service import saturation_payload
+        result = self.svc.saturation_for_request(9999, window_days=14)
+        payload = saturation_payload(result)
+        # Even the not-found path emits the five summary fields so a
+        # client can read them without branching on outcome.
+        self.assertEqual(payload["total_searches"], 0)
+        self.assertEqual(payload["saturated_searches"], 0)
+        self.assertEqual(payload["saturation_rate"], 0.0)
+        self.assertEqual(payload["total_pre_filter_skips"], 0)
+        self.assertEqual(payload["window_days"], 14)
+        self.assertEqual(payload["outcome"], "request_not_found")
 
 
 class TestSearchPlanConfigFromCratedigger(unittest.TestCase):

--- a/tests/test_search_plan_service.py
+++ b/tests/test_search_plan_service.py
@@ -926,6 +926,104 @@ class TestSearchPlanServiceHistoryPage(unittest.TestCase):
         self.assertEqual(result.outcome, RESULT_HISTORY_PAGE_SUCCESS)
 
 
+class TestSearchPlanServiceDryRun(unittest.TestCase):
+    """U6 service contract: ``SearchPlanService.dry_run_for_request``.
+
+    Pure read-only simulator — no DB writes, no advisory lock, no
+    ``active_plan_id`` mutation, no resolver call. Returns a typed
+    ``DryRunResult`` with ``RESULT_DRY_RUN_SUCCESS`` |
+    ``RESULT_DRY_RUN_GENERATION_FAILED`` |
+    ``RESULT_REQUEST_NOT_FOUND``.
+    """
+
+    def setUp(self):
+        self.db = FakePipelineDB()
+        self.cfg = CratediggerConfig()
+        self.svc = SearchPlanService(self.db, self.cfg)
+
+    def _seed(self, **overrides) -> int:
+        row = make_request_row(
+            artist_name="Radiohead", album_title="Kid A",
+            year=2008, release_group_year=2000,
+            **overrides,
+        )
+        self.db.seed_request(row)
+        rid = int(row["id"])
+        self.db.set_tracks(rid, [
+            {"track_number": 1, "title": "Everything In Its Right Place"},
+            {"track_number": 2, "title": "Kid A"},
+            {"track_number": 3, "title": "The National Anthem"},
+        ])
+        return rid
+
+    def test_dry_run_returns_plan_without_persisting(self):
+        from lib.search_plan_service import RESULT_DRY_RUN_SUCCESS
+        rid = self._seed(id=1)
+        plans_before = dict(self.db.search_plans)
+        items_before = dict(self.db.search_plan_items)
+        result = self.svc.dry_run_for_request(rid)
+        self.assertEqual(result.outcome, RESULT_DRY_RUN_SUCCESS)
+        self.assertEqual(result.request_id, rid)
+        self.assertIsNotNone(result.plan)
+        assert result.plan is not None
+        self.assertGreater(len(result.plan.items), 0)
+        # Persistence invariants — nothing written.
+        self.assertEqual(self.db.search_plans, plans_before)
+        self.assertEqual(self.db.search_plan_items, items_before)
+        self.assertIsNone(self.db._requests[rid]["active_plan_id"])
+
+    def test_dry_run_request_not_found_returns_typed_outcome(self):
+        from lib.search_plan_service import RESULT_REQUEST_NOT_FOUND
+        result = self.svc.dry_run_for_request(9999)
+        self.assertEqual(result.outcome, RESULT_REQUEST_NOT_FOUND)
+        self.assertEqual(result.request_id, 9999)
+        self.assertIsNone(result.plan)
+        self.assertIsNotNone(result.error_message)
+
+    def test_dry_run_takes_no_advisory_lock(self):
+        rid = self._seed(id=2)
+        before = list(self.db.advisory_lock_calls)
+        self.svc.dry_run_for_request(rid)
+        # Lock list unchanged — dry-run is read-only and contention-free.
+        self.assertEqual(self.db.advisory_lock_calls, before)
+
+    def test_dry_run_does_not_invoke_resolver(self):
+        # Seed a request with NO tracks and a resolver that would raise
+        # if called — proves dry_run never reaches into the resolver.
+        from lib.search_plan_service import RESULT_DRY_RUN_SUCCESS
+        rid = self._seed(id=3)
+        self.db.set_tracks(rid, [])
+        resolver = MagicMock()
+        resolver.resolve_tracks.side_effect = AssertionError(
+            "resolver must not be called from dry_run")
+        svc = SearchPlanService(self.db, self.cfg, resolver=resolver)
+        result = svc.dry_run_for_request(rid)
+        # Even with empty tracks the generator emits a non-track plan.
+        self.assertEqual(result.outcome, RESULT_DRY_RUN_SUCCESS)
+        resolver.resolve_tracks.assert_not_called()
+
+    def test_dry_run_uses_release_group_year_from_row(self):
+        rid = self._seed(id=4)
+        result = self.svc.dry_run_for_request(rid)
+        assert result.snapshot is not None
+        self.assertEqual(result.snapshot.release_group_year, 2000)
+
+    def test_dry_run_metadata_snapshot_includes_release_group_year(self):
+        rid = self._seed(id=5)
+        result = self.svc.dry_run_for_request(rid)
+        assert result.metadata_snapshot is not None
+        self.assertEqual(
+            result.metadata_snapshot.get("release_group_year"), 2000)
+
+    def test_dry_run_uses_current_generator_id(self):
+        from lib.search import SEARCH_PLAN_GENERATOR_ID
+        rid = self._seed(id=6)
+        result = self.svc.dry_run_for_request(rid)
+        assert result.plan is not None
+        self.assertEqual(
+            result.plan.generator_id, SEARCH_PLAN_GENERATOR_ID)
+
+
 class TestSearchPlanConfigFromCratedigger(unittest.TestCase):
     def test_threshold_propagates(self):
         cfg = CratediggerConfig(search_escalation_threshold=7)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3393,8 +3393,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.mock_db.add_request.return_value = 501
         self.mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
 
+    @patch("web.routes.pipeline.mb_api.get_release_group_year",
+           return_value=2024)
     @patch("web.routes.pipeline.mb_api.get_release")
-    def test_pipeline_add_contract(self, mock_get_release):
+    def test_pipeline_add_contract(self, mock_get_release, _mock_rgy):
         mock_get_release.return_value = {
             "release_group_id": "rg-1",
             "artist_id": "artist-1",
@@ -3411,8 +3413,12 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         _assert_required_fields(self, data, self.ADD_REQUIRED_FIELDS,
                                 "pipeline add response")
 
+    @patch("web.routes.pipeline.mb_api.get_release_group_year",
+           return_value=2014)
     @patch("web.routes.pipeline.mb_api.get_release")
-    def test_pipeline_add_runs_plan_generation_after_set_tracks(self, mock_get_release):
+    def test_pipeline_add_runs_plan_generation_after_set_tracks(
+        self, mock_get_release, _mock_rgy,
+    ):
         """Web add path generates a search plan after `set_tracks()`,
         consistent with the CLI add path. Failures must not break the
         HTTP response."""
@@ -3459,6 +3465,146 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.EXISTS_REQUIRED_FIELDS,
                                 "pipeline add exists response")
+
+    @patch("web.routes.pipeline.mb_api.get_release_group_year")
+    @patch("web.routes.pipeline.mb_api.get_release")
+    def test_pipeline_add_mb_persists_release_group_year_reissue(
+        self, mock_get_release, mock_rgy,
+    ):
+        """U4: reissue MB release → ``release_group_year`` is fetched
+        from the mirror and passed through to ``add_request``."""
+        mock_get_release.return_value = {
+            "release_group_id": "rg-kid-a",
+            "artist_id": "rh-1",
+            "artist_name": "Radiohead",
+            "title": "Kid A",
+            "year": 2008,  # reissue
+            "country": "US",
+            "tracks": [{"title": "Everything In Its Right Place"}],
+        }
+        mock_rgy.return_value = 2000  # release-group's first year
+
+        status, _data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "kid-a-mbid"})
+
+        self.assertEqual(status, 200)
+        mock_rgy.assert_called_once_with("rg-kid-a")
+        add_kwargs = self.mock_db.add_request.call_args.kwargs
+        self.assertEqual(add_kwargs["year"], 2008)
+        self.assertEqual(add_kwargs["release_group_year"], 2000)
+
+    @patch("web.routes.pipeline.mb_api.get_release_group_year")
+    @patch("web.routes.pipeline.mb_api.get_release")
+    def test_pipeline_add_mb_persists_release_group_year_original(
+        self, mock_get_release, mock_rgy,
+    ):
+        """U4: original release MB release → ``release_group_year``
+        equals the per-release year."""
+        mock_get_release.return_value = {
+            "release_group_id": "rg-self",
+            "artist_id": "willow-1",
+            "artist_name": "Willow",
+            "title": "Willow",
+            "year": 2007,
+            "country": "AU",
+            "tracks": [{"title": "And Finally I Can Breathe"}],
+        }
+        mock_rgy.return_value = 2007
+
+        status, _data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "willow-mbid"})
+
+        self.assertEqual(status, 200)
+        add_kwargs = self.mock_db.add_request.call_args.kwargs
+        self.assertEqual(add_kwargs["year"], 2007)
+        self.assertEqual(add_kwargs["release_group_year"], 2007)
+
+    @patch("web.routes.pipeline.mb_api.get_release_group_year")
+    @patch("web.routes.pipeline.mb_api.get_release")
+    def test_pipeline_add_mb_release_group_404_leaves_column_null(
+        self, mock_get_release, mock_rgy,
+    ):
+        """U4: 404 from the release-group fetch → ``release_group_year``
+        is NULL on the new row, no error raised, request still added."""
+        mock_get_release.return_value = {
+            "release_group_id": "rg-missing",
+            "artist_id": "a-1",
+            "artist_name": "A",
+            "title": "T",
+            "year": 2020,
+            "country": "US",
+            "tracks": [{"title": "Track"}],
+        }
+        mock_rgy.return_value = None  # mirror returned 404 / unparseable
+
+        status, data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "abc-rgmiss"})
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.ADD_REQUIRED_FIELDS,
+                                "pipeline add response (rg 404)")
+        add_kwargs = self.mock_db.add_request.call_args.kwargs
+        self.assertEqual(add_kwargs["year"], 2020)
+        self.assertIsNone(add_kwargs["release_group_year"])
+
+    @patch("web.routes.pipeline.mb_api.get_release_group_year")
+    @patch("web.routes.pipeline.mb_api.get_release")
+    def test_pipeline_add_mb_skips_rgy_lookup_when_no_rg_id(
+        self, mock_get_release, mock_rgy,
+    ):
+        """U4: when MB doesn't return a ``release_group_id`` (e.g. very
+        old data), the helper isn't called and ``release_group_year`` is
+        left NULL."""
+        mock_get_release.return_value = {
+            # No release_group_id key — get() returns None.
+            "artist_id": "a-1",
+            "artist_name": "A",
+            "title": "T",
+            "year": 2020,
+            "country": "US",
+            "tracks": [{"title": "Track"}],
+        }
+
+        status, _data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "abc-norg"})
+
+        self.assertEqual(status, 200)
+        mock_rgy.assert_not_called()
+        add_kwargs = self.mock_db.add_request.call_args.kwargs
+        self.assertIsNone(add_kwargs["release_group_year"])
+
+    def test_pipeline_add_mb_integration_persists_release_group_year(self):
+        """U4 integration: full add-from-web flow against ``FakePipelineDB``
+        creates the new row with ``release_group_year`` populated and
+        the request reads back correctly."""
+        import web.server as srv
+        fake_db = FakePipelineDB()
+        with patch("web.routes.pipeline.mb_api.get_release") as mock_rel, \
+             patch("web.routes.pipeline.mb_api.get_release_group_year",
+                   return_value=2000) as mock_rgy, \
+             patch.object(srv, "db", fake_db):
+            mock_rel.return_value = {
+                "release_group_id": "rg-kid-a",
+                "artist_id": "rh-1",
+                "artist_name": "Radiohead",
+                "title": "Kid A",
+                "year": 2008,
+                "country": "US",
+                "tracks": [
+                    {"title": "Everything In Its Right Place",
+                     "track_number": 1, "disc_number": 1},
+                ],
+            }
+            status, data = self._post(
+                "/api/pipeline/add", {"mb_release_id": "kid-a-int"})
+
+        self.assertEqual(status, 200)
+        new_id = data["id"]
+        row = fake_db.get_request(new_id)
+        assert row is not None
+        self.assertEqual(row["year"], 2008)
+        self.assertEqual(row["release_group_year"], 2000)
+        mock_rgy.assert_called_once_with("rg-kid-a")
 
     def test_pipeline_add_duplicate_does_not_regenerate(self):
         """Duplicate add returns the existing request without generating
@@ -3724,8 +3870,12 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
     # -- fresh=True seam (Codex review on issue #101) ----------------
 
+    @patch("routes.pipeline.mb_api.get_release_group_year",
+           return_value=2024)
     @patch("routes.pipeline.mb_api.get_release")
-    def test_pipeline_add_mb_fetches_release_fresh(self, mock_get_release):
+    def test_pipeline_add_mb_fetches_release_fresh(
+        self, mock_get_release, _mock_rgy,
+    ):
         """POST /api/pipeline/add (MusicBrainz) MUST bypass the 24h meta
         cache — the fetched metadata is persisted into `album_requests`
         and `request_tracks`. A stale cached payload from an earlier

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -989,6 +989,7 @@ class TestRouteContractAudit(unittest.TestCase):
         r"^/api/pipeline/(\d+)$",
         r"^/api/pipeline/(\d+)/search-plan$",
         r"^/api/pipeline/(\d+)/search-plan/dry-run$",
+        r"^/api/pipeline/(\d+)/search-plan/saturation$",
         r"^/api/pipeline/(\d+)/search-plan/history$",
         r"^/api/pipeline/(\d+)/search-plan/regenerate$",
         r"^/api/pipeline/(\d+)/search-plan/advance$",
@@ -2317,6 +2318,150 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
         # The plan the simulator emits must be pinned to the same id.
         self.assertEqual(
             data["plan"]["generator_id"], SEARCH_PLAN_GENERATOR_ID)
+
+
+class TestPipelineSearchPlanSaturationContract(_WebServerCase):
+    """U7 contract for ``GET /api/pipeline/<id>/search-plan/saturation``.
+
+    Read-only telemetry aggregator. The route wraps
+    ``SearchPlanService.saturation_for_request``; both this route and
+    ``pipeline-cli search-plan saturation`` go through the same
+    service method so input semantics + outcome mapping cannot drift.
+    The contract guarantees the payload shape consumed by the future
+    search-plan dashboard.
+    """
+
+    REQUIRED_FIELDS = {
+        "total_searches",
+        "saturated_searches",
+        "saturation_rate",
+        "total_pre_filter_skips",
+        "window_days",
+    }
+    FULL_REQUIRED_FIELDS = REQUIRED_FIELDS | {
+        "request_id", "outcome", "error_message",
+    }
+
+    def setUp(self) -> None:
+        from tests.helpers import make_request_row
+        # Production-shape mock: use real datetime + UUID values on the
+        # request row so the JSON encoder path is exercised end-to-end.
+        # The route does not consult timestamps directly, but the
+        # ``get_request`` call walks through the JSON encoder boundary
+        # if anything else does — keep the row shape honest.
+        import uuid
+        self.mock_db.get_request.return_value = make_request_row(
+            id=100, status="wanted",
+            artist_name="Radiohead", album_title="Kid A",
+            mb_release_id=str(uuid.uuid4()),
+        )
+        # Route reads runtime config — patch to a default config.
+        from lib.config import CratediggerConfig
+        import configparser
+        cp = configparser.RawConfigParser()
+        cp.read_string("[General]\n")
+        self._cfg_patcher = patch(
+            "lib.config.read_runtime_config",
+            return_value=CratediggerConfig.from_ini(cp),
+        )
+        self._cfg_patcher.start()
+        # Default saturation summary — happy-path scenario.
+        from lib.pipeline_db import SaturationSummary
+        self.mock_db.get_saturation_summary.return_value = SaturationSummary(
+            total_searches=30,
+            saturated_searches=10,
+            saturation_rate=10 / 30,
+            total_pre_filter_skips=50,
+            window_days=14,
+        )
+
+    def tearDown(self) -> None:
+        self._cfg_patcher.stop()
+        self.mock_db.get_saturation_summary.reset_mock(
+            return_value=True, side_effect=True)
+
+    def test_happy_path_returns_200_with_required_fields(self):
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/saturation")
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.FULL_REQUIRED_FIELDS, "saturation")
+        self.assertEqual(data["request_id"], 100)
+        self.assertEqual(data["outcome"], "success")
+        self.assertEqual(data["total_searches"], 30)
+        self.assertEqual(data["saturated_searches"], 10)
+        self.assertAlmostEqual(data["saturation_rate"], 10 / 30)
+        self.assertEqual(data["total_pre_filter_skips"], 50)
+        self.assertEqual(data["window_days"], 14)
+        self.assertIsNone(data["error_message"])
+
+    def test_empty_window_is_200_with_zeros_not_404(self):
+        # Found-but-quiet: request exists, window is just empty.
+        from lib.pipeline_db import SaturationSummary
+        self.mock_db.get_saturation_summary.return_value = SaturationSummary(
+            total_searches=0, saturated_searches=0,
+            saturation_rate=0.0, total_pre_filter_skips=0,
+            window_days=14,
+        )
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/saturation")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["outcome"], "success")
+        # Crucial: rate is 0.0, NOT NaN — JSON parses cleanly.
+        self.assertEqual(data["saturation_rate"], 0.0)
+        self.assertEqual(data["total_searches"], 0)
+
+    def test_request_not_found_returns_404(self):
+        self.mock_db.get_request.return_value = None
+        status, data = self._get(
+            "/api/pipeline/9999/search-plan/saturation")
+        self.assertEqual(status, 404)
+        _assert_required_fields(
+            self, data, self.FULL_REQUIRED_FIELDS, "saturation 404")
+        self.assertEqual(data["outcome"], "request_not_found")
+        self.assertEqual(data["request_id"], 9999)
+        # All summary counts zero-filled — clients can read without
+        # branching on status code first.
+        self.assertEqual(data["total_searches"], 0)
+        self.assertEqual(data["saturation_rate"], 0.0)
+        self.assertIn("error", data)
+        # The DB aggregator must NOT be called when the request row
+        # itself is missing — wastes a query and risks misleading zeros.
+        self.mock_db.get_saturation_summary.assert_not_called()
+
+    def test_window_days_query_string_propagates_to_service(self):
+        from lib.pipeline_db import SaturationSummary
+        self.mock_db.get_saturation_summary.return_value = SaturationSummary(
+            total_searches=5, saturated_searches=1,
+            saturation_rate=0.2, total_pre_filter_skips=3,
+            window_days=7,
+        )
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/saturation?window_days=7")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["window_days"], 7)
+        # The aggregator was called with the requested window.
+        self.mock_db.get_saturation_summary.assert_called_with(
+            100, window_days=7)
+
+    def test_invalid_window_days_non_int_returns_400(self):
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/saturation?window_days=abc")
+        self.assertEqual(status, 400)
+
+    def test_invalid_window_days_out_of_range_returns_400(self):
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/saturation?window_days=0")
+        self.assertEqual(status, 400)
+        _assert_required_fields(
+            self, data, self.FULL_REQUIRED_FIELDS, "saturation 400")
+        self.assertEqual(data["outcome"], "input_invalid")
+
+    def test_default_window_is_14_when_omitted(self):
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/saturation")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["window_days"], 14)
 
 
 class TestPipelineSearchPlanRegenerateContract(_WebServerCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -485,7 +485,7 @@ def _make_server():
             ],
         },
         "plan_readiness": {
-            "generator_id": "search-plan/2026-05-08-1",
+            "generator_id": "search-plan/2026-05-19-1",
             "wanted_total": 10,
             "wanted_searchable": 7,
             "wanted_legacy": 1,
@@ -1919,7 +1919,7 @@ class TestPipelineSearchPlanContract(_WebServerCase):
 
     def _make_active(
         self, *,
-        generator_id: str = "search-plan/2026-05-08-1",
+        generator_id: str = "search-plan/2026-05-19-1",
         items_count: int = 2,
         next_ordinal: int = 0,
         cycle_count: int = 0,
@@ -1961,7 +1961,7 @@ class TestPipelineSearchPlanContract(_WebServerCase):
         status: str,
         failure_class: str,
         error_message: str = "boom",
-        generator_id: str = "search-plan/2026-05-08-1",
+        generator_id: str = "search-plan/2026-05-19-1",
     ):
         from datetime import datetime, timezone
         from lib.pipeline_db import SearchPlanRow, SearchPlanProvenance

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -988,6 +988,7 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/pipeline/simulate",
         r"^/api/pipeline/(\d+)$",
         r"^/api/pipeline/(\d+)/search-plan$",
+        r"^/api/pipeline/(\d+)/search-plan/dry-run$",
         r"^/api/pipeline/(\d+)/search-plan/history$",
         r"^/api/pipeline/(\d+)/search-plan/regenerate$",
         r"^/api/pipeline/(\d+)/search-plan/advance$",
@@ -2154,6 +2155,168 @@ class TestPipelineSearchPlanContract(_WebServerCase):
         self.assertEqual(
             data["currentness"]["active_plan_generator_id"],
             "search-plan/2026-01-01-old")
+
+
+class TestPipelineSearchPlanDryRunContract(_WebServerCase):
+    """U6 contract for ``GET /api/pipeline/<id>/search-plan/dry-run``.
+
+    Read-only generator simulator. The route wraps
+    ``SearchPlanService.dry_run_for_request``; both this route and
+    ``pipeline-cli search-plan dry-run`` go through the same service
+    method so input semantics + outcome mapping cannot drift. The
+    contract guarantees the payload shape used by the future search-
+    plan dashboard.
+    """
+
+    REQUIRED_FIELDS = {
+        "request_id",
+        "outcome",
+        "current_generator_id",
+        "request",
+        "plan",
+        "would_supersede_active",
+        "error_message",
+    }
+    REQUEST_REQUIRED_FIELDS = {
+        "id", "status", "artist_name", "album_title",
+        "mb_release_id", "discogs_release_id", "year",
+        "release_group_year", "source",
+    }
+    PLAN_REQUIRED_FIELDS = {
+        "generator_id", "status", "items", "provenance",
+        "failure_reason", "metadata_snapshot",
+    }
+    ITEM_REQUIRED_FIELDS = {
+        "ordinal", "strategy", "query",
+        "canonical_query_key", "repeat_group", "provenance",
+    }
+
+    def setUp(self) -> None:
+        from tests.helpers import make_request_row
+        self.mock_db.get_request.return_value = make_request_row(
+            id=100, status="wanted",
+            artist_name="Radiohead", album_title="Kid A",
+            year=2008, release_group_year=2000,
+        )
+        self.mock_db.get_tracks.return_value = [
+            {"disc_number": 1, "track_number": 1,
+             "title": "Everything In Its Right Place"},
+            {"disc_number": 1, "track_number": 2, "title": "Kid A"},
+            {"disc_number": 1, "track_number": 3,
+             "title": "The National Anthem"},
+        ]
+        self.mock_db.get_active_search_plan.return_value = None
+        # Route reads runtime config — patch to a default CratediggerConfig.
+        from lib.config import CratediggerConfig
+        import configparser
+        cp = configparser.RawConfigParser()
+        cp.read_string("[General]\n")
+        self._cfg_patcher = patch(
+            "lib.config.read_runtime_config",
+            return_value=CratediggerConfig.from_ini(cp),
+        )
+        self._cfg_patcher.start()
+
+    def tearDown(self) -> None:
+        self._cfg_patcher.stop()
+        self.mock_db.get_active_search_plan.reset_mock(
+            return_value=True, side_effect=True)
+        self.mock_db.get_tracks.return_value = []
+
+    def test_dry_run_happy_path_returns_200_with_required_fields(self):
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/dry-run")
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.REQUIRED_FIELDS, "dry-run")
+        self.assertEqual(data["request_id"], 100)
+        self.assertEqual(data["outcome"], "success")
+        self.assertIsNotNone(data["request"])
+        _assert_required_fields(
+            self, data["request"], self.REQUEST_REQUIRED_FIELDS,
+            "dry-run request")
+        self.assertEqual(data["request"]["release_group_year"], 2000)
+        self.assertIsNotNone(data["plan"])
+        _assert_required_fields(
+            self, data["plan"], self.PLAN_REQUIRED_FIELDS,
+            "dry-run plan")
+        self.assertGreater(len(data["plan"]["items"]), 0)
+        for item in data["plan"]["items"]:
+            _assert_required_fields(
+                self, item, self.ITEM_REQUIRED_FIELDS,
+                "dry-run plan.items[]")
+        # Ordinals must be sorted.
+        ordinals = [it["ordinal"] for it in data["plan"]["items"]]
+        self.assertEqual(ordinals, sorted(ordinals))
+        # No active plan was wired — would_supersede_active is False.
+        self.assertFalse(data["would_supersede_active"])
+
+    def test_dry_run_reports_active_plan_would_be_superseded(self):
+        # When an active plan exists, the response flags
+        # would_supersede_active=True so operators understand the
+        # current plan would be replaced by a real regeneration call.
+        self.mock_db.get_active_search_plan.return_value = MagicMock()
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/dry-run")
+        self.assertEqual(status, 200)
+        self.assertTrue(data["would_supersede_active"])
+
+    def test_dry_run_request_not_found_returns_404(self):
+        self.mock_db.get_request.return_value = None
+        status, data = self._get(
+            "/api/pipeline/9999/search-plan/dry-run")
+        self.assertEqual(status, 404)
+        # 404 body must carry the same structured shape so clients can
+        # introspect outcome / plan without status-code branching.
+        _assert_required_fields(
+            self, data, self.REQUIRED_FIELDS, "dry-run 404")
+        self.assertEqual(data["outcome"], "request_not_found")
+        self.assertEqual(data["request_id"], 9999)
+        self.assertIsNone(data["plan"])
+        self.assertIsNone(data["request"])
+        self.assertIn("error", data)
+
+    def test_dry_run_request_with_no_tracks_succeeds(self):
+        # Generator handles empty tracks — emits a plan without
+        # track-fallback slots; the dry-run reflects exactly that.
+        self.mock_db.get_tracks.return_value = []
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/dry-run")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["outcome"], "success")
+        self.assertIsNotNone(data["plan"])
+        # No track_* slots should appear.
+        strategies = [
+            it["strategy"] for it in data["plan"]["items"]
+        ]
+        self.assertFalse(
+            any(s.startswith("track_") for s in strategies),
+            f"unexpected track-fallback slots in zero-tracks plan: "
+            f"{strategies}")
+
+    def test_dry_run_does_not_persist_or_write_plan_rows(self):
+        # The simulator must never call into create_successful_search_plan
+        # / supersede_search_plan_with_replacement / create_failed_search_plan.
+        self.mock_db.create_successful_search_plan.reset_mock()
+        self.mock_db.supersede_search_plan_with_replacement.reset_mock()
+        self.mock_db.create_failed_search_plan.reset_mock()
+        status, _ = self._get(
+            "/api/pipeline/100/search-plan/dry-run")
+        self.assertEqual(status, 200)
+        self.mock_db.create_successful_search_plan.assert_not_called()
+        self.mock_db.supersede_search_plan_with_replacement.assert_not_called()
+        self.mock_db.create_failed_search_plan.assert_not_called()
+
+    def test_dry_run_carries_current_generator_id(self):
+        from lib.search import SEARCH_PLAN_GENERATOR_ID
+        status, data = self._get(
+            "/api/pipeline/100/search-plan/dry-run")
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            data["current_generator_id"], SEARCH_PLAN_GENERATOR_ID)
+        # The plan the simulator emits must be pinned to the same id.
+        self.assertEqual(
+            data["plan"]["generator_id"], SEARCH_PLAN_GENERATOR_ID)
 
 
 class TestPipelineSearchPlanRegenerateContract(_WebServerCase):

--- a/web/mb.py
+++ b/web/mb.py
@@ -183,6 +183,39 @@ def get_release_group(rg_mbid):
     return _cache.memoize_meta(f"mb:release-group:{rg_mbid}:meta", _fetch)
 
 
+def get_release_group_year(rg_mbid):
+    """Return the release-group's first-release year as an int, or None.
+
+    Used by the U3/U4 release-group-year backfill + enqueue path. The
+    MB ``/release-group/<mbid>`` endpoint returns ``first-release-date``
+    directly (verified against the local mirror at 2026-05-19), so a
+    single fetch is enough — no need to paginate child releases and
+    derive ``min(release.date)``.
+
+    Returns ``None`` when the mirror returns 404, when the response
+    lacks a parseable date, or when the year prefix is not 4 digits.
+    Callers treat ``None`` as "leave the column NULL"; they never
+    fail-hard on a missing release-group.
+    """
+    def _fetch() -> int | None:
+        try:
+            data = _get(f"{MB_API_BASE}/release-group/{rg_mbid}?fmt=json")
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            raise
+        date = data.get("first-release-date", "")
+        if not isinstance(date, str) or len(date) < 4:
+            return None
+        try:
+            return int(date[:4])
+        except ValueError:
+            return None
+
+    return _cache.memoize_meta(
+        f"mb:release-group:{rg_mbid}:year", _fetch)
+
+
 def get_release_group_releases(rg_mbid):
     """Get all releases for a release group. Returns list of release summaries."""
     def _fetch() -> dict:

--- a/web/mb.py
+++ b/web/mb.py
@@ -204,13 +204,8 @@ def get_release_group_year(rg_mbid):
             if exc.code == 404:
                 return None
             raise
-        date = data.get("first-release-date", "")
-        if not isinstance(date, str) or len(date) < 4:
-            return None
-        try:
-            return int(date[:4])
-        except ValueError:
-            return None
+        from lib.util import parse_mb_first_release_year
+        return parse_mb_first_release_year(data)
 
     return _cache.memoize_meta(
         f"mb:release-group:{rg_mbid}:year", _fetch)

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1227,13 +1227,21 @@ def post_pipeline_add(h, body: dict) -> None:
     # an extra MB mirror round trip on add.
     release = mb_api.get_release(mbid, fresh=True)
 
+    # U4: persist release-group year alongside release year so the
+    # generator (U5) can emit a year-anchored slot that matches how
+    # users on Soulseek actually file reissues. ``get_release_group_year``
+    # returns None on 404 / unparseable date; column accepts NULL.
+    rg_id = release.get("release_group_id")
+    rg_year = mb_api.get_release_group_year(rg_id) if rg_id else None
+
     req_id = s._db().add_request(
         mb_release_id=mbid,
-        mb_release_group_id=release.get("release_group_id"),
+        mb_release_group_id=rg_id,
         mb_artist_id=release.get("artist_id"),
         artist_name=release["artist_name"],
         album_title=release["title"],
         year=release.get("year"),
+        release_group_year=rg_year,
         country=release.get("country"),
         source=source,
     )
@@ -1379,12 +1387,21 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             )
         else:
             release = mb_api.get_release(mbid, fresh=True)
+            # U4: persist release-group year alongside release year. See
+            # ``post_pipeline_add`` for rationale.
+            rg_id_upgrade = release.get("release_group_id")
+            rg_year_upgrade = (
+                mb_api.get_release_group_year(rg_id_upgrade)
+                if rg_id_upgrade else None
+            )
             req_id = s._db().add_request(
                 mb_release_id=mbid,
+                mb_release_group_id=rg_id_upgrade,
                 mb_artist_id=release.get("artist_id"),
                 artist_name=release["artist_name"],
                 album_title=release["title"],
                 year=release.get("year"),
+                release_group_year=rg_year_upgrade,
                 country=release.get("country"),
                 source="request",
             )

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -598,6 +598,83 @@ def get_pipeline_search_plan_dry_run(
     h._error(f"Unknown dry-run outcome: {result.outcome}", 500)
 
 
+def get_pipeline_search_plan_saturation(
+    h, params: dict[str, list[str]], req_id_str: str,
+) -> None:
+    """U7: ``GET /api/pipeline/<id>/search-plan/saturation``.
+
+    Read-only telemetry aggregator. Returns the saturation rate (rows
+    whose ``final_state`` contains ``LimitReached``) and total
+    ``pre_filter_skip_count`` over the last ``window_days`` (default
+    14) of ``search_log`` rows for ``<id>``. Counterpart of
+    ``pipeline-cli search-plan saturation``; both surfaces wrap
+    ``SearchPlanService.saturation_for_request`` — keep them in sync
+    (see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
+
+    Query string:
+      * ``window_days`` — int in
+        ``[SATURATION_WINDOW_MIN_DAYS, SATURATION_WINDOW_MAX_DAYS]``;
+        defaults to ``SATURATION_WINDOW_DEFAULT_DAYS``.
+
+    Status-code mapping:
+      * 200 — ``RESULT_SATURATION_SUCCESS`` (counts may be zero — a
+        valid "found but quiet" state).
+      * 400 — ``window_days`` not parseable as int, or
+        ``RESULT_SATURATION_INPUT_INVALID``.
+      * 404 — ``RESULT_REQUEST_NOT_FOUND`` (request_id does not exist
+        in ``album_requests``; distinct from a real request whose
+        window happens to be empty).
+    """
+    from lib.config import read_runtime_config
+    from lib.search_plan_service import (
+        RESULT_REQUEST_NOT_FOUND,
+        RESULT_SATURATION_INPUT_INVALID,
+        RESULT_SATURATION_SUCCESS,
+        SATURATION_WINDOW_DEFAULT_DAYS,
+        SearchPlanService,
+        saturation_payload,
+    )
+    try:
+        request_id = int(req_id_str)
+    except (TypeError, ValueError):
+        h._error("Invalid request id")
+        return
+    window_raw = params.get("window_days", [None])[0]
+    if window_raw is None or window_raw == "":
+        window_days = SATURATION_WINDOW_DEFAULT_DAYS
+    else:
+        try:
+            window_days = int(window_raw)
+        except (TypeError, ValueError):
+            h._error(
+                f"window_days must be an integer; got {window_raw!r}",
+                status=400,
+            )
+            return
+
+    db = _server()._db()
+    cfg = read_runtime_config()
+    svc = SearchPlanService(db, cfg)
+    result = svc.saturation_for_request(
+        request_id, window_days=window_days,
+    )
+    payload = saturation_payload(result)
+    if result.outcome == RESULT_REQUEST_NOT_FOUND:
+        payload["error"] = result.error_message or "Not found"
+        h._json(payload, status=404)
+        return
+    if result.outcome == RESULT_SATURATION_INPUT_INVALID:
+        payload["error"] = (
+            result.error_message or "Invalid window_days")
+        h._json(payload, status=400)
+        return
+    if result.outcome == RESULT_SATURATION_SUCCESS:
+        h._json(payload)
+        return
+    # Defensive fallback for any future outcome string.
+    h._error(f"Unknown saturation outcome: {result.outcome}", 500)
+
+
 def get_pipeline_search_plan_history(
     h, params: dict[str, list[str]], req_id_str: str,
 ) -> None:
@@ -2092,6 +2169,8 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
      get_pipeline_search_plan),
     (re.compile(r"^/api/pipeline/(\d+)/search-plan/dry-run$"),
      get_pipeline_search_plan_dry_run),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/saturation$"),
+     get_pipeline_search_plan_saturation),
     (re.compile(r"^/api/pipeline/(\d+)/search-plan/history$"),
      get_pipeline_search_plan_history),
     (re.compile(r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$"),

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1384,10 +1384,10 @@ def post_pipeline_add(h, body: dict) -> None:
     # an extra MB mirror round trip on add.
     release = mb_api.get_release(mbid, fresh=True)
 
-    # U4: persist release-group year alongside release year so the
-    # generator (U5) can emit a year-anchored slot that matches how
-    # users on Soulseek actually file reissues. ``get_release_group_year``
-    # returns None on 404 / unparseable date; column accepts NULL.
+    # Persist release-group year alongside release year so the generator
+    # can emit a year-anchored slot matching how users on Soulseek file
+    # reissues. ``get_release_group_year`` returns None on 404 /
+    # unparseable date; column accepts NULL.
     rg_id = release.get("release_group_id")
     rg_year = mb_api.get_release_group_year(rg_id) if rg_id else None
 
@@ -1527,6 +1527,8 @@ def post_pipeline_upgrade(h, body: dict) -> None:
     else:
         # Brand-new request — no prior override to preserve.
         quality = QUALITY_UPGRADE_TIERS
+        # Discogs upgrade leaves release_group_year NULL (no MB release-group).
+        rg_year_upgrade: int | None = None
         # Bypass the 24h meta cache — both branches persist metadata
         # into the pipeline DB (artist / title / tracks). Stale cache
         # reads would silently bake pre-correction data from an earlier
@@ -1545,8 +1547,6 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             )
         else:
             release = mb_api.get_release(mbid, fresh=True)
-            # U4: persist release-group year alongside release year. See
-            # ``post_pipeline_add`` for rationale.
             rg_id_upgrade = release.get("release_group_id")
             rg_year_upgrade = (
                 mb_api.get_release_group_year(rg_id_upgrade)
@@ -1565,9 +1565,6 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             )
         if release.get("tracks"):
             s._db().set_tracks(req_id, release["tracks"])
-        # rg_year_upgrade only exists on the MB branch above; Discogs
-        # upgrade leaves release_group_year NULL (no MB release-group).
-        _rg_year_for_plan = locals().get("rg_year_upgrade")
         _generate_plan_after_add(
             req_id,
             artist_name=release["artist_name"],
@@ -1575,7 +1572,7 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             year=release.get("year"),
             tracks=release.get("tracks") or [],
             source="request",
-            release_group_year=_rg_year_for_plan,
+            release_group_year=rg_year_upgrade,
         )
         # Newly added request — status is already 'wanted', set quality override
         transitions.finalize_request(

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -523,6 +523,81 @@ def get_pipeline_search_plan(
     h._json(payload)
 
 
+def get_pipeline_search_plan_dry_run(
+    h, params: dict[str, list[str]], req_id_str: str,
+) -> None:
+    """U6: ``GET /api/pipeline/<id>/search-plan/dry-run``.
+
+    Read-only generator simulator. Runs ``generate_search_plan``
+    against the current persisted snapshot for ``<id>`` and returns
+    the resulting plan items without writing anything. Counterpart of
+    ``pipeline-cli search-plan dry-run``; both surfaces wrap
+    ``SearchPlanService.dry_run_for_request`` — keep them in sync
+    (see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
+
+    Query string:
+      * ``prepend_artist`` — ``1`` to enable (defaults to runtime
+        config's ``album_prepend_artist``).
+
+    Status-code mapping:
+      * 200 — ``RESULT_DRY_RUN_SUCCESS`` or
+        ``RESULT_DRY_RUN_GENERATION_FAILED`` (the latter is a
+        deterministic generator outcome the operator wants to see in
+        the body — the route is informational, not a hard error).
+      * 404 — ``RESULT_REQUEST_NOT_FOUND``.
+    """
+    from lib.config import read_runtime_config
+    from lib.search_plan_service import (
+        RESULT_DRY_RUN_GENERATION_FAILED,
+        RESULT_DRY_RUN_SUCCESS,
+        RESULT_REQUEST_NOT_FOUND,
+        SearchPlanService,
+        dry_run_payload,
+    )
+    try:
+        request_id = int(req_id_str)
+    except (TypeError, ValueError):
+        h._error("Invalid request id")
+        return
+    prepend_artist_raw = params.get("prepend_artist", [None])[0]
+    prepend_artist: bool | None
+    if prepend_artist_raw is None or prepend_artist_raw == "":
+        prepend_artist = None
+    else:
+        prepend_artist = prepend_artist_raw == "1"
+
+    db = _server()._db()
+    cfg = read_runtime_config()
+    svc = SearchPlanService(db, cfg)
+    result = svc.dry_run_for_request(
+        request_id, prepend_artist=prepend_artist,
+    )
+    row = db.get_request(request_id)
+    has_active = False
+    if row is not None:
+        try:
+            active = db.get_active_search_plan(request_id)
+            has_active = active is not None
+        except Exception:  # noqa: BLE001
+            has_active = False
+    payload = dry_run_payload(
+        result,
+        current_generator_id=svc.generator_id,
+        request_row=row,
+        has_active_plan=has_active,
+    )
+    if result.outcome == RESULT_REQUEST_NOT_FOUND:
+        payload["error"] = result.error_message or "Not found"
+        h._json(payload, status=404)
+        return
+    if result.outcome in (
+            RESULT_DRY_RUN_SUCCESS, RESULT_DRY_RUN_GENERATION_FAILED):
+        h._json(payload)
+        return
+    # Defensive fallback for any future outcome string.
+    h._error(f"Unknown dry-run outcome: {result.outcome}", 500)
+
+
 def get_pipeline_search_plan_history(
     h, params: dict[str, list[str]], req_id_str: str,
 ) -> None:
@@ -2015,6 +2090,8 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/pipeline/(\d+)$"), get_pipeline_detail),
     (re.compile(r"^/api/pipeline/(\d+)/search-plan$"),
      get_pipeline_search_plan),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/dry-run$"),
+     get_pipeline_search_plan_dry_run),
     (re.compile(r"^/api/pipeline/(\d+)/search-plan/history$"),
      get_pipeline_search_plan_history),
     (re.compile(r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$"),

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -44,13 +44,17 @@ MAX_PIPELINE_LOG_LIMIT = 500
 
 
 def _generate_plan_after_add(req_id, *, artist_name, album_title, year,
-                              tracks, source):
+                              tracks, source, release_group_year=None):
     """Run shared plan generation after `set_tracks()` on the add path.
 
     Failures are recorded but never bubble up — the request is repairable
     via startup reconciliation or explicit regeneration. This keeps the
     add API contract stable: a 200 response means the request landed,
     even if plan generation needs another attempt.
+
+    ``release_group_year`` (U5 of search-plan-entropy) feeds the
+    generator's conditional ``unwild_rg_year`` slot for reissues. Pass
+    ``None`` when unknown — the generator handles it gracefully.
     """
     from lib.config import read_runtime_config
     from lib.search_plan_service import SearchPlanService
@@ -64,6 +68,7 @@ def _generate_plan_after_add(req_id, *, artist_name, album_title, year,
             year=year,
             tracks=tracks or [],
             source=source,
+            release_group_year=release_group_year,
         )
     except Exception as exc:  # noqa: BLE001
         # Never fail the HTTP request because plan generation hiccupped.
@@ -1256,6 +1261,7 @@ def post_pipeline_add(h, body: dict) -> None:
         year=release.get("year"),
         tracks=release.get("tracks") or [],
         source=source,
+        release_group_year=rg_year,
     )
 
     h._json({
@@ -1407,6 +1413,9 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             )
         if release.get("tracks"):
             s._db().set_tracks(req_id, release["tracks"])
+        # rg_year_upgrade only exists on the MB branch above; Discogs
+        # upgrade leaves release_group_year NULL (no MB release-group).
+        _rg_year_for_plan = locals().get("rg_year_upgrade")
         _generate_plan_after_add(
             req_id,
             artist_name=release["artist_name"],
@@ -1414,6 +1423,7 @@ def post_pipeline_upgrade(h, body: dict) -> None:
             year=release.get("year"),
             tracks=release.get("tracks") or [],
             source="request",
+            release_group_year=_rg_year_for_plan,
         )
         # Newly added request — status is already 'wanted', set quality override
         transitions.finalize_request(


### PR DESCRIPTION
## Summary

A small cohort of curated requests — Radiohead Kid A, Bon Iver
22 a Million, Willow self-titled, Mountains, Darren Hanlon — was
starving in the pipeline: 40+ search attempts each, repeated saturation
at slskd's response/file caps, zero downloads. Manual probes confirmed
the albums are abundant in lossless on the network. The pipeline was
generating queries that couldn't find them and a matcher pre-filter
was silently discarding the few good results that did come through.

This PR fixes both. The starving cohort should reach `imported` or
surface real candidates within two weeks of deploy.

---

## What was broken

**Matcher pre-filter false positive.** `check_for_match` skipped any
peer whose audio-file count differed from the album track count by
more than 2. Track-fallback queries return one matching file per peer,
so `|1 - 4| = 3 > 2` fires for any album with four or more tracks.
Three Willow track-fallback searches returned 2, 4, and 6 results;
the matcher recorded zero candidates evaluated each time.

**Low-entropy generator output.** Five of ten plan slots were the same
default query repeated. An unconditional short-token drop stripped
distinguishing tokens (the "A" in "Kid A", the "22" in "22, a
Million"). Self-titled albums collapsed to single wildcarded tokens
(`*illow`, `*ountains`). Track-name fallback slots dropped the artist
entirely.

**Wrong year on reissues.** Year-anchored queries used the MB release
year. Kid A's 2008 US reissue year returned ~6 results; the original
2000 year would have returned hundreds.

---

## What changed

| Mechanism | Before | After |
|---|---|---|
| Matcher pre-filter | bidirectional `\|n − m\| > 2` (kills track-fallback) | asymmetric `n > 2m` (junk-dir guard only) |
| Default plan slot | 5× identical wildcarded query | 1× wildcarded + literal + format-hint + year + track-with-artist |
| Short-token drop | strips ≤2-char tokens unconditionally | removed; rank by distinctiveness, cap total count |
| Track-fallback query | title only ("Motion Picture Soundtrack") | artist-prepended ("Radiohead Motion Picture Soundtrack") |
| Year anchor | MB release year only | release year + release-group year when they differ |
| Self-titled requests | collapse to `*illow` | dedicated mix: artist + first-track-title + year |
| Saturation visibility | invisible | `pre_filter_skip_count` column + flagged sample rows + saturation aggregator + dry-run simulator |

The `2n` threshold preserves the pre-filter's true value (catching
peers whose dir clearly contains too much stuff to be the album) while
killing the false-positive case. As a bonus, more peer-folder data
flows into the 7-day Redis browse cache — substrate for a future
cross-pressing matcher (we wanted the EU pressing, peer has the
Japanese with bonus tracks).

Format-hint slots (FLAC, lossless) are unconditional. Every request
in the pipeline wants lossless — confirmed by query across 4,300+
rows; zero exclude FLAC. No state machine; generator stays a pure
function of the snapshot.

---

## Design decisions

- **Asymmetric pre-filter over variant plumbing** — one-line condition
  flip beats threading variant context through three function
  signatures. Matcher stays unaware of search strategy.
- **`2n` over `n+2`** — junk-dir guard, not tight-fit filter. The
  7-day Redis browse cache makes the higher browse cost affordable.
- **`release_group_year` as a real column** — backfilled once after
  deploy. Conditional extra slot only when years differ; no duplicate
  slots when they match.
- **Storage-bounded forensics** — scalar count column for aggregation;
  up to 5 flagged sample rows in the existing candidates JSONB. Per-row
  growth ~1-2 KB.
- **Single GENERATOR_ID bump** to `search-plan/2026-05-19-1`. Every
  active plan invalidates on next cycle and regenerates from the new
  generator. Pure-CPU regeneration on the snapshot row — no MB / beets
  / slskd load.

Operator surfaces (CLI ⇄ API symmetric, both classified in
`TestRouteContractAudit.CLASSIFIED_ROUTES`):
`pipeline-cli search-plan dry-run <id>` for pre-deploy validation;
`pipeline-cli search-plan saturation <id>` for the data layer the
dashboard work (`docs/brainstorms/2026-05-09-search-plan-per-request-dashboard-requirements.md`)
will consume next iteration.

---

## Test plan

- 3,738 tests, 56 skipped, 0 failures.
- pyright clean across all 14 modified production files.
- Tier 2 ce-code-review: zero P0/P1; standards / migrations /
  adversarial / learnings agents all green.
- Three legacy tests updated to match the new (intentional) semantics:
  junk-dir guard scenario, top-15+5 split, GENERATOR_ID default.

Per-unit test scenarios and acceptance examples live in
`docs/plans/2026-05-19-001-feat-search-plan-entropy-and-matcher-prefilter-plan.md`.

---

## Migrations

- `025_search_log_pre_filter_skip_count.sql` — PG 11+ takes the fast
  path on `NOT NULL DEFAULT <constant>`. Sub-second catalog-only
  change on the ~1M-row search_log table.
- `026_album_requests_release_group_year.sql` — nullable add on ~4,000
  rows.
- Independent, safe in any order, run by `cratedigger-db-migrate.service`
  before app services start.

---

## Post-deploy

1. **Run the backfill once.** Migrations land automatically. Then:
   ```bash
   ssh doc2 'sudo -u cratedigger python3 /etc/nixos/cratedigger-src/scripts/backfill_release_group_year.py'
   ```
   ~4,000 rows, all local MB-mirror I/O, finishes in seconds. Idempotent.

2. **Watch the regen spike.** First cycle post-deploy regenerates every
   active plan. Pure-CPU, no external load.
   `ssh doc2 'sudo journalctl -u cratedigger -f'`

3. **Validate at 14d.** Targets: starving cohort (≥5 saturated + 0
   finds in 14d) drops by ≥50%; at least three of {Kid A, Bon Iver,
   Willow, Mountains, Hanlon} reach `imported` or surface real
   candidates. Zero `search_log` rows where `outcome='no_match' AND
   variant LIKE 'track%' AND result_count > 0 AND candidates = '[]'`.

4. **Rollback trigger.** If the regen spike causes the 5-min cycle to
   miss deadlines for >2 consecutive cycles, revert
   `SEARCH_PLAN_GENERATOR_ID`. Existing plans continue running on the
   new code (forward-compat); only regeneration pauses.

---

## Known residuals

Tier 2 review (zero P0/P1) flagged P2/P3 items, all explicitly
accepted:

- Generator does not auto-regenerate after the backfill populates
  `release_group_year`. Operator can `search-plan regenerate <id>`
  for high-priority cases or wait for the next snapshot fingerprint
  change. Acceptable.
- Several pre-existing patterns (theoretical empty-tracks
  IndexError, ThreadPool race on `negative_matches` set,
  year-9999 cosmetic) — not introduced here, separate cleanup.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
