### PR TITLE
refactor(wrong-matches): typed DB protocols for cleanup + delete services (#409 pilot)

### DIFF
--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -277,7 +277,7 @@ class _DownloadLogMixin(_PipelineDBBase):
         return row
 
 
-    def get_download_log_entry(self, log_id):
+    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None:
         """Get a single download_log entry by its ID."""
         cur = self._execute(
             self._DOWNLOAD_LOG_HISTORY_SELECT + " WHERE dl.id = %s",

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Iterable
+from contextlib import AbstractContextManager
+from typing import Any, Iterable, Protocol, runtime_checkable
 
 import msgspec
 
 from lib.import_evidence import CURRENT_STATUS_LOADED, load_current_evidence_for_action
+from lib.import_queue import ImportJob
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_WRONG_MATCH_CLEANUP,
     wrong_match_cleanup_lock_key,
@@ -30,6 +32,47 @@ from lib.validation_envelope import (
 from lib.wrong_matches import cleanup_wrong_match_source, validation_failed_path
 
 logger = logging.getLogger("cratedigger")
+
+
+@runtime_checkable
+class WrongMatchCleanupDB(Protocol):
+    """The PipelineDB surface this service uses directly (#409).
+
+    ``PipelineDB`` and ``FakePipelineDB`` satisfy it structurally — pyright
+    enforces signature parity at every call site, and the issubclass parity
+    tests in ``tests/test_wrong_match_cleanup_service.py`` guard method
+    presence at runtime. The handle is also forwarded to helpers in other
+    modules (``cleanup_wrong_match_source``, evidence loaders, ``preview_fn``)
+    whose own surfaces get protocols in their own #409 increments.
+    """
+
+    def get_wrong_matches(self) -> list[dict[str, object]]: ...
+
+    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
+
+    def get_request(self, request_id: int) -> dict[str, Any] | None: ...
+
+    def advisory_lock(
+        self, namespace: int, key: int,
+    ) -> AbstractContextManager[bool]: ...
+
+    def update_request_fields(self, request_id: int, **extra: Any) -> None: ...
+
+    def list_active_import_jobs_for_wrong_match(
+        self,
+        *,
+        download_log_id: int,
+        request_id: int | None,
+        failed_paths: Iterable[str],
+        source_dirs: Iterable[str],
+        ignore_import_job_id: int | None = None,
+        limit: int = 50,
+    ) -> list[ImportJob]: ...
+
+    def record_wrong_match_triage(
+        self, log_id: int, triage_result: WrongMatchTriageAudit,
+    ) -> bool: ...
+
 
 OUTCOME_DELETED = "deleted"
 OUTCOME_DELETED_VERIFIED_LOSSLESS_PARENT = "deleted_verified_lossless_parent"
@@ -138,7 +181,7 @@ class _LoadedEvidence(msgspec.Struct, frozen=True):
 
 
 def cleanup_all_wrong_matches(
-    db: Any,
+    db: WrongMatchCleanupDB,
     *,
     confirm_all_wrong_matches: bool = False,
     ignore_import_job_id: int | None = None,
@@ -173,7 +216,7 @@ def cleanup_all_wrong_matches(
 
 
 def cleanup_wrong_match(
-    db: Any,
+    db: WrongMatchCleanupDB,
     download_log_id: int,
     *,
     failed_path_hint: str | None = None,
@@ -212,7 +255,7 @@ def cleanup_wrong_match(
 
 
 def _cleanup_wrong_match(
-    db: Any,
+    db: WrongMatchCleanupDB,
     download_log_id: int,
     *,
     failed_path_hint: str | None,
@@ -431,7 +474,7 @@ def _cleanup_wrong_match(
 
 
 def _perform_cleanup_deletion(
-    db: Any,
+    db: WrongMatchCleanupDB,
     *,
     download_log_id: int,
     request_id: int,
@@ -573,7 +616,7 @@ def _perform_cleanup_deletion(
 
 
 def _load_candidate_evidence(
-    db: Any,
+    db: WrongMatchCleanupDB,
     download_log_id: int,
     source_path: str,
 ) -> _LoadedEvidence:
@@ -598,7 +641,7 @@ def _load_candidate_evidence(
 
 
 def _refresh_stale_candidate_evidence(
-    db: Any,
+    db: WrongMatchCleanupDB,
     *,
     request_id: int,
     download_log_id: int,
@@ -672,31 +715,21 @@ def _refresh_stale_candidate_evidence(
 
 
 def _matching_active_jobs(
-    db: Any,
+    db: WrongMatchCleanupDB,
     *,
     download_log_id: int,
     request_id: int | None,
     failed_paths: Iterable[str],
     source_dirs: Iterable[str],
     ignore_import_job_id: int | None,
-) -> list[Any]:
-    finder: Any = getattr(db, "list_active_import_jobs_for_wrong_match", None)
-    if callable(finder):
-        result: Any = finder(
-            download_log_id=download_log_id,
-            request_id=request_id,
-            failed_paths=failed_paths,
-            source_dirs=source_dirs,
-            ignore_import_job_id=ignore_import_job_id,
-        )
-        return list(result)
-
-    jobs = getattr(db, "list_active_import_jobs", lambda **_: [])(
-        request_id=request_id
+) -> list[ImportJob]:
+    return db.list_active_import_jobs_for_wrong_match(
+        download_log_id=download_log_id,
+        request_id=request_id,
+        failed_paths=failed_paths,
+        source_dirs=source_dirs,
+        ignore_import_job_id=ignore_import_job_id,
     )
-    if ignore_import_job_id is None:
-        return list(jobs)
-    return [job for job in jobs if getattr(job, "id", None) != ignore_import_job_id]
 
 
 def _path_candidates(*paths: str | None) -> list[str]:
@@ -828,16 +861,14 @@ def _cleanup_audit_payload(
 
 
 def _persist_cleanup_audit(
-    db: Any,
+    db: WrongMatchCleanupDB,
     result: WrongMatchCleanupOutcome,
 ) -> None:
     if result.outcome not in AUDITED_OUTCOMES:
         return
-    recorder = getattr(db, "record_wrong_match_triage", None)
-    if not callable(recorder):
-        return
     try:
-        recorder(result.download_log_id, _cleanup_audit_payload(result))
+        db.record_wrong_match_triage(
+            result.download_log_id, _cleanup_audit_payload(result))
     except Exception:  # noqa: BLE001
         logger.exception(
             "wrong_match_cleanup.audit_persist_failed download_log_id=%s",

--- a/lib/wrong_match_delete_service.py
+++ b/lib/wrong_match_delete_service.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, cast
+from contextlib import AbstractContextManager
+from typing import Any, Iterable, Protocol, cast, runtime_checkable
 
 import msgspec
 
+from lib.import_queue import ImportJob
 from lib.wrong_matches import (
     cleanup_wrong_match_source,
     unsafe_failed_import_path_reason,
@@ -20,6 +22,37 @@ from lib.validation_envelope import (
     ValidationResultEnvelope,
     decode_validation_envelope,
 )
+
+
+@runtime_checkable
+class WrongMatchDeleteDB(Protocol):
+    """The PipelineDB surface this service uses directly (#409).
+
+    Satisfied structurally by ``PipelineDB`` and ``FakePipelineDB``; parity
+    tests live in ``tests/test_wrong_matches_cleanup.py``. The handle is
+    also forwarded to ``cleanup_wrong_match_source`` (lib/wrong_matches.py),
+    which gets its own protocol in its own #409 increment.
+    """
+
+    def get_wrong_matches(self) -> list[dict[str, object]]: ...
+
+    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
+
+    def advisory_lock(
+        self, namespace: int, key: int,
+    ) -> AbstractContextManager[bool]: ...
+
+    def list_active_import_jobs_for_wrong_match(
+        self,
+        *,
+        download_log_id: int,
+        request_id: int | None,
+        failed_paths: Iterable[str],
+        source_dirs: Iterable[str],
+        ignore_import_job_id: int | None = None,
+        limit: int = 50,
+    ) -> list[ImportJob]: ...
+
 
 OUTCOME_DELETED = "deleted"
 OUTCOME_DELETE_FAILED = "delete_failed"
@@ -75,7 +108,7 @@ class WrongMatchDeleteSummary(msgspec.Struct, frozen=True):
 
 
 def delete_wrong_match(
-    db: Any,
+    db: WrongMatchDeleteDB,
     download_log_id: int,
     *,
     failed_path_hint: str | None = None,
@@ -103,7 +136,7 @@ def delete_wrong_match(
 
 
 def delete_wrong_match_group(
-    db: Any,
+    db: WrongMatchDeleteDB,
     request_id: int,
 ) -> WrongMatchDeleteSummary:
     results: list[WrongMatchDeleteResult] = []
@@ -162,7 +195,7 @@ def delete_wrong_match_group(
 
 
 def _delete_wrong_match(
-    db: Any,
+    db: WrongMatchDeleteDB,
     download_log_id: int,
     *,
     failed_path_hint: str | None,
@@ -391,14 +424,14 @@ def _group_outcome(
     return GROUP_OUTCOME_PARTIAL
 
 
-def _visible_wrong_match_row(db: Any, download_log_id: int) -> dict[str, Any] | None:
+def _visible_wrong_match_row(db: WrongMatchDeleteDB, download_log_id: int) -> dict[str, Any] | None:
     for row in db.get_wrong_matches():
         if row.get("download_log_id") == download_log_id:
             return row
     return None
 
 
-def _remaining_visible_count(db: Any, request_id: int) -> int:
+def _remaining_visible_count(db: WrongMatchDeleteDB, request_id: int) -> int:
     return sum(1 for row in db.get_wrong_matches() if row.get("request_id") == request_id)
 
 
@@ -434,28 +467,18 @@ def _resolve_first_existing(paths: Iterable[str]) -> str | None:
 
 
 def _active_jobs(
-    db: Any,
+    db: WrongMatchDeleteDB,
     *,
     download_log_id: int,
     request_id: int | None,
     failed_paths: Iterable[str],
     source_dirs: Iterable[str],
     ignore_import_job_id: int | None,
-) -> list[Any]:
-    finder: Any = getattr(db, "list_active_import_jobs_for_wrong_match", None)
-    if callable(finder):
-        result: Any = finder(
-            download_log_id=download_log_id,
-            request_id=request_id,
-            failed_paths=failed_paths,
-            source_dirs=source_dirs,
-            ignore_import_job_id=ignore_import_job_id,
-        )
-        return list(result)
-
-    jobs = getattr(db, "list_active_import_jobs", lambda **_: [])(
-        request_id=request_id
+) -> list[ImportJob]:
+    return db.list_active_import_jobs_for_wrong_match(
+        download_log_id=download_log_id,
+        request_id=request_id,
+        failed_paths=failed_paths,
+        source_dirs=source_dirs,
+        ignore_import_job_id=ignore_import_job_id,
     )
-    if ignore_import_job_id is None:
-        return list(jobs)
-    return [job for job in jobs if getattr(job, "id", None) != ignore_import_job_id]

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -8,6 +8,7 @@ import tempfile
 import types
 import unittest
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import msgspec
@@ -1035,6 +1036,39 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
         _candidate_arg, current_arg = decider.call_args.args[:2]
         self.assertIsNone(current_arg)
         self.assertEqual(result.outcome, OUTCOME_KEPT_WOULD_IMPORT)
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.pipeline_db import PipelineDB
+    from lib.wrong_match_cleanup_service import WrongMatchCleanupDB as _CleanupDB
+
+    # Static parity proof: production callers pass db as Any, so without
+    # these assignments pyright never structurally checks the impls against
+    # the protocol. A signature mismatch fails pyright here.
+    _pipeline_db_satisfies_cleanup_protocol: _CleanupDB = cast("PipelineDB", None)
+    _fake_db_satisfies_cleanup_protocol: _CleanupDB = cast("FakePipelineDB", None)
+
+
+class TestCleanupDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy WrongMatchCleanupDB.
+
+    issubclass on the runtime_checkable Protocol guards method *presence*;
+    signature parity is pyright's job (the protocol-typed params make every
+    call site a structural check, plus the TYPE_CHECKING assignment above).
+    """
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.pipeline_db import PipelineDB
+        from lib.wrong_match_cleanup_service import WrongMatchCleanupDB
+
+        self.assertTrue(issubclass(PipelineDB, WrongMatchCleanupDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.wrong_match_cleanup_service import WrongMatchCleanupDB
+
+        self.assertTrue(issubclass(FakePipelineDB, WrongMatchCleanupDB))
 
 
 class TestSummaryOutcomeContract(unittest.TestCase):

--- a/tests/test_wrong_matches_cleanup.py
+++ b/tests/test_wrong_matches_cleanup.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from tests.fakes import FakePipelineDB
@@ -512,6 +513,33 @@ class TestWrongMatchDeleteService(unittest.TestCase):
             self.assertEqual(len(db.get_wrong_matches()), 1)
         finally:
             shutil.rmtree(source, ignore_errors=True)
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.pipeline_db import PipelineDB
+    from lib.wrong_match_delete_service import WrongMatchDeleteDB as _DeleteDB
+
+    # Static parity proof — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_delete_protocol: _DeleteDB = cast("PipelineDB", None)
+    _fake_db_satisfies_delete_protocol: _DeleteDB = cast("FakePipelineDB", None)
+
+
+class TestDeleteDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy WrongMatchDeleteDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.pipeline_db import PipelineDB
+        from lib.wrong_match_delete_service import WrongMatchDeleteDB
+
+        self.assertTrue(issubclass(PipelineDB, WrongMatchDeleteDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.wrong_match_delete_service import WrongMatchDeleteDB
+
+        self.assertTrue(issubclass(FakePipelineDB, WrongMatchDeleteDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem (#409)

Service-layer functions take `db: Any`, so pyright can't catch a misspelled or removed `PipelineDB` method at call sites, fake/production parity is enforced only socially, and defensive `getattr(db, ...)` capability-probing accumulates around methods both implementations have had for ages.

## Change — the pilot, plus its twin

The issue names `wrong_match_cleanup_service` as the pilot; `wrong_match_delete_service` carries the *identical* dead fallback, so both wrong-match services land together.

- **`WrongMatchCleanupDB`** (7 methods) and **`WrongMatchDeleteDB`** (4 methods): `@runtime_checkable` Protocols declared in their consuming modules, listing exactly the `PipelineDB` surface each service calls directly. Every `db` param in both modules is typed against them. No inheritance — `PipelineDB` and `FakePipelineDB` satisfy them structurally.
- **Dead fallbacks deleted**: `_matching_active_jobs` / `_active_jobs` drop the `getattr` probe and the legacy `list_active_import_jobs` fallback branch (review confirmed zero test coverage — genuinely dead); `_persist_cleanup_audit` drops its `getattr`/`callable` recorder dance (the try/except audit-failure guard stays).
- **`PipelineDB.get_download_log_entry` annotated** (`log_id: int -> dict[str, Any] | None`): unannotated params are `Unknown` to pyright (bidirectionally assignable), which made the parity proof vacuous for that method. Caught by the review pass.

## Parity enforcement — three layers

1. **Pyright structural checks** at every typed call site (tests pass `FakePipelineDB` into the protocol-typed functions).
2. **Explicit `TYPE_CHECKING` cast-assignments** for *both* impls in the two test modules — production callers pass `db` as `Any`, so without these anchors pyright would never structurally check `PipelineDB` at all. Verified RED: adding a bogus method to the protocol fails pyright with `"nonexistent_method_409" is not present`.
3. **Runtime `issubclass` tests** (`TestCleanupDBProtocolParity`, `TestDeleteDBProtocolParity`) guarding method presence.

## Review

Pre-commit review agent verified: all 11 protocol signatures exactly admit both impls (keyword-only markers, param names, defaults, the `@contextmanager` → `AbstractContextManager[bool]` assignability); no caller anywhere relies on the deleted fallbacks; every helper the handle is forwarded to is still `db: Any` (their protocols come in future #409 increments); no string-based db access remains in either module. Its one should-fix (the annotation gap) and both nits are addressed.

## Scope

One increment of #409 — the remaining ~40 `db: Any` sites across `lib/` get their own per-service protocols in follow-up PRs per the issue's incremental plan. The issue stays open.

## Verification

- Full suite: 4332 tests OK (4 new parity tests)
- pyright (full repo): 0 errors
- `scripts/find_dead_code.sh`: clean

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)