### PR TITLE
fix(coverage): match the deployed store path so prod collection works

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,9 +18,16 @@ branch = True
 # The oneshot timer doesn't need this — atexit already covers it.
 sigterm = True
 # Production systemd units run with WorkingDirectory=stateDir while the Python
-# source lives under /nix/store/<hash>-source. Use include globs instead of
-# source=. so coverage tracks the packaged source rather than the mutable state
-# directory. The local repo glob keeps test-suite coverage comparable.
+# source lives in the Nix store. Use include globs instead of source=. so
+# coverage tracks the packaged source rather than the mutable state directory.
+# The local repo glob keeps test-suite coverage comparable.
+#
+# The store-path NAME is owned by the downstream nixosconfig wrapper, which
+# renames the flake input (currently `cratedigger-src-group-permissions`).
+# Anchor on the bare substring `cratedigger` — anything tighter has already
+# broken collection twice (see tests/test_coverage_config.py, which pins the
+# real deployed shape). `/nix/store/*-source/*` covers the unrenamed
+# flake-input convention.
 #
 # Don't track the test suite itself — that conflates "test runs" with "real code
 # paths." The whole point of the prod-vs-test diff is to find code only tests
@@ -28,7 +35,7 @@ sigterm = True
 include =
     */cratedigger/*
     /nix/store/*-source/*
-    /nix/store/*-cratedigger-src/*
+    /nix/store/*cratedigger*/*
 omit =
     tests/*
     */tests/*
@@ -66,12 +73,16 @@ output = build/coverage.xml
 # files.
 #
 # coverage 7.x rejects patterns ending in a bare wildcard, so each entry
-# anchors on a concrete suffix. The flake builds cratedigger into a Nix
-# store path ending in `-source` (the convention for `src = ./.;` paths);
-# `*-cratedigger*` covers any future renames. The first line — `.` — is
-# the canonical prefix; everything else gets rewritten to it.
+# anchors on a concrete suffix — which means the deployed store-path name
+# (owned by the nixosconfig wrapper, which renames the flake input) must be
+# spelled out exactly here. If the wrapper renames the derivation, this entry
+# AND tests/test_coverage_config.py::DEPLOYED_SRC must follow; the harvest
+# guard in scripts/coverage_report.sh (combined file with 0 measured files
+# fails loudly) is the runtime backstop. `/nix/store/*-source` covers the
+# unrenamed `src = ./.;` convention. The first line — `.` — is the canonical
+# prefix; everything else gets rewritten to it.
 source =
     .
     /nix/store/*-source
-    /nix/store/*-cratedigger-src
+    /nix/store/*-cratedigger-src-group-permissions
     /home/*/cratedigger

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -57,7 +57,28 @@ else
   exit 1
 fi
 
-echo "=== coverage report ==="
+# Guard against silently-empty collection. Twice now (2026-05-28 source=.,
+# 2026-06-11 include globs missing the renamed store path) production wrote
+# thousands of shards that tracked zero files — combine "succeeds" and the
+# report is just empty. A harvest with no measured files is always a
+# collection bug, never a real signal; fail loudly so it gets fixed instead
+# of feeding an all-test-only diff into dead-code decisions.
+MEASURED=$(python3 - "$DEST_DIR/.coverage" <<'PY'
+import sys
+from coverage import CoverageData
+data = CoverageData(sys.argv[1])
+data.read()
+print(len(data.measured_files()))
+PY
+)
+if [[ "$MEASURED" -eq 0 ]]; then
+  echo "ERROR: combined coverage data measures 0 files — collection is broken." >&2
+  echo "Check that .coveragerc include globs match the deployed store path" >&2
+  echo "(see tests/test_coverage_config.py) and that COVERAGE_PROCESS_START" >&2
+  echo "points at the same rcfile." >&2
+  exit 1
+fi
+echo "=== coverage report ($MEASURED files measured) ==="
 coverage report --rcfile=.coveragerc --data-file="$DEST_DIR/.coverage" || true
 echo
 

--- a/tests/test_coverage_config.py
+++ b/tests/test_coverage_config.py
@@ -1,0 +1,105 @@
+"""Guard .coveragerc against the deployed-path drift that broke prod coverage.
+
+Production services run from a Nix store path whose name is owned by the
+downstream nixosconfig wrapper — currently
+``/nix/store/<hash>-cratedigger-src-group-permissions`` (the wrapper renames
+the flake input when it patches group permissions). The include globs in
+.coveragerc are matched against that absolute path at collection time, and
+the [paths] aliases are matched against it again at ``coverage combine``
+time on the dev box.
+
+This has silently broken twice (2026-05-28: ``source = .`` vs prod CWD;
+2026-06-11: globs anchored on ``*-cratedigger-src`` missing the
+``-group-permissions`` suffix — two weeks of empty shards). Both failures
+were invisible: coverage runs happily and writes data files that track zero
+files. These tests pin the contract with coverage.py's own matchers so a
+rename that escapes the globs fails the suite instead of the deploy.
+"""
+
+import configparser
+import unittest
+from pathlib import Path
+
+from coverage.files import GlobMatcher, PathAliases
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Real production store path as deployed on doc2 (hash is illustrative; the
+# name shape — flake input renamed by the nixosconfig wrapper — is the part
+# under test). If the wrapper renames the derivation again, update this AND
+# make sure .coveragerc still matches it.
+DEPLOYED_SRC = (
+    "/nix/store/blqiv3zg77zklql3zm5vczqi32vckdww-cratedigger-src-group-permissions"
+)
+# The unrenamed flake-input shape (`src = ./.;` convention) — what prod would
+# use if the downstream wrapper ever stops patching permissions.
+FLAKE_INPUT_SRC = "/nix/store/8a1k2j3h4g5f6d7s8a9p0o1i2u3y4t5r-source"
+LOCAL_SRC = str(REPO_ROOT)
+
+
+def _read_coveragerc() -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    parser.read(REPO_ROOT / ".coveragerc")
+    return parser
+
+
+def _multiline_list(value: str) -> list[str]:
+    return [line.strip() for line in value.splitlines() if line.strip()]
+
+
+class TestCoverageIncludeGlobs(unittest.TestCase):
+    """[run] include must match production source files, omit must still bite."""
+
+    def setUp(self):
+        cfg = _read_coveragerc()
+        self.include = GlobMatcher(_multiline_list(cfg["run"]["include"]))
+        self.omit = GlobMatcher(_multiline_list(cfg["run"]["omit"]))
+
+    def test_include_matches_deployed_prod_paths(self):
+        for rel in ("lib/quality.py", "web/server.py", "scripts/importer.py",
+                    "cratedigger.py", "harness/import_one.py"):
+            for root in (DEPLOYED_SRC, FLAKE_INPUT_SRC):
+                path = f"{root}/{rel}"
+                with self.subTest(path=path):
+                    self.assertTrue(
+                        self.include.match(path),
+                        f"include globs miss the production path {path} — "
+                        "prod coverage would silently collect nothing",
+                    )
+
+    def test_include_matches_local_repo_paths(self):
+        self.assertTrue(self.include.match(f"{LOCAL_SRC}/lib/quality.py"))
+
+    def test_omit_still_excludes_tests_and_site_packages(self):
+        for path in (
+            f"{DEPLOYED_SRC}/tests/test_quality_decisions.py",
+            f"{LOCAL_SRC}/tests/test_quality_decisions.py",
+            "/nix/store/abc-cratedigger-python-env/lib/python3.13/site-packages/msgspec/__init__.py",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(self.omit.match(path))
+
+
+class TestCoveragePathAliases(unittest.TestCase):
+    """[paths] must fold prod store paths onto the local repo at combine time."""
+
+    def test_deployed_paths_alias_to_canonical(self):
+        cfg = _read_coveragerc()
+        patterns = _multiline_list(cfg["paths"]["source"])
+        canonical = patterns[0]
+        aliases = PathAliases(relative=True)
+        for pattern in patterns[1:]:
+            aliases.add(pattern, canonical)
+        for root in (DEPLOYED_SRC, FLAKE_INPUT_SRC):
+            mapped = aliases.map(f"{root}/lib/quality.py")
+            with self.subTest(root=root):
+                self.assertNotEqual(
+                    mapped, f"{root}/lib/quality.py",
+                    f"[paths] aliases do not rewrite {root} — the prod-vs-test "
+                    "diff would treat prod files as a disjoint tree",
+                )
+                self.assertTrue(mapped.endswith("lib/quality.py"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Production coverage (`services.cratedigger.coverage.enable`) has been collecting **nothing** since it was enabled — every one of the ~17,400 shards on doc2 is an empty SQLite file tracking 0 measured files.

Root cause: the deployed source path is `/nix/store/<hash>-cratedigger-src-group-permissions` (the downstream nixosconfig wrapper renames the flake input when patching group permissions). The include globs from the 2026-05-28 fix anchor on `*-source/*` and `*-cratedigger-src/*` — neither matches the `-group-permissions` suffix, so coverage started, matched no files, and wrote empty shards. The May 28 smoke test passed because it ran locally, where `*/cratedigger/*` matches.

## Fix

- `[run] include` widened to `/nix/store/*cratedigger*/*` — rename-robust (verified with `coverage.files.GlobMatcher` against the live deployed path).
- `[paths]` alias pinned to the exact deployed name — coverage forbids trailing wildcards in alias patterns, so genericity is impossible there.
- **Regression test** `tests/test_coverage_config.py` pins the real deployed path shape against the rcfile using coverage.py's own `GlobMatcher`/`PathAliases`. A future derivation rename fails the suite, not the harvest.
- **Harvest guard** in `scripts/coverage_report.sh`: a combined data file measuring 0 files now exits 1 with a pointed error instead of feeding an all-test-only diff into dead-code decisions. Verified against the actual empty data from doc2.

## Why it matters

Issue #352's remaining dead-code candidates (the PipelineDB methods batch) were deferred pending prod coverage data. That data never existed. After this deploys, the collection clock actually starts.

Part of #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)