### PR TITLE
test(audit): allowlist PipelineDB class-level patches

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -257,6 +257,15 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^lib\.beets_db\.BeetsDB\.delete_album$"),  # SQLite write + file delete seam
     re.compile(r"^web\.server\._real_beets_db$"),
 
+    # PipelineDB class itself — patching the class replaces the
+    # PostgreSQL boundary at the constructor. Per-method patches against
+    # PipelineDB.<method> stay flagged (FakePipelineDB is the right
+    # replacement); the class entry is for tests that swap the
+    # constructor wholesale (e.g. ``patch("scripts.X.PipelineDB",
+    # return_value=fake_db)``).
+    re.compile(r"^lib\.pipeline_db\.PipelineDB$"),
+    re.compile(r"^scripts\.\w+\.PipelineDB$"),
+
     # web.server.db — module-level pipeline DB connection cache.
     # Tests patch.object(server, "db", fake) to inject a per-test DB.
     # Equivalent to the constructor-replacement pattern.

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -35,14 +35,12 @@
     "patch:harness.import_one.determine_verified_lossless": 1,
     "patch:harness.import_one.provisional_lossless_decision": 1,
     "patch:harness.import_one.quality_decision_stage": 1,
-    "patch:lib.pipeline_db.PipelineDB": 4,
     "patch:lib.transitions.finalize_request": 4,
     "stateful_mock_assign:beets": 4,
     "stateful_mock_assign:db": 4
   },
   "test_import_queue.py": {
     "patch:lib.download._handle_valid_result": 1,
-    "patch:scripts.import_preview_worker.PipelineDB": 4,
     "patch:scripts.import_preview_worker.run_once": 3,
     "stateful_mock_assign:beets": 1
   },


### PR DESCRIPTION
Issue #290. The PipelineDB class itself wraps a PostgreSQL connection — patching the constructor (`patch.object(scripts.x, "PipelineDB", return_value=fake_db)` style) swaps the whole DB. Same shape as the already-allowlisted `lib.beets_db.BeetsDB` class entry.

Method-level `PipelineDB.<method>` patches stay flagged (FakePipelineDB is the right replacement; class-level is for wholesale swaps).

## Result

| | Before | After |
|---|---|---|
| Baseline findings | 168 | 160 |

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3692 tests, 0 skipped, 0 failed
- [x] `nix-shell --run pyright` — 0 errors on full repo

Tracking: #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)