### PR TITLE
fix(pipeline_db): harden _atomic / _execute error paths (#395)

### DIFF
--- a/lib/pipeline_db/_core.py
+++ b/lib/pipeline_db/_core.py
@@ -85,6 +85,17 @@ class _CoreMixin(_PipelineDBBase):
             # connection open — re-raise those so the caller sees them.
             if not self.conn.closed:
                 raise
+            # The reconnect below returns a fresh ``autocommit=True``
+            # connection (see ``_connect``). That heal is only safe OUTSIDE a
+            # transaction. If we are mid-transaction (``autocommit=False`` —
+            # i.e. called inside ``with self._atomic():``), silently swapping
+            # to a fresh connection would drop the in-flight transaction's
+            # partial writes onto a connection that doesn't know it is
+            # supposed to be in a transaction. Re-raise so ``_atomic`` sees
+            # the error and rolls back. (Latent today — no ``_atomic`` body
+            # calls ``_execute`` — but nothing else enforces the invariant.)
+            if not self.conn.autocommit:
+                raise
             self.conn = self._connect()
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
             if params:
@@ -157,14 +168,23 @@ class _CoreMixin(_PipelineDBBase):
 
         Contract: the **caller commits explicitly** inside the block (every
         site already does, exactly once on its success path). On any exception
-        the transaction is rolled back and re-raised; the prior autocommit
-        mode is ALWAYS restored on the way out. Because the body commits
-        (success) or this rolls back (failure) before the ``finally``,
+        the transaction is rolled back and the ORIGINAL exception is re-raised;
+        the prior autocommit mode is restored on the way out. Because the body
+        commits (success) or this rolls back (failure) before the ``finally``,
         autocommit is only ever restored with no transaction in flight —
         matching the original per-method ordering. A caller that needs to
         abort with no writes may ``rollback()`` and return early inside the
         block (``abandon_auto_import_request`` does this); that path is
         preserved unchanged.
+
+        Dead-connection error paths (issue #395): if the connection died
+        mid-transaction (or the caller's ``commit()`` raised), both the
+        ``rollback()`` and the autocommit-restore raise a *secondary*
+        ``InterfaceError``. Both are wrapped so the secondary error can never
+        mask the original — the same shape as ``advisory_lock``'s unlock
+        guard. A dead connection that fails to restore autocommit is harmless:
+        the next ``_ensure_conn`` reconnects with a fresh ``autocommit=True``
+        connection.
 
         Yields the live connection for convenience; callers continue to use
         ``self.conn`` directly.
@@ -175,7 +195,28 @@ class _CoreMixin(_PipelineDBBase):
         try:
             yield self.conn
         except Exception:
-            self.conn.rollback()  # discard partial writes; re-raise to caller
-            raise
+            # The connection may have died mid-transaction (or the caller's
+            # ``commit()`` itself raised). ``rollback()`` on a dead connection
+            # raises a *secondary* ``InterfaceError`` that would replace the
+            # original error the caller must see. Swallow it — same shape as
+            # ``advisory_lock``'s unlock guard.
+            try:
+                self.conn.rollback()  # discard partial writes
+            except Exception:  # noqa: BLE001 — never mask the original error
+                logger.debug(
+                    "rollback failed during _atomic (connection likely "
+                    "dead); original error propagates")
+            raise  # re-raise the ORIGINAL exception to the caller
         finally:
-            self.conn.autocommit = old_autocommit  # restore one-statement mode
+            # Restoring autocommit on a dead connection ALSO raises
+            # ``InterfaceError``, and from a ``finally`` block that would
+            # re-mask the original error. Guard it the same way; the next
+            # ``_ensure_conn`` reconnects with a fresh ``autocommit=True``
+            # connection regardless of whether this restore landed.
+            try:
+                self.conn.autocommit = old_autocommit  # restore one-stmt mode
+            except Exception:  # noqa: BLE001 — never mask the original error
+                logger.debug(
+                    "autocommit restore failed during _atomic (connection "
+                    "likely dead); a fresh connection will be established on "
+                    "next use")

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
+import psycopg2
+
 # Bootstrap ephemeral PostgreSQL if available
 sys.path.insert(0, os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
@@ -7963,6 +7965,137 @@ class TestYoutubeIngestDownloadLog(unittest.TestCase):
         batch = self.db.get_download_history_batch([self.request_id])
         rows = batch[self.request_id]
         self.assertEqual({r["source"] for r in rows}, {"slskd", "youtube"})
+
+
+def _terminate_backend(dsn, pid):
+    """Kill a PostgreSQL backend from a *second* session so the next statement
+    on the original connection dies mid-flight (``conn.closed`` flips truthy).
+
+    This is the real "server closed the socket unexpectedly" failure mode the
+    ``_execute`` reconnect branch and the ``_atomic`` rollback handler must
+    survive — reproduced deterministically instead of via a fake socket.
+    """
+    killer = psycopg2.connect(dsn)
+    killer.autocommit = True
+    try:
+        with killer.cursor() as cur:
+            cur.execute("SELECT pg_terminate_backend(%s)", (pid,))
+            cur.fetchone()
+    finally:
+        killer.close()
+
+
+@requires_postgres
+class TestAtomicAndExecuteHardening(unittest.TestCase):
+    """Issue #395 — error-path hardening for the shared transaction
+    primitives in ``lib/pipeline_db/_core.py``, exercised against real PG.
+
+    Item 1: ``_execute`` must NOT silently reconnect onto a fresh
+    ``autocommit=True`` connection when it dies mid-statement *inside* a
+    transaction (``autocommit=False``) — that would drop the in-flight
+    transaction's partial writes. It must re-raise so ``_atomic`` rolls back.
+    Outside a transaction the reconnect-and-retry heal must still fire.
+
+    Item 2: when the connection is dead, both ``rollback()`` and the
+    autocommit-restore in ``_atomic``'s ``finally`` raise a *secondary*
+    ``InterfaceError``. Neither may mask the ORIGINAL exception the caller
+    should see.
+    """
+
+    @staticmethod
+    def _backend_pid(db):
+        with db.conn.cursor() as cur:
+            cur.execute("SELECT pg_backend_pid()")
+            return cur.fetchone()[0]
+
+    def test_execute_inside_transaction_reraises_instead_of_reconnecting(self):
+        """Item 1 guard: a mid-statement socket death while ``autocommit=False``
+        re-raises and leaves the connection object untouched — no silent swap
+        to a fresh autocommit=True connection that would lose the transaction.
+        """
+        db = make_db()
+        self.addCleanup(db.close)
+        original_conn = db.conn
+        # Simulate being inside `with self._atomic():` — explicit transaction.
+        db.conn.autocommit = False
+        pid = self._backend_pid(db)  # also opens the transaction
+        _terminate_backend(db.dsn, pid)
+        with self.assertRaises((psycopg2.OperationalError, psycopg2.InterfaceError)):
+            db._execute("SELECT 1")
+        # The guard held: _execute did NOT reconnect.
+        self.assertIs(db.conn, original_conn)
+
+    def test_execute_reconnects_outside_transaction(self):
+        """Item 1 scope check: outside a transaction (``autocommit=True``) a
+        dead socket must still heal via reconnect-and-retry. The guard is
+        scoped to ``autocommit=False`` only and must not regress this — the
+        live failure mode the reconnect branch exists for.
+        """
+        db = make_db()
+        self.addCleanup(db.close)
+        original_conn = db.conn
+        self.assertTrue(db.conn.autocommit)
+        pid = self._backend_pid(db)
+        _terminate_backend(db.dsn, pid)
+        cur = db._execute("SELECT 1 AS one")
+        self.assertEqual(cur.fetchone()["one"], 1)
+        self.assertIsNot(db.conn, original_conn)  # reconnected
+        self.assertTrue(db.conn.autocommit)
+
+    def test_atomic_rollback_failure_preserves_original_exception(self):
+        """Item 2: a dead connection makes both ``rollback()`` and the
+        autocommit-restore raise ``InterfaceError``. The ORIGINAL exception
+        from the block body must still propagate.
+        """
+        db = make_db()
+        self.addCleanup(db.close)
+
+        class _Boom(Exception):
+            pass
+
+        with self.assertRaises(_Boom):
+            with db._atomic():
+                # Kill the connection so BOTH rollback() (except handler) and
+                # autocommit-restore (finally) raise a secondary InterfaceError.
+                db.conn.close()
+                raise _Boom("the real failure the operator must see")
+
+    def test_atomic_commit_failure_propagates_commit_error(self):
+        """Item 2: when the caller's ``commit()`` raises ``OperationalError``
+        because the backend died, that commit error propagates — not a
+        secondary ``InterfaceError`` from the guarded rollback / restore.
+        (``InterfaceError`` is a sibling of ``OperationalError``, so a leak
+        would fail this assertion.)
+        """
+        db = make_db()
+        self.addCleanup(db.close)
+        with self.assertRaises(psycopg2.OperationalError):
+            with db._atomic():
+                pid = self._backend_pid(db)
+                _terminate_backend(db.dsn, pid)
+                db.conn.commit()  # backend gone -> raises OperationalError
+
+    def test_atomic_happy_path_commits_and_restores_autocommit(self):
+        """No behaviour change on the happy path: flip to ``autocommit=False``
+        for the block, caller commits, autocommit is restored, write persists.
+        """
+        db = make_db()
+        self.addCleanup(db.close)
+        self.assertTrue(db.conn.autocommit)
+        rid = db.add_request(
+            artist_name="Atomic", album_title="Happy Path", source="request")
+        with db._atomic():
+            self.assertFalse(db.conn.autocommit)  # flipped for the block
+            with db.conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE album_requests SET reasoning = %s WHERE id = %s",
+                    ("atomic-write", rid),
+                )
+            db.conn.commit()
+        self.assertTrue(db.conn.autocommit)  # restored
+        row = db.get_request(rid)
+        assert row is not None
+        self.assertEqual(row["reasoning"], "atomic-write")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #395.

## What

Two pre-existing latent reliability gaps in the shared PostgreSQL transaction primitives (`lib/pipeline_db/_core.py`), surfaced by the ce-code-review pass on #379/#382. Neither was introduced by those PRs — `_atomic` faithfully preserved main's hand-rolled flip blocks — this is the focused hardening follow-up.

**Item 1 — `_execute` reconnect now guards the transactional case.** The reconnect branch returns a fresh `autocommit=True` connection, which is only safe *outside* a transaction. If `_execute` were ever called inside `with self._atomic():` (`autocommit=False`), a mid-statement socket death would silently swap in a fresh connection and drop the in-flight transaction's partial writes. Now re-raises when `autocommit=False` so `_atomic` sees the error and rolls back. Latent today (no `_atomic` body calls `_execute` — verified across all 10 call sites) but nothing else enforced the invariant.

**Item 2 — `_atomic` no longer lets a dead-connection rollback mask the original exception.** On a dead connection, **both** `rollback()` *and* the `finally`'s autocommit-restore raise a secondary `InterfaceError`. The issue proposed guarding only `rollback()`; a real-PG reproduction proved the unguarded `finally` re-masks the original error, so **both** are now wrapped (same shape as `advisory_lock`'s unlock guard). A failed restore is harmless — the next `_ensure_conn` reconnects with a fresh `autocommit=True` connection.

## Tests

New `TestAtomicAndExecuteHardening` in `tests/test_pipeline_db.py`, against real ephemeral PG, deterministic via `pg_terminate_backend`:
- `_execute` inside a transaction re-raises, does not reconnect
- `_execute` outside a transaction still heals (guard scoped correctly)
- `_atomic` dead-conn rollback preserves the original exception
- `_atomic` commit-failure propagates the commit error, not the secondary `InterfaceError`
- `_atomic` happy path commits + restores autocommit (no behaviour change)

All RED→GREEN verified. Full suite: 4284 tests OK, 0 skipped. Pyright: 0 errors.

Scope held to `_core.py` only; forward-only; no happy-path behaviour change. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)