### PR TITLE
fix(test): _empty_wrong_match_summary arity matches delete_wrong_match_group

### DIFF
--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -46,7 +46,15 @@ RG_ID = "11111111-1111-1111-1111-111111111111"
 OTHER_RG_ID = "22222222-2222-2222-2222-222222222222"
 
 
-def _empty_wrong_match_summary(request_id: int) -> WrongMatchDeleteSummary:
+def _empty_wrong_match_summary(_db, request_id: int) -> WrongMatchDeleteSummary:
+    """Stand-in for ``delete_wrong_match_group(db, request_id)``.
+
+    Matches the production signature (two positional args). Tests previously
+    declared this with one arg; production caught the resulting TypeError
+    and logged ``Replace: warning ... wrong-matches cleanup raised
+    TypeError`` while still passing because the warning path continued.
+    The migration to ``FakeSlskdAPI`` surfaced the latent mismatch.
+    """
     return WrongMatchDeleteSummary(
         request_id=request_id,
         outcome="group_empty",


### PR DESCRIPTION
## Summary

Fixes the latent test-helper signature bug surfaced by #294 (MagicMock → FakeSlskdAPI migration on `test_mbid_replace_service.py`).

`_empty_wrong_match_summary` was declared as `(request_id)` but patched in as `side_effect` for `delete_wrong_match_group(db, request_id)` — production calls it with two positional args. Production catches the resulting TypeError and emits `Replace: warning request_id=X: wrong-matches cleanup raised TypeError: _empty_wrong_match_summary() takes 1 positional argument but 2 were given` (see `lib/mbid_replace_service.py:529`). Tests still passed because the warning path continued and assertions held.

This is the exact class of bug the audit was designed to flag. MagicMock would have absorbed any signature mismatch silently, but the typed helper's contract was breached. The fix adds the missing `_db` parameter.

## Before

```
Replace: warning request_id=42: wrong-matches cleanup raised TypeError:
  _empty_wrong_match_summary() takes 1 positional argument but 2 were given
```
(emitted from 8+ tests; not visible in test output because they assert against final state, not log records)

## After

Warning no longer fires. Other `Replace: warning ...` entries in test output are now only the warnings the tests explicitly assert on.

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_mbid_replace_service -v"` — 34 tests pass with no spurious TypeError warning
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3693 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290 (surfaced as a side effect of the audit work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
