### PR TITLE
chore(tests): wire find_dead_code.sh into the test suite (#352)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,8 @@ nix-shell --run "python3 -m unittest tests.test_X -v"      # single module
 
 **Never re-run the full suite just to grep output differently.** Read `/tmp/cratedigger-test-output.txt`.
 
+The suite has three Python-side gates that all must pass: JS syntax + JS unit tests, then `bash scripts/find_dead_code.sh` (vulture against the whitelist baseline at `tools/vulture/whitelist.py`), then the Python unittest discovery. The dead-code sweep fails the run as soon as a new vulture finding appears that isn't whitelisted — operator either deletes it or regenerates the baseline per CLAUDE.md § "Finding dead code".
+
 ### Skipped tests are an anti-pattern
 
 **At our size, a test either runs or it doesn't exist.** No `@unittest.skipUnless`, no `raise unittest.SkipTest`, no env-gated "only when CRATEDIGGER_REAL_X is set", no "fixtures must be generated first." If you write a test, it runs every single invocation of `bash scripts/run_tests.sh` on a freshly-cloned dev shell. Period.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -23,6 +23,14 @@ node tests/test_js_history.mjs || exit 1
 node tests/test_js_wrong_matches.mjs || exit 1
 echo ""
 
+# Dead-code sweep — fails fast on new vulture findings before the slow
+# Python suite runs. Whitelist baseline lives at tools/vulture/whitelist.py;
+# operator either deletes the dead code or regenerates the whitelist with
+# the new entry (see CLAUDE.md § "Finding dead code").
+echo "=== Dead-code sweep ==="
+bash "$(dirname "$0")/find_dead_code.sh"
+echo ""
+
 # Python tests
 echo "=== Python tests ==="
 python3 -m unittest discover tests -v 2>&1 | tee "$OUT"


### PR DESCRIPTION
Fifteenth (and final-for-now) PR from #352. **Wires the audit's findings into the standard test suite** so dead code can't silently re-accumulate between audit passes.

## Change
Adds a "Dead-code sweep" step to \`scripts/run_tests.sh\` between the JS tests and the Python tests:

\`\`\`bash
=== Dead-code sweep ===
bash scripts/find_dead_code.sh
\`\`\`

Runs vulture against the whitelist baseline at \`tools/vulture/whitelist.py\`. Fails the run on any new finding that isn't whitelisted. \`find_dead_code.sh\` already prints the next-steps checklist on failure (delete OR regenerate the whitelist OR re-run with \`--baseline\` for the full candidate list).

## Why now
Until this PR, vulture was only invoked when an engineer manually ran \`find_dead_code.sh\`. Nothing prevented new dead code from landing between audit passes. The 14-PR / ~−2,400 LOC audit (#352) would silently rot without a gate.

## Trade-offs considered
- **Pre-commit hook** — rejected. Vulture adds ~5s to every WIP commit; pre-commit is meant to stay snappy (pyright on staged files only).
- **Pre-push hook** — feasible but the repo has no \`.git/hooks/pre-push\` convention; layering on the existing test-suite gate is simpler.
- **GitHub Actions / CI** — there is none. The test suite is the canonical "are we OK to ship" gate.
- **Placement** — BEFORE the Python tests so an obvious dead-code finding fails fast (~5s in) instead of after the 50s unittest run.

## Verification
End-to-end smoke:
1. Suite green on a clean tree.
2. Injected \`_intentionally_dead_for_gate_test\` into \`lib/peer_cache.py\` → suite halted at the dead-code sweep with exit 3, BEFORE Python tests ran.
3. Restored file → suite back to green.

CLAUDE.md "Running tests" section now documents the gate. The "Finding dead code" section already covers regen + cascading-orphan workflow.

## Stats
- \`scripts/run_tests.sh\`: +7 lines (sweep step + comment)
- \`CLAUDE.md\`: +2 lines

## Test plan
- [x] Suite passes on clean tree (3572 tests still pass)
- [x] Suite fails on a newly-introduced dead function
- [x] CLAUDE.md cross-references the existing "Finding dead code" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)