### PR TITLE
fix(import): stop mutating source files in process_completed_album (#248)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Literal, TYPE_CHECKING
 
-import music_tag
 
 from lib.download_recovery import (
     classify_processing_path,
@@ -1117,18 +1116,6 @@ def process_completed_album(
         return materialized
 
     logger.info(f"Processing completed download: {album_data.artist} - {album_data.title}")
-    for file in album_data.files:
-        try:
-            song = music_tag.load_file(file.import_path)
-            assert song is not None
-            if file.disk_no is not None:
-                song["discnumber"] = file.disk_no
-                song["totaldiscs"] = file.disk_count
-            song["albumartist"] = album_data.artist
-            song["album"] = album_data.title
-            song.save()
-        except Exception:
-            logger.exception(f"Error writing tags for: {file.import_path}")
     if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
         _validate = validate_fn if validate_fn is not None else _process_beets_validation
         outcome = _validate(

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -225,20 +225,12 @@ def _snapshot_match_key(
 ) -> tuple[str, int, str, str, str | None]:
     """Stable identity tuple for snapshot equality.
 
-    Excludes ``mtime_ns`` because:
-    * ``process_completed_album`` writes ID3 tags to source files via
-      ``music_tag.save()`` AFTER preview snapshots them. Tagging bumps
-      mtime even when the audio bytes are unchanged. With strict mtime
-      equality the importer requeues every job to preview as
-      ``"candidate source changed since evidence capture"`` and the
-      queue never drains — see issue audit-2026-05-15.
-    * virtiofs has been observed to return slightly different
-      ``st_mtime_ns`` between back-to-back ``stat`` calls on the same
-      file. Strict equality is fragile under that flake.
-
-    Size + path + extension/container/codec is sufficient to detect any
-    content change that matters here. ``mtime_ns`` stays in the
-    persisted struct as a forensic field but does not gate freshness.
+    Excludes ``mtime_ns`` because virtiofs has been observed to return
+    slightly different ``st_mtime_ns`` between back-to-back ``stat``
+    calls on the same file. Size + path + extension/container/codec is
+    sufficient to detect any content change that matters here.
+    ``mtime_ns`` stays in the persisted struct as a forensic field but
+    does not gate freshness.
     """
     return (
         file.relative_path,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1173,8 +1173,7 @@ class TestRederiveTransferIds(unittest.TestCase):
 class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
     """Test process_completed_album return ownership."""
 
-    @patch("lib.download.music_tag")
-    def test_returns_true_on_success(self, mock_mt):
+    def test_returns_true_on_success(self):
         """Successful file move + processing returns True."""
         from lib.download import process_completed_album
         import tempfile, os
@@ -1193,14 +1192,11 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            mock_mt.load_file.return_value = MagicMock()
             result = process_completed_album(album, [], ctx)
             self.assertTrue(result)
 
-    @patch("lib.download.music_tag")
     def test_dispatch_outcome_summary_is_returned_to_queue_owner(
         self,
-        mock_mt,
     ):
         """Auto-import summaries must survive for the importer queue result."""
         from lib.download import process_completed_album
@@ -1220,7 +1216,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = True
-            mock_mt.load_file.return_value = MagicMock()
             stub_outcome = DispatchOutcome(
                 success=True,
                 message="Import successful",
@@ -1239,10 +1234,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertEqual(len(validate_calls), 1)
 
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_beets_rejection_summary_is_returned_to_queue_owner(
         self,
-        mock_mt,
         mock_beets_validate,
     ):
         """Validation rejections must fail the queue job, not look completed."""
@@ -1272,7 +1265,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
             ctx = make_ctx_with_fake_db(db, cfg=cfg)
-            mock_mt.load_file.return_value = MagicMock()
             mock_beets_validate.return_value = ValidationResult(
                 valid=False,
                 distance=0.1919,
@@ -1321,8 +1313,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             result = process_completed_album(album, [], ctx)
             self.assertFalse(result)
 
-    @patch("lib.download.music_tag")
-    def test_resumes_from_persisted_current_path(self, mock_mt):
+    def test_resumes_from_persisted_current_path(self):
         """A post-move retry must process the persisted current_path, not slskd."""
         from lib.download import process_completed_album
         import tempfile
@@ -1351,7 +1342,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
 
             result = process_completed_album(album, [], ctx)
 
@@ -1359,8 +1349,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertEqual(files[0].import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
-    @patch("lib.download.music_tag")
-    def test_resumes_multi_disc_from_persisted_current_path(self, mock_mt):
+    def test_resumes_multi_disc_from_persisted_current_path(self):
         """Resume must preserve the staged multi-disc filenames on disk."""
         from lib.download import process_completed_album
         import tempfile
@@ -1391,7 +1380,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
 
             result = process_completed_album(album, [], ctx)
 
@@ -1399,8 +1387,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertEqual(file.import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
-    @patch("lib.download.music_tag")
-    def test_persists_canonical_current_path_for_fresh_materialization(self, mock_mt):
+    def test_persists_canonical_current_path_for_fresh_materialization(self):
         """The first local materialization must persist the canonical path to DB."""
         from lib.download import process_completed_album
         import tempfile
@@ -1432,7 +1419,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
             cfg.beets_validation_enabled = False
             ctx = make_ctx_with_fake_db(fake_db, cfg=cfg)
-            mock_mt.load_file.return_value = MagicMock()
 
             result = process_completed_album(album, [], ctx)
 
@@ -1444,10 +1430,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
     @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_returns_none_for_post_move_auto_import_retry(
         self,
-        mock_mt,
         mock_beets_validate,
         mock_measure_preimport_state,
     ):
@@ -1489,7 +1473,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
             mock_beets_validate.return_value = ValidationResult(
                 valid=True,
                 distance=0.05,
@@ -1513,10 +1496,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertEqual(dispatch_calls, [])
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
-    @patch("lib.download.music_tag")
     def test_request_scoped_staged_path_without_request_id_blocks_manual_recovery(
         self,
-        mock_mt,
     ):
         """Request-scoped auto-import staging without request id must stay blocked."""
         from lib.download import process_completed_album
@@ -1554,7 +1535,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_staging_dir = staging_root
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
 
             with self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(album, [], ctx)
@@ -1562,10 +1542,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertIsNone(result)
             self.assertIn("missing db_request_id", "\n".join(logs.output))
 
-    @patch("lib.download.music_tag")
     def test_post_validation_staged_path_without_request_id_still_resumes(
         self,
-        mock_mt,
     ):
         """Post-validation staging remains resumable without the auto-import guard."""
         from lib.download import process_completed_album
@@ -1604,7 +1582,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_staging_dir = staging_root
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
 
             result = process_completed_album(album, [], ctx)
 
@@ -1613,10 +1590,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
     @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_request_auto_import_without_request_id_fails_before_staging_move(
         self,
-        mock_mt,
         mock_beets_validate,
         mock_measure_preimport_state,
     ):
@@ -1662,7 +1637,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            mock_mt.load_file.return_value = MagicMock()
             mock_beets_validate.return_value = ValidationResult(
                 valid=True,
                 distance=0.05,
@@ -1729,10 +1703,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
     @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_request_auto_import_without_resolvable_request_logs_warning(
         self,
-        mock_mt,
         mock_beets_validate,
         mock_measure_preimport_state,
     ):
@@ -1769,7 +1741,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            mock_mt.load_file.return_value = MagicMock()
             mock_beets_validate.return_value = ValidationResult(
                 valid=True,
                 distance=0.05,
@@ -1806,10 +1777,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
     @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_request_auto_import_without_request_id_matches_row_when_album_year_blank(
         self,
-        mock_mt,
         mock_beets_validate,
         mock_measure_preimport_state,
     ):
@@ -1854,7 +1823,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            mock_mt.load_file.return_value = MagicMock()
             mock_beets_validate.return_value = ValidationResult(
                 valid=True,
                 distance=0.05,
@@ -1883,10 +1851,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
     @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_returns_none_for_legacy_shared_staged_retry(
         self,
-        mock_mt,
         mock_beets_validate,
         mock_measure_preimport_state,
     ):
@@ -1920,7 +1886,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
             from lib.measurement import PreimportMeasurement
             mock_measure_preimport_state.return_value = PreimportMeasurement(
                 folder_layout="flat",
@@ -1942,10 +1907,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
     @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
-    @patch("lib.download.music_tag")
     def test_retries_post_move_redownload_path_without_blocking(
         self,
-        mock_mt,
         mock_beets_validate,
         mock_measure_preimport_state,
     ):
@@ -1987,7 +1950,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_mt.load_file.return_value = MagicMock()
             mock_beets_validate.return_value = ValidationResult(
                 valid=True,
                 distance=0.05,
@@ -2289,8 +2251,7 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
     rename. Directly reproduces the issue #144 crash — file landed on disk
     with ``_<ticks>`` appended; the move must still succeed."""
 
-    @patch("lib.download.music_tag")
-    def test_moves_collision_renamed_files(self, mock_mt):
+    def test_moves_collision_renamed_files(self):
         from lib.download import process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2313,7 +2274,6 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            mock_mt.load_file.return_value = MagicMock()
             result = process_completed_album(album, [], ctx)
             self.assertTrue(result)
             # Source should be gone; destination should exist.
@@ -2325,8 +2285,7 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             # Destination keeps the clean (non-suffixed) basename.
             self.assertEqual(moved[0], f"{base}.mp3")
 
-    @patch("lib.download.music_tag")
-    def test_moves_file_from_incomplete_ancestor_folder(self, mock_mt):
+    def test_moves_file_from_incomplete_ancestor_folder(self):
         """Regression: full processing must tolerate legacy slskd layouts
         where the finished files still sit under ``incomplete/<album>/CD2``.
         """
@@ -2362,7 +2321,6 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            mock_mt.load_file.return_value = MagicMock()
 
             result = process_completed_album(album, [], ctx)
 
@@ -2374,8 +2332,7 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             moved = os.listdir(import_folder)
             self.assertEqual(moved, ["Disk 2 - 01.- The Ronettes - Be My Baby.mp3"])
 
-    @patch("lib.download.music_tag")
-    def test_moves_file_with_forward_slash_remote_path(self, mock_mt):
+    def test_moves_file_with_forward_slash_remote_path(self):
         """Compatibility: some remote path payloads may arrive slash-normalized.
         Basename extraction and on-disk resolution must accept either separator.
         """
@@ -2401,7 +2358,6 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            mock_mt.load_file.return_value = MagicMock()
 
             result = process_completed_album(album, [], ctx)
 

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2709,8 +2709,7 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             )
 
             from lib.measurement import PreimportMeasurement
-            with patch("lib.download.music_tag.load_file", return_value=MagicMock()), \
-                 patch("lib.beets.beets_validate", return_value=ValidationResult(
+            with patch("lib.beets.beets_validate", return_value=ValidationResult(
                      valid=True,
                      distance=0.05,
                      scenario="strong_match",

--- a/tests/test_quality_evidence.py
+++ b/tests/test_quality_evidence.py
@@ -369,21 +369,11 @@ class TestQualityEvidenceConstruction(unittest.TestCase):
 class TestAudioSnapshotMatches(unittest.TestCase):
     """Snapshot equality must ignore mtime_ns.
 
-    Real failure: ``process_completed_album`` writes ID3 tags to the
-    source files via ``music_tag.save()`` AFTER the preview worker has
-    already snapshotted them. The ``save()`` rewrites mtimes by
-    nanoseconds, the strict struct equality fails, the importer
-    requeues the job to preview as ``"candidate source changed since
-    evidence capture"``, preview re-runs, importer re-tags, infinite
-    loop. The queue grows but never drains.
-
-    virtiofs adds a second source of mtime jitter — the same file's
-    ``stat().st_mtime_ns`` can flicker by a few ns between reads. Any
-    fix must also make the snapshot resilient to that.
-
-    Comparison key is (relative_path, size_bytes, extension, container,
-    codec). mtime_ns stays in the struct as a forensic field but does
-    not participate in equality.
+    virtiofs has been observed to return slightly different
+    ``st_mtime_ns`` between back-to-back ``stat`` calls on the same
+    file. The comparison key is (relative_path, size_bytes, extension,
+    container, codec); mtime_ns stays in the struct as a forensic
+    field but does not participate in equality.
     """
 
     def setUp(self) -> None:
@@ -399,8 +389,6 @@ class TestAudioSnapshotMatches(unittest.TestCase):
     def test_snapshot_matches_after_mtime_only_change(self):
         """Touching a file (size unchanged) must not invalidate the snapshot."""
         captured = snapshot_audio_files(self.root)
-        # Simulate music_tag.save() rewriting the file in place: mtime
-        # advances even if the byte content (and so size) is identical.
         for entry in os.listdir(self.root):
             full = os.path.join(self.root, entry)
             stat = os.stat(full)


### PR DESCRIPTION
## Summary

Closes #248.

`process_completed_album` (`lib/download.py`) ran a `music_tag.save()` loop on every source file before handing off to beets. The loop fired **twice** per attempt — once when the timer detected download-complete, and again when the importer claimed the queued job — and `music_tag.save()` is not idempotent. Each pass shrank FLAC files by ~1MB (embedded-art normalisation). The importer's snapshot freshness check ran *after* its own tag rewrite, so it mismatched its own evidence and requeued the job to preview. Preview re-snapshotted the post-tag state; importer ran again; tagged again; this time the new state matched and it proceeded.

Live impact at filing time: ~65 \"candidate source changed since evidence capture\" requeues per day in `cratedigger-importer`. Self-healing in ~16s each, no stuck states, but every event is wasted preview work and log noise.

## Why deleting the loop is safe

The tag write was functionally only a hint to beets' fuzzy matcher:

- Beets is the next thing to touch these files. With `--search-id <mbid>` it reads tags as hints, fuzzy-matches to MB, and overwrites every tag with MB-canonical values during real import. The on-disk tags after import are 100% beets' work.
- Of the four fields we wrote, `album` and `albumartist` came from MB anyway → pure waste.
- `discnumber` / `totaldiscs` were only load-bearing on multi-disc albums whose source folders followed `try_multi_enqueue`'s one-folder-per-disc contract. Beets can derive disc numbers from MB metadata + filename matching when the hint is absent.

Reframing per the author: we're not trusting beets blindly — we're trusting the tags soulseek uploaders actually wrote, instead of overwriting them with our own assumptions. The signal we were forcing was *coming from us*, so any wrong-match it currently prevents might itself be a self-inflicted false positive.

## Risk

For multi-disc albums, beets' match distance may bloat slightly without the explicit disc hint — usually fine, occasionally pushes distance over 0.15 → wrong-matches. The live wrong-matches stream is the test set; if multi-disc imports start landing there at a higher rate after deploy, we relocate the disc-only write into the preview worker *before* the snapshot is taken (which fixes the snapshot churn either way).

## Changes

- `lib/download.py` — delete `music_tag.save()` loop in `process_completed_album`; drop the now-unused `import music_tag`.
- `tests/test_download.py` — drop 17 `@patch(\"lib.download.music_tag\")` decorators + their `mock_mt` params + setup lines.
- `tests/test_integration_slices.py` — drop one stranded `lib.download.music_tag.load_file` patch.
- `lib/quality_evidence.py` + `tests/test_quality_evidence.py` — trim two stale docstrings that explained mtime exclusion via the music_tag.save() bug; they now cite only virtiofs jitter (the live reason mtime stays out of the snapshot key).

## Test plan

- [x] Full suite: \`Ran 3701 tests in 56.374s\` → OK.
- [x] `nix-shell --run \"pyright\"` → 0 errors, 0 warnings, 0 informations.
- [ ] Post-deploy: watch `cratedigger-importer` for \"candidate source changed since evidence capture\" — should drop to zero on Iron & Wine / Mountain Goats / mc chris–shaped requests.
- [ ] Post-deploy: watch wrong-matches for any multi-disc-distance regressions; if a flat-multi-disc source starts routing to wrong-matches that previously imported cleanly, file a follow-up to relocate a minimal disc-only write into the preview worker.

## Related

Matcher gap: `try_multi_enqueue` requires one-folder-per-disc and can't handle flat-multi-disc sources. `try_enqueue` would still claim a flat 20-track 2-disc folder as a single-disc match; files arrive with `disk_no=None` and beets has to disambiguate from MB metadata. This is pre-existing behaviour and not changed by this PR; filed separately for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)