### PR TITLE
refactor(lib): final db protocols — youtube, disk-coverage, dispatch getattrs (#409)

### DIFF
--- a/lib/disk_coverage_service.py
+++ b/lib/disk_coverage_service.py
@@ -5,7 +5,7 @@ present in beets?" without treating ``album_requests.status`` as disk state.
 """
 
 from collections import Counter
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import msgspec
 
@@ -94,9 +94,27 @@ def _beets_row(row: dict[str, Any]) -> BeetsUntrackedAlbum:
     )
 
 
+@runtime_checkable
+class DiskCoveragePipelineDB(Protocol):
+    """The PipelineDB surface disk_coverage uses (#409)."""
+
+    def list_non_replaced_requests(self) -> list[dict[str, Any]]: ...
+
+
+@runtime_checkable
+class DiskCoverageBeetsDB(Protocol):
+    """The BeetsDB surface disk_coverage uses (#409) — the first
+    BeetsDB-side protocol; ``BeetsDB`` and ``FakeBeetsDB`` satisfy it
+    structurally."""
+
+    def check_mbids(self, mbids: list[str]) -> set[str]: ...
+
+    def list_release_identities(self) -> list[dict[str, object]]: ...
+
+
 def disk_coverage(
-    pipeline_db: Any,
-    beets_db: Any | None,
+    pipeline_db: DiskCoveragePipelineDB,
+    beets_db: DiskCoverageBeetsDB | None,
     *,
     include_rows: bool = True,
     include_inverse: bool = False,

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -118,11 +118,8 @@ def _origin_manifest_for_download_log(
 ) -> list[str]:
     if download_log_id is None:
         return []
-    get_entry = getattr(db, "get_download_log_entry", None)
-    if get_entry is None:
-        return []
-    entry = get_entry(download_log_id)
-    if not isinstance(entry, dict):
+    entry = db.get_download_log_entry(download_log_id)
+    if entry is None:
         return []
     vr = decode_validation_envelope(entry.get("validation_result"))
     if not vr.items:
@@ -131,17 +128,12 @@ def _origin_manifest_for_download_log(
 
 
 def _expected_request_track_count(db: "PipelineDB", request_id: int) -> int | None:
-    get_tracks = getattr(db, "get_tracks", None)
-    if get_tracks is None:
-        return None
     try:
-        tracks = get_tracks(request_id)
+        tracks = db.get_tracks(request_id)
     except Exception:
         logger.debug("Failed to read expected tracks for manifest guard", exc_info=True)
         return None
-    if not isinstance(tracks, list) or not tracks:
-        return None
-    return len(tracks)
+    return len(tracks) if tracks else None
 
 
 def _guard_reject(

--- a/lib/youtube_album_service.py
+++ b/lib/youtube_album_service.py
@@ -36,7 +36,7 @@ import re
 import socket
 import time
 import urllib.error
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
 
 import msgspec
 import requests
@@ -415,6 +415,27 @@ DistanceFn = Callable[..., BeetsDistanceResult]
 can supply canned results."""
 
 
+@runtime_checkable
+class YoutubeResolverDB(Protocol):
+    """The PipelineDB surface the resolver uses directly (#409).
+
+    The handle is also forwarded into ``distance_fn`` (a ``Callable[...]``
+    — ``compute_beets_distance`` types its own db param). Parity tests
+    live in ``tests/test_youtube_album_service.py``.
+    """
+
+    def get_youtube_album_mapping(
+        self, release_group_identifier: str, source: str,
+    ) -> Optional[list[dict[str, Any]]]: ...
+
+    def upsert_youtube_album_mapping(
+        self,
+        release_group_identifier: str,
+        source: str,
+        rows: list[dict[str, Any]],
+    ) -> None: ...
+
+
 # ---------------------------------------------------------------------------
 # Public service entrypoint.
 # ---------------------------------------------------------------------------
@@ -423,7 +444,7 @@ can supply canned results."""
 def resolve_youtube_album(
     identifier: str,
     *,
-    pdb: Any,
+    pdb: YoutubeResolverDB,
     mb_get_release: MBLookup,
     mb_get_release_group_releases: MBRGReleases,
     discogs_get_release: DiscogsLookup,
@@ -1300,7 +1321,7 @@ def _score_against_siblings(
     sibling_mbids: list[str],
     mb_release_group_id: Optional[str],
     distance_fn: DistanceFn,
-    pdb: Any,
+    pdb: YoutubeResolverDB,
     mb_fetcher: Callable[[str], Optional[dict]],
     deadline_breached: Optional[Callable[[], bool]] = None,
 ) -> list[ResolvedDistance]:

--- a/lib/youtube_ingest_service.py
+++ b/lib/youtube_ingest_service.py
@@ -470,7 +470,7 @@ def default_mb_track_count_from_mirror(mbid: str) -> Optional[int]:
     return len(tracks)
 
 
-def default_youtube_ingest_service_factory(pdb: Any) -> "YoutubeIngestService":
+def default_youtube_ingest_service_factory(pdb: _PipelineDB) -> "YoutubeIngestService":
     """Construct a production ``YoutubeIngestService`` for CLI / API.
 
     Wires the live MB-mirror ``mb_track_count_fn`` (other ports retain

--- a/tests/test_disk_coverage_service.py
+++ b/tests/test_disk_coverage_service.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import TYPE_CHECKING
 
 import msgspec
 
@@ -96,6 +97,42 @@ class TestDiskCoverageService(unittest.TestCase):
 
         self.assertEqual(payload["counts"]["off_disk_total"], 1)
         self.assertEqual(payload["off_disk"][0]["id"], 1)
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.beets_db import BeetsDB
+    from lib.disk_coverage_service import (
+        DiskCoverageBeetsDB as _CovBeetsDB,
+        DiskCoveragePipelineDB as _CovPipelineDB,
+    )
+    from lib.pipeline_db import PipelineDB
+
+    # Static parity proof (#409) — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_coverage_protocol: _CovPipelineDB = cast("PipelineDB", None)
+    _fake_db_satisfies_coverage_protocol: _CovPipelineDB = cast("FakePipelineDB", None)
+    _beets_db_satisfies_coverage_protocol: _CovBeetsDB = cast("BeetsDB", None)
+    _fake_beets_satisfies_coverage_protocol: _CovBeetsDB = cast("FakeBeetsDB", None)
+
+
+class TestDiskCoverageDBProtocolParity(unittest.TestCase):
+    """#409: both impl pairs must satisfy the disk-coverage protocols."""
+
+    def test_pipeline_impls_satisfy_protocol(self) -> None:
+        from lib.disk_coverage_service import DiskCoveragePipelineDB
+        from lib.pipeline_db import PipelineDB
+
+        self.assertTrue(issubclass(PipelineDB, DiskCoveragePipelineDB))
+        self.assertTrue(issubclass(FakePipelineDB, DiskCoveragePipelineDB))
+
+    def test_beets_impls_satisfy_protocol(self) -> None:
+        from lib.beets_db import BeetsDB
+        from lib.disk_coverage_service import DiskCoverageBeetsDB
+
+        self.assertTrue(issubclass(BeetsDB, DiskCoverageBeetsDB))
+        self.assertTrue(issubclass(FakeBeetsDB, DiskCoverageBeetsDB))
 
 
 if __name__ == "__main__":

--- a/tests/test_youtube_album_service.py
+++ b/tests/test_youtube_album_service.py
@@ -13,7 +13,7 @@ Outcome vocabulary is pinned via ``test_outcome_set_is_stable`` per
 from __future__ import annotations
 
 import unittest
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TYPE_CHECKING
 from unittest.mock import patch
 
 import msgspec
@@ -2886,6 +2886,33 @@ class TestRedisCacheWiring(unittest.TestCase):
         }
         self.assertIn("MPREb-seed", browse_ids)
         self.assertNotIn("MPREb-STALE", browse_ids)
+
+
+if TYPE_CHECKING:
+    from typing import cast
+
+    from lib.pipeline_db import PipelineDB
+    from lib.youtube_album_service import YoutubeResolverDB as _ResolverDB
+
+    # Static parity proof (#409) — see the matching block in
+    # tests/test_wrong_match_cleanup_service.py for the rationale.
+    _pipeline_db_satisfies_resolver_protocol: _ResolverDB = cast("PipelineDB", None)
+    _fake_db_satisfies_resolver_protocol: _ResolverDB = cast("FakePipelineDB", None)
+
+
+class TestResolverDBProtocolParity(unittest.TestCase):
+    """#409: PipelineDB and FakePipelineDB must satisfy YoutubeResolverDB."""
+
+    def test_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.pipeline_db import PipelineDB
+        from lib.youtube_album_service import YoutubeResolverDB
+
+        self.assertTrue(issubclass(PipelineDB, YoutubeResolverDB))
+
+    def test_fake_pipeline_db_satisfies_protocol(self) -> None:
+        from lib.youtube_album_service import YoutubeResolverDB
+
+        self.assertTrue(issubclass(FakePipelineDB, YoutubeResolverDB))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

The closing #409 increment:

- **`YoutubeResolverDB`** — the YT album resolver's two `pdb: Any` params (the handle also forwards into `distance_fn`, a `Callable[...]`, which types its own db).
- **`youtube_ingest_service`** — the factory's `pdb: Any` adopts the module's pre-existing `_PipelineDB` protocol (it predated #409, mirroring `triage_service`).
- **`DiskCoveragePipelineDB` + `DiskCoverageBeetsDB`** — `disk_coverage()` typed on both handles; the BeetsDB one is the **first BeetsDB-side protocol**, satisfied structurally by `BeetsDB` and `FakeBeetsDB` (four-way parity anchors + runtime tests).
- **`import_dispatch`** — the two remaining `getattr(db, ...)` dances deleted; its db was already concretely typed, so they were pure dead defense.

## Scoreboard

The issue opened with **51 `db: Any`** occurrences and **12 `getattr(db, ...)`** probes across `lib/`. After eight increments (#417–#423 + this): **both are zero**. Every service's PipelineDB surface is a named, pyright-checked, runtime-verified protocol, and the protocol inheritance graph mirrors the real handle-forwarding graph:

```
MbidReplaceDB ─┬─ WrongMatchDeleteDB ── WrongMatchSourceDB
               ├─ ReleaseCleanupDB
               └─ SearchPlanDB
WrongMatchCleanupDB ─┬─ WrongMatchSourceDB
                     └─ QualityEvidenceDB ── ImportPreviewDB (extends)
DownloadDB / DownloadOwnershipDB ── TransitionsDB
YoutubeResolverDB · DiskCoveragePipelineDB · DiskCoverageBeetsDB · _PipelineDB (ingest, triage)
```

## Verification

- Full suite: 4355 tests OK (4 new parity tests)
- pyright (full repo): 0 errors
- Dead-code sweep: clean

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)