### PR TITLE
test(cli/queue): finalize residual seam allowlist + FakeBeetsDB import-job worker harness

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -360,6 +360,46 @@ _LEAF_SEAM_PATTERNS = [
     # rather than the production ``beets_staging_dir``.
     re.compile(r"^lib\.download\.stage_to_ai_path$"),
 
+    # ``preview_import_from_values`` is the preview-engine entrypoint —
+    # synthesises an ``ImportPreviewResult`` (verdict + decision tree)
+    # from caller-supplied measurement values. Same shape as
+    # ``quality_gate_decision``: pure decision being stubbed by
+    # orchestration tests that exercise the CLI / web route wrappers.
+    # Behaviour of the engine itself is covered by
+    # ``tests/test_import_preview.py``; CLI / route tests stub it to
+    # return a deterministic verdict and check the wire-shape mapping.
+    re.compile(r"^lib\.import_preview\.preview_import_from_values$"),
+    re.compile(r"^web\.routes\.pipeline\.preview_import_from_values$"),
+
+    # ``full_pipeline_decision`` is the flat-kwargs simulator twin of
+    # ``full_pipeline_decision_from_evidence`` — same pure-decision
+    # rationale as ``quality_gate_decision``. The simulator's own
+    # behaviour is covered in test_quality_classification.py; CLI
+    # orchestration tests stub it to control which decision branch
+    # ``pipeline-cli quality`` displays.
+    re.compile(r"^lib\.quality\.full_pipeline_decision$"),
+
+    # Service-class constructor replacement. ``MbidReplaceService`` is
+    # the operator's MBID-replace surface (CLI + web route both wrap
+    # it). The service's own behaviour is covered in
+    # ``tests/test_mbid_replace_service.py``; the CLI test in
+    # ``test_pipeline_cli.py`` only asserts the wire-shape mapping
+    # (exit code per outcome). Same constructor-replacement shape as
+    # ``lib.beets_db.BeetsDB`` / ``lib.pipeline_db.PipelineDB`` above.
+    re.compile(r"^lib\.mbid_replace_service\.MbidReplaceService$"),
+
+    # ``scripts.import_preview_worker.run_once`` is the preview-worker
+    # tick. Tests in ``test_import_queue.py`` stub it to drive the
+    # outer loop without going through full preview measurement on
+    # every iteration. Worker behaviour is covered by its own dedicated
+    # tests; queue tests are about the dispatcher around it.
+    re.compile(r"^scripts\.import_preview_worker\.run_once$"),
+
+    # In-module DI seam for ``_handle_valid_result`` (defined in
+    # ``lib.download``). Same module-local DI shape as
+    # ``lib.download.process_completed_album`` etc.
+    re.compile(r"^lib\.download\._handle_valid_result$"),
+
     # Filesystem-write wrapper. ``log_validation_result`` (defined in
     # ``lib.util``) appends to the beets-tracking JSONL file — a thin
     # filesystem-boundary helper. Tests in ``test_download.py`` patch

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -4132,6 +4132,7 @@ class FakeBeetsDB:
         # explicit seeds.
         self._album_exists_default = False
         self._album_ids_default: list[int] = []
+        self._album_info_default: Any = None
         self._item_paths_default: list[tuple[int, str]] = []
         self.close_calls: int = 0
         self.album_exists_calls: list[str] = []
@@ -4172,7 +4173,7 @@ class FakeBeetsDB:
         self, mb_release_id: str, _cfg: Any = None,
     ) -> Any:
         self.get_album_info_calls.append(mb_release_id)
-        return self._album_info.get(mb_release_id)
+        return self._album_info.get(mb_release_id, self._album_info_default)
 
     def get_item_paths(self, release_id: str) -> list[tuple[int, str]]:
         self.get_item_paths_calls.append(release_id)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -412,17 +412,19 @@ def make_ctx_with_fake_db(
 def noop_quality_gate(**_kwargs: Any) -> None:
     """No-op quality-gate stub for ``dispatch_import_core(quality_gate_fn=...)``.
 
-    Replaces ``patch("lib.import_dispatch._check_quality_gate_core")`` for
-    dispatch tests that don't care about the post-import quality gate's
-    side effects — they want a no-op so the dispatch decision tree runs
-    end-to-end without inspecting beets DB state."""
+    Replaces the legacy module-attribute patch on
+    ``_check_quality_gate_core`` for dispatch tests that don't care
+    about the post-import quality gate's side effects — they want a
+    no-op so the dispatch decision tree runs end-to-end without
+    inspecting beets DB state."""
     return None
 
 
 class RecordingQualityGate:
-    """Recorder ``quality_gate_fn`` stub. Replaces
-    ``patch("lib.import_dispatch._check_quality_gate_core") as mock_gate``
-    for tests that assert ``mock_gate.assert_called_once()``.
+    """Recorder ``quality_gate_fn`` stub. Replaces the legacy
+    module-attribute patch on ``_check_quality_gate_core`` (paired with
+    ``as mock_gate``) for tests that assert
+    ``mock_gate.assert_called_once()``.
 
     Records each invocation's kwargs (the gate is keyword-only) so tests
     can assert call counts and arguments."""

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -1,7 +1,4 @@
 {
-  "helpers.py": {
-    "patch:lib.import_dispatch._check_quality_gate_core": 2
-  },
   "test_beets_album_op.py": {
     "stateful_mock_assign:beets": 1
   },
@@ -11,30 +8,15 @@
   "test_dispatch_core.py": {
     "stateful_mock_assign:beets": 1
   },
-  "test_enqueue_fanout.py": {
-    "patch:lib.enqueue.check_for_match": 3
-  },
   "test_import_one_stages.py": {
     "patch:harness.import_one.determine_verified_lossless": 1,
     "patch:harness.import_one.provisional_lossless_decision": 1,
     "patch:harness.import_one.quality_decision_stage": 1
   },
-  "test_import_queue.py": {
-    "patch:lib.download._handle_valid_result": 1,
-    "patch:scripts.import_preview_worker.run_once": 3,
-    "stateful_mock_assign:beets": 1
-  },
   "test_matching.py": {
     "patch:lib.matching._track_titles_cross_check": 1
   },
-  "test_pipeline_cli.py": {
-    "patch:lib.import_preview.preview_import_from_values": 2,
-    "patch:lib.mbid_replace_service.MbidReplaceService": 1,
-    "patch:lib.quality.full_pipeline_decision": 2,
-    "stateful_mock_assign:db": 1
-  },
   "test_web_server.py": {
-    "patch:web.routes.pipeline.preview_import_from_values": 1,
     "stateful_mock_assign:failing_db": 1,
     "stateful_mock_assign:mock_db": 1
   },

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -162,14 +162,18 @@ def _nomatch() -> MatchResult:
 
 
 def _always_nomatch(*_args, **_kwargs) -> MatchResult:
-    """Stub ``match_fn`` that never matches — replaces
-    ``patch("lib.enqueue.check_for_match", return_value=_nomatch())``."""
+    """Stub match_fn that never matches.
+
+    Replaces the legacy ``return_value=_nomatch()`` patch on the
+    check_for_match module attribute."""
     return _nomatch()
 
 
 def _const_match(result: MatchResult):
-    """Stub ``match_fn`` that always returns ``result`` — replaces
-    ``patch("lib.enqueue.check_for_match", return_value=result)``."""
+    """Stub match_fn that always returns ``result``.
+
+    Replaces the legacy ``return_value=result`` patch on the
+    check_for_match module attribute."""
 
     def _fn(*_args, **_kwargs) -> MatchResult:
         return result
@@ -178,9 +182,9 @@ def _const_match(result: MatchResult):
 
 
 class _RecordingMatchFn:
-    """Recorder ``match_fn`` for tests that previously did
-    ``patch("lib.enqueue.check_for_match") as m_match`` and then asserted
-    on call shape (``assert_not_called``, ``call_count``, ``call_args``).
+    """Recorder match_fn for tests that previously bound the
+    check_for_match module attribute via patch and then asserted on
+    call shape (``assert_not_called``, ``call_count``, ``call_args``).
 
     Wraps an inner stub and records each invocation's positional args so
     tests can assert call counts and arguments without mocking module

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -33,7 +33,7 @@ from lib.quality import (
 )
 from lib.quality_evidence import snapshot_audio_files
 from lib.staged_album import StagedAlbum
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
     make_album_quality_evidence,
     make_ctx_with_fake_db,
@@ -253,10 +253,8 @@ class TestImporterWorker(unittest.TestCase):
     def _patch_beets_album(self, album_path: str, *, min_bitrate: int):
         from lib.beets_db import AlbumInfo
 
-        beets = MagicMock()
-        beets.__enter__.return_value = beets
-        beets.__exit__.return_value = None
-        beets.get_album_info.return_value = AlbumInfo(
+        beets = FakeBeetsDB()
+        info = AlbumInfo(
             album_id=1,
             track_count=1,
             min_bitrate_kbps=min_bitrate,
@@ -266,6 +264,10 @@ class TestImporterWorker(unittest.TestCase):
             album_path=album_path,
             format="MP3",
         )
+        # Seed the same row for any release_id the test queries — the
+        # importer worker uses the request's mb_release_id, which the
+        # tests don't pin to a specific value.
+        beets._album_info_default = info
         return patch("lib.beets_db.BeetsDB", return_value=beets)
 
     def _mark_importable(

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1371,8 +1371,8 @@ class TestCmdQuality(unittest.TestCase):
                 or kwargs.get("verified_lossless_target"),
             }
 
-        db = MagicMock()
-        db.get_request.return_value = request_row
+        db = FakePipelineDB()
+        db.seed_request(request_row)
         stdout = io.StringIO()
         with patch("scripts.pipeline_cli._load_runtime_rank_config",
                    return_value=QualityRankConfig.defaults()), \
@@ -1383,7 +1383,7 @@ class TestCmdQuality(unittest.TestCase):
              patch("lib.quality.full_pipeline_decision",
                    side_effect=fake_full_pipeline_decision), \
              redirect_stdout(stdout):
-            pipeline_cli.cmd_quality(db, MagicMock(id=9))
+            pipeline_cli.cmd_quality(cast(Any, db), MagicMock(id=9))
 
         output = stdout.getvalue()
         # The gate must say NEEDS UPGRADE (not DONE)


### PR DESCRIPTION
## Summary

Drains the remaining mid-baseline clusters across \`test_pipeline_cli.py\`, \`test_import_queue.py\`, \`test_enqueue_fanout.py\` (docstring noise), and \`helpers.py\` (same).

## Changes

### A. Pure-decision DI seams (orchestration tests stub the branch)

- \`lib.import_preview.preview_import_from_values\` + \`web.routes.pipeline.preview_import_from_values\` re-export — synthesises \`ImportPreviewResult\` from caller values. Engine behaviour: \`tests/test_import_preview.py\`. CLI / route tests stub it to control verdict.
- \`lib.quality.full_pipeline_decision\` — flat-kwargs simulator twin of the evidence-driven full pipeline. Engine behaviour: \`tests/test_quality_classification.py\`. CLI \`pipeline-cli quality\` tests stub it to control which branch displays.

### B. Constructor / module-local DI seams (matches existing precedents)

- \`lib.mbid_replace_service.MbidReplaceService\` — constructor-replacement seam (same shape as \`BeetsDB\` / \`PipelineDB\`).
- \`scripts.import_preview_worker.run_once\` — worker tick stub for queue-dispatcher tests.
- \`lib.download._handle_valid_result\` — in-module call from \`poll_active_downloads\` / \`process_completed_album\`; same as other \`lib.download.*\` seams from #326.

### Docstring noise

Baseline was carrying 3 false-positive findings from helper docstrings in \`test_enqueue_fanout.py\` and 2 from \`tests/helpers.py\`. The docstrings contained literal \`patch(\"lib.enqueue.check_for_match\", ...)\` strings as documentation; the scanner regex matched them. Rephrased the docstrings to describe the legacy patch without quoting the source.

### MagicMock migrations

- \`db = MagicMock()\` in \`test_pipeline_cli.py::test_quality_label_matches_gate_after_spectral_clamp\` → \`FakePipelineDB\` with \`seed_request\`.
- \`beets = MagicMock()\` in \`test_import_queue.py::TestImporterWorker._patch_beets_album\` → \`FakeBeetsDB\`. Required adding an \`_album_info_default\` field on the fake (matching the existing \`_album_exists_default\` / \`_album_ids_default\` / \`_item_paths_default\` pattern) so the helper can return the same \`AlbumInfo\` regardless of which \`mb_release_id\` the importer queries.

## Result

- Mock-audit baseline: **27 → 10** (-17 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3700 tests, all green

Cumulative across all PRs in this session (since 160-baseline):
**160 → 10 findings (-150, 94% retired).**

## Remaining 10 findings

- 3 pure-decision patches in \`test_import_one_stages.py\` (harness measurement helpers) — need real audio scaffolding
- 2 \`mock_db\` / \`failing_db\` in \`test_web_server.py\` — distinct from the shared \`mock_db\` harness, narrow per-test cases
- 2 \`beets = MagicMock()\` (one in \`test_dispatch_core.py\`, one in \`test_beets_album_op.py\`)
- Items A / J from #301 (pure-input migrations)
- 1 \`lib.wrong_matches.resolve_failed_path\` allowlist gap

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors
- [x] \`nix-shell --run \"python3 tests/_rebuild_mock_audit_baseline.py\"\` — 10 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)