### PR TITLE
test(import-dispatch): module-local quality_gate_decision seam + FakePipelineDB-driven ctx

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -43,6 +43,7 @@ from lib.quality import (parse_import_result, DispatchAction, DownloadInfo,
                          narrow_override_on_downgrade,
                          narrow_override_on_lossless_source_lock,
                          override_bitrate_from_current_evidence,
+                         quality_gate_decision,
                          rejection_backfill_override)
 from lib.quality_evidence import (
     audit_v0_probe_from_metric,
@@ -1310,7 +1311,7 @@ def _check_quality_gate_core(
     don't care about mixed-format reduction still work. Commit 5 will thread
     the real runtime config through from dispatch_import_core().
     """
-    from lib.quality import quality_gate_decision, QualityRankConfig, gate_rank
+    from lib.quality import QualityRankConfig, gate_rank
 
     if quality_ranks is None:
         quality_ranks = QualityRankConfig.defaults()

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -340,6 +340,26 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^scripts\.repair\.find_orphaned_downloads$"),
     re.compile(r"^scripts\.repair\.find_blocked_recovery_issues$"),
 
+    # Module-local DI seam for ``quality_gate_decision``. The orchestration
+    # wrapper ``lib.import_dispatch._check_quality_gate_core`` binds the
+    # pure decision at import time so orchestration tests can stub the
+    # branch via ``patch("lib.import_dispatch.quality_gate_decision")``
+    # without setting up full ``AudioQualityMeasurement`` fixtures for
+    # every requeue/accept/transcode/downgrade scenario. The decision's
+    # own contract is exercised in ``tests/test_quality_classification.py``
+    # (TestQualityGateDecision); this seam keeps wrapper tests focused
+    # on the orchestration around the gate (status transitions,
+    # search-override updates, requeue-vs-accept routing).
+    re.compile(r"^lib\.import_dispatch\.quality_gate_decision$"),
+
+    # Auto-import staging-destination seam. ``stage_to_ai_path`` is a
+    # path-construction helper that the auto-import flow consults to
+    # decide where to move staged audio. Tests patch its
+    # ``lib.download`` re-export to return a tempdir-relative path so
+    # downstream subprocess calls land inside the test's working dir
+    # rather than the production ``beets_staging_dir``.
+    re.compile(r"^lib\.download\.stage_to_ai_path$"),
+
     # Filesystem-write wrapper. ``log_validation_result`` (defined in
     # ``lib.util``) appends to the beets-tracking JSONL file — a thin
     # filesystem-boundary helper. Tests in ``test_download.py`` patch

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -14,11 +14,6 @@
   "test_enqueue_fanout.py": {
     "patch:lib.enqueue.check_for_match": 3
   },
-  "test_import_dispatch.py": {
-    "patch:lib.download.stage_to_ai_path": 1,
-    "patch:lib.quality.quality_gate_decision": 5,
-    "stateful_mock_assign:ctx": 1
-  },
   "test_import_one_stages.py": {
     "patch:harness.import_one.determine_verified_lossless": 1,
     "patch:harness.import_one.provisional_lossless_decision": 1,

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -23,6 +23,7 @@ from lib.quality import (DownloadInfo, ImportResult, ConversionInfo,
 from tests.fakes import FakePipelineDB
 from tests.helpers import (
     RecordingQualityGate,
+    make_ctx_with_fake_db,
     make_import_result,
     make_request_row,
     noop_quality_gate,
@@ -55,20 +56,24 @@ def _make_album_data(artist="Test Artist", title="Test Album",
 
 
 def _make_ctx():
-    """Build a mock CratediggerContext."""
-    ctx = MagicMock()
-    ctx.cfg.beets_harness_path = "/nix/store/fake/harness/run_beets_harness.sh"
-    ctx.cfg.beets_distance_threshold = 0.15
-    ctx.cfg.beets_staging_dir = "/tmp/staging"
-    ctx.cfg.verified_lossless_target = ""
-    ctx.cfg.quality_ranks.to_json.return_value = "{}"
+    """Build a CratediggerContext wired to a seeded FakePipelineDB.
+
+    The DB is seeded with request id 42 in ``downloading`` status — the
+    auto-import dispatch path expects to find an owning request. The
+    config remains a ``MagicMock`` because the tests only read a handful
+    of attributes from it; ``cfg`` is not a stateful-collaborator name
+    in the audit's heuristic.
+    """
+    cfg = MagicMock()
+    cfg.beets_harness_path = "/nix/store/fake/harness/run_beets_harness.sh"
+    cfg.beets_distance_threshold = 0.15
+    cfg.beets_staging_dir = "/tmp/staging"
+    cfg.verified_lossless_target = ""
+    cfg.quality_ranks.to_json.return_value = "{}"
+    fake_db = FakePipelineDB()
+    fake_db.seed_request(make_request_row(id=42, status="downloading"))
+    ctx = make_ctx_with_fake_db(fake_db, cfg=cfg)
     ctx.cooled_down_users = set()
-    ctx.pipeline_db_source = MagicMock()
-    db_mock = MagicMock()
-    db_mock.get_request.return_value = make_request_row(status="downloading")
-    db_mock.advisory_lock.return_value.__enter__.return_value = True
-    db_mock.advisory_lock.return_value.__exit__.return_value = False
-    ctx.pipeline_db_source._get_db.return_value = db_mock
     return ctx
 
 
@@ -99,9 +104,16 @@ def _dispatch_valid_result_cmd(
 
     album_data = album_data or _make_album_data()
     ctx = ctx or _make_ctx()
-    db_mock = ctx.pipeline_db_source._get_db.return_value
     if db_fields is not None:
-        db_mock.get_request.return_value = db_fields
+        # Reseed request 42 with the test-supplied row shape. The default
+        # _make_ctx() ships a downloading row keyed by id=42; tests that
+        # need a different shape pass ``db_fields`` and we overwrite.
+        # Force id=42 so ``_handle_valid_result`` finds the override when
+        # looking up by ``album_data.db_request_id``.
+        override = dict(db_fields)
+        override["id"] = album_data.db_request_id
+        fake_db = ctx.pipeline_db_source._get_db()
+        fake_db.seed_request(override)
     bv_result = _make_bv_result()
     ir = ir or make_import_result(decision="import")
 
@@ -1121,7 +1133,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
         db.seed_request(make_request_row(id=42, **merged))
 
         with patch("lib.beets_db.BeetsDB") as mock_beets_cls, \
-             patch("lib.quality.quality_gate_decision",
+             patch("lib.import_dispatch.quality_gate_decision",
                    return_value=gate_decision):
             mock_beets = MagicMock()
             mock_beets.__enter__ = MagicMock(return_value=mock_beets)
@@ -1288,7 +1300,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
             return "accept"
 
         with patch("lib.beets_db.BeetsDB") as mock_beets_cls, \
-             patch("lib.quality.quality_gate_decision",
+             patch("lib.import_dispatch.quality_gate_decision",
                    side_effect=capture_decision):
             mock_beets = MagicMock()
             mock_beets.__enter__ = MagicMock(return_value=mock_beets)
@@ -1328,7 +1340,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
             return quality_gate_decision(measurement)
 
         with patch("lib.beets_db.BeetsDB") as mock_beets_cls, \
-             patch("lib.quality.quality_gate_decision",
+             patch("lib.import_dispatch.quality_gate_decision",
                    side_effect=capture_and_decide):
             mock_beets = MagicMock()
             mock_beets.__enter__ = MagicMock(return_value=mock_beets)
@@ -1369,7 +1381,7 @@ class TestQualityGateUsesIntent(unittest.TestCase):
             return "accept"
 
         with patch("lib.beets_db.BeetsDB") as mock_beets_cls, \
-             patch("lib.quality.quality_gate_decision", side_effect=capture):
+             patch("lib.import_dispatch.quality_gate_decision", side_effect=capture):
             mock_beets = MagicMock()
             mock_beets.__enter__ = MagicMock(return_value=mock_beets)
             mock_beets.__exit__ = MagicMock(return_value=False)
@@ -1450,7 +1462,7 @@ class TestQualityGatePreservesTargetFormat(unittest.TestCase):
         ))
 
         with patch("lib.beets_db.BeetsDB") as mock_beets_cls, \
-             patch("lib.quality.quality_gate_decision",
+             patch("lib.import_dispatch.quality_gate_decision",
                    return_value="accept"):
             mock_beets = MagicMock()
             mock_beets.__enter__ = MagicMock(return_value=mock_beets)


### PR DESCRIPTION
## Summary

\`test_import_dispatch.py\` had 7 audit findings — 5 patches on \`lib.quality.quality_gate_decision\`, 1 on \`lib.download.stage_to_ai_path\`, 1 \`ctx = MagicMock()\`.

## Changes

### 1. Module-local seam for `quality_gate_decision`

Lifted \`quality_gate_decision\` from the lazy import inside \`_check_quality_gate_core\` to a module-level import in \`lib.import_dispatch\`. Tests now patch \`lib.import_dispatch.quality_gate_decision\` — same module-local DI shape as the \`finalize_request\` / dispatch seams from PRs #322, #324, #326.

**Why allowlist not migrate to real decision inputs?** The pure decision's own contract is covered by \`tests/test_quality_classification.py::TestQualityGateDecision\`. The orchestration wrapper layer (status transitions, search-override updates, requeue/accept routing) is what these tests cover — stubbing the gate to return each branch and asserting the wrapper's downstream behaviour is the right shape for that scope.

### 2. `ctx = MagicMock()` → seeded `FakePipelineDB`

Rewrote \`_make_ctx()\` to use \`make_ctx_with_fake_db\` with a seeded \`FakePipelineDB\`. The \`ctx = MagicMock()\` pattern is gone; \`cfg\` stays a MagicMock (it's not a flagged stateful-collaborator name and is only used as an attribute bag).

Updated \`_dispatch_valid_result_cmd\` to reseed the fake's request 42 row when \`db_fields\` is supplied — the helper previously relied on \`db_mock.get_request.return_value\` which doesn't apply to a real \`FakePipelineDB\` keyed by request id.

### 3. Allowlist additions

- \`lib.import_dispatch.quality_gate_decision\` — module-local DI seam (rationale: orchestration test scope).
- \`lib.download.stage_to_ai_path\` — auto-import staging-destination seam; tests patch the re-export to land subprocess targets inside the test tempdir.

## Result

- Mock-audit baseline: **34 → 27** (-7 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3700 tests, all green

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors
- [x] \`test_import_dispatch.py\` standalone (58 tests) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)