### PR TITLE
fix(youtube-ingest): remux bestaudio to an importer-recognized container

### DIFF
--- a/scripts/youtube_ingest_worker.py
+++ b/scripts/youtube_ingest_worker.py
@@ -234,12 +234,23 @@ def _build_ytdlp_argv(
     ``ens19`` → pfSense WireGuard, so YouTube egress is VPN-routed while
     the worker's DB/control traffic stays on the main NIC. ``None`` leaves
     the argv unchanged (default-route egress).
+
+    ``--remux-video`` does a lossless container remux so the staged files
+    land in a container the importer recognizes: YouTube Music ``bestaudio``
+    is opus-in-webm (``.webm``) or aac-in-mp4, and the importer's
+    audio-extension set accepts neither (it would measure ``empty_fileset``
+    and reject). ``--remux-video`` is stream-copy only — it fails rather
+    than re-encoding if the codec is incompatible with the target container
+    — so ``webm``(opus)→``.opus`` and ``mp4``(aac)→``.m4a`` are guaranteed
+    lossless. ``.m4a`` / ``.mp3`` / ``.opus`` match no rule and pass through
+    untouched. Requires ffmpeg on PATH (the systemd unit provides it).
     """
     argv = [
         ytdlp_bin,
         "--ignore-config",
         "--no-ignore-errors",
         "-f", "bestaudio",
+        "--remux-video", "webm>opus/mp4>m4a",
         "--output", output_template,
     ]
     if source_address:

--- a/tests/test_youtube_ingest_worker.py
+++ b/tests/test_youtube_ingest_worker.py
@@ -368,6 +368,23 @@ class TestYtdlpArgvShape(unittest.TestCase):
         idx = argv.index("-f")
         self.assertEqual(argv[idx + 1], "bestaudio")
 
+    def test_remux_video_webm_to_opus(self) -> None:
+        # YouTube Music bestaudio is opus-in-webm (.webm) / aac-in-mp4,
+        # neither of which the importer's audio-extension set recognizes
+        # (it sees them as empty_fileset). --remux-video is stream-copy only
+        # (fails rather than re-encoding), so webm(opus)->.opus and
+        # mp4(aac)->.m4a are lossless container changes the importer accepts.
+        argv = worker._build_ytdlp_argv(
+            ytdlp_bin="/usr/bin/yt-dlp",
+            url="https://music.youtube.com/playlist?list=FAKE",
+            output_template="/tmp/out/%(title)s.%(ext)s",
+        )
+        self.assertIn("--remux-video", argv)
+        self.assertEqual(
+            argv[argv.index("--remux-video") + 1], "webm>opus/mp4>m4a")
+        # Still a postprocessor flag, so it precedes the '--' separator.
+        self.assertLess(argv.index("--remux-video"), argv.index("--"))
+
     def test_source_address_absent_by_default(self) -> None:
         # When no source address is configured the argv is unchanged — the
         # worker egresses on the host's default route (no VPN binding).


### PR DESCRIPTION
## Summary

First live YouTube rescue (Gelbison EP) revealed the staging→import handoff silently fails: the worker's yt-dlp succeeded (`youtube_success`, 5 tracks) but the importer rejected the staged album as `empty_fileset`.

Root cause: YouTube Music `bestaudio` is **opus-in-webm** (itag 251, confirmed via `yt-dlp -F`). The importer's audio-extension set (`lib/measurement.py:AUDIO_EXTS`, `lib/quality.py:AUDIO_EXTENSIONS`, `lib/quality_evidence.py:_AUDIO_EXTENSIONS`) doesn't include `.webm`/`.mp4`, so it measured 0 audio files → `empty_fileset` → reject. The worker's own gate set *did* include `.webm`, so the two sides disagreed and the handoff failed quietly.

Fix: add `--remux-video webm>opus/mp4>m4a` to the worker's yt-dlp argv. `--remux-video` is stream-copy only (it fails rather than re-encoding if the codec is incompatible with the target container), so:
- `webm`(opus) → `.opus` — lossless
- `mp4`(aac) → `.m4a` — lossless
- `.m4a` / `.mp3` / `.opus` — match no rule, pass through untouched

This closes exactly the gap between the worker's gate set and the importer's recognized set, with no transcoding. ffmpeg is already on the worker unit's PATH.

## Verification

- Live: `yt-dlp -f bestaudio --remux-video "webm>opus"` on the Gelbison playlist → `.opus` (ogg/opus), `ffprobe codec_name=opus`, 365.7s duration preserved (= source).
- `pyright` 0 errors; `bash scripts/run_tests.sh` 4221 passed.

## Test plan

- [x] argv regression test asserts `--remux-video webm>opus/mp4>m4a` present, before `--`
- [ ] Live: re-run the Gelbison rescue and confirm it imports to beets with `rescued_at` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)