### PR TITLE
test(mock-cleanup): kwarg DI on check_for_match — clears deferred items A & J

### DIFF
--- a/lib/matching.py
+++ b/lib/matching.py
@@ -6,7 +6,7 @@ import difflib
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, Sequence, TYPE_CHECKING
+from typing import Any, Callable, Sequence, TYPE_CHECKING
 
 from lib.browse import (
     _browse_directories_for_ctx,
@@ -321,6 +321,9 @@ def check_for_match(
     file_dirs: list[str],
     username: str,
     ctx: CratediggerContext,
+    *,
+    album_match_fn: "Callable[..., Any] | None" = None,
+    cross_check_fn: "Callable[..., bool] | None" = None,
 ) -> MatchResult:
     """Check candidate directories for an album match.
 
@@ -331,7 +334,23 @@ def check_for_match(
     on filename ratio but failed `_track_titles_cross_check` (full score
     plus a negative_matches entry). U5 persists `candidates` to
     `search_log.candidates` for forensic introspection.
+
+    ``album_match_fn`` and ``cross_check_fn`` are dependency-injection
+    seams. Production callers leave them at their defaults (the
+    module-level :func:`album_match` and :func:`_track_titles_cross_check`);
+    tests pass stubs by value to exercise the try/finally credit
+    accumulator on exception and the cross-check-failure candidate path
+    without constructing inputs that happen to land in the right
+    rejection bucket. Both default to ``None`` so the function resolves
+    to the live module-level binding at call time — keeps the seam
+    cheap when callers don't override.
     """
+    _album_match: Callable[..., Any] = (
+        album_match_fn if album_match_fn is not None else album_match
+    )
+    _cross_check: Callable[..., bool] = (
+        cross_check_fn if cross_check_fn is not None else _track_titles_cross_check
+    )
     candidates: list[CandidateScore] = []
     pre_filter_skip_count = 0
     pre_filter_skip_samples_emitted = 0
@@ -496,7 +515,7 @@ def check_for_match(
 
             # Count gate passed — score the dir.
             score_files = _audio_files_for_filetype(directory, allowed_filetype)
-            score = album_match(tracks, score_files, username, allowed_filetype, ctx)
+            score = _album_match(tracks, score_files, username, allowed_filetype, ctx)
             candidates.append(CandidateScore(
                 username=username,
                 dir=file_dir,
@@ -513,7 +532,7 @@ def check_for_match(
                 and username not in ctx.cfg.ignored_users
             )
             if strict_accept:
-                if _track_titles_cross_check(tracks, score_files):
+                if _cross_check(tracks, score_files):
                     # Log SUCCESSFUL MATCH at the one place enqueue is going
                     # to happen — the previous log site in album_match fired
                     # before the cross-check / ignored_users gate at the

--- a/tests/mock_audit_baseline.json
+++ b/tests/mock_audit_baseline.json
@@ -1,8 +1,1 @@
-{
-  "test_cycle_summary.py": {
-    "patch:lib.matching.album_match": 1
-  },
-  "test_matching.py": {
-    "patch:lib.matching._track_titles_cross_check": 1
-  }
-}
+{}

--- a/tests/test_cycle_summary.py
+++ b/tests/test_cycle_summary.py
@@ -204,14 +204,26 @@ class TestMatchTimeAccumulator(unittest.TestCase):
     def test_match_time_credited_when_album_match_raises(self):
         """An exception inside the matching loop must still credit
         match_time_s (try/finally contract). Regression guard for the
-        pre-fix bug where two += sites silently dropped time on raise."""
+        pre-fix bug where two += sites silently dropped time on raise.
+
+        Uses the ``album_match_fn`` kwarg DI on ``check_for_match`` to
+        inject an exception-raising stub. The production code path
+        runs through the same try/finally accumulator as a real
+        ``album_match`` call would.
+        """
         ctx = _make_real_ctx()
         self._seed_cache(ctx, "dirA", [
             _file("Alpha.flac"), _file("Bravo.flac"), _file("Charlie.flac"),
         ])
-        with patch("lib.matching.album_match", side_effect=RuntimeError("boom")):
-            with self.assertRaises(RuntimeError):
-                check_for_match(self.TRACKS, "flac", ["dirA"], self.USERNAME, ctx)
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            check_for_match(
+                self.TRACKS, "flac", ["dirA"], self.USERNAME, ctx,
+                album_match_fn=_boom,
+            )
         self.assertGreater(
             ctx.match_time_s, 0.0,
             "exception inside matching loop must still credit match_time_s",

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -478,24 +478,19 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
         self.assertEqual(candidates[0].matched_tracks, 0)
 
     def test_cross_check_failure_continues_loop_and_records_score(self) -> None:
-        """When _track_titles_cross_check fails, dir is added to negative_matches
+        """When the title cross-check fails, dir is added to negative_matches
         and the score is still appended to candidates so the forensic record
-        captures the cross-check rejection."""
-        # Files match the count gate but titles are wildly different — cross-check
-        # tolerates 1/5 mismatch but here every title is wrong, so cross-check fails.
-        # However, album_match's filename-ratio path happily accepts these because
-        # of separator/album-name retries... we need filenames that pass album_match
-        # filename ratio but fail _track_titles_cross_check. The cross-check uses
-        # _normalize_title + extracted-title fuzzy matching with 0.5 threshold.
-        # Easiest construction: tracks all named distinctly, files use those titles
-        # *embedded* but with very different content elsewhere.
-        # In practice, the strict-accept path is: all tracks above ratio AND
-        # cross-check passes. If the filenames are exact title matches, cross-check
-        # also passes — they're correlated. To force cross-check failure we need
-        # the album_match per-track ratios to clear minimum_match_ratio while the
-        # extracted-title fuzzy check fails.
-        # We achieve this with a low minimum_match_ratio so the strict accept path
-        # triggers, but slskd filenames are very long so extracted_title differs.
+        captures the cross-check rejection.
+
+        The strict-accept path is correlated: filenames that clear the
+        per-track ratio almost always also pass the extracted-title
+        fuzzy check, which makes constructing a real failing input
+        fragile. Use the ``cross_check_fn`` kwarg DI on
+        ``check_for_match`` to pass a stub that always returns False —
+        this exercises the failure branch directly without coupling
+        the test to whichever input shape happens to fail
+        ``_track_titles_cross_check`` today.
+        """
         cfg = _make_cfg(minimum_match_ratio=0.1)
         ctx = _make_ctx(cfg, album_id=1, album_title="Cool Album")
         ctx.folder_cache.setdefault(self.username, {})["dirX"] = {
@@ -506,24 +501,15 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
                 _file("Charlie.flac"),
             ],
         }
-        # Make tracks barely passing the filename ratio (>=0.1) but with names
-        # that differ enough for cross-check.
         tracks = [
             _track(1, "Alpha"),
             _track(1, "Bravo"),
             _track(1, "Charlie"),
         ]
-        # With identical filenames and titles, both will accept. To force cross-
-        # check failure we need filenames that pass album_match's per-track filename
-        # ratio but produce extracted titles that fail _track_titles_cross_check.
-        # In practice this means matching is tight — skip this case if cross-check
-        # ends up succeeding. The contract we care about: IF cross-check fails,
-        # THEN candidate is still appended. We test that contract by mocking.
-        from unittest.mock import patch
-        with patch("lib.matching._track_titles_cross_check", return_value=False):
-            result = check_for_match(
-                tracks, "flac", ["dirX"], self.username, ctx,
-            )
+        result = check_for_match(
+            tracks, "flac", ["dirX"], self.username, ctx,
+            cross_check_fn=lambda *_args, **_kwargs: False,
+        )
         self.assertFalse(self._matched(result))
         candidates = self._candidates(result)
         self.assertEqual(len(candidates), 1)


### PR DESCRIPTION
Clears the two remaining baseline-grandfathered findings (items A and J from the prior cleanup phase).

## Summary
- Adds two opt-in DI kwargs to \`lib.matching.check_for_match\`: \`album_match_fn\` and \`cross_check_fn\`. Both default to the module-level functions, so the public API at production call sites is unchanged.
- \`test_cycle_summary.py::test_match_time_credited_when_album_match_raises\` (item J): injects a raise via \`album_match_fn=_boom\` instead of \`patch(\"lib.matching.album_match\")\`. Same try/finally credit contract is exercised.
- \`test_matching.py::test_cross_check_failure_continues_loop_and_records_score\` (item A): passes \`cross_check_fn=lambda *_: False\` to drive the cross-check-failure branch directly. The prior test had a long comment explaining why constructing a real failing input was fragile — the kwarg seam makes that comment obsolete.

## Mock-audit baseline
**Before:** 2 findings across 2 files
**After:** **0 findings across 0 files**

## Test plan
- [x] \`nix-shell --run \"python3 -m unittest tests.test_matching tests.test_cycle_summary tests.test_mock_audit\"\` — green
- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)