### PR TITLE
docs(290): rules + resume doc for the cleanup-phase handoff

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -172,6 +172,7 @@ Before writing any new code, decide which test types you owe and what infrastruc
 | A new slskd interaction | An orchestration test using `FakeSlskdAPI` | `FakeSlskdAPI` from `tests/fakes.py` |
 | A new typed dataclass | A pure test of construction + serialization, and a builder in `tests/helpers.py` if it crosses test boundaries | `tests/helpers.py` |
 | A new `PipelineDB` method | An equivalent stub on `FakePipelineDB`, with a self-test in `tests/test_fakes.py` | `tests/fakes.py`, `tests/test_fakes.py` |
+| A new `BeetsDB` method | Either (a) an equivalent stub on `FakeBeetsDB` with a self-test in `tests/test_fakes.py::TestFakeBeetsDB`, OR (b) drive the test against a real test SQLite DB if it's a read-only query | `tests/fakes.py`, `tests/test_fakes.py` |
 
 Routes are the strictest gate: `TestRouteContractAudit` will fail at test time if you add a route to `web/routes/` without classifying it. This is intentional — it prevents shipping endpoints the frontend can rely on without contract coverage.
 
@@ -231,10 +232,14 @@ Always use these instead of inventing parallel scaffolding:
 - `make_spectral_context(...)` — `SpectralContext`
 - `make_ctx_with_fake_db(fake_db)` — `CratediggerContext` wired to a fake
 - `patch_dispatch_externals()` — context manager for the 6 dispatch external patches
+- `noop_quality_gate(**kwargs) -> None` — drop-in `quality_gate_fn` stub for dispatch tests that don't care about the post-import gate. Pair with `dispatch_import_core(..., quality_gate_fn=noop_quality_gate)`.
+- `RecordingQualityGate()` — recorder `quality_gate_fn` with `assert_called_once()` / `assert_not_called()` / `call_count` / `calls` (list of kwargs). For tests that assert the gate ran with specific args.
 
 **`tests/fakes.py`** — stateful fakes:
-- `FakePipelineDB` — full PipelineDB stand-in: requests, download_logs, denylist, cooldowns, status history, spectral state, attempt counters. Includes `assert_log()` helper.
+- `FakePipelineDB` — full PipelineDB stand-in: requests, download_logs, denylist, cooldowns, status history, spectral state, attempt counters. Includes `assert_log()` helper. Has `queue_execute_results(*cursors)` + `execute_calls` recording for tests driving raw-SQL CLI paths.
+- `FakeBeetsDB` — minimal BeetsDB stand-in: `album_exists`, `get_album_info(mb_release_id, cfg)`, `get_all_album_ids_for_release`, `get_item_paths`, `get_album_path_by_id`, `close` + context-manager + per-method call recorders + seed helpers (`set_album_exists`, `set_album_info`, `set_album_ids_for_release`, `set_item_paths`, `set_album_path_by_id`). Each method also has a `_default` field for "any key returns the same value" tests. Extend the surface only when a test exercises a new BeetsDB method.
 - `FakeSlskdAPI` — stateful slskd client: `transfers` (enqueue, get_all_downloads, get_download, cancel_download, queued snapshots), `users` (directory with per-directory results and errors), call recording.
+- `FakePipelineDBSource` — typed PipelineDBSource fake wrapping a `FakePipelineDB`. Use via `make_ctx_with_fake_db(fake_db)` rather than constructing directly.
 
 **`tests/test_web_server.py`** — `_WebServerCase` harness with `_get`/`_post` helpers + `TestRouteContractAudit` guard.
 
@@ -269,13 +274,36 @@ These are functions whose body is mostly "construct args and dispatch to a netwo
 
 When adding a new seam-wrapper function, the bar is: **its body must be ≤10 lines AND mostly forward to an external boundary.** Anything fatter is pure logic with a side effect, not a seam wrapper — drive it with a fake.
 
+**ALLOWED — module-local DI seams (route/CLI dispatch only):**
+
+When production code is dispatched by URL (web routes) or argparse subcommands (CLI), there's no kwarg path to inject a dependency through. The established pattern: bind the dependency at module-attribute scope and let tests patch the attribute.
+
+```python
+# lib/<module>.py at module top
+from lib import transitions
+finalize_request = transitions.finalize_request   # the DI seam
+
+# tests patch the module attribute
+@patch("lib.<module>.finalize_request")
+def test_x(self, mock_finalize):
+    ...
+```
+
+Examples currently allowlisted: `web.routes.pipeline.finalize_request`, `harness.import_one.finalize_request`, `scripts.pipeline_cli.finalize_request`, `scripts.repair.finalize_request`, `lib.import_dispatch.finalize_request`.
+
+**This is only legitimate when the entry point cannot accept a kwarg.** A mid-tier private helper called from another production function CAN accept a kwarg — see `try_enqueue(..., match_fn=check_for_match)` and `dispatch_import_core(..., quality_gate_fn=_check_quality_gate_core)` as the canonical kwarg-DI examples. Module-local seams are the second-best option; kwarg DI is the first-best.
+
+When you find yourself reaching for an in-module patch on a mid-tier function (e.g. `patch("lib.download._handle_valid_result")` from within a `process_completed_album` test), ask: could this function take the dependency as a kwarg? If yes, refactor. If no (URL or argparse dispatcher), allowlist with rationale.
+
 **FORBIDDEN — stateful collaborators and pure-logic functions:**
-- `MagicMock()` assigned to a variable named `db`, `mock_db`, `failing_db`, `pdb`, `ctx`, `context`, `beets`, `source`, `pipeline_db`, `slskd`, `fake_db` — **use `FakePipelineDB`, `FakeBeetsDB`, `FakeSlskdAPI` from `tests/fakes.py`**
-- `patch("lib.enqueue.check_for_match")` — pure matching logic. Drive the real function with seeded folder cache / track data.
-- `patch("lib.transitions.finalize_request")`, `patch("lib.transitions.apply_transition")` — DB transition logic. Drive through `FakePipelineDB`.
-- `patch("lib.import_dispatch.parse_import_result")`, `patch("lib.import_dispatch._check_quality_gate_core")`, `patch("lib.quality.quality_gate_decision")` — pure decision logic. Build inputs, call the real function.
+- `MagicMock()` assigned to a variable named `db`, `mock_db`, `failing_db`, `pdb`, `ctx`, `context`, `beets`, `beets_db`, `source`, `pipeline_db`, `slskd`, `fake_db` — **use `FakePipelineDB`, `FakeBeetsDB`, `FakeSlskdAPI` from `tests/fakes.py`**.
+- `patch("lib.enqueue.check_for_match")` — pure matching logic. Use the `try_enqueue(..., match_fn=)` kwarg DI seam, or drive the real function with seeded folder cache / track data.
+- `patch("lib.transitions.finalize_request")` / `patch("lib.transitions.apply_transition")` on the ORIGIN module. The route / CLI / harness modules each expose a `finalize_request = transitions.finalize_request` module-local seam — patch THAT instead (e.g. `patch("web.routes.pipeline.finalize_request")`).
+- `patch("lib.import_dispatch.parse_import_result")` is forbidden on lib.import_dispatch.parse_import_result — `lib.quality.parse_import_result` is a thin harness-stdout parser and is allowlisted; the `lib.import_dispatch` re-export is also allowlisted. Use one of those.
 - `patch("lib.beets_db.BeetsDB.<method>")` — use `FakeBeetsDB`; the class itself is allowlisted but per-method stubbing is not.
 - Any `patch("lib.<our-module>.<our-function>")` whose target is **not** explicitly on the seam-wrapper allowlist in `_mock_audit_scanner.py`. **If you're mocking your own logic, you're testing the mock, not the code.**
+
+**Pure-decision allowlist debt (known cleanup):** Three pure-decision functions are currently allowlisted as orchestration test seams: `lib.import_dispatch.quality_gate_decision`, `lib.quality.full_pipeline_decision`, and `lib.import_preview.preview_import_from_values` (+ its `web.routes.pipeline` re-export). The rationale (orchestration tests stub the branch; the decision's own tests live elsewhere) is defensible scoping but the proper migration is to drive the tests with real measurement / value inputs that produce each branch. Tracked in the active follow-up issue — do not allowlist new pure-decision functions; migrate them.
 
 **The rule of thumb:** does the thing you're about to mock cross a process / network / third-party boundary as its primary purpose? If yes, mock — and if the function is a thin wrapper around that boundary, add it to `_mock_audit_scanner.py`'s seam-wrapper list with a rationale. If the function is pure logic with a side effect, use a `Fake*` or drive the real function with constructed inputs.
 

--- a/docs/issue-290-resume.md
+++ b/docs/issue-290-resume.md
@@ -1,14 +1,21 @@
-# Issue #290 — resume note
+# MagicMock removal — cleanup-phase resume note
 
-This is the **entry point** for picking up the stateful-MagicMock removal effort with fresh context. Read this first; the long-form context lives in issues #290 (master plan) and #301 (deferred items + refactor ideas).
+This is the **entry point** for picking up the cleanup phase of the stateful-MagicMock removal effort with fresh context. Read this first. The long-form history (Phase 1 + Phase 2, 30+ landed PRs, 160→4 baseline) lives in **closed** issues #290 and #301. The remaining work is tracked in the **active cover issue** (linked at the top of those closed issues).
 
-## Current state
+## Where we are
 
-Baseline last measured at **4 findings across 3 files** (the documented-as-deferred remainder). To check the live count:
+- Mock-audit baseline: **4 findings across 3 files** (down from 613 → 160 → 4).
+- Pyright clean on full repo.
+- Full suite: 3700 tests green.
+- Infrastructure shipped: `FakePipelineDB` (+ `queue_execute_results`), `FakeBeetsDB`, `FakeSlskdAPI`, `FakePipelineDBSource`, `make_ctx_with_fake_db`, `noop_quality_gate`, `RecordingQualityGate`, `try_enqueue(match_fn=)`, `dispatch_import_core(quality_gate_fn=)`.
+- DI seams shipped: module-local `finalize_request` bindings across `web.routes.pipeline`, `lib.import_dispatch`, `harness.import_one`, `scripts.pipeline_cli`, `scripts.repair`. Module-local `quality_gate_decision` binding on `lib.import_dispatch`. In-module DI seams in `lib.download` and `scripts.repair`.
+
+The 4-finding floor sounds great but masks **allowlist debt**. The cleanup phase below is about repaying that debt and addressing the documented deferred items, not chasing the baseline further per se.
+
+## Live count check
 
 ```bash
 nix-shell --run "python3 tests/_rebuild_mock_audit_baseline.py"
-# Then:
 nix-shell --run "python3 -c '
 import json
 b = json.load(open(\"tests/mock_audit_baseline.json\"))
@@ -18,182 +25,133 @@ for f, kinds in sorted(b.items(), key=lambda kv: sum(kv[1].values())):
 '"
 ```
 
-If the live count differs from this doc, this doc is stale — trust the live count and update this file as part of your next PR.
+If the live count differs from this doc, trust the live count and update this file as part of the next PR.
+
+## The cleanup phase — 4 steps
+
+These are the four open work items, ordered by value-per-effort. Each is a separate PR.
+
+### Step 1 — Migrate pure-decision allowlists to real-input tests (~3 entries, biggest correctness win)
+
+Three allowlist entries explicitly contradict the audit rule's "drive with real inputs" guidance:
+
+- `lib.import_dispatch.quality_gate_decision` — used by `_check_quality_gate_core` orchestration tests in `test_import_dispatch.py` (5 patch sites in `TestQualityGate*` classes around `_run_quality_gate(gate_decision)`).
+- `lib.quality.full_pipeline_decision` — used by `test_pipeline_cli.py::TestCmdQuality` and `TestQualityLabel` (2 patch sites, via `fake_full_pipeline_decision`).
+- `lib.import_preview.preview_import_from_values` + `web.routes.pipeline.preview_import_from_values` re-export — used by `test_pipeline_cli.py::TestCmdImportPreview` (2 sites) and `test_web_server.py::TestImportPreviewRouteContract` (1 site).
+
+**Why migrate:** the decision functions have dedicated coverage in `test_quality_classification.py::TestQualityGateDecision` and `tests/test_import_preview.py`. The orchestration tests currently stub the branch and assert the wrapper's downstream behaviour. That's a defensible scoping argument BUT the rule explicitly forbids this pattern — the tests don't actually exercise the real decision, so silent drift between decision-output shape and orchestration-input shape can creep in.
+
+**The migration:** for each test, construct real measurement / value inputs that produce the desired decision branch. Fixtures already exist in `test_quality_classification.py::TestLiveBugReproductions` — borrow them.
+
+- Remove the three allowlist entries in `tests/_mock_audit_scanner.py`.
+- Rewrite 8 orchestration tests to pass real inputs.
+- Update `.claude/rules/code-quality.md` to remove the "pure-decision allowlist debt" callout once cleared.
+
+### Step 2 — `stage_to_ai_path` allowlist removal (~30 min, smallest)
+
+`lib.download.stage_to_ai_path` is pure path-construction with no I/O. Currently allowlisted as a "staging-destination seam" — that rationale is a stretch.
+
+**The migration:** `test_import_dispatch.py::_dispatch_valid_result_cmd` patches it to return `dest_dir = os.path.join(tmpdir, "dest")`. Compute the real path: configure the test's `ctx.cfg.beets_staging_dir = tmpdir` and call the real `stage_to_ai_path` to compute the destination, then create that directory.
+
+- Remove the allowlist entry.
+- Update the helper to drive the real function with a tempdir staging root.
+- Verify file moves still land where the test expects.
+
+### Step 3 — In-module DI seam audit (~half day)
+
+Module-local DI seams are legitimate when production is dispatched by URL or argparse (no kwarg path). For mid-tier private helpers called from other production functions, kwarg DI would be cleaner.
+
+**Candidates to audit:**
+
+| Current allowlist entry | Caller | Could be kwarg DI? |
+|-------------------------|--------|---------------------|
+| `lib.download._handle_valid_result` | `process_completed_album` | Likely yes — `process_completed_album` could take `handle_valid_fn=_handle_valid_result` |
+| `lib.download._process_beets_validation` | `process_completed_album` | Likely yes — same shape |
+| `lib.download.process_completed_album` | `poll_active_downloads` | Maybe — `poll_active_downloads` already wraps a stateful loop |
+| `lib.download.dispatch_import_core` | `_handle_valid_result` | Already wraps `dispatch_import_core`'s kwarg `quality_gate_fn`; the re-import is for testing the wrapper |
+| `scripts.repair._collect_issues` | `cmd_fix` / `cmd_scan` | CLI dispatch — keep as module-local seam |
+| `scripts.repair.find_orphaned_downloads` | `_collect_issues` | Mid-tier — could be kwarg DI |
+
+For each candidate that could be kwarg DI, prototype the change in a single tests/file pair, measure how the test reads vs the module-attribute version, and decide. Mid-tier wins might be small but they're more architecturally honest.
+
+**Approach for each:**
+- Add a kwarg to the calling function with the seam fn as the default.
+- Update tests to pass the stub by value.
+- Remove the allowlist entry.
+
+### Step 4 — `test_web_server.py` shared MagicMock harness (multi-PR effort)
+
+The two remaining audit findings (`mock_db = MagicMock()` at line ~149 and `failing_db = MagicMock()` around line 6875) are the shared file-level harness backing hundreds of contract tests in `test_web_server.py::_make_server()`. Plus the existing `make_db.foo.return_value = ...` chains throughout the file.
+
+**Why deferred:** migrating `_make_server()` to use `FakePipelineDB` requires rewriting every `self.mock_db.foo.return_value = ...` in every test that uses `_WebServerCase`. That's ~300+ tests. Each one needs:
+- Real seeded request rows via `seed_request(make_request_row(...))`
+- Domain-state assertions via `db.request(id)["status"]` instead of `mock_db.update_status.assert_called_with(...)`
+- Production-shape data for JSONB / datetime / UUID columns (see `.claude/rules/code-quality.md` § API Contract Tests)
+
+**Approach (multi-PR):**
+- PR A: Rebuild `_make_server()` to construct a `FakePipelineDB` with a sensible base seed. Keep the `self.mock_db` attribute pointing at it for now (introduce `self.fake_db` alias). Migrate ~10 simple tests as a proof.
+- PR B-N: Per test class, rewrite the per-test seed + assertion patterns. Each PR should drop the count of tests still relying on `mock_db.*.return_value` patterns.
+- Final PR: `mock_db` attribute is gone, only `fake_db`. Remove the 2 remaining audit findings.
+
+This is genuinely 5-10 PRs of work, but each one is small and ships independently.
+
+### Deferred items (do not block phase 3)
+
+These two from #301 are explicitly deferred indefinitely — each requires production refactor and the cost-benefit doesn't justify the work:
+
+- **Item A** — `lib.matching._track_titles_cross_check` patch in `test_matching.py`. Needs tight input tuning. Tracked in cover issue for visibility, not for active work.
+- **Item J** — `lib.matching.album_match` exception-injection in `test_cycle_summary.py`. Needs production refactor (extract try/finally credit helper).
+
+Both are 1 finding each and have been baseline-grandfathered since they were filed. Address only if a future change touches the same file.
 
 ## Mental model
 
-A finding is one of two things:
-1. **`stateful_mock_assign:NAME`** — a variable assignment like `db = MagicMock()` for a name implying a stateful collaborator. Replacement: `FakePipelineDB` / `FakePipelineDBSource` / `FakeSlskdAPI` / a `Fake*` subclass.
-2. **`patch:lib.x.y`** — a `patch()` call against a function the audit considers "ours, not a seam." Either migrate to drive real code with a fake, or — if the function is genuinely a thin boundary wrapper — add to `tests/_mock_audit_scanner.py::_LEAF_SEAM_PATTERNS` with a rationale comment.
+A finding is one of:
 
-The audit is in `tests/test_mock_audit.py`; the scanner heuristic lives in `tests/_mock_audit_scanner.py`; the frozen call-site count is in `tests/mock_audit_baseline.json`.
+1. **`stateful_mock_assign:NAME`** — `MagicMock()` assigned to a flagged variable name. Replacement: `FakePipelineDB` / `FakeBeetsDB` / `FakeSlskdAPI` / `FakePipelineDBSource` / `make_ctx_with_fake_db()`.
+2. **`patch:lib.x.y`** — `patch()` on a target the audit considers ours-not-a-seam. Options:
+   - **Migrate** — drive the real function with constructed inputs (preferred for pure logic).
+   - **Kwarg DI** — refactor the caller to take the dependency as a kwarg (preferred for mid-tier private helpers).
+   - **Module-local DI seam** — bind at module top in the caller's module; patch the local attribute (legitimate only for URL / argparse dispatchers).
+   - **Allowlist** — add to `tests/_mock_audit_scanner.py::_LEAF_SEAM_PATTERNS` with rationale (only for thin boundary wrappers).
 
-## Next moves (in order of value-per-effort)
+The audit lives in `tests/test_mock_audit.py`; the scanner heuristic in `tests/_mock_audit_scanner.py`; the frozen call-site count in `tests/mock_audit_baseline.json`.
 
-### ~~1. Item N in #301 — DI refactor for `try_enqueue` match function~~ (LANDED)
+## Workflow
 
-Shipped: `try_enqueue` / `try_multi_enqueue` / `_iter_wave_matches` now take
-`match_fn: MatchFn = check_for_match` (keyword-only). Migrated all wave-shape
-tests in `test_enqueue_fanout.py`, plus three sites in
-`test_integration_slices.py` and three in `test_integration.py`. Dropped 34
-findings (160 → 126).
-
-### ~~2. Item K in #301 — DI refactor for `_check_quality_gate_core`~~ (LANDED)
-
-Shipped: `dispatch_import_core` takes `quality_gate_fn: QualityGateFn =
-_check_quality_gate_core` (keyword-only). Threaded as an optional
-`quality_gate_fn` kwarg through `dispatch_import_from_db` and
-`_handle_valid_result` so tests that hit those entry points can inject the
-stub too. Test helpers `noop_quality_gate` + `RecordingQualityGate` added
-to `tests/helpers.py`. Migrated `test_dispatch_core.py` (4),
-`test_dispatch_from_db.py` (5), `test_import_dispatch.py` (3). Dropped 11
-findings (126 → 115).
-
-### ~~3. Item M in #301 — `_execute` support on `FakePipelineDB`~~ (LANDED)
-
-Shipped: `FakePipelineDB.queue_execute_results(*cursors)` registers a
-deterministic cursor sequence; `_execute(sql, params)` records calls in
-`db.execute_calls` and pops the next entry (raising it if it's an
-`Exception` instance). Migrated 5 sites in `test_pipeline_cli.py`
-(`TestCmdQuery` 4, `TestCmdRepairSpectral` 1). Other test_pipeline_cli
-sites use different MagicMock patterns that aren't `_execute` queues —
-those remain for separate migration. Dropped 5 findings (115 → 110).
-
-### ~~4. Web routes `finalize_request` DI (the long pole)~~ (LANDED)
-
-Shipped: `web/routes/pipeline.py` now binds `finalize_request =
-transitions.finalize_request` at module scope. Routes call the local
-name (not `transitions.finalize_request` directly), so tests can swap
-the dependency with `patch("web.routes.pipeline.finalize_request")` —
-allowlisted as a route-scope DI seam in the same way
-`web.server.db` is. Migrated all 26 patch sites in
-`tests/test_web_server.py`. Dropped 26 findings (110 → 84).
-
-### ~~5. Allowlist remaining web.routes DI seams + migrate match_folders_to_requests~~ (LANDED)
-
-Shipped in PR #323. `web.routes.imports.cleanup_all_wrong_matches` (3
-sites) and `web.server.compute_library_rank` (1 site) allowlisted as
-route-scope DI seams. `web.routes.imports.match_folders_to_requests` (1
-site) migrated to drive the real fuzzy matcher with shared
-artist/album tokens. Dropped 5 findings (84 → 79).
-
-### ~~6. Item P — per-module `finalize_request` DI seams for non-web tests~~ (LANDED)
-
-Shipped in PR #324. Same shape as PR #322 applied to four more
-modules: `lib.import_dispatch`, `harness.import_one`,
-`scripts.pipeline_cli`, `scripts.repair`. Each binds
-`finalize_request = transitions.finalize_request` at module scope and
-exposes it as an allowlisted seam. Migrated 10 test patches. Dropped
-10 findings (79 → 69).
-
-### ~~7. test_import_one_stages.py harness migration~~ (LANDED)
-
-Shipped in PR #325. Built `FakeBeetsDB` in `tests/fakes.py` (minimal
-surface: `album_exists`, `get_album_info(mb_release_id, cfg)`,
-`get_all_album_ids_for_release`, `get_item_paths`, `close` +
-seed-helpers + a context-manager) with five self-tests in
-`tests/test_fakes.py`. Migrated `TestPipelineDbUpdate` (4 sites,
-`MagicMock()` → `FakePipelineDB()`) and the four
-`beets = MagicMock()` sites to `FakeBeetsDB`. Dropped 8 findings
-(69 → 61).
-
-### ~~8. test_download.py harness migration~~ (LANDED)
-
-Shipped in PR #326. Allowlisted four in-module DI seams in `lib.download`
-(`dispatch_import_core`, `process_completed_album`, `_process_beets_validation`,
-`log_validation_result`) plus the `cleanup_wrong_match` service-layer seam.
-Migrated `slskd = MagicMock()` in `_make_ctx` to `FakeSlskdAPI()`.
-Dropped 19 findings via allowlist + 1 migration (61 → 42).
-
-### ~~9. test_repair_cli.py harness migration~~ (LANDED)
-
-Shipped in PR #327. Migrated 4 `db = MagicMock()` sites in
-`TestCollectIssues.test_auto_import_in_progress_*` to `FakePipelineDB`
-using `queue_execute_results` from PR #321. Allowlisted three
-`scripts.repair` in-module DI seams (`_collect_issues`,
-`find_orphaned_downloads`, `find_blocked_recovery_issues`). Dropped 8
-findings (42 → 34).
-
-### ~~10. test_import_dispatch.py harness migration~~ (LANDED)
-
-Shipped in PR #328. Lifted `quality_gate_decision` to a module-level
-binding in `lib.import_dispatch` (same shape as `finalize_request` in
-#322); migrated 5 patches to the new seam. Rewrote `_make_ctx()` to use
-`make_ctx_with_fake_db` with a seeded `FakePipelineDB`. Allowlisted
-`stage_to_ai_path` as a staging-destination seam. Dropped 7 findings
-(34 → 27).
-
-### ~~11. test_pipeline_cli.py / test_import_queue.py residuals~~ (LANDED)
-
-Shipped in PR #329. Allowlisted `preview_import_from_values` /
-`full_pipeline_decision` (pure-decision DI seams matching the
-`quality_gate_decision` rationale), `MbidReplaceService`
-(constructor-replacement seam), `import_preview_worker.run_once`
-(worker tick stub), and `lib.download._handle_valid_result` (in-module
-seam). Migrated remaining `db = MagicMock()` (test_pipeline_cli) and
-`beets = MagicMock()` (test_import_queue). Fixed docstring noise where
-helper docstrings tripped the audit regex. Dropped 17 findings
-(27 → 10).
-
-### ~~12. Residual cleanup~~ (LANDED)
-
-Shipped in PR #330. Added `FakeBeetsDB.get_album_path_by_id` + seed
-helper; migrated `test_beets_album_op.py::TestMoveAlbum` (5 sites)
-and `test_dispatch_core.py::_patch_beets_album`. Broadened
-`resolve_failed_path` allowlist to `lib.\\w+.resolve_failed_path`.
-Allowlisted three RED-guard patches in `test_import_one_stages.py`
-(harness measurement helpers — patches assert NONE are called when
-pre-recorded evidence is supplied). Dropped 6 findings (10 → 4).
-
-## Remaining 4 findings (deferred per #301)
-
-| File | Item | Why |
-|------|------|-----|
-| `test_cycle_summary.py` | J | `album_match` exception-injection. Needs production refactor (extract try/finally credit helper). |
-| `test_matching.py` | A | `_track_titles_cross_check` migration. Needs tight input tuning to construct passing-but-failing match cases. |
-| `test_web_server.py` (×2) | (harness) | `mock_db = MagicMock()` + `failing_db = MagicMock()` — the shared file-level harness backing hundreds of contract tests. Migrating would mean rewriting every `mock_db.foo.return_value = ...` to per-test `FakePipelineDB` seeding. Worth its own multi-PR effort. |
-
-## What's NOT next
-
-- **Don't migrate one-off var-name sites** until the three DI refactors land. They're already on the residual list and individually low-yield.
-- **Don't extend the allowlist further** unless you find a genuine thin seam wrapper I missed. The current allowlist is already covering all the obvious subprocess/HTTP/filesystem wrappers.
-- **Don't try to delete `mock_audit_baseline.json`** (Phase 3 of #290) until the baseline reaches 0. The grandfather approach is the whole point.
-
-## How to run the workflow
-
-Each migration PR follows the same shape:
+Each cleanup PR follows the same shape:
 
 ```bash
-git checkout -b feat/mock-migrate-WHAT main
+git checkout -b feat/mock-cleanup-WHAT main
 # Make changes
-nix-shell --run "python3 -m unittest tests.test_WHAT"    # target file passes
-nix-shell --run "bash scripts/run_tests.sh"               # full suite passes
-nix-shell --run pyright                                   # 0 errors on full repo
-python3 tests/_rebuild_mock_audit_baseline.py             # baseline shrinks
+nix-shell --run "python3 -m unittest tests.test_WHAT"      # target file passes
+nix-shell --run "bash scripts/run_tests.sh"                 # full suite passes
+nix-shell --run pyright                                     # 0 errors on full repo
+python3 tests/_rebuild_mock_audit_baseline.py               # baseline shrinks
 git add -A && git commit -m "test(WHAT): migrate ..."
-git push -u origin feat/mock-migrate-WHAT
+git push -u origin feat/mock-cleanup-WHAT
 gh pr create --base main --title "test(WHAT): ..." --body "..."
 gh pr merge <PR> --merge --delete-branch
 ```
 
-The pre-commit hook + audit + skip-audit gates all enforce themselves. If the audit fails on a PR, either:
-- You added a new anti-pattern site → fix or use a typed fake
-- You removed sites but didn't re-snapshot → run `python3 tests/_rebuild_mock_audit_baseline.py`
+The pre-commit hook, audit, and skip-audit gates all enforce themselves. If the audit fails on a PR:
+- New anti-pattern site → fix or use a typed fake.
+- Removed sites but didn't re-snapshot → run `python3 tests/_rebuild_mock_audit_baseline.py`.
 
 ## Pointers
 
-- **Master plan**: issue #290
-- **Deferred items / refactor ideas**: issue #301
-- **Rule**: `.claude/rules/code-quality.md` § "MOCKS: LEAF-SEAM ONLY"
-- **Audit**: `tests/test_mock_audit.py`, `tests/_mock_audit_scanner.py`
-- **Fakes**: `tests/fakes.py` (FakePipelineDB, FakePipelineDBSource, FakeSlskdAPI)
-- **Skip-test ban (related)**: `tests/test_skip_audit.py`, CLAUDE.md § "Skipped tests are an anti-pattern"
+- **Active cover issue**: see the GitHub issue tracker (filed after #290 / #301 closed).
+- **History**: closed issues #290 (master plan), #301 (deferred items log).
+- **Rule**: `.claude/rules/code-quality.md` § "MOCKS: LEAF-SEAM ONLY".
+- **Audit**: `tests/test_mock_audit.py`, `tests/_mock_audit_scanner.py`.
+- **Fakes**: `tests/fakes.py` (`FakePipelineDB`, `FakeBeetsDB`, `FakeSlskdAPI`, `FakePipelineDBSource`).
+- **Helpers**: `tests/helpers.py` (`make_ctx_with_fake_db`, `noop_quality_gate`, `RecordingQualityGate`, `patch_dispatch_externals`, builders).
 
 ## Maintenance
 
 Update this file whenever:
-- Baseline drops or grows significantly (every PR is fine)
-- An item on the "three next moves" list lands — replace with the new next-best
-- The mental model changes (new heuristic, new fake category)
+- A cleanup step (1-4) lands — strike through or remove the section.
+- Baseline drops or grows significantly.
+- A new category of debt is discovered.
 
-Don't update for individual migrations that don't change the strategic picture.
+When all four steps are done and the baseline is at the deferred floor (Items A + J = 2 findings, or 0 if those are also addressed), this file and the cover issue close together.


### PR DESCRIPTION
Wraps up #290/#301 and stages the cleanup phase. Sets up rules and the resume doc as a handoff for a new cover issue (to be filed post-merge).