### PR TITLE
refactor(evidence): QualityEvidenceDB protocol for the evidence loaders (#409)

### DIFF
--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -16,6 +16,7 @@ import msgspec
 from lib.quality import AlbumQualityEvidence, QualityRankConfig
 from lib.quality_evidence import (
     EvidenceBuildResult,
+    QualityEvidenceDB,
     audio_snapshot_matches,
     backfill_current_evidence_from_album_info,
     load_candidate_evidence_for_source,
@@ -84,7 +85,7 @@ class CurrentEvidenceActionResult(msgspec.Struct, frozen=True):
 
 
 def ensure_candidate_evidence_for_action(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     source_path: str,
     download_log_id: int | None = None,
@@ -120,7 +121,7 @@ def ensure_candidate_evidence_for_action(
 
 
 def ensure_current_evidence_for_action(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     request_id: int,
     mb_release_id: str,
@@ -237,7 +238,7 @@ def ensure_current_evidence_for_action(
 
 
 def load_current_evidence_for_action(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     request_id: int,
     mb_release_id: str,

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -7,7 +7,7 @@ import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from lib.quality import (
     LOSSLESS_CODECS,
@@ -28,6 +28,57 @@ from lib.quality import (
 
 if TYPE_CHECKING:
     from lib.measurement import PreimportMeasurement
+
+
+@runtime_checkable
+class QualityEvidenceDB(Protocol):
+    """The PipelineDB surface the evidence persist/load helpers use (#409).
+
+    Shared by ``lib/import_evidence.py`` (which forwards its handle into
+    these loaders) and extended by ``WrongMatchCleanupDB`` for the same
+    reason. Parity tests live in ``tests/test_quality_evidence.py``.
+    """
+
+    def get_request(self, request_id: int) -> dict[str, Any] | None: ...
+
+    def upsert_album_quality_evidence(
+        self, evidence: AlbumQualityEvidence,
+    ) -> None: ...
+
+    def find_album_quality_evidence(
+        self,
+        *,
+        mb_release_id: str,
+        snapshot_fingerprint: str,
+    ) -> AlbumQualityEvidence | None: ...
+
+    def load_album_quality_evidence_by_id(
+        self, evidence_id: int | None,
+    ) -> AlbumQualityEvidence | None: ...
+
+    def set_import_job_candidate_evidence(
+        self, import_job_id: int, evidence_id: int | None,
+    ) -> None: ...
+
+    def set_download_log_candidate_evidence(
+        self, download_log_id: int, evidence_id: int | None,
+    ) -> None: ...
+
+    def set_request_current_evidence(
+        self, request_id: int, evidence_id: int | None,
+    ) -> None: ...
+
+    def get_import_job_candidate_evidence_id(
+        self, import_job_id: int,
+    ) -> int | None: ...
+
+    def get_download_log_candidate_evidence_id(
+        self, download_log_id: int,
+    ) -> int | None: ...
+
+    def get_request_current_evidence_id(
+        self, request_id: int,
+    ) -> int | None: ...
 
 
 _AUDIO_EXTENSIONS = {
@@ -727,7 +778,7 @@ def evidence_from_album_info(
 
 
 def persist_candidate_evidence_from_import_result(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     mb_release_id: str,
     source_path: str,
@@ -777,7 +828,7 @@ def persist_candidate_evidence_from_import_result(
 
 
 def persist_candidate_evidence_from_measurement(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     mb_release_id: str,
     source_path: str,
@@ -827,7 +878,7 @@ def persist_candidate_evidence_from_measurement(
 
 
 def propagate_candidate_evidence_to_current(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     request_id: int,
     candidate_evidence: AlbumQualityEvidence,
@@ -957,7 +1008,7 @@ def propagate_candidate_evidence_to_current(
 
 
 def backfill_current_evidence_from_album_info(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     request_id: int,
     mb_release_id: str,
@@ -1003,7 +1054,7 @@ def backfill_current_evidence_from_album_info(
 
 
 def load_candidate_evidence_for_source(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     source_path: str,
     download_log_id: int | None = None,
@@ -1054,7 +1105,7 @@ def load_candidate_evidence_for_source(
 
 
 def load_or_backfill_current_evidence(
-    db: Any,
+    db: QualityEvidenceDB,
     *,
     request_id: int,
     mb_release_id: str,

--- a/lib/wrong_match_cleanup_service.py
+++ b/lib/wrong_match_cleanup_service.py
@@ -23,7 +23,10 @@ from lib.quality import (
     full_pipeline_decision_from_evidence,
     narrow_override_on_lossless_source_lock,
 )
-from lib.quality_evidence import load_candidate_evidence_for_source
+from lib.quality_evidence import (
+    QualityEvidenceDB,
+    load_candidate_evidence_for_source,
+)
 from lib.util import resolve_failed_path
 from lib.validation_envelope import (
     WrongMatchTriageAudit,
@@ -39,20 +42,17 @@ logger = logging.getLogger("cratedigger")
 
 
 @runtime_checkable
-class WrongMatchCleanupDB(WrongMatchSourceDB, Protocol):
+class WrongMatchCleanupDB(WrongMatchSourceDB, QualityEvidenceDB, Protocol):
     """The PipelineDB surface this service uses (#409).
 
-    Extends ``WrongMatchSourceDB`` because the handle is forwarded into
-    ``cleanup_wrong_match_source``. ``PipelineDB`` and ``FakePipelineDB``
-    satisfy it structurally — pyright enforces signature parity at every
-    call site, and the issubclass parity tests in
+    Extends ``WrongMatchSourceDB`` (the handle is forwarded into
+    ``cleanup_wrong_match_source``) and ``QualityEvidenceDB`` (forwarded
+    into the evidence loaders and ``preview_fn``). ``PipelineDB`` and
+    ``FakePipelineDB`` satisfy it structurally — pyright enforces signature
+    parity at every call site, and the issubclass parity tests in
     ``tests/test_wrong_match_cleanup_service.py`` guard method presence at
-    runtime. The handle is also forwarded to the evidence loaders and
-    ``preview_fn``, whose surfaces get protocols in their own #409
-    increments.
+    runtime.
     """
-
-    def get_request(self, request_id: int) -> dict[str, Any] | None: ...
 
     def advisory_lock(
         self, namespace: int, key: int,

--- a/tests/test_quality_evidence.py
+++ b/tests/test_quality_evidence.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from typing import TYPE_CHECKING
 
 from lib.beets_db import AlbumInfo
 from lib.quality import (
@@ -425,6 +426,43 @@ class TestAudioSnapshotMatches(unittest.TestCase):
         """Sanity: an unchanged tree always matches."""
         captured = snapshot_audio_files(self.root)
         self.assertTrue(audio_snapshot_matches(self.root, captured))
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.pipeline_db import PipelineDB
+    from lib.quality_evidence import QualityEvidenceDB as _EvidenceDB
+    from tests.fakes import FakePipelineDB as _FakeDB
+
+    # Static parity proof (#409) — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_evidence_protocol: _EvidenceDB = cast("PipelineDB", None)
+    _fake_db_satisfies_evidence_protocol: _EvidenceDB = cast("_FakeDB", None)
+
+
+class TestEvidenceDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy QualityEvidenceDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.pipeline_db import PipelineDB
+        from lib.quality_evidence import QualityEvidenceDB
+
+        self.assertTrue(issubclass(PipelineDB, QualityEvidenceDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.quality_evidence import QualityEvidenceDB
+        from tests.fakes import FakePipelineDB
+
+        self.assertTrue(issubclass(FakePipelineDB, QualityEvidenceDB))
+
+    def test_cleanup_protocol_extends_evidence_protocol(self) -> None:
+        """The cleanup service forwards its handle into the evidence
+        loaders, so its protocol must declare this surface too."""
+        from lib.quality_evidence import QualityEvidenceDB
+        from lib.wrong_match_cleanup_service import WrongMatchCleanupDB
+
+        self.assertTrue(issubclass(WrongMatchCleanupDB, QualityEvidenceDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

Third #409 increment: the evidence persist/load layer. `lib/quality_evidence.py` declares **`QualityEvidenceDB`** (10 methods — evidence upsert/find/load-by-id, the three candidate/current FK setters and their three getters, plus `get_request`) and types its six `db: Any` params. `lib/import_evidence.py` forwards its handle into those loaders, so its three `db` params reuse the same protocol rather than declaring a narrower one that would fail at the handoff.

`WrongMatchCleanupDB` now extends `QualityEvidenceDB` alongside `WrongMatchSourceDB` — the cleanup service forwards its handle into `load_candidate_evidence_for_source` / `load_current_evidence_for_action` / `preview_fn`, and the protocol-inheritance composition from #418 is what keeps those forwarding sites honest. The protocol now states the service's real transitive DB surface (~17 methods), which is exactly the visibility #409 is after.

## Parity (same three layers)

- `TYPE_CHECKING` cast-anchors for `PipelineDB` and `FakePipelineDB` in `tests/test_quality_evidence.py`
- Runtime `issubclass` tests for both impls
- A guard pinning `WrongMatchCleanupDB` ⊇ `QualityEvidenceDB`

## Verification

- Full suite: 4338 tests OK (3 new)
- pyright (full repo): 0 errors
- Dead-code sweep: clean

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)