### PR TITLE
fix(import): force/manual guard rejects self-heal to wanted without deleting the source

### DIFF
--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -159,59 +159,154 @@ def _expected_request_track_count(db: "PipelineDB", request_id: int) -> int | No
     return len(tracks)
 
 
+def _guard_reject(
+    db: "PipelineDB",
+    *,
+    request_id: int,
+    failed_path: str,
+    source_username: str | None,
+    detail: str,
+    scenario: str,
+) -> DispatchOutcome:
+    """Reject a force/manual import at the manifest guard.
+
+    The request self-heals back to ``wanted`` (R20): the *album* is still
+    wanted — only this particular source folder is unimportable. Writes the
+    mandatory ``download_log`` audit row and bumps the validation attempt
+    counter via the shared importer rejection writer
+    (``_record_rejection_and_maybe_requeue``). The flip is idempotent when
+    the request is already ``wanted`` (the common case for a Wrong Matches
+    force-import) and recovers a ``downloading``/``manual`` row otherwise.
+
+    The audit row carries no ``validation_result.failed_path``, so it never
+    becomes a *new* Wrong Matches entry (``get_wrong_matches`` keys on that
+    JSONB field).
+
+    Always returns ``DISPATCH_CODE_IMPORT_MANIFEST_REJECTED`` so the importer
+    worker (``scripts/importer.py::_cleanup_failed_force_import``) PRESERVES
+    the operator's source folder — that path skips cleanup on any code other
+    than ``QUALITY_PIPELINE_REJECTED``, and for a FORCE job
+    ``QUALITY_PIPELINE_REJECTED`` runs ``delete_wrong_match`` →
+    ``shutil.rmtree`` (``lib/wrong_matches.py``). The guard only ever sees a
+    *non-empty* folder (an empty source returns ``None`` from the caller and
+    self-heals through the evidence pipeline's ``empty_fileset`` early-exit
+    instead), so deleting here would always destroy real audio the operator
+    chose to import — the irreversible auto-decision the archivist frame
+    forbids. Wrong-match-folder deletion is reserved for the genuinely-empty
+    (0-file) case, which routes through the evidence pipeline, not this guard.
+
+    No denylist write either — a manifest mismatch reflects the operator's
+    folder choice, not the peer's quality (mirrors ``nested_layout``).
+    """
+    logger.error("IMPORT GUARD REJECT (%s): path=%s %s", scenario, failed_path, detail)
+    _record_rejection_and_maybe_requeue(
+        db,
+        request_id,
+        DownloadInfo(username=source_username),
+        distance=0.0,
+        scenario=scenario,
+        detail=detail,
+        error=None,
+        requeue=True,
+        outcome_label="rejected",
+        staged_path=failed_path,
+    )
+    return DispatchOutcome(
+        success=False,
+        message=detail,
+        code=DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
+    )
+
+
 def _guard_force_manual_audio_manifest(
     db: "PipelineDB",
     *,
     request_id: int,
     failed_path: str,
     download_log_id: int | None,
+    source_username: str | None,
 ) -> DispatchOutcome | None:
-    """Block force/manual import if the source contains unowned audio."""
+    """Reconcile the staged source against its validated audio reference.
+
+    Outcomes, keyed on whether the source has *extra*, *matching*, or
+    *missing* audio relative to the reference (origin manifest, else request
+    track count). Every reject self-heals the request to ``wanted`` (R20) and
+    PRESERVES the operator's source folder (see ``_guard_reject``); they
+    differ only in the audit ``scenario`` label.
+
+    * **PROCEED** (``None``) — on-disk audio matches the reference, OR the
+      source is empty (0 audio files). An empty source flows through to the
+      canonical ``empty_fileset`` early-exit in
+      ``full_pipeline_decision_from_evidence`` (or a requeue-to-preview when
+      evidence isn't ready) — either way the request keeps searching, and the
+      (empty) folder cleanup is owned there. The guard does NOT own the
+      ``empty_fileset`` decision; that lives in ONE place (see CLAUDE.md
+      § "Quality decisions live in ONE place").
+    * **INCOMPLETE** (``incomplete_fileset``) — the source is *missing* audio
+      (under-count or manifest subset, no extras) but still has real files on
+      disk. Self-heal + keep the folder for review.
+    * **EXTRA / UNVERIFIABLE** (``untracked_audio`` / ``unverifiable_source``)
+      — the source carries *extra* untracked audio, or there is no reference
+      at all for a non-empty source. Self-heal + keep the folder; passing it
+      to beets would import unowned files, so the operator must review it.
+    """
     expected_count = _expected_request_track_count(db, request_id)
     manifest = _origin_manifest_for_download_log(
         db,
         download_log_id=download_log_id,
         failed_path=failed_path,
     )
+    actual_audio = audio_relative_paths(failed_path)
+
+    def incomplete(detail: str) -> DispatchOutcome:
+        return _guard_reject(
+            db, request_id=request_id, failed_path=failed_path,
+            source_username=source_username, detail=detail,
+            scenario="incomplete_fileset")
+
+    def extra(detail: str, *, scenario: str = "untracked_audio") -> DispatchOutcome:
+        return _guard_reject(
+            db, request_id=request_id, failed_path=failed_path,
+            source_username=source_username, detail=detail,
+            scenario=scenario)
+
+    # Empty source: the canonical empty_fileset early-exit in the evidence
+    # pipeline self-heals this. Returning None lets the import flow reach it.
+    if not actual_audio:
+        return None
+
     if manifest:
         if expected_count is not None and len(manifest) != expected_count:
-            detail = (
+            if len(manifest) > expected_count:
+                return extra(
+                    "Origin validation manifest has "
+                    f"{len(manifest)} audio files but the request expects "
+                    f"{expected_count}; refusing force/manual import")
+            return incomplete(
                 "Origin validation manifest has "
                 f"{len(manifest)} audio files but the request expects "
-                f"{expected_count}; refusing force/manual import"
-            )
-            logger.error("IMPORT MANIFEST REJECTED: path=%s %s", failed_path, detail)
-            return DispatchOutcome(
-                success=False,
-                message=detail,
-                code=DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
-            )
+                f"{expected_count}; source is missing audio")
         check = check_audio_manifest(failed_path, manifest)
         if check.ok:
             return None
-        detail = (
-            "Force/manual import source does not match the original selected "
-            f"audio manifest: {check.detail()}"
-        )
-        logger.error("IMPORT MANIFEST REJECTED: path=%s %s", failed_path, detail)
-        return DispatchOutcome(
-            success=False,
-            message=detail,
-            code=DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
-        )
+        if check.extra_audio:
+            return extra(
+                "Force/manual import source does not match the original "
+                f"selected audio manifest: {check.detail()}")
+        # Only missing audio — the source is a strict subset of the manifest.
+        return incomplete(
+            "Force/manual import source is missing validated audio: "
+            f"{check.detail()}")
 
     if expected_count is None:
-        detail = (
+        # Non-empty source with no manifest and no track rows: we cannot
+        # verify the folder is owned, so fail closed against beets and keep
+        # it for review.
+        return extra(
             "Force/manual import requires either an origin audio manifest or "
-            "request track rows; refusing to pass an unowned folder to beets"
-        )
-        logger.error("IMPORT MANIFEST REJECTED: path=%s %s", failed_path, detail)
-        return DispatchOutcome(
-            success=False,
-            message=detail,
-            code=DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
-        )
-    actual_audio = audio_relative_paths(failed_path)
+            "request track rows; refusing to pass an unowned folder to beets",
+            scenario="unverifiable_source")
+
     if len(actual_audio) == expected_count:
         return None
     detail = (
@@ -219,12 +314,10 @@ def _guard_force_manual_audio_manifest(
         f"{len(actual_audio)} audio files but the request expects "
         f"{expected_count}; source audio: {', '.join(actual_audio)}"
     )
-    logger.error("IMPORT MANIFEST REJECTED: path=%s %s", failed_path, detail)
-    return DispatchOutcome(
-        success=False,
-        message=detail,
-        code=DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
-    )
+    if len(actual_audio) > expected_count:
+        return extra(detail)
+    # Under-count — fewer audio files than the request expects.
+    return incomplete(detail)
 
 
 def _should_cleanup_path(scenario: str, action: "DispatchAction") -> bool:
@@ -2381,6 +2474,7 @@ def _dispatch_import_from_db_locked(
         request_id=request_id,
         failed_path=failed_path,
         download_log_id=download_log_id,
+        source_username=source_username,
     )
     if manifest_reject is not None:
         return manifest_reject

--- a/tests/test_import_manifest.py
+++ b/tests/test_import_manifest.py
@@ -133,8 +133,18 @@ class TestForceImportManifestGuard(unittest.TestCase):
             )
 
         self.assertFalse(outcome.success)
+        # Extra/untracked audio: keep the Wrong Matches entry for operator
+        # review (the importer skips cleanup on this code).
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("12 Wash.opus", outcome.message)
+        # R20: the album is still wanted — only this source is contaminated.
+        # The request self-heals to wanted (idempotent here) + an audit row is
+        # written, but the WM entry is preserved (code above).
+        self.assertEqual(db.request(42)["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "untracked_audio"), outcomes)
+        # Operator's folder choice, not the peer's fault — never denylist.
+        self.assertEqual(len(db.denylist), 0)
 
     def test_force_import_rejects_origin_manifest_with_extra_items(self):
         db = FakePipelineDB()
@@ -172,6 +182,10 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("manifest has 2 audio files", outcome.message)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "untracked_audio"), outcomes)
+        self.assertEqual(len(db.denylist), 0)
 
     def test_force_import_without_origin_manifest_rejects_track_count_mismatch(self):
         db = FakePipelineDB()
@@ -201,8 +215,16 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("3 audio files", outcome.message)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "untracked_audio"), outcomes)
+        self.assertEqual(len(db.denylist), 0)
 
-    def test_manual_import_without_manifest_or_tracks_fails_closed(self):
+    def test_manual_import_without_manifest_or_tracks_keeps_wm_and_self_heals(self):
+        """No manifest and no track rows for a non-empty source: we can't
+        verify the folder, so it fails closed against beets AND keeps the
+        Wrong Matches entry for review — but the request still self-heals to
+        ``wanted`` (R20), the album is still wanted."""
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42,
@@ -224,3 +246,92 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("requires either an origin audio manifest", outcome.message)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "unverifiable_source"), outcomes)
+        self.assertEqual(len(db.denylist), 0)
+
+    def test_undercount_without_manifest_self_heals_to_wanted(self):
+        """Issue #387: an under-count source (fewer audio files than the
+        request expects, no extra files) is a missing-audio integrity fault.
+        The guard self-heals the request back to ``wanted`` (R20) rather than
+        stall it, but still returns ``IMPORT_MANIFEST_REJECTED`` so the
+        importer PRESERVES the operator's partial audio (it is not 'nothing
+        to inspect' — there are real files on disk)."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-123",
+            status="manual",
+        ))
+        db.set_tracks(42, [
+            {"track_number": 1, "title": "One"},
+            {"track_number": 2, "title": "Two"},
+        ])
+
+        with tempfile.TemporaryDirectory() as root:
+            open(os.path.join(root, "01.mp3"), "wb").close()
+
+            outcome = dispatch_import_from_db(
+                cast(Any, db),
+                request_id=42,
+                failed_path=root,
+                force=False,
+                import_job_id=99,
+            )
+
+        self.assertFalse(outcome.success)
+        # Preserve-folder code (importer skips deletion) — a non-empty source
+        # must never route through the rmtree-ing QUALITY_PIPELINE_REJECTED.
+        self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "incomplete_fileset"), outcomes)
+        # Missing audio is not the peer's fault — never denylist.
+        self.assertEqual(len(db.denylist), 0)
+
+    def test_manifest_subset_self_heals_to_wanted(self):
+        """Issue #387: the on-disk folder is a strict subset of the validated
+        origin manifest (some validated tracks went missing, no extra audio).
+        Missing audio → self-heal + preserve the folder, not the
+        untracked-audio framing."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-123",
+            status="manual",
+        ))
+        db.set_tracks(42, [
+            {"track_number": 1, "title": "One"},
+            {"track_number": 2, "title": "Two"},
+        ])
+
+        with tempfile.TemporaryDirectory() as root:
+            open(os.path.join(root, "01.mp3"), "wb").close()
+            log_id = db.log_download(
+                42,
+                outcome="rejected",
+                validation_result={
+                    "failed_path": root,
+                    "items": [
+                        {"path": os.path.join(root, "01.mp3")},
+                        {"path": os.path.join(root, "02.mp3")},
+                    ],
+                },
+            )
+
+            outcome = dispatch_import_from_db(
+                cast(Any, db),
+                request_id=42,
+                failed_path=root,
+                force=True,
+                import_job_id=99,
+                download_log_id=log_id,
+            )
+
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "incomplete_fileset"), outcomes)
+        self.assertEqual(len(db.denylist), 0)

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -687,6 +687,139 @@ class TestImporterWorker(unittest.TestCase):
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
+    def test_force_import_extra_audio_keeps_wm_and_self_heals_end_to_end(self):
+        """Issue #387 composition: force-importing a folder with extra audio,
+        through the REAL manifest guard (no mocked dispatch).
+
+        Proves the two halves compose: the guard self-heals the request to
+        ``wanted`` (R20) AND its audit row does NOT inflate Wrong Matches,
+        while the importer preserves the original WM entry for review (the
+        ``IMPORT_MANIFEST_REJECTED`` code skips cleanup). beets never runs —
+        the guard rejects upstream of it.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            with open(os.path.join(source, "bonus.mp3"), "wb") as f:
+                f.write(b"audio")
+            db.seed_request(make_request_row(
+                id=42,
+                mb_release_id="mbid-123",
+                status="manual",
+            ))
+            # One expected track but two audio files on disk → extra audio.
+            db.set_tracks(42, [{"track_number": 1, "title": "One"}])
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            self._mark_importable(db, job)
+            claimed = db.claim_next_import_job(worker_id="worker")
+            assert claimed is not None
+
+            # No dispatch patch — the real guard runs. beets is never reached.
+            updated = importer.process_claimed_job(cast(Any, db), claimed)
+
+            assert updated is not None
+            self.assertEqual(updated.status, "failed")
+            # R20: the album is still wanted; the request self-heals.
+            self.assertEqual(db.request(42)["status"], "wanted")
+            # The dead WM entry is preserved (extra audio → operator review),
+            # and the audit row did NOT create a second entry.
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            self.assertTrue(os.path.isdir(source))
+            outcomes = [
+                (log.outcome, log.beets_scenario) for log in db.download_logs
+            ]
+            self.assertIn(("rejected", "untracked_audio"), outcomes)
+            cleanup = self._result(updated)["cleanup"]
+            self.assertTrue(cleanup["skipped"])
+            self.assertEqual(len(db.denylist), 0)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_force_import_undercount_preserves_folder_and_self_heals_end_to_end(self):
+        """Issue #387 regression: force-importing an UNDER-COUNT folder (fewer
+        audio files than the request's track rows, no extras) must NOT delete
+        the operator's partial audio.
+
+        An under-count source physically contains audio the operator chose to
+        import — it is not 'nothing to inspect'. The guard self-heals the
+        request to ``wanted`` (R20) but returns ``IMPORT_MANIFEST_REJECTED``
+        so the importer PRESERVES the folder (``_cleanup_failed_force_import``
+        skips deletion on that code). Routing it through
+        ``QUALITY_PIPELINE_REJECTED`` would ``shutil.rmtree`` the only
+        surviving copy — the exact irreversible auto-decision the archivist
+        frame forbids. Wrong-match deletion is reserved for the genuinely
+        empty (0-file) case, which routes through the evidence pipeline, not
+        this guard.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            # One disc on disk; the request expects two tracks → under-count.
+            with open(os.path.join(source, "01.mp3"), "wb") as f:
+                f.write(b"audio")
+            db.seed_request(make_request_row(
+                id=42,
+                mb_release_id="mbid-123",
+                status="manual",
+            ))
+            db.set_tracks(42, [
+                {"track_number": 1, "title": "One"},
+                {"track_number": 2, "title": "Two"},
+            ])
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            self._mark_importable(db, job)
+            claimed = db.claim_next_import_job(worker_id="worker")
+            assert claimed is not None
+
+            updated = importer.process_claimed_job(cast(Any, db), claimed)
+
+            assert updated is not None
+            self.assertEqual(updated.status, "failed")
+            # THE regression assertion: the operator's partial audio survives.
+            self.assertTrue(
+                os.path.isdir(source),
+                "under-count force-import must NOT delete the operator's folder")
+            self.assertTrue(os.path.isfile(os.path.join(source, "01.mp3")))
+            # R20: the album is still wanted; the request self-heals.
+            self.assertEqual(db.request(42)["status"], "wanted")
+            # WM entry preserved (something to inspect), no duplicate.
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            outcomes = [
+                (log.outcome, log.beets_scenario) for log in db.download_logs
+            ]
+            self.assertIn(("rejected", "incomplete_fileset"), outcomes)
+            cleanup = self._result(updated)["cleanup"]
+            self.assertTrue(cleanup["skipped"])
+            self.assertEqual(len(db.denylist), 0)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
     def test_force_import_requeued_for_preview_does_not_mark_failed(self):
         """U2: when dispatch returns DISPATCH_CODE_REQUEUED_FOR_PREVIEW the
         importer does NOT write a terminal failed status and does NOT run

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -6094,19 +6094,15 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         # — denylisting the peer would be unfair.
         self.assertEqual(len(db.denylist), 0)
 
-    def test_empty_fileset_force_manual_rejected_by_untracked_audio_guard(self):
-        """KNOWN REGRESSION — issue #387.
+    def test_empty_fileset_evidence_routes_through_self_heal(self):
+        """AE4 (issue #387): an empty source (0 audio files) with no request
+        track rows must self-heal, not stick.
 
-        An empty source (0 audio files) is hard-rejected by the
-        untracked-audio guard (``_guard_force_manual_audio_manifest``)
-        before the evidence-based ``empty_fileset`` decision runs, so the
-        request does NOT self-heal to ``wanted`` even though ``empty_fileset``
-        is a documented "always self-heal" integrity fact (R20).
-
-        This test pins the CURRENT (buggy) behavior so the suite stays
-        green. When #387 is fixed, restore the original assertions:
-        ``status == "wanted"`` and a ``("rejected", "empty_fileset")``
-        download_log row.
+        The untracked-audio guard no longer hard-rejects an empty source —
+        it returns None so the import reaches the canonical ``empty_fileset``
+        early-exit in ``full_pipeline_decision_from_evidence``, which
+        self-heals the request back to ``wanted`` (R20). ``empty_fileset``
+        is a documented "always self-heal" integrity fact.
         """
         db = FakePipelineDB()
         cfg = self._common_cfg()
@@ -6137,11 +6133,61 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
             )
 
         self.assertFalse(result.success)
-        # The untracked-audio guard owns the rejection (not the evidence path).
-        self.assertIn("audio manifest or request track rows", result.message or "")
+        self.assertIn("empty_fileset", result.message or "")
         self.assertEqual(ext.run.call_count, 0)
-        # BUG (#387): no self-heal — the request stays out of the search loop.
-        self.assertEqual(db.request(44)["status"], "manual")
+        row = db.request(44)
+        self.assertEqual(row["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "empty_fileset"), outcomes)
+        # empty_fileset is a missing-audio fault, not a peer-quality problem —
+        # denylisting the peer would be unfair.
+        self.assertEqual(len(db.denylist), 0)
+
+    def test_empty_fileset_with_track_rows_routes_through_self_heal(self):
+        """AE4 (issue #387): the auto-import shape — a ``source='request'``
+        row that DOES carry track rows but stages 0 audio files.
+
+        Previously the guard rejected with "source has 0 audio files but
+        expects N" before the evidence decision ran, stalling the request.
+        Now the empty source flows to the canonical ``empty_fileset``
+        self-heal regardless of track rows.
+        """
+        db = FakePipelineDB()
+        cfg = self._common_cfg()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+            db.seed_request(make_request_row(
+                id=46, status="manual", mb_release_id="mbid-u6-empty-tracks",
+            ))
+            db.set_tracks(46, [{"track_number": 1, "title": "Track"}])
+            job = db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=46,
+                payload=manual_import_payload(failed_path=tmpdir),
+            )
+            self._wire_candidate(
+                db, job.id,
+                self._build_candidate_evidence(
+                    owner_id=job.id,
+                    files=[],
+                    audio_file_count=0,
+                    folder_layout="flat",
+                ),
+            )
+            self._wire_current(db, 46, self._build_current_evidence(owner_id=46))
+
+            result, ext = self._drive_dispatch(
+                db, request_id=46, tmpdir=tmpdir,
+                import_job_id=job.id, cfg=cfg,
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("empty_fileset", result.message or "")
+        self.assertEqual(ext.run.call_count, 0)
+        row = db.request(46)
+        self.assertEqual(row["status"], "wanted")
+        outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
+        self.assertIn(("rejected", "empty_fileset"), outcomes)
 
     def test_spectral_reject_evidence_routes_through_evidence_pipeline(self):
         """likely_transcode candidate spectral matches existing transcode


### PR DESCRIPTION
Closes #387.

## Problem

The untracked-audio guard (`_guard_force_manual_audio_manifest`) hard-rejected mismatched / empty / under-count force-manual import sources with a bare `return`, **skipping the self-heal**. An `empty_fileset`-class reject left the request stuck off `wanted` instead of returning it to the search loop — violating R20 ("the system never stops searching").

## Fix

Every guard reject now routes through one helper (`_guard_reject`) that:
- **self-heals the request to `wanted`** (idempotent when already wanted — the common Wrong Matches force-import case; recovers `downloading`/`manual` rows otherwise),
- **writes the mandatory `download_log` audit row** (the old hard-reject path wrote none) with no `validation_result.failed_path`, so it never spawns a duplicate Wrong Matches entry, and
- **always returns `IMPORT_MANIFEST_REJECTED`** so the importer **preserves the operator's source folder**.

An empty (0-file) source returns `None` and flows to the canonical `empty_fileset` early-exit in `full_pipeline_decision_from_evidence` — the guard doesn't own that decision (CLAUDE.md "quality decisions live in ONE place").

## The data-loss guard (caught by adversarial review)

An earlier iteration routed missing-audio rejects through `QUALITY_PIPELINE_REJECTED`. For a FORCE job that makes the importer call `delete_wrong_match` → `shutil.rmtree`. A non-empty under-count source (e.g. disc 1 of 2) physically contains audio the operator chose to import — deleting it is the exact irreversible auto-decision the archivist frame forbids. **The guard now never reaches the delete path**: every branch returns the preserve-folder code, so misclassification cannot delete. Folder deletion stays reserved for the genuinely-empty case (evidence pipeline).

## Tests
- Guard-unit: incomplete / manifest-subset / extra / unverifiable — all self-heal + preserve, `IMPORT_MANIFEST_REJECTED`.
- Two `empty_fileset` integration slices (0-file → evidence-pipeline self-heal).
- Two end-to-end `process_claimed_job` tests asserting the operator's folder **survives** both an extra-audio and an under-count force-import (the latter is the regression guard for the data-loss bug).

Full suite 4227 OK, pyright 0 errors, dead-code clean (verified locally — CI only runs GitGuardian).

🤖 Generated with [Claude Code](https://claude.com/claude-code)