### PR TITLE
test(fakes): add FakeBeetsDB and migrate test_import_one_stages.py

### DIFF
--- a/docs/issue-290-resume.md
+++ b/docs/issue-290-resume.md
@@ -4,7 +4,7 @@ This is the **entry point** for picking up the stateful-MagicMock removal effort
 
 ## Current state
 
-Baseline last measured at **84 findings across 15 files**. To check the live count:
+Baseline last measured at **61 findings across 15 files**. To check the live count:
 
 ```bash
 nix-shell --run "python3 tests/_rebuild_mock_audit_baseline.py"
@@ -69,25 +69,54 @@ allowlisted as a route-scope DI seam in the same way
 `web.server.db` is. Migrated all 26 patch sites in
 `tests/test_web_server.py`. Dropped 26 findings (110 → 84).
 
-### 1. Smaller cleanups (~29 findings across 5 files)
+### ~~5. Allowlist remaining web.routes DI seams + migrate match_folders_to_requests~~ (LANDED)
 
-`test_import_one_stages.py` (15) and `test_download.py` (14) are the
-next clusters worth a look — both feel like they'd benefit from
-specific Fake helpers rather than a single DI move.
+Shipped in PR #323. `web.routes.imports.cleanup_all_wrong_matches` (3
+sites) and `web.server.compute_library_rank` (1 site) allowlisted as
+route-scope DI seams. `web.routes.imports.match_folders_to_requests` (1
+site) migrated to drive the real fuzzy matcher with shared
+artist/album tokens. Dropped 5 findings (84 → 79).
 
-### 2. Remaining `lib.transitions.finalize_request` patches in non-web tests (10 findings)
+### ~~6. Item P — per-module `finalize_request` DI seams for non-web tests~~ (LANDED)
 
-After the web migration, ~10 patches on `lib.transitions.finalize_request`
-remain in CLI / import / repair tests:
-- `test_import_one_stages.py` (4)
-- `test_pipeline_cli.py` (3)
-- `test_import_dispatch.py` (1)
-- `test_integration_slices.py` (1)
-- `test_repair_cli.py` (1)
+Shipped in PR #324. Same shape as PR #322 applied to four more
+modules: `lib.import_dispatch`, `harness.import_one`,
+`scripts.pipeline_cli`, `scripts.repair`. Each binds
+`finalize_request = transitions.finalize_request` at module scope and
+exposes it as an allowlisted seam. Migrated 10 test patches. Dropped
+10 findings (79 → 69).
 
-These flow through different code paths and would need either DI on
-each entry point or migration to `FakePipelineDB` (let
-`finalize_request` actually run against fake state).
+### ~~7. test_import_one_stages.py harness migration~~ (LANDED)
+
+Shipped in PR #325. Built `FakeBeetsDB` in `tests/fakes.py` (minimal
+surface: `album_exists`, `get_album_info(mb_release_id, cfg)`,
+`get_all_album_ids_for_release`, `get_item_paths`, `close` +
+seed-helpers + a context-manager) with five self-tests in
+`tests/test_fakes.py`. Migrated `TestPipelineDbUpdate` (4 sites,
+`MagicMock()` → `FakePipelineDB()`) and the four
+`beets = MagicMock()` sites to `FakeBeetsDB`. Dropped 8 findings
+(69 → 61).
+
+### 1. test_download.py harness migration (~14 findings)
+
+Now the largest remaining single-file cluster. Likely a similar shape
+to test_import_one_stages.py — mix of `db = MagicMock()` and
+`beets = MagicMock()` patterns that could move to
+`FakePipelineDB` / `FakeBeetsDB` now that the latter exists.
+
+### 2. Remaining `test_import_dispatch.py` / `test_repair_cli.py` clusters (~16 findings)
+
+`test_import_dispatch.py` (8) and `test_repair_cli.py` (8) are the
+next-biggest clusters after `test_download.py`. Mixed patterns; both
+warrant per-file analysis.
+
+### 3. Pure-decision patches in `test_import_one_stages.py` (3 findings)
+
+Still patches on `harness.import_one.determine_verified_lossless`,
+`harness.import_one.provisional_lossless_decision`, and
+`harness.import_one.quality_decision_stage`. Migrating these would
+require driving the real decision functions with real audio
+measurement scaffolding — likely worth the effort but non-trivial.
 
 ## What's NOT next
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -4100,3 +4100,90 @@ class FakePipelineDBSource:
 
     def close(self) -> None:
         self.close_calls += 1
+
+
+class FakeBeetsDB:
+    """In-memory fake for ``lib.beets_db.BeetsDB`` — minimal surface.
+
+    Records state for assertions and lets tests register return values
+    for the query methods used by ``harness/import_one.py`` and a few
+    web routes. Intentionally narrow — extend only when a test surface
+    actually exercises a new method. The real ``BeetsDB`` is the
+    contract; the audit's ``test_fake_only_methods_stay_on_the_allowlist``
+    catches drift.
+
+    Usage:
+        beets = FakeBeetsDB()
+        beets.set_album_exists("mbid-123", False)
+        beets.set_album_ids_for_release("mbid-123", [77])
+        beets.set_album_info(77, AlbumInfo(...))
+        beets.set_item_paths("mbid-123", [(11, "/path/01.flac")])
+        # ... drive code that calls beets.album_exists("mbid-123") ...
+        assert beets.close_calls == 1
+    """
+
+    def __init__(self) -> None:
+        self._album_exists: dict[str, bool] = {}
+        self._album_ids_for_release: dict[str, list[int]] = {}
+        self._album_info: dict[str, Any] = {}
+        self._item_paths: dict[str, list[tuple[int, str]]] = {}
+        # Default return values for unseeded keys — match the real
+        # BeetsDB's "no row" shapes so tests don't crash on missing
+        # explicit seeds.
+        self._album_exists_default = False
+        self._album_ids_default: list[int] = []
+        self._item_paths_default: list[tuple[int, str]] = []
+        self.close_calls: int = 0
+        self.album_exists_calls: list[str] = []
+        self.get_album_info_calls: list[str] = []
+        self.get_all_album_ids_for_release_calls: list[str] = []
+        self.get_item_paths_calls: list[str] = []
+
+    # --- Seeding helpers ---
+
+    def set_album_exists(self, release_id: str, value: bool) -> None:
+        self._album_exists[release_id] = value
+
+    def set_album_ids_for_release(
+        self, release_id: str, ids: list[int],
+    ) -> None:
+        self._album_ids_for_release[release_id] = list(ids)
+
+    def set_album_info(self, mb_release_id: str, info: Any) -> None:
+        self._album_info[mb_release_id] = info
+
+    def set_item_paths(
+        self, release_id: str, paths: list[tuple[int, str]],
+    ) -> None:
+        self._item_paths[release_id] = list(paths)
+
+    # --- Real-method surface ---
+
+    def album_exists(self, release_id: str) -> bool:
+        self.album_exists_calls.append(release_id)
+        return self._album_exists.get(release_id, self._album_exists_default)
+
+    def get_all_album_ids_for_release(self, release_id: str) -> list[int]:
+        self.get_all_album_ids_for_release_calls.append(release_id)
+        return self._album_ids_for_release.get(
+            release_id, list(self._album_ids_default))
+
+    def get_album_info(
+        self, mb_release_id: str, _cfg: Any = None,
+    ) -> Any:
+        self.get_album_info_calls.append(mb_release_id)
+        return self._album_info.get(mb_release_id)
+
+    def get_item_paths(self, release_id: str) -> list[tuple[int, str]]:
+        self.get_item_paths_calls.append(release_id)
+        return self._item_paths.get(
+            release_id, list(self._item_paths_default))
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+    def __enter__(self) -> "FakeBeetsDB":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -31,9 +31,7 @@
   "test_import_one_stages.py": {
     "patch:harness.import_one.determine_verified_lossless": 1,
     "patch:harness.import_one.provisional_lossless_decision": 1,
-    "patch:harness.import_one.quality_decision_stage": 1,
-    "stateful_mock_assign:beets": 4,
-    "stateful_mock_assign:db": 4
+    "patch:harness.import_one.quality_decision_stage": 1
   },
   "test_import_queue.py": {
     "patch:lib.download._handle_valid_result": 1,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.pipeline_db import PipelineDB, RequestSpectralStateUpdate
 from lib.quality import SpectralContext, SpectralMeasurement, ValidationResult
-from tests.fakes import FakePipelineDB, FakeSlskdAPI
+from tests.fakes import FakeBeetsDB, FakePipelineDB, FakeSlskdAPI
 from tests.helpers import (
     make_album_quality_evidence,
     make_download_file,
@@ -3363,3 +3363,68 @@ class TestPipelineDBFakeContractInternals(unittest.TestCase):
                   test_only: bool = False) -> None:
                 ...
         self.assertEqual(_diff_signatures(Real, Fake), [])
+
+
+class TestFakeBeetsDB(unittest.TestCase):
+    """Self-tests for FakeBeetsDB — the minimal in-memory BeetsDB stand-in."""
+
+    def test_album_exists_returns_seeded_value(self) -> None:
+        beets = FakeBeetsDB()
+        beets.set_album_exists("mbid-1", True)
+        beets.set_album_exists("mbid-2", False)
+        self.assertTrue(beets.album_exists("mbid-1"))
+        self.assertFalse(beets.album_exists("mbid-2"))
+        # Unseeded keys default to False (matches "no row" semantics).
+        self.assertFalse(beets.album_exists("mbid-unknown"))
+        self.assertEqual(
+            beets.album_exists_calls,
+            ["mbid-1", "mbid-2", "mbid-unknown"],
+        )
+
+    def test_get_album_info_keyed_by_release_id(self) -> None:
+        from lib.beets_db import AlbumInfo
+        beets = FakeBeetsDB()
+        info = AlbumInfo(
+            album_id=7,
+            track_count=10,
+            min_bitrate_kbps=320,
+            avg_bitrate_kbps=320,
+            median_bitrate_kbps=320,
+            format="MP3",
+            is_cbr=False,
+            album_path="/Beets/Artist/Album",
+        )
+        beets.set_album_info("mbid-1", info)
+        # Two-arg form (matches real signature: mb_release_id + cfg).
+        self.assertIs(beets.get_album_info("mbid-1", None), info)
+        # Unseeded returns None.
+        self.assertIsNone(beets.get_album_info("mbid-unknown"))
+        self.assertEqual(
+            beets.get_album_info_calls,
+            ["mbid-1", "mbid-unknown"],
+        )
+
+    def test_get_all_album_ids_for_release_returns_list(self) -> None:
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release("mbid-1", [77, 88])
+        self.assertEqual(beets.get_all_album_ids_for_release("mbid-1"), [77, 88])
+        # Unseeded returns empty list (matches "no row" semantics).
+        self.assertEqual(beets.get_all_album_ids_for_release("mbid-other"), [])
+
+    def test_get_item_paths_returns_list_of_pairs(self) -> None:
+        beets = FakeBeetsDB()
+        paths = [(11, "/Beets/01.flac"), (12, "/Beets/02.flac")]
+        beets.set_item_paths("mbid-1", paths)
+        self.assertEqual(beets.get_item_paths("mbid-1"), paths)
+        self.assertEqual(beets.get_item_paths("mbid-other"), [])
+
+    def test_close_is_context_manager(self) -> None:
+        beets = FakeBeetsDB()
+        with beets as ctx:
+            self.assertIs(ctx, beets)
+            self.assertEqual(beets.close_calls, 0)
+        self.assertEqual(beets.close_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -6,7 +6,6 @@ takes data inputs and returns a StageResult without I/O.
 """
 
 import io
-import importlib
 import json
 import os
 import subprocess
@@ -14,7 +13,8 @@ import sys
 import tempfile
 import unittest
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from typing import Any, cast
+from unittest.mock import patch
 
 import msgspec
 
@@ -23,6 +23,8 @@ HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
 
 sys.path.insert(0, ROOT_DIR)
 sys.path.insert(0, HARNESS_DIR)
+
+from tests.fakes import FakeBeetsDB, FakePipelineDB  # noqa: E402
 
 
 class TestImportBootstrap(unittest.TestCase):
@@ -68,7 +70,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
     ) -> None:
         from harness import import_one
 
-        db = MagicMock()
+        db = FakePipelineDB()
         mock_db_cls.return_value = db
 
         import_one.update_pipeline_db(
@@ -92,7 +94,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
                 "beets_scenario": "preflight_existing",
             },
         )
-        db.close.assert_called_once()
+        self.assertEqual(db.close_calls, 1)
 
     @patch("harness.import_one.finalize_request", side_effect=RuntimeError("boom"))
     @patch("lib.pipeline_db.PipelineDB")
@@ -103,14 +105,14 @@ class TestPipelineDbUpdate(unittest.TestCase):
     ) -> None:
         from harness import import_one
 
-        db = MagicMock()
+        db = FakePipelineDB()
         mock_db_cls.return_value = db
         stderr = io.StringIO()
 
         with patch("sys.stderr", stderr):
             import_one.update_pipeline_db(42, "imported")
 
-        db.close.assert_called_once()
+        self.assertEqual(db.close_calls, 1)
         self.assertIn("Pipeline DB update failed", stderr.getvalue())
 
     @patch("harness.import_one.finalize_request")
@@ -122,7 +124,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
     ) -> None:
         from harness import import_one
 
-        db = MagicMock()
+        db = FakePipelineDB()
         mock_db_cls.return_value = db
         stderr = io.StringIO()
 
@@ -134,7 +136,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
             )
 
         mock_finalize.assert_not_called()
-        db.close.assert_called_once()
+        self.assertEqual(db.close_calls, 1)
         self.assertIn("Pipeline DB transition rejected", stderr.getvalue())
         self.assertIn("imported_path", stderr.getvalue())
 
@@ -147,7 +149,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
     ) -> None:
         from harness import import_one
 
-        db = MagicMock()
+        db = FakePipelineDB()
         mock_db_cls.return_value = db
         stderr = io.StringIO()
 
@@ -155,7 +157,7 @@ class TestPipelineDbUpdate(unittest.TestCase):
             import_one.update_pipeline_db(42, "queued")
 
         mock_finalize.assert_not_called()
-        db.close.assert_called_once()
+        self.assertEqual(db.close_calls, 1)
         self.assertIn("Pipeline DB transition rejected", stderr.getvalue())
         self.assertIn("queued", stderr.getvalue())
 
@@ -249,11 +251,11 @@ class TestPostflightBadExtensionWarnings(unittest.TestCase):
             with open(good_path, "wb") as f:
                 f.write(b"not real audio")
 
-            beets = MagicMock()
-            beets.get_item_paths.return_value = [
+            beets = FakeBeetsDB()
+            beets.set_item_paths("mbid-123", [
                 (11, bad_path),
                 (12, good_path),
-            ]
+            ])
             result = ImportResult(
                 postflight=PostflightInfo(
                     beets_id=99,
@@ -265,7 +267,7 @@ class TestPostflightBadExtensionWarnings(unittest.TestCase):
             with patch("os.rename") as mock_rename, \
                  patch("sqlite3.connect") as mock_connect:
                 found = import_one._record_bad_extension_warnings(
-                    beets, "mbid-123", result)
+                    cast(Any, beets), "mbid-123", result)
 
             self.assertEqual(found, ["01 Track.bak"])
             self.assertEqual(result.postflight.bad_extensions, ["01 Track.bak"])
@@ -1057,10 +1059,10 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
             action_path = os.path.join(tmpdir, "action.json")
             self._write_payload(self._payload_for_album(album), action_path)
 
-            beets = MagicMock()
-            beets.album_exists.return_value = False
-            beets.get_all_album_ids_for_release.return_value = [77]
-            beets.get_album_info.return_value = AlbumInfo(
+            beets = FakeBeetsDB()
+            beets.set_album_exists("mbid-123", False)
+            beets.set_album_ids_for_release("mbid-123", [77])
+            beets.set_album_info("mbid-123", AlbumInfo(
                 album_id=77,
                 track_count=1,
                 min_bitrate_kbps=245,
@@ -1069,8 +1071,8 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
                 avg_bitrate_kbps=252,
                 median_bitrate_kbps=250,
                 format="MP3",
-            )
-            beets.get_item_paths.return_value = []
+            ))
+            beets.set_item_paths("mbid-123", [])
 
             stdout = io.StringIO()
             argv = [
@@ -1134,8 +1136,8 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
             with open(track, "ab") as f:
                 f.write(b" changed")
 
-            beets = MagicMock()
-            beets.album_exists.return_value = False
+            beets = FakeBeetsDB()
+            beets.set_album_exists("mbid-123", False)
 
             stdout = io.StringIO()
             argv = [
@@ -1171,8 +1173,8 @@ class TestQualityEvidenceAuthorizedImport(unittest.TestCase):
             with open(action_path, "wb") as f:
                 f.write(b"{")
 
-            beets = MagicMock()
-            beets.album_exists.return_value = False
+            beets = FakeBeetsDB()
+            beets.set_album_exists("mbid-123", False)
 
             stdout = io.StringIO()
             argv = [


### PR DESCRIPTION
## Summary

\`test_import_one_stages.py\` carried 11 audit findings, second only to \`test_web_server.py\` before #322:

- 4 \`db = MagicMock()\` in \`TestPipelineDbUpdate\` — paired with \`patch(\"lib.pipeline_db.PipelineDB\", return_value=db)\` so the patched constructor returns the mock. Only \`db.close()\` is exercised; nothing reads state through \`db\`.
- 4 \`beets = MagicMock()\` patterns — each configures a small set of \`BeetsDB\` query methods (\`album_exists\`, \`get_all_album_ids_for_release\`, \`get_album_info\`, \`get_item_paths\`) to control test fixture reads.

## FakeBeetsDB

Minimal in-memory \`BeetsDB\` stand-in in \`tests/fakes.py\` — intentionally narrow (extend only when a test surface needs it). Matches the real two-arg \`get_album_info(mb_release_id, cfg)\` signature so callers don't have to special-case the fake. Surface:

| Method | Default for unseeded |
|--------|----------------------|
| \`album_exists(release_id)\` | False |
| \`get_album_info(release_id, cfg=None)\` | None |
| \`get_all_album_ids_for_release(release_id)\` | empty list |
| \`get_item_paths(release_id)\` | empty list |
| \`close()\` | increments \`close_calls\` |
| \`__enter__\` / \`__exit__\` | context-manager shape |

Seed helpers (\`set_album_exists\`, \`set_album_info\`, \`set_album_ids_for_release\`, \`set_item_paths\`) plus per-method call recorders (\`album_exists_calls\`, etc.) for assertion.

Five self-tests in \`tests/test_fakes.py::TestFakeBeetsDB\` cover the query surface + seeded/unseeded defaults + the context-manager contract.

## Migration

- \`TestPipelineDbUpdate\` (4 sites): \`db = MagicMock()\` → \`FakePipelineDB()\`; \`db.close.assert_called_once()\` → \`self.assertEqual(db.close_calls, 1)\`.
- \`beets = MagicMock()\` (4 sites): → \`FakeBeetsDB()\` with seed helpers. One \`cast(Any, beets)\` at the \`_record_bad_extension_warnings\` boundary because Pyright doesn't see the fake as a structural \`BeetsDB\`.
- Removed unused \`MagicMock\` / \`importlib\` imports.

## Result

- Mock-audit baseline: **69 → 61** (-8 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3700 tests, all green (+5 FakeBeetsDB self-tests)

Cumulative across the seven DI/Fake PRs:
**160 → 61** (-99 findings, 62% of original baseline retired).

Remaining 3 findings in \`test_import_one_stages.py\` are pure-decision patches (\`determine_verified_lossless\`, \`provisional_lossless_decision\`, \`quality_decision_stage\`) — migrating those would require driving the real decision functions with audio-measurement scaffolding; deferred.

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors
- [x] \`nix-shell --run \"python3 tests/_rebuild_mock_audit_baseline.py\"\` — 61 findings
- [x] FakeBeetsDB self-tests pass and exercise the query surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)