### PR TITLE
test(sweep): four small migrations (overlay, album-source, matching, analyze_track)

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -135,11 +135,15 @@ _LEAF_SEAM_PATTERNS = [
     # Spectral / audio measurement wrappers. Each invokes sox / ffmpeg /
     # mp3val subprocesses and reads files on disk; equivalent to a
     # subprocess seam. ``inspect_local_files`` reads tag/codec metadata.
+    # ``spectral_check.analyze_track`` runs 17 sox commands per file
+    # (1 reference band + 16 test slices) — body is all subprocess
+    # dispatch despite the length.
     re.compile(r"^lib\.measurement\.spectral_analyze$"),
     re.compile(r"^lib\.measurement\.inspect_local_files$"),
     re.compile(r"^lib\.measurement\.repair_mp3_headers$"),
     re.compile(r"^lib\.measurement\._needs_spectral_check$"),
     re.compile(r"^lib\.measurement\.measure_preimport_state$"),
+    re.compile(r"^lib\.spectral_check\.analyze_track$"),
 
     # Re-exports of measurement / harness / dispatch into the
     # import_preview surface — same underlying subprocess seams.

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -1,8 +1,4 @@
 {
-  "test_album_source.py": {
-    "patch:lib.import_dispatch._do_mark_done": 1,
-    "patch:lib.transitions.finalize_request": 1
-  },
   "test_beets_album_op.py": {
     "stateful_mock_assign:beets": 1
   },

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -83,8 +83,7 @@
     "patch:lib.beets_db.BeetsDB.delete_album": 5
   },
   "test_matching.py": {
-    "patch:lib.matching._track_titles_cross_check": 1,
-    "stateful_mock_assign:slskd": 1
+    "patch:lib.matching._track_titles_cross_check": 1
   },
   "test_measurement.py": {
     "patch:lib.measurement._iter_audio_files": 2,

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -96,9 +96,6 @@
     "patch:lib.measurement.validate_audio": 1,
     "stateful_mock_assign:db": 2
   },
-  "test_overlay.py": {
-    "patch:web.server.compute_library_rank": 1
-  },
   "test_pipeline_cli.py": {
     "patch:lib.import_preview.preview_import_from_values": 2,
     "patch:lib.mbid_replace_service.MbidReplaceService": 1,

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -30,9 +30,6 @@
     "stateful_mock_assign:slskd": 3,
     "stateful_mock_assign:source": 2
   },
-  "test_force_import_gates.py": {
-    "patch:lib.spectral_check.analyze_track": 1
-  },
   "test_import_dispatch.py": {
     "patch:lib.download.log_validation_result": 1,
     "patch:lib.download.stage_to_ai_path": 1,

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -95,11 +95,17 @@ class TestAlbumRecordFromDbRow(unittest.TestCase):
 class TestDatabaseSourceRejectAndRequeueSeam(unittest.TestCase):
     """Pin the non-DB seam around reject-and-requeue finalization."""
 
-    @patch("lib.transitions.finalize_request")
-    def test_reject_and_requeue_defers_from_status_to_shared_seam(
-        self,
-        mock_finalize: MagicMock,
-    ) -> None:
+    def test_reject_and_requeue_defers_from_status_to_shared_seam(self) -> None:
+        """``reject_and_requeue`` lets the shared transition seam look up
+        ``from_status`` from the DB instead of pinning it at the call site.
+
+        End-to-end: seed a row in ``manual``, call ``reject_and_requeue``
+        without any ``from_status`` argument, observe the row land in
+        ``wanted``. If the source had hard-coded ``from_status="wanted"``
+        (or any other non-current value), the transition guard would have
+        refused the change. The user-visible behavior (status='wanted')
+        is therefore proof that the seam resolved from_status itself.
+        """
         fake_db = FakePipelineDB()
         fake_db.seed_request(make_request_row(id=42, status="manual"))
 
@@ -116,11 +122,9 @@ class TestDatabaseSourceRejectAndRequeueSeam(unittest.TestCase):
 
         source.reject_and_requeue(album_record, bv_result)
 
-        db_arg, request_id, outcome = mock_finalize.call_args.args
-        self.assertIs(db_arg, fake_db)
-        self.assertEqual(request_id, 42)
-        self.assertEqual(outcome.target_status, "wanted")
-        self.assertIsNone(outcome.from_status)
+        row = fake_db.request(42)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["validation_attempts"], 1)
 
 
 class TestDatabaseSource(unittest.TestCase):
@@ -203,36 +207,13 @@ class TestDatabaseSource(unittest.TestCase):
         assert req is not None
         self.assertEqual(req["status"], "imported")
 
-    @patch("lib.import_dispatch._do_mark_done")
-    def test_mark_done_delegates_to_shared_helper(self, mock_mark_done):
-        source, db = self._make_source()
-        req_id = db.add_request(
-            mb_release_id="delegate-uuid",
-            artist_name="A",
-            album_title="B",
-            source="request",
-        )
-        record = _make_record(db_request_id=req_id, db_source="request")
-        bv_result = ValidationResult(
-            valid=True, distance=0.05, scenario="strong_match", detail="ok")
-        dl = DownloadInfo(username="user1", filetype="mp3")
-
-        source.mark_done(
-            record,
-            bv_result,
-            dest_path="/Incoming/A/B",
-            download_info=dl,
-        )
-
-        mock_mark_done.assert_called_once_with(
-            db=db,
-            request_id=req_id,
-            dl_info=dl,
-            distance=0.05,
-            scenario="strong_match",
-            dest_path="/Incoming/A/B",
-            detail="ok",
-        )
+    # NOTE: the former ``test_mark_done_delegates_to_shared_helper`` was a
+    # wire-check that patched ``lib.import_dispatch._do_mark_done`` and
+    # asserted the call args. It was redundant with
+    # ``test_mark_done_redownload_stages`` above, which exercises the real
+    # ``_do_mark_done`` and asserts the user-visible outcome (row status
+    # advances to ``imported``). Deleted as part of #290 migration: the
+    # behavioral test already proves the delegation works.
 
     def test_reject_and_requeue_updates_status_and_denylists(self):
         source, db = self._make_source()

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -28,6 +28,7 @@ from lib.matching import (
 )
 from lib.peer_cache import PeerCache
 from lib.quality import CandidateScore
+from tests.fakes import FakePipelineDBSource, FakeSlskdAPI
 from tests.test_peer_cache import FakeRedis
 
 
@@ -75,8 +76,8 @@ def _make_ctx(
 ) -> CratediggerContext:
     ctx = CratediggerContext(
         cfg=cfg,
-        slskd=MagicMock(),
-        pipeline_db_source=MagicMock(),
+        slskd=FakeSlskdAPI(),
+        pipeline_db_source=FakePipelineDBSource(),
     )
     ctx.current_album_cache[album_id] = _make_album(album_title, album_artist)
     return ctx

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -31,9 +31,6 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
             "bad-quality": {"beets_format": None, "beets_bitrate": None},
         }
 
-        def _rank(fmt, bitrate):
-            return f"{fmt or 'unknown'}:{bitrate}"
-
         with patch("web.server.check_beets_library",
                    return_value={"held", "both", "bad-quality"}), \
                 patch("web.server.check_pipeline",
@@ -41,8 +38,7 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
                           "queued": {"id": 21, "status": "wanted"},
                           "both": {"id": 22, "status": "queued"},
                       }), \
-                patch("web.server._beets_db", return_value=mock_beets), \
-                patch("web.server.compute_library_rank", side_effect=_rank):
+                patch("web.server._beets_db", return_value=mock_beets):
             overlay_release_rows_in_place(rows, [r["id"] for r in rows])
 
         by_id = {row["id"]: row for row in rows}
@@ -51,7 +47,8 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
         self.assertEqual(by_id["held"]["beets_album_id"], 10)
         self.assertEqual(by_id["held"]["library_format"], "FLAC")
         self.assertEqual(by_id["held"]["library_min_bitrate"], 1100)
-        self.assertEqual(by_id["held"]["library_rank"], "FLAC:1100")
+        # Real compute_library_rank — 1100kbps FLAC is lossless.
+        self.assertEqual(by_id["held"]["library_rank"], "lossless")
         self.assertIsNone(by_id["held"]["pipeline_status"])
 
         self.assertFalse(by_id["queued"]["in_library"])
@@ -71,7 +68,8 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
 
         self.assertEqual(by_id["bad-quality"]["library_format"], "")
         self.assertEqual(by_id["bad-quality"]["library_min_bitrate"], 0)
-        self.assertEqual(by_id["bad-quality"]["library_rank"], "unknown:0")
+        # Real compute_library_rank — empty format/bitrate is unknown.
+        self.assertEqual(by_id["bad-quality"]["library_rank"], "unknown")
 
     def test_empty_inputs_do_not_touch_backends(self):
         with patch("web.server.check_beets_library") as check_lib, \


### PR DESCRIPTION
## Summary

Sweep PR for Phase 2 of #290 — four small migrations (4 commits, each one logical file).

| Commit | File | Findings cleared |
|---|---|---|
| f4ee79b | test_overlay.py | 1× `patch:web.server.compute_library_rank` |
| 0334c2a | test_album_source.py | 1× `patch:lib.transitions.finalize_request`, 1× `patch:lib.import_dispatch._do_mark_done` |
| a454cd9 | test_matching.py | 1× `stateful_mock_assign:slskd` (kwarg form) |
| 05b3a8f | scanner allowlist | 1× `patch:lib.spectral_check.analyze_track` (sox subprocess seam) |

Each commit's message has the per-file rationale. Quick summary:

- **test_overlay.py** — the patched `compute_library_rank` was being replaced with a custom lambda that just formatted `f"{fmt}:{bitrate}"`. The test was asserting against the lambda's output, not the real ranking logic. Migrated to use the real function (`"FLAC", 1100 → "lossless"`).
- **test_album_source.py** — two wire-check patches removed. `test_reject_and_requeue_defers_from_status_to_shared_seam` rewritten to assert DB-state outcomes (`status='wanted'`, `validation_attempts=1`) instead of `mock.call_args.args`. `test_mark_done_delegates_to_shared_helper` deleted as fully redundant with `test_mark_done_redownload_stages` immediately above.
- **test_matching.py** — kwarg-form `slskd=MagicMock()` / `pipeline_db_source=MagicMock()` swapped for `FakeSlskdAPI()` / `FakePipelineDBSource()`. The `_track_titles_cross_check` patch site stays grandfathered (the author flagged it as "tight inputs" — would need crafted track+filename combos that pass the per-track filename ratio but produce extracted titles that fail cross-check; not in scope for this sweep).
- **scanner allowlist** — `lib.spectral_check.analyze_track` added to the seam-wrapper allowlist with rationale. The function runs 17 sox commands per file; patching it is morally equivalent to mocking sox itself, same logic as `_fanout_browse_users` from #292.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 340 | 335 |
| Files in baseline | 23 | 20 |

Files fully off the baseline: `test_overlay.py`, `test_album_source.py`, `test_force_import_gates.py`. `test_matching.py` remains at 1 finding (the `_track_titles_cross_check` patch).

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
