### PR TITLE
test(web): allowlist two route-scope DI seams + migrate one to real inputs

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -287,6 +287,23 @@ _LEAF_SEAM_PATTERNS = [
     # handlers are dispatched by URL and don't take dependency kwargs.
     re.compile(r"^web\.routes\.pipeline\.finalize_request$"),
 
+    # Route-to-service DI seam. ``cleanup_all_wrong_matches`` triggers
+    # real DB mutations + filesystem deletes via the wrong-match cleanup
+    # service. Service behaviour is tested in
+    # ``tests/test_wrong_matches_cleanup.py``; the contract tests in
+    # ``test_web_server.py`` pin the HTTP wire shape (status code,
+    # JSON fields, response summary). Patching the route-module binding
+    # keeps those contract tests focused on the wire shape.
+    re.compile(r"^web\.routes\.imports\.cleanup_all_wrong_matches$"),
+
+    # Web-server module-level swap, same pattern as ``web.server.db``.
+    # ``compute_library_rank`` is the in-library rank-badge producer
+    # (codec-aware tier label). Tests in ``test_web_server.py`` patch
+    # it via ``side_effect`` to stamp deterministic rank labels into
+    # browse / label / artist responses without setting up a real
+    # rank-config + beets album fixture for every contract test.
+    re.compile(r"^web\.server\.compute_library_rank$"),
+
     # Deleted-shim regression guard. ``check_beets_by_artist_album``
     # was removed in issue #123; tests patch it with create=True to
     # ensure it stays gone (the patch acts as a RED guard against

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -65,10 +65,7 @@
     "stateful_mock_assign:db": 4
   },
   "test_web_server.py": {
-    "patch:web.routes.imports.cleanup_all_wrong_matches": 3,
-    "patch:web.routes.imports.match_folders_to_requests": 1,
     "patch:web.routes.pipeline.preview_import_from_values": 1,
-    "patch:web.server.compute_library_rank": 1,
     "stateful_mock_assign:failing_db": 1,
     "stateful_mock_assign:mock_db": 1
   },

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 
-from lib.manual_import import FolderInfo, FolderMatch, ImportRequest
+from lib.manual_import import FolderInfo
 from lib.import_preview import ImportPreviewResult
 from lib.import_queue import ImportJob
 from lib.pipeline_db import SearchPlanProvenance
@@ -4937,9 +4937,13 @@ class TestManualImportRouteContracts(_WebServerCase):
         self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
         self.mock_db.get_by_status.side_effect = None
 
-    @patch("web.routes.imports.match_folders_to_requests")
     @patch("web.routes.imports.scan_complete_folder")
-    def test_manual_import_scan_contract(self, mock_scan, mock_match):
+    def test_manual_import_scan_contract(self, mock_scan):
+        # Drive the real ``match_folders_to_requests`` against folder +
+        # request inputs that share an artist/album token set so the
+        # fuzzy matcher produces a high-confidence FolderMatch. Patching
+        # the matcher away would hide its contract — score field,
+        # match-or-skip threshold, sort order — from this test.
         folder = FolderInfo(
             name="Test Artist - Test Album",
             path="/complete/Test Artist - Test Album",
@@ -4947,16 +4951,15 @@ class TestManualImportRouteContracts(_WebServerCase):
             album="Test Album",
             file_count=10,
         )
-        request = ImportRequest(
-            id=100,
-            artist_name="Test Artist",
-            album_title="Test Album",
-            mb_release_id="abc-123",
-        )
         mock_scan.return_value = [folder]
-        mock_match.return_value = [FolderMatch(folder=folder, request=request, score=0.91)]
         self.mock_db.get_by_status.return_value = [
-            make_request_row(id=100, status="wanted", mb_release_id="abc-123"),
+            make_request_row(
+                id=100,
+                status="wanted",
+                mb_release_id="abc-123",
+                artist_name="Test Artist",
+                album_title="Test Album",
+            ),
         ]
 
         status, data = self._get("/api/manual-import/scan")
@@ -4968,6 +4971,10 @@ class TestManualImportRouteContracts(_WebServerCase):
                                 "manual import folder")
         _assert_required_fields(self, data["folders"][0]["match"], self.MATCH_REQUIRED_FIELDS,
                                 "manual import match")
+        # Real matcher should report a perfect score for identical
+        # artist/album tokens — this is the actual production contract.
+        self.assertEqual(data["folders"][0]["match"]["request_id"], 100)
+        self.assertGreaterEqual(data["folders"][0]["match"]["score"], 0.99)
 
     @patch("web.routes.imports.resolve_failed_path",
            return_value="/complete/Test Artist - Test Album")


### PR DESCRIPTION
## Summary

Cheap follow-on after PR #322. Five residual findings on \`test_web_server.py\` traced to three patch targets — handled as a mix of allowlist (where it matches the existing route-scope DI shape) and real-input migration (where the function is pure logic with no boundary).

## Changes

1. **\`web.routes.imports.cleanup_all_wrong_matches\` (3 sites)** — service-layer DI seam. Triggers DB mutations + filesystem deletes; behaviour is covered by \`tests/test_wrong_matches_cleanup.py\`. The web contract test pins HTTP wire shape only. **Allowlisted** with rationale.

2. **\`web.server.compute_library_rank\` (1 site)** — pure rank-label producer on \`web.server\`. Matches the existing \`web.server.db\` allowlist precedent (web.server module-level swap = the route-scope DI shape in this codebase). **Allowlisted** with rationale.

3. **\`web.routes.imports.match_folders_to_requests\` (1 site)** — pure fuzzy matcher with no boundary. **Migrated to drive the real function** against folder + request inputs that share artist/album tokens. Replaces \`mock_match.return_value = [FolderMatch(..., score=0.91)]\` with an actual assertion that the matcher reports score >= 0.99 for identical tokens. The patched scaffold hid the real contract; the real function now exercises it.

## Result

- Mock-audit baseline: **84 → 79** (-5 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3695 tests, all green

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3695/3695 green
- [x] \`nix-shell --run pyright\` — 0 errors
- [x] Real matcher in \`test_manual_import_scan_contract\` returns score >= 0.99

🤖 Generated with [Claude Code](https://claude.com/claude-code)