### PR TITLE
feat(web): Pydantic for the rest of pipeline.py POST routes

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2681,6 +2681,12 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
         self.assertIsNone(mock_gen.call_args.kwargs.get("prepend_artist"))
 
     def test_regenerate_rejects_string_prepend_artist(self):
+        """Strict-bool field rejects the string ``"false"`` (Pydantic
+        v2 lax mode would coerce it). The exact phrasing comes from
+        Pydantic now; assert the field name appears in the error so
+        the frontend can render a sensible message regardless of which
+        validator wrote it.
+        """
         from unittest.mock import patch as _patch
         with _patch(
             "lib.search_plan_service.SearchPlanService.generate_for_request",
@@ -2689,7 +2695,7 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
                 "/api/pipeline/100/search-plan/regenerate",
                 {"prepend_artist": "false"})
         self.assertEqual(status, 400)
-        self.assertEqual(data["error"], "prepend_artist must be a boolean")
+        self.assertIn("prepend_artist", data["error"])
         mock_gen.assert_not_called()
 
     def test_regenerate_rejects_non_dict_body_with_400(self):

--- a/web/routes/_pydantic.py
+++ b/web/routes/_pydantic.py
@@ -11,7 +11,7 @@ handled; routes never catch it inline.
 
 from __future__ import annotations
 
-from typing import Any, Type, TypeVar
+from typing import Any, Sequence, Type, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
@@ -47,15 +47,40 @@ def parse_body(handler: Any, body: Any, model: Type[M]) -> M | None:
         # ``@model_validator`` errors, which the stdlib ``json`` encoder
         # cannot serialise. ``include_input=False`` keeps the response
         # compact (the frontend only needs ``loc`` + ``msg`` + ``type``).
+        errors = exc.errors(
+            include_url=False,
+            include_context=False,
+            include_input=False,
+        )
         handler._json(
             {
-                "error": "validation failed",
-                "errors": exc.errors(
-                    include_url=False,
-                    include_context=False,
-                    include_input=False,
-                ),
+                "error": _summarise_error(errors),
+                "errors": errors,
             },
             status=400,
         )
         return None
+
+
+def _summarise_error(errors: Sequence[Any]) -> str:
+    """Single-line summary of the first error for the legacy ``error`` field.
+
+    Pre-Pydantic routes returned ad-hoc strings like ``"to_ordinal must be
+    an integer"`` in the top-level ``error`` field. Keep the legacy
+    surface alive — existing tests + the frontend's older error toasts
+    grep this string — while ``errors`` carries the structured list.
+
+    Shape (canonical):
+      - "<field>: <msg>" when the error has a non-root location.
+      - "<msg>" for model-level / root errors.
+    """
+    if not errors:
+        return "validation failed"
+    first = errors[0]
+    msg = str(first.get("msg") or "validation failed")
+    loc = first.get("loc") or ()
+    if loc:
+        field = ".".join(str(x) for x in loc if x != "__root__")
+        if field:
+            return f"{field}: {msg}"
+    return msg

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 from pathlib import Path
+from typing import Literal
 
 import msgspec
 from pydantic import BaseModel, Field, model_validator
@@ -788,6 +789,13 @@ def get_pipeline_search_plan_history(
     h._error(f"Unknown history outcome: {result.outcome}", 500)
 
 
+class PipelineSearchPlanRegenerateRequest(BaseModel):
+    # ``strict=True`` because Pydantic v2's default lax mode coerces
+    # ``"true"``/``"false"`` strings to bool — the regenerate route's
+    # contract is JSON-bool only and the test pins that.
+    prepend_artist: bool | None = Field(default=None, strict=True)
+
+
 def post_pipeline_search_plan_regenerate(
     h, body: dict, req_id_str: str,
 ) -> None:
@@ -818,17 +826,10 @@ def post_pipeline_search_plan_regenerate(
     except (TypeError, ValueError):
         h._error("Invalid request id")
         return
-    # F2: guard against non-dict bodies (e.g. raw JSON string) before
-    # calling body.get(), mirroring post_pipeline_search_plan_advance.
-    if body is not None and not isinstance(body, dict):
-        h._error("Invalid body — expected JSON object", 400)
+    req_body = parse_body(h, body or {}, PipelineSearchPlanRegenerateRequest)
+    if req_body is None:
         return
-    prepend_artist: bool | None = None
-    if body is not None and "prepend_artist" in body:
-        if not isinstance(body["prepend_artist"], bool):
-            h._json({"error": "prepend_artist must be a boolean"}, status=400)
-            return
-        prepend_artist = body["prepend_artist"]
+    prepend_artist: bool | None = req_body.prepend_artist
     db = _server()._db()
     cfg = read_runtime_config()
     svc = SearchPlanService(db, cfg)
@@ -879,6 +880,26 @@ def post_pipeline_search_plan_regenerate(
     h._json(payload)
 
 
+class PipelineSearchPlanAdvanceRequest(BaseModel):
+    """HTTP body for ``POST /api/pipeline/<id>/search-plan/advance``.
+
+    Exactly one of ``to_ordinal`` / ``to_strategy`` is required. The
+    ``@model_validator`` enforces the XOR — Pydantic checks types but
+    not "exactly one of two".
+    """
+
+    to_ordinal: int | None = None
+    to_strategy: str | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_target(self) -> "PipelineSearchPlanAdvanceRequest":
+        if (self.to_ordinal is None) == (self.to_strategy is None):
+            raise ValueError(
+                "exactly one of to_ordinal or to_strategy is required"
+            )
+        return self
+
+
 def post_pipeline_search_plan_advance(
     h, body: dict, req_id_str: str,
 ) -> None:
@@ -917,29 +938,17 @@ def post_pipeline_search_plan_advance(
     except (TypeError, ValueError):
         h._error("Invalid request id")
         return
-    body = body or {}
-    if not isinstance(body, dict):
-        h._json({"error": "body must be a JSON object"}, status=400)
-        return
-    to_ordinal = body.get("to_ordinal")
-    to_strategy = body.get("to_strategy")
-    if (to_ordinal is None) == (to_strategy is None):
-        h._json({
-            "error": "exactly one of to_ordinal or to_strategy is required",
-        }, status=400)
-        return
-    if to_ordinal is not None and not isinstance(to_ordinal, int):
-        h._json({"error": "to_ordinal must be an integer"}, status=400)
-        return
-    if to_strategy is not None and not isinstance(to_strategy, str):
-        h._json({"error": "to_strategy must be a string"}, status=400)
+    req_body = parse_body(h, body or {}, PipelineSearchPlanAdvanceRequest)
+    if req_body is None:
         return
 
     db = _server()._db()
     cfg = read_runtime_config()
     svc = SearchPlanService(db, cfg)
     result = svc.advance_for_request(
-        request_id, to_ordinal=to_ordinal, to_strategy=to_strategy,
+        request_id,
+        to_ordinal=req_body.to_ordinal,
+        to_strategy=req_body.to_strategy,
     )
     payload: dict[str, object] = {
         "request_id": result.request_id,
@@ -1106,6 +1115,10 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
     })
 
 
+class PipelineReplaceRequest(BaseModel):
+    target_mb_release_id: str = Field(min_length=1)
+
+
 def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
     """``POST /api/pipeline/<id>/replace``.
 
@@ -1147,14 +1160,11 @@ def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
         h._error("Invalid request id")
         return
 
-    # The server dispatcher (web/server.py::do_POST) always passes a
-    # JSON-decoded value here; for empty bodies that's ``{}``. The
-    # picker only ever sends a dict, so no defensive type check is
-    # needed. If a list or scalar somehow slipped through, the
-    # ``.get`` below would raise and the dispatcher's outer except
-    # would surface a 500 — acceptable for a malformed request.
-    target = body.get("target_mb_release_id")
-    if not isinstance(target, str) or not target.strip():
+    req_body = parse_body(h, body, PipelineReplaceRequest)
+    if req_body is None:
+        return
+    target = req_body.target_mb_release_id.strip()
+    if not target:
         h._json({
             "error": "target_mb_release_id must be a non-empty string",
         }, status=400)
@@ -1164,7 +1174,7 @@ def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
     cfg = read_runtime_config()
     svc = MbidReplaceService(db=db, config=cfg)
     result = svc.replace_request_mbid(
-        request_id, target_mb_release_id=target.strip(),
+        request_id, target_mb_release_id=target,
     )
 
     payload: dict[str, object] = {
@@ -1456,17 +1466,18 @@ def post_pipeline_add(h, body: dict) -> None:
     })
 
 
-def post_pipeline_update(h, body: dict) -> None:
-    s = _server()
-    req_id = body.get("id")
-    new_status = body.get("status", "").strip()
+class PipelineUpdateRequest(BaseModel):
+    id: int = Field(gt=0)
+    status: Literal["wanted", "imported", "manual"]
 
-    if not req_id or not new_status:
-        h._error("Missing id or status")
+
+def post_pipeline_update(h, body: dict) -> None:
+    req_body = parse_body(h, body, PipelineUpdateRequest)
+    if req_body is None:
         return
-    if new_status not in ("wanted", "imported", "manual"):
-        h._error(f"Invalid status: {new_status}")
-        return
+    s = _server()
+    req_id = req_body.id
+    new_status = req_body.status
 
     req = s._db().get_request(int(req_id))
     if not req:
@@ -1635,11 +1646,20 @@ def post_pipeline_upgrade(h, body: dict) -> None:
         })
 
 
+class PipelineSetQualityRequest(BaseModel):
+    mb_release_id: str = Field(min_length=1)
+    status: Literal["", "wanted", "imported", "manual"] = ""
+    min_bitrate: int | None = None
+
+
 def post_pipeline_set_quality(h, body: dict) -> None:
+    req_body = parse_body(h, body, PipelineSetQualityRequest)
+    if req_body is None:
+        return
     s = _server()
-    mbid = normalize_release_id(body.get("mb_release_id"))
-    new_status = body.get("status", "").strip()
-    min_bitrate = body.get("min_bitrate")
+    mbid = normalize_release_id(req_body.mb_release_id)
+    new_status = req_body.status
+    min_bitrate = req_body.min_bitrate
 
     if not mbid:
         h._error("Missing mb_release_id")
@@ -1703,19 +1723,31 @@ def post_pipeline_set_quality(h, body: dict) -> None:
     })
 
 
+class PipelineSetIntentRequest(BaseModel):
+    """HTTP body for ``POST /api/pipeline/set-intent``.
+
+    ``intent`` aliases (``flac``/``flac_only`` → ``lossless``,
+    ``best_effort``/``upgrade`` → ``default``) are normalised inside the
+    handler, not the model — the model accepts any string and the
+    handler validates against the canonical set after the alias swap.
+    """
+
+    id: int = Field(gt=0)
+    intent: str = ""
+
+
 def post_pipeline_set_intent(h, body: dict) -> None:
     """Toggle lossless-on-disk intent for a pipeline request.
 
     Accepts intent: "lossless" (keep lossless on disk) or "default" (pipeline decides).
     Backward compat: "flac", "flac_only" → "lossless"; "best_effort" → "default".
     """
-    s = _server()
-    req_id = body.get("id")
-    intent_str = body.get("intent", "").strip()
-
-    if not req_id:
-        h._error("Missing id")
+    req_body = parse_body(h, body, PipelineSetIntentRequest)
+    if req_body is None:
         return
+    s = _server()
+    req_id = req_body.id
+    intent_str = req_body.intent.strip()
 
     # Normalize to toggle: lossless or default
     _ALIASES = {"flac": "lossless", "flac_only": "lossless",
@@ -1775,15 +1807,25 @@ def post_pipeline_set_intent(h, body: dict) -> None:
         })
 
 
-def post_pipeline_ban_source(h, body: dict) -> None:
-    s = _server()
-    req_id = body.get("request_id")
-    username_raw = body.get("username")
-    username_in = username_raw.strip() if isinstance(username_raw, str) else ""
-    mb_release_id = normalize_release_id(body.get("mb_release_id"))
+class PipelineBanSourceRequest(BaseModel):
+    request_id: int = Field(gt=0)
+    mb_release_id: str = Field(min_length=1)
+    username: str | None = None
 
-    if not req_id or not mb_release_id:
-        h._error("Missing request_id or mb_release_id")
+
+def post_pipeline_ban_source(h, body: dict) -> None:
+    req_body = parse_body(h, body, PipelineBanSourceRequest)
+    if req_body is None:
+        return
+    s = _server()
+    req_id = req_body.request_id
+    username_in = req_body.username.strip() if req_body.username else ""
+    mb_release_id = normalize_release_id(req_body.mb_release_id)
+
+    if not mb_release_id:
+        # ``normalize_release_id`` can strip whitespace down to None
+        # even when the min_length=1 raw input passed Pydantic.
+        h._error("Missing mb_release_id")
         return
 
     db = s._db()
@@ -1971,13 +2013,16 @@ def post_pipeline_ban_source(h, body: dict) -> None:
     h._json(payload)
 
 
-def post_pipeline_force_import(h, body: dict) -> None:
-    s = _server()
-    log_id = body.get("download_log_id")
+class PipelineForceImportRequest(BaseModel):
+    download_log_id: int = Field(gt=0)
 
-    if not log_id:
-        h._error("Missing download_log_id")
+
+def post_pipeline_force_import(h, body: dict) -> None:
+    req_body = parse_body(h, body, PipelineForceImportRequest)
+    if req_body is None:
         return
+    s = _server()
+    log_id = req_body.download_log_id
 
     entry = s._db().get_download_log_entry(int(log_id))
     if not entry:
@@ -2031,12 +2076,16 @@ def post_pipeline_force_import(h, body: dict) -> None:
     }, status=202)
 
 
+class PipelineDeleteRequest(BaseModel):
+    id: int = Field(gt=0)
+
+
 def post_pipeline_delete(h, body: dict) -> None:
-    s = _server()
-    req_id = body.get("id")
-    if not req_id:
-        h._error("Missing id")
+    req_body = parse_body(h, body, PipelineDeleteRequest)
+    if req_body is None:
         return
+    s = _server()
+    req_id = req_body.id
     db = s._db()
     req = db.get_request(int(req_id))
     if not req:


### PR DESCRIPTION
Migrates the remaining 9 \`web/routes/pipeline.py\` POST handlers to the Pydantic boundary established by #344. Issue #343.

## Handlers converted
- \`post_pipeline_update\` → \`PipelineUpdateRequest\`
- \`post_pipeline_set_quality\` → \`PipelineSetQualityRequest\`
- \`post_pipeline_set_intent\` → \`PipelineSetIntentRequest\`
- \`post_pipeline_ban_source\` → \`PipelineBanSourceRequest\`
- \`post_pipeline_force_import\` → \`PipelineForceImportRequest\`
- \`post_pipeline_delete\` → \`PipelineDeleteRequest\`
- \`post_pipeline_search_plan_regenerate\` → \`PipelineSearchPlanRegenerateRequest\`
- \`post_pipeline_search_plan_advance\` → \`PipelineSearchPlanAdvanceRequest\` (with @model_validator XOR check on to_ordinal/to_strategy)
- \`post_pipeline_replace\` → \`PipelineReplaceRequest\`

## Adapter improvement
\`_summarise_error\` builds a legacy single-line \`error\` field from the first structured entry (\`<field>: <msg>\`) so existing tests that grep for the field name in \`data[\"error\"]\` keep working alongside the new structured \`errors\` list.

## Strictness note
\`prepend_artist\` on the search-plan-regenerate body uses \`Field(strict=True)\` because Pydantic v2's default lax mode coerces \`\"true\"\` / \`\"false\"\` strings to bool. Existing contract is JSON-bool only.

## Test plan
- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3699/3699 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)