### PR TITLE
test(audit): allowlist repair seams + clear false-positive docstring

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -187,6 +187,7 @@ _LEAF_SEAM_PATTERNS = [
     # filesystem read. The replacement (constructing a CratediggerConfig
     # in-memory) is also valid and used in many tests.
     re.compile(r"^lib\.config\.read_runtime_config$"),
+    re.compile(r"^scripts\.\w+\.read_runtime_config$"),  # re-exports
     re.compile(r"^lib\.config\.CratediggerConfig\.from_ini$"),
 
     # Filesystem permission helper — wraps chmod calls.
@@ -220,6 +221,12 @@ _LEAF_SEAM_PATTERNS = [
     # MusicBrainz / Discogs API fetch helpers — HTTP boundary.
     re.compile(r"^scripts\.pipeline_cli\.fetch_mb_release$"),
     re.compile(r"^lib\.\w+\.fetch_mb_release$"),
+
+    # scripts.repair helpers that wrap external boundaries.
+    # ``_get_slskd_active_transfers`` is a thin slskd_api call;
+    # ``_get_all_rows`` runs a single SELECT against the pipeline DB.
+    re.compile(r"^scripts\.repair\._get_slskd_active_transfers$"),
+    re.compile(r"^scripts\.repair\._get_all_rows$"),
 
     # DB connection reconnect — network/socket boundary.
     re.compile(r"^web\.server\._try_reconnect_db$"),

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -90,15 +90,9 @@
   "test_repair_cli.py": {
     "patch:lib.transitions.finalize_request": 1,
     "patch:scripts.repair._collect_issues": 1,
-    "patch:scripts.repair._get_all_rows": 3,
-    "patch:scripts.repair._get_slskd_active_transfers": 3,
     "patch:scripts.repair.find_blocked_recovery_issues": 1,
     "patch:scripts.repair.find_orphaned_downloads": 2,
-    "patch:scripts.repair.read_runtime_config": 3,
     "stateful_mock_assign:db": 5
-  },
-  "test_transitions.py": {
-    "patch:lib.transitions.apply_transition": 1
   },
   "test_web_server.py": {
     "patch:lib.transitions.finalize_request": 26,

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -363,11 +363,11 @@ class TestRequestTransition(unittest.TestCase):
 class TestFinalizeRequest(unittest.TestCase):
     """Final request-state command execution lives in lib.transitions.
 
-    Migrated from ``patch('lib.transitions.apply_transition')`` +
-    ``mock.assert_called_with`` to driving real ``finalize_request``
-    against a ``FakePipelineDB`` and asserting on the resulting row.
-    Validation-error tests verify the DB row stays unchanged when the
-    transition raises before any mutation.
+    Tests drive real ``finalize_request`` against a ``FakePipelineDB``
+    and assert on the resulting row. Validation-error tests verify the
+    DB row stays unchanged when the transition raises before any
+    mutation. (Migrated from MagicMock + ``mock.assert_called_with``
+    introspection per issue #290.)
     """
 
     def test_forwards_transition_fields_and_attempt_type(self):


### PR DESCRIPTION
Phase 2 of #290. Three more seam-wrapper functions added to the allowlist + a docstring false-positive fix on test_transitions.py.

| Change | Impact |
|---|---|
| Allowlist `scripts.repair._get_slskd_active_transfers` | network call wrapper |
| Allowlist `scripts.repair._get_all_rows` | single SELECT, pure SQL |
| Allowlist `scripts.<mod>.read_runtime_config` re-exports | already allowlisted at canonical site |
| Clear test_transitions.py docstring containing literal `patch(...)` pattern | scanner matched docstring text |

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 313 | 303 |
| Files in baseline | 17 | 16 |

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)