### PR TITLE
feat(web): run bulk wrong-match triage on a background thread

### DIFF
--- a/lib/pipeline_db/_core.py
+++ b/lib/pipeline_db/_core.py
@@ -116,9 +116,12 @@ class _CoreMixin(_PipelineDBBase):
         same ``(namespace, key)`` pair across different DB sessions — e.g.
         two ``pipeline-cli force-import`` invocations racing on the same
         ``request_id`` (issue #92). Advisory locks are reentrant within a
-        single session, so this only protects against inter-session races;
-        the web server (single-threaded ``HTTPServer``) already serialises
-        within its own session.
+        single session, so this only protects against inter-session races.
+        The web server's request thread and its background bulk-triage
+        sweep thread (``web/triage_runner.py``) each hold their OWN
+        connection/session — cross-thread serialisation in that process
+        depends on never sharing a ``PipelineDB`` connection between
+        threads (``web/server.py::_new_db``).
 
         See ``docs/advisory-locks.md`` for namespaces, keys, ordering,
         and call-site index.

--- a/tests/test_js_wrong_matches.mjs
+++ b/tests/test_js_wrong_matches.mjs
@@ -428,33 +428,51 @@ console.log('bulkTriageWrongMatches() posts full-queue confirmation and refreshe
   assert(dom.wrongMatches.innerHTML.includes('Cleanup Wrong Matches (3)'), 'renders full-queue cleanup button');
   const calls = [];
   globalThis.confirm = () => true;
+  // The sweep runs server-side on a background thread; the client polls.
+  // Collapse the poll delay so the test doesn't sleep for real.
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (fn) => { fn(); return 0; };
   globalThis.fetch = async (url, options = {}) => {
     calls.push({ url, options });
     if (url === '/api/wrong-matches/triage') {
       return {
         ok: true,
+        status: 202,
+        json: async () => ({ status: 'started', state: 'running' }),
+      };
+    }
+    if (url === '/api/wrong-matches/triage/status') {
+      return {
+        ok: true,
+        status: 200,
         json: async () => ({
-          status: 'ok',
-          processed: 3,
-          deleted: 2,
-          kept_would_import: 1,
-          kept_uncertain: 0,
-          skipped_candidate_evidence_missing: 0,
-          skipped_candidate_evidence_stale: 0,
-          skipped_current_evidence_missing: 0,
-          skipped_current_evidence_stale: 0,
-          skipped_active_job: 0,
-          skipped_invalid_row: 0,
-          skipped_missing_path: 0,
-          skipped_operational: 0,
-          delete_failed: 0,
-          results: [],
+          state: 'completed',
+          started_at: '2026-06-11T00:00:00+00:00',
+          finished_at: '2026-06-11T00:01:00+00:00',
+          error: null,
+          summary: {
+            processed: 3,
+            deleted: 2,
+            kept_would_import: 1,
+            kept_uncertain: 0,
+            skipped_candidate_evidence_missing: 0,
+            skipped_candidate_evidence_stale: 0,
+            skipped_current_evidence_missing: 0,
+            skipped_current_evidence_stale: 0,
+            skipped_active_job: 0,
+            skipped_invalid_row: 0,
+            skipped_missing_path: 0,
+            skipped_operational: 0,
+            delete_failed: 0,
+            results: [],
+          },
         }),
       };
     }
     if (url === '/api/wrong-matches') {
       return {
         ok: true,
+        status: 200,
         json: async () => ({ groups: [] }),
       };
     }
@@ -468,9 +486,102 @@ console.log('bulkTriageWrongMatches() posts full-queue confirmation and refreshe
     { confirm_all_wrong_matches: true },
     'posts explicit full-queue confirmation',
   );
+  assert(calls.some(call => call.url === '/api/wrong-matches/triage/status'),
+    'polls the background sweep status');
   assert(calls.some(call => call.url === '/api/wrong-matches'), 'refetches the full pane after cleanup');
   assert(dom.toast.textContent.includes('Deleted 2 candidates'), 'toasts cleanup result');
   assert(dom.wrongMatches.innerHTML.includes('No wrong matches'), 'renders refreshed empty state');
+  globalThis.setTimeout = realSetTimeout;
+}
+
+console.log('bulkTriageWrongMatches() handles a restart-lost sweep as partial, not failed');
+{
+  installStorage();
+  const dom = installDom();
+  const data = wrongMatchesData();
+  __test__.renderWrongMatches(data, dom.wrongMatches);
+  globalThis.confirm = () => true;
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (fn) => { fn(); return 0; };
+  globalThis.fetch = async (url, _options = {}) => {
+    if (url === '/api/wrong-matches/triage') {
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({ status: 'started', state: 'running' }),
+      };
+    }
+    if (url === '/api/wrong-matches/triage/status') {
+      // Web service restarted mid-sweep: fresh runner reports idle.
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          state: 'idle',
+          started_at: null,
+          finished_at: null,
+          error: null,
+          summary: null,
+        }),
+      };
+    }
+    if (url === '/api/wrong-matches') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ groups: [] }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const btn = { disabled: true, textContent: 'Cleaning...', style: {} };
+  await __test__.bulkTriageWrongMatches(btn);
+  assertEqual(btn.disabled, false, 'restart-lost sweep restores button enabled');
+  assert(dom.toast.textContent.includes('status lost'), 'restart-lost sweep explains the lost status');
+  assert(!dom.toast.textContent.includes('failed'), 'restart-lost sweep is not reported as failed');
+  assert(dom.wrongMatches.innerHTML.includes('No wrong matches'), 'restart-lost sweep still refreshes the pane');
+  globalThis.setTimeout = realSetTimeout;
+}
+
+console.log('bulkTriageWrongMatches() surfaces a failed sweep and restores the button');
+{
+  installStorage();
+  const dom = installDom();
+  const data = wrongMatchesData();
+  __test__.renderWrongMatches(data, dom.wrongMatches);
+  globalThis.confirm = () => true;
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (fn) => { fn(); return 0; };
+  globalThis.fetch = async (url, _options = {}) => {
+    if (url === '/api/wrong-matches/triage') {
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({ status: 'started', state: 'running' }),
+      };
+    }
+    if (url === '/api/wrong-matches/triage/status') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          state: 'failed',
+          started_at: '2026-06-11T00:00:00+00:00',
+          finished_at: '2026-06-11T00:01:00+00:00',
+          error: 'RuntimeError: sweep blew up',
+          summary: null,
+        }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const btn = { disabled: true, textContent: 'Cleaning...', style: {} };
+  await __test__.bulkTriageWrongMatches(btn);
+  assertEqual(btn.disabled, false, 'failed sweep restores button enabled');
+  assertEqual(btn.textContent, 'Cleanup Wrong Matches (3)', 'failed sweep restores button text');
+  assert(dom.toast.textContent.includes('sweep blew up'), 'failed sweep toasts the error');
+  assertEqual(dom.toast.className, 'toast error', 'failed sweep shows error toast');
+  globalThis.setTimeout = realSetTimeout;
 }
 
 console.log('formatEntryEvidence() formats spectral and lossless-source V0 cells');

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -154,6 +154,19 @@ class _WebServerCase(unittest.TestCase):
             return e.code, json.loads(e.read())
 
 
+def _fresh_triage_runner(case: unittest.TestCase):
+    """Swap in a fresh runner so triage tests don't share sweep state."""
+    from web import triage_runner as triage_runner_module
+    from web.routes import imports as imports_module
+    previous = imports_module._triage_runner
+    runner = triage_runner_module.TriageRunner()
+    imports_module._triage_runner = runner
+    case.addCleanup(
+        setattr, imports_module, "_triage_runner", previous,
+    )
+    return runner
+
+
 def _pipeline_db_test_harness(fake: "FakePipelineDB | None" = None) -> MagicMock:
     """Build the contract-test pipeline-DB harness.
 
@@ -1131,6 +1144,7 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/wrong-matches/delete-group",
         "/api/wrong-matches/converge",
         "/api/wrong-matches/triage",
+        "/api/wrong-matches/triage/status",
         "/api/wrong-matches/explorer",
         # U17: /api/triage HTTP endpoints. Per-request composition and
         # cohort listing both wrap ``lib.triage_service`` (U15) — same
@@ -1404,14 +1418,17 @@ class TestPipelineRouteContracts(_WebServerCase):
         "mode", "verdict", "would_import", "confident_reject", "uncertain",
         "cleanup_eligible", "decision", "reason", "stage_chain",
     }
-    WRONG_MATCH_TRIAGE_REQUIRED_FIELDS = {
-        "status", "processed", "deleted", "deleted_verified_lossless_parent",
+    WRONG_MATCH_TRIAGE_SUMMARY_REQUIRED_FIELDS = {
+        "processed", "deleted", "deleted_verified_lossless_parent",
         "kept_would_import", "kept_uncertain",
         "skipped_candidate_evidence_missing", "skipped_candidate_evidence_stale",
         "skipped_current_evidence_missing", "skipped_current_evidence_stale",
         "skipped_current_evidence_failed",
         "skipped_active_job", "skipped_invalid_row", "skipped_missing_path",
         "skipped_operational", "delete_failed", "results",
+    }
+    WRONG_MATCH_TRIAGE_STATUS_REQUIRED_FIELDS = {
+        "state", "started_at", "finished_at", "summary", "error",
     }
     IMPORT_JOB_REQUIRED_FIELDS = {
         "id", "job_type", "status", "request_id", "dedupe_key", "payload",
@@ -2071,8 +2088,9 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.assertIn("error", data)
 
     @patch("web.routes.imports.cleanup_all_wrong_matches")
-    def test_wrong_match_triage_contract(self, mock_cleanup):
+    def test_wrong_match_triage_starts_background_sweep(self, mock_cleanup):
         from lib.wrong_match_cleanup_service import WrongMatchCleanupSummary
+        runner = _fresh_triage_runner(self)
         mock_cleanup.return_value = WrongMatchCleanupSummary(
             processed=2,
             deleted=1,
@@ -2082,19 +2100,83 @@ class TestPipelineRouteContracts(_WebServerCase):
             "confirm_all_wrong_matches": True,
         })
 
-        self.assertEqual(status, 200)
-        _assert_required_fields(self, data, self.WRONG_MATCH_TRIAGE_REQUIRED_FIELDS,
-                                "wrong match triage response")
+        # Issue: bulk triage must not hold the single server thread — the
+        # POST returns immediately and the sweep runs on a background thread.
+        self.assertEqual(status, 202)
+        self.assertEqual(data["status"], "started")
+        self.assertEqual(data["state"], "running")
+
+        runner.join(timeout=5)
         mock_cleanup.assert_called_once_with(
             self.mock_db,
             confirm_all_wrong_matches=True,
         )
-        self.assertEqual(data["status"], "ok")
-        self.assertEqual(data["processed"], 2)
-        self.assertEqual(data["deleted"], 1)
+
+        status, data = self._get("/api/wrong-matches/triage/status")
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.WRONG_MATCH_TRIAGE_STATUS_REQUIRED_FIELDS,
+            "wrong match triage status response")
+        self.assertEqual(data["state"], "completed")
+        self.assertIsNone(data["error"])
+        _assert_required_fields(
+            self, data["summary"],
+            self.WRONG_MATCH_TRIAGE_SUMMARY_REQUIRED_FIELDS,
+            "wrong match triage summary")
+        self.assertEqual(data["summary"]["processed"], 2)
+        self.assertEqual(data["summary"]["deleted"], 1)
+
+    @patch("web.routes.imports.cleanup_all_wrong_matches")
+    def test_wrong_match_triage_rejects_concurrent_sweep(self, mock_cleanup):
+        import threading
+
+        from lib.wrong_match_cleanup_service import WrongMatchCleanupSummary
+        runner = _fresh_triage_runner(self)
+        release = threading.Event()
+        entered = threading.Event()
+
+        def slow_cleanup(db, *, confirm_all_wrong_matches):
+            entered.set()
+            release.wait(timeout=5)
+            return WrongMatchCleanupSummary(processed=0)
+
+        mock_cleanup.side_effect = slow_cleanup
+
+        status, data = self._post("/api/wrong-matches/triage", {
+            "confirm_all_wrong_matches": True,
+        })
+        self.assertEqual(status, 202)
+        self.assertTrue(entered.wait(timeout=5))
+
+        status, data = self._post("/api/wrong-matches/triage", {
+            "confirm_all_wrong_matches": True,
+        })
+        self.assertEqual(status, 409)
+        self.assertIn("already running", data["error"])
+
+        status, data = self._get("/api/wrong-matches/triage/status")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["state"], "running")
+        self.assertIsNone(data["summary"])
+
+        release.set()
+        runner.join(timeout=5)
+
+    def test_wrong_match_triage_status_idle_contract(self):
+        _fresh_triage_runner(self)
+        status, data = self._get("/api/wrong-matches/triage/status")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.WRONG_MATCH_TRIAGE_STATUS_REQUIRED_FIELDS,
+            "wrong match triage status response")
+        self.assertEqual(data["state"], "idle")
+        self.assertIsNone(data["summary"])
+        self.assertIsNone(data["error"])
 
     @patch("web.routes.imports.cleanup_all_wrong_matches")
     def test_wrong_match_triage_requires_full_queue_confirmation(self, mock_cleanup):
+        _fresh_triage_runner(self)
         status, data = self._post("/api/wrong-matches/triage", {})
 
         self.assertEqual(status, 400)
@@ -8658,6 +8740,7 @@ class TestWrongMatchesContract(unittest.TestCase):
     def test_bulk_triage_runs_full_wrong_matches_queue(self, mock_cleanup):
         from lib.wrong_match_cleanup_service import WrongMatchCleanupSummary
 
+        runner = _fresh_triage_runner(self)
         mock_cleanup.return_value = WrongMatchCleanupSummary(
             processed=3,
             deleted=2,
@@ -8669,14 +8752,20 @@ class TestWrongMatchesContract(unittest.TestCase):
             {"confirm_all_wrong_matches": True},
         )
 
-        self.assertEqual(status, 200)
-        self.assertEqual(data["status"], "ok")
-        self.assertEqual(data["processed"], 3)
-        self.assertEqual(data["deleted"], 2)
+        self.assertEqual(status, 202)
+        self.assertEqual(data["status"], "started")
+
+        runner.join(timeout=5)
         mock_cleanup.assert_called_once_with(
             self.mock_db,
             confirm_all_wrong_matches=True,
         )
+
+        status, data = self._get("/api/wrong-matches/triage/status")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["state"], "completed")
+        self.assertEqual(data["summary"]["processed"], 3)
+        self.assertEqual(data["summary"]["deleted"], 2)
 
     def test_groups_in_beets_still_shown(self):
         """Wrong matches still appear when the release is already in the library."""

--- a/tests/test_web_triage_runner.py
+++ b/tests/test_web_triage_runner.py
@@ -1,0 +1,134 @@
+"""Tests for the background Wrong Matches bulk-triage runner."""
+
+from __future__ import annotations
+
+import threading
+import unittest
+
+from lib.wrong_match_cleanup_service import WrongMatchCleanupSummary
+from web.triage_runner import (
+    STATE_COMPLETED,
+    STATE_FAILED,
+    STATE_IDLE,
+    STATE_RUNNING,
+    TriageRunner,
+)
+
+
+class _ClosableDB:
+    """Minimal sweep-DB stand-in recording close() calls."""
+
+    def __init__(self) -> None:
+        self.closed = 0
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+class TriageRunnerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = TriageRunner()
+        self.db = _ClosableDB()
+
+    def _factory(self):
+        return self.db
+
+    def test_initial_status_is_idle(self) -> None:
+        status = self.runner.status()
+        self.assertEqual(status["state"], STATE_IDLE)
+        self.assertIsNone(status["started_at"])
+        self.assertIsNone(status["finished_at"])
+        self.assertIsNone(status["summary"])
+        self.assertIsNone(status["error"])
+
+    def test_start_runs_cleanup_to_completion(self) -> None:
+        seen: dict[str, object] = {}
+
+        def cleanup_fn(db, *, confirm_all_wrong_matches):
+            seen["db"] = db
+            seen["confirm"] = confirm_all_wrong_matches
+            return WrongMatchCleanupSummary(processed=3, deleted=2,
+                                            kept_uncertain=1)
+
+        started = self.runner.start(
+            db_factory=self._factory, cleanup_fn=cleanup_fn,
+        )
+        self.assertTrue(started)
+        self.runner.join(timeout=5)
+
+        status = self.runner.status()
+        self.assertEqual(status["state"], STATE_COMPLETED)
+        self.assertIsNotNone(status["started_at"])
+        self.assertIsNotNone(status["finished_at"])
+        self.assertIsNone(status["error"])
+        summary = status["summary"]
+        assert isinstance(summary, dict)
+        self.assertEqual(summary["processed"], 3)
+        self.assertEqual(summary["deleted"], 2)
+        self.assertIs(seen["db"], self.db)
+        self.assertTrue(seen["confirm"])
+        self.assertEqual(self.db.closed, 1)
+
+    def test_second_start_rejected_while_running(self) -> None:
+        release = threading.Event()
+        entered = threading.Event()
+
+        def cleanup_fn(db, *, confirm_all_wrong_matches):
+            entered.set()
+            release.wait(timeout=5)
+            return WrongMatchCleanupSummary(processed=0)
+
+        self.assertTrue(self.runner.start(
+            db_factory=self._factory, cleanup_fn=cleanup_fn,
+        ))
+        self.assertTrue(entered.wait(timeout=5))
+        self.assertEqual(self.runner.status()["state"], STATE_RUNNING)
+        self.assertFalse(self.runner.start(
+            db_factory=self._factory, cleanup_fn=cleanup_fn,
+        ))
+
+        release.set()
+        self.runner.join(timeout=5)
+        self.assertEqual(self.runner.status()["state"], STATE_COMPLETED)
+
+        # A finished runner accepts the next sweep.
+        self.assertTrue(self.runner.start(
+            db_factory=self._factory, cleanup_fn=cleanup_fn,
+        ))
+        self.runner.join(timeout=5)
+
+    def test_cleanup_failure_records_error_and_closes_db(self) -> None:
+        def cleanup_fn(db, *, confirm_all_wrong_matches):
+            raise RuntimeError("sweep blew up")
+
+        self.assertTrue(self.runner.start(
+            db_factory=self._factory, cleanup_fn=cleanup_fn,
+        ))
+        self.runner.join(timeout=5)
+
+        status = self.runner.status()
+        self.assertEqual(status["state"], STATE_FAILED)
+        self.assertIn("RuntimeError", str(status["error"]))
+        self.assertIn("sweep blew up", str(status["error"]))
+        self.assertIsNone(status["summary"])
+        self.assertEqual(self.db.closed, 1)
+
+    def test_db_factory_failure_records_error(self) -> None:
+        def bad_factory():
+            raise RuntimeError("no dsn")
+
+        def cleanup_fn(db, *, confirm_all_wrong_matches):
+            raise AssertionError("must not run without a db")
+
+        self.assertTrue(self.runner.start(
+            db_factory=bad_factory, cleanup_fn=cleanup_fn,
+        ))
+        self.runner.join(timeout=5)
+
+        status = self.runner.status()
+        self.assertEqual(status["state"], STATE_FAILED)
+        self.assertIn("no dsn", str(status["error"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -1495,6 +1495,10 @@ export async function bulkTriageWrongMatches(btn) {
 
   btn.disabled = true;
   btn.textContent = 'Cleaning...';
+  const restore = () => {
+    btn.disabled = false;
+    btn.textContent = `Cleanup Wrong Matches (${counts.entries})`;
+  };
   try {
     const r = await fetch(`${API}/api/wrong-matches/triage`, {
       method: 'POST',
@@ -1502,18 +1506,57 @@ export async function bulkTriageWrongMatches(btn) {
       body: JSON.stringify({confirm_all_wrong_matches: true}),
     });
     const data = await r.json();
-    if (r.ok && data.status === 'ok') {
-      toast(cleanupSummaryToast(data));
+    // 202 = sweep started; 409 = one is already running. Either way a
+    // sweep is in flight server-side, so poll for its result.
+    if (r.status !== 202 && r.status !== 409) {
+      restore();
+      toast(data.error || data.message || 'Cleanup failed', true);
+      return;
+    }
+    const status = await pollTriageStatus();
+    if (status && status.state === 'completed') {
+      restore();
+      toast(cleanupSummaryToast(status.summary || {}));
       invalidateWrongMatches();
       await _refreshWrongMatches();
-    } else {
-      btn.disabled = false;
-      btn.textContent = `Cleanup Wrong Matches (${counts.entries})`;
-      toast(data.message || 'Cleanup failed', true);
+      return;
     }
+    if (status && status.state === 'idle') {
+      // The web service restarted mid-sweep and lost the in-memory status.
+      // Deletions already performed are durable — refresh to show them.
+      restore();
+      toast('Sweep status lost (web service restarted) — queue may be partially cleaned', true);
+      invalidateWrongMatches();
+      await _refreshWrongMatches();
+      return;
+    }
+    restore();
+    toast((status && status.error) || 'Cleanup sweep failed', true);
   } catch (_e) {
-    btn.disabled = false;
-    btn.textContent = `Cleanup Wrong Matches (${counts.entries})`;
+    restore();
     toast('Cleanup request failed', true);
   }
+}
+
+/**
+ * Poll the background sweep until it leaves the running state.
+ * @returns {Promise<{state: string, summary: Object|null, error: string|null}|null>}
+ */
+async function pollTriageStatus() {
+  // The sweep legitimately takes minutes when stale rows re-measure or
+  // the queue is large; poll gently and give up only after an hour.
+  const intervalMs = 3000;
+  const maxPolls = 1200;
+  for (let i = 0; i < maxPolls; i++) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    try {
+      const r = await fetch(`${API}/api/wrong-matches/triage/status`);
+      if (!r.ok) continue;
+      const status = await r.json();
+      if (status.state !== 'running') return status;
+    } catch (_e) {
+      // Transient fetch failure — keep polling.
+    }
+  }
+  return null;
 }

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -43,6 +43,7 @@ from lib.import_preview import (
     preview_import_from_values,
 )
 from web.routes.pipeline import _serialize_import_job
+from web.triage_runner import TriageRunner
 from web.wrong_match_file_service import (
     build_wrong_match_explorer,
     resolve_wrong_match_stream_file,
@@ -970,25 +971,43 @@ class WrongMatchTriageRequest(BaseModel):
         return self
 
 
+# Module singleton: at most one bulk sweep at a time, status shared
+# between the POST trigger and the GET status poller. In-memory only —
+# a web restart aborts the sweep, same as the old synchronous handler.
+_triage_runner = TriageRunner()
+
+
 def post_wrong_match_triage(h, body: dict) -> None:
+    """Start the bulk triage sweep on a background thread (202).
+
+    The sweep takes minutes when stale rows trigger re-measurement
+    (#271); running it inline wedged the single-threaded server for the
+    duration. The sweep thread opens its own DB connection via
+    ``_server()._new_db`` — psycopg2 handles are not thread-safe to
+    share with the request thread.
+    """
     req_body = parse_body(h, body, WrongMatchTriageRequest)
     if req_body is None:
         return
-    try:
-        summary = cleanup_all_wrong_matches(
-            _server()._db(),
-            confirm_all_wrong_matches=True,
-        )
-    except (ValueError, TypeError) as exc:
-        h._error(f"Invalid cleanup input: {exc}")
+    started = _triage_runner.start(
+        db_factory=_server()._new_db,
+        cleanup_fn=cleanup_all_wrong_matches,
+    )
+    if not started:
+        h._error("triage sweep already running", status=409)
         return
-    data = summary.to_dict()
-    data["status"] = "ok"
-    h._json(data)
+    h._json({"status": "started", "state": "running"}, status=202)
+
+
+def get_wrong_match_triage_status(h, params: dict) -> None:
+    h._json(_triage_runner.status())
+
+
 GET_ROUTES: dict[str, object] = {
     "/api/manual-import/scan": get_manual_import_scan,
     "/api/wrong-matches": get_wrong_matches,
     "/api/wrong-matches/audio": get_wrong_match_audio,
+    "/api/wrong-matches/triage/status": get_wrong_match_triage_status,
     "/api/wrong-matches/explorer": get_wrong_match_explorer,
 }
 POST_ROUTES: dict[str, object] = {
@@ -1013,6 +1032,10 @@ GET_DESCRIPTIONS: dict[str, str] = {
     ),
     "/api/wrong-matches/audio": (
         "Stream one wrong-match audio file with byte-range support."
+    ),
+    "/api/wrong-matches/triage/status": (
+        "Status of the background bulk-triage sweep — state plus the "
+        "cleanup summary once completed."
     ),
     "/api/wrong-matches/explorer": (
         "Filesystem-backed file/tag explorer payload for one wrong match."
@@ -1040,7 +1063,8 @@ POST_DESCRIPTIONS: dict[str, str] = {
         "rest for one request (one-click cleanup)."
     ),
     "/api/wrong-matches/triage": (
-        "Run the full Wrong Matches cleanup classifier across the queue "
-        "(DESTRUCTIVE); requires confirm_all_wrong_matches=true."
+        "Start the full Wrong Matches cleanup sweep on a background "
+        "thread (DESTRUCTIVE); requires confirm_all_wrong_matches=true. "
+        "Returns 202 immediately; poll /api/wrong-matches/triage/status."
     ),
 }

--- a/web/server.py
+++ b/web/server.py
@@ -78,6 +78,19 @@ def _db() -> PipelineDB:
     return db
 
 
+def _new_db() -> PipelineDB:
+    """Open a fresh pipeline-DB connection for a background thread.
+
+    psycopg2 connections must not be shared across threads, so background
+    work (the bulk-triage sweep) gets its own connection. Falls back to
+    the shared handle when no DSN is configured (test harness — the
+    handler mock stands in for both).
+    """
+    if _db_dsn:
+        return PipelineDB(_db_dsn)
+    return _db()
+
+
 def _beets_db() -> BeetsDB | None:
     """Return the BeetsDB instance, or None if not configured."""
     return _beets

--- a/web/triage_runner.py
+++ b/web/triage_runner.py
@@ -1,0 +1,124 @@
+"""Background runner for the bulk Wrong Matches triage sweep.
+
+The web server is a single-threaded ``http.server`` — a synchronous bulk
+triage sweep (minutes when stale rows trigger re-measurement, see #271)
+held the only request thread and made the whole UI unresponsive. The POST
+handler now starts the sweep here and returns immediately; the UI polls
+the status endpoint for the summary.
+
+The sweep thread gets its OWN pipeline-DB connection from ``db_factory``
+— psycopg2 connections must not be shared between the handler thread and
+the sweep thread.
+
+In-memory state only: a web-service restart aborts the sweep and resets
+the status to idle, which matches the old synchronous behaviour (the
+sweep died with the process there too) and is fine for the single
+operator. Per-row deletions stay protected by the WMCL advisory lock
+inside the cleanup service itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+logger = logging.getLogger("cratedigger")
+
+STATE_IDLE = "idle"
+STATE_RUNNING = "running"
+STATE_COMPLETED = "completed"
+STATE_FAILED = "failed"
+
+
+class TriageRunner:
+    """Owns at most one background bulk-triage sweep at a time."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._state: str = STATE_IDLE
+        self._summary: dict[str, Any] | None = None
+        self._error: str | None = None
+        self._started_at: str | None = None
+        self._finished_at: str | None = None
+
+    def start(
+        self,
+        *,
+        db_factory: Callable[[], Any],
+        cleanup_fn: Callable[..., Any],
+    ) -> bool:
+        """Start a sweep on a background thread.
+
+        Returns False (and starts nothing) when a sweep is already
+        running. ``db_factory`` is called ON the sweep thread so the
+        connection is created and used by one thread only.
+        """
+        with self._lock:
+            if self._state == STATE_RUNNING:
+                return False
+            self._state = STATE_RUNNING
+            self._summary = None
+            self._error = None
+            self._started_at = _utcnow_iso()
+            self._finished_at = None
+            self._thread = threading.Thread(
+                target=self._run,
+                args=(db_factory, cleanup_fn),
+                name="wrong-match-triage",
+                daemon=True,
+            )
+            self._thread.start()
+        return True
+
+    def status(self) -> dict[str, Any]:
+        """Snapshot of the current sweep state for the status endpoint."""
+        with self._lock:
+            return {
+                "state": self._state,
+                "started_at": self._started_at,
+                "finished_at": self._finished_at,
+                "summary": self._summary,
+                "error": self._error,
+            }
+
+    def join(self, timeout: float | None = None) -> None:
+        """Wait for the in-flight sweep thread (tests / shutdown)."""
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    def _run(
+        self,
+        db_factory: Callable[[], Any],
+        cleanup_fn: Callable[..., Any],
+    ) -> None:
+        db: Any = None
+        try:
+            db = db_factory()
+            summary = cleanup_fn(db, confirm_all_wrong_matches=True)
+            with self._lock:
+                self._state = STATE_COMPLETED
+                self._summary = summary.to_dict()
+                self._finished_at = _utcnow_iso()
+            logger.info("wrong_match_triage_sweep.completed")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("wrong_match_triage_sweep.failed")
+            with self._lock:
+                self._state = STATE_FAILED
+                self._error = f"{type(exc).__name__}: {exc}"
+                self._finished_at = _utcnow_iso()
+        finally:
+            if db is not None:
+                try:
+                    db.close()
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "wrong_match_triage_sweep.db_close_failed",
+                    )
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## What

The bulk Wrong Matches triage sweep ran synchronously inside the single-threaded `http.server` handler — with #271's stale-evidence re-measurement it legitimately takes minutes, and the whole web UI was unresponsive for the duration (observed live: 3.5 minutes wedged on the first post-#271 sweep).

- **POST `/api/wrong-matches/triage`** now starts the sweep on a background daemon thread (`web/triage_runner.py`) and returns **202** immediately; a concurrent POST returns **409**.
- **New GET `/api/wrong-matches/triage/status`** returns `{state, started_at, finished_at, summary, error}`; the UI polls it every 3s and toasts the cleanup summary on completion.
- The sweep thread opens its **own pipeline-DB connection** (`web/server.py::_new_db`) — psycopg2 handles aren't thread-safe to share with the request thread. Per-row deletions stay serialised by the existing WMCL advisory lock, which now operates across two sessions in the same process (advisory-lock docstring updated to record the new invariant).
- Status is **in-memory only** per single-operator scope: a web restart aborts the sweep and resets to idle — same blast radius as the old synchronous handler dying mid-sweep. The frontend reports that case as "status lost (web service restarted), queue may be partially cleaned" rather than a fake failure, since completed deletions are durable and the next sweep self-heals the rest.
- CLI `pipeline-cli wrong-match-triage` stays synchronous — its process is the operator's terminal; the status endpoint is an artifact of the async web surface, not a missing CLI twin.

## Why it's shaped this way

This is the first carve of the **"web issues commands, never runs business logic inline"** seam from `docs/solutions/web-rewrite-deferred-pending-runtime-redesign.md`, and it unblocks #234's per-request watchdog for this endpoint (the worst long-running handler is gone from the request path).

## Review notes

Adversarial review (Opus) findings addressed pre-commit: idle-after-restart now reported as partial/lost rather than failed (was the one major); success path restores the button before the pane refresh so a transient refresh failure can't leave it stuck on "Cleaning…"; stale advisory-lock docstring updated. Accepted as-is: 409-then-poll can report the other invocation's outcome (single-operator, no run-id machinery per scope rules).

## Tests

- `tests/test_web_triage_runner.py` — runner lifecycle: completion, failure, factory failure, concurrent-start rejection, restart-after-completion, DB closed on every path.
- Contract tests — 202 + status lifecycle, 409 while running, idle status shape, confirmation guard; new GET route classified in `TestRouteContractAudit` with description.
- JS tests — async poll flow (completed / failed / restart-lost), `setTimeout` collapsed so no real sleeps.
- Full suite: 4,305 tests OK; pyright 0 errors full-repo; `node --check` + JS units green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)