### PR TITLE
refactor(mp3val): run once on source, before snapshot

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -50,7 +50,7 @@ _bootstrap_import_paths()
 from lib.beets_db import AlbumInfo, BeetsDB
 from lib.permissions import fix_library_modes, reset_umask
 from lib.release_identity import ReleaseIdentity
-from lib.util import beets_subprocess_env, repair_mp3_headers
+from lib.util import beets_subprocess_env
 from lib import transitions
 
 # Module-level DI seam for ``transitions.finalize_request`` — see
@@ -1322,9 +1322,6 @@ def _run_quality_evidence_authorized_import(
             _emit_and_exit(r)
 
         _validate_quality_evidence_action_snapshot(args.path, payload)
-        stage_start = time.monotonic()
-        repair_mp3_headers(args.path)
-        _log_timing("evidence_mp3_repair", stage_start)
         quality_is_transcode = _materialize_quality_evidence_action(
             work_path=args.path,
             payload=payload,

--- a/lib/download.py
+++ b/lib/download.py
@@ -57,6 +57,7 @@ from lib.util import (
     move_abandoned_auto_import,
     move_failed_import,
     log_validation_result,
+    repair_mp3_headers,
 )
 
 if TYPE_CHECKING:
@@ -1228,6 +1229,10 @@ def _process_beets_validation(
             # ``_handle_rejected_result`` → ``reject_and_requeue`` (which
             # writes the standard "beets validation rejected" denylist
             # entry). This caller does not issue per-fact denylist writes.
+            try:
+                repair_mp3_headers(current_path)
+            except Exception:
+                pass
             measurement = measure_preimport_state(
                 path=current_path,
                 mb_release_id=album_data.mb_release_id or "",

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -448,6 +448,17 @@ def _preview_import_from_path_worker_mode(
             source_path=path,
         )
 
+    # --- Source cleanup BEFORE snapshot ---
+    # mp3val runs once on the source so the snapshot captures the
+    # post-cleanup state. Source is then immutable until beets consumes
+    # it: the importer's freshness check, the harness's
+    # ``_validate_quality_evidence_action_snapshot``, and any later
+    # wrong-match triage all see the same bytes the preview measured.
+    try:
+        repair_mp3_headers(path)
+    except Exception:
+        pass
+
     # --- Snapshot for freshness guard + evidence files column ---
     try:
         source_snapshot = snapshot_audio_files(path)
@@ -887,6 +898,16 @@ def preview_import_from_path(
     from lib.config import read_runtime_config
 
     cfg = read_runtime_config()
+
+    # --- Source cleanup BEFORE snapshot ---
+    # mp3val runs once on the source so the snapshot captures the
+    # post-cleanup state and the source stays stable through the
+    # importer + harness lifecycle.
+    try:
+        repair_mp3_headers(path)
+    except Exception:
+        pass
+
     source_snapshot = None
     if persist_candidate_evidence:
         try:
@@ -947,10 +968,6 @@ def preview_import_from_path(
             os.path.basename(os.path.abspath(path)) or "album",
         )
         shutil.copytree(path, preview_path)
-        try:
-            repair_mp3_headers(preview_path)
-        except Exception:
-            pass
         inspection = inspect_local_files(preview_path)
         if inspection.has_nested_audio:
             detail = (

--- a/lib/measurement.py
+++ b/lib/measurement.py
@@ -34,7 +34,7 @@ from lib.audio_hash import AudioHashError, hash_audio_content
 _BAD_HASH_SUPPORTED_EXTS: frozenset[str] = frozenset({"flac", "mp3", "m4a", "aac", "ogg", "opus"})
 from lib.pipeline_db import RequestSpectralStateUpdate
 from lib.quality import SPECTRAL_TRANSCODE_GRADES, SpectralMeasurement
-from lib.util import repair_mp3_headers, validate_audio
+from lib.util import validate_audio
 
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
@@ -98,11 +98,11 @@ class LocalFileInspection:
 
     ``has_nested_audio`` reports whether any audio files were found below the
     root directory. Callers should reject nested layouts early: the
-    preimport gates (validate_audio / analyze_album / repair_mp3_headers)
-    recurse, but the downstream beets harness (``harness/import_one.py``)
-    still uses ``os.listdir`` for bitrate measurement and conversion, so a
-    nested force/manual import would pass gates and then produce a
-    misclassified/empty measurement in the harness.
+    preimport gates (validate_audio / analyze_album) recurse, but the
+    downstream beets harness (``harness/import_one.py``) still uses
+    ``os.listdir`` for bitrate measurement and conversion, so a nested
+    force/manual import would pass gates and then produce a misclassified/
+    empty measurement in the harness.
 
     ``avg_bitrate_bps`` is the mean bitrate across all readable MP3 files —
     used by the VBR spectral-gate threshold (issue #93). Genuine V0 averages
@@ -416,17 +416,13 @@ def measure_preimport_state(
         PreimportMeasurement with all gate facts populated. Audio-corrupt and
         bad-hash matches short-circuit the spectral steps to avoid wasting
         cycles, but the returned Struct still has the corresponding flag set.
-    """
-    # --- MP3 header repair (unconditional) ---
-    # mp3val runs regardless of audio_check_mode: deployments with
-    # audio_check=off still want fixable MP3 header issues cleaned up before
-    # spectral analysis and the import subprocess. Matches the auto path's
-    # original behavior pre-refactor.
-    try:
-        repair_mp3_headers(path)
-    except Exception:
-        logger.debug("repair_mp3_headers failed", exc_info=True)
 
+    Note: ``repair_mp3_headers`` is **not** called here. Callers must run
+    mp3val on the source before measurement (and before snapshotting, in
+    the preview worker) so that header fixes are visible in the evidence
+    snapshot and never mutate the source after the importer's freshness
+    check.
+    """
     filetype_band = _filetype_band(download_filetype)
 
     # --- Audio integrity gate ---

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -446,43 +446,6 @@ class TestPreimportFallsBackToPersistedSpectral(unittest.TestCase):
         self.assertFalse(measurement.audio_corrupt)
 
 
-class TestPreimportRepairsEvenWhenAudioCheckOff(unittest.TestCase):
-    """MP3 header repair must run regardless of audio_check_mode — installs
-    that disable ffmpeg validation still rely on mp3val to fix fixable
-    header issues before spectral analysis and the import subprocess.
-    Matches the pre-refactor auto-path behavior.
-    """
-
-    def test_repair_runs_with_audio_check_off(self):
-        import os
-        from unittest.mock import patch
-        from lib.measurement import measure_preimport_state
-
-        cfg = CratediggerConfig(audio_check_mode="off")
-        tmpdir = tempfile.mkdtemp()
-        try:
-            with open(os.path.join(tmpdir, "01.mp3"), "wb") as f:
-                f.write(b"x")
-            with patch("lib.measurement.repair_mp3_headers") as mock_repair, \
-                 patch("lib.measurement.spectral_analyze",
-                       return_value=_analyze_result("genuine", None)):
-                measure_preimport_state(
-                    path=tmpdir,
-                    mb_release_id="",  # skip existing lookup
-                    label="Test",
-                    download_filetype="mp3",
-                    download_min_bitrate_bps=None,
-                    download_is_vbr=None,
-                    cfg=cfg,
-                )
-            self.assertEqual(
-                mock_repair.call_count, 1,
-                "repair_mp3_headers must run even with audio_check_mode=off")
-        finally:
-            import shutil
-            shutil.rmtree(tmpdir, ignore_errors=True)
-
-
 class TestUnknownVbrResolvesViaInspection(unittest.TestCase):
     """When the caller passes ``is_vbr=None`` (auto-path resumed download
     or force-path mutagen failure), the gate must attempt to resolve VBR

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -201,8 +201,7 @@ class TestMeasurePreimportState(unittest.TestCase):
             valid=False, error="decode failed",
             failed_files=[("track01.mp3", "decode error")],
         )
-        with patch("lib.measurement.validate_audio", return_value=bad_result), \
-             patch("lib.measurement.repair_mp3_headers"):
+        with patch("lib.measurement.validate_audio", return_value=bad_result):
             m = measure_preimport_state(
                 path="/tmp/does-not-exist",
                 mb_release_id="mbid-corrupt",
@@ -225,8 +224,7 @@ class TestMeasurePreimportState(unittest.TestCase):
         from lib.measurement import measure_preimport_state
 
         cfg = CratediggerConfig(audio_check_mode="off")
-        with patch("lib.measurement.repair_mp3_headers"), \
-             patch("lib.measurement._iter_audio_files", return_value=[]), \
+        with patch("lib.measurement._iter_audio_files", return_value=[]), \
              patch("lib.measurement._needs_spectral_check", return_value=False):
             m = measure_preimport_state(
                 path="/tmp/empty",
@@ -254,8 +252,7 @@ class TestMeasurePreimportState(unittest.TestCase):
             filetype="mp3", min_bitrate_bps=320_000,
             avg_bitrate_bps=320_000, is_vbr=False, has_nested_audio=True,
         )
-        with patch("lib.measurement.repair_mp3_headers"), \
-             patch(
+        with patch(
                  "lib.measurement._iter_audio_files",
                  return_value=[Path("/tmp/album/CD1/01.mp3"),
                                Path("/tmp/album/CD2/01.mp3")],
@@ -280,8 +277,7 @@ class TestMeasurePreimportState(unittest.TestCase):
         from lib.measurement import measure_preimport_state
 
         cfg = CratediggerConfig(audio_check_mode="off")
-        with patch("lib.measurement.repair_mp3_headers"), \
-             patch("lib.measurement._iter_audio_files", return_value=[]), \
+        with patch("lib.measurement._iter_audio_files", return_value=[]), \
              patch("lib.measurement._needs_spectral_check", return_value=False):
             m = measure_preimport_state(
                 path="/tmp/album",


### PR DESCRIPTION
## Summary

Follow-up to #348. Same architectural cleanup applied to mp3val: source bytes are mutated *once*, in the preview worker, *before* the snapshot. The importer + harness become pure consumers of the post-cleanup state.

## Before

\`repair_mp3_headers\` ran in three places:

1. \`lib/measurement.py::measure_preimport_state\` — called on whatever \`path\` the caller passed. Preview workers passed the throwaway temp copy, so the mutation was pure overhead (bytes thrown away with the copy seconds later).
2. \`lib/import_preview.py:951\` — second mp3val call on the temp copy, inside the legacy preview path's harness sub-path.
3. \`harness/import_one.py:1326\` — mp3val on the **source** path, right before beets materialised the import.

Site 3 was the one that actually mattered for beets (it operated on the real bytes beets was about to consume). The other two were no-ops in effect — they fixed copies that were then deleted.

The harness mp3val was timed safely (it ran *after* the importer's freshness check), but it left the \"source is immutable from preview onward\" invariant fuzzy — the harness still mutated source bytes.

## After

\`repair_mp3_headers(source_path)\` runs exactly once per album, in the preview worker, **before** \`snapshot_audio_files(source_path)\`. The snapshot captures the post-cleanup state. From snapshot onward, source bytes are immutable:

- Importer's freshness check (\`audio_snapshot_matches\`) → no mismatch (no mutation since snapshot).
- Harness's \`_validate_quality_evidence_action_snapshot\` → no mismatch.
- Wrong-match triage (if invoked later) → sees same bytes preview measured.
- Beets consumes the source.

## Why this is safe

- mp3val is a no-op on non-MP3 files, so FLAC/Opus/etc sources see zero behaviour change.
- \`repair_mp3_headers\` still calls \`mp3val -f -nb\` (\`-nb\` = no backup). No regression to the historical .bak file bug (fixed in d7fdff7; documented in \`harness/import_one.py:1115-1117\`).
- The new ordering invariant — mp3val before snapshot — is structurally obvious from reading the code. If someone flipped the order, the bug from #348 would re-emerge immediately (snapshot mismatch cascade) so failure mode is loud.

## Net effect

Fewer mp3val invocations per album:
- Before: 2-3 calls (temp-copy in worker preview + temp-copy in legacy preview's harness sub-path + source in harness real-import)
- After: 1 call (source in preview worker)

Net reduction is meaningful at scale — every MP3 album previously got mp3val-walked twice for nothing.

## Changes

- \`lib/measurement.py\` — drop \`repair_mp3_headers\` call from \`measure_preimport_state\`; drop unused import. Docstring notes callers must run mp3val on source before measurement.
- \`lib/import_preview.py\` — add \`repair_mp3_headers(path)\` before \`snapshot_audio_files(path)\` in both \`_preview_import_from_path_worker_mode\` (worker) and \`preview_import_from_path\` (legacy). Drop the temp-copy call.
- \`lib/download.py\` — add \`repair_mp3_headers(current_path)\` before \`measure_preimport_state\` in the legacy auto-import fallback, since the helper no longer runs it internally.
- \`harness/import_one.py\` — drop \`repair_mp3_headers(args.path)\` + its timing log; drop unused import.
- \`tests/test_measurement.py\` — drop 4 no-op \`patch(\"lib.measurement.repair_mp3_headers\")\` wrappers (no longer needed).
- \`tests/test_force_import_gates.py\` — delete \`TestPreimportRepairsEvenWhenAudioCheckOff\`. Behaviour previously tested: \"mp3val runs even with audio_check_mode=off inside \`measure_preimport_state\`\". New home: preview worker + legacy download fallback; both unconditional with no audio_check_mode branch. Invariant is structurally enforced rather than flag-guarded.

## Test plan

- [x] \`nix-shell --run \"pyright\"\` → 0 errors, 0 warnings, 0 informations.
- [x] Full suite: \`Ran 3700 tests in 51.477s\` → OK. (-1 test from the deletion noted above.)
- [ ] Post-deploy: confirm zero \`candidate source changed since evidence capture\` events for MP3 sources (previously could have fired if mp3val timing in the harness ever drifted past the snapshot check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)