### PR TITLE
test(fakes): add _execute cursor stubbing to FakePipelineDB

### DIFF
--- a/docs/issue-290-resume.md
+++ b/docs/issue-290-resume.md
@@ -4,7 +4,7 @@ This is the **entry point** for picking up the stateful-MagicMock removal effort
 
 ## Current state
 
-Baseline last measured at **115 findings across 15 files**. To check the live count:
+Baseline last measured at **110 findings across 15 files**. To check the live count:
 
 ```bash
 nix-shell --run "python3 tests/_rebuild_mock_audit_baseline.py"
@@ -28,7 +28,7 @@ A finding is one of two things:
 
 The audit is in `tests/test_mock_audit.py`; the scanner heuristic lives in `tests/_mock_audit_scanner.py`; the frozen call-site count is in `tests/mock_audit_baseline.json`.
 
-## One concrete next move (in order of value-per-effort)
+## Next moves (in order of value-per-effort)
 
 ### ~~1. Item N in #301 — DI refactor for `try_enqueue` match function~~ (LANDED)
 
@@ -49,11 +49,35 @@ to `tests/helpers.py`. Migrated `test_dispatch_core.py` (4),
 `test_dispatch_from_db.py` (5), `test_import_dispatch.py` (3). Dropped 11
 findings (126 → 115).
 
-### 1. Item M in #301 — `_execute` support on `FakePipelineDB` (~2 hours)
+### ~~3. Item M in #301 — `_execute` support on `FakePipelineDB`~~ (LANDED)
 
-14 sites in `test_pipeline_cli.py` (mostly TestCmdQuery, TestCmdRepairSpectral) inject SQL cursor results via `db._execute.side_effect = [cursor1, cursor2, ...]`. Add a minimal `_execute` simulator to FakePipelineDB that lets tests register the cursor sequence — same shape as the existing `set_directory_*` pattern on FakeSlskdAPI. PR title: `test(fakes): add _execute cursor stubbing to FakePipelineDB`. Drops 14 findings.
+Shipped: `FakePipelineDB.queue_execute_results(*cursors)` registers a
+deterministic cursor sequence; `_execute(sql, params)` records calls in
+`db.execute_calls` and pops the next entry (raising it if it's an
+`Exception` instance). Migrated 5 sites in `test_pipeline_cli.py`
+(`TestCmdQuery` 4, `TestCmdRepairSpectral` 1). Other test_pipeline_cli
+sites use different MagicMock patterns that aren't `_execute` queues —
+those remain for separate migration. Dropped 5 findings (115 → 110).
 
-After this one: baseline drops 115 → ~101 remaining. That residual is mostly `finalize_request` in `test_web_server.py` contract tests (26 sites) — those need either per-test DB seeding (heavy) OR the same DI treatment for `finalize_request` (likely the right move; tracked separately).
+### 1. Residual `test_web_server.py` (~34 findings, the long pole)
+
+Biggest remaining block. Mix of `MagicMock()` assigned to `db` /
+`pipeline_db_source` / `mock_db` and `patch("lib.transitions.finalize_request")`.
+These contract tests assemble a minimal mock for the route handler's
+collaborator graph. Two viable paths:
+- Per-test DB seeding through `FakePipelineDB` plus `make_request_row` —
+  heavy because each contract test needs different shapes.
+- DI on `finalize_request` (matches Items N + K patterns; the route
+  handler would take `finalize_fn` and pass it through). 26 of the 34
+  findings would go away from that one change.
+
+Pick that up as `refactor(web): inject finalize_request through route handlers`.
+
+### 2. Smaller cleanups (~14 findings across 5 files)
+
+`test_import_one_stages.py` (15) and `test_download.py` (14) are the
+next clusters worth a look — both feel like they'd benefit from
+specific Fake helpers rather than a single DI move.
 
 ## What's NOT next
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -716,6 +716,16 @@ class FakePipelineDB:
         self.search_plan_items: dict[int, _FakeSearchPlanItemRow] = {}
         self._next_search_plan_id = 0
         self._next_search_plan_item_id = 0
+        # ``_execute`` stubbing for tests that drive raw-SQL CLI paths
+        # (``pipeline-cli query``, ``pipeline-cli repair-spectral``, ...).
+        # ``queue_execute_results`` lets tests register a deterministic
+        # cursor sequence; each ``_execute`` call pops the next entry,
+        # raising it if it is an ``Exception`` and otherwise returning
+        # it as the cursor. ``execute_calls`` records the (sql, params)
+        # arguments for assertion.
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self._execute_queue: list[Any] = []
+        self._execute_default: Any = None
 
     # --- Seeding ---
 
@@ -729,6 +739,33 @@ class FakePipelineDB:
     def request(self, request_id: int) -> dict[str, Any]:
         """Get a request row (for test assertions). Raises KeyError if missing."""
         return self._requests[request_id]
+
+    def queue_execute_results(self, *results: Any) -> None:
+        """Register a deterministic cursor sequence for ``_execute`` calls.
+
+        Each subsequent ``_execute(sql, params)`` call pops the next entry:
+        - If the entry is an ``Exception`` instance/subclass, it is raised
+          (so tests can simulate ``psycopg2.ProgrammingError`` etc.).
+        - Otherwise the entry is returned as the cursor.
+
+        Replaces ``MagicMock(); db._execute.side_effect = [c1, c2, c3]``.
+        Inspect call args via ``db.execute_calls``.
+        """
+        self._execute_queue = list(results)
+
+    def _execute(self, sql: str, params: tuple[Any, ...] = ()) -> Any:
+        """Stand-in for ``PipelineDB._execute``.
+
+        Records the call and returns the next entry from
+        ``queue_execute_results``. If the queue is empty, returns
+        ``self._execute_default`` (defaults to ``None``)."""
+        self.execute_calls.append((sql, params))
+        if not self._execute_queue:
+            return self._execute_default
+        entry = self._execute_queue.pop(0)
+        if isinstance(entry, Exception):
+            raise entry
+        return entry
 
     def set_cooldown_result(self, result: bool | Callable[[str], bool]) -> None:
         """Configure what check_and_apply_cooldown returns.

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -55,7 +55,7 @@
     "patch:lib.mbid_replace_service.MbidReplaceService": 1,
     "patch:lib.quality.full_pipeline_decision": 2,
     "patch:lib.transitions.finalize_request": 3,
-    "stateful_mock_assign:db": 6
+    "stateful_mock_assign:db": 1
   },
   "test_repair_cli.py": {
     "patch:lib.transitions.finalize_request": 1,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -4,7 +4,7 @@ import inspect
 import unittest
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
 from lib.grab_list import DownloadFile, GrabListEntry
@@ -229,6 +229,43 @@ class TestFakePipelineDB(unittest.TestCase):
         assert loaded is not None
         self.assertEqual(loaded.audio_file_count, 0)
         self.assertEqual(loaded.files, [])
+
+    def test_execute_records_calls_and_returns_queued_cursors(self):
+        """``queue_execute_results`` registers a deterministic cursor sequence;
+        each ``_execute`` call pops the next entry and records the call."""
+        db = FakePipelineDB()
+        cur1 = MagicMock(name="cur1")
+        cur2 = MagicMock(name="cur2")
+        db.queue_execute_results(cur1, cur2)
+
+        result1 = db._execute("SELECT 1")
+        result2 = db._execute("SELECT 2", (42,))
+
+        self.assertIs(result1, cur1)
+        self.assertIs(result2, cur2)
+        self.assertEqual(
+            db.execute_calls,
+            [("SELECT 1", ()), ("SELECT 2", (42,))],
+        )
+
+    def test_execute_raises_when_queued_entry_is_exception(self):
+        """Queued ``Exception`` entries are raised, not returned — replaces
+        ``side_effect=[..., ProgrammingError(...), ...]`` from MagicMock."""
+        db = FakePipelineDB()
+        boom = RuntimeError("syntax error")
+        db.queue_execute_results(MagicMock(), boom)
+
+        db._execute("SELECT 1")
+        with self.assertRaises(RuntimeError) as raised:
+            db._execute("BOOM")
+        self.assertIs(raised.exception, boom)
+
+    def test_execute_with_empty_queue_returns_default(self):
+        """Empty queue returns ``None`` so tests that don't care about the
+        cursor result can still call ``_execute`` without setup."""
+        db = FakePipelineDB()
+        self.assertIsNone(db._execute("SELECT 1"))
+        self.assertEqual(db.execute_calls, [("SELECT 1", ())])
 
     def test_record_attempt_updates_retry_metadata(self):
         db = FakePipelineDB()
@@ -2923,6 +2960,7 @@ class TestPipelineDBFakeContract(unittest.TestCase):
             "assert_log",
             "set_advisory_lock_result",
             "set_cooldown_result",
+            "queue_execute_results",
         }
         real = _public_methods(PipelineDB)
         fake = _public_methods(FakePipelineDB)

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -913,13 +913,13 @@ class TestMainExitCodes(unittest.TestCase):
 
 class TestCmdQuery(unittest.TestCase):
     def test_query_renders_table_output_in_read_only_mode(self):
-        db = MagicMock()
+        db = FakePipelineDB()
         query_cur = MagicMock()
         query_cur.description = [("id",), ("artist_name",), ("details",)]
         query_cur.fetchall.return_value = [
             {"id": 7, "artist_name": "Buke and Gase", "details": {"tracks": 3}},
         ]
-        db._execute.side_effect = [MagicMock(), query_cur, MagicMock()]
+        db.queue_execute_results(MagicMock(), query_cur, MagicMock())
 
         args = MagicMock(sql="SELECT id, artist_name, details FROM album_requests", json=False)
         stdout = io.StringIO()
@@ -929,36 +929,35 @@ class TestCmdQuery(unittest.TestCase):
         # Behavior: query succeeds, output is formatted, read-only mode was used
         self.assertIsNone(rc)
         # 3 _execute calls: enable read-only, run query, disable read-only
-        self.assertEqual(db._execute.call_count, 3)
+        self.assertEqual(len(db.execute_calls), 3)
         output = stdout.getvalue()
         self.assertIn("id | artist_name", output)
         self.assertIn('{"tracks": 3}', output)
         self.assertIn("(1 row)", output)
 
     def test_query_reads_sql_from_stdin_when_dash_is_passed(self):
-        db = MagicMock()
+        db = FakePipelineDB()
         query_cur = MagicMock()
         query_cur.description = [("value",)]
         query_cur.fetchall.return_value = [{"value": 1}]
-        db._execute.side_effect = [MagicMock(), query_cur, MagicMock()]
+        db.queue_execute_results(MagicMock(), query_cur, MagicMock())
 
         args = MagicMock(sql="-", json=False)
         stdout = io.StringIO()
         with patch("sys.stdin", io.StringIO("SELECT 1 AS value")), redirect_stdout(stdout):
             pipeline_cli.cmd_query(db, args)
 
-        self.assertEqual(
-            db._execute.call_args_list[1][0][0],
-            "SELECT 1 AS value",
-        )
+        # Second _execute call is the query itself; the first/third are
+        # read-only session toggles.
+        self.assertEqual(db.execute_calls[1][0], "SELECT 1 AS value")
         self.assertIn("value", stdout.getvalue())
 
     def test_query_can_emit_json(self):
-        db = MagicMock()
+        db = FakePipelineDB()
         query_cur = MagicMock()
         query_cur.description = [("id",), ("status",)]
         query_cur.fetchall.return_value = [{"id": 3, "status": "wanted"}]
-        db._execute.side_effect = [MagicMock(), query_cur, MagicMock()]
+        db.queue_execute_results(MagicMock(), query_cur, MagicMock())
 
         args = MagicMock(sql="SELECT id, status FROM album_requests", json=True)
         stdout = io.StringIO()
@@ -973,12 +972,12 @@ class TestCmdQuery(unittest.TestCase):
     def test_query_reports_sql_errors_and_cleans_up(self):
         import psycopg2
 
-        db = MagicMock()
-        db._execute.side_effect = [
+        db = FakePipelineDB()
+        db.queue_execute_results(
             MagicMock(),
             psycopg2.ProgrammingError('syntax error at or near "BOOM"'),
             MagicMock(),
-        ]
+        )
 
         args = MagicMock(sql="BOOM", json=False)
         stderr = io.StringIO()
@@ -989,7 +988,7 @@ class TestCmdQuery(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("syntax error", stderr.getvalue())
         # Cleanup call happened (3rd _execute call for read-only reset)
-        self.assertEqual(db._execute.call_count, 3)
+        self.assertEqual(len(db.execute_calls), 3)
 
 
 class TestCmdQueryIntegration(unittest.TestCase):
@@ -1177,8 +1176,8 @@ class TestCmdRepairSpectral(unittest.TestCase):
             delete_cur.fetchall.return_value = []
             finalize_request = MagicMock()
 
-            db = MagicMock()
-            db.get_request.return_value = make_request_row(
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
                 id=42,
                 status="wanted",
                 mb_release_id="mbid-123",
@@ -1189,12 +1188,8 @@ class TestCmdRepairSpectral(unittest.TestCase):
                 current_spectral_bitrate=96,
                 verified_lossless=True,
                 final_format="mp3 v0",
-            )
-            db._execute.side_effect = [
-                candidate_cur,
-                clear_cur,
-                delete_cur,
-            ]
+            ))
+            db.queue_execute_results(candidate_cur, clear_cur, delete_cur)
 
             beets_info = AlbumInfo(
                 album_id=1,
@@ -1217,12 +1212,12 @@ class TestCmdRepairSpectral(unittest.TestCase):
                  patch("lib.beets_db.BeetsDB", return_value=mock_beets), \
                  patch("lib.transitions.finalize_request", finalize_request), \
                  redirect_stdout(stdout):
-                pipeline_cli.cmd_repair_spectral(db, args)
+                pipeline_cli.cmd_repair_spectral(cast(Any, db), args)
 
             output = stdout.getvalue()
             self.assertIn("quality_gate_decision → accept", output)
             self.assertIn("→ transitioned to imported", output)
-            self.assertEqual(db._execute.call_count, 3)
+            self.assertEqual(len(db.execute_calls), 3)
             called_db, request_id, transition = finalize_request.call_args.args
             self.assertIs(called_db, db)
             self.assertEqual(request_id, 42)


### PR DESCRIPTION
## Summary

Item M of issue #290. Adds \`FakePipelineDB.queue_execute_results(*cursors)\` plus a state-respecting \`_execute(sql, params)\` implementation that records calls in \`db.execute_calls\` and pops the next queued cursor. Queued \`Exception\` instances are raised, so tests can simulate \`psycopg2.ProgrammingError\` etc. without \`side_effect=[..., err, ...]\` on a \`MagicMock\`.

## Why

The raw-SQL CLI paths in \`scripts/pipeline_cli.py\` (\`cmd_query\`, \`cmd_repair_spectral\`) call \`db._execute(sql)\` directly and consume the cursor. Tests were doing \`db = MagicMock(); db._execute.side_effect = [c1, c2, c3]\` — a stateful MagicMock pattern the audit treats as the canonical anti-pattern. The new fake helper preserves the ergonomics (queue results, inspect calls) without instantiating MagicMock at the \`db\` boundary.

## Migration scope

\`tests/test_pipeline_cli.py\` — 5 sites retired:
- 4 in \`TestCmdQuery\` (table output / stdin SQL / JSON output / error-with-cleanup)
- 1 in \`TestCmdRepairSpectral\` (lo-fi V0 repair reload)

The other 9 \`test_pipeline_cli.py\` findings use different MagicMock patterns and aren't \`_execute\` queues — those remain for separate migration.

## Self-tests

\`tests/test_fakes.py::TestFakePipelineDB\` gets three new contract tests:
- \`test_execute_records_calls_and_returns_queued_cursors\` — queue + record
- \`test_execute_raises_when_queued_entry_is_exception\` — exceptional entries raise
- \`test_execute_with_empty_queue_returns_default\` — empty queue is a no-op

The audit \`test_fake_only_methods_stay_on_the_allowlist\` allowlist now includes \`queue_execute_results\`.

## Result

- Mock-audit baseline: **115 → 110** (-5 findings)
- Pyright: 0 errors / 0 warnings / 0 informations on full repo
- Full suite: 3695 tests, all green (+3 self-tests)

Cumulative across the three DI/Fake PRs landed in this push:
**160 → 110** (-50 findings, 31% of the original baseline).

Next moves documented in \`docs/issue-290-resume.md\` — the long pole is \`test_web_server.py\` (34 findings, likely \`finalize_request\` DI).

## Test plan

- [x] \`nix-shell --run \"python3 -m unittest tests.test_pipeline_cli tests.test_fakes\"\` — green
- [x] \`nix-shell --run pyright\` — 0 errors on full repo
- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3695/3695 green
- [x] \`nix-shell --run \"python3 tests/_rebuild_mock_audit_baseline.py\"\` — 110 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)