### PR TITLE
test(transitions): migrate test_request_finalization to FakePipelineDB

### DIFF
--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -130,10 +130,6 @@
     "patch:scripts.repair.read_runtime_config": 3,
     "stateful_mock_assign:db": 5
   },
-  "test_request_finalization.py": {
-    "patch:lib.transitions.apply_transition": 2,
-    "stateful_mock_assign:db": 1
-  },
   "test_transitions.py": {
     "patch:lib.transitions.apply_transition": 4,
     "stateful_mock_assign:db": 6

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import ast
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from typing import Any, cast
 
 from lib.import_dispatch import DispatchOutcome
 from lib.transitions import RequestTransition, finalize_request
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_request_row
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PRODUCTION_ROOTS = ("lib", "web", "harness", "scripts")
@@ -32,45 +34,58 @@ class TestDispatchOutcomeSummary(unittest.TestCase):
 class TestFinalizeRequest(unittest.TestCase):
     """Unit tests for the shared request-finalization seam."""
 
-    @patch("lib.transitions.apply_transition")
-    def test_forwards_transition_fields_and_attempt_type(
-        self,
-        mock_transition: MagicMock,
-    ) -> None:
-        db = MagicMock()
+    def test_forwards_transition_fields_and_attempt_type(self) -> None:
+        """``finalize_request`` writes through to the DB so the row reflects
+        the transition. Asserts on resulting DB state instead of mock call
+        args — the contract is "the row got these fields", not "this Python
+        function got these positional args."
+
+        ``prev_min_bitrate`` is intentionally not passed: the production
+        ``reset_downloading_to_wanted`` derives it via
+        ``prev_min_bitrate = COALESCE(min_bitrate, prev_min_bitrate)``,
+        i.e. the previous ``min_bitrate`` becomes ``prev_min_bitrate``.
+        Seeding with ``min_bitrate=320`` and transitioning to
+        ``min_bitrate=245`` exercises that derivation end-to-end.
+        """
+        db = FakePipelineDB()
+        db.seed_request(
+            make_request_row(
+                id=42,
+                status="downloading",
+                search_filetype_override=None,
+                min_bitrate=320,
+                prev_min_bitrate=None,
+            ),
+        )
 
         finalize_request(
-            db,
+            cast(Any, db),
             42,
             RequestTransition.to_wanted(
                 from_status="downloading",
                 attempt_type="download",
                 search_filetype_override="flac,mp3 v0",
                 min_bitrate=245,
-                prev_min_bitrate=320,
             ),
         )
 
-        mock_transition.assert_called_once_with(
-            db,
-            42,
-            "wanted",
-            from_status="downloading",
-            attempt_type="download",
-            search_filetype_override="flac,mp3 v0",
-            min_bitrate=245,
-            prev_min_bitrate=320,
-        )
+        row = db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_filetype_override"], "flac,mp3 v0")
+        self.assertEqual(row["min_bitrate"], 245)
+        self.assertEqual(row["prev_min_bitrate"], 320)
+        # attempt_type="download" → an attempt counter advanced
+        self.assertEqual(row["download_attempts"], 1)
 
-    @patch("lib.transitions.apply_transition")
-    def test_rejects_target_specific_wrong_fields_at_construction(
-        self,
-        mock_transition: MagicMock,
-    ) -> None:
+    def test_rejects_target_specific_wrong_fields_at_construction(self) -> None:
+        """RequestTransition rejects target-specific kwargs at construction
+        time, before any DB call. The previous version of this test patched
+        ``apply_transition`` to verify it wasn't reached — but the
+        construction failure happens upstream of ``finalize_request``
+        entirely, so the patch was provably redundant.
+        """
         with self.assertRaises(TypeError):
             RequestTransition.to_wanted(beets_distance=0.12)  # type: ignore[call-arg]
-
-        mock_transition.assert_not_called()
 
 
 class _RequestStatusWriteVisitor(ast.NodeVisitor):


### PR DESCRIPTION
## Summary

Phase 2 migration of #290. Migrates the three anti-pattern sites in `test_request_finalization.py` to drive real `finalize_request` against `FakePipelineDB` instead of patching `apply_transition` and asserting on mock call args.

## What changed

**`test_forwards_transition_fields_and_attempt_type`** — was a wire-test that `finalize_request` forwarded its kwargs to `apply_transition`. Now asserts the user-visible behavior end-to-end: after the transition, the row reflects `status='wanted'`, the new `search_filetype_override` and `min_bitrate`, `prev_min_bitrate` derived via the production COALESCE rule, and the `download_attempts` counter bumped. The old assertion tested the wrapper's translation; the new one tests the contract through the full stack.

**`test_rejects_target_specific_wrong_fields_at_construction`** — dropped the redundant `mock_transition.assert_not_called()`. The TypeError raises during `RequestTransition.to_wanted(...)` construction, **upstream** of any DB call. The original `@patch("lib.transitions.apply_transition")` decorator was provably redundant — unreached code can't be called.

## Subtle finding the migration exposed

The old test passed `prev_min_bitrate=320` to the transition builder, and the MagicMock-based assertion happily verified it was forwarded. But production's `reset_downloading_to_wanted` ignores `prev_min_bitrate` entirely — it derives it via `prev_min_bitrate = COALESCE(min_bitrate, prev_min_bitrate)`. The old test was therefore testing a no-op kwarg path; the wire-level assertion couldn't see that. The new test seeds `min_bitrate=320`, transitions to `min_bitrate=245`, and asserts `prev_min_bitrate=320` — exercising the actual derivation.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 347 | 344 |
| Files in baseline | 25 | 24 |

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_request_finalization -v"` — 11 tests pass
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3693 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
