### PR TITLE
test(audit): allowlist scripts.pipeline_cli loaders

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -220,7 +220,15 @@ _LEAF_SEAM_PATTERNS = [
 
     # MusicBrainz / Discogs API fetch helpers — HTTP boundary.
     re.compile(r"^scripts\.pipeline_cli\.fetch_mb_release$"),
+    re.compile(r"^scripts\.pipeline_cli\.fetch_mb_release_group_year$"),
     re.compile(r"^lib\.\w+\.fetch_mb_release$"),
+
+    # scripts.pipeline_cli loaders — each is a thin wrapper around a
+    # disk/SQLite read in lib.config or lib.beets_db.
+    re.compile(r"^scripts\.pipeline_cli\._load_runtime_rank_config$"),
+    re.compile(r"^scripts\.pipeline_cli\._load_runtime_verified_lossless_target$"),
+    re.compile(r"^scripts\.pipeline_cli\._load_beets_album_info$"),
+    re.compile(r"^scripts\.pipeline_cli\._resolve_failed_path$"),
 
     # scripts.repair helpers that wrap external boundaries.
     # ``_get_slskd_active_transfers`` is a thin slskd_api call;

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -77,11 +77,6 @@
     "patch:lib.mbid_replace_service.MbidReplaceService": 1,
     "patch:lib.quality.full_pipeline_decision": 2,
     "patch:lib.transitions.finalize_request": 3,
-    "patch:scripts.pipeline_cli._load_beets_album_info": 2,
-    "patch:scripts.pipeline_cli._load_runtime_rank_config": 2,
-    "patch:scripts.pipeline_cli._load_runtime_verified_lossless_target": 2,
-    "patch:scripts.pipeline_cli._resolve_failed_path": 5,
-    "patch:scripts.pipeline_cli.fetch_mb_release_group_year": 3,
     "stateful_mock_assign:db": 42
   },
   "test_repair_cli.py": {


### PR DESCRIPTION
Five more thin seam wrappers allowlisted. All are loaders that dispatch to a filesystem read, SQLite read, or HTTP fetch.

| Function | Boundary |
|---|---|
| `_load_runtime_rank_config` | filesystem (INI) |
| `_load_runtime_verified_lossless_target` | filesystem (INI) |
| `_load_beets_album_info` | SQLite (beets DB) |
| `_resolve_failed_path` | filesystem (isdir) |
| `fetch_mb_release_group_year` | HTTP (MB API) |

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 290 | 276 |
| Files in baseline | 15 | 15 |

The 42 remaining `db = MagicMock()` findings in test_pipeline_cli.py are the next migration target — that's now the bulk of what's left on that file.

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)