### PR TITLE
refactor(download_log): typed msgspec view over validation_result JSONB (#410)

### DIFF
--- a/lib/beets_distance.py
+++ b/lib/beets_distance.py
@@ -58,6 +58,8 @@ from beets.autotag import distance as _beets_distance_mod  # noqa: E402
 from beets.autotag import hooks as _beets_hooks  # noqa: E402
 from beets.autotag import match as _beets_match_mod  # noqa: E402
 
+from lib.validation_envelope import decode_validation_envelope
+
 
 log = logging.getLogger(__name__)
 
@@ -573,8 +575,8 @@ def compute_beets_distance(
     else:
         # Resolve the on-disk path for the rejected download.
         assert log_row is not None  # narrowed above; Replace-mode invariant
-        vr = log_row.get("validation_result") or {}
-        failed_path = (vr.get("failed_path") if isinstance(vr, dict) else None) or ""
+        failed_path = decode_validation_envelope(
+            log_row.get("validation_result")).failed_path or ""
         resolver = resolve_failed_path
         if resolver is None:
             from lib.util import resolve_failed_path as default_resolver

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -6,7 +6,6 @@ that runs import_one.py and dispatches on the ImportResult decision.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import shutil
@@ -65,6 +64,7 @@ from lib.import_manifest import (
     tracked_audio_paths_from_validation_items,
 )
 from lib.processing_paths import normalize_source_dirs
+from lib.validation_envelope import decode_validation_envelope
 from lib.util import (beets_subprocess_env, cleanup_disambiguation_orphans,
                       trigger_meelo_clean)
 
@@ -110,18 +110,6 @@ DISPATCH_CODE_IMPORT_MANIFEST_REJECTED = "import_manifest_rejected"
 FORCE_MANUAL_SCENARIOS: frozenset[str] = frozenset({"force_import", "manual_import"})
 
 
-def _validation_result_dict(raw: Any) -> dict[str, Any] | None:
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except (json.JSONDecodeError, ValueError):
-            return None
-        return parsed if isinstance(parsed, dict) else None
-    return None
-
-
 def _origin_manifest_for_download_log(
     db: "PipelineDB",
     *,
@@ -136,13 +124,10 @@ def _origin_manifest_for_download_log(
     entry = get_entry(download_log_id)
     if not isinstance(entry, dict):
         return []
-    vr = _validation_result_dict(entry.get("validation_result"))
-    if not vr:
+    vr = decode_validation_envelope(entry.get("validation_result"))
+    if not vr.items:
         return []
-    items = vr.get("items")
-    if not isinstance(items, list):
-        return []
-    return tracked_audio_paths_from_validation_items(items, root=failed_path)
+    return tracked_audio_paths_from_validation_items(vr.items, root=failed_path)
 
 
 def _expected_request_track_count(db: "PipelineDB", request_id: int) -> int | None:

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -8,7 +8,6 @@ import, but runs both against isolated temporary copies.
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import tempfile
@@ -44,6 +43,7 @@ from lib.quality import (
     quality_gate_decision,
 )
 from lib.util import repair_mp3_headers, resolve_failed_path
+from lib.validation_envelope import decode_validation_envelope
 
 
 def _load_current_evidence_by_request(
@@ -318,18 +318,6 @@ def preview_import_from_values(
         simulation=simulation,
         cleanup_eligible=cleanup_eligible,
     )
-
-
-def _validation_result_dict(raw: Any) -> dict[str, Any]:
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except (TypeError, ValueError, json.JSONDecodeError):
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
 
 
 def _quality_gate_stage(measurement: AudioQualityMeasurement | None,
@@ -1155,9 +1143,9 @@ def preview_import_from_download_log(
             reason="Download log row has no request_id",
             download_log_id=download_log_id,
         )
-    vr = _validation_result_dict(entry.get("validation_result"))
-    raw_path = vr.get("failed_path")
-    if not isinstance(raw_path, str) or not raw_path:
+    vr = decode_validation_envelope(entry.get("validation_result"))
+    raw_path = vr.failed_path
+    if not raw_path:
         return _preview_result(
             mode="download_log",
             verdict=PREVIEW_VERDICT_UNCERTAIN,

--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -2,6 +2,7 @@
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
+import msgspec
 import psycopg2
 import psycopg2.extras
 
@@ -11,6 +12,12 @@ from lib.pipeline_db._shared import (
 )
 
 from lib.pipeline_db._core import _PipelineDBBase
+from lib.validation_envelope import (
+    FAILED_PATH_KEY,
+    SCENARIO_KEY,
+    WRONG_MATCH_TRIAGE_KEY,
+    WrongMatchTriageAudit,
+)
 
 
 class _DownloadLogMixin(_PipelineDBBase):
@@ -338,8 +345,8 @@ class _DownloadLogMixin(_PipelineDBBase):
         # wrong-match reject — they only get populated for the request's
         # current-state row. COALESCE keeps the older audit history working
         # if any pre-evidence rows are still around.
-        cur = self._execute("""
-            SELECT DISTINCT ON (dl.request_id, dl.validation_result->>'failed_path')
+        cur = self._execute(f"""
+            SELECT DISTINCT ON (dl.request_id, dl.validation_result->>'{FAILED_PATH_KEY}')
                 dl.id AS download_log_id,
                 dl.request_id,
                 ar.artist_name,
@@ -366,10 +373,10 @@ class _DownloadLogMixin(_PipelineDBBase):
             LEFT JOIN album_quality_evidence e
                 ON e.id = dl.candidate_evidence_id
             WHERE dl.outcome = 'rejected'
-              AND dl.validation_result->>'failed_path' IS NOT NULL
-              AND (dl.validation_result->>'scenario' IS NULL
-                   OR dl.validation_result->>'scenario' NOT IN ('audio_corrupt', 'spectral_reject'))
-            ORDER BY dl.request_id, dl.validation_result->>'failed_path', dl.id DESC
+              AND dl.validation_result->>'{FAILED_PATH_KEY}' IS NOT NULL
+              AND (dl.validation_result->>'{SCENARIO_KEY}' IS NULL
+                   OR dl.validation_result->>'{SCENARIO_KEY}' NOT IN ('audio_corrupt', 'spectral_reject'))
+            ORDER BY dl.request_id, dl.validation_result->>'{FAILED_PATH_KEY}', dl.id DESC
         """)
         rows = [dict(r) for r in cur.fetchall()]
         # DISTINCT ON sorts by path within a request; re-sort so the route
@@ -384,10 +391,10 @@ class _DownloadLogMixin(_PipelineDBBase):
 
         Returns True if the entry was found and updated.
         """
-        cur = self._execute("""
+        cur = self._execute(f"""
             UPDATE download_log
-            SET validation_result = validation_result - 'failed_path'
-            WHERE id = %s AND validation_result->>'failed_path' IS NOT NULL
+            SET validation_result = validation_result - '{FAILED_PATH_KEY}'
+            WHERE id = %s AND validation_result->>'{FAILED_PATH_KEY}' IS NOT NULL
         """, (log_id,))
         return cur.rowcount > 0
 
@@ -404,10 +411,10 @@ class _DownloadLogMixin(_PipelineDBBase):
         placeholders = ", ".join(["%s"] * len(paths))
         cur = self._execute(f"""
             UPDATE download_log
-            SET validation_result = validation_result - 'failed_path'
+            SET validation_result = validation_result - '{FAILED_PATH_KEY}'
             WHERE request_id = %s
               AND outcome = 'rejected'
-              AND validation_result->>'failed_path' IN ({placeholders})
+              AND validation_result->>'{FAILED_PATH_KEY}' IN ({placeholders})
         """, tuple([request_id, *paths]))
         self.conn.commit()
         return cur.rowcount
@@ -416,23 +423,23 @@ class _DownloadLogMixin(_PipelineDBBase):
     def record_wrong_match_triage(
         self,
         log_id: int,
-        triage_result: dict[str, object],
+        triage_result: WrongMatchTriageAudit,
     ) -> bool:
         """Persist cleanup audit details on a download_log row."""
-        cur = self._execute("""
+        cur = self._execute(f"""
             UPDATE download_log
             SET validation_result = jsonb_set(
                 CASE
                     WHEN jsonb_typeof(validation_result) = 'object'
                     THEN validation_result
-                    ELSE '{}'::jsonb
+                    ELSE '{{}}'::jsonb
                 END,
-                '{wrong_match_triage}',
+                '{{{WRONG_MATCH_TRIAGE_KEY}}}',
                 %s::jsonb,
                 true
             )
             WHERE id = %s
-        """, (json.dumps(triage_result), log_id))
+        """, (msgspec.json.encode(triage_result).decode(), log_id))
         self.conn.commit()
         return cur.rowcount > 0
 

--- a/lib/validation_envelope.py
+++ b/lib/validation_envelope.py
@@ -1,0 +1,93 @@
+"""Typed msgspec view over ``download_log.validation_result`` JSONB (#410).
+
+The blob is written by ``ValidationResult.to_json()`` (lib/quality.py) on
+rejection rows, by the curator-ban route with its own audit shape, and has
+``wrong_match_triage`` grafted on later via ``jsonb_set``
+(``PipelineDB.record_wrong_match_triage``). This module is the single read
+contract: every consumer that branches on a key in the blob decodes through
+``decode_validation_envelope`` and uses the typed fields — no per-module
+dict-poking.
+
+Strictness: declared keys are validated (wrong-typed JSONB raises
+``msgspec.ValidationError`` — the wire-boundary rule in
+``.claude/rules/code-quality.md``); unknown keys are ignored, which is what
+keeps the curator-ban shape and legacy triage-writer keys decodable. The
+full live table was probed clean against these types on 2026-06-11.
+
+SQL writers (``get_wrong_matches``, ``clear_wrong_match_path(s)``,
+``record_wrong_match_triage``) interpolate the ``*_KEY`` constants below so
+the key names in SQL come from this contract.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import msgspec
+
+
+class WrongMatchTriageAudit(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Cleanup/triage audit persisted under ``wrong_match_triage``.
+
+    Written by ``lib/wrong_match_cleanup_service.py`` (the only producer);
+    read by ``web/classify.py`` for the recents triage verdict line.
+    ``omit_defaults=True`` keeps unset fields out of the JSONB, matching the
+    historical conditional dict building.
+    """
+
+    action: str | None = None
+    outcome: str | None = None
+    success: bool = False
+    reason: str | None = None
+    preview_verdict: str | None = None
+    preview_decision: str | None = None
+    cleanup_eligible: bool = False
+    source_path: str | None = None
+    stage_chain: list[str] = []
+    cleared_rows: int = 0
+    deleted_path: str | None = None
+    path_missing: bool = False
+    error: str | None = None
+
+
+class ValidationResultEnvelope(msgspec.Struct, frozen=True):
+    """Read view declaring the blob keys consumers branch on.
+
+    Field names ARE the JSONB key contract; every field except
+    ``wrong_match_triage`` must exist on ``ValidationResult`` (drift guard
+    in ``tests/test_validation_envelope.py``). ``candidates`` and ``items``
+    stay ``list[dict]``: pre-#100 rows use the ``mbid`` wire key where
+    ``CandidateSummary`` now expects ``album_id`` (see the format note on
+    ``CandidateSummary`` in lib/quality.py), so strict nested decoding
+    would reject valid historical audit rows.
+    """
+
+    valid: bool = False
+    scenario: str | None = None
+    detail: str | None = None
+    distance: float | None = None
+    failed_path: str | None = None
+    soulseek_username: str | None = None
+    source_dirs: list[str] = []
+    items: list[dict] = []
+    candidates: list[dict] = []
+    wrong_match_triage: WrongMatchTriageAudit | None = None
+
+
+FAILED_PATH_KEY = "failed_path"
+SCENARIO_KEY = "scenario"
+WRONG_MATCH_TRIAGE_KEY = "wrong_match_triage"
+
+
+def decode_validation_envelope(raw: Any) -> ValidationResultEnvelope:
+    """The ONE decode site for ``download_log.validation_result``.
+
+    Accepts the raw column value: ``None`` (no validation ran), a dict
+    (psycopg2 JSONB), or a JSON string (fakes / pre-decode callers).
+    """
+    if raw is None or raw == "" or raw == b"":
+        return ValidationResultEnvelope()
+    if isinstance(raw, (str, bytes)):
+        raw = json.loads(raw)
+    return msgspec.convert(raw, type=ValidationResultEnvelope)

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any, Iterable
@@ -24,6 +23,10 @@ from lib.quality import (
 )
 from lib.quality_evidence import load_candidate_evidence_for_source
 from lib.util import resolve_failed_path
+from lib.validation_envelope import (
+    WrongMatchTriageAudit,
+    decode_validation_envelope,
+)
 from lib.wrong_matches import cleanup_wrong_match_source, validation_failed_path
 
 logger = logging.getLogger("cratedigger")
@@ -263,7 +266,9 @@ def _cleanup_wrong_match(
             reason="failed_path_missing_on_disk",
         )
     candidates = _path_candidates(*candidates, resolved_path)
-    source_dirs = _validation_source_dirs(entry.get("validation_result"))
+    source_dirs = tuple(
+        decode_validation_envelope(entry.get("validation_result")).source_dirs
+    )
 
     active_jobs = _matching_active_jobs(
         db,
@@ -694,26 +699,6 @@ def _matching_active_jobs(
     return [job for job in jobs if getattr(job, "id", None) != ignore_import_job_id]
 
 
-def _validation_result_dict(raw: Any) -> dict[str, Any]:
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
-def _validation_source_dirs(raw: Any) -> tuple[str, ...]:
-    data = _validation_result_dict(raw)
-    value = data.get("source_dirs")
-    if not isinstance(value, (list, tuple)):
-        return ()
-    return tuple(str(path) for path in value if path)
-
-
 def _path_candidates(*paths: str | None) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
@@ -822,34 +807,24 @@ def _stage_chain_from_decision(decision: dict[str, Any]) -> list[str]:
 
 def _cleanup_audit_payload(
     result: WrongMatchCleanupOutcome,
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "action": _audit_action(result.outcome),
-        "success": result.success,
-        "outcome": result.outcome,
-    }
-    if result.reason is not None:
-        payload["reason"] = result.reason
-    if result.verdict is not None:
-        payload["preview_verdict"] = result.verdict
-    if result.preview_decision is not None:
-        payload["preview_decision"] = result.preview_decision
-    if result.cleanup_eligible:
-        payload["cleanup_eligible"] = True
-    if result.source_path is not None:
-        payload["source_path"] = result.source_path
-    stage_chain = _stage_chain_from_decision(result.decision)
-    if stage_chain:
-        payload["stage_chain"] = stage_chain
-    if result.cleared_rows:
-        payload["cleared_rows"] = result.cleared_rows
-    if result.deleted_path is not None:
-        payload["deleted_path"] = result.deleted_path
-    if result.path_missing:
-        payload["path_missing"] = True
-    if result.error is not None:
-        payload["error"] = result.error
-    return payload
+) -> WrongMatchTriageAudit:
+    # omit_defaults on the Struct keeps unset fields out of the JSONB,
+    # matching the old conditional dict building.
+    return WrongMatchTriageAudit(
+        action=_audit_action(result.outcome),
+        outcome=result.outcome,
+        success=result.success,
+        reason=result.reason,
+        preview_verdict=result.verdict,
+        preview_decision=result.preview_decision,
+        cleanup_eligible=result.cleanup_eligible,
+        source_path=result.source_path,
+        stage_chain=_stage_chain_from_decision(result.decision),
+        cleared_rows=result.cleared_rows,
+        deleted_path=result.deleted_path,
+        path_missing=result.path_missing,
+        error=result.error,
+    )
 
 
 def _persist_cleanup_audit(

--- a/lib/wrong_match_delete_service.py
+++ b/lib/wrong_match_delete_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any, Iterable, cast
 
 import msgspec
@@ -10,7 +9,6 @@ import msgspec
 from lib.wrong_matches import (
     cleanup_wrong_match_source,
     unsafe_failed_import_path_reason,
-    validation_failed_path,
 )
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_WRONG_MATCH_CLEANUP,
@@ -18,6 +16,10 @@ from lib.pipeline_db import (
 )
 from lib.processing_paths import normalize_source_dirs
 from lib.util import resolve_failed_path
+from lib.validation_envelope import (
+    ValidationResultEnvelope,
+    decode_validation_envelope,
+)
 
 OUTCOME_DELETED = "deleted"
 OUTCOME_DELETE_FAILED = "delete_failed"
@@ -177,8 +179,8 @@ def _delete_wrong_match(
         )
     request_id_raw = entry.get("request_id")
     request_id = request_id_raw if type(request_id_raw) is int else None
-    validation_result = _validation_result_dict(entry.get("validation_result"))
-    raw_failed_path = validation_failed_path(validation_result)
+    validation_result = decode_validation_envelope(entry.get("validation_result"))
+    raw_failed_path = validation_result.failed_path or None
     if not raw_failed_path:
         return _result(
             download_log_id,
@@ -400,26 +402,11 @@ def _remaining_visible_count(db: Any, request_id: int) -> int:
     return sum(1 for row in db.get_wrong_matches() if row.get("request_id") == request_id)
 
 
-def _validation_result_dict(raw: Any) -> dict[str, Any]:
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
 def _source_dirs(
-    validation_result: dict[str, Any],
+    validation_result: ValidationResultEnvelope,
     source_dirs_hint: Iterable[str],
 ) -> tuple[str, ...]:
-    raw = validation_result.get("source_dirs")
-    dirs: list[str] = []
-    if isinstance(raw, list):
-        dirs.extend(str(path) for path in raw if path)
+    dirs = [*validation_result.source_dirs]
     dirs.extend(str(path) for path in source_dirs_hint if path)
     return tuple(normalize_source_dirs(dirs))
 

--- a/lib/wrong_matches.py
+++ b/lib/wrong_matches.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 from dataclasses import dataclass
 from typing import Any
 
 from lib.util import FAILED_IMPORT_SEARCH_DIRS, resolve_failed_path
+from lib.validation_envelope import decode_validation_envelope
 
 
 @dataclass(frozen=True)
@@ -73,22 +73,8 @@ class WrongMatchDismissResult:
         }
 
 
-def _validation_result_dict(raw: Any) -> dict[str, Any]:
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
 def validation_failed_path(raw: Any) -> str | None:
-    data = _validation_result_dict(raw)
-    failed_path = data.get("failed_path")
-    return failed_path if isinstance(failed_path, str) and failed_path else None
+    return decode_validation_envelope(raw).failed_path or None
 
 
 def _path_candidates(*paths: str | None) -> list[str]:

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -1370,8 +1370,9 @@ def cmd_force_import(db, args):
         print(f"  No validation_result on download_log {log_id}.")
         return
 
-    vr = vr_raw if isinstance(vr_raw, dict) else json.loads(vr_raw)
-    failed_path = vr.get("failed_path")
+    from lib.validation_envelope import decode_validation_envelope
+
+    failed_path = decode_validation_envelope(vr_raw).failed_path
     if not failed_path:
         print(f"  No failed_path in validation_result for download_log {log_id}.")
         return

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -64,6 +64,7 @@ from lib.quality import (
     AlbumQualityEvidence,
 )
 from lib.release_identity import ReleaseIdentity, normalize_release_id
+from lib.validation_envelope import WrongMatchTriageAudit
 from lib.search_classification import (
     SearchSummary as _SearchSummary,
     classify_failure_class as _classify_failure_class,
@@ -4082,14 +4083,16 @@ class FakePipelineDB:
     def record_wrong_match_triage(
         self,
         log_id: int,
-        triage_result: dict[str, object],
+        triage_result: WrongMatchTriageAudit,
     ) -> bool:
         for entry in self.download_logs:
             if entry.id != log_id:
                 continue
             vr = self._validation_result_dict(entry.validation_result) or {}
             new_vr = dict(vr)
-            new_vr["wrong_match_triage"] = dict(triage_result)
+            # Mirror the real writer: msgspec encode honours omit_defaults.
+            new_vr["wrong_match_triage"] = msgspec.json.decode(
+                msgspec.json.encode(triage_result))
             if isinstance(entry.validation_result, str):
                 entry.validation_result = json.dumps(new_vr)
             else:

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -3232,6 +3232,33 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         stored = _json.loads(db.download_logs[0].validation_result)  # type: ignore[arg-type]
         self.assertNotIn("failed_path", stored)
 
+    def test_record_wrong_match_triage_merges_typed_audit(self):
+        """Mirrors the real jsonb_set writer: typed audit in, omit-defaults
+        dict merged onto the existing blob."""
+        from lib.validation_envelope import (
+            WrongMatchTriageAudit,
+            decode_validation_envelope,
+        )
+        db = FakePipelineDB()
+        db.log_download(1, outcome="rejected",
+                        validation_result={"failed_path": "/p1",
+                                           "scenario": "wrong_match"})
+        log_id = db.download_logs[0].id
+        audit = WrongMatchTriageAudit(action="deleted_reject", success=True)
+        self.assertTrue(db.record_wrong_match_triage(log_id, audit))
+
+        vr = db.download_logs[0].validation_result
+        assert isinstance(vr, dict)
+        # omit_defaults parity with the real writer — unset fields absent.
+        self.assertEqual(vr["wrong_match_triage"],
+                         {"action": "deleted_reject", "success": True})
+        # Merge, not replace.
+        self.assertEqual(vr["failed_path"], "/p1")
+        env = decode_validation_envelope(vr)
+        self.assertEqual(env.wrong_match_triage, audit)
+        # Unknown log id returns False.
+        self.assertFalse(db.record_wrong_match_triage(99999, audit))
+
     def test_clear_wrong_match_paths_clears_matching_request_and_paths(self):
         db = FakePipelineDB()
         db.log_download(1, outcome="rejected",

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -7998,5 +7998,80 @@ class TestAtomicAndExecuteHardening(unittest.TestCase):
         self.assertEqual(row["reasoning"], "atomic-write")
 
 
+@requires_postgres
+class TestWrongMatchTriageRoundTrip(unittest.TestCase):
+    """Real-PG round-trip for the typed triage write path (#410).
+
+    Test-fidelity Rule A: the typed payload must survive the jsonb_set
+    write and decode back identical through the one envelope decode site.
+    """
+
+    def setUp(self):
+        self.db = make_db()
+        self.req_id = self.db.add_request(
+            mb_release_id="triage-uuid",
+            artist_name="A",
+            album_title="B",
+            source="request",
+        )
+        self.log_id = self.db.log_download(
+            request_id=self.req_id,
+            soulseek_username="peer",
+            outcome="rejected",
+            validation_result=json.dumps({
+                "failed_path": "/mnt/x/failed_imports/B",
+                "scenario": "wrong_match",
+            }),
+        )
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_triage_audit_round_trips_every_field(self):
+        from lib.validation_envelope import (
+            WrongMatchTriageAudit,
+            decode_validation_envelope,
+        )
+
+        audit = WrongMatchTriageAudit(
+            action="deleted_reject",
+            outcome="deleted",
+            success=True,
+            reason="confident_reject",
+            preview_verdict="reject",
+            preview_decision="rejected_spectral",
+            cleanup_eligible=True,
+            source_path="/mnt/x/failed_imports/B",
+            stage_chain=["stage1_spectral", "stage2_import"],
+            cleared_rows=2,
+            deleted_path="/mnt/x/failed_imports/B",
+            path_missing=False,
+            error=None,
+        )
+        self.assertTrue(
+            self.db.record_wrong_match_triage(self.log_id, audit))
+
+        cur = self.db._execute(
+            "SELECT validation_result FROM download_log WHERE id = %s",
+            (self.log_id,))
+        row = cur.fetchone()
+        assert row is not None
+        env = decode_validation_envelope(row["validation_result"])
+        self.assertEqual(env.wrong_match_triage, audit)
+        # jsonb_set must merge, not replace — the pre-existing keys survive.
+        self.assertEqual(env.failed_path, "/mnt/x/failed_imports/B")
+        self.assertEqual(env.scenario, "wrong_match")
+
+    def test_clear_wrong_match_path_removes_only_the_failed_path_key(self):
+        from lib.validation_envelope import decode_validation_envelope
+
+        self.assertTrue(self.db.clear_wrong_match_path(self.log_id))
+        entry = self.db.get_download_log_entry(self.log_id)
+        assert entry is not None
+        env = decode_validation_envelope(entry["validation_result"])
+        self.assertIsNone(env.failed_path)
+        self.assertEqual(env.scenario, "wrong_match")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_db_write_audit.py
+++ b/tests/test_pipeline_db_write_audit.py
@@ -103,10 +103,6 @@ ALLOWLIST: dict[str, str] = {
         "the importer's RequestV0ProbeStateUpdate fields (which reach the row "
         "via finalize_request -> mark_imported_with_rescue/update_status) ARE "
         "column-checked by tests/test_pipeline_db_column_contract.py.",
-    "record_wrong_match_triage":
-        "writes an opaque dict into one JSONB column (validation_result) via "
-        "jsonb_set -- no per-column write list to drift. The sole caller, "
-        "wrong_match_cleanup_service.py, invokes it via getattr.",
     "update_track_artists":
         "positional list[str|None] driving a single-scalar-column UPDATE; no "
         "column-list payload to round-trip.",

--- a/tests/test_validation_envelope.py
+++ b/tests/test_validation_envelope.py
@@ -1,0 +1,153 @@
+"""Tests for the typed view over download_log.validation_result JSONB (#410)."""
+
+from __future__ import annotations
+
+import unittest
+
+import msgspec
+
+from lib.quality import ValidationResult
+from lib.validation_envelope import (
+    FAILED_PATH_KEY,
+    SCENARIO_KEY,
+    WRONG_MATCH_TRIAGE_KEY,
+    ValidationResultEnvelope,
+    WrongMatchTriageAudit,
+    decode_validation_envelope,
+)
+
+
+class TestDecodeValidationEnvelope(unittest.TestCase):
+
+    def test_none_decodes_to_empty_envelope(self) -> None:
+        env = decode_validation_envelope(None)
+        self.assertIsNone(env.failed_path)
+        self.assertEqual(env.source_dirs, [])
+        self.assertIsNone(env.wrong_match_triage)
+
+    def test_dict_decodes_declared_keys(self) -> None:
+        env = decode_validation_envelope({
+            "valid": False,
+            "scenario": "wrong_match",
+            "distance": 0.42,
+            "failed_path": "/mnt/x/failed_imports/Album",
+            "source_dirs": ["a", "b"],
+            "items": [{"path": "01.mp3"}],
+            "candidates": [{"album_id": "mbid-1", "is_target": True}],
+        })
+        self.assertEqual(env.scenario, "wrong_match")
+        self.assertEqual(env.distance, 0.42)
+        self.assertEqual(env.failed_path, "/mnt/x/failed_imports/Album")
+        self.assertEqual(env.source_dirs, ["a", "b"])
+        self.assertEqual(env.items, [{"path": "01.mp3"}])
+        self.assertEqual(env.candidates[0]["is_target"], True)
+
+    def test_json_string_decodes(self) -> None:
+        env = decode_validation_envelope('{"failed_path": "/p", "distance": 0.1}')
+        self.assertEqual(env.failed_path, "/p")
+        self.assertEqual(env.distance, 0.1)
+
+    def test_unknown_keys_are_ignored_curator_ban_shape(self) -> None:
+        env = decode_validation_envelope({
+            "scenario": "curator_ban",
+            "hashes_recorded": 12,
+            "denylisted_username": "peer",
+            "reason": "bad rip",
+            "cleanup_errors": [],
+        })
+        self.assertEqual(env.scenario, "curator_ban")
+        self.assertIsNone(env.failed_path)
+        self.assertIsNone(env.wrong_match_triage)
+
+    def test_triage_decodes_typed_and_tolerates_legacy_extra_keys(self) -> None:
+        env = decode_validation_envelope({
+            "failed_path": "/p",
+            "wrong_match_triage": {
+                "action": "kept_uncertain",
+                "outcome": "kept_uncertain",
+                "success": True,
+                "reason": "no_confident_reject",
+                "preview_verdict": "uncertain",
+                "preview_decision": "kept",
+                "stage_chain": ["preview", "decide"],
+                "cleared_rows": 2,
+                # legacy writer keys observed in prod rows — must be ignored
+                "confident_reject": False,
+                "would_import": True,
+                "uncertain": True,
+                "preview_reason": "x",
+                "cleanup": {},
+            },
+        })
+        triage = env.wrong_match_triage
+        assert triage is not None
+        self.assertEqual(triage.action, "kept_uncertain")
+        self.assertEqual(triage.stage_chain, ["preview", "decide"])
+        self.assertEqual(triage.cleared_rows, 2)
+
+    def test_wrong_typed_failed_path_raises(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            decode_validation_envelope({"failed_path": 123})
+
+    def test_wrong_typed_source_dirs_raises(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            decode_validation_envelope({"source_dirs": "/not/a/list"})
+
+    def test_wrong_typed_triage_raises(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            decode_validation_envelope({"wrong_match_triage": ["not", "a", "dict"]})
+
+    def test_wrong_typed_stage_chain_raises(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            decode_validation_envelope(
+                {"wrong_match_triage": {"stage_chain": [1, 2]}})
+
+    def test_non_object_json_raises(self) -> None:
+        with self.assertRaises(msgspec.ValidationError):
+            decode_validation_envelope('["not", "an", "object"]')
+
+
+class TestEnvelopeContract(unittest.TestCase):
+    """Drift guards binding the envelope to its producers."""
+
+    def test_envelope_fields_are_validation_result_fields(self) -> None:
+        """Every envelope key except the grafted triage key must exist on
+        ValidationResult — the writer that produces the blob."""
+        envelope_fields = set(ValidationResultEnvelope.__struct_fields__)
+        envelope_fields.discard(WRONG_MATCH_TRIAGE_KEY)
+        producer_fields = set(ValidationResult.__struct_fields__)
+        self.assertLessEqual(envelope_fields, producer_fields)
+
+    def test_sql_key_constants_are_envelope_fields(self) -> None:
+        for key in (FAILED_PATH_KEY, SCENARIO_KEY, WRONG_MATCH_TRIAGE_KEY):
+            self.assertIn(key, ValidationResultEnvelope.__struct_fields__)
+
+    def test_triage_audit_round_trips_through_json(self) -> None:
+        audit = WrongMatchTriageAudit(
+            action="deleted_reject",
+            outcome="deleted",
+            success=True,
+            reason="confident_reject",
+            preview_verdict="reject",
+            preview_decision="rejected_spectral",
+            cleanup_eligible=True,
+            source_path="/p",
+            stage_chain=["preview", "spectral"],
+            cleared_rows=1,
+            deleted_path="/p",
+        )
+        wire = msgspec.json.encode(audit)
+        env = decode_validation_envelope(
+            {"wrong_match_triage": msgspec.json.decode(wire)})
+        self.assertEqual(env.wrong_match_triage, audit)
+
+    def test_triage_audit_encoding_omits_defaults(self) -> None:
+        """Parity with the old conditional dict building — unset fields stay
+        out of the JSONB instead of writing nulls."""
+        wire = msgspec.json.decode(
+            msgspec.json.encode(WrongMatchTriageAudit(action="deleted_reject")))
+        self.assertEqual(wire, {"action": "deleted_reject"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -29,6 +29,7 @@ from lib.import_evidence import (
     ActionEvidenceProvenance,
     CurrentEvidenceActionResult,
 )
+from lib.validation_envelope import decode_validation_envelope
 from lib.wrong_match_cleanup_service import (
     OUTCOME_DELETE_FAILED,
     OUTCOME_DELETED,
@@ -420,7 +421,12 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         self.assertEqual(
             triage["action"], OUTCOME_SKIPPED_CANDIDATE_EVIDENCE_STALE,
         )
-        self.assertFalse(triage["success"])
+        # success=False is a default and omit_defaults keeps it out of the
+        # JSONB; the typed decode restores it.
+        decoded = decode_validation_envelope(
+            by_id[log_id].validation_result).wrong_match_triage
+        assert decoded is not None
+        self.assertFalse(decoded.success)
         self.assertIn("evidence_refresh_failed", triage["reason"])
 
         missing_source = _make_source(self.tmp, "audit-missing-source")

--- a/web/classify.py
+++ b/web/classify.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 import msgspec
 
 from lib.quality import AudioQualityMeasurement, ImportResult
+from lib.validation_envelope import decode_validation_envelope
 
 # ---------------------------------------------------------------------------
 # Types
@@ -222,35 +223,6 @@ def _empty_wrong_match_triage() -> dict[str, Any]:
     }
 
 
-def _validation_result_dict(entry: LogEntry) -> dict[str, Any] | None:
-    raw = entry.validation_result
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            decoded = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
-            return None
-        return decoded if isinstance(decoded, dict) else None
-    return None
-
-
-def _str_or_none(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return value
-    if isinstance(value, (bool, int, float)):
-        return str(value)
-    return None
-
-
-def _string_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str)]
-
-
 def _humanize_token(value: str | None) -> str | None:
     if not value:
         return None
@@ -361,39 +333,39 @@ def _build_wrong_match_triage_detail(
 
 def _extract_wrong_match_triage(entry: LogEntry) -> dict[str, Any]:
     """Pull preview-driven wrong-match triage audit out of ValidationResult."""
-    validation_result = _validation_result_dict(entry)
-    if validation_result is None:
+    # Render path: one malformed historical audit row must not 500 the
+    # whole recents page (contract pinned by TestClassifyWrongMatchTriageAudit
+    # ``*_does_not_raise`` tests). The envelope decode stays strict; the
+    # fail-open lives here, at the display boundary only.
+    try:
+        triage = decode_validation_envelope(
+            entry.validation_result).wrong_match_triage
+    except (msgspec.ValidationError, json.JSONDecodeError):
         return _empty_wrong_match_triage()
-    triage = validation_result.get("wrong_match_triage")
-    if not isinstance(triage, dict):
+    if triage is None:
         return _empty_wrong_match_triage()
 
-    action = _str_or_none(triage.get("action"))
-    reason = _str_or_none(triage.get("reason"))
-    preview_verdict = _str_or_none(triage.get("preview_verdict"))
-    preview_decision = _str_or_none(triage.get("preview_decision"))
-    stage_chain = _string_list(triage.get("stage_chain"))
     summary = _build_wrong_match_triage_summary(
-        action,
-        reason,
-        preview_verdict,
-        preview_decision,
-        stage_chain,
+        triage.action,
+        triage.reason,
+        triage.preview_verdict,
+        triage.preview_decision,
+        triage.stage_chain,
     )
     detail = _build_wrong_match_triage_detail(
-        action,
-        reason,
-        preview_verdict,
-        preview_decision,
-        stage_chain,
+        triage.action,
+        triage.reason,
+        triage.preview_verdict,
+        triage.preview_decision,
+        triage.stage_chain,
     )
     return {
-        "action": action,
+        "action": triage.action,
         "summary": summary,
-        "reason": reason,
-        "preview_verdict": preview_verdict,
-        "preview_decision": preview_decision,
-        "stage_chain": stage_chain,
+        "reason": triage.reason,
+        "preview_verdict": triage.preview_verdict,
+        "preview_decision": triage.preview_decision,
+        "stage_chain": triage.stage_chain,
         "detail": detail,
     }
 

--- a/web/routes/imports.py
+++ b/web/routes/imports.py
@@ -42,27 +42,23 @@ from lib.import_preview import (
     preview_import_from_path,
     preview_import_from_values,
 )
+from lib.validation_envelope import (
+    ValidationResultEnvelope,
+    decode_validation_envelope,
+)
 from web.routes.pipeline import _serialize_import_job
 from web.triage_runner import TriageRunner
 from web.wrong_match_file_service import (
     build_wrong_match_explorer,
     resolve_wrong_match_stream_file,
     source_dirs_from_validation_result,
+    target_candidate,
 )
 
 
 def _server():
     from web import server
     return server
-
-
-def _parse_validation_result(vr_raw: object) -> dict[str, object]:
-    """Parse a validation_result JSONB value into a plain dict."""
-    if isinstance(vr_raw, dict):
-        return vr_raw
-    if not vr_raw:
-        return {}
-    return json.loads(str(vr_raw))
 
 
 def _row_presence(
@@ -88,25 +84,6 @@ def _row_presence(
     return "absent"
 
 
-def _target_candidate(vr: dict[str, object]) -> dict[str, object] | None:
-    """Return the target candidate from a validation_result payload."""
-    raw_candidates = vr.get("candidates", [])
-    if not isinstance(raw_candidates, list):
-        return None
-
-    candidates = [
-        candidate for candidate in raw_candidates
-        if isinstance(candidate, dict)
-    ]
-    target = next(
-        (candidate for candidate in candidates if candidate.get("is_target")),
-        None,
-    )
-    if target is not None:
-        return target
-    return candidates[0] if candidates else None
-
-
 def _threshold_milli(value: object) -> int:
     try:
         parsed = int(value) if isinstance(value, (str, int, float)) else 180
@@ -115,21 +92,11 @@ def _threshold_milli(value: object) -> int:
     return max(0, min(parsed, 999))
 
 
-def _distance_value(vr: dict[str, object]) -> float | None:
-    raw = vr.get("distance")
-    if isinstance(raw, bool) or raw is None:
-        return None
-    if isinstance(raw, (int, float)):
-        return float(raw)
-    try:
-        return float(str(raw))
-    except (TypeError, ValueError):
-        return None
-
-
-def _is_green_distance(vr: dict[str, object], threshold_milli: int) -> bool:
-    distance = _distance_value(vr)
-    return distance is not None and distance <= threshold_milli / 1000
+def _is_green_distance(
+    vr: ValidationResultEnvelope,
+    threshold_milli: int,
+) -> bool:
+    return vr.distance is not None and vr.distance <= threshold_milli / 1000
 
 
 # Numeric rank for the per-entry sort. Higher = better quality. Mirrors
@@ -406,9 +373,8 @@ def _build_wrong_match_groups(
     for row in rows:
         if not include_replaced and row.get("request_status") == "replaced":
             continue
-        vr = _parse_validation_result(row.get("validation_result"))
-        failed_path_raw = vr.get("failed_path")
-        failed_path = failed_path_raw if isinstance(failed_path_raw, str) else ""
+        vr = decode_validation_envelope(row.get("validation_result"))
+        failed_path = vr.failed_path or ""
         resolved_path = resolve_failed_path(failed_path)
         files_exist = resolved_path is not None
         if not files_exist:
@@ -444,7 +410,7 @@ def _build_wrong_match_groups(
             groups[request_id] = group
             order.append(request_id)
 
-        target = _target_candidate(vr)
+        target = target_candidate(vr)
         entries_list = group["entries"]
         assert isinstance(entries_list, list)
         log_id = row.get("download_log_id")
@@ -468,14 +434,14 @@ def _build_wrong_match_groups(
             "download_log_id": log_id,
             "failed_path": resolved_path or failed_path,
             "files_exist": files_exist,
-            "distance": vr.get("distance"),
-            "scenario": vr.get("scenario"),
-            "detail": vr.get("detail"),
+            "distance": vr.distance,
+            "scenario": vr.scenario,
+            "detail": vr.detail,
             "soulseek_username": row.get("soulseek_username")
-                or vr.get("soulseek_username"),
+                or vr.soulseek_username,
             "source_dirs": source_dirs_from_validation_result(vr),
             "candidate": target,
-            "local_items": vr.get("items", []),
+            "local_items": vr.items,
             "import_job": import_job,
             "spectral_grade": row.get("spectral_grade"),
             "spectral_bitrate": row.get("spectral_bitrate"),
@@ -800,10 +766,9 @@ def post_wrong_match_converge(h, body: dict) -> None:
             remaining += 1
             continue
 
-        vr = _parse_validation_result(row.get("validation_result"))
-        failed_path_raw = vr.get("failed_path")
-        failed_path = failed_path_raw if isinstance(failed_path_raw, str) else ""
-        distance = _distance_value(vr)
+        vr = decode_validation_envelope(row.get("validation_result"))
+        failed_path = vr.failed_path or ""
+        distance = vr.distance
         green = _is_green_distance(vr, threshold_milli)
 
         if green:
@@ -821,7 +786,7 @@ def post_wrong_match_converge(h, body: dict) -> None:
                 "failed_path": resolved_path,
                 "source_username": (
                     row.get("soulseek_username")
-                    or vr.get("soulseek_username")
+                    or vr.soulseek_username
                 ),
                 "source_dirs": source_dirs_from_validation_result(vr),
             })

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -45,6 +45,7 @@ from lib.import_preview import ImportPreviewValues, preview_import_from_values
 from lib.release_identity import detect_release_source, normalize_release_id
 from lib.release_cleanup import remove_and_reset_release
 from lib.util import resolve_failed_path
+from lib.validation_envelope import decode_validation_envelope
 from lib.spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,
                                 ALBUM_SUSPECT_PCT, MIN_CLIFF_SLICES,
                                 CLIFF_THRESHOLD_DB_PER_KHZ)
@@ -2184,8 +2185,8 @@ def post_pipeline_force_import(h, body: dict) -> None:
     if not vr_raw:
         h._error("No validation_result on this download log entry")
         return
-    vr = vr_raw if isinstance(vr_raw, dict) else json.loads(vr_raw)
-    failed_path = vr.get("failed_path")
+    vr = decode_validation_envelope(vr_raw)
+    failed_path = vr.failed_path
     if not failed_path:
         h._error("No failed_path in validation_result")
         return

--- a/web/wrong_match_file_service.py
+++ b/web/wrong_match_file_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import mimetypes
 import os
 import re
@@ -12,6 +11,10 @@ from typing import Any, Mapping
 from lib.processing_paths import normalize_source_dirs, path_is_within_root
 from lib.quality import AUDIO_EXTENSIONS_DOTTED
 from lib.util import resolve_failed_path
+from lib.validation_envelope import (
+    ValidationResultEnvelope,
+    decode_validation_envelope,
+)
 
 _PLAYABLE_AUDIO_EXTENSIONS: frozenset[str] = frozenset({
     ".aac",
@@ -73,14 +76,11 @@ _TXXX_TAG_ALIASES: dict[str, str] = {
 }
 
 
-def _target_candidate(validation_result: Mapping[str, Any]) -> dict[str, Any] | None:
-    raw_candidates = validation_result.get("candidates")
-    if not isinstance(raw_candidates, list):
-        return None
-    candidates = [
-        candidate for candidate in raw_candidates
-        if isinstance(candidate, dict)
-    ]
+def target_candidate(
+    validation_result: ValidationResultEnvelope,
+) -> dict[str, Any] | None:
+    """Return the target candidate (or first) from a decoded envelope."""
+    candidates = validation_result.candidates
     target = next(
         (candidate for candidate in candidates if candidate.get("is_target")),
         None,
@@ -88,25 +88,17 @@ def _target_candidate(validation_result: Mapping[str, Any]) -> dict[str, Any] | 
     return target if target is not None else (candidates[0] if candidates else None)
 
 
-def _validation_result_dict(raw: Any) -> dict[str, Any]:
-    if isinstance(raw, dict):
-        return raw
-    if not raw:
-        return {}
-    return json.loads(str(raw))
+def source_dirs_from_validation_result(
+    validation_result: ValidationResultEnvelope,
+) -> list[str]:
+    return normalize_source_dirs(validation_result.source_dirs)
 
 
-def source_dirs_from_validation_result(validation_result: Mapping[str, Any]) -> list[str]:
-    raw = validation_result.get("source_dirs")
-    if not isinstance(raw, list):
-        return []
-    return normalize_source_dirs(raw)
-
-
-def _resolved_wrong_match_root(entry: Mapping[str, Any]) -> tuple[dict[str, Any], str]:
-    validation_result = _validation_result_dict(entry.get("validation_result"))
-    failed_path_raw = validation_result.get("failed_path")
-    failed_path = failed_path_raw if isinstance(failed_path_raw, str) else ""
+def _resolved_wrong_match_root(
+    entry: Mapping[str, Any],
+) -> tuple[ValidationResultEnvelope, str]:
+    validation_result = decode_validation_envelope(entry.get("validation_result"))
+    failed_path = validation_result.failed_path or ""
     resolved_path = resolve_failed_path(failed_path)
     if resolved_path is None:
         raise FileNotFoundError(f"Wrong-match files not found: {failed_path or '<missing>'}")
@@ -225,9 +217,9 @@ def _mapping_sort_key(mapping_row: Mapping[str, Any], fallback_index: int) -> tu
 
 def _reorder_files_by_match(
     files: list[dict[str, object]],
-    validation_result: Mapping[str, Any],
+    validation_result: ValidationResultEnvelope,
 ) -> tuple[list[dict[str, object]], str]:
-    target = _target_candidate(validation_result)
+    target = target_candidate(validation_result)
     if not target:
         return files, "folder"
 


### PR DESCRIPTION
## Problem (#410)

`download_log.validation_result` was a stringly-typed junk drawer. The contract for which keys exist only existed as grep results, navigated by **eight** per-module `_validation_result_dict` copies (the issue listed five sites; the sweep found more) plus inline `json.loads` in the force-import route and CLI.

## Change

**`lib/validation_envelope.py`** — the single read contract:

- `ValidationResultEnvelope` (frozen `msgspec.Struct`, all fields defaulted) declaring the keys consumers branch on: `valid`, `scenario`, `detail`, `distance`, `failed_path`, `soulseek_username`, `source_dirs`, `items`, `candidates`, `wrong_match_triage`.
- `WrongMatchTriageAudit` — the typed triage audit, now used on **both** sides: `_cleanup_audit_payload` constructs it and `record_wrong_match_triage` takes it (`omit_defaults` encoding preserves the old conditional-dict JSONB shape).
- `decode_validation_envelope` — the ONE decode site (`None`/dict/JSON-string in, validated envelope out).
- `FAILED_PATH_KEY` / `SCENARIO_KEY` / `WRONG_MATCH_TRIAGE_KEY` — interpolated into the SQL in `get_wrong_matches` / `clear_wrong_match_path(s)` / `record_wrong_match_triage`, so the JSONB key names in SQL come from the struct's contract.

**Converted consumers** (dict-poking helpers deleted): `lib/wrong_matches.py`, `lib/wrong_match_cleanup_service.py`, `lib/wrong_match_delete_service.py`, `lib/import_preview.py`, `lib/import_dispatch.py`, `lib/beets_distance.py`, `web/classify.py`, `web/wrong_match_file_service.py`, `web/routes/imports.py` (also deduped its private `_target_candidate` into the shared `target_candidate`), `web/routes/pipeline.py`, `scripts/pipeline_cli.py`, `tests/fakes.py`.

## Strictness decisions

- Wrong-typed declared keys raise `msgspec.ValidationError` at the boundary (wire-boundary rule). **Live prod table probed first: all 22,927 blobs conform**, including triage sub-keys and array element types.
- Unknown keys are ignored — this is what keeps the `curator_ban` audit shape and legacy triage-writer keys (`confident_reject`, `would_import`, …) decodable.
- The single fail-open is `classify._extract_wrong_match_triage` (recents render path) — one malformed historical row must not 500 the whole page; pinned by the pre-existing `*_does_not_raise` tests.
- `candidates`/`items` deliberately stay `list[dict]`: pre-#100 rows carry the `mbid` wire key where `CandidateSummary` expects `album_id`, so strict nested decode would reject valid historical audit rows.
- New triage JSONB omits `success: false` (and other defaults) — typed decode restores them; nothing reads the raw key. Forward-only.

## Guards (the RED tests from the issue's acceptance)

- `tests/test_validation_envelope.py` — wrong-typed JSONB raises (`failed_path: 123`, `source_dirs: str`, triage as list, non-str stage_chain), envelope-fields ⊆ `ValidationResult` fields drift guard, SQL key constants ∈ struct fields, triage encode/decode round-trip + omit-defaults parity.
- `tests/test_pipeline_db.py::TestWrongMatchTriageRoundTrip` — real-PG round-trip through `jsonb_set` (test-fidelity Rule A), which let the `record_wrong_match_triage` entry be **deleted** from the write-audit allowlist.
- `tests/test_fakes.py` — self-test for the fake's typed mirror.

## Review

Pre-commit review agent pass found one missed consumer (`beets_distance.py` dict-poke) — fixed — and verified SQL f-string rendering, msgspec frozen/mutable-default/omit-defaults semantics, `success:false` blast radius (zero raw readers), and that no callers of deleted helpers remain.

## Verification

- Full suite: 4328 tests OK (+17 net new)
- pyright (full repo): 0 errors
- `scripts/find_dead_code.sh`: clean

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)