### PR TITLE
fix(resolver): three post-deploy gaps from PR1 backfill (#1 VA dispatch, #2 raw MB payload, #3 4xx sticky)

### DIFF
--- a/lib/field_resolver_service.py
+++ b/lib/field_resolver_service.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 ResolverStatus = Literal[
     "resolved",
     "unresolved_404",
+    "unresolved_4xx_client",
     "unresolved_malformed",
     "unresolved_mirror_unavailable",
     "unresolved_timeout",
@@ -192,15 +193,35 @@ def _classify_lookup_exception(
     """Map an exception from a mirror call to a status + reason_code.
 
     Centralised so the four resolvers share the same retry-window
-    semantics. ``urllib.error.HTTPError`` with ``code=404`` becomes
-    ``unresolved_404`` (sticky 30d); ``TimeoutError`` becomes
-    ``unresolved_timeout`` (retry 1d); other URL/socket/JSON errors
-    become ``unresolved_mirror_unavailable`` (retry 1d). Anything else
-    re-raises -- callers are responsible for catching programmer
-    errors.
+    semantics:
+
+    - ``HTTPError(404)`` → ``unresolved_404`` (sticky 30d). Treated
+      as its own bucket because "release doesn't exist" is the
+      most common upstream cause and operators triage it
+      differently from other client errors.
+    - ``HTTPError(4xx)`` other than 404 / 408 → ``unresolved_4xx_client``
+      (sticky). Permanent client-error semantics — retrying the same
+      input gives the same answer (400 Bad Request, 410 Gone, 422
+      Unprocessable Entity, etc.). 408 Request Timeout stays in the
+      transient bucket. Fix #3 from the 2026-05-25 deploy: 74 wanted
+      rows hit MB 400 Bad Request and were retried-forever as
+      ``unresolved_mirror_unavailable`` instead of being surfaced.
+    - ``HTTPError(5xx)`` → ``unresolved_mirror_unavailable`` (retry 1d).
+      Server-side, legitimate to retry.
+    - ``TimeoutError`` / ``socket.timeout`` / ``HTTPError(408)`` →
+      ``unresolved_timeout`` (retry 1d).
+    - Other URL/socket/JSON errors → ``unresolved_mirror_unavailable``
+      (retry 1d).
+
+    Anything else re-raises — callers are responsible for catching
+    programmer errors.
     """
-    if isinstance(exc, urllib.error.HTTPError) and exc.code == 404:
-        return ("unresolved_404", "http_404")
+    if isinstance(exc, urllib.error.HTTPError):
+        if exc.code == 404:
+            return ("unresolved_404", "http_404")
+        if 400 <= exc.code < 500 and exc.code != 408:
+            return ("unresolved_4xx_client", f"http_{exc.code}")
+        # 408 falls through to timeout, 5xx falls through to mirror_unavailable.
     if _is_timeout_exception(exc):
         return ("unresolved_timeout", type(exc).__name__)
     if isinstance(exc, _MIRROR_UNAVAILABLE_EXCEPTIONS):
@@ -235,8 +256,16 @@ def _default_discogs_get_master_year(master_id: str) -> int | None:
 def _default_mb_get_release(
     mbid: str, *, fresh: bool = False,
 ) -> dict[str, Any]:
-    from web.mb import get_release
-    return get_release(mbid, fresh=fresh)
+    # The resolvers need the *raw* MB JSON shape — they extract
+    # ``label-info`` (for catalog_number), ``media[].tracks[].artist-
+    # credit`` (for track_artist), and ``release-group`` nested fields
+    # (for VA Rule 2). The slimmed shape returned by
+    # ``web.mb.get_release`` drops all three. Pre-2026-05-25 deploy
+    # the resolver service silently downgraded those fields to
+    # ``unresolved_field_missing_upstream`` for every MB request
+    # because the wrong fetcher was wired in here.
+    from web.mb import get_release_raw
+    return get_release_raw(mbid, fresh=fresh)
 
 
 def _default_discogs_get_release(
@@ -1083,7 +1112,18 @@ def detect_va_compilation(
     out.
     """
     discogs_release_id = request.get("discogs_release_id")
-    is_discogs = bool(discogs_release_id) and not request.get("mb_release_id")
+    mb_release_id = request.get("mb_release_id")
+    # Discogs-sourced rows store the discogs id in BOTH columns for
+    # pipeline-compat (the web/CLI Discogs add path stuffs the discogs
+    # id into ``mb_release_id`` so existing pipeline code that keys on
+    # ``mb_release_id`` keeps working). A numeric ``mb_release_id`` is
+    # therefore a Discogs signal — MB MBIDs are always hyphenated UUIDs.
+    # Without this, the 18 wanted Discogs-VA rows from the 2026-05-25
+    # backfill weren't VA-flagged because Rule 1 compared the canonical
+    # Discogs id ``"194"`` against the MB UUID and never matched.
+    is_discogs = bool(discogs_release_id) and (
+        not mb_release_id or _looks_numeric(mb_release_id)
+    )
 
     # Rule 1.
     artist_id = request.get("mb_artist_id")

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -126,8 +126,20 @@ def _load_beets_album_info(mb_release_id, rank_cfg):
 
 
 def fetch_mb_release(mb_release_id):
-    """Fetch release metadata + tracks from MusicBrainz API."""
-    url = f"{MB_API}/release/{mb_release_id}?inc=recordings+artist-credits&fmt=json"
+    """Fetch release metadata + tracks from MusicBrainz API.
+
+    Returns raw MB JSON. The ``media+release-groups+labels`` inc params
+    are required so the field resolver service can extract
+    ``label-info`` (catalog_number), per-track ``artist-credit``
+    (track_artist), and the nested ``release-group`` primary-type/
+    secondary-types (VA Rule 2). Without them, every MB request adds
+    its rows to the side table as ``unresolved_field_missing_upstream``
+    even though MB has the data.
+    """
+    url = (
+        f"{MB_API}/release/{mb_release_id}"
+        f"?inc=recordings+artist-credits+media+release-groups+labels&fmt=json"
+    )
     req = urllib.request.Request(url)
     req.add_header("User-Agent", "pipeline-cli/1.0")
     try:

--- a/tests/test_field_resolver_service.py
+++ b/tests/test_field_resolver_service.py
@@ -110,6 +110,68 @@ class TestResolveReleaseGroupYear(unittest.TestCase):
         assert row is not None
         self.assertEqual(row["status"], "unresolved_404")
 
+    def test_mb_4xx_other_than_404_records_sticky_4xx_client(self):
+        """Fix #3: HTTP 4xx responses from the mirror (other than 404
+        and 408) are permanent client-error semantics — retrying the
+        same request gives the same answer. Classify as sticky
+        ``unresolved_4xx_client`` instead of the 1d-retry
+        ``unresolved_mirror_unavailable``.
+
+        Live evidence from the 2026-05-25 deploy backfill: 74 wanted
+        rows hit MB ``HTTP 400 Bad Request`` (likely deprecated /
+        malformed-stored MBIDs) and got marked transient — they'd
+        retry forever instead of being surfaced for operator
+        attention.
+        """
+        # Subtests for the codes seen in the deploy backfill + a few
+        # canonical 4xx (410 Gone, 422 Unprocessable Entity).
+        for code, expected_reason in [
+            (400, "http_400"),
+            (410, "http_410"),
+            (422, "http_422"),
+        ]:
+            with self.subTest(http_code=code):
+                db = FakePipelineDB()
+                req = _request(id=44, mb_release_group_id="abc-uuid")
+
+                def _raise(_: str, c: int = code) -> int | None:
+                    raise urllib.error.HTTPError(
+                        url="x", code=c, msg="Client Error",
+                        hdrs=None,  # type: ignore[arg-type]
+                        fp=None,
+                    )
+
+                result = resolve_release_group_year(
+                    req, db, mb_get_release_group_year=_raise,
+                )
+                self.assertEqual(result.status, "unresolved_4xx_client")
+                self.assertEqual(result.reason_code, expected_reason)
+                self.assertIsNone(result.value)
+                row = db.get_field_resolution(44, FIELD_RELEASE_GROUP_YEAR)
+                assert row is not None
+                self.assertEqual(row["status"], "unresolved_4xx_client")
+
+    def test_mb_5xx_stays_mirror_unavailable(self):
+        """5xx is server-side — retry is legitimate. Stays in the 1d
+        retry bucket (``unresolved_mirror_unavailable``)."""
+        for code in [500, 502, 503]:
+            with self.subTest(http_code=code):
+                db = FakePipelineDB()
+                req = _request(id=44, mb_release_group_id="abc-uuid")
+
+                def _raise(_: str, c: int = code) -> int | None:
+                    raise urllib.error.HTTPError(
+                        url="x", code=c, msg="Server Error",
+                        hdrs=None,  # type: ignore[arg-type]
+                        fp=None,
+                    )
+
+                result = resolve_release_group_year(
+                    req, db, mb_get_release_group_year=_raise,
+                )
+                self.assertEqual(
+                    result.status, "unresolved_mirror_unavailable")
+
     def test_mirror_network_error_records_unresolved_mirror_unavailable(self):
         db = FakePipelineDB()
         req = _request(id=45, mb_release_group_id="abc-uuid")
@@ -561,6 +623,30 @@ class TestDetectVaCompilation(unittest.TestCase):
         self.assertTrue(detect_va_compilation(
             req, mb_release_payload=release_payload,
         ))
+
+    def test_rule1_discogs_va_when_mb_release_id_is_numeric(self):
+        """Live-bug repro from the 2026-05-25 deploy backfill: 18 wanted
+        rows had ``mb_release_id`` holding a numeric Discogs id (the
+        web/CLI Discogs add stuffs the Discogs id into both
+        ``mb_release_id`` and ``discogs_release_id`` for pipeline
+        compat). With ``mb_release_id`` non-null, the detector treated
+        them as MB-sourced, then compared the canonical Discogs VA id
+        ``"194"`` against the MB UUID ``"89ad4ac3-..."`` — never
+        matched.
+
+        Fix: a numeric ``mb_release_id`` is a Discogs-source signal
+        (UUIDs always contain ``-``); switch the detector's branch
+        accordingly so Rule 1 compares against ``DISCOGS_VA_ARTIST_ID``.
+        """
+        req = _request(
+            id=2522,
+            mb_release_id="32457180",          # numeric → Discogs id
+            discogs_release_id="32457180",
+            mb_release_group_id=None,
+            mb_artist_id="194",                 # canonical Discogs VA id
+            artist_name="Various",
+        )
+        self.assertTrue(detect_va_compilation(req))
 
     def test_negative_artist_named_various_without_canonical_mbid(self):
         """Regression guard: name == "Various" with non-canonical MBID != VA."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3766,6 +3766,20 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.mock_db.get_request_by_discogs_release_id.return_value = None
         self.mock_db.add_request.return_value = 501
         self.mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
+        # MB add path also calls ``get_release_raw`` (for the resolver's
+        # raw payload) alongside the existing ``get_release`` (for slim
+        # add_request fields). Class-wide stub so individual tests only
+        # need to mock ``get_release``; the resolver receives an empty
+        # dict and records ``unresolved_field_missing_upstream`` for
+        # catalog/track_artist as before. Tests that care about
+        # catalog_number / track_artist / VA Rule 2 resolution mock
+        # ``get_release_raw`` themselves.
+        _patch_raw = patch(
+            "web.routes.pipeline.mb_api.get_release_raw",
+            return_value={},
+        )
+        _patch_raw.start()
+        self.addCleanup(_patch_raw.stop)
 
     @patch("web.routes.pipeline.mb_api.get_release_group_year",
            return_value=2024)
@@ -3988,14 +4002,22 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(rg_year_writes, [],
                          "unresolved rg_year must NOT be written")
 
+    @patch("web.routes.pipeline.mb_api.get_release_raw")
     @patch("web.routes.pipeline.mb_api.get_release_group_year")
     @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_add_mb_va_compilation_flag_set(
-        self, mock_get_release, mock_rgy,
+        self, mock_get_release, mock_rgy, mock_get_raw,
     ):
         """U4 web happy path for VA: a release-group typed as
         Compilation flips ``is_va_compilation=True`` once at enqueue,
-        via the resolver service detecting the type on rule 2."""
+        via the resolver service detecting the type on rule 2.
+
+        VA Rule 2 reads ``release-group.primary-type`` from the raw MB
+        payload — so the test mocks ``get_release_raw`` (the new
+        primary fetcher) with a shape that has the rg nested. The
+        slim ``get_release`` mock supplies the fields ``add_request``
+        / ``set_tracks`` need.
+        """
         mock_get_release.return_value = {
             "release_group_id": "rg-va",
             "artist_id": "a-1",
@@ -4004,9 +4026,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "year": 2008,
             "country": "US",
             "tracks": [{"title": "T1"}],
-            # The resolver's track_artist / release_group_id resolvers
-            # also fetch via the same mock; surface the Compilation
-            # primary-type so rule 2 fires.
+        }
+        mock_get_raw.return_value = {
+            "id": "va-mbid",
             "release-group": {"primary-type": "Compilation"},
         }
         mock_rgy.return_value = 2008
@@ -4021,6 +4043,52 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         ]
         self.assertGreaterEqual(len(va_writes), 1,
                                 "is_va_compilation=True must be written")
+
+    @patch("web.routes.pipeline.mb_api.get_release_raw")
+    @patch("web.routes.pipeline.mb_api.get_release_group_year",
+           return_value=2010)
+    @patch("web.routes.pipeline.mb_api.get_release")
+    def test_pipeline_add_mb_resolves_catalog_number_from_raw_payload(
+        self, mock_get_release, _mock_rgy, mock_get_raw,
+    ):
+        """Fix #2 regression guard: when the raw MB payload carries
+        ``label-info``, the resolver service extracts the catno and
+        the helper writes it to ``album_requests.catalog_number``.
+
+        Pre-fix, ``post_pipeline_add`` passed the slim ``get_release``
+        shape to the resolver — which doesn't include ``label-info`` —
+        and the catno landed as ``unresolved_field_missing_upstream``
+        every single time. Post-fix the inline path also fetches
+        ``get_release_raw`` and passes that as ``mb_release_payload``,
+        so the catno reaches the resolver.
+        """
+        mock_get_release.return_value = {
+            "release_group_id": "rg-1",
+            "artist_id": "a-1",
+            "artist_name": "Artist",
+            "title": "Album",
+            "year": 2010,
+            "country": "GB",
+            "tracks": [{"title": "T1"}],
+        }
+        # Raw MB JSON shape with label-info present.
+        mock_get_raw.return_value = {
+            "id": "abc-mbid",
+            "label-info": [{"catalog-number": "STRMRT-001"}],
+        }
+
+        status, _data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "abc-mbid"})
+        self.assertEqual(status, 200)
+
+        catno_writes = [
+            c for c in self.mock_db.update_request_fields.call_args_list
+            if c.kwargs.get("catalog_number") == "STRMRT-001"
+        ]
+        self.assertGreaterEqual(
+            len(catno_writes), 1,
+            "resolver-extracted catalog_number must be persisted",
+        )
 
     def test_pipeline_add_mb_integration_persists_release_group_year(self):
         """U4 integration: full add-from-web flow against ``FakePipelineDB``

--- a/web/mb.py
+++ b/web/mb.py
@@ -253,67 +253,96 @@ def get_release_group_releases(rg_mbid):
     return _cache.memoize_meta(f"mb:release-group:{rg_mbid}:releases", _fetch)
 
 
+def get_release_raw(release_mbid, *, fresh: bool = False) -> dict:
+    """Raw MB release JSON with the full inc clause preserved.
+
+    Returned shape is the literal MB API response — `media[]`,
+    `artist-credit[]` (album and per-track), `release-group`,
+    `label-info`, etc. Cached at its own key so multiple consumers
+    (resolver service + frontend stripping) share a single
+    cache+network round trip.
+
+    `fresh=True` bypasses the cache.
+
+    Consumers that need a slimmed shape (frontend rendering, pipeline
+    DB inserts) call `get_release` which strips this via
+    `_strip_release`. Consumers that need raw fields (the field
+    resolver service for label-info / per-track artist-credit /
+    release-group primary-type) call this directly.
+    """
+    def _fetch() -> dict:
+        return _get(
+            f"{MB_API_BASE}/release/{release_mbid}"
+            f"?inc=recordings+artist-credits+media+release-groups+labels&fmt=json"
+        )
+    return _cache.memoize_meta(
+        f"mb:release_raw:{release_mbid}", _fetch, fresh=fresh)
+
+
+def _strip_release(data: dict) -> dict:
+    """Slim a raw MB release JSON down to the shape the frontend +
+    pipeline DB inserts want. Pure function over `data`."""
+    artist_credit = data.get("artist-credit", [{}])
+    artist_name = artist_credit[0].get("name", "Unknown") if artist_credit else "Unknown"
+    artist_id = (artist_credit[0].get("artist", {}).get("id") if artist_credit else None)
+    rg_id = (data.get("release-group") or {}).get("id")
+
+    tracks = []
+    for medium in data.get("media", []):
+        disc = medium.get("position", 1)
+        if "pregap" in medium:
+            pg = medium["pregap"]
+            length_ms = pg.get("length") or (pg.get("recording") or {}).get("length")
+            tracks.append({
+                "disc_number": disc,
+                "track_number": 0,
+                "title": pg.get("title", ""),
+                "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
+            })
+        for track in medium.get("tracks", []):
+            length_ms = track.get("length") or (track.get("recording") or {}).get("length")
+            tracks.append({
+                "disc_number": disc,
+                "track_number": track.get("position", track.get("number", 0)),
+                "title": track.get("title", ""),
+                "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
+            })
+
+    year = None
+    if data.get("date"):
+        try:
+            year = int(data["date"][:4])
+        except (ValueError, IndexError):
+            pass
+
+    return {
+        "id": data["id"],
+        "title": data.get("title", ""),
+        "artist_name": artist_name,
+        "artist_id": artist_id,
+        "release_group_id": rg_id,
+        "date": data.get("date", ""),
+        "year": year,
+        "country": data.get("country", ""),
+        "status": data.get("status", ""),
+        "tracks": tracks,
+    }
+
+
 def get_release(release_mbid, *, fresh: bool = False):
-    """Get full release details with tracks.
+    """Get full release details with tracks (slimmed shape).
 
     `fresh=True` bypasses the cache. Used by POST handlers in
     `web/routes/pipeline.py` that persist this metadata into the
     pipeline DB — a 24h cache hit would silently write stale
     artist/title/track data into `album_requests` / `request_tracks`.
+
+    Built on top of `get_release_raw` so the raw MB JSON is the single
+    cached truth; this just re-derives the slim shape per call. The
+    re-derivation is a pure traversal, ~microseconds.
     """
-    def _fetch() -> dict:
-        data = _get(
-            f"{MB_API_BASE}/release/{release_mbid}"
-            f"?inc=recordings+artist-credits+media+release-groups&fmt=json"
-        )
-        artist_credit = data.get("artist-credit", [{}])
-        artist_name = artist_credit[0].get("name", "Unknown") if artist_credit else "Unknown"
-        artist_id = (artist_credit[0].get("artist", {}).get("id") if artist_credit else None)
-        rg_id = (data.get("release-group") or {}).get("id")
-
-        tracks = []
-        for medium in data.get("media", []):
-            disc = medium.get("position", 1)
-            if "pregap" in medium:
-                pg = medium["pregap"]
-                length_ms = pg.get("length") or (pg.get("recording") or {}).get("length")
-                tracks.append({
-                    "disc_number": disc,
-                    "track_number": 0,
-                    "title": pg.get("title", ""),
-                    "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
-                })
-            for track in medium.get("tracks", []):
-                length_ms = track.get("length") or (track.get("recording") or {}).get("length")
-                tracks.append({
-                    "disc_number": disc,
-                    "track_number": track.get("position", track.get("number", 0)),
-                    "title": track.get("title", ""),
-                    "length_seconds": round(length_ms / 1000, 1) if length_ms else None,
-                })
-
-        year = None
-        if data.get("date"):
-            try:
-                year = int(data["date"][:4])
-            except (ValueError, IndexError):
-                pass
-
-        return {
-            "id": data["id"],
-            "title": data.get("title", ""),
-            "artist_name": artist_name,
-            "artist_id": artist_id,
-            "release_group_id": rg_id,
-            "date": data.get("date", ""),
-            "year": year,
-            "country": data.get("country", ""),
-            "status": data.get("status", ""),
-            "tracks": tracks,
-        }
-
-    return _cache.memoize_meta(
-        f"mb:release:{release_mbid}", _fetch, fresh=fresh)
+    raw = get_release_raw(release_mbid, fresh=fresh)
+    return _strip_release(raw)
 
 
 def get_artist_name(artist_mbid):

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1512,6 +1512,13 @@ def post_pipeline_add(h, body: dict) -> None:
     # above. Writing stale metadata into the pipeline DB is worse than
     # an extra MB mirror round trip on add.
     release = mb_api.get_release(mbid, fresh=True)
+    # The resolver service needs the full raw MB JSON (``label-info``
+    # for catalog_number, per-track ``artist-credit`` for track_artist,
+    # nested ``release-group`` primary-type for VA Rule 2 — none of
+    # which survive ``get_release`` stripping). ``get_release`` calls
+    # ``get_release_raw`` internally so this is a single network round
+    # trip; the second call is a cache hit.
+    release_raw = mb_api.get_release_raw(mbid, fresh=True)
 
     rg_id = release.get("release_group_id")
 
@@ -1541,7 +1548,7 @@ def post_pipeline_add(h, body: dict) -> None:
         discogs_release_id=None,
         mb_release_group_id=rg_id,
         mb_artist_id=release.get("artist_id"),
-        mb_release_payload=release,
+        mb_release_payload=release_raw,
     )
 
     _generate_plan_after_add(


### PR DESCRIPTION
Three small structural fixes for the under-resolution the PR #370 backfill surfaced on 2026-05-25. Each is RED-tested first, paired with the live cohort shape that motivated it.

## Findings on which it landed

The deploy heredoc walked 825 wanted requests in 55s, 0 crashes — but the side-table outcomes showed:
- 18 string-matched VA rows didn't get `is_va_compilation=TRUE` flipped
- 74 rows hit `unresolved_mirror_unavailable` on MB and would retry forever
- 747 rows recorded `mb_no_catalog_number` and 747 `mb_payload_lacks_per_track_artist` even when MB had the data

All three traced back to PR1 design constraints rather than bad data.

## Fix 1 — VA detector dispatch (`detect_va_compilation`)

The web/CLI Discogs add path stores the Discogs id in **both** `mb_release_id` and `discogs_release_id` for pipeline compat. The detector keyed off `not request.get("mb_release_id")` to decide source — so Discogs rows always went through the MB branch and compared the canonical Discogs id `"194"` against the MB UUID `"89ad4ac3-..."`. Fix: a numeric `mb_release_id` is a Discogs signal (MB MBIDs are always hyphenated UUIDs). Use the existing `_looks_numeric` helper.

Live cohort: 18 wanted Discogs-VA rows with `mb_release_id=<numeric>`, `mb_artist_id="194"`.

## Fix 2 — `web/mb.py` raw payload + resolver consumption

`web/mb.py::get_release` returns a slimmed shape (id/title/artist/tracks) for the frontend and `add_request` writes. The field resolver service was designed for the **raw** MB JSON (label-info → catalog_number, per-track artist-credit → track_artist, nested release-group primary-type → VA Rule 2). It received the slim shape and silently downgraded those fields to `unresolved_field_missing_upstream` for every MB request.

Refactor:
- Factor `web/mb.py::get_release` into `get_release_raw` (raw, cached) + `_strip_release` (pure slim derivation). `get_release` becomes `_strip_release(get_release_raw(...))` — single cache, single network round trip, slim callers see no behaviour change.
- `lib/field_resolver_service.py::_default_mb_get_release` now fetches via `get_release_raw`.
- `web/routes/pipeline.py::post_pipeline_add` fetches raw alongside slim and threads it through as `mb_release_payload`.
- `scripts/pipeline_cli.py::fetch_mb_release` broadens its inc clause to `recordings+artist-credits+media+release-groups+labels` so its already-raw shape gains the missing fields.

The MB raw payload also requires `+labels` in the inc clause for `label-info` — added.

## Fix 3 — HTTPError 4xx other than 404/408 → sticky

`_classify_lookup_exception` only special-cased `HTTPError(404)`. Every other 4xx fell through to `unresolved_mirror_unavailable` (1d-retry) — so 74 rows hitting MB `HTTP 400 Bad Request` (likely deprecated/malformed MBIDs) would have been retried forever instead of surfaced for triage. Adds `unresolved_4xx_client` status; 4xx other than 404 (specific bucket) and 408 (timeout) route here with `reason_code='http_<code>'`. 5xx stays transient (legitimate to retry).

## Quality gates

- 3661 tests, 0 failures (+4 from main: 1 for #1, 1 for #2, 2 `subTest` tables for #3)
- Pyright: 0 errors, 0 warnings, 0 informations on the full repo
- Vulture: clean

## Deploy plan

Standard flake bump + rebuild. **No migration**, no controlled window needed for the schema (Fix #3's new `unresolved_4xx_client` status is enum-side only; the side table column has no CHECK constraint). The new status will appear on future resolver invocations; existing `unresolved_mirror_unavailable` rows from the prior backfill stay where they are unless re-resolved.

## Post-deploy backfill rerun (optional)

After this PR lands, a re-run of the deploy heredoc (with `WHERE` filter to target the affected cohort) will:
- flip the 18 Discogs-VA rows to `is_va_compilation=TRUE`
- resolve `catalog_number` and `track_artist` for the ~747 MB-released rows that actually have the data upstream
- re-classify the 74 mirror errors that are real 4xx as sticky `unresolved_4xx_client` instead of transient

🤖 Generated with [Claude Code](https://claude.com/claude-code)