### PR TITLE
refactor(dispatch/cli/harness): module-local finalize_request DI seams

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -51,6 +51,11 @@ from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
 from lib.release_identity import ReleaseIdentity
 from lib.util import beets_subprocess_env, repair_mp3_headers
+from lib import transitions
+
+# Module-level DI seam for ``transitions.finalize_request`` — see
+# ``lib.import_dispatch.finalize_request`` for the rationale.
+finalize_request = transitions.finalize_request
 from lib.quality import (AUDIO_EXTENSIONS_DOTTED as AUDIO_EXTENSIONS,
                          AudioQualityMeasurement, DuplicateRemoveCandidate,
                          DuplicateRemoveGuardInfo, ImportResult,
@@ -1036,7 +1041,6 @@ def update_pipeline_db(request_id, status, imported_path=None, distance=None, sc
     Best-effort — failures are logged but do not block the import harness.
     """
     try:
-        from lib import transitions
         from lib.pipeline_db import PipelineDB
         dsn = os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger")
         db = PipelineDB(dsn)
@@ -1062,7 +1066,7 @@ def update_pipeline_db(request_id, status, imported_path=None, distance=None, sc
                 transition = transitions.RequestTransition.to_manual()
             else:
                 transition = transitions.RequestTransition.status_only(status)
-            transitions.finalize_request(
+            finalize_request(
                 db,
                 request_id,
                 transition,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -19,6 +19,15 @@ from typing import Any, Callable, Sequence, TYPE_CHECKING
 import msgspec
 
 from lib import transitions
+
+# Module-level DI seam for ``transitions.finalize_request``. Internal
+# call sites bind through this name (not ``transitions.finalize_request``
+# directly) so tests can swap the dependency via
+# ``patch("lib.import_dispatch.finalize_request")`` at the same module
+# scope as the route-level seam in ``web.routes.pipeline``. See the
+# leaf-seam allowlist in ``tests/_mock_audit_scanner.py``.
+finalize_request = transitions.finalize_request
+
 from lib.quality import (parse_import_result, DispatchAction, DownloadInfo,
                          ImportResult, MeasurementFailure,
                          SpectralMeasurement, V0ProbeEvidence,
@@ -874,7 +883,7 @@ def _do_mark_done(
             ).as_update_fields()
         )
     update_fields["final_format"] = dl_info.final_format
-    transitions.finalize_request(
+    finalize_request(
         db,
         request_id,
         transitions.RequestTransition.to_imported_fields(fields=update_fields),
@@ -966,7 +975,7 @@ def _finalize_request_and_log_rejection(
         transition_kwargs: dict[str, object] = {}
         if search_filetype_override is not None:
             transition_kwargs["search_filetype_override"] = search_filetype_override
-        transitions.finalize_request(
+        finalize_request(
             db,
             request_id,
             transitions.RequestTransition.to_wanted_fields(
@@ -1331,7 +1340,7 @@ def _check_quality_gate_core(
 
         if decision == "requeue_upgrade":
             upgrade_override = QUALITY_UPGRADE_TIERS
-            transitions.finalize_request(
+            finalize_request(
                 db,
                 request_id,
                 transitions.RequestTransition.to_wanted(
@@ -1360,7 +1369,7 @@ def _check_quality_gate_core(
                 f"(searching {upgrade_override})")
         elif decision == "requeue_lossless":
             lossless_override = QUALITY_LOSSLESS
-            transitions.finalize_request(
+            finalize_request(
                 db,
                 request_id,
                 transitions.RequestTransition.to_wanted(
@@ -1374,7 +1383,7 @@ def _check_quality_gate_core(
                 f"min_bitrate={min_br_kbps}kbps CBR, not verified lossless — "
                 f"searching for lossless to verify")
         else:  # accept
-            transitions.finalize_request(
+            finalize_request(
                 db,
                 request_id,
                 transitions.RequestTransition.to_imported(
@@ -1801,7 +1810,7 @@ def dispatch_import_core(
                     if decision in ("import", "preflight_existing"):
                         if prev_br is not None or new_br is not None:
                             try:
-                                transitions.finalize_request(
+                                finalize_request(
                                     db,
                                     request_id,
                                     transitions.RequestTransition.to_imported(
@@ -2031,7 +2040,7 @@ def dispatch_import_core(
                     }
                     if action.mark_done and new_br is not None:
                         requeue_fields["min_bitrate"] = new_br
-                    transitions.finalize_request(
+                    finalize_request(
                         db,
                         request_id,
                         transitions.RequestTransition.to_wanted_fields(

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -49,6 +49,11 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 from lib import transitions
+
+# Module-level DI seam for ``transitions.finalize_request`` — see
+# ``lib.import_dispatch.finalize_request`` for the rationale.
+finalize_request = transitions.finalize_request
+
 from lib.import_queue import (
     IMPORT_JOB_FORCE,
     IMPORT_JOB_MANUAL,
@@ -422,7 +427,7 @@ def cmd_retry(db, args):
     if not req:
         print(f"  Request {args.id} not found.")
         return
-    transitions.finalize_request(
+    finalize_request(
         db,
         args.id,
         transitions.RequestTransition.to_wanted(from_status=req["status"]),
@@ -435,7 +440,7 @@ def cmd_cancel(db, args):
     if not req:
         print(f"  Request {args.id} not found.")
         return
-    transitions.finalize_request(
+    finalize_request(
         db,
         args.id,
         transitions.RequestTransition.to_manual(from_status=req["status"]),
@@ -455,7 +460,7 @@ def cmd_set(db, args):
     if old_status == args.status:
         print(f"  [{args.id}] already has status '{args.status}'.")
         return
-    transitions.finalize_request(
+    finalize_request(
         db,
         args.id,
         transitions.RequestTransition.status_only(
@@ -489,7 +494,7 @@ def cmd_set_intent(db, args):
     if req["status"] == "imported" and target_format:
         # Re-queue to search for lossless source
         min_br = req.get("min_bitrate")
-        transitions.finalize_request(
+        finalize_request(
             db,
             args.id,
             transitions.RequestTransition.to_wanted(
@@ -1382,7 +1387,7 @@ def cmd_repair_spectral(db, args):
 
         # If quality gate would accept, transition to imported
         if decision == "accept" and effective_min_br is not None:
-            transitions.finalize_request(
+            finalize_request(
                 db,
                 rid,
                 transitions.RequestTransition.to_imported(

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -20,6 +20,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.config import read_runtime_config
 from lib import transitions
+
+# Module-level DI seam for ``transitions.finalize_request`` — see
+# ``lib.import_dispatch.finalize_request`` for the rationale.
+finalize_request = transitions.finalize_request
+
 from lib.download_recovery import (find_blocked_processing_path_issues,
                                    find_blocked_recovery_issues)
 from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE, PipelineDB,
@@ -241,7 +246,7 @@ def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
     for issue in issues:
         repair = suggest_repair(issue)
         if repair.action == "reset_to_wanted":
-            transitions.finalize_request(
+            finalize_request(
                 db,
                 issue.request_id,
                 transitions.RequestTransition.to_wanted(

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -304,6 +304,18 @@ _LEAF_SEAM_PATTERNS = [
     # rank-config + beets album fixture for every contract test.
     re.compile(r"^web\.server\.compute_library_rank$"),
 
+    # Module-local DI seams for ``transitions.finalize_request``. Each
+    # calling module binds ``finalize_request = transitions.finalize_request``
+    # at import time so tests swap the dependency on the route/CLI/harness/
+    # dispatch module rather than on ``lib.transitions``. Same shape as
+    # ``web.routes.pipeline.finalize_request`` above — route handlers
+    # and CLI subcommands are dispatched without keyword args, so
+    # module-attribute swap is the established DI shape in this codebase.
+    re.compile(r"^lib\.import_dispatch\.finalize_request$"),
+    re.compile(r"^harness\.import_one\.finalize_request$"),
+    re.compile(r"^scripts\.pipeline_cli\.finalize_request$"),
+    re.compile(r"^scripts\.repair\.finalize_request$"),
+
     # Deleted-shim regression guard. ``check_beets_by_artist_album``
     # was removed in issue #123; tests patch it with create=True to
     # ensure it stays gone (the patch acts as a RED guard against

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -26,14 +26,12 @@
     "patch:lib.download.log_validation_result": 1,
     "patch:lib.download.stage_to_ai_path": 1,
     "patch:lib.quality.quality_gate_decision": 5,
-    "patch:lib.transitions.finalize_request": 1,
     "stateful_mock_assign:ctx": 1
   },
   "test_import_one_stages.py": {
     "patch:harness.import_one.determine_verified_lossless": 1,
     "patch:harness.import_one.provisional_lossless_decision": 1,
     "patch:harness.import_one.quality_decision_stage": 1,
-    "patch:lib.transitions.finalize_request": 4,
     "stateful_mock_assign:beets": 4,
     "stateful_mock_assign:db": 4
   },
@@ -44,8 +42,7 @@
   },
   "test_integration_slices.py": {
     "patch:lib.download.dispatch_import_core": 1,
-    "patch:lib.download.process_completed_album": 3,
-    "patch:lib.transitions.finalize_request": 1
+    "patch:lib.download.process_completed_album": 3
   },
   "test_matching.py": {
     "patch:lib.matching._track_titles_cross_check": 1
@@ -54,11 +51,9 @@
     "patch:lib.import_preview.preview_import_from_values": 2,
     "patch:lib.mbid_replace_service.MbidReplaceService": 1,
     "patch:lib.quality.full_pipeline_decision": 2,
-    "patch:lib.transitions.finalize_request": 3,
     "stateful_mock_assign:db": 1
   },
   "test_repair_cli.py": {
-    "patch:lib.transitions.finalize_request": 1,
     "patch:scripts.repair._collect_issues": 1,
     "patch:scripts.repair.find_blocked_recovery_issues": 1,
     "patch:scripts.repair.find_orphaned_downloads": 2,

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -253,7 +253,7 @@ class TestCleanupStagedDir(unittest.TestCase):
 class TestRecordRejectionAndRequeueSeam(unittest.TestCase):
     """Seam tests for the shared rejection finalizer."""
 
-    @patch("lib.transitions.finalize_request")
+    @patch("lib.import_dispatch.finalize_request")
     def test_requeue_defers_from_status_lookup_to_finalize_request(
         self,
         mock_finalize,

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -59,7 +59,7 @@ class TestImportBootstrap(unittest.TestCase):
 
 
 class TestPipelineDbUpdate(unittest.TestCase):
-    @patch("lib.transitions.finalize_request")
+    @patch("harness.import_one.finalize_request")
     @patch("lib.pipeline_db.PipelineDB")
     def test_update_pipeline_db_routes_through_shared_finalizer(
         self,
@@ -94,7 +94,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
         )
         db.close.assert_called_once()
 
-    @patch("lib.transitions.finalize_request", side_effect=RuntimeError("boom"))
+    @patch("harness.import_one.finalize_request", side_effect=RuntimeError("boom"))
     @patch("lib.pipeline_db.PipelineDB")
     def test_update_pipeline_db_closes_db_when_finalizer_raises(
         self,
@@ -113,7 +113,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
         db.close.assert_called_once()
         self.assertIn("Pipeline DB update failed", stderr.getvalue())
 
-    @patch("lib.transitions.finalize_request")
+    @patch("harness.import_one.finalize_request")
     @patch("lib.pipeline_db.PipelineDB")
     def test_update_pipeline_db_distinguishes_transition_whitelist_errors(
         self,
@@ -138,7 +138,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
         self.assertIn("Pipeline DB transition rejected", stderr.getvalue())
         self.assertIn("imported_path", stderr.getvalue())
 
-    @patch("lib.transitions.finalize_request")
+    @patch("harness.import_one.finalize_request")
     @patch("lib.pipeline_db.PipelineDB")
     def test_update_pipeline_db_rejects_unknown_status_and_closes_db(
         self,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -5504,7 +5504,7 @@ class TestRecordPreviewMeasurementFailedSlice(unittest.TestCase):
         )
 
         # Spy on finalize_request to prove it is NOT called.
-        with patch("lib.transitions.finalize_request") as mock_finalize:
+        with patch("lib.import_dispatch.finalize_request") as mock_finalize:
             _record_preview_measurement_failed(
                 cast(Any, db),
                 request_id=None,

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -264,7 +264,7 @@ class TestCmdCancel(unittest.TestCase):
 
 class TestCmdSet(unittest.TestCase):
     @patch("builtins.print")
-    @patch("lib.transitions.finalize_request")
+    @patch("scripts.pipeline_cli.finalize_request")
     def test_set_routes_dynamic_status_through_shared_finalizer(
         self,
         mock_finalize,
@@ -1092,7 +1092,7 @@ class TestCmdSetIntent(unittest.TestCase):
         self.assertEqual(db.update_request_fields_calls, [(1, dict(target_format=None))])
 
     @patch("builtins.print")
-    @patch("lib.transitions.finalize_request")
+    @patch("scripts.pipeline_cli.finalize_request")
     def test_set_lossless_on_imported_requeues(self, mock_finalize, _mock_print):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
@@ -1210,7 +1210,7 @@ class TestCmdRepairSpectral(unittest.TestCase):
             stdout = io.StringIO()
             with patch.dict(os.environ, {"CRATEDIGGER_RUNTIME_CONFIG": cfg_path}), \
                  patch("lib.beets_db.BeetsDB", return_value=mock_beets), \
-                 patch("lib.transitions.finalize_request", finalize_request), \
+                 patch("scripts.pipeline_cli.finalize_request", finalize_request), \
                  redirect_stdout(stdout):
                 pipeline_cli.cmd_repair_spectral(cast(Any, db), args)
 

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -20,7 +20,7 @@ from tests.fakes import FakePipelineDB
 
 
 class TestCmdFix(unittest.TestCase):
-    @patch("lib.transitions.finalize_request")
+    @patch("scripts.repair.finalize_request")
     @patch("scripts.repair._collect_issues")
     def test_reset_to_wanted_routes_through_shared_finalizer(
         self,


### PR DESCRIPTION
## Summary

Item P from #301. Ten residual \`patch(\"lib.transitions.finalize_request\")\` sites lived in CLI / dispatch / harness tests. PR #322 already established the route-scope pattern for \`web.routes.pipeline.finalize_request\`; this PR applies the same shape to the four other modules with their own test patches.

Each module now binds \`finalize_request = transitions.finalize_request\` at import time, and every internal call site goes through the local name. Tests swap the dependency on the calling module rather than on \`lib.transitions\`.

## Migrated modules

- \`lib.import_dispatch\` — 7 internal call sites
- \`scripts.pipeline_cli\` — 5 internal call sites
- \`scripts.repair\` — 1 internal call site
- \`harness.import_one\` — 1 internal call site (lifted the in-function \`from lib import transitions\` import to module scope so the binding can be swapped)

## Test patches migrated (10 sites)

| Test file | Sites | New target |
|-----------|------:|------------|
| test_import_one_stages.py | 4 | \`harness.import_one.finalize_request\` |
| test_pipeline_cli.py | 3 | \`scripts.pipeline_cli.finalize_request\` |
| test_import_dispatch.py | 1 | \`lib.import_dispatch.finalize_request\` |
| test_integration_slices.py | 1 | \`lib.import_dispatch.finalize_request\` |
| test_repair_cli.py | 1 | \`scripts.repair.finalize_request\` |

Four new allowlist entries in \`_mock_audit_scanner.py\` with shared rationale referencing the \`web.routes.pipeline.finalize_request\` precedent.

## Result

- Mock-audit baseline: **79 → 69** (-10 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3695 tests, all green

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3695/3695 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)