### PR TITLE
test(repair-cli): migrate db mocks to FakePipelineDB + allowlist DI seams

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -329,6 +329,17 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^lib\.download\.process_completed_album$"),
     re.compile(r"^lib\.download\._process_beets_validation$"),
 
+    # ``scripts.repair`` in-module DI seams. The repair CLI orchestrates
+    # ``_collect_issues`` (aggregates orphan/recovery checks) which
+    # internally calls ``find_orphaned_downloads`` (from ``lib.quality``)
+    # and ``find_blocked_recovery_issues`` (from ``lib.download_recovery``)
+    # via local imports. Tests stub the inner pieces to drive each
+    # branch of ``cmd_fix`` / ``cmd_scan`` without setting up real
+    # orphan fixtures. Same module-local DI shape as ``lib.download``.
+    re.compile(r"^scripts\.repair\._collect_issues$"),
+    re.compile(r"^scripts\.repair\.find_orphaned_downloads$"),
+    re.compile(r"^scripts\.repair\.find_blocked_recovery_issues$"),
+
     # Filesystem-write wrapper. ``log_validation_result`` (defined in
     # ``lib.util``) appends to the beets-tracking JSONL file — a thin
     # filesystem-boundary helper. Tests in ``test_download.py`` patch

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -38,12 +38,6 @@
     "patch:lib.quality.full_pipeline_decision": 2,
     "stateful_mock_assign:db": 1
   },
-  "test_repair_cli.py": {
-    "patch:scripts.repair._collect_issues": 1,
-    "patch:scripts.repair.find_blocked_recovery_issues": 1,
-    "patch:scripts.repair.find_orphaned_downloads": 2,
-    "stateful_mock_assign:db": 4
-  },
   "test_web_server.py": {
     "patch:web.routes.pipeline.preview_import_from_values": 1,
     "stateful_mock_assign:failing_db": 1,

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -76,41 +76,45 @@ class TestCollectIssues(unittest.TestCase):
         self.assertEqual(issues[1].detail, "different detail")
 
     def test_auto_import_in_progress_returns_true_when_lock_is_held(self) -> None:
-        db = MagicMock()
-        db._execute.return_value.fetchone.return_value = {"held": True}
+        db = FakePipelineDB()
+        cur = MagicMock()
+        cur.fetchone.return_value = {"held": True}
+        db.queue_execute_results(cur)
 
-        result = repair._auto_import_in_progress(db, 17, "test-mbid")
+        result = repair._auto_import_in_progress(cast(Any, db), 17, "test-mbid")
 
         self.assertTrue(result)
-        db._execute.assert_called_once()
-        sql, params = db._execute.call_args[0]
+        self.assertEqual(len(db.execute_calls), 1)
+        sql, params = db.execute_calls[0]
         self.assertIn("FROM pg_locks", sql)
         self.assertIn("objsubid = 2", sql)
         self.assertEqual(params[0], repair.ADVISORY_LOCK_NAMESPACE_RELEASE)
 
     def test_auto_import_in_progress_returns_false_when_no_lock_is_held(self) -> None:
-        db = MagicMock()
-        db._execute.return_value.fetchone.return_value = {"held": False}
+        db = FakePipelineDB()
+        cur = MagicMock()
+        cur.fetchone.return_value = {"held": False}
+        db.queue_execute_results(cur)
 
-        result = repair._auto_import_in_progress(db, 17, "test-mbid")
+        result = repair._auto_import_in_progress(cast(Any, db), 17, "test-mbid")
 
         self.assertFalse(result)
 
     def test_auto_import_in_progress_returns_false_without_mbid(self) -> None:
-        db = MagicMock()
+        db = FakePipelineDB()
 
-        result = repair._auto_import_in_progress(db, 17, None)
+        result = repair._auto_import_in_progress(cast(Any, db), 17, None)
 
         self.assertFalse(result)
-        db._execute.assert_not_called()
+        self.assertEqual(db.execute_calls, [])
 
     def test_auto_import_in_progress_reports_probe_failure(self) -> None:
-        db = MagicMock()
-        db._execute.side_effect = RuntimeError("db boom")
+        db = FakePipelineDB()
+        db.queue_execute_results(RuntimeError("db boom"))
 
         stdout = io.StringIO()
         with redirect_stdout(stdout):
-            result = repair._auto_import_in_progress(db, 17, "test-mbid")
+            result = repair._auto_import_in_progress(cast(Any, db), 17, "test-mbid")
 
         self.assertIsNone(result)
         self.assertIn("could not probe auto-import lock for request 17", stdout.getvalue())


### PR DESCRIPTION
## Summary

\`test_repair_cli.py\` had 8 audit findings. Four \`db = MagicMock()\` sites in the \`_auto_import_in_progress\` probe tests, plus four patches on \`scripts.repair\` internal helpers that orchestrate orphan detection.

## Migration

\`db = MagicMock()\` (4 sites in \`TestCollectIssues.test_auto_import_in_progress_*\`) → \`FakePipelineDB()\`.

The cursor sequence stubbing built in PR #321 (\`queue_execute_results\`) absorbs both the \"fetchone returns dict\" and \"execute raises\" cases without per-test MagicMock chains:
\`\`\`python
# before
db._execute.return_value.fetchone.return_value = {\"held\": True}
# after
cur = MagicMock(); cur.fetchone.return_value = {\"held\": True}
db.queue_execute_results(cur)
\`\`\`

Call-count and call-args assertions move from MagicMock introspection to the fake's recording fields:
\`\`\`python
# before
db._execute.assert_called_once()
sql, params = db._execute.call_args[0]
# after
self.assertEqual(len(db.execute_calls), 1)
sql, params = db.execute_calls[0]
\`\`\`

## Allowlist additions

\`scripts.repair\` in-module DI seams for the orphan-detection chain:
- \`scripts.repair._collect_issues\` — aggregator
- \`scripts.repair.find_orphaned_downloads\` — re-import from \`lib.quality\`
- \`scripts.repair.find_blocked_recovery_issues\` — re-import from \`lib.download_recovery\`

Same module-local DI shape as the \`lib.download\` seams allowlisted in PR #326.

## Result

- Mock-audit baseline: **42 → 34** (-8 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3700 tests, all green

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)