### PR TITLE
test(audit): allowlist harness.import_one subprocess wrappers + analyze_album

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -193,6 +193,38 @@ _LEAF_SEAM_PATTERNS = [
 
     # Filesystem permission helper — wraps chmod calls.
     re.compile(r"^lib\.permissions\.fix_library_modes$"),
+    re.compile(r"^harness\.import_one\.fix_library_modes$"),
+
+    # harness.import_one subprocess wrappers. ``run_import`` invokes
+    # ``beet import``; ``convert_lossless`` runs ffmpeg; the probe
+    # helpers run ffprobe/sox; ``_get_folder_*`` read tag metadata.
+    re.compile(r"^harness\.import_one\.run_import$"),
+    re.compile(r"^harness\.import_one\.convert_lossless$"),
+    re.compile(r"^harness\.import_one\._probe_lossless_source_as_v0$"),
+    re.compile(r"^harness\.import_one\._probe_native_lossy_as_v0$"),
+    re.compile(r"^harness\.import_one\._get_folder_bitrates$"),
+    re.compile(r"^harness\.import_one\._get_folder_min_bitrate$"),
+    re.compile(r"^harness\.import_one\.BeetsDB$"),  # class replacement, see lib.beets_db.BeetsDB
+
+    # Album-level spectral analysis — same sox/ffmpeg seam as
+    # analyze_track, just aggregating across an album's tracks.
+    re.compile(r"^lib\.spectral_check\.analyze_album$"),
+    re.compile(r"^harness\.import_one\.fix_library_modes$"),
+
+    # harness.import_one subprocess wrappers. ``run_import`` invokes
+    # ``beet import``; ``convert_lossless`` runs ffmpeg; the probe
+    # helpers run ffprobe/sox; ``_get_folder_*`` read tag metadata.
+    re.compile(r"^harness\.import_one\.run_import$"),
+    re.compile(r"^harness\.import_one\.convert_lossless$"),
+    re.compile(r"^harness\.import_one\._probe_lossless_source_as_v0$"),
+    re.compile(r"^harness\.import_one\._probe_native_lossy_as_v0$"),
+    re.compile(r"^harness\.import_one\._get_folder_bitrates$"),
+    re.compile(r"^harness\.import_one\._get_folder_min_bitrate$"),
+    re.compile(r"^harness\.import_one\.BeetsDB$"),  # class replacement, see lib.beets_db.BeetsDB
+
+    # Album-level spectral analysis — same sox/ffmpeg seam as
+    # analyze_track, just aggregating across an album's tracks.
+    re.compile(r"^lib\.spectral_check\.analyze_album$"),
 
     # Logger objects — patching the module-level logger lets tests
     # assert against log records without subclassing the logger. Also

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -32,19 +32,10 @@
     "stateful_mock_assign:ctx": 1
   },
   "test_import_one_stages.py": {
-    "patch:harness.import_one.BeetsDB": 3,
-    "patch:harness.import_one._get_folder_bitrates": 1,
-    "patch:harness.import_one._get_folder_min_bitrate": 1,
-    "patch:harness.import_one._probe_lossless_source_as_v0": 1,
-    "patch:harness.import_one._probe_native_lossy_as_v0": 1,
-    "patch:harness.import_one.convert_lossless": 3,
     "patch:harness.import_one.determine_verified_lossless": 1,
-    "patch:harness.import_one.fix_library_modes": 1,
     "patch:harness.import_one.provisional_lossless_decision": 1,
     "patch:harness.import_one.quality_decision_stage": 1,
-    "patch:harness.import_one.run_import": 3,
     "patch:lib.pipeline_db.PipelineDB": 4,
-    "patch:lib.spectral_check.analyze_album": 1,
     "patch:lib.transitions.finalize_request": 4,
     "stateful_mock_assign:beets": 4,
     "stateful_mock_assign:db": 4


### PR DESCRIPTION
Issue #290. Eight new seam-wrapper entries — `harness.import_one` subprocess wrappers (`run_import`, `convert_lossless`, probe helpers, folder-bitrate readers) and `lib.spectral_check.analyze_album` (aggregator on top of analyze_track).

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 183 | 168 |
| test_import_one_stages.py | 34 | 19 |

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)