### PR TITLE
refactor(wrong-matches): WrongMatchSourceDB protocol for the source helpers (#409)

### DIFF
--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -29,26 +29,28 @@ from lib.validation_envelope import (
     WrongMatchTriageAudit,
     decode_validation_envelope,
 )
-from lib.wrong_matches import cleanup_wrong_match_source, validation_failed_path
+from lib.wrong_matches import (
+    WrongMatchSourceDB,
+    cleanup_wrong_match_source,
+    validation_failed_path,
+)
 
 logger = logging.getLogger("cratedigger")
 
 
 @runtime_checkable
-class WrongMatchCleanupDB(Protocol):
-    """The PipelineDB surface this service uses directly (#409).
+class WrongMatchCleanupDB(WrongMatchSourceDB, Protocol):
+    """The PipelineDB surface this service uses (#409).
 
-    ``PipelineDB`` and ``FakePipelineDB`` satisfy it structurally — pyright
-    enforces signature parity at every call site, and the issubclass parity
-    tests in ``tests/test_wrong_match_cleanup_service.py`` guard method
-    presence at runtime. The handle is also forwarded to helpers in other
-    modules (``cleanup_wrong_match_source``, evidence loaders, ``preview_fn``)
-    whose own surfaces get protocols in their own #409 increments.
+    Extends ``WrongMatchSourceDB`` because the handle is forwarded into
+    ``cleanup_wrong_match_source``. ``PipelineDB`` and ``FakePipelineDB``
+    satisfy it structurally — pyright enforces signature parity at every
+    call site, and the issubclass parity tests in
+    ``tests/test_wrong_match_cleanup_service.py`` guard method presence at
+    runtime. The handle is also forwarded to the evidence loaders and
+    ``preview_fn``, whose surfaces get protocols in their own #409
+    increments.
     """
-
-    def get_wrong_matches(self) -> list[dict[str, object]]: ...
-
-    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
 
     def get_request(self, request_id: int) -> dict[str, Any] | None: ...
 

--- a/lib/wrong_match_delete_service.py
+++ b/lib/wrong_match_delete_service.py
@@ -9,6 +9,7 @@ import msgspec
 
 from lib.import_queue import ImportJob
 from lib.wrong_matches import (
+    WrongMatchSourceDB,
     cleanup_wrong_match_source,
     unsafe_failed_import_path_reason,
 )
@@ -25,18 +26,14 @@ from lib.validation_envelope import (
 
 
 @runtime_checkable
-class WrongMatchDeleteDB(Protocol):
-    """The PipelineDB surface this service uses directly (#409).
+class WrongMatchDeleteDB(WrongMatchSourceDB, Protocol):
+    """The PipelineDB surface this service uses (#409).
 
-    Satisfied structurally by ``PipelineDB`` and ``FakePipelineDB``; parity
-    tests live in ``tests/test_wrong_matches_cleanup.py``. The handle is
-    also forwarded to ``cleanup_wrong_match_source`` (lib/wrong_matches.py),
-    which gets its own protocol in its own #409 increment.
+    Extends ``WrongMatchSourceDB`` because the handle is forwarded into
+    ``cleanup_wrong_match_source``. Satisfied structurally by ``PipelineDB``
+    and ``FakePipelineDB``; parity tests live in
+    ``tests/test_wrong_matches_cleanup.py``.
     """
-
-    def get_wrong_matches(self) -> list[dict[str, object]]: ...
-
-    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
 
     def advisory_lock(
         self, namespace: int, key: int,

--- a/lib/wrong_matches.py
+++ b/lib/wrong_matches.py
@@ -5,10 +5,32 @@ from __future__ import annotations
 import os
 import shutil
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from lib.util import FAILED_IMPORT_SEARCH_DIRS, resolve_failed_path
 from lib.validation_envelope import decode_validation_envelope
+
+
+@runtime_checkable
+class WrongMatchSourceDB(Protocol):
+    """The PipelineDB surface the wrong-match source helpers use (#409).
+
+    ``WrongMatchCleanupDB`` and ``WrongMatchDeleteDB`` extend this protocol
+    because their services forward the handle into these helpers. Parity
+    tests live in ``tests/test_wrong_matches_cleanup.py``.
+    """
+
+    def get_wrong_matches(self) -> list[dict[str, object]]: ...
+
+    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
+
+    def clear_wrong_match_path(self, log_id: int) -> bool: ...
+
+    def clear_wrong_match_paths(
+        self,
+        request_id: int,
+        failed_paths: list[str] | tuple[str, ...] | set[str],
+    ) -> int: ...
 
 
 @dataclass(frozen=True)
@@ -92,7 +114,7 @@ def _path_candidates(*paths: str | None) -> list[str]:
 
 
 def _wrong_match_entry_parts(
-    db: Any,
+    db: WrongMatchSourceDB,
     download_log_id: int,
 ) -> tuple[dict[str, Any] | None, int | None, str | None]:
     entry = db.get_download_log_entry(download_log_id)
@@ -149,7 +171,7 @@ def _has_failed_imports_ancestor(path: str) -> bool:
 
 
 def _equivalent_failed_path_aliases(
-    db: Any,
+    db: WrongMatchSourceDB,
     request_id: int | None,
     resolved_path: str | None,
 ) -> list[str]:
@@ -170,7 +192,7 @@ def _equivalent_failed_path_aliases(
 
 
 def dismiss_wrong_match_source(
-    db: Any,
+    db: WrongMatchSourceDB,
     download_log_id: int,
     *,
     failed_path_hint: str | None = None,
@@ -215,7 +237,7 @@ def dismiss_wrong_match_source(
 
 
 def cleanup_wrong_match_source(
-    db: Any,
+    db: WrongMatchSourceDB,
     download_log_id: int,
     *,
     failed_path_hint: str | None = None,

--- a/tests/test_wrong_matches_cleanup.py
+++ b/tests/test_wrong_matches_cleanup.py
@@ -520,11 +520,14 @@ if TYPE_CHECKING:
 
     from lib.pipeline_db import PipelineDB
     from lib.wrong_match_delete_service import WrongMatchDeleteDB as _DeleteDB
+    from lib.wrong_matches import WrongMatchSourceDB as _SourceDB
 
     # Static parity proof — see the matching block in
     # tests/test_wrong_match_cleanup_service.py for the rationale.
     _pipeline_db_satisfies_delete_protocol: _DeleteDB = cast("PipelineDB", None)
     _fake_db_satisfies_delete_protocol: _DeleteDB = cast("FakePipelineDB", None)
+    _pipeline_db_satisfies_source_protocol: _SourceDB = cast("PipelineDB", None)
+    _fake_db_satisfies_source_protocol: _SourceDB = cast("FakePipelineDB", None)
 
 
 class TestDeleteDBProtocolParity(unittest.TestCase):
@@ -540,6 +543,31 @@ class TestDeleteDBProtocolParity(unittest.TestCase):
         from lib.wrong_match_delete_service import WrongMatchDeleteDB
 
         self.assertTrue(issubclass(FakePipelineDB, WrongMatchDeleteDB))
+
+
+class TestSourceDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy WrongMatchSourceDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.pipeline_db import PipelineDB
+        from lib.wrong_matches import WrongMatchSourceDB
+
+        self.assertTrue(issubclass(PipelineDB, WrongMatchSourceDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.wrong_matches import WrongMatchSourceDB
+
+        self.assertTrue(issubclass(FakePipelineDB, WrongMatchSourceDB))
+
+    def test_service_protocols_extend_source_protocol(self) -> None:
+        """The services forward their handle into wrong_matches helpers, so
+        their protocols must declare the source surface too."""
+        from lib.wrong_match_cleanup_service import WrongMatchCleanupDB
+        from lib.wrong_match_delete_service import WrongMatchDeleteDB
+        from lib.wrong_matches import WrongMatchSourceDB
+
+        self.assertTrue(issubclass(WrongMatchCleanupDB, WrongMatchSourceDB))
+        self.assertTrue(issubclass(WrongMatchDeleteDB, WrongMatchSourceDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

Second #409 increment, completing the wrong-match subsystem: `lib/wrong_matches.py` (the source-helper module the two services forward their handle into) gets `WrongMatchSourceDB` — `get_wrong_matches`, `get_download_log_entry`, `clear_wrong_match_path`, `clear_wrong_match_paths` — typing its four `db: Any` params.

The structural insight: `WrongMatchCleanupDB` and `WrongMatchDeleteDB` now **extend** `WrongMatchSourceDB` instead of duplicating the shared method declarations. Both services pass their protocol-typed handle into `cleanup_wrong_match_source`, so protocol inheritance is what makes those forwarding call sites type-check honestly — a service protocol that didn't cover the forwarded surface would fail pyright at the handoff.

## Parity (same three layers as #417)

- `TYPE_CHECKING` cast-anchors for `PipelineDB` *and* `FakePipelineDB` against the new protocol
- Runtime `issubclass` presence tests
- A new guard asserting both service protocols are subclasses of the source protocol (pins the inheritance relationship)

## Verification

- Full suite: 4335 tests OK (3 new)
- pyright (full repo): 0 errors
- Dead-code sweep: clean

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)