### PR TITLE
fix(quality): reject mixed lossless+lossy sources at the decision layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,8 +262,10 @@ fallback — spectral compares to spectral evidence only (invariant of #257).
 
 **The album test set is what defines behavior.** Live-bug scenarios go in
 `tests/test_quality_classification.py::TestLiveBugReproductions` (Bride,
-Flux, Taboo, Tyler Lambert, BoC, Heretic Pride, etc.) and the four-fact
-scenarios go in `TestFourFactPreimportRejects` (same file). Every scenario
+Flux, Taboo, Tyler Lambert, BoC, Heretic Pride, etc.) and the
+preimport-fact scenarios (audio_corrupt, bad_audio_hash, nested_layout,
+empty_fileset, mixed_source) go in `TestPreimportFactRejects` (same file).
+Every scenario
 MUST also be exercised through the production decider via
 `TestLiveBugReproductionsThroughEvidencePipeline` — the parity contract is
 that the simulator and the evidence pipeline reach the same outcome on the

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1715,13 +1715,36 @@ def main():
     if new_avg_br is not None:
         _log(f"  new_avg_bitrate={new_avg_br}")
 
+    # Mixed-source guard: a folder bundling lossless + lossy audio (e.g.
+    # 15 FLAC + 2 MP3 bonus tracks) is rejected at the evidence layer via
+    # ``preimport_mixed_source``. The lossy files would otherwise pass
+    # through to the library untouched and the album would falsely stamp
+    # verified-lossless. Look at the original source directory (``args.path``)
+    # — ``work_path`` has already been mutated by conversion so it contains
+    # the V0 outputs alongside the kept FLAC originals.
+    try:
+        _source_audio_files = [
+            f for f in os.listdir(args.path)
+            if os.path.splitext(f)[1].lower() in AUDIO_EXTENSIONS
+        ]
+        has_lossy_passthrough = (
+            any(_is_lossless_file(f, args.path) for f in _source_audio_files)
+            and any(
+                not _is_lossless_file(f, args.path)
+                for f in _source_audio_files
+            )
+        )
+    except OSError:
+        has_lossy_passthrough = False
+
     # Verified lossless: single source of truth in quality.py. r.v0_probe is
     # populated above (lossless source path) and lets the V0-avg trust
     # override flip a spectral suspect/likely_transcode sparse-HF lossless
     # source to verified when the V0 evidence corroborates a genuine master.
     will_be_verified_lossless = determine_verified_lossless(
         args.target_format, spectral_grade, converted, is_transcode,
-        v0_probe=r.v0_probe)
+        v0_probe=r.v0_probe,
+        has_lossy_passthrough=has_lossy_passthrough)
     v0_verified_lossless_override = (
         will_be_verified_lossless
         and spectral_grade in SPECTRAL_TRANSCODE_GRADES

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -376,6 +376,7 @@ _PREIMPORT_FACT_REJECT_DECISIONS: frozenset[str] = frozenset({
     "bad_audio_hash",
     "nested_layout",
     "empty_fileset",
+    "mixed_source",
 })
 
 
@@ -796,6 +797,8 @@ def _reject_import_from_evidence_decision(
             if decision == "bad_audio_hash"
             else "spectral analysis rejected the source"
             if decision == "spectral_reject"
+            else "mixed lossless+lossy source"
+            if decision == "mixed_source"
             else f"rejected: {decision}"
         )
         for username in usernames:

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -2631,6 +2631,8 @@ def determine_verified_lossless(
     converted_count: int,
     is_transcode: bool,
     v0_probe: "V0ProbeEvidence | None" = None,
+    *,
+    has_lossy_passthrough: bool = False,
 ) -> bool:
     """Single source of truth for verified lossless status (pure).
 
@@ -2646,7 +2648,18 @@ def determine_verified_lossless(
     ``lossless_source_v0`` probe at avg≥230kbps AND min≥200kbps), trust
     the V0 probe and certify as verified. The override is monotonic — it
     only flips False→True, never True→False.
+
+    Mixed-source guard (``has_lossy_passthrough``): when the source folder
+    contains lossless audio AND audio that will pass through unconverted
+    (e.g. 15 FLAC + 2 MP3 bonus tracks), the album can never be
+    verified-lossless regardless of converted_count / spectral / V0. The
+    decision layer rejects these sources outright via
+    ``preimport_mixed_source`` in ``full_pipeline_decision_from_evidence``;
+    this argument is the harness-side defense in depth so the persisted
+    candidate measurement field is honest even on the never-imported row.
     """
+    if has_lossy_passthrough:
+        return False
     if target_format in ("flac", "lossless"):
         if spectral_grade in ("genuine", "marginal", None):
             return True
@@ -2803,6 +2816,14 @@ def dispatch_action(decision: str) -> DispatchAction:
         # U11: folder-shape reject (no audio files). Not a peer quality
         # problem — no denylist. Clean the staged dir; caller forces requeue.
         return DispatchAction(record_rejection=True, denylist=False, cleanup=True)
+    elif decision == "mixed_source":
+        # Mixed lossless + lossy in one folder. Peer chose to bundle lossy
+        # bonus tracks alongside lossless audio — denylist them so the same
+        # source doesn't burn another cycle on the same mixed bag. Clean
+        # the staged dir; caller forces requeue via
+        # ``_PREIMPORT_FACT_REJECT_DECISIONS`` so the album stays searchable
+        # for a fully-lossless source. See ``has_mixed_lossless_and_lossy``.
+        return DispatchAction(record_rejection=True, denylist=True, cleanup=True)
     elif decision == "duplicate_remove_guard_failed":
         return DispatchAction(record_rejection=True, denylist=True, requeue=False,
                               cleanup=False)
@@ -3013,6 +3034,42 @@ AUDIO_EXTENSIONS_DOTTED: frozenset[str] = frozenset(f".{e}" for e in AUDIO_EXTEN
 
 # Codecs that are lossless by definition
 LOSSLESS_CODECS: frozenset[str] = frozenset({"flac", "alac", "wav"})
+
+# Container-level lossless/lossy sets used by the mixed-source preimport
+# reject in ``full_pipeline_decision_from_evidence``. Container is the
+# discriminator (codec is too noisy: ``.m4a`` can hold ALAC or AAC). We
+# duplicate the sets from ``lib.quality_evidence`` deliberately —
+# importing them would invert the existing one-way dependency
+# (``quality_evidence -> quality``). The mixed-source check has no other
+# need for the broader filetype-band machinery.
+_MIXED_REJECT_LOSSLESS_CONTAINERS: frozenset[str] = frozenset(
+    {"flac", "alac", "wav", "aiff", "ape"}
+)
+_MIXED_REJECT_LOSSY_CONTAINERS: frozenset[str] = frozenset(
+    {"mp3", "aac", "m4a", "ogg", "opus", "wma"}
+)
+
+
+def has_mixed_lossless_and_lossy(
+    files: "Sequence[AlbumQualityEvidenceFile]",
+) -> bool:
+    """True when the snapshot contains both lossless and lossy containers.
+
+    Cratedigger stays release-based: a folder that ships 15 FLACs + 2 MP3
+    bonus tracks must be rejected outright, not partially imported. The
+    historical bug (request 4445 Fast Times at Barrington High) was that
+    ``determine_verified_lossless`` saw ``converted_count=15`` and stamped
+    the whole album as verified-lossless, which then poisoned wrong-match
+    cleanup against future fully-FLAC candidates. See
+    ``TestPreimportFactRejects::test_mixed_source_routes_through_full_pipeline``.
+    """
+    if not files:
+        return False
+    containers = {f.container.lower() for f in files if f.container}
+    return bool(
+        containers & _MIXED_REJECT_LOSSLESS_CONTAINERS
+        and containers & _MIXED_REJECT_LOSSY_CONTAINERS
+    )
 
 # Sentinel: matches any audio file (used for catch-all "download anything" mode)
 # Assigned after AudioFileSpec class definition below
@@ -3722,6 +3779,7 @@ def full_pipeline_decision(
         # dict shapes identical.
         "preimport_bad_hash": None,
         "preimport_empty_fileset": None,
+        "preimport_mixed_source": None,
         "stage0_spectral_gate": None,
         "stage1_spectral": None,
         "stage2_import": None,
@@ -4203,6 +4261,8 @@ def evidence_decision_name(
         return "nested_layout"
     if result.get("preimport_empty_fileset") == "reject_empty":
         return "empty_fileset"
+    if result.get("preimport_mixed_source") == "reject_mixed_source":
+        return "mixed_source"
     for key in ("stage2_import", "stage3_quality_gate"):
         value = result.get(key)
         if isinstance(value, str) and value:
@@ -4282,6 +4342,8 @@ def classify_full_pipeline_decision(
         return "confident_reject", True, "bad_audio_hash"
     if decision.get("preimport_empty_fileset") == "reject_empty":
         return "confident_reject", True, "empty_fileset"
+    if decision.get("preimport_mixed_source") == "reject_mixed_source":
+        return "confident_reject", True, "mixed_source"
     if (
         decision.get("stage1_spectral") == "reject"
         and not decision.get("stage2_import")
@@ -4421,6 +4483,7 @@ def full_pipeline_decision_from_evidence(
             "preimport_nested": str | None,
             "preimport_bad_hash": str | None,       # U11
             "preimport_empty_fileset": str | None,  # U11
+            "preimport_mixed_source": str | None,   # mixed-source reject
             "stage0_spectral_gate": str | None,
             "stage1_spectral": str | None,
             "stage2_import": str | None,
@@ -4433,20 +4496,24 @@ def full_pipeline_decision_from_evidence(
             "verified_lossless": bool,
         }
 
-    U11: four folder/audio-integrity facts are read directly off
-    ``candidate`` as early-exit rejects (in the same order the deleted
-    ``preimport_decide`` evaluated them):
+    Folder/audio-integrity facts are read directly off ``candidate`` as
+    early-exit rejects (in priority order):
 
       1. ``audio_corrupt``  — sets ``preimport_audio='reject_corrupt'``
       2. ``bad_audio_hash`` — sets ``preimport_bad_hash='reject_bad_hash'``
       3. ``nested_layout``  — sets ``preimport_nested='reject_nested'``
       4. ``empty_fileset``  — sets ``preimport_empty_fileset='reject_empty'``
+      5. ``mixed_source``   — sets
+         ``preimport_mixed_source='reject_mixed_source'`` when the
+         snapshot contains both lossless and lossy containers (e.g.
+         15 FLAC + 2 MP3). Keeps Cratedigger release-based — never
+         partially-imports an album.
 
     The accompanying ``evidence_decision_name`` maps these dict shapes to
     ``audio_corrupt`` / ``bad_audio_hash`` / ``nested_layout`` /
-    ``empty_fileset`` decision strings, which the importer feeds to
-    ``dispatch_action`` and the unified ``_reject_import_from_evidence_decision``
-    helper.
+    ``empty_fileset`` / ``mixed_source`` decision strings, which the
+    importer feeds to ``dispatch_action`` and the unified
+    ``_reject_import_from_evidence_decision`` helper.
     """
 
     if facts is None:
@@ -4473,9 +4540,10 @@ def full_pipeline_decision_from_evidence(
         preimport_nested: str | None = None,
         preimport_bad_hash: str | None = None,
         preimport_empty_fileset: str | None = None,
+        preimport_mixed_source: str | None = None,
         denylisted: bool,
     ) -> dict[str, Any]:
-        # Mirror the live four-fact reject side effects: auto-import
+        # Mirror the live preimport-fact reject side effects: auto-import
         # rejects re-queue to ``wanted``; force/manual leaves the
         # request alone (the unified reject helper forces ``requeue=True``
         # for these decisions regardless, but the dict's ``final_status``
@@ -4489,6 +4557,7 @@ def full_pipeline_decision_from_evidence(
             "preimport_nested": preimport_nested,
             "preimport_bad_hash": preimport_bad_hash,
             "preimport_empty_fileset": preimport_empty_fileset,
+            "preimport_mixed_source": preimport_mixed_source,
             "stage0_spectral_gate": None,
             "stage1_spectral": None,
             "stage2_import": None,
@@ -4530,6 +4599,16 @@ def full_pipeline_decision_from_evidence(
         return _early_reject_result(
             preimport_empty_fileset="reject_empty",
             denylisted=False,
+        )
+
+    # Mixed-source reject: lossless + lossy containers in the same folder.
+    # Cratedigger stays release-based — a partial FLAC+MP3 source must
+    # never get partially-imported and stamped verified-lossless. See
+    # ``has_mixed_lossless_and_lossy`` and the Fast Times reproduction.
+    if has_mixed_lossless_and_lossy(candidate.files):
+        return _early_reject_result(
+            preimport_mixed_source="reject_mixed_source",
+            denylisted=True,
         )
 
     candidate_measurement = candidate.measurement

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -677,14 +677,14 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
         self.assertTrue(cleanup_eligible)
 
 
-class TestFourFactPreimportRejects(unittest.TestCase):
-    """U11: the four folder/audio-integrity facts that used to live in
-    ``preimport_decide`` are now early-exit rejects at the top of
-    ``full_pipeline_decision_from_evidence``. Each test covers one fact:
-    asserts the decision dict carries the right ``preimport_*`` key AND
-    that ``evidence_decision_name`` maps it to the expected decision string.
+class TestPreimportFactRejects(unittest.TestCase):
+    """U11+: folder/audio-integrity facts that fire as early-exit rejects at
+    the top of ``full_pipeline_decision_from_evidence`` before any quality
+    stage runs. Each test covers one fact: asserts the decision dict carries
+    the right ``preimport_*`` key AND that ``evidence_decision_name`` maps
+    it to the expected decision string.
 
-    Parity with the (deleted) ``preimport_decide``:
+    Facts (in reject-priority order):
       * ``audio_corrupt``  → ``preimport_audio='reject_corrupt'``,
         ``evidence_decision_name='audio_corrupt'``,
         ``classify_full_pipeline_decision`` → confident_reject
@@ -694,9 +694,12 @@ class TestFourFactPreimportRejects(unittest.TestCase):
         ``evidence_decision_name='nested_layout'``
       * ``empty_fileset`` → ``preimport_empty_fileset='reject_empty'``,
         ``evidence_decision_name='empty_fileset'``
-
-    The reject order matches the deleted ``preimport_decide``: corrupt >
-    bad-hash > nested > empty.
+      * ``mixed_source`` (lossless+lossy in one folder) →
+        ``preimport_mixed_source='reject_mixed_source'``,
+        ``evidence_decision_name='mixed_source'``. Lives here so a partial
+        FLAC+MP3 source never stamps the parent album as verified-lossless
+        — Cratedigger stays release-based, not song-based. See the Fast
+        Times at Barrington High reproduction (request 4445, evidence 5888).
     """
 
     # Reuse the parity helpers so the new tests share the exact shape used
@@ -831,6 +834,146 @@ class TestFourFactPreimportRejects(unittest.TestCase):
         self.assertTrue(cleanup_eligible)
         self.assertEqual(reason, "empty_fileset")
 
+    def test_mixed_source_routes_through_full_pipeline(self):
+        """Fast Times at Barrington High reproduction (request 4445).
+
+        Source folder had 15 .flac + 2 .mp3 (bonus tracks). Previously
+        ``determine_verified_lossless(converted_count=15, is_transcode=False)``
+        returned True with no knowledge that 2 untouched lossy files would
+        be copied into the library, producing a ``verified_lossless=true``
+        stamp on a ``mixed_lossy`` album that then poisoned the wrong-match
+        cleanup short-circuit (parent_album_verified_lossless → auto-delete
+        future fully-FLAC candidates against the same MBID).
+
+        The fix: detect lossless+lossy containers in the candidate snapshot
+        files and reject before any conversion or import runs. Self-heals
+        back to ``wanted`` like the other preimport-fact rejects.
+        """
+        from lib.quality import (
+            AlbumQualityEvidence,
+            AlbumQualityEvidenceDecisionFacts,
+            AlbumQualityEvidenceFile,
+            AudioQualityMeasurement,
+            classify_full_pipeline_decision,
+            evidence_decision_name,
+            full_pipeline_decision_from_evidence,
+        )
+        from datetime import datetime, timezone
+
+        # 15 FLAC + 2 MP3, mirroring the live download 17772 source folder.
+        files = [
+            AlbumQualityEvidenceFile(
+                relative_path=f"{i:02d}.flac",
+                size_bytes=1, mtime_ns=1,
+                extension="flac", container="flac", codec="flac",
+            )
+            for i in range(1, 16)
+        ] + [
+            AlbumQualityEvidenceFile(
+                relative_path="16.mp3",
+                size_bytes=1, mtime_ns=1,
+                extension="mp3", container="mp3", codec="mp3",
+            ),
+            AlbumQualityEvidenceFile(
+                relative_path="17.mp3",
+                size_bytes=1, mtime_ns=1,
+                extension="mp3", container="mp3", codec="mp3",
+            ),
+        ]
+        candidate = AlbumQualityEvidence(
+            mb_release_id="mbid-fast-times",
+            snapshot_fingerprint="sha256:fast-times-mixed",
+            source_path="/Incoming/auto-import/candidate",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=900,
+                avg_bitrate_kbps=900,
+                median_bitrate_kbps=900,
+                format="FLAC",
+                is_cbr=False,
+                spectral_grade="genuine",
+            ),
+            measured_at=datetime(2026, 5, 21, tzinfo=timezone.utc),
+            files=files,
+            codec="flac",
+            container="flac",
+            storage_format="flac",
+            audio_file_count=len(files),
+            # The slskd-string filetype_band that produced the live row 5887.
+            filetype_band="flac, mp3",
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, None,
+            facts=AlbumQualityEvidenceDecisionFacts(import_mode="auto"),
+        )
+
+        self.assertEqual(r["preimport_mixed_source"], "reject_mixed_source")
+        self.assertFalse(r["imported"])
+        # Mixed source is a peer-quality problem (peer chose to bundle lossy
+        # bonus tracks). Denylist them so the same person serving the same
+        # mixed bag doesn't burn another cycle.
+        self.assertTrue(r["denylisted"])
+        self.assertEqual(r["final_status"], "wanted")
+        self.assertTrue(r["keep_searching"])
+        self.assertFalse(r["verified_lossless"])
+        self.assertEqual(evidence_decision_name(r), "mixed_source")
+        verdict, cleanup_eligible, reason = classify_full_pipeline_decision(r)
+        self.assertEqual(verdict, "confident_reject")
+        self.assertTrue(cleanup_eligible)
+        self.assertEqual(reason, "mixed_source")
+
+    def test_mixed_source_all_lossless_multi_codec_does_not_trip(self):
+        """FLAC + WAV in the same folder is all-lossless — must NOT trip
+        the mixed_source reject. The check is specifically "lossless +
+        lossy in the same folder", not "multiple containers"."""
+        from lib.quality import (
+            AlbumQualityEvidence,
+            AlbumQualityEvidenceDecisionFacts,
+            AlbumQualityEvidenceFile,
+            AudioQualityMeasurement,
+            full_pipeline_decision_from_evidence,
+        )
+        from datetime import datetime, timezone
+
+        files = [
+            AlbumQualityEvidenceFile(
+                relative_path="01.flac",
+                size_bytes=1, mtime_ns=1,
+                extension="flac", container="flac", codec="flac",
+            ),
+            AlbumQualityEvidenceFile(
+                relative_path="02.wav",
+                size_bytes=1, mtime_ns=1,
+                extension="wav", container="wav", codec="wav",
+            ),
+        ]
+        candidate = AlbumQualityEvidence(
+            mb_release_id="mbid-multi-lossless",
+            snapshot_fingerprint="sha256:multi-lossless",
+            source_path="/Incoming/auto-import/candidate",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=900,
+                avg_bitrate_kbps=900,
+                median_bitrate_kbps=900,
+                format="FLAC",
+                is_cbr=False,
+            ),
+            measured_at=datetime(2026, 5, 21, tzinfo=timezone.utc),
+            files=files,
+            codec="flac",
+            container="flac",
+            storage_format="flac",
+            audio_file_count=len(files),
+            filetype_band="flac, wav",
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, None,
+            facts=AlbumQualityEvidenceDecisionFacts(import_mode="auto"),
+        )
+
+        self.assertIsNone(r["preimport_mixed_source"])
+
     def test_decision_order_corrupt_takes_priority_over_other_facts(self):
         """When multiple facts are present, ``audio_corrupt`` wins
         (matches the deleted ``preimport_decide`` evaluation order)."""
@@ -859,7 +1002,7 @@ class TestFourFactPreimportRejects(unittest.TestCase):
         self.assertEqual(evidence_decision_name(r), "audio_corrupt")
 
     def test_force_mode_does_not_set_keep_searching(self):
-        """The four-fact reject dict reflects the auto-path requeue
+        """The preimport-fact reject dict reflects the auto-path requeue
         invariant; force/manual leaves the parent request alone
         (the unified reject helper independently forces requeue=True via
         ``_PREIMPORT_FACT_REJECT_DECISIONS`` — that's tested in

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -185,10 +185,10 @@ class TestSpectralImportDecision(unittest.TestCase):
 
 # ============================================================================
 # U11: ``preimport_decide`` was folded into ``full_pipeline_decision_from_evidence``.
-# Its four folder/audio-integrity reject branches (audio_corrupt,
-# bad_audio_hash, nested_layout, empty_fileset) are now early-exit rejects
+# Its folder/audio-integrity reject branches (audio_corrupt, bad_audio_hash,
+# nested_layout, empty_fileset, mixed_source) are now early-exit rejects
 # at the top of the unified decider. The pure-branch coverage lives in
-# ``tests/test_quality_classification.py::TestFourFactPreimportRejects`` and
+# ``tests/test_quality_classification.py::TestPreimportFactRejects`` and
 # the parity contract in
 # ``TestLiveBugReproductionsThroughEvidencePipeline``.
 # ============================================================================
@@ -866,7 +866,9 @@ EXPECTED_RESULT_KEYS = {
     "preimport_audio", "preimport_nested",
     # U11: bad_audio_hash + empty_fileset early branches read from evidence;
     # the flat-kwargs simulator leaves them None.
+    # mixed_source (lossless+lossy in one folder) is also evidence-only.
     "preimport_bad_hash", "preimport_empty_fileset",
+    "preimport_mixed_source",
     "stage0_spectral_gate",
     "stage1_spectral", "stage2_import", "stage3_quality_gate",
     "final_status", "imported", "denylisted", "keep_searching",


### PR DESCRIPTION
## Summary

- Adds a fifth preimport-fact early-exit (`preimport_mixed_source`) to `full_pipeline_decision_from_evidence` that fires whenever the candidate snapshot contains both lossless and lossy containers (e.g. 15 FLAC + 2 MP3 bonus tracks).
- Denylists the peer (same source bundling same mix would burn another cycle) and self-heals the request back to `wanted` so it stays searchable for a fully-lossless source.
- Defense in depth: `determine_verified_lossless` gains a `has_lossy_passthrough` kwarg so the persisted candidate measurement is honest even on the rejected row; `harness/import_one.py` snapshots `args.path` before any conversion to compute it.

## Live repro

Request 4445 (The Academy Is… Fast Times at Barrington High), evidence row 5888: 15 Opus tracks transcoded from FLAC + 2 MP3 bonus tracks passed through untouched, stamped `verified_lossless=true` on disk filetype band `mixed_lossy`. The stamp poisoned `wrong_match_cleanup_service` short-circuit (`OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT`) — any future fully-FLAC candidate against the same MBID would have been auto-deleted before any quality comparison.

Cratedigger stays release-based, not song-based: reject the mixed source outright, never partially-import.

## Test plan

- [x] New `TestPreimportFactRejects::test_mixed_source_routes_through_full_pipeline` (15 FLAC + 2 MP3 evidence shape) asserts `decision='mixed_source'`, `verified_lossless=False`, `denylisted=True`, `final_status='wanted'`.
- [x] New `test_mixed_source_all_lossless_multi_codec_does_not_trip` (FLAC + WAV) confirms the check is specifically "lossless + lossy", not "multi-container".
- [x] Full suite: `nix-shell --run "bash scripts/run_tests.sh"` — 3574 tests, OK.
- [x] Pyright: 0 errors.
- [ ] Post-deploy: backfill `album_quality_evidence` 5888 (clear `verified_lossless` + proof fields) and reset `album_requests` 4445 to `wanted`. Verify the wrong-match short-circuit no longer fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)