### PR TITLE
test(measurement): swap db MagicMock for FakePipelineDB; allowlist audio seams

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -162,7 +162,11 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^lib\.measurement\.repair_mp3_headers$"),
     re.compile(r"^lib\.measurement\._needs_spectral_check$"),
     re.compile(r"^lib\.measurement\.measure_preimport_state$"),
+    re.compile(r"^lib\.measurement\._iter_audio_files$"),
+    re.compile(r"^lib\.measurement\.hash_audio_content$"),
+    re.compile(r"^lib\.measurement\.validate_audio$"),
     re.compile(r"^lib\.spectral_check\.analyze_track$"),
+    re.compile(r"^lib\.audio_hash\.hash_audio_content$"),
 
     # Re-exports of measurement / harness / dispatch into the
     # import_preview surface — same underlying subprocess seams.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -668,6 +668,11 @@ class FakePipelineDB:
         self.user_cooldowns: dict[str, UserCooldownRow] = {}
         self.denylist: list[DenylistEntry] = []
         self.bad_audio_hashes: list[BadAudioHashRow] = []
+        # Call-count tracking for the bad-audio-hash gate. Tests that
+        # used to assert ``mock.assert_called_once()`` / ``assert_not_called()``
+        # on the MagicMock-source can now inspect these instead.
+        self.has_any_bad_audio_hashes_calls: int = 0
+        self.lookup_bad_audio_hash_calls: list[tuple[bytes, str]] = []
         # Keyed by (mb_release_id, snapshot_fingerprint) — content-addressed
         # after migration 021. Each row also has a surrogate ``id``; the
         # parallel ``_evidence_by_id`` dict mirrors load-by-id lookups.
@@ -1782,12 +1787,14 @@ class FakePipelineDB:
         hash_value: bytes,
         audio_format: str,
     ) -> BadAudioHashRow | None:
+        self.lookup_bad_audio_hash_calls.append((hash_value, audio_format))
         for row in self.bad_audio_hashes:
             if row.hash_value == hash_value and row.audio_format == audio_format:
                 return row
         return None
 
     def has_any_bad_audio_hashes(self) -> bool:
+        self.has_any_bad_audio_hashes_calls += 1
         return bool(self.bad_audio_hashes)
 
     def get_recent_successful_uploader(

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -69,7 +69,6 @@
     "patch:lib.download.dispatch_import_core": 1,
     "patch:lib.download.process_completed_album": 3,
     "patch:lib.enqueue.check_for_match": 4,
-    "patch:lib.measurement.hash_audio_content": 1,
     "patch:lib.transitions.finalize_request": 1,
     "stateful_mock_assign:source": 4
   },
@@ -78,12 +77,6 @@
   },
   "test_matching.py": {
     "patch:lib.matching._track_titles_cross_check": 1
-  },
-  "test_measurement.py": {
-    "patch:lib.measurement._iter_audio_files": 2,
-    "patch:lib.measurement.hash_audio_content": 2,
-    "patch:lib.measurement.validate_audio": 1,
-    "stateful_mock_assign:db": 2
   },
   "test_pipeline_cli.py": {
     "patch:lib.import_preview.preview_import_from_values": 2,

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from typing import Any, cast
+from unittest.mock import patch
 
 from lib.measurement import _check_bad_audio_hashes, _iter_audio_files
 from tests.fakes import FakePipelineDB
@@ -150,9 +151,8 @@ class TestBadAudioHashGateFastPath(unittest.TestCase):
         from lib.config import CratediggerConfig
         from lib.measurement import measure_preimport_state
 
-        db = MagicMock()
-        db.has_any_bad_audio_hashes.return_value = False
-
+        db = FakePipelineDB()
+        # empty bad_audio_hashes table → fast-path skip
         cfg = CratediggerConfig(audio_check_mode="off")
 
         # Bypass spectral and existing-album lookups so we isolate the
@@ -167,12 +167,16 @@ class TestBadAudioHashGateFastPath(unittest.TestCase):
                 download_min_bitrate_bps=320_000,
                 download_is_vbr=False,
                 cfg=cfg,
-                db=db,
+                db=cast(Any, db),
                 request_id=42,
             )
 
-        db.has_any_bad_audio_hashes.assert_called_once()
-        db.lookup_bad_audio_hash.assert_not_called()
+        # ``has_any_bad_audio_hashes`` is the fast-path gate — it must be
+        # called once. ``lookup_bad_audio_hash`` and ``hash_audio_content``
+        # must NOT have been touched (the gate short-circuited because
+        # the table is empty).
+        self.assertEqual(db.has_any_bad_audio_hashes_calls, 1)
+        self.assertEqual(db.lookup_bad_audio_hash_calls, [])
         hashfn.assert_not_called()
 
 
@@ -191,8 +195,7 @@ class TestMeasurePreimportState(unittest.TestCase):
         from lib.measurement import measure_preimport_state
         from lib.util import AudioValidationResult
 
-        db = MagicMock()
-        db.has_any_bad_audio_hashes.return_value = False
+        db = FakePipelineDB()
         cfg = CratediggerConfig(audio_check_mode="normal")
         bad_result = AudioValidationResult(
             valid=False, error="decode failed",
@@ -208,7 +211,7 @@ class TestMeasurePreimportState(unittest.TestCase):
                 download_min_bitrate_bps=320_000,
                 download_is_vbr=False,
                 cfg=cfg,
-                db=db,
+                db=cast(Any, db),
                 request_id=42,
             )
         self.assertTrue(m.audio_corrupt)


### PR DESCRIPTION
## Summary

Phase 2 of #290. Clears all 7 anti-pattern sites in `test_measurement.py`.

## What changed

**FakePipelineDB enhancement:** added two call counters for the bad-audio-hash gate, since the migrated test needs to distinguish "fast-path short-circuit" from "called and returned empty":

```python
self.has_any_bad_audio_hashes_calls: int = 0
self.lookup_bad_audio_hash_calls: list[tuple[bytes, str]] = []
```

**Test migration:**

- 2× `db = MagicMock()` → `FakePipelineDB`. The fast-path test now asserts `has_any_bad_audio_hashes_calls == 1` and `lookup_bad_audio_hash_calls == []` instead of MagicMock introspection.

**Scanner allowlist:** the patches into `lib.measurement` audio-content helpers are subprocess/filesystem seams. Added:

- `lib.measurement._iter_audio_files` (filesystem walk)
- `lib.measurement.hash_audio_content` (ffmpeg subprocess + mutagen)
- `lib.measurement.validate_audio` (ffmpeg subprocess)
- `lib.audio_hash.hash_audio_content` (canonical definition)

The `_iter_audio_files` patches in this file use `return_value=[]` to simulate "empty audio dir" — morally equivalent to a filesystem mock.

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 349 | 341 |
| Files in baseline | 19 | 18 |
| `test_measurement.py` | 7 findings | gone |

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_measurement -v"` — 13 tests pass
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290, #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
