### PR TITLE
chore(web): audit-enforce Pydantic on POST routes; tighten the rule

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -67,48 +67,33 @@ Call the full pipeline.
 
 ## HTTP request bodies — use `pydantic.BaseModel`
 
-Inbound HTTP request bodies in `web/routes/*.py` are an external, untrusted boundary. They get validated with `pydantic.BaseModel` (Pydantic v2) at the handler entry. Pydantic stops at the route layer; everything internal stays `msgspec.Struct` / `@dataclass` per the next section.
+Inbound HTTP request bodies in `web/routes/*.py` go through `pydantic.BaseModel` (v2) at the handler entry. Pydantic stops at the route layer; internal types stay `msgspec.Struct` / `@dataclass` per the next section. Enforced by `tests/test_pydantic_route_audit.py` — any `post_*` handler that reads the raw `body` dict instead of going through `parse_body` fails the audit (small allowlist with a rationale per entry).
 
-Why Pydantic and not msgspec at this seam:
-- `ValidationError.errors()` gives structured field-path errors, which the route returns as JSON so the frontend can show real messages.
-- The `*Request` model declared above the handler is the operator-facing contract — the request shape is visible without reading the parsing code.
+Why Pydantic at this seam: `ValidationError.errors()` gives structured field-path errors the frontend renders directly, and the `*Request` model declared above the handler is the operator-facing contract.
 
-Pattern (canonical: `post_pipeline_add` in `web/routes/pipeline.py`):
+Pattern (canonical: `PipelineAddRequest` + `post_pipeline_add` in `web/routes/pipeline.py`):
 
 ```python
-from pydantic import BaseModel, ValidationError, model_validator
+from pydantic import BaseModel, model_validator
+from web.routes._pydantic import parse_body
 
-class PipelineAddRequest(BaseModel):
-    mb_release_id: str | None = None
-    discogs_release_id: str | None = None
-    source: str = "request"
+class MyRouteRequest(BaseModel):
+    foo: str
+    bar: int | None = None
 
-    @model_validator(mode="after")
-    def _at_least_one_id(self):
-        if not self.mb_release_id and not self.discogs_release_id:
-            raise ValueError("Missing mb_release_id or discogs_release_id")
-        return self
-
-def post_pipeline_add(h, body: dict) -> None:
-    payload = _parse_body(h, body, PipelineAddRequest)
-    if payload is None:
+def post_my_route(h, body: dict) -> None:
+    req = parse_body(h, body, MyRouteRequest)
+    if req is None:
         return
-    # payload.mb_release_id is typed; route logic uses it directly
+    # req.foo / req.bar are typed; use them directly
 ```
 
-`_parse_body` (defined in `web/routes/_pydantic.py`) is the single adapter that converts `ValidationError → 400` with `{"error": ..., "errors": [...]}`. Use it; do not catch `ValidationError` inline.
+`parse_body` (in `web/routes/_pydantic.py`) is the single adapter that turns `ValidationError → 400` with `{"error": "<field>: <msg>", "errors": [...]}`. Use it; do not catch `ValidationError` inline.
 
 Scope:
-- HTTP request bodies → Pydantic. That's it.
-- Internal types (msgspec wire boundaries, route response dicts, service-layer dataclasses) → unchanged.
-- Pydantic is NOT for query-string parsing yet — query strings stay hand-parsed for now (smaller surface, less win).
-- No response models — frontend depends on the existing JSON shape; routes still emit dicts via `h._json(...)`.
-
-When migrating an existing route:
-1. Declare the `*Request` model above the handler with the fields the existing code reads from `body`.
-2. Wrap entry with `payload = _parse_body(h, body, MyRequest); if payload is None: return`.
-3. Replace `body.get("x")` with `payload.x`.
-4. Existing tests should pass unchanged — preserve response shape and the 400-on-bad-input contract.
+- HTTP request bodies → Pydantic.
+- Query strings, response shapes, internal types → unchanged.
+- Pydantic v2's lax mode coerces `"true"`/`"false"` strings to bool; use `Field(strict=True)` when the route's contract is JSON-bool only.
 
 ## Wire-boundary types — use `msgspec.Struct`, not `@dataclass`
 Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blob written to or read from the DB, a subprocess's stdout — is a `msgspec.Struct`. **Same policy both directions:** encode via `msgspec.json.encode` (or `msgspec.to_builtins` when a dict is needed), decode via `msgspec.convert`. The declared Struct is the single contract that validates type drift at the boundary. Pyright does not see inside `dict.get()` — only runtime validation catches int-vs-str drift, mis-typed fields, or missing required data. This is the lesson of issue #99 / PR #98 (every Discogs validation silently logged `mbid_not_found` because a dataclass said `str` but the wire carried `int`) and the pre-#141 asymmetry (the old "dataclass if re-encoded, Struct if decoded only" split let docstrings lie about which side was strict).

--- a/tests/test_pydantic_route_audit.py
+++ b/tests/test_pydantic_route_audit.py
@@ -1,0 +1,136 @@
+"""Audit: every ``post_*`` handler in ``web/routes/*.py`` validates its
+body through ``parse_body`` (Pydantic).
+
+See ``.claude/rules/code-quality.md`` § "HTTP request bodies". A handler
+that reads from the raw ``body`` dict instead of a typed model is a
+boundary regression — error responses become inconsistent and the
+request contract disappears from the file.
+
+Zero-tolerance with a small allowlist. Allowlisted handlers must carry a
+``# pydantic-audit: skip — <reason>`` comment on the def line so the
+exception is visible in code review.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+
+
+TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
+ROUTES_DIR = os.path.abspath(os.path.join(TESTS_DIR, "..", "web", "routes"))
+
+# Handlers that are intentionally NOT routed through ``parse_body``.
+# Each entry must carry a rationale because the audit's whole point is
+# that route validation goes through one shared adapter.
+_ALLOWLIST: dict[str, str] = {
+    # Tri-mode body (values / download_log / request+path); the values
+    # branch already validates through ``msgspec.convert`` against
+    # ``ImportPreviewValues``. A Pydantic model for the dispatch shape
+    # would be uglier than the existing mode-detection logic.
+    "web/routes/imports.py:post_import_preview": "tri-mode body, msgspec-validated in _preview_values_from_body",
+}
+
+
+def _route_files() -> list[str]:
+    paths: list[str] = []
+    for fn in sorted(os.listdir(ROUTES_DIR)):
+        if not fn.endswith(".py"):
+            continue
+        if fn.startswith("_"):
+            continue
+        paths.append(os.path.join(ROUTES_DIR, fn))
+    return paths
+
+
+def _handler_uses_parse_body(fn: ast.FunctionDef) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            target = node.func
+            if isinstance(target, ast.Name) and target.id == "parse_body":
+                return True
+            if isinstance(target, ast.Attribute) and target.attr == "parse_body":
+                return True
+    return False
+
+
+def _handler_reads_raw_body(fn: ast.FunctionDef) -> bool:
+    """Detect ``body.get(...)`` or ``body[...]`` access in the handler body."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            target = node.func
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "get"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "body"
+            ):
+                return True
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Name) and node.value.id == "body":
+                return True
+    return False
+
+
+class TestPydanticRouteAudit(unittest.TestCase):
+    def test_every_post_handler_uses_pydantic(self) -> None:
+        violations: list[str] = []
+        for path in _route_files():
+            relpath = os.path.relpath(path, os.path.dirname(ROUTES_DIR) + "/..")
+            with open(path, encoding="utf-8") as f:
+                src = f.read()
+            tree = ast.parse(src, filename=path)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.FunctionDef):
+                    continue
+                if not node.name.startswith("post_"):
+                    continue
+                key = f"{relpath}:{node.name}"
+                if key in _ALLOWLIST:
+                    continue
+                if _handler_uses_parse_body(node):
+                    continue
+                if _handler_reads_raw_body(node):
+                    violations.append(
+                        f"  - {key}: reads ``body`` directly without "
+                        "going through ``parse_body``"
+                    )
+                    continue
+                # No parse_body call and no raw body access — handler
+                # doesn't use the body at all. That's fine.
+        if violations:
+            self.fail(
+                "Pydantic route audit — see "
+                "`.claude/rules/code-quality.md` § 'HTTP request bodies'.\n"
+                "Each POST handler in `web/routes/` must declare a typed "
+                "request model and parse via `parse_body`. Add a rationale "
+                "to `_ALLOWLIST` in this file if a handler legitimately "
+                "cannot use the standard adapter.\n\n"
+                + "\n".join(violations)
+            )
+
+    def test_allowlist_entries_still_exist(self) -> None:
+        """If an allowlisted handler is gone or renamed, the allowlist is
+        stale and silently lets a new handler skip the audit."""
+        present: set[str] = set()
+        for path in _route_files():
+            relpath = os.path.relpath(path, os.path.dirname(ROUTES_DIR) + "/..")
+            with open(path, encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=path)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name.startswith("post_"):
+                    present.add(f"{relpath}:{node.name}")
+        stale = sorted(set(_ALLOWLIST) - present)
+        if stale:
+            self.fail(
+                "Pydantic route audit allowlist is stale — these entries "
+                "no longer match any POST handler:\n\n"
+                + "\n".join(f"  - {s}" for s in stale)
+                + "\n\nRemove them from `_ALLOWLIST` in "
+                "`tests/test_pydantic_route_audit.py`."
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #343.

## Audit
\`tests/test_pydantic_route_audit.py\` walks \`web/routes/*.py\` and asserts that every \`post_*\` handler validates its body through \`parse_body\`. Zero-tolerance with a small allowlist (currently one entry: \`post_import_preview\`, with a rationale). A second test fails when an allowlist entry no longer matches any real handler — prevents silent drift after a rename.

Detection is AST-based: a handler is flagged if it calls \`body.get(...)\` or \`body[...]\` without first calling \`parse_body\`. Handlers that ignore the body entirely pass.

## Rule tightening
\`code-quality.md\` § \"HTTP request bodies\" cut from ~40 lines to ~25. Replaces the multi-paragraph preamble with one sentence, trims the code example to a small skeleton, folds the migration ladder into the principle text. Fixes the broken \`_parse_body\` reference (the actual import is \`parse_body\`). Adds the strict-bool footgun note we hit on \`prepend_artist\`.

## Test plan
- [x] \`nix-shell --run \"python3 -m unittest tests.test_pydantic_route_audit -v\"\` — 2/2 green
- [x] \`nix-shell --run \"bash scripts/run_tests.sh\"\` — 3701/3701 green
- [x] \`nix-shell --run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)