### PR TITLE
fix(youtube-ingest): embed YouTube metadata so the beets match converges

### DIFF
--- a/scripts/youtube_ingest_worker.py
+++ b/scripts/youtube_ingest_worker.py
@@ -244,6 +244,14 @@ def _build_ytdlp_argv(
     — so ``webm``(opus)→``.opus`` and ``mp4``(aac)→``.m4a`` are guaranteed
     lossless. ``.m4a`` / ``.mp3`` / ``.opus`` match no rule and pass through
     untouched. Requires ffmpeg on PATH (the systemd unit provides it).
+
+    ``--embed-metadata`` writes YouTube Music's title / artist / album /
+    date into the file tags during the same ffmpeg pass. Without it the
+    staged audio is untagged and the import-time beets match (pinned to the
+    release via ``--search-id``) falls back to filename + track-length
+    similarity, scoring well above the 0.15 auto-import threshold. The
+    embedded tags only serve the match — beets rewrites canonical
+    release tags on import.
     """
     argv = [
         ytdlp_bin,
@@ -251,6 +259,7 @@ def _build_ytdlp_argv(
         "--no-ignore-errors",
         "-f", "bestaudio",
         "--remux-video", "webm>opus/mp4>m4a",
+        "--embed-metadata",
         "--output", output_template,
     ]
     if source_address:

--- a/tests/test_youtube_ingest_worker.py
+++ b/tests/test_youtube_ingest_worker.py
@@ -385,6 +385,17 @@ class TestYtdlpArgvShape(unittest.TestCase):
         # Still a postprocessor flag, so it precedes the '--' separator.
         self.assertLess(argv.index("--remux-video"), argv.index("--"))
 
+    def test_embed_metadata_present(self) -> None:
+        # Without embedded tags the import-time beets match falls back to
+        # filename/length similarity and exceeds the 0.15 auto-import gate.
+        argv = worker._build_ytdlp_argv(
+            ytdlp_bin="/usr/bin/yt-dlp",
+            url="https://music.youtube.com/playlist?list=FAKE",
+            output_template="/tmp/out/%(title)s.%(ext)s",
+        )
+        self.assertIn("--embed-metadata", argv)
+        self.assertLess(argv.index("--embed-metadata"), argv.index("--"))
+
     def test_source_address_absent_by_default(self) -> None:
         # When no source address is configured the argv is unchanged — the
         # worker egresses on the host's default route (no VPN binding).


### PR DESCRIPTION
## Summary

Follow-up to the remux fix (#389). With the container fixed, a live Gelbison rescue got to the beets match but rejected at `high_distance` (0.4504 > 0.15) because the staged `.opus` files had **no tags** — beets fell back to filename + track-length similarity.

Add `--embed-metadata` to the worker's yt-dlp argv. yt-dlp writes YouTube Music's title/artist/album/date into the file tags during the same ffmpeg pass as the remux. Verified live: `ffprobe` on the staged `.opus` shows per-track `TITLE` + `ALBUM=Gelbison` + `ARTIST`. The tags only serve the match; beets rewrites canonical release tags on import (`--search-id` pins the release).

## Verification

- Live: `yt-dlp -f bestaudio --remux-video webm>opus --embed-metadata` → Opus Vorbis comments with correct title/album/artist.
- `pyright` 0 errors; `bash scripts/run_tests.sh` 4222 passed.

## Test plan

- [x] argv test asserts `--embed-metadata` present, before `--`
- [ ] Live: re-run the Gelbison rescue → distance < 0.15 → imports, `rescued_at` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)