### PR TITLE
test(fakes): FakeBeetsDB.get_album_path_by_id + drain residual cleanup sites

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -400,6 +400,24 @@ _LEAF_SEAM_PATTERNS = [
     # ``lib.download.process_completed_album`` etc.
     re.compile(r"^lib\.download\._handle_valid_result$"),
 
+    # Broadened ``resolve_failed_path`` re-export allowlist. The pattern
+    # already covers ``web.routes.*`` re-exports; ``lib.wrong_matches``
+    # also re-exports ``resolve_failed_path`` from ``lib.util``. Same
+    # rationale: ``lib.util.resolve_failed_path`` is the actual
+    # filesystem boundary; the re-export is the test seam.
+    re.compile(r"^lib\.\w+\.resolve_failed_path$"),
+
+    # ``harness.import_one`` RED-guard seams. The test
+    # ``test_evidence_backed_import_skips_candidate_measurement_helpers``
+    # patches these three pure-decision helpers with ``side_effect=AssertionError``
+    # to assert NONE of them run when pre-recorded evidence is supplied.
+    # The patch is a regression guard, not a stub — if any helper runs,
+    # the test trips. The decisions themselves are tested in
+    # ``test_quality_classification.py``.
+    re.compile(r"^harness\.import_one\.determine_verified_lossless$"),
+    re.compile(r"^harness\.import_one\.provisional_lossless_decision$"),
+    re.compile(r"^harness\.import_one\.quality_decision_stage$"),
+
     # Filesystem-write wrapper. ``log_validation_result`` (defined in
     # ``lib.util``) appends to the beets-tracking JSONL file — a thin
     # filesystem-boundary helper. Tests in ``test_download.py`` patch

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -4127,17 +4127,20 @@ class FakeBeetsDB:
         self._album_ids_for_release: dict[str, list[int]] = {}
         self._album_info: dict[str, Any] = {}
         self._item_paths: dict[str, list[tuple[int, str]]] = {}
+        self._album_path_by_id: dict[int, str | None] = {}
         # Default return values for unseeded keys — match the real
         # BeetsDB's "no row" shapes so tests don't crash on missing
         # explicit seeds.
         self._album_exists_default = False
         self._album_ids_default: list[int] = []
         self._album_info_default: Any = None
+        self._album_path_by_id_default: str | None = None
         self._item_paths_default: list[tuple[int, str]] = []
         self.close_calls: int = 0
         self.album_exists_calls: list[str] = []
         self.get_album_info_calls: list[str] = []
         self.get_all_album_ids_for_release_calls: list[str] = []
+        self.get_album_path_by_id_calls: list[int] = []
         self.get_item_paths_calls: list[str] = []
 
     # --- Seeding helpers ---
@@ -4157,6 +4160,9 @@ class FakeBeetsDB:
         self, release_id: str, paths: list[tuple[int, str]],
     ) -> None:
         self._item_paths[release_id] = list(paths)
+
+    def set_album_path_by_id(self, album_id: int, path: str | None) -> None:
+        self._album_path_by_id[album_id] = path
 
     # --- Real-method surface ---
 
@@ -4179,6 +4185,11 @@ class FakeBeetsDB:
         self.get_item_paths_calls.append(release_id)
         return self._item_paths.get(
             release_id, list(self._item_paths_default))
+
+    def get_album_path_by_id(self, album_id: int) -> str | None:
+        self.get_album_path_by_id_calls.append(album_id)
+        return self._album_path_by_id.get(
+            album_id, self._album_path_by_id_default)
 
     def close(self) -> None:
         self.close_calls += 1

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -1,17 +1,6 @@
 {
-  "test_beets_album_op.py": {
-    "stateful_mock_assign:beets": 1
-  },
   "test_cycle_summary.py": {
     "patch:lib.matching.album_match": 1
-  },
-  "test_dispatch_core.py": {
-    "stateful_mock_assign:beets": 1
-  },
-  "test_import_one_stages.py": {
-    "patch:harness.import_one.determine_verified_lossless": 1,
-    "patch:harness.import_one.provisional_lossless_decision": 1,
-    "patch:harness.import_one.quality_decision_stage": 1
   },
   "test_matching.py": {
     "patch:lib.matching._track_titles_cross_check": 1
@@ -19,8 +8,5 @@
   "test_web_server.py": {
     "stateful_mock_assign:failing_db": 1,
     "stateful_mock_assign:mock_db": 1
-  },
-  "test_wrong_matches_cleanup.py": {
-    "patch:lib.wrong_matches.resolve_failed_path": 1
   }
 }

--- a/tests/test_beets_album_op.py
+++ b/tests/test_beets_album_op.py
@@ -22,8 +22,10 @@ import re
 import subprocess as sp
 import unittest
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+from tests.fakes import FakeBeetsDB
 from lib.beets_album_op import (BeetsAlbumHandle, BeetsOpFailure,
                                 BeetsOpResult, move_album, remove_album,
                                 remove_by_selector)
@@ -176,9 +178,12 @@ class TestRemoveAlbum(unittest.TestCase):
 class TestMoveAlbum(unittest.TestCase):
 
     def _beets(self, new_path: str | None = "/Beets/Artist/Album [2007]"
-               ) -> MagicMock:
-        beets = MagicMock()
-        beets.get_album_path_by_id.return_value = new_path
+               ) -> FakeBeetsDB:
+        beets = FakeBeetsDB()
+        # The default ``new_path`` covers album_id 42 (the only album_id
+        # exercised by these tests); use the default-path field so any
+        # album_id query returns it without per-test seeding.
+        beets._album_path_by_id_default = new_path
         return beets
 
     @patch("lib.beets_album_op.sp.run")
@@ -188,7 +193,7 @@ class TestMoveAlbum(unittest.TestCase):
         # patch the source module so the deferred lookup resolves to the mock.
         mock_run.return_value = _ok()
         with patch("lib.permissions.fix_library_modes") as mock_fix:
-            r = move_album(BeetsAlbumHandle(album_id=42), self._beets())
+            r = move_album(BeetsAlbumHandle(album_id=42), cast(Any, self._beets()))
         self.assertTrue(r.success)
         self.assertEqual(r.new_path, "/Beets/Artist/Album [2007]")
         mock_fix.assert_called_once_with("/Beets/Artist/Album [2007]")
@@ -199,7 +204,7 @@ class TestMoveAlbum(unittest.TestCase):
         mock_run.return_value = _ok()
         beets = self._beets()
         with patch("lib.permissions.fix_library_modes"):
-            move_album(BeetsAlbumHandle(album_id=42), beets)
+            move_album(BeetsAlbumHandle(album_id=42), cast(Any, beets))
         argv = mock_run.call_args.args[0]
         self.assertEqual(argv[1:], ["move", "-a", "id:42"])
         # -d must NEVER appear on a move
@@ -212,12 +217,12 @@ class TestMoveAlbum(unittest.TestCase):
             cmd=["beet", "move"], timeout=120)
         beets = self._beets()
         with patch("lib.permissions.fix_library_modes") as mock_fix:
-            r = move_album(BeetsAlbumHandle(album_id=42), beets)
+            r = move_album(BeetsAlbumHandle(album_id=42), cast(Any, beets))
         self.assertFalse(r.success)
         assert r.failure is not None
         self.assertEqual(r.failure.reason, "timeout")
         self.assertIsNone(r.new_path)
-        beets.get_album_path_by_id.assert_not_called()
+        self.assertEqual(beets.get_album_path_by_id_calls, [])
         mock_fix.assert_not_called()
 
     @patch("lib.beets_album_op.sp.run")
@@ -225,11 +230,11 @@ class TestMoveAlbum(unittest.TestCase):
         mock_run.return_value = _rc(2, stderr="no matching albums\n")
         beets = self._beets()
         with patch("lib.permissions.fix_library_modes") as mock_fix:
-            r = move_album(BeetsAlbumHandle(album_id=42), beets)
+            r = move_album(BeetsAlbumHandle(album_id=42), cast(Any, beets))
         self.assertFalse(r.success)
         assert r.failure is not None
         self.assertEqual(r.failure.reason, "nonzero_rc")
-        beets.get_album_path_by_id.assert_not_called()
+        self.assertEqual(beets.get_album_path_by_id_calls, [])
         mock_fix.assert_not_called()
 
     @patch("lib.beets_album_op.sp.run")
@@ -241,7 +246,7 @@ class TestMoveAlbum(unittest.TestCase):
         mock_run.return_value = _ok()
         beets = self._beets(new_path=None)
         with patch("lib.permissions.fix_library_modes") as mock_fix:
-            r = move_album(BeetsAlbumHandle(album_id=42), beets)
+            r = move_album(BeetsAlbumHandle(album_id=42), cast(Any, beets))
         self.assertTrue(r.success)
         self.assertIsNone(r.new_path)
         mock_fix.assert_not_called()

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -22,7 +22,7 @@ from lib.quality import (
     QualityEvidenceActionPayload,
     VerifiedLosslessProof,
 )
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
     make_album_quality_evidence,
     make_import_result,
@@ -79,10 +79,8 @@ _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"
 
 
 def _patch_beets_album(album_path: str | None, *, min_bitrate: int = 128):
-    beets = MagicMock()
-    beets.__enter__.return_value = beets
-    beets.__exit__.return_value = None
-    beets.get_album_info.return_value = (
+    beets = FakeBeetsDB()
+    beets._album_info_default = (
         AlbumInfo(
             album_id=1,
             track_count=1,


### PR DESCRIPTION
## Summary

Brings the mock-audit baseline from 10 to 4 findings (the documented-as-deferred remainder).

## Changes

### FakeBeetsDB extension

Adds \`get_album_path_by_id(album_id) -> str | None\` to FakeBeetsDB (matches the real BeetsDB signature) with a \`set_album_path_by_id\` seed helper and an \`_album_path_by_id_default\` field for \"any album_id returns the same path\" tests.

Used to migrate:
- \`test_beets_album_op.py::TestMoveAlbum\` — 5 sites (\`_beets()\` helper + all callers)
- \`test_dispatch_core.py::_patch_beets_album\` — 1 site

### Allowlist additions

- \`lib\\.\\w+\\.resolve_failed_path\` — broadened to include \`lib.wrong_matches.resolve_failed_path\` (re-export from \`lib.util\`). Same rationale as the existing \`web.routes.*.resolve_failed_path\` allowlist entry.
- \`harness.import_one.determine_verified_lossless\` / \`provisional_lossless_decision\` / \`quality_decision_stage\` — RED-guard seams. \`test_evidence_backed_import_skips_candidate_measurement_helpers\` patches these with \`side_effect=AssertionError\` to assert NONE of them run when pre-recorded evidence is supplied. Patches are regression guards, not stubs; the decisions themselves are tested in \`test_quality_classification.py\`.

## Result

- Mock-audit baseline: **10 → 4** (-6 findings)
- Pyright: 0 errors / 0 warnings / 0 informations
- Full suite: 3700 tests, all green

Cumulative across all PRs in this push:
**160 → 4 findings (-156, 97.5% retired).**

## Remaining 4 findings (deferred per #301)

| File | Item | Why |
|------|------|-----|
| test_cycle_summary.py | J | \`album_match\` exception-injection. Needs production refactor (extract try/finally credit helper). |
| test_matching.py | A | \`_track_titles_cross_check\` migration. Needs tight input tuning to construct passing-but-failing cases. |
| test_web_server.py | (harness) | \`mock_db = MagicMock()\` + \`failing_db = MagicMock()\` — the shared file-level harness backing hundreds of contract tests. Migrating would mean rewriting every \`mock_db.foo.return_value = ...\` to per-test \`FakePipelineDB\` seeding. Tracked as a separate effort. |

## Test plan

- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors
- [x] \`nix-shell --run \"python3 tests/_rebuild_mock_audit_baseline.py\"\` — 4 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)