### PR TITLE
refactor(replace): MbidReplaceDB + ReleaseCleanupDB protocols (#409)

### DIFF
--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -32,7 +32,7 @@ import shutil
 import socket
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, Protocol, runtime_checkable
 from urllib.error import URLError
 
 
@@ -55,16 +55,54 @@ from lib.pipeline_db import (
     SupersedeRaceError,
 )
 from lib.processing_paths import stage_to_ai_path
-from lib.release_cleanup import remove_and_reset_release
-from lib.search_plan_service import SearchPlanService
+from lib.release_cleanup import ReleaseCleanupDB, remove_and_reset_release
+from lib.search_plan_service import SearchPlanDB, SearchPlanService
 from lib.util import (
     trigger_jellyfin_scan,
     trigger_meelo_scan,
     trigger_plex_scan,
 )
-from lib.wrong_match_delete_service import delete_wrong_match_group
+from lib.wrong_match_delete_service import (
+    WrongMatchDeleteDB,
+    delete_wrong_match_group,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class MbidReplaceDB(
+    WrongMatchDeleteDB, ReleaseCleanupDB, SearchPlanDB, Protocol,
+):
+    """The PipelineDB surface the Replace action uses (#409).
+
+    Extends the protocols of everything the handle is forwarded into:
+    ``delete_wrong_match_group``, ``remove_and_reset_release``, and the
+    constructor-built ``SearchPlanService``. Parity tests live in
+    ``tests/test_mbid_replace_service.py``.
+    """
+
+    def get_request_by_mb_release_id(
+        self, mb_release_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    def get_request_by_replaces_request_id(
+        self, replaced_id: int,
+    ) -> dict[str, Any] | None: ...
+
+    def supersede_request_mbid(
+        self,
+        old_request_id: int,
+        *,
+        new_mb_release_id: str,
+        new_mb_release_group_id: str | None,
+        new_mb_artist_id: str | None,
+        new_artist_name: str,
+        new_album_title: str,
+        new_year: int | None,
+        new_country: str | None,
+        new_tracks: list[dict[str, Any]],
+    ) -> int: ...
 
 
 # Result outcome constants.
@@ -139,7 +177,7 @@ class MbidReplaceService:
 
     def __init__(
         self,
-        db: Any,
+        db: MbidReplaceDB,
         config: CratediggerConfig,
         slskd: Any = None,
         beets_db_factory: BeetsDBFactory | None = None,
@@ -260,6 +298,18 @@ class MbidReplaceService:
 
         source_rg = source.get("mb_release_group_id")
         if not source_rg:
+            # A source row without an MBID (Discogs-only) cannot be
+            # RG-resolved — same TARGET_INVALID outcome the lookup
+            # exception path produced before the typed narrowing.
+            if not isinstance(source_mbid, str) or not source_mbid:
+                return ReplaceResult(
+                    outcome=RESULT_TARGET_INVALID,
+                    request_id=request_id,
+                    error_message=(
+                        f"source MBID {source_mbid!r} could not be "
+                        "resolved: source request has no MB release id"
+                    ),
+                )
             # Lazy-backfill: resolve the source MBID's RG fresh.
             try:
                 src_data = self.mb_lookup(source_mbid, fresh=True)

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -83,7 +83,7 @@ class _RequestsMixin(_PipelineDBBase):
         return dict(row) if row else None
 
 
-    def get_request_by_mb_release_id(self, mb_release_id) -> dict[str, Any] | None:
+    def get_request_by_mb_release_id(self, mb_release_id: str) -> dict[str, Any] | None:
         cur = self._execute(
             "SELECT * FROM album_requests WHERE mb_release_id = %s", (mb_release_id,)
         )

--- a/lib/release_cleanup.py
+++ b/lib/release_cleanup.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from lib.beets_album_op import (BeetsOpFailure as SelectorFailure,
                                 BeetsOpFailureReason as SelectorFailureReason,
@@ -60,10 +60,16 @@ from lib.beets_album_op import BeetsAlbumHandle
 
 if TYPE_CHECKING:
     from lib.beets_db import BeetsDB
-    from lib.pipeline_db import PipelineDB
 
 
 log = logging.getLogger("cratedigger")
+
+
+@runtime_checkable
+class ReleaseCleanupDB(Protocol):
+    """The PipelineDB surface remove_and_reset_release uses (#409)."""
+
+    def clear_on_disk_quality_fields(self, request_id: int) -> None: ...
 
 # Re-export for historical call sites (web/routes/pipeline.py, tests,
 # harness/import_one.py) that import these names from this module.
@@ -182,7 +188,7 @@ def remove_album_by_selectors(
 
 def remove_and_reset_release(
     beets_db: "BeetsDB",
-    pipeline_db: "PipelineDB",
+    pipeline_db: ReleaseCleanupDB,
     release_id: str,
     request_id: int,
     *,

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 from urllib.error import URLError
 
@@ -1081,6 +1082,45 @@ class TestReplaceCallOrder(_ServiceCase):
             )
         # slskd was never touched (R23).
         self._assert_slskd_untouched(svc.slskd)
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.mbid_replace_service import MbidReplaceDB as _ReplaceDB
+    from lib.pipeline_db import PipelineDB
+
+    # Static parity proof (#409) — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_replace_protocol: _ReplaceDB = cast("PipelineDB", None)
+    _fake_db_satisfies_replace_protocol: _ReplaceDB = cast("FakePipelineDB", None)
+
+
+class TestReplaceDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy MbidReplaceDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.mbid_replace_service import MbidReplaceDB
+        from lib.pipeline_db import PipelineDB
+
+        self.assertTrue(issubclass(PipelineDB, MbidReplaceDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.mbid_replace_service import MbidReplaceDB
+
+        self.assertTrue(issubclass(FakePipelineDB, MbidReplaceDB))
+
+    def test_replace_protocol_extends_forwarded_surfaces(self) -> None:
+        """Replace forwards its handle into wrong-match group delete,
+        release cleanup, and SearchPlanService."""
+        from lib.mbid_replace_service import MbidReplaceDB
+        from lib.release_cleanup import ReleaseCleanupDB
+        from lib.search_plan_service import SearchPlanDB
+        from lib.wrong_match_delete_service import WrongMatchDeleteDB
+
+        self.assertTrue(issubclass(MbidReplaceDB, WrongMatchDeleteDB))
+        self.assertTrue(issubclass(MbidReplaceDB, ReleaseCleanupDB))
+        self.assertTrue(issubclass(MbidReplaceDB, SearchPlanDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

Sixth #409 increment: the Replace operator action. **`MbidReplaceDB`** composes the protocols of everything the handle is forwarded into — `WrongMatchDeleteDB` (`delete_wrong_match_group`), **`ReleaseCleanupDB`** (new single-method protocol in `lib/release_cleanup.py`, replacing the concrete `"PipelineDB"` annotation on `remove_and_reset_release`), and `SearchPlanDB` (the constructor-built `SearchPlanService`) — plus the three replace-specific request methods.

The protocol graph now mirrors the real runtime dependency graph:

```
MbidReplaceDB ── WrongMatchDeleteDB ── WrongMatchSourceDB
             ├── ReleaseCleanupDB
             └── SearchPlanDB
```

## Typed narrowing caught a real gap

A Discogs-only source row (`mb_release_id` = None) reaching the lazy RG-backfill would previously have passed `None` into the MB lookup and crashed into the generic exception handler. An explicit guard now returns the same `RESULT_TARGET_INVALID` outcome with an honest message. `PipelineDB.get_request_by_mb_release_id` also gains its missing param annotation (the recurring vacuous-parity gap).

## Verification

- Full suite: 4346 tests OK (3 new, incl. a guard pinning the three-parent composition)
- pyright (full repo): 0 errors
- Dead-code sweep: clean

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)