### PR TITLE
test(cooldown): migrate to FakePipelineDB + FakeSlskdAPI

### DIFF
--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -6,12 +6,6 @@
   "test_beets_album_op.py": {
     "stateful_mock_assign:beets": 1
   },
-  "test_cooldown.py": {
-    "patch:lib.enqueue.check_for_match": 1,
-    "stateful_mock_assign:db": 1,
-    "stateful_mock_assign:slskd": 1,
-    "stateful_mock_assign:source": 1
-  },
   "test_cycle_summary.py": {
     "patch:lib.matching.album_match": 1,
     "stateful_mock_assign:slskd": 2

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -9,7 +9,12 @@ from lib.config import CratediggerConfig
 from lib.context import CratediggerContext
 from lib.quality import CooldownConfig, should_cooldown
 from cratedigger import TrackRecord
-from tests.fakes import FakePipelineDB
+from tests.fakes import (
+    DenylistEntry,
+    FakePipelineDB,
+    FakePipelineDBSource,
+    FakeSlskdAPI,
+)
 from tests.helpers import (
     make_ctx_with_fake_db,
     make_download_file,
@@ -74,30 +79,44 @@ class TestShouldCooldown(unittest.TestCase):
 class TestEnqueueCooldownFiltering(unittest.TestCase):
     """Cooled-down users should be skipped during enqueue with distinct log messages."""
 
-    def _make_ctx(self, cooled_down_users: set[str] | None = None,
-                  denied_users: list[str] | None = None) -> CratediggerContext:
-        source = MagicMock()
-        db = MagicMock()
-        db.get_denylisted_users.return_value = [
-            {"username": u} for u in (denied_users or [])
-        ]
-        source._get_db.return_value = db
+    def _make_ctx(
+        self,
+        cooled_down_users: set[str] | None = None,
+        denied_users: list[str] | None = None,
+        slskd: FakeSlskdAPI | None = None,
+    ) -> CratediggerContext:
+        """Build a context with cooldowns + denylist seeded into a real
+        FakePipelineDB. Replaces the prior MagicMock-source pattern so the
+        cooldown-filter test can observe outcomes through the FakeSlskdAPI
+        call log rather than mock introspection."""
+        db = FakePipelineDB()
+        for username in denied_users or []:
+            db.denylist.append(
+                DenylistEntry(request_id=1, username=username),
+            )
         # Use a real CratediggerConfig with defaults so wave-based enqueue
         # (issue #198 U3) reads numeric values for browse_top_k rather
         # than MagicMock proxies.
         cfg = CratediggerConfig.from_ini(configparser.ConfigParser())
         ctx = CratediggerContext(
             cfg=cfg,
-            slskd=MagicMock(),
-            pipeline_db_source=source,
+            slskd=slskd if slskd is not None else FakeSlskdAPI(),
+            pipeline_db_source=FakePipelineDBSource(db),
             cooled_down_users=cooled_down_users or set(),
         )
         return ctx
 
     def test_cooled_user_skipped_in_try_enqueue(self):
-        """A user on cooldown should be skipped even if they have matching results."""
+        """A user on cooldown should be filtered before any slskd traffic.
+
+        The cooldown gate runs in ``try_enqueue`` upstream of the browse
+        wave, so a cooled user's directories should never be requested.
+        Asserts on ``FakeSlskdAPI.users.directory_calls`` instead of
+        patching ``check_for_match`` and counting mock invocations.
+        """
         from lib.enqueue import try_enqueue
-        ctx = self._make_ctx(cooled_down_users={"deaduser"})
+        slskd = FakeSlskdAPI()
+        ctx = self._make_ctx(cooled_down_users={"deaduser"}, slskd=slskd)
         ctx.current_album_cache[1] = MagicMock(title="Album", artist_name="Artist")
         ctx.user_upload_speed["deaduser"] = 100
 
@@ -106,12 +125,19 @@ class TestEnqueueCooldownFiltering(unittest.TestCase):
         ]
         results = {"deaduser": {"flac": ["Music\\Album"]}}
 
-        with patch("lib.enqueue.check_for_match") as mock_match:
-            attempt = try_enqueue(tracks, results, "flac", ctx)
+        attempt = try_enqueue(tracks, results, "flac", ctx)
 
-        # check_for_match should never have been called for the cooled-down user
-        mock_match.assert_not_called()
         self.assertFalse(attempt.matched)
+        # The cooled user must never have had their directory browsed —
+        # the cooldown filter is upstream of the slskd browse phase.
+        cooled_browse_calls = [
+            (u, d) for (u, d) in slskd.users.directory_calls
+            if u == "deaduser"
+        ]
+        self.assertEqual(
+            cooled_browse_calls, [],
+            f"cooldown filter let a browse through: {cooled_browse_calls}",
+        )
 
     def test_non_cooled_user_proceeds(self):
         """A user NOT on cooldown should proceed through normal matching."""


### PR DESCRIPTION
## Summary

Phase 2 migration of #290. Clears all 4 anti-pattern sites in `test_cooldown.py` — including the canonical "patch `check_for_match` and assert on mock call count" pattern that the audit was built to catch.

## What changed

**Test helper:** `TestEnqueueCooldownFiltering._make_ctx` was constructing a MagicMock source + db. Replaced with a real `FakePipelineDB` seeded with per-request `DenylistEntry` rows, wrapped in `FakePipelineDBSource`, with a configurable `FakeSlskdAPI`.

**`test_cooled_user_skipped_in_try_enqueue` — the canonical migration:**

Before:
```python
with patch("lib.enqueue.check_for_match") as mock_match:
    attempt = try_enqueue(...)
mock_match.assert_not_called()
```

After:
```python
attempt = try_enqueue(...)
# Cooldown filter runs upstream of the slskd browse phase
cooled_browse_calls = [
    (u, d) for (u, d) in slskd.users.directory_calls
    if u == "deaduser"
]
self.assertEqual(cooled_browse_calls, [])
```

The intent stays identical ("cooldown filter runs upstream of browse"); the observation point moves from "our own function's mock call count" to "the actual external network boundary." Better signal, no MagicMock introspection.

**`test_non_cooled_user_proceeds` and `test_cooldown_log_message_distinct_from_denylist`** — inherit the new typed source for free. They already asserted on observable outcomes; the MagicMock source was just a placeholder.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 344 | 340 |
| Files in baseline | 24 | 23 |
| `test_cooldown.py` | 4 findings | gone |

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_cooldown -v"` — 16 tests pass
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3693 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
