### PR TITLE
test(cycle-summary): swap slskd/source MagicMock kwargs for typed fakes

### DIFF
--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -3,8 +3,7 @@
     "stateful_mock_assign:beets": 1
   },
   "test_cycle_summary.py": {
-    "patch:lib.matching.album_match": 1,
-    "stateful_mock_assign:slskd": 2
+    "patch:lib.matching.album_match": 1
   },
   "test_dispatch_core.py": {
     "patch:lib.import_dispatch._check_quality_gate_core": 4,

--- a/tests/test_cycle_summary.py
+++ b/tests/test_cycle_summary.py
@@ -15,13 +15,17 @@ from lib.config import CratediggerConfig
 from lib.context import CratediggerContext
 from lib.cycle_summary import format_cycle_summary
 from lib.matching import check_for_match
+from tests.fakes import FakePipelineDBSource, FakeSlskdAPI
 
 
 def _make_ctx() -> CratediggerContext:
     cfg = MagicMock()
     cfg.var_dir = "/tmp/unused"
-    slskd = MagicMock()
-    return CratediggerContext(cfg=cfg, slskd=slskd, pipeline_db_source=MagicMock())
+    return CratediggerContext(
+        cfg=cfg,
+        slskd=FakeSlskdAPI(),
+        pipeline_db_source=FakePipelineDBSource(),
+    )
 
 
 def _make_real_cfg() -> CratediggerConfig:
@@ -39,8 +43,8 @@ def _make_real_ctx() -> CratediggerContext:
     cfg = _make_real_cfg()
     ctx = CratediggerContext(
         cfg=cfg,
-        slskd=MagicMock(),
-        pipeline_db_source=MagicMock(),
+        slskd=FakeSlskdAPI(),
+        pipeline_db_source=FakePipelineDBSource(),
     )
     album = MagicMock()
     album.title = "Cool Album"


### PR DESCRIPTION
## Summary

Two anti-pattern sites in `test_cycle_summary.py` migrated. Both were kwarg-form placeholders — the cycle-summary tests don't exercise slskd or pipeline_db, they just need something to satisfy the `CratediggerContext` constructor.

| Site | Before | After |
|---|---|---|
| `_make_ctx` | `slskd=MagicMock(), pipeline_db_source=MagicMock()` | `FakeSlskdAPI(), FakePipelineDBSource()` |
| `_make_real_ctx` | same | same |

## Deferred to #301 (item J)

`patch:lib.matching.album_match` stays on the baseline. The test is a try/finally regression check forcing an exception via mock — `album_match` doesn't normally raise. Fix idea logged in #301: extract the try/finally credit into a callable-taking helper. Small production refactor not in scope here.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 351 | 349 |
| `test_cycle_summary.py` | 3 findings | 1 finding (deferred to #301) |

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_cycle_summary -v"` — 11 tests pass
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290, #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
