### PR TITLE
feat(pr4): operator surface — triage subsystem + API discoverability (closes #369 PR4)

### DIFF
--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -6685,6 +6685,17 @@ class PipelineDB:
         ``RequestMeta`` + ``UnfindableState``; the field-resolutions /
         search summaries / recent search_log entries come from the
         sibling bulk getters.
+
+        **Replaced rows are intentionally included.** Rows with
+        ``status='replaced'`` are frozen audit tombstones from the
+        operator's Replace action (see ``CLAUDE.md`` invariant #6).
+        Including them in cohort listings lets the operator spot
+        patterns across replacement history — e.g. an MBID-shape that
+        keeps tripping HTTP 4xx and keeps getting replaced. The
+        lineage chain (``replaces_request_id``) is read via
+        ``pipeline-cli show <id>`` for per-request audit detail.
+        ``tests/test_triage_service.py::test_list_includes_replaced_rows``
+        pins this contract.
         """
         select_cols = (
             "ar.id, ar.artist_name, ar.album_title, ar.year, ar.status, "

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator
 
 if TYPE_CHECKING:
     from lib.quality import CandidateScore
+    from lib.triage_service import ParsedTriageFilter
     from lib.unfindable_detection_service import UnfindableSearchLogSignal
 
 import psycopg2
@@ -6664,17 +6665,17 @@ class PipelineDB:
     def list_triage_page(
         self,
         *,
-        filter_spec: Any,
+        filter_spec: "ParsedTriageFilter",
         page_size: int,
         after_request_id: int | None,
     ) -> list[dict[str, Any]]:
         """One cohort page of ``album_requests`` rows for the triage view.
 
         ``filter_spec`` is the ``ParsedTriageFilter`` produced by
-        ``lib.triage_service.parse_filter``. We accept it as ``Any`` here
-        rather than importing the service-layer type to keep
-        ``pipeline_db`` free of upstream service imports — the service
-        owns the parser, the DB owns the SQL.
+        ``lib.triage_service.parse_filter``. We type via ``TYPE_CHECKING``
+        so static analysis can catch a caller passing a wrong shape, but
+        the import stays deferred at runtime — the service owns the
+        parser, the DB owns the SQL.
 
         Ordered by ``id`` ASC; ``after_request_id`` is the keyset cursor
         from the previous page's last row. ``page_size`` is honoured
@@ -6700,6 +6701,7 @@ class PipelineDB:
         kind = getattr(filter_spec, "kind", None)
         unfindable_category = getattr(filter_spec, "unfindable_category", None)
         field_name = getattr(filter_spec, "field_name", None)
+        status_code = getattr(filter_spec, "status_code", None)
         reason_code = getattr(filter_spec, "reason_code", None)
 
         where_clauses: list[str] = []
@@ -6712,18 +6714,29 @@ class PipelineDB:
                 where_clauses.append("ar.unfindable_category = %s")
                 params.append(unfindable_category)
         elif kind == "data_quality":
-            # EXISTS-join — any row in the side table whose status starts
-            # with ``unresolved_`` qualifies. Sub-filters narrow on field
-            # name or reason_code.
+            # EXISTS-join — any row in the side table whose status is in
+            # the unresolved-* enum qualifies. Sub-filters narrow on
+            # field name, status, or reason_code. Status values come from
+            # ``lib.field_resolver_service.ResolverStatus`` to avoid the
+            # ``LIKE 'unresolved_%%'`` underscore-wildcard ambiguity.
+            from lib.field_resolver_service import ResolverStatus
+            from typing import get_args as _get_args
+            unresolved_statuses = [
+                s for s in _get_args(ResolverStatus)
+                if s.startswith("unresolved_")
+            ]
             sub = (
                 "SELECT 1 FROM album_request_field_resolutions fr "
                 "WHERE fr.request_id = ar.id "
-                "AND fr.status LIKE 'unresolved_%%'"
+                "AND fr.status = ANY(%s)"
             )
-            sub_params: list[Any] = []
+            sub_params: list[Any] = [unresolved_statuses]
             if field_name is not None:
                 sub += " AND fr.field_name = %s"
                 sub_params.append(field_name)
+            if status_code is not None:
+                sub += " AND fr.status = %s"
+                sub_params.append(status_code)
             if reason_code is not None:
                 sub += " AND fr.reason_code = %s"
                 sub_params.append(reason_code)

--- a/lib/pipeline_db.py
+++ b/lib/pipeline_db.py
@@ -6651,3 +6651,219 @@ class PipelineDB:
         """, (request_id,))
         row = cur.fetchone()
         return dict(row) if row else None
+
+    # --- Triage (U15) -----------------------------------------------------
+    #
+    # The cohort-listing service ``lib.triage_service.list_triage`` reads
+    # one bulk page query + three ``WHERE ... = ANY(%s)`` bulk queries
+    # (field resolutions, search summaries, recent search_log slice).
+    # These four methods are the DB-layer half. Filter parsing lives in
+    # ``lib.triage_service.parse_filter`` and the parsed filter is what
+    # the service passes here; this method never inspects raw strings.
+
+    def list_triage_page(
+        self,
+        *,
+        filter_spec: Any,
+        page_size: int,
+        after_request_id: int | None,
+    ) -> list[dict[str, Any]]:
+        """One cohort page of ``album_requests`` rows for the triage view.
+
+        ``filter_spec`` is the ``ParsedTriageFilter`` produced by
+        ``lib.triage_service.parse_filter``. We accept it as ``Any`` here
+        rather than importing the service-layer type to keep
+        ``pipeline_db`` free of upstream service imports — the service
+        owns the parser, the DB owns the SQL.
+
+        Ordered by ``id`` ASC; ``after_request_id`` is the keyset cursor
+        from the previous page's last row. ``page_size`` is honoured
+        verbatim (caller clamps).
+
+        SELECT lists the columns the triage service composes into
+        ``RequestMeta`` + ``UnfindableState``; the field-resolutions /
+        search summaries / recent search_log entries come from the
+        sibling bulk getters.
+        """
+        select_cols = (
+            "ar.id, ar.artist_name, ar.album_title, ar.year, ar.status, "
+            "ar.source, ar.mb_release_id, ar.discogs_release_id, "
+            "ar.release_group_year, ar.is_va_compilation, ar.catalog_number, "
+            "ar.failure_class, ar.search_filetype_override, "
+            "ar.unfindable_category, ar.unfindable_categorised_at, "
+            "ar.last_artist_probe_at, ar.last_artist_probe_match_count, "
+            "ar.rescued_at, ar.prior_unfindable_category"
+        )
+
+        # filter_spec's attributes are normalised + safe-by-parse; the
+        # values flow into placeholders, never string-interpolation.
+        kind = getattr(filter_spec, "kind", None)
+        unfindable_category = getattr(filter_spec, "unfindable_category", None)
+        field_name = getattr(filter_spec, "field_name", None)
+        reason_code = getattr(filter_spec, "reason_code", None)
+
+        where_clauses: list[str] = []
+        params: list[Any] = []
+        joins: list[str] = []
+
+        if kind == "unfindable":
+            where_clauses.append("ar.unfindable_category IS NOT NULL")
+            if unfindable_category is not None:
+                where_clauses.append("ar.unfindable_category = %s")
+                params.append(unfindable_category)
+        elif kind == "data_quality":
+            # EXISTS-join — any row in the side table whose status starts
+            # with ``unresolved_`` qualifies. Sub-filters narrow on field
+            # name or reason_code.
+            sub = (
+                "SELECT 1 FROM album_request_field_resolutions fr "
+                "WHERE fr.request_id = ar.id "
+                "AND fr.status LIKE 'unresolved_%%'"
+            )
+            sub_params: list[Any] = []
+            if field_name is not None:
+                sub += " AND fr.field_name = %s"
+                sub_params.append(field_name)
+            if reason_code is not None:
+                sub += " AND fr.reason_code = %s"
+                sub_params.append(reason_code)
+            where_clauses.append(f"EXISTS ({sub})")
+            params.extend(sub_params)
+        elif kind == "search_not_converting":
+            joins.append(
+                "JOIN request_search_summary rss ON rss.request_id = ar.id"
+            )
+            where_clauses.append("rss.total_searches > 0")
+            where_clauses.append("rss.found_count = 0")
+        elif kind == "all":
+            pass  # No predicate.
+        else:  # pragma: no cover — parser is the gate
+            raise ValueError(f"unsupported triage filter kind: {kind!r}")
+
+        if after_request_id is not None:
+            where_clauses.append("ar.id > %s")
+            params.append(int(after_request_id))
+
+        sql = f"SELECT {select_cols} FROM album_requests ar"
+        if joins:
+            sql += " " + " ".join(joins)
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+        sql += " ORDER BY ar.id ASC LIMIT %s"
+        params.append(int(page_size))
+
+        cur = self._execute(sql, tuple(params))
+        return [dict(r) for r in cur.fetchall()]
+
+    def get_field_resolutions_for_requests(
+        self,
+        request_ids: list[int],
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Bulk-fetch ``album_request_field_resolutions`` for a request set.
+
+        Returns ``{request_id: [row, ...]}``. Each row dict carries the
+        same fields ``get_field_resolution`` returns (id, request_id,
+        field_name, resolved_at, status, reason_code, attempts).
+        Requests with no resolutions are omitted from the result; the
+        triage composer treats absence as an empty list.
+
+        Ordering: ``field_name`` ASC for stable per-request rendering.
+        """
+        if not request_ids:
+            return {}
+        cur = self._execute(
+            """
+            SELECT id, request_id, field_name, resolved_at, status,
+                   reason_code, attempts
+            FROM album_request_field_resolutions
+            WHERE request_id = ANY(%s)
+            ORDER BY request_id, field_name
+            """,
+            ([int(r) for r in request_ids],),
+        )
+        out: dict[int, list[dict[str, Any]]] = {}
+        for row in cur.fetchall():
+            rid = int(row["request_id"])
+            out.setdefault(rid, []).append(dict(row))
+        return out
+
+    def get_search_summaries_for_requests(
+        self,
+        request_ids: list[int],
+    ) -> dict[int, dict[str, Any]]:
+        """Bulk-fetch rows from the ``request_search_summary`` view.
+
+        Returns ``{request_id: row_dict}``. Requests with zero searches
+        in the view's 14-day window are absent from the result; the
+        triage composer renders the all-zeros summary in that case.
+        """
+        if not request_ids:
+            return {}
+        cur = self._execute(
+            """
+            SELECT request_id, total_searches, with_cands_count,
+                   found_count, near_cap_count, zero_results_count,
+                   pre_filter_skips_total, first_strategy_with_cands,
+                   dominant_rejection_reason, last_search_at
+            FROM request_search_summary
+            WHERE request_id = ANY(%s)
+            """,
+            ([int(r) for r in request_ids],),
+        )
+        out: dict[int, dict[str, Any]] = {}
+        for row in cur.fetchall():
+            rid = int(row["request_id"])
+            out[rid] = dict(row)
+        return out
+
+    def get_recent_search_log_for_requests(
+        self,
+        request_ids: list[int],
+        *,
+        per_request_limit: int,
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Bulk-fetch the most-recent N ``search_log`` rows per request.
+
+        Returns ``{request_id: [row, ...]}`` newest-first; each list is
+        at most ``per_request_limit`` rows long. Uses a single
+        ``ROW_NUMBER() OVER (PARTITION BY request_id ORDER BY created_at
+        DESC)`` window so the bulk path stays one query regardless of
+        how many requests are in the cohort.
+
+        Rows carry the columns the triage forensics struct needs —
+        id, created_at, plan_strategy, query, outcome, result_count,
+        rejection_reason, matcher_score_top1. Anything else stays in
+        ``search_log``; ``search-plan history`` is the full-row view.
+        """
+        if not request_ids:
+            return {}
+        cur = self._execute(
+            """
+            SELECT id, request_id, created_at, plan_strategy, query,
+                   outcome, result_count, rejection_reason,
+                   matcher_score_top1
+            FROM (
+                SELECT sl.id, sl.request_id, sl.created_at,
+                       sl.plan_strategy, sl.query, sl.outcome,
+                       sl.result_count, sl.rejection_reason,
+                       sl.matcher_score_top1,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY sl.request_id
+                           ORDER BY sl.created_at DESC, sl.id DESC
+                       ) AS rn
+                FROM search_log sl
+                WHERE sl.request_id = ANY(%s)
+            ) ranked
+            WHERE rn <= %s
+            ORDER BY request_id, created_at DESC, id DESC
+            """,
+            (
+                [int(r) for r in request_ids],
+                int(per_request_limit),
+            ),
+        )
+        out: dict[int, list[dict[str, Any]]] = {}
+        for row in cur.fetchall():
+            rid = int(row["request_id"])
+            out.setdefault(rid, []).append(dict(row))
+        return out

--- a/lib/triage_service.py
+++ b/lib/triage_service.py
@@ -15,9 +15,10 @@ result for one request_id; ``list_triage`` returns a paged cohort under
 an operator filter spec.
 
 The cohort path is N+1-bounded: regardless of page size, ``list_triage``
-emits **at most 4 DB queries** (page + bulk field-resolutions + bulk
-search-summaries + bulk recent search_log rows). The N+1 guard test in
-``tests/test_triage_service.py`` asserts the bound holds at page_size=50.
+emits **4 DB queries (+ 1 headroom for future growth)** — the page +
+bulk field-resolutions + bulk search-summaries + bulk recent search_log
+rows. The N+1 guard test in ``tests/test_triage_service.py`` asserts
+the bound holds at page_size=50.
 
 This module deliberately lives upstream of the CLI / HTTP wrappers.
 ``pipeline-cli triage`` and ``/api/triage`` are thin adapters mapping
@@ -35,6 +36,19 @@ from typing import Any, Iterable, Optional, Protocol
 
 import msgspec
 
+from lib.field_resolver_service import (
+    FIELD_CATALOG_NUMBER,
+    FIELD_RELEASE_GROUP_ID,
+    FIELD_RELEASE_GROUP_YEAR,
+    FIELD_TRACK_ARTIST,
+)
+from lib.unfindable_detection_service import (
+    CATEGORY_ALBUM_ABSENT_ARTIST_PRESENT,
+    CATEGORY_ARTIST_ABSENT,
+    CATEGORY_ONE_TRACK_STRUCTURAL,
+    CATEGORY_WRONG_PRESSING_AVAILABLE,
+)
+
 
 # --- Filter parsing -------------------------------------------------------
 
@@ -49,12 +63,41 @@ _FILTER_UNFINDABLE = "unfindable"
 _FILTER_DATA_QUALITY = "data_quality"
 _FILTER_SEARCH_NOT_CONVERTING = "search_not_converting"
 
-_UNFINDABLE_CATEGORIES = frozenset({
-    "artist_absent",
-    "album_absent_artist_present",
-    "one_track_structural",
-    "wrong_pressing_available",
+# Sourced from ``lib.unfindable_detection_service`` — the daily detection
+# service owns the vocabulary; this parser is downstream. Adding a new
+# category there auto-flows into the cohort filter.
+VALID_UNFINDABLE_CATEGORIES: frozenset[str] = frozenset({
+    CATEGORY_ARTIST_ABSENT,
+    CATEGORY_ALBUM_ABSENT_ARTIST_PRESENT,
+    CATEGORY_ONE_TRACK_STRUCTURAL,
+    CATEGORY_WRONG_PRESSING_AVAILABLE,
 })
+
+# Sourced from ``lib.field_resolver_service`` — the resolver service owns
+# the side-table column names. Used by the ``data_quality:<field>`` filter
+# arm to reject typos before they reach the DB.
+VALID_DATA_QUALITY_FIELD_NAMES: frozenset[str] = frozenset({
+    FIELD_RELEASE_GROUP_YEAR,
+    FIELD_RELEASE_GROUP_ID,
+    FIELD_TRACK_ARTIST,
+    FIELD_CATALOG_NUMBER,
+})
+
+
+# Canonical list of valid filter forms — single source of truth for the
+# CLI ``--help`` text and the API 400 envelope. CLI and HTTP route both
+# import this tuple; the values are machine-parseable tokens that the
+# operator can paste back into a follow-up request.
+VALID_FILTER_FORMS: tuple[str, ...] = (
+    _FILTER_ALL,
+    _FILTER_UNFINDABLE,
+    f"{_FILTER_UNFINDABLE}:<category>",
+    _FILTER_DATA_QUALITY,
+    f"{_FILTER_DATA_QUALITY}:<field>",
+    f"{_FILTER_DATA_QUALITY}:status=<status>",
+    f"{_FILTER_DATA_QUALITY}:reason=<code>",
+    _FILTER_SEARCH_NOT_CONVERTING,
+)
 
 
 class InvalidFilterError(ValueError):
@@ -75,12 +118,18 @@ class ParsedTriageFilter(msgspec.Struct, frozen=True):
 
     * ``unfindable_category`` — set for ``unfindable:<cat>``.
     * ``field_name`` — set for ``data_quality:<field>``.
-    * ``reason_code`` — set for ``data_quality:reason=<reason>`` (#374).
+    * ``status_code`` — set for ``data_quality:status=<status>`` (#374
+      canonical form — matches ``album_request_field_resolutions.status``
+      which is what ``lib.field_resolver_service`` actually writes).
+    * ``reason_code`` — set for ``data_quality:reason=<code>`` (filters
+      on ``album_request_field_resolutions.reason_code``, e.g.
+      ``http_400`` / ``http_410`` / ``http_422``).
     """
 
     kind: str
     unfindable_category: Optional[str] = None
     field_name: Optional[str] = None
+    status_code: Optional[str] = None
     reason_code: Optional[str] = None
     raw: str = ""
 
@@ -110,10 +159,10 @@ def parse_filter(spec: str) -> ParsedTriageFilter:
             raise InvalidFilterError(
                 "unfindable:<category> requires a non-empty category"
             )
-        if cat not in _UNFINDABLE_CATEGORIES:
+        if cat not in VALID_UNFINDABLE_CATEGORIES:
             raise InvalidFilterError(
                 f"unknown unfindable category {cat!r}; "
-                f"expected one of {sorted(_UNFINDABLE_CATEGORIES)}"
+                f"expected one of {sorted(VALID_UNFINDABLE_CATEGORIES)}"
             )
         return ParsedTriageFilter(
             kind=_FILTER_UNFINDABLE, unfindable_category=cat, raw=raw,
@@ -126,7 +175,17 @@ def parse_filter(spec: str) -> ParsedTriageFilter:
         rest = raw[len(_FILTER_DATA_QUALITY) + 1 :].strip()
         if not rest:
             raise InvalidFilterError(
-                "data_quality:<field>|reason=<code> requires a value"
+                "data_quality:<field>|status=<status>|reason=<code> "
+                "requires a value"
+            )
+        if rest.startswith("status="):
+            status = rest[len("status=") :].strip()
+            if not status:
+                raise InvalidFilterError(
+                    "data_quality:status= requires a status value"
+                )
+            return ParsedTriageFilter(
+                kind=_FILTER_DATA_QUALITY, status_code=status, raw=raw,
             )
         if rest.startswith("reason="):
             code = rest[len("reason=") :].strip()
@@ -137,7 +196,12 @@ def parse_filter(spec: str) -> ParsedTriageFilter:
             return ParsedTriageFilter(
                 kind=_FILTER_DATA_QUALITY, reason_code=code, raw=raw,
             )
-        # No "reason=" prefix → field name selector.
+        # No "status=" / "reason=" prefix → field name selector.
+        if rest not in VALID_DATA_QUALITY_FIELD_NAMES:
+            raise InvalidFilterError(
+                f"unknown data_quality field {rest!r}; expected one of "
+                f"{sorted(VALID_DATA_QUALITY_FIELD_NAMES)}"
+            )
         return ParsedTriageFilter(
             kind=_FILTER_DATA_QUALITY, field_name=rest, raw=raw,
         )
@@ -244,13 +308,17 @@ class SearchForensicsSummary(msgspec.Struct, frozen=True):
 
 
 class TriageResult(msgspec.Struct, frozen=True):
-    """The full per-request triage payload."""
+    """The full per-request triage payload.
+
+    ``failure_class`` is on ``request_meta`` (the canonical home —
+    every other ``album_requests`` column lives there). Consumers
+    that need it should read ``result.request_meta.failure_class``.
+    """
 
     request_meta: RequestMeta
     unfindable: Optional[UnfindableState]
     field_quality: list[FieldResolutionState]
     search_forensics: SearchForensicsSummary
-    failure_class: Optional[str]
 
 
 # --- Service entrypoint ---------------------------------------------------
@@ -260,6 +328,13 @@ class TriageResult(msgspec.Struct, frozen=True):
 # scroll of the last attempts; the historical timeline lives behind
 # ``search-plan history``.
 DEFAULT_RECENT_SEARCH_LOG_LIMIT = 10
+
+# Page-size + cursor bounds for ``list_triage`` — single source of truth
+# for the CLI and HTTP wrappers, so both surfaces reject the same set of
+# out-of-range values. Mirrors the convention of ``search-plan history``.
+TRIAGE_LIMIT_MIN = 1
+TRIAGE_LIMIT_MAX = 200
+TRIAGE_AFTER_MIN = 1
 
 # Default page size for ``list_triage``.
 DEFAULT_TRIAGE_PAGE_SIZE = 50
@@ -335,8 +410,8 @@ def list_triage(
 ) -> list[TriageResult]:
     """List one page of triage results matching ``filter_spec``.
 
-    N+1-bounded: regardless of ``page_size``, the call emits at most
-    four DB queries:
+    N+1-bounded: regardless of ``page_size``, the call emits 4 DB
+    queries (+ 1 headroom for future growth):
 
     1. ``list_triage_page`` — the cohort page filtered + keyset-paged.
     2. ``get_field_resolutions_for_requests`` — one bulk
@@ -396,7 +471,6 @@ def _compose_one(
         unfindable=unfindable,
         field_quality=field_quality,
         search_forensics=search_forensics,
-        failure_class=request_row.get("failure_class"),
     )
 
 

--- a/lib/triage_service.py
+++ b/lib/triage_service.py
@@ -1,0 +1,513 @@
+"""Triage service — composes the per-request "why is this request stuck?"
+view from the four observability domains shipped in PR1-PR3:
+
+1. ``album_requests`` metadata and failure-class column (U12).
+2. Unfindable cohort state (U13 — ``unfindable_category``, probe history,
+   long-tail-rescue audit).
+3. ``album_request_field_resolutions`` — external metadata resolver status
+   (U2).
+4. ``search_log`` forensics — the ``request_search_summary`` view (U11)
+   plus a window of recent rejection-reason rows.
+
+The service produces a single typed ``TriageResult`` (``msgspec.Struct``)
+that wraps every domain. ``compose_triage_for_request`` returns the
+result for one request_id; ``list_triage`` returns a paged cohort under
+an operator filter spec.
+
+The cohort path is N+1-bounded: regardless of page size, ``list_triage``
+emits **at most 4 DB queries** (page + bulk field-resolutions + bulk
+search-summaries + bulk recent search_log rows). The N+1 guard test in
+``tests/test_triage_service.py`` asserts the bound holds at page_size=50.
+
+This module deliberately lives upstream of the CLI / HTTP wrappers.
+``pipeline-cli triage`` and ``/api/triage`` are thin adapters mapping
+the ``TriageResult`` (and the parametric filter parser's
+``InvalidFilterError``) onto exit-code / status-code surfaces — same
+shape as ``search_plan_service`` and ``beets_distance``. Per
+``docs/solutions/architecture/service-first-then-glue.md`` the service
+ships green before either wrapper exists; U16 / U17 fill those in.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable, Optional, Protocol
+
+import msgspec
+
+
+# --- Filter parsing -------------------------------------------------------
+
+
+# The cohort filter is a small DSL. The CLI accepts the same string the
+# HTTP endpoint accepts so operators can paste between surfaces without
+# adjusting syntax. Service-layer parser raises ``InvalidFilterError``
+# on garbage; CLI maps to exit code 3, API maps to HTTP 400 (per the
+# CLI ⇄ API symmetry convention).
+_FILTER_ALL = "all"
+_FILTER_UNFINDABLE = "unfindable"
+_FILTER_DATA_QUALITY = "data_quality"
+_FILTER_SEARCH_NOT_CONVERTING = "search_not_converting"
+
+_UNFINDABLE_CATEGORIES = frozenset({
+    "artist_absent",
+    "album_absent_artist_present",
+    "one_track_structural",
+    "wrong_pressing_available",
+})
+
+
+class InvalidFilterError(ValueError):
+    """Raised by ``parse_filter`` when the spec is garbage.
+
+    Carries the offending spec for the wrapper layers to echo back to
+    the operator. The CLI emits the message on stderr; the HTTP route
+    embeds it in the 400 body.
+    """
+
+
+class ParsedTriageFilter(msgspec.Struct, frozen=True):
+    """Normalised filter spec.
+
+    ``kind`` is one of ``"all"`` / ``"unfindable"`` / ``"data_quality"``
+    / ``"search_not_converting"``. The parameter columns are populated
+    only on the parameterised forms:
+
+    * ``unfindable_category`` — set for ``unfindable:<cat>``.
+    * ``field_name`` — set for ``data_quality:<field>``.
+    * ``reason_code`` — set for ``data_quality:reason=<reason>`` (#374).
+    """
+
+    kind: str
+    unfindable_category: Optional[str] = None
+    field_name: Optional[str] = None
+    reason_code: Optional[str] = None
+    raw: str = ""
+
+
+def parse_filter(spec: str) -> ParsedTriageFilter:
+    """Parse ``spec`` into a normalised filter.
+
+    Trim + lowercase; accept the documented forms; raise
+    ``InvalidFilterError`` on anything else. The DB layer trusts the
+    parser — invalid specs never reach SQL.
+    """
+    if not isinstance(spec, str):  # type: ignore[unreachable]
+        raise InvalidFilterError(f"filter spec must be str, got {type(spec)!r}")
+    raw = spec.strip().lower()
+    if not raw:
+        raise InvalidFilterError("filter spec is empty")
+
+    if raw == _FILTER_ALL:
+        return ParsedTriageFilter(kind=_FILTER_ALL, raw=raw)
+
+    if raw == _FILTER_UNFINDABLE:
+        return ParsedTriageFilter(kind=_FILTER_UNFINDABLE, raw=raw)
+
+    if raw.startswith(_FILTER_UNFINDABLE + ":"):
+        cat = raw[len(_FILTER_UNFINDABLE) + 1 :].strip()
+        if not cat:
+            raise InvalidFilterError(
+                "unfindable:<category> requires a non-empty category"
+            )
+        if cat not in _UNFINDABLE_CATEGORIES:
+            raise InvalidFilterError(
+                f"unknown unfindable category {cat!r}; "
+                f"expected one of {sorted(_UNFINDABLE_CATEGORIES)}"
+            )
+        return ParsedTriageFilter(
+            kind=_FILTER_UNFINDABLE, unfindable_category=cat, raw=raw,
+        )
+
+    if raw == _FILTER_DATA_QUALITY:
+        return ParsedTriageFilter(kind=_FILTER_DATA_QUALITY, raw=raw)
+
+    if raw.startswith(_FILTER_DATA_QUALITY + ":"):
+        rest = raw[len(_FILTER_DATA_QUALITY) + 1 :].strip()
+        if not rest:
+            raise InvalidFilterError(
+                "data_quality:<field>|reason=<code> requires a value"
+            )
+        if rest.startswith("reason="):
+            code = rest[len("reason=") :].strip()
+            if not code:
+                raise InvalidFilterError(
+                    "data_quality:reason= requires a reason_code value"
+                )
+            return ParsedTriageFilter(
+                kind=_FILTER_DATA_QUALITY, reason_code=code, raw=raw,
+            )
+        # No "reason=" prefix → field name selector.
+        return ParsedTriageFilter(
+            kind=_FILTER_DATA_QUALITY, field_name=rest, raw=raw,
+        )
+
+    if raw == _FILTER_SEARCH_NOT_CONVERTING:
+        return ParsedTriageFilter(kind=_FILTER_SEARCH_NOT_CONVERTING, raw=raw)
+
+    raise InvalidFilterError(f"unknown filter spec {spec!r}")
+
+
+# --- Typed result Structs -------------------------------------------------
+
+
+class RequestMeta(msgspec.Struct, frozen=True):
+    """Static identity columns lifted off ``album_requests``.
+
+    Mirrors the operator-relevant subset of the row — enough to render
+    "Artist – Album (year) #N" plus the three identity probes the
+    forensic surfaces use (failure_class, source, search_filetype_override).
+    """
+
+    id: int
+    artist_name: str
+    album_title: str
+    year: Optional[int]
+    status: str
+    source: Optional[str]
+    mb_release_id: Optional[str]
+    discogs_release_id: Optional[str]
+    release_group_year: Optional[int]
+    is_va_compilation: bool
+    catalog_number: Optional[str]
+    failure_class: Optional[str]
+    search_filetype_override: Optional[str]
+
+
+class UnfindableState(msgspec.Struct, frozen=True):
+    """Per-request unfindable cohort state (U13).
+
+    Populated only when the request has at least one signal:
+    ``unfindable_category``, ``unfindable_categorised_at``,
+    ``last_artist_probe_at``, or ``rescued_at``. Healthy requests get
+    ``unfindable=None`` on the parent ``TriageResult`` so the operator
+    surface can render "no concerns" without a sentinel struct.
+    """
+
+    category: Optional[str]
+    categorised_at: Optional[datetime]
+    last_artist_probe_at: Optional[datetime]
+    last_artist_probe_match_count: Optional[int]
+    rescued_at: Optional[datetime]
+    prior_unfindable_category: Optional[str]
+
+
+class FieldResolutionState(msgspec.Struct, frozen=True):
+    """One row of ``album_request_field_resolutions`` lifted to the wire."""
+
+    field_name: str
+    status: str
+    reason_code: Optional[str]
+    attempts: int
+    resolved_at: datetime
+
+
+class SearchLogEntry(msgspec.Struct, frozen=True):
+    """One row from the ``recent_entries`` slice.
+
+    Carries the columns the operator surface actually renders — id,
+    timestamp, the strategy + query that produced the row, outcome,
+    and the U11 forensics scalars (``rejection_reason``,
+    ``matcher_score_top1``). Anything else stays on the raw
+    ``search_log`` row.
+    """
+
+    id: int
+    created_at: datetime
+    plan_strategy: Optional[str]
+    query: Optional[str]
+    outcome: str
+    result_count: Optional[int]
+    rejection_reason: Optional[str]
+    matcher_score_top1: Optional[float]
+
+
+class SearchForensicsSummary(msgspec.Struct, frozen=True):
+    """Rollup over ``request_search_summary`` view + a 10-row slice.
+
+    The summary scalars are read straight from the view; ``recent_entries``
+    is the last ten ``search_log`` rows for the request (newest-first).
+    Both come from bulk queries scoped to the page's request_ids so the
+    cohort path stays N+1-bounded.
+    """
+
+    total_searches: int
+    with_cands_count: int
+    found_count: int
+    near_cap_count: int
+    zero_results_count: int
+    pre_filter_skips_total: int
+    first_strategy_with_cands: Optional[str]
+    dominant_rejection_reason: Optional[str]
+    last_search_at: Optional[datetime]
+    recent_entries: list[SearchLogEntry]
+
+
+class TriageResult(msgspec.Struct, frozen=True):
+    """The full per-request triage payload."""
+
+    request_meta: RequestMeta
+    unfindable: Optional[UnfindableState]
+    field_quality: list[FieldResolutionState]
+    search_forensics: SearchForensicsSummary
+    failure_class: Optional[str]
+
+
+# --- Service entrypoint ---------------------------------------------------
+
+
+# Limit for ``recent_entries`` — small, since the operator only wants a
+# scroll of the last attempts; the historical timeline lives behind
+# ``search-plan history``.
+DEFAULT_RECENT_SEARCH_LOG_LIMIT = 10
+
+# Default page size for ``list_triage``.
+DEFAULT_TRIAGE_PAGE_SIZE = 50
+
+
+class _PipelineDB(Protocol):
+    """Duck-typed pipeline DB — service body never imports the concrete
+    class so tests can drop in a ``FakePipelineDB`` without monkey-patching.
+    """
+
+    def get_request(self, request_id: int) -> Optional[dict[str, Any]]: ...
+
+    def list_triage_page(
+        self,
+        *,
+        filter_spec: ParsedTriageFilter,
+        page_size: int,
+        after_request_id: Optional[int],
+    ) -> list[dict[str, Any]]: ...
+
+    def get_field_resolutions_for_requests(
+        self, request_ids: list[int],
+    ) -> dict[int, list[dict[str, Any]]]: ...
+
+    def get_search_summaries_for_requests(
+        self, request_ids: list[int],
+    ) -> dict[int, dict[str, Any]]: ...
+
+    def get_recent_search_log_for_requests(
+        self,
+        request_ids: list[int],
+        *,
+        per_request_limit: int,
+    ) -> dict[int, list[dict[str, Any]]]: ...
+
+
+def compose_triage_for_request(
+    request_id: int,
+    pdb: _PipelineDB,
+) -> Optional[TriageResult]:
+    """Compose a single-request triage payload.
+
+    Returns ``None`` when the row doesn't exist. Composes by reading
+    one request row + the same bulk-scoped per-domain getters
+    ``list_triage`` uses (passing a single-element list). Pull paths
+    stay symmetric: any caller asking "show me triage" goes through
+    the same SQL, just at different page sizes.
+    """
+    row = pdb.get_request(int(request_id))
+    if row is None:
+        return None
+
+    field_rows = pdb.get_field_resolutions_for_requests([int(request_id)])
+    summary_rows = pdb.get_search_summaries_for_requests([int(request_id)])
+    log_rows = pdb.get_recent_search_log_for_requests(
+        [int(request_id)],
+        per_request_limit=DEFAULT_RECENT_SEARCH_LOG_LIMIT,
+    )
+    return _compose_one(
+        row,
+        field_rows.get(int(request_id), []),
+        summary_rows.get(int(request_id)),
+        log_rows.get(int(request_id), []),
+    )
+
+
+def list_triage(
+    filter_spec: str,
+    pdb: _PipelineDB,
+    *,
+    page_size: int = DEFAULT_TRIAGE_PAGE_SIZE,
+    after_request_id: Optional[int] = None,
+) -> list[TriageResult]:
+    """List one page of triage results matching ``filter_spec``.
+
+    N+1-bounded: regardless of ``page_size``, the call emits at most
+    four DB queries:
+
+    1. ``list_triage_page`` — the cohort page filtered + keyset-paged.
+    2. ``get_field_resolutions_for_requests`` — one bulk
+       ``WHERE request_id = ANY(%s)`` over the page's ids.
+    3. ``get_search_summaries_for_requests`` — one bulk join against
+       ``request_search_summary``.
+    4. ``get_recent_search_log_for_requests`` — one bulk window-function
+       slice of the last N rows per request.
+
+    The result list preserves the page's ``id`` ASC ordering so
+    keyset pagination is stable across calls.
+    """
+    parsed = parse_filter(filter_spec)
+    rows = pdb.list_triage_page(
+        filter_spec=parsed,
+        page_size=int(page_size),
+        after_request_id=(int(after_request_id)
+                          if after_request_id is not None else None),
+    )
+    if not rows:
+        return []
+
+    request_ids = [int(r["id"]) for r in rows]
+    field_rows = pdb.get_field_resolutions_for_requests(request_ids)
+    summary_rows = pdb.get_search_summaries_for_requests(request_ids)
+    log_rows = pdb.get_recent_search_log_for_requests(
+        request_ids, per_request_limit=DEFAULT_RECENT_SEARCH_LOG_LIMIT,
+    )
+
+    out: list[TriageResult] = []
+    for r in rows:
+        rid = int(r["id"])
+        out.append(_compose_one(
+            r,
+            field_rows.get(rid, []),
+            summary_rows.get(rid),
+            log_rows.get(rid, []),
+        ))
+    return out
+
+
+# --- Composition helpers --------------------------------------------------
+
+
+def _compose_one(
+    request_row: dict[str, Any],
+    field_rows: Iterable[dict[str, Any]],
+    summary_row: Optional[dict[str, Any]],
+    log_rows: Iterable[dict[str, Any]],
+) -> TriageResult:
+    request_meta = _request_meta(request_row)
+    unfindable = _unfindable_state(request_row)
+    field_quality = [_field_resolution(r) for r in field_rows]
+    search_forensics = _search_forensics(summary_row, log_rows)
+    return TriageResult(
+        request_meta=request_meta,
+        unfindable=unfindable,
+        field_quality=field_quality,
+        search_forensics=search_forensics,
+        failure_class=request_row.get("failure_class"),
+    )
+
+
+def _request_meta(row: dict[str, Any]) -> RequestMeta:
+    return RequestMeta(
+        id=int(row["id"]),
+        artist_name=str(row.get("artist_name") or ""),
+        album_title=str(row.get("album_title") or ""),
+        year=_int_or_none(row.get("year")),
+        status=str(row.get("status") or ""),
+        source=row.get("source"),
+        mb_release_id=row.get("mb_release_id"),
+        discogs_release_id=row.get("discogs_release_id"),
+        release_group_year=_int_or_none(row.get("release_group_year")),
+        is_va_compilation=bool(row.get("is_va_compilation") or False),
+        catalog_number=row.get("catalog_number"),
+        failure_class=row.get("failure_class"),
+        search_filetype_override=row.get("search_filetype_override"),
+    )
+
+
+def _unfindable_state(row: dict[str, Any]) -> Optional[UnfindableState]:
+    category = row.get("unfindable_category")
+    categorised_at = row.get("unfindable_categorised_at")
+    last_probe = row.get("last_artist_probe_at")
+    rescued_at = row.get("rescued_at")
+    if (category is None and categorised_at is None and last_probe is None
+            and rescued_at is None):
+        return None
+    return UnfindableState(
+        category=category,
+        categorised_at=categorised_at,
+        last_artist_probe_at=last_probe,
+        last_artist_probe_match_count=_int_or_none(
+            row.get("last_artist_probe_match_count")
+        ),
+        rescued_at=rescued_at,
+        prior_unfindable_category=row.get("prior_unfindable_category"),
+    )
+
+
+def _field_resolution(row: dict[str, Any]) -> FieldResolutionState:
+    return FieldResolutionState(
+        field_name=str(row["field_name"]),
+        status=str(row["status"]),
+        reason_code=row.get("reason_code"),
+        attempts=int(row.get("attempts") or 0),
+        resolved_at=row["resolved_at"],
+    )
+
+
+def _search_forensics(
+    summary_row: Optional[dict[str, Any]],
+    log_rows: Iterable[dict[str, Any]],
+) -> SearchForensicsSummary:
+    entries = [_search_log_entry(r) for r in log_rows]
+    if summary_row is None:
+        # No view row for this request — every counter is zero. ``last_search_at``
+        # stays None; the operator surface renders the "no searches yet" state.
+        return SearchForensicsSummary(
+            total_searches=0,
+            with_cands_count=0,
+            found_count=0,
+            near_cap_count=0,
+            zero_results_count=0,
+            pre_filter_skips_total=0,
+            first_strategy_with_cands=None,
+            dominant_rejection_reason=None,
+            last_search_at=None,
+            recent_entries=entries,
+        )
+    return SearchForensicsSummary(
+        total_searches=int(summary_row.get("total_searches") or 0),
+        with_cands_count=int(summary_row.get("with_cands_count") or 0),
+        found_count=int(summary_row.get("found_count") or 0),
+        near_cap_count=int(summary_row.get("near_cap_count") or 0),
+        zero_results_count=int(summary_row.get("zero_results_count") or 0),
+        pre_filter_skips_total=int(
+            summary_row.get("pre_filter_skips_total") or 0
+        ),
+        first_strategy_with_cands=summary_row.get("first_strategy_with_cands"),
+        dominant_rejection_reason=summary_row.get("dominant_rejection_reason"),
+        last_search_at=summary_row.get("last_search_at"),
+        recent_entries=entries,
+    )
+
+
+def _search_log_entry(row: dict[str, Any]) -> SearchLogEntry:
+    matcher = row.get("matcher_score_top1")
+    matcher_f: Optional[float] = None
+    if matcher is not None:
+        try:
+            matcher_f = float(matcher)
+        except (TypeError, ValueError):
+            matcher_f = None
+    return SearchLogEntry(
+        id=int(row["id"]),
+        created_at=row["created_at"],
+        plan_strategy=row.get("plan_strategy"),
+        query=row.get("query"),
+        outcome=str(row.get("outcome") or ""),
+        result_count=_int_or_none(row.get("result_count")),
+        rejection_reason=row.get("rejection_reason"),
+        matcher_score_top1=matcher_f,
+    )
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -2380,6 +2380,282 @@ def cmd_search_plan_history(db, args):
     return _search_plan_exit_code(result.outcome)
 
 
+# --- U16: pipeline-cli triage ------------------------------------------------
+#
+# Two subcommands wrap the U15 triage service:
+#
+#   * ``pipeline-cli triage show <id>`` — per-request composition.
+#   * ``pipeline-cli triage list --filter=<spec>`` — cohort listing.
+#
+# Both adhere to CLAUDE.md § "CLI ⇄ API surface symmetry": each one is a
+# thin wrapper around ``lib.triage_service``; the matching HTTP routes
+# (U17) wrap the same service with the same outcome → exit-code /
+# status-code mapping.
+
+
+_TRIAGE_VALID_FILTER_FORMS = (
+    "all",
+    "unfindable",
+    "unfindable:<category>  (category ∈ "
+    "{artist_absent, album_absent_artist_present, "
+    "one_track_structural, wrong_pressing_available})",
+    "data_quality",
+    "data_quality:<field_name>",
+    "data_quality:reason=<reason_code>",
+    "search_not_converting",
+)
+
+
+def _truncate(text: str, width: int) -> str:
+    """Truncate ``text`` to ``width`` characters, marking with an ellipsis.
+
+    Pure helper used by ``triage list``'s human-readable table renderer.
+    Avoids pulling in textwrap for a 4-line helper.
+    """
+    if text is None:
+        return ""
+    if len(text) <= width:
+        return text
+    if width <= 1:
+        return text[:width]
+    return text[: width - 1] + "…"
+
+
+def _format_dt(value) -> str:
+    """Compact display of a datetime/date/time for table cells.
+
+    Uses the same ISO 8601 rendering ``_json_default`` emits, but strips
+    sub-second precision so the table stays narrow. Returns ``"-"`` on
+    ``None`` so empty cells are visually distinct from a zero-length
+    string.
+    """
+    if value is None:
+        return "-"
+    if isinstance(value, (date, datetime, time)):
+        iso = value.isoformat()
+        # Drop microseconds + timezone marker for table compactness.
+        if "." in iso:
+            iso = iso.split(".", 1)[0]
+        if iso.endswith("+00:00"):
+            iso = iso[:-6] + "Z"
+        return iso
+    return str(value)
+
+
+def cmd_triage_show(db, args):
+    """``pipeline-cli triage show <id>`` — per-request triage composition.
+
+    Wraps ``compose_triage_for_request`` and renders the full payload
+    (request meta + unfindable + field-quality + search forensics +
+    recent search_log slice). Mirrors the human/JSON conventions
+    established by ``cmd_search_plan_show`` and the U17 API.
+
+    Exit codes:
+      * 0 — success
+      * 2 — request not found
+    """
+    from lib.triage_service import compose_triage_for_request
+
+    rid = int(args.id)
+    result = compose_triage_for_request(rid, db)
+    if result is None:
+        if getattr(args, "json", False):
+            print(json.dumps({
+                "error": "Not found",
+                "request_id": rid,
+            }, indent=2, sort_keys=True))
+        else:
+            print(f"  Request {rid} not found.", file=sys.stderr)
+        return 2
+
+    if getattr(args, "json", False):
+        payload = msgspec.to_builtins(result)
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+        return 0
+
+    # Human-readable rendering.
+    meta = result.request_meta
+    print(f"  Request ID:        {meta.id}")
+    print(f"  Artist / Album:    {meta.artist_name} — {meta.album_title}")
+    if meta.year is not None:
+        print(f"  Year:              {meta.year}")
+    print(f"  Status:            {meta.status}")
+    print(f"  Source:            {meta.source or '-'}")
+    if meta.mb_release_id:
+        print(f"  MB release id:     {meta.mb_release_id}")
+    if meta.discogs_release_id:
+        print(f"  Discogs id:        {meta.discogs_release_id}")
+    if meta.failure_class:
+        print(f"  Failure class:     {meta.failure_class}")
+    if meta.search_filetype_override:
+        print(f"  Search filetype:   {meta.search_filetype_override}")
+
+    # Unfindable cohort state.
+    if result.unfindable is None:
+        print("  Unfindable:        (no signals)")
+    else:
+        u = result.unfindable
+        print("  Unfindable:")
+        print(f"    category:                  {u.category or '-'}")
+        print(f"    categorised_at:            {_format_dt(u.categorised_at)}")
+        print(
+            f"    last_artist_probe_at:      "
+            f"{_format_dt(u.last_artist_probe_at)}"
+        )
+        if u.last_artist_probe_match_count is not None:
+            print(
+                f"    last_probe_match_count:    "
+                f"{u.last_artist_probe_match_count}"
+            )
+        if u.rescued_at is not None:
+            print(f"    rescued_at:                {_format_dt(u.rescued_at)}")
+            print(
+                f"    prior_unfindable_category: "
+                f"{u.prior_unfindable_category or '-'}"
+            )
+
+    # Field-quality rows (the resolver side table, U2).
+    if not result.field_quality:
+        print("  Field quality:     (no resolutions)")
+    else:
+        print(f"  Field quality:     {len(result.field_quality)} resolution(s)")
+        for fr in result.field_quality:
+            reason = fr.reason_code or "-"
+            print(
+                f"    [{fr.field_name}] status={fr.status} reason={reason} "
+                f"attempts={fr.attempts} resolved_at={_format_dt(fr.resolved_at)}"
+            )
+
+    # Search forensics summary + recent entries.
+    sf = result.search_forensics
+    print("  Search forensics:")
+    print(f"    total_searches:            {sf.total_searches}")
+    print(f"    with_cands_count:          {sf.with_cands_count}")
+    print(f"    found_count:               {sf.found_count}")
+    print(f"    near_cap_count:            {sf.near_cap_count}")
+    print(f"    zero_results_count:        {sf.zero_results_count}")
+    print(f"    pre_filter_skips_total:    {sf.pre_filter_skips_total}")
+    print(
+        f"    first_strategy_with_cands: "
+        f"{sf.first_strategy_with_cands or '-'}"
+    )
+    print(
+        f"    dominant_rejection_reason: "
+        f"{sf.dominant_rejection_reason or '-'}"
+    )
+    print(f"    last_search_at:            {_format_dt(sf.last_search_at)}")
+
+    if not sf.recent_entries:
+        print("    recent_entries:            (none)")
+    else:
+        print(f"    recent_entries:            {len(sf.recent_entries)} "
+              f"(newest first, max 10)")
+        for entry in sf.recent_entries:
+            strategy = entry.plan_strategy or "(legacy)"
+            reason = entry.rejection_reason or "-"
+            matcher = (
+                f"{entry.matcher_score_top1:.2f}"
+                if entry.matcher_score_top1 is not None else "-"
+            )
+            rc = (
+                str(entry.result_count) if entry.result_count is not None
+                else "-"
+            )
+            query = entry.query or ""
+            print(
+                f"      [{_format_dt(entry.created_at)}] id={entry.id} "
+                f"{entry.outcome} {strategy} rc={rc} reject={reason} "
+                f"matcher={matcher} query={query!r}"
+            )
+
+    return 0
+
+
+def cmd_triage_list(db, args):
+    """``pipeline-cli triage list --filter=<spec>`` — cohort listing.
+
+    Wraps ``list_triage``. Default page size is 50. Use ``--after=<id>``
+    to resume; the page footer prints the next ``--after`` value when
+    the returned page is exactly ``--limit`` long.
+
+    Exit codes:
+      * 0 — success (empty list is a valid cohort state)
+      * 3 — invalid filter spec (``InvalidFilterError``)
+    """
+    from lib.triage_service import InvalidFilterError, list_triage
+
+    limit = int(args.limit) if args.limit is not None else 50
+    after = int(args.after) if args.after is not None else None
+
+    try:
+        results = list_triage(
+            args.filter, db,
+            page_size=limit,
+            after_request_id=after,
+        )
+    except InvalidFilterError as exc:
+        message = (
+            f"Invalid filter spec: {exc}\n"
+            "Valid forms:\n"
+            + "\n".join(f"  - {form}" for form in _TRIAGE_VALID_FILTER_FORMS)
+        )
+        print(message, file=sys.stderr)
+        return 3
+
+    if getattr(args, "json", False):
+        payload = [msgspec.to_builtins(r) for r in results]
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+        return 0
+
+    if not results:
+        print(f"  No results for filter={args.filter!r}.")
+        return 0
+
+    # Human table.
+    header_cols = (
+        ("id", 6),
+        ("artist", 25),
+        ("album", 25),
+        ("status", 12),
+        ("category/failure", 28),
+        ("last_search_at", 20),
+    )
+    header_line = "  ".join(name.ljust(width) for name, width in header_cols)
+    print(header_line)
+    print("  ".join("-" * width for _, width in header_cols))
+
+    for r in results:
+        meta = r.request_meta
+        category_or_failure = (
+            (r.unfindable.category if r.unfindable is not None else None)
+            or meta.failure_class
+            or "-"
+        )
+        last_search = _format_dt(r.search_forensics.last_search_at)
+        row_cells = (
+            str(meta.id),
+            _truncate(meta.artist_name, 25),
+            _truncate(meta.album_title, 25),
+            _truncate(meta.status, 12),
+            _truncate(category_or_failure, 28),
+            _truncate(last_search, 20),
+        )
+        print("  ".join(
+            cell.ljust(width) for cell, (_, width) in zip(row_cells, header_cols)
+        ))
+
+    print(f"  ({len(results)} rows)")
+    if len(results) == limit:
+        next_after = results[-1].request_meta.id
+        print(
+            f"  next page: pipeline-cli triage list --filter={args.filter} "
+            f"--limit={limit} --after={next_after}"
+        )
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description="Pipeline CLI — manage download pipeline DB")
     parser.add_argument("--dsn", default=DEFAULT_DSN, help="PostgreSQL connection string")
@@ -2498,6 +2774,44 @@ def main():
         help="Resume cursor: pass the previous page's next_before_id")
     p_sp_history.add_argument("--json", action="store_true",
                               help="Print structured JSON instead of text")
+
+    # triage (U16) — operator-facing composition of unfindable + field-quality
+    # + search-forensics. Wraps ``lib.triage_service`` (U15). Nested under a
+    # subparser for the same reason ``search-plan`` is: the per-request view
+    # and the cohort list share enough state to benefit from a shared
+    # namespace, and the convention is consistent with the rest of this CLI.
+    p_triage_op = sub.add_parser(
+        "triage",
+        help="Operator triage (U16) — compose unfindable + field-quality + "
+             "search-forensics for one request, or list a cohort by filter")
+    tr_sub = p_triage_op.add_subparsers(dest="triage_command")
+
+    p_tr_show = tr_sub.add_parser(
+        "show",
+        help="Per-request triage composition (request meta + unfindable + "
+             "field-quality + search forensics + last 10 search_log rows). "
+             "Note: subcommand form mirrors `search-plan show <id>`; bare "
+             "`triage <id>` is not accepted.")
+    p_tr_show.add_argument("id", type=int, help="Request ID")
+    p_tr_show.add_argument("--json", action="store_true",
+                            help="Print structured JSON instead of text")
+
+    p_tr_list = tr_sub.add_parser(
+        "list",
+        help="Cohort listing by filter spec")
+    p_tr_list.add_argument(
+        "--filter", default="all",
+        help="Filter spec: all | unfindable[:<category>] | "
+             "data_quality[:<field>] | data_quality:reason=<code> | "
+             "search_not_converting")
+    p_tr_list.add_argument(
+        "--limit", type=int, default=50,
+        help="Page size (default 50)")
+    p_tr_list.add_argument(
+        "--after", type=int, default=None,
+        help="Resume cursor: last request_id from prior page")
+    p_tr_list.add_argument("--json", action="store_true",
+                            help="Print structured JSON instead of text")
 
     # quality
     p_quality = sub.add_parser("quality", help="Show quality state and simulate decisions")
@@ -2636,6 +2950,10 @@ def main():
             args, "search_plan_command", None):
         p_sp.print_help()
         sys.exit(1)
+    if args.command == "triage" and not getattr(
+            args, "triage_command", None):
+        p_triage_op.print_help()
+        sys.exit(1)
 
     db = PipelineDB(args.dsn)
 
@@ -2669,9 +2987,15 @@ def main():
         "dry-run": cmd_search_plan_dry_run,
         "saturation": cmd_search_plan_saturation,
     }
+    triage_commands = {
+        "show": cmd_triage_show,
+        "list": cmd_triage_list,
+    }
     try:
         if args.command == "search-plan":
             rc = search_plan_commands[args.search_plan_command](db, args)
+        elif args.command == "triage":
+            rc = triage_commands[args.triage_command](db, args)
         else:
             rc = commands[args.command](db, args)
     finally:

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -2656,7 +2656,17 @@ def cmd_triage_list(db, args):
     return 0
 
 
-def main():
+def _build_parser() -> tuple[
+    argparse.ArgumentParser, argparse.ArgumentParser, argparse.ArgumentParser
+]:
+    """Build the full pipeline-cli argument parser.
+
+    Returned tuple is ``(top_level, search_plan_subparser,
+    triage_subparser)``; ``main()`` uses the nested subparsers to print
+    helpful errors when an operator runs ``search-plan`` / ``triage``
+    without a subcommand, and ``cmd_routes`` uses the top-level parser
+    to introspect every registered subcommand.
+    """
     parser = argparse.ArgumentParser(description="Pipeline CLI — manage download pipeline DB")
     parser.add_argument("--dsn", default=DEFAULT_DSN, help="PostgreSQL connection string")
     sub = parser.add_subparsers(dest="command")
@@ -2942,6 +2952,144 @@ def main():
     p_bd.add_argument("--json", action="store_true",
                       help="Print structured JSON instead of text")
 
+    # routes (U18 step 3): self-document the CLI surface. Mirrors
+    # ``GET /api/_index`` on the web side; both are read-only and zero-arg.
+    p_routes = sub.add_parser(
+        "routes",
+        help="Self-document the CLI surface — every subcommand, "
+             "its args, and its description.",
+    )
+    p_routes.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON instead of human-readable text.",
+    )
+
+    return parser, p_sp, p_triage_op
+
+
+def _describe_argparse_action(
+    action: argparse.Action,
+) -> str | None:
+    """Render one argparse Action as a human-readable arg label.
+
+    Returns the metavar / option-string form with a hint for type or
+    choices when present. Returns None for the subparsers placeholder
+    (those are sibling subcommands, not arguments).
+    """
+    if isinstance(action, argparse._SubParsersAction):  # noqa: SLF001
+        return None
+    if isinstance(action, argparse._HelpAction):  # noqa: SLF001
+        return None
+    label: str
+    if action.option_strings:
+        label = action.option_strings[0]
+    else:
+        metavar = action.metavar
+        # ``metavar`` is typed ``str | tuple[str, ...] | None`` upstream;
+        # nargs forms like ``nargs="?"`` can yield a tuple here. Render
+        # tuples by joining for a stable string representation.
+        if isinstance(metavar, tuple):
+            label = " ".join(str(m) for m in metavar)
+        else:
+            label = metavar or action.dest
+    type_hint: str | None = None
+    if action.choices:
+        type_hint = "{" + ",".join(str(c) for c in action.choices) + "}"
+    elif action.type is int:
+        type_hint = "int"
+    elif action.type is float:
+        type_hint = "float"
+    if type_hint:
+        return f"{label} ({type_hint})"
+    return label
+
+
+def _collect_cli_routes(
+    parser: argparse.ArgumentParser,
+) -> list[dict[str, object]]:
+    """Walk a parser's subparsers and emit one entry per leaf subcommand.
+
+    Returns a list of ``{subcommand, args, description}`` rows sorted by
+    ``subcommand``. Nested subparsers (e.g. ``search-plan show``) emit
+    one row per leaf path; the parent ``search-plan`` itself is not
+    emitted because its help is already covered by its children.
+    """
+    rows: list[dict[str, object]] = []
+
+    def _walk(p: argparse.ArgumentParser, prefix: str) -> None:
+        sub_actions = [
+            a for a in p._actions  # noqa: SLF001
+            if isinstance(a, argparse._SubParsersAction)  # noqa: SLF001
+        ]
+        if not sub_actions:
+            return
+        for sub_action in sub_actions:
+            for name, sub_parser in sub_action.choices.items():
+                label = f"{prefix} {name}".strip()
+                # Recurse first to detect leaves.
+                nested = [
+                    a for a in sub_parser._actions  # noqa: SLF001
+                    if isinstance(a, argparse._SubParsersAction)  # noqa: SLF001
+                    and a.choices
+                ]
+                if nested:
+                    _walk(sub_parser, label)
+                    continue
+                args: list[str] = []
+                for action in sub_parser._actions:  # noqa: SLF001
+                    rendered = _describe_argparse_action(action)
+                    if rendered is not None:
+                        args.append(rendered)
+                description = ""
+                # Recover the parent's help text for this subcommand.
+                # argparse stores per-choice help on
+                # ``_SubParsersAction._choices_actions`` (a private list of
+                # ``_ChoicesPseudoAction`` whose ``dest`` matches the name).
+                choices_actions = getattr(
+                    sub_action, "_choices_actions", []) or []
+                for ca in choices_actions:
+                    if ca.dest == name:
+                        description = ca.help or ""
+                        break
+                rows.append({
+                    "subcommand": label,
+                    "args": args,
+                    "description": description,
+                })
+
+    _walk(parser, "")
+    rows.sort(key=lambda r: str(r["subcommand"]))
+    return rows
+
+
+def cmd_routes(db, args) -> int:
+    """Emit every CLI subcommand with its args and description.
+
+    Reads the parser from ``_build_parser`` so the listing cannot drift
+    from the actual surface — adding a subparser anywhere updates this
+    output automatically.
+    """
+    parser, _, _ = _build_parser()
+    rows = _collect_cli_routes(parser)
+    if getattr(args, "json", False):
+        print(json.dumps(rows, indent=2))
+        return 0
+    for row in rows:
+        raw_args = row["args"]
+        args_list = raw_args if isinstance(raw_args, list) else []
+        args_str = " ".join(str(a) for a in args_list) if args_list else ""
+        if args_str:
+            print(f"{row['subcommand']}  [{args_str}]")
+        else:
+            print(f"{row['subcommand']}")
+        desc = row["description"]
+        if desc:
+            print(f"    {desc}")
+    return 0
+
+
+def main():
+    parser, p_sp, p_triage_op = _build_parser()
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -2954,6 +3102,15 @@ def main():
             args, "triage_command", None):
         p_triage_op.print_help()
         sys.exit(1)
+
+    # ``routes`` is the only subcommand that doesn't require a DB
+    # connection — short-circuit before constructing PipelineDB so the
+    # command works without a reachable database.
+    if args.command == "routes":
+        rc = cmd_routes(None, args)
+        if isinstance(rc, int):
+            sys.exit(rc)
+        return
 
     db = PipelineDB(args.dsn)
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -2393,6 +2393,13 @@ def cmd_search_plan_history(db, args):
 # status-code mapping.
 
 
+# The canonical machine-parseable forms come from the service-layer
+# ``VALID_FILTER_FORMS`` (single source of truth across CLI and HTTP);
+# the prose variants below are CLI-only embellishments to help operators
+# remember the parameterised vocab. New filter forms get added at the
+# service layer; both wrappers auto-pick them up.
+from lib.triage_service import VALID_FILTER_FORMS as _TRIAGE_VALID_FILTER_FORMS_BASE  # noqa: E402
+
 _TRIAGE_VALID_FILTER_FORMS = (
     "all",
     "unfindable",
@@ -2400,8 +2407,12 @@ _TRIAGE_VALID_FILTER_FORMS = (
     "{artist_absent, album_absent_artist_present, "
     "one_track_structural, wrong_pressing_available})",
     "data_quality",
-    "data_quality:<field_name>",
-    "data_quality:reason=<reason_code>",
+    "data_quality:<field_name>  (field ∈ "
+    "{release_group_year, release_group_id, track_artist, catalog_number})",
+    "data_quality:status=<resolver_status>  (e.g. "
+    "unresolved_4xx_client, unresolved_404, unresolved_timeout)",
+    "data_quality:reason=<reason_code>  (e.g. http_400, http_410, "
+    "http_422)",
     "search_not_converting",
 )
 
@@ -2412,8 +2423,6 @@ def _truncate(text: str, width: int) -> str:
     Pure helper used by ``triage list``'s human-readable table renderer.
     Avoids pulling in textwrap for a 4-line helper.
     """
-    if text is None:
-        return ""
     if len(text) <= width:
         return text
     if width <= 1:
@@ -2421,13 +2430,14 @@ def _truncate(text: str, width: int) -> str:
     return text[: width - 1] + "…"
 
 
-def _format_dt(value) -> str:
+def _format_dt(value: object) -> str:
     """Compact display of a datetime/date/time for table cells.
 
     Uses the same ISO 8601 rendering ``_json_default`` emits, but strips
     sub-second precision so the table stays narrow. Returns ``"-"`` on
     ``None`` so empty cells are visually distinct from a zero-length
-    string.
+    string. ``object`` is wider than necessary, but the helper is used
+    against ``msgspec.to_builtins`` output which is statically untyped.
     """
     if value is None:
         return "-"
@@ -2581,12 +2591,44 @@ def cmd_triage_list(db, args):
 
     Exit codes:
       * 0 — success (empty list is a valid cohort state)
-      * 3 — invalid filter spec (``InvalidFilterError``)
-    """
-    from lib.triage_service import InvalidFilterError, list_triage
+      * 3 — invalid filter spec (``InvalidFilterError``) or out-of-range
+        ``--limit`` / ``--after``
 
+    JSON envelope (mirrors the API):
+        ``{"results": [...], "next_after": <int|null>,
+           "page_size": <int>, "filter": <spec>}``
+    """
+    from lib.triage_service import (
+        InvalidFilterError,
+        TRIAGE_AFTER_MIN,
+        TRIAGE_LIMIT_MAX,
+        TRIAGE_LIMIT_MIN,
+        list_triage,
+    )
+
+    json_mode = bool(getattr(args, "json", False))
     limit = int(args.limit) if args.limit is not None else 50
     after = int(args.after) if args.after is not None else None
+
+    # Bounds — mirrors the API's [1..200] / [>=1] check so the two
+    # surfaces reject the same set of out-of-range values.
+    if not (TRIAGE_LIMIT_MIN <= limit <= TRIAGE_LIMIT_MAX):
+        msg = (
+            f"--limit must be in [{TRIAGE_LIMIT_MIN}, {TRIAGE_LIMIT_MAX}]; "
+            f"got {limit}"
+        )
+        if json_mode:
+            print(json.dumps({"error": msg}, indent=2, sort_keys=True))
+        else:
+            print(msg, file=sys.stderr)
+        return 3
+    if after is not None and after < TRIAGE_AFTER_MIN:
+        msg = f"--after must be >= {TRIAGE_AFTER_MIN}; got {after}"
+        if json_mode:
+            print(json.dumps({"error": msg}, indent=2, sort_keys=True))
+        else:
+            print(msg, file=sys.stderr)
+        return 3
 
     try:
         results = list_triage(
@@ -2595,16 +2637,52 @@ def cmd_triage_list(db, args):
             after_request_id=after,
         )
     except InvalidFilterError as exc:
-        message = (
-            f"Invalid filter spec: {exc}\n"
-            "Valid forms:\n"
-            + "\n".join(f"  - {form}" for form in _TRIAGE_VALID_FILTER_FORMS)
+        from lib.triage_service import (
+            VALID_DATA_QUALITY_FIELD_NAMES,
+            VALID_UNFINDABLE_CATEGORIES,
         )
-        print(message, file=sys.stderr)
+        if json_mode:
+            # JSON-mode error path — emit a structured payload on stdout
+            # so callers piping ``--json | jq`` keep parsing. Mirrors
+            # cmd_triage_show's 404 JSON path and the API 400 envelope.
+            print(json.dumps(
+                {
+                    "error": str(exc),
+                    "valid_filters": list(_TRIAGE_VALID_FILTER_FORMS_BASE),
+                    "valid_unfindable_categories": sorted(
+                        VALID_UNFINDABLE_CATEGORIES
+                    ),
+                    "valid_data_quality_fields": sorted(
+                        VALID_DATA_QUALITY_FIELD_NAMES
+                    ),
+                },
+                indent=2, sort_keys=True,
+            ))
+        else:
+            message = (
+                f"Invalid filter spec: {exc}\n"
+                "Valid forms:\n"
+                + "\n".join(f"  - {form}" for form in _TRIAGE_VALID_FILTER_FORMS)
+            )
+            print(message, file=sys.stderr)
         return 3
 
-    if getattr(args, "json", False):
-        payload = [msgspec.to_builtins(r) for r in results]
+    # ``next_after`` matches the API's ``>= limit`` predicate so the
+    # CLI and HTTP surfaces report identical pagination state on the
+    # same data.
+    next_after: int | None = None
+    if results and len(results) >= limit:
+        next_after = results[-1].request_meta.id
+
+    if json_mode:
+        # Envelope wrap matches the API shape so agents pipe-and-jq the
+        # same way against both surfaces.
+        payload = {
+            "results": msgspec.to_builtins(results),
+            "next_after": next_after,
+            "page_size": limit,
+            "filter": args.filter,
+        }
         print(json.dumps(payload, indent=2, sort_keys=True,
                          default=_json_default))
         return 0
@@ -2647,8 +2725,7 @@ def cmd_triage_list(db, args):
         ))
 
     print(f"  ({len(results)} rows)")
-    if len(results) == limit:
-        next_after = results[-1].request_meta.id
+    if next_after is not None:
         print(
             f"  next page: pipeline-cli triage list --filter={args.filter} "
             f"--limit={limit} --after={next_after}"
@@ -2812,8 +2889,8 @@ def _build_parser() -> tuple[
     p_tr_list.add_argument(
         "--filter", default="all",
         help="Filter spec: all | unfindable[:<category>] | "
-             "data_quality[:<field>] | data_quality:reason=<code> | "
-             "search_not_converting")
+             "data_quality[:<field>] | data_quality:status=<status> | "
+             "data_quality:reason=<code> | search_not_converting")
     p_tr_list.add_argument(
         "--limit", type=int, default=50,
         help="Page size (default 50)")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -779,6 +779,13 @@ class FakePipelineDB:
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
         self._execute_queue: list[Any] = []
         self._execute_default: Any = None
+        # U15 triage N+1 guard: every triage-bound bulk getter increments
+        # its counter exactly once per call. ``list_triage`` is bounded
+        # to four entries (one page + three bulk getters) regardless of
+        # page size; the test asserts ``sum(query_counts.values()) <= 5``
+        # (extra headroom for the per-request compose path's request
+        # fetch).
+        self.query_counts: dict[str, int] = {}
 
     # --- Seeding ---
 
@@ -2044,6 +2051,235 @@ class FakePipelineDB:
             "status": row.status,
             "reason_code": row.reason_code,
             "attempts": row.attempts,
+        }
+
+    # --- Triage cohort (U15) ---------------------------------------------
+    #
+    # Mirrors the four new ``PipelineDB`` triage methods so the service
+    # layer can be exercised without a real Postgres. Each method bumps
+    # ``self.query_counts`` exactly once per invocation so the N+1 guard
+    # test can assert ``sum(query_counts.values()) <= 5`` across the
+    # cohort path.
+
+    def list_triage_page(
+        self,
+        *,
+        filter_spec: Any,
+        page_size: int,
+        after_request_id: int | None,
+    ) -> list[dict[str, Any]]:
+        """In-memory mirror of ``PipelineDB.list_triage_page``."""
+        self.query_counts["list_triage_page"] = (
+            self.query_counts.get("list_triage_page", 0) + 1
+        )
+        kind = getattr(filter_spec, "kind", None)
+        unfindable_category = getattr(filter_spec, "unfindable_category", None)
+        field_name = getattr(filter_spec, "field_name", None)
+        reason_code = getattr(filter_spec, "reason_code", None)
+
+        def keep(row: dict[str, Any]) -> bool:
+            if kind == "unfindable":
+                if row.get("unfindable_category") is None:
+                    return False
+                if (unfindable_category is not None
+                        and row.get("unfindable_category") != unfindable_category):
+                    return False
+                return True
+            if kind == "data_quality":
+                rid = int(row["id"])
+                matched = False
+                for (resolution_rid, _fname), fr in self.field_resolutions.items():
+                    if resolution_rid != rid:
+                        continue
+                    if not fr.status.startswith("unresolved_"):
+                        continue
+                    if field_name is not None and fr.field_name != field_name:
+                        continue
+                    if reason_code is not None and fr.reason_code != reason_code:
+                        continue
+                    matched = True
+                    break
+                return matched
+            if kind == "search_not_converting":
+                summary = self._compute_search_summary(int(row["id"]))
+                return (summary is not None
+                        and summary["total_searches"] > 0
+                        and summary["found_count"] == 0)
+            if kind == "all":
+                return True
+            raise ValueError(f"unsupported triage filter kind: {kind!r}")
+
+        rows = sorted(
+            (r for r in self._requests.values() if keep(r)),
+            key=lambda r: int(r["id"]),
+        )
+        if after_request_id is not None:
+            rows = [r for r in rows if int(r["id"]) > int(after_request_id)]
+        rows = rows[: int(page_size)]
+        # Return projection mirroring the real SELECT list — kept
+        # deliberately narrow so tests can't accidentally rely on a
+        # column the production page query doesn't include.
+        projection_keys = (
+            "id", "artist_name", "album_title", "year", "status", "source",
+            "mb_release_id", "discogs_release_id", "release_group_year",
+            "is_va_compilation", "catalog_number", "failure_class",
+            "search_filetype_override", "unfindable_category",
+            "unfindable_categorised_at", "last_artist_probe_at",
+            "last_artist_probe_match_count", "rescued_at",
+            "prior_unfindable_category",
+        )
+        return [{k: r.get(k) for k in projection_keys} for r in rows]
+
+    def get_field_resolutions_for_requests(
+        self,
+        request_ids: list[int],
+    ) -> dict[int, list[dict[str, Any]]]:
+        """In-memory mirror of ``PipelineDB.get_field_resolutions_for_requests``."""
+        self.query_counts["get_field_resolutions_for_requests"] = (
+            self.query_counts.get("get_field_resolutions_for_requests", 0) + 1
+        )
+        wanted = {int(r) for r in request_ids}
+        out: dict[int, list[dict[str, Any]]] = {}
+        # Order by (request_id, field_name) to mirror the production
+        # ORDER BY clause.
+        for (rid, _fn), fr in sorted(
+            self.field_resolutions.items(), key=lambda kv: kv[0]
+        ):
+            if rid not in wanted:
+                continue
+            out.setdefault(rid, []).append({
+                "id": fr.id,
+                "request_id": fr.request_id,
+                "field_name": fr.field_name,
+                "resolved_at": fr.resolved_at,
+                "status": fr.status,
+                "reason_code": fr.reason_code,
+                "attempts": fr.attempts,
+            })
+        return out
+
+    def get_search_summaries_for_requests(
+        self,
+        request_ids: list[int],
+    ) -> dict[int, dict[str, Any]]:
+        """In-memory mirror of ``PipelineDB.get_search_summaries_for_requests``.
+
+        Aggregates ``self.search_logs`` against the same shape the
+        production view emits. Requests with zero rows in window are
+        omitted (the view excludes empty groups via ``GROUP BY``).
+        """
+        self.query_counts["get_search_summaries_for_requests"] = (
+            self.query_counts.get("get_search_summaries_for_requests", 0) + 1
+        )
+        out: dict[int, dict[str, Any]] = {}
+        for rid in request_ids:
+            summary = self._compute_search_summary(int(rid))
+            if summary is not None:
+                out[int(rid)] = summary
+        return out
+
+    def get_recent_search_log_for_requests(
+        self,
+        request_ids: list[int],
+        *,
+        per_request_limit: int,
+    ) -> dict[int, list[dict[str, Any]]]:
+        """In-memory mirror of ``PipelineDB.get_recent_search_log_for_requests``.
+
+        Walks ``self.search_logs`` newest-first and emits at most
+        ``per_request_limit`` rows per request id.
+        """
+        self.query_counts["get_recent_search_log_for_requests"] = (
+            self.query_counts.get("get_recent_search_log_for_requests", 0) + 1
+        )
+        wanted = {int(r) for r in request_ids}
+        out: dict[int, list[dict[str, Any]]] = {}
+        # Sort by (created_at, id) DESC so the most recent rows come
+        # first per request.
+        for entry in sorted(
+            self.search_logs,
+            key=lambda e: (e.created_at, e.id),
+            reverse=True,
+        ):
+            if entry.request_id not in wanted:
+                continue
+            bucket = out.setdefault(entry.request_id, [])
+            if len(bucket) >= int(per_request_limit):
+                continue
+            bucket.append({
+                "id": entry.id,
+                "request_id": entry.request_id,
+                "created_at": entry.created_at,
+                "plan_strategy": entry.plan_strategy,
+                "query": entry.query,
+                "outcome": entry.outcome,
+                "result_count": entry.result_count,
+                "rejection_reason": entry.rejection_reason,
+                "matcher_score_top1": entry.matcher_score_top1,
+            })
+        return out
+
+    def _compute_search_summary(
+        self, request_id: int,
+    ) -> dict[str, Any] | None:
+        """Compute one row of the ``request_search_summary`` view.
+
+        Mirrors the SQL aggregate against ``self.search_logs``. Returns
+        ``None`` when the request has zero rows — matches the view's
+        ``GROUP BY`` semantics (empty groups produce no row).
+        """
+        rows = [e for e in self.search_logs if e.request_id == int(request_id)]
+        if not rows:
+            return None
+        total = len(rows)
+        with_cands = sum(
+            1 for e in rows
+            if e.candidates is not None and e.candidates not in ("", "[]")
+        )
+        found = sum(1 for e in rows if e.outcome == "found")
+        near_cap = sum(
+            1 for e in rows
+            if (e.result_count is not None and e.result_count >= 950)
+        )
+        zero_results = sum(1 for e in rows if e.result_count == 0)
+        pre_filter_skips = sum(
+            int(e.pre_filter_skip_count or 0) for e in rows
+        )
+        # first_strategy_with_cands = earliest row that had candidates
+        # (mirrors the view's correlated subquery ASC ordering).
+        with_cands_sorted = sorted(
+            (e for e in rows
+             if e.candidates is not None and e.candidates not in ("", "[]")),
+            key=lambda e: (e.created_at, e.id),
+        )
+        first_strategy = (
+            with_cands_sorted[0].plan_strategy
+            if with_cands_sorted else None
+        )
+        # dominant_rejection_reason — mode of non-null rejection_reason values.
+        reason_counts: dict[str, int] = {}
+        for e in rows:
+            if e.rejection_reason is None:
+                continue
+            reason_counts[e.rejection_reason] = (
+                reason_counts.get(e.rejection_reason, 0) + 1
+            )
+        dominant = (
+            max(reason_counts.items(), key=lambda kv: kv[1])[0]
+            if reason_counts else None
+        )
+        last_search = max(rows, key=lambda e: (e.created_at, e.id)).created_at
+        return {
+            "request_id": int(request_id),
+            "total_searches": total,
+            "with_cands_count": with_cands,
+            "found_count": found,
+            "near_cap_count": near_cap,
+            "zero_results_count": zero_results,
+            "pre_filter_skips_total": pre_filter_skips,
+            "first_strategy_with_cands": first_strategy,
+            "dominant_rejection_reason": dominant,
+            "last_search_at": last_search,
         }
 
     def update_spectral_state(self, request_id: int,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2075,6 +2075,7 @@ class FakePipelineDB:
         kind = getattr(filter_spec, "kind", None)
         unfindable_category = getattr(filter_spec, "unfindable_category", None)
         field_name = getattr(filter_spec, "field_name", None)
+        status_code = getattr(filter_spec, "status_code", None)
         reason_code = getattr(filter_spec, "reason_code", None)
 
         def keep(row: dict[str, Any]) -> bool:
@@ -2094,6 +2095,8 @@ class FakePipelineDB:
                     if not fr.status.startswith("unresolved_"):
                         continue
                     if field_name is not None and fr.field_name != field_name:
+                        continue
+                    if status_code is not None and fr.status != status_code:
                         continue
                     if reason_code is not None and fr.reason_code != reason_code:
                         continue

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -798,6 +798,99 @@ class TestFakePipelineDBTriage(unittest.TestCase):
         )
         self.assertEqual([r["id"] for r in page], [3, 4])
 
+    def test_list_triage_page_filter_data_quality(self):
+        """The EXISTS-join branch over ``album_request_field_resolutions``.
+
+        Three rows: (1) has an unresolved field-resolution, (2) has only
+        a resolved-status row, (3) has none. Only row 1 must match the
+        bare ``data_quality`` filter; narrowing on field_name / status_code
+        / reason_code further restricts the cohort. Mirrors the production
+        SQL contract — same shape would fail if the fake forgot a sub-filter.
+        """
+        from lib.triage_service import parse_filter
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.seed_request(make_request_row(id=2))
+        db.seed_request(make_request_row(id=3))
+        db.record_field_resolution(
+            request_id=1, field_name="release_group_year",
+            status="unresolved_4xx_client", reason_code="http_400",
+        )
+        db.record_field_resolution(
+            request_id=2, field_name="catalog_number",
+            status="resolved", reason_code=None,
+        )
+
+        # Bare data_quality — only request 1 (has unresolved_*).
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("data_quality"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1])
+
+        # Narrow on field_name — release_group_year matches request 1.
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("data_quality:release_group_year"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1])
+
+        # Narrow on status — unresolved_4xx_client matches request 1.
+        rows = db.list_triage_page(
+            filter_spec=parse_filter(
+                "data_quality:status=unresolved_4xx_client",
+            ),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1])
+
+        # Narrow on reason_code — http_400 matches request 1.
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("data_quality:reason=http_400"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1])
+
+        # Negative narrow — a mismatched reason_code excludes request 1.
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("data_quality:reason=http_999"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual(rows, [])
+
+    def test_list_triage_page_filter_search_not_converting(self):
+        """The join against ``request_search_summary`` excludes rows with
+        no search log entries AND rows with any found outcome.
+
+        Three rows: (1) 3 searches all rejected → matches; (2) one found
+        outcome → excluded; (3) no searches → excluded.
+        """
+        from lib.triage_service import parse_filter
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.seed_request(make_request_row(id=2))
+        db.seed_request(make_request_row(id=3))
+        for _ in range(3):
+            db.log_search(
+                request_id=1, query="q", result_count=10, outcome="rejected",
+            )
+        db.log_search(
+            request_id=2, query="q", result_count=10, outcome="found",
+        )
+        # Request 3: no search log rows.
+
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("search_not_converting"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1])
+
     def test_get_field_resolutions_for_requests_groups_by_id(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=1))

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -743,6 +743,119 @@ class TestFakePipelineDBFieldResolutions(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Triage cohort fakes (U15)
+# ---------------------------------------------------------------------------
+
+
+class TestFakePipelineDBTriage(unittest.TestCase):
+    """Each of the four triage-bound methods on ``FakePipelineDB`` has a
+    self-test so the cohort path stays trustworthy when the production
+    SQL is updated. The N+1 guard test lives in
+    ``tests/test_triage_service.py``.
+    """
+
+    def _seed_two_requests(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, artist_name="Artist One", album_title="Album One",
+            unfindable_category="artist_absent",
+        ))
+        db.seed_request(make_request_row(
+            id=2, artist_name="Artist Two", album_title="Album Two",
+        ))
+        return db
+
+    def test_list_triage_page_filter_all(self):
+        from lib.triage_service import parse_filter
+        db = self._seed_two_requests()
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("all"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1, 2])
+        self.assertEqual(db.query_counts["list_triage_page"], 1)
+
+    def test_list_triage_page_filter_unfindable(self):
+        from lib.triage_service import parse_filter
+        db = self._seed_two_requests()
+        rows = db.list_triage_page(
+            filter_spec=parse_filter("unfindable"),
+            page_size=10,
+            after_request_id=None,
+        )
+        self.assertEqual([r["id"] for r in rows], [1])
+
+    def test_list_triage_page_keyset_pagination(self):
+        from lib.triage_service import parse_filter
+        db = FakePipelineDB()
+        for i in range(1, 6):
+            db.seed_request(make_request_row(id=i))
+        page = db.list_triage_page(
+            filter_spec=parse_filter("all"),
+            page_size=2,
+            after_request_id=2,
+        )
+        self.assertEqual([r["id"] for r in page], [3, 4])
+
+    def test_get_field_resolutions_for_requests_groups_by_id(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.seed_request(make_request_row(id=2))
+        db.record_field_resolution(
+            request_id=1, field_name="release_group_year",
+            status="resolved", reason_code=None,
+        )
+        db.record_field_resolution(
+            request_id=1, field_name="catalog_number",
+            status="unresolved_404", reason_code="http_404",
+        )
+        db.record_field_resolution(
+            request_id=2, field_name="release_group_year",
+            status="resolved", reason_code=None,
+        )
+        out = db.get_field_resolutions_for_requests([1, 2])
+        self.assertEqual(len(out[1]), 2)
+        self.assertEqual(len(out[2]), 1)
+        self.assertEqual(db.query_counts["get_field_resolutions_for_requests"], 1)
+
+    def test_get_field_resolutions_for_requests_empty_input(self):
+        db = FakePipelineDB()
+        self.assertEqual(db.get_field_resolutions_for_requests([]), {})
+
+    def test_get_search_summaries_for_requests_emits_zero_groups_only_when_present(
+        self,
+    ):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.seed_request(make_request_row(id=2))
+        db.log_search(
+            request_id=1, query="q", result_count=5, outcome="found",
+        )
+        out = db.get_search_summaries_for_requests([1, 2])
+        # Only request 1 has search_log rows; request 2 has no row in
+        # the view (mirrors GROUP BY excluding empty groups).
+        self.assertIn(1, out)
+        self.assertNotIn(2, out)
+        self.assertEqual(out[1]["total_searches"], 1)
+        self.assertEqual(out[1]["found_count"], 1)
+        self.assertEqual(db.query_counts["get_search_summaries_for_requests"], 1)
+
+    def test_get_recent_search_log_for_requests_bounded_per_request(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        for i in range(20):
+            db.log_search(
+                request_id=1, query=f"q{i}", result_count=i, outcome="error",
+            )
+        out = db.get_recent_search_log_for_requests([1], per_request_limit=5)
+        self.assertEqual(len(out[1]), 5)
+        # Newest first — last logged query is "q19".
+        self.assertEqual(out[1][0]["query"], "q19")
+        self.assertEqual(db.query_counts["get_recent_search_log_for_requests"], 1)
+
+
+# ---------------------------------------------------------------------------
 # Persisted search plans (U1) — fake parity
 # ---------------------------------------------------------------------------
 

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9624,5 +9624,228 @@ class TestRescueCaptureSlice(unittest.TestCase):
             retried["prior_unfindable_category"], "wrong_pressing_available")
 
 
+class TestTriageServiceSlice(unittest.TestCase):
+    """U15: end-to-end ``TriageResult`` round-trip through msgspec.
+
+    Validates the wire-boundary contract by encoding a fully-populated
+    ``TriageResult`` (production-shaped fields: ``datetime`` timestamps,
+    nested Structs, ``Optional`` fields exercised in both populated
+    and ``None`` shapes) to JSON and decoding back into a Struct.
+    Equality round-trip proves the contract.
+
+    Per ``docs/solutions/testing/contract-test-mocks-must-mirror-
+    production-shape.md``: contract tests that exercise wire types
+    must use the same shapes production emits. Naive str/int mocks
+    pass Pyright + the schema test but 500 the moment the JSON
+    encoder hits a real ``datetime``. This slice forces that path.
+    """
+
+    @staticmethod
+    def _populated_triage_result():
+        from datetime import datetime, timezone
+        from lib.triage_service import (
+            FieldResolutionState,
+            RequestMeta,
+            SearchForensicsSummary,
+            SearchLogEntry,
+            TriageResult,
+            UnfindableState,
+        )
+        now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+        return TriageResult(
+            request_meta=RequestMeta(
+                id=42,
+                artist_name="Russian Winters",
+                album_title="An Album That Vanished",
+                year=2008,
+                status="wanted",
+                source="request",
+                mb_release_id="mbid-russian-winters",
+                discogs_release_id=None,
+                release_group_year=2008,
+                is_va_compilation=False,
+                catalog_number=None,
+                failure_class="A_zero_results_dominant",
+                search_filetype_override="lossless",
+            ),
+            unfindable=UnfindableState(
+                category="artist_absent",
+                categorised_at=now,
+                last_artist_probe_at=now,
+                last_artist_probe_match_count=0,
+                rescued_at=None,
+                prior_unfindable_category=None,
+            ),
+            field_quality=[
+                FieldResolutionState(
+                    field_name="release_group_year",
+                    status="resolved",
+                    reason_code=None,
+                    attempts=1,
+                    resolved_at=now,
+                ),
+                FieldResolutionState(
+                    field_name="catalog_number",
+                    status="unresolved_404",
+                    reason_code="http_404",
+                    attempts=3,
+                    resolved_at=now,
+                ),
+            ],
+            search_forensics=SearchForensicsSummary(
+                total_searches=42,
+                with_cands_count=3,
+                found_count=0,
+                near_cap_count=12,
+                zero_results_count=8,
+                pre_filter_skips_total=120,
+                first_strategy_with_cands="full_release_query",
+                dominant_rejection_reason="album_token_missing",
+                last_search_at=now,
+                recent_entries=[
+                    SearchLogEntry(
+                        id=1001,
+                        created_at=now,
+                        plan_strategy="full_release_query",
+                        query="russian winters album",
+                        outcome="rejected",
+                        result_count=12,
+                        rejection_reason="album_token_missing",
+                        matcher_score_top1=0.32,
+                    ),
+                ],
+            ),
+            failure_class="A_zero_results_dominant",
+        )
+
+    def test_populated_triage_result_round_trips_through_msgspec(self) -> None:
+        """Production-shaped fields → encode → decode → equal Struct."""
+        import msgspec
+
+        from lib.triage_service import TriageResult
+
+        original = self._populated_triage_result()
+        encoded = msgspec.json.encode(original)
+        decoded = msgspec.json.decode(encoded, type=TriageResult)
+        self.assertEqual(decoded, original)
+        # Belt-and-braces: nested types remain Structs (not dicts).
+        from lib.triage_service import (
+            FieldResolutionState, RequestMeta, SearchForensicsSummary,
+            UnfindableState,
+        )
+        self.assertIsInstance(decoded.request_meta, RequestMeta)
+        assert decoded.unfindable is not None
+        self.assertIsInstance(decoded.unfindable, UnfindableState)
+        self.assertIsInstance(
+            decoded.search_forensics, SearchForensicsSummary,
+        )
+        self.assertTrue(
+            all(isinstance(f, FieldResolutionState)
+                for f in decoded.field_quality)
+        )
+
+    def test_unfindable_none_path_round_trips(self) -> None:
+        """A healthy request has ``unfindable=None`` and an empty
+        ``field_quality`` list. Pin this shape so the wrappers can
+        rely on it."""
+        import msgspec
+
+        from lib.triage_service import (
+            RequestMeta,
+            SearchForensicsSummary,
+            TriageResult,
+        )
+
+        result = TriageResult(
+            request_meta=RequestMeta(
+                id=1,
+                artist_name="Healthy",
+                album_title="Album",
+                year=None,
+                status="imported",
+                source="request",
+                mb_release_id=None,
+                discogs_release_id=None,
+                release_group_year=None,
+                is_va_compilation=False,
+                catalog_number=None,
+                failure_class="resolved",
+                search_filetype_override=None,
+            ),
+            unfindable=None,
+            field_quality=[],
+            search_forensics=SearchForensicsSummary(
+                total_searches=0,
+                with_cands_count=0,
+                found_count=0,
+                near_cap_count=0,
+                zero_results_count=0,
+                pre_filter_skips_total=0,
+                first_strategy_with_cands=None,
+                dominant_rejection_reason=None,
+                last_search_at=None,
+                recent_entries=[],
+            ),
+            failure_class="resolved",
+        )
+
+        encoded = msgspec.json.encode(result)
+        decoded = msgspec.json.decode(encoded, type=TriageResult)
+        self.assertEqual(decoded, result)
+        self.assertIsNone(decoded.unfindable)
+        self.assertEqual(decoded.field_quality, [])
+
+    def test_compose_then_round_trip_against_fake_db(self) -> None:
+        """End-to-end: seed a FakePipelineDB → compose_triage_for_request
+        → encode → decode → equal Struct. Validates the full chain that
+        runs in production: bulk getter → in-memory compose → wire
+        encoding.
+        """
+        import msgspec
+        from datetime import datetime, timezone
+
+        from lib.triage_service import (
+            TriageResult,
+            compose_triage_for_request,
+        )
+
+        now = datetime(2026, 5, 20, 9, 0, 0, tzinfo=timezone.utc)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=99,
+            artist_name="Slice Artist",
+            album_title="Slice Album",
+            year=2010,
+            status="wanted",
+            unfindable_category="wrong_pressing_available",
+            unfindable_categorised_at=now,
+        ))
+        db.record_field_resolution(
+            request_id=99, field_name="release_group_year",
+            status="resolved", reason_code=None,
+        )
+        db.log_search(
+            request_id=99, query="slice artist album",
+            result_count=5, outcome="rejected",
+            rejection_reason="album_token_missing",
+            matcher_score_top1=0.41,
+        )
+
+        result = compose_triage_for_request(99, db)
+        assert result is not None
+        encoded = msgspec.json.encode(result)
+        decoded = msgspec.json.decode(encoded, type=TriageResult)
+        self.assertEqual(decoded, result)
+        assert decoded.unfindable is not None
+        self.assertEqual(
+            decoded.unfindable.category, "wrong_pressing_available",
+        )
+        self.assertEqual(len(decoded.field_quality), 1)
+        self.assertEqual(decoded.search_forensics.total_searches, 1)
+        self.assertEqual(
+            len(decoded.search_forensics.recent_entries), 1,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9715,7 +9715,6 @@ class TestTriageServiceSlice(unittest.TestCase):
                     ),
                 ],
             ),
-            failure_class="A_zero_results_dominant",
         )
 
     def test_populated_triage_result_round_trips_through_msgspec(self) -> None:
@@ -9786,7 +9785,6 @@ class TestTriageServiceSlice(unittest.TestCase):
                 last_search_at=None,
                 recent_entries=[],
             ),
-            failure_class="resolved",
         )
 
         encoded = msgspec.json.encode(result)

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2818,8 +2818,16 @@ class TestPipelineCliTriage(unittest.TestCase):
     def _seed_data_quality(
         self, db, rid: int, *,
         field_name: str = "release_group_year",
+        status: str = "unresolved_404",
         reason_code: str = "http_404",
     ) -> None:
+        """Seed a request with one unresolved field-resolution row.
+
+        Production shape: ``status`` is the resolver-status bucket
+        (``unresolved_4xx_client`` / ``unresolved_404`` / ...) and
+        ``reason_code`` is the per-occurrence specifier (``http_400`` /
+        ``http_404`` / ...). See ``lib/field_resolver_service.py``.
+        """
         from tests.helpers import make_request_row
         db.seed_request(make_request_row(
             id=rid, artist_name=f"DataOnly {rid}",
@@ -2827,7 +2835,7 @@ class TestPipelineCliTriage(unittest.TestCase):
         ))
         db.record_field_resolution(
             request_id=rid, field_name=field_name,
-            status="unresolved_404", reason_code=reason_code,
+            status=status, reason_code=reason_code,
         )
 
     # --- triage show ----------------------------------------------------
@@ -2927,9 +2935,12 @@ class TestPipelineCliTriage(unittest.TestCase):
         self._seed_healthy(db, 1)
         self._seed_unfindable(db, 2, category="artist_absent")
         self._seed_unfindable(db, 3, category="wrong_pressing_available")
+        # Production shape: status='unresolved_4xx_client' (the sticky
+        # bucket #374 surfaces on), reason_code='http_400' (the specific
+        # HTTP code the resolver hit).
         self._seed_data_quality(
             db, 4, field_name="release_group_year",
-            reason_code="unresolved_4xx_client",
+            status="unresolved_4xx_client", reason_code="http_400",
         )
         return db
 
@@ -2954,10 +2965,23 @@ class TestPipelineCliTriage(unittest.TestCase):
         self.assertNotIn("Healthy", out)
         self.assertNotIn("Vanished 2", out)
 
-    def test_list_data_quality_reason_code_filter_374(self):
+    def test_list_data_quality_status_filter_374(self):
+        """#374 canonical form — ``data_quality:status=<resolver_status>``
+        filters on the resolver-status column (what
+        ``lib/field_resolver_service.py`` actually writes)."""
         db = self._seed_cohort()
         rc, out, err = self._run_list(
-            db, filter_spec="data_quality:reason=unresolved_4xx_client",
+            db, filter_spec="data_quality:status=unresolved_4xx_client",
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("DataOnly 4", out)
+
+    def test_list_data_quality_reason_code_filter(self):
+        """``data_quality:reason=<code>`` complementary filter on the
+        ``reason_code`` column (HTTP code-specific)."""
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(
+            db, filter_spec="data_quality:reason=http_400",
         )
         self.assertEqual(rc, 0)
         self.assertIn("DataOnly 4", out)
@@ -2973,7 +2997,11 @@ class TestPipelineCliTriage(unittest.TestCase):
         self.assertIn("data_quality", err)
         self.assertIn("search_not_converting", err)
 
-    def test_list_json_emits_array_of_triage_results(self):
+    def test_list_json_emits_envelope_matching_api_shape(self):
+        """CLI ``--json`` wraps results in the same envelope the API
+        emits: ``{results, next_after, page_size, filter}``. Without
+        the envelope, agents piping ``--json | jq '.next_after'``
+        cannot extract the pagination cursor."""
         from lib.triage_service import TriageResult
         db = self._seed_cohort()
         rc, out, err = self._run_list(
@@ -2982,14 +3010,58 @@ class TestPipelineCliTriage(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(err, "")
         payload = json.loads(out)
-        self.assertIsInstance(payload, list)
-        self.assertEqual(len(payload), 2)
+        # Envelope-shape contract.
+        self.assertIsInstance(payload, dict)
+        self.assertIn("results", payload)
+        self.assertIn("next_after", payload)
+        self.assertIn("page_size", payload)
+        self.assertIn("filter", payload)
+        self.assertEqual(payload["filter"], "unfindable")
+        self.assertEqual(payload["page_size"], 50)
+        # Partial page (2 of 50) → next_after is None.
+        self.assertIsNone(payload["next_after"])
+        self.assertIsInstance(payload["results"], list)
+        self.assertEqual(len(payload["results"]), 2)
         # Each element must round-trip back to TriageResult.
         triage_rows = [
-            msgspec.convert(entry, type=TriageResult) for entry in payload
+            msgspec.convert(entry, type=TriageResult)
+            for entry in payload["results"]
         ]
         ids = sorted(r.request_meta.id for r in triage_rows)
         self.assertEqual(ids, [2, 3])
+
+    def test_list_json_invalid_filter_emits_json_error_envelope(self):
+        """``--json`` + invalid filter must emit a JSON-parseable
+        payload on stdout (mirrors cmd_triage_show's 404 path and the
+        API 400 envelope). Without this, agents piping ``--json | jq``
+        break on the text-stderr fallback."""
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(
+            db, filter_spec="garbage_value", json_out=True,
+        )
+        self.assertEqual(rc, 3)
+        self.assertEqual(err, "")  # Nothing on stderr in JSON mode.
+        payload = json.loads(out)
+        self.assertIn("error", payload)
+        self.assertIn("valid_filters", payload)
+        self.assertIn("valid_unfindable_categories", payload)
+        self.assertIn("valid_data_quality_fields", payload)
+        self.assertIsInstance(payload["valid_filters"], list)
+        self.assertIn("all", payload["valid_filters"])
+
+    def test_list_limit_out_of_range_returns_3(self):
+        """API-parity bounds check: limit must be in [1, 200]."""
+        db = self._seed_cohort()
+        rc, _out, err = self._run_list(db, filter_spec="all", limit=500)
+        self.assertEqual(rc, 3)
+        self.assertIn("--limit", err)
+
+    def test_list_after_below_one_returns_3(self):
+        """API-parity bounds check: after must be >= 1."""
+        db = self._seed_cohort()
+        rc, _out, err = self._run_list(db, filter_spec="all", after=0)
+        self.assertEqual(rc, 3)
+        self.assertIn("--after", err)
 
     def test_list_empty_result_is_exit_0(self):
         db = FakePipelineDB()
@@ -3067,15 +3139,16 @@ class TestPipelineCliRoutes(unittest.TestCase):
             self.assertIsInstance(entry["subcommand"], str)
             self.assertIsInstance(entry["args"], list)
             self.assertIsInstance(entry["description"], str)
-        names = {entry["subcommand"] for entry in data}
+        names_list = [entry["subcommand"] for entry in data]
+        names_set = set(names_list)
         for expected in ("list", "search-plan show", "triage list", "routes"):
-            self.assertIn(expected, names)
+            self.assertIn(expected, names_set)
 
         # Sort invariant — operators consume this as a stable index.
-        names_sorted = sorted(names)
-        self.assertEqual(
-            [entry["subcommand"] for entry in data], names_sorted,
-        )
+        # Compare the raw list against ``sorted(names_list)`` (not
+        # ``sorted(names_set)``) so a duplicate subcommand surfaces as
+        # the inequality it is, rather than being silently deduped.
+        self.assertEqual(names_list, sorted(names_list))
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -3022,5 +3022,61 @@ class TestPipelineCliTriage(unittest.TestCase):
         self.assertNotIn("--after=", out)
 
 
+class TestPipelineCliRoutes(unittest.TestCase):
+    """U18 step 3: ``pipeline-cli routes`` self-documents the CLI surface."""
+
+    def _run_routes(
+        self, json_mode: bool = False,
+    ) -> tuple[int, str]:
+        argv = ["pipeline_cli.py", "routes"]
+        if json_mode:
+            argv.append("--json")
+        # ``cmd_routes`` doesn't need a DB; ``main()`` short-circuits the
+        # PipelineDB construction for this subcommand. The patch is still
+        # in place defensively in case a future caller flips that wiring.
+        db = FakePipelineDB()
+        with patch.object(sys, "argv", argv), patch(
+            "scripts.pipeline_cli.PipelineDB", return_value=db,
+        ), redirect_stdout(io.StringIO()) as out:
+            with self.assertRaises(SystemExit) as raised:
+                pipeline_cli.main()
+        code = raised.exception.code
+        return (code if isinstance(code, int) else 0), out.getvalue()
+
+    def test_routes_text_lists_known_subcommands(self):
+        rc, output = self._run_routes()
+        self.assertEqual(rc, 0)
+        # Top-level subcommands that exist regardless of nested routing.
+        self.assertIn("list", output)
+        self.assertIn("status", output)
+        # Nested commands are emitted as space-separated leaves.
+        self.assertIn("search-plan show", output)
+        self.assertIn("triage list", output)
+        # The ``routes`` command must self-describe.
+        self.assertIn("routes", output)
+
+    def test_routes_json_emits_shape_matching_help_metadata(self):
+        rc, output = self._run_routes(json_mode=True)
+        self.assertEqual(rc, 0)
+        data = json.loads(output)
+        self.assertIsInstance(data, list)
+        for entry in data:
+            self.assertIn("subcommand", entry)
+            self.assertIn("args", entry)
+            self.assertIn("description", entry)
+            self.assertIsInstance(entry["subcommand"], str)
+            self.assertIsInstance(entry["args"], list)
+            self.assertIsInstance(entry["description"], str)
+        names = {entry["subcommand"] for entry in data}
+        for expected in ("list", "search-plan show", "triage list", "routes"):
+            self.assertIn(expected, names)
+
+        # Sort invariant — operators consume this as a stable index.
+        names_sorted = sorted(names)
+        self.assertEqual(
+            [entry["subcommand"] for entry in data], names_sorted,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -10,6 +10,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
+import msgspec
+
 # Bootstrap ephemeral PostgreSQL if available
 sys.path.insert(0, os.path.dirname(__file__))
 import conftest  # noqa: F401
@@ -2782,6 +2784,242 @@ class TestCmdSearchPlanHistory(unittest.TestCase):
         self.assertIn("request_id", payload)
         self.assertIn("rows", payload)
         self.assertIn("next_before_id", payload)
+
+
+class TestPipelineCliTriage(unittest.TestCase):
+    """``pipeline-cli triage`` (U16) wraps ``lib.triage_service``.
+
+    Counterpart of the U17 HTTP routes — both wrap the same service and
+    must stay in sync (CLAUDE.md § "CLI ⇄ API surface symmetry"). Tests
+    drive the real service against ``FakePipelineDB`` rather than
+    mocking ``compose_triage_for_request`` / ``list_triage`` — those are
+    our own logic, not leaf seams. See `MOCKS: LEAF-SEAM ONLY`.
+    """
+
+    def _seed_healthy(self, db, rid: int) -> None:
+        from tests.helpers import make_request_row
+        db.seed_request(make_request_row(
+            id=rid, artist_name="Healthy", album_title="Imported Album",
+            status="imported", failure_class="resolved",
+        ))
+
+    def _seed_unfindable(self, db, rid: int, category: str = "artist_absent") -> None:
+        from datetime import datetime, timezone
+        from tests.helpers import make_request_row
+        now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+        db.seed_request(make_request_row(
+            id=rid, artist_name=f"Vanished {rid}",
+            album_title=f"Unfindable Album {rid}",
+            status="wanted",
+            unfindable_category=category,
+            unfindable_categorised_at=now,
+        ))
+
+    def _seed_data_quality(
+        self, db, rid: int, *,
+        field_name: str = "release_group_year",
+        reason_code: str = "http_404",
+    ) -> None:
+        from tests.helpers import make_request_row
+        db.seed_request(make_request_row(
+            id=rid, artist_name=f"DataOnly {rid}",
+            album_title=f"Field Album {rid}", status="wanted",
+        ))
+        db.record_field_resolution(
+            request_id=rid, field_name=field_name,
+            status="unresolved_404", reason_code=reason_code,
+        )
+
+    # --- triage show ----------------------------------------------------
+
+    def _run_show(self, db, rid, *, json_out=False):
+        args = SimpleNamespace(id=rid, json=json_out)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_triage_show(db, args)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_show_human_renders_request_meta_and_search_log(self):
+        from lib.triage_service import TriageResult  # noqa: F401
+        db = FakePipelineDB()
+        self._seed_unfindable(db, 42)
+        # One search_log row so the recent_entries renderer is exercised.
+        db.log_search(
+            request_id=42, query="vanished album", result_count=0,
+            outcome="exhausted", rejection_reason=None,
+        )
+        rc, out, err = self._run_show(db, 42)
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("Vanished 42", out)
+        self.assertIn("Unfindable Album 42", out)
+        self.assertIn("wanted", out)
+        self.assertIn("artist_absent", out)
+        # At least one rendered search log row.
+        self.assertIn("exhausted", out)
+        self.assertIn("recent_entries", out)
+
+    def test_show_json_round_trips_through_msgspec(self):
+        """`--json` payload must decode back into a ``TriageResult`` so
+        the API consumer gets the same wire shape on both surfaces."""
+        from lib.triage_service import TriageResult
+        db = FakePipelineDB()
+        self._seed_unfindable(db, 42)
+        db.log_search(
+            request_id=42, query="q", result_count=0, outcome="exhausted",
+        )
+        rc, out, err = self._run_show(db, 42, json_out=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        # Valid JSON parseable as TriageResult via msgspec convert.
+        payload = json.loads(out)
+        result = msgspec.convert(payload, type=TriageResult)
+        self.assertEqual(result.request_meta.id, 42)
+        self.assertEqual(result.request_meta.artist_name, "Vanished 42")
+        assert result.unfindable is not None
+        self.assertEqual(result.unfindable.category, "artist_absent")
+
+    def test_show_unknown_id_returns_2_with_stderr_message(self):
+        db = FakePipelineDB()
+        rc, out, err = self._run_show(db, 9999)
+        self.assertEqual(rc, 2)
+        # Human path writes to stderr; the operator running `triage show`
+        # should see the error there, not on stdout.
+        self.assertIn("9999", err)
+        self.assertIn("not found", err.lower())
+
+    def test_show_unknown_id_json_returns_2_with_structured_payload(self):
+        db = FakePipelineDB()
+        rc, out, err = self._run_show(db, 9999, json_out=True)
+        self.assertEqual(rc, 2)
+        payload = json.loads(out)
+        self.assertEqual(payload["error"], "Not found")
+        self.assertEqual(payload["request_id"], 9999)
+
+    def test_show_healthy_request_renders_no_unfindable_signal(self):
+        db = FakePipelineDB()
+        self._seed_healthy(db, 1)
+        rc, out, err = self._run_show(db, 1)
+        self.assertEqual(rc, 0)
+        self.assertIn("Healthy", out)
+        self.assertIn("Imported Album", out)
+        self.assertIn("(no signals)", out)
+
+    # --- triage list ----------------------------------------------------
+
+    def _run_list(self, db, *, filter_spec="all", limit=50, after=None,
+                  json_out=False):
+        args = SimpleNamespace(
+            filter=filter_spec,
+            limit=limit,
+            after=after,
+            json=json_out,
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_triage_list(db, args)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def _seed_cohort(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        self._seed_healthy(db, 1)
+        self._seed_unfindable(db, 2, category="artist_absent")
+        self._seed_unfindable(db, 3, category="wrong_pressing_available")
+        self._seed_data_quality(
+            db, 4, field_name="release_group_year",
+            reason_code="unresolved_4xx_client",
+        )
+        return db
+
+    def test_list_unfindable_returns_only_unfindable_rows(self):
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(db, filter_spec="unfindable")
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        # Rows 2 and 3 are unfindable. Row 1 (healthy) and row 4 (data
+        # quality only) must be absent from the rendered table.
+        self.assertIn("Vanished 2", out)
+        self.assertIn("Vanished 3", out)
+        self.assertNotIn("Healthy", out)
+        self.assertNotIn("DataOnly 4", out)
+
+    def test_list_data_quality_returns_data_quality_rows(self):
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(db, filter_spec="data_quality")
+        self.assertEqual(rc, 0)
+        self.assertIn("DataOnly 4", out)
+        # Healthy + unfindable rows without resolutions must not appear.
+        self.assertNotIn("Healthy", out)
+        self.assertNotIn("Vanished 2", out)
+
+    def test_list_data_quality_reason_code_filter_374(self):
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(
+            db, filter_spec="data_quality:reason=unresolved_4xx_client",
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("DataOnly 4", out)
+
+    def test_list_invalid_filter_returns_3_and_emits_valid_forms(self):
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(db, filter_spec="garbage_value")
+        self.assertEqual(rc, 3)
+        # Operator sees the valid forms on stderr.
+        self.assertIn("Invalid filter spec", err)
+        self.assertIn("all", err)
+        self.assertIn("unfindable", err)
+        self.assertIn("data_quality", err)
+        self.assertIn("search_not_converting", err)
+
+    def test_list_json_emits_array_of_triage_results(self):
+        from lib.triage_service import TriageResult
+        db = self._seed_cohort()
+        rc, out, err = self._run_list(
+            db, filter_spec="unfindable", json_out=True,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        payload = json.loads(out)
+        self.assertIsInstance(payload, list)
+        self.assertEqual(len(payload), 2)
+        # Each element must round-trip back to TriageResult.
+        triage_rows = [
+            msgspec.convert(entry, type=TriageResult) for entry in payload
+        ]
+        ids = sorted(r.request_meta.id for r in triage_rows)
+        self.assertEqual(ids, [2, 3])
+
+    def test_list_empty_result_is_exit_0(self):
+        db = FakePipelineDB()
+        # No rows seeded — empty cohort under any filter.
+        rc, out, err = self._run_list(db, filter_spec="unfindable")
+        self.assertEqual(rc, 0)
+        self.assertIn("No results", out)
+
+    def test_list_limit_returns_page_with_next_after_footer(self):
+        db = self._seed_cohort()
+        # 2 unfindable rows seeded (ids 2 and 3); limit=2 means full page
+        # and the footer should print the next --after cursor.
+        rc, out, err = self._run_list(
+            db, filter_spec="unfindable", limit=2,
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("Vanished 2", out)
+        self.assertIn("Vanished 3", out)
+        self.assertIn("--after=3", out)
+        self.assertIn("--limit=2", out)
+
+    def test_list_partial_page_omits_next_after_footer(self):
+        db = self._seed_cohort()
+        # Only 2 unfindable rows; limit=10 returns a partial page with no
+        # follow-on cursor.
+        rc, out, err = self._run_list(
+            db, filter_spec="unfindable", limit=10,
+        )
+        self.assertEqual(rc, 0)
+        self.assertNotIn("--after=", out)
 
 
 if __name__ == "__main__":

--- a/tests/test_triage_service.py
+++ b/tests/test_triage_service.py
@@ -7,9 +7,9 @@ Covers the three deliverables of the service:
   ``InvalidFilterError``; the wrappers map onto exit/status codes.
 * ``compose_triage_for_request`` — single-request payload composed
   from ``album_requests`` + the three side domains.
-* ``list_triage`` — cohort listing with N+1 mitigation. The "≤5 DB
-  queries" guard is the contract; it runs against ``FakePipelineDB``
-  which records per-method call counts.
+* ``list_triage`` — cohort listing with N+1 mitigation. The contract
+  is "4 queries (+ 1 headroom for future growth)" — the guard runs
+  against ``FakePipelineDB`` which records per-method call counts.
 """
 
 from __future__ import annotations
@@ -65,12 +65,31 @@ class TestParseFilter(unittest.TestCase):
         self.assertEqual(parsed.field_name, "release_group_year")
         self.assertIsNone(parsed.reason_code)
 
-    def test_data_quality_with_reason_code(self) -> None:
-        """#374 — sticky 4xx-client cohort uses the reason=<code> form."""
-        parsed = parse_filter("data_quality:reason=unresolved_4xx_client")
+    def test_data_quality_with_status(self) -> None:
+        """#374 canonical form — sticky 4xx-client cohort uses
+        ``status=<resolver_status>`` (matches the ``status`` column
+        ``lib/field_resolver_service.py`` writes)."""
+        parsed = parse_filter("data_quality:status=unresolved_4xx_client")
         self.assertEqual(parsed.kind, "data_quality")
         self.assertIsNone(parsed.field_name)
-        self.assertEqual(parsed.reason_code, "unresolved_4xx_client")
+        self.assertIsNone(parsed.reason_code)
+        self.assertEqual(parsed.status_code, "unresolved_4xx_client")
+
+    def test_data_quality_with_reason_code(self) -> None:
+        """Complementary form — filter on the specific HTTP code
+        in the ``reason_code`` column (e.g. http_400, http_410)."""
+        parsed = parse_filter("data_quality:reason=http_400")
+        self.assertEqual(parsed.kind, "data_quality")
+        self.assertIsNone(parsed.field_name)
+        self.assertIsNone(parsed.status_code)
+        self.assertEqual(parsed.reason_code, "http_400")
+
+    def test_data_quality_unknown_field_raises(self) -> None:
+        """A typo in the field name (e.g. ``release_year``) is rejected
+        at parse time; the operator sees the four valid names in the
+        error message."""
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("data_quality:release_year")
 
     def test_search_not_converting(self) -> None:
         parsed = parse_filter("search_not_converting")
@@ -100,6 +119,10 @@ class TestParseFilter(unittest.TestCase):
     def test_data_quality_empty_reason_raises(self) -> None:
         with self.assertRaises(InvalidFilterError):
             parse_filter("data_quality:reason=")
+
+    def test_data_quality_empty_status_raises(self) -> None:
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("data_quality:status=")
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +160,7 @@ class TestComposeTriage(unittest.TestCase):
         self.assertEqual(result.request_meta.id, 1)
         self.assertEqual(result.request_meta.artist_name, "Healthy Artist")
         self.assertEqual(result.request_meta.status, "imported")
-        self.assertEqual(result.failure_class, "resolved")
+        self.assertEqual(result.request_meta.failure_class, "resolved")
         self.assertIsNone(result.unfindable)
         self.assertEqual(result.field_quality, [])
         # Empty search forensics: zero counters, empty recent_entries.
@@ -302,17 +325,17 @@ class TestListTriage(unittest.TestCase):
             request_id=3, field_name="release_group_year",
             status="unresolved_404", reason_code="http_404",
         )
-        # 4 — only data-quality issue, no unfindable cohort. Carries the
-        # ``reason_code=unresolved_4xx_client`` we filter on for #374; the
-        # status is the side-table's ``unresolved_*`` shape (whatever the
-        # resolver emitted) and reason_code carries the sticky 4xx-class
-        # marker the operator pages on.
+        # 4 — only data-quality issue, no unfindable cohort. Production
+        # shape per ``lib/field_resolver_service.py::_classify_lookup_exception``:
+        # ``status='unresolved_4xx_client'`` is the sticky-bucket marker
+        # operators page on for #374; ``reason_code='http_400'`` is the
+        # specific HTTP code the resolver hit.
         db.seed_request(make_request_row(
             id=4, artist_name="DataOnly", album_title="Album", status="wanted",
         ))
         db.record_field_resolution(
             request_id=4, field_name="catalog_number",
-            status="unresolved_404", reason_code="unresolved_4xx_client",
+            status="unresolved_4xx_client", reason_code="http_400",
         )
         return db
 
@@ -349,11 +372,30 @@ class TestListTriage(unittest.TestCase):
         )
         self.assertEqual([r.request_meta.id for r in results], [3])
 
-    def test_filter_data_quality_by_reason_code(self) -> None:
-        """#374: the sticky 4xx-client cohort selector."""
+    def test_filter_data_quality_by_status_code(self) -> None:
+        """#374: the canonical sticky 4xx-client cohort selector.
+
+        ``data_quality:status=unresolved_4xx_client`` matches on the
+        ``status`` column — which is what ``lib/field_resolver_service.py``
+        actually writes for sticky 4xx errors. Operator workflow:
+        ``triage list --filter=data_quality:status=unresolved_4xx_client``.
+        """
         db = self._seed_three()
         results = list_triage(
-            "data_quality:reason=unresolved_4xx_client", db, page_size=10,
+            "data_quality:status=unresolved_4xx_client", db, page_size=10,
+        )
+        self.assertEqual([r.request_meta.id for r in results], [4])
+
+    def test_filter_data_quality_by_reason_code(self) -> None:
+        """The complementary form: filter on the ``reason_code`` column.
+
+        ``reason_code`` carries the specific HTTP code (``http_400`` /
+        ``http_410`` / ``http_422`` / etc.). Useful when triaging
+        a specific upstream behaviour.
+        """
+        db = self._seed_three()
+        results = list_triage(
+            "data_quality:reason=http_400", db, page_size=10,
         )
         self.assertEqual([r.request_meta.id for r in results], [4])
 
@@ -400,7 +442,8 @@ class TestListTriage(unittest.TestCase):
 
 
 class TestListTriageN1Guard(unittest.TestCase):
-    """The cohort path emits ≤5 DB queries regardless of page size.
+    """The cohort path emits 4 queries (+ 1 headroom for future growth)
+    regardless of page size.
 
     Asserted by counting calls on ``FakePipelineDB.query_counts``. The
     list path is bounded to four entries (page + three bulk getters);
@@ -436,7 +479,8 @@ class TestListTriageN1Guard(unittest.TestCase):
         self.assertLessEqual(
             total_queries, 5,
             f"list_triage emitted {total_queries} DB queries "
-            f"(breakdown: {db.query_counts}); contract is ≤5",
+            f"(breakdown: {db.query_counts}); contract is "
+            "4 queries (+ 1 headroom for future growth)",
         )
         # Belt-and-braces — each bulk method must fire exactly once.
         self.assertEqual(db.query_counts.get("list_triage_page"), 1)
@@ -467,7 +511,7 @@ class TestStructShape(unittest.TestCase):
         self.assertIsInstance(result, TriageResult)
         # Frozen — assignment fails.
         with self.assertRaises((AttributeError, TypeError)):
-            result.failure_class = "mutated"  # type: ignore[misc]
+            result.unfindable = None  # type: ignore[misc]
 
     def test_search_forensics_summary_has_required_fields(self) -> None:
         # Defensive check: keep the field set explicit so a refactor

--- a/tests/test_triage_service.py
+++ b/tests/test_triage_service.py
@@ -351,6 +351,34 @@ class TestListTriage(unittest.TestCase):
         ids = sorted(r.request_meta.id for r in results)
         self.assertEqual(ids, [2, 3])
 
+    def test_list_includes_replaced_rows(self) -> None:
+        """Pins behavior: replaced rows (frozen audit) ARE included.
+
+        ``status='replaced'`` rows are Replace-action tombstones (see
+        ``CLAUDE.md`` invariant #6). Triage cohorts intentionally include
+        them so the operator can spot patterns across replacement
+        history — e.g. an MBID-shape that keeps tripping HTTP 4xx and
+        keeps getting replaced. ``lib/pipeline_db.py::list_triage_page``
+        docstring documents this contract; this test pins it.
+        """
+        db = self._seed_three()
+        # Replace request id=2 (the artist_absent unfindable). The old
+        # row flips to status='replaced' with unfindable_category still
+        # populated (frozen audit shape, mirrors lib/mbid_replace_service).
+        replaced_row = db.request(2)
+        assert replaced_row is not None
+        replaced_row["status"] = "replaced"
+        results_all = list_triage("all", db, page_size=10)
+        results_unfindable = list_triage("unfindable", db, page_size=10)
+        ids_all = sorted(r.request_meta.id for r in results_all)
+        ids_unfindable = sorted(
+            r.request_meta.id for r in results_unfindable)
+        self.assertIn(2, ids_all,
+                      "filter='all' must include replaced rows")
+        self.assertIn(2, ids_unfindable,
+                      "filter='unfindable' must include replaced rows "
+                      "whose unfindable_category remains populated")
+
     def test_filter_unfindable_with_subcategory(self) -> None:
         db = self._seed_three()
         results = list_triage(

--- a/tests/test_triage_service.py
+++ b/tests/test_triage_service.py
@@ -1,0 +1,503 @@
+"""Tests for ``lib.triage_service`` — service layer for the operator
+triage surface (U15).
+
+Covers the three deliverables of the service:
+
+* ``parse_filter`` — DSL for cohort selection. Garbage raises
+  ``InvalidFilterError``; the wrappers map onto exit/status codes.
+* ``compose_triage_for_request`` — single-request payload composed
+  from ``album_requests`` + the three side domains.
+* ``list_triage`` — cohort listing with N+1 mitigation. The "≤5 DB
+  queries" guard is the contract; it runs against ``FakePipelineDB``
+  which records per-method call counts.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from lib.triage_service import (
+    InvalidFilterError,
+    ParsedTriageFilter,
+    SearchForensicsSummary,
+    SearchLogEntry,
+    TriageResult,
+    compose_triage_for_request,
+    list_triage,
+    parse_filter,
+)
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_request_row
+
+
+# ---------------------------------------------------------------------------
+# Filter parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseFilter(unittest.TestCase):
+    """``parse_filter`` covers seven accepted shapes plus the garbage path."""
+
+    def test_all(self) -> None:
+        parsed = parse_filter("all")
+        self.assertEqual(parsed.kind, "all")
+
+    def test_unfindable_bare(self) -> None:
+        parsed = parse_filter("unfindable")
+        self.assertEqual(parsed.kind, "unfindable")
+        self.assertIsNone(parsed.unfindable_category)
+
+    def test_unfindable_with_category(self) -> None:
+        parsed = parse_filter("unfindable:artist_absent")
+        self.assertEqual(parsed.kind, "unfindable")
+        self.assertEqual(parsed.unfindable_category, "artist_absent")
+
+    def test_data_quality_bare(self) -> None:
+        parsed = parse_filter("data_quality")
+        self.assertEqual(parsed.kind, "data_quality")
+        self.assertIsNone(parsed.field_name)
+        self.assertIsNone(parsed.reason_code)
+
+    def test_data_quality_with_field(self) -> None:
+        parsed = parse_filter("data_quality:release_group_year")
+        self.assertEqual(parsed.kind, "data_quality")
+        self.assertEqual(parsed.field_name, "release_group_year")
+        self.assertIsNone(parsed.reason_code)
+
+    def test_data_quality_with_reason_code(self) -> None:
+        """#374 — sticky 4xx-client cohort uses the reason=<code> form."""
+        parsed = parse_filter("data_quality:reason=unresolved_4xx_client")
+        self.assertEqual(parsed.kind, "data_quality")
+        self.assertIsNone(parsed.field_name)
+        self.assertEqual(parsed.reason_code, "unresolved_4xx_client")
+
+    def test_search_not_converting(self) -> None:
+        parsed = parse_filter("search_not_converting")
+        self.assertEqual(parsed.kind, "search_not_converting")
+
+    def test_trims_and_lowercases(self) -> None:
+        parsed = parse_filter("  UNFINDABLE:Artist_Absent  ")
+        self.assertEqual(parsed.kind, "unfindable")
+        self.assertEqual(parsed.unfindable_category, "artist_absent")
+
+    def test_empty_string_raises(self) -> None:
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("")
+
+    def test_unknown_kind_raises(self) -> None:
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("not_a_filter")
+
+    def test_unknown_unfindable_category_raises(self) -> None:
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("unfindable:bogus_category")
+
+    def test_data_quality_empty_suffix_raises(self) -> None:
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("data_quality:")
+
+    def test_data_quality_empty_reason_raises(self) -> None:
+        with self.assertRaises(InvalidFilterError):
+            parse_filter("data_quality:reason=")
+
+
+# ---------------------------------------------------------------------------
+# compose_triage_for_request
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestComposeTriage(unittest.TestCase):
+    """One-request triage payload composition."""
+
+    def test_non_existent_id_returns_none(self) -> None:
+        db = FakePipelineDB()
+        self.assertIsNone(compose_triage_for_request(9999, db))
+
+    def test_healthy_request_no_unfindable_no_field_quality(self) -> None:
+        """A converted/healthy request has unfindable=None and an empty
+        field_quality list."""
+        db = FakePipelineDB()
+        row = make_request_row(
+            id=1,
+            artist_name="Healthy Artist",
+            album_title="Imported Album",
+            status="imported",
+            failure_class="resolved",
+        )
+        db.seed_request(row)
+
+        result = compose_triage_for_request(1, db)
+
+        assert result is not None
+        self.assertEqual(result.request_meta.id, 1)
+        self.assertEqual(result.request_meta.artist_name, "Healthy Artist")
+        self.assertEqual(result.request_meta.status, "imported")
+        self.assertEqual(result.failure_class, "resolved")
+        self.assertIsNone(result.unfindable)
+        self.assertEqual(result.field_quality, [])
+        # Empty search forensics: zero counters, empty recent_entries.
+        self.assertEqual(result.search_forensics.total_searches, 0)
+        self.assertEqual(result.search_forensics.recent_entries, [])
+
+    def test_unfindable_populated_when_any_signal_present(self) -> None:
+        db = FakePipelineDB()
+        categorised_at = _now() - timedelta(days=3)
+        row = make_request_row(
+            id=42,
+            artist_name="Unfindable Artist",
+            album_title="Unfindable Album",
+            status="wanted",
+            unfindable_category="artist_absent",
+            unfindable_categorised_at=categorised_at,
+            last_artist_probe_at=categorised_at,
+            last_artist_probe_match_count=0,
+        )
+        db.seed_request(row)
+
+        result = compose_triage_for_request(42, db)
+
+        assert result is not None
+        assert result.unfindable is not None
+        self.assertEqual(result.unfindable.category, "artist_absent")
+        self.assertEqual(result.unfindable.categorised_at, categorised_at)
+        self.assertEqual(result.unfindable.last_artist_probe_match_count, 0)
+
+    def test_unfindable_populated_for_rescued_only(self) -> None:
+        """A long-tail rescue clears unfindable_category but still
+        populates rescued_at — the unfindable struct must surface so the
+        operator sees the audit trail."""
+        db = FakePipelineDB()
+        rescued_at = _now()
+        row = make_request_row(
+            id=7,
+            status="imported",
+            rescued_at=rescued_at,
+            prior_unfindable_category="wrong_pressing_available",
+        )
+        db.seed_request(row)
+
+        result = compose_triage_for_request(7, db)
+
+        assert result is not None
+        assert result.unfindable is not None
+        self.assertIsNone(result.unfindable.category)
+        self.assertEqual(result.unfindable.rescued_at, rescued_at)
+        self.assertEqual(
+            result.unfindable.prior_unfindable_category,
+            "wrong_pressing_available",
+        )
+
+    def test_field_quality_carries_resolutions(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=99))
+        db.record_field_resolution(
+            request_id=99, field_name="release_group_year",
+            status="resolved", reason_code=None,
+        )
+        db.record_field_resolution(
+            request_id=99, field_name="catalog_number",
+            status="unresolved_404", reason_code="http_404",
+        )
+
+        result = compose_triage_for_request(99, db)
+
+        assert result is not None
+        fields = sorted(result.field_quality, key=lambda f: f.field_name)
+        self.assertEqual(
+            [f.field_name for f in fields],
+            ["catalog_number", "release_group_year"],
+        )
+        self.assertEqual(fields[0].status, "unresolved_404")
+        self.assertEqual(fields[0].reason_code, "http_404")
+        self.assertEqual(fields[1].status, "resolved")
+
+    def test_search_forensics_summary_and_recent_entries(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=11))
+        # Two found rows + a rejected row with a rejection_reason.
+        db.log_search(
+            request_id=11, query="artist album", result_count=42,
+            outcome="found", candidates=None,
+        )
+        db.log_search(
+            request_id=11, query="artist album wild", result_count=12,
+            outcome="rejected", rejection_reason="album_token_missing",
+            matcher_score_top1=0.32,
+        )
+        db.log_search(
+            request_id=11, query="artist album",
+            result_count=0, outcome="exhausted",
+        )
+
+        result = compose_triage_for_request(11, db)
+
+        assert result is not None
+        self.assertEqual(result.search_forensics.total_searches, 3)
+        self.assertEqual(result.search_forensics.found_count, 1)
+        self.assertEqual(result.search_forensics.zero_results_count, 1)
+        self.assertEqual(
+            result.search_forensics.dominant_rejection_reason,
+            "album_token_missing",
+        )
+        # Newest first.
+        self.assertEqual(len(result.search_forensics.recent_entries), 3)
+        recent_outcomes = [
+            e.outcome for e in result.search_forensics.recent_entries
+        ]
+        self.assertEqual(
+            recent_outcomes, ["exhausted", "rejected", "found"],
+        )
+
+    def test_search_forensics_caps_recent_entries_at_ten(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=12))
+        for i in range(15):
+            db.log_search(
+                request_id=12, query=f"q{i}", result_count=i, outcome="error",
+            )
+
+        result = compose_triage_for_request(12, db)
+
+        assert result is not None
+        # 15 rows logged; recent_entries is bounded to 10.
+        self.assertEqual(result.search_forensics.total_searches, 15)
+        self.assertEqual(len(result.search_forensics.recent_entries), 10)
+
+
+# ---------------------------------------------------------------------------
+# list_triage
+# ---------------------------------------------------------------------------
+
+
+class TestListTriage(unittest.TestCase):
+    """Cohort listing under filter specs."""
+
+    def _seed_three(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        # 1 — healthy.
+        db.seed_request(make_request_row(
+            id=1, artist_name="Healthy", album_title="Album",
+            status="imported", failure_class="resolved",
+        ))
+        # 2 — unfindable: artist_absent.
+        db.seed_request(make_request_row(
+            id=2, artist_name="Vanished", album_title="Album",
+            status="wanted",
+            unfindable_category="artist_absent",
+            unfindable_categorised_at=_now(),
+        ))
+        # 3 — unfindable: wrong_pressing_available, plus a data-quality issue.
+        db.seed_request(make_request_row(
+            id=3, artist_name="Pressed", album_title="Album",
+            status="wanted",
+            unfindable_category="wrong_pressing_available",
+            unfindable_categorised_at=_now(),
+        ))
+        db.record_field_resolution(
+            request_id=3, field_name="release_group_year",
+            status="unresolved_404", reason_code="http_404",
+        )
+        # 4 — only data-quality issue, no unfindable cohort. Carries the
+        # ``reason_code=unresolved_4xx_client`` we filter on for #374; the
+        # status is the side-table's ``unresolved_*`` shape (whatever the
+        # resolver emitted) and reason_code carries the sticky 4xx-class
+        # marker the operator pages on.
+        db.seed_request(make_request_row(
+            id=4, artist_name="DataOnly", album_title="Album", status="wanted",
+        ))
+        db.record_field_resolution(
+            request_id=4, field_name="catalog_number",
+            status="unresolved_404", reason_code="unresolved_4xx_client",
+        )
+        return db
+
+    def test_filter_all(self) -> None:
+        db = self._seed_three()
+        results = list_triage("all", db, page_size=10)
+        ids = sorted(r.request_meta.id for r in results)
+        self.assertEqual(ids, [1, 2, 3, 4])
+
+    def test_filter_unfindable(self) -> None:
+        db = self._seed_three()
+        results = list_triage("unfindable", db, page_size=10)
+        ids = sorted(r.request_meta.id for r in results)
+        self.assertEqual(ids, [2, 3])
+
+    def test_filter_unfindable_with_subcategory(self) -> None:
+        db = self._seed_three()
+        results = list_triage(
+            "unfindable:artist_absent", db, page_size=10,
+        )
+        self.assertEqual([r.request_meta.id for r in results], [2])
+
+    def test_filter_data_quality_bare(self) -> None:
+        db = self._seed_three()
+        results = list_triage("data_quality", db, page_size=10)
+        ids = sorted(r.request_meta.id for r in results)
+        # Both 3 and 4 have unresolved field resolutions.
+        self.assertEqual(ids, [3, 4])
+
+    def test_filter_data_quality_by_field(self) -> None:
+        db = self._seed_three()
+        results = list_triage(
+            "data_quality:release_group_year", db, page_size=10,
+        )
+        self.assertEqual([r.request_meta.id for r in results], [3])
+
+    def test_filter_data_quality_by_reason_code(self) -> None:
+        """#374: the sticky 4xx-client cohort selector."""
+        db = self._seed_three()
+        results = list_triage(
+            "data_quality:reason=unresolved_4xx_client", db, page_size=10,
+        )
+        self.assertEqual([r.request_meta.id for r in results], [4])
+
+    def test_filter_search_not_converting(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=5))
+        db.seed_request(make_request_row(id=6))
+        # Request 5: 3 searches, no founds.
+        for _ in range(3):
+            db.log_search(
+                request_id=5, query="q", result_count=10, outcome="rejected",
+            )
+        # Request 6: searches with one found row.
+        db.log_search(
+            request_id=6, query="q", result_count=10, outcome="found",
+        )
+        results = list_triage(
+            "search_not_converting", db, page_size=10,
+        )
+        self.assertEqual([r.request_meta.id for r in results], [5])
+
+    def test_page_size_and_keyset(self) -> None:
+        db = FakePipelineDB()
+        for i in range(1, 11):
+            db.seed_request(make_request_row(
+                id=i, artist_name=f"A{i}", album_title="Album",
+            ))
+        page1 = list_triage("all", db, page_size=4)
+        self.assertEqual([r.request_meta.id for r in page1], [1, 2, 3, 4])
+        page2 = list_triage("all", db, page_size=4, after_request_id=4)
+        self.assertEqual([r.request_meta.id for r in page2], [5, 6, 7, 8])
+        page3 = list_triage("all", db, page_size=4, after_request_id=8)
+        self.assertEqual([r.request_meta.id for r in page3], [9, 10])
+
+    def test_invalid_filter_raises(self) -> None:
+        db = FakePipelineDB()
+        with self.assertRaises(InvalidFilterError):
+            list_triage("bogus", db)
+
+
+# ---------------------------------------------------------------------------
+# N+1 guard
+# ---------------------------------------------------------------------------
+
+
+class TestListTriageN1Guard(unittest.TestCase):
+    """The cohort path emits ≤5 DB queries regardless of page size.
+
+    Asserted by counting calls on ``FakePipelineDB.query_counts``. The
+    list path is bounded to four entries (page + three bulk getters);
+    the +1 headroom covers any single optional lookup the service
+    might add later.
+    """
+
+    def test_list_triage_page_size_50_under_query_cap(self) -> None:
+        db = FakePipelineDB()
+        for i in range(1, 51):
+            db.seed_request(make_request_row(
+                id=i, artist_name=f"Artist {i}", album_title="Album",
+            ))
+            # Field resolutions + search log rows for every request, so
+            # the bulk fetchers always have data to load. Without this
+            # the test would pass via vacuous "no rows so no queries"
+            # paths.
+            db.record_field_resolution(
+                request_id=i, field_name="release_group_year",
+                status="resolved", reason_code=None,
+            )
+            for _ in range(3):
+                db.log_search(
+                    request_id=i, query="q", result_count=10,
+                    outcome="rejected", rejection_reason="album_token_missing",
+                )
+
+        results = list_triage("all", db, page_size=50)
+        self.assertEqual(len(results), 50)
+        # Four bulk methods + a +1 headroom: page + field_resolutions +
+        # search_summaries + recent_search_log.
+        total_queries = sum(db.query_counts.values())
+        self.assertLessEqual(
+            total_queries, 5,
+            f"list_triage emitted {total_queries} DB queries "
+            f"(breakdown: {db.query_counts}); contract is ≤5",
+        )
+        # Belt-and-braces — each bulk method must fire exactly once.
+        self.assertEqual(db.query_counts.get("list_triage_page"), 1)
+        self.assertEqual(
+            db.query_counts.get("get_field_resolutions_for_requests"), 1,
+        )
+        self.assertEqual(
+            db.query_counts.get("get_search_summaries_for_requests"), 1,
+        )
+        self.assertEqual(
+            db.query_counts.get("get_recent_search_log_for_requests"), 1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Struct exposed via the wire — keep this tight so refactors fail loudly
+# ---------------------------------------------------------------------------
+
+
+class TestStructShape(unittest.TestCase):
+    """Pin the wire-boundary shape of the typed result structs."""
+
+    def test_triage_result_is_frozen_struct(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        result = compose_triage_for_request(1, db)
+        assert result is not None
+        self.assertIsInstance(result, TriageResult)
+        # Frozen — assignment fails.
+        with self.assertRaises((AttributeError, TypeError)):
+            result.failure_class = "mutated"  # type: ignore[misc]
+
+    def test_search_forensics_summary_has_required_fields(self) -> None:
+        # Defensive check: keep the field set explicit so a refactor
+        # that drops one of them fails this test before it breaks the
+        # operator surface.
+        sample = SearchForensicsSummary(
+            total_searches=0, with_cands_count=0, found_count=0,
+            near_cap_count=0, zero_results_count=0,
+            pre_filter_skips_total=0,
+            first_strategy_with_cands=None,
+            dominant_rejection_reason=None,
+            last_search_at=None,
+            recent_entries=[],
+        )
+        self.assertEqual(sample.total_searches, 0)
+
+    def test_search_log_entry_optional_fields(self) -> None:
+        entry = SearchLogEntry(
+            id=1, created_at=_now(), plan_strategy=None, query=None,
+            outcome="error", result_count=None, rejection_reason=None,
+            matcher_score_top1=None,
+        )
+        self.assertEqual(entry.outcome, "error")
+
+    def test_parsed_filter_is_frozen(self) -> None:
+        parsed = parse_filter("all")
+        self.assertIsInstance(parsed, ParsedTriageFilter)
+        with self.assertRaises((AttributeError, TypeError)):
+            parsed.kind = "mutated"  # type: ignore[misc]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1140,6 +1140,42 @@ class TestRouteContractAudit(unittest.TestCase):
             f"{sorted(missing_post_patterns)}",
         )
 
+        # Empty-string registration would pass the presence check above
+        # and defeat the U18 intent — every route must carry a non-empty
+        # one-liner. Surface each offender by name so the fix is
+        # one-route-at-a-time.
+        def _empty_desc_paths(registered: dict[str, str]) -> list[str]:
+            return sorted(p for p, d in registered.items() if not (d and d.strip()))
+
+        empty_get = _empty_desc_paths(srv.Handler._FUNC_GET_DESCRIPTIONS)
+        empty_post = _empty_desc_paths(srv.Handler._FUNC_POST_DESCRIPTIONS)
+        empty_get_pat = sorted(
+            p.pattern
+            for p, d in srv.Handler._FUNC_GET_PATTERN_DESCRIPTIONS
+            if not (d and d.strip())
+        )
+        empty_post_pat = sorted(
+            p.pattern
+            for p, d in srv.Handler._FUNC_POST_PATTERN_DESCRIPTIONS
+            if not (d and d.strip())
+        )
+        self.assertFalse(
+            empty_get,
+            f"GET routes with empty description string: {empty_get}",
+        )
+        self.assertFalse(
+            empty_post,
+            f"POST routes with empty description string: {empty_post}",
+        )
+        self.assertFalse(
+            empty_get_pat,
+            f"GET pattern routes with empty description string: {empty_get_pat}",
+        )
+        self.assertFalse(
+            empty_post_pat,
+            f"POST pattern routes with empty description string: {empty_post_pat}",
+        )
+
 
 class TestRouteDescriptionMechanism(unittest.TestCase):
     """U18 step 1: structural test that the route-description dispatch tables exist.
@@ -9670,7 +9706,6 @@ class TestTriageRouteContracts(_WebServerCase):
     # field rename can't silently break the JS without flipping a test.
     SHOW_REQUIRED_FIELDS = {
         "request_meta", "unfindable", "field_quality", "search_forensics",
-        "failure_class",
     }
 
     # ``request_meta`` fields the frontend depends on for the "Artist –
@@ -9763,7 +9798,9 @@ class TestTriageRouteContracts(_WebServerCase):
         composed = msgspec.convert(data, type=TriageResult)
         self.assertEqual(composed.request_meta.id, 4242)
         self.assertEqual(composed.request_meta.artist_name, "Triage Artist")
-        self.assertEqual(composed.failure_class, "search_not_converting")
+        self.assertEqual(
+            composed.request_meta.failure_class, "search_not_converting",
+        )
         # Unfindable struct populated because the seeded row has signals.
         self.assertIsNotNone(composed.unfindable)
         assert composed.unfindable is not None
@@ -9777,7 +9814,7 @@ class TestTriageRouteContracts(_WebServerCase):
         self.assertIn("error", data)
         self.assertEqual(data["request_id"], 99999)
 
-    def test_show_returns_400_for_non_int_id(self):
+    def test_show_returns_404_for_non_int_path(self):
         """A non-numeric path segment doesn't even match the regex
         (which requires ``\\d+``), so the route table itself replies
         404. This test pins the route-table contract (no silent
@@ -9819,35 +9856,65 @@ class TestTriageRouteContracts(_WebServerCase):
         # (cohort exhausted).
         self.assertIsNone(data["next_after"])
 
-    def test_list_filter_data_quality_reason_filters_by_reason_code(self):
-        """``filter=data_quality:reason=<code>`` (issue #374 scope)
-        returns only requests with at least one ``unresolved_*`` field
-        whose ``reason_code`` matches the spec."""
-        # Seeded request A: has a release_group_year resolution with
-        # the matching reason_code.
+    def test_list_filter_data_quality_status_filters_by_status_column(self):
+        """``filter=data_quality:status=<status>`` (issue #374 canonical
+        form) returns only requests with at least one
+        ``album_request_field_resolutions`` row whose ``status`` column
+        matches the spec. Mirrors what
+        ``lib/field_resolver_service.py::_classify_lookup_exception``
+        actually writes."""
+        # Seeded request A: has a release_group_year resolution in the
+        # sticky 4xx-client bucket — matches.
         self._fake.seed_request(make_request_row(id=20))
         self._fake.record_field_resolution(
             request_id=20, field_name="release_group_year",
-            status="unresolved_404", reason_code="unresolved_4xx_client",
+            status="unresolved_4xx_client", reason_code="http_400",
         )
-        # Seeded request B: also has a field resolution but a different
-        # reason_code — must NOT appear in the filtered cohort.
+        # Seeded request B: has a field resolution but a different
+        # status bucket — must NOT appear.
         self._fake.seed_request(make_request_row(id=21))
         self._fake.record_field_resolution(
             request_id=21, field_name="catalog_number",
-            status="unresolved_5xx", reason_code="unresolved_5xx_server",
+            status="unresolved_mirror_unavailable",
+            reason_code="ConnectionError",
         )
 
         status, data = self._get(
-            "/api/triage/list?filter=data_quality:reason=unresolved_4xx_client"
+            "/api/triage/list?filter=data_quality:status=unresolved_4xx_client"
         )
 
         self.assertEqual(status, 200)
         self.assertEqual(
-            data["filter"], "data_quality:reason=unresolved_4xx_client",
+            data["filter"], "data_quality:status=unresolved_4xx_client",
         )
         self.assertEqual(len(data["results"]), 1)
         self.assertEqual(data["results"][0]["request_meta"]["id"], 20)
+
+    def test_list_filter_data_quality_reason_filters_by_reason_code(self):
+        """``filter=data_quality:reason=<code>`` filters on the
+        ``reason_code`` column (HTTP code specifier — http_400,
+        http_410, http_422, etc.)."""
+        # Seeded request A: 4xx-client status, reason_code=http_400 — matches.
+        self._fake.seed_request(make_request_row(id=22))
+        self._fake.record_field_resolution(
+            request_id=22, field_name="release_group_year",
+            status="unresolved_4xx_client", reason_code="http_400",
+        )
+        # Seeded request B: 4xx-client status but reason_code=http_410 — excluded.
+        self._fake.seed_request(make_request_row(id=23))
+        self._fake.record_field_resolution(
+            request_id=23, field_name="catalog_number",
+            status="unresolved_4xx_client", reason_code="http_410",
+        )
+
+        status, data = self._get(
+            "/api/triage/list?filter=data_quality:reason=http_400"
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["filter"], "data_quality:reason=http_400")
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["request_meta"]["id"], 22)
 
     def test_list_invalid_filter_returns_400_with_valid_filters_array(self):
         """An unparseable filter spec surfaces as a 400 carrying

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1087,6 +1087,54 @@ class TestRouteContractAudit(unittest.TestCase):
                          f"Stale route classifications: {sorted(self.CLASSIFIED_ROUTES - actual)}")
 
 
+class TestRouteDescriptionMechanism(unittest.TestCase):
+    """U18 step 1: structural test that the route-description dispatch tables exist.
+
+    Proves the registration plumbing mirrors the GET_ROUTES / POST_ROUTES /
+    GET_PATTERNS / POST_PATTERNS pattern in web/server.py. Contents are
+    populated in U18 step 2; empty is fine here.
+    """
+
+    def test_description_dispatch_tables_exist_with_correct_shapes(self):
+        import re
+        import web.server as srv
+
+        # All four class attributes must exist.
+        self.assertTrue(hasattr(srv.Handler, "_FUNC_GET_DESCRIPTIONS"))
+        self.assertTrue(hasattr(srv.Handler, "_FUNC_POST_DESCRIPTIONS"))
+        self.assertTrue(hasattr(srv.Handler, "_FUNC_GET_PATTERN_DESCRIPTIONS"))
+        self.assertTrue(hasattr(srv.Handler, "_FUNC_POST_PATTERN_DESCRIPTIONS"))
+
+        get_desc = srv.Handler._FUNC_GET_DESCRIPTIONS
+        post_desc = srv.Handler._FUNC_POST_DESCRIPTIONS
+        get_pattern_desc = srv.Handler._FUNC_GET_PATTERN_DESCRIPTIONS
+        post_pattern_desc = srv.Handler._FUNC_POST_PATTERN_DESCRIPTIONS
+
+        # Dict shapes: path (str) → description (str).
+        self.assertIsInstance(get_desc, dict)
+        self.assertIsInstance(post_desc, dict)
+        for path, desc in get_desc.items():
+            self.assertIsInstance(path, str)
+            self.assertIsInstance(desc, str)
+        for path, desc in post_desc.items():
+            self.assertIsInstance(path, str)
+            self.assertIsInstance(desc, str)
+
+        # List-of-tuple shapes: (re.Pattern, str).
+        self.assertIsInstance(get_pattern_desc, list)
+        self.assertIsInstance(post_pattern_desc, list)
+        for entry in get_pattern_desc:
+            self.assertIsInstance(entry, tuple)
+            self.assertEqual(len(entry), 2)
+            self.assertIsInstance(entry[0], re.Pattern)
+            self.assertIsInstance(entry[1], str)
+        for entry in post_pattern_desc:
+            self.assertIsInstance(entry, tuple)
+            self.assertEqual(len(entry), 2)
+            self.assertIsInstance(entry[0], re.Pattern)
+            self.assertIsInstance(entry[1], str)
+
+
 class TestPipelineRouteContracts(_WebServerCase):
     """Contract tests for frontend-consumed pipeline GET routes."""
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1012,6 +1012,8 @@ class TestRouteContractAudit(unittest.TestCase):
     """Every web/routes.py endpoint must be covered by a frontend contract decision."""
 
     CLASSIFIED_ROUTES = {
+        # U18 step 2: self-documenting API surface.
+        "/api/_index",
         "/api/search",
         "/api/browse/resolve",
         "/api/library/artist",
@@ -1093,6 +1095,51 @@ class TestRouteContractAudit(unittest.TestCase):
         self.assertFalse(self.CLASSIFIED_ROUTES - actual,
                          f"Stale route classifications: {sorted(self.CLASSIFIED_ROUTES - actual)}")
 
+    def test_every_registered_route_has_a_description(self):
+        """U18 step 3: every registered route must carry a human-readable
+        one-liner in the parallel description dispatch tables. Fails if a
+        future route is added without one — fixing it is a one-line edit
+        in the route module."""
+        import web.server as srv
+
+        get_paths = set(srv.Handler._FUNC_GET_ROUTES.keys())
+        post_paths = set(srv.Handler._FUNC_POST_ROUTES.keys())
+        get_pattern_strs = {
+            p.pattern for p, _fn in srv.Handler._FUNC_GET_PATTERNS}
+        post_pattern_strs = {
+            p.pattern for p, _fn in srv.Handler._FUNC_POST_PATTERNS}
+
+        get_desc_paths = set(srv.Handler._FUNC_GET_DESCRIPTIONS.keys())
+        post_desc_paths = set(srv.Handler._FUNC_POST_DESCRIPTIONS.keys())
+        get_pattern_desc_strs = {
+            p.pattern for p, _d in srv.Handler._FUNC_GET_PATTERN_DESCRIPTIONS}
+        post_pattern_desc_strs = {
+            p.pattern for p, _d in srv.Handler._FUNC_POST_PATTERN_DESCRIPTIONS}
+
+        missing_get = get_paths - get_desc_paths
+        missing_post = post_paths - post_desc_paths
+        missing_get_patterns = get_pattern_strs - get_pattern_desc_strs
+        missing_post_patterns = post_pattern_strs - post_pattern_desc_strs
+
+        self.assertFalse(
+            missing_get,
+            f"GET routes missing descriptions: {sorted(missing_get)}",
+        )
+        self.assertFalse(
+            missing_post,
+            f"POST routes missing descriptions: {sorted(missing_post)}",
+        )
+        self.assertFalse(
+            missing_get_patterns,
+            "GET pattern routes missing descriptions: "
+            f"{sorted(missing_get_patterns)}",
+        )
+        self.assertFalse(
+            missing_post_patterns,
+            "POST pattern routes missing descriptions: "
+            f"{sorted(missing_post_patterns)}",
+        )
+
 
 class TestRouteDescriptionMechanism(unittest.TestCase):
     """U18 step 1: structural test that the route-description dispatch tables exist.
@@ -1140,6 +1187,48 @@ class TestRouteDescriptionMechanism(unittest.TestCase):
             self.assertEqual(len(entry), 2)
             self.assertIsInstance(entry[0], re.Pattern)
             self.assertIsInstance(entry[1], str)
+
+
+class TestApiIndexRouteContract(_WebServerCase):
+    """U18 step 2: contract test for the self-documenting ``/api/_index``."""
+
+    INDEX_ENTRY_REQUIRED_FIELDS = {
+        "method", "path", "description", "request_model",
+    }
+
+    def test_api_index_returns_classified_routes_with_pydantic_models(self):
+        status, data = self._get("/api/_index")
+        self.assertEqual(status, 200)
+        self.assertIsInstance(data, list)
+        # We register ~40+ routes; assert a healthy floor so a regression
+        # that empties the merge can't silently sneak through.
+        self.assertGreaterEqual(len(data), 30, msg=f"only {len(data)} entries")
+
+        for entry in data:
+            _assert_required_fields(
+                self, entry, self.INDEX_ENTRY_REQUIRED_FIELDS,
+                f"_index entry {entry.get('path')!r}",
+            )
+            self.assertIn(entry["method"], {"GET", "POST"})
+            self.assertIsInstance(entry["path"], str)
+            self.assertIsInstance(entry["description"], str)
+
+        # The Pydantic introspection must surface at least one known
+        # POST handler so we know the regex is biting the real source.
+        post_models = {
+            (e["path"], e["request_model"])
+            for e in data if e["method"] == "POST"
+        }
+        self.assertIn(
+            ("/api/pipeline/add", "PipelineAddRequest"),
+            post_models,
+            f"PipelineAddRequest not surfaced in post_models: {post_models}",
+        )
+
+        # Sort invariant — operators consume this as a stable index.
+        sorted_entries = sorted(
+            data, key=lambda e: (str(e["method"]), str(e["path"])))
+        self.assertEqual(data, sorted_entries)
 
 
 class TestPipelineRouteContracts(_WebServerCase):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -20,6 +20,8 @@ from unittest.mock import MagicMock, patch
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
+import msgspec
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
@@ -1069,6 +1071,11 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/wrong-matches/converge",
         "/api/wrong-matches/triage",
         "/api/wrong-matches/explorer",
+        # U17: /api/triage HTTP endpoints. Per-request composition and
+        # cohort listing both wrap ``lib.triage_service`` (U15) — same
+        # service as ``pipeline-cli triage`` (U16) per CLI ⇄ API symmetry.
+        "/api/triage/list",
+        r"^/api/triage/(\d+)$",
     }
 
     def test_all_web_routes_are_classified_for_contract_coverage(self):
@@ -9548,6 +9555,270 @@ class TestBeetsDistanceRouteContract(_WebServerCase):
         # Numeric id (Discogs-shaped) — pattern shouldn't match.
         status, _ = self._get("/api/beets-distance/100/2048516")
         self.assertEqual(status, 404)
+
+
+class TestTriageRouteContracts(_WebServerCase):
+    """U17 contracts for ``GET /api/triage/<id>`` and ``GET /api/triage/list``.
+
+    Both endpoints wrap ``lib.triage_service`` (U15) — the same service
+    layer ``pipeline-cli triage show/list`` (U16) wraps. The wire shape
+    on the cohort + composition payloads is the
+    ``msgspec.to_builtins(TriageResult)`` shape verbatim, so the same
+    Struct round-trips through ``msgspec.convert`` on both sides (CLI
+    ⇄ API surface symmetry).
+
+    Tests drive the real ``compose_triage_for_request`` and
+    ``list_triage`` paths against a real :class:`FakePipelineDB`
+    (reached via ``self.mock_db._fake``) — no service-layer mocking,
+    per ``code-quality.md`` § MOCKS: LEAF-SEAM ONLY. Seeded rows use
+    production-shape values: ``datetime.datetime`` for timestamps via
+    ``make_request_row``'s defaults, real ``FieldResolutionRow`` /
+    ``SearchLogRow`` via the typed seed helpers.
+    """
+
+    # The frontend triage drawer renders these top-level fields out of
+    # ``msgspec.to_builtins(TriageResult)``. Pin every one so a future
+    # field rename can't silently break the JS without flipping a test.
+    SHOW_REQUIRED_FIELDS = {
+        "request_meta", "unfindable", "field_quality", "search_forensics",
+        "failure_class",
+    }
+
+    # ``request_meta`` fields the frontend depends on for the "Artist –
+    # Album (year) #N" header + identity probes (failure_class, source,
+    # search_filetype_override).
+    SHOW_REQUEST_META_FIELDS = {
+        "id", "artist_name", "album_title", "year", "status", "source",
+        "mb_release_id", "discogs_release_id", "release_group_year",
+        "is_va_compilation", "catalog_number", "failure_class",
+        "search_filetype_override",
+    }
+
+    LIST_REQUIRED_FIELDS = {"results", "next_after", "page_size", "filter"}
+
+    # MagicMock attribute names whose pre-set ``.return_value`` /
+    # ``.side_effect`` from ``_make_server`` would short-circuit a call
+    # to the wrapped fake. We need the triage path to hit the fresh
+    # FakePipelineDB on every method ``compose_triage_for_request`` /
+    # ``list_triage`` touches, so each test resets the relevant child
+    # mocks to forwarding ``side_effect`` lambdas that call through to
+    # the fresh backing fake.
+    _TRIAGE_DB_METHODS = (
+        "get_request",
+        "list_triage_page",
+        "get_field_resolutions_for_requests",
+        "get_search_summaries_for_requests",
+        "get_recent_search_log_for_requests",
+    )
+
+    def setUp(self) -> None:
+        # Each test gets its own FakePipelineDB so seeded rows from one
+        # test never bleed into the next. Re-wrap the harness so the
+        # MagicMock layer keeps recording but `._fake` points at the
+        # fresh fake.
+        fresh = FakePipelineDB()
+        self._old_backing = self.mock_db._fake
+        self.mock_db._mock_wraps = fresh
+        self.mock_db._fake = fresh
+        # Snapshot the pre-existing child-mock state for the methods
+        # the triage service touches, then force them to forward to the
+        # fresh fake. Without this, _make_server's static
+        # ``mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST``
+        # would short-circuit every composed triage to request_id=100.
+        self._triage_method_state: dict[str, MagicMock] = {}
+        for name in self._TRIAGE_DB_METHODS:
+            self._triage_method_state[name] = getattr(self.mock_db, name)
+            forwarder = MagicMock(side_effect=getattr(fresh, name))
+            setattr(self.mock_db, name, forwarder)
+
+    def tearDown(self) -> None:
+        for name, prev in self._triage_method_state.items():
+            setattr(self.mock_db, name, prev)
+        self.mock_db._mock_wraps = self._old_backing
+        self.mock_db._fake = self._old_backing
+
+    @property
+    def _fake(self) -> "FakePipelineDB":
+        return self.mock_db._fake
+
+    # --- /api/triage/<id> -------------------------------------------------
+
+    def test_show_returns_200_with_required_fields_and_roundtrips(self):
+        """Happy path: a seeded request composes through to a 200 with
+        the full TriageResult shape, and the response body round-trips
+        through ``msgspec.convert(payload, type=TriageResult)`` — the
+        wire-boundary contract per CLI ⇄ API symmetry."""
+        from lib.triage_service import TriageResult
+        self._fake.seed_request(make_request_row(
+            id=4242,
+            artist_name="Triage Artist",
+            album_title="Triage Album",
+            status="wanted",
+            failure_class="search_not_converting",
+            unfindable_category="artist_absent",
+            unfindable_categorised_at=datetime(2026, 5, 20, tzinfo=timezone.utc),
+            last_artist_probe_at=datetime(2026, 5, 22, tzinfo=timezone.utc),
+            last_artist_probe_match_count=0,
+        ))
+
+        status, data = self._get("/api/triage/4242")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.SHOW_REQUIRED_FIELDS,
+                                "triage show response")
+        _assert_required_fields(self, data["request_meta"],
+                                self.SHOW_REQUEST_META_FIELDS,
+                                "triage show request_meta")
+        # The wire shape is exactly the Struct shape — round-trip proves
+        # no field drift / coercion happened at the boundary.
+        composed = msgspec.convert(data, type=TriageResult)
+        self.assertEqual(composed.request_meta.id, 4242)
+        self.assertEqual(composed.request_meta.artist_name, "Triage Artist")
+        self.assertEqual(composed.failure_class, "search_not_converting")
+        # Unfindable struct populated because the seeded row has signals.
+        self.assertIsNotNone(composed.unfindable)
+        assert composed.unfindable is not None
+        self.assertEqual(composed.unfindable.category, "artist_absent")
+
+    def test_show_returns_404_when_request_id_missing(self):
+        """Unknown request id → 404 with ``error`` + ``request_id`` in body
+        so the frontend can surface "not found" with the right id."""
+        status, data = self._get("/api/triage/99999")
+        self.assertEqual(status, 404)
+        self.assertIn("error", data)
+        self.assertEqual(data["request_id"], 99999)
+
+    def test_show_returns_400_for_non_int_id(self):
+        """A non-numeric path segment doesn't even match the regex
+        (which requires ``\\d+``), so the route table itself replies
+        404. This test pins the route-table contract (no silent
+        coercion to a different handler)."""
+        status, _ = self._get("/api/triage/not-an-int")
+        # The regex r"^/api/triage/(\d+)$" does not match — falls
+        # through to the catch-all 404.
+        self.assertEqual(status, 404)
+
+    # --- /api/triage/list --------------------------------------------------
+
+    def test_list_filter_unfindable_returns_200_with_required_fields(self):
+        """A seeded unfindable request shows up under
+        ``filter=unfindable`` with the documented envelope shape."""
+        from lib.triage_service import TriageResult
+        self._fake.seed_request(make_request_row(
+            id=10, artist_name="Stuck Artist",
+            unfindable_category="artist_absent",
+            unfindable_categorised_at=datetime(2026, 5, 20, tzinfo=timezone.utc),
+        ))
+        # Decoy row without any unfindable signal — must NOT appear in
+        # the filtered cohort.
+        self._fake.seed_request(make_request_row(
+            id=11, artist_name="Healthy Artist", status="imported",
+        ))
+
+        status, data = self._get("/api/triage/list?filter=unfindable")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.LIST_REQUIRED_FIELDS,
+                                "triage list response")
+        self.assertEqual(data["filter"], "unfindable")
+        self.assertEqual(data["page_size"], 50)
+        # Only the unfindable row should be returned.
+        self.assertEqual(len(data["results"]), 1)
+        composed = msgspec.convert(data["results"][0], type=TriageResult)
+        self.assertEqual(composed.request_meta.id, 10)
+        # Page is shorter than page_size → next_after is None
+        # (cohort exhausted).
+        self.assertIsNone(data["next_after"])
+
+    def test_list_filter_data_quality_reason_filters_by_reason_code(self):
+        """``filter=data_quality:reason=<code>`` (issue #374 scope)
+        returns only requests with at least one ``unresolved_*`` field
+        whose ``reason_code`` matches the spec."""
+        # Seeded request A: has a release_group_year resolution with
+        # the matching reason_code.
+        self._fake.seed_request(make_request_row(id=20))
+        self._fake.record_field_resolution(
+            request_id=20, field_name="release_group_year",
+            status="unresolved_404", reason_code="unresolved_4xx_client",
+        )
+        # Seeded request B: also has a field resolution but a different
+        # reason_code — must NOT appear in the filtered cohort.
+        self._fake.seed_request(make_request_row(id=21))
+        self._fake.record_field_resolution(
+            request_id=21, field_name="catalog_number",
+            status="unresolved_5xx", reason_code="unresolved_5xx_server",
+        )
+
+        status, data = self._get(
+            "/api/triage/list?filter=data_quality:reason=unresolved_4xx_client"
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            data["filter"], "data_quality:reason=unresolved_4xx_client",
+        )
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["request_meta"]["id"], 20)
+
+    def test_list_invalid_filter_returns_400_with_valid_filters_array(self):
+        """An unparseable filter spec surfaces as a 400 carrying
+        ``error`` + a ``valid_filters`` array, so the operator can
+        self-correct without leaving the network response."""
+        status, data = self._get("/api/triage/list?filter=garbage_value")
+
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+        self.assertIn("valid_filters", data)
+        self.assertIsInstance(data["valid_filters"], list)
+        # The four canonical scalar forms must be advertised.
+        self.assertIn("all", data["valid_filters"])
+        self.assertIn("unfindable", data["valid_filters"])
+        self.assertIn("data_quality", data["valid_filters"])
+        self.assertIn("search_not_converting", data["valid_filters"])
+
+    def test_list_limit_caps_results_and_emits_next_after_cursor(self):
+        """When the page is exactly ``limit`` long the response carries
+        ``next_after`` = last request_id so the operator can paginate."""
+        for rid in (30, 31, 32):
+            self._fake.seed_request(make_request_row(
+                id=rid, status="imported",
+            ))
+
+        status, data = self._get("/api/triage/list?filter=all&limit=2")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["page_size"], 2)
+        self.assertEqual(len(data["results"]), 2)
+        # Page was full → next_after is the last id in the page.
+        self.assertEqual(data["next_after"],
+                         data["results"][-1]["request_meta"]["id"])
+
+    def test_list_default_filter_when_query_string_omitted(self):
+        """Missing ``filter=`` defaults to ``all`` so a bare hit on
+        ``/api/triage/list`` is meaningful."""
+        self._fake.seed_request(make_request_row(id=40, status="imported"))
+
+        status, data = self._get("/api/triage/list")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["filter"], "all")
+        self.assertGreaterEqual(len(data["results"]), 1)
+
+    def test_list_rejects_non_int_limit(self):
+        status, data = self._get("/api/triage/list?filter=all&limit=abc")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+
+    def test_list_rejects_out_of_bounds_limit(self):
+        status, data = self._get("/api/triage/list?filter=all&limit=500")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+
+    def test_list_rejects_non_int_after(self):
+        status, data = self._get(
+            "/api/triage/list?filter=all&after=not-an-int")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
 
 
 if __name__ == "__main__":

--- a/tools/vulture/whitelist.py
+++ b/tools/vulture/whitelist.py
@@ -151,21 +151,3 @@ _.do_GET  # unused method (web/server.py:299)
 _.do_POST  # unused method (web/server.py:339)
 _.do_OPTIONS  # unused method (web/server.py:384)
 ALL_FAILURE_CLASSES  # exported for tests (lib/search_classification.py:48)
-# lib/triage_service.py — msgspec.Struct fields read via JSON serialization
-# (not attribute access) plus public service functions called from
-# wrappers shipped in U16 / U17 (CLI + HTTP); both wrappers post-date this
-# whitelist entry.
-last_artist_probe_at  # unused variable (lib/triage_service.py:189)
-last_artist_probe_match_count  # unused variable (lib/triage_service.py:190)
-prior_unfindable_category  # unused variable (lib/triage_service.py:192)
-resolved_at  # unused variable (lib/triage_service.py:202)
-with_cands_count  # unused variable (lib/triage_service.py:235)
-near_cap_count  # unused variable (lib/triage_service.py:237)
-zero_results_count  # unused variable (lib/triage_service.py:238)
-pre_filter_skips_total  # unused variable (lib/triage_service.py:239)
-first_strategy_with_cands  # unused variable (lib/triage_service.py:240)
-dominant_rejection_reason  # unused variable (lib/triage_service.py:241)
-last_search_at  # unused variable (lib/triage_service.py:242)
-recent_entries  # unused variable (lib/triage_service.py:243)
-compose_triage_for_request  # unused function (lib/triage_service.py:299)
-list_triage  # unused function (lib/triage_service.py:329)

--- a/tools/vulture/whitelist.py
+++ b/tools/vulture/whitelist.py
@@ -151,3 +151,21 @@ _.do_GET  # unused method (web/server.py:299)
 _.do_POST  # unused method (web/server.py:339)
 _.do_OPTIONS  # unused method (web/server.py:384)
 ALL_FAILURE_CLASSES  # exported for tests (lib/search_classification.py:48)
+# lib/triage_service.py — msgspec.Struct fields read via JSON serialization
+# (not attribute access) plus public service functions called from
+# wrappers shipped in U16 / U17 (CLI + HTTP); both wrappers post-date this
+# whitelist entry.
+last_artist_probe_at  # unused variable (lib/triage_service.py:189)
+last_artist_probe_match_count  # unused variable (lib/triage_service.py:190)
+prior_unfindable_category  # unused variable (lib/triage_service.py:192)
+resolved_at  # unused variable (lib/triage_service.py:202)
+with_cands_count  # unused variable (lib/triage_service.py:235)
+near_cap_count  # unused variable (lib/triage_service.py:237)
+zero_results_count  # unused variable (lib/triage_service.py:238)
+pre_filter_skips_total  # unused variable (lib/triage_service.py:239)
+first_strategy_with_cands  # unused variable (lib/triage_service.py:240)
+dominant_rejection_reason  # unused variable (lib/triage_service.py:241)
+last_search_at  # unused variable (lib/triage_service.py:242)
+recent_entries  # unused variable (lib/triage_service.py:243)
+compose_triage_for_request  # unused function (lib/triage_service.py:299)
+list_triage  # unused function (lib/triage_service.py:329)

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -653,3 +653,9 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/discogs/master/(\d+)$"), get_discogs_master),
     (re.compile(r"^/api/discogs/release/(\d+)$"), get_discogs_release),
 ]
+
+# Human-readable descriptions for the route index (U18). Parallel to the
+# GET_ROUTES / GET_PATTERNS dispatch tables above. Populated incrementally;
+# empty entries are intentional until U18 step 2.
+GET_DESCRIPTIONS: dict[str, str] = {}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -655,7 +655,43 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
 ]
 
 # Human-readable descriptions for the route index (U18). Parallel to the
-# GET_ROUTES / GET_PATTERNS dispatch tables above. Populated incrementally;
-# empty entries are intentional until U18 step 2.
-GET_DESCRIPTIONS: dict[str, str] = {}
-PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []
+# GET_ROUTES / GET_PATTERNS dispatch tables above.
+GET_DESCRIPTIONS: dict[str, str] = {
+    "/api/search": (
+        "MusicBrainz search by artist (default) or release group "
+        "(type=release)."
+    ),
+    "/api/browse/resolve": (
+        "Resolve a pasted MBID / Discogs ID / URL into the artist-view "
+        "drop-in target (source, kind, expand_id, leaf_id)."
+    ),
+    "/api/library/artist": (
+        "Library albums by artist (beets-backed), pipeline-status enriched."
+    ),
+    "/api/artist/compare": (
+        "Side-by-side MB + Discogs discographies for one artist, "
+        "fuzzy-merged with in-library overlay."
+    ),
+    "/api/discogs/search": (
+        "Discogs search by artist (default) or release (type=release)."
+    ),
+}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/api/artist/([a-f0-9-]+)$"),
+     "MB artist detail — release groups with library/pipeline overlay."),
+    (re.compile(r"^/api/artist/([a-f0-9-]+)/disambiguate$"),
+     "MB artist disambiguate view — per-release-group pressing analysis "
+     "with in-library + pipeline overlay."),
+    (re.compile(r"^/api/release-group/([a-f0-9-]+)$"),
+     "MB release group detail — releases in this group with overlay."),
+    (re.compile(r"^/api/release/([a-f0-9-]+)$"),
+     "MB release detail (auto-routes to Discogs for numeric IDs); "
+     "library + pipeline status and beets tracks if present."),
+    (re.compile(r"^/api/discogs/artist/(\d+)$"),
+     "Discogs artist detail — masters with in-library overlay."),
+    (re.compile(r"^/api/discogs/master/(\d+)$"),
+     "Discogs master detail — releases under this master with overlay."),
+    (re.compile(r"^/api/discogs/release/(\d+)$"),
+     "Discogs release detail — library + pipeline status and beets "
+     "tracks if present."),
+]

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -999,3 +999,9 @@ POST_ROUTES: dict[str, object] = {
     "/api/wrong-matches/converge": post_wrong_match_converge,
     "/api/wrong-matches/triage": post_wrong_match_triage,
 }
+
+# Human-readable descriptions for the route index (U18). Parallel to the
+# GET_ROUTES / POST_ROUTES dispatch tables above. Populated incrementally;
+# empty entries are intentional until U18 step 2.
+GET_DESCRIPTIONS: dict[str, str] = {}
+POST_DESCRIPTIONS: dict[str, str] = {}

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -1001,7 +1001,46 @@ POST_ROUTES: dict[str, object] = {
 }
 
 # Human-readable descriptions for the route index (U18). Parallel to the
-# GET_ROUTES / POST_ROUTES dispatch tables above. Populated incrementally;
-# empty entries are intentional until U18 step 2.
-GET_DESCRIPTIONS: dict[str, str] = {}
-POST_DESCRIPTIONS: dict[str, str] = {}
+# GET_ROUTES / POST_ROUTES dispatch tables above.
+GET_DESCRIPTIONS: dict[str, str] = {
+    "/api/manual-import/scan": (
+        "Scan a Complete folder for album dirs and fuzzy-match each to "
+        "wanted pipeline requests."
+    ),
+    "/api/wrong-matches": (
+        "Wrong-match queue — rejected downloads grouped by request, with "
+        "per-entry quality + on-disk fields for operator review."
+    ),
+    "/api/wrong-matches/audio": (
+        "Stream one wrong-match audio file with byte-range support."
+    ),
+    "/api/wrong-matches/explorer": (
+        "Filesystem-backed file/tag explorer payload for one wrong match."
+    ),
+}
+POST_DESCRIPTIONS: dict[str, str] = {
+    "/api/manual-import/import": (
+        "Enqueue a manual-import job for an on-disk folder against a "
+        "pipeline request."
+    ),
+    "/api/import-preview": (
+        "Preview whether an import would pass — accepts typed values, "
+        "a download_log_id, or a request_id+path."
+    ),
+    "/api/wrong-matches/delete": (
+        "Operator-triggered deletion of one visible Wrong Matches "
+        "candidate (DESTRUCTIVE on disk)."
+    ),
+    "/api/wrong-matches/delete-group": (
+        "Operator-triggered deletion of all current Wrong Matches for "
+        "a request (DESTRUCTIVE on disk)."
+    ),
+    "/api/wrong-matches/converge": (
+        "Queue acceptable candidates for force-import and delete the "
+        "rest for one request (one-click cleanup)."
+    ),
+    "/api/wrong-matches/triage": (
+        "Run the full Wrong Matches cleanup classifier across the queue "
+        "(DESTRUCTIVE); requires confirm_all_wrong_matches=true."
+    ),
+}

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -201,3 +201,9 @@ GET_ROUTES: dict[str, object] = {
 GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/discogs/label/(\d+)$"), get_discogs_label_detail),
 ]
+
+# Human-readable descriptions for the route index (U18). Parallel to the
+# GET_ROUTES / GET_PATTERNS dispatch tables above. Populated incrementally;
+# empty entries are intentional until U18 step 2.
+GET_DESCRIPTIONS: dict[str, str] = {}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []

--- a/web/routes/labels.py
+++ b/web/routes/labels.py
@@ -203,7 +203,15 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
 ]
 
 # Human-readable descriptions for the route index (U18). Parallel to the
-# GET_ROUTES / GET_PATTERNS dispatch tables above. Populated incrementally;
-# empty entries are intentional until U18 step 2.
-GET_DESCRIPTIONS: dict[str, str] = {}
-PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []
+# GET_ROUTES / GET_PATTERNS dispatch tables above.
+GET_DESCRIPTIONS: dict[str, str] = {
+    "/api/discogs/label/search": (
+        "Discogs label search — returns label entities (no release overlay)."
+    ),
+}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/api/discogs/label/(\d+)$"),
+     "Discogs label detail — entity + paginated release catalogue with "
+     "library/pipeline overlay; auto-flips include_sublabels off for "
+     "UMG-class big labels."),
+]

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -147,3 +147,10 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
 POST_ROUTES: dict[str, object] = {
     "/api/beets/delete": post_beets_delete,
 }
+
+# Human-readable descriptions for the route index (U18). Parallel to the
+# GET_ROUTES / GET_PATTERNS / POST_ROUTES dispatch tables above. Populated
+# incrementally; empty entries are intentional until U18 step 2.
+GET_DESCRIPTIONS: dict[str, str] = {}
+POST_DESCRIPTIONS: dict[str, str] = {}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -149,8 +149,22 @@ POST_ROUTES: dict[str, object] = {
 }
 
 # Human-readable descriptions for the route index (U18). Parallel to the
-# GET_ROUTES / GET_PATTERNS / POST_ROUTES dispatch tables above. Populated
-# incrementally; empty entries are intentional until U18 step 2.
-GET_DESCRIPTIONS: dict[str, str] = {}
-POST_DESCRIPTIONS: dict[str, str] = {}
-PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []
+# GET_ROUTES / GET_PATTERNS / POST_ROUTES dispatch tables above.
+GET_DESCRIPTIONS: dict[str, str] = {
+    "/api/beets/search": (
+        "Beets library album search by query string; pipeline-enriched."
+    ),
+    "/api/beets/recent": (
+        "Recently imported beets albums; pipeline-enriched."
+    ),
+}
+POST_DESCRIPTIONS: dict[str, str] = {
+    "/api/beets/delete": (
+        "Delete a beets album (DESTRUCTIVE — files removed); optional "
+        "pipeline purge. Requires confirm='DELETE'."
+    ),
+}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/api/beets/album/(\d+)$"),
+     "Beets album detail — full tracks + library / pipeline overlay."),
+]

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import re
+import textwrap
 import urllib.error
 from pathlib import Path
 from typing import Literal
@@ -2394,27 +2395,23 @@ def get_beets_distance(
 # (``compose_triage_for_request`` / ``list_triage``) so the CLI ⇄ API
 # symmetry rule holds — see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry".
 
-# Filter forms surfaced in the 400 body so operators can self-correct
-# without leaving the network response. Kept narrow to mirror the CLI's
-# ``_TRIAGE_VALID_FILTER_FORMS`` (the API echoes machine-parseable
-# tokens; the CLI's prose-form parenthetical lives only in CLI help).
-_TRIAGE_VALID_FILTER_FORMS_API: tuple[str, ...] = (
-    "all",
-    "unfindable",
-    "unfindable:<category>",
-    "data_quality",
-    "data_quality:<field>",
-    "data_quality:reason=<code>",
-    "search_not_converting",
-)
+# Filter forms surfaced in the 400 body — single source of truth lives
+# in ``lib.triage_service.VALID_FILTER_FORMS`` so the CLI and the HTTP
+# 400 envelope advertise the same vocabulary.
+from lib.triage_service import VALID_FILTER_FORMS as _TRIAGE_VALID_FILTER_FORMS_API  # noqa: E402
 
-# Page-size bounds for ``GET /api/triage/list``. Mirrors the convention
-# established by ``get_pipeline_search_plan_history`` (1..200): a hard
-# upper bound prevents an unbounded scan; the lower bound rules out the
-# nonsense ``limit=0`` request shape.
-_TRIAGE_LIST_MIN_LIMIT = 1
-_TRIAGE_LIST_MAX_LIMIT = 200
-_TRIAGE_LIST_DEFAULT_LIMIT = 50
+# Page-size bounds for ``GET /api/triage/list`` — re-exports of the
+# single-source-of-truth constants on ``lib.triage_service`` so the CLI
+# and API enforce the same ranges. Mirrors the convention established by
+# ``get_pipeline_search_plan_history`` (1..200): a hard upper bound
+# prevents an unbounded scan; the lower bound rules out the nonsense
+# ``limit=0`` request shape.
+from lib.triage_service import (  # noqa: E402
+    DEFAULT_TRIAGE_PAGE_SIZE as _TRIAGE_LIST_DEFAULT_LIMIT,
+    TRIAGE_AFTER_MIN as _TRIAGE_LIST_MIN_AFTER,
+    TRIAGE_LIMIT_MAX as _TRIAGE_LIST_MAX_LIMIT,
+    TRIAGE_LIMIT_MIN as _TRIAGE_LIST_MIN_LIMIT,
+)
 
 
 def get_triage_for_request(
@@ -2431,18 +2428,16 @@ def get_triage_for_request(
 
     Status-code mapping (mirrors ``cmd_triage_show``'s exit codes):
       * 200 — composition success.
-      * 400 — non-int request id (caught here; the service never sees
-              garbage).
       * 404 — ``compose_triage_for_request`` returned ``None`` (no row).
+
+    The route's regex (``r"^/api/triage/(\\d+)$"``) requires a digit-only
+    path segment, so ``req_id_str`` is always coercible — non-digit
+    paths never match this pattern in the first place and fall through
+    to the catch-all 404 in ``web/server.py``.
     """
     from lib.triage_service import compose_triage_for_request
 
-    try:
-        request_id = int(req_id_str)
-    except (TypeError, ValueError):
-        h._error("Invalid request id")
-        return
-
+    request_id = int(req_id_str)
     db = _server()._db()
     result = compose_triage_for_request(request_id, db)
     if result is None:
@@ -2517,8 +2512,10 @@ def get_triage_list(
         except (TypeError, ValueError):
             h._error("after must be an integer")
             return
-        if after < 1:
-            h._error("after must be >= 1", status=400)
+        if after < _TRIAGE_LIST_MIN_AFTER:
+            h._error(
+                f"after must be >= {_TRIAGE_LIST_MIN_AFTER}", status=400,
+            )
             return
 
     db = _server()._db()
@@ -2527,10 +2524,24 @@ def get_triage_list(
             filter_spec, db, page_size=limit, after_request_id=after,
         )
     except InvalidFilterError as exc:
+        # Pull the parameter-vocab arrays so API-only operators can
+        # self-correct from the response body alone (e.g. on
+        # ``unfindable:<bad_cat>``, the operator sees the four valid
+        # categories without needing to consult --help).
+        from lib.triage_service import (
+            VALID_DATA_QUALITY_FIELD_NAMES,
+            VALID_UNFINDABLE_CATEGORIES,
+        )
         h._json(
             {
                 "error": str(exc),
                 "valid_filters": list(_TRIAGE_VALID_FILTER_FORMS_API),
+                "valid_unfindable_categories": sorted(
+                    VALID_UNFINDABLE_CATEGORIES
+                ),
+                "valid_data_quality_fields": sorted(
+                    VALID_DATA_QUALITY_FIELD_NAMES
+                ),
             },
             status=400,
         )
@@ -2541,7 +2552,7 @@ def get_triage_list(
         next_after = results[-1].request_meta.id
 
     payload: dict[str, object] = {
-        "results": [msgspec.to_builtins(r) for r in results],
+        "results": msgspec.to_builtins(results),
         "next_after": next_after,
         "page_size": limit,
         "filter": filter_spec,
@@ -2554,38 +2565,56 @@ def get_triage_list(
 # Walks ``web.server.Handler``'s merged dispatch tables and emits one row per
 # registered route: path/pattern, method, description, and the Pydantic
 # ``*Request`` model name extracted from the handler's body. The Pydantic
-# field comes from ``inspect.getsource`` + a regex against the canonical
-# ``parse_body(h, body, SomeRequest)`` shape — see
+# field comes from ``inspect.getsource`` + an AST walk for the
+# ``parse_body(h, body, SomeRequest)`` call — see
 # ``code-quality.md`` § "HTTP request bodies — use pydantic.BaseModel".
 #
 # Frontends and the CLI's ``routes`` command both consume this to build
 # self-documenting indexes — keep the response shape stable.
 
-_PARSE_BODY_RE = re.compile(
-    # Match ``parse_body(h, body, ModelClass)`` and the
-    # ``parse_body(h, body or {}, ModelClass)`` variant used by route
-    # handlers whose body may be empty.
-    r"parse_body\s*\(\s*[A-Za-z_][\w]*\s*,\s*[^,]+?\s*,\s*"
-    r"([A-Za-z_][\w]*)\s*\)"
-)
-
-
 def _extract_request_model(fn: object) -> str | None:
     """Pull the Pydantic ``*Request`` model name from a POST handler.
 
-    Returns the class name found in the first ``parse_body(h, body, X)``
-    call inside the handler's source, or None if the handler doesn't
-    use Pydantic.
+    Walks the handler's AST and returns the class name of the first
+    ``parse_body(h, body, X)`` call (third positional argument). Returns
+    ``None`` if the handler doesn't use ``parse_body`` or if the source
+    is unavailable (e.g. .pyc-only deploys).
+
+    Uses the same AST-walk pattern as ``tests/test_pydantic_route_audit.py
+    ::_handler_uses_parse_body`` — no regex brittleness on non-canonical
+    arg shapes.
     """
     if not callable(fn):
         return None
+    import ast
     import inspect
     try:
         source = inspect.getsource(fn)  # type: ignore[arg-type]
     except (OSError, TypeError):
         return None
-    m = _PARSE_BODY_RE.search(source)
-    return m.group(1) if m else None
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if isinstance(target, ast.Name) and target.id == "parse_body":
+            pass
+        elif isinstance(target, ast.Attribute) and target.attr == "parse_body":
+            pass
+        else:
+            continue
+        # Third positional arg is the Pydantic model class.
+        if len(node.args) < 3:
+            continue
+        cls_arg = node.args[2]
+        if isinstance(cls_arg, ast.Name):
+            return cls_arg.id
+        if isinstance(cls_arg, ast.Attribute):
+            return cls_arg.attr
+    return None
 
 
 def get_api_index(h, params: dict[str, list[str]]) -> None:
@@ -2754,7 +2783,11 @@ GET_DESCRIPTIONS: dict[str, str] = {
     ),
     "/api/triage/list": (
         "Cohort triage listing — filter by unfindable category, "
-        "field-quality reason, or search-not-converting state."
+        "field-quality field/status/reason, or search-not-converting "
+        "state. ``data_quality:status=<status>`` filters on the "
+        "resolver-status column (e.g. unresolved_4xx_client); "
+        "``data_quality:reason=<code>`` filters on the reason_code "
+        "column (e.g. http_400)."
     ),
 }
 POST_DESCRIPTIONS: dict[str, str] = {

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -2549,7 +2549,104 @@ def get_triage_list(
     h._json(payload)
 
 
+# --- U18 step 2: /api/_index — self-documenting API surface ----------------
+#
+# Walks ``web.server.Handler``'s merged dispatch tables and emits one row per
+# registered route: path/pattern, method, description, and the Pydantic
+# ``*Request`` model name extracted from the handler's body. The Pydantic
+# field comes from ``inspect.getsource`` + a regex against the canonical
+# ``parse_body(h, body, SomeRequest)`` shape — see
+# ``code-quality.md`` § "HTTP request bodies — use pydantic.BaseModel".
+#
+# Frontends and the CLI's ``routes`` command both consume this to build
+# self-documenting indexes — keep the response shape stable.
+
+_PARSE_BODY_RE = re.compile(
+    # Match ``parse_body(h, body, ModelClass)`` and the
+    # ``parse_body(h, body or {}, ModelClass)`` variant used by route
+    # handlers whose body may be empty.
+    r"parse_body\s*\(\s*[A-Za-z_][\w]*\s*,\s*[^,]+?\s*,\s*"
+    r"([A-Za-z_][\w]*)\s*\)"
+)
+
+
+def _extract_request_model(fn: object) -> str | None:
+    """Pull the Pydantic ``*Request`` model name from a POST handler.
+
+    Returns the class name found in the first ``parse_body(h, body, X)``
+    call inside the handler's source, or None if the handler doesn't
+    use Pydantic.
+    """
+    if not callable(fn):
+        return None
+    import inspect
+    try:
+        source = inspect.getsource(fn)  # type: ignore[arg-type]
+    except (OSError, TypeError):
+        return None
+    m = _PARSE_BODY_RE.search(source)
+    return m.group(1) if m else None
+
+
+def get_api_index(h, params: dict[str, list[str]]) -> None:
+    """``GET /api/_index`` — self-documenting API surface.
+
+    Returns a list of ``{method, path, description, request_model}`` rows
+    sorted by ``(method, path)``. ``path`` is the registered string for
+    static routes and the compiled regex pattern for pattern routes.
+    ``request_model`` is the Pydantic model name for POST handlers that
+    use ``parse_body``; null otherwise.
+    """
+    from web import server as srv
+
+    entries: list[dict[str, object]] = []
+
+    for path, fn in srv.Handler._FUNC_GET_ROUTES.items():
+        entries.append({
+            "method": "GET",
+            "path": path,
+            "description": srv.Handler._FUNC_GET_DESCRIPTIONS.get(path, ""),
+            "request_model": None,
+        })
+
+    get_pattern_desc_by_str = {
+        p.pattern: d
+        for p, d in srv.Handler._FUNC_GET_PATTERN_DESCRIPTIONS
+    }
+    for pattern, _fn in srv.Handler._FUNC_GET_PATTERNS:
+        entries.append({
+            "method": "GET",
+            "path": pattern.pattern,
+            "description": get_pattern_desc_by_str.get(pattern.pattern, ""),
+            "request_model": None,
+        })
+
+    for path, fn in srv.Handler._FUNC_POST_ROUTES.items():
+        entries.append({
+            "method": "POST",
+            "path": path,
+            "description": srv.Handler._FUNC_POST_DESCRIPTIONS.get(path, ""),
+            "request_model": _extract_request_model(fn),
+        })
+
+    post_pattern_desc_by_str = {
+        p.pattern: d
+        for p, d in srv.Handler._FUNC_POST_PATTERN_DESCRIPTIONS
+    }
+    for pattern, fn in srv.Handler._FUNC_POST_PATTERNS:
+        entries.append({
+            "method": "POST",
+            "path": pattern.pattern,
+            "description": post_pattern_desc_by_str.get(pattern.pattern, ""),
+            "request_model": _extract_request_model(fn),
+        })
+
+    entries.sort(key=lambda e: (str(e["method"]), str(e["path"])))
+    h._json(entries)
+
+
 GET_ROUTES: dict[str, object] = {
+    "/api/_index": get_api_index,
     "/api/pipeline/log": get_pipeline_log,
     "/api/pipeline/status": get_pipeline_status,
     "/api/pipeline/recent": get_pipeline_recent,
@@ -2608,18 +2705,123 @@ POST_PATTERNS: list[tuple[re.Pattern[str], object]] = [
 
 # Human-readable descriptions for the route index (U18). Parallel to the
 # GET_ROUTES / GET_PATTERNS / POST_ROUTES / POST_PATTERNS dispatch tables
-# above. Populated incrementally; empty entries are intentional until U18
-# step 2.
+# above.
 GET_DESCRIPTIONS: dict[str, str] = {
+    "/api/_index": (
+        "Self-documenting API surface — every route's path, method, "
+        "description, and Pydantic request model."
+    ),
+    "/api/pipeline/log": (
+        "Recent download_log rows with per-row classification badges + "
+        "rolling found-search counts."
+    ),
+    "/api/pipeline/status": (
+        "Status counts + the first 50 wanted requests for the dashboard."
+    ),
+    "/api/pipeline/recent": (
+        "Recently updated pipeline requests with beets / pipeline / "
+        "download-history enrichment."
+    ),
+    "/api/pipeline/all": (
+        "All pipeline requests bucketed by status; latest download "
+        "history attached per row. include_replaced=true opts in to "
+        "frozen audit rows."
+    ),
+    "/api/pipeline/downloading": (
+        "Pipeline requests currently in the downloading status."
+    ),
+    "/api/pipeline/dashboard": (
+        "Operational metrics for the dashboard subtab (searches, "
+        "cycles, redis)."
+    ),
+    "/api/pipeline/constants": (
+        "Decision tree structure + thresholds for the Decisions diagram."
+    ),
+    "/api/pipeline/simulate": (
+        "Run the full pipeline decision with query-string inputs "
+        "(simulator)."
+    ),
+    "/api/import-jobs": (
+        "Recent import-queue jobs filtered by status / request_id."
+    ),
+    "/api/import-jobs/timeline": (
+        "Recent import-queue jobs with request metadata attached "
+        "(timeline view)."
+    ),
+    "/api/pipeline/active-rgs": (
+        "Distinct release-group IDs held by any non-replaced request "
+        "(Replace-button enable set)."
+    ),
     "/api/triage/list": (
         "Cohort triage listing — filter by unfindable category, "
         "field-quality reason, or search-not-converting state."
     ),
 }
-POST_DESCRIPTIONS: dict[str, str] = {}
+POST_DESCRIPTIONS: dict[str, str] = {
+    "/api/pipeline/add": (
+        "Add a new pipeline request by MB or Discogs release id."
+    ),
+    "/api/pipeline/update": (
+        "Change the status of a pipeline request."
+    ),
+    "/api/pipeline/upgrade": (
+        "Queue an upgrade search for a release (lossless tiers, MB / "
+        "Discogs aware)."
+    ),
+    "/api/pipeline/set-quality": (
+        "Set a request's min_bitrate and/or status."
+    ),
+    "/api/pipeline/set-intent": (
+        "Toggle lossless-on-disk intent for a request."
+    ),
+    "/api/pipeline/ban-source": (
+        "Mark a rip as bad: denylist the uploader, hash + bad-byte "
+        "ripple-stop, and remove from beets."
+    ),
+    "/api/pipeline/force-import": (
+        "Enqueue a force-import job for a rejected download_log row."
+    ),
+    "/api/pipeline/delete": (
+        "Delete a pipeline request (blocked when a superseding "
+        "request exists)."
+    ),
+}
 PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/api/beets-distance/(\d+)/([a-f0-9-]{36})$"),
+     "Real beets match distance for one (download_log_id, mbid) pair; "
+     "refuses cross-release-group comparisons."),
+    (re.compile(r"^/api/pipeline/(\d+)$"),
+     "Full pipeline request detail — tracks, download history, last "
+     "search, beets tracks if present."),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan$"),
+     "Read-only view of a request's persisted search plan (cursor, "
+     "items, provenance, per-slot stats)."),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/dry-run$"),
+     "Generator simulator — runs generate_search_plan against the "
+     "current snapshot without writing."),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/saturation$"),
+     "Saturation rate + pre-filter skip total over a recent search_log "
+     "window for this request."),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/history$"),
+     "Cursor-paginated read of one request's search_log rows."),
+    (re.compile(r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$"),
+     "Non-replaced album_requests rows sharing the given release "
+     "group, id-descending."),
+    (re.compile(r"^/api/import-jobs/(\d+)$"),
+     "Single import-job detail by job id."),
     (re.compile(r"^/api/triage/(\d+)$"),
      "Per-request triage composition — unfindable categorisation, "
      "field-resolution telemetry, search-log forensics."),
 ]
-POST_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []
+POST_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/regenerate$"),
+     "Regenerate the search plan for a request."),
+    (re.compile(r"^/api/pipeline/(\d+)/search-plan/advance$"),
+     "Forward-only operator advance of the search-plan cursor "
+     "(by ordinal or strategy prefix)."),
+    (re.compile(r"^/api/pipeline/(\d+)/replace$"),
+     "Supersede the source request with a new row at a different "
+     "MBID in the same release group."),
+    (re.compile(r"^/api/pipeline/(\d+)/resolve-rg$"),
+     "Lazy-backfill mb_release_group_id for a legacy request row."),
+]

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -2428,3 +2428,12 @@ POST_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/pipeline/(\d+)/resolve-rg$"),
      post_pipeline_resolve_rg),
 ]
+
+# Human-readable descriptions for the route index (U18). Parallel to the
+# GET_ROUTES / GET_PATTERNS / POST_ROUTES / POST_PATTERNS dispatch tables
+# above. Populated incrementally; empty entries are intentional until U18
+# step 2.
+GET_DESCRIPTIONS: dict[str, str] = {}
+POST_DESCRIPTIONS: dict[str, str] = {}
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []
+POST_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -2374,6 +2374,181 @@ def get_beets_distance(
     h._json(payload, status=status)
 
 
+# --- U17: /api/triage HTTP endpoints --------------------------------------
+#
+# Two HTTP routes wrap the U15 triage service (``lib.triage_service``):
+#
+#   * ``GET /api/triage/<id>`` — per-request composition. Mirrors
+#     ``pipeline-cli triage show <id>`` (U16). Outcome → status:
+#       - 200: ``TriageResult`` payload (msgspec.to_builtins).
+#       - 400: non-int request id (h._error default).
+#       - 404: request_id has no album_requests row.
+#
+#   * ``GET /api/triage/list`` — cohort listing. Mirrors
+#     ``pipeline-cli triage list --filter=<spec>`` (U16). Outcome →
+#     status:
+#       - 200: ``{results, next_after, page_size, filter}`` payload.
+#       - 400: ``InvalidFilterError`` or non-int ``limit``/``after``.
+#
+# Both surfaces route through the same service entrypoints
+# (``compose_triage_for_request`` / ``list_triage``) so the CLI ⇄ API
+# symmetry rule holds — see ``CLAUDE.md`` § "CLI ⇄ API surface symmetry".
+
+# Filter forms surfaced in the 400 body so operators can self-correct
+# without leaving the network response. Kept narrow to mirror the CLI's
+# ``_TRIAGE_VALID_FILTER_FORMS`` (the API echoes machine-parseable
+# tokens; the CLI's prose-form parenthetical lives only in CLI help).
+_TRIAGE_VALID_FILTER_FORMS_API: tuple[str, ...] = (
+    "all",
+    "unfindable",
+    "unfindable:<category>",
+    "data_quality",
+    "data_quality:<field>",
+    "data_quality:reason=<code>",
+    "search_not_converting",
+)
+
+# Page-size bounds for ``GET /api/triage/list``. Mirrors the convention
+# established by ``get_pipeline_search_plan_history`` (1..200): a hard
+# upper bound prevents an unbounded scan; the lower bound rules out the
+# nonsense ``limit=0`` request shape.
+_TRIAGE_LIST_MIN_LIMIT = 1
+_TRIAGE_LIST_MAX_LIMIT = 200
+_TRIAGE_LIST_DEFAULT_LIMIT = 50
+
+
+def get_triage_for_request(
+    h, params: dict[str, list[str]], req_id_str: str,
+) -> None:
+    """U17: ``GET /api/triage/<id>``.
+
+    Compose the per-request triage payload via
+    ``lib.triage_service.compose_triage_for_request``. The response
+    body is ``msgspec.to_builtins(TriageResult)`` — the JSON shape on
+    the wire IS the Struct shape verbatim, which is what makes
+    ``msgspec.convert(payload, type=TriageResult)`` round-trip on the
+    consumer side (frontend or CLI parity tests).
+
+    Status-code mapping (mirrors ``cmd_triage_show``'s exit codes):
+      * 200 — composition success.
+      * 400 — non-int request id (caught here; the service never sees
+              garbage).
+      * 404 — ``compose_triage_for_request`` returned ``None`` (no row).
+    """
+    from lib.triage_service import compose_triage_for_request
+
+    try:
+        request_id = int(req_id_str)
+    except (TypeError, ValueError):
+        h._error("Invalid request id")
+        return
+
+    db = _server()._db()
+    result = compose_triage_for_request(request_id, db)
+    if result is None:
+        h._json(
+            {"error": "Not found", "request_id": request_id},
+            status=404,
+        )
+        return
+
+    payload = msgspec.to_builtins(result)
+    h._json(payload)
+
+
+def get_triage_list(
+    h, params: dict[str, list[str]],
+) -> None:
+    """U17: ``GET /api/triage/list``.
+
+    Cohort-filtered triage listing. Query string:
+      * ``filter`` — filter spec (default ``"all"``). Forms documented
+        in ``_TRIAGE_VALID_FILTER_FORMS_API`` and ``lib.triage_service
+        .parse_filter``.
+      * ``limit`` — int in ``[_TRIAGE_LIST_MIN_LIMIT,
+        _TRIAGE_LIST_MAX_LIMIT]``; defaults to
+        ``_TRIAGE_LIST_DEFAULT_LIMIT``.
+      * ``after`` — int >= 1; the ``next_after`` cursor from the
+        previous page. Omit for the first page.
+
+    Response shape (success):
+        ``{"results": [...], "next_after": <int|null>,
+           "page_size": <int>, "filter": <spec str>}``
+
+    ``next_after`` is ``None`` when ``len(results) < page_size`` (the
+    page exhausts the cohort); otherwise the last request id so
+    operators can keep paging.
+
+    Status-code mapping (mirrors ``cmd_triage_list``'s exit codes):
+      * 200 — success (empty results list is a valid cohort state).
+      * 400 — ``InvalidFilterError`` (parser rejects the spec) OR
+              non-int ``limit`` / ``after`` / out-of-range ``limit``.
+    """
+    from lib.triage_service import InvalidFilterError, list_triage
+
+    filter_spec = params.get("filter", ["all"])[0]
+    if filter_spec == "":
+        filter_spec = "all"
+
+    limit_raw = params.get("limit", [None])[0]
+    if limit_raw is None or limit_raw == "":
+        limit = _TRIAGE_LIST_DEFAULT_LIMIT
+    else:
+        try:
+            limit = int(limit_raw)
+        except (TypeError, ValueError):
+            h._error("limit must be an integer")
+            return
+    if not (_TRIAGE_LIST_MIN_LIMIT <= limit <= _TRIAGE_LIST_MAX_LIMIT):
+        h._error(
+            f"limit must be in [{_TRIAGE_LIST_MIN_LIMIT}, "
+            f"{_TRIAGE_LIST_MAX_LIMIT}]",
+            status=400,
+        )
+        return
+
+    after_raw = params.get("after", [None])[0]
+    after: int | None
+    if after_raw is None or after_raw == "":
+        after = None
+    else:
+        try:
+            after = int(after_raw)
+        except (TypeError, ValueError):
+            h._error("after must be an integer")
+            return
+        if after < 1:
+            h._error("after must be >= 1", status=400)
+            return
+
+    db = _server()._db()
+    try:
+        results = list_triage(
+            filter_spec, db, page_size=limit, after_request_id=after,
+        )
+    except InvalidFilterError as exc:
+        h._json(
+            {
+                "error": str(exc),
+                "valid_filters": list(_TRIAGE_VALID_FILTER_FORMS_API),
+            },
+            status=400,
+        )
+        return
+
+    next_after: int | None = None
+    if len(results) >= limit and results:
+        next_after = results[-1].request_meta.id
+
+    payload: dict[str, object] = {
+        "results": [msgspec.to_builtins(r) for r in results],
+        "next_after": next_after,
+        "page_size": limit,
+        "filter": filter_spec,
+    }
+    h._json(payload)
+
+
 GET_ROUTES: dict[str, object] = {
     "/api/pipeline/log": get_pipeline_log,
     "/api/pipeline/status": get_pipeline_status,
@@ -2386,6 +2561,7 @@ GET_ROUTES: dict[str, object] = {
     "/api/import-jobs": get_import_jobs,
     "/api/import-jobs/timeline": get_import_jobs_timeline,
     "/api/pipeline/active-rgs": get_pipeline_active_rgs,
+    "/api/triage/list": get_triage_list,
 }
 
 GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
@@ -2405,6 +2581,7 @@ GET_PATTERNS: list[tuple[re.Pattern[str], object]] = [
     (re.compile(r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$"),
      get_pipeline_requests_by_rg),
     (re.compile(r"^/api/import-jobs/(\d+)$"), get_import_job),
+    (re.compile(r"^/api/triage/(\d+)$"), get_triage_for_request),
 ]
 
 POST_ROUTES: dict[str, object] = {
@@ -2433,7 +2610,16 @@ POST_PATTERNS: list[tuple[re.Pattern[str], object]] = [
 # GET_ROUTES / GET_PATTERNS / POST_ROUTES / POST_PATTERNS dispatch tables
 # above. Populated incrementally; empty entries are intentional until U18
 # step 2.
-GET_DESCRIPTIONS: dict[str, str] = {}
+GET_DESCRIPTIONS: dict[str, str] = {
+    "/api/triage/list": (
+        "Cohort triage listing — filter by unfindable category, "
+        "field-quality reason, or search-not-converting state."
+    ),
+}
 POST_DESCRIPTIONS: dict[str, str] = {}
-PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []
+PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/api/triage/(\d+)$"),
+     "Per-request triage composition — unfindable categorisation, "
+     "field-resolution telemetry, search-log forensics."),
+]
 POST_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = []

--- a/web/server.py
+++ b/web/server.py
@@ -239,6 +239,35 @@ class Handler(BaseHTTPRequestHandler):
         *getattr(_pipeline_routes, "POST_PATTERNS", []),
     ]
 
+    # Description tables (U18): human-readable strings for the route index,
+    # mirroring the dispatch-table merge above. Each route module exports
+    # parallel `*_DESCRIPTIONS` dicts/lists that start empty and are
+    # populated incrementally. Empty until U18 step 2.
+    _FUNC_GET_DESCRIPTIONS: dict[str, str] = {
+        **_browse_routes.GET_DESCRIPTIONS,
+        **_labels_routes.GET_DESCRIPTIONS,
+        **_pipeline_routes.GET_DESCRIPTIONS,
+        **_library_routes.GET_DESCRIPTIONS,
+        **_imports_routes.GET_DESCRIPTIONS,
+    }
+
+    _FUNC_POST_DESCRIPTIONS: dict[str, str] = {
+        **_pipeline_routes.POST_DESCRIPTIONS,
+        **_library_routes.POST_DESCRIPTIONS,
+        **_imports_routes.POST_DESCRIPTIONS,
+    }
+
+    _FUNC_GET_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+        *_browse_routes.PATTERN_DESCRIPTIONS,
+        *_labels_routes.PATTERN_DESCRIPTIONS,
+        *_pipeline_routes.PATTERN_DESCRIPTIONS,
+        *_library_routes.PATTERN_DESCRIPTIONS,
+    ]
+
+    _FUNC_POST_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
+        *getattr(_pipeline_routes, "POST_PATTERN_DESCRIPTIONS", []),
+    ]
+
     def log_message(self, format: str, *args: object) -> None:  # noqa: A002
         log.info(format % args)
 


### PR DESCRIPTION
## Summary

PR4 of [issue #369](https://github.com/abl030/cratedigger/issues/369) (search-plan iteration 2). Ships the operator surface for the data domains PR1-PR3 already wrote:

- **Triage subsystem** (U15-U17) — one composable service layer + CLI + HTTP wrapper combining unfindable categorisation (PR3), field-resolution telemetry (PR1), and search-log forensics (PR3) behind a single typed `TriageResult: msgspec.Struct`. Filter syntax includes `data_quality:reason=<reason_code>` so operators can target the #374 sticky `unresolved_4xx_client` cohort directly.
- **API discoverability** (U18) — `/api/_index` + `pipeline-cli routes` self-document every route and CLI subcommand. `TestRouteContractAudit` now requires a one-line description on every registered route — future drift fails CI.

Closes PR4 of #369. Bundles the cohort-query scope of #374 (operator actions like `triage replace` / `triage skip` are deferred — read-only triage is what PR4 owes).

## What's in each unit

| Unit | Surface | What it ships |
|------|---------|---------------|
| U15 | `lib/triage_service.py` | `TriageResult` Struct tree (5 nested Structs) + `compose_triage_for_request` + `list_triage` with mandatory N+1 mitigation (4 bulk queries at page_size=50, guarded by a fake-DB call-count assertion) + filter parser supporting `all`, `unfindable[:cat]`, `data_quality[:field]`, `data_quality:reason=<code>` (#374), `search_not_converting`. Service-first pattern per `docs/solutions/architecture/service-first-then-glue.md` — typed Struct, Protocol-based DB seam, real-service tests against `FakePipelineDB`. |
| U16 | `pipeline-cli triage show <id>` + `triage list --filter=…` | Wrappers around U15. Exit codes 0/2/3 (success / not_found / invalid_filter). `--json` emits the same `msgspec` shape as U17's API for CLI ⇄ API parity. |
| U17 | `GET /api/triage/<id>` + `GET /api/triage/list?filter=…` | Wrappers around U15. Status codes 200/400/404. `next_after` keyset cursor in list responses. Routes register with descriptions from day one via U18 step 1's mechanism. |
| U18 step 1 | `web/routes/*` description dicts + `web/server.py` merge tables | Parallel `GET_DESCRIPTIONS` / `POST_DESCRIPTIONS` / `PATTERN_DESCRIPTIONS` per module, merged into `Handler._FUNC_*_DESCRIPTIONS` mirroring the existing dispatch-table block. |
| U18 step 2-3 | `GET /api/_index` + `pipeline-cli routes` + 62 backfilled descriptions + tightened audit | `/api/_index` walks dispatch tables + Pydantic request-model introspection (18/19 POST routes). `pipeline-cli routes` walks the argparse subparser tree, bypasses DB construction so it's usable without Postgres reachability. `TestRouteContractAudit::test_every_registered_route_has_a_description` fails per-bucket with a specific list of missing routes. |

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 3861 tests pass, 0 failures, no new skips. Pre-flight JS syntax + JS unit tests + vulture dead-code sweep all clean.
- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings on the full repo.
- [x] Vulture dead-code sweep clean (no new findings; whitelist updated for U15's public exports).
- [x] N+1 guard test: 50-request seed → `list_triage` makes ≤5 DB queries (assertion enforces 4 actual + 1 headroom).
- [x] Audit smoke test: temporarily removed `/api/search` description → audit fails with `GET routes missing descriptions: ['/api/search']`. Restored.
- [x] CLI ⇄ API parity: `pipeline-cli triage show <id> --json` and `GET /api/triage/<id>` return the same `msgspec.to_builtins(TriageResult)` shape.
- [x] Production-shape mocks (datetime, nested Structs, not dicts) per `docs/solutions/testing/contract-test-mocks-must-mirror-production-shape.md`.
- [ ] Operator smoke after deploy: `curl https://music.ablz.au/api/_index | jq` returns the route inventory.
- [ ] Operator smoke after deploy: `pipeline-cli triage list --filter=data_quality:reason=unresolved_4xx_client` returns the 75 sticky-4xx requests (#374).

## Deploy notes

`cratedigger-web.service` restarts on `nixos-rebuild switch`; the 5-min `cratedigger.service` timer is unaffected (no behavior change to the search loop). No new migration files — every schema dependency landed in PR1's 027–032 sequence.

## Operator workflow once deployed

```bash
# Query the #374 sticky-4xx cohort
pipeline-cli triage list --filter=data_quality:reason=unresolved_4xx_client

# Inspect one request's triage envelope (unfindable + field-quality + search forensics)
pipeline-cli triage show 1868

# Discover the full HTTP surface from a fresh shell
curl https://music.ablz.au/api/_index | jq '.[] | select(.method == "GET")'

# Discover the full CLI surface
pipeline-cli routes --json | jq '.[] | select(.subcommand | startswith("triage"))'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)