### PR TITLE
fix(wrong-matches): refresh stale candidate evidence + audit stuck skips (#271)

### DIFF
--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -68,6 +68,23 @@ FINAL_AUDIT_OUTCOMES: frozenset[str] = frozenset({
     OUTCOME_DELETE_FAILED,
 })
 
+# Issue #271: stuck-skip outcomes are persisted to the triage audit too, so
+# a row that cleanup cannot classify shows WHY in the UI instead of sitting
+# in the queue with no indication. Transient skips (active job, lock
+# contention, invalid row, operational crash) are deliberately excluded —
+# they resolve on their own and would overwrite a meaningful audit with
+# noise.
+STUCK_SKIP_AUDIT_OUTCOMES: frozenset[str] = frozenset({
+    OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
+    OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+    OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING,
+    OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE,
+    OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED,
+    OUTCOME_SKIPPED_MISSING_PATH,
+})
+
+AUDITED_OUTCOMES: frozenset[str] = FINAL_AUDIT_OUTCOMES | STUCK_SKIP_AUDIT_OUTCOMES
+
 
 class WrongMatchCleanupOutcome(msgspec.Struct, frozen=True):
     download_log_id: int
@@ -123,6 +140,7 @@ def cleanup_all_wrong_matches(
     confirm_all_wrong_matches: bool = False,
     ignore_import_job_id: int | None = None,
     cfg: Any = None,
+    preview_fn: Any = None,
 ) -> WrongMatchCleanupSummary:
     """Run cleanup over the full current Wrong Matches queue."""
     if confirm_all_wrong_matches is not True:
@@ -146,6 +164,7 @@ def cleanup_all_wrong_matches(
             download_log_id,
             ignore_import_job_id=ignore_import_job_id,
             cfg=cfg,
+            preview_fn=preview_fn,
         ))
     return _summary(results)
 
@@ -157,8 +176,13 @@ def cleanup_wrong_match(
     failed_path_hint: str | None = None,
     ignore_import_job_id: int | None = None,
     cfg: Any = None,
+    preview_fn: Any = None,
 ) -> WrongMatchCleanupOutcome:
-    """Evaluate and possibly delete one Wrong Matches source row."""
+    """Evaluate and possibly delete one Wrong Matches source row.
+
+    ``preview_fn`` is the DI seam for the stale-evidence refresh (issue
+    #271); production resolves it to ``preview_import_from_path``.
+    """
     try:
         result = _cleanup_wrong_match(
             db,
@@ -166,6 +190,7 @@ def cleanup_wrong_match(
             failed_path_hint=failed_path_hint,
             ignore_import_job_id=ignore_import_job_id,
             cfg=cfg,
+            preview_fn=preview_fn,
         )
         _persist_cleanup_audit(db, result)
         return result
@@ -189,6 +214,7 @@ def _cleanup_wrong_match(
     failed_path_hint: str | None,
     ignore_import_job_id: int | None,
     cfg: Any,
+    preview_fn: Any = None,
 ) -> WrongMatchCleanupOutcome:
     entry = db.get_download_log_entry(download_log_id)
     if not entry:
@@ -256,6 +282,17 @@ def _cleanup_wrong_match(
         )
 
     candidate = _load_candidate_evidence(db, download_log_id, resolved_path)
+    if (
+        candidate.evidence is None
+        and candidate.outcome == OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE
+    ):
+        candidate = _refresh_stale_candidate_evidence(
+            db,
+            request_id=request_id,
+            download_log_id=download_log_id,
+            source_path=resolved_path,
+            preview_fn=preview_fn,
+        )
     if candidate.evidence is None:
         return _result(
             download_log_id,
@@ -554,6 +591,80 @@ def _load_candidate_evidence(
     )
 
 
+def _refresh_stale_candidate_evidence(
+    db: Any,
+    *,
+    request_id: int,
+    download_log_id: int,
+    source_path: str,
+    preview_fn: Any,
+) -> _LoadedEvidence:
+    """Re-measure a stale candidate and reload its evidence (issue #271).
+
+    Candidate evidence goes stale when slskd races the original capture —
+    a file that was still 0 bytes at measurement time completes later, or
+    the failed_imports move truncates a file after measurement. Either way
+    the snapshot no longer describes the disk, so cleanup could neither
+    classify nor surface the row. Delegating to the worker-mode preview
+    path (the one existing measure-and-persist surface) rebuilds evidence
+    from current disk truth; the reload then goes through the same
+    freshness check as any other candidate. One attempt only — a source
+    that is still churning stays a stale skip until the next sweep.
+    """
+    if preview_fn is None:
+        from lib.import_preview import preview_import_from_path
+
+        preview_fn = preview_import_from_path
+    try:
+        preview = preview_fn(
+            db,
+            request_id=request_id,
+            path=source_path,
+            download_log_id=download_log_id,
+            worker_mode=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "wrong_match_cleanup.evidence_refresh_crashed download_log_id=%s",
+            download_log_id,
+        )
+        return _LoadedEvidence(
+            None,
+            OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+            f"evidence_refresh_crashed: {type(exc).__name__}: {exc}",
+        )
+
+    from lib.import_preview import PREVIEW_VERDICT_EVIDENCE_READY
+
+    verdict = getattr(preview, "verdict", None)
+    if verdict != PREVIEW_VERDICT_EVIDENCE_READY:
+        detail = (
+            getattr(preview, "reason", None)
+            or getattr(preview, "detail", None)
+            or verdict
+            or "no_preview_result"
+        )
+        return _LoadedEvidence(
+            None,
+            OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+            f"evidence_refresh_failed: {detail}",
+        )
+
+    reloaded = _load_candidate_evidence(db, download_log_id, source_path)
+    if reloaded.evidence is None:
+        return _LoadedEvidence(
+            None,
+            reloaded.outcome or OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+            f"after_refresh: {reloaded.reason}",
+        )
+    logger.info(
+        "wrong_match_cleanup.evidence_refreshed download_log_id=%s path=%s",
+        download_log_id,
+        source_path,
+    )
+    return reloaded
+
+
 def _matching_active_jobs(
     db: Any,
     *,
@@ -765,7 +876,7 @@ def _persist_cleanup_audit(
     db: Any,
     result: WrongMatchCleanupOutcome,
 ) -> None:
-    if result.outcome not in FINAL_AUDIT_OUTCOMES:
+    if result.outcome not in AUDITED_OUTCOMES:
         return
     recorder = getattr(db, "record_wrong_match_triage", None)
     if not callable(recorder):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -6962,6 +6962,134 @@ class TestWrongMatchCleanupFKChainAvoidsRemeasurement(unittest.TestCase):
             _shutil.rmtree(source, ignore_errors=True)
 
 
+class TestWrongMatchStaleEvidenceRefreshSlice(unittest.TestCase):
+    """Issue #271 end-to-end: stale evidence re-measures via the REAL preview.
+
+    Drives ``cleanup_wrong_match`` with the production ``preview_fn`` default
+    (``preview_import_from_path(worker_mode=True)``) against a real temp
+    folder — no ``_RefreshStub``. Covers the live chain the unit tests fake:
+    stale snapshot → worker-mode re-measure (mp3val + ffmpeg decode gate) →
+    corrupt evidence persisted + FK re-pointed → unified decider rejects →
+    source deleted. Also pins the no-amplification property: the refresh must
+    not enqueue import jobs or write new download_log rows.
+    """
+
+    def _patch_cfg(self):
+        from lib.quality import QualityRankConfig
+        from types import SimpleNamespace as _SN
+        cfg = _SN(
+            quality_ranks=QualityRankConfig.defaults(),
+            verified_lossless_target="",
+            beets_directory="",
+            audio_check_mode="normal",
+        )
+        return patch("lib.config.read_runtime_config", return_value=cfg)
+
+    def test_stale_evidence_refreshes_through_real_preview_and_deletes(self) -> None:
+        from datetime import datetime, timezone
+        from lib.quality import (
+            AlbumQualityEvidence,
+            AlbumQualityEvidenceFile,
+            AudioQualityMeasurement,
+        )
+        from lib.quality_evidence import snapshot_fingerprint
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_DELETED,
+            cleanup_wrong_match,
+        )
+
+        root = tempfile.mkdtemp()
+        source = os.path.join(root, "failed_imports", "stale-album")
+        os.makedirs(source)
+        try:
+            # The track the original evidence describes: a real size that no
+            # longer matches disk (the #271 race — file truncated to 0 bytes
+            # after capture).
+            track = os.path.join(source, "01.mp3")
+            with open(track, "wb") as fp:
+                fp.write(b"")
+            stat = os.stat(track)
+            stale_files = [
+                AlbumQualityEvidenceFile(
+                    relative_path="01.mp3",
+                    size_bytes=13927478,
+                    mtime_ns=int(stat.st_mtime_ns),
+                    extension="mp3",
+                    container="mp3",
+                    codec="mp3",
+                ),
+            ]
+            evidence = AlbumQualityEvidence(
+                mb_release_id="mbid-1",
+                snapshot_fingerprint=snapshot_fingerprint(stale_files),
+                source_path=source,
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=245,
+                    avg_bitrate_kbps=256,
+                    median_bitrate_kbps=252,
+                    format="mp3 v0",
+                    spectral_grade="genuine",
+                ),
+                measured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                files=stale_files,
+                codec="mp3",
+                container="mp3",
+                storage_format="mp3 v0",
+                audio_file_count=1,
+                filetype_band="mp3",
+                folder_layout="flat",
+            )
+
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=1, status="manual", mb_release_id="mbid-1",
+            ))
+            db.log_download(
+                1,
+                outcome="rejected",
+                validation_result={
+                    "scenario": "wrong_match",
+                    "failed_path": source,
+                },
+            )
+            log_id = db.download_logs[-1].id
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id="mbid-1",
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_download_log_candidate_evidence(log_id, stored.id)
+            stale_evidence_id = stored.id
+
+            with self._patch_cfg():
+                result = cleanup_wrong_match(db, log_id)
+
+            # The real worker-mode preview re-measured the 0-byte file as
+            # audio_corrupt, persisted fresh evidence, and the unified
+            # decider confidently rejected → source deleted.
+            self.assertEqual(result.outcome, OUTCOME_DELETED)
+            self.assertFalse(os.path.exists(source))
+
+            # Fresh evidence row exists and the FK was re-pointed off the
+            # stale row.
+            new_evidence_id = db.get_download_log_candidate_evidence_id(log_id)
+            self.assertIsNotNone(new_evidence_id)
+            self.assertNotEqual(new_evidence_id, stale_evidence_id)
+            assert new_evidence_id is not None
+            refreshed = db.load_album_quality_evidence_by_id(new_evidence_id)
+            assert refreshed is not None
+            self.assertTrue(refreshed.audio_corrupt)
+
+            # No amplification: refresh must not enqueue import jobs or
+            # write new download_log rows.
+            self.assertEqual(db.list_import_jobs(), [])
+            self.assertEqual(len(db.download_logs), 1)
+        finally:
+            import shutil as _shutil
+            _shutil.rmtree(root, ignore_errors=True)
+
+
 class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
     """U3: AE1 end-to-end — propagate transcoded-FLAC evidence to the library
     row, then trigger ``cleanup_wrong_match`` against an identical-source FLAC

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -19,7 +19,12 @@ from lib.quality import (
     QualityRankConfig,
     VerifiedLosslessProof,
 )
-from lib.quality_evidence import snapshot_fingerprint
+from lib.import_preview import (
+    PREVIEW_VERDICT_EVIDENCE_READY,
+    PREVIEW_VERDICT_MEASUREMENT_FAILED,
+    ImportPreviewResult,
+)
+from lib.quality_evidence import snapshot_audio_files, snapshot_fingerprint
 from lib.import_evidence import (
     ActionEvidenceProvenance,
     CurrentEvidenceActionResult,
@@ -80,8 +85,10 @@ def _evidence(
     *,
     mb_release_id: str = "mbid-1",
     audio_corrupt: bool = False,
+    files: list[AlbumQualityEvidenceFile] | None = None,
 ) -> AlbumQualityEvidence:
-    files = _evidence_files(source)
+    if files is None:
+        files = _evidence_files(source)
     return AlbumQualityEvidence(
         mb_release_id=mb_release_id,
         snapshot_fingerprint=snapshot_fingerprint(files),
@@ -116,6 +123,47 @@ def _store_evidence(
     )
     assert stored is not None and stored.id is not None
     return stored.id
+
+
+class _RefreshStub:
+    """Stub for the ``preview_fn`` DI seam (issue #271 stale-evidence refresh).
+
+    Mirrors the worker-mode ``preview_import_from_path`` contract: on success
+    it persists candidate evidence and re-points the download_log FK, and it
+    returns a real ``ImportPreviewResult`` either way.
+    """
+
+    def __init__(
+        self,
+        *,
+        persist_evidence: AlbumQualityEvidence | None = None,
+        verdict: str = PREVIEW_VERDICT_EVIDENCE_READY,
+        reason: str | None = None,
+    ) -> None:
+        self.persist_evidence = persist_evidence
+        self.verdict = verdict
+        self.reason = reason
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, db, *, request_id, path, download_log_id, worker_mode):
+        self.calls.append({
+            "request_id": request_id,
+            "path": path,
+            "download_log_id": download_log_id,
+            "worker_mode": worker_mode,
+        })
+        if self.persist_evidence is not None:
+            db.set_download_log_candidate_evidence(
+                download_log_id,
+                _store_evidence(db, self.persist_evidence),
+            )
+        return ImportPreviewResult(
+            mode="path", verdict=self.verdict, reason=self.reason,
+        )
+
+
+def _refresh_stub(**kwargs) -> _RefreshStub:
+    return _RefreshStub(**kwargs)
 
 
 def _log_wrong_match(
@@ -223,6 +271,10 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
             self.db,
             confirm_all_wrong_matches=True,
             cfg=_cfg(),
+            preview_fn=_refresh_stub(
+                verdict=PREVIEW_VERDICT_MEASUREMENT_FAILED,
+                reason="snapshot_stale",
+            ),
         )
 
         self.assertEqual(summary.deleted, 1)
@@ -233,6 +285,177 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(keep_source))
         self.assertTrue(os.path.isdir(stale_source))
         self.assertTrue(os.path.isdir(missing_source))
+
+    def _make_stale_row(self, name: str) -> tuple[str, int]:
+        """Wrong-match row whose evidence predates a late-arriving file."""
+        source = _make_source(self.tmp, name)
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source)),
+        )
+        with open(os.path.join(source, "02.mp3"), "wb") as handle:
+            handle.write(b"late arrival")
+        return source, log_id
+
+    def test_stale_evidence_refreshes_then_classifies(self) -> None:
+        """Issue #271: stale candidate evidence re-measures and re-decides."""
+        source, log_id = self._make_stale_row("refresh-source")
+        fresh = _evidence(
+            source,
+            audio_corrupt=True,
+            files=snapshot_audio_files(source),
+        )
+        preview_fn = _refresh_stub(persist_evidence=fresh)
+
+        result = cleanup_wrong_match(
+            self.db, log_id, cfg=_cfg(), preview_fn=preview_fn,
+        )
+
+        self.assertEqual(result.outcome, OUTCOME_DELETED)
+        self.assertFalse(os.path.exists(source))
+        self.assertEqual(len(preview_fn.calls), 1)
+        call = preview_fn.calls[0]
+        self.assertEqual(call["request_id"], 1)
+        self.assertEqual(call["path"], source)
+        self.assertEqual(call["download_log_id"], log_id)
+        self.assertTrue(call["worker_mode"])
+
+    def test_stale_refresh_failure_keeps_stale_skip(self) -> None:
+        source, log_id = self._make_stale_row("refresh-fail-source")
+        preview_fn = _refresh_stub(
+            verdict=PREVIEW_VERDICT_MEASUREMENT_FAILED,
+            reason="materialization_error",
+        )
+
+        result = cleanup_wrong_match(
+            self.db, log_id, cfg=_cfg(), preview_fn=preview_fn,
+        )
+
+        self.assertEqual(
+            result.outcome, OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+        )
+        self.assertIn("evidence_refresh_failed", result.reason or "")
+        self.assertIn("materialization_error", result.reason or "")
+        self.assertTrue(os.path.isdir(source))
+
+    def test_stale_refresh_crash_keeps_stale_skip(self) -> None:
+        source, log_id = self._make_stale_row("refresh-crash-source")
+
+        def crashing_preview(db, **_kwargs):
+            raise RuntimeError("preview blew up")
+
+        result = cleanup_wrong_match(
+            self.db, log_id, cfg=_cfg(), preview_fn=crashing_preview,
+        )
+
+        self.assertEqual(
+            result.outcome, OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+        )
+        self.assertIn("evidence_refresh_crashed", result.reason or "")
+        self.assertTrue(os.path.isdir(source))
+
+    def test_stale_after_refresh_skips_without_looping(self) -> None:
+        """Refresh that leaves evidence stale must not retry forever."""
+        source, log_id = self._make_stale_row("still-stale-source")
+        # evidence_ready verdict but nothing persisted: reload stays stale.
+        preview_fn = _refresh_stub()
+
+        result = cleanup_wrong_match(
+            self.db, log_id, cfg=_cfg(), preview_fn=preview_fn,
+        )
+
+        self.assertEqual(
+            result.outcome, OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+        )
+        self.assertIn("after_refresh", result.reason or "")
+        self.assertEqual(len(preview_fn.calls), 1)
+        self.assertTrue(os.path.isdir(source))
+
+    def test_fresh_evidence_does_not_invoke_refresh(self) -> None:
+        source = _make_source(self.tmp, "fresh-no-refresh-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source, audio_corrupt=True)),
+        )
+        preview_fn = _refresh_stub()
+
+        result = cleanup_wrong_match(
+            self.db, log_id, cfg=_cfg(), preview_fn=preview_fn,
+        )
+
+        self.assertEqual(result.outcome, OUTCOME_DELETED)
+        self.assertEqual(preview_fn.calls, [])
+
+    def test_missing_candidate_evidence_is_not_refreshed(self) -> None:
+        """Refresh covers stale only — missing-FK rows stay manual (#271)."""
+        source = _make_source(self.tmp, "missing-no-refresh-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        preview_fn = _refresh_stub()
+
+        result = cleanup_wrong_match(
+            self.db, log_id, cfg=_cfg(), preview_fn=preview_fn,
+        )
+
+        self.assertEqual(
+            result.outcome, OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
+        )
+        self.assertEqual(preview_fn.calls, [])
+        self.assertTrue(os.path.isdir(source))
+
+    def test_stuck_skip_outcomes_persist_recents_triage_audit(self) -> None:
+        """Issue #271: stuck skips leave an audit row the UI can render."""
+        source, log_id = self._make_stale_row("audit-stale-source")
+        preview_fn = _refresh_stub(
+            verdict=PREVIEW_VERDICT_MEASUREMENT_FAILED,
+            reason="snapshot_stale",
+        )
+
+        cleanup_wrong_match(self.db, log_id, cfg=_cfg(), preview_fn=preview_fn)
+
+        by_id = {row.id: row for row in self.db.download_logs}
+        triage = by_id[log_id].validation_result["wrong_match_triage"]
+        self.assertEqual(
+            triage["outcome"], OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+        )
+        self.assertEqual(
+            triage["action"], OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
+        )
+        self.assertFalse(triage["success"])
+        self.assertIn("evidence_refresh_failed", triage["reason"])
+
+        missing_source = _make_source(self.tmp, "audit-missing-source")
+        missing_id = _log_wrong_match(self.db, 1, missing_source)
+        cleanup_wrong_match(
+            self.db, missing_id, cfg=_cfg(), preview_fn=preview_fn,
+        )
+        by_id = {row.id: row for row in self.db.download_logs}
+        triage = by_id[missing_id].validation_result["wrong_match_triage"]
+        self.assertEqual(
+            triage["outcome"], OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING,
+        )
+
+    def test_transient_skip_outcomes_do_not_persist_triage_audit(self) -> None:
+        source = _make_source(self.tmp, "audit-transient-source")
+        log_id = _log_wrong_match(self.db, 1, source)
+        self.db.set_download_log_candidate_evidence(
+            log_id,
+            _store_evidence(self.db, _evidence(source, audio_corrupt=True)),
+        )
+        self.db.enqueue_import_job(
+            "force_import",
+            request_id=1,
+            payload={"download_log_id": log_id, "failed_path": source},
+        )
+
+        result = cleanup_wrong_match(self.db, log_id, cfg=_cfg())
+
+        self.assertEqual(result.outcome, OUTCOME_SKIPPED_ACTIVE_JOB)
+        by_id = {row.id: row for row in self.db.download_logs}
+        self.assertNotIn(
+            "wrong_match_triage", by_id[log_id].validation_result,
+        )
 
     def test_final_outcomes_persist_recents_triage_audit(self) -> None:
         delete_source = _make_source(self.tmp, "audit-delete-source")
@@ -457,6 +680,9 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         self.assertEqual(summary.skipped_missing_path, 1)
         self.assertEqual(summary.results[0].outcome, OUTCOME_SKIPPED_MISSING_PATH)
         self.assertIn("failed_path", self.db.download_logs[-1].validation_result)
+        # Issue #271: missing-path skips are stuck states — audited.
+        triage = self.db.download_logs[-1].validation_result["wrong_match_triage"]
+        self.assertEqual(triage["outcome"], OUTCOME_SKIPPED_MISSING_PATH)
 
     def test_operational_failure_is_counted_at_service_layer(self) -> None:
         source = _make_source(self.tmp, "operational-source")
@@ -607,6 +833,12 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         assert result.reason is not None
         self.assertIn("RuntimeError", result.reason)
         self.assertIn("boom", result.reason)
+        # Issue #271: current-evidence skips are stuck states — audited.
+        by_id = {row.id: row for row in self.db.download_logs}
+        triage = by_id[log_id].validation_result["wrong_match_triage"]
+        self.assertEqual(
+            triage["outcome"], OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED,
+        )
 
     def test_verified_lossless_parent_short_circuits_to_deletion(self) -> None:
         """Verified-lossless current → cleanup deletes without calling the reducer."""


### PR DESCRIPTION
## What

Fixes #271 — Wrong Matches rows stuck forever on `skipped_candidate_evidence_stale`.

1. **Stale-evidence auto-refresh.** When cleanup finds the candidate evidence snapshot no longer matches disk, it re-measures through the existing worker-mode preview path (`preview_import_from_path(worker_mode=True)` — no parallel measure/persist code), reloads the fresh evidence through the same freshness check, and continues to the unified decider. One attempt per sweep; a still-churning source remains a stale skip until the next sweep. `preview_fn` is the kwarg-DI seam.
2. **Stuck skips are audited.** `skipped_candidate_evidence_{stale,missing}`, `skipped_current_evidence_{missing,stale,failed}`, and `skipped_missing_path` now write the `wrong_match_triage` audit, so the UI shows *why* a row is stuck (renders via the existing `_humanize_token` fallback — zero JS changes). Transient skips (active job, invalid row, operational) stay unaudited so they can't overwrite a meaningful verdict.

## Root cause (corrected from the issue)

Live verification on doc2 (read-only sweep with the production `audio_snapshot_matches` over all 1,066 queue rows): 1,058 fresh, 4 stale, 4 missing-FK. The issue's `failed_imports/..._N` rename hypothesis is **disproven** — all 1,058 fresh rows live under renamed `_N` paths and match fine. The actual cause is 0-byte file races: evidence captured while slskd was still writing a track (file completed later), or a track truncated to 0 bytes during the failed_imports move.

## Deliberately out of scope (operator decision)

- No refresh for rows with **no** evidence FK at all (`skipped_candidate_evidence_missing`) — they're audited now but stay manual.
- No rescue/backfill for the 4 currently-stuck rows; operator handles them by hand. (The next sweep will, however, refresh-and-classify any that remain — for the two truncated-on-disk ones that means a corrupt-evidence confident reject, consistent with existing corrupt-candidate policy.)

## Review notes

Adversarial review raised two majors, both triaged as acceptable:
- *Inline preview cost in the 5-min loop*: the post-rejection auto-triage caller is event-driven (fires once per fresh rejection, where evidence was just captured), not a queue scan — refresh fires only on a rare capture race, bounded to one preview.
- *Re-measured 0-byte source auto-deletes*: matches existing policy (corrupt candidate evidence already auto-deletes via the unified decider); adding a narrower upstream guard is explicitly forbidden by the decision-architecture rules.

## Tests

- 7 new unit tests (refresh success/failure/crash/still-stale/no-loop, fresh-path no-op, missing-FK no-refresh) + stuck-vs-transient audit coverage.
- New integration slice drives the **production** `preview_fn` default end-to-end against a real 0-byte source (real mp3val/ffmpeg decode gate → corrupt evidence persisted → FK re-pointed → confident reject → delete) and pins no-amplification (no jobs enqueued, no new download_log rows).
- Full suite: 4,298 tests OK. Pyright: 0 errors full-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)