### PR TITLE
refactor(wrong-matches): derive cleanup summary from OUTCOME_KEYS (#411)

### DIFF
--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -745,39 +745,18 @@ def _runtime_config() -> Any:
 def _summary(
     results: list[WrongMatchCleanupOutcome],
 ) -> WrongMatchCleanupSummary:
+    # Outcome strings ARE the Summary's count-field names (guarded by
+    # TestSummaryOutcomeContract), so the counts dict splats straight in.
     counts = {key: 0 for key in OUTCOME_KEYS}
     for result in results:
         if result.outcome in counts:
             counts[result.outcome] += 1
-    return WrongMatchCleanupSummary(
-        processed=len(results),
-        deleted=counts[OUTCOME_DELETED],
-        deleted_verified_lossless_parent=counts[
-            OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT
-        ],
-        kept_would_import=counts[OUTCOME_KEPT_WOULD_IMPORT],
-        kept_uncertain=counts[OUTCOME_KEPT_UNCERTAIN],
-        skipped_candidate_evidence_missing=counts[
-            OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_MISSING
-        ],
-        skipped_candidate_evidence_stale=counts[
-            OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE
-        ],
-        skipped_current_evidence_missing=counts[
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_MISSING
-        ],
-        skipped_current_evidence_stale=counts[
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_STALE
-        ],
-        skipped_current_evidence_failed=counts[
-            OUTCOME_SKIPPED_CURRENT_EVIDENCE_FAILED
-        ],
-        skipped_active_job=counts[OUTCOME_SKIPPED_ACTIVE_JOB],
-        skipped_invalid_row=counts[OUTCOME_SKIPPED_INVALID_ROW],
-        skipped_missing_path=counts[OUTCOME_SKIPPED_MISSING_PATH],
-        skipped_operational=counts[OUTCOME_SKIPPED_OPERATIONAL],
-        delete_failed=counts[OUTCOME_DELETE_FAILED],
-        results=tuple(results),
+    return msgspec.structs.replace(
+        WrongMatchCleanupSummary(
+            processed=len(results),
+            results=tuple(results),
+        ),
+        **counts,
     )
 
 

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -1031,5 +1031,55 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         self.assertEqual(result.outcome, OUTCOME_KEPT_WOULD_IMPORT)
 
 
+class TestSummaryOutcomeContract(unittest.TestCase):
+    """Guard: OUTCOME_KEYS and the Summary's count fields cannot drift (#411)."""
+
+    def test_outcome_keys_equal_struct_count_fields(self) -> None:
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_KEYS,
+            WrongMatchCleanupSummary,
+        )
+
+        count_fields = (
+            set(WrongMatchCleanupSummary.__struct_fields__)
+            - {"processed", "results"}
+        )
+        self.assertEqual(set(OUTCOME_KEYS), count_fields)
+
+    def test_summary_counts_each_outcome_into_its_field(self) -> None:
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_KEYS,
+            WrongMatchCleanupOutcome,
+            _summary,
+        )
+
+        for key in OUTCOME_KEYS:
+            with self.subTest(outcome=key):
+                summary = _summary([
+                    WrongMatchCleanupOutcome(download_log_id=1, outcome=key),
+                ])
+                self.assertEqual(getattr(summary, key), 1)
+                self.assertEqual(summary.processed, 1)
+                for other in OUTCOME_KEYS:
+                    if other != key:
+                        self.assertEqual(getattr(summary, other), 0)
+
+    def test_summary_preserves_results_and_ignores_unknown_outcomes(self) -> None:
+        from lib.wrong_match_cleanup_service import (
+            OUTCOME_DELETED,
+            WrongMatchCleanupOutcome,
+            _summary,
+        )
+
+        results = [
+            WrongMatchCleanupOutcome(download_log_id=1, outcome=OUTCOME_DELETED),
+            WrongMatchCleanupOutcome(download_log_id=2, outcome="not_a_real_outcome"),
+        ]
+        summary = _summary(results)
+        self.assertEqual(summary.processed, 2)
+        self.assertEqual(summary.deleted, 1)
+        self.assertEqual(summary.results, tuple(results))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Adding one cleanup outcome touched five places (#411). Places 4–5 (JS toast, contract-test REQUIRED_FIELDS) are genuine contract surfaces; places 1–3 were pure duplication inside `lib/wrong_match_cleanup_service.py`: the `OUTCOME_KEYS` tuple, the matching `WrongMatchCleanupSummary` fields, and a ~35-line `_summary()` mechanically transcribing `field=counts[OUTCOME_X]` — drifting silently if a key was added to one but not the other.

## Change

The issue's option (a), tightened: the outcome key strings (`"deleted"`, `"skipped_active_job"`, …) **are** the Struct's count-field names, so no key→field mapping dict is needed — the mapping is identity. `_summary()` now splats the counts dict via `msgspec.structs.replace` on a base Summary. The wire contract (explicit per-outcome Struct fields) is unchanged; CLI/API/JS consumers see identical payloads.

## Guard tests (`TestSummaryOutcomeContract`)

- `test_outcome_keys_equal_struct_count_fields` — `set(OUTCOME_KEYS)` must equal the Struct's fields minus `{processed, results}`. Adding an outcome to one side without the other fails RED.
- `test_summary_counts_each_outcome_into_its_field` — per-key subTest: one result of each outcome counts into exactly its own field.
- `test_summary_preserves_results_and_ignores_unknown_outcomes` — pins the existing unknown-outcome and results-tuple behaviour.

## Acceptance (from #411)

Adding a hypothetical new outcome now touches: the constant, the Struct field, and (if operator-facing) the JS/test contract — with guard tests that fail if the constant and Struct drift.

## Verification

- Full suite: 4311 tests OK
- pyright (full repo): 0 errors
- `scripts/find_dead_code.sh`: clean

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)