### PR TITLE
refactor: delete legacy non-queue fallback in _process_beets_validation

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -46,7 +46,6 @@ from lib.import_evidence import (
     CandidateEvidenceActionResult,
     ensure_candidate_evidence_for_action,
 )
-from lib.measurement import measure_preimport_state
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
     automation_import_dedupe_key,
@@ -57,7 +56,6 @@ from lib.util import (
     move_abandoned_auto_import,
     move_failed_import,
     log_validation_result,
-    repair_mp3_headers,
 )
 
 if TYPE_CHECKING:
@@ -1090,7 +1088,7 @@ def process_completed_album(
     failed_grab: list[Any],
     ctx: CratediggerContext,
     *,
-    import_job_id: int | None = None,
+    import_job_id: int,
     validate_fn: "Callable[..., DispatchOutcome | None] | None" = None,
     handle_valid_fn: "Callable[..., DispatchOutcome | None] | None" = None,
     dispatch_fn: "Callable[..., DispatchOutcome | None] | None" = None,
@@ -1146,31 +1144,18 @@ def _process_beets_validation(
     staged_album: StagedAlbum,
     ctx: CratediggerContext,
     *,
-    import_job_id: int | None = None,
+    import_job_id: int,
     handle_valid_fn: "Callable[..., DispatchOutcome | None] | None" = None,
     dispatch_fn: "Callable[..., DispatchOutcome | None] | None" = None,
 ) -> "DispatchOutcome | None":
     """Beets validation sub-path of process_completed_album.
 
-    After beets validation passes, the queue-backed caller (``import_job_id``
-    + ``db`` set) relies on the preview/importer evidence pipeline:
-    ``ensure_candidate_evidence_for_action`` has already persisted candidate
-    evidence, and the importer runs ``full_pipeline_decision_from_evidence``
-    downstream. The legacy non-queue fallback (CLI / test callers with no
-    ``import_job_id`` or no DB) instead measures inline via
-    ``lib.measurement.measure_preimport_state`` and surfaces only the two
-    folder/audio-integrity facts (``audio_corrupt`` and ``bad_audio_hash``)
-    — quality decisions belong to the unified importer decider in U11.
-
-    Denylist on reject: this caller does NOT denylist peers directly from the
-    measurement. When the measurement flips ``bv_result.valid=False``, the
-    function returns into ``_handle_rejected_result``, which calls
-    ``reject_and_requeue(usernames=...)`` — that path writes the denylist
-    with the standard "beets validation rejected" reason. Per-fact denylist
-    differentiation (audio_corrupt → "audio decode failures", bad_audio_hash →
-    "matched curated bad audio hash") is the importer's concern via the
-    unified reject path (U11); the legacy fallback inherits whatever the
-    reject_and_requeue helper does, which is intentionally coarser.
+    After beets validation passes, ``ensure_candidate_evidence_for_action``
+    confirms the preview worker has persisted candidate evidence keyed to
+    this import_job. Missing evidence requeues the job to preview rather
+    than measuring inline — the importer never measures, the preview
+    worker owns evidence production, and the full pipeline decider
+    (``full_pipeline_decision_from_evidence``) runs downstream of evidence.
 
     Returns the dispatch outcome when the auto-import path fires,
     ``None`` when beets validation rejects (``_handle_rejected_result``
@@ -1187,96 +1172,27 @@ def _process_beets_validation(
     bv_result.soulseek_username = ", ".join(sorted(usernames_pre)) if usernames_pre else None
     bv_result.download_folder = current_path
     bv_result.source_dirs = _source_dirs_for_album(album_data)
-    candidate_evidence_result: CandidateEvidenceActionResult | None = None
-
     if bv_result.valid:
-        dl_pre = _build_download_info(album_data)
-        db = (ctx.pipeline_db_source._get_db()
-              if ctx.pipeline_db_source is not None else None)
-        candidate_evidence_available = False
-        if import_job_id is not None and db is not None:
-            candidate_result = ensure_candidate_evidence_for_action(
+        db = ctx.pipeline_db_source._get_db()
+        candidate_result = ensure_candidate_evidence_for_action(
+            db,
+            source_path=current_path,
+            import_job_id=import_job_id,
+        )
+        if not candidate_result.available:
+            reason = (
+                candidate_result.provenance.fallback_reason
+                or candidate_result.provenance.candidate_status
+                or "missing"
+            )
+            # Preview owns candidate-evidence production; the importer
+            # never measures. Requeue rather than fail; the dispatch-side
+            # requeue keeps the advisory-lock atomicity intact.
+            return _requeue_import_job_to_preview(
                 db,
-                source_path=current_path,
                 import_job_id=import_job_id,
+                reason=reason,
             )
-            candidate_evidence_result = candidate_result
-            candidate_evidence_available = candidate_result.available
-            if not candidate_evidence_available:
-                reason = (
-                    candidate_result.provenance.fallback_reason
-                    or candidate_result.provenance.candidate_status
-                    or "missing"
-                )
-                # U2: requeue the import_job to preview rather than failing.
-                # Preview owns candidate-evidence production; the importer
-                # never measures. The dispatch-side requeue keeps the
-                # advisory-lock atomicity intact.
-                return _requeue_import_job_to_preview(
-                    db,
-                    import_job_id=import_job_id,
-                    reason=reason,
-                )
-
-        if not candidate_evidence_available:
-            # U7: legacy non-queue fallback. Measure only; never decide. The
-            # importer's full pipeline decider owns spectral / codec rank /
-            # quality-gate outcomes. We inline only the two folder/audio-
-            # integrity facts (``audio_corrupt`` and ``bad_audio_hash``) —
-            # ``nested_layout`` and ``empty_fileset`` are intentionally NOT
-            # checked here, matching the historical scope of this fallback.
-            # Denylist on reject is handled downstream by
-            # ``_handle_rejected_result`` → ``reject_and_requeue`` (which
-            # writes the standard "beets validation rejected" denylist
-            # entry). This caller does not issue per-fact denylist writes.
-            try:
-                repair_mp3_headers(current_path)
-            except Exception:
-                pass
-            measurement = measure_preimport_state(
-                path=current_path,
-                mb_release_id=album_data.mb_release_id or "",
-                label=f"{album_data.artist} - {album_data.title}",
-                download_filetype=dl_pre.filetype or "",
-                download_min_bitrate_bps=dl_pre.bitrate,
-                download_is_vbr=dl_pre.is_vbr,
-                cfg=ctx.cfg,
-                db=db,
-                request_id=album_data.db_request_id,
-                propagate_download_to_existing=True,
-            )
-            album_data.download_spectral = measurement.download_spectral
-            album_data.current_spectral = measurement.existing_spectral
-            album_data.current_min_bitrate = measurement.existing_min_bitrate
-            audio_corrupt = measurement.audio_corrupt
-            bad_audio_hash = measurement.matched_bad_hash_id is not None
-            if audio_corrupt or bad_audio_hash:
-                scenario = "audio_corrupt" if audio_corrupt else "bad_audio_hash"
-                if audio_corrupt and measurement.corrupt_files:
-                    detail = (
-                        f"{len(measurement.corrupt_files)} files failed "
-                        "ffmpeg decode"
-                    )
-                elif bad_audio_hash and measurement.matched_bad_track_path:
-                    detail = (
-                        f"matched bad_audio_hash id="
-                        f"{measurement.matched_bad_hash_id} on track "
-                        f"{measurement.matched_bad_track_path}"
-                    )
-                else:
-                    detail = scenario
-                bv_result.valid = False
-                bv_result.scenario = scenario
-                bv_result.detail = detail
-                if audio_corrupt and measurement.corrupt_files:
-                    bv_result.corrupt_files = measurement.corrupt_files
-                # Carry bad-audio-hash gate match through to download_log via
-                # ValidationResult JSONB (plan 2026-04-29-005 / U5).
-                if bad_audio_hash:
-                    bv_result.matched_bad_hash_id = measurement.matched_bad_hash_id
-                    bv_result.matched_bad_track_path = measurement.matched_bad_track_path
-
-    if bv_result.valid:
         _handle_valid = (
             handle_valid_fn if handle_valid_fn is not None else _handle_valid_result
         )
@@ -1286,7 +1202,7 @@ def _process_beets_validation(
             staged_album,
             ctx,
             import_job_id=import_job_id,
-            prevalidated_candidate_result=candidate_evidence_result,
+            prevalidated_candidate_result=candidate_result,
             dispatch_fn=dispatch_fn,
         )
     return _handle_rejected_result(
@@ -2109,7 +2025,7 @@ def _run_completed_processing(
     db: Any,
     ctx: CratediggerContext,
     *,
-    import_job_id: int | None = None,
+    import_job_id: int,
     process_album_fn: "Callable[..., bool | DispatchOutcome | None] | None" = None,
 ) -> bool | DispatchOutcome | None:
     """Run or resume local post-download processing for a completed album.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1192,7 +1192,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
             self.assertTrue(result)
 
     def test_dispatch_outcome_summary_is_returned_to_queue_owner(
@@ -1227,7 +1227,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 return stub_outcome
 
             result = process_completed_album(
-                album, [], ctx, validate_fn=_stub_validate,
+                album, [], ctx, import_job_id=1, validate_fn=_stub_validate,
             )
 
             self.assertIs(result, stub_outcome)
@@ -1284,7 +1284,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 db_source="request",
             )
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             assert isinstance(result, DispatchOutcome)
             self.assertFalse(result.success)
@@ -1310,7 +1310,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
             self.assertFalse(result)
 
     def test_resumes_from_persisted_current_path(self):
@@ -1343,7 +1343,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertTrue(result)
             self.assertEqual(files[0].import_path, resumed_file)
@@ -1381,7 +1381,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertTrue(result)
             self.assertEqual(file.import_path, resumed_file)
@@ -1420,7 +1420,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = False
             ctx = make_ctx_with_fake_db(fake_db, cfg=cfg)
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertTrue(result)
             self.assertEqual(
@@ -1428,12 +1428,10 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 os.path.join(tmpdir, "downloads", "Artist - Album (2024)"),
             )
 
-    @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
     def test_returns_none_for_post_move_auto_import_retry(
         self,
         mock_beets_validate,
-        mock_measure_preimport_state,
     ):
         """Post-move auto-import retries must stop before re-dispatch."""
         from lib.download import process_completed_album
@@ -1478,17 +1476,11 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 distance=0.05,
                 scenario="strong_match",
             )
-            from lib.measurement import PreimportMeasurement
-            mock_measure_preimport_state.return_value = PreimportMeasurement(
-                folder_layout="flat",
-                audio_file_count=1,
-                filetype_band="mp3",
-            )
 
             dispatch_calls: list[dict] = []
             with self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(
-                    album, [], ctx,
+                    album, [], ctx, import_job_id=1,
                     dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
                 )
 
@@ -1537,7 +1529,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
 
             with self.assertLogs("cratedigger", level="ERROR") as logs:
-                result = process_completed_album(album, [], ctx)
+                result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertIsNone(result)
             self.assertIn("missing db_request_id", "\n".join(logs.output))
@@ -1583,278 +1575,15 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertTrue(result)
             self.assertEqual(album.files[0].import_path, resumed_file)
 
-    @patch("lib.download.measure_preimport_state")
-    @patch("lib.beets.beets_validate")
-    def test_request_auto_import_without_request_id_fails_before_staging_move(
-        self,
-        mock_beets_validate,
-        mock_measure_preimport_state,
-    ):
-        """Fresh request auto-imports must fail before moving into staged auto-import."""
-        from lib.download import process_completed_album
-        from lib.processing_paths import stage_to_ai_path
-        from lib.quality import ValidationResult
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            downloads_root = os.path.join(tmpdir, "downloads")
-            source_dir = os.path.join(downloads_root, "Music")
-            os.makedirs(source_dir)
-            source_file = os.path.join(source_dir, "01 - Track.mp3")
-            with open(source_file, "w") as f:
-                f.write("fake audio")
-
-            album = make_grab_list_entry(
-                files=[make_download_file(
-                    filename="user1\\Music\\01 - Track.mp3",
-                    file_dir="user1\\Music",
-                )],
-                album_id=1,
-                artist="Artist",
-                title="Album",
-                year="2024",
-                mb_release_id="test-mbid",
-                db_request_id=None,
-                db_source="request",
-            )
-            db = FakePipelineDB()
-            db.seed_request(make_request_row(
-                id=1,
-                status="downloading",
-                artist_name="Artist",
-                album_title="Album",
-                year=2024,
-                mb_release_id="test-mbid",
-            ))
-            cfg = cast(Any, _make_ctx().cfg)
-            ctx = make_ctx_with_fake_db(db, cfg=cfg)
-            cfg = cast(Any, ctx.cfg)
-            cfg.slskd_download_dir = downloads_root
-            cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
-            cfg.beets_validation_enabled = True
-            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            mock_beets_validate.return_value = ValidationResult(
-                valid=True,
-                distance=0.05,
-                scenario="strong_match",
-            )
-            from lib.measurement import PreimportMeasurement
-            mock_measure_preimport_state.return_value = PreimportMeasurement(
-                folder_layout="flat",
-                audio_file_count=1,
-                filetype_band="mp3",
-            )
-
-            expected_canonical = os.path.join(
-                downloads_root,
-                "Artist - Album (2024)",
-            )
-            unexpected_staged = stage_to_ai_path(
-                artist="Artist",
-                title="Album",
-                staging_dir=cfg.beets_staging_dir,
-                request_id=None,
-                auto_import=True,
-            )
-
-            dispatch_calls: list[dict] = []
-            with self.assertLogs("cratedigger", level="ERROR") as logs:
-                result = process_completed_album(
-                    album, [], ctx,
-                    dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
-                )
-
-            from lib.import_dispatch import DispatchOutcome
-            assert isinstance(result, DispatchOutcome)
-            self.assertFalse(result.success)
-            self.assertFalse(result.deferred)
-            self.assertIn("missing db_request_id", result.message)
-            failed_path = os.path.join(
-                downloads_root,
-                "failed_imports",
-                "Artist - Album (2024)",
-            )
-            self.assertFalse(os.path.exists(expected_canonical))
-            self.assertTrue(os.path.isfile(
-                os.path.join(failed_path, "01 - Track.mp3")))
-            self.assertFalse(os.path.exists(unexpected_staged))
-            self.assertEqual(dispatch_calls, [])
-            self.assertEqual(db.request(1)["status"], "wanted")
-            self.assertEqual(db.recorded_attempts, [(1, "validation")])
-            self.assertEqual(len(db.download_logs), 1)
-            self.assertEqual(
-                db.download_logs[0].beets_scenario,
-                "request_missing_request_id",
-            )
-            self.assertIsNotNone(db.download_logs[0].validation_result)
-            self.assertIn(
-                "missing_request_id",
-                str(db.download_logs[0].validation_result),
-            )
-            self.assertIn(
-                "failed_imports",
-                str(db.download_logs[0].validation_result),
-            )
-            self.assertIn("missing db_request_id", "\n".join(logs.output))
-
-    @patch("lib.download.measure_preimport_state")
-    @patch("lib.beets.beets_validate")
-    def test_request_auto_import_without_resolvable_request_logs_warning(
-        self,
-        mock_beets_validate,
-        mock_measure_preimport_state,
-    ):
-        """Unresolvable request ids must block in place, not orphan files."""
-        from lib.download import process_completed_album
-        from lib.quality import ValidationResult
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            downloads_root = os.path.join(tmpdir, "downloads")
-            source_dir = os.path.join(downloads_root, "Music")
-            os.makedirs(source_dir)
-            source_file = os.path.join(source_dir, "01 - Track.mp3")
-            with open(source_file, "w") as f:
-                f.write("fake audio")
-
-            album = make_grab_list_entry(
-                files=[make_download_file(
-                    filename="user1\\Music\\01 - Track.mp3",
-                    file_dir="user1\\Music",
-                )],
-                album_id=-1,
-                artist="Artist",
-                title="Album",
-                year="2024",
-                mb_release_id="test-mbid",
-                db_request_id=None,
-                db_source="request",
-            )
-            db = FakePipelineDB()
-            cfg = cast(Any, _make_ctx().cfg)
-            ctx = make_ctx_with_fake_db(db, cfg=cfg)
-            cfg = cast(Any, ctx.cfg)
-            cfg.slskd_download_dir = downloads_root
-            cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
-            cfg.beets_validation_enabled = True
-            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            mock_beets_validate.return_value = ValidationResult(
-                valid=True,
-                distance=0.05,
-                scenario="strong_match",
-            )
-            from lib.measurement import PreimportMeasurement
-            mock_measure_preimport_state.return_value = PreimportMeasurement(
-                folder_layout="flat",
-                audio_file_count=1,
-                filetype_band="mp3",
-            )
-
-            expected_canonical = os.path.join(
-                downloads_root,
-                "Artist - Album (2024)",
-            )
-            with self.assertLogs("cratedigger", level="ERROR") as logs:
-                result = process_completed_album(album, [], ctx)
-
-            self.assertIsNone(result)
-            self.assertEqual(db.download_logs, [])
-            self.assertEqual(db.status_history, [])
-            self.assertTrue(os.path.isfile(
-                os.path.join(expected_canonical, "01 - Track.mp3")))
-            self.assertFalse(os.path.exists(os.path.join(
-                downloads_root,
-                "failed_imports",
-                "Artist - Album (2024)",
-            )))
-            self.assertIn(
-                "BLOCKED WITHOUT REQUEST AUDIT",
-                "\n".join(logs.output),
-            )
-
-    @patch("lib.download.measure_preimport_state")
-    @patch("lib.beets.beets_validate")
-    def test_request_auto_import_without_request_id_matches_row_when_album_year_blank(
-        self,
-        mock_beets_validate,
-        mock_measure_preimport_state,
-    ):
-        """Blank album years must not block safe request-row recovery."""
-        from lib.download import process_completed_album
-        from lib.quality import ValidationResult
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            downloads_root = os.path.join(tmpdir, "downloads")
-            source_dir = os.path.join(downloads_root, "Music")
-            os.makedirs(source_dir)
-            source_file = os.path.join(source_dir, "01 - Track.mp3")
-            with open(source_file, "w") as f:
-                f.write("fake audio")
-
-            album = make_grab_list_entry(
-                files=[make_download_file(
-                    filename="user1\\Music\\01 - Track.mp3",
-                    file_dir="user1\\Music",
-                )],
-                album_id=1,
-                artist="Artist",
-                title="Album",
-                year="",
-                mb_release_id="test-mbid",
-                db_request_id=None,
-                db_source="request",
-            )
-            db = FakePipelineDB()
-            db.seed_request(make_request_row(
-                id=1,
-                status="downloading",
-                artist_name="Artist",
-                album_title="Album",
-                year=2024,
-                mb_release_id="test-mbid",
-            ))
-            cfg = cast(Any, _make_ctx().cfg)
-            ctx = make_ctx_with_fake_db(db, cfg=cfg)
-            cfg = cast(Any, ctx.cfg)
-            cfg.slskd_download_dir = downloads_root
-            cfg.beets_staging_dir = os.path.join(tmpdir, "staging")
-            cfg.beets_validation_enabled = True
-            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            mock_beets_validate.return_value = ValidationResult(
-                valid=True,
-                distance=0.05,
-                scenario="strong_match",
-            )
-            from lib.measurement import PreimportMeasurement
-            mock_measure_preimport_state.return_value = PreimportMeasurement(
-                folder_layout="flat",
-                audio_file_count=1,
-                filetype_band="mp3",
-            )
-
-            result = process_completed_album(album, [], ctx)
-
-            from lib.import_dispatch import DispatchOutcome
-            assert isinstance(result, DispatchOutcome)
-            self.assertFalse(result.success)
-            self.assertFalse(result.deferred)
-            self.assertIn("missing db_request_id", result.message)
-            self.assertEqual(db.request(1)["status"], "wanted")
-            self.assertEqual(len(db.download_logs), 1)
-            self.assertEqual(
-                db.download_logs[0].beets_scenario,
-                "request_missing_request_id",
-            )
-
-    @patch("lib.download.measure_preimport_state")
     @patch("lib.beets.beets_validate")
     def test_returns_none_for_legacy_shared_staged_retry(
         self,
         mock_beets_validate,
-        mock_measure_preimport_state,
     ):
         """Legacy shared staged retries must stop before validation reruns."""
         from lib.download import process_completed_album
@@ -1886,17 +1615,11 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = True
             cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            from lib.measurement import PreimportMeasurement
-            mock_measure_preimport_state.return_value = PreimportMeasurement(
-                folder_layout="flat",
-                audio_file_count=1,
-                filetype_band="mp3",
-            )
 
             dispatch_calls: list[dict] = []
             with self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(
-                    album, [], ctx,
+                    album, [], ctx, import_job_id=1,
                     dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
                 )
 
@@ -1904,75 +1627,6 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             mock_beets_validate.assert_not_called()
             self.assertEqual(dispatch_calls, [])
             self.assertIn("legacy shared staged path", "\n".join(logs.output))
-
-    @patch("lib.download.measure_preimport_state")
-    @patch("lib.beets.beets_validate")
-    def test_retries_post_move_redownload_path_without_blocking(
-        self,
-        mock_beets_validate,
-        mock_measure_preimport_state,
-    ):
-        """Post-move non-auto retries should re-enter and finish mark_done."""
-        from lib.download import process_completed_album
-        from lib.quality import ValidationResult
-        from lib.processing_paths import stage_to_ai_path
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            staging_root = os.path.join(tmpdir, "staging")
-            resumed_path = stage_to_ai_path(
-                artist="Artist",
-                title="Album",
-                staging_dir=staging_root,
-                request_id=42,
-                auto_import=False,
-            )
-            os.makedirs(resumed_path)
-            with open(os.path.join(resumed_path, "01 - Track.mp3"), "w") as f:
-                f.write("fake audio")
-
-            album = make_grab_list_entry(
-                files=[make_download_file(
-                    filename="user1\\Music\\01 - Track.mp3",
-                    file_dir="user1\\Music",
-                )],
-                artist="Artist",
-                title="Album",
-                year="2024",
-                mb_release_id="test-mbid",
-                db_request_id=42,
-                db_source="redownload",
-            )
-            album.import_folder = resumed_path
-            ctx = _make_ctx()
-            cfg = cast(Any, ctx.cfg)
-            cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
-            cfg.beets_staging_dir = staging_root
-            cfg.beets_validation_enabled = True
-            cfg.beets_tracking_file = os.path.join(tmpdir, "beets-tracking.jsonl")
-            os.makedirs(cfg.slskd_download_dir, exist_ok=True)
-            mock_beets_validate.return_value = ValidationResult(
-                valid=True,
-                distance=0.05,
-                scenario="strong_match",
-            )
-            from lib.measurement import PreimportMeasurement
-            mock_measure_preimport_state.return_value = PreimportMeasurement(
-                folder_layout="flat",
-                audio_file_count=1,
-                filetype_band="mp3",
-            )
-
-            dispatch_calls: list[dict] = []
-            result = process_completed_album(
-                album, [], ctx,
-                dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
-            )
-
-            self.assertTrue(result)
-            self.assertEqual(dispatch_calls, [])
-            source = ctx.pipeline_db_source
-            assert isinstance(source, FakePipelineDBSource)
-            self.assertEqual(len(source.mark_done_calls), 1)
 
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""
@@ -1995,7 +1649,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.slskd_download_dir = os.path.join(tmpdir, "downloads")
             cfg.beets_validation_enabled = False
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertFalse(result)
 
@@ -2023,7 +1677,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.beets_validation_enabled = False
             os.makedirs(cfg.slskd_download_dir, exist_ok=True)
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertFalse(result)
 
@@ -2274,7 +1928,7 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
             self.assertTrue(result)
             # Source should be gone; destination should exist.
             self.assertFalse(os.path.exists(src_suffixed))
@@ -2322,7 +1976,7 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertTrue(result)
             self.assertFalse(os.path.exists(src))
@@ -2359,7 +2013,7 @@ class TestProcessCompletedAlbumCollisionSuffix(unittest.TestCase):
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
 
-            result = process_completed_album(album, [], ctx)
+            result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertTrue(result)
             self.assertFalse(os.path.exists(src))

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -151,11 +151,6 @@ class TestAutomationEvidenceReuse(unittest.TestCase):
                 scenario="strong_match",
             )), \
                  patch(
-                     "lib.download.measure_preimport_state",
-                     side_effect=AssertionError(
-                         "valid preview evidence must skip preimport gates"),
-                 ) as gates, \
-                 patch(
                      "lib.download._handle_valid_result",
                      return_value=DispatchOutcome(True, "imported"),
                  ) as handle_valid:
@@ -168,7 +163,6 @@ class TestAutomationEvidenceReuse(unittest.TestCase):
 
         assert result is not None
         self.assertTrue(result.success)
-        gates.assert_not_called()
         handle_valid.assert_called_once()
         self.assertEqual(handle_valid.call_args.kwargs["import_job_id"], job.id)
 
@@ -238,8 +232,7 @@ class TestAutomationEvidenceReuse(unittest.TestCase):
                 valid=True,
                 distance=0.05,
                 scenario="strong_match",
-            )), \
-                 patch("lib.download.measure_preimport_state") as gates:
+            )):
                 result = _process_beets_validation(
                     album_data,
                     staged_album,
@@ -251,7 +244,6 @@ class TestAutomationEvidenceReuse(unittest.TestCase):
         assert result is not None
         self.assertFalse(result.success)
         self.assertIn("Candidate quality evidence unavailable", result.message)
-        gates.assert_not_called()
         self.assertEqual(handle_valid_calls, [])
 
 

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2561,6 +2561,7 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             current_spectral_bitrate=245))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
+            import_job_id=1,
             process_album_fn=lambda *_a, **_kw: None,
         )
         self.assertEqual(db.request(42)["status"], "downloading")
@@ -2579,6 +2580,7 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         db.seed_request(make_request_row(id=42, status="downloading"))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
+            import_job_id=1,
             process_album_fn=lambda *_a, **_kw: True,
         )
         self.assertEqual(db.request(42)["status"], "imported")
@@ -2592,6 +2594,7 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         db.seed_request(make_request_row(id=42, status="downloading"))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
+            import_job_id=1,
             process_album_fn=lambda *_a, **_kw: False,
         )
         self.assertEqual(db.request(42)["status"], "wanted")
@@ -2622,6 +2625,7 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             self._state(),
             db,
             self._ctx(db),
+            import_job_id=1,
             process_album_fn=reject_inside_process,
         )
 
@@ -2651,94 +2655,12 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
                 self._state(),
                 db,
                 self._ctx(db),
+                import_job_id=1,
             )
 
         self.assertIs(outcome, dispatch_outcome)
         self.assertEqual(db.request(42)["status"], "downloading")
         self.assertEqual(db.status_history, [])
-
-    def test_real_missing_request_id_rejection_transitions_once(self):
-        """The real missing-request-id reject path must transition exactly once."""
-        from lib import download as dl_mod
-        from lib.quality import ValidationResult
-        from tests.helpers import (
-            make_ctx_with_fake_db,
-            make_download_file,
-            make_grab_list_entry,
-        )
-
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(
-            id=42,
-            status="downloading",
-            artist_name="Artist",
-            album_title="Album",
-            year=2024,
-            mb_release_id="test-mbid",
-        ))
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            downloads_root = os.path.join(tmpdir, "downloads")
-            source_dir = os.path.join(downloads_root, "Music")
-            os.makedirs(source_dir)
-            with open(os.path.join(source_dir, "01 - Track.mp3"), "w") as fp:
-                fp.write("fake audio")
-
-            cfg = CratediggerConfig(
-                beets_harness_path=_HARNESS,
-                pipeline_db_enabled=True,
-                beets_validation_enabled=True,
-                beets_distance_threshold=0.15,
-                beets_staging_dir=os.path.join(tmpdir, "staging"),
-                slskd_download_dir=downloads_root,
-                beets_tracking_file=os.path.join(tmpdir, "beets-tracking.jsonl"),
-            )
-            ctx = make_ctx_with_fake_db(db, cfg=cfg)
-            entry = make_grab_list_entry(
-                album_id=42,
-                files=[make_download_file(
-                    filename="user1\\Music\\01 - Track.mp3",
-                    file_dir="user1\\Music",
-                )],
-                artist="Artist",
-                title="Album",
-                year="2024",
-                mb_release_id="test-mbid",
-                db_source="request",
-                db_request_id=None,
-            )
-
-            from lib.measurement import PreimportMeasurement
-            with patch("lib.beets.beets_validate", return_value=ValidationResult(
-                     valid=True,
-                     distance=0.05,
-                     scenario="strong_match",
-                 )), \
-                 patch(
-                     "lib.download.measure_preimport_state",
-                     return_value=PreimportMeasurement(
-                         folder_layout="flat",
-                         audio_file_count=1,
-                         filetype_band="mp3",
-                     ),
-                 ):
-                dl_mod._run_completed_processing(
-                    entry,
-                    42,
-                    self._state(),
-                    db,
-                    ctx,
-                )
-
-        self.assertEqual(db.request(42)["status"], "wanted")
-        self.assertEqual(db.status_history, [(42, "wanted")])
-        self.assertEqual(db.recorded_attempts, [(42, "validation")])
-        self.assertEqual(len(db.download_logs), 1)
-        self.assertEqual(
-            db.download_logs[0].beets_scenario,
-            "request_missing_request_id",
-        )
-
 
 class TestBadAudioHashSlice(unittest.TestCase):
     """Integration slice: bad-audio-hash gate inside ``measure_preimport_state``.


### PR DESCRIPTION
## Summary

Delete the legacy non-queue fallback in \`lib/download.py::_process_beets_validation\`. The fallback was the pre-queue architecture's inline measurement+integrity-gate — dead in production since #258/#261 made the queue/evidence path mandatory, kept alive only by test scaffolding.

Discussion thread that motivated this: we just finished moving mp3val to run once on source before snapshot (#350). The mp3val refactor added a defensive \`repair_mp3_headers\` call to the fallback for parity. Reviewing why that call was needed surfaced that the fallback itself is dead-in-production scaffolding: every production caller (\`scripts/importer.py::execute_automation_import_job\`) passes \`import_job_id\`, the evidence-check early return handles missing-evidence by requeuing to preview, and the fallback's \`if import_job_id is None OR db is None\` guard can't fire.

## Changes

- **\`lib/download.py\`** — make \`import_job_id\` required at \`process_completed_album\`, \`_process_beets_validation\`, and \`_run_completed_processing\` (drop \`int | None = None\` defaults). Delete the fallback block — the entire inline \`repair_mp3_headers\` + \`measure_preimport_state\` + \`audio_corrupt\`/\`bad_audio_hash\` integrity gate. Drop now-unused \`measure_preimport_state\` import and \`repair_mp3_headers\` import. Merge the two \`if bv_result.valid:\` arms in the simplified function since the early-return already handles missing-evidence.

- **\`tests/test_download.py\`** — pass \`import_job_id=1\` everywhere \`process_completed_album\` is called. Drop 6 stranded \`@patch(\"lib.download.measure_preimport_state\")\` decorators + their parameters + setup blocks (the import no longer exists in \`lib.download\`).

- **\`tests/test_integration_slices.py\`** — pass \`import_job_id=1\` everywhere \`_run_completed_processing\` is called. Drop the stranded \`patch(\"lib.download.measure_preimport_state\")\` in \`test_real_missing_request_id_rejection_transitions_once\`.

- **\`tests/test_import_queue.py::TestAutomationEvidenceReuse\`** — drop \`patch(\"lib.download.measure_preimport_state\")\` blocks. The \"valid evidence skips inline measurement\" invariant is now structural (no inline measurement exists to skip).

## Tests deleted (equivalence proof)

Five tests deleted because they exercised the legacy fallback's interaction with \`_handle_valid_result\`. Under the queue-and-evidence architecture, the same trigger conditions (\`db_request_id=None\` entries, or evidence-not-yet-seeded) hit the evidence-check requeue before reaching \`_handle_valid_result\`, so the tests can no longer drive the code paths they were asserting:

- \`test_download.py::test_request_auto_import_without_request_id_fails_before_staging_move\`
- \`test_download.py::test_request_auto_import_without_resolvable_request_logs_warning\`
- \`test_download.py::test_request_auto_import_without_request_id_matches_row_when_album_year_blank\`
- \`test_download.py::test_retries_post_move_redownload_path_without_blocking\`
- \`test_integration_slices.py::test_real_missing_request_id_rejection_transitions_once\`

The defensive code at \`_handle_valid_result:1385\` (missing \`db_request_id\` rejection) **still exists**. In production it is unreachable because the importer always constructs entries with a resolved \`db_request_id\` from \`active_download_state\`; if a future regression produces a null-\`db_request_id\` entry, the rejection still fires. Coverage of that branch via a live integration path would require seeding \`album_quality_evidence\` with a snapshot fingerprint matching the post-materialize canonical folder — possible but heavy. Deferred to a focused unit test against \`_handle_valid_result\` directly if/when a regression motivates it.

The redownload-mark_done re-entry path tested by the fourth deletion is covered by other tests in the redownload suite.

## Test plan

- [x] \`nix-shell --run \"pyright\"\` → 0 errors, 0 warnings, 0 informations.
- [x] Full suite: \`Ran 3695 tests in 50.872s\` → OK. (-5 from deletions noted above.)
- [ ] Post-deploy: production importer continues to claim and process automation_import jobs cleanly. The dead-in-prod fallback being deleted is a no-op — production never executed it.

## Stats

\`\`\`
4 files changed, 49 insertions(+), 565 deletions(-)
\`\`\`

Mostly deletion. Largely a code-honesty win: the production architecture is now matched by the code, no parallel \"what if someone calls this without a queue\" maintenance burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)