### PR TITLE
test(mbid-replace): swap MagicMock slskd for FakeSlskdAPI

### DIFF
--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -96,9 +96,6 @@
     "patch:lib.matching._track_titles_cross_check": 1,
     "stateful_mock_assign:slskd": 1
   },
-  "test_mbid_replace_service.py": {
-    "stateful_mock_assign:slskd": 1
-  },
   "test_measurement.py": {
     "patch:lib.measurement._iter_audio_files": 2,
     "patch:lib.measurement.hash_audio_content": 2,

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -33,7 +33,7 @@ from lib.mbid_replace_service import (
 from lib.pipeline_db import MbidCollisionError, SupersedeRaceError
 from lib.release_cleanup import ReleaseCleanupResult
 from lib.wrong_match_delete_service import WrongMatchDeleteSummary
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
 from tests.helpers import make_request_row
 
 
@@ -140,11 +140,26 @@ class _ServiceCase(unittest.TestCase):
         return MbidReplaceService(
             db=db,
             config=cfg or CratediggerConfig(),
-            slskd=MagicMock(),
+            slskd=FakeSlskdAPI(),
             beets_db_factory=beets_db_factory,
             mb_lookup=mb_lookup,
             search_plan_service=search_plan_service,
         )
+
+    def _assert_slskd_untouched(self, slskd: object) -> None:
+        """Assert FakeSlskdAPI recorded zero calls across every surface.
+
+        Replaces the legacy ``MagicMock.mock_calls == []`` snapshot pattern.
+        With a typed fake, every API entry-point appends to a per-method
+        call log — so "never touched" means every log is empty.
+        """
+        assert isinstance(slskd, FakeSlskdAPI)
+        self.assertEqual(slskd.transfers.enqueue_calls, [])
+        self.assertEqual(slskd.transfers.cancel_download_calls, [])
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [])
+        self.assertEqual(slskd.transfers.get_download_calls, [])
+        self.assertEqual(slskd.users.directory_calls, [])
+        self.assertEqual(slskd.users.status_calls, [])
 
 
 class TestReplaceOutcomeMatrix(_ServiceCase):
@@ -605,7 +620,7 @@ class TestReplaceHappyPath(_ServiceCase):
             result.new_request_id, regenerate=False,
         )
         # slskd never touched.
-        self.assertEqual(slskd.mock_calls, [])
+        self._assert_slskd_untouched(slskd)
 
     def test_happy_path_imported_calls_beets_with_clear_false(self):
         self._patch_externals()
@@ -637,7 +652,7 @@ class TestReplaceHappyPath(_ServiceCase):
         # Warning about orphaned transfer.
         self.assertTrue(any("downloading" in w for w in result.warnings))
         # slskd was never called.
-        self.assertEqual(slskd.mock_calls, [])
+        self._assert_slskd_untouched(slskd)
 
     def test_happy_path_manual(self):
         self._patch_externals()
@@ -1032,11 +1047,9 @@ class TestReplaceCallOrder(_ServiceCase):
             manager.attach_mock(mock_jelly, "trigger_jellyfin_scan")
 
             svc = self._make_service(db)
-            slskd_calls_before = list(svc.slskd.mock_calls)
             result = svc.replace_request_mbid(
                 42, target_mb_release_id=NEW_MBID,
             )
-            slskd_calls_after = list(svc.slskd.mock_calls)
 
         self.assertEqual(result.outcome, RESULT_REPLACED)
         # Extract the recorded call sequence as method names.
@@ -1058,8 +1071,10 @@ class TestReplaceCallOrder(_ServiceCase):
                 f"{fs_helper} ran after a rescan helper "
                 f"(call order: {call_names})",
             )
-        # slskd was never touched (R23).
-        self.assertEqual(slskd_calls_before, slskd_calls_after)
+        # slskd was never touched (R23). FakeSlskdAPI records every call;
+        # the assertion replaces the MagicMock.mock_calls snapshot
+        # pattern with explicit empty-call-log checks.
+        self._assert_slskd_untouched(svc.slskd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

First real Phase 2 migration of #290. Smallest target (1 baseline finding) chosen as a pattern probe before tackling larger offenders.

**Stacked on #292** — review that one first; this branch will be rebased on `main` after `#292` merges.

## What changed

`_ServiceCase._make_service` constructed `MbidReplaceService` with `slskd=MagicMock()`. `MbidReplaceService` takes slskd as a constructor arg but the Replace flow deliberately doesn't touch it (issue #278 — in-flight transfers are left for separate convergence). The MagicMock was a placeholder; `FakeSlskdAPI()` is the same shape and intent, plus actual call-record tracking.

Two `slskd.mock_calls == []` assertions and one `svc.slskd.mock_calls` snapshot relied on MagicMock's introspection attribute. Replaced with `_assert_slskd_untouched(slskd)` on the shared `_ServiceCase` base — asserts every recorded call log on `FakeSlskdAPI.transfers` and `.users` is empty.

## Result

| Metric | Before | After |
|---|---|---|
| Baseline findings | 352 | 351 |
| Files in baseline | 27 | 26 |
| `test_mbid_replace_service.py` | 1 finding | gone |

## What I learned

Mid-migration, swapping in `FakeSlskdAPI` exposed a latent test-helper bug that MagicMock had been absorbing silently. The test helper `_empty_wrong_match_summary(request_id)` is patched in as `side_effect` for `delete_wrong_match_group(db, request_id)` (two args). The production code in `lib/mbid_replace_service.py` catches the TypeError and logs `Replace: warning request_id=X: wrong-matches cleanup raised TypeError: _empty_wrong_match_summary() takes 1 positional argument but 2 were given` — the tests still passed because the error path emits a warning and continues.

That's the audit doing its job: MagicMock was concealing a real signature mismatch. The fix isn't in this PR — it's a follow-up. Filed as a note on #290. This PR is scoped to the slskd swap.

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_mbid_replace_service -v"` — 34 tests pass
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3693 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo
- [x] Baseline re-snapshotted; audit passes

Tracking issue: #290
Stacked on: #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
