### PR TITLE
refactor(search-plan): SearchPlanDB protocol for SearchPlanService (#409)

### DIFF
--- a/lib/pipeline_db/misc.py
+++ b/lib/pipeline_db/misc.py
@@ -27,7 +27,7 @@ class _MiscMixin(_PipelineDBBase):
 
     # --- Track management ---
 
-    def set_tracks(self, request_id, tracks):
+    def set_tracks(self, request_id: int, tracks: list[dict[str, Any]]) -> None:
         self._execute("DELETE FROM album_tracks WHERE request_id = %s", (request_id,))
         for t in tracks:
             self._execute("""
@@ -44,7 +44,7 @@ class _MiscMixin(_PipelineDBBase):
         self.conn.commit()
 
 
-    def get_tracks(self, request_id):
+    def get_tracks(self, request_id: int) -> list[dict[str, Any]]:
         cur = self._execute("""
             SELECT disc_number, track_number, title, length_seconds, track_artist
             FROM album_tracks

--- a/lib/search_plan_service.py
+++ b/lib/search_plan_service.py
@@ -31,13 +31,17 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from contextlib import AbstractContextManager
+from typing import Any, Optional, Protocol, runtime_checkable
 
 from lib.config import CratediggerConfig
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_PLAN,
     PLAN_STATUS_ACTIVE,
+    ActiveSearchPlan,
     SaturationSummary,
+    SearchLogHistoryPage,
+    SearchPlanInspection,
     SearchPlanItemInput,
 )
 from lib.release_snapshot import (
@@ -59,6 +63,87 @@ from lib.search import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SearchPlanDB(Protocol):
+    """The PipelineDB surface SearchPlanService uses (#409).
+
+    Parity tests live in ``tests/test_search_plan_service.py``.
+    """
+
+    def get_request(self, request_id: int) -> dict[str, Any] | None: ...
+
+    def get_tracks(self, request_id: int) -> list[dict[str, Any]]: ...
+
+    def set_tracks(
+        self, request_id: int, tracks: list[dict[str, Any]],
+    ) -> None: ...
+
+    def advisory_lock(
+        self, namespace: int, key: int,
+    ) -> AbstractContextManager[bool]: ...
+
+    def get_active_search_plan(
+        self, request_id: int,
+    ) -> ActiveSearchPlan | None: ...
+
+    def create_successful_search_plan(
+        self,
+        *,
+        request_id: int,
+        generator_id: str,
+        items: list[SearchPlanItemInput],
+        metadata_snapshot: dict[str, object] | None = None,
+        provenance: dict[str, object] | None = None,
+        set_active: bool = True,
+    ) -> int: ...
+
+    def create_failed_search_plan(
+        self,
+        *,
+        request_id: int,
+        generator_id: str,
+        failure_class: str,
+        error_message: str | None = None,
+        transient: bool,
+        metadata_snapshot: dict[str, object] | None = None,
+        provenance: dict[str, object] | None = None,
+    ) -> int: ...
+
+    def supersede_search_plan_with_replacement(
+        self,
+        *,
+        request_id: int,
+        generator_id: str,
+        items: list[SearchPlanItemInput],
+        metadata_snapshot: dict[str, object] | None = None,
+        provenance: dict[str, object] | None = None,
+    ) -> int: ...
+
+    def advance_search_plan_cursor(
+        self,
+        request_id: int,
+        *,
+        target_ordinal: int,
+        plan_item_count: int,
+    ) -> tuple[int, int, int]: ...
+
+    def get_saturation_summary(
+        self, request_id: int, *, window_days: int = 14,
+    ) -> SaturationSummary: ...
+
+    def get_search_history_page(
+        self,
+        request_id: int,
+        *,
+        limit: int,
+        before_id: int | None = None,
+    ) -> SearchLogHistoryPage: ...
+
+    def get_search_plan_inspection(
+        self, request_id: int,
+    ) -> SearchPlanInspection: ...
 
 
 # Failure-class strings (mirror migration 014's CHECK constraint and the
@@ -377,7 +462,7 @@ class SearchPlanService:
 
     def __init__(
         self,
-        db: Any,
+        db: SearchPlanDB,
         config: CratediggerConfig,
         resolver: Optional[TrackResolver] = None,
     ) -> None:

--- a/tests/test_search_plan_service.py
+++ b/tests/test_search_plan_service.py
@@ -21,6 +21,7 @@ import os
 import sys
 import unittest
 from datetime import timedelta
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -1535,6 +1536,33 @@ class TestSearchPlanServiceU12NoServiceWrap(unittest.TestCase):
         # natural wrap inside ``record_consumed_search_attempt``
         # writes it.
         self.assertIsNone(self.db.request(42)["failure_class"])
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.pipeline_db import PipelineDB
+    from lib.search_plan_service import SearchPlanDB as _PlanDB
+
+    # Static parity proof (#409) — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_plan_protocol: _PlanDB = cast("PipelineDB", None)
+    _fake_db_satisfies_plan_protocol: _PlanDB = cast("FakePipelineDB", None)
+
+
+class TestSearchPlanDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy SearchPlanDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.pipeline_db import PipelineDB
+        from lib.search_plan_service import SearchPlanDB
+
+        self.assertTrue(issubclass(PipelineDB, SearchPlanDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.search_plan_service import SearchPlanDB
+
+        self.assertTrue(issubclass(FakePipelineDB, SearchPlanDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

Fifth #409 increment: `SearchPlanService`. **`SearchPlanDB`** declares the 12-method surface the service actually uses — `get_request`, `get_tracks`/`set_tracks`, `advisory_lock`, the plan family (`get_active_search_plan`, `create_successful_search_plan`, `create_failed_search_plan`, `supersede_search_plan_with_replacement`, `advance_search_plan_cursor`), and the iter2 readers (`get_saturation_summary`, `get_search_history_page`, `get_search_plan_inspection`). The constructor's `db: Any` becomes `db: SearchPlanDB`.

`PipelineDB.get_tracks` / `set_tracks` gain annotations — same vacuous-parity gap as `get_download_log_entry` in #417 (unannotated params are `Unknown`, bidirectionally assignable, so pyright wasn't actually checking them against the protocol).

## Parity (same three layers)

- `TYPE_CHECKING` cast-anchors for `PipelineDB` and `FakePipelineDB` in `tests/test_search_plan_service.py`
- Runtime `issubclass` tests for both impls

## Verification

- Full suite: 4343 tests OK (2 new)
- pyright (full repo): 0 errors
- Dead-code sweep: clean

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)