### PR TITLE
test(mock-cleanup): convert repair helpers to kwarg DI; document chain decisions

### DIFF
--- a/docs/issue-290-resume.md
+++ b/docs/issue-290-resume.md
@@ -48,27 +48,25 @@ Landed: `_dispatch_valid_result_cmd` now configures
 setup is needed. Allowlist entry removed from
 `tests/_mock_audit_scanner.py`.
 
-### Step 3 — In-module DI seam audit (~half day)
+### Step 3 — In-module DI seam audit ✅ DONE
 
-Module-local DI seams are legitimate when production is dispatched by URL or argparse (no kwarg path). For mid-tier private helpers called from other production functions, kwarg DI would be cleaner.
+Decisions per candidate:
 
-**Candidates to audit:**
+| Allowlist entry | Caller | Decision |
+|-----------------|--------|----------|
+| `lib.download._handle_valid_result` | `process_completed_album` | **Keep.** Chain is 5 levels deep (`poll_active_downloads` → `_run_completed_processing` → `process_completed_album` → `_process_beets_validation` → `_handle_valid_result`). Threading a kwarg through every level just to surface the test seam at the top would cascade for negligible win. |
+| `lib.download._process_beets_validation` | `process_completed_album` | **Keep.** Same chain. |
+| `lib.download.process_completed_album` | `poll_active_downloads` | **Keep.** Stateful poller; same chain. |
+| `lib.download.dispatch_import_core` | `_handle_valid_result` | **Keep.** Already provides its OWN kwarg DI for the post-import gate (`quality_gate_fn`); the re-import seam is for the wrapper tests. |
+| `scripts.repair._collect_issues` | `cmd_fix` / `cmd_scan` | **Keep.** CLI argparse dispatchers — no kwarg path from the entry point. |
+| `scripts.repair.find_orphaned_downloads` | `_collect_issues` | **Converted to kwarg DI.** `_collect_issues(..., find_orphaned_fn=find_orphaned_downloads)`. Allowlist entry removed. |
+| `scripts.repair.find_blocked_recovery_issues` | `_collect_issues` | **Converted to kwarg DI.** `_collect_issues(..., find_blocked_recovery_fn=find_blocked_recovery_issues)`. Allowlist entry removed. |
 
-| Current allowlist entry | Caller | Could be kwarg DI? |
-|-------------------------|--------|---------------------|
-| `lib.download._handle_valid_result` | `process_completed_album` | Likely yes — `process_completed_album` could take `handle_valid_fn=_handle_valid_result` |
-| `lib.download._process_beets_validation` | `process_completed_album` | Likely yes — same shape |
-| `lib.download.process_completed_album` | `poll_active_downloads` | Maybe — `poll_active_downloads` already wraps a stateful loop |
-| `lib.download.dispatch_import_core` | `_handle_valid_result` | Already wraps `dispatch_import_core`'s kwarg `quality_gate_fn`; the re-import is for testing the wrapper |
-| `scripts.repair._collect_issues` | `cmd_fix` / `cmd_scan` | CLI dispatch — keep as module-local seam |
-| `scripts.repair.find_orphaned_downloads` | `_collect_issues` | Mid-tier — could be kwarg DI |
-
-For each candidate that could be kwarg DI, prototype the change in a single tests/file pair, measure how the test reads vs the module-attribute version, and decide. Mid-tier wins might be small but they're more architecturally honest.
-
-**Approach for each:**
-- Add a kwarg to the calling function with the seam fn as the default.
-- Update tests to pass the stub by value.
-- Remove the allowlist entry.
+Net: 2 allowlist entries cleared (the two mid-tier helpers in
+`scripts.repair`); 5 entries documented as intentional in-module DI
+seams (chain depth / argparse dispatch). The lib.download chain decision
+is recorded in the allowlist rationale comment to head off "why not
+kwarg DI here?" follow-up audits.
 
 ### Step 4 — `test_web_server.py` shared MagicMock harness (multi-PR effort)
 

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from typing import Any
+from typing import Any, Callable
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -121,9 +121,21 @@ def _blocked_processing_issue_type(detail: str) -> str:
     return "blocked_post_move"
 
 
-def _collect_issues(db: PipelineDB, slskd_host: str | None,
-                    slskd_key: str | None) -> list:
-    """Collect all issues: DB inconsistencies + optional orphaned downloads."""
+def _collect_issues(
+    db: PipelineDB,
+    slskd_host: str | None,
+    slskd_key: str | None,
+    *,
+    find_orphaned_fn: "Callable[..., list[OrphanInfo]]" = find_orphaned_downloads,
+    find_blocked_recovery_fn: "Callable[..., list[Any]]" = find_blocked_recovery_issues,
+) -> list:
+    """Collect all issues: DB inconsistencies + optional orphaned downloads.
+
+    The two ``find_*_fn`` kwargs are dependency-injection seams. Production
+    leaves them at their default (the imported helpers); tests pass stubs
+    to drive each branch without going through real slskd / filesystem
+    fixtures.
+    """
     rows = _get_all_rows(db)
     issues = find_inconsistencies(rows)
     if slskd_host and slskd_key:
@@ -133,7 +145,7 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
             print(f"  slskd: could not check orphans: {e}")
             return _dedupe_issues(issues)
 
-        orphans = find_orphaned_downloads(
+        orphans = find_orphaned_fn(
             rows,
             active,
             existing_local_paths=None,
@@ -182,7 +194,7 @@ def _collect_issues(db: PipelineDB, slskd_host: str | None,
                     issue_type="blocked_recovery",
                     detail=issue.detail,
                 )
-                for issue in find_blocked_recovery_issues(
+                for issue in find_blocked_recovery_fn(
                     rows,
                     active,
                     staging_dir=cfg.beets_staging_dir,

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -329,16 +329,13 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^lib\.download\.process_completed_album$"),
     re.compile(r"^lib\.download\._process_beets_validation$"),
 
-    # ``scripts.repair`` in-module DI seams. The repair CLI orchestrates
-    # ``_collect_issues`` (aggregates orphan/recovery checks) which
-    # internally calls ``find_orphaned_downloads`` (from ``lib.quality``)
-    # and ``find_blocked_recovery_issues`` (from ``lib.download_recovery``)
-    # via local imports. Tests stub the inner pieces to drive each
-    # branch of ``cmd_fix`` / ``cmd_scan`` without setting up real
-    # orphan fixtures. Same module-local DI shape as ``lib.download``.
+    # ``scripts.repair._collect_issues`` is the argparse-dispatched CLI
+    # aggregator (``cmd_fix`` / ``cmd_scan`` call it without an injection
+    # path). The orphan and blocked-recovery helpers it composes are
+    # injected via kwarg DI (``find_orphaned_fn`` / ``find_blocked_recovery_fn``);
+    # tests pass stubs by value, so only ``_collect_issues`` itself
+    # retains the module-local seam shape.
     re.compile(r"^scripts\.repair\._collect_issues$"),
-    re.compile(r"^scripts\.repair\.find_orphaned_downloads$"),
-    re.compile(r"^scripts\.repair\.find_blocked_recovery_issues$"),
 
     # Service-class constructor replacement. ``MbidReplaceService`` is
     # the operator's MBID-replace surface (CLI + web route both wrap

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -143,7 +143,6 @@ class TestCollectIssues(unittest.TestCase):
             stdout.getvalue(),
         )
 
-    @patch("scripts.repair.find_orphaned_downloads")
     @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
     @patch("scripts.repair.read_runtime_config", side_effect=RuntimeError("cfg boom"))
     @patch("scripts.repair._get_all_rows", return_value=[])
@@ -152,9 +151,8 @@ class TestCollectIssues(unittest.TestCase):
         _mock_get_rows,
         _mock_read_runtime_config,
         _mock_active_transfers,
-        mock_find_orphaned,
     ) -> None:
-        mock_find_orphaned.return_value = [
+        orphans = [
             OrphanInfo(
                 request_id=17,
                 issue_type="orphaned_download",
@@ -168,6 +166,7 @@ class TestCollectIssues(unittest.TestCase):
                 MagicMock(),
                 slskd_host="http://slskd",
                 slskd_key="secret",
+                find_orphaned_fn=lambda rows, active, existing_local_paths=None: orphans,
             )
 
         self.assertEqual(len(issues), 1)
@@ -177,12 +176,10 @@ class TestCollectIssues(unittest.TestCase):
             stdout.getvalue(),
         )
 
-    @patch("scripts.repair.find_blocked_recovery_issues", return_value=[])
     @patch(
         "scripts.repair.find_blocked_processing_path_issues",
         side_effect=PermissionError("perm boom"),
     )
-    @patch("scripts.repair.find_orphaned_downloads")
     @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
     @patch("scripts.repair.read_runtime_config")
     @patch("scripts.repair._get_all_rows", return_value=[])
@@ -191,15 +188,13 @@ class TestCollectIssues(unittest.TestCase):
         _mock_get_rows,
         mock_read_runtime_config,
         _mock_active_transfers,
-        mock_find_orphaned,
         _mock_find_blocked_processing,
-        _mock_find_blocked_recovery,
     ) -> None:
         mock_read_runtime_config.return_value = SimpleNamespace(
             beets_staging_dir="/tmp/staging",
             slskd_download_dir="/tmp/downloads",
         )
-        mock_find_orphaned.return_value = [
+        orphans = [
             OrphanInfo(
                 request_id=17,
                 issue_type="orphaned_download",
@@ -213,6 +208,8 @@ class TestCollectIssues(unittest.TestCase):
                 MagicMock(),
                 slskd_host="http://slskd",
                 slskd_key="secret",
+                find_orphaned_fn=lambda rows, active, existing_local_paths=None: orphans,
+                find_blocked_recovery_fn=lambda *args, **kwargs: [],
             )
 
         self.assertEqual(len(issues), 1)


### PR DESCRIPTION
Step 3 of cleanup-phase issue #333.

## Summary
- `scripts.repair._collect_issues` now accepts `find_orphaned_fn` and `find_blocked_recovery_fn` kwarg-DI seams. Tests pass stubs by value; the two allowlist entries are removed.
- The `lib.download` chain (poll → completion → validation → handle → dispatch) keeps its module-local DI seams. Chain is 5 levels deep and threading a kwarg from the poller down to each inner seam cascades for negligible win. Decision documented in the audit-scanner rationale and the cleanup-phase resume doc.

## Decisions per candidate
| Allowlist entry | Caller | Decision |
|-----------------|--------|----------|
| `lib.download._handle_valid_result` | `process_completed_album` | Keep — 5-level chain |
| `lib.download._process_beets_validation` | `process_completed_album` | Keep — same chain |
| `lib.download.process_completed_album` | `poll_active_downloads` | Keep — stateful poller |
| `lib.download.dispatch_import_core` | `_handle_valid_result` | Keep — already provides `quality_gate_fn` kwarg DI |
| `scripts.repair._collect_issues` | `cmd_fix` / `cmd_scan` | Keep — argparse dispatch |
| `scripts.repair.find_orphaned_downloads` | `_collect_issues` | **Converted to kwarg DI** |
| `scripts.repair.find_blocked_recovery_issues` | `_collect_issues` | **Converted to kwarg DI** |

## Test plan
- [x] `nix-shell --run \"python3 -m unittest tests.test_repair_cli tests.test_mock_audit\"` — green
- [x] `nix-shell --run \"bash scripts/run_tests.sh\"` — 3700/3700 green
- [x] `nix-shell --run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)