### PR TITLE
test(fidelity): Layer 3 — adapter contract tests + lambda-audit (#382)

### DIFF
--- a/tests/_lambda_audit.py
+++ b/tests/_lambda_audit.py
@@ -1,0 +1,134 @@
+"""Shared scanner for the adapter-lambda audit (test-fidelity Rule B, #382).
+
+Isolated so ``test_lambda_audit.py`` and any future baseline helper share one
+source of truth for the heuristic — same arrangement as
+``tests/_mock_audit_scanner.py``.
+
+What it flags
+-------------
+The precise Rule-B smell: a **strict-raise** mirror-adapter kwarg bound to a
+lambda whose body is a bare ``None``, used to fake a not-found::
+
+    compute_beets_distance(..., mb_get_release=lambda mbid: None)   # FLAGGED
+
+Production ``web.mb.get_release`` / ``web.discogs.get_release`` (and the
+release-group / master listings) **raise** ``urllib.error.HTTPError`` on a
+404 — they never return ``None``. A ``lambda: None`` miss-fake therefore
+exercises a branch production cannot produce (round-1 P0 of the YT-resolver
+PR). New tests must use ``tests/fakes.py::FakeMBLookup`` /
+``FakeDiscogsLookup`` (``raises_on_404=True``) instead, so the fake mirrors
+the real exception contract pinned by ``tests/test_mirror_contracts.py``.
+
+Why it is deliberately NARROW (no false positives)
+--------------------------------------------------
+* Only the strict-raise adapters are scanned. The year lookups
+  (``mb_get_release_group_year`` / ``discogs_get_master_year``) and
+  ``resolve_failed_path`` legitimately return ``None`` on their documented
+  "record exists but no year" / "file not on disk" paths — ``: None`` there
+  is correct, not a violation.
+* Only a bare-``None`` lambda body is flagged. A lambda returning a
+  constructed payload is a happy-path stub, not a miss-fake, and is fine.
+
+Finding keys are ``relpath::enclosing_function`` — stable and line-number
+free, so the allowlist survives edits above the flagged line (mirrors the
+write-audit's name-keyed allowlist).
+"""
+from __future__ import annotations
+
+import ast
+import os
+from typing import Dict, List, Tuple
+
+TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
+
+# Mirror adapters whose production contract is "raise HTTPError on 404,
+# never return None". A bare-None lambda for one of these is the Rule-B
+# anti-pattern. Keep this set in lockstep with the contracts pinned in
+# tests/test_mirror_contracts.py.
+STRICT_RAISE_ADAPTER_KWARGS = frozenset({
+    "mb_get_release",
+    "mb_get_release_group_releases",
+    "discogs_get_release",
+    "discogs_get_master_releases",
+})
+
+# Grandfathered call sites: flagged-shape but benign. Each entry is
+# ``"<filename>::<enclosing_function>" -> rationale``. New violations must
+# either use the canonical fake or earn an entry here with a one-line
+# reason. Keep this list short; it is a tripwire, not a dumping ground.
+ALLOWLIST: Dict[str, str] = {
+    "test_beets_distance.py::test_mb_lookup_failed_when_returns_empty":
+        "benign: compute_beets_distance has an explicit `if release is None` "
+        "branch (-> mb_lookup_failed); the production exception path (real "
+        "adapter raises HTTPError) is separately covered by "
+        "test_mb_lookup_failed_on_exception.",
+    "test_beets_distance.py::test_mb_lookup_failed_in_override_path":
+        "benign: same explicit None branch on the items_override path; "
+        "exception path covered by test_mb_lookup_failed_on_exception.",
+}
+
+
+def _is_bare_none_lambda(node: ast.expr) -> bool:
+    """True for ``lambda ...: None`` (body is the literal ``None``)."""
+    return (
+        isinstance(node, ast.Lambda)
+        and isinstance(node.body, ast.Constant)
+        and node.body.value is None
+    )
+
+
+class _Visitor(ast.NodeVisitor):
+    """Collects ``(enclosing_function, lineno, kwarg)`` violations, tracking
+    the function stack so each finding gets a stable, line-free key."""
+
+    def __init__(self) -> None:
+        self._func_stack: List[str] = []
+        self.findings: List[Tuple[str, int, str]] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    # async defs are functions too.
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Call(self, node: ast.Call) -> None:
+        for kw in node.keywords:
+            if (
+                kw.arg in STRICT_RAISE_ADAPTER_KWARGS
+                and _is_bare_none_lambda(kw.value)
+            ):
+                func = self._func_stack[-1] if self._func_stack else "<module>"
+                self.findings.append((func, kw.value.lineno, kw.arg))
+        self.generic_visit(node)
+
+
+def scan_file(path: str) -> List[Tuple[str, int, str]]:
+    """Return ``[(enclosing_function, lineno, kwarg), ...]`` for one file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    visitor = _Visitor()
+    visitor.visit(tree)
+    return visitor.findings
+
+
+def scan_tree() -> Dict[str, List[Tuple[str, int, str]]]:
+    """Scan every ``tests/*.py`` and return non-allowlisted violations.
+
+    Result shape: ``{filename: [(enclosing_function, lineno, kwarg), ...]}``.
+    Allowlisted ``filename::function`` keys are filtered out.
+    """
+    out: Dict[str, List[Tuple[str, int, str]]] = {}
+    for name in sorted(os.listdir(TESTS_DIR)):
+        if not name.endswith(".py") or not name.startswith("test_"):
+            continue
+        path = os.path.join(TESTS_DIR, name)
+        kept = [
+            (func, lineno, kwarg)
+            for func, lineno, kwarg in scan_file(path)
+            if f"{name}::{func}" not in ALLOWLIST
+        ]
+        if kept:
+            out[name] = kept
+    return out

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -8,8 +8,10 @@ instead of MagicMock call shapes.
 from __future__ import annotations
 
 import copy
+import email.message
 import json
 import time
+import urllib.error
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
@@ -834,6 +836,128 @@ class FakeYTMusic:
             "tracks": copy.deepcopy(tracks),
             "other_versions": copy.deepcopy(other_versions or []),
         }
+
+
+# ---------------------------------------------------------------------------
+# Mirror-adapter lookup fakes (test-fidelity Rule B).
+#
+# ``web/mb.py::get_release`` and ``web/discogs.py::get_release`` RAISE
+# ``urllib.error.HTTPError(404)`` when the id is absent — they NEVER return
+# ``None``. A test that fakes a miss with ``lambda mbid: None`` simulates a
+# code path production never produces. This was the round-1 P0 of the
+# YT-resolver PR: ``_resolve_mb_group`` expected ``None`` on 404, the real
+# adapter raised, and every test used ``lambda: None`` so the production
+# crash never surfaced. These fakes mirror the real exception contract:
+# seed known releases; any un-seeded id raises ``HTTPError(404)`` by
+# default. See ``.claude/rules/test-fidelity.md`` § "Rule B".
+# ---------------------------------------------------------------------------
+
+
+def http_error(
+    code: int,
+    *,
+    url: str = "http://mirror.test/x",
+    msg: str | None = None,
+) -> urllib.error.HTTPError:
+    """Construct a real ``urllib.error.HTTPError`` for ``code``.
+
+    The canonical way to make a fake adapter raise exactly what the live
+    MB / Discogs mirror raises on a 4xx/5xx. ``HTTPError`` is a subclass
+    of ``urllib.error.URLError``, so callers that catch either type see it.
+    """
+    return urllib.error.HTTPError(
+        url, code, msg or f"HTTP {code}", email.message.Message(), None,
+    )
+
+
+class FakeMBLookup:
+    """Callable stand-in for ``web.mb.get_release`` with the REAL exception
+    contract.
+
+    Production ``web.mb.get_release(mbid)`` raises
+    ``urllib.error.HTTPError(code=404)`` for an absent MBID and returns a
+    slim release dict for a present one — it NEVER returns ``None``. Faking
+    a miss with ``lambda mbid: None`` is the test-fidelity Rule B
+    anti-pattern: it exercises a ``None`` branch production cannot reach
+    while hiding the exception branch production actually takes.
+
+    Usage::
+
+        mb = FakeMBLookup()
+        mb.set_release("rel-1", {"id": "rel-1", "title": "X", ...})
+        resolve(..., mb_get_release=mb)   # hit -> dict
+        # any other mbid -> raises HTTPError(404), exactly like production
+
+    Pass ``raises_on_404=False`` only to model an adapter variant that
+    genuinely returns ``None`` on miss (rare — document why at the call
+    site). Accepts the ``fresh=`` kwarg the production callable takes.
+    """
+
+    def __init__(
+        self,
+        releases: dict[str, dict[str, Any]] | None = None,
+        *,
+        raises_on_404: bool = True,
+    ) -> None:
+        self._releases: dict[str, dict[str, Any]] = dict(releases or {})
+        self._raises_on_404 = raises_on_404
+        self.calls: list[str] = []
+
+    def set_release(
+        self, identifier: str, payload: dict[str, Any],
+    ) -> "FakeMBLookup":
+        """Seed a hit for ``identifier``. Returns self for chaining."""
+        self._releases[identifier] = copy.deepcopy(payload)
+        return self
+
+    def __call__(
+        self, identifier: str, *, fresh: bool = False,
+    ) -> Optional[dict[str, Any]]:
+        self.calls.append(identifier)
+        if identifier in self._releases:
+            return copy.deepcopy(self._releases[identifier])
+        if self._raises_on_404:
+            raise http_error(404, url=f"http://mb.test/release/{identifier}")
+        return None
+
+
+class FakeDiscogsLookup:
+    """Callable stand-in for ``web.discogs.get_release`` with the REAL
+    exception contract — the Discogs analogue of :class:`FakeMBLookup`.
+
+    Production ``web.discogs.get_release(release_id)`` raises
+    ``urllib.error.HTTPError(404)`` for an absent id (the mirror's ``_get``
+    propagates ``urlopen``'s ``HTTPError`` directly — no retry) and never
+    returns ``None``.
+    """
+
+    def __init__(
+        self,
+        releases: dict[str, dict[str, Any]] | None = None,
+        *,
+        raises_on_404: bool = True,
+    ) -> None:
+        self._releases: dict[str, dict[str, Any]] = dict(releases or {})
+        self._raises_on_404 = raises_on_404
+        self.calls: list[str] = []
+
+    def set_release(
+        self, identifier: str, payload: dict[str, Any],
+    ) -> "FakeDiscogsLookup":
+        """Seed a hit for ``identifier``. Returns self for chaining."""
+        self._releases[identifier] = copy.deepcopy(payload)
+        return self
+
+    def __call__(
+        self, identifier: str, *, fresh: bool = False,
+    ) -> Optional[dict[str, Any]]:
+        self.calls.append(identifier)
+        if identifier in self._releases:
+            return copy.deepcopy(self._releases[identifier])
+        if self._raises_on_404:
+            raise http_error(
+                404, url=f"http://discogs.test/releases/{identifier}")
+        return None
 
 
 class FakePipelineDB:

--- a/tests/test_lambda_audit.py
+++ b/tests/test_lambda_audit.py
@@ -1,0 +1,71 @@
+"""Audit: ban bare-``None`` lambdas for strict-raise mirror adapters.
+
+Layer 3 of the test-fidelity hardening (#382). See
+``.claude/rules/test-fidelity.md`` § "Rule B — Fakes must mirror real-adapter
+exception contracts" and ``tests/_lambda_audit.py`` for the heuristic.
+
+Zero-tolerance, allowlist-grandfathered: any *new* ``mb_get_release=lambda
+…: None`` (or the other strict-raise adapters) anywhere under ``tests/``
+fails the audit. The real adapters raise ``urllib.error.HTTPError`` on 404 —
+fake the miss with ``tests/fakes.py::FakeMBLookup`` / ``FakeDiscogsLookup``
+(``raises_on_404=True``) so the test exercises the branch production actually
+takes. If a flagged site is genuinely benign (the consumer has an explicit
+``None`` branch), add it to ``_lambda_audit.ALLOWLIST`` with a one-line
+rationale.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _lambda_audit import ALLOWLIST, scan_file, scan_tree  # noqa: E402
+
+
+class TestAdapterLambdaAudit(unittest.TestCase):
+    def test_no_strict_raise_none_lambdas(self) -> None:
+        current = scan_tree()
+        if not current:
+            return
+        lines = []
+        for fname in sorted(current):
+            for func, lineno, kwarg in sorted(current[fname]):
+                lines.append(f"  - {fname}:{lineno} {func}: {kwarg}=lambda …: None")
+        self.fail(
+            "Adapter-lambda audit (test-fidelity Rule B). A strict-raise "
+            "mirror adapter is faked with `lambda …: None`, but production "
+            "raises urllib.error.HTTPError on 404 — the None branch is "
+            "unreachable in production.\nUse tests/fakes.py::FakeMBLookup / "
+            "FakeDiscogsLookup (raises_on_404=True), or — if the consumer has "
+            "a real None branch — allowlist it in _lambda_audit.ALLOWLIST "
+            "with a rationale.\n\n" + "\n".join(lines)
+        )
+
+    def test_allowlist_entries_still_match_real_sites(self) -> None:
+        """Catch stale allowlist entries — a grandfathered site that was
+        renamed, deleted, or migrated to the fake but left its row behind."""
+        live: set[str] = set()
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        for name in sorted(os.listdir(tests_dir)):
+            if not name.endswith(".py") or not name.startswith("test_"):
+                continue
+            for func, _lineno, _kwarg in scan_file(os.path.join(tests_dir, name)):
+                live.add(f"{name}::{func}")
+        stale = sorted(k for k in ALLOWLIST if k not in live)
+        self.assertEqual(
+            stale, [],
+            msg=(
+                "ALLOWLIST has entries that no longer match a flagged site — "
+                "delete them (the site was migrated to a fake, which is the "
+                "goal):\n  - " + "\n  - ".join(stale)
+            ),
+        )
+
+    def test_allowlist_rationales_are_non_empty(self) -> None:
+        empty = sorted(k for k, v in ALLOWLIST.items() if not v.strip())
+        self.assertEqual(empty, [], msg="ALLOWLIST entries need a rationale.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mirror_contracts.py
+++ b/tests/test_mirror_contracts.py
@@ -1,0 +1,206 @@
+"""Adapter contract tests — Layer 3 of test-fidelity hardening (#382).
+
+Documents and locks **what the real MB / Discogs mirror adapters raise**.
+Rule B (``.claude/rules/test-fidelity.md``) forbids fakes that are more
+permissive than production — but a fake can only mirror a contract that is
+itself pinned. These tests are that pin: they exercise the *real* adapter
+code in ``web/mb.py`` and ``web/discogs.py`` with the HTTP transport stubbed
+at the ``urllib.request.urlopen`` leaf seam, so they run fully offline and
+deterministically (no live mirror, no skip-gating — see CLAUDE.md
+§ "Skipped tests are an anti-pattern").
+
+The canonical fakes that consumers should use —
+``tests/fakes.py::FakeMBLookup`` / ``FakeDiscogsLookup`` — are asserted here
+to raise the SAME exception type the real adapter raises, closing the loop:
+if the production contract ever drifts (adapter starts returning ``None``
+on 404, say), the contract test fails and the fake is updated in lockstep.
+
+Round-1 P0 recap: ``_resolve_mb_group`` expected ``None`` on 404; the real
+``web.mb.get_release`` raises ``urllib.error.HTTPError``. Every resolver
+test used ``lambda m: None`` so the production crash never surfaced. The
+404-raises contract below is the one that bug violated.
+"""
+from __future__ import annotations
+
+import email.message
+import json
+import socket
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+import web.cache as _cache
+import web.discogs as discogs
+import web.mb as mb
+from tests.fakes import FakeDiscogsLookup, FakeMBLookup, http_error
+
+
+class _FakeResp:
+    """Minimal stand-in for the object ``urllib.request.urlopen`` yields:
+    a context manager whose ``.read()`` returns the response body bytes."""
+
+    def __init__(self, payload: object) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def _raise_http(code: int):
+    """An ``urlopen`` replacement that always raises ``HTTPError(code)``.
+
+    Always-raise (not one-shot) because ``web.mb._get`` retries once on a
+    ``URLError`` — and ``HTTPError`` is a ``URLError`` subclass — so the
+    transport is hit twice before the error escapes. The contract is that
+    it still escapes; a one-shot stub would mask the retry."""
+
+    def _urlopen(*_a: object, **_k: object):
+        raise urllib.error.HTTPError(
+            "http://mirror.test/x", code, f"HTTP {code}",
+            email.message.Message(), None,
+        )
+
+    return _urlopen
+
+
+def _raise_timeout():
+    """An ``urlopen`` replacement that always times out (the mirror's
+    documented transient-failure mode)."""
+
+    def _urlopen(*_a: object, **_k: object):
+        raise urllib.error.URLError(socket.timeout("timed out"))
+
+    return _urlopen
+
+
+def _return(payload: object):
+    """An ``urlopen`` replacement that returns ``payload`` as JSON body."""
+
+    def _urlopen(*_a: object, **_k: object) -> _FakeResp:
+        return _FakeResp(payload)
+
+    return _urlopen
+
+
+class _MirrorContractCase(unittest.TestCase):
+    """Base case: neutralise the Redis cache so ``memoize_meta`` always runs
+    the wrapped ``_fetch`` and never reaches a real Redis. ``meta_get`` /
+    ``meta_set`` are the thin Redis leaf-seam wrappers (allowed to patch)."""
+
+    def setUp(self) -> None:
+        get_p = patch.object(_cache, "meta_get", lambda *_a, **_k: None)
+        set_p = patch.object(_cache, "meta_set", lambda *_a, **_k: None)
+        get_p.start()
+        set_p.start()
+        self.addCleanup(get_p.stop)
+        self.addCleanup(set_p.stop)
+
+
+class TestMBAdapterContract(_MirrorContractCase):
+    def test_get_release_raises_HTTPError_on_404(self) -> None:
+        with patch("urllib.request.urlopen", _raise_http(404)):
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                mb.get_release("00000000-0000-0000-0000-000000000000")
+        self.assertEqual(ctx.exception.code, 404)
+
+    def test_get_release_raises_HTTPError_on_5xx(self) -> None:
+        with patch("urllib.request.urlopen", _raise_http(503)):
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                mb.get_release("00000000-0000-0000-0000-000000000000")
+        self.assertEqual(ctx.exception.code, 503)
+
+    def test_get_release_group_releases_raises_HTTPError_on_404(self) -> None:
+        with patch("urllib.request.urlopen", _raise_http(404)):
+            with self.assertRaises(urllib.error.HTTPError):
+                mb.get_release_group_releases(
+                    "00000000-0000-0000-0000-000000000000")
+
+    def test_transport_timeout_propagates(self) -> None:
+        """Timeouts surface as a URLError subclass — the field resolver
+        classifies these as transient, distinct from a 404."""
+        with patch("urllib.request.urlopen", _raise_timeout()):
+            with self.assertRaises(urllib.error.URLError):
+                mb.get_release("00000000-0000-0000-0000-000000000000")
+
+
+class TestMBReleaseGroupYearDualContract(_MirrorContractCase):
+    """The year lookup has a TWO-pronged contract the field resolver
+    depends on: 404 *raises* (``unresolved_404``, sticky) while
+    "record exists but no parseable year" *returns None*
+    (``unresolved_field_missing_upstream``). Conflating them — e.g. faking
+    a 404 with ``lambda: None`` — routes a missing MBID to the wrong
+    triage bucket. Both prongs are pinned here."""
+
+    def test_404_raises(self) -> None:
+        with patch("urllib.request.urlopen", _raise_http(404)):
+            with self.assertRaises(urllib.error.HTTPError):
+                mb.get_release_group_year(
+                    "00000000-0000-0000-0000-000000000000")
+
+    def test_exists_but_no_year_returns_none(self) -> None:
+        # A valid release-group record carrying no first-release-date.
+        with patch("urllib.request.urlopen",
+                   _return({"id": "rg-x", "title": "Untitled"})):
+            self.assertIsNone(
+                mb.get_release_group_year("rg-x"))
+
+
+class TestDiscogsAdapterContract(_MirrorContractCase):
+    def test_get_release_raises_HTTPError_on_404(self) -> None:
+        with patch("urllib.request.urlopen", _raise_http(404)):
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                discogs.get_release(99999999)
+        self.assertEqual(ctx.exception.code, 404)
+
+    def test_get_master_releases_raises_HTTPError_on_404(self) -> None:
+        with patch("urllib.request.urlopen", _raise_http(404)):
+            with self.assertRaises(urllib.error.HTTPError):
+                discogs.get_master_releases(99999999)
+
+
+class TestFakesMirrorTheRealContract(unittest.TestCase):
+    """The fakes in ``tests/fakes.py`` MUST raise the same exception type
+    the real adapters raise (asserted above), or Rule B's whole premise —
+    "the fake mirrors production" — is hollow."""
+
+    def test_fake_mb_lookup_raises_HTTPError_on_unseeded_id(self) -> None:
+        mb_fake = FakeMBLookup()
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            mb_fake("never-seeded")
+        self.assertEqual(ctx.exception.code, 404)
+
+    def test_fake_mb_lookup_returns_seeded_payload(self) -> None:
+        mb_fake = FakeMBLookup()
+        mb_fake.set_release("rel-1", {"id": "rel-1", "title": "X"})
+        self.assertEqual(mb_fake("rel-1"), {"id": "rel-1", "title": "X"})
+        self.assertEqual(mb_fake.calls, ["rel-1"])
+
+    def test_fake_discogs_lookup_raises_HTTPError_on_unseeded_id(self) -> None:
+        dc_fake = FakeDiscogsLookup()
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            dc_fake("404404")
+        self.assertEqual(ctx.exception.code, 404)
+
+    def test_fake_opt_out_returns_none_when_configured(self) -> None:
+        """The escape hatch for the rare adapter variant that genuinely
+        returns None on miss must still be available — documented at the
+        call site per the fake's docstring."""
+        mb_fake = FakeMBLookup(raises_on_404=False)
+        self.assertIsNone(mb_fake("missing"))
+
+    def test_http_error_factory_is_a_urlerror_subclass(self) -> None:
+        # HTTPError IS-A URLError — code catching either sees a 404.
+        err = http_error(404)
+        self.assertIsInstance(err, urllib.error.HTTPError)
+        self.assertIsInstance(err, urllib.error.URLError)
+        self.assertEqual(err.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Implements **Layer 3** of the three stronger-enforcement layers tracked in #382 (Layer 2 — the PipelineDB write audit — already shipped). This is the **Rule B** half of the test-fidelity hardening: *fakes must mirror real-adapter exception contracts.*

The round-1 P0 from the YT-resolver PR: `_resolve_mb_group` expected `None` on 404, but the real `web.mb.get_release` raises `urllib.error.HTTPError`. Every test used `lambda m: None`, so the production crash never surfaced. This PR makes that class of divergence detectable.

## Three pieces

1. **`tests/fakes.py` — canonical adapter fakes.** `FakeMBLookup` / `FakeDiscogsLookup` seed known releases and raise `urllib.error.HTTPError(404)` for any un-seeded id by default (they never return `None`), plus an `http_error(code)` factory. These are the stand-ins the shipped `.claude/rules/test-fidelity.md` § Rule B already names (`tests/fakes.py::FakeMBLookup`).

2. **`tests/test_mirror_contracts.py` — pins the real contracts.** Exercises the production code in `web/mb.py` + `web/discogs.py` with the HTTP transport stubbed at the `urllib.request.urlopen` leaf seam — **fully offline, no live mirror, no skip-gating** (honours CLAUDE.md § "Skipped tests are an anti-pattern"). Covers:
   - 404 / 5xx / timeout on `get_release`, `get_release_group_releases`, `get_master_releases`
   - the `get_release_group_year` **dual contract** (404 *raises* → `unresolved_404`; record-exists-but-no-year *returns None* → `unresolved_field_missing_upstream`) — the exact distinction the field resolver's triage buckets depend on
   - that the fakes raise the **same** exception type the real adapters raise (closes the loop)

3. **`tests/_lambda_audit.py` + `tests/test_lambda_audit.py` — zero-tolerance scanner.** Flags `<strict-raise-adapter>=lambda …: None` (the precise Rule-B smell). Deliberately **narrow** to avoid false positives: only the raise-on-404 adapters are scanned (the `*_year` lookups and `resolve_failed_path` legitimately return `None`), and only bare-`None` lambda bodies are flagged (success-payload stubs are fine). Two existing benign sites in `test_beets_distance.py` are grandfathered in a name-keyed allowlist with rationales (the consumer has an explicit `None` branch; the exception path is separately covered).

## Why not the literal `assertRaises` against the live mirror in #382's sketch

The issue's example (`web.mb.get_release(...)` hitting the real mirror) would depend on network + the MB mirror being up, which violates the self-contained-suite / no-skipped-tests rule. Stubbing `urlopen` runs the **same** adapter code deterministically and offline, and is strictly better — it can't rot when the mirror is down.

## Gates

- Full suite: **4243 tests OK**
- pyright: **0 errors**
- vulture: clean
- mock-audit + skip-audit: untripped

## Scope / sequencing

Part of the #382 + #379 effort. This is the file-disjoint, independent piece. Layer 1 (Struct-typed writes) follows the #379 decomposition so it lands in clean modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)