### PR TITLE
test(audit): allowlist logger methods + slskd_download_status

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -145,6 +145,7 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^lib\.enqueue\.slskd_do_enqueue$"),
     re.compile(r"^lib\.enqueue\.slskd_enqueue_with_outcome$"),
     re.compile(r"^lib\.(download|enqueue)\.cancel_and_delete$"),
+    re.compile(r"^lib\.download\.slskd_download_status$"),
 
     # Beets harness subprocess wrapper. ``beets_validate`` invokes
     # ``run_beets_harness.sh`` and parses JSON — equivalent to mocking
@@ -194,10 +195,16 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^lib\.permissions\.fix_library_modes$"),
 
     # Logger objects — patching the module-level logger lets tests
-    # assert against log records without subclassing the logger.
+    # assert against log records without subclassing the logger. Also
+    # logger.error / .warning / .exception methods directly.
     re.compile(r"^lib\.\w+\.logger$"),
     re.compile(r"^harness\.\w+\.logger$"),
     re.compile(r"^web\.\w+\.logger$"),
+    re.compile(r"^scripts\.\w+\.logger$"),
+    re.compile(r"^lib\.\w+\.logger\.(error|warning|exception|info|debug)$"),
+    re.compile(r"^scripts\.\w+\.logger\.(error|warning|exception|info|debug)$"),
+    re.compile(r"^web\.\w+\.logger\.(error|warning|exception|info|debug)$"),
+    re.compile(r"^harness\.\w+\.logger\.(error|warning|exception|info|debug)$"),
 
     # Internal logging helper in the harness — wraps stderr writes.
     re.compile(r"^harness\.import_one\._log$"),

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -17,7 +17,6 @@
     "patch:lib.download.dispatch_import_core": 4,
     "patch:lib.download.log_validation_result": 1,
     "patch:lib.download.process_completed_album": 3,
-    "patch:lib.download.slskd_download_status": 2,
     "patch:lib.wrong_match_cleanup_service.cleanup_wrong_match": 4,
     "stateful_mock_assign:slskd": 1
   },
@@ -53,9 +52,6 @@
   "test_import_queue.py": {
     "patch:lib.download._handle_valid_result": 1,
     "patch:scripts.import_preview_worker.PipelineDB": 4,
-    "patch:scripts.import_preview_worker.logger.error": 2,
-    "patch:scripts.import_preview_worker.logger.exception": 2,
-    "patch:scripts.import_preview_worker.logger.warning": 2,
     "patch:scripts.import_preview_worker.run_once": 3,
     "stateful_mock_assign:beets": 1
   },
@@ -81,7 +77,7 @@
     "patch:scripts.repair._collect_issues": 1,
     "patch:scripts.repair.find_blocked_recovery_issues": 1,
     "patch:scripts.repair.find_orphaned_downloads": 2,
-    "stateful_mock_assign:db": 5
+    "stateful_mock_assign:db": 4
   },
   "test_web_server.py": {
     "patch:lib.transitions.finalize_request": 26,

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -12,8 +12,11 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from typing import Any, cast
+
 from lib.quality import OrphanInfo
 from scripts import repair
+from tests.fakes import FakePipelineDB
 
 
 class TestCmdFix(unittest.TestCase):
@@ -24,7 +27,7 @@ class TestCmdFix(unittest.TestCase):
         mock_collect_issues,
         mock_finalize,
     ) -> None:
-        db = MagicMock()
+        db = FakePipelineDB()
         mock_collect_issues.return_value = [
             OrphanInfo(
                 request_id=17,
@@ -35,7 +38,7 @@ class TestCmdFix(unittest.TestCase):
 
         stdout = io.StringIO()
         with redirect_stdout(stdout):
-            repair.cmd_fix(db)
+            repair.cmd_fix(cast(Any, db))
 
         called_db, request_id, transition = mock_finalize.call_args.args
         self.assertIs(called_db, db)


### PR DESCRIPTION
Two audit refinements + a small test_repair_cli migration.

| Change | Notes |
|---|---|
| Allowlist `logger.error/warning/exception/info/debug` patches | Across lib/scripts/web/harness; legitimate "verify log line emitted" pattern |
| Allowlist `scripts.<mod>.logger` | Module-level objects |
| Allowlist `lib.download.slskd_download_status` | slskd-network wrapper |
| Migrate one test_repair_cli site to FakePipelineDB | Other 4 sites use `db._execute` — deferred to #301 item M |

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 196 | 187 |
| Files | 15 | 15 |

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290, #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)