### PR TITLE
test(mbid-replace): swap MagicMock slskd for FakeSlskdAPI

### DIFF
--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -96,9 +96,6 @@
     "patch:lib.matching._track_titles_cross_check": 1,
     "stateful_mock_assign:slskd": 1
   },
-  "test_mbid_replace_service.py": {
-    "stateful_mock_assign:slskd": 1
-  },
   "test_measurement.py": {
     "patch:lib.measurement._iter_audio_files": 2,
     "patch:lib.measurement.hash_audio_content": 2,

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -33,7 +33,7 @@ from lib.mbid_replace_service import (
 from lib.pipeline_db import MbidCollisionError, SupersedeRaceError
 from lib.release_cleanup import ReleaseCleanupResult
 from lib.wrong_match_delete_service import WrongMatchDeleteSummary
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
 from tests.helpers import make_request_row
 
 
@@ -140,11 +140,26 @@ class _ServiceCase(unittest.TestCase):
         return MbidReplaceService(
             db=db,
             config=cfg or CratediggerConfig(),
-            slskd=MagicMock(),
+            slskd=FakeSlskdAPI(),
             beets_db_factory=beets_db_factory,
             mb_lookup=mb_lookup,
             search_plan_service=search_plan_service,
         )
+
+    def _assert_slskd_untouched(self, slskd: object) -> None:
+        """Assert FakeSlskdAPI recorded zero calls across every surface.
+
+        Replaces the legacy ``MagicMock.mock_calls == []`` snapshot pattern.
+        With a typed fake, every API entry-point appends to a per-method
+        call log — so "never touched" means every log is empty.
+        """
+        assert isinstance(slskd, FakeSlskdAPI)
+        self.assertEqual(slskd.transfers.enqueue_calls, [])
+        self.assertEqual(slskd.transfers.cancel_download_calls, [])
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [])
+        self.assertEqual(slskd.transfers.get_download_calls, [])
+        self.assertEqual(slskd.users.directory_calls, [])
+        self.assertEqual(slskd.users.status_calls, [])
 
 
 class TestReplaceOutcomeMatrix(_ServiceCase):
@@ -605,7 +620,7 @@ class TestReplaceHappyPath(_ServiceCase):
             result.new_request_id, regenerate=False,
         )
         # slskd never touched.
-        self.assertEqual(slskd.mock_calls, [])
+        self._assert_slskd_untouched(slskd)
 
     def test_happy_path_imported_calls_beets_with_clear_false(self):
         self._patch_externals()
@@ -637,7 +652,7 @@ class TestReplaceHappyPath(_ServiceCase):
         # Warning about orphaned transfer.
         self.assertTrue(any("downloading" in w for w in result.warnings))
         # slskd was never called.
-        self.assertEqual(slskd.mock_calls, [])
+        self._assert_slskd_untouched(slskd)
 
     def test_happy_path_manual(self):
         self._patch_externals()
@@ -1032,11 +1047,9 @@ class TestReplaceCallOrder(_ServiceCase):
             manager.attach_mock(mock_jelly, "trigger_jellyfin_scan")
 
             svc = self._make_service(db)
-            slskd_calls_before = list(svc.slskd.mock_calls)
             result = svc.replace_request_mbid(
                 42, target_mb_release_id=NEW_MBID,
             )
-            slskd_calls_after = list(svc.slskd.mock_calls)
 
         self.assertEqual(result.outcome, RESULT_REPLACED)
         # Extract the recorded call sequence as method names.
@@ -1059,7 +1072,7 @@ class TestReplaceCallOrder(_ServiceCase):
                 f"(call order: {call_names})",
             )
         # slskd was never touched (R23).
-        self.assertEqual(slskd_calls_before, slskd_calls_after)
+        self._assert_slskd_untouched(svc.slskd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

First Phase 2 migration of #290 against current `main`. Smallest target (1 baseline finding) — pattern probe for the rest of the suite. Replaces the closed #293 which was stacked on #292 before it merged.

`_ServiceCase._make_service` constructed `MbidReplaceService` with `slskd=MagicMock()`. Replace deliberately doesn't touch slskd (issue #278 — in-flight transfers are left for separate convergence); the mock was a neutral placeholder. `FakeSlskdAPI()` is the same shape, with a typed call surface.

Three `slskd.mock_calls == []` snapshots replaced by `_assert_slskd_untouched(slskd)` on the shared `_ServiceCase` base — asserts every recorded call log on `FakeSlskdAPI.transfers` and `.users` is empty.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 352 | 351 |
| Files in baseline | 27 | 26 |

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_mbid_replace_service -v"` — 34 tests pass
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3693 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
