### PR TITLE
refactor(import_preview): ImportPreviewDB protocol (#409)

### DIFF
--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import msgspec
 
@@ -21,6 +21,7 @@ from lib.measurement import (
     measure_preimport_state,
 )
 from lib.quality_evidence import (
+    QualityEvidenceDB,
     audio_snapshot_matches,
     legacy_current_lossless_v0_probe_from_request,
     load_or_backfill_current_evidence,
@@ -46,8 +47,20 @@ from lib.util import repair_mp3_headers, resolve_failed_path
 from lib.validation_envelope import decode_validation_envelope
 
 
+@runtime_checkable
+class ImportPreviewDB(QualityEvidenceDB, Protocol):
+    """The PipelineDB surface the preview entry points use (#409).
+
+    Extends ``QualityEvidenceDB`` because the handle is forwarded into the
+    evidence persisters. Parity tests live in
+    ``tests/test_import_preview.py``.
+    """
+
+    def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
+
+
 def _load_current_evidence_by_request(
-    db: Any, request_id: int
+    db: ImportPreviewDB, request_id: int
 ) -> Any:
     """U3 FK reader: load current evidence via ``album_requests.current_evidence_id``.
 
@@ -356,7 +369,7 @@ def _request_label(req: dict[str, Any]) -> str:
 
 
 def measure_and_persist_candidate_evidence(
-    db: Any,
+    db: ImportPreviewDB,
     *,
     request_id: int,
     path: str,
@@ -788,7 +801,7 @@ def _measurement_decision_hint(measurement: Any) -> str:
 
 
 def preview_import_from_path(
-    db: Any,
+    db: ImportPreviewDB,
     *,
     request_id: int,
     path: str,
@@ -1116,7 +1129,7 @@ def preview_import_from_path(
 
 
 def preview_import_from_download_log(
-    db: Any,
+    db: ImportPreviewDB,
     download_log_id: int,
 ) -> ImportPreviewResult:
     """Preview the failed source referenced by one download_log row.

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from lib.config import CratediggerConfig
@@ -632,6 +633,40 @@ class TestImportPreviewPath(unittest.TestCase):
         finally:
             import shutil
             shutil.rmtree(source, ignore_errors=True)
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.import_preview import ImportPreviewDB as _PreviewDB
+    from lib.pipeline_db import PipelineDB
+
+    # Static parity proof (#409) — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_preview_protocol: _PreviewDB = cast("PipelineDB", None)
+    _fake_db_satisfies_preview_protocol: _PreviewDB = cast("FakePipelineDB", None)
+
+
+class TestPreviewDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy ImportPreviewDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.import_preview import ImportPreviewDB
+        from lib.pipeline_db import PipelineDB
+
+        self.assertTrue(issubclass(PipelineDB, ImportPreviewDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.import_preview import ImportPreviewDB
+
+        self.assertTrue(issubclass(FakePipelineDB, ImportPreviewDB))
+
+    def test_preview_protocol_extends_evidence_protocol(self) -> None:
+        """Preview forwards its handle into the evidence persisters."""
+        from lib.import_preview import ImportPreviewDB
+        from lib.quality_evidence import QualityEvidenceDB
+
+        self.assertTrue(issubclass(ImportPreviewDB, QualityEvidenceDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

Fourth #409 increment: `lib/import_preview.py`. **`ImportPreviewDB`** extends `QualityEvidenceDB` (the preview entry points forward their handle into the evidence persisters from #419) and adds `get_download_log_entry`. All four `db: Any` params are protocol-typed: `measure_and_persist_candidate_evidence`, `preview_import_from_path`, `preview_import_from_download_log`, and the U3 FK reader `_load_current_evidence_by_request`.

## Parity (same three layers)

- `TYPE_CHECKING` cast-anchors for `PipelineDB` and `FakePipelineDB` in `tests/test_import_preview.py`
- Runtime `issubclass` tests for both impls
- A guard pinning `ImportPreviewDB` ⊇ `QualityEvidenceDB`

## Verification

- Full suite: 4341 tests OK (3 new)
- pyright (full repo): 0 errors
- Dead-code sweep: clean

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)