### PR TITLE
test(fakes): introduce FakePipelineDBSource; migrate test_search_max_inflight

### DIFF
--- a/lib/context.py
+++ b/lib/context.py
@@ -9,11 +9,45 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import threading
-from typing import Any, TYPE_CHECKING
+from typing import Any, Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
-    from album_source import DatabaseSource
     from lib.config import CratediggerConfig
+
+
+@runtime_checkable
+class PipelineDBSource(Protocol):
+    """Structural surface of the pipeline DB source used throughout the engine.
+
+    Production implementation is ``album_source.DatabaseSource``; tests use
+    ``tests.fakes.FakePipelineDBSource``. The protocol lets either satisfy
+    the ``CratediggerContext.pipeline_db_source`` slot without the test fake
+    having to inherit from the production class (which would require a DSN
+    constructor it doesn't need).
+    """
+
+    def _get_db(self) -> Any: ...
+    def get_tracks(self, album_record: Any) -> list[dict[str, Any]]: ...
+    def get_wanted_searchable(
+        self, generator_id: str, limit: int | None = None,
+    ) -> list[Any]: ...
+    def mark_done(
+        self,
+        album_record: Any,
+        bv_result: Any,
+        dest_path: Any = None,
+        download_info: Any = None,
+    ) -> None: ...
+    def reject_and_requeue(
+        self,
+        album_record: Any,
+        bv_result: Any,
+        usernames: Any = None,
+        download_info: Any = None,
+        search_filetype_override: Any = None,
+        cooled_down_users: set[str] | None = None,
+    ) -> int | None: ...
+    def close(self) -> None: ...
 
 
 @dataclass
@@ -23,7 +57,7 @@ class CratediggerContext:
     # --- Core dependencies (set once in main()) ---
     cfg: CratediggerConfig
     slskd: Any  # slskd_api.SlskdClient — Any to avoid import
-    pipeline_db_source: DatabaseSource
+    pipeline_db_source: PipelineDBSource
     download_ownership: Any = None
 
     # --- Runtime caches (reset each cycle) ---

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3941,3 +3941,102 @@ class FakePipelineDB:
             test.assertEqual(actual, value,
                              f"download_log[{index}].{field}: "
                              f"expected {value!r}, got {actual!r}")
+
+
+class FakePipelineDBSource:
+    """Typed stand-in for ``album_source.DatabaseSource`` / similar.
+
+    Production calls ``ctx.pipeline_db_source._get_db()`` (and a handful of
+    higher-level methods) to reach the pipeline DB. Tests historically
+    constructed this with ``MagicMock`` and ``source._get_db.return_value
+    = ...``; replace with this typed fake so the surface is explicit and
+    the test fails loudly if production calls an unexpected method.
+
+    Surface mirrors the production source's six public callables:
+    ``_get_db``, ``get_tracks``, ``get_wanted_searchable``, ``mark_done``,
+    ``reject_and_requeue``, ``close``. The fake's behavior is intentionally
+    minimal — tests that exercise real DB activity should rely on the
+    underlying ``FakePipelineDB`` directly (via ``source.db``).
+    """
+
+    def __init__(self, db: FakePipelineDB | None = None) -> None:
+        self.db: FakePipelineDB = db if db is not None else FakePipelineDB()
+        # Call records — empty unless production reached a method.
+        self.get_tracks_calls: list[Any] = []
+        self.mark_done_calls: list[dict[str, Any]] = []
+        self.reject_and_requeue_calls: list[dict[str, Any]] = []
+        self.close_calls: int = 0
+        # Test-configurable returns for the wanted iterator. Default empty
+        # so the worker pipeline observes "nothing to do."
+        self._wanted_searchable: list[Any] = []
+
+    def _get_db(self) -> FakePipelineDB:
+        return self.db
+
+    def get_tracks(self, album_record: Any) -> list[dict[str, Any]]:
+        self.get_tracks_calls.append(album_record)
+        request_id = getattr(album_record, "db_request_id", None)
+        if not request_id:
+            return []
+        rows = self.db._tracks.get(request_id, [])
+        album_id = request_id * -1
+        out: list[dict[str, Any]] = []
+        for t in rows:
+            out.append({
+                "title": t.get("title"),
+                "trackNumber": str(t.get("track_number") or ""),
+                "mediumNumber": t.get("disc_number"),
+                "duration": int((t.get("length_seconds") or 0) * 10_000_000),
+                "id": 0,
+                "albumId": album_id,
+            })
+        return out
+
+    def set_wanted_searchable(self, records: list[Any]) -> None:
+        """Configure what ``get_wanted_searchable`` returns."""
+        self._wanted_searchable = list(records)
+
+    def get_wanted_searchable(
+        self,
+        generator_id: str,
+        limit: int | None = None,
+    ) -> list[Any]:
+        if limit is None:
+            return list(self._wanted_searchable)
+        return list(self._wanted_searchable[:limit])
+
+    def mark_done(
+        self,
+        album_record: Any,
+        bv_result: Any,
+        dest_path: Any = None,
+        download_info: Any = None,
+    ) -> None:
+        self.mark_done_calls.append({
+            "album_record": album_record,
+            "bv_result": bv_result,
+            "dest_path": dest_path,
+            "download_info": download_info,
+        })
+
+    def reject_and_requeue(
+        self,
+        album_record: Any,
+        bv_result: Any,
+        usernames: Any = None,
+        download_info: Any = None,
+        search_filetype_override: Any = None,
+        cooled_down_users: set[str] | None = None,
+    ) -> int | None:
+        self.reject_and_requeue_calls.append({
+            "album_record": album_record,
+            "bv_result": bv_result,
+            "usernames": usernames,
+            "download_info": download_info,
+            "search_filetype_override": search_filetype_override,
+            "cooled_down_users": cooled_down_users,
+        })
+        return None
+
+    def close(self) -> None:
+        self.close_calls += 1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -394,16 +394,18 @@ def make_ctx_with_fake_db(
 ) -> Any:
     """Build a CratediggerContext wired to a FakePipelineDB.
 
-    The fake is wired via pipeline_db_source._get_db() so production code
-    that calls ctx.pipeline_db_source._get_db() gets the fake.
+    The fake is wrapped in a ``FakePipelineDBSource`` so production code
+    that calls ``ctx.pipeline_db_source._get_db()`` (or any of the source's
+    higher-level methods) hits a typed surface, not a MagicMock that
+    silently accepts arbitrary attribute access.
     """
     from lib.context import CratediggerContext
-    mock_source = MagicMock()
-    mock_source._get_db.return_value = fake_db
+    from tests.fakes import FakePipelineDBSource
+    source = FakePipelineDBSource(fake_db)
     return CratediggerContext(
         cfg=cfg if cfg is not None else MagicMock(),
         slskd=slskd if slskd is not None else MagicMock(),
-        pipeline_db_source=mock_source,
+        pipeline_db_source=source,
     )
 
 

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -134,10 +134,6 @@
     "patch:lib.transitions.apply_transition": 2,
     "stateful_mock_assign:db": 1
   },
-  "test_search_max_inflight.py": {
-    "stateful_mock_assign:ctx": 1,
-    "stateful_mock_assign:source": 3
-  },
   "test_transitions.py": {
     "patch:lib.transitions.apply_transition": 4,
     "stateful_mock_assign:db": 6

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,7 +25,7 @@ from tests.helpers import (
     make_grab_list_entry,
     make_request_row,
 )
-from tests.fakes import FakePipelineDB, FakeSlskdAPI
+from tests.fakes import FakePipelineDB, FakePipelineDBSource, FakeSlskdAPI
 
 
 def _utc_now_iso() -> str:
@@ -83,7 +83,7 @@ def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None):
     if slskd is None:
         slskd = MagicMock()
     if pipeline_db_source is None:
-        pipeline_db_source = MagicMock()
+        pipeline_db_source = FakePipelineDBSource()
     return CratediggerContext(cfg=cfg, slskd=slskd,
                           pipeline_db_source=pipeline_db_source)
 
@@ -1296,7 +1296,9 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 result.message,
                 "Rejected: high_distance - distance=0.1919",
             )
-            ctx.pipeline_db_source.reject_and_requeue.assert_called_once()
+            source = ctx.pipeline_db_source
+            assert isinstance(source, FakePipelineDBSource)
+            self.assertEqual(len(source.reject_and_requeue_calls), 1)
 
     def test_returns_false_on_file_move_failure(self):
         """File move failure returns False."""
@@ -1989,8 +1991,9 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             self.assertTrue(result)
             mock_dispatch.assert_not_called()
-            mark_done = cast(Any, ctx.pipeline_db_source.mark_done)
-            mark_done.assert_called_once()
+            source = ctx.pipeline_db_source
+            assert isinstance(source, FakePipelineDBSource)
+            self.assertEqual(len(source.mark_done_calls), 1)
 
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""

--- a/tests/test_search_max_inflight.py
+++ b/tests/test_search_max_inflight.py
@@ -34,7 +34,7 @@ from lib.quality import CandidateScore
 from lib.search import (
     SEARCH_PLAN_GENERATOR_ID, PlanExecutionContext, SearchResult,
 )
-from tests.fakes import FakePipelineDB, FakeSlskdAPI
+from tests.fakes import FakePipelineDB, FakePipelineDBSource, FakeSlskdAPI
 
 
 def _seed_plan(db: FakePipelineDB, request_id: int, *, query: str = "Artist Album") -> PlanExecutionContext:
@@ -89,9 +89,11 @@ class TestSearchMaxInflightPipelineLog(unittest.TestCase):
         """Run _search_and_queue_parallel with an empty album list, return
         the captured "Pipelined search" log line."""
         cratedigger.cfg = cfg
-        cratedigger.slskd = MagicMock()
-        ctx = MagicMock()
-        ctx.cfg = cfg
+        slskd = FakeSlskdAPI()
+        cratedigger.slskd = slskd
+        ctx = CratediggerContext(
+            cfg=cfg, slskd=slskd, pipeline_db_source=FakePipelineDBSource(),
+        )
         with self.assertLogs("cratedigger", level=logging.INFO) as captured:
             cratedigger._search_and_queue_parallel([], ctx)
         for record in captured.records:
@@ -119,8 +121,7 @@ class TestFindDownloadDoesNotBlockSearchRefill(unittest.TestCase):
         cfg = _empty_cfg(search_max_inflight=1)
         slskd = FakeSlskdAPI()
         slskd.searches.search_text_id_sequence = [101, 102]
-        source = MagicMock()
-        source._get_db.return_value = MagicMock()
+        source = FakePipelineDBSource()
         ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=source)
         albums = [
             MagicMock(id=1, artist_name="Artist", title="One"),
@@ -229,8 +230,7 @@ class TestFindDownloadDoesNotBlockSearchRefill(unittest.TestCase):
         plan_exec_found = _seed_plan(db, rid_found, query="Artist Found")
         plan_exec_miss = _seed_plan(db, rid_miss, query="Artist Miss")
         plan_for = {-rid_found: plan_exec_found, -rid_miss: plan_exec_miss}
-        source = MagicMock()
-        source._get_db.return_value = db
+        source = FakePipelineDBSource(db)
         ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=source)
         albums = [
             MagicMock(
@@ -401,8 +401,7 @@ class TestFindDownloadDoesNotBlockSearchRefill(unittest.TestCase):
         )
         plan_exec_found = _seed_plan(db, rid_found, query="Artist Found")
         plan_for = {-rid_found: plan_exec_found}
-        source = MagicMock()
-        source._get_db.return_value = db
+        source = FakePipelineDBSource(db)
         ctx = CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=source)
         albums = [
             MagicMock(


### PR DESCRIPTION
## Summary

Phase 2 migration of #290. Introduces shared infrastructure for the rest of the source-MagicMock migrations.

## What changed

**Production:** `lib/context.py` — `CratediggerContext.pipeline_db_source` is now typed as a new `PipelineDBSource` Protocol (a `runtime_checkable` Protocol matching the six public callables: `_get_db`, `get_tracks`, `get_wanted_searchable`, `mark_done`, `reject_and_requeue`, `close`). `DatabaseSource` (production) and `FakePipelineDBSource` (tests) both satisfy it structurally — no inheritance required, the test fake doesn't have to drag a DSN constructor it doesn't use.

**Test infra:** `tests/fakes.py` — `FakePipelineDBSource` mirrors the production surface and tracks every call via per-method `*_calls` lists. Tests assert against those instead of `mock.assert_called_once()`.

**Helper update:** `tests/helpers.py::make_ctx_with_fake_db` now wires the typed source instead of constructing a MagicMock with `._get_db.return_value = ...`. All 43 existing call sites benefit automatically.

**File migration:** `tests/test_search_max_inflight.py` — 4 anti-pattern sites:
- 3× `source = MagicMock()` → `FakePipelineDBSource(db)`
- 1× `ctx = MagicMock()` → real `CratediggerContext` with the typed source

**Collateral:** `tests/test_download.py` — two assertions used `mock.assert_called_once()` against the source's MagicMock-only introspection. Migrated to `len(source.reject_and_requeue_calls) == 1` / `len(source.mark_done_calls) == 1`. Local `_make_ctx` helper upgraded to default `pipeline_db_source=FakePipelineDBSource()`; the 8 call sites inherit the typed default.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 351 | 347 |
| Files in baseline | 26 | 25 |

Absolute drop is small, but the infrastructure unlocks every downstream migration — Phase 2 PRs for `test_request_finalization`, `test_cooldown`, `test_pipeline_cli`, `test_web_server` can all reuse `FakePipelineDBSource` without re-doing the Protocol / helper work.

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_search_max_inflight -v"` — passes
- [x] `nix-shell --run "python3 -m unittest tests.test_download -v"` — passes (including the two migrated assertions)
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3693 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
