### PR TITLE
test(mock-cleanup): kwarg DI on the lib.download chain + dedupe allowlist

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -1091,6 +1091,9 @@ def process_completed_album(
     ctx: CratediggerContext,
     *,
     import_job_id: int | None = None,
+    validate_fn: "Callable[..., DispatchOutcome | None] | None" = None,
+    handle_valid_fn: "Callable[..., DispatchOutcome | None] | None" = None,
+    dispatch_fn: "Callable[..., DispatchOutcome | None] | None" = None,
 ) -> "bool | DispatchOutcome | None":
     """Process a fully-downloaded album: move files, tag, validate, stage/import.
 
@@ -1127,11 +1130,14 @@ def process_completed_album(
         except Exception:
             logger.exception(f"Error writing tags for: {file.import_path}")
     if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
-        outcome = _process_beets_validation(
+        _validate = validate_fn if validate_fn is not None else _process_beets_validation
+        outcome = _validate(
             album_data,
             staged_album,
             ctx,
             import_job_id=import_job_id,
+            handle_valid_fn=handle_valid_fn,
+            dispatch_fn=dispatch_fn,
         )
         if outcome is not None:
             if outcome.deferred:
@@ -1153,6 +1159,8 @@ def _process_beets_validation(
     ctx: CratediggerContext,
     *,
     import_job_id: int | None = None,
+    handle_valid_fn: "Callable[..., DispatchOutcome | None] | None" = None,
+    dispatch_fn: "Callable[..., DispatchOutcome | None] | None" = None,
 ) -> "DispatchOutcome | None":
     """Beets validation sub-path of process_completed_album.
 
@@ -1277,13 +1285,17 @@ def _process_beets_validation(
                     bv_result.matched_bad_track_path = measurement.matched_bad_track_path
 
     if bv_result.valid:
-        return _handle_valid_result(
+        _handle_valid = (
+            handle_valid_fn if handle_valid_fn is not None else _handle_valid_result
+        )
+        return _handle_valid(
             album_data,
             bv_result,
             staged_album,
             ctx,
             import_job_id=import_job_id,
             prevalidated_candidate_result=candidate_evidence_result,
+            dispatch_fn=dispatch_fn,
         )
     return _handle_rejected_result(
         album_data,
@@ -1421,6 +1433,7 @@ def _handle_valid_result(
     import_job_id: int | None = None,
     prevalidated_candidate_result: CandidateEvidenceActionResult | None = None,
     quality_gate_fn: QualityGateFn | None = None,
+    dispatch_fn: "Callable[..., DispatchOutcome | None] | None" = None,
 ) -> "DispatchOutcome | None":
     """Handle a valid beets validation result: stage and optionally auto-import.
 
@@ -1610,7 +1623,8 @@ def _handle_valid_result(
             )
             if quality_gate_fn is not None:
                 core_kwargs["quality_gate_fn"] = quality_gate_fn
-            return dispatch_import_core(**core_kwargs)
+            _dispatch = dispatch_fn if dispatch_fn is not None else dispatch_import_core
+            return _dispatch(**core_kwargs)
         ctx.pipeline_db_source.mark_done(
             album_data, bv_result, dest_path=dest, download_info=dl_info)
         return None
@@ -2104,8 +2118,19 @@ def _run_completed_processing(
     ctx: CratediggerContext,
     *,
     import_job_id: int | None = None,
+    process_album_fn: "Callable[..., bool | DispatchOutcome | None] | None" = None,
 ) -> bool | DispatchOutcome | None:
-    """Run or resume local post-download processing for a completed album."""
+    """Run or resume local post-download processing for a completed album.
+
+    ``process_album_fn`` is an opt-in DI seam for tests that exercise the
+    outer transition flow without going through the full
+    ``process_completed_album`` body. Defaults to the real production
+    function so callers in ``scripts/importer.py`` are unchanged.
+    """
+    _process = (
+        process_album_fn if process_album_fn is not None else process_completed_album
+    )
+
     if state.processing_started_at is None:
         if entry.import_folder is None:
             entry.import_folder = _canonical_import_folder_path(
@@ -2116,7 +2141,7 @@ def _run_completed_processing(
         _persist_updated_download_state(db, request_id, entry, state)
 
     try:
-        outcome = process_completed_album(
+        outcome = _process(
             entry,
             [],
             ctx,

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -209,22 +209,6 @@ _LEAF_SEAM_PATTERNS = [
     # Album-level spectral analysis — same sox/ffmpeg seam as
     # analyze_track, just aggregating across an album's tracks.
     re.compile(r"^lib\.spectral_check\.analyze_album$"),
-    re.compile(r"^harness\.import_one\.fix_library_modes$"),
-
-    # harness.import_one subprocess wrappers. ``run_import`` invokes
-    # ``beet import``; ``convert_lossless`` runs ffmpeg; the probe
-    # helpers run ffprobe/sox; ``_get_folder_*`` read tag metadata.
-    re.compile(r"^harness\.import_one\.run_import$"),
-    re.compile(r"^harness\.import_one\.convert_lossless$"),
-    re.compile(r"^harness\.import_one\._probe_lossless_source_as_v0$"),
-    re.compile(r"^harness\.import_one\._probe_native_lossy_as_v0$"),
-    re.compile(r"^harness\.import_one\._get_folder_bitrates$"),
-    re.compile(r"^harness\.import_one\._get_folder_min_bitrate$"),
-    re.compile(r"^harness\.import_one\.BeetsDB$"),  # class replacement, see lib.beets_db.BeetsDB
-
-    # Album-level spectral analysis — same sox/ffmpeg seam as
-    # analyze_track, just aggregating across an album's tracks.
-    re.compile(r"^lib\.spectral_check\.analyze_album$"),
 
     # Logger objects — patching the module-level logger lets tests
     # assert against log records without subclassing the logger. Also
@@ -255,7 +239,9 @@ _LEAF_SEAM_PATTERNS = [
     # that can be exercised against a real test SQLite DB.
     re.compile(r"^lib\.beets_db\.BeetsDB$"),
     re.compile(r"^lib\.beets_db\.BeetsDB\.delete_album$"),  # SQLite write + file delete seam
-    re.compile(r"^web\.server\._real_beets_db$"),
+    # ``web.server._real_beets_db`` is already covered by the broader
+    # ``^web\.server\.(...|_real_beets_db|...)`` pattern higher up
+    # (MusicBrainz / Discogs / beets module-level boundaries).
 
     # PipelineDB class itself — patching the class replaces the
     # PostgreSQL boundary at the constructor. Per-method patches against
@@ -316,18 +302,15 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^scripts\.pipeline_cli\.finalize_request$"),
     re.compile(r"^scripts\.repair\.finalize_request$"),
 
-    # ``lib.download`` in-module DI seams. ``lib.download.poll_active_downloads``
-    # calls ``process_completed_album`` (same module) which calls
-    # ``_process_beets_validation`` (same module) which calls
-    # ``dispatch_import_core`` (re-imported from ``lib.import_dispatch``).
-    # Tests that exercise the poll / completion / dispatch decision tree
-    # stub the inner step on its ``lib.download`` binding rather than
-    # restructuring every chain to take dependency kwargs. ``Dispatch
-    # decisions live in ONE place'' — these are seams for testing the
-    # caller's wrapper logic, not parallel decision paths.
-    re.compile(r"^lib\.download\.dispatch_import_core$"),
-    re.compile(r"^lib\.download\.process_completed_album$"),
-    re.compile(r"^lib\.download\._process_beets_validation$"),
+    # ``lib.download`` formerly had module-local DI seams for the chain
+    # ``poll_active_downloads`` → ``process_completed_album`` →
+    # ``_process_beets_validation`` → ``_handle_valid_result`` →
+    # ``dispatch_import_core``. The chain now exposes opt-in kwarg DI
+    # (``validate_fn``, ``handle_valid_fn``, ``dispatch_fn``) on each
+    # downstream step; tests pass stubs by value. Defensive guards
+    # against future regressions assert on observable state (no new
+    # ``import_jobs`` row, no ``download_log`` entry) rather than
+    # patching the production binding.
 
     # ``scripts.repair._collect_issues`` is the argparse-dispatched CLI
     # aggregator (``cmd_fix`` / ``cmd_scan`` call it without an injection
@@ -353,10 +336,8 @@ _LEAF_SEAM_PATTERNS = [
     # tests; queue tests are about the dispatcher around it.
     re.compile(r"^scripts\.import_preview_worker\.run_once$"),
 
-    # In-module DI seam for ``_handle_valid_result`` (defined in
-    # ``lib.download``). Same module-local DI shape as
-    # ``lib.download.process_completed_album`` etc.
-    re.compile(r"^lib\.download\._handle_valid_result$"),
+    # ``lib.download._handle_valid_result`` migrated to kwarg DI alongside
+    # the rest of the lib.download chain (see comment above).
 
     # Broadened ``resolve_failed_path`` re-export allowlist. The pattern
     # already covers ``web.routes.*`` re-exports; ``lib.wrong_matches``

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1197,12 +1197,10 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             result = process_completed_album(album, [], ctx)
             self.assertTrue(result)
 
-    @patch("lib.download._process_beets_validation")
     @patch("lib.download.music_tag")
     def test_dispatch_outcome_summary_is_returned_to_queue_owner(
         self,
         mock_mt,
-        mock_validation,
     ):
         """Auto-import summaries must survive for the importer queue result."""
         from lib.download import process_completed_album
@@ -1223,15 +1221,22 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = True
             mock_mt.load_file.return_value = MagicMock()
-            mock_validation.return_value = DispatchOutcome(
+            stub_outcome = DispatchOutcome(
                 success=True,
                 message="Import successful",
             )
+            validate_calls: list[dict] = []
 
-            result = process_completed_album(album, [], ctx)
+            def _stub_validate(*args, **kwargs):
+                validate_calls.append(kwargs)
+                return stub_outcome
 
-            self.assertIs(result, mock_validation.return_value)
-            mock_validation.assert_called_once()
+            result = process_completed_album(
+                album, [], ctx, validate_fn=_stub_validate,
+            )
+
+            self.assertIs(result, stub_outcome)
+            self.assertEqual(len(validate_calls), 1)
 
     @patch("lib.beets.beets_validate")
     @patch("lib.download.music_tag")
@@ -1497,12 +1502,15 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 filetype_band="mp3",
             )
 
-            with patch("lib.download.dispatch_import_core") as mock_dispatch, \
-                 self.assertLogs("cratedigger", level="ERROR") as logs:
-                result = process_completed_album(album, [], ctx)
+            dispatch_calls: list[dict] = []
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(
+                    album, [], ctx,
+                    dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
+                )
 
             self.assertIsNone(result)
-            mock_dispatch.assert_not_called()
+            self.assertEqual(dispatch_calls, [])
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
     @patch("lib.download.music_tag")
@@ -1679,9 +1687,12 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 auto_import=True,
             )
 
-            with patch("lib.download.dispatch_import_core") as mock_dispatch, \
-                 self.assertLogs("cratedigger", level="ERROR") as logs:
-                result = process_completed_album(album, [], ctx)
+            dispatch_calls: list[dict] = []
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(
+                    album, [], ctx,
+                    dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
+                )
 
             from lib.import_dispatch import DispatchOutcome
             assert isinstance(result, DispatchOutcome)
@@ -1697,7 +1708,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertTrue(os.path.isfile(
                 os.path.join(failed_path, "01 - Track.mp3")))
             self.assertFalse(os.path.exists(unexpected_staged))
-            mock_dispatch.assert_not_called()
+            self.assertEqual(dispatch_calls, [])
             self.assertEqual(db.request(1)["status"], "wanted")
             self.assertEqual(db.recorded_attempts, [(1, "validation")])
             self.assertEqual(len(db.download_logs), 1)
@@ -1917,13 +1928,16 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 filetype_band="mp3",
             )
 
-            with patch("lib.download.dispatch_import_core") as mock_dispatch, \
-                 self.assertLogs("cratedigger", level="ERROR") as logs:
-                result = process_completed_album(album, [], ctx)
+            dispatch_calls: list[dict] = []
+            with self.assertLogs("cratedigger", level="ERROR") as logs:
+                result = process_completed_album(
+                    album, [], ctx,
+                    dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
+                )
 
             self.assertIsNone(result)
             mock_beets_validate.assert_not_called()
-            mock_dispatch.assert_not_called()
+            self.assertEqual(dispatch_calls, [])
             self.assertIn("legacy shared staged path", "\n".join(logs.output))
 
     @patch("lib.download.measure_preimport_state")
@@ -1986,11 +2000,14 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 filetype_band="mp3",
             )
 
-            with patch("lib.download.dispatch_import_core") as mock_dispatch:
-                result = process_completed_album(album, [], ctx)
+            dispatch_calls: list[dict] = []
+            result = process_completed_album(
+                album, [], ctx,
+                dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
+            )
 
             self.assertTrue(result)
-            mock_dispatch.assert_not_called()
+            self.assertEqual(dispatch_calls, [])
             source = ctx.pipeline_db_source
             assert isinstance(source, FakePipelineDBSource)
             self.assertEqual(len(source.mark_done_calls), 1)
@@ -2942,9 +2959,14 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.request(1)["status"], "wanted")
         self.assertEqual(fake_db.status_history, [(1, "wanted")])
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_all_errors(self, mock_process):
-        """All files errored → timeout the album."""
+    def test_poll_active_all_errors(self):
+        """All files errored → timeout the album.
+
+        ``poll_active_downloads`` enqueues an import job rather than
+        calling ``process_completed_album`` directly, so the absence of a
+        new ``import_jobs`` row is the observable contract for "no
+        downstream processing started".
+        """
         from lib.download import poll_active_downloads
         row = self._make_downloading_row()
         ctx, fake_db = self._make_poll_ctx(
@@ -2963,7 +2985,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         with patch("lib.download.cancel_and_delete"):
             poll_active_downloads(ctx)
 
-        mock_process.assert_not_called()
+        self.assertEqual(fake_db._import_jobs, [])
         fake_db.assert_log(self, 0, outcome="timeout")
         self.assertEqual(fake_db.request(1)["status"], "wanted")
 
@@ -3041,9 +3063,13 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.update_download_state_calls, [])
         self.assertEqual(fake_db.request(1)["status"], "downloading")
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_transfer_vanished_partial(self, mock_process):
-        """7/12 files vanish → treated as errors, not complete."""
+    def test_poll_transfer_vanished_partial(self):
+        """7/12 files vanish → treated as errors, not complete.
+
+        ``poll_active_downloads`` only kicks off downstream processing
+        via the import-job queue, so the assertions below check the
+        observable contract (no new import_jobs row, no download_log).
+        """
         from lib.download import poll_active_downloads
         # 12 files, only 5 have transfers in slskd
         files = []
@@ -3079,7 +3105,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             poll_active_downloads(ctx)
 
         # Should NOT process — 7 files vanished (errored), album not complete
-        mock_process.assert_not_called()
+        self.assertEqual(fake_db._import_jobs, [])
         self.assertEqual(
             "\n".join(logs.output).count("Failed to re-enqueue file"),
             7,
@@ -3090,8 +3116,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.request(1)["status"], "downloading")
 
 
-    @patch("lib.download.process_completed_album")
-    def test_poll_active_partial_errors_with_retry(self, mock_process):
+    def test_poll_active_partial_errors_with_retry(self):
         """Some files errored, retries available → re-enqueue those files."""
         from lib.download import poll_active_downloads
         # 3 files: 2 complete, 1 errored
@@ -3150,7 +3175,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             poll_active_downloads(ctx)
 
         # Should NOT process (not all done) and NOT timeout
-        mock_process.assert_not_called()
+        self.assertEqual(fake_db._import_jobs, [])
         self.assertEqual(fake_db.download_logs, [])
         # Should re-enqueue the errored file
         self.assertEqual(len(slskd.transfers.enqueue_calls), 1)

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -228,25 +228,31 @@ class TestAutomationEvidenceReuse(unittest.TestCase):
             )
             staged_album = StagedAlbum(current_path=tmpdir, request_id=42)
 
+            handle_valid_calls: list[tuple] = []
+
+            def _record_handle_valid(*args, **kwargs):
+                handle_valid_calls.append((args, kwargs))
+                return None
+
             with patch("lib.beets.beets_validate", return_value=ValidationResult(
                 valid=True,
                 distance=0.05,
                 scenario="strong_match",
             )), \
-                 patch("lib.download.measure_preimport_state") as gates, \
-                 patch("lib.download._handle_valid_result") as handle_valid:
+                 patch("lib.download.measure_preimport_state") as gates:
                 result = _process_beets_validation(
                     album_data,
                     staged_album,
                     ctx,
                     import_job_id=job.id,
+                    handle_valid_fn=_record_handle_valid,
                 )
 
         assert result is not None
         self.assertFalse(result.success)
         self.assertIn("Candidate quality evidence unavailable", result.message)
         gates.assert_not_called()
-        handle_valid.assert_not_called()
+        self.assertEqual(handle_valid_calls, [])
 
 
 class TestImporterWorker(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2249,8 +2249,8 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
 
         # The staged move and dispatch MUST NOT run on contention.
         import_folder_fullpath = "/tmp/test-import-folder"
-        with patch.object(dl_mod.StagedAlbum, "move_to") as mock_move, \
-             patch.object(dl_mod, "dispatch_import_core") as mock_dispatch:
+        dispatch_calls: list[dict] = []
+        with patch.object(dl_mod.StagedAlbum, "move_to") as mock_move:
             outcome = dl_mod._handle_valid_result(
                 entry,
                 bv_result,
@@ -2259,6 +2259,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
                     request_id=42,
                 ),
                 ctx,
+                dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
             )
 
         assert outcome is not None
@@ -2268,7 +2269,7 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         # import_folder_fullpath where process_completed_album's
         # resume guard can pick them up next cycle.
         mock_move.assert_not_called()
-        mock_dispatch.assert_not_called()
+        self.assertEqual(dispatch_calls, [])
 
     def test_redownload_path_does_not_take_release_lock(self):
         """Redownload path (source != 'request') must NOT take the
@@ -2558,10 +2559,10 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             id=42, status="downloading",
             current_spectral_grade="genuine",
             current_spectral_bitrate=245))
-        with patch.object(dl_mod, "process_completed_album",
-                          return_value=None):
-            dl_mod._run_completed_processing(
-                self._entry(), 42, self._state(), db, self._ctx(db))
+        dl_mod._run_completed_processing(
+            self._entry(), 42, self._state(), db, self._ctx(db),
+            process_album_fn=lambda *_a, **_kw: None,
+        )
         self.assertEqual(db.request(42)["status"], "downloading")
         # Spectral untouched.
         self.assertEqual(
@@ -2576,10 +2577,10 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         from lib import download as dl_mod
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
-        with patch.object(dl_mod, "process_completed_album",
-                          return_value=True):
-            dl_mod._run_completed_processing(
-                self._entry(), 42, self._state(), db, self._ctx(db))
+        dl_mod._run_completed_processing(
+            self._entry(), 42, self._state(), db, self._ctx(db),
+            process_album_fn=lambda *_a, **_kw: True,
+        )
         self.assertEqual(db.request(42)["status"], "imported")
 
     def test_false_outcome_resets_to_wanted_with_attempt(self):
@@ -2589,10 +2590,10 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         from lib import download as dl_mod
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
-        with patch.object(dl_mod, "process_completed_album",
-                          return_value=False):
-            dl_mod._run_completed_processing(
-                self._entry(), 42, self._state(), db, self._ctx(db))
+        dl_mod._run_completed_processing(
+            self._entry(), 42, self._state(), db, self._ctx(db),
+            process_album_fn=lambda *_a, **_kw: False,
+        )
         self.assertEqual(db.request(42)["status"], "wanted")
 
     def test_false_outcome_after_inner_rejection_does_not_double_transition(self):
@@ -2615,18 +2616,14 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             )
             return False
 
-        with patch.object(
-            dl_mod,
-            "process_completed_album",
-            side_effect=reject_inside_process,
-        ):
-            dl_mod._run_completed_processing(
-                self._entry(),
-                42,
-                self._state(),
-                db,
-                self._ctx(db),
-            )
+        dl_mod._run_completed_processing(
+            self._entry(),
+            42,
+            self._state(),
+            db,
+            self._ctx(db),
+            process_album_fn=reject_inside_process,
+        )
 
         self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(db.status_history, [(42, "wanted")])


### PR DESCRIPTION
Drops four more allowlist entries via kwarg DI and removes 12 lines of duplicate scanner config.

## kwarg DI surface
- \`_handle_valid_result(..., *, dispatch_fn=None)\`
- \`_process_beets_validation(..., *, handle_valid_fn=None, dispatch_fn=None)\`
- \`process_completed_album(..., *, validate_fn=None, handle_valid_fn=None, dispatch_fn=None)\`
- \`_run_completed_processing(..., *, process_album_fn=None)\`

All defaults preserve production behaviour; \`scripts/importer.py\` and internal forwarders pass no new kwargs.

## Test migrations
- \`tests/test_download.py\` (9 sites): the 4 dispatch defensive patches use \`dispatch_fn=\`; the 1 \`_process_beets_validation\` stub uses \`validate_fn=\`; the 3 \`process_completed_album\` defensive guards become observable assertions on \`fake_db._import_jobs == []\` (the patch was always trivially-not-called — \`poll_active_downloads\` enqueues a job, never calls \`process_completed_album\` directly).
- \`tests/test_import_queue.py\` (1 site): records \`handle_valid_fn\` calls inline.
- \`tests/test_integration_slices.py\` (4 sites): one \`_handle_valid_result\` site uses \`dispatch_fn=\`; three \`_run_completed_processing\` outer-transition tests use \`process_album_fn=\`.

## Allowlist cleanup
- Removes the 4 \`lib.download\` in-module DI entries.
- Deletes the 12-line duplicate block (lines 196-211 = 212-227).
- Removes redundant narrow \`^web\\.server\\._real_beets_db\$\` (already covered by the broader server-boundary pattern).

## Mock-audit baseline
Holds at **0** findings.

## Test plan
- [x] \`nix-shell --run \"python3 -m unittest tests.test_download tests.test_import_queue tests.test_integration_slices tests.test_mock_audit\"\` — green
- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3700/3700 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)