### PR TITLE
test(audit): allowlist parse_import_result as harness-stdout parser

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -151,6 +151,14 @@ _LEAF_SEAM_PATTERNS = [
     # a subprocess seam.
     re.compile(r"^lib\.beets\.beets_validate$"),
 
+    # ``parse_import_result`` is the parsed-output side of the SAME
+    # harness subprocess: scans import_one.py's stdout for the
+    # ``__IMPORT_RESULT__`` sentinel and decodes it via msgspec.
+    # Patching it is morally equivalent to constructing a fake harness
+    # stdout — same wire-boundary seam as ``beets_validate``.
+    re.compile(r"^lib\.quality\.parse_import_result$"),
+    re.compile(r"^lib\.import_dispatch\.parse_import_result$"),
+
     # Spectral / audio measurement wrappers. Each invokes sox / ffmpeg /
     # mp3val subprocesses and reads files on disk; equivalent to a
     # subprocess seam. ``inspect_local_files`` reads tag/codec metadata.

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -7,12 +7,10 @@
   },
   "test_dispatch_core.py": {
     "patch:lib.import_dispatch._check_quality_gate_core": 4,
-    "patch:lib.import_dispatch.parse_import_result": 4,
     "stateful_mock_assign:beets": 1
   },
   "test_dispatch_from_db.py": {
-    "patch:lib.import_dispatch._check_quality_gate_core": 5,
-    "patch:lib.import_dispatch.parse_import_result": 5
+    "patch:lib.import_dispatch._check_quality_gate_core": 5
   },
   "test_download.py": {
     "patch:lib.download._process_beets_validation": 1,
@@ -33,7 +31,6 @@
     "patch:lib.download.log_validation_result": 1,
     "patch:lib.download.stage_to_ai_path": 1,
     "patch:lib.import_dispatch._check_quality_gate_core": 4,
-    "patch:lib.import_dispatch.parse_import_result": 5,
     "patch:lib.quality.quality_gate_decision": 5,
     "patch:lib.transitions.finalize_request": 1,
     "stateful_mock_assign:ctx": 1


### PR DESCRIPTION
## Summary

Allowlist `parse_import_result` at both binding sites. It's the parsed-output side of the harness subprocess that `beets_validate` invokes — patching it is equivalent to constructing a fake harness stdout, the same wire-boundary seam. Already allowlisted: `lib.beets.beets_validate`.

## Why

Spotted while sketching the `test_dispatch_core.py` migration. The file has 9 baseline findings: 4× `parse_import_result` patches (this PR), 4× `_check_quality_gate_core` patches (deferred), 1× `beets = MagicMock()` (deferred, needs FakeBeetsDB).

`parse_import_result(stdout_text)` is 100% wire-boundary work: scan the last line backward for `__IMPORT_RESULT__`, decode via `msgspec`. Tests patch it with `return_value=ir` to construct a fake harness outcome — exactly the kind of seam mock the rule allows.

`_check_quality_gate_core` and the `beets` MagicMock are real anti-patterns and stay flagged. Documented as items K and L in #301 with fix ideas (DI for the quality gate, FakeBeetsDB for class replacement).

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 341 | 327 |
| Files in baseline | 18 | 18 |

No files fully cleared by this allowlist alone, but 14 false positives removed across `test_dispatch_core.py`, `test_dispatch_from_db.py`, `test_import_dispatch.py`, `test_import_one_stages.py`.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290, #301 (items K, L)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
