### PR TITLE
feat: Long-Tail Triage Console

### DIFF
--- a/docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md
+++ b/docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md
@@ -1,0 +1,360 @@
+---
+date: 2026-05-30
+topic: long-tail-triage-console
+---
+
+# Long-Tail Triage Console
+
+## Summary
+
+A new long-tail worklist under the Pipeline tab that opens on the `wanted` set, with
+quality-band filter tabs (`Missing`, `Transparent`, `Excellent`, …) and a search box.
+Selecting a release opens an action console that explains why the request is stuck —
+the unfindable buckets, the Soulseek peers actually seen and why each was rejected,
+which sibling pressings exist, and what YouTube Music has — and lets the operator act on
+it inline: rescue off YouTube, accept a sibling pressing, set quality intent, or
+re-search. This is the first consumer of three already-built backends (search-analytics
+/ triage, the YouTube resolver, and the YouTube rescue ingest API); no new pipeline
+behavior is introduced.
+
+---
+
+## Problem Frame
+
+The operator has built three backends — the triage / search-analytics surface, the
+YouTube Music resolver, and the YouTube rescue ingest API — but none of them has a UI
+consumer yet. They answer powerful per-request questions ("why can't we find this?",
+"what does YouTube Music have for this MBID?", "rescue it off YouTube") but only from the
+CLI or via raw HTTP. There is no place in the app where the operator can stand in front
+of the long tail as a *cohort* and work it down.
+
+And the long tail is real and measurable. Of 820 `wanted` requests, 391 currently carry
+an unfindable category and 454 already have a provisional copy on disk at some quality
+band — meaning more than half the `wanted` set is "have something, want better" rather
+than "have nothing." The operator's instinct is not to rank these on one forced ladder
+but to *select* a band — start with `Missing`, then climb the quality levels — and focus
+attention where it pays off most: the things that are missing or lowest-quality on disk.
+
+The pain is that answering "what's missing, and what can I do about each one" today means
+bouncing between CLI commands (`pipeline-cli triage show`, `youtube-album`,
+`youtube-rescue`), the pipeline detail panel, and the Replace picker — with no single
+surface that shows the evidence and offers the verbs in one place. The long-tail-rescue
+narrative this product is built around (a `wanted`-for-weeks request finally importing
+because the operator found it on YouTube Music and clicked rescue) has no front door.
+
+---
+
+## Key Decisions
+
+- **A cohort worklist, not a per-release popup.** The brainstorm started as "click any
+  release anywhere → popup explorer" and deliberately pivoted. Discoverability of the
+  long tail is a cohort problem — the operator wants to stand in front of "everything I
+  can't find" and triage it, not open one release at a time from scattered contexts. The
+  per-release explorer survives only as the in-place detail that expands when a row in
+  this view is selected.
+
+- **Scoped to the `wanted` set.** The view opens on the ~820 `wanted` requests, not the
+  ~3,500 `imported` "done" pile. This keeps it a focused worklist instead of a
+  whole-library health dashboard. The imported collection re-ranked by quality is a
+  separate, deferred idea.
+
+- **Quality bands are selectable filters, not a forced ranking.** Filter tabs across the
+  top — `Missing` plus the on-disk `QualityRank` bands — let the operator pick a band and
+  see only that cohort. `Missing` is the floor (a `wanted` request with nothing on disk);
+  the higher tabs are `wanted` requests whose best on-disk copy lands in that band but is
+  still open because the operator wants better.
+
+- **Action console, not a read-only lens.** Selecting a release shows the evidence *and*
+  the verbs inline. This is where all three backends finally pay off in one place — the
+  YouTube rescue button is only useful here. The operator accepted the larger build over
+  a read-only triage lens because reading-without-acting would just relocate the
+  CLI-bouncing problem into the UI.
+
+- **The quality gate does not block first acquisition; rescue needs no bar-drop.** The
+  gate is comparative (never replace a better copy with a worse one), not an absolute
+  floor applied to an empty slot. Per `docs/quality-ranks.md`, unconstrained Opus 128
+  classifies as `TRANSPARENT` (rank 60), which sits *above* the default `EXCELLENT` (rank
+  50) gate floor. A YouTube rescue therefore imports cleanly and lands in the
+  `Transparent` band — it needs no "lower the bar" step. This explicitly **corrects** the
+  assumption recorded in `docs/brainstorms/2026-05-28-youtube-rescue-ingest-api-requirements.md`
+  ("the default EXCELLENT gate rejects it … auto-import requires the operator to pre-lower
+  min_bitrate"), which was wrong.
+
+- **Evidence in, operator decides.** Every console action is operator-initiated and the
+  view never auto-substitutes a pressing or auto-rescues. This inherits the archivist
+  invariants (strict pressing identity; the system never auto-decides anything
+  irreversible; the system never stops searching).
+
+---
+
+## Actors
+
+- A1. Operator — opens the worklist, filters by band, searches, selects a release, and
+  fires console actions.
+- A2. Search-analytics / triage backend — supplies the per-request unfindable category,
+  field-resolution telemetry, and search forensics (which Soulseek peers were seen and
+  why each was rejected).
+- A3. YouTube resolver — supplies the (YT sibling × MB pressing) distance matrix for a
+  release group. Must have been run for a release group before a rescue is possible.
+- A4. YouTube rescue ingest — executes a rescue against an operator-chosen `browse_id`
+  from the resolver matrix.
+- A5. Importer worker — drains the resulting import and owns every grind-up / quality /
+  wrong-matches decision downstream. Unchanged by this work.
+
+---
+
+## Key Flows
+
+- F1. Open the worklist and triage by band
+  - **Trigger:** operator opens the long-tail sub-view under the Pipeline tab
+  - **Actors:** A1, A2
+  - **Steps:** the view loads the `wanted` set; band filter tabs are shown (`Missing` +
+    on-disk quality bands); operator selects a band and the list filters to that cohort
+  - **Outcome:** the operator sees only the cohort they want to work (e.g. everything
+    `Missing` on disk)
+  - **Covers:** R1, R2, R3, R4
+
+- F2. Find a specific release
+  - **Trigger:** operator types into the search box
+  - **Actors:** A1
+  - **Steps:** the list filters to releases matching the query within the current scope
+  - **Outcome:** the operator jumps straight to a known release without scrolling the
+    cohort
+  - **Covers:** R5
+
+- F3. Select a release — the console renders evidence
+  - **Trigger:** operator selects a row
+  - **Actors:** A1, A2, A3
+  - **Steps:** the row expands into the action console; the console shows the
+    band-appropriate evidence — for a `Missing` / unfindable item: the unfindable
+    bucket(s), the Soulseek peers actually seen and their rejection reasons, the sibling
+    pressings that exist, and (if resolved) the YouTube Music matrix; for an
+    on-disk-below-intent item: current band vs. intent plus what better is available
+  - **Outcome:** the operator understands *why* the item is where it is, in one place
+  - **Covers:** R6, R7, R8
+
+- F4. Rescue off YouTube (two-step)
+  - **Trigger:** operator wants the YouTube copy of a `Missing` item
+  - **Actors:** A1, A3, A4, A5
+  - **Steps:** if no resolver matrix is cached for the release group, the console offers a
+    "check YouTube" step that runs the resolver; the operator then picks a YT sibling from
+    the matrix and confirms rescue; the rescue ingest runs; on success the importer
+    imports it (clean, no bar-drop) and the item moves to the `Transparent` band
+  - **Outcome:** a long-tail item the operator could not find on Soulseek is imported from
+    YouTube Music
+  - **Covers:** R9, R10, R11, R12
+
+- F5. Accept a sibling pressing
+  - **Trigger:** the exact pressing is unfindable but a sibling is available, and the
+    operator chooses to accept it
+  - **Actors:** A1
+  - **Steps:** the operator picks an available sibling pressing from the console and
+    confirms; the request is replaced to point at the chosen pressing (the existing
+    Replace operator action)
+  - **Outcome:** the request re-sources against a pressing the network actually has, by
+    explicit operator choice — never an automatic substitution
+  - **Covers:** R13
+
+- F6. Set quality intent / re-search
+  - **Trigger:** operator wants to change how hard the system keeps grinding, or to kick a
+    search now
+  - **Actors:** A1
+  - **Steps:** the operator sets the request's quality intent (keep grinding toward
+    lossless, or accept the current band as the floor) and/or triggers an immediate
+    re-search from the console
+  - **Outcome:** the operator steers the watch loop without leaving the console
+  - **Covers:** R14, R15
+
+---
+
+## Requirements
+
+**The worklist view**
+
+- R1. A new sub-view exists under the Pipeline tab dedicated to the long tail. It is
+  reachable from the existing tab/sub-view navigation.
+- R2. The view's default scope is the `wanted` set. `imported`, `manual`, `downloading`,
+  and `replaced` requests are not part of this worklist.
+- R3. The view presents quality-band filter tabs: `Missing` plus each on-disk
+  `QualityRank` band present in the cohort. Selecting a tab filters the list to that
+  cohort. Bands are selectable filters, not a forced sort order.
+- R4. `Missing` means a `wanted` request with no acceptable audio on disk. Each on-disk
+  band means a `wanted` request whose current best on-disk copy classifies into that band
+  (still open because the operator wants better).
+- R5. The view has a search box that filters the current cohort to releases matching the
+  query (by artist / album).
+
+**The action console (release detail)**
+
+- R6. Selecting a release expands it in place into an action console (reusing the app's
+  existing in-place detail / modal substrate, not a new bespoke overlay paradigm).
+- R7. For a `Missing` / unfindable release, the console surfaces: the unfindable
+  category and its reason (the 4-bucket taxonomy), the Soulseek peers actually seen for
+  recent searches and why each was rejected, the sibling pressings that exist for the
+  release group, and — when the YouTube resolver has been run — the YouTube Music distance
+  matrix.
+- R8. For an on-disk-below-intent release, the console surfaces the current band versus
+  the operator's intent and what better is available (peers seen, sibling pressings,
+  YouTube). The console adapts its emphasis to the release's state rather than showing an
+  identical panel for every row.
+
+**Console actions**
+
+- R9. The console offers a YouTube rescue action for a release. When no resolver matrix
+  is cached for the release group, the console first offers a step that runs the resolver;
+  rescue is only offered against a resolver-supplied `browse_id`.
+- R10. The rescue action targets a specific operator-chosen YouTube sibling from the
+  matrix. The view never auto-picks a sibling.
+- R11. A YouTube rescue requires no quality-bar adjustment to import. The view must not
+  add a "lower the bar before rescue" step.
+- R12. After a successful rescue + import, the release reflects its new on-disk band
+  (e.g. moves into the `Transparent` tab). The long-tail-rescue audit (`rescued_at` +
+  `prior_unfindable_category`) is populated by the existing import path, not by this view.
+- R13. The console offers an "accept a sibling pressing" action that replaces the request
+  to target an operator-chosen available sibling, via the existing Replace operator
+  action. The choice is always explicit; no sibling is ever auto-substituted.
+- R14. The console offers a quality-intent control for the request (keep grinding toward
+  lossless vs. accept the current band as the floor).
+- R15. The console offers a re-search action that triggers a search for the request
+  without waiting for the next watch-loop cycle.
+
+**Surface symmetry**
+
+- R16. Any new backend list/filter or read surface introduced specifically for this view
+  follows the project's CLI ⇄ API symmetry convention. The console's mutating actions
+  (rescue, replace, set-intent, re-search) already have CLI counterparts and must continue
+  to route through the same service-layer methods rather than gaining a parallel path.
+
+---
+
+## Acceptance Examples
+
+- AE1. Covers R2, R3, R4. Given the worklist is open, when the operator selects the
+  `Missing` tab, the list shows only `wanted` requests with no acceptable audio on disk —
+  not `imported` albums and not `wanted` requests that already have an on-disk copy.
+
+- AE2. Covers R3, R4. Given the worklist is open, when the operator selects the
+  `Transparent` tab, the list shows only `wanted` requests whose current best on-disk copy
+  classifies as `Transparent` (the "have a decent copy, still want lossless" cohort).
+
+- AE3. Covers R6, R7. Given a `Missing` request that has been categorised
+  `wrong_pressing_available`, when the operator selects it, the console shows that category
+  and reason, the Soulseek peers seen with their rejection reasons, and the sibling
+  pressings that exist — making it obvious that the exact pressing is unavailable but a
+  sibling is.
+
+- AE4. Covers R9. Given a release whose release group has never been run through the
+  YouTube resolver, when the operator opens the console, the YouTube section offers a
+  "check YouTube" step rather than a one-click rescue. After the resolver runs, the matrix
+  of YT siblings is shown and each becomes a rescue target.
+
+- AE5. Covers R10, R11, R12. Given a 10-track `Missing` request whose release group is
+  resolved and has a matching YT sibling, when the operator picks that sibling and confirms
+  rescue, the rescue ingest runs and the album imports with no bar-drop step; afterward the
+  release appears under the `Transparent` tab.
+
+- AE6. Covers R13. Given a `Missing` request whose exact pressing is unfindable but a
+  sibling pressing exists, when the operator picks the sibling and confirms "accept this
+  pressing," the request is replaced to target the chosen sibling MBID and re-sources on
+  the next cycle. No substitution happens without that explicit confirmation.
+
+---
+
+## Scope Boundaries
+
+- The ~3,500 `imported` albums re-ranked by quality (a whole-collection health
+  dashboard) is deferred. This view is the `wanted` worklist only.
+- The original "click any release anywhere → popup explorer" framing is dropped. The
+  only detail surface this work adds is the in-place console that expands when a row in
+  this view is selected.
+- No new pipeline behavior. The three backends (triage / search analytics, resolver,
+  rescue ingest) and the importer are consumed as-is. The only possible backend addition
+  is a thin band-filterable `wanted` list surface if one does not already exist (see
+  Dependencies).
+- No "lower the quality bar before rescue" step — the gate does not block first
+  acquisition and Opus 128 is `Transparent`.
+- No automatic / background rescue. Rescue stays operator-initiated, consistent with the
+  rescue ingest API's own scope.
+- The watch loop is never throttled by this view. Surfacing the unfindable cohort is the
+  point; search cadence is unchanged.
+
+---
+
+## Dependencies / Assumptions
+
+- D1. The triage / search-analytics surface exists and supplies the console's evidence:
+  unfindable category, field-resolution telemetry, and search forensics (peers seen +
+  rejection reasons). See `lib/triage_service.py` and the `GET /api/triage/<id>` endpoint.
+- D2. The YouTube resolver exists (`GET /api/youtube-album`, `lib/youtube_album_service.py`)
+  and must be run for a release group before a rescue is possible — the rescue API rejects
+  submissions with no resolver mapping.
+- D3. The YouTube rescue ingest API exists (`POST /api/pipeline/<id>/youtube-rescue`,
+  `lib/youtube_ingest_service.py`) and is the only path the rescue action calls.
+- D4. The Replace operator action exists (`lib/mbid_replace_service.py`, the
+  `web/js/replace_picker.js` modal) and is the only path "accept a sibling pressing"
+  calls. Sibling enumeration is available via `GET /api/release-group/<rg>`.
+- D5. The `QualityRank` classifier and band table exist (`docs/quality-ranks.md`,
+  `lib/quality.py`). Per-request on-disk quality fields (`min_bitrate`,
+  `current_spectral_grade`, `current_spectral_bitrate`) already exist on `album_requests`,
+  so banding the `wanted` set is feasible from existing data.
+- D6. Whether a band-filterable `wanted` *list* endpoint already exists is unverified. The
+  raw quality fields are present per request, but a surface that returns the `wanted`
+  cohort filtered/grouped by computed band may be a thin new addition or a client-side
+  banding over the existing pipeline list. Planning verifies this against the codebase
+  early, since R3/R4 depend on it.
+- D7. Set-intent (the request `target_format` toggle) and re-search both have existing
+  operator surfaces; the exact CLI/web entry points are confirmed during planning.
+- D8. The existing in-place detail pattern and the Promise-based Replace-picker modal are
+  the UI substrate for the console; no generic modal primitive exists, so the console
+  follows the Replace-picker pattern.
+
+---
+
+## Outstanding Questions
+
+### Deferred to planning
+
+- Q1. [Affects R3, R4, R6] Does a band-filterable `wanted` list surface already exist, or
+  is banding done client-side over the existing pipeline list, or is a thin new endpoint
+  warranted? Verify against the codebase before building the view. If a new endpoint is
+  added, R16 (CLI ⇄ API symmetry) applies.
+- Q2. [Affects R3] Exact band tab set and whether each tab shows a live count of its
+  cohort. The band names come from `QualityRank`; whether to show counts is a UI call.
+- Q3. [Affects R1] Default band on open — show the whole `wanted` set with bands as
+  optional filters, or default to `Missing` first. The dialogue leaned toward "opens on
+  the `wanted` set, then click a band."
+- Q4. [Affects R15] The exact mechanism behind "re-search now" (trigger a cycle vs. a
+  search-plan advance/regenerate) and what feedback the console shows while it runs.
+- Q5. [Affects R6, R7, R8] Console layout — how the unfindable reason, the Soulseek
+  peers-seen list, the sibling pressings, and the YouTube matrix coexist without
+  overwhelming the panel, and how the panel adapts between the `Missing` and
+  on-disk-below-intent cases.
+
+---
+
+## Sources / Research
+
+- `docs/brainstorms/2026-05-27-youtube-music-album-resolver-requirements.md` — the
+  resolver this console drives (matrix shape, cache semantics, "surface evidence, decide
+  nothing").
+- `docs/brainstorms/2026-05-28-youtube-rescue-ingest-api-requirements.md` — the rescue
+  ingest API this console fires. Note: its stated gate assumption (EXCELLENT gate rejects
+  Opus 128, must pre-lower `min_bitrate`) is corrected by this brainstorm; see Key
+  Decisions.
+- `docs/quality-ranks.md` — the `QualityRank` band table. `TRANSPARENT` (60) > `EXCELLENT`
+  (50); `Opus 128+` → `TRANSPARENT`. Grounds both the band tabs and the no-bar-drop
+  decision.
+- Triage / unfindable subsystem — `lib/triage_service.py`, `lib/unfindable_detection_service.py`,
+  and the `CLAUDE.md` "Triage subsystem" / "Unfindable detection" entries. Supplies the
+  4-bucket taxonomy and search forensics the console renders.
+- Search forensics — `search_log.candidates` (top-20 peers seen, with filetype /
+  matched-tracks / avg-ratio), `search_log.rejection_reason`, and the
+  `request_search_summary` view. The raw material for "what's actually on the Soulseek
+  network for this album."
+- Existing UI substrate — `web/js/replace_picker.js` (the only reusable modal pattern),
+  the in-place `.p-detail` / `.release-detail` expansion pattern, `web/js/pipeline.js`
+  (the Pipeline tab this sub-view joins), and `web/routes/_overlay.py` (the on-disk /
+  quality overlay that stamps release rows).
+- Live data grounding (2026-05-30): 820 `wanted` requests — 454 (55%) with audio on disk,
+  391 with an unfindable category — versus 3,561 `imported`. Confirms the `wanted` set
+  genuinely spans `Missing` plus on-disk bands, and that the worklist is a tractable size.

--- a/docs/plans/2026-05-30-001-feat-long-tail-triage-console-plan.md
+++ b/docs/plans/2026-05-30-001-feat-long-tail-triage-console-plan.md
@@ -1,6 +1,6 @@
 ---
 title: "feat: Long-Tail Triage Console"
-status: active
+status: completed
 date: 2026-05-30
 type: feat
 origin: docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md

--- a/docs/plans/2026-05-30-001-feat-long-tail-triage-console-plan.md
+++ b/docs/plans/2026-05-30-001-feat-long-tail-triage-console-plan.md
@@ -1,0 +1,621 @@
+---
+title: "feat: Long-Tail Triage Console"
+status: active
+date: 2026-05-30
+type: feat
+origin: docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md
+deepened: 2026-05-30
+---
+
+# feat: Long-Tail Triage Console
+
+## Summary
+
+Build a new long-tail worklist as a sub-view under the Pipeline tab: it opens on the
+`wanted` set, banded by on-disk quality (`Missing` + the `QualityRank` bands) as selectable
+filter tabs, with a search box. Selecting a release expands an in-place action console that
+renders why it's stuck (unfindable category, Soulseek peers seen, sibling pressings, the
+YouTube Music resolver matrix) and offers inline operator actions — YouTube rescue,
+accept-a-sibling-pressing, set quality intent, and re-search. The view is the first UI
+consumer of three already-built backends; the only new backend is a banded worklist read
+(with a CLI counterpart) plus a small widening of how many Soulseek peers the detail returns.
+No new pipeline behavior.
+
+---
+
+## Problem Frame
+
+Three backends shipped without a UI consumer: the triage / search-analytics surface, the
+YouTube Music resolver, and the YouTube rescue ingest API. They answer powerful per-request
+questions but only from the CLI or raw HTTP — there's no place to stand in front of the long
+tail as a cohort and work it down. The long tail is measurable: of 820 `wanted` requests, 391
+carry an unfindable category and 454 already hold a provisional on-disk copy at some quality
+band. The operator wants to *select* a band (start at `Missing`, climb the quality levels) and
+spend attention where it pays off, resolving each stuck item in one place instead of bouncing
+between `pipeline-cli triage show`, `youtube-album`, `youtube-rescue`, the pipeline detail
+panel, and the Replace picker.
+
+Research confirmed the brainstorm's central unknown (origin Q1 / D6) and surfaced two scope
+corrections that this plan resolves up front:
+
+1. There is **no band-filterable `wanted` endpoint** and no server-side banding of
+   `album_requests` rows. The existing quality overlay bands *beets-library* release rows in a
+   bounded batch (`web/routes/_overlay.py` → `web/server.py::compute_library_rank`); that is the
+   reuse target, and "Missing" means the release isn't in the library at all.
+2. There is **no "re-search now" backend** (origin Q4 / R15). Searches fire only on the 5-minute
+   `cratedigger.service` cycle. This plan defines re-search as "regenerate the plan + reset the
+   cursor" via the existing `search-plan/regenerate` surface, honestly labeled as next-cycle —
+   not an instant search. A genuine single-request search trigger would be new watch-loop
+   behavior and is deferred (see Scope Boundaries).
+
+---
+
+## High-Level Technical Design
+
+### Band classification (server-side, per `wanted` row)
+
+Banding reuses the beets-library quality machinery the rest of the UI already uses. A `wanted`
+request's on-disk copy is its beets-library album (keyed by `mb_release_id`); "Missing" means
+no such album exists.
+
+```mermaid
+flowchart TB
+  A[wanted request] --> B{In beets library?\nmb_release_id match}
+  B -->|no| M[Missing]
+  B -->|yes| C{format + bitrate\nclassifiable?}
+  C -->|yes| R[QualityRank band\nTransparent / Excellent / Good / ...]
+  C -->|no| U[Unknown band\nhas audio, never Missing]
+  M --> F{active youtube_running\ndownload_log row?}
+  R --> F
+  U --> F
+  F -->|yes| FL[stamp in_flight_rescue = true]
+  F -->|no| FN[stamp in_flight_rescue = false]
+```
+
+Key rule: "Missing" means **no clean beets-library album for the `mb_release_id`** (the
+`check_mbids` membership test) — honestly "no library copy to upgrade." That also covers brief
+transients (mid-import, a download routed to wrong-matches) that have files on disk but no
+imported album; the `in_flight_rescue` stamp (KTD4) disambiguates the active-rescue case. An
+in-library row whose format/bitrate can't be classified bands as `Unknown`, never `Missing` —
+these are two distinct mechanisms (absent from the membership set vs. present-but-rank-unknown)
+and both are fixtured in U1.
+
+### YouTube section state machine (per release, inside the console)
+
+The resolver `GET` is slow and side-effectful (MB/Discogs mirror + per-pressing beets distance +
+YT API). The console renders four explicit states derived from
+`(cached-row-exists, outcome, releases length, from_cache, error_message)`:
+
+```mermaid
+stateDiagram-v2
+  [*] --> never_run: no cached matrix
+  never_run --> resolving: operator clicks "Check YouTube"
+  resolving --> resolved_with_matrix: ok + releases > 0
+  resolving --> resolved_empty: ok + releases == 0
+  resolving --> resolver_failed: 503 / transient
+  resolved_with_matrix --> rescuing: operator picks sibling + confirms
+  rescuing --> in_flight: accepted (youtube_running)
+  rescuing --> rejected: 409 / 422 (per-outcome copy)
+  resolver_failed --> resolving: retry
+  resolved_empty --> resolving: re-check
+```
+
+### Console panel → data-source map
+
+The console reuses existing read endpoints rather than a new aggregate endpoint:
+
+| Console panel | Source endpoint | Key fields |
+|---|---|---|
+| Header band + status | worklist read (new, U1) | band, `in_flight_rescue`, status, `min_bitrate`, `target_format`, `search_filetype_override` |
+| Why-unfindable | `GET /api/triage/<id>` | `unfindable.category`, `search_forensics.*`, `field_quality` |
+| Soulseek peers seen | `GET /api/pipeline/<id>` `last_search.top_candidates` | username, dir, matched/total, avg_ratio, filetype, rejection per-search |
+| Recent rescue attempts | `GET /api/pipeline/<id>` download history | `download_log` source/outcome (incl. terminal `youtube_*`) |
+| Sibling pressings | `GET /api/release-group/<rg>` | id, title, date, country, track_count, `in_library`, `pipeline_status` |
+| YouTube matrix | `GET /api/youtube-album?identifier=<id>` | `youtube_releases[].yt_browse_id`, `distances[]` |
+
+### New sub-view wiring (frontend)
+
+```mermaid
+flowchart LR
+  N[renderPipelineNav button] --> SV[setPipelineView 'long-tail']
+  SV --> LP[loadPipeline dispatch]
+  LP --> LT[long_tail.js: fetch worklist read]
+  LT --> TABS[band tabs + search box + row list]
+  TABS --> CON[in-place console expansion]
+  CON --> ACT[actions: rescue / accept-sibling / set-intent / re-search]
+  ACT --> RF[await -> refetch cohort -> re-render]
+```
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Band the cohort from the beets-library copy, not from `album_requests` spectral columns —
+  via a beets-only banding helper factored out of the existing overlay.** `web/server.py::compute_library_rank`
+  is the rank function and `web/routes/_overlay.py::overlay_release_rows_in_place` already bands beets
+  rows in one batched query (N+1-safe), stamping `library_rank` — the exact field `web/js/badges.js`
+  renders. Two refinements from review: (a) the overlay keys on `r["id"]` = *release* id, but
+  `album_requests` rows key on request id with the release in `mb_release_id`, so U1 factors out the
+  beets-only core (membership + detail + `compute_library_rank`) into a release-id→band helper and maps
+  the band back onto request rows by `mb_release_id` — it does **not** feed request rows into the
+  overlay verbatim; (b) U1 calls only that beets-only half, skipping the overlay's `check_pipeline`
+  query (the cohort row already carries the pipeline columns). Banding is three-way: `mb_release_id`
+  absent from the membership set → `Missing`; present but no detail row / `compute_library_rank` →
+  `"unknown"` → `Unknown`; otherwise the band. Because the list, the console header, and the sibling
+  panel all band through this one function (the sibling panel via the same overlay on
+  `GET /api/release-group/<rg>`), there is no divergence path — header and list always agree.
+  Badge rendering comes for free. Spectral-aware refinement (using `current_spectral_grade`) is
+  deferred. (Resolves origin D5/D6 and the divergent-banding-source risk.)
+
+- KTD2. **One server-banded fetch + client-side tab/search filtering — not a per-band endpoint.**
+  The `wanted` cohort is ~820 rows; fetching it once (each row pre-banded server-side) and filtering
+  tabs/search in JS kills stale-response races, avoids reimplementing `quality_rank` in JS (which
+  would drift), and keeps the query *fan-out* bounded. The CLI counterpart (R16) accepts an optional
+  `--band` filter so the service method supports both shapes; the UI uses the unfiltered fetch.
+  **Scope correction from review:** U1 inherits `list_triage`'s N+1 *fan-out* bound but **not** its
+  50-row pagination bound — this is a deliberate v1 choice (full-cohort fetch enables client-side
+  filtering), and the true scaling driver is the beets banding batch against the whole `mb_release_id`
+  list on the single web thread, not the Postgres cohort query. The `wanted` set grows without a
+  product cap ("the system never stops searching"), so this carries an explicit ceiling (~1,500 rows):
+  beyond it the read must paginate. See System-Wide Impact.
+
+- KTD3. **"Re-search now" = regenerate the search plan + reset the cursor, labeled next-cycle.**
+  Reuses the existing `POST /api/pipeline/<id>/search-plan/regenerate` (which always supersedes and
+  starts the fresh plan at ordinal 0 — a reset cursor is a natural consequence, not a bolt-on). Button
+  copy is explicit ("will be searched fresh on the next cycle, ~5 min"), never implying instant
+  results. No new pipeline behavior; respects "the system never stops searching." **Failure outcomes
+  are triage signal, not errors** (review): a `Missing`-band long-tail row is the *most likely* request
+  to return `failed_deterministic` (no runnable query / incomplete metadata) — so the button surfaces
+  *why the plan can't be built* (the same gap the console is triaging), with `failed_transient` mapped
+  to retry. A genuine immediate single-request search trigger is deferred. (Resolves origin Q4/R15.)
+
+- KTD4. **In-flight and failed rescues are surfaced by reading `download_log`, never by moving the
+  row optimistically.** A rescue leaves `album_requests.status` untouched (`wanted`), so the row stays
+  in `Missing` until the importer completes minutes later. The `in_flight_rescue` stamp is the existing
+  `download_log` predicate `source='youtube' AND outcome='youtube_running'` — the same one already in
+  `get_wanted_searchable` (as `NOT EXISTS`) and `list_active_youtube_rescues`, backed exactly by
+  migration 037's partial unique index `one_youtube_running_per_request` (so it probes a tiny index,
+  never a seq scan). Use the `EXISTS` form for planner consistency, and centralize the predicate literal
+  rather than carrying a third copy. (Note: this is **not** `find_active_youtube_import_job`, which
+  queries `import_jobs`.) The console reads the request's `download_log` history to show "rescue
+  running" (`youtube_running`) or "last rescue failed: <reason>" (terminal `youtube_failed`
+  specifically — distinct from `youtube_success`). Rows move bands only on a later refetch. (Resolves
+  research gaps on in-flight banding and async-failure invisibility.)
+
+- KTD5. **The console reuses existing read endpoints; the only read-path backend change is widening
+  the `last_search` candidate cap.** Per-peer Soulseek rows live on `GET /api/pipeline/<id>`'s
+  `last_search.top_candidates`, currently capped at 3 (the JSONB stores up to 20). Widen the cap for
+  the peers panel. Folding candidates into the triage payload is deferred. (Resolves the split
+  peers-data-source finding.)
+
+- KTD6. **Console substrate: in-place expansion for evidence + actions; confirm-overlay modal for the
+  two destructive confirmations.** The evidence/action console expands in place (the `.p-detail` /
+  `.release-detail` pattern, per origin R6). The two-step rescue pick and the accept-sibling
+  confirmation reuse the Promise-based `web/js/replace_picker.js` `.confirm-overlay` /
+  `.replace-picker-shell` modal — the only reusable modal substrate in the app.
+
+- KTD7. **Accept-a-sibling-pressing is MusicBrainz-only in v1.** Sibling enumeration is MB-keyed
+  (`GET /api/release-group/<rg>`); Discogs-sourced requests have no MB release group. For Discogs
+  requests the action renders disabled with a one-line reason. Rescue / set-intent / re-search still
+  work for Discogs requests. No MB↔Discogs adapter is introduced (honors the no-adapter invariant).
+  (Resolves the Discogs sibling-gap finding.)
+
+- KTD8. **Post-action freshness: refetch the acted-on row and patch it in — not the whole cohort.**
+  No optimistic band moves, no polling. The full banding read (KTD2) is the app's heaviest, so
+  re-running it after every action — when a rescue/set-intent usually doesn't move the band immediately
+  (KTD4) — would block the single-threaded server to re-render an essentially-identical cohort. Instead
+  each action awaits, refetches just that request's authoritative band/flags (a single-id variant of
+  the worklist read), and patches the one row. A successful Replace is the exception: it removes the old
+  row (now a frozen `replaced` row) and closes the console, so it triggers a full cohort refetch; the
+  explicit "Refresh" affordance also refetches the whole cohort. (Resolves research freshness gaps and
+  the per-action heavy-read cost.)
+
+---
+
+## Requirements
+
+Traceability to origin (`docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md`).
+
+**Worklist view**
+
+- R1. New sub-view under the Pipeline tab, reachable from the existing sub-view nav (origin R1).
+- R2. Default scope is the `wanted` set; `imported` / `manual` / `downloading` / `replaced` are
+  excluded (origin R2).
+- R3. Quality-band filter tabs (`Missing` + the on-disk `QualityRank` bands present), selectable
+  filters not a forced sort (origin R3).
+- R4. `Missing` = a `wanted` request with no beets-library album; each band = a `wanted` request whose
+  beets-library copy classifies into that band; unclassifiable-but-present = `Unknown` band (origin R4,
+  refined by KTD1).
+- R5. Search box filtering the current cohort by artist / album, within the selected band, with a
+  stale-response token guard (origin R5).
+
+**Action console**
+
+- R6. Selecting a release expands it in place into the action console, reusing the in-place detail
+  substrate (origin R6).
+- R7. For a `Missing` / unfindable release, the console surfaces the unfindable category + reason, the
+  Soulseek peers seen + rejection reasons, the sibling pressings, and the YouTube matrix when resolved.
+  A not-yet-categorised state is rendered distinctly from an error (origin R7, refined by research).
+- R8. For an on-disk-below-intent release, the console surfaces current band vs. intent and what better
+  is available, adapting emphasis to the row's state (origin R8).
+
+**Console actions**
+
+- R9. YouTube rescue action with a two-step flow (run resolver when no cached matrix, then rescue
+  against a resolver-supplied `browse_id`), with the four-state YouTube section (origin R9).
+- R10. Rescue targets an operator-chosen sibling; never auto-picked (origin R10).
+- R11. Rescue requires no quality-bar step (origin R11).
+- R12. After a successful rescue the row reflects its new band only on a later refetch (import owns the
+  transition); audit fields are populated by the existing import path (origin R12, refined by KTD4).
+- R13. Accept-a-sibling-pressing via the existing Replace action, MB-only in v1 (origin R13, refined by
+  KTD7).
+- R14. Quality-intent control (keep grinding to lossless vs. accept current floor) via the existing
+  set-intent surface (origin R14).
+- R15. Re-search action = regenerate-plan-and-reset-cursor, next-cycle, never implying instant search
+  (origin R15, redefined by KTD3).
+
+**Surface symmetry**
+
+- R16. The new worklist read ships with a `pipeline-cli` counterpart through the same service method,
+  classified in the route-contract audit; the existing mutating actions keep their single service path
+  (origin R16). The read also exposes a single-id variant used by the post-action single-row refetch (KTD8),
+  so U1 and U6 both trace here.
+
+---
+
+## Implementation Units
+
+### U1. Worklist banding service + read API + CLI counterpart
+
+- **Goal:** Return the `wanted` cohort with each row pre-banded (`Missing` / band / `Unknown`) and
+  stamped with `in_flight_rescue`, in a bounded number of queries, exposed via both an HTTP read and a
+  `pipeline-cli` subcommand.
+- **Requirements:** R1, R2, R3, R4, R16.
+- **Dependencies:** none.
+- **Files:**
+  - `lib/long_tail_service.py` (new) — service method + typed `msgspec.Struct` result (`outcome`, banded
+    rows). Injected collaborators (DB, band fn, active-rescue lookup) per the service-first pattern.
+  - `lib/pipeline_db.py` — a bounded cohort query stamping `in_flight_rescue` via the existing
+    `download_log` predicate `source='youtube' AND outcome='youtube_running'` (the `EXISTS` form already
+    in `get_wanted_searchable` / `list_active_youtube_rescues`, backed by migration 037's partial unique
+    index). Centralize the predicate literal; do NOT reach for `find_active_youtube_import_job` (that
+    queries `import_jobs`, not the `youtube_running` flag KTD4 needs).
+  - `web/routes/pipeline.py` — `GET /api/pipeline/long-tail` handler wrapping the service; rows mapped
+    through `_server()._serialize_row(...)`; band applied via the beets-only helper (KTD1). Add the
+    route description to this module's `GET_DESCRIPTIONS` dict (the audit gate fails on an empty one).
+  - `web/server.py` / `web/routes/_overlay.py` — factor the beets-only banding core (membership +
+    `check_mbids_detail` + `compute_library_rank`) into a release-id→band helper U1 and the overlay both
+    call; U1 maps the band onto request rows by `mb_release_id` and skips the overlay's redundant
+    `check_pipeline` query (the cohort already carries those columns).
+  - `scripts/pipeline_cli.py` — `pipeline-cli long-tail [--band=<band>] [--json]` wrapping the same
+    service; outcome → exit-code mapping per convention.
+  - `tests/test_long_tail_service.py` (new), `tests/test_web_server.py`, `tests/test_pipeline_cli.py`,
+    `tests/fakes.py` + `tests/test_fakes.py` (new `FakePipelineDB` method + self-test if one is added).
+- **Approach:** Service-first (KTD2): typed result is the contract; the HTTP route and CLI are thin
+  adapters. Band per row via the beets-only helper (KTD1) — batched beets queries for the whole cohort,
+  never per row, and no redundant `check_pipeline`. Three-way band derivation: `mb_release_id` absent
+  from the membership set → `Missing`; present but rank-unknown → `Unknown`; else the band. Stamp
+  `in_flight_rescue` via the centralized `EXISTS` `youtube_running` predicate (KTD4), not an N-query
+  loop. The endpoint returns the full `wanted` cohort unfiltered (UI filters client-side, KTD2); the
+  service's optional `band` filter backs the CLI's `--band`, and a single-id variant backs the
+  per-action single-row refetch (KTD8). Add the route to `TestRouteContractAudit.CLASSIFIED_ROUTES`
+  AND a non-empty entry to `GET_DESCRIPTIONS`.
+- **Execution note:** Start with a failing real-PG round-trip test asserting every returned field
+  (especially band + `in_flight_rescue`) survives the production query, then build the service.
+- **Patterns to follow:** `lib/triage_service.py::list_triage` (4-query N+1 bound + typed result),
+  `web/routes/_overlay.py::overlay_release_rows_in_place` (batched banding), the
+  `scripts/pipeline_cli.py` triage/youtube subcommands (CLI adapter shape), `web/server.py::_serialize_row`.
+- **Test scenarios:**
+  - Covers AE1. A `wanted` request with no beets-library album bands as `Missing`; an `imported` request
+    is absent from the result entirely.
+  - Covers AE2. A `wanted` request whose beets copy classifies `Transparent` bands as `Transparent`.
+  - A `wanted` request present in the library but with an unclassifiable / absent detail row bands as
+    `Unknown`, not `Missing` (the two mechanisms — absent-from-membership vs. present-but-rank-unknown —
+    are fixtured separately).
+  - A Discogs-sourced `wanted` request bands correctly via the existing dual-key membership lookup
+    (`check_mbids` already buckets MB UUIDs and Discogs numerics → `discogs_albumid` — no new lookup
+    path is introduced); banding must work for Discogs rows even though KTD7 makes accept-sibling MB-only.
+  - A `wanted` request with an active `youtube_running` `download_log` row is stamped
+    `in_flight_rescue = true`; one without is `false`.
+  - N+1 guard: the total query count is constant regardless of cohort size — and the assertion counts
+    the beets membership + `check_mbids_detail` queries too, not just the Postgres cohort query (model
+    on `TestListTriageN1Guard`).
+  - Production-shape round-trip: a row populated with real `datetime` / `uuid.UUID` / typed JSONB
+    serializes without error through the endpoint (guards the datetime-500 class).
+  - CLI `long-tail --band=missing` returns only `Missing` rows; exit 0; `--json` emits the typed shape.
+  - Route is present in `CLASSIFIED_ROUTES` and has a non-empty description (audit gate).
+- **Verification:** `GET /api/pipeline/long-tail` returns banded `wanted` rows; `pipeline-cli long-tail`
+  prints the same cohort; full suite green including the route-contract audit and the N+1 guard.
+
+### U2. Widen the `last_search` candidate cap for the peers panel
+
+- **Goal:** Expose more than the current 3 Soulseek peers per search so the console's "peers seen" panel
+  shows a useful slice (the JSONB stores up to 20).
+- **Requirements:** R7.
+- **Dependencies:** none.
+- **Files:**
+  - `web/routes/pipeline.py` — `_build_last_search_payload` candidate limit raised from 3 to the stored
+    maximum (top-20; the JSONB already caps there, so no value is left open).
+  - `tests/test_web_server.py` — assert the widened cap in the `last_search` contract.
+- **Approach:** A bounded read-path tweak only; no schema change. Keep the existing `CandidateScore`
+  decode path. Confirm `GET /api/triage/<id>`, `GET /api/youtube-album`, `GET /api/release-group/<rg>`
+  already provide the rest of the console's evidence (they do, per research) — no other backend change.
+- **Patterns to follow:** the existing `_build_last_search_payload` decode + `top_candidates` cap.
+- **Test scenarios:**
+  - `last_search.top_candidates` returns up to the new cap when the stored JSONB has more than 3
+    candidates; still truncates at the stored maximum.
+  - `LAST_SEARCH_REQUIRED_FIELDS` / `CANDIDATE_SCORE_REQUIRED_FIELDS` still hold after the change.
+- **Verification:** the detail endpoint returns the widened peer list; existing contract tests pass.
+
+### U3. Pipeline sub-view scaffold: nav, dispatch, band tabs, search box
+
+- **Goal:** Register a new `long-tail` Pipeline sub-view that fetches the worklist read and renders the
+  band tabs, search box, and row list — without the action console yet.
+- **Requirements:** R1, R2, R3, R5.
+- **Dependencies:** U1.
+- **Files:**
+  - `web/js/state.js` — add `pipelineView` value `'long-tail'` (and any detail context field needed).
+  - `web/js/pipeline.js` — dispatch branches in `loadPipeline`, `setPipelineView`, `renderPipeline`; a
+    nav button in `renderPipelineNav`.
+  - `web/js/main.js` — register `window.*` bindings for the new module's handlers. The F12 detail-reset
+    guard in `showTab` likely needs **no** change: `long-tail` is a list view (like `dashboard`, which
+    survives F12 because it isn't named in the reset condition), not a per-request detail with stashed
+    context. Confirm the intended F12 behavior and only touch the guard if `long-tail` should reset to
+    `queue` on re-click.
+  - `web/js/long_tail.js` (new) — fetch `/api/pipeline/long-tail`, derive tab set from present bands,
+    render tabs + search box + row list; client-side band/search filtering; stale-response token guard;
+    pure helpers exported via the repo's `export const __test__ = {…}` named-object convention.
+  - `web/index.html` — band-tab / list CSS (reuse existing `badge-rank-*` colours).
+  - `web/js/util.js` — any pure helper (band-label formatting, count rollup) added here for testability.
+  - `tests/test_js_util.mjs` — unit tests for the pure helpers.
+- **Approach:** Mirror the `search-plan-detail` sub-view registration (the worked template). Band tabs are
+  derived from the bands present in the fetched cohort (KTD2); filtering is client-side over the single
+  fetch. The search box uses the `browse.js` in-flight token + 300ms debounce pattern and filters within
+  the selected band (with a "N matches in other bands" hint to avoid dead-ends). Reuse `badges.js` for
+  per-row band badges. Each tab shows a live count computed in the same banding pass, so counts stay
+  consistent with `Unknown` / in-flight rows by construction. The list has three explicit states: a
+  loading row beneath the tabs while the worklist fetch is in flight (distinct from empty); the
+  empty-cohort state (zero `wanted` rows); and an empty-band state ("No <band> releases match" when a
+  search filters the selected band to zero — the tab stays visible while filtered, and disappears only
+  after a full-cohort refetch drops the band entirely).
+- **Patterns to follow:** `web/js/search_plan.js::openSearchPlanDetail`, `web/js/pipeline.js`
+  dispatch trio, `web/js/browse.js` stale-token search, `web/js/badges.js`.
+- **Test scenarios:**
+  - Pure: band-tab derivation from a cohort with mixed bands yields the expected ordered tab set
+    (`Missing` first).
+  - Pure: search filter within a selected band matches by artist/album substring; cross-band match count
+    is reported for the hint.
+  - Pure: stale-token guard discards an earlier fetch's result when a newer fetch has started.
+  - Pure: per-tab counts derived in the banding pass equal the row count of each band.
+  - Render: loading, empty-cohort, and empty-band states each show their own affordance — never a blank area.
+  - `node --check web/js/*.js` passes; the new module is `// @ts-check` clean.
+- **Verification:** the new sub-view loads, shows band tabs + search, lists the cohort, and filters
+  client-side; JS unit tests + syntax check pass.
+
+### U4. Action console evidence panel
+
+- **Goal:** On row select, expand an in-place console rendering the band-aware evidence: unfindable
+  category, Soulseek peers seen, recent rescue attempts, sibling pressings, and the YouTube matrix —
+  with the not-yet-categorised, four-YouTube-state, and async-rescue-failure states handled.
+- **Requirements:** R6, R7, R8.
+- **Dependencies:** U2, U3.
+- **Files:**
+  - `web/js/long_tail.js` — console expansion + evidence rendering; fetches `GET /api/triage/<id>` and
+    `GET /api/pipeline/<id>` (peers + rescue history), and `GET /api/release-group/<rg>` for siblings;
+    YouTube section reads cached `GET /api/youtube-album` state.
+  - `web/js/util.js` — reuse `renderForensicBlock` for the peers table; add pure state-mapping helpers
+    (YouTube four-state classifier, band-aware emphasis selector).
+  - `web/index.html` — console CSS (in-place `.p-detail` / `.release-detail` family).
+  - `tests/test_js_util.mjs` — unit tests for the YouTube state classifier and emphasis selector.
+- **Approach:** In-place expansion (KTD6). Render distinct states: not-yet-categorised (origin's 429
+  un-categorised cohort) shown as "detection runs daily" rather than an error; the YouTube section driven
+  by the four-state classifier (KTD6 / HTD); an `in_flight_rescue` row shows "rescue running"; a row with
+  a latest-terminal `youtube_failed` `download_log` (specifically, not `youtube_success`) shows "last rescue failed:
+  <reason>". `Missing` rows lead with the unfindable category; on-disk rows lead with band-vs-intent.
+  The evidence panels load **independently** (parallel fetches, per-panel loading + error states): a slow
+  or failing `GET /api/release-group/<rg>` (the 15s mirror timeout) renders that panel's own error
+  affordance and never blocks the unfindable/peers panels or silently drops one. Information architecture
+  to keep the action buttons reachable without scrolling past evidence: the peers list shows a few rows
+  with a "show all" expansion, and the YouTube matrix stays collapsed until "Check YouTube" is clicked.
+- **Patterns to follow:** `web/js/pipeline.js::toggleDetail` (in-place fetch + render), `web/js/util.js::renderForensicBlock`,
+  `web/js/replace_picker.js` row-expansion structure.
+- **Test scenarios:**
+  - Covers AE3. A `Missing` request categorised `wrong_pressing_available` renders the category + reason,
+    the peers-seen table, and the sibling-pressings list.
+  - Pure: the YouTube state classifier maps `(no cached matrix)` → `never_run`; `(ok, releases>0)` →
+    `resolved_with_matrix`; `(ok, releases==0)` → `resolved_empty`; `(503/transient)` → `resolver_failed`;
+    `(ok, from_cache, error_message)` → matrix-with-staleness-flag.
+  - Pure: a not-yet-categorised request (`unfindable == null`) selects the "not categorised" emphasis, not
+    an error state.
+  - A row with an active `youtube_running` row renders "rescue running"; a row with a terminal
+    `youtube_failed` renders the failure reason.
+  - On-disk-below-intent row leads with band-vs-intent rather than the unfindable category.
+  - Partial failure: a non-200 from one evidence endpoint (e.g. `release-group` times out) renders that
+    panel's error state while the other panels still render — the console is never blank on partial failure.
+- **Verification:** selecting rows in each state renders the correct panel; pure-helper unit tests pass; a
+  Playwright smoke (small/obscure artist) shows real triage + sibling + matrix content.
+
+### U5. Console rescue flow (two-step)
+
+- **Goal:** Wire the YouTube rescue action: "Check YouTube" runs the resolver (guarded against
+  double-fire), the matrix renders pickable siblings, and confirming a pick submits the rescue with
+  per-outcome feedback.
+- **Requirements:** R9, R10, R11, R12.
+- **Dependencies:** U4.
+- **Files:**
+  - `web/js/long_tail.js` — the two-step flow: resolver call with in-progress/disabled state; matrix
+    render; confirm step reusing the `web/js/replace_picker.js` `.confirm-overlay` modal; submit to
+    `POST /api/pipeline/<id>/youtube-rescue`; outcome → copy mapping; on `accepted`, mark the row
+    in-flight and refetch (KTD8).
+  - `web/index.html` — any rescue-specific console CSS.
+  - `tests/test_js_util.mjs` — unit tests for the outcome → copy mapping.
+- **Approach:** Two-step mirrors the Replace picker's list→confirm shape (KTD6). The resolver "Check
+  YouTube" button disables while outstanding (slow side-effectful GET). Map every ingest outcome to
+  specific copy: `in_flight` (fold into the in-flight indicator, surface existing `download_log_id`),
+  `wrong_state` ("request changed — refresh"), `no_resolver_mapping` ("re-run Check YouTube"),
+  `track_count_precheck_failed` (show expected vs. resolver count), `transient` (retry). Never optimistically
+  move the row to a band; the importer owns the transition (KTD4).
+- **Patterns to follow:** `web/js/replace_picker.js` (`openReplacePicker` Promise + confirm overlay +
+  `runWithConcurrency`), `web/routes/youtube.py` outcome vocabulary.
+- **Test scenarios:**
+  - Covers AE4. With no cached matrix, the YouTube section offers "Check YouTube"; after a successful
+    resolve, sibling rescue targets render.
+  - Covers AE5. Picking a sibling and confirming submits the rescue and, on `accepted`, the row is marked
+    in-flight (stays in `Missing` until a later refetch); no bar-drop step appears.
+  - Pure: each ingest outcome (`accepted` / `in_flight` / `wrong_state` / `no_resolver_mapping` /
+    `track_count_precheck_failed` / `transient`) maps to its intended console copy.
+  - Double-fire guard: clicking "Check YouTube" twice while a resolve is outstanding fires one request.
+  - `resolved_empty` hides the rescue button and shows "not on YouTube Music — re-check".
+- **Verification:** the rescue flow completes end-to-end against a resolved release; rejections render the
+  right copy; unit tests pass; Playwright smoke confirms the two-step.
+
+### U6. Console secondary actions + post-action freshness
+
+- **Goal:** Wire accept-a-sibling-pressing (MB-only), set quality intent, and re-search, plus the shared
+  refetch-after-action freshness model.
+- **Requirements:** R13, R14, R15, R16.
+- **Dependencies:** U4.
+- **Files:**
+  - `web/js/long_tail.js` — accept-sibling via `window.openReplacePicker` (disabled with a note for
+    Discogs-sourced requests); set-intent via the existing `{id, intent}` POST (render the current intent
+    as a label/badge with a small toggle to switch lossless ↔ default; mirror `web/js/library.js::setIntent`,
+    which lives in a different view context); re-search via `POST /api/pipeline/<id>/search-plan/regenerate` with
+    next-cycle copy and `regenerate` outcome mapping; shared `action → await → single-row
+    refetch-and-patch` helper; on successful Replace, close the console (old id now a frozen `replaced`
+    row) and full-cohort refetch.
+  - `web/js/main.js` — `window.*` bindings for the new handlers.
+  - `tests/test_js_util.mjs` — unit tests for the regenerate outcome → copy mapping and the
+    Discogs-disable predicate.
+- **Approach:** Reuse the existing operator-action endpoints unchanged (no parallel paths, R16). Accept-sibling
+  is MB-only (KTD7) — disabled with a one-line reason when the request is Discogs-sourced or has no
+  pickable siblings (siblings already tracked as requests are shown non-pickable). Re-search maps to
+  `regenerate` with honest next-cycle copy and handles `noop_active_plan_exists` / `failed_*` outcomes
+  (KTD3); the button disables while outstanding. On `failed_deterministic` (no runnable query / incomplete
+  metadata — common on `Missing`-band rows) it does not simply re-enable to fire again; it surfaces the
+  metadata gap inline (pointing at the field-quality detail) so re-clicking isn't futile. Every action
+  awaits then refetches just the acted-on row and patches it (KTD8); a successful Replace closes the
+  console and refetches the full cohort; no optimistic band moves.
+- **Patterns to follow:** `web/js/library.js::setIntent`, `web/js/main.js::openReplacePickerAndHandle`,
+  `web/js/search_plan.js` regenerate handling, `lib/mbid_replace_service.py` outcomes.
+- **Test scenarios:**
+  - Covers AE6. Accept-sibling on an MB request opens the Replace picker; confirming replaces the request
+    to the chosen sibling; the console closes and the cohort refetches.
+  - Pure: the Discogs-disable predicate disables accept-sibling for a Discogs-sourced request and enables
+    it for an MB request with pickable siblings.
+  - Set-intent to `lossless` posts `{id, intent}`; the row refetches and reflects the new intent.
+  - Pure: `regenerate` outcomes (`success` / `noop_active_plan_exists` / `failed_deterministic` /
+    `failed_transient`) map to their intended next-cycle copy; the button guards double-fire.
+  - After any successful action, the cohort is refetched (no optimistic band move asserted).
+- **Verification:** all three actions complete against real requests with correct copy and refetch
+  behavior; Discogs requests show accept-sibling disabled; unit tests + CLI/contract suites pass;
+  Playwright smoke confirms the action set.
+
+---
+
+## Scope Boundaries
+
+Carried from origin (`docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md`):
+
+- The ~3,500 `imported` albums re-ranked by quality (whole-collection health dashboard) — not in this view.
+- The "click any release anywhere → popup" framing — dropped; the only detail surface is the in-place
+  console.
+- No "lower the quality bar before rescue" step — the gate doesn't block first acquisition and Opus 128 is
+  `Transparent`.
+- No automatic / background rescue; rescue stays operator-initiated.
+- The watch loop is never throttled by this view.
+
+### Deferred to Follow-Up Work
+
+- **Spectral-aware banding.** v1 bands from the beets-library `(format, bitrate)` via the existing overlay
+  (KTD1). Refining the band with `current_spectral_grade` / `current_spectral_bitrate` is a later
+  enhancement.
+- **A genuine immediate single-request search trigger.** v1 re-search = regenerate + next-cycle (KTD3). A
+  true "search this one now" verb is new watch-loop behavior (new service + CLI + API, R16) and is out of
+  v1.
+- **Folding Soulseek candidates into the triage payload.** v1 widens the existing `last_search` cap (U2)
+  and reads two endpoints; consolidating into one triage response is deferred.
+- **Discogs sibling support in accept-sibling.** v1 is MB-only (KTD7); a Discogs-master sibling path is
+  deferred and must not introduce an MB↔Discogs adapter.
+
+---
+
+## System-Wide Impact
+
+- **Single-threaded web server.** `cratedigger-web` is stdlib `http.server` (not threading); a slow
+  worklist read blocks every other route. Keep U1 bounded: one Postgres cohort query + the batched
+  beets banding (membership + `check_mbids_detail`, ≤ a handful of `IN (...)` queries, no redundant
+  `check_pipeline`) + one `EXISTS` `youtube_running` probe (index-backed by migration 037 — negligible).
+  At ~820 rows this lands in the low-hundreds-of-ms; the dominant cost is the beets banding batch, not
+  the cohort query.
+- **Growth ceiling.** The `wanted` set accumulates monotonically (the system never stops searching) with
+  no product cap. The full-cohort fetch is a deliberate v1 choice (KTD2) and inherits `list_triage`'s
+  N+1 *fan-out* bound but NOT its pagination — so it carries an explicit ~1,500-row ceiling, beyond which
+  the read must paginate. First latency lever before that: a banding-only beets getter that selects just
+  `(mb_albumid, format, MIN(bitrate))`, dropping the three unused correlated subqueries in
+  `check_mbids_detail`. Implement only if profiling on the real cohort exceeds a few-hundred-ms budget.
+- **Per-action read cost.** Because the banding read is the heaviest in the app, the post-action refresh
+  is a single-row refetch-and-patch (KTD8), not a full-cohort re-band; the whole-cohort read fires only
+  on explicit Refresh or after a Replace removes a row.
+- **Route-contract audit gate.** The new read must be added to `TestRouteContractAudit.CLASSIFIED_ROUTES`
+  with a description or the suite fails (U1).
+- **No pipeline/importer/beets changes.** The view consumes existing read + action endpoints; Meelo / Plex /
+  the importer are unaffected. `album_requests.status` is never written by this work.
+- **CLI ⇄ API symmetry.** Only the new worklist read adds a surface; it ships with a `pipeline-cli`
+  counterpart (R16). The three mutating actions keep their single existing service path.
+
+---
+
+## Risks & Mitigation
+
+- **Serialization 500 on the first real row** (datetime / UUID / JSONB). Mitigation: route every row through
+  `_serialize_row`; write the production-shaped contract mock and a real-PG round-trip test (U1) — the
+  highest-probability bug for the new read.
+- **Mock-vs-helper drift** for resolver-matrix and sibling rendering (mocks encode the author's mental model,
+  not the mirror's real output). Mitigation: gate "done" on a live Playwright smoke against `music.ablz.au`
+  using small/obscure artists (15s mirror timeout), per the institutional learning.
+- **Band cohort-filter mismatch** (operator band vocabulary vs. the value the writer persists). Mitigation:
+  band off `compute_library_rank`'s actual `library_rank` output and fixture the exact persisted band value,
+  not the tab label (U1).
+- **"Re-search now" implying instant results.** Mitigation: explicit next-cycle copy (KTD3); never label the
+  regenerate action as an immediate search.
+- **Operator double-fires** (slow resolver, regenerate writes). Mitigation: disable each action button while
+  outstanding; map idempotent/`in_flight`/`noop` outcomes to clear copy (U5, U6).
+- **Heaviest-read-on-a-single-thread, issued per action.** The full banding read can block other routes;
+  re-issued on every action it compounds. Mitigation: single-row refetch-and-patch (KTD8); full-cohort
+  ceiling + the `check_mbids_detail` subquery trim held as the first latency lever (System-Wide Impact).
+- **Unbounded `wanted` growth** silently degrading the full-cohort fetch. Mitigation: the documented
+  ~1,500 ceiling and the pagination switch (Open Questions); the cited `list_triage` model is N+1-bound
+  but the plan does NOT inherit its pagination, so the ceiling is stated, not assumed.
+
+---
+
+## Open Questions (deferred to implementation)
+
+- The precise row-count ceiling at which the full-cohort fetch must switch to pagination (planned ~1,500)
+  — confirm against measured per-cohort banding latency at deploy.
+- Keyboard operability for repetitive triage (focusable band tabs + rows, Enter-to-expand,
+  Escape-to-dismiss) — advisory for v1; worth adding if the operator works long cohorts by keyboard.
+- Final console copy strings for each rescue / regenerate outcome (U5, U6).
+- Whether `GET /api/release-group/<rg>` should grow a Discogs-master path later (deferred; out of v1 per KTD7).
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md`.
+- Resolver + rescue backends: `docs/brainstorms/2026-05-27-youtube-music-album-resolver-requirements.md`,
+  `docs/brainstorms/2026-05-28-youtube-rescue-ingest-api-requirements.md`; routes in `web/routes/youtube.py`,
+  services `lib/youtube_album_service.py`, `lib/youtube_ingest_service.py`.
+- Banding reuse: `web/server.py::compute_library_rank`, `web/routes/_overlay.py`, `lib/quality.py::quality_rank`,
+  `docs/quality-ranks.md` (TRANSPARENT 60 > EXCELLENT 50; Opus 128 → TRANSPARENT).
+- Triage / forensics: `lib/triage_service.py`, `web/routes/pipeline.py` (`/api/triage/...`,
+  `_build_last_search_payload`), `request_search_summary` view, `search_log.candidates` / `rejection_reason`.
+- Sub-view + modal substrate: `web/js/search_plan.js` (sub-view template), `web/js/pipeline.js`
+  (dispatch trio + `toggleDetail`), `web/js/replace_picker.js` (modal), `web/js/browse.js` (stale-token
+  search), `web/js/badges.js`, `web/js/library.js::setIntent`.
+- Empirical justification: `docs/brainstorms/2026-05-25-search-plan-post-deploy-findings.md` (Cohort B =
+  strict-count rejections = the accept-sibling / rescue targets).
+- Institutional learnings: `docs/solutions/testing/contract-test-mocks-must-mirror-production-shape.md`,
+  `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`,
+  `docs/solutions/testing/cohort-filter-must-match-production-column-shape.md`,
+  `docs/solutions/architecture/service-first-then-glue.md`.

--- a/lib/banding.py
+++ b/lib/banding.py
@@ -1,0 +1,81 @@
+"""Beets-library quality banding — shared by the web overlay and the CLI.
+
+Lives in ``lib/`` (not ``web/``) so ``scripts/pipeline_cli.py`` can band the
+long-tail worklist without importing the web server. ``web/server.py::
+compute_library_rank`` and ``web/routes/_overlay.py::_band_from_detail`` both
+delegate here, so every surface (web badges, browse/label overlays, the
+long-tail list, and the CLI) shares ONE banding decision (KTD1) with no
+parallel logic — only the beets-access seam and the config source differ.
+"""
+
+from __future__ import annotations
+
+from lib.quality import QualityRankConfig
+
+BAND_MISSING = "missing"
+BAND_UNKNOWN = "unknown"
+
+
+def load_rank_config() -> QualityRankConfig:
+    """Runtime ``QualityRankConfig`` (config.ini), falling back to defaults.
+
+    The CLI calls this directly — the web process's cached ``_rank_cfg`` is
+    unavailable cross-process. Mirrors ``web/server.py::_rank_cfg``'s loader.
+    """
+    try:
+        from lib.config import read_runtime_rank_config
+        return read_runtime_rank_config()
+    except Exception:
+        return QualityRankConfig.defaults()
+
+
+def compute_library_rank(
+    format_str: str | None,
+    bitrate_kbps: int | None,
+    cfg: QualityRankConfig,
+) -> str:
+    """Codec-aware quality-rank label for a beets album, given the rank cfg.
+
+    Pure (moved from ``web/server.py``, which keeps a 2-arg wrapper supplying
+    the cached cfg). Returns the lowercase rank name (``lossless`` /
+    ``transparent`` / ``excellent`` / ``good`` / ``acceptable`` / ``poor`` /
+    ``unknown``). Treats MP3 as VBR — cratedigger only produces VBR-V0 MP3, and
+    the badge buckets barely care about the VBR/CBR distinction.
+    """
+    if not format_str:
+        return BAND_UNKNOWN
+    fmt = format_str.split(",")[0].strip()
+    if not fmt:
+        return BAND_UNKNOWN
+    from lib.quality import quality_rank
+    return quality_rank(fmt, bitrate_kbps, is_cbr=False, cfg=cfg).name.lower()
+
+
+def band_from_detail(
+    rid: str,
+    in_library: set[str],
+    quality: dict[str, dict],
+    cfg: QualityRankConfig,
+) -> str:
+    """Three-way band for one release id given already-fetched membership +
+    ``check_mbids_detail`` output (KTD1).
+
+    * ``rid`` absent from the beets membership set → ``"missing"``.
+    * present but no detail row / unrankable → ``"unknown"`` (has audio, never
+      ``"missing"``).
+    * otherwise → the lowercase ``QualityRank`` band.
+
+    The single banding decision the web overlay and the CLI both route through
+    — header, list, and sibling panel can never diverge. Membership / detail
+    queries are the caller's responsibility (batched once); this is pure.
+    """
+    if rid not in in_library:
+        return BAND_MISSING
+    q = quality.get(rid)
+    if not q:
+        return BAND_UNKNOWN
+    fmt_raw = q.get("beets_format")
+    fmt = fmt_raw if isinstance(fmt_raw, str) else ""
+    br_raw = q.get("beets_bitrate")
+    br = br_raw if isinstance(br_raw, int) else 0
+    return compute_library_rank(fmt, br, cfg)

--- a/lib/long_tail_service.py
+++ b/lib/long_tail_service.py
@@ -1,0 +1,211 @@
+"""Long-tail worklist service — returns the ``wanted`` cohort with each
+row pre-banded by on-disk quality (``Missing`` / a ``QualityRank`` band /
+``Unknown``) and stamped with ``in_flight_rescue``.
+
+This is the read backend for the Long-Tail Triage Console (U1). It is the
+first UI consumer of the existing beets-library banding machinery —
+``web.server.compute_library_rank`` via the beets-only banding core
+factored out of ``web.routes._overlay`` — applied to ``album_requests``
+rows keyed by ``mb_release_id`` rather than to beets release rows keyed
+by release id.
+
+Service-first (KTD2): the typed ``LongTailResult`` is the contract; the
+HTTP route (``GET /api/pipeline/long-tail``) and the CLI
+(``pipeline-cli long-tail``) are thin adapters that wrap this module and
+map ``outcome`` onto status / exit codes. Both surfaces wrap the SAME
+service method per CLI ⇄ API symmetry.
+
+Banding rules (KTD1, three-way):
+
+* ``mb_release_id`` absent from the beets membership set → ``Missing``.
+* present in the library but no detail row / ``compute_library_rank``
+  returns ``"unknown"`` → ``Unknown`` (has audio, never ``Missing``).
+* otherwise → the lowercase ``QualityRank`` band (``transparent`` /
+  ``excellent`` / ``good`` / ``acceptable`` / ``poor``).
+
+The band labels are lowercase to match ``library_rank`` /
+``badge-rank-*`` exactly so badge rendering comes for free.
+
+``in_flight_rescue`` is stamped by the DB cohort query via the existing
+``download_log`` predicate ``source='youtube' AND outcome='youtube_running'``
+(inlined as an ``EXISTS`` in ``_RequestsMixin._LONG_TAIL_SELECT``), backed by
+migration 037's partial unique index ``one_youtube_running_per_request`` —
+never an N-query loop.
+
+The banding ``band_fn`` collaborator is injected so tests drop in a
+counting fake (the N+1 guard counts both the cohort query AND the beets
+membership + ``check_mbids_detail`` queries). Per the service-first
+pattern the service body never imports ``web.server`` — the route passes
+the concrete banding function in.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Protocol
+
+import msgspec
+
+
+# The ``Missing`` band sentinel — a release id absent from the beets
+# membership set has no library copy to upgrade. ``"unknown"`` (in-library
+# but unrankable) and the lowercase ``QualityRank`` names come straight
+# from ``compute_library_rank`` via the injected ``band_fn``, so they
+# aren't re-declared here.
+BAND_MISSING = "missing"
+
+
+class LongTailRow(msgspec.Struct, frozen=True):
+    """One ``wanted`` request, pre-banded and rescue-stamped.
+
+    ``band`` is one of ``"missing"`` / ``"unknown"`` / a lowercase
+    ``QualityRank`` name. ``in_flight_rescue`` is the
+    ``youtube_running`` flag stamped by the cohort query. The remaining
+    columns are the operator-facing subset the console header renders
+    (``min_bitrate``, ``target_format``, ``search_filetype_override``)
+    plus the identity columns used by tab / search filtering client-side.
+    """
+
+    id: int
+    artist_name: str
+    album_title: str
+    year: Optional[int]
+    status: str
+    source: Optional[str]
+    mb_release_id: Optional[str]
+    discogs_release_id: Optional[str]
+    target_format: Optional[str]
+    min_bitrate: Optional[int]
+    search_filetype_override: Optional[str]
+    unfindable_category: Optional[str]
+    band: str
+    in_flight_rescue: bool
+
+
+class LongTailResult(msgspec.Struct, frozen=True):
+    """The full worklist payload.
+
+    ``outcome`` is ``"ok"`` on success — the read has no error branch
+    today (a bad ``band`` filter is rejected by the wrapper before the
+    service runs), but the field keeps the result shape symmetric with
+    the rest of the service layer's typed results and gives the wrappers
+    a single field to map onto status / exit codes.
+
+    ``band_filter`` echoes the optional ``band`` argument (``None`` for
+    the unfiltered full-cohort fetch the UI uses).
+    """
+
+    outcome: str
+    rows: list[LongTailRow]
+    band_filter: Optional[str]
+
+
+# ``band_fn`` maps a list of release ids (``mb_release_id`` values) to a
+# ``{release_id: band}`` dict in a bounded number of queries. The route
+# wires this to the beets-only banding core in ``web.routes._overlay``;
+# tests inject a counting fake. Release ids absent from the returned dict
+# band as ``Missing``.
+BandFn = Callable[[list[str]], dict[str, str]]
+
+
+class _PipelineDB(Protocol):
+    """Duck-typed pipeline DB — service body never imports the concrete
+    class so tests can drop in a ``FakePipelineDB`` without monkey-patching.
+    """
+
+    def get_long_tail_cohort(self) -> list[dict[str, Any]]: ...
+
+    def get_long_tail_request(
+        self, request_id: int,
+    ) -> Optional[dict[str, Any]]: ...
+
+
+def list_long_tail(
+    pdb: _PipelineDB,
+    band_fn: BandFn,
+    *,
+    band: Optional[str] = None,
+) -> LongTailResult:
+    """Return the ``wanted`` cohort pre-banded and rescue-stamped.
+
+    Bounded query fan-out regardless of cohort size:
+
+    1. ``get_long_tail_cohort`` — one Postgres query for the whole
+       ``wanted`` set, each row carrying ``in_flight_rescue``.
+    2. ``band_fn`` — the beets-only banding core, batched over the whole
+       ``mb_release_id`` list (membership + ``check_mbids_detail``), never
+       per row.
+
+    ``band`` optionally filters the result to a single band (backs the
+    CLI's ``--band``). The UI fetches unfiltered and filters client-side.
+    """
+    rows = pdb.get_long_tail_cohort()
+    out_rows = _band_rows(rows, band_fn)
+    if band is not None:
+        out_rows = [r for r in out_rows if r.band == band]
+    return LongTailResult(outcome="ok", rows=out_rows, band_filter=band)
+
+
+def band_one_long_tail(
+    pdb: _PipelineDB,
+    band_fn: BandFn,
+    request_id: int,
+) -> Optional[LongTailRow]:
+    """Band a single ``wanted`` request by id.
+
+    Backs the post-action single-row refetch (KTD8) and the single-id
+    variant of the worklist read (R16). Returns ``None`` when the row
+    doesn't exist OR is no longer ``wanted`` (the cohort query is
+    ``status='wanted'`` only — an imported / replaced row is correctly
+    absent from the worklist). Uses the same banding path as
+    ``list_long_tail`` so the single-row band always agrees with the
+    cohort band.
+    """
+    row = pdb.get_long_tail_request(int(request_id))
+    if row is None:
+        return None
+    banded = _band_rows([row], band_fn)
+    return banded[0] if banded else None
+
+
+def _band_rows(
+    rows: list[dict[str, Any]],
+    band_fn: BandFn,
+) -> list[LongTailRow]:
+    """Band a cohort of request rows by ``mb_release_id`` in one batch."""
+    release_ids = [
+        str(r["mb_release_id"])
+        for r in rows
+        if r.get("mb_release_id")
+    ]
+    bands = band_fn(release_ids) if release_ids else {}
+    return [_band_row(r, bands) for r in rows]
+
+
+def _band_row(row: dict[str, Any], bands: dict[str, str]) -> LongTailRow:
+    rid = row.get("mb_release_id")
+    band = bands.get(str(rid), BAND_MISSING) if rid else BAND_MISSING
+    return LongTailRow(
+        id=int(row["id"]),
+        artist_name=str(row.get("artist_name") or ""),
+        album_title=str(row.get("album_title") or ""),
+        year=_int_or_none(row.get("year")),
+        status=str(row.get("status") or ""),
+        source=row.get("source"),
+        mb_release_id=row.get("mb_release_id"),
+        discogs_release_id=row.get("discogs_release_id"),
+        target_format=row.get("target_format"),
+        min_bitrate=_int_or_none(row.get("min_bitrate")),
+        search_filetype_override=row.get("search_filetype_override"),
+        unfindable_category=row.get("unfindable_category"),
+        band=band,
+        in_flight_rescue=bool(row.get("in_flight_rescue")),
+    )
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -1198,6 +1198,76 @@ class _RequestsMixin(_PipelineDBBase):
         return {r["status"]: r["cnt"] for r in cur.fetchall()}
 
 
+    # --- Long-tail worklist cohort (U1) ---------------------------------
+    #
+    # The Long-Tail Triage Console opens on the ``wanted`` set. Both methods
+    # below return the row UNbanded — banding is the beets-only concern of the
+    # web layer (``compute_library_rank`` keyed by ``mb_release_id``) and lives
+    # in the service's injected ``band_fn``. The DB layer's only
+    # banding-adjacent responsibility is stamping ``in_flight_rescue`` via the
+    # ``youtube_running`` EXISTS predicate (KTD4) — backed by the partial unique
+    # index ``one_youtube_running_per_request`` (migration 037), so it probes a
+    # tiny index, not a seq scan — so the service doesn't issue an N-query loop.
+    #
+    # Operator-facing column projection shared by the cohort + single-id reads.
+    # ``ar.*`` would carry the full row, but the worklist only renders this
+    # subset plus ``in_flight_rescue``; pinning the list keeps the wire payload
+    # narrow and the contract explicit.
+    _LONG_TAIL_SELECT = """
+        SELECT
+            ar.id,
+            ar.artist_name,
+            ar.album_title,
+            ar.year,
+            ar.status,
+            ar.source,
+            ar.mb_release_id,
+            ar.discogs_release_id,
+            ar.target_format,
+            ar.min_bitrate,
+            ar.search_filetype_override,
+            ar.unfindable_category,
+            EXISTS (
+                SELECT 1 FROM download_log dl
+                WHERE dl.request_id = ar.id
+                  AND dl.source = 'youtube'
+                  AND dl.outcome = 'youtube_running'
+            ) AS in_flight_rescue
+        FROM album_requests ar
+    """
+
+    def get_long_tail_cohort(self) -> list[dict[str, Any]]:
+        """Return the full ``wanted`` cohort, each row stamped with
+        ``in_flight_rescue``.
+
+        One Postgres query regardless of cohort size. Banding happens
+        downstream in the service (beets-only, batched). Ordered by id ASC for
+        stable rendering. ``replaced`` / ``imported`` / ``manual`` /
+        ``downloading`` rows are correctly excluded (R2 — worklist is the
+        ``wanted`` set only).
+        """
+        sql = (self._LONG_TAIL_SELECT
+               + " WHERE ar.status = 'wanted' ORDER BY ar.id ASC")
+        cur = self._execute(sql)
+        return [dict(r) for r in cur.fetchall()]
+
+    def get_long_tail_request(
+        self, request_id: int,
+    ) -> dict[str, Any] | None:
+        """Return a single ``wanted`` request stamped with ``in_flight_rescue``,
+        or ``None``.
+
+        Single-id variant of ``get_long_tail_cohort`` (KTD8 / R16 — backs the
+        post-action single-row refetch). Returns ``None`` when the row doesn't
+        exist OR is no longer ``wanted`` (an imported / replaced row is
+        correctly absent from the worklist).
+        """
+        sql = self._LONG_TAIL_SELECT + " WHERE ar.id = %s AND ar.status = 'wanted'"
+        cur = self._execute(sql, (int(request_id),))
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
     def list_requests_by_artist(
         self,
         artist_name: str,

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -3048,6 +3048,143 @@ def cmd_triage_list(db, args):
     return 0
 
 
+def _cli_band_fn(release_ids):
+    """Build the long-tail band map for the CLI.
+
+    Reuses the SAME banding decision the web overlay uses
+    (``web.routes._overlay._band_from_detail`` →
+    ``web.server.compute_library_rank``) but sources beets membership /
+    detail from a directly-opened ``BeetsDB`` rather than the web
+    server's module-level ``_beets`` global (which the CLI process never
+    sets). No parallel banding logic — only the beets-access seam
+    differs between the two surfaces.
+
+    Returns ``{release_id: band}`` (``"missing"`` / a lowercase
+    ``QualityRank`` / ``"unknown"``). Best-effort: if beets is
+    unreachable every id bands ``"missing"`` (no on-disk copy to upgrade
+    is the honest fallback).
+    """
+    from lib.beets_db import BeetsDB
+    from web.routes._overlay import _band_from_detail
+
+    ids_list = [str(rid) for rid in release_ids]
+    if not ids_list:
+        return {}
+    try:
+        with BeetsDB() as beets:
+            in_library = beets.check_mbids(ids_list)
+            quality = (
+                beets.check_mbids_detail(list(in_library))
+                if in_library else {}
+            )
+    except Exception:
+        return {rid: "missing" for rid in ids_list}
+    return {
+        rid: _band_from_detail(rid, in_library, quality) for rid in ids_list
+    }
+
+
+def cmd_long_tail(db, args, *, band_fn=None):
+    """``pipeline-cli long-tail [--band=<band>] [--json]``.
+
+    The long-tail worklist read — every ``wanted`` request pre-banded by
+    on-disk quality (``missing`` / a lowercase ``QualityRank`` band /
+    ``unknown``) and stamped with ``in_flight_rescue``. Counterpart of
+    ``GET /api/pipeline/long-tail`` (U1). Both surfaces wrap
+    ``lib.long_tail_service.list_long_tail`` — keep them in sync
+    (CLI ⇄ API symmetry).
+
+    ``--id`` requests a single banded row (KTD8 — the post-action
+    refetch counterpart of ``GET /api/pipeline/long-tail?id=``); exits 2
+    when the id doesn't exist or is no longer ``wanted``.
+
+    ``band_fn`` is a kwarg-DI seam (defaults to ``_cli_band_fn``, the
+    real BeetsDB-backed banding); tests inject a deterministic fake so
+    they don't need a live beets library.
+
+    Exit codes:
+      * 0 — success (empty cohort is a valid state)
+      * 2 — ``--id`` not found / not ``wanted``
+
+    JSON envelope (mirrors the API):
+        ``{"results": [...], "band": <str|null>, "count": <int>}``
+    Single-id JSON (mirrors the API):
+        ``{"result": <row>, "id": <int>}``
+    """
+    from lib.long_tail_service import band_one_long_tail, list_long_tail
+
+    json_mode = bool(getattr(args, "json", False))
+    resolved_band_fn = band_fn if band_fn is not None else _cli_band_fn
+
+    request_id = getattr(args, "id", None)
+    if request_id is not None:
+        row = band_one_long_tail(db, resolved_band_fn, int(request_id))
+        if row is None:
+            msg = f"request {int(request_id)} not found or not wanted"
+            if json_mode:
+                print(json.dumps(
+                    {"error": "Not found", "id": int(request_id)},
+                    indent=2, sort_keys=True))
+            else:
+                print(msg, file=sys.stderr)
+            return 2
+        if json_mode:
+            print(json.dumps(
+                {"result": msgspec.to_builtins(row), "id": int(request_id)},
+                indent=2, sort_keys=True, default=_json_default))
+        else:
+            print(f"  [{row.id}] {row.artist_name} - {row.album_title}")
+            print(f"  band:            {row.band}")
+            print(f"  in_flight_rescue: {row.in_flight_rescue}")
+        return 0
+
+    band = getattr(args, "band", None)
+    if band == "":
+        band = None
+
+    result = list_long_tail(db, resolved_band_fn, band=band)
+
+    if json_mode:
+        payload = {
+            "results": msgspec.to_builtins(result.rows),
+            "band": result.band_filter,
+            "count": len(result.rows),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True,
+                         default=_json_default))
+        return 0
+
+    if not result.rows:
+        suffix = f" for band={band!r}" if band else ""
+        print(f"  No wanted rows{suffix}.")
+        return 0
+
+    header_cols = (
+        ("id", 6),
+        ("artist", 25),
+        ("album", 25),
+        ("band", 12),
+        ("rescue", 7),
+        ("category", 22),
+    )
+    print("  ".join(name.ljust(width) for name, width in header_cols))
+    print("  ".join("-" * width for _, width in header_cols))
+    for r in result.rows:
+        row_cells = (
+            str(r.id),
+            _truncate(r.artist_name, 25),
+            _truncate(r.album_title, 25),
+            _truncate(r.band, 12),
+            "yes" if r.in_flight_rescue else "-",
+            _truncate(r.unfindable_category or "-", 22),
+        )
+        print("  ".join(
+            cell.ljust(width) for cell, (_, width) in zip(row_cells, header_cols)
+        ))
+    print(f"  ({len(result.rows)} rows)")
+    return 0
+
+
 def _build_parser() -> tuple[
     argparse.ArgumentParser, argparse.ArgumentParser, argparse.ArgumentParser
 ]:
@@ -3235,6 +3372,22 @@ def _build_parser() -> tuple[
         help="Resume cursor: last request_id from prior page")
     p_tr_list.add_argument("--json", action="store_true",
                             help="Print structured JSON instead of text")
+
+    # long-tail
+    p_long_tail = sub.add_parser(
+        "long-tail",
+        help="Long-tail worklist — wanted cohort pre-banded by on-disk "
+             "quality (missing / QualityRank / unknown) + in_flight_rescue")
+    p_long_tail.add_argument(
+        "--band", default=None,
+        help="Filter to a single band: missing | transparent | excellent "
+             "| good | acceptable | poor | unknown")
+    p_long_tail.add_argument(
+        "--id", type=int, default=None,
+        help="Band a single request by id (post-action refetch); "
+             "exits 2 if not found / not wanted")
+    p_long_tail.add_argument("--json", action="store_true",
+                             help="Print structured JSON instead of text")
 
     # quality
     p_quality = sub.add_parser("quality", help="Show quality state and simulate decisions")
@@ -3601,6 +3754,7 @@ def main():
         "beets-distance": cmd_beets_distance,
         "youtube-album": cmd_youtube_album,
         "youtube-rescue": cmd_youtube_rescue,
+        "long-tail": cmd_long_tail,
     }
     search_plan_commands = {
         "show": cmd_search_plan_show,

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -867,8 +867,9 @@ def _render_search_forensics_summary(
         lines.append("    candidates:     (empty list)")
         return lines
 
-    # Top-3 by (matched_tracks DESC, avg_ratio DESC) — same ordering as the
-    # web UI route, so CLI and web surfaces show the same scoring. Shared
+    # Top-3 by (matched_tracks DESC, avg_ratio DESC) for the compact CLI
+    # glance; the web long-tail console's "peers seen" panel renders the full
+    # stored slice (top-20). Same ranking, different surface depth. Shared
     # ranking lives in lib/quality.py.
     top = top_candidates(candidates, limit=3)
     lines.append(f"    top candidates ({len(top)} of {len(candidates)}):")

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -3053,12 +3053,11 @@ def _cli_band_fn(release_ids):
     """Build the long-tail band map for the CLI.
 
     Reuses the SAME banding decision the web overlay uses
-    (``web.routes._overlay._band_from_detail`` →
-    ``web.server.compute_library_rank``) but sources beets membership /
+    (``lib.banding.band_from_detail``) but sources beets membership /
     detail from a directly-opened ``BeetsDB`` rather than the web
     server's module-level ``_beets`` global (which the CLI process never
-    sets). No parallel banding logic — only the beets-access seam
-    differs between the two surfaces.
+    sets). No parallel banding logic — only the beets-access seam and the
+    rank-config source differ between the two surfaces.
 
     Returns ``{release_id: band}`` (``"missing"`` / a lowercase
     ``QualityRank`` / ``"unknown"``). Best-effort: if beets is
@@ -3066,11 +3065,12 @@ def _cli_band_fn(release_ids):
     is the honest fallback).
     """
     from lib.beets_db import BeetsDB
-    from web.routes._overlay import _band_from_detail
+    from lib.banding import band_from_detail, load_rank_config
 
     ids_list = [str(rid) for rid in release_ids]
     if not ids_list:
         return {}
+    cfg = load_rank_config()
     try:
         with BeetsDB() as beets:
             in_library = beets.check_mbids(ids_list)
@@ -3081,7 +3081,8 @@ def _cli_band_fn(release_ids):
     except Exception:
         return {rid: "missing" for rid in ids_list}
     return {
-        rid: _band_from_detail(rid, in_library, quality) for rid in ids_list
+        rid: band_from_detail(rid, in_library, quality, cfg)
+        for rid in ids_list
     }
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3514,6 +3514,68 @@ class FakePipelineDB:
                 key=lambda r: _as_datetime(r.get("created_at")))
         ]
 
+    def _has_youtube_running(self, request_id: int) -> bool:
+        """Mirror of the ``_LONG_TAIL_SELECT`` ``youtube_running`` EXISTS.
+
+        A request has an in-flight rescue iff a ``download_log`` row with
+        ``source='youtube' AND outcome='youtube_running'`` exists for it.
+        """
+        return any(
+            entry.source == "youtube"
+            and entry.outcome == "youtube_running"
+            and entry.request_id == request_id
+            for entry in self.download_logs
+        )
+
+    def _long_tail_projection(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Project a request row to the long-tail cohort SELECT shape.
+
+        Mirrors ``PipelineDB._LONG_TAIL_SELECT``'s narrow column list +
+        the ``in_flight_rescue`` stamp so tests can't rely on a column
+        the production query doesn't return.
+        """
+        keys = (
+            "id", "artist_name", "album_title", "year", "status", "source",
+            "mb_release_id", "discogs_release_id", "target_format",
+            "min_bitrate", "search_filetype_override", "unfindable_category",
+        )
+        out: dict[str, Any] = {k: row.get(k) for k in keys}
+        out["in_flight_rescue"] = self._has_youtube_running(int(row["id"]))
+        return out
+
+    def get_long_tail_cohort(self) -> list[dict[str, Any]]:
+        """In-memory mirror of ``PipelineDB.get_long_tail_cohort``.
+
+        Returns every ``wanted`` request projected to the cohort SELECT
+        shape, id ASC, each stamped with ``in_flight_rescue``. Counts as
+        ONE query for the N+1 guard.
+        """
+        self.query_counts["get_long_tail_cohort"] = (
+            self.query_counts.get("get_long_tail_cohort", 0) + 1
+        )
+        rows = sorted(
+            (r for r in self._requests.values()
+             if r.get("status") == "wanted"),
+            key=lambda r: int(r["id"]),
+        )
+        return [self._long_tail_projection(r) for r in rows]
+
+    def get_long_tail_request(
+        self, request_id: int,
+    ) -> dict[str, Any] | None:
+        """In-memory mirror of ``PipelineDB.get_long_tail_request``.
+
+        Single-id variant — returns ``None`` when the row is missing or
+        no longer ``wanted``.
+        """
+        self.query_counts["get_long_tail_request"] = (
+            self.query_counts.get("get_long_tail_request", 0) + 1
+        )
+        row = self._requests.get(int(request_id))
+        if row is None or row.get("status") != "wanted":
+            return None
+        return self._long_tail_projection(row)
+
     def get_recent(self, limit: int = 20) -> list[dict[str, Any]]:
         """Return requests that have at least one download_log row."""
         with_history = {row.request_id for row in self.download_logs}

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -3151,6 +3151,43 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         self.assertEqual(
             db.count_by_status(), {"wanted": 2, "imported": 1})
 
+    def test_get_long_tail_cohort_returns_only_wanted_stamped(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+        db.seed_request(make_request_row(
+            id=2, status="imported", mb_release_id="rel-2"))
+        db.seed_request(make_request_row(
+            id=3, status="wanted", mb_release_id="rel-3"))
+        # Row 3 has an in-flight youtube rescue.
+        db.insert_youtube_running(
+            request_id=3, browse_id="MPREb_x", audio_playlist_id=None,
+            yt_url="https://music.youtube.com/playlist?list=x",
+            expected_track_count=10,
+        )
+        rows = db.get_long_tail_cohort()
+        self.assertEqual([r["id"] for r in rows], [1, 3])
+        by_id = {r["id"]: r for r in rows}
+        self.assertFalse(by_id[1]["in_flight_rescue"])
+        self.assertTrue(by_id[3]["in_flight_rescue"])
+        # Projection is narrow — must not carry the full request row.
+        self.assertNotIn("reasoning", by_id[1])
+        self.assertIn("target_format", by_id[1])
+
+    def test_get_long_tail_request_single_id(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=5, status="wanted", mb_release_id="rel-5"))
+        db.seed_request(make_request_row(
+            id=6, status="imported", mb_release_id="rel-6"))
+        row = db.get_long_tail_request(5)
+        assert row is not None
+        self.assertEqual(row["id"], 5)
+        self.assertFalse(row["in_flight_rescue"])
+        # Non-wanted and missing ids return None.
+        self.assertIsNone(db.get_long_tail_request(6))
+        self.assertIsNone(db.get_long_tail_request(999))
+
     def test_count_by_status_preserves_none_bucket(self):
         """Real SQL ``GROUP BY status`` keeps NULL as its own key; the
         fake must not collapse it to an empty string."""

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_util.mjs
  */
 
-import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock, parsePastedId } from '../web/js/util.js';
+import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock, parsePastedId, youtubeSectionState, consoleEmphasis } from '../web/js/util.js';
 import { state } from '../web/js/state.js';
 import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, loadLabelReleases, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls, renderLabelRows } from '../web/js/labels.js';
 import { __test__ as longTailTest } from '../web/js/long_tail.js';
@@ -531,6 +531,73 @@ assert(!xssBlock.includes('<script>x</script>'),
   'malicious username escaped');
 assert(!xssBlock.includes('"><img>'),
   'malicious dir escaped');
+
+// --- youtubeSectionState tests (U4 four-state classifier) ---
+console.log('youtubeSectionState()');
+// null / undefined / non-object → never_run (the side-effectful GET has
+// not been run; U4 must NOT auto-call it).
+assertEqual(youtubeSectionState(null).state, 'never_run', 'null → never_run');
+assertEqual(youtubeSectionState(undefined).state, 'never_run', 'undefined → never_run');
+// A truthy object with no `outcome` field is a malformed/failed resolve
+// (its outcome is not "ok"), NOT never_run — only null/undefined defaults
+// to the not-yet-run state.
+assertEqual(youtubeSectionState({}).state, 'resolver_failed', 'object with no outcome → resolver_failed');
+assertEqual(youtubeSectionState(null).stale, false, 'never_run is never stale');
+// ok + releases → resolved_with_matrix.
+const ytMatrix = youtubeSectionState({
+  outcome: 'ok',
+  youtube_releases: [{ yt_browse_id: 'MPREb_x', distances: [] }],
+  from_cache: false,
+});
+assertEqual(ytMatrix.state, 'resolved_with_matrix', 'ok + releases>0 → resolved_with_matrix');
+assertEqual(ytMatrix.stale, false, 'fresh matrix not stale');
+assertEqual(ytMatrix.message, '', 'fresh matrix needs no message');
+// ok + empty releases → resolved_empty.
+const ytEmpty = youtubeSectionState({ outcome: 'ok', youtube_releases: [], from_cache: false });
+assertEqual(ytEmpty.state, 'resolved_empty', 'ok + releases==0 → resolved_empty');
+assert(ytEmpty.message.includes('Not on YouTube Music'), 'resolved_empty surfaces "not on YouTube Music" copy');
+// ok + missing youtube_releases key → resolved_empty (no releases).
+assertEqual(youtubeSectionState({ outcome: 'ok' }).state, 'resolved_empty', 'ok + no releases key → resolved_empty');
+// transient / 503 outcomes → resolver_failed.
+assertEqual(youtubeSectionState({ outcome: 'transient' }).state, 'resolver_failed', 'transient → resolver_failed');
+assertEqual(youtubeSectionState({ outcome: 'unresolved_timeout' }).state, 'resolver_failed', 'unresolved_timeout → resolver_failed');
+assertEqual(youtubeSectionState({ outcome: 'unresolved_mirror_unavailable' }).state, 'resolver_failed', 'mirror unavailable → resolver_failed');
+assertEqual(youtubeSectionState({ outcome: 'not_found' }).state, 'resolver_failed', 'not_found → resolver_failed');
+const ytFail = youtubeSectionState({ outcome: 'transient', error_message: 'mirror down' });
+assert(ytFail.message.includes('mirror down'), 'resolver_failed surfaces the error_message');
+// from_cache + error_message → staleness flag on an otherwise-resolved state.
+const ytStaleMatrix = youtubeSectionState({
+  outcome: 'ok',
+  youtube_releases: [{ yt_browse_id: 'MPREb_y', distances: [] }],
+  from_cache: true,
+  error_message: 'live YT fetch failed; served cache',
+});
+assertEqual(ytStaleMatrix.state, 'resolved_with_matrix', 'cached matrix still resolves with matrix');
+assertEqual(ytStaleMatrix.stale, true, 'from_cache + error_message sets the staleness flag');
+assert(ytStaleMatrix.message.includes('stale'), 'stale matrix surfaces a staleness message');
+// from_cache WITHOUT error_message is a clean cache hit, not stale.
+assertEqual(
+  youtubeSectionState({ outcome: 'ok', youtube_releases: [{ yt_browse_id: 'z', distances: [] }], from_cache: true }).stale,
+  false,
+  'from_cache alone (no error_message) is not stale',
+);
+
+// --- consoleEmphasis tests (U4 band-aware emphasis selector) ---
+console.log('consoleEmphasis()');
+assertEqual(consoleEmphasis({ band: 'missing' }).lead, 'unfindable', 'Missing band leads with unfindable panel');
+assertEqual(consoleEmphasis({ band: 'MISSING' }).lead, 'unfindable', 'Missing band is case-insensitive');
+assertEqual(consoleEmphasis({ band: '' }).lead, 'unfindable', 'no band (treated Missing-like) leads with unfindable');
+assertEqual(consoleEmphasis({}).lead, 'unfindable', 'missing band key leads with unfindable');
+assertEqual(consoleEmphasis(null).lead, 'unfindable', 'null row leads with unfindable');
+assertEqual(consoleEmphasis({ band: 'poor' }).lead, 'band_vs_intent', 'on-disk band leads with band-vs-intent');
+assertEqual(consoleEmphasis({ band: 'transparent' }).lead, 'band_vs_intent', 'on-disk transparent leads with band-vs-intent');
+// An on-disk row carrying an unfindable_category still leads with unfindable
+// (the operator's first question is "why stuck", even if a copy exists).
+assertEqual(
+  consoleEmphasis({ band: 'poor', unfindable_category: 'wrong_pressing_available' }).lead,
+  'unfindable',
+  'on-disk row with an unfindable_category leads with unfindable',
+);
 
 // --- parsePastedId tests (search-by-ID) ---
 console.log('parsePastedId()');
@@ -1149,6 +1216,229 @@ console.log('long_tail.js __test__');
   );
   // Reset shared state so later tests are not affected.
   state.longTail = { rows: null, band: null, query: '' };
+}
+
+// --- long_tail.js action console pure helpers (U4) ---
+console.log('long_tail.js __test__ (U4 console)');
+{
+  const {
+    renderUnfindableBody,
+    renderPeersBody,
+    renderRescuesBody,
+    renderSiblingsBody,
+    renderYoutubeBody,
+    renderConsoleShell,
+    renderPanelError,
+    youtubeHistoryRows,
+    youtubeFailureReason,
+    PEERS_VISIBLE_CAP,
+  } = longTailTest;
+
+  // --- renderUnfindableBody: categorised vs not-yet-categorised ---
+  // Categorised → category badge + forensics rollup.
+  const categorised = renderUnfindableBody({
+    unfindable: { category: 'wrong_pressing_available', categorised_at: '2026-05-20T00:00:00Z',
+      last_artist_probe_match_count: 3, last_artist_probe_at: '2026-05-21T00:00:00Z' },
+    search_forensics: { total_searches: 40, with_cands_count: 12, zero_results_count: 5,
+      dominant_rejection_reason: 'strict_count', last_search_at: '2026-05-22T00:00:00Z' },
+  });
+  assert(categorised.includes('wrong_pressing_available'),
+    'renderUnfindableBody renders the category for a categorised request');
+  assert(categorised.includes('40 searches') && categorised.includes('dominant reject: strict_count'),
+    'renderUnfindableBody renders the search-forensics rollup');
+  assert(categorised.includes('artist probe: 3 matches'),
+    'renderUnfindableBody renders the artist-probe rollup');
+  // Not-yet-categorised (unfindable == null) → daily-detection state, NOT
+  // an error, NOT blank (R7).
+  const uncategorised = renderUnfindableBody({
+    unfindable: null,
+    search_forensics: { total_searches: 2, with_cands_count: 0, zero_results_count: 2 },
+  });
+  assert(uncategorised.includes('not yet categorised') && uncategorised.includes('detection runs daily'),
+    'renderUnfindableBody renders the not-yet-categorised daily-detection state');
+  assert(!uncategorised.toLowerCase().includes("couldn't load"),
+    'not-yet-categorised is distinct from an error affordance');
+  // category explicitly absent on the unfindable struct also → uncategorised.
+  const catNull = renderUnfindableBody({ unfindable: { category: null }, search_forensics: {} });
+  assert(catNull.includes('not yet categorised'),
+    'renderUnfindableBody treats a null category as not-yet-categorised');
+
+  // --- youtubeHistoryRows: only source==="youtube" rows ---
+  // Production-shaped: a youtube_failed row carries its reason in the
+  // youtube_metadata JSONB blob (per YoutubeIngestMetadata.reason), NOT in
+  // a top-level field.
+  const mixedHistory = [
+    { source: 'youtube', outcome: 'youtube_failed', created_at: '2026-05-25T00:00:00Z',
+      youtube_metadata: { reason: 'track_count_mismatch' } },
+    { source: 'request', outcome: 'rejected' },
+    { source: 'youtube', outcome: 'youtube_running', created_at: '2026-05-26T00:00:00Z' },
+  ];
+  assertEqual(youtubeHistoryRows(mixedHistory).length, 2,
+    'youtubeHistoryRows keeps only source==="youtube" rows');
+  assertEqual(youtubeHistoryRows([]).length, 0, 'youtubeHistoryRows empty → []');
+  assertEqual(youtubeHistoryRows(null).length, 0, 'youtubeHistoryRows null → []');
+
+  // --- youtubeFailureReason: reads the production-shaped reason field ---
+  assertEqual(
+    youtubeFailureReason({ youtube_metadata: { reason: 'track_count_mismatch' } }),
+    'track_count_mismatch',
+    'youtubeFailureReason reads youtube_metadata.reason (the production field)');
+  assertEqual(
+    youtubeFailureReason({ error_message: 'yt-dlp died' }),
+    'yt-dlp died',
+    'youtubeFailureReason falls back to error_message');
+  assertEqual(
+    youtubeFailureReason({ verdict: 'rejected' }),
+    'rejected',
+    'youtubeFailureReason falls back to verdict');
+  assertEqual(
+    youtubeFailureReason({}),
+    'unknown',
+    'youtubeFailureReason → "unknown" when no reason field present');
+
+  // --- renderRescuesBody: running / failed / success / none ---
+  // Active youtube_running row → "rescue running".
+  const running = renderRescuesBody(
+    [{ source: 'youtube', outcome: 'youtube_running', created_at: '2026-05-26T00:00:00Z' }], false);
+  assert(running.includes('rescue running'), 'renderRescuesBody shows "rescue running" for an active youtube_running row');
+  // in_flight flag alone (no history) → "rescue running" (KTD4 same predicate).
+  assert(renderRescuesBody([], true).includes('rescue running'),
+    'renderRescuesBody honours the in_flight_rescue flag with no history');
+  // Latest terminal youtube_failed → "last rescue failed: <reason>".
+  // Reason comes from the production-shaped youtube_metadata.reason blob.
+  const failed = renderRescuesBody(
+    [{ source: 'youtube', outcome: 'youtube_failed', created_at: '2026-05-25T00:00:00Z',
+       youtube_metadata: { reason: 'track_count_mismatch' } }], false);
+  assert(failed.includes('last rescue failed') && failed.includes('track_count_mismatch'),
+    'renderRescuesBody shows the failure reason (from youtube_metadata) for a terminal youtube_failed row');
+  // A terminal youtube_success is NOT a failure (distinct from youtube_failed).
+  const succeeded = renderRescuesBody(
+    [{ source: 'youtube', outcome: 'youtube_success', created_at: '2026-05-24T00:00:00Z' }], false);
+  assert(!succeeded.includes('last rescue failed'),
+    'renderRescuesBody does NOT render a failure for a youtube_success row');
+  assert(succeeded.includes('youtube_success'),
+    'renderRescuesBody lists a youtube_success attempt');
+  // No youtube rows at all → "no rescue attempts".
+  assert(renderRescuesBody([{ source: 'request', outcome: 'success' }], false).includes('No rescue attempts'),
+    'renderRescuesBody shows "no rescue attempts" when there are no youtube rows');
+
+  // --- renderPeersBody: cap + show-all toggle ---
+  const fewPeers = {
+    variant: 'v1', final_state: 'Completed', outcome: 'no_match',
+    top_candidates: [
+      { username: 'a', dir: 'x', filetype: 'flac', matched_tracks: 1, total_tracks: 1, avg_ratio: 1, missing_titles: [], file_count: 1 },
+    ],
+  };
+  const fewHtml = renderPeersBody(fewPeers, 7);
+  assert(fewHtml.includes('p-forensic') && !fewHtml.includes('show all'),
+    'renderPeersBody under the cap renders the plain forensic block (no show-all)');
+  const manyCands = [];
+  for (let i = 0; i < PEERS_VISIBLE_CAP + 4; i++) {
+    manyCands.push({ username: `u${i}`, dir: `d${i}`, filetype: 'flac',
+      matched_tracks: 1, total_tracks: 1, avg_ratio: 1, missing_titles: [], file_count: 1 });
+  }
+  const manyHtml = renderPeersBody(
+    { variant: 'v1', final_state: 'Completed', outcome: 'no_match', top_candidates: manyCands }, 7);
+  assert(manyHtml.includes(`show all ${manyCands.length} peers`),
+    'renderPeersBody over the cap offers a show-all toggle with the full count');
+  assert(manyHtml.includes('window.toggleLongTailPeers(7)'),
+    'renderPeersBody wires the show-all toggle to toggleLongTailPeers with the row id');
+  assert(manyHtml.includes('lt-peers-full'),
+    'renderPeersBody pre-renders the full block for the toggle');
+  // Null last_search → forensic block "no data yet" (not a crash).
+  assert(renderPeersBody(null, 7).includes('No search forensic data yet'),
+    'renderPeersBody null last_search → forensic "no data yet"');
+
+  // --- renderSiblingsBody: rows + empty ---
+  const siblings = renderSiblingsBody({ releases: [
+    { id: 'r1', title: 'Pressing A', date: '2008-01-01', country: 'US', track_count: 14, format: 'CD',
+      in_library: true, library_rank: 'transparent', pipeline_status: null },
+    { id: 'r2', title: 'Pressing B', date: '2000-01-01', country: 'GB', track_count: 10, format: 'CD',
+      in_library: false, pipeline_status: 'wanted' },
+  ] });
+  assert(siblings.includes('Pressing A') && siblings.includes('Pressing B'),
+    'renderSiblingsBody renders each sibling pressing');
+  assert(siblings.includes('in library') && siblings.includes('badge-rank-transparent'),
+    'renderSiblingsBody renders the in-library badge with the rank colour');
+  assert(siblings.includes('badge-wanted') || siblings.includes('wanted'),
+    'renderSiblingsBody renders the pipeline status for a sibling already requested');
+  assert(renderSiblingsBody({ releases: [] }).includes('No sibling pressings'),
+    'renderSiblingsBody empty → "no sibling pressings"');
+  assert(renderSiblingsBody(null).includes('No sibling pressings'),
+    'renderSiblingsBody null → "no sibling pressings"');
+
+  // --- renderYoutubeBody: four states (display-only matrix in U4) ---
+  // never_run (null result) → Check YouTube button, no matrix.
+  const ytNever = renderYoutubeBody(null, 9);
+  assert(ytNever.includes('Check YouTube') && ytNever.includes('window.checkYoutube(9)'),
+    'renderYoutubeBody never_run renders the Check-YouTube stub wired to window.checkYoutube');
+  assert(!ytNever.includes('lt-yt-row'),
+    'renderYoutubeBody never_run renders no matrix rows (no auto-resolve)');
+  // resolved_with_matrix → display-only matrix rows.
+  const ytMatrixHtml = renderYoutubeBody({
+    outcome: 'ok', from_cache: false, youtube_releases: [
+      { yt_browse_id: 'MPREb_z', year: 2008, track_count: 14, tracks: [],
+        distances: [{ mbid: 'm', outcome: 'ok', distance: 0.07 }, { mbid: 'n', outcome: 'no_audio' }] },
+    ],
+  }, 9);
+  assert(ytMatrixHtml.includes('MPREb_z') && ytMatrixHtml.includes('lt-yt-row'),
+    'renderYoutubeBody resolved_with_matrix renders the display-only matrix rows');
+  assert(ytMatrixHtml.includes('dist 0.070'),
+    'renderYoutubeBody matrix surfaces the best ok distance');
+  // resolved_empty → "not on YouTube Music".
+  const ytEmptyHtml = renderYoutubeBody({ outcome: 'ok', youtube_releases: [] }, 9);
+  assert(ytEmptyHtml.includes('Not on YouTube Music'),
+    'renderYoutubeBody resolved_empty renders the "not on YouTube Music" copy');
+  // resolver_failed → error message + retry (Check YouTube).
+  const ytFailedHtml = renderYoutubeBody({ outcome: 'transient', error_message: 'mirror down' }, 9);
+  assert(ytFailedHtml.includes('mirror down') && ytFailedHtml.includes('Check YouTube'),
+    'renderYoutubeBody resolver_failed renders the error + retry affordance');
+  // staleness flag on a cached matrix.
+  const ytStaleHtml = renderYoutubeBody({
+    outcome: 'ok', from_cache: true, error_message: 'live fetch failed',
+    youtube_releases: [{ yt_browse_id: 'b', track_count: 1, tracks: [], distances: [] }],
+  }, 9);
+  assert(ytStaleHtml.includes('lt-yt-stale'),
+    'renderYoutubeBody surfaces a staleness flag on a cached-but-stale matrix');
+
+  // --- renderConsoleShell: band-aware emphasis + panel containers ---
+  // Missing row → why-unfindable leads; the per-panel containers exist.
+  const missingShell = renderConsoleShell({ id: 11, band: 'missing', source: 'mb', target_format: 'lossless' });
+  assert(missingShell.includes('id="lt-panel-unfindable-11"'),
+    'renderConsoleShell emits the why-unfindable panel container');
+  assert(missingShell.includes('id="lt-panel-peers-11"')
+    && missingShell.includes('id="lt-panel-rescues-11"')
+    && missingShell.includes('id="lt-panel-siblings-11"')
+    && missingShell.includes('id="lt-panel-youtube-11"'),
+    'renderConsoleShell emits all five evidence-panel containers');
+  // Lead emphasis: the unfindable panel carries the lead class for a Missing row.
+  assert(/lt-panel-unfindable[^"]*lt-panel-lead|lt-panel-lead[^"]*lt-panel-unfindable/.test(missingShell.replace(/\n/g, ' '))
+    || missingShell.includes('lt-panel lt-panel-unfindable lt-panel-lead'),
+    'renderConsoleShell makes why-unfindable the lead panel for a Missing row');
+  // The YouTube panel opens in never_run (no auto-resolve) — Check button present.
+  assert(missingShell.includes('window.checkYoutube(11)'),
+    'renderConsoleShell opens the YouTube panel in never_run (Check-YouTube stub, no auto-resolve)');
+  // On-disk row → band-vs-intent leads (R8), why-unfindable does not.
+  const onDiskShell = renderConsoleShell({ id: 12, band: 'poor', source: 'mb', target_format: 'lossless' });
+  assert(onDiskShell.includes('Quality vs intent') && onDiskShell.includes('lt-band-intent'),
+    'renderConsoleShell leads an on-disk row with the band-vs-intent header');
+  assert(onDiskShell.indexOf('lt-band-intent') < onDiskShell.indexOf('lt-panel-unfindable-12'),
+    'renderConsoleShell orders band-vs-intent BEFORE why-unfindable for an on-disk row');
+
+  // --- partial-failure render: one panel error, others still render ---
+  // Simulate the loaders' per-panel catch: the siblings panel gets the
+  // error affordance while the other panels render their content. The pure
+  // pieces guarantee a failing panel never blanks or drops its siblings.
+  const errBody = renderPanelError('sibling pressings');
+  assert(errBody.includes("Couldn't load sibling pressings") && errBody.includes('other panels are unaffected'),
+    'renderPanelError renders the isolated per-panel error affordance');
+  // Compose the shell + a per-panel error swap + a sibling content render,
+  // proving the three coexist (the independent-load contract).
+  const composed = renderConsoleShell({ id: 13, band: 'missing' })
+    + renderUnfindableBody({ unfindable: { category: 'artist_absent' }, search_forensics: {} })
+    + renderPanelError('sibling pressings');
+  assert(composed.includes('artist_absent') && composed.includes("Couldn't load sibling pressings"),
+    'a panel error and other panels\' content coexist (independent-load contract)');
 }
 
 // --- Summary ---

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -1198,9 +1198,14 @@ console.log('long_tail.js __test__');
     populated.includes('lt-band-tabs') && populated.includes('lt-search-input'),
     'renderLongTailBody renders band tabs + search box for a populated cohort',
   );
+  assert(
+    populated.includes(
+      `lt-band-tab active-status" type="button" onclick="window.setLongTailBand('missing')`),
+    'renderLongTailBody renders Missing as the default active tab',
+  );
   assertEqual(
-    state.longTail.band, 'missing',
-    'renderLongTailBody defaults the selected band to Missing',
+    state.longTail.band, null,
+    'renderLongTailBody is pure — it does not mutate state.longTail.band',
   );
   // Empty-band -> a search filters the selected band to zero; the
   // affordance + cross-band hint show, never a blank area.

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -1389,9 +1389,13 @@ console.log('long_tail.js __test__ (U4 console)');
   const ytEmptyHtml = renderYoutubeBody({ outcome: 'ok', youtube_releases: [] }, 9);
   assert(ytEmptyHtml.includes('Not on YouTube Music'),
     'renderYoutubeBody resolved_empty renders the "not on YouTube Music" copy');
-  // resolver_failed → error message + retry (Check YouTube).
+  // resolver_failed → error message + retry affordance. The retry button
+  // is relabelled "Retry" in U5 (still wired to window.checkYoutube), so
+  // assert on the retry verb + the wired handler rather than the original
+  // "Check YouTube" label.
   const ytFailedHtml = renderYoutubeBody({ outcome: 'transient', error_message: 'mirror down' }, 9);
-  assert(ytFailedHtml.includes('mirror down') && ytFailedHtml.includes('Check YouTube'),
+  assert(ytFailedHtml.includes('mirror down') && ytFailedHtml.includes('Retry')
+    && ytFailedHtml.includes('window.checkYoutube(9)'),
     'renderYoutubeBody resolver_failed renders the error + retry affordance');
   // staleness flag on a cached matrix.
   const ytStaleHtml = renderYoutubeBody({
@@ -1439,6 +1443,151 @@ console.log('long_tail.js __test__ (U4 console)');
     + renderPanelError('sibling pressings');
   assert(composed.includes('artist_absent') && composed.includes("Couldn't load sibling pressings"),
     'a panel error and other panels\' content coexist (independent-load contract)');
+}
+
+// --- long_tail.js U5 rescue flow pure helpers ---
+console.log('long_tail.js __test__ (U5 rescue flow)');
+{
+  const {
+    youtubeBestDistance,
+    youtubeRescueTargets,
+    rescueOutcomeCopy,
+    canStartInFlight,
+    renderYoutubeBody,
+    renderRescueConfirm,
+  } = longTailTest;
+
+  // --- youtubeBestDistance: lowest ok distance, ignores non-ok rows ---
+  assertEqual(
+    youtubeBestDistance({ distances: [
+      { mbid: 'a', outcome: 'ok', distance: 0.21 },
+      { mbid: 'b', outcome: 'ok', distance: 0.07 },
+      { mbid: 'c', outcome: 'no_audio' },
+    ] }),
+    0.07,
+    'youtubeBestDistance picks the lowest ok distance');
+  assertEqual(
+    youtubeBestDistance({ distances: [{ mbid: 'a', outcome: 'no_audio' }] }),
+    null,
+    'youtubeBestDistance → null when no ok row scored');
+  assertEqual(youtubeBestDistance({}), null, 'youtubeBestDistance no distances → null');
+  assertEqual(youtubeBestDistance({ distances: null }), null, 'youtubeBestDistance null distances → null');
+
+  // --- youtubeRescueTargets: each target carries its browse id + meta ---
+  const resolverOk = {
+    outcome: 'ok', from_cache: false, youtube_releases: [
+      { yt_browse_id: 'MPREb_one', year: 2008, track_count: 14, tracks: [],
+        distances: [{ mbid: 'm', outcome: 'ok', distance: 0.07 }, { mbid: 'n', outcome: 'no_audio' }] },
+      { yt_browse_id: 'MPREb_two', year: 2000, track_count: 10, tracks: [],
+        distances: [{ mbid: 'p', outcome: 'ok', distance: 0.19 }] },
+    ],
+  };
+  const targets = youtubeRescueTargets(resolverOk);
+  assertEqual(targets.length, 2, 'youtubeRescueTargets yields one target per release');
+  assertEqual(targets[0].yt_browse_id, 'MPREb_one', 'target 0 carries its browse id');
+  assertEqual(targets[1].yt_browse_id, 'MPREb_two', 'target 1 carries its browse id');
+  assertEqual(targets[0].year, 2008, 'target carries year');
+  assertEqual(targets[0].track_count, 14, 'target carries track_count');
+  assertEqual(targets[0].best_distance, 0.07, 'target carries best ok distance');
+  assertEqual(targets[1].best_distance, 0.19, 'second target best distance');
+  // A release missing a browse id is NOT a pickable target (the submit
+  // needs the id).
+  const targetsWithBad = youtubeRescueTargets({
+    outcome: 'ok', youtube_releases: [
+      { yt_browse_id: '', year: 1999, track_count: 8, distances: [] },
+      { yt_browse_id: 'MPREb_keep', year: 2001, track_count: 9, distances: [] },
+    ],
+  });
+  assertEqual(targetsWithBad.length, 1, 'youtubeRescueTargets drops a release with no browse id');
+  assertEqual(targetsWithBad[0].yt_browse_id, 'MPREb_keep', 'kept the release that has a browse id');
+
+  // resolved_empty → NO rescue targets (rescue affordance hidden).
+  assertEqual(
+    youtubeRescueTargets({ outcome: 'ok', youtube_releases: [] }).length,
+    0,
+    'youtubeRescueTargets: resolved_empty yields no rescue targets');
+  // resolver_failed → no targets.
+  assertEqual(
+    youtubeRescueTargets({ outcome: 'transient', error_message: 'down' }).length,
+    0,
+    'youtubeRescueTargets: resolver_failed yields no targets');
+  // never_run (null) → no targets.
+  assertEqual(youtubeRescueTargets(null).length, 0, 'youtubeRescueTargets: null yields no targets');
+
+  // --- renderYoutubeBody: matrix rows are pickable rescue targets (U5) ---
+  const matrixHtml = renderYoutubeBody(resolverOk, 9);
+  assert(matrixHtml.includes('window.pickYoutubeRescue(9, ')
+    && matrixHtml.includes('MPREb_one') && matrixHtml.includes('MPREb_two'),
+    'renderYoutubeBody resolved_with_matrix makes each release a pickable rescue target');
+  assert(matrixHtml.includes('Rescue from this'),
+    'renderYoutubeBody matrix rows carry a "Rescue from this" button');
+  // resolved_empty HIDES the rescue affordance (R9 — nothing to pick).
+  const emptyHtml = renderYoutubeBody({ outcome: 'ok', youtube_releases: [] }, 9);
+  assert(!emptyHtml.includes('Rescue from this') && emptyHtml.includes('Not on YouTube Music'),
+    'renderYoutubeBody resolved_empty hides the rescue affordance and shows "not on YouTube Music"');
+  assert(emptyHtml.includes('Re-check'),
+    'renderYoutubeBody resolved_empty offers a re-check');
+  // resolver_failed → Retry affordance.
+  assert(renderYoutubeBody({ outcome: 'transient', error_message: 'mirror down' }, 9).includes('Retry'),
+    'renderYoutubeBody resolver_failed offers a Retry affordance');
+
+  // --- rescueOutcomeCopy: every ingest outcome → its intended copy ---
+  // accepted → success tone, "rescue queued".
+  const accepted = rescueOutcomeCopy({ outcome: 'accepted', download_log_id: 42 });
+  assertEqual(accepted.tone, 'success', 'rescueOutcomeCopy accepted → success tone');
+  assert(accepted.title.toLowerCase().includes('queued'), 'rescueOutcomeCopy accepted title says queued');
+  assert(accepted.detail.includes('42'), 'rescueOutcomeCopy accepted surfaces the download_log_id');
+  // in_flight → error tone, surfaces the existing download_log_id.
+  const inFlight = rescueOutcomeCopy({ outcome: 'in_flight', download_log_id: 7 });
+  assertEqual(inFlight.tone, 'error', 'rescueOutcomeCopy in_flight → error tone');
+  assert(inFlight.detail.includes('already running') && inFlight.detail.includes('7'),
+    'rescueOutcomeCopy in_flight surfaces the existing download_log_id');
+  // wrong_state → "request changed — refresh".
+  const wrongState = rescueOutcomeCopy({ outcome: 'wrong_state' });
+  assert(wrongState.detail.toLowerCase().includes('refresh'),
+    'rescueOutcomeCopy wrong_state tells the operator to refresh');
+  // no_resolver_mapping → "re-run Check YouTube".
+  const noMapping = rescueOutcomeCopy({ outcome: 'no_resolver_mapping' });
+  assert(noMapping.detail.toLowerCase().includes('re-run check youtube'),
+    'rescueOutcomeCopy no_resolver_mapping tells the operator to re-run Check YouTube');
+  // track_count_precheck_failed → shows the precheck mismatch detail.
+  const trackMismatch = rescueOutcomeCopy({
+    outcome: 'track_count_precheck_failed', detail: 'expected 14, got 10' });
+  assert(trackMismatch.detail.includes('expected 14, got 10'),
+    'rescueOutcomeCopy track_count_precheck_failed surfaces the mismatch detail');
+  // transient → retry.
+  const transient = rescueOutcomeCopy({ outcome: 'transient' });
+  assert(transient.detail.toLowerCase().includes('retry'),
+    'rescueOutcomeCopy transient tells the operator to retry');
+  assertEqual(transient.tone, 'error', 'rescueOutcomeCopy transient → error tone');
+  // request_not_found → refresh.
+  assert(rescueOutcomeCopy({ outcome: 'request_not_found' }).detail.toLowerCase().includes('refresh'),
+    'rescueOutcomeCopy request_not_found tells the operator to refresh');
+  // unknown outcome → generic error (never blank), surfaces the error field.
+  const unknown = rescueOutcomeCopy({ outcome: 'who_knows', error: 'boom' });
+  assertEqual(unknown.tone, 'error', 'rescueOutcomeCopy unknown → error tone');
+  assert(unknown.detail.length > 0, 'rescueOutcomeCopy unknown → non-blank detail');
+  // null result → generic error, never throws.
+  assertEqual(rescueOutcomeCopy(null).tone, 'error', 'rescueOutcomeCopy null → error tone (no throw)');
+
+  // --- canStartInFlight: double-fire guard predicate ---
+  const inFlightSet = new Set();
+  assertEqual(canStartInFlight(inFlightSet, 5), true,
+    'canStartInFlight: nothing outstanding → may start');
+  inFlightSet.add(5);
+  assertEqual(canStartInFlight(inFlightSet, 5), false,
+    'canStartInFlight: an outstanding call for the id → suppressed (double-fire guard)');
+  assertEqual(canStartInFlight(inFlightSet, 6), true,
+    'canStartInFlight: a different id is independent');
+
+  // --- renderRescueConfirm: reuses the .confirm-box shell ---
+  const confirm = renderRescueConfirm(11, 'MPREb_x', { artist_name: 'Smog', album_title: 'Knock Knock' });
+  assert(confirm.includes('confirm-box') && confirm.includes('MPREb_x'),
+    'renderRescueConfirm renders the confirm-box shell carrying the target browse id');
+  assert(confirm.includes('Smog') && confirm.includes('Knock Knock'),
+    'renderRescueConfirm labels the request being rescued');
+  assert(confirm.includes('id="lt-rescue-confirm"') && confirm.includes('id="lt-rescue-cancel"'),
+    'renderRescueConfirm wires confirm + cancel buttons');
 }
 
 // --- Summary ---

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -6,6 +6,7 @@
 import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, manualReasonLabel, renderForensicBlock, parsePastedId } from '../web/js/util.js';
 import { state } from '../web/js/state.js';
 import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, loadLabelReleases, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls, renderLabelRows } from '../web/js/labels.js';
+import { __test__ as longTailTest } from '../web/js/long_tail.js';
 
 let passed = 0;
 let failed = 0;
@@ -974,6 +975,181 @@ assertEqual(stdNoSource, '',
 const activeRgSet = new Set(['rg-1', 'rg-2']);
 assertEqual(activeRgSet.has('rg-1'), true, 'active-RG Set hit');
 assertEqual(activeRgSet.has('rg-not-active'), false, 'active-RG Set miss');
+
+// --- long_tail.js pure helpers (U3) ---
+console.log('long_tail.js __test__');
+{
+  const {
+    bandLabel,
+    deriveBandTabs,
+    defaultBand,
+    filterRows,
+    countOtherBandMatches,
+    renderLongTailRow,
+  } = longTailTest;
+
+  // A mixed cohort spanning Missing + several on-disk bands, deliberately
+  // out of canonical order so the ordering assertion is meaningful.
+  const cohort = [
+    { id: 1, artist_name: 'Mount Eerie', album_title: 'Clear Moon', band: 'transparent' },
+    { id: 2, artist_name: 'The Mountain Goats', album_title: 'Tallahassee', band: 'missing' },
+    { id: 3, artist_name: 'Bill Callahan', album_title: 'Apocalypse', band: 'poor' },
+    { id: 4, artist_name: 'Smog', album_title: 'Knock Knock', band: 'missing' },
+    { id: 5, artist_name: 'Grouper', album_title: 'Dragging a Dead Deer', band: 'unknown' },
+    { id: 6, artist_name: 'Tim Hecker', album_title: 'Ravedeath, 1972', band: 'transparent' },
+    { id: 7, artist_name: 'Loscil', album_title: 'Submers', band: 'lossless' },
+  ];
+
+  // --- bandLabel ---
+  assertEqual(bandLabel('missing'), 'Missing', 'bandLabel capitalises missing');
+  assertEqual(bandLabel('transparent'), 'Transparent', 'bandLabel capitalises transparent');
+  assertEqual(bandLabel(''), '?', 'bandLabel empty -> ?');
+  assertEqual(bandLabel(null), '?', 'bandLabel null -> ?');
+  assertEqual(bandLabel('LOSSLESS'), 'Lossless', 'bandLabel lower-cases then capitalises');
+
+  // --- deriveBandTabs: ordering Missing-first + ascending QualityRank ---
+  const tabs = deriveBandTabs(cohort);
+  assertEqual(
+    tabs.map((t) => t.band).join(','),
+    'missing,unknown,poor,transparent,lossless',
+    'deriveBandTabs orders Missing first, then ascending by rank (only present bands)',
+  );
+  // Counts are correct per band.
+  const countOf = (b) => (tabs.find((t) => t.band === b) || {}).count;
+  assertEqual(countOf('missing'), 2, 'deriveBandTabs counts Missing rows');
+  assertEqual(countOf('transparent'), 2, 'deriveBandTabs counts Transparent rows');
+  assertEqual(countOf('poor'), 1, 'deriveBandTabs counts Poor rows');
+  assertEqual(countOf('unknown'), 1, 'deriveBandTabs counts Unknown rows');
+  assertEqual(countOf('lossless'), 1, 'deriveBandTabs counts Lossless rows');
+  // Bands not present in the cohort produce no tab.
+  assert(!tabs.some((t) => t.band === 'good'), 'deriveBandTabs omits absent bands');
+  // Each tab carries a display label.
+  assertEqual((tabs[0]).label, 'Missing', 'deriveBandTabs first tab label is Missing');
+  // Empty cohort -> no tabs.
+  assertEqual(deriveBandTabs([]).length, 0, 'deriveBandTabs empty cohort -> no tabs');
+  // Unrecognised band sorts to the end, not dropped.
+  const withWeird = deriveBandTabs([
+    { band: 'missing' }, { band: 'sparkle' }, { band: 'good' },
+  ]);
+  assertEqual(
+    withWeird.map((t) => t.band).join(','),
+    'missing,good,sparkle',
+    'deriveBandTabs sorts unrecognised band to the end',
+  );
+
+  // --- defaultBand ---
+  assertEqual(defaultBand(tabs), 'missing', 'defaultBand prefers Missing when present');
+  assertEqual(
+    defaultBand(deriveBandTabs([{ band: 'good' }, { band: 'poor' }])),
+    'poor',
+    'defaultBand falls back to first canonical band when Missing absent',
+  );
+  assertEqual(defaultBand([]), null, 'defaultBand empty -> null');
+
+  // --- filterRows: within-band substring match ---
+  const missingRows = filterRows(cohort, 'missing', '');
+  assertEqual(missingRows.length, 2, 'filterRows missing band, no query -> 2 rows');
+  assert(
+    missingRows.every((r) => r.band === 'missing'),
+    'filterRows only returns rows of the selected band',
+  );
+  // Substring matches artist.
+  const goatHits = filterRows(cohort, 'missing', 'mountain');
+  assertEqual(goatHits.length, 1, 'filterRows substring matches artist within band');
+  assertEqual(goatHits[0].id, 2, 'filterRows artist-substring hit is the right row');
+  // Substring matches album, case-insensitively.
+  const knockHits = filterRows(cohort, 'missing', 'KNOCK');
+  assertEqual(knockHits.length, 1, 'filterRows substring matches album (case-insensitive)');
+  assertEqual(knockHits[0].id, 4, 'filterRows album-substring hit is the right row');
+  // A query that only matches rows in OTHER bands -> empty in-band result.
+  assertEqual(
+    filterRows(cohort, 'missing', 'hecker').length,
+    0,
+    'filterRows cross-band query -> empty for the selected band',
+  );
+  // Null band -> no rows (no tab selected).
+  assertEqual(filterRows(cohort, null, '').length, 0, 'filterRows null band -> no rows');
+
+  // --- countOtherBandMatches: cross-band hint count ---
+  assertEqual(
+    countOtherBandMatches(cohort, 'missing', 'hecker'),
+    1,
+    'countOtherBandMatches counts matches in other bands',
+  );
+  assertEqual(
+    countOtherBandMatches(cohort, 'missing', 'eerie'),
+    1,
+    'countOtherBandMatches: Mount Eerie (transparent) matches "eerie" outside Missing',
+  );
+  // Selected-band matches are excluded from the cross-band count.
+  assertEqual(
+    countOtherBandMatches(cohort, 'missing', 'goats'),
+    0,
+    'countOtherBandMatches excludes the selected band',
+  );
+  // Blank query -> 0 (no hint while not searching).
+  assertEqual(
+    countOtherBandMatches(cohort, 'missing', ''),
+    0,
+    'countOtherBandMatches blank query -> 0',
+  );
+
+  // --- renderLongTailRow: sanity (clickable + detail container) ---
+  const rowHtml = renderLongTailRow(cohort[1]);
+  assert(
+    rowHtml.includes('window.toggleLongTailDetail(2)'),
+    'renderLongTailRow wires the row click to toggleLongTailDetail',
+  );
+  assert(
+    rowHtml.includes('id="lt-detail-2"'),
+    'renderLongTailRow emits the per-row detail container',
+  );
+  assert(
+    rowHtml.includes('badge-wanted') && rowHtml.includes('Missing'),
+    'renderLongTailRow renders a Missing band chip for a missing row',
+  );
+  // An on-disk-band row gets the rank colour class + capitalised label.
+  const transparentRow = renderLongTailRow(cohort[0]);
+  assert(
+    transparentRow.includes('badge-rank-transparent') && transparentRow.includes('Transparent'),
+    'renderLongTailRow renders a rank-coloured chip for an on-disk band',
+  );
+
+  // --- renderLongTailBody: the three list states (DOM-free string paint) ---
+  const { renderLongTailBody } = longTailTest;
+  // Empty cohort -> empty-cohort affordance, never blank.
+  state.longTail = { rows: [], band: null, query: '' };
+  const emptyCohort = renderLongTailBody();
+  assert(
+    emptyCohort.includes('No wanted releases in the long tail'),
+    'renderLongTailBody empty cohort shows the empty-cohort affordance',
+  );
+  // Populated cohort -> tab strip + rows for the default (Missing) band.
+  state.longTail = { rows: cohort, band: null, query: '' };
+  const populated = renderLongTailBody();
+  assert(
+    populated.includes('lt-band-tabs') && populated.includes('lt-search-input'),
+    'renderLongTailBody renders band tabs + search box for a populated cohort',
+  );
+  assertEqual(
+    state.longTail.band, 'missing',
+    'renderLongTailBody defaults the selected band to Missing',
+  );
+  // Empty-band -> a search filters the selected band to zero; the
+  // affordance + cross-band hint show, never a blank area.
+  state.longTail = { rows: cohort, band: 'missing', query: 'hecker' };
+  const emptyBand = renderLongTailBody();
+  assert(
+    emptyBand.includes('No Missing releases match'),
+    'renderLongTailBody empty-band shows the per-band no-match affordance',
+  );
+  assert(
+    emptyBand.includes('1 match in other bands'),
+    'renderLongTailBody empty-band surfaces the cross-band match hint',
+  );
+  // Reset shared state so later tests are not affected.
+  state.longTail = { rows: null, band: null, query: '' };
+}
 
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -1590,6 +1590,182 @@ console.log('long_tail.js __test__ (U5 rescue flow)');
     'renderRescueConfirm wires confirm + cancel buttons');
 }
 
+// --- long_tail.js U6 secondary-action pure helpers ---
+console.log('long_tail.js __test__ (U6 secondary actions)');
+{
+  const {
+    canAcceptSibling,
+    acceptDisabledReason,
+    intentToggleTarget,
+    regenerateOutcomeCopy,
+    buildAcceptSiblingOptions,
+    renderActionsBar,
+  } = longTailTest;
+
+  // --- canAcceptSibling: MB-only predicate (KTD7) ---
+  assertEqual(
+    canAcceptSibling({ source: 'request' }, 'rg-1'),
+    true,
+    'canAcceptSibling: MB request with a release group → true');
+  assertEqual(
+    canAcceptSibling({ source: 'discogs' }, 'rg-1'),
+    false,
+    'canAcceptSibling: Discogs-sourced request → false (no MB↔Discogs adapter)');
+  assertEqual(
+    canAcceptSibling({ source: 'DISCOGS' }, 'rg-1'),
+    false,
+    'canAcceptSibling: Discogs source is case-insensitive');
+  assertEqual(
+    canAcceptSibling({ source: 'request' }, null),
+    false,
+    'canAcceptSibling: no release group → false even for an MB request');
+  assertEqual(
+    canAcceptSibling({ source: 'request' }, ''),
+    false,
+    'canAcceptSibling: empty release group → false');
+  assertEqual(
+    canAcceptSibling(null, 'rg-1'),
+    false,
+    'canAcceptSibling: null row → false (no throw)');
+
+  // --- acceptDisabledReason: one-line reason, empty when enabled ---
+  assertEqual(
+    acceptDisabledReason({ source: 'request' }, 'rg-1'),
+    '',
+    'acceptDisabledReason: enabled → empty string');
+  assert(
+    acceptDisabledReason({ source: 'discogs' }, 'rg-1').toLowerCase().includes('discogs'),
+    'acceptDisabledReason: Discogs reason mentions Discogs');
+  assert(
+    acceptDisabledReason({ source: 'request' }, null).toLowerCase().includes('release group'),
+    'acceptDisabledReason: no-rg reason mentions the missing release group');
+
+  // --- intentToggleTarget: lossless ⇄ default toggle ---
+  assertEqual(
+    intentToggleTarget('lossless'),
+    'default',
+    'intentToggleTarget: lossless target_format → toggle to default (accept floor)');
+  assertEqual(
+    intentToggleTarget('flac'),
+    'default',
+    'intentToggleTarget: flac target_format reads as lossless → toggle to default');
+  assertEqual(
+    intentToggleTarget(null),
+    'lossless',
+    'intentToggleTarget: no target_format (default intent) → toggle to lossless');
+  assertEqual(
+    intentToggleTarget(''),
+    'lossless',
+    'intentToggleTarget: empty target_format → toggle to lossless');
+  assertEqual(
+    intentToggleTarget('mp3'),
+    'lossless',
+    'intentToggleTarget: non-lossless target_format → toggle to lossless');
+
+  // --- regenerateOutcomeCopy: every outcome → next-cycle copy (KTD3) ---
+  const regenSuccess = regenerateOutcomeCopy({ outcome: 'success' });
+  assertEqual(regenSuccess.tone, 'success', 'regenerateOutcomeCopy success → success tone');
+  assertEqual(regenSuccess.requeued, true, 'regenerateOutcomeCopy success → requeued (refetch)');
+  assertEqual(regenSuccess.metadataGap, false, 'regenerateOutcomeCopy success → not a metadata gap');
+  assert(
+    regenSuccess.detail.toLowerCase().includes('next cycle')
+      && !regenSuccess.detail.toLowerCase().includes('instant'),
+    'regenerateOutcomeCopy success copy is honest next-cycle, never "instant"');
+
+  const regenNoop = regenerateOutcomeCopy({ outcome: 'noop_active_plan_exists' });
+  assertEqual(regenNoop.tone, 'success', 'regenerateOutcomeCopy noop → success tone');
+  assertEqual(regenNoop.requeued, true, 'regenerateOutcomeCopy noop → requeued (already queued)');
+  assertEqual(regenNoop.metadataGap, false, 'regenerateOutcomeCopy noop → not a metadata gap');
+  assert(
+    regenNoop.detail.toLowerCase().includes('already'),
+    'regenerateOutcomeCopy noop says a fresh plan already exists');
+
+  // failed_deterministic is the METADATA-GAP variant — NOT a re-fire.
+  const regenDet = regenerateOutcomeCopy({
+    outcome: 'failed_deterministic',
+    error_message: 'no runnable query',
+    failure_class: 'incomplete_metadata',
+  });
+  assertEqual(regenDet.tone, 'error', 'regenerateOutcomeCopy failed_deterministic → error tone');
+  assertEqual(regenDet.metadataGap, true,
+    'regenerateOutcomeCopy failed_deterministic → metadataGap=true (surface inline, do NOT re-fire)');
+  assertEqual(regenDet.requeued, false,
+    'regenerateOutcomeCopy failed_deterministic → not requeued (no refetch)');
+  assert(regenDet.detail.includes('no runnable query'),
+    'regenerateOutcomeCopy failed_deterministic surfaces the API error');
+  assert(regenDet.detail.includes('incomplete_metadata'),
+    'regenerateOutcomeCopy failed_deterministic surfaces the failure class');
+  assert(regenDet.detail.toLowerCase().includes('field-quality'),
+    'regenerateOutcomeCopy failed_deterministic points at the field-quality detail');
+
+  const regenTrans = regenerateOutcomeCopy({ outcome: 'failed_transient', error: 'db hiccup' });
+  assertEqual(regenTrans.tone, 'error', 'regenerateOutcomeCopy failed_transient → error tone');
+  assertEqual(regenTrans.metadataGap, false,
+    'regenerateOutcomeCopy failed_transient → not a metadata gap (retryable)');
+  assertEqual(regenTrans.requeued, false, 'regenerateOutcomeCopy failed_transient → not requeued');
+  assert(regenTrans.detail.toLowerCase().includes('retry'),
+    'regenerateOutcomeCopy failed_transient tells the operator to retry');
+
+  const regenNotFound = regenerateOutcomeCopy({ outcome: 'request_not_found' });
+  assertEqual(regenNotFound.tone, 'error', 'regenerateOutcomeCopy request_not_found → error tone');
+  assert(regenNotFound.detail.toLowerCase().includes('refresh'),
+    'regenerateOutcomeCopy request_not_found tells the operator to refresh');
+
+  const regenUnknown = regenerateOutcomeCopy({ outcome: 'who_knows' });
+  assertEqual(regenUnknown.tone, 'error', 'regenerateOutcomeCopy unknown → error tone');
+  assert(regenUnknown.detail.length > 0, 'regenerateOutcomeCopy unknown → non-blank detail');
+  assertEqual(regenerateOutcomeCopy(null).tone, 'error',
+    'regenerateOutcomeCopy null → error tone (no throw)');
+
+  // --- buildAcceptSiblingOptions: standard-mode picker options ---
+  const opts = buildAcceptSiblingOptions({
+    id: 77, artist_name: 'Smog', album_title: 'Knock Knock', mb_release_group_id: 'rg-9' });
+  assertEqual(opts.sourceRequestId, 77, 'buildAcceptSiblingOptions carries the source request id');
+  assertEqual(opts.releaseGroupId, 'rg-9', 'buildAcceptSiblingOptions carries the release group id');
+  assert(opts.sourceLabel.includes('Smog') && opts.sourceLabel.includes('Knock Knock'),
+    'buildAcceptSiblingOptions builds an "Artist — Album" source label');
+  assertEqual(
+    buildAcceptSiblingOptions({ id: 5, artist_name: 'A', album_title: 'B' }).releaseGroupId,
+    null,
+    'buildAcceptSiblingOptions: no rg on row → null (picker lazily resolves)');
+
+  // --- renderActionsBar: enable/disable + intent badge + research btn ---
+  const mbBar = renderActionsBar({
+    id: 12, source: 'request', mb_release_group_id: 'rg-1', target_format: null });
+  assert(mbBar.includes('window.longTailAcceptSibling(12)'),
+    'renderActionsBar: MB row wires the accept-sibling handler');
+  assert(!/lt-act-accept[^>]*disabled/.test(mbBar),
+    'renderActionsBar: MB row accept-sibling is enabled');
+  assert(mbBar.includes('window.longTailSetIntent(12)'),
+    'renderActionsBar wires the set-intent toggle');
+  assert(mbBar.includes('window.longTailReSearch(12)'),
+    'renderActionsBar wires the re-search button');
+  assert(mbBar.includes('next cycle'),
+    'renderActionsBar re-search copy is honest next-cycle');
+  // default intent (no target_format) → toggle offers "switch to lossless".
+  assert(mbBar.includes('switch to lossless') && mbBar.includes('lt-intent-default'),
+    'renderActionsBar: default intent renders a default badge + "switch to lossless"');
+
+  const discogsBar = renderActionsBar({
+    id: 13, source: 'discogs', mb_release_group_id: null, target_format: 'lossless' });
+  assert(/lt-act-accept[^>]*disabled/.test(discogsBar),
+    'renderActionsBar: Discogs row disables accept-sibling');
+  assert(discogsBar.toLowerCase().includes('musicbrainz-only')
+    || discogsBar.toLowerCase().includes('discogs'),
+    'renderActionsBar: Discogs row shows the one-line disable reason');
+  assert(!discogsBar.includes('window.longTailAcceptSibling(13)'),
+    'renderActionsBar: disabled accept-sibling does not wire the handler onclick');
+  // lossless intent → badge + "accept current floor" toggle.
+  assert(discogsBar.includes('lt-intent-lossless') && discogsBar.includes('accept current floor'),
+    'renderActionsBar: lossless intent renders a lossless badge + "accept current floor"');
+
+  // MB row with no release group → accept-sibling disabled.
+  const noRgBar = renderActionsBar({
+    id: 14, source: 'request', mb_release_group_id: null, target_format: null });
+  assert(/lt-act-accept[^>]*disabled/.test(noRgBar),
+    'renderActionsBar: MB row with no release group disables accept-sibling');
+}
+
 // --- Summary ---
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_long_tail_service.py
+++ b/tests/test_long_tail_service.py
@@ -1,0 +1,331 @@
+"""Tests for ``lib.long_tail_service`` — the Long-Tail Triage Console
+worklist read backend (U1).
+
+Two layers:
+
+* Service-level banding logic against ``FakePipelineDB`` + an injected
+  counting ``band_fn`` (the N+1 guard counts both the cohort query AND
+  the beets membership / detail queries the real ``band_fn`` issues).
+* A real-PG round-trip (``TestLongTailCohortRoundTrip``) asserting that
+  ``in_flight_rescue`` and the projected columns survive the production
+  ``get_long_tail_cohort`` / ``get_long_tail_request`` queries — per
+  test-fidelity Rule A. Written FIRST (RED) before the DB method existed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+import uuid
+from datetime import datetime, timezone
+
+import msgspec
+
+# Bootstrap ephemeral PostgreSQL if available (sets TEST_DB_DSN).
+sys.path.insert(0, os.path.dirname(__file__))
+import conftest  # noqa: F401,E402
+
+from lib.long_tail_service import (  # noqa: E402
+    BAND_MISSING,
+    LongTailResult,
+    LongTailRow,
+    band_one_long_tail,
+    list_long_tail,
+)
+
+# In-library-but-unrankable band, produced by ``compute_library_rank`` /
+# the injected band_fn (not a service constant).
+BAND_UNKNOWN = "unknown"
+from tests.fakes import FakePipelineDB  # noqa: E402
+from tests.helpers import make_request_row  # noqa: E402
+
+TEST_DSN = os.environ.get("TEST_DB_DSN")
+
+
+def requires_postgres(cls):
+    """Gate a PG round-trip class on TEST_DB_DSN.
+
+    The nix-shell dev shell always provides ephemeral PostgreSQL (initdb
+    + pg_ctl), so this never actually skips in CI / local runs — it is a
+    last-resort guard for an environment with the tools genuinely absent.
+    Mirrors ``tests/test_pipeline_db.py::requires_postgres`` — the
+    non-decorator helper form the skip-audit allows.
+    """
+    if not TEST_DSN:
+        return unittest.skip("TEST_DB_DSN not set")(cls)
+    return cls
+
+
+def _fixed_band_fn(mapping: dict[str, str]):
+    """Return a band_fn that maps each release id to its band per
+    ``mapping``; release ids absent from ``mapping`` are simply omitted
+    from the returned dict (the service bands them ``Missing``)."""
+
+    def _fn(release_ids: list[str]) -> dict[str, str]:
+        return {rid: mapping[rid] for rid in release_ids if rid in mapping}
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# Service-level banding
+# ---------------------------------------------------------------------------
+
+
+class TestListLongTailBanding(unittest.TestCase):
+    def test_missing_when_no_beets_album(self) -> None:
+        """AE1: a wanted request whose release isn't in the library bands
+        Missing; an imported request is absent from the result."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1",
+            artist_name="A", album_title="Album"))
+        db.seed_request(make_request_row(
+            id=2, status="imported", mb_release_id="rel-2"))
+        # Band fn returns nothing → not in library → Missing.
+        result = list_long_tail(db, _fixed_band_fn({}))
+        self.assertIsInstance(result, LongTailResult)
+        self.assertEqual(result.outcome, "ok")
+        self.assertEqual([r.id for r in result.rows], [1])
+        self.assertEqual(result.rows[0].band, BAND_MISSING)
+
+    def test_transparent_on_disk(self) -> None:
+        """AE2: a wanted request whose beets copy classifies Transparent
+        bands Transparent."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+        result = list_long_tail(
+            db, _fixed_band_fn({"rel-1": "transparent"}))
+        self.assertEqual(result.rows[0].band, "transparent")
+
+    def test_present_but_rank_unknown_bands_unknown(self) -> None:
+        """In-library-but-unclassifiable bands Unknown, not Missing.
+
+        The band_fn returns ``"unknown"`` for a release that IS in the
+        membership set but whose detail row can't be ranked — distinct
+        from absent-from-membership (which bands Missing)."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-present"))
+        db.seed_request(make_request_row(
+            id=2, status="wanted", mb_release_id="rel-absent"))
+        result = list_long_tail(
+            db, _fixed_band_fn({"rel-present": BAND_UNKNOWN}))
+        by_id = {r.id: r for r in result.rows}
+        # Present-but-rank-unknown → Unknown.
+        self.assertEqual(by_id[1].band, BAND_UNKNOWN)
+        # Absent-from-membership → Missing (the other mechanism).
+        self.assertEqual(by_id[2].band, BAND_MISSING)
+
+    def test_discogs_sourced_row_bands_via_dual_key_lookup(self) -> None:
+        """A Discogs-sourced wanted request bands correctly — the
+        mb_release_id carries the Discogs numeric, banded the same way
+        (no new lookup path; KTD7 only restricts accept-sibling, not
+        banding)."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", source="request",
+            mb_release_id="12856590", discogs_release_id="12856590"))
+        result = list_long_tail(
+            db, _fixed_band_fn({"12856590": "excellent"}))
+        self.assertEqual(result.rows[0].band, "excellent")
+        self.assertEqual(result.rows[0].discogs_release_id, "12856590")
+
+    def test_in_flight_rescue_stamp(self) -> None:
+        """An active youtube_running download_log row → in_flight_rescue
+        True; a row without → False."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+        db.seed_request(make_request_row(
+            id=2, status="wanted", mb_release_id="rel-2"))
+        db.insert_youtube_running(
+            request_id=2, browse_id="MPREb_a", audio_playlist_id=None,
+            yt_url="https://music.youtube.com/playlist?list=a",
+            expected_track_count=12,
+        )
+        result = list_long_tail(db, _fixed_band_fn({}))
+        by_id = {r.id: r for r in result.rows}
+        self.assertFalse(by_id[1].in_flight_rescue)
+        self.assertTrue(by_id[2].in_flight_rescue)
+
+    def test_band_filter_narrows_to_single_band(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+        db.seed_request(make_request_row(
+            id=2, status="wanted", mb_release_id="rel-2"))
+        db.seed_request(make_request_row(
+            id=3, status="wanted", mb_release_id="rel-3"))
+        band_fn = _fixed_band_fn({
+            "rel-2": "transparent", "rel-3": "transparent",
+        })
+        # rel-1 absent → missing; rel-2/3 transparent.
+        result = list_long_tail(db, band_fn, band="transparent")
+        self.assertEqual([r.id for r in result.rows], [2, 3])
+        self.assertEqual(result.band_filter, "transparent")
+
+        missing = list_long_tail(db, band_fn, band=BAND_MISSING)
+        self.assertEqual([r.id for r in missing.rows], [1])
+
+
+class TestBandOneLongTail(unittest.TestCase):
+    def test_single_id_bands_one_request(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=7, status="wanted", mb_release_id="rel-7"))
+        row = band_one_long_tail(
+            db, _fixed_band_fn({"rel-7": "good"}), 7)
+        assert row is not None
+        self.assertIsInstance(row, LongTailRow)
+        self.assertEqual(row.id, 7)
+        self.assertEqual(row.band, "good")
+
+    def test_single_id_missing_or_not_wanted_returns_none(self) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=8, status="imported", mb_release_id="rel-8"))
+        self.assertIsNone(band_one_long_tail(db, _fixed_band_fn({}), 8))
+        self.assertIsNone(band_one_long_tail(db, _fixed_band_fn({}), 999))
+
+
+class TestListLongTailN1Guard(unittest.TestCase):
+    """The cohort path's total query count is constant regardless of
+    cohort size — counting BOTH the Postgres cohort query AND the beets
+    membership + check_mbids_detail batch (modelled on
+    ``TestListTriageN1Guard``)."""
+
+    def test_query_count_constant_across_cohort_size(self) -> None:
+        db = FakePipelineDB()
+        band_calls: list[list[str]] = []
+
+        def counting_band_fn(release_ids: list[str]) -> dict[str, str]:
+            # The real band_fn issues exactly two beets queries
+            # (membership + check_mbids_detail). We record each batch
+            # call here and assert it fires once for the whole cohort.
+            band_calls.append(list(release_ids))
+            return {rid: "transparent" for rid in release_ids}
+
+        for i in range(1, 51):
+            db.seed_request(make_request_row(
+                id=i, status="wanted", mb_release_id=f"rel-{i}",
+                artist_name=f"Artist {i}", album_title="Album"))
+
+        result = list_long_tail(db, counting_band_fn)
+        self.assertEqual(len(result.rows), 50)
+        # Exactly one Postgres cohort query.
+        self.assertEqual(db.query_counts.get("get_long_tail_cohort"), 1)
+        self.assertEqual(sum(db.query_counts.values()), 1)
+        # Exactly one batched band call for the whole cohort — never per
+        # row. This stands in for the two beets queries the real band_fn
+        # issues against the whole mb_release_id list.
+        self.assertEqual(len(band_calls), 1)
+        self.assertEqual(len(band_calls[0]), 50)
+
+
+# ---------------------------------------------------------------------------
+# Real-PG round-trip (test-fidelity Rule A) — written RED first
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+class TestLongTailCohortRoundTrip(unittest.TestCase):
+    """Production-query round-trip: the projected columns + in_flight_rescue
+    survive ``get_long_tail_cohort`` / ``get_long_tail_request``, and a
+    row populated with real datetime / uuid serializes through the
+    service → ``msgspec.to_builtins`` without error (datetime-500 guard).
+    """
+
+    def setUp(self) -> None:
+        from lib import pipeline_db
+        self.db = pipeline_db.PipelineDB(TEST_DSN)
+        for table in ("download_log", "album_requests"):
+            self.db._execute(f"TRUNCATE {table} CASCADE")
+        self.db.conn.commit()
+
+    def tearDown(self) -> None:
+        self.db.close()
+
+    def test_cohort_query_stamps_in_flight_rescue_and_projects_columns(self):
+        rel_uuid = str(uuid.uuid4())
+        rid_plain = self.db.add_request(
+            artist_name="Vanishing Artist", album_title="Lost Pressing",
+            source="request", mb_release_id=rel_uuid, year=1972,
+            status="wanted")
+        rid_rescue = self.db.add_request(
+            artist_name="Rescue Artist", album_title="Found On YouTube",
+            source="request", mb_release_id=str(uuid.uuid4()),
+            status="wanted")
+        # An imported request must NOT appear in the cohort.
+        self.db.add_request(
+            artist_name="Done", album_title="Imported",
+            source="request", mb_release_id=str(uuid.uuid4()),
+            status="imported")
+        # In-flight youtube rescue on rid_rescue.
+        self.db.insert_youtube_running(
+            request_id=rid_rescue, browse_id="MPREb_rt",
+            audio_playlist_id=None,
+            yt_url="https://music.youtube.com/playlist?list=rt",
+            expected_track_count=10,
+        )
+
+        rows = self.db.get_long_tail_cohort()
+        by_id = {r["id"]: r for r in rows}
+        self.assertEqual(set(by_id), {rid_plain, rid_rescue})
+
+        plain = by_id[rid_plain]
+        # Every projected column round-trips.
+        self.assertEqual(plain["artist_name"], "Vanishing Artist")
+        self.assertEqual(plain["album_title"], "Lost Pressing")
+        self.assertEqual(plain["year"], 1972)
+        self.assertEqual(plain["status"], "wanted")
+        self.assertEqual(plain["mb_release_id"], rel_uuid)
+        self.assertIn("target_format", plain)
+        self.assertIn("min_bitrate", plain)
+        self.assertIn("search_filetype_override", plain)
+        self.assertIn("unfindable_category", plain)
+        # in_flight_rescue stamped correctly by the EXISTS predicate.
+        self.assertFalse(plain["in_flight_rescue"])
+        self.assertTrue(by_id[rid_rescue]["in_flight_rescue"])
+
+    def test_single_id_query_round_trips(self) -> None:
+        rid = self.db.add_request(
+            artist_name="Solo", album_title="One",
+            source="request", mb_release_id=str(uuid.uuid4()),
+            status="wanted")
+        row = self.db.get_long_tail_request(rid)
+        assert row is not None
+        self.assertEqual(row["id"], rid)
+        self.assertFalse(row["in_flight_rescue"])
+        # Non-wanted / missing → None.
+        self.db.add_request(
+            artist_name="X", album_title="Y", source="request",
+            mb_release_id=str(uuid.uuid4()), status="imported")
+        self.assertIsNone(self.db.get_long_tail_request(999999))
+
+    def test_service_serializes_real_row_without_error(self) -> None:
+        """The datetime-500 guard: a real production row routed through
+        the service serializes via ``msgspec.to_builtins`` cleanly."""
+        rid = self.db.add_request(
+            artist_name="Ser", album_title="Ialize",
+            source="request", mb_release_id=str(uuid.uuid4()),
+            status="wanted", year=2001)
+
+        def band_fn(release_ids: list[str]) -> dict[str, str]:
+            return {rid_: "poor" for rid_ in release_ids}
+
+        result = list_long_tail(self.db, band_fn)
+        self.assertEqual([r.id for r in result.rows], [rid])
+        # to_builtins must not raise on the real row's value types.
+        builtins = msgspec.to_builtins(result.rows)
+        self.assertEqual(builtins[0]["band"], "poor")
+        # And it round-trips back into the Struct.
+        back = msgspec.convert(builtins[0], type=LongTailRow)
+        self.assertEqual(back.id, rid)
+        self.assertEqual(back.year, 2001)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from web.routes._overlay import overlay_release_rows_in_place
+from web.routes._overlay import band_release_ids, overlay_release_rows_in_place
 
 
 class TestOverlayReleaseRowsInPlace(unittest.TestCase):
@@ -86,6 +86,34 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
                 patch("web.server._beets_db", return_value=None):
             with self.assertRaises(KeyError):
                 overlay_release_rows_in_place([{"title": "No ID"}], [])
+
+
+class TestBandReleaseIds(unittest.TestCase):
+    def test_degrades_to_missing_on_beets_error(self):
+        """Beets unavailable (locked / missing DB) → all-"missing" rather than
+        propagating the exception (which would 500 the worklist). Matches the
+        CLI's _cli_band_fn fallback (REL-002)."""
+        with patch("web.server.check_beets_library",
+                   side_effect=OSError("db locked")):
+            out = band_release_ids(["rel-1", "rel-2"])
+        self.assertEqual(out, {"rel-1": "missing", "rel-2": "missing"})
+
+    def test_bands_three_way_from_membership_and_detail(self):
+        """Direct coverage of the three-way (missing / unknown / band) the
+        long-tail worklist depends on (previously only indirect via the route
+        contract test)."""
+        mock_beets = MagicMock()
+        mock_beets.check_mbids_detail.return_value = {
+            "on-disk": {"beets_format": "FLAC", "beets_bitrate": 1100},
+            "no-detail": {},
+        }
+        with patch("web.server.check_beets_library",
+                   return_value={"on-disk", "no-detail"}), \
+                patch("web.server._beets_db", return_value=mock_beets):
+            out = band_release_ids(["on-disk", "no-detail", "gone"])
+        self.assertEqual(out["on-disk"], "lossless")   # FLAC 1100 → lossless
+        self.assertEqual(out["no-detail"], "unknown")  # in library, no detail
+        self.assertEqual(out["gone"], "missing")       # absent from membership
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -3470,6 +3470,15 @@ class TestPipelineCliLongTail(unittest.TestCase):
         self.assertEqual(payload["band"], "missing")
         self.assertEqual(payload["count"], 2)
 
+    def test_cli_band_fn_degrades_to_missing_when_beets_unavailable(self):
+        """The production band_fn (_cli_band_fn) bands every id "missing" when
+        BeetsDB raises (locked / missing DB) rather than propagating — matches
+        band_release_ids' web fallback, so a beets hiccup degrades the worklist
+        instead of erroring it."""
+        with patch("lib.beets_db.BeetsDB", side_effect=OSError("db locked")):
+            out = pipeline_cli._cli_band_fn(["rel-1", "rel-2"])
+        self.assertEqual(out, {"rel-1": "missing", "rel-2": "missing"})
+
     def test_empty_cohort_exit_zero(self):
         db = FakePipelineDB()
         rc, out, err = self._run(db, band_fn=self._band_fn({}))

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -3396,6 +3396,105 @@ class TestPipelineCliTriage(unittest.TestCase):
         self.assertNotIn("--after=", out)
 
 
+class TestPipelineCliLongTail(unittest.TestCase):
+    """``pipeline-cli long-tail`` — the worklist read counterpart of
+    ``GET /api/pipeline/long-tail`` (CLI ⇄ API symmetry, U1).
+
+    Both surfaces wrap ``lib.long_tail_service.list_long_tail``. Tests
+    inject a deterministic ``band_fn`` via the kwarg-DI seam so they
+    don't need a live beets library.
+    """
+
+    @staticmethod
+    def _band_fn(mapping):
+        def _fn(release_ids):
+            return {rid: mapping[rid] for rid in release_ids if rid in mapping}
+        return _fn
+
+    def _seed(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1",
+            artist_name="Missing Artist", album_title="Gone"))
+        db.seed_request(make_request_row(
+            id=2, status="wanted", mb_release_id="rel-2",
+            artist_name="On Disk", album_title="Have It"))
+        db.seed_request(make_request_row(
+            id=3, status="imported", mb_release_id="rel-3"))
+        return db
+
+    def _run(self, db, *, band=None, request_id=None, json_out=False,
+             band_fn=None):
+        args = SimpleNamespace(band=band, id=request_id, json=json_out)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = pipeline_cli.cmd_long_tail(
+                cast(Any, db), args, band_fn=band_fn)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_band_missing_filter_returns_only_missing_rows(self):
+        db = self._seed()
+        band_fn = self._band_fn({"rel-2": "transparent"})  # rel-1 missing
+        rc, out, err = self._run(db, band="missing", band_fn=band_fn)
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("Missing Artist", out)
+        self.assertNotIn("On Disk", out)  # transparent, filtered out
+
+    def test_json_emits_typed_envelope(self):
+        db = self._seed()
+        band_fn = self._band_fn({"rel-2": "transparent"})
+        rc, out, err = self._run(db, json_out=True, band_fn=band_fn)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(set(payload), {"results", "band", "count"})
+        self.assertIsNone(payload["band"])
+        self.assertEqual(payload["count"], 2)
+        # Both wanted rows present; imported row absent. Round-trips into
+        # the Struct (wire shape == Struct shape).
+        from lib.long_tail_service import LongTailRow
+        rows = [msgspec.convert(r, type=LongTailRow) for r in payload["results"]]
+        by_id = {r.id: r for r in rows}
+        self.assertEqual(set(by_id), {1, 2})
+        self.assertEqual(by_id[1].band, "missing")
+        self.assertEqual(by_id[2].band, "transparent")
+
+    def test_json_band_filter_echoed(self):
+        db = self._seed()
+        band_fn = self._band_fn({"rel-1": "missing", "rel-2": "missing"})
+        rc, out, _ = self._run(
+            db, band="missing", json_out=True, band_fn=band_fn)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["band"], "missing")
+        self.assertEqual(payload["count"], 2)
+
+    def test_empty_cohort_exit_zero(self):
+        db = FakePipelineDB()
+        rc, out, err = self._run(db, band_fn=self._band_fn({}))
+        self.assertEqual(rc, 0)
+        self.assertIn("No wanted rows", out)
+
+    def test_single_id_exit_zero_with_band(self):
+        db = self._seed()
+        band_fn = self._band_fn({"rel-2": "transparent"})
+        rc, out, err = self._run(
+            db, request_id=2, json_out=True, band_fn=band_fn)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual(set(payload), {"result", "id"})
+        self.assertEqual(payload["id"], 2)
+        self.assertEqual(payload["result"]["band"], "transparent")
+
+    def test_single_id_not_wanted_exit_two(self):
+        db = self._seed()
+        rc, out, err = self._run(
+            db, request_id=3, band_fn=self._band_fn({}))  # id 3 is imported
+        self.assertEqual(rc, 2)
+        self.assertIn("not found or not wanted", err)
+
+
 class TestPipelineCliRoutes(unittest.TestCase):
     """U18 step 3: ``pipeline-cli routes`` self-documents the CLI surface."""
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1378,6 +1378,7 @@ class TestPipelineRouteContracts(_WebServerCase):
         "disambiguation_failure", "disambiguation_detail", "bad_extensions",
         "spectral_grade", "spectral_bitrate", "existing_min_bitrate",
         "existing_spectral_bitrate",
+        "source", "youtube_metadata",
         "wrong_match_triage_action", "wrong_match_triage_summary",
         "wrong_match_triage_reason", "wrong_match_triage_preview_verdict",
         "wrong_match_triage_preview_decision",

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1772,7 +1772,8 @@ class TestPipelineRouteContracts(_WebServerCase):
 
     def test_pipeline_detail_surfaces_last_search_top_candidates(self):
         """When the latest search_log row has candidates, the route emits the
-        top-3 by (matched_tracks DESC, avg_ratio DESC) via msgspec.to_builtins."""
+        full slice (up to 20) by (matched_tracks DESC, avg_ratio DESC) via
+        msgspec.to_builtins."""
         candidates_blob = [
             {"username": "u1", "dir": "A", "filetype": "flac",
              "matched_tracks": 26, "total_tracks": 26, "avg_ratio": 0.95,
@@ -1808,14 +1809,42 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.assertEqual(last["variant"], "v3_artist_only")
         self.assertEqual(last["final_state"], "Completed")
         self.assertEqual(last["outcome"], "no_match")
-        # Top-3, sorted by (matched_tracks DESC, avg_ratio DESC):
-        # u1 (26, 0.95) → u3 (26, 0.85) → u2 (22, 0.80)
+        # All 4 (≤20 cap), sorted by (matched_tracks DESC, avg_ratio DESC):
+        # u1 (26, 0.95) → u3 (26, 0.85) → u2 (22, 0.80) → u4 (20, 0.99)
         usernames = [c["username"] for c in last["top_candidates"]]
-        self.assertEqual(usernames, ["u1", "u3", "u2"])
+        self.assertEqual(usernames, ["u1", "u3", "u2", "u4"])
         for cand in last["top_candidates"]:
             _assert_required_fields(self, cand,
                                     self.CANDIDATE_SCORE_REQUIRED_FIELDS,
                                     "candidate score")
+
+    def test_pipeline_detail_caps_top_candidates_at_twenty(self):
+        """U2: the peers panel widened from 3 to the full stored cap (20). A
+        search row with >20 candidates surfaces exactly 20, still ranked."""
+        blob = [
+            {"username": f"u{i:02d}", "dir": f"D{i}", "filetype": "flac",
+             "matched_tracks": 26, "total_tracks": 26,
+             "avg_ratio": 1.0 - i / 100.0,
+             "missing_titles": [], "file_count": 26}
+            for i in range(25)
+        ]
+        self.mock_db.get_search_history.return_value = [{
+            "id": 99, "request_id": 100, "query": "q",
+            "result_count": 100, "elapsed_s": 1.0, "outcome": "no_match",
+            "created_at": "2026-04-29T00:00:00+00:00",
+            "candidates": blob,
+            "variant": "v3_artist_only", "final_state": "Completed",
+        }]
+        try:
+            status, data = self._get("/api/pipeline/100")
+        finally:
+            self.mock_db.get_search_history.return_value = []
+        self.assertEqual(status, 200)
+        top = data["last_search"]["top_candidates"]
+        self.assertEqual(len(top), 20)
+        # All matched_tracks equal → highest avg_ratio first: u00..u19
+        self.assertEqual(top[0]["username"], "u00")
+        self.assertEqual(top[-1]["username"], "u19")
 
     def test_pipeline_detail_handles_null_candidates_gracefully(self):
         """Historical search_log row with NULL candidates → top_candidates=[]."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1103,6 +1103,10 @@ class TestRouteContractAudit(unittest.TestCase):
         r"^/api/pipeline/requests-by-rg/([a-f0-9-]{36})$",
         r"^/api/beets-distance/(\d+)/([a-f0-9-]{36})$",
         "/api/pipeline/active-rgs",
+        # U1: Long-Tail Triage Console worklist read. Wraps
+        # ``lib.long_tail_service.list_long_tail`` — same service as
+        # ``pipeline-cli long-tail`` per CLI ⇄ API symmetry.
+        "/api/pipeline/long-tail",
         "/api/pipeline/add",
         "/api/pipeline/update",
         "/api/pipeline/upgrade",
@@ -10099,6 +10103,183 @@ class TestTriageRouteContracts(_WebServerCase):
     def test_list_rejects_non_int_after(self):
         status, data = self._get(
             "/api/triage/list?filter=all&after=not-an-int")
+        self.assertEqual(status, 400)
+        self.assertIn("error", data)
+
+
+class TestLongTailRouteContracts(_WebServerCase):
+    """U1 contract for ``GET /api/pipeline/long-tail``.
+
+    Wraps ``lib.long_tail_service.list_long_tail`` — the same service
+    ``pipeline-cli long-tail`` wraps (CLI ⇄ API symmetry). Drives the
+    real service + DB cohort query against a fresh :class:`FakePipelineDB`
+    (no service mocking, per MOCKS: LEAF-SEAM ONLY). Banding's beets
+    collaborators (``check_beets_library`` / ``_beets_db`` /
+    ``compute_library_rank``) are the leaf seam — patched at
+    ``web.server`` only when a test exercises an in-library band.
+    """
+
+    # The frontend long-tail list renders these fields per row out of the
+    # serialized ``LongTailRow``. Pin every one so a rename can't silently
+    # break the JS.
+    ROW_REQUIRED_FIELDS = {
+        "id", "artist_name", "album_title", "year", "status", "source",
+        "mb_release_id", "discogs_release_id", "target_format",
+        "min_bitrate", "search_filetype_override", "unfindable_category",
+        "band", "in_flight_rescue",
+    }
+    ENVELOPE_REQUIRED_FIELDS = {"results", "band", "count"}
+
+    _LONG_TAIL_DB_METHODS = (
+        "get_long_tail_cohort",
+        "get_long_tail_request",
+    )
+
+    def setUp(self) -> None:
+        fresh = FakePipelineDB()
+        self._old_backing = self.mock_db._fake
+        self.mock_db._mock_wraps = fresh
+        self.mock_db._fake = fresh
+        self._lt_method_state: dict[str, MagicMock] = {}
+        for name in self._LONG_TAIL_DB_METHODS:
+            self._lt_method_state[name] = getattr(self.mock_db, name)
+            forwarder = MagicMock(side_effect=getattr(fresh, name))
+            setattr(self.mock_db, name, forwarder)
+
+    def tearDown(self) -> None:
+        for name, prev in self._lt_method_state.items():
+            setattr(self.mock_db, name, prev)
+        self.mock_db._mock_wraps = self._old_backing
+        self.mock_db._fake = self._old_backing
+
+    @property
+    def _fake(self) -> "FakePipelineDB":
+        return self.mock_db._fake
+
+    def test_missing_row_bands_missing_and_imported_absent(self):
+        """AE1 at the HTTP boundary: a wanted row with no beets album
+        bands ``missing``; an imported request is absent from the
+        result. (No beets configured → everything Missing.)"""
+        from lib.long_tail_service import LongTailRow
+        self._fake.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1",
+            artist_name="Vanishing", album_title="Lost"))
+        self._fake.seed_request(make_request_row(
+            id=2, status="imported", mb_release_id="rel-2"))
+
+        status, data = self._get("/api/pipeline/long-tail")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.ENVELOPE_REQUIRED_FIELDS,
+                                "long-tail envelope")
+        self.assertEqual(data["count"], 1)
+        self.assertIsNone(data["band"])
+        row = data["results"][0]
+        _assert_required_fields(self, row, self.ROW_REQUIRED_FIELDS,
+                                "long-tail row")
+        self.assertEqual(row["id"], 1)
+        self.assertEqual(row["band"], "missing")
+        self.assertFalse(row["in_flight_rescue"])
+        # Wire shape IS the Struct shape — round-trips cleanly.
+        back = msgspec.convert(row, type=LongTailRow)
+        self.assertEqual(back.id, 1)
+
+    def test_transparent_band_via_beets_seam(self):
+        """AE2 at the HTTP boundary: a wanted row whose beets copy
+        classifies Transparent bands ``transparent``. The beets leaf
+        seam is patched to report the release in-library with a
+        lossless detail row."""
+        import web.server as srv
+        self._fake.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+
+        mock_beets = MagicMock()
+        # MP3 @ 256 kbps classifies TRANSPARENT in the default rank model
+        # (Opus 128 / MP3 V0 are transparent; see docs/quality-ranks.md).
+        mock_beets.check_mbids_detail.return_value = {
+            "rel-1": {"beets_format": "MP3", "beets_bitrate": 256},
+        }
+        with patch("web.server.check_beets_library",
+                   return_value={"rel-1"}), \
+                patch("web.server._beets_db", return_value=mock_beets):
+            status, data = self._get("/api/pipeline/long-tail")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["results"][0]["band"], "transparent")
+
+    def test_unknown_band_when_in_library_but_unrankable(self):
+        """In-library but no detail / unrankable → ``unknown``, not
+        ``missing``."""
+        self._fake.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+
+        mock_beets = MagicMock()
+        mock_beets.check_mbids_detail.return_value = {}  # no detail row
+        with patch("web.server.check_beets_library",
+                   return_value={"rel-1"}), \
+                patch("web.server._beets_db", return_value=mock_beets):
+            status, data = self._get("/api/pipeline/long-tail")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["results"][0]["band"], "unknown")
+
+    def test_in_flight_rescue_stamped(self):
+        self._fake.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+        self._fake.insert_youtube_running(
+            request_id=1, browse_id="MPREb_z", audio_playlist_id=None,
+            yt_url="https://music.youtube.com/playlist?list=z",
+            expected_track_count=10,
+        )
+        status, data = self._get("/api/pipeline/long-tail")
+        self.assertEqual(status, 200)
+        self.assertTrue(data["results"][0]["in_flight_rescue"])
+
+    def test_band_filter_narrows_result(self):
+        self._fake.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="rel-1"))
+        self._fake.seed_request(make_request_row(
+            id=2, status="wanted", mb_release_id="rel-2"))
+        # No beets → both Missing.
+        status, data = self._get("/api/pipeline/long-tail?band=missing")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["band"], "missing")
+        self.assertEqual({r["id"] for r in data["results"]}, {1, 2})
+        # A band with no members returns an empty cohort, still 200.
+        status, data = self._get("/api/pipeline/long-tail?band=transparent")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["count"], 0)
+
+    def test_empty_cohort_returns_200(self):
+        status, data = self._get("/api/pipeline/long-tail")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["count"], 0)
+        self.assertEqual(data["results"], [])
+
+    def test_single_id_returns_one_banded_row(self):
+        """KTD8: ``?id=`` returns just that request's authoritative band."""
+        from lib.long_tail_service import LongTailRow
+        self._fake.seed_request(make_request_row(
+            id=42, status="wanted", mb_release_id="rel-42",
+            artist_name="One", album_title="Row"))
+        status, data = self._get("/api/pipeline/long-tail?id=42")
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, {"result", "id"},
+                                "long-tail single-id envelope")
+        self.assertEqual(data["id"], 42)
+        row = msgspec.convert(data["result"], type=LongTailRow)
+        self.assertEqual(row.id, 42)
+        self.assertEqual(row.band, "missing")
+
+    def test_single_id_404_when_not_wanted(self):
+        self._fake.seed_request(make_request_row(
+            id=42, status="imported", mb_release_id="rel-42"))
+        status, data = self._get("/api/pipeline/long-tail?id=42")
+        self.assertEqual(status, 404)
+        self.assertEqual(data["id"], 42)
+
+    def test_single_id_400_on_non_int(self):
+        status, data = self._get("/api/pipeline/long-tail?id=not-an-int")
         self.assertEqual(status, 400)
         self.assertIn("error", data)
 

--- a/web/index.html
+++ b/web/index.html
@@ -157,6 +157,14 @@
   .lt-yt-meta { color: #888; font-size: 0.92em; }
   .lt-yt-check { padding: 5px 12px; background: #2a2a2a; color: #ddd; border: 1px solid #444; border-radius: 6px; cursor: pointer; font-size: 0.85em; }
   .lt-yt-check:hover { background: #333; border-color: #56b; }
+  .lt-yt-check:disabled { opacity: 0.6; cursor: default; }
+  /* Long-tail YouTube rescue (U5) — pickable matrix targets. The
+     "Rescue from this" button sits on each matrix row; the confirm step
+     reuses the shared `.confirm-overlay` / `.confirm-box` modal. */
+  .lt-yt-matrix .lt-yt-check { margin-top: 8px; }
+  .lt-yt-rescue { margin-left: auto; padding: 3px 10px; background: #2a3a2a; color: #9c9; border: 1px solid #3a4a3a; border-radius: 6px; cursor: pointer; font-size: 0.8em; }
+  .lt-yt-rescue:hover { background: #344a34; color: #beb; border-color: #5a8; }
+  .lt-yt-checking .lt-yt-msg { color: #ca8; }
   .lt-link-btn { background: none; border: none; color: #6af; cursor: pointer; font-size: 0.82em; padding: 4px 0; }
   .lt-link-btn:hover { text-decoration: underline; }
   /* Search-plan inspector — per-row magnifier button, in-place summary

--- a/web/index.html
+++ b/web/index.html
@@ -167,6 +167,22 @@
   .lt-yt-checking .lt-yt-msg { color: #ca8; }
   .lt-link-btn { background: none; border: none; color: #6af; cursor: pointer; font-size: 0.82em; padding: 4px 0; }
   .lt-link-btn:hover { text-decoration: underline; }
+  /* Long-tail secondary actions (U6) — the action bar sits at the top of
+     the console so accept-sibling / set-intent / re-search stay reachable
+     without scrolling past the evidence panels. */
+  .lt-actions { display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center; padding: 8px 10px; background: #161616; border-radius: 6px; }
+  .lt-act-group { display: flex; flex-direction: column; gap: 4px; }
+  .lt-act-btn { padding: 5px 12px; background: #2a2a2a; color: #ddd; border: 1px solid #444; border-radius: 6px; cursor: pointer; font-size: 0.82em; }
+  .lt-act-btn:hover:not(:disabled) { background: #333; border-color: #56b; }
+  .lt-act-btn:disabled { opacity: 0.5; cursor: default; }
+  .lt-act-note { color: #888; font-size: 0.78em; max-width: 260px; }
+  .lt-act-intent { display: flex; gap: 6px; align-items: center; }
+  .lt-act-label { color: #888; font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.04em; }
+  .lt-intent-badge { font-size: 0.78em; }
+  .lt-intent-lossless { background: #2a3a3a; color: #9cc; }
+  .lt-intent-default { background: #2a2a2a; color: #aaa; }
+  .lt-act-intent-toggle { font-size: 0.78em; padding: 3px 8px; }
+  .lt-act-research-note { color: #d88; font-size: 0.78em; max-width: 320px; margin-top: 2px; }
   /* Search-plan inspector — per-row magnifier button, in-place summary
      panel rendered as a sibling of the row (mirrors `.p-detail` shape but
      kept visually distinct so a row with both expanded is readable). */

--- a/web/index.html
+++ b/web/index.html
@@ -107,6 +107,23 @@
   .p-detail-row { display: flex; gap: 8px; margin-bottom: 4px; font-size: 0.8em; }
   .p-detail-label { color: #666; min-width: 80px; }
   .p-detail-value { color: #bbb; }
+  /* Long-tail triage worklist (Pipeline sub-view). Band tabs + search
+     box + clickable rows. Reuses the .p-item / .p-detail visual language
+     and the shared badge-rank-* colours for the per-row band badge. */
+  .lt-band-tabs { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
+  .lt-band-tab { display: inline-flex; align-items: center; gap: 6px; }
+  .lt-band-count { color: #888; font-weight: 400; font-size: 0.85em; }
+  .lt-band-tab.active-status .lt-band-count { color: #cde; }
+  .lt-search { margin-bottom: 10px; }
+  .lt-search-input { width: 100%; box-sizing: border-box; padding: 7px 10px; background: #1a1a1a; color: #ddd; border: 1px solid #333; border-radius: 6px; font-size: 0.9em; }
+  .lt-search-input:focus { outline: none; border-color: #56b; }
+  .lt-item { padding: 10px 12px; background: #1e1e1e; border-left: 3px solid #444; margin-bottom: 4px; border-radius: 0 6px 6px 0; cursor: pointer; }
+  .lt-item:hover { background: #252525; }
+  .lt-meta-chip { color: #888; font-size: 0.9em; }
+  .lt-detail { background: #191919; padding: 0; margin: 0 0 4px 0; border-radius: 0 0 6px 6px; display: none; border-left: 3px solid #333; }
+  .lt-detail.open { display: block; padding: 10px 12px; }
+  .lt-empty-band { padding: 4px 0; }
+  .lt-empty-hint { color: #888; font-size: 0.82em; padding: 4px 0; }
   /* Search-plan inspector — per-row magnifier button, in-place summary
      panel rendered as a sibling of the row (mirrors `.p-detail` shape but
      kept visually distinct so a row with both expanded is readable). */

--- a/web/index.html
+++ b/web/index.html
@@ -124,6 +124,41 @@
   .lt-detail.open { display: block; padding: 10px 12px; }
   .lt-empty-band { padding: 4px 0; }
   .lt-empty-hint { color: #888; font-size: 0.82em; padding: 4px 0; }
+  /* Long-tail action console (U4) — in-place evidence panels rendered
+     inside `.lt-detail`. Mirrors the .p-detail / .p-forensic visual
+     language: dark surface, small type, per-panel sections that each load
+     independently (loading / error / content states). */
+  .lt-console { display: flex; flex-direction: column; gap: 10px; }
+  .lt-panel { background: #161616; border-radius: 6px; padding: 8px 10px; }
+  .lt-panel-lead { border-left: 3px solid #56b; }
+  .lt-panel-title { color: #888; font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 5px; }
+  .lt-panel-body { font-size: 0.82em; color: #bbb; }
+  .lt-panel-loading { color: #777; font-size: 0.82em; }
+  .lt-panel-error { color: #d88; font-size: 0.82em; }
+  .lt-panel-error-hint { color: #777; font-size: 0.92em; }
+  .lt-panel-empty { color: #777; font-size: 0.82em; }
+  .lt-band-intent { background: #161616; border-radius: 6px; padding: 8px 10px; }
+  .lt-rollup { color: #888; font-size: 0.92em; margin-top: 4px; }
+  .lt-uncategorised { display: flex; gap: 8px; align-items: center; }
+  .lt-uncategorised-note { color: #777; font-size: 0.92em; }
+  .lt-unfindable-cat { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .lt-rescue-status { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .lt-rescue-reason { color: #d88; }
+  .lt-rescue-item { color: #999; padding: 1px 0; }
+  .lt-sibling { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; padding: 2px 0; border-bottom: 1px solid #222; }
+  .lt-sibling:last-child { border-bottom: none; }
+  .lt-sibling-title { color: #ccc; }
+  .lt-sibling-meta { color: #888; font-size: 0.92em; }
+  .lt-yt-prompt, .lt-yt-msg { color: #999; margin-bottom: 6px; }
+  .lt-yt-stale { color: #ca8; font-size: 0.92em; margin-bottom: 6px; }
+  .lt-yt-row { display: flex; gap: 8px; align-items: center; padding: 2px 0; border-bottom: 1px solid #222; }
+  .lt-yt-row:last-child { border-bottom: none; }
+  .lt-yt-id { color: #ccc; font-family: monospace; font-size: 0.92em; }
+  .lt-yt-meta { color: #888; font-size: 0.92em; }
+  .lt-yt-check { padding: 5px 12px; background: #2a2a2a; color: #ddd; border: 1px solid #444; border-radius: 6px; cursor: pointer; font-size: 0.85em; }
+  .lt-yt-check:hover { background: #333; border-color: #56b; }
+  .lt-link-btn { background: none; border: none; color: #6af; cursor: pointer; font-size: 0.82em; padding: 4px 0; }
+  .lt-link-btn:hover { text-decoration: underline; }
   /* Search-plan inspector — per-row magnifier button, in-place summary
      panel rendered as a sibling of the row (mirrors `.p-detail` shape but
      kept visually distinct so a row with both expanded is readable). */

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -110,7 +110,7 @@ import {
   overrideToIntent,
   awstDateTime,
 } from './util.js';
-import { openReplacePicker } from './replace_picker.js';
+import { openReplacePicker, pressingMeta } from './replace_picker.js';
 
 /**
  * The `Missing` band sentinel — a `wanted` request with no clean
@@ -848,9 +848,9 @@ export function toggleLongTailPeers(id) {
  */
 function renderSiblingRow(rel) {
   const title = rel.title || '?';
-  const meta = [rel.country, (rel.date || '').slice(0, 4), rel.format,
-    (rel.track_count != null ? `${rel.track_count}t` : '')]
-    .filter((x) => x).join(' · ');
+  // Reuse the Replace picker's pressing-summary formatter so the siblings
+  // panel and the picker render the same "country · year · format · Nt".
+  const meta = pressingMeta(rel);
   const inLib = rel.in_library
     ? `<span class="badge badge-rank-${esc(String(rel.library_rank || 'library').toLowerCase())}">in library</span>`
     : '';
@@ -1084,16 +1084,30 @@ function renderConsoleShell(row) {
  * @param {Object} row  The worklist row (band, source, intent, rg).
  * @returns {string}
  */
-function renderActionsBar(row) {
+/**
+ * Render the accept-a-sibling-pressing control (active button, or disabled
+ * button + reason). Split out so `patchActionsBar` can refresh ONLY this
+ * group after the detail fetch stamps the release group — without clobbering
+ * the re-search button's independently-managed disabled / metadata-gap state
+ * (set by `longTailReSearch` on a sticky `failed_deterministic`). Pure.
+ *
+ * @param {Object} row
+ * @returns {string}
+ */
+function renderAcceptGroup(row) {
   const id = row.id;
   const rg = row.mb_release_group_id || null;
-  const acceptOk = canAcceptSibling(row, rg);
   // Discogs / no-rg disable reason (KTD7 — no MB↔Discogs adapter).
   const acceptReason = acceptDisabledReason(row, rg);
-  const acceptBtn = acceptOk
+  return canAcceptSibling(row, rg)
     ? `<button class="lt-act-btn lt-act-accept" type="button" onclick="event.stopPropagation(); window.longTailAcceptSibling(${id})">Accept a sibling pressing…</button>`
     : `<button class="lt-act-btn lt-act-accept" type="button" disabled title="${esc(acceptReason)}">Accept a sibling pressing…</button>
        <span class="lt-act-note">${esc(acceptReason)}</span>`;
+}
+
+function renderActionsBar(row) {
+  const id = row.id;
+  const acceptBtn = renderAcceptGroup(row);
 
   const intent = overrideToIntent(row.target_format);
   const intentLabel = intent === 'lossless' ? 'lossless' : 'default';
@@ -1109,7 +1123,7 @@ function renderActionsBar(row) {
   const researchBtn = `<button class="lt-act-btn lt-act-research" type="button" onclick="event.stopPropagation(); window.longTailReSearch(${id})">Re-search (next cycle)</button>`;
 
   return `<div class="lt-actions" id="lt-actions-${id}">
-    <div class="lt-act-group">${acceptBtn}</div>
+    <div class="lt-act-group" id="lt-act-accept-${id}">${acceptBtn}</div>
     <div class="lt-act-group">${intentCtl}</div>
     <div class="lt-act-group">${researchBtn}<div class="lt-act-research-note" id="lt-research-note-${id}"></div></div>
   </div>`;
@@ -1219,12 +1233,14 @@ function stampRowReleaseGroup(id, rgId) {
 function patchActionsBar(id, token) {
   if (typeof document === 'undefined') return;
   if (consoleTokens.get(id) !== token) return;  // stale console — discard.
-  const bar = document.getElementById(`lt-actions-${id}`);
-  if (!bar) return;
+  // Only the accept-sibling group depends on the release group that the
+  // detail fetch stamps. Patch JUST that group — rebuilding the whole bar
+  // would clobber the re-search button's disabled / metadata-gap state, which
+  // longTailReSearch sets independently on a sticky failed_deterministic.
+  const group = document.getElementById(`lt-act-accept-${id}`);
+  if (!group) return;
   const row = consoleRow(id) || { id };
-  // Replace the whole bar (renderActionsBar emits the same wrapper id, so
-  // we swap its outerHTML to keep the id stable for the next patch).
-  bar.outerHTML = renderActionsBar(row);
+  group.innerHTML = renderAcceptGroup(row);
 }
 
 /**

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -427,12 +427,12 @@ export function renderLongTailBody() {
   const lt = state.longTail;
   const rows = Array.isArray(lt.rows) ? lt.rows : [];
   const tabs = deriveBandTabs(rows);
-  // If the selected band is no longer present (e.g. after a refetch
-  // dropped it), fall back to the default.
+  // Display band: fall back to the default when the selected band is absent
+  // (e.g. a refetch dropped it). Pure — does NOT write state.longTail.band;
+  // the canonical default is set by loadLongTail / setLongTailBand.
   let band = lt.band;
   if (band == null || !tabs.some((t) => t.band === band)) {
     band = defaultBand(tabs);
-    lt.band = band;
   }
   const tabStrip = renderBandTabs(tabs, band);
   const searchBox = tabs.length ? renderSearchBox(lt.query) : '';
@@ -1299,6 +1299,10 @@ export function toggleLongTailDetail(id) {
   if (typeof document === 'undefined') return;
   const el = document.getElementById(`lt-detail-${id}`);
   if (!el) return;
+  // Re-opening or collapsing this console: drop stale action guards so the
+  // fresh console's buttons aren't silently dead from a prior mid-flight op
+  // (LT-R1). Any outstanding fetch's result is still token-discarded below.
+  clearActionGuards(id);
   if (el.classList.contains('open')) {
     el.classList.remove('open');
     // Bump the token so any in-flight panel fetch is discarded on resolve.
@@ -1435,6 +1439,41 @@ const resolveInFlight = new Set();
  * @type {Set<number>}
  */
 const submitInFlight = new Set();
+
+/**
+ * Request ids with an outstanding set-intent POST. Guards the intent toggle
+ * against double-fire (two rapid clicks racing opposite intents at the DB).
+ *
+ * @type {Set<number>}
+ */
+const intentInFlight = new Set();
+
+/**
+ * True while a rescue confirm overlay is open. The overlay mounts into the
+ * single shared modal host, so a second `pickYoutubeRescue` would overwrite
+ * the first overlay's DOM and orphan its promise — this boolean serialises
+ * them (one confirm at a time).
+ */
+let rescueConfirmOpen = false;
+
+/**
+ * Clear any stale per-id action guards when a console is (re)opened or
+ * collapsed (LT-R1). The guards' `finally` blocks delete on settle, but a
+ * console destroyed mid-flight (collapse/reopen, list re-render) would
+ * otherwise leave a stale entry that silently no-ops the re-opened button
+ * until the orphaned fetch settles. The outstanding fetch's result is still
+ * token-discarded; clearing just re-enables the fresh console's buttons (a
+ * duplicate resolver call hits the server-side cache, so it's harmless).
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function clearActionGuards(id) {
+  resolveInFlight.delete(id);
+  submitInFlight.delete(id);
+  researchInFlight.delete(id);
+  intentInFlight.delete(id);
+}
 
 /**
  * Double-fire predicate for the resolver GET. Pure. `true` when a Check
@@ -1626,10 +1665,16 @@ function confirmRescue(id, browseId, row) {
  * @returns {Promise<void>}
  */
 export async function pickYoutubeRescue(id, browseId) {
-  const row = consoleRow(id);
-  const ok = await confirmRescue(id, browseId, row);
-  if (!ok) return;
-  await submitYoutubeRescue(id, browseId);
+  if (rescueConfirmOpen) return;  // one confirm overlay at a time (shared host).
+  rescueConfirmOpen = true;
+  try {
+    const row = consoleRow(id);
+    const ok = await confirmRescue(id, browseId, row);
+    if (!ok) return;
+    await submitYoutubeRescue(id, browseId);
+  } finally {
+    rescueConfirmOpen = false;
+  }
 }
 
 /**
@@ -2040,31 +2085,37 @@ function closeConsole(id) {
 export async function longTailSetIntent(id) {
   const row = consoleRow(id);
   if (!row) return;
+  if (!canStartInFlight(intentInFlight, id)) return;  // double-fire guard.
+  intentInFlight.add(id);
   const intent = intentToggleTarget(row.target_format);
-  let data;
   try {
-    const r = await fetch(`${API}/api/pipeline/set-intent`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, intent }),
-    });
-    data = await r.json();
-  } catch (_e) {
-    if (typeof toast === 'function') toast('Failed to set intent', true);
-    return;
-  }
-  if (!data || data.status !== 'ok') {
-    if (typeof toast === 'function') {
-      toast((data && data.error) || 'Failed to set intent', true);
+    let data;
+    try {
+      const r = await fetch(`${API}/api/pipeline/set-intent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, intent }),
+      });
+      data = await r.json();
+    } catch (_e) {
+      if (typeof toast === 'function') toast('Failed to set intent', true);
+      return;
     }
-    return;
+    if (!data || data.status !== 'ok') {
+      if (typeof toast === 'function') {
+        toast((data && data.error) || 'Failed to set intent', true);
+      }
+      return;
+    }
+    if (typeof toast === 'function') {
+      toast(data.requeued ? `Intent: ${intent} (requeued)` : `Intent: ${intent}`, false);
+    }
+    // Single-row refetch-and-patch (KTD8) — the badge reflects the new intent
+    // off the authoritative refetched row.
+    await refetchLongTailRow(id);
+  } finally {
+    intentInFlight.delete(id);
   }
-  if (typeof toast === 'function') {
-    toast(data.requeued ? `Intent: ${intent} (requeued)` : `Intent: ${intent}`, false);
-  }
-  // Single-row refetch-and-patch (KTD8) — the badge reflects the new intent
-  // off the authoritative refetched row.
-  await refetchLongTailRow(id);
 }
 
 /**
@@ -2103,11 +2154,14 @@ export async function longTailReSearch(id) {
     }
     const copy = regenerateOutcomeCopy(result);
     if (copy.metadataGap) {
-      // Sticky deterministic failure — surface the gap inline and leave the
-      // button DISABLED (re-clicking is futile until the metadata is fixed).
+      // Sticky deterministic failure — surface the gap inline and put the
+      // button into a TERMINAL disabled state (re-clicking is futile until the
+      // metadata is fixed). Not the 'Re-searching…' spinner label, which would
+      // imply work is still happening.
       setResearchNote(id, copy.detail);
+      setResearchTerminal(id);
       if (typeof toast === 'function') toast(`${copy.title}: ${copy.detail}`, true);
-      return;  // intentionally leave disabled; no refetch.
+      return;
     }
     if (typeof toast === 'function') {
       toast(`${copy.title}: ${copy.detail}`, copy.tone === 'error');
@@ -2141,6 +2195,25 @@ function setResearchDisabled(id, disabled) {
   if (!btn) return;
   btn.disabled = disabled;
   btn.textContent = disabled ? 'Re-searching…' : 'Re-search (next cycle)';
+}
+
+/**
+ * Put the re-search button into a TERMINAL disabled state — a sticky
+ * `failed_deterministic` (the search plan can't be built until the metadata
+ * gap is fixed). Distinct from `setResearchDisabled(id, true)`'s
+ * 'Re-searching…' in-progress label. DOM-side; no-op when not mounted.
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function setResearchTerminal(id) {
+  if (typeof document === 'undefined') return;
+  const bar = document.getElementById(`lt-actions-${id}`);
+  if (!bar) return;
+  const btn = /** @type {HTMLButtonElement|null} */ (bar.querySelector('.lt-act-research'));
+  if (!btn) return;
+  btn.disabled = true;
+  btn.textContent = 'Re-search blocked (metadata gap)';
 }
 
 /**

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -1,0 +1,528 @@
+// @ts-check
+
+/**
+ * Long-tail triage worklist (Pipeline sub-view).
+ *
+ * U3 (this unit): the list shell — band tabs (with live counts), a
+ * search box, and the row list. Fetches `GET /api/pipeline/long-tail`
+ * once (KTD2 — one server-banded fetch, all tab/search filtering happens
+ * client-side over that single payload), derives the band tab set from
+ * the bands present in the cohort, and renders the rows for the selected
+ * band. Rows are clickable and carry an (empty) `.lt-detail` container;
+ * U4 fleshes the in-place action console out.
+ *
+ * Pure / DOM-free helpers (band ordering, tab derivation, in-band search
+ * filtering, cross-band match count) are exported via `__test__` for the
+ * Node unit suite. Rendering and fetch live alongside them but never
+ * leak into the pure helpers.
+ *
+ * Shape mirrors `web/js/search_plan.js` / `web/js/recents.js`:
+ * `// @ts-check`, ES6 module, JSDoc on exports, the
+ * `export const __test__ = {…}` named-object test convention.
+ */
+
+import { state, API } from './state.js';
+import { esc } from './util.js';
+
+/**
+ * The `Missing` band sentinel — a `wanted` request with no clean
+ * beets-library album for its `mb_release_id`. Matches the lowercase
+ * `band` value U1 stamps on each row.
+ *
+ * @type {string}
+ */
+export const MISSING_BAND = 'missing';
+
+/**
+ * Canonical band ordering for the tab strip: `Missing` first, then the
+ * on-disk bands ascending by `QualityRank` value. `unknown` (in-library
+ * but unclassifiable) sits right after `missing` — it is a distinct
+ * mechanism (present-but-rank-unknown vs. absent-from-membership) and
+ * reads as "lowest known quality" for triage purposes.
+ *
+ * Ascending QualityRank: poor < acceptable < good < excellent <
+ * transparent < lossless (LOSSLESS > TRANSPARENT > EXCELLENT > … per the
+ * codec-aware rank gate, so highest-quality bands sort last).
+ *
+ * @type {string[]}
+ */
+export const BAND_ORDER = [
+  'missing',
+  'unknown',
+  'poor',
+  'acceptable',
+  'good',
+  'excellent',
+  'transparent',
+  'lossless',
+];
+
+/**
+ * Human-friendly label for a band value. Capitalises the lowercase
+ * `band` the API emits. Unknown / future band values fall back to the
+ * raw value so a new rank tier is never silently swallowed.
+ *
+ * @param {string|null|undefined} band
+ * @returns {string}
+ */
+export function bandLabel(band) {
+  const b = String(band || '').toLowerCase();
+  if (!b) return '?';
+  return b.charAt(0).toUpperCase() + b.slice(1);
+}
+
+/**
+ * Sort key for a band — its index in {@link BAND_ORDER}, or a large
+ * sentinel for bands not in the canonical list (so unrecognised bands
+ * sort to the end in stable, alphabetical order via the tie-break).
+ *
+ * @param {string} band
+ * @returns {number}
+ */
+function bandSortKey(band) {
+  const idx = BAND_ORDER.indexOf(band);
+  return idx === -1 ? BAND_ORDER.length : idx;
+}
+
+/**
+ * Derive the band-tab set from the fetched cohort. Pure / DOM-free.
+ *
+ * Returns one entry per band actually present in `rows`, ordered
+ * `Missing` first then ascending by `QualityRank` value
+ * ({@link BAND_ORDER}), each carrying a live `count`. Bands with zero
+ * rows are omitted — the tab strip only shows bands that exist in the
+ * cohort. Unrecognised band values sort to the end (alphabetically
+ * among themselves) rather than being dropped.
+ *
+ * @param {Array<Object>} rows
+ * @returns {Array<{band: string, label: string, count: number}>}
+ */
+export function deriveBandTabs(rows) {
+  const counts = new Map();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const band = String((row && row.band) || '').toLowerCase();
+    if (!band) continue;
+    counts.set(band, (counts.get(band) || 0) + 1);
+  }
+  const bands = [...counts.keys()];
+  bands.sort((a, b) => {
+    const ka = bandSortKey(a);
+    const kb = bandSortKey(b);
+    if (ka !== kb) return ka - kb;
+    return a.localeCompare(b);
+  });
+  return bands.map((band) => ({
+    band,
+    label: bandLabel(band),
+    count: counts.get(band) || 0,
+  }));
+}
+
+/**
+ * Pick the default band tab for a freshly-fetched cohort. Pure.
+ *
+ * Prefers `Missing` (the operator's usual entry point — the most-stuck
+ * cohort) when present, else the first band in canonical order. Returns
+ * `null` for an empty cohort (no tabs to select).
+ *
+ * @param {Array<{band: string}>} tabs  Output of {@link deriveBandTabs}.
+ * @returns {string|null}
+ */
+export function defaultBand(tabs) {
+  if (!Array.isArray(tabs) || tabs.length === 0) return null;
+  const missing = tabs.find((t) => t.band === MISSING_BAND);
+  if (missing) return missing.band;
+  return tabs[0].band;
+}
+
+/**
+ * Lower-cased "artist album" haystack for one row. Pure.
+ *
+ * @param {Object} row
+ * @returns {string}
+ */
+function rowHaystack(row) {
+  const artist = (row && row.artist_name) || '';
+  const album = (row && row.album_title) || '';
+  return `${artist} ${album}`.toLowerCase();
+}
+
+/**
+ * Does a row match the search query (artist / album substring)? Pure.
+ * Empty/whitespace query matches everything.
+ *
+ * @param {Object} row
+ * @param {string} query
+ * @returns {boolean}
+ */
+function rowMatchesQuery(row, query) {
+  const q = String(query || '').trim().toLowerCase();
+  if (!q) return true;
+  return rowHaystack(row).includes(q);
+}
+
+/**
+ * Filter the cohort to the rows shown in the list: the selected band,
+ * narrowed by the search query (artist / album substring). Pure /
+ * DOM-free. A null/empty `band` matches no rows (no tab selected); an
+ * empty query keeps every in-band row.
+ *
+ * @param {Array<Object>} rows
+ * @param {string|null} band
+ * @param {string} query
+ * @returns {Array<Object>}
+ */
+export function filterRows(rows, band, query) {
+  const target = String(band || '').toLowerCase();
+  if (!target) return [];
+  return (Array.isArray(rows) ? rows : []).filter((row) => {
+    const rowBand = String((row && row.band) || '').toLowerCase();
+    if (rowBand !== target) return false;
+    return rowMatchesQuery(row, query);
+  });
+}
+
+/**
+ * Count rows matching the search query in bands OTHER than the selected
+ * one. Pure. Drives the "N matches in other bands" hint shown when the
+ * in-band result is empty/sparse so the operator isn't dead-ended by a
+ * search that only hits a different band. A blank query returns 0 (no
+ * hint when not searching).
+ *
+ * @param {Array<Object>} rows
+ * @param {string|null} band
+ * @param {string} query
+ * @returns {number}
+ */
+export function countOtherBandMatches(rows, band, query) {
+  const q = String(query || '').trim();
+  if (!q) return 0;
+  const target = String(band || '').toLowerCase();
+  let n = 0;
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const rowBand = String((row && row.band) || '').toLowerCase();
+    if (rowBand === target) continue;
+    if (rowMatchesQuery(row, q)) n += 1;
+  }
+  return n;
+}
+
+// --- Rendering -------------------------------------------------------
+
+/**
+ * Render the band tab strip from the derived tabs. The selected band
+ * gets `active-status`. Each tab shows its live count.
+ *
+ * @param {Array<{band: string, label: string, count: number}>} tabs
+ * @param {string|null} selected
+ * @returns {string}
+ */
+function renderBandTabs(tabs, selected) {
+  if (!tabs.length) return '';
+  const buttons = tabs.map((t) => {
+    const active = t.band === selected ? ' active-status' : '';
+    return `<button class="p-btn lt-band-tab${active}" type="button" onclick="window.setLongTailBand('${esc(t.band)}')">${esc(t.label)} <span class="lt-band-count">${t.count}</span></button>`;
+  }).join('');
+  return `<div class="lt-band-tabs">${buttons}</div>`;
+}
+
+/**
+ * Render the search box. The current query is reflected as the input
+ * value so a re-render preserves what the operator typed. The
+ * `oninput` handler routes through `window.onLongTailSearchInput`,
+ * which debounces + stamps the in-flight token.
+ *
+ * @param {string} query
+ * @returns {string}
+ */
+function renderSearchBox(query) {
+  return `<div class="lt-search">
+    <input type="text" id="lt-search-input" class="lt-search-input"
+      placeholder="Filter this band by artist or album…"
+      value="${esc(query)}"
+      oninput="window.onLongTailSearchInput(this.value)">
+  </div>`;
+}
+
+/**
+ * Render one worklist row. Clickable — the `.lt-item` click toggles the
+ * (empty for now) `.lt-detail` console container via
+ * `window.toggleLongTailDetail`. U4 fills the detail in.
+ *
+ * @param {Object} row
+ * @returns {string}
+ */
+export function renderLongTailRow(row) {
+  const id = row.id;
+  const artist = row.artist_name || 'Unknown';
+  const album = row.album_title || '';
+  const year = row.year || '?';
+  // Per-row band badge. We reuse the shared `badge-rank-*` colour classes
+  // (the badges.js reuse target named in the plan) but render the band
+  // *name* as the chip text — the worklist's organising axis is the band,
+  // not "in library". `missing` (no library copy) gets the wanted-blue
+  // chip; every on-disk band gets its rank colour. We deliberately do NOT
+  // append a format/bitrate suffix here: the row carries `target_format`
+  // (the request's intent), not the on-disk codec, so a suffix would
+  // mislabel the actual file. The band name + colour is the honest
+  // signal; the console (U4) surfaces the exact on-disk format.
+  const band = String(row.band || '').toLowerCase();
+  const bandCls = band === MISSING_BAND ? 'badge-wanted' : `badge-rank-${esc(band)}`;
+  const bandBadge = `<span class="badge ${bandCls}">${esc(bandLabel(band))}</span>`;
+  const flight = row.in_flight_rescue
+    ? '<span class="badge badge-new">rescue running</span>'
+    : '';
+  const unfindable = row.unfindable_category
+    ? `<span class="lt-meta-chip" title="unfindable category">${esc(row.unfindable_category)}</span>`
+    : '';
+  const src = row.source ? `<span class="lt-meta-chip">${esc(row.source)}</span>` : '';
+  return `
+    <div class="lt-item" onclick="window.toggleLongTailDetail(${id})">
+      <div class="p-top">
+        <div>
+          <div class="p-title">${esc(album)} ${bandBadge}${flight}</div>
+          <div class="p-artist">${esc(artist)}</div>
+        </div>
+        <div class="p-row-actions"><span style="font-size:0.75em;color:#666;">#${id}</span></div>
+      </div>
+      <div class="p-meta">
+        <span>${esc(String(year))}</span>
+        ${src}
+        ${unfindable}
+      </div>
+    </div>
+    <div class="lt-detail" id="lt-detail-${id}"></div>
+  `;
+}
+
+/**
+ * Render the list body for the currently-selected band + query. Returns
+ * one of three explicit states so the area is never blank:
+ *   * empty-cohort  → no `wanted` rows at all.
+ *   * empty-band    → a search filtered the selected band to zero (the
+ *     tab stays visible); shows the "N matches in other bands" hint.
+ *   * rows          → the matching rows.
+ *
+ * @param {Array<Object>} rows  Full cohort.
+ * @param {string|null} band    Selected band.
+ * @param {string} query        Search query.
+ * @returns {string}
+ */
+function renderListBody(rows, band, query) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return '<div class="loading">No wanted releases in the long tail.</div>';
+  }
+  const shown = filterRows(rows, band, query);
+  if (shown.length === 0) {
+    const other = countOtherBandMatches(rows, band, query);
+    const hint = other > 0
+      ? `<div class="lt-empty-hint">${other} match${other === 1 ? '' : 'es'} in other bands.</div>`
+      : '';
+    const label = bandLabel(band);
+    return `<div class="lt-empty-band">
+      <div class="loading">No ${esc(label)} releases match${query ? ` “${esc(query)}”` : ''}.</div>
+      ${hint}
+    </div>`;
+  }
+  return shown.map(renderLongTailRow).join('');
+}
+
+/**
+ * Render the whole long-tail sub-view from the current
+ * `state.longTail`. Writes into `#pipeline-content` beneath the Pipeline
+ * nav (the caller supplies the nav prefix). Pure-ish: reads state,
+ * returns the inner HTML body (no nav).
+ *
+ * @returns {string}
+ */
+export function renderLongTailBody() {
+  const lt = state.longTail;
+  const rows = Array.isArray(lt.rows) ? lt.rows : [];
+  const tabs = deriveBandTabs(rows);
+  // If the selected band is no longer present (e.g. after a refetch
+  // dropped it), fall back to the default.
+  let band = lt.band;
+  if (band == null || !tabs.some((t) => t.band === band)) {
+    band = defaultBand(tabs);
+    lt.band = band;
+  }
+  const tabStrip = renderBandTabs(tabs, band);
+  const searchBox = tabs.length ? renderSearchBox(lt.query) : '';
+  const body = renderListBody(rows, band, lt.query);
+  return `<div class="lt-worklist">
+    ${tabStrip}
+    ${searchBox}
+    <div class="lt-list" id="lt-list">${body}</div>
+  </div>`;
+}
+
+// --- Fetch + dispatch -----------------------------------------------
+
+/**
+ * Module-scoped in-flight token for the worklist fetch. Bumped on every
+ * `loadLongTail` call; a fetch whose token is stale when it resolves is
+ * discarded before it renders (browse.js stale-token pattern). Shared
+ * with the search debounce so a search-triggered re-render and a fresh
+ * fetch can't clobber each other.
+ *
+ * @type {number}
+ */
+let longTailRequestToken = 0;
+
+/**
+ * Debounce timer handle for the search box. Cleared on each keystroke.
+ *
+ * @type {number|null}
+ */
+let longTailSearchTimer = null;
+
+/**
+ * Debounce window (ms) for the search box, matching the browse-tab
+ * search debounce.
+ *
+ * @type {number}
+ */
+const LONG_TAIL_SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Fetch the banded `wanted` cohort and render it. Stamps an in-flight
+ * token so a slow response superseded by a newer load is discarded
+ * before it paints.
+ *
+ * @returns {Promise<void>}
+ */
+export async function loadLongTail() {
+  const token = ++longTailRequestToken;
+  const el = (typeof document !== 'undefined')
+    ? document.getElementById('pipeline-content')
+    : null;
+  if (el) {
+    // Transient loading affordance — distinct from the empty-cohort
+    // state. We paint the body only (no nav): pipeline.js owns
+    // `renderPipelineNav` and the success path routes back through
+    // `renderPipeline` which re-emits it, so there is never a navless
+    // *permanent* state. Duplicating the nav here would be a parallel
+    // code path.
+    el.innerHTML = '<div class="loading">Loading long tail…</div>';
+  }
+  try {
+    const r = await fetch(`${API}/api/pipeline/long-tail`);
+    if (token !== longTailRequestToken) return;
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const data = await r.json();
+    if (token !== longTailRequestToken) return;
+    const rows = Array.isArray(data.results) ? data.results : [];
+    state.longTail.rows = rows;
+    const tabs = deriveBandTabs(rows);
+    // Pick a default band when none selected or the prior selection is
+    // gone from the new cohort.
+    if (state.longTail.band == null
+        || !tabs.some((t) => t.band === state.longTail.band)) {
+      state.longTail.band = defaultBand(tabs);
+    }
+    renderLongTail();
+  } catch (e) {
+    if (token !== longTailRequestToken) return;
+    if (el) {
+      el.innerHTML = '<div class="loading">Failed to load long tail.</div>';
+    }
+  }
+}
+
+/**
+ * Re-render the long-tail sub-view from cached state without refetching.
+ * Delegates to pipeline.js's render dispatcher so the Pipeline nav is
+ * emitted consistently with the other sub-views. Bound at call time to
+ * avoid a static circular import.
+ *
+ * @returns {void}
+ */
+export function renderLongTail() {
+  if (typeof window === 'undefined') return;
+  const fn = /** @type {undefined | (() => void)} */ (
+    /** @type {any} */ (window).renderPipeline);
+  if (typeof fn === 'function') fn();
+}
+
+/**
+ * Select a band tab. Mutates `state.longTail.band` and re-renders. The
+ * search query is preserved across band switches (the operator may want
+ * the same filter applied to a different band; the "N in other bands"
+ * hint already nudges them here).
+ *
+ * @param {string} band
+ * @returns {void}
+ */
+export function setLongTailBand(band) {
+  state.longTail.band = String(band || '').toLowerCase() || null;
+  renderLongTail();
+}
+
+/**
+ * Search-box input handler. Debounced + stamped with the in-flight token
+ * so a stale debounced render (from a superseded keystroke or a fetch
+ * that has since started) is discarded before it paints. Re-renders only
+ * the list body in place so the input keeps focus + caret position.
+ *
+ * @param {string} value
+ * @returns {void}
+ */
+export function onLongTailSearchInput(value) {
+  state.longTail.query = String(value == null ? '' : value);
+  const token = longTailRequestToken;
+  if (longTailSearchTimer != null && typeof clearTimeout === 'function') {
+    clearTimeout(longTailSearchTimer);
+  }
+  const run = () => {
+    // Stale-guard: a fresh fetch (loadLongTail) bumps the token; if it
+    // has moved on, that fetch's render will repaint — skip this one.
+    if (token !== longTailRequestToken) return;
+    const listEl = (typeof document !== 'undefined')
+      ? document.getElementById('lt-list')
+      : null;
+    if (!listEl) return;
+    const rows = Array.isArray(state.longTail.rows) ? state.longTail.rows : [];
+    // Re-render only the list body; the tabs + input stay put so the
+    // search box keeps focus and the caret position.
+    listEl.innerHTML = renderListBody(rows, state.longTail.band, state.longTail.query);
+  };
+  if (typeof setTimeout === 'function') {
+    longTailSearchTimer = /** @type {any} */ (
+      setTimeout(run, LONG_TAIL_SEARCH_DEBOUNCE_MS));
+  } else {
+    run();
+  }
+}
+
+/**
+ * Toggle the in-place action console for one row. U3 ships the stub:
+ * locate the `.lt-detail` container and toggle its `.open` class with an
+ * empty body. U4 fills the console (evidence + actions) in.
+ *
+ * @param {number} id  album_requests.id
+ * @returns {void}
+ */
+export function toggleLongTailDetail(id) {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById(`lt-detail-${id}`);
+  if (!el) return;
+  if (el.classList.contains('open')) {
+    el.classList.remove('open');
+    return;
+  }
+  // U4 will populate this; for now the container just opens empty so the
+  // click is observable and the wiring is in place.
+  el.classList.add('open');
+}
+
+export const __test__ = {
+  MISSING_BAND,
+  BAND_ORDER,
+  bandLabel,
+  deriveBandTabs,
+  defaultBand,
+  filterRows,
+  countOtherBandMatches,
+  renderLongTailRow,
+  renderLongTailBody,
+};

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -29,10 +29,32 @@
  *      with a "Check YouTube" button (U5 wires the actual resolver call —
  *      U4 must NOT auto-call the slow, side-effectful resolver GET).
  *
- * The evidence/action SUBMIT flows are out of scope here: the rescue
- * submit + live resolver call are U5; accept-sibling / set-intent /
- * re-search are U6. U4 builds the panels + the YouTube state shell + a
- * Check-YouTube stub only.
+ * U5 (this unit): the two-step YouTube rescue flow.
+ *
+ *   1. "Check YouTube" (`checkYoutube`) — replaces U4's placeholder. Calls
+ *      the SLOW, SIDE-EFFECTFUL resolver GET
+ *      (`GET /api/youtube-album?identifier=<mb_release_id>`), disables the
+ *      button + shows in-progress, GUARDS double-fire (a module-scoped
+ *      `resolveInFlight` Set keyed by request id — a second click while
+ *      outstanding fires nothing), and STAMPS the fetch with a per-row
+ *      console token so a stale result (operator collapsed the console or
+ *      moved to another row) never paints. On return the YouTube panel is
+ *      re-rendered via `youtubeSectionState`: `resolved_with_matrix` →
+ *      pickable rescue targets; `resolved_empty` → "not on YouTube Music —
+ *      re-check" (rescue affordance HIDDEN); `resolver_failed` → error +
+ *      Retry; cached-but-stale → matrix with a "cached" note.
+ *   2. Pick + confirm + submit — clicking a matrix target's "Rescue from
+ *      this" (`pickYoutubeRescue`) opens a Promise-based confirm overlay
+ *      (mirrors `web/js/replace_picker.js`'s `.confirm-overlay` shell +
+ *      backdrop-click-cancel). On confirm →
+ *      `POST /api/pipeline/<id>/youtube-rescue {browse_id}`. Every ingest
+ *      outcome maps to specific console copy (`rescueOutcomeCopy`). On
+ *      `accepted` the row is marked in-flight and a SINGLE-ROW refetch
+ *      (`GET /api/pipeline/long-tail?id=<id>`) patches just that cohort
+ *      row (KTD8 — never optimistically move the row to a band; the
+ *      importer owns the transition, KTD4).
+ *
+ * accept-sibling / set-intent / re-search remain U6.
  *
  * Pure / DOM-free helpers (band ordering, tab derivation, in-band search
  * filtering, cross-band match count, YouTube state classifier, console
@@ -47,9 +69,10 @@
  * `export const __test__ = {…}` named-object test convention.
  */
 
-import { state, API } from './state.js';
+import { state, API, toast } from './state.js';
 import {
   esc,
+  jsArg,
   renderForensicBlock,
   youtubeSectionState,
   consoleEmphasis,
@@ -824,14 +847,81 @@ function renderSiblingsBody(rgData) {
 }
 
 /**
+ * @typedef {Object} YoutubeRescueTarget
+ * @property {string} yt_browse_id  The YT Music album browseId — the value
+ *   the rescue submit (`POST .../youtube-rescue`) takes as `browse_id`.
+ * @property {number|null} year
+ * @property {number|null} track_count
+ * @property {number|null} best_distance  Lowest `ok` beets distance across
+ *   the release's `distances[]`, or `null` when none scored.
+ */
+
+/**
+ * Lowest `ok` beets distance across a YT release's `distances[]`. Pure /
+ * DOM-free. Returns `null` when no distance row scored `ok` (so callers can
+ * render "no distance" without a special-case branch).
+ *
+ * @param {{distances?: Array<{outcome?: string, distance?: number}>|null}} rel
+ * @returns {number|null}
+ */
+export function youtubeBestDistance(rel) {
+  const dists = (rel && Array.isArray(rel.distances)) ? rel.distances : [];
+  let best = /** @type {number|null} */ (null);
+  for (const d of dists) {
+    if (!d || d.outcome !== 'ok' || typeof d.distance !== 'number') continue;
+    if (best == null || d.distance < best) best = d.distance;
+  }
+  return best;
+}
+
+/**
+ * Extract the pickable rescue targets from a resolver result. Pure /
+ * DOM-free. Each target carries its `yt_browse_id` (the value the rescue
+ * submit needs) plus display meta (year / track_count / best distance).
+ *
+ * Only `resolved_with_matrix` yields targets — `resolved_empty` (ok with
+ * zero releases), `resolver_failed`, and `never_run` (null) all yield an
+ * empty list, so the rescue affordance is hidden (R9 / R10: the operator
+ * picks a target, the system never auto-picks; "not on YouTube Music"
+ * offers nothing to pick). A release missing a `yt_browse_id` is dropped —
+ * it cannot be a rescue target without the id the submit requires.
+ *
+ * @param {{outcome?: string, youtube_releases?: Array<Object>|null, from_cache?: boolean, error_message?: string|null}|null|undefined} result
+ * @returns {YoutubeRescueTarget[]}
+ */
+export function youtubeRescueTargets(result) {
+  const cls = youtubeSectionState(result);
+  if (cls.state !== 'resolved_with_matrix') return [];
+  const releases = (result && Array.isArray(result.youtube_releases))
+    ? result.youtube_releases : [];
+  /** @type {YoutubeRescueTarget[]} */
+  const targets = [];
+  for (const rel of releases) {
+    const browseId = rel && rel.yt_browse_id ? String(rel.yt_browse_id) : '';
+    if (!browseId) continue;  // no id → not a pickable target.
+    targets.push({
+      yt_browse_id: browseId,
+      year: (rel.year != null) ? Number(rel.year) : null,
+      track_count: (rel.track_count != null) ? Number(rel.track_count) : null,
+      best_distance: youtubeBestDistance(rel),
+    });
+  }
+  return targets;
+}
+
+/**
  * Render the YouTube panel body for a given section state + payload. Pure.
  *
- * U4 renders all four states; the matrix rows are display-only (U5 makes
- * them pickable rescue targets). The default (`never_run`) state renders
- * the "Check YouTube" button whose click is a STUB wired to
- * `window.checkYoutube(id)` — U5 defines that handler and the live
- * resolver fetch. U4 must NOT auto-call the slow, side-effectful resolver
- * GET, so the panel opens in `never_run` until the operator clicks.
+ * Renders all four states. In `resolved_with_matrix` each release is a
+ * PICKABLE rescue target (U5): a "Rescue from this" button carrying the
+ * release's `yt_browse_id` opens the confirm step
+ * (`window.pickYoutubeRescue(id, browse_id)`). `resolved_empty` HIDES the
+ * rescue affordance and shows "not on YouTube Music — re-check"
+ * (R9 / R10 — nothing to pick). `never_run` / `resolver_failed` render the
+ * "Check YouTube" / retry button wired to `window.checkYoutube(id)` (U5's
+ * real resolver handler, replacing U4's placeholder). The console must NOT
+ * auto-call the slow, side-effectful resolver GET — the panel opens in
+ * `never_run` until the operator clicks.
  *
  * @param {{outcome?: string, youtube_releases?: Array<Object>|null, from_cache?: boolean, error_message?: string|null}|null} result
  *   A cached resolver result, or `null` for the default never-run state.
@@ -840,7 +930,10 @@ function renderSiblingsBody(rgData) {
  */
 function renderYoutubeBody(result, id) {
   const cls = youtubeSectionState(result);
-  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">Check YouTube</button>`;
+  const checkLabel = (cls.state === 'resolver_failed') ? 'Retry'
+    : (cls.state === 'resolved_empty') ? 'Re-check'
+    : 'Check YouTube';
+  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">${checkLabel}</button>`;
   if (cls.state === 'never_run') {
     return `<div class="lt-yt lt-yt-never-run">
       <div class="lt-yt-prompt">Resolve this release against YouTube Music.</div>
@@ -854,33 +947,36 @@ function renderYoutubeBody(result, id) {
     </div>`;
   }
   if (cls.state === 'resolved_empty') {
+    // Not on YouTube Music — HIDE the rescue affordance (nothing to pick),
+    // offer only a re-check.
     return `<div class="lt-yt lt-yt-empty">
       <div class="lt-yt-msg">${esc(cls.message)}</div>
       ${checkBtn}
     </div>`;
   }
-  // resolved_with_matrix — display-only matrix in U4.
-  const releases = (result && Array.isArray(result.youtube_releases))
-    ? result.youtube_releases : [];
+  // resolved_with_matrix — each release is a pickable rescue target (U5).
   const staleFlag = cls.stale
     ? `<div class="lt-yt-stale">${esc(cls.message)}</div>`
     : '';
-  const rows = releases.map((rel) => {
-    const dists = Array.isArray(rel.distances) ? rel.distances : [];
-    const best = dists
-      .filter((d) => d && d.outcome === 'ok' && typeof d.distance === 'number')
-      .reduce((acc, d) => (acc == null || d.distance < acc ? d.distance : acc), /** @type {number|null} */ (null));
-    const bestStr = (best != null) ? `dist ${best.toFixed(3)}` : 'no distance';
-    const tc = (rel.track_count != null) ? `${rel.track_count}t` : '';
-    const yr = (rel.year != null) ? String(rel.year) : '';
+  const targets = youtubeRescueTargets(result);
+  const rows = targets.map((t) => {
+    const bestStr = (t.best_distance != null)
+      ? `dist ${t.best_distance.toFixed(3)}` : 'no distance';
+    const tc = (t.track_count != null) ? `${t.track_count}t` : '';
+    const yr = (t.year != null) ? String(t.year) : '';
+    const meta = [yr, tc, bestStr].filter((x) => x).join(' · ');
+    // The browse id is embedded via jsArg so a confirm picks the exact
+    // target the operator clicked (R10 — never auto-picked).
     return `<div class="lt-yt-row">
-      <span class="lt-yt-id">${esc(String(rel.yt_browse_id || '?'))}</span>
-      <span class="lt-yt-meta">${esc([yr, tc, bestStr].filter((x) => x).join(' · '))}</span>
+      <span class="lt-yt-id">${esc(t.yt_browse_id)}</span>
+      <span class="lt-yt-meta">${esc(meta)}</span>
+      <button class="lt-yt-rescue" type="button" onclick="event.stopPropagation(); window.pickYoutubeRescue(${id}, ${jsArg(t.yt_browse_id)})">Rescue from this</button>
     </div>`;
   }).join('');
   return `<div class="lt-yt lt-yt-matrix">
     ${staleFlag}
     <div class="lt-yt-rows">${rows}</div>
+    ${checkBtn}
   </div>`;
 }
 
@@ -1076,6 +1172,441 @@ export function toggleLongTailDetail(id) {
   loadPipelinePanels(id, token, inFlightFlag);
 }
 
+// --- Console rescue flow (U5) ----------------------------------------
+//
+// Two steps: "Check YouTube" runs the slow side-effectful resolver GET and
+// re-renders the YouTube panel with pickable rescue targets; picking a
+// target opens a confirm overlay and submits the rescue. Both steps are
+// double-fire-guarded (a module-scoped Set keyed by request id). The
+// resolver result is stamped with the row's console token so a stale result
+// (operator moved on) is discarded before it paints.
+
+/**
+ * @typedef {Object} RescueCopy
+ * @property {string} title    Short headline for the outcome.
+ * @property {string} detail   One-line operator-facing explanation.
+ * @property {'success'|'error'} tone  Drives toast styling (error → red).
+ */
+
+/**
+ * Map a YouTube-rescue ingest outcome to specific operator-facing console
+ * copy. Pure / DOM-free. Keys mirror the EXACT outcome vocabulary in
+ * `lib/youtube_ingest_service.py` / `web/routes/youtube.py`
+ * (`OUTCOME_HTTP_STATUS`): `accepted`, `request_not_found`, `wrong_state`,
+ * `in_flight`, `no_resolver_mapping`, `track_count_precheck_failed`,
+ * `transient`.
+ *
+ * `result` is the parsed rescue-submit response body — its `outcome`
+ * selects the copy; `download_log_id` / `detail` decorate the `in_flight`
+ * and `track_count_precheck_failed` messages with the specifics the
+ * backend returns. An unknown outcome falls back to a generic error so a
+ * future backend value never renders blank.
+ *
+ * @param {{outcome?: string, download_log_id?: number|null, detail?: string|null, error?: string|null}|null|undefined} result
+ * @returns {RescueCopy}
+ */
+export function rescueOutcomeCopy(result) {
+  const outcome = String((result && result.outcome) || '');
+  const detail = (result && result.detail) ? String(result.detail) : '';
+  const logId = (result && result.download_log_id != null)
+    ? result.download_log_id : null;
+  switch (outcome) {
+    case 'accepted':
+      return {
+        title: 'Rescue queued',
+        detail: logId != null
+          ? `Rescue queued (download_log #${logId}). The importer owns the import; the row updates when it lands.`
+          : 'Rescue queued. The importer owns the import; the row updates when it lands.',
+        tone: 'success',
+      };
+    case 'in_flight':
+      return {
+        title: 'Rescue already running',
+        detail: logId != null
+          ? `A rescue is already running for this request (download_log #${logId}).`
+          : 'A rescue is already running for this request.',
+        tone: 'error',
+      };
+    case 'wrong_state':
+      return {
+        title: 'Request changed',
+        detail: 'This request is no longer wanted/manual — refresh and try again.',
+        tone: 'error',
+      };
+    case 'no_resolver_mapping':
+      return {
+        title: 'No resolver mapping',
+        detail: 'No cached YouTube mapping for this release — re-run Check YouTube first.',
+        tone: 'error',
+      };
+    case 'track_count_precheck_failed':
+      return {
+        title: 'Track-count mismatch',
+        detail: detail
+          ? `Track-count precheck failed: ${detail}`
+          : 'Track-count precheck failed: the resolver and MB mirror disagree — refresh and re-check.',
+        tone: 'error',
+      };
+    case 'transient':
+      return {
+        title: 'Temporary failure',
+        detail: detail
+          ? `Temporary failure: ${detail}. Retry.`
+          : 'Temporary failure (DB / mirror hiccup). Retry.',
+        tone: 'error',
+      };
+    case 'request_not_found':
+      return {
+        title: 'Request not found',
+        detail: 'This request no longer exists — refresh.',
+        tone: 'error',
+      };
+    default:
+      return {
+        title: 'Rescue failed',
+        detail: detail || (result && result.error
+          ? String(result.error)
+          : `Unexpected outcome: ${outcome || 'unknown'}.`),
+        tone: 'error',
+      };
+  }
+}
+
+/**
+ * Request ids with an outstanding resolver GET. Guards the slow,
+ * side-effectful Check-YouTube call against double-fire: a second click
+ * while one is outstanding fires nothing.
+ *
+ * @type {Set<number>}
+ */
+const resolveInFlight = new Set();
+
+/**
+ * Request ids with an outstanding rescue-submit POST. Guards the confirm →
+ * submit step against double-fire.
+ *
+ * @type {Set<number>}
+ */
+const submitInFlight = new Set();
+
+/**
+ * Double-fire predicate for the resolver GET. Pure. `true` when a Check
+ * YouTube call may START for this id (none outstanding); `false` when one
+ * is already in flight (the click is suppressed).
+ *
+ * @param {Set<number>} inFlight  The in-flight id set.
+ * @param {number} id
+ * @returns {boolean}
+ */
+export function canStartInFlight(inFlight, id) {
+  return !inFlight.has(id);
+}
+
+/**
+ * Re-render just the YouTube panel body for one row's open console, guarded
+ * by the row's console token so a stale result doesn't paint. DOM-side.
+ *
+ * @param {number} id
+ * @param {number} token  The console token captured when the resolve fired.
+ * @param {{outcome?: string, youtube_releases?: Array<Object>|null, from_cache?: boolean, error_message?: string|null}|null} result
+ * @returns {void}
+ */
+function patchYoutubePanel(id, token, result) {
+  patchPanel(id, 'youtube', token, renderYoutubeBody(result, id));
+}
+
+/**
+ * "Check YouTube" handler (U5) — replaces U4's placeholder toast. Runs the
+ * slow, side-effectful resolver GET for the row's `mb_release_id`, then
+ * re-renders the YouTube panel with the fresh classification.
+ *
+ * Guards:
+ *   * Double-fire — a module-scoped `resolveInFlight` Set keyed by request
+ *     id; a second click while outstanding returns immediately.
+ *   * Stale result — the result is only painted if the row's console token
+ *     still matches the one captured when the fetch fired (operator may
+ *     have collapsed the console or clicked another row meanwhile).
+ *   * Disabled button — the live "Check YouTube" / "Retry" button is
+ *     disabled + relabelled while outstanding so the operator sees progress
+ *     and can't re-click it.
+ *
+ * The resolver identifier is the request's `mb_release_id` (an MB release
+ * MBID or a Discogs release id) — the same id the resolver's
+ * `?identifier=` query takes. A row without one cannot be resolved; the
+ * panel shows that explicitly rather than firing a doomed fetch.
+ *
+ * @param {number} id  album_requests.id
+ * @returns {Promise<void>}
+ */
+export async function checkYoutube(id) {
+  if (!canStartInFlight(resolveInFlight, id)) return;  // double-fire guard.
+  const row = consoleRow(id);
+  const identifier = row && row.mb_release_id ? String(row.mb_release_id) : '';
+  const token = consoleTokens.get(id) || 0;
+  if (!identifier) {
+    patchYoutubePanel(id, token, /** @type {any} */ (
+      { outcome: 'transient', error_message: 'No release identifier on this request.' }));
+    return;
+  }
+  resolveInFlight.add(id);
+  setYoutubeChecking(id);
+  try {
+    const r = await fetch(
+      `${API}/api/youtube-album?identifier=${encodeURIComponent(identifier)}`);
+    // 404/503 still carry a typed body; the classifier maps any non-`ok`
+    // outcome to `resolver_failed`, so we read the body regardless of
+    // status and only fall back to a synthetic failure if the body is
+    // unreadable.
+    let result;
+    try {
+      result = await r.json();
+    } catch (_e) {
+      result = { outcome: 'transient', error_message: `HTTP ${r.status}` };
+    }
+    patchYoutubePanel(id, token, result);
+  } catch (_e) {
+    patchYoutubePanel(id, token, /** @type {any} */ (
+      { outcome: 'transient', error_message: 'Could not reach the resolver. Retry.' }));
+  } finally {
+    resolveInFlight.delete(id);
+  }
+}
+
+/**
+ * Swap the YouTube panel into an in-progress state while the resolver GET
+ * is outstanding (disabled button + spinner copy). DOM-side; no-op when the
+ * panel isn't mounted (Node tests / collapsed console).
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function setYoutubeChecking(id) {
+  if (typeof document === 'undefined') return;
+  const panel = document.getElementById(`lt-panel-youtube-${id}`);
+  if (!panel) return;
+  const body = panel.querySelector('.lt-panel-body');
+  if (!body) return;
+  body.innerHTML = `<div class="lt-yt lt-yt-checking">
+    <div class="lt-yt-msg">Resolving against YouTube Music…</div>
+    <button class="lt-yt-check" type="button" disabled>Checking…</button>
+  </div>`;
+}
+
+/**
+ * Render the rescue confirm dialog body. Pure. Mirrors the
+ * `.confirm-box` shell used by `replace_picker.js` so the visual language
+ * matches the only other destructive-confirm in the app.
+ *
+ * @param {number} id        album_requests.id
+ * @param {string} browseId  The YT Music album browseId being submitted.
+ * @param {Object|null} row  The worklist row (for the album label).
+ * @returns {string}
+ */
+export function renderRescueConfirm(id, browseId, row) {
+  const album = (row && row.album_title) ? String(row.album_title) : `request #${id}`;
+  const artist = (row && row.artist_name) ? String(row.artist_name) : '';
+  const label = artist ? `${artist} — ${album}` : album;
+  return `<div class="confirm-box" role="dialog" aria-modal="true">
+    <h3>Rescue from YouTube Music?</h3>
+    <p>Queue a YouTube-Music rescue for:<br><strong>${esc(label)}</strong></p>
+    <p>Target album:<br><code>${esc(browseId)}</code></p>
+    <p style="font-size:0.85em;color:#999;">The request stays <code>wanted</code> until the
+    importer lands the rescue (minutes later) — the row won't move bands immediately.</p>
+    <div class="actions">
+      <button class="btn" id="lt-rescue-cancel">Cancel</button>
+      <button class="btn p-btn" id="lt-rescue-confirm">Rescue</button>
+    </div>
+  </div>`;
+}
+
+/**
+ * The dedicated mount node for the rescue confirm overlay. Reuses the
+ * shared `replace-picker-modal` host (same pattern as the Replace picker —
+ * one modal host, wiped on close).
+ *
+ * @returns {HTMLElement|null}
+ */
+function rescueModalHost() {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById('replace-picker-modal');
+}
+
+/**
+ * Open the Promise-based rescue confirm overlay. Mirrors
+ * `replace_picker.js`'s overlay shell: a full-screen `.confirm-overlay`
+ * backdrop (click-to-cancel) wrapping the `.confirm-box`. Resolves `true`
+ * on confirm, `false` on cancel / backdrop click. DOM-side.
+ *
+ * @param {number} id
+ * @param {string} browseId
+ * @param {Object|null} row
+ * @returns {Promise<boolean>}
+ */
+function confirmRescue(id, browseId, row) {
+  const host = rescueModalHost();
+  if (!host) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    let settled = false;
+    /** @param {boolean} ok */
+    function close(ok) {
+      if (settled) return;
+      settled = true;
+      host.style.display = 'none';
+      host.innerHTML = '';
+      resolve(ok);
+    }
+    host.innerHTML = `<div class="confirm-overlay">${renderRescueConfirm(id, browseId, row)}</div>`;
+    host.style.display = '';
+    const overlay = host.querySelector('.confirm-overlay');
+    if (overlay) {
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) close(false);  // backdrop-click cancel.
+      });
+    }
+    const cancel = host.querySelector('#lt-rescue-cancel');
+    if (cancel) cancel.addEventListener('click', () => close(false));
+    const confirm = host.querySelector('#lt-rescue-confirm');
+    if (confirm) confirm.addEventListener('click', () => close(true));
+  });
+}
+
+/**
+ * Pick a rescue target (U5) — opens the confirm overlay, and on confirm
+ * submits the rescue. Double-fire-guarded on the submit step.
+ *
+ * @param {number} id        album_requests.id
+ * @param {string} browseId  The chosen target's `yt_browse_id`.
+ * @returns {Promise<void>}
+ */
+export async function pickYoutubeRescue(id, browseId) {
+  const row = consoleRow(id);
+  const ok = await confirmRescue(id, browseId, row);
+  if (!ok) return;
+  await submitYoutubeRescue(id, browseId);
+}
+
+/**
+ * Submit the rescue (`POST /api/pipeline/<id>/youtube-rescue {browse_id}`)
+ * and map the outcome to console copy. On `accepted`, mark the row
+ * in-flight and refetch JUST that row (KTD8 — single-row patch, no
+ * full-cohort re-band, no optimistic band move; the importer owns the
+ * transition, KTD4). Every other outcome surfaces its specific copy as a
+ * toast. Double-fire-guarded.
+ *
+ * @param {number} id
+ * @param {string} browseId
+ * @returns {Promise<void>}
+ */
+async function submitYoutubeRescue(id, browseId) {
+  if (!canStartInFlight(submitInFlight, id)) return;  // double-fire guard.
+  submitInFlight.add(id);
+  try {
+    let result;
+    try {
+      const r = await fetch(`${API}/api/pipeline/${id}/youtube-rescue`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ browse_id: browseId }),
+      });
+      result = await r.json();
+    } catch (_e) {
+      result = { outcome: 'transient', error_message: 'Submit failed — retry.' };
+    }
+    const copy = rescueOutcomeCopy(result);
+    if (typeof toast === 'function') {
+      toast(`${copy.title}: ${copy.detail}`, copy.tone === 'error');
+    }
+    if (result && result.outcome === 'accepted') {
+      // KTD8: mark the row in-flight locally for an immediate signal, then
+      // refetch just this row's authoritative band/flags and patch it in.
+      markRowInFlight(id);
+      await refetchLongTailRow(id);
+    }
+  } finally {
+    submitInFlight.delete(id);
+  }
+}
+
+/**
+ * Mark one cohort row `in_flight_rescue` in place (optimistic local signal
+ * only — NOT a band move). Pure-ish: mutates `state.longTail.rows`. The
+ * authoritative flags arrive via {@link refetchLongTailRow}.
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function markRowInFlight(id) {
+  const rows = Array.isArray(state.longTail.rows) ? state.longTail.rows : [];
+  const row = rows.find((r) => r && r.id === id);
+  if (row) row.in_flight_rescue = true;
+}
+
+/**
+ * Single-row refetch + patch (KTD8). Fetches just this request's
+ * authoritative banded row via `GET /api/pipeline/long-tail?id=<id>` and
+ * replaces it in `state.longTail.rows`, then re-renders the list. NO
+ * full-cohort re-band (the heaviest read in the app), NO optimistic band
+ * move — the row stays in `Missing` until the importer completes (KTD4).
+ *
+ * A 404 (the row left the `wanted` worklist — e.g. already imported)
+ * removes it from the cohort. A failed fetch is non-fatal: the local
+ * in-flight mark from {@link markRowInFlight} already gives the operator a
+ * signal; the next Refresh reconciles.
+ *
+ * @param {number} id
+ * @returns {Promise<void>}
+ */
+async function refetchLongTailRow(id) {
+  let data;
+  try {
+    const r = await fetch(`${API}/api/pipeline/long-tail?id=${encodeURIComponent(String(id))}`);
+    if (r.status === 404) {
+      removeRowFromCohort(id);
+      renderLongTail();
+      return;
+    }
+    if (!r.ok) return;
+    data = await r.json();
+  } catch (_e) {
+    return;  // non-fatal — local in-flight mark stands; Refresh reconciles.
+  }
+  const fresh = data && data.result;
+  if (!fresh) return;
+  patchRowInCohort(id, fresh);
+  renderLongTail();
+}
+
+/**
+ * Replace one row in the cohort with a freshly-refetched authoritative row.
+ * Pure-ish: mutates `state.longTail.rows`. No-op when the cohort isn't
+ * loaded or the id is gone (a concurrent full refetch already reconciled).
+ *
+ * @param {number} id
+ * @param {Object} fresh  The refetched `LongTailRow`.
+ * @returns {void}
+ */
+function patchRowInCohort(id, fresh) {
+  const rows = Array.isArray(state.longTail.rows) ? state.longTail.rows : null;
+  if (!rows) return;
+  const idx = rows.findIndex((r) => r && r.id === id);
+  if (idx === -1) return;
+  rows[idx] = fresh;
+}
+
+/**
+ * Drop one row from the cohort (the single-row refetch 404'd — the row left
+ * the `wanted` worklist). Pure-ish: mutates `state.longTail.rows`.
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function removeRowFromCohort(id) {
+  const rows = Array.isArray(state.longTail.rows) ? state.longTail.rows : null;
+  if (!rows) return;
+  const idx = rows.findIndex((r) => r && r.id === id);
+  if (idx !== -1) rows.splice(idx, 1);
+}
+
 export const __test__ = {
   MISSING_BAND,
   BAND_ORDER,
@@ -1099,4 +1630,10 @@ export const __test__ = {
   youtubeHistoryRows,
   youtubeFailureReason,
   PEERS_VISIBLE_CAP,
+  // U5 — two-step rescue flow pure helpers.
+  youtubeBestDistance,
+  youtubeRescueTargets,
+  rescueOutcomeCopy,
+  canStartInFlight,
+  renderRescueConfirm,
 };

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -54,7 +54,38 @@
  *      row (KTD8 — never optimistically move the row to a band; the
  *      importer owns the transition, KTD4).
  *
- * accept-sibling / set-intent / re-search remain U6.
+ * U6 (this unit): the console's three secondary operator actions, plus
+ * the shared post-action freshness model.
+ *
+ *   1. Accept-a-sibling-pressing — wires the existing Replace operator
+ *      action (`openReplacePicker`, standard mode) so the operator can
+ *      switch the request to a different pressing in the same MB release
+ *      group. MB-only (KTD7): disabled with a one-line reason for
+ *      Discogs-sourced requests or rows with no `mb_release_group_id`
+ *      (the `canAcceptSibling` predicate). On a confirmed Replace the old
+ *      request becomes a frozen `replaced` row that LEAVES the worklist —
+ *      so this is the one action that closes the console and does a FULL
+ *      cohort refetch (`loadLongTail`), not the single-row patch.
+ *   2. Set-intent — renders the request's current quality intent
+ *      (lossless vs. default, from `target_format`) as a badge with a
+ *      toggle; switching posts `{id, intent}` to the existing set-intent
+ *      surface (`intentToggleTarget` picks the opposite of the current
+ *      intent), then single-row refetch-and-patch so the badge reflects
+ *      the new value.
+ *   3. Re-search — regenerates the search plan + resets the cursor via the
+ *      existing `search-plan/regenerate` surface, with honest NEXT-CYCLE
+ *      copy (never "instant"; the watch loop owns the actual search,
+ *      KTD3). `regenerateOutcomeCopy` maps every outcome; the button
+ *      disables while outstanding (double-fire guard) and, on a sticky
+ *      `failed_deterministic` (no runnable query / incomplete metadata —
+ *      the same gap the console is triaging), surfaces the metadata gap
+ *      INLINE pointing at the field-quality detail rather than re-enabling
+ *      to fire a futile re-click.
+ *
+ * Shared freshness (KTD8): every action awaits then refetches just the
+ * acted-on row (`refetchLongTailRow`, the U5 helper) and patches it in —
+ * no optimistic band moves, no polling. The confirmed Replace is the lone
+ * exception (full-cohort refetch because the row leaves the cohort).
  *
  * Pure / DOM-free helpers (band ordering, tab derivation, in-band search
  * filtering, cross-band match count, YouTube state classifier, console
@@ -76,8 +107,10 @@ import {
   renderForensicBlock,
   youtubeSectionState,
   consoleEmphasis,
+  overrideToIntent,
   awstDateTime,
 } from './util.js';
+import { openReplacePicker } from './replace_picker.js';
 
 /**
  * The `Missing` band sentinel — a `wanted` request with no clean
@@ -1023,7 +1056,63 @@ function renderConsoleShell(row) {
   const ordered = leadUnfindable
     ? [unfindablePanel, peersPanel, rescuesPanel, siblingsPanel, youtubePanel]
     : [bandVsIntent, unfindablePanel, peersPanel, rescuesPanel, siblingsPanel, youtubePanel];
-  return `<div class="lt-console">${ordered.join('')}</div>`;
+  // The action bar (U6) renders FIRST so the operator's secondary actions
+  // (accept-sibling / set-intent / re-search) stay reachable without
+  // scrolling past the evidence panels. Accept-sibling needs the request's
+  // `mb_release_group_id`, which the console shell doesn't have yet (the
+  // cohort row doesn't carry it — `loadPipelinePanels` resolves it off the
+  // pipeline detail). So it renders disabled at open and `patchActionsBar`
+  // re-renders once the rg is known.
+  const actionsBar = renderActionsBar(row);
+  return `<div class="lt-console">${actionsBar}${ordered.join('')}</div>`;
+}
+
+/**
+ * Render the secondary-action bar (U6). Pure. Carries three controls:
+ *   * Accept-sibling — the Replace operator action, MB-only (KTD7). When
+ *     `canAcceptSibling(row, rg)` is false (Discogs-sourced or no MB
+ *     release group) the button is disabled with a one-line reason.
+ *   * Set-intent — the current intent rendered as a badge with a toggle to
+ *     the opposite intent (`intentToggleTarget`).
+ *   * Re-search — the regenerate-plan action with honest next-cycle copy.
+ *
+ * The release-group id is read from the row's `mb_release_group_id`, which
+ * is absent at shell-render time (the cohort row doesn't carry it) and
+ * stamped onto the row by `loadPipelinePanels` once the pipeline detail
+ * resolves — at which point `patchActionsBar` re-renders this bar.
+ *
+ * @param {Object} row  The worklist row (band, source, intent, rg).
+ * @returns {string}
+ */
+function renderActionsBar(row) {
+  const id = row.id;
+  const rg = row.mb_release_group_id || null;
+  const acceptOk = canAcceptSibling(row, rg);
+  // Discogs / no-rg disable reason (KTD7 — no MB↔Discogs adapter).
+  const acceptReason = acceptDisabledReason(row, rg);
+  const acceptBtn = acceptOk
+    ? `<button class="lt-act-btn lt-act-accept" type="button" onclick="event.stopPropagation(); window.longTailAcceptSibling(${id})">Accept a sibling pressing…</button>`
+    : `<button class="lt-act-btn lt-act-accept" type="button" disabled title="${esc(acceptReason)}">Accept a sibling pressing…</button>
+       <span class="lt-act-note">${esc(acceptReason)}</span>`;
+
+  const intent = overrideToIntent(row.target_format);
+  const intentLabel = intent === 'lossless' ? 'lossless' : 'default';
+  const toggleTarget = intentToggleTarget(row.target_format);
+  const toggleLabel = toggleTarget === 'lossless'
+    ? 'switch to lossless' : 'accept current floor';
+  const intentCtl = `<div class="lt-act-intent">
+      <span class="lt-act-label">intent:</span>
+      <span class="badge lt-intent-badge lt-intent-${esc(intentLabel)}">${esc(intentLabel)}</span>
+      <button class="lt-act-btn lt-act-intent-toggle" type="button" onclick="event.stopPropagation(); window.longTailSetIntent(${id})">${esc(toggleLabel)}</button>
+    </div>`;
+
+  const researchBtn = `<button class="lt-act-btn lt-act-research" type="button" onclick="event.stopPropagation(); window.longTailReSearch(${id})">Re-search (next cycle)</button>`;
+
+  return `<div class="lt-actions" id="lt-actions-${id}">
+    <div class="lt-act-group">${acceptBtn}</div>
+    <div class="lt-act-group">${intentCtl}</div>
+    <div class="lt-act-group">${researchBtn}<div class="lt-act-research-note" id="lt-research-note-${id}"></div></div>
+  </div>`;
 }
 
 /**
@@ -1086,6 +1175,13 @@ async function loadPipelinePanels(id, token, inFlightFlag) {
     patchPanel(id, 'rescues', token, renderRescuesBody(data.history, inFlightFlag));
     const req = data.request || {};
     rgId = req.mb_release_group_id || null;
+    // KTD7 reuse: stamp the resolved release-group id onto the cohort row
+    // so the U6 accept-sibling button (rendered disabled at console open,
+    // before the detail fetch) can enable for MB rows that actually have a
+    // release group. Re-render the action bar in place once known — no
+    // extra fetch (we already have the detail payload here).
+    stampRowReleaseGroup(id, rgId);
+    patchActionsBar(id, token);
   } catch (_e) {
     patchPanel(id, 'peers', token, renderPanelError('peers'));
     patchPanel(id, 'rescues', token, renderPanelError('rescue history'));
@@ -1094,6 +1190,41 @@ async function loadPipelinePanels(id, token, inFlightFlag) {
   // detail fetch failed (rgId null) we render the "no rg" state; otherwise
   // we fire the release-group fetch on its own so its latency is isolated.
   loadSiblingsPanel(id, token, rgId);
+}
+
+/**
+ * Stamp the resolved `mb_release_group_id` onto the cached cohort row so
+ * the U6 accept-sibling control can read it. Pure-ish: mutates
+ * `state.longTail.rows`. No-op when the cohort isn't loaded or the id is
+ * gone.
+ *
+ * @param {number} id
+ * @param {string|null} rgId
+ * @returns {void}
+ */
+function stampRowReleaseGroup(id, rgId) {
+  const row = consoleRow(id);
+  if (row) row.mb_release_group_id = rgId || null;
+}
+
+/**
+ * Re-render the console's action bar in place, guarded by the row's console
+ * token so a stale detail fetch (operator moved on) doesn't repaint a
+ * collapsed/replaced console. DOM-side.
+ *
+ * @param {number} id
+ * @param {number} token  The console token captured when the console opened.
+ * @returns {void}
+ */
+function patchActionsBar(id, token) {
+  if (typeof document === 'undefined') return;
+  if (consoleTokens.get(id) !== token) return;  // stale console — discard.
+  const bar = document.getElementById(`lt-actions-${id}`);
+  if (!bar) return;
+  const row = consoleRow(id) || { id };
+  // Replace the whole bar (renderActionsBar emits the same wrapper id, so
+  // we swap its outerHTML to keep the id stable for the next patch).
+  bar.outerHTML = renderActionsBar(row);
 }
 
 /**
@@ -1607,6 +1738,421 @@ function removeRowFromCohort(id) {
   if (idx !== -1) rows.splice(idx, 1);
 }
 
+// --- Console secondary actions (U6) ----------------------------------
+//
+// Three operator actions wired to EXISTING endpoints — no parallel code
+// paths (R16):
+//   * accept-sibling → `openReplacePicker` (standard mode) → `POST .../replace`
+//   * set-intent     → `POST /api/pipeline/set-intent {id, intent}`
+//   * re-search      → `POST /api/pipeline/<id>/search-plan/regenerate`
+// Shared freshness (KTD8): each awaits then refetches just the acted-on
+// row and patches it (`refetchLongTailRow`); the confirmed Replace is the
+// exception — the old row leaves the cohort so it closes the console and
+// full-cohort refetches.
+
+/**
+ * Can the operator accept a sibling pressing for this row? Pure / DOM-free.
+ *
+ * MB-only in v1 (KTD7 — sibling enumeration is MB-keyed via the release
+ * group; there is no MB↔Discogs adapter). `false` when:
+ *   * the request is Discogs-sourced (`row.source === 'discogs'`), OR
+ *   * there is no `mb_release_group_id` to enumerate siblings from.
+ * `true` otherwise (an MB-sourced request with a resolved release group).
+ *
+ * @param {Object|null|undefined} row  The worklist row.
+ * @param {string|null|undefined} releaseGroupId  The resolved MB rg id.
+ * @returns {boolean}
+ */
+export function canAcceptSibling(row, releaseGroupId) {
+  if (!row || typeof row !== 'object') return false;
+  const source = String(row.source || '').toLowerCase();
+  if (source === 'discogs') return false;
+  if (!releaseGroupId) return false;
+  return true;
+}
+
+/**
+ * One-line reason the accept-sibling action is disabled. Pure / DOM-free.
+ * Returns the empty string when the action is enabled.
+ *
+ * @param {Object|null|undefined} row
+ * @param {string|null|undefined} releaseGroupId
+ * @returns {string}
+ */
+export function acceptDisabledReason(row, releaseGroupId) {
+  if (canAcceptSibling(row, releaseGroupId)) return '';
+  const source = String((row && row.source) || '').toLowerCase();
+  if (source === 'discogs') {
+    return 'Sibling pressings are MusicBrainz-only — Discogs requests have no MB release group.';
+  }
+  return 'No MusicBrainz release group for this request — no siblings to pick from.';
+}
+
+/**
+ * The intent to POST when toggling. Pure / DOM-free. The set-intent
+ * surface is a two-value toggle (`lossless` ⇄ `default`); given the row's
+ * current `target_format`, this returns the OPPOSITE intent. A lossless
+ * `target_format` (`"lossless"` / `"flac"`) currently means "keep grinding
+ * to lossless", so the toggle target is `"default"` (accept current
+ * floor); anything else toggles to `"lossless"`.
+ *
+ * @param {string|null|undefined} targetFormat  The row's `target_format`.
+ * @returns {'lossless'|'default'}
+ */
+export function intentToggleTarget(targetFormat) {
+  return overrideToIntent(targetFormat) === 'lossless' ? 'default' : 'lossless';
+}
+
+/**
+ * @typedef {Object} RegenerateCopy
+ * @property {string} title    Short headline for the outcome.
+ * @property {string} detail   One-line operator-facing explanation.
+ * @property {'success'|'error'} tone  Drives toast styling (error → red).
+ * @property {boolean} metadataGap  When true, the failure is the sticky
+ *   `failed_deterministic` (no runnable query / incomplete metadata) — the
+ *   caller must surface the gap INLINE and NOT re-enable the button to fire
+ *   a futile re-click (KTD3). Every other outcome leaves this `false`.
+ * @property {boolean} requeued  When true, the plan was (re)generated and
+ *   the request is queued for the next 5-minute cycle — the caller refetches
+ *   the row. `noop_active_plan_exists` also sets this (a fresh plan already
+ *   exists, so the request is already searchable next cycle).
+ */
+
+/**
+ * Map a `search-plan/regenerate` outcome to next-cycle operator copy.
+ * Pure / DOM-free. Keys mirror the EXACT outcome vocabulary in
+ * `lib/search_plan_service.py` / the route
+ * `web/routes/pipeline.py::post_pipeline_search_plan_regenerate`:
+ * `success`, `noop_active_plan_exists`, `request_not_found`,
+ * `failed_deterministic` (422 — sticky metadata gap), `failed_transient`
+ * (503 — retryable).
+ *
+ * Copy is honest NEXT-CYCLE (KTD3): regenerate resets the plan + cursor,
+ * but the actual search fires on the 5-minute watch-loop cycle — never
+ * "instant". `failed_deterministic` is special-cased to the
+ * metadata-gap variant (`metadataGap: true`) so the caller surfaces the
+ * gap inline instead of re-firing.
+ *
+ * `result` is the parsed regenerate response body; its `outcome` selects
+ * the copy and `error`/`error_message`/`failure_class` decorate the
+ * deterministic-failure message. An unknown outcome falls back to a
+ * generic error so a future backend value never renders blank.
+ *
+ * @param {{outcome?: string, error?: string|null, error_message?: string|null, failure_class?: string|null}|null|undefined} result
+ * @returns {RegenerateCopy}
+ */
+export function regenerateOutcomeCopy(result) {
+  const outcome = String((result && result.outcome) || '');
+  const err = (result && (result.error_message || result.error))
+    ? String(result.error_message || result.error) : '';
+  const failureClass = (result && result.failure_class)
+    ? String(result.failure_class) : '';
+  switch (outcome) {
+    case 'success':
+      return {
+        title: 'Re-search queued',
+        detail: 'Fresh search plan generated. This request will be searched '
+          + 'fresh on the next cycle (~5 min) — not immediately.',
+        tone: 'success',
+        metadataGap: false,
+        requeued: true,
+      };
+    case 'noop_active_plan_exists':
+      return {
+        title: 'Already queued',
+        detail: 'A fresh search plan already exists for this request — it is '
+          + 'already in line for the next cycle (~5 min).',
+        tone: 'success',
+        metadataGap: false,
+        requeued: true,
+      };
+    case 'failed_deterministic':
+      return {
+        title: 'Cannot build a search plan',
+        detail: (err || 'No runnable query — the request metadata is incomplete')
+          + (failureClass ? ` (${failureClass})` : '')
+          + '. Re-clicking won’t help until the metadata gap is fixed — '
+          + 'see the field-quality detail above.',
+        tone: 'error',
+        metadataGap: true,
+        requeued: false,
+      };
+    case 'failed_transient':
+      return {
+        title: 'Temporary failure',
+        detail: (err || 'Plan generation hit a transient error (DB / mirror hiccup)')
+          + '. Retry.',
+        tone: 'error',
+        metadataGap: false,
+        requeued: false,
+      };
+    case 'request_not_found':
+      return {
+        title: 'Request not found',
+        detail: 'This request no longer exists — refresh.',
+        tone: 'error',
+        metadataGap: false,
+        requeued: false,
+      };
+    default:
+      return {
+        title: 'Re-search failed',
+        detail: err || `Unexpected outcome: ${outcome || 'unknown'}.`,
+        tone: 'error',
+        metadataGap: false,
+        requeued: false,
+      };
+  }
+}
+
+/**
+ * Build the standard-mode `openReplacePicker` options for one cohort row.
+ * Pure / DOM-free. `sourceLabel` is the "Artist — Album" the picker shows
+ * as the current request; `releaseGroupId` is the stamped MB rg (may be
+ * null — the picker lazily resolves a null rg via `resolve-rg`, but U6
+ * only enables the button when one is present, KTD7).
+ *
+ * @param {Object} row
+ * @returns {import('./replace_picker.js').ReplacePickerOptionsStandard}
+ */
+export function buildAcceptSiblingOptions(row) {
+  const artist = (row && row.artist_name) ? String(row.artist_name) : '';
+  const album = (row && row.album_title) ? String(row.album_title) : '';
+  const label = artist ? `${artist} — ${album}` : (album || `request #${row.id}`);
+  return {
+    sourceRequestId: row.id,
+    releaseGroupId: (row && row.mb_release_group_id) || null,
+    sourceLabel: label,
+    source: 'long-tail',
+  };
+}
+
+/**
+ * Request ids with an outstanding re-search (regenerate) POST. Guards the
+ * re-search button against double-fire.
+ *
+ * @type {Set<number>}
+ */
+const researchInFlight = new Set();
+
+/**
+ * Accept-a-sibling-pressing handler (U6). Opens the existing Replace picker
+ * (standard mode) for the row's MB release group; the picker owns the
+ * sibling list + confirm + `POST .../replace`. On a CONFIRMED Replace the
+ * old request becomes a frozen `replaced` row that LEAVES the worklist, so
+ * we close the console and do a FULL-cohort refetch (KTD8 exception) — not
+ * the single-row patch. Cancel / failure is a no-op (the picker toasts its
+ * own errors).
+ *
+ * Reuses the raw `openReplacePicker` (not the `window.openReplacePicker`
+ * wrapper) because the wrapper refetches the Pipeline/Manual tabs, not the
+ * long-tail cohort — and it doesn't return the confirmed result we need to
+ * decide on the full-cohort refetch.
+ *
+ * @param {number} id  album_requests.id
+ * @returns {Promise<void>}
+ */
+export async function longTailAcceptSibling(id) {
+  const row = consoleRow(id);
+  if (!row) return;
+  if (!canAcceptSibling(row, row.mb_release_group_id || null)) {
+    // Defensive — the button is disabled in this case, but a stale onclick
+    // (rg dropped between render and click) should fail loudly, not POST.
+    if (typeof toast === 'function') {
+      toast(acceptDisabledReason(row, row.mb_release_group_id || null), true);
+    }
+    return;
+  }
+  const result = await openReplacePicker(buildAcceptSiblingOptions(row));
+  if (!result || result.outcome !== 'confirmed') return;  // cancelled.
+  const resp = result.response || { status: 0, body: {} };
+  const status = resp.status;
+  const body = resp.body || {};
+  if (status === 200) {
+    if (typeof toast === 'function') {
+      const newId = body.new_request_id;
+      toast(newId != null
+        ? `Replaced — new request #${newId}. The old request is frozen for audit.`
+        : 'Replaced — the old request is frozen for audit.', false);
+    }
+    // The old row left the cohort (now `status='replaced'`). Close the
+    // console and FULL-cohort refetch (KTD8 exception — the single-row
+    // patch can't express a row leaving).
+    closeConsole(id);
+    await loadLongTail();
+    return;
+  }
+  // Non-200 confirmed POST — surface the picker's error shape (mirrors
+  // main.js::openReplacePickerAndHandle), leave the cohort untouched.
+  if (typeof toast === 'function') {
+    if (status === 409 && body && body.descendant_request_id) {
+      toast(`Already replaced. New request is #${body.descendant_request_id}.`, true);
+    } else if (body && body.error) {
+      toast(`Replace failed: ${body.error}`, true);
+    } else {
+      toast(`Replace failed (HTTP ${status})`, true);
+    }
+  }
+}
+
+/**
+ * Close one row's console (collapse `.lt-detail`, bump its token so an
+ * in-flight panel fetch is discarded on resolve). DOM-side; no-op when the
+ * console isn't mounted.
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function closeConsole(id) {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById(`lt-detail-${id}`);
+  if (el) el.classList.remove('open');
+  consoleTokens.set(id, (consoleTokens.get(id) || 0) + 1);
+}
+
+/**
+ * Set-intent handler (U6). Toggles the request's quality intent (lossless
+ * ⇄ default) via the EXISTING set-intent surface
+ * (`POST /api/pipeline/set-intent {id, intent}` — mirrors
+ * `library.js::setIntent`), then single-row refetch-and-patch so the badge
+ * reflects the new intent (KTD8). The target intent is the opposite of the
+ * row's current `target_format` (`intentToggleTarget`).
+ *
+ * @param {number} id  album_requests.id
+ * @returns {Promise<void>}
+ */
+export async function longTailSetIntent(id) {
+  const row = consoleRow(id);
+  if (!row) return;
+  const intent = intentToggleTarget(row.target_format);
+  let data;
+  try {
+    const r = await fetch(`${API}/api/pipeline/set-intent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, intent }),
+    });
+    data = await r.json();
+  } catch (_e) {
+    if (typeof toast === 'function') toast('Failed to set intent', true);
+    return;
+  }
+  if (!data || data.status !== 'ok') {
+    if (typeof toast === 'function') {
+      toast((data && data.error) || 'Failed to set intent', true);
+    }
+    return;
+  }
+  if (typeof toast === 'function') {
+    toast(data.requeued ? `Intent: ${intent} (requeued)` : `Intent: ${intent}`, false);
+  }
+  // Single-row refetch-and-patch (KTD8) — the badge reflects the new intent
+  // off the authoritative refetched row.
+  await refetchLongTailRow(id);
+}
+
+/**
+ * Re-search handler (U6). Regenerates the request's search plan + resets
+ * the cursor via the EXISTING `search-plan/regenerate` surface (mirrors
+ * `search_plan.js::searchPlanRegenerate`), with honest NEXT-CYCLE copy —
+ * the watch loop owns the actual search (KTD3), never instant.
+ *
+ * Double-fire-guarded (`researchInFlight`); the button disables while
+ * outstanding. Outcome mapping via `regenerateOutcomeCopy`:
+ *   * `success` / `noop_active_plan_exists` → toast + single-row refetch.
+ *   * `failed_transient` → retry toast; re-enable.
+ *   * `failed_deterministic` → surface the metadata gap INLINE (point at the
+ *     field-quality detail) and do NOT just re-enable to re-fire (KTD3).
+ *   * `request_not_found` / unknown → error toast.
+ *
+ * @param {number} id  album_requests.id
+ * @returns {Promise<void>}
+ */
+export async function longTailReSearch(id) {
+  if (!canStartInFlight(researchInFlight, id)) return;  // double-fire guard.
+  researchInFlight.add(id);
+  setResearchDisabled(id, true);
+  clearResearchNote(id);
+  try {
+    let result;
+    try {
+      const r = await fetch(`${API}/api/pipeline/${id}/search-plan/regenerate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      result = await r.json();
+    } catch (_e) {
+      result = { outcome: 'failed_transient', error: 'Could not reach the server. Retry.' };
+    }
+    const copy = regenerateOutcomeCopy(result);
+    if (copy.metadataGap) {
+      // Sticky deterministic failure — surface the gap inline and leave the
+      // button DISABLED (re-clicking is futile until the metadata is fixed).
+      setResearchNote(id, copy.detail);
+      if (typeof toast === 'function') toast(`${copy.title}: ${copy.detail}`, true);
+      return;  // intentionally leave disabled; no refetch.
+    }
+    if (typeof toast === 'function') {
+      toast(`${copy.title}: ${copy.detail}`, copy.tone === 'error');
+    }
+    if (copy.requeued) {
+      // success / noop — refetch the row (KTD8). The list re-render closes
+      // the console; the row stays `wanted` (no optimistic band move).
+      await refetchLongTailRow(id);
+      return;
+    }
+    // Transient / not-found / unknown — re-enable so the operator can retry.
+    setResearchDisabled(id, false);
+  } finally {
+    researchInFlight.delete(id);
+  }
+}
+
+/**
+ * Enable/disable the re-search button for one row's console. DOM-side;
+ * no-op when the console isn't mounted.
+ *
+ * @param {number} id
+ * @param {boolean} disabled
+ * @returns {void}
+ */
+function setResearchDisabled(id, disabled) {
+  if (typeof document === 'undefined') return;
+  const bar = document.getElementById(`lt-actions-${id}`);
+  if (!bar) return;
+  const btn = /** @type {HTMLButtonElement|null} */ (bar.querySelector('.lt-act-research'));
+  if (!btn) return;
+  btn.disabled = disabled;
+  btn.textContent = disabled ? 'Re-searching…' : 'Re-search (next cycle)';
+}
+
+/**
+ * Surface the re-search inline note (the metadata-gap explanation on a
+ * sticky `failed_deterministic`). DOM-side; no-op when not mounted.
+ *
+ * @param {number} id
+ * @param {string} text
+ * @returns {void}
+ */
+function setResearchNote(id, text) {
+  if (typeof document === 'undefined') return;
+  const note = document.getElementById(`lt-research-note-${id}`);
+  if (note) note.textContent = text;
+}
+
+/**
+ * Clear the re-search inline note (on a fresh re-search attempt). DOM-side.
+ *
+ * @param {number} id
+ * @returns {void}
+ */
+function clearResearchNote(id) {
+  if (typeof document === 'undefined') return;
+  const note = document.getElementById(`lt-research-note-${id}`);
+  if (note) note.textContent = '';
+}
+
 export const __test__ = {
   MISSING_BAND,
   BAND_ORDER,
@@ -1636,4 +2182,11 @@ export const __test__ = {
   rescueOutcomeCopy,
   canStartInFlight,
   renderRescueConfirm,
+  // U6 — secondary action pure helpers.
+  canAcceptSibling,
+  acceptDisabledReason,
+  intentToggleTarget,
+  regenerateOutcomeCopy,
+  buildAcceptSiblingOptions,
+  renderActionsBar,
 };

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -3,18 +3,44 @@
 /**
  * Long-tail triage worklist (Pipeline sub-view).
  *
- * U3 (this unit): the list shell — band tabs (with live counts), a
- * search box, and the row list. Fetches `GET /api/pipeline/long-tail`
- * once (KTD2 — one server-banded fetch, all tab/search filtering happens
- * client-side over that single payload), derives the band tab set from
- * the bands present in the cohort, and renders the rows for the selected
- * band. Rows are clickable and carry an (empty) `.lt-detail` container;
- * U4 fleshes the in-place action console out.
+ * U3: the list shell — band tabs (with live counts), a search box, and
+ * the row list. Fetches `GET /api/pipeline/long-tail` once (KTD2 — one
+ * server-banded fetch, all tab/search filtering happens client-side over
+ * that single payload), derives the band tab set from the bands present
+ * in the cohort, and renders the rows for the selected band.
+ *
+ * U4 (this unit): the in-place action console. Selecting a row expands
+ * its `.lt-detail` container into a band-aware evidence console with five
+ * panels, each loading INDEPENDENTLY (per-panel loading + error states)
+ * so a slow / failing `GET /api/release-group/<rg>` (the 15s MB-mirror
+ * timeout) never blanks the console or silently drops another panel:
+ *
+ *   1. Why-unfindable  ← `GET /api/triage/<id>` (unfindable category +
+ *      reason + search-forensics rollup; "not yet categorised" rendered
+ *      distinctly from an error).
+ *   2. Soulseek peers  ← `GET /api/pipeline/<id>` `last_search.top_candidates`
+ *      (reuses `renderForensicBlock`; a few rows with a "show all" toggle).
+ *   3. Recent rescues  ← `GET /api/pipeline/<id>` `history` rows where
+ *      `source==='youtube'` ("rescue running" / "last rescue failed: …").
+ *   4. Sibling pressings ← `GET /api/release-group/<rg>` (rg taken from the
+ *      pipeline-detail `request.mb_release_group_id`; skipped for rows
+ *      without one, e.g. Discogs-sourced).
+ *   5. YouTube matrix  ← the four-state shell. Defaults to `never_run`
+ *      with a "Check YouTube" button (U5 wires the actual resolver call —
+ *      U4 must NOT auto-call the slow, side-effectful resolver GET).
+ *
+ * The evidence/action SUBMIT flows are out of scope here: the rescue
+ * submit + live resolver call are U5; accept-sibling / set-intent /
+ * re-search are U6. U4 builds the panels + the YouTube state shell + a
+ * Check-YouTube stub only.
  *
  * Pure / DOM-free helpers (band ordering, tab derivation, in-band search
- * filtering, cross-band match count) are exported via `__test__` for the
- * Node unit suite. Rendering and fetch live alongside them but never
- * leak into the pure helpers.
+ * filtering, cross-band match count, YouTube state classifier, console
+ * emphasis selector) are exported via `__test__` for the Node unit suite.
+ * The classifier + emphasis selector live in `util.js` (the shared pure
+ * home) and are re-exported through `__test__` here for convenience.
+ * Rendering and fetch live alongside them but never leak into the pure
+ * helpers.
  *
  * Shape mirrors `web/js/search_plan.js` / `web/js/recents.js`:
  * `// @ts-check`, ES6 module, JSDoc on exports, the
@@ -22,7 +48,13 @@
  */
 
 import { state, API } from './state.js';
-import { esc } from './util.js';
+import {
+  esc,
+  renderForensicBlock,
+  youtubeSectionState,
+  consoleEmphasis,
+  awstDateTime,
+} from './util.js';
 
 /**
  * The `Missing` band sentinel — a `wanted` request with no clean
@@ -494,10 +526,528 @@ export function onLongTailSearchInput(value) {
   }
 }
 
+// --- Action console (U4) --------------------------------------------
+//
+// Five evidence panels rendered in place, each loading independently. The
+// pure render helpers below take already-fetched data (or an error
+// sentinel) and return an HTML string; the DOM-side loaders fetch each
+// source and patch only that panel's container. A per-row token guard
+// discards a console fetch that resolves after the operator has clicked a
+// different row (or re-collapsed this one).
+
 /**
- * Toggle the in-place action console for one row. U3 ships the stub:
- * locate the `.lt-detail` container and toggle its `.open` class with an
- * empty body. U4 fills the console (evidence + actions) in.
+ * Per-row console-fetch token. Bumped every time a row's console is
+ * (re)opened so a slow panel fetch that resolves against a stale console
+ * is discarded before it paints. Keyed by `album_requests.id`.
+ *
+ * @type {Map<number, number>}
+ */
+const consoleTokens = new Map();
+
+/**
+ * Visible-row cap for the Soulseek peers panel before the "show all"
+ * expansion. The peers list shows a few rows so the action buttons (U5/U6)
+ * stay reachable without scrolling past a long candidate table.
+ *
+ * @type {number}
+ */
+const PEERS_VISIBLE_CAP = 5;
+
+/**
+ * Format an ISO timestamp for the console, defensively. Falls back to the
+ * raw string when it can't be parsed (never throws into a render).
+ *
+ * @param {string|null|undefined} iso
+ * @returns {string}
+ */
+function consoleTimestamp(iso) {
+  if (!iso) return '';
+  try {
+    return awstDateTime(String(iso));
+  } catch (_e) {
+    return String(iso);
+  }
+}
+
+/**
+ * A small panel scaffold: a titled section with a body. Used by every
+ * panel so the console reads consistently. Pure.
+ *
+ * @param {string} name   Stable slug for the panel container id.
+ * @param {number} id     album_requests.id (namespaces the container).
+ * @param {string} title  Panel heading.
+ * @param {string} body   Inner HTML (already escaped where needed).
+ * @param {boolean} [lead]  When true, flag the panel as the console's
+ *   lead panel (band-aware emphasis).
+ * @returns {string}
+ */
+function renderPanel(name, id, title, body, lead) {
+  const leadCls = lead ? ' lt-panel-lead' : '';
+  return `<div class="lt-panel lt-panel-${esc(name)}${leadCls}" id="lt-panel-${esc(name)}-${id}">
+    <div class="lt-panel-title">${esc(title)}</div>
+    <div class="lt-panel-body">${body}</div>
+  </div>`;
+}
+
+/**
+ * Per-panel loading affordance (distinct from empty/error). Pure.
+ *
+ * @param {string} label
+ * @returns {string}
+ */
+function renderPanelLoading(label) {
+  return `<div class="lt-panel-loading">Loading ${esc(label)}…</div>`;
+}
+
+/**
+ * Per-panel error affordance — the independent-load contract: one panel's
+ * fetch failing renders THIS, never blanking the console or dropping
+ * another panel. Pure.
+ *
+ * @param {string} label
+ * @returns {string}
+ */
+function renderPanelError(label) {
+  return `<div class="lt-panel-error">Couldn't load ${esc(label)}. <span class="lt-panel-error-hint">(other panels are unaffected)</span></div>`;
+}
+
+/**
+ * Render the why-unfindable panel body from a triage payload. Pure.
+ *
+ * Three states:
+ *   * `triage == null` → caller passed nothing yet (defensive; the loader
+ *     uses the loading/error affordances instead).
+ *   * `triage.unfindable == null` → NOT yet categorised. Rendered as an
+ *     explicit "detection runs daily" state — not an error, not blank
+ *     (R7).
+ *   * categorised → the category + a search-forensics rollup.
+ *
+ * @param {Object|null} triage  The `TriageResult` payload.
+ * @returns {string}
+ */
+function renderUnfindableBody(triage) {
+  if (!triage || typeof triage !== 'object') {
+    return '<div class="lt-panel-empty">No triage data.</div>';
+  }
+  const unfindable = triage.unfindable;
+  const sf = triage.search_forensics || {};
+  const rollupParts = [];
+  if (sf.total_searches != null) rollupParts.push(`${sf.total_searches} searches`);
+  if (sf.with_cands_count != null) rollupParts.push(`${sf.with_cands_count} with candidates`);
+  if (sf.zero_results_count != null) rollupParts.push(`${sf.zero_results_count} zero-result`);
+  if (sf.dominant_rejection_reason) rollupParts.push(`dominant reject: ${sf.dominant_rejection_reason}`);
+  const lastAt = sf.last_search_at ? consoleTimestamp(sf.last_search_at) : '';
+  const rollup = rollupParts.length
+    ? `<div class="lt-rollup">${esc(rollupParts.join(' · '))}${lastAt ? ` · last ${esc(lastAt)}` : ''}</div>`
+    : '';
+  if (!unfindable || unfindable.category == null) {
+    // Not-yet-categorised — daily detection state, distinct from an error.
+    return `<div class="lt-uncategorised">
+      <span class="lt-meta-chip">not yet categorised</span>
+      <span class="lt-uncategorised-note">detection runs daily</span>
+    </div>${rollup}`;
+  }
+  const catAt = unfindable.categorised_at ? consoleTimestamp(unfindable.categorised_at) : '';
+  const probe = (unfindable.last_artist_probe_match_count != null)
+    ? `<div class="lt-rollup">artist probe: ${unfindable.last_artist_probe_match_count} match${unfindable.last_artist_probe_match_count === 1 ? '' : 'es'}${unfindable.last_artist_probe_at ? ` · ${esc(consoleTimestamp(unfindable.last_artist_probe_at))}` : ''}</div>`
+    : '';
+  return `<div class="lt-unfindable-cat">
+      <span class="badge badge-manual">${esc(String(unfindable.category))}</span>
+      ${catAt ? `<span class="lt-meta-chip">categorised ${esc(catAt)}</span>` : ''}
+    </div>${rollup}${probe}`;
+}
+
+/**
+ * Pluck the YouTube rescue rows out of a pipeline-detail history list.
+ * Pure. Returns the `source==='youtube'` rows newest-first (the history
+ * already arrives newest-first; we preserve order).
+ *
+ * @param {Array<Object>|null|undefined} history
+ * @returns {Array<Object>}
+ */
+function youtubeHistoryRows(history) {
+  return (Array.isArray(history) ? history : [])
+    .filter((h) => h && h.source === 'youtube');
+}
+
+/**
+ * Extract the classified failure reason for a terminal `youtube_failed`
+ * download-history row. Pure. The reason is persisted in the
+ * `youtube_metadata` JSONB blob (`reason`) by the ingest worker's terminal
+ * write — see `lib/youtube_ingest_service.py::YoutubeIngestMetadata.reason`.
+ * Falls back to the row's `error_message` then `verdict` (the shared
+ * download-history-view fields) and finally a generic sentinel so the
+ * panel never shows an empty reason.
+ *
+ * @param {Object} row  A `source==='youtube'` download-history row.
+ * @returns {string}
+ */
+function youtubeFailureReason(row) {
+  const meta = row && row.youtube_metadata;
+  if (meta && typeof meta === 'object' && meta.reason) {
+    return String(meta.reason);
+  }
+  if (row && row.error_message) return String(row.error_message);
+  if (row && row.verdict) return String(row.verdict);
+  return 'unknown';
+}
+
+/**
+ * Render the "recent rescue attempts" panel body. Pure.
+ *
+ * Reads the `source==='youtube'` history rows (KTD4 — rescues never move
+ * the request row; their state lives in `download_log`). Surfaces:
+ *   * "rescue running" when an active `youtube_running` row exists, OR the
+ *     worklist row carried `in_flight_rescue` (the same predicate).
+ *   * "last rescue failed: <reason>" when the latest terminal youtube row
+ *     is `youtube_failed` SPECIFICALLY (distinct from `youtube_success`).
+ *   * the recent attempts list otherwise.
+ *
+ * @param {Array<Object>|null|undefined} history  Pipeline-detail history.
+ * @param {boolean} inFlightFlag  The worklist row's `in_flight_rescue`.
+ * @returns {string}
+ */
+function renderRescuesBody(history, inFlightFlag) {
+  const rows = youtubeHistoryRows(history);
+  const running = rows.find((h) => h.outcome === 'youtube_running');
+  if (running || inFlightFlag) {
+    return `<div class="lt-rescue-status"><span class="badge badge-new">rescue running</span>${running && running.created_at ? `<span class="lt-meta-chip">since ${esc(consoleTimestamp(running.created_at))}</span>` : ''}</div>`;
+  }
+  // The latest TERMINAL youtube row (youtube_failed / youtube_success).
+  const terminal = rows.find(
+    (h) => h.outcome === 'youtube_failed' || h.outcome === 'youtube_success');
+  if (terminal && terminal.outcome === 'youtube_failed') {
+    const reason = youtubeFailureReason(terminal);
+    return `<div class="lt-rescue-status"><span class="badge badge-manual">last rescue failed</span> <span class="lt-rescue-reason">${esc(reason)}</span></div>`;
+  }
+  if (rows.length === 0) {
+    return '<div class="lt-panel-empty">No rescue attempts yet.</div>';
+  }
+  // Some succeeded / mixed — list the recent attempts.
+  const items = rows.slice(0, 5).map((h) => {
+    const when = h.created_at ? consoleTimestamp(h.created_at) : '';
+    return `<div class="lt-rescue-item">${esc(String(h.outcome || '?'))}${when ? ` · ${esc(when)}` : ''}</div>`;
+  }).join('');
+  return `<div class="lt-rescue-list">${items}</div>`;
+}
+
+/**
+ * Render the Soulseek peers panel body. Reuses `renderForensicBlock` for
+ * the candidates table; caps the visible rows with a "show all" toggle so
+ * the action buttons stay reachable (IA per the plan). Pure.
+ *
+ * @param {Object|null|undefined} lastSearch  `last_search` payload.
+ * @param {number} id  album_requests.id (namespaces the show-all toggle).
+ * @returns {string}
+ */
+function renderPeersBody(lastSearch, id) {
+  if (!lastSearch) {
+    return renderForensicBlock(null);
+  }
+  const cands = Array.isArray(lastSearch.top_candidates)
+    ? lastSearch.top_candidates : [];
+  if (cands.length <= PEERS_VISIBLE_CAP) {
+    return renderForensicBlock(/** @type {any} */ (lastSearch));
+  }
+  // Cap the visible candidates; offer a "show all" toggle that swaps in
+  // the full block. The capped + full blocks are both pre-rendered; the
+  // toggle flips which is shown without a refetch.
+  const capped = { ...lastSearch, top_candidates: cands.slice(0, PEERS_VISIBLE_CAP) };
+  const cappedHtml = renderForensicBlock(/** @type {any} */ (capped));
+  const fullHtml = renderForensicBlock(/** @type {any} */ (lastSearch));
+  return `<div class="lt-peers" id="lt-peers-${id}">
+    <div class="lt-peers-capped">${cappedHtml}
+      <button class="lt-link-btn" type="button" onclick="event.stopPropagation(); window.toggleLongTailPeers(${id})">show all ${cands.length} peers</button>
+    </div>
+    <div class="lt-peers-full" style="display:none;">${fullHtml}
+      <button class="lt-link-btn" type="button" onclick="event.stopPropagation(); window.toggleLongTailPeers(${id})">show fewer</button>
+    </div>
+  </div>`;
+}
+
+/**
+ * Toggle the capped ⇄ full Soulseek peers view in place. No refetch — both
+ * blocks are already rendered; this flips visibility.
+ *
+ * @param {number} id  album_requests.id
+ * @returns {void}
+ */
+export function toggleLongTailPeers(id) {
+  if (typeof document === 'undefined') return;
+  const wrap = document.getElementById(`lt-peers-${id}`);
+  if (!wrap) return;
+  const capped = /** @type {HTMLElement|null} */ (wrap.querySelector('.lt-peers-capped'));
+  const full = /** @type {HTMLElement|null} */ (wrap.querySelector('.lt-peers-full'));
+  if (!capped || !full) return;
+  const showFull = full.style.display === 'none';
+  full.style.display = showFull ? 'block' : 'none';
+  capped.style.display = showFull ? 'none' : 'block';
+}
+
+/**
+ * Render one sibling-pressing row for the siblings panel. Pure.
+ *
+ * @param {Object} rel  A release row from `/api/release-group/<rg>`.
+ * @returns {string}
+ */
+function renderSiblingRow(rel) {
+  const title = rel.title || '?';
+  const meta = [rel.country, (rel.date || '').slice(0, 4), rel.format,
+    (rel.track_count != null ? `${rel.track_count}t` : '')]
+    .filter((x) => x).join(' · ');
+  const inLib = rel.in_library
+    ? `<span class="badge badge-rank-${esc(String(rel.library_rank || 'library').toLowerCase())}">in library</span>`
+    : '';
+  const pStatus = rel.pipeline_status
+    ? `<span class="badge badge-${esc(String(rel.pipeline_status))}">${esc(String(rel.pipeline_status))}</span>`
+    : '';
+  return `<div class="lt-sibling">
+    <span class="lt-sibling-title">${esc(String(title))}</span>
+    <span class="lt-sibling-meta">${esc(meta)}</span>
+    ${inLib}${pStatus}
+  </div>`;
+}
+
+/**
+ * Render the sibling-pressings panel body from a release-group payload.
+ * Pure. Evidence-only in U4 — the accept-sibling action is U6.
+ *
+ * @param {Object|null|undefined} rgData  `{releases:[...]}`.
+ * @returns {string}
+ */
+function renderSiblingsBody(rgData) {
+  const releases = (rgData && Array.isArray(rgData.releases)) ? rgData.releases : [];
+  if (releases.length === 0) {
+    return '<div class="lt-panel-empty">No sibling pressings found.</div>';
+  }
+  return releases.map(renderSiblingRow).join('');
+}
+
+/**
+ * Render the YouTube panel body for a given section state + payload. Pure.
+ *
+ * U4 renders all four states; the matrix rows are display-only (U5 makes
+ * them pickable rescue targets). The default (`never_run`) state renders
+ * the "Check YouTube" button whose click is a STUB wired to
+ * `window.checkYoutube(id)` — U5 defines that handler and the live
+ * resolver fetch. U4 must NOT auto-call the slow, side-effectful resolver
+ * GET, so the panel opens in `never_run` until the operator clicks.
+ *
+ * @param {{outcome?: string, youtube_releases?: Array<Object>|null, from_cache?: boolean, error_message?: string|null}|null} result
+ *   A cached resolver result, or `null` for the default never-run state.
+ * @param {number} id  album_requests.id
+ * @returns {string}
+ */
+function renderYoutubeBody(result, id) {
+  const cls = youtubeSectionState(result);
+  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">Check YouTube</button>`;
+  if (cls.state === 'never_run') {
+    return `<div class="lt-yt lt-yt-never-run">
+      <div class="lt-yt-prompt">Resolve this release against YouTube Music.</div>
+      ${checkBtn}
+    </div>`;
+  }
+  if (cls.state === 'resolver_failed') {
+    return `<div class="lt-yt lt-yt-failed">
+      <div class="lt-yt-msg">${esc(cls.message)}</div>
+      ${checkBtn}
+    </div>`;
+  }
+  if (cls.state === 'resolved_empty') {
+    return `<div class="lt-yt lt-yt-empty">
+      <div class="lt-yt-msg">${esc(cls.message)}</div>
+      ${checkBtn}
+    </div>`;
+  }
+  // resolved_with_matrix — display-only matrix in U4.
+  const releases = (result && Array.isArray(result.youtube_releases))
+    ? result.youtube_releases : [];
+  const staleFlag = cls.stale
+    ? `<div class="lt-yt-stale">${esc(cls.message)}</div>`
+    : '';
+  const rows = releases.map((rel) => {
+    const dists = Array.isArray(rel.distances) ? rel.distances : [];
+    const best = dists
+      .filter((d) => d && d.outcome === 'ok' && typeof d.distance === 'number')
+      .reduce((acc, d) => (acc == null || d.distance < acc ? d.distance : acc), /** @type {number|null} */ (null));
+    const bestStr = (best != null) ? `dist ${best.toFixed(3)}` : 'no distance';
+    const tc = (rel.track_count != null) ? `${rel.track_count}t` : '';
+    const yr = (rel.year != null) ? String(rel.year) : '';
+    return `<div class="lt-yt-row">
+      <span class="lt-yt-id">${esc(String(rel.yt_browse_id || '?'))}</span>
+      <span class="lt-yt-meta">${esc([yr, tc, bestStr].filter((x) => x).join(' · '))}</span>
+    </div>`;
+  }).join('');
+  return `<div class="lt-yt lt-yt-matrix">
+    ${staleFlag}
+    <div class="lt-yt-rows">${rows}</div>
+  </div>`;
+}
+
+/**
+ * Render the full console shell synchronously on open. Each panel starts
+ * in its loading state; the independent loaders patch them as their
+ * fetches settle. Band-aware emphasis (`consoleEmphasis`) decides which
+ * panel leads: `Missing` / unfindable rows lead with why-unfindable;
+ * on-disk rows lead with the band-vs-intent header. Pure.
+ *
+ * @param {Object} row  The worklist row (carries band, source, intent).
+ * @returns {string}
+ */
+function renderConsoleShell(row) {
+  const id = row.id;
+  const emphasis = consoleEmphasis(row);
+  const leadUnfindable = emphasis.lead === 'unfindable';
+  // Band-vs-intent header for on-disk rows (R8). `band` is the on-disk
+  // band; `target_format` is the request's intent. The console surfaces
+  // the comparison; the exact on-disk codec is in the peers/quality data.
+  const band = String(row.band || '').toLowerCase();
+  const intent = row.target_format || (row.min_bitrate ? `${row.min_bitrate}k` : 'default');
+  const bandVsIntent = !leadUnfindable
+    ? `<div class="lt-band-intent lt-panel-lead">
+        <div class="lt-panel-title">Quality vs intent</div>
+        <div class="lt-panel-body">on disk: <strong>${esc(bandLabel(band))}</strong> · intent: <strong>${esc(String(intent))}</strong></div>
+      </div>`
+    : '';
+  const unfindablePanel = renderPanel(
+    'unfindable', id, 'Why unfindable',
+    renderPanelLoading('triage'), leadUnfindable);
+  const peersPanel = renderPanel(
+    'peers', id, 'Soulseek peers seen', renderPanelLoading('peers'), false);
+  const rescuesPanel = renderPanel(
+    'rescues', id, 'Recent rescue attempts', renderPanelLoading('rescues'), false);
+  const siblingsPanel = renderPanel(
+    'siblings', id, 'Sibling pressings', renderPanelLoading('siblings'), false);
+  // The YouTube panel opens in `never_run` immediately — no fetch (U4 must
+  // not auto-call the side-effectful resolver GET).
+  const youtubePanel = renderPanel(
+    'youtube', id, 'YouTube Music', renderYoutubeBody(null, id), false);
+  // Order: lead panel first. For Missing/unfindable, why-unfindable leads;
+  // for on-disk rows, the band-vs-intent header leads, then why-unfindable.
+  const ordered = leadUnfindable
+    ? [unfindablePanel, peersPanel, rescuesPanel, siblingsPanel, youtubePanel]
+    : [bandVsIntent, unfindablePanel, peersPanel, rescuesPanel, siblingsPanel, youtubePanel];
+  return `<div class="lt-console">${ordered.join('')}</div>`;
+}
+
+/**
+ * Patch one panel's body in place, guarded by the row's console token so a
+ * stale fetch (operator moved on) doesn't paint. DOM-side.
+ *
+ * @param {number} id     album_requests.id
+ * @param {string} name   Panel slug.
+ * @param {number} token  The token captured when the console opened.
+ * @param {string} html   New body HTML.
+ * @returns {void}
+ */
+function patchPanel(id, name, token, html) {
+  if (typeof document === 'undefined') return;
+  if (consoleTokens.get(id) !== token) return;  // stale console — discard.
+  const panel = document.getElementById(`lt-panel-${name}-${id}`);
+  if (!panel) return;
+  const body = panel.querySelector('.lt-panel-body');
+  if (body) body.innerHTML = html;
+}
+
+/**
+ * Load the why-unfindable panel from `GET /api/triage/<id>`. Independent —
+ * a failure renders only this panel's error affordance.
+ *
+ * @param {number} id
+ * @param {number} token
+ * @returns {Promise<void>}
+ */
+async function loadUnfindablePanel(id, token) {
+  try {
+    const r = await fetch(`${API}/api/triage/${id}`);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const data = await r.json();
+    patchPanel(id, 'unfindable', token, renderUnfindableBody(data));
+  } catch (_e) {
+    patchPanel(id, 'unfindable', token, renderPanelError('triage'));
+  }
+}
+
+/**
+ * Load the peers + rescues panels from one `GET /api/pipeline/<id>` fetch,
+ * and kick off the (independent) sibling-pressings fetch using the
+ * release-group id off the detail payload. Peers + rescues are patched
+ * from this fetch; siblings is fired separately so a slow release-group
+ * (the 15s MB-mirror timeout) blocks only its own panel.
+ *
+ * @param {number} id
+ * @param {number} token
+ * @param {boolean} inFlightFlag  The worklist row's `in_flight_rescue`.
+ * @returns {Promise<void>}
+ */
+async function loadPipelinePanels(id, token, inFlightFlag) {
+  let rgId = null;
+  try {
+    const r = await fetch(`${API}/api/pipeline/${id}`);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const data = await r.json();
+    patchPanel(id, 'peers', token, renderPeersBody(data.last_search, id));
+    patchPanel(id, 'rescues', token, renderRescuesBody(data.history, inFlightFlag));
+    const req = data.request || {};
+    rgId = req.mb_release_group_id || null;
+  } catch (_e) {
+    patchPanel(id, 'peers', token, renderPanelError('peers'));
+    patchPanel(id, 'rescues', token, renderPanelError('rescue history'));
+  }
+  // Siblings is dependent on the rg id but loads independently: if the
+  // detail fetch failed (rgId null) we render the "no rg" state; otherwise
+  // we fire the release-group fetch on its own so its latency is isolated.
+  loadSiblingsPanel(id, token, rgId);
+}
+
+/**
+ * Load the sibling-pressings panel from `GET /api/release-group/<rg>`.
+ * Independent — a slow / failing release-group renders only this panel's
+ * error affordance and never blocks the others. Rows without a release
+ * group (Discogs-sourced, or a legacy MB row with none) render an explicit
+ * "no sibling data" state rather than firing a doomed fetch (KTD7).
+ *
+ * @param {number} id
+ * @param {number} token
+ * @param {string|null} rgId  The request's `mb_release_group_id`, or null.
+ * @returns {Promise<void>}
+ */
+async function loadSiblingsPanel(id, token, rgId) {
+  if (!rgId) {
+    patchPanel(id, 'siblings', token,
+      '<div class="lt-panel-empty">No release group — sibling pressings unavailable for this request.</div>');
+    return;
+  }
+  try {
+    const r = await fetch(`${API}/api/release-group/${encodeURIComponent(rgId)}`);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const data = await r.json();
+    patchPanel(id, 'siblings', token, renderSiblingsBody(data));
+  } catch (_e) {
+    patchPanel(id, 'siblings', token, renderPanelError('sibling pressings'));
+  }
+}
+
+/**
+ * Look up the cached worklist row for an id (band-aware console needs the
+ * row's band / source / intent). Returns `null` when the cohort isn't
+ * loaded or the id is gone.
+ *
+ * @param {number} id
+ * @returns {Object|null}
+ */
+function consoleRow(id) {
+  const rows = Array.isArray(state.longTail.rows) ? state.longTail.rows : [];
+  return rows.find((r) => r && r.id === id) || null;
+}
+
+/**
+ * Toggle the in-place action console for one row (U4). Opening renders the
+ * console shell synchronously (band-aware), then fires the evidence panels
+ * INDEPENDENTLY — each patches its own container as it settles, so a slow
+ * or failing panel never blanks the console or drops another panel. A
+ * per-row token stamps the fetch so a stale console (operator clicked
+ * another row, or re-collapsed this one) is discarded before it paints.
  *
  * @param {number} id  album_requests.id
  * @returns {void}
@@ -508,11 +1058,22 @@ export function toggleLongTailDetail(id) {
   if (!el) return;
   if (el.classList.contains('open')) {
     el.classList.remove('open');
+    // Bump the token so any in-flight panel fetch is discarded on resolve.
+    consoleTokens.set(id, (consoleTokens.get(id) || 0) + 1);
     return;
   }
-  // U4 will populate this; for now the container just opens empty so the
-  // click is observable and the wiring is in place.
+  const token = (consoleTokens.get(id) || 0) + 1;
+  consoleTokens.set(id, token);
+  const row = consoleRow(id) || { id };
+  el.innerHTML = renderConsoleShell(row);
   el.classList.add('open');
+  const inFlightFlag = !!row.in_flight_rescue;
+  // Independent panel loads — no Promise.all, no shared await. One panel's
+  // rejection can't reject another's promise (each loader try/catches and
+  // patches its own error affordance). The YouTube panel is already in its
+  // never_run state from the shell (no fetch in U4).
+  loadUnfindablePanel(id, token);
+  loadPipelinePanels(id, token, inFlightFlag);
 }
 
 export const __test__ = {
@@ -525,4 +1086,17 @@ export const __test__ = {
   countOtherBandMatches,
   renderLongTailRow,
   renderLongTailBody,
+  // U4 — console pure render helpers + re-exported util classifiers.
+  youtubeSectionState,
+  consoleEmphasis,
+  renderConsoleShell,
+  renderUnfindableBody,
+  renderPeersBody,
+  renderRescuesBody,
+  renderSiblingsBody,
+  renderYoutubeBody,
+  renderPanelError,
+  youtubeHistoryRows,
+  youtubeFailureReason,
+  PEERS_VISIBLE_CAP,
 };

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -10,6 +10,7 @@ import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, open
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter } from './pipeline.js';
+import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail } from './long_tail.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
@@ -169,6 +170,14 @@ Object.assign(window, {
   toggleDetail,
   deleteRequest,
   updateStatus,
+  // Long-tail triage worklist (U3): nav + tab/search/list handlers. The
+  // per-row action console expansion lands in U4 (toggleLongTailDetail is
+  // a stub for now). renderPipeline (already exposed) re-emits the nav for
+  // the long-tail sub-view; long_tail.js calls it via window.renderPipeline.
+  loadLongTail,
+  setLongTailBand,
+  onLongTailSearchInput,
+  toggleLongTailDetail,
   renderLibraryResults,
   renderLibraryResultsInto,
   toggleLibDetail,

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -10,7 +10,7 @@ import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, open
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter } from './pipeline.js';
-import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail, toggleLongTailPeers } from './long_tail.js';
+import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue } from './long_tail.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
@@ -232,11 +232,14 @@ Object.assign(window, {
   openReplacePicker: openReplacePickerAndHandle,
   togglePipelineReplacedFilter,
   toggleWrongMatchesReplacedFilter,
-  // Long-tail YouTube rescue — the console's "Check YouTube" button calls
-  // this. U4 ships only the placeholder so the click is observable and
-  // never throws; U5 replaces it with the real two-step resolver→rescue
-  // flow (the slow, side-effectful resolver GET deliberately is NOT auto-
-  // called on console open).
-  checkYoutube: (id) => toast(`Check YouTube for #${id} — coming in the next update`),
+  // Long-tail YouTube rescue (U5) — the two-step flow. `checkYoutube` runs
+  // the slow, side-effectful resolver GET (double-fire-guarded, stale-result
+  // stamped) and re-renders the YouTube panel with pickable rescue targets;
+  // `pickYoutubeRescue` opens the confirm overlay for a chosen target and
+  // submits the rescue, mapping every ingest outcome to specific console
+  // copy. The resolver GET is NOT auto-called on console open (U4 leaves the
+  // panel in `never_run` until the operator clicks).
+  checkYoutube,
+  pickYoutubeRescue,
   toast,
 });

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -10,7 +10,7 @@ import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, open
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter } from './pipeline.js';
-import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue } from './long_tail.js';
+import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue, longTailAcceptSibling, longTailSetIntent, longTailReSearch } from './long_tail.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
@@ -241,5 +241,16 @@ Object.assign(window, {
   // panel in `never_run` until the operator clicks).
   checkYoutube,
   pickYoutubeRescue,
+  // Long-tail secondary actions (U6) — accept-a-sibling-pressing (the
+  // existing Replace operator action, MB-only per KTD7; disabled with a
+  // reason for Discogs requests), set-intent (lossless ⇄ default toggle via
+  // the existing set-intent surface), and re-search (regenerate-plan +
+  // reset-cursor via the existing search-plan/regenerate surface, honest
+  // next-cycle copy). Each reuses the U5 single-row refetch helper for
+  // post-action freshness; the confirmed Replace closes the console and
+  // full-cohort refetches because the old row leaves the worklist.
+  longTailAcceptSibling,
+  longTailSetIntent,
+  longTailReSearch,
   toast,
 });

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -10,7 +10,7 @@ import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, open
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter } from './pipeline.js';
-import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail } from './long_tail.js';
+import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail, toggleLongTailPeers } from './long_tail.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
 import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
@@ -170,14 +170,16 @@ Object.assign(window, {
   toggleDetail,
   deleteRequest,
   updateStatus,
-  // Long-tail triage worklist (U3): nav + tab/search/list handlers. The
-  // per-row action console expansion lands in U4 (toggleLongTailDetail is
-  // a stub for now). renderPipeline (already exposed) re-emits the nav for
-  // the long-tail sub-view; long_tail.js calls it via window.renderPipeline.
+  // Long-tail triage worklist: nav + tab/search/list handlers (U3) plus
+  // the per-row action console (U4 — toggleLongTailDetail opens the
+  // evidence console; toggleLongTailPeers flips the capped/full peers
+  // view). renderPipeline (already exposed) re-emits the nav for the
+  // long-tail sub-view; long_tail.js calls it via window.renderPipeline.
   loadLongTail,
   setLongTailBand,
   onLongTailSearchInput,
   toggleLongTailDetail,
+  toggleLongTailPeers,
   renderLibraryResults,
   renderLibraryResultsInto,
   toggleLibDetail,
@@ -230,5 +232,11 @@ Object.assign(window, {
   openReplacePicker: openReplacePickerAndHandle,
   togglePipelineReplacedFilter,
   toggleWrongMatchesReplacedFilter,
+  // Long-tail YouTube rescue — the console's "Check YouTube" button calls
+  // this. U4 ships only the placeholder so the click is observable and
+  // never throws; U5 replaces it with the real two-step resolver→rescue
+  // flow (the slow, side-effectful resolver GET deliberately is NOT auto-
+  // called on console open).
+  checkYoutube: (id) => toast(`Check YouTube for #${id} — coming in the next update`),
   toast,
 });

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -4,6 +4,7 @@ import { esc, awstDate, awstDateTime, awstTime, qualityLabel, externalReleaseUrl
 import { renderDownloadHistoryItem } from './history.js';
 import { renderBadRipButton, renderReplaceButton } from './release_actions.js';
 import { renderSearchPlanButton, renderSearchPlanDetail } from './search_plan.js';
+import { loadLongTail, renderLongTailBody } from './long_tail.js';
 
 /**
  * Load pipeline data from API and render.
@@ -12,6 +13,13 @@ import { renderSearchPlanButton, renderSearchPlanDetail } from './search_plan.js
 export async function loadPipeline() {
   if (state.pipelineView === 'dashboard') {
     await loadPipelineDashboard();
+    return;
+  }
+  if (state.pipelineView === 'long-tail') {
+    // U3: the long-tail worklist owns its own fetch lifecycle. It paints
+    // a loading affordance, fetches the banded cohort, then routes back
+    // through renderPipeline (which re-emits the Pipeline nav).
+    await loadLongTail();
     return;
   }
   if (state.pipelineView === 'search-plan-detail') {
@@ -60,6 +68,17 @@ export function setPipelineView(view) {
   if (view === 'dashboard') {
     state.pipelineView = 'dashboard';
     loadPipelineDashboard();
+    return;
+  }
+  if (view === 'long-tail') {
+    state.pipelineView = 'long-tail';
+    // Re-render from cache if we already have a cohort (cheap band/search
+    // re-paint); otherwise kick the initial fetch.
+    if (state.longTail.rows) {
+      renderPipeline();
+    } else {
+      loadLongTail();
+    }
     return;
   }
   if (view === 'search-plan-detail') {
@@ -120,12 +139,17 @@ export function setFilter(f) {
  * Dispatches on `state.pipelineView`:
  *   * `'queue'` (default)  → list of pipeline rows
  *   * `'dashboard'`        → metrics dashboard
+ *   * `'long-tail'`        → banded long-tail triage worklist
  *   * `'search-plan-detail'` → per-request inspector (U4)
  */
 export function renderPipeline() {
   const el = document.getElementById('pipeline-content');
   if (state.pipelineView === 'dashboard') {
     renderPipelineDashboard();
+    return;
+  }
+  if (state.pipelineView === 'long-tail') {
+    el.innerHTML = `${renderPipelineNav()}${renderLongTailBody()}`;
     return;
   }
   if (state.pipelineView === 'search-plan-detail') {
@@ -204,12 +228,15 @@ export function renderPipeline() {
 function renderPipelineNav() {
   const refreshAction = state.pipelineView === 'dashboard'
     ? 'window.loadPipelineDashboard()'
-    : 'window.loadPipeline()';
+    : state.pipelineView === 'long-tail'
+      ? 'window.loadLongTail()'
+      : 'window.loadPipeline()';
 
   return `
     <div class="pipeline-subtabs">
       <button class="p-btn ${state.pipelineView === 'queue' ? 'active-status' : ''}" onclick="window.setPipelineView('queue')">Queue</button>
       <button class="p-btn ${state.pipelineView === 'dashboard' ? 'active-status' : ''}" onclick="window.setPipelineView('dashboard')">Dashboard</button>
+      <button class="p-btn ${state.pipelineView === 'long-tail' ? 'active-status' : ''}" onclick="window.setPipelineView('long-tail')">Long Tail</button>
       <button class="p-btn subtab-refresh" onclick="${refreshAction}">Refresh</button>
     </div>
   `;

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -21,7 +21,19 @@ import { invalidateActiveRgs } from './active_rgs.js';
  * @property {string|null} originSubView  Sub-view to restore (e.g. `'queue'`/`'dashboard'` on Pipeline). `null` for tabs with no sub-view.
  */
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
+/**
+ * Long-tail triage worklist state. `rows` is the full server-banded
+ * `wanted` cohort fetched once (KTD2 — one banded fetch, client-side
+ * tab/search filtering); `band` is the selected band tab (`null` until
+ * the first fetch picks a default); `query` is the live search box value.
+ *
+ * @typedef {Object} LongTailState
+ * @property {Array<Object>|null} rows  The fetched cohort, or `null` before the first load.
+ * @property {string|null} band         Selected band tab, or `null` (no selection yet).
+ * @property {string} query             Current search-box substring filter.
+ */
+
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
@@ -38,6 +50,10 @@ export const state = {
   pipelineMatchGraphOpen: false,
   pipelineHourlyMatchGraphOpen: false,
   pipelineDailyMatchGraphOpen: false,
+  // Long-tail triage worklist (U3). `rows` null until the first fetch;
+  // `band` null until the cohort's default band is picked; `query` is
+  // the live in-band search-box filter.
+  longTail: { rows: null, band: null, query: '' },
   recentsCounts: {
     all: 0,
     imported: 0,

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -251,6 +251,117 @@ export function renderForensicBlock(last) {
 }
 
 /**
+ * @typedef {Object} YoutubeSectionState
+ * @property {'never_run'|'resolved_with_matrix'|'resolved_empty'|'resolver_failed'} state
+ *   The four-state YouTube section machine (HLD "YouTube section state
+ *   machine"). `never_run` — no resolver result yet (the side-effectful
+ *   GET has not been run; the console renders the "Check YouTube" button).
+ *   `resolved_with_matrix` — resolver returned `ok` with at least one YT
+ *   release. `resolved_empty` — resolver returned `ok` with zero releases
+ *   ("not on YouTube Music"). `resolver_failed` — any non-`ok` outcome
+ *   (404 / 503 / transient), which the console renders with a retry
+ *   affordance.
+ * @property {boolean} stale  True when a cached matrix is served alongside
+ *   an `error_message` describing a fresh upstream YT failure
+ *   (`from_cache && error_message`). The matrix is still real and shown,
+ *   but flagged as potentially stale. Only ever true together with
+ *   `resolved_with_matrix` / `resolved_empty` (an `ok` cached row).
+ * @property {string} message  Operator-facing copy for the state (empty
+ *   for the happy `resolved_with_matrix` case where the matrix speaks for
+ *   itself).
+ */
+
+/**
+ * Classify a YouTube-album resolver result into the four-state console
+ * section machine. Pure / DOM-free — the renderer branches on the
+ * returned `state`.
+ *
+ * IMPORTANT: the resolver GET is slow and side-effectful (it runs the
+ * resolve + caches). U4 must NOT auto-call it; `null` (no result yet)
+ * always maps to `never_run` so the console defaults to the "Check
+ * YouTube" button. U5 wires the actual fetch and re-classifies the
+ * fresh result here.
+ *
+ * Service-level outcomes (from `lib/youtube_album_service.py`
+ * `OUTCOME_HTTP_STATUS`): `ok`, `not_found`, `unresolved_4xx_client`,
+ * `unresolved_mirror_unavailable`, `unresolved_timeout`,
+ * `youtube_parse_failed`, `transient`. Only `ok` is a success; every
+ * other value is a `resolver_failed`.
+ *
+ * @param {{outcome?: string, youtube_releases?: Array<Object>|null, from_cache?: boolean, error_message?: string|null}|null|undefined} result
+ *   The `YoutubeAlbumResolverResult` payload, or `null`/`undefined` when
+ *   the resolver has not been run yet.
+ * @returns {YoutubeSectionState}
+ */
+export function youtubeSectionState(result) {
+  if (!result || typeof result !== 'object') {
+    return { state: 'never_run', stale: false, message: '' };
+  }
+  const outcome = String(result.outcome || '');
+  const releases = Array.isArray(result.youtube_releases)
+    ? result.youtube_releases : [];
+  // `from_cache` with a non-empty error_message means the cache served a
+  // real matrix while the latest live resolve failed upstream — the matrix
+  // is shown but flagged potentially stale (HLD staleness flag).
+  const stale = !!(result.from_cache && result.error_message);
+  if (outcome === 'ok') {
+    if (releases.length > 0) {
+      return {
+        state: 'resolved_with_matrix',
+        stale,
+        message: stale
+          ? 'Showing a cached match — the latest live check failed, this may be stale.'
+          : '',
+      };
+    }
+    return {
+      state: 'resolved_empty',
+      stale,
+      message: 'Not on YouTube Music. Re-check later.',
+    };
+  }
+  // Any non-ok outcome — transient mirror/YT failure. Retryable.
+  return {
+    state: 'resolver_failed',
+    stale: false,
+    message: result.error_message
+      ? String(result.error_message)
+      : 'Could not reach YouTube Music. Retry.',
+  };
+}
+
+/**
+ * @typedef {Object} ConsoleEmphasis
+ * @property {'unfindable'|'band_vs_intent'} lead  Which panel leads the
+ *   console. `unfindable` — `Missing` / unfindable rows lead with the
+ *   why-unfindable panel (the operator's first question is "why is this
+ *   stuck?"). `band_vs_intent` — an on-disk row whose copy is below intent
+ *   leads with current-band-vs-target-format (the operator's first
+ *   question is "what better is available?").
+ */
+
+/**
+ * Select the console's lead panel for one worklist row. Pure / DOM-free.
+ *
+ * `Missing` rows (no on-disk copy) and any row carrying an
+ * `unfindable_category` lead with the why-unfindable panel. Every other
+ * on-disk row leads with band-vs-intent (R8). A row with no band value at
+ * all is treated as `Missing`-like (lead with unfindable) — there is no
+ * on-disk copy to compare against intent.
+ *
+ * @param {{band?: string|null, unfindable_category?: string|null}|null|undefined} row
+ * @returns {ConsoleEmphasis}
+ */
+export function consoleEmphasis(row) {
+  const band = String((row && row.band) || '').toLowerCase();
+  const unfindable = !!(row && row.unfindable_category);
+  if (!band || band === 'missing' || unfindable) {
+    return { lead: 'unfindable' };
+  }
+  return { lead: 'band_vs_intent' };
+}
+
+/**
  * Parse pasted text for the Browse > Search-by-ID flow.
  *
  * Accepts a bare MBID, bare Discogs ID, or a canonical MB / Discogs URL

--- a/web/routes/_overlay.py
+++ b/web/routes/_overlay.py
@@ -18,6 +18,70 @@ from __future__ import annotations
 from typing import Iterable
 
 
+def _band_from_detail(
+    rid: str,
+    in_library: set[str],
+    quality: dict[str, dict],
+) -> str:
+    """Three-way band for one release id given already-fetched membership
+    + ``check_mbids_detail`` output (KTD1).
+
+    The single banding decision both ``band_release_ids`` and
+    ``overlay_release_rows_in_place`` route through — header, list, and
+    sibling panel can never diverge because they share this function. The
+    membership / detail queries are the caller's responsibility (batched
+    once); this is pure given them.
+    """
+    from web import server as srv
+
+    if rid not in in_library:
+        return "missing"
+    q = quality.get(rid)
+    if not q:
+        return "unknown"
+    fmt_raw = q.get("beets_format")
+    fmt = fmt_raw if isinstance(fmt_raw, str) else ""
+    br_raw = q.get("beets_bitrate")
+    br = br_raw if isinstance(br_raw, int) else 0
+    return srv.compute_library_rank(fmt, br)
+
+
+def band_release_ids(release_ids: Iterable[str]) -> dict[str, str]:
+    """Map each release id to its beets-library quality band.
+
+    The beets-only banding core, factored out of
+    ``overlay_release_rows_in_place`` so the long-tail worklist (U1) and
+    the overlay both band through one function — header and list always
+    agree. Three-way (KTD1):
+
+    * release id absent from the beets membership set → ``"missing"``.
+    * present but no detail row / ``compute_library_rank`` returns
+      ``"unknown"`` → ``"unknown"`` (has audio, never ``"missing"``).
+    * otherwise → the lowercase ``QualityRank`` band.
+
+    Bounded query fan-out: one membership query (``check_beets_library``)
+    + one ``check_mbids_detail`` batch over the in-library subset — never
+    per row. Skips the overlay's ``check_pipeline`` query: the long-tail
+    cohort row already carries the pipeline columns, and the band depends
+    only on the on-disk copy.
+
+    Returns a dict keyed by the release id string. Ids that are
+    ``"missing"`` ARE present in the dict (banded ``"missing"``) so a
+    caller can distinguish "banded missing" from "not asked about" — but
+    the long-tail service treats both the same (absent → ``Missing``).
+    """
+    from web import server as srv
+
+    ids_list = [str(rid) for rid in release_ids]
+    if not ids_list:
+        return {}
+    in_library = srv.check_beets_library(ids_list)
+    b = srv._beets_db()
+    quality = b.check_mbids_detail(list(in_library)) if in_library and b else {}
+
+    return {rid: _band_from_detail(rid, in_library, quality) for rid in ids_list}
+
+
 def overlay_release_rows_in_place(rows: list[dict], release_ids: Iterable[str]) -> None:
     """Annotate each release row with library + pipeline state in place.
 
@@ -60,7 +124,12 @@ def overlay_release_rows_in_place(rows: list[dict], release_ids: Iterable[str]) 
             br = br_raw if isinstance(br_raw, int) else 0
             r["library_format"] = fmt
             r["library_min_bitrate"] = br
-            r["library_rank"] = srv.compute_library_rank(fmt, br)
+            # Band through the one shared decision so the overlay's
+            # ``library_rank`` and the long-tail worklist's band can
+            # never diverge. ``rid`` is in ``in_library`` here (we're
+            # inside ``if q:`` on a detail row), so this returns the
+            # lowercase QualityRank, identical to the prior inline call.
+            r["library_rank"] = _band_from_detail(rid, in_library, quality)
         pi = in_pipeline.get(rid)
         r["pipeline_status"] = pi["status"] if pi else None
         r["pipeline_id"] = pi["id"] if pi else None

--- a/web/routes/_overlay.py
+++ b/web/routes/_overlay.py
@@ -15,7 +15,10 @@ contract in `web/routes/browse.py`).
 
 from __future__ import annotations
 
+import logging
 from typing import Iterable
+
+log = logging.getLogger(__name__)
 
 
 def _band_from_detail(
@@ -33,17 +36,12 @@ def _band_from_detail(
     once); this is pure given them.
     """
     from web import server as srv
+    from lib.banding import band_from_detail
 
-    if rid not in in_library:
-        return "missing"
-    q = quality.get(rid)
-    if not q:
-        return "unknown"
-    fmt_raw = q.get("beets_format")
-    fmt = fmt_raw if isinstance(fmt_raw, str) else ""
-    br_raw = q.get("beets_bitrate")
-    br = br_raw if isinstance(br_raw, int) else 0
-    return srv.compute_library_rank(fmt, br)
+    # Delegate to the shared lib decision, supplying the web process's cached
+    # rank cfg. The decision lives in lib/ so the CLI bands without importing
+    # web (no parallel three-way logic).
+    return band_from_detail(rid, in_library, quality, srv._rank_cfg())
 
 
 def band_release_ids(release_ids: Iterable[str]) -> dict[str, str]:
@@ -75,9 +73,20 @@ def band_release_ids(release_ids: Iterable[str]) -> dict[str, str]:
     ids_list = [str(rid) for rid in release_ids]
     if not ids_list:
         return {}
-    in_library = srv.check_beets_library(ids_list)
-    b = srv._beets_db()
-    quality = b.check_mbids_detail(list(in_library)) if in_library and b else {}
+    try:
+        in_library = srv.check_beets_library(ids_list)
+        b = srv._beets_db()
+        quality = b.check_mbids_detail(list(in_library)) if in_library and b else {}
+    except Exception:
+        # Beets unavailable (locked / missing DB) — degrade to all-"missing"
+        # rather than 500-ing the whole worklist (matches the CLI's
+        # _cli_band_fn fallback). "No clean copy to upgrade" is the honest
+        # default; the long-tail view still renders.
+        log.warning(
+            "band_release_ids: beets unavailable, banding all-missing",
+            exc_info=True,
+        )
+        return {rid: "missing" for rid in ids_list}
 
     return {rid: _band_from_detail(rid, in_library, quality) for rid in ids_list}
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -2565,6 +2565,83 @@ def get_triage_list(
     h._json(payload)
 
 
+def get_pipeline_long_tail(h, params: dict[str, list[str]]) -> None:
+    """U1: ``GET /api/pipeline/long-tail`` — banded ``wanted`` worklist.
+
+    Returns every ``wanted`` request pre-banded by on-disk quality
+    (``missing`` / a lowercase ``QualityRank`` band / ``unknown``) and
+    stamped with ``in_flight_rescue``. Wraps
+    ``lib.long_tail_service.list_long_tail`` — the SAME service method
+    ``pipeline-cli long-tail`` wraps (CLI ⇄ API symmetry, R16).
+
+    Query string:
+      * ``band`` — optional single-band filter (``missing`` / a rank /
+        ``unknown``). The UI fetches unfiltered and filters client-side;
+        this backs scripted / CLI-parity callers.
+      * ``id`` — optional single request id. Returns just that request's
+        authoritative band + flags (KTD8 — the post-action single-row
+        refetch). 404 when the id doesn't exist OR is no longer
+        ``wanted`` (an imported / replaced row is correctly absent from
+        the worklist). Mutually exclusive with ``band`` (``band`` is
+        ignored when ``id`` is present — a single row is already its own
+        cohort).
+
+    Response shape (cohort success):
+        ``{"results": [...], "band": <str|null>, "count": <int>}``
+    Response shape (single-id success):
+        ``{"result": <row>, "id": <int>}``
+
+    Each result is a ``LongTailRow`` serialized via
+    ``msgspec.to_builtins`` so ``msgspec.convert(row, type=LongTailRow)``
+    round-trips on the consumer side. Datetime / UUID columns are pinned
+    out of the row by ``_LONG_TAIL_SELECT``'s projection, but the row is
+    still routed through ``_serialize_row`` to guard the datetime-500
+    class against any future column add.
+
+    Status-code mapping:
+      * 200 — success (empty cohort is a valid state).
+      * 400 — non-int ``id``.
+      * 404 — ``id`` not found / not ``wanted``.
+    """
+    from lib.long_tail_service import band_one_long_tail, list_long_tail
+    from web.routes._overlay import band_release_ids
+
+    s = _server()
+
+    id_raw = params.get("id", [None])[0]
+    if id_raw is not None and id_raw != "":
+        try:
+            request_id = int(id_raw)
+        except (TypeError, ValueError):
+            h._error("id must be an integer")
+            return
+        row = band_one_long_tail(s._db(), band_release_ids, request_id)
+        if row is None:
+            h._json(
+                {"error": "Not found", "id": request_id},
+                status=404,
+            )
+            return
+        serialized = s._serialize_row(msgspec.to_builtins(row))
+        h._json({"result": serialized, "id": request_id})
+        return
+
+    band = params.get("band", [None])[0]
+    if band == "":
+        band = None
+
+    result = list_long_tail(s._db(), band_release_ids, band=band)
+
+    # Route the serialized rows through _serialize_row to convert any
+    # datetime / UUID columns to JSON-safe values (datetime-500 guard).
+    rows = [s._serialize_row(r) for r in msgspec.to_builtins(result.rows)]
+    h._json({
+        "results": rows,
+        "band": result.band_filter,
+        "count": len(rows),
+    })
+
+
 # --- U18 step 2: /api/_index — self-documenting API surface ----------------
 #
 # Walks ``web.server.Handler``'s merged dispatch tables and emits one row per
@@ -2692,6 +2769,7 @@ GET_ROUTES: dict[str, object] = {
     "/api/import-jobs": get_import_jobs,
     "/api/import-jobs/timeline": get_import_jobs_timeline,
     "/api/pipeline/active-rgs": get_pipeline_active_rgs,
+    "/api/pipeline/long-tail": get_pipeline_long_tail,
     "/api/triage/list": get_triage_list,
 }
 
@@ -2786,6 +2864,11 @@ GET_DESCRIPTIONS: dict[str, str] = {
     "/api/pipeline/active-rgs": (
         "Distinct release-group IDs held by any non-replaced request "
         "(Replace-button enable set)."
+    ),
+    "/api/pipeline/long-tail": (
+        "Long-tail worklist — the full wanted cohort pre-banded by "
+        "on-disk quality (missing / QualityRank band / unknown) and "
+        "stamped with in_flight_rescue. Optional ?band= filter."
     ),
     "/api/triage/list": (
         "Cohort triage listing — filter by unfindable category, "

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -561,10 +561,12 @@ def _build_last_search_payload(
                 latest.get("request_id"), latest.get("id"), exc,
             )
             candidates = []
-    # Top-3 by (matched_tracks DESC, avg_ratio DESC) for compact list view;
-    # full forensic blob still reachable via the search history for
-    # operators who want it. Shared ranking lives in lib/quality.py.
-    top = top_candidates(candidates, limit=3)
+    # Top-20 by (matched_tracks DESC, avg_ratio DESC) — the full stored cap
+    # (search_log.candidates persists at most 20). The long-tail console's
+    # "peers seen" panel renders the wider slice; the compact detail view
+    # shows the same ranking, just more rows. Shared ranking lives in
+    # lib/quality.py.
+    top = top_candidates(candidates, limit=20)
     return {
         "variant": latest.get("variant"),
         "final_state": latest.get("final_state"),

--- a/web/server.py
+++ b/web/server.py
@@ -186,15 +186,12 @@ def compute_library_rank(format_str: str | None, bitrate_kbps: int | None) -> st
     'poor', 'unknown'). Treats MP3 as VBR — cratedigger's pipeline only
     produces VBR-V0 MP3, and for the bitrate buckets the badge cares
     about the VBR-vs-CBR distinction barely matters at the display level.
+
+    Thin wrapper supplying the web process's cached rank cfg; the pure
+    decision lives in ``lib.banding`` so the CLI bands without importing web.
     """
-    if not format_str:
-        return "unknown"
-    fmt = format_str.split(",")[0].strip()
-    if not fmt:
-        return "unknown"
-    from lib.quality import quality_rank
-    rank = quality_rank(fmt, bitrate_kbps, is_cbr=False, cfg=_rank_cfg())
-    return rank.name.lower()
+    from lib.banding import compute_library_rank as _band_rank
+    return _band_rank(format_str, bitrate_kbps, _rank_cfg())
 
 
 def apply_pipeline_bitrate_override(album: dict, pipeline_info: dict) -> None:


### PR DESCRIPTION
## Long-Tail Triage Console

A new sub-view under the **Pipeline** tab that turns the long tail into a worklist: it opens on the `wanted` set (~820 requests), banded by on-disk quality as selectable filter tabs (`Missing` + the `QualityRank` bands), with a search box. Selecting a release expands an in-place **action console** that explains why it's stuck — the unfindable category, the Soulseek peers actually seen and why each was rejected, the sibling pressings that exist, and what YouTube Music has — and lets the operator act inline: **rescue off YouTube**, **accept a sibling pressing**, **set quality intent**, or **re-search**.

This is the first UI consumer of three already-built backends (triage / search-analytics, the YouTube resolver, and the YouTube rescue ingest API). **No new pipeline behaviour** — the only backend additions are a banded worklist read (+ its `pipeline-cli` counterpart) and a widening of how many peers the detail endpoint returns.

Brainstorm: `docs/brainstorms/2026-05-30-long-tail-triage-console-requirements.md`
Plan: `docs/plans/2026-05-30-001-feat-long-tail-triage-console-plan.md`

### What shipped (by unit)

- **U1** — `lib/long_tail_service.py` (typed `LongTailRow`/`LongTailResult`), `get_long_tail_cohort`/`get_long_tail_request` in `pipeline_db`, `GET /api/pipeline/long-tail` (`?band`, `?id`) + `pipeline-cli long-tail`. Bands the cohort via a beets-only helper factored out of `_overlay` (Missing = not in library / Unknown = rank-unknown / else the band); stamps `in_flight_rescue` via the centralized `youtube_running` `EXISTS` predicate (index-backed by migration 037).
- **U2** — widened the `last_search` peers cap from 3 to the stored max (20) for the console's peers panel.
- **U3** — new `web/js/long_tail.js`: band tabs (Missing-first, ascending `QualityRank`) with live counts, debounced within-band search (stale-token-guarded) + cross-band hint, and loading / empty-cohort / empty-band states.
- **U4** — the action console: five evidence panels loading **independently** (per-panel error states so a slow `release-group` mirror call can't blank the console), the four-state YouTube section shell, not-yet-categorised + in-flight/failed-rescue indicators, band-aware emphasis.
- **U5** — two-step YouTube rescue: live "Check YouTube" (double-fire-guarded), matrix-as-rescue-targets, confirm overlay → `POST youtube-rescue`, full outcome→copy mapping, single-row refetch on accept (no optimistic band move).
- **U6** — accept-sibling (MB-only via the Replace picker; disabled for Discogs), set-intent toggle, re-search (`regenerate`, honest next-cycle copy; `failed_deterministic` surfaces the metadata gap instead of re-firing), shared single-row refetch.

### Key decisions (from the plan)

- **Band off the beets-library copy** via the existing quality overlay (badge rendering for free), not a second spectral source. "Missing" = no clean library album.
- **One server-banded fetch + client-side tab/search filtering** (~820 rows) — kills stale-response races, no `quality_rank` reimplementation in JS. Documented ~1,500-row pagination ceiling.
- **"Re-search now" = regenerate-plan + next-cycle**, never an instant search (a true single-request search trigger would be new watch-loop behaviour — deferred).
- **Rescue needs no quality-bar drop** — Opus 128 classifies `TRANSPARENT`, above the `EXCELLENT` gate floor. (Corrects the `2026-05-28` rescue brainstorm's wrong assumption.)
- **Accept-sibling is MB-only** — no MB↔Discogs adapter introduced.

### Testing

- **pyright: 0 errors / 0 warnings** on the full repo.
- **Full suite green:** `run_tests.sh` → 4257 Python tests OK, JS syntax + 491 JS unit tests, vulture dead-code clean.
- New coverage: `tests/test_long_tail_service.py` (real-PG round-trip per test-fidelity Rule A, N+1 guard counting the beets queries, Discogs/Missing/Unknown banding, in-flight stamp), web contract + `CLASSIFIED_ROUTES` audit, CLI test, `FakePipelineDB` mirrors + self-tests, and JS `__test__` coverage for every pure helper (band derivation, four-state classifier, outcome→copy maps, predicates).
- A full code-review pass (4 finder angles) ran over the assembled diff; the backend↔frontend **contract finder returned zero mismatches**. Findings addressed in `e199388`. Two "Discogs broken" findings were verified non-issues against live data (wanted rows store their id in `mb_release_id`, incl. Discogs numerics).

### Post-Deploy Monitoring & Validation

The new read is the heaviest single query the web app issues (full cohort + batched beets banding on a single-threaded server). After deploy:

- **Live smoke (owed):** open `music.ablz.au` → Pipeline → Long Tail; confirm band tabs + counts render, a `Missing`/`wrong_pressing_available` row's console shows real triage + peers + siblings, and "Check YouTube" returns a matrix for a known-on-YT release. Use a small/obscure artist (15s mirror timeout). This is the gate the unit/contract tests can't cover (resolver matrix + siblings depend on live mirror-helper output).
- **Watch:** `cratedigger-web` request latency / any wedge after opening the view on the live ~820-row cohort; `journalctl -u cratedigger-web`. **Healthy:** view loads in low-hundreds-of-ms. **Rollback trigger:** the worklist read visibly stalls other routes — fall back by reverting; the ~1,500-row pagination ceiling is the documented next lever.
- No migrations, no `album_requests.status` writes, no importer/beets changes — Meelo/Plex unaffected.

### Known follow-ups (non-blocking, from review)

- After a set-intent/re-search single-row refetch, the cached row loses the console-stamped `mb_release_group_id` (self-heals on next console open; accept-sibling isn't visible while the console is closed).
- `pickYoutubeRescue` lacks an entry-level double-fire guard (a rapid double-click leaks a never-settling confirm promise; harmless to data).
- Typing in the band search re-renders the list and collapses an open console.
- `longTailSetIntent` is a thin parallel path to `library.js::setIntent` (same endpoint); worth unifying via an optional refetch callback.
- `renderPeersBody` renders `renderForensicBlock` twice (duplicate `p-forensic-block` DOM id; works via `parentElement`).

> Merge via **Create a merge commit** (repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
