### PR TITLE
feat(web): Pydantic for HTTP request bodies — first slice

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -65,6 +65,51 @@ Call the full pipeline.
 - Inner data structures must also be typed — no `list[dict]` when a dataclass exists
 - Verify with: `pyright <files>` on every touched file before committing
 
+## HTTP request bodies — use `pydantic.BaseModel`
+
+Inbound HTTP request bodies in `web/routes/*.py` are an external, untrusted boundary. They get validated with `pydantic.BaseModel` (Pydantic v2) at the handler entry. Pydantic stops at the route layer; everything internal stays `msgspec.Struct` / `@dataclass` per the next section.
+
+Why Pydantic and not msgspec at this seam:
+- `ValidationError.errors()` gives structured field-path errors, which the route returns as JSON so the frontend can show real messages.
+- The `*Request` model declared above the handler is the operator-facing contract — the request shape is visible without reading the parsing code.
+
+Pattern (canonical: `post_pipeline_add` in `web/routes/pipeline.py`):
+
+```python
+from pydantic import BaseModel, ValidationError, model_validator
+
+class PipelineAddRequest(BaseModel):
+    mb_release_id: str | None = None
+    discogs_release_id: str | None = None
+    source: str = "request"
+
+    @model_validator(mode="after")
+    def _at_least_one_id(self):
+        if not self.mb_release_id and not self.discogs_release_id:
+            raise ValueError("Missing mb_release_id or discogs_release_id")
+        return self
+
+def post_pipeline_add(h, body: dict) -> None:
+    payload = _parse_body(h, body, PipelineAddRequest)
+    if payload is None:
+        return
+    # payload.mb_release_id is typed; route logic uses it directly
+```
+
+`_parse_body` (defined in `web/routes/_pydantic.py`) is the single adapter that converts `ValidationError → 400` with `{"error": ..., "errors": [...]}`. Use it; do not catch `ValidationError` inline.
+
+Scope:
+- HTTP request bodies → Pydantic. That's it.
+- Internal types (msgspec wire boundaries, route response dicts, service-layer dataclasses) → unchanged.
+- Pydantic is NOT for query-string parsing yet — query strings stay hand-parsed for now (smaller surface, less win).
+- No response models — frontend depends on the existing JSON shape; routes still emit dicts via `h._json(...)`.
+
+When migrating an existing route:
+1. Declare the `*Request` model above the handler with the fields the existing code reads from `body`.
+2. Wrap entry with `payload = _parse_body(h, body, MyRequest); if payload is None: return`.
+3. Replace `body.get("x")` with `payload.x`.
+4. Existing tests should pass unchanged — preserve response shape and the 400-on-bad-input contract.
+
 ## Wire-boundary types — use `msgspec.Struct`, not `@dataclass`
 Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blob written to or read from the DB, a subprocess's stdout — is a `msgspec.Struct`. **Same policy both directions:** encode via `msgspec.json.encode` (or `msgspec.to_builtins` when a dict is needed), decode via `msgspec.convert`. The declared Struct is the single contract that validates type drift at the boundary. Pyright does not see inside `dict.get()` — only runtime validation catches int-vs-str drift, mis-typed fields, or missing required data. This is the lesson of issue #99 / PR #98 (every Discogs validation silently logged `mbid_not_found` because a dataclass said `str` but the wire carried `int`) and the pre-#141 asymmetry (the old "dataclass if re-encoded, Struct if decoded only" split let docstrings lie about which side was strict).
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@ let
     ps.psycopg2
     ps.music-tag
     ps.msgspec
+    ps.pydantic  # HTTP request-body validation in web/routes/* (issue #343); msgspec stays for internal wire boundaries
     ps.redis     # web UI cache (graceful no-op if redis server is down, but the module must be importable)
     ps.zstandard # peer cache compresses msgpack directory payloads before writing Redis bytes
     ps.beets     # beets.autotag.distance for /api/beets-distance — library import only

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -779,6 +779,16 @@ class TestServerEndpoints(unittest.TestCase):
         status, data = self._post("/api/pipeline/add", {})
         self.assertEqual(status, 400)
         self.assertIn("error", data)
+        # Pydantic adapter populates ``errors`` with structured field-path
+        # entries — the frontend uses ``loc`` + ``msg`` + ``type`` to
+        # render real validation messages instead of a single string.
+        self.assertIn("errors", data)
+        self.assertIsInstance(data["errors"], list)
+        self.assertTrue(data["errors"])
+        first = data["errors"][0]
+        self.assertIn("loc", first)
+        self.assertIn("msg", first)
+        self.assertIn("type", first)
 
     def test_post_pipeline_delete_missing_id(self):
         status, data = self._post("/api/pipeline/delete", {})

--- a/web/routes/_pydantic.py
+++ b/web/routes/_pydantic.py
@@ -1,0 +1,61 @@
+"""Shared Pydantic adapter for HTTP request-body validation.
+
+The single entry point is :func:`parse_body`, which validates a request
+body against a Pydantic ``BaseModel`` and routes ``ValidationError`` to
+the standard ``{"error": ..., "errors": [...]}`` HTTP 400 response.
+
+See ``.claude/rules/code-quality.md`` § "HTTP request bodies" for the
+boundary policy. This adapter is the only place ``ValidationError`` is
+handled; routes never catch it inline.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+
+M = TypeVar("M", bound=BaseModel)
+
+
+def parse_body(handler: Any, body: Any, model: Type[M]) -> M | None:
+    """Validate ``body`` against ``model``; on failure, send HTTP 400 and return None.
+
+    Returns the parsed model instance on success, or ``None`` after
+    sending the error response. Callers check ``if payload is None:
+    return`` and proceed against the typed payload otherwise.
+
+    The 400 status matches the existing route convention (hand-rolled
+    body parsers raised 400 on missing fields); using 400 preserves
+    every existing contract test that asserted ``status == 400`` for
+    bad input. ``ValidationError.errors(include_url=False)`` produces a
+    list of ``{"loc": [...], "msg": "...", "type": "..."}`` entries
+    that the frontend can render directly.
+    """
+    if not isinstance(body, dict):
+        handler._json(
+            {"error": "request body must be a JSON object", "errors": []},
+            status=400,
+        )
+        return None
+    try:
+        return model.model_validate(body)
+    except ValidationError as exc:
+        # ``include_context=False`` strips the ``ctx`` dict — Pydantic
+        # populates it with the raw ValueError / TypeError object for
+        # ``@model_validator`` errors, which the stdlib ``json`` encoder
+        # cannot serialise. ``include_input=False`` keeps the response
+        # compact (the frontend only needs ``loc`` + ``msg`` + ``type``).
+        handler._json(
+            {
+                "error": "validation failed",
+                "errors": exc.errors(
+                    include_url=False,
+                    include_context=False,
+                    include_input=False,
+                ),
+            },
+            status=400,
+        )
+        return None

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -4,7 +4,11 @@ import json
 import logging
 import re
 from pathlib import Path
+
 import msgspec
+from pydantic import BaseModel, Field, model_validator
+
+from web.routes._pydantic import parse_body
 
 logger = logging.getLogger(__name__)
 
@@ -1298,15 +1302,35 @@ def get_import_job(h, params: dict[str, list[str]], job_id_str: str) -> None:
 # ── POST handlers ────────────────────────────────────────────────
 
 
-def post_pipeline_add(h, body: dict) -> None:
-    s = _server()
-    mbid = normalize_release_id(body.get("mb_release_id"))
-    discogs_id = normalize_release_id(body.get("discogs_release_id"))
-    source = body.get("source", "request")
+class PipelineAddRequest(BaseModel):
+    """HTTP body for ``POST /api/pipeline/add``.
 
-    if not mbid and not discogs_id:
-        h._error("Missing mb_release_id or discogs_release_id")
+    At least one of ``mb_release_id`` / ``discogs_release_id`` is required;
+    the @model_validator below enforces that. Both IDs are normalised
+    after parsing (downcase, strip) by ``normalize_release_id`` inside
+    the handler — keeping normalisation in route logic, not in the model,
+    matches how other handlers consume these fields.
+    """
+
+    mb_release_id: str | None = None
+    discogs_release_id: str | None = None
+    source: str = "request"
+
+    @model_validator(mode="after")
+    def _at_least_one_release_id(self) -> "PipelineAddRequest":
+        if not self.mb_release_id and not self.discogs_release_id:
+            raise ValueError("Missing mb_release_id or discogs_release_id")
+        return self
+
+
+def post_pipeline_add(h, body: dict) -> None:
+    req = parse_body(h, body, PipelineAddRequest)
+    if req is None:
         return
+    s = _server()
+    mbid = normalize_release_id(req.mb_release_id)
+    discogs_id = normalize_release_id(req.discogs_release_id)
+    source = req.source
 
     if discogs_id:
         # Discogs flow: store discogs ID in both columns for pipeline compat
@@ -1488,10 +1512,21 @@ def post_pipeline_update(h, body: dict) -> None:
     h._json({"status": "ok", "id": req_id, "new_status": new_status})
 
 
+class PipelineUpgradeRequest(BaseModel):
+    """HTTP body for ``POST /api/pipeline/upgrade``."""
+
+    mb_release_id: str = Field(min_length=1)
+
+
 def post_pipeline_upgrade(h, body: dict) -> None:
+    req = parse_body(h, body, PipelineUpgradeRequest)
+    if req is None:
+        return
     s = _server()
-    mbid = normalize_release_id(body.get("mb_release_id"))
+    mbid = normalize_release_id(req.mb_release_id)
     if not mbid:
+        # ``normalize_release_id`` strips/lowercases and can return None
+        # for whitespace-only inputs that passed the min_length=1 check.
         h._error("Missing mb_release_id")
         return
 


### PR DESCRIPTION
Resolves the proof-of-pattern step in #343. Introduces Pydantic 2 as the HTTP request-body validation layer for \`web/routes/*.py\`. Two routes converted; the remaining ~38 POST handlers can migrate one-by-one once the shape is settled.

## What lands
- \`ps.pydantic\` added to \`nix/package.nix\` (Pydantic 2.12).
- \`web/routes/_pydantic.py\` — single \`parse_body(handler, body, Model)\` adapter. Routes never catch \`ValidationError\` inline; the adapter routes failures to \`{\"error\": ..., \"errors\": [...]}\` HTTP 400.
- \`PipelineAddRequest\` + \`PipelineUpgradeRequest\` declared above their handlers in \`web/routes/pipeline.py\`. The \"at least one of mb_release_id / discogs_release_id\" rule becomes a \`@model_validator\` on the request type.
- Existing 400 contract preserved — \`test_post_pipeline_add_missing_mbid\` still passes. Test grown to assert the structured \`errors\` field shape (\`loc\` / \`msg\` / \`type\`).
- Rule added to \`code-quality.md\` § \"HTTP request bodies\" — Pydantic owns inbound HTTP, msgspec stays internal. Includes the migration ladder.

## Out of scope
- msgspec wire-boundary types untouched.
- Response models / query-string parsing / Pydantic Settings → separate future work.

## Test plan
- [x] \`nix-shell --run \"python3 -m unittest tests.test_web_server.TestPipelineMutationRouteContracts.test_pipeline_add_contract tests.test_web_server.TestPipelineMutationRouteContracts.test_pipeline_add_exists_contract tests.test_web_server.TestPipelineMutationRouteContracts.test_pipeline_add_discogs_contract tests.test_web_server.TestPipelineMutationRouteContracts.test_pipeline_upgrade_contract tests.test_web_server.TestServerEndpoints.test_post_pipeline_add_missing_mbid\"\` — 5/5 green
- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3699/3699 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)