### PR TITLE
test(mock-cleanup): drop stage_to_ai_path allowlist entry

### DIFF
--- a/docs/issue-290-resume.md
+++ b/docs/issue-290-resume.md
@@ -39,15 +39,14 @@ inputs. Allowlist entries removed from `tests/_mock_audit_scanner.py`;
 `.claude/rules/code-quality.md` "Pure-decision allowlist policy" callout
 flipped from "known cleanup" to "never reintroduce".
 
-### Step 2 — `stage_to_ai_path` allowlist removal (~30 min, smallest)
+### Step 2 — `stage_to_ai_path` allowlist removal ✅ DONE
 
-`lib.download.stage_to_ai_path` is pure path-construction with no I/O. Currently allowlisted as a "staging-destination seam" — that rationale is a stretch.
-
-**The migration:** `test_import_dispatch.py::_dispatch_valid_result_cmd` patches it to return `dest_dir = os.path.join(tmpdir, "dest")`. Compute the real path: configure the test's `ctx.cfg.beets_staging_dir = tmpdir` and call the real `stage_to_ai_path` to compute the destination, then create that directory.
-
-- Remove the allowlist entry.
-- Update the helper to drive the real function with a tempdir staging root.
-- Verify file moves still land where the test expects.
+Landed: `_dispatch_valid_result_cmd` now configures
+`ctx.cfg.beets_staging_dir = tmpdir` and lets the real
+`stage_to_ai_path` compute the destination.
+`StagedAlbum.move_to` already mkdir-p's the target, so no extra
+setup is needed. Allowlist entry removed from
+`tests/_mock_audit_scanner.py`.
 
 ### Step 3 — In-module DI seam audit (~half day)
 

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -340,14 +340,6 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^scripts\.repair\.find_orphaned_downloads$"),
     re.compile(r"^scripts\.repair\.find_blocked_recovery_issues$"),
 
-    # Auto-import staging-destination seam. ``stage_to_ai_path`` is a
-    # path-construction helper that the auto-import flow consults to
-    # decide where to move staged audio. Tests patch its
-    # ``lib.download`` re-export to return a tempdir-relative path so
-    # downstream subprocess calls land inside the test's working dir
-    # rather than the production ``beets_staging_dir``.
-    re.compile(r"^lib\.download\.stage_to_ai_path$"),
-
     # Service-class constructor replacement. ``MbidReplaceService`` is
     # the operator's MBID-replace surface (CLI + web route both wrap
     # it). The service's own behaviour is covered in

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -119,13 +119,16 @@ def _dispatch_valid_result_cmd(
 
     with tempfile.TemporaryDirectory() as tmpdir:
         source_dir = os.path.join(tmpdir, "import")
-        dest_dir = os.path.join(tmpdir, "dest")
         os.makedirs(source_dir)
         with open(os.path.join(source_dir, "01 - Track.mp3"), "w", encoding="utf-8") as fp:
             fp.write("fake audio")
 
-        with patch("lib.download.stage_to_ai_path", return_value=dest_dir), \
-             patch("lib.download.log_validation_result"), \
+        # Drive the real ``stage_to_ai_path`` by pointing the staging dir at
+        # the tempdir. ``StagedAlbum.move_to`` creates the destination
+        # directory itself, so we just need the staging root to exist.
+        ctx.cfg.beets_staging_dir = tmpdir
+
+        with patch("lib.download.log_validation_result"), \
              patch_dispatch_externals() as ext, \
              patch("lib.import_dispatch.parse_import_result", return_value=ir):
             _handle_valid_result(


### PR DESCRIPTION
Step 2 of cleanup-phase issue #333.

## Summary
- `lib.download.stage_to_ai_path` is pure path-construction with no I/O — the "staging-destination seam" rationale was a stretch.
- `_dispatch_valid_result_cmd` now points `ctx.cfg.beets_staging_dir` at the existing tempdir and lets the real function compute the destination. `StagedAlbum.move_to` already does the `os.makedirs`, so no extra setup is needed.
- Allowlist entry removed from `tests/_mock_audit_scanner.py`.

## Test plan
- [x] `nix-shell --run \"python3 -m unittest tests.test_import_dispatch tests.test_mock_audit\"` — green
- [x] `nix-shell --run \"bash scripts/run_tests.sh\"` — 3700/3700 green
- [x] `nix-shell --run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)