### PR TITLE
perf(pipeline): recency window + server search replace the 16MB /api/pipeline/all (#426)

### DIFF
--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -340,6 +340,50 @@ class _DownloadLogMixin(_PipelineDBBase):
         return result
 
 
+    def get_latest_download_summaries(
+        self, request_ids: list[int],
+    ) -> dict[int, dict]:
+        """Batch fetch only the NEWEST download_log row + history count
+        per request: ``{request_id: {"latest": row, "count": n}}``.
+
+        #426: the pipeline queue only renders the latest verdict and a
+        count, but ``get_download_history_batch`` dragged every
+        historical row (with fat JSONB) through Postgres and Python to
+        get them. ``DISTINCT ON`` returns one detoasted row per request;
+        the count aggregate never touches the JSONB columns.
+        """
+        if not request_ids:
+            return {}
+        ids = [int(r) for r in request_ids]
+        latest_cur = self._execute(
+            "SELECT * FROM ("
+            + self._DOWNLOAD_LOG_HISTORY_SELECT.replace(
+                "SELECT",
+                "SELECT DISTINCT ON (dl.request_id)",
+                1,
+            )
+            + " WHERE dl.request_id = ANY(%s)"
+            " ORDER BY dl.request_id, dl.id DESC"
+            ") latest",
+            (ids,),
+        )
+        result: dict[int, dict] = {}
+        for row in latest_cur.fetchall():
+            r = self._overlay_evidence_onto_download_log_row(dict(row))
+            result[int(r["request_id"])] = {"latest": r, "count": 0}
+
+        count_cur = self._execute(
+            "SELECT request_id, COUNT(*)::int AS n FROM download_log"
+            " WHERE request_id = ANY(%s) GROUP BY request_id",
+            (ids,),
+        )
+        for row in count_cur.fetchall():
+            rid = int(row["request_id"])
+            if rid in result:
+                result[rid]["count"] = int(row["n"])
+        return result
+
+
     # -- Wrong matches ---------------------------------------------------------
 
     def get_wrong_matches(self) -> list[dict[str, object]]:

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -1026,10 +1026,54 @@ class _RequestsMixin(_PipelineDBBase):
         return [dict(r) for r in cur.fetchall()]
 
 
-    def get_by_status(self, status):
+    def get_by_status(self, status, *, limit=None, newest_first=False):
+        """Rows in one status. ``newest_first`` orders by ``updated_at``
+        DESC (recency window for the imported list, #426); ``limit``
+        caps the result. Defaults preserve the original full-list shape.
+        """
+        order = "updated_at DESC" if newest_first else "created_at ASC"
+        sql = f"SELECT * FROM album_requests WHERE status = %s ORDER BY {order}"
+        params: list[object] = [status]
+        if limit is not None:
+            sql += " LIMIT %s"
+            params.append(int(limit))
+        cur = self._execute(sql, tuple(params))
+        return [dict(r) for r in cur.fetchall()]
+
+
+    def search_requests(
+        self,
+        query: str,
+        *,
+        limit: int = 200,
+        status: str | None = None,
+    ) -> list[dict]:
+        """Operator search over artist/album (#426).
+
+        Case-insensitive substring match with LIKE wildcards escaped, so
+        ``100%`` finds the artist named ``100% Wool`` rather than
+        everything. Ordered like the queue view: artist, then year.
+        ``status`` narrows in SQL — filtering after the LIMIT would
+        silently under-report on queries matching more rows than the cap.
+        """
+        q = (query or "").strip()
+        if not q:
+            return []
+        pattern = f"%{_escape_like_pattern(q)}%"
+        status_clause = ""
+        params: list[object] = [pattern, pattern]
+        if status is not None:
+            status_clause = " AND status = %s"
+            params.append(status)
+        params.append(max(1, min(int(limit), 500)))
         cur = self._execute(
-            "SELECT * FROM album_requests WHERE status = %s ORDER BY created_at ASC",
-            (status,),
+            "SELECT * FROM album_requests"
+            " WHERE (artist_name ILIKE %s ESCAPE '\\'"
+            "    OR album_title ILIKE %s ESCAPE '\\')"
+            f"{status_clause}"
+            " ORDER BY artist_name, year NULLS LAST, id"
+            " LIMIT %s",
+            tuple(params),
         )
         return [dict(r) for r in cur.fetchall()]
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -198,7 +198,11 @@ def tracks_from_mb_release(release_data):
 
 
 def cmd_list(db, args):
-    if args.filter_status:
+    if args.search:
+        # Status narrowing happens in SQL — a Python post-filter after
+        # the LIMIT would silently drop matches on common tokens.
+        albums = db.search_requests(args.search, status=args.filter_status)
+    elif args.filter_status:
         albums = db.get_by_status(args.filter_status)
     else:
         rows = db._execute("SELECT * FROM album_requests ORDER BY created_at ASC").fetchall()
@@ -3205,6 +3209,11 @@ def _build_parser() -> tuple[
     # list
     p_list = sub.add_parser("list", help="List album requests")
     p_list.add_argument("filter_status", nargs="?", help="Filter by status")
+    p_list.add_argument(
+        "--search",
+        help="Case-insensitive substring match on artist or album "
+             "(mirrors GET /api/pipeline/search)",
+    )
 
     # add
     p_add = sub.add_parser("add", help="Add a new request by MBID or Discogs ID")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3331,13 +3331,49 @@ class FakePipelineDB:
                 break
         return rows
 
-    def get_by_status(self, status: str) -> list[dict[str, Any]]:
-        return [
-            copy.deepcopy(r) for r in sorted(
+    def get_by_status(
+        self,
+        status: str,
+        *,
+        limit: int | None = None,
+        newest_first: bool = False,
+    ) -> list[dict[str, Any]]:
+        if newest_first:
+            rows = sorted(
+                (r for r in self._requests.values()
+                 if r.get("status") == status),
+                key=lambda r: _as_datetime(r.get("updated_at")),
+                reverse=True)
+        else:
+            rows = sorted(
                 (r for r in self._requests.values()
                  if r.get("status") == status),
                 key=lambda r: _as_datetime(r.get("created_at")))
+        if limit is not None:
+            rows = rows[:int(limit)]
+        return [copy.deepcopy(r) for r in rows]
+
+    def search_requests(
+        self, query: str, *, limit: int = 200, status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Mirror ``PipelineDB.search_requests``: case-insensitive
+        substring over artist/album, optionally narrowed to one status."""
+        q = (query or "").strip().lower()
+        if not q:
+            return []
+        rows = [
+            r for r in self._requests.values()
+            if (q in str(r.get("artist_name") or "").lower()
+                or q in str(r.get("album_title") or "").lower())
+            and (status is None or r.get("status") == status)
         ]
+        rows.sort(key=lambda r: (
+            str(r.get("artist_name") or ""),
+            r.get("year") is None,
+            int(str(r.get("year") or 0)),
+            int(str(r["id"])),
+        ))
+        return [copy.deepcopy(r) for r in rows[:int(limit)]]
 
     def _has_youtube_running(self, request_id: int) -> bool:
         """Mirror of the ``_LONG_TAIL_SELECT`` ``youtube_running`` EXISTS.
@@ -3540,6 +3576,17 @@ class FakePipelineDB:
             result.setdefault(entry.request_id, []).append(
                 self._download_log_to_dict(entry))
         return result
+
+    def get_latest_download_summaries(
+        self, request_ids: list[int],
+    ) -> dict[int, dict[str, Any]]:
+        """Mirror ``PipelineDB.get_latest_download_summaries``: newest
+        row + history count per request (#426)."""
+        return {
+            rid: {"latest": history[0], "count": len(history)}
+            for rid, history in
+            self.get_download_history_batch(request_ids).items()
+        }
 
     # --- Pipeline dashboard telemetry ---
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -3416,6 +3416,61 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         self.assertEqual(len(db.user_cooldowns), 2)
         self.assertEqual(db.user_cooldowns["alice"].reason, "y")
 
+    # --- #426: recency window + search + latest-summaries mirrors ---
+
+    def test_get_by_status_recent_window(self):
+        db = FakePipelineDB()
+        ids = []
+        for i in range(3):
+            ids.append(db.add_request(
+                artist_name=f"A{i}", album_title=f"T{i}", source="request",
+                mb_release_id=f"win-{i}", status="imported"))
+        db.update_request_fields(ids[0], reasoning="touched")
+
+        rows = db.get_by_status("imported", limit=2, newest_first=True)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["id"], ids[0])
+        # Default shape unchanged.
+        self.assertEqual(len(db.get_by_status("imported")), 3)
+
+    def test_search_requests_matches_artist_and_album(self):
+        db = FakePipelineDB()
+        db.add_request(
+            artist_name="The Mountain Goats", album_title="Tallahassee",
+            source="request", mb_release_id="f-sr-1", status="imported")
+        db.add_request(
+            artist_name="Goat", album_title="World Music",
+            source="request", mb_release_id="f-sr-2", status="wanted")
+
+        self.assertEqual(
+            [r["mb_release_id"] for r in db.search_requests("mountain")],
+            ["f-sr-1"])
+        self.assertEqual(
+            [r["mb_release_id"] for r in db.search_requests("world mus")],
+            ["f-sr-2"])
+        self.assertEqual(
+            {r["mb_release_id"] for r in db.search_requests("goat")},
+            {"f-sr-1", "f-sr-2"})
+        self.assertEqual(db.search_requests("  "), [])
+        self.assertEqual(
+            [r["mb_release_id"]
+             for r in db.search_requests("goat", status="wanted")],
+            ["f-sr-2"])
+
+    def test_get_latest_download_summaries_mirror(self):
+        db = FakePipelineDB()
+        rid = db.add_request(
+            artist_name="A", album_title="T", source="request",
+            mb_release_id="f-sum-1", status="wanted")
+        db.log_download(rid, "old_user", "flac", "/tmp/1", outcome="rejected")
+        db.log_download(rid, "new_user", "flac", "/tmp/2", outcome="success")
+
+        summaries = db.get_latest_download_summaries([rid, 9999])
+        self.assertEqual(set(summaries), {rid})
+        self.assertEqual(summaries[rid]["count"], 2)
+        self.assertEqual(
+            summaries[rid]["latest"]["soulseek_username"], "new_user")
+
     # --- peer_observations roster mirror (#227) ---
 
     def test_peer_metrics_cumulative_totals_carry_forward(self):

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -241,5 +241,60 @@ console.log('renderPeersCard() with no observations renders the empty row');
   assertContains(html, 'No peer observations yet', 'empty state rendered');
 }
 
+console.log('renderPipelineListBody() flags the imported recency window');
+{
+  state.pipelineFilter = 'imported';
+  state.pipelineSearchResults = null;
+  state.pipelineData = {
+    counts: { imported: 6828 },
+    imported: [],
+    imported_total: 6828,
+    imported_truncated: true,
+  };
+  const html = __test__.renderPipelineListBody();
+  assertContains(html, 'most recent of 6828 imported',
+    'truncation note names the full imported count');
+  assertContains(html, 'search above', 'note points at the search box');
+}
+
+console.log('renderPipelineListBody() renders server search results across statuses');
+{
+  state.pipelineFilter = 'wanted';
+  state.pipelineData = { counts: {}, wanted: [], imported: [] };
+  state.pipelineSearchResults = [
+    {
+      id: 7, artist_name: 'The Mountain Goats', album_title: 'Tallahassee',
+      status: 'imported', source: 'request', year: 2002,
+      created_at: '2026-06-01T00:00:00+00:00',
+      updated_at: '2026-06-02T00:00:00+00:00',
+      mb_release_id: 'mbid-7', mb_release_group_id: 'rg-7',
+    },
+  ];
+  const html = __test__.renderPipelineListBody();
+  assertContains(html, 'The Mountain Goats', 'search result row rendered');
+  assertExcludes(html, 'most recent of', 'no truncation note while searching');
+
+  state.pipelineSearchResults = [];
+  const emptyHtml = __test__.renderPipelineListBody();
+  assertContains(emptyHtml, 'No matches', 'empty search shows No matches');
+  state.pipelineSearchResults = null;
+}
+
+console.log('clearPipelineSearch() makes filters and search mutually exclusive');
+{
+  state.pipelineFilter = 'imported';
+  state.pipelineSearchQuery = 'mountain';
+  state.pipelineSearchResults = [{ id: 1 }];
+  __test__.clearPipelineSearch();
+  if (state.pipelineSearchQuery === '' && state.pipelineSearchResults === null) {
+    passed++;
+  } else {
+    failed++;
+    console.error('  FAIL: clearPipelineSearch did not reset search state');
+  }
+  const html = __test__.renderPipelineListBody();
+  assertExcludes(html, 'No matches', 'list body is back in filter mode after clear');
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -325,13 +325,53 @@ class TestCmdList(unittest.TestCase):
         id2 = self.db.add_request(mb_release_id="b", artist_name="C", album_title="D", source="request")
         self.db.update_status(id2, "imported")
 
-        args = MagicMock(filter_status="wanted")
+        args = MagicMock(filter_status="wanted", search=None)
         pipeline_cli.cmd_list(self.db, args)
 
     def test_list_all(self):
         self.db.add_request(mb_release_id="a", artist_name="A", album_title="B", source="request")
-        args = MagicMock(filter_status=None)
+        args = MagicMock(filter_status=None, search=None)
         pipeline_cli.cmd_list(self.db, args)
+
+    def test_list_search_mirrors_api_search(self):
+        """CLI ⇄ API symmetry (#426): ``list --search`` wraps the same
+        ``search_requests`` the web search endpoint uses."""
+        import contextlib
+        import io
+
+        self.db.add_request(
+            mb_release_id="s-1", artist_name="The Mountain Goats",
+            album_title="Tallahassee", source="request")
+        self.db.add_request(
+            mb_release_id="s-2", artist_name="Other",
+            album_title="Album", source="request")
+
+        out = io.StringIO()
+        args = MagicMock(filter_status=None, search="mountain")
+        with contextlib.redirect_stdout(out):
+            pipeline_cli.cmd_list(self.db, args)
+        text = out.getvalue()
+        self.assertIn("The Mountain Goats", text)
+        self.assertNotIn("Other", text)
+
+    def test_list_search_with_status_filter(self):
+        rid = self.db.add_request(
+            mb_release_id="s-3", artist_name="Goat", album_title="One",
+            source="request")
+        self.db.add_request(
+            mb_release_id="s-4", artist_name="Goat", album_title="Two",
+            source="request")
+        self.db.update_status(rid, "imported")
+
+        import contextlib
+        import io
+        out = io.StringIO()
+        args = MagicMock(filter_status="imported", search="goat")
+        with contextlib.redirect_stdout(out):
+            pipeline_cli.cmd_list(self.db, args)
+        text = out.getvalue()
+        self.assertIn("One", text)
+        self.assertNotIn("Two", text)
 
 
 class TestCmdRetry(unittest.TestCase):

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -7771,5 +7771,164 @@ class TestWrongMatchTriageRoundTrip(unittest.TestCase):
         self.assertEqual(env.scenario, "wrong_match")
 
 
+@requires_postgres
+class TestLatestDownloadSummaries(unittest.TestCase):
+    """#426: ``get_latest_download_summaries`` returns only the newest
+    download_log row + a history count per request, instead of dragging
+    the full per-request history (with fat JSONB) over the wire."""
+
+    def setUp(self):
+        self.db = make_db()
+        self.r1 = self.db.add_request(
+            artist_name="A", album_title="One", source="request",
+            mb_release_id="sum-1")
+        self.r2 = self.db.add_request(
+            artist_name="B", album_title="Two", source="request",
+            mb_release_id="sum-2")
+        self.r3 = self.db.add_request(
+            artist_name="C", album_title="NoHistory", source="request",
+            mb_release_id="sum-3")
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_latest_row_and_count_per_request(self):
+        self.db.log_download(self.r1, "user_old", "flac", "/tmp/1",
+                             outcome="rejected")
+        self.db.log_download(self.r1, "user_mid", "flac", "/tmp/2",
+                             outcome="rejected")
+        self.db.log_download(self.r1, "user_new", "flac", "/tmp/3",
+                             outcome="success",
+                             validation_result=json.dumps({"valid": True}))
+        self.db.log_download(self.r2, "solo", "mp3", "/tmp/4",
+                             outcome="rejected")
+
+        summaries = self.db.get_latest_download_summaries(
+            [self.r1, self.r2, self.r3])
+
+        self.assertEqual(set(summaries), {self.r1, self.r2})
+        s1 = summaries[self.r1]
+        self.assertEqual(s1["count"], 3)
+        self.assertEqual(s1["latest"]["soulseek_username"], "user_new")
+        self.assertEqual(s1["latest"]["outcome"], "success")
+        # The latest row must carry everything the history classifier
+        # consumes (JSONB included) — it feeds build_download_history_row.
+        self.assertIn("validation_result", s1["latest"])
+        self.assertIn("import_result", s1["latest"])
+        self.assertEqual(summaries[self.r2]["count"], 1)
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(self.db.get_latest_download_summaries([]), {})
+
+    def test_latest_row_overlays_candidate_evidence(self):
+        """The evidence overlay that get_download_history_batch applied
+        must survive on the summary's latest row."""
+        from lib.quality import AudioQualityMeasurement
+        log_id = self.db.log_download(self.r1, "u", "flac", "/tmp/x",
+                                      outcome="rejected")
+        evidence = make_album_quality_evidence(
+            mb_release_id="sum-1",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=900,
+                avg_bitrate_kbps=950,
+                median_bitrate_kbps=940,
+                format="flac",
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=998,
+            ),
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id="sum-1",
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.db.set_download_log_candidate_evidence(log_id, stored.id)
+
+        summaries = self.db.get_latest_download_summaries([self.r1])
+        latest = summaries[self.r1]["latest"]
+        self.assertEqual(latest["spectral_grade"], "genuine")
+        self.assertEqual(latest["spectral_bitrate"], 998)
+
+
+@requires_postgres
+class TestSearchRequests(unittest.TestCase):
+    """#426: operator search over artist/album across all statuses."""
+
+    def setUp(self):
+        self.db = make_db()
+        self.db.add_request(
+            artist_name="The Mountain Goats", album_title="Tallahassee",
+            source="request", mb_release_id="sr-1", status="imported")
+        self.db.add_request(
+            artist_name="Goat", album_title="World Music",
+            source="request", mb_release_id="sr-2", status="wanted")
+        self.db.add_request(
+            artist_name="100% Wool", album_title="Felt",
+            source="request", mb_release_id="sr-3", status="manual")
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_matches_artist_case_insensitive(self):
+        rows = self.db.search_requests("mountain")
+        self.assertEqual([r["mb_release_id"] for r in rows], ["sr-1"])
+
+    def test_matches_album_title(self):
+        rows = self.db.search_requests("world mus")
+        self.assertEqual([r["mb_release_id"] for r in rows], ["sr-2"])
+
+    def test_matches_across_statuses(self):
+        rows = self.db.search_requests("goat")
+        self.assertEqual(
+            {r["mb_release_id"] for r in rows}, {"sr-1", "sr-2"})
+
+    def test_like_wildcards_are_escaped(self):
+        rows = self.db.search_requests("100%")
+        self.assertEqual([r["mb_release_id"] for r in rows], ["sr-3"])
+
+    def test_status_narrowing_happens_in_sql(self):
+        rows = self.db.search_requests("goat", status="wanted")
+        self.assertEqual([r["mb_release_id"] for r in rows], ["sr-2"])
+
+    def test_limit_and_blank_query(self):
+        self.assertEqual(self.db.search_requests("  "), [])
+        rows = self.db.search_requests("o", limit=2)
+        self.assertEqual(len(rows), 2)
+
+
+@requires_postgres
+class TestGetByStatusRecentWindow(unittest.TestCase):
+    """#426: the imported list is served newest-first with a cap."""
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_newest_first_with_limit(self):
+        ids = []
+        for i in range(3):
+            ids.append(self.db.add_request(
+                artist_name=f"A{i}", album_title=f"T{i}",
+                source="request", mb_release_id=f"recent-{i}",
+                status="imported"))
+        # Touch the oldest row so updated_at ordering (not insert order)
+        # decides recency.
+        self.db.update_request_fields(ids[0], reasoning="touched")
+
+        rows = self.db.get_by_status("imported", limit=2, newest_first=True)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["id"], ids[0])
+
+    def test_default_shape_unchanged(self):
+        self.db.add_request(
+            artist_name="A", album_title="T", source="request",
+            mb_release_id="legacy-order", status="wanted")
+        rows = self.db.get_by_status("wanted")
+        self.assertEqual(len(rows), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -232,6 +232,8 @@ def _make_server():
     }))
     mock_db.count_by_status.return_value = {"wanted": 0, "imported": 1, "manual": 0}
     mock_db.get_by_status.return_value = []
+    mock_db.get_latest_download_summaries.return_value = {}
+    mock_db.search_requests.return_value = []
     mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
     mock_db.get_tracks.return_value = []
     mock_db.get_download_history.return_value = [

--- a/tests/web/test_route_audit.py
+++ b/tests/web/test_route_audit.py
@@ -41,6 +41,7 @@ class TestRouteContractAudit(unittest.TestCase):
         "/api/pipeline/status",
         "/api/pipeline/recent",
         "/api/pipeline/all",
+        "/api/pipeline/search",
         "/api/pipeline/downloading",
         "/api/pipeline/dashboard",
         "/api/pipeline/constants",

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -211,6 +211,7 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.mock_db.get_by_status.side_effect = None
         self.mock_db.get_by_status.return_value = []
         self.mock_db.get_download_history_batch.return_value = {}
+        self.mock_db.get_latest_download_summaries.return_value = {}
         self.mock_db.get_recent.return_value = []
         self.mock_db.get_track_counts.return_value = {}
 
@@ -328,15 +329,68 @@ class TestPipelineRouteContracts(_WebServerCase):
 
     def test_pipeline_all_contract(self):
         row = make_request_row(id=201, status="wanted", album_title="Wanted Album")
-        self.mock_db.get_by_status.side_effect = lambda s: [row] if s == "wanted" else []
+        self.mock_db.get_by_status.side_effect = (
+            lambda s, **kw: [row] if s == "wanted" else [])
 
         status, data = self._get("/api/pipeline/all")
 
         self.assertEqual(status, 200)
-        _assert_required_fields(self, data, {"counts", "wanted", "downloading", "imported", "manual"},
+        _assert_required_fields(self, data, {"counts", "wanted", "downloading", "imported", "manual",
+                                             "imported_total", "imported_truncated"},
                                 "pipeline all response")
         _assert_required_fields(self, data["wanted"][0], self.PIPELINE_ITEM_REQUIRED_FIELDS,
                                 "pipeline all item")
+
+    def test_pipeline_all_imported_is_a_recency_window(self):
+        """#426: the imported bucket is capped (newest first) and the
+        payload flags the truncation so the UI can say so."""
+        from web.routes.pipeline import IMPORTED_RECENT_LIMIT
+        row = make_request_row(id=301, status="imported",
+                               album_title="Imported Album")
+        calls = []
+
+        def _by_status(s, **kw):
+            calls.append((s, kw))
+            return [row] if s == "imported" else []
+
+        self.mock_db.get_by_status.side_effect = _by_status
+        self.mock_db.count_by_status.return_value = {
+            "wanted": 0, "imported": IMPORTED_RECENT_LIMIT + 50, "manual": 0,
+        }
+
+        status, data = self._get("/api/pipeline/all")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["imported_total"], IMPORTED_RECENT_LIMIT + 50)
+        self.assertTrue(data["imported_truncated"])
+        imported_call = next(c for c in calls if c[0] == "imported")
+        self.assertEqual(imported_call[1],
+                         {"limit": IMPORTED_RECENT_LIMIT, "newest_first": True})
+
+    SEARCH_REQUIRED_FIELDS = {"query", "items", "total"}
+
+    def test_pipeline_search_contract(self):
+        row = make_request_row(id=401, status="imported",
+                               artist_name="The Mountain Goats",
+                               album_title="Tallahassee")
+        self.mock_db.search_requests.return_value = [row]
+
+        status, data = self._get("/api/pipeline/search?q=mountain")
+
+        self.assertEqual(status, 200)
+        _assert_required_fields(self, data, self.SEARCH_REQUIRED_FIELDS,
+                                "pipeline search response")
+        self.assertEqual(data["query"], "mountain")
+        self.assertEqual(data["total"], 1)
+        _assert_required_fields(self, data["items"][0],
+                                self.PIPELINE_ITEM_REQUIRED_FIELDS,
+                                "pipeline search item")
+
+    def test_pipeline_search_blank_query_is_empty(self):
+        self.mock_db.search_requests.return_value = []
+        status, data = self._get("/api/pipeline/search")
+        self.assertEqual(status, 200)
+        self.assertEqual(data["items"], [])
 
     def test_pipeline_dashboard_contract(self):
         status, data = self._get("/api/pipeline/dashboard")

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -31,7 +31,7 @@ class TestReplacedFilterContract(_WebServerCase):
 
     def test_pipeline_all_default_excludes_replaced(self):
         captured: list[tuple[str, ...]] = []
-        def fake_get_by_status(status):
+        def fake_get_by_status(status, **kw):
             captured.append((status,))
             return []
         self.mock_db.get_by_status.side_effect = fake_get_by_status
@@ -44,7 +44,7 @@ class TestReplacedFilterContract(_WebServerCase):
 
     def test_pipeline_all_include_replaced_true_fetches_replaced(self):
         captured: list[tuple[str, ...]] = []
-        def fake_get_by_status(status):
+        def fake_get_by_status(status, **kw):
             captured.append((status,))
             return []
         self.mock_db.get_by_status.side_effect = fake_get_by_status

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -142,7 +142,7 @@ class TestServerEndpoints(unittest.TestCase):
             mb_release_id="dl-uuid", status="downloading",
             active_download_state={"filetype": "flac", "enqueued_at": "now", "files": []},
         )
-        self.mock_db.get_by_status.side_effect = lambda s: [downloading_row] if s == "downloading" else []
+        self.mock_db.get_by_status.side_effect = lambda s, **kw: [downloading_row] if s == "downloading" else []
         self.mock_db.count_by_status.return_value = {"downloading": 1}
         self.mock_db.get_download_history_batch.return_value = {}
         status, data = self._get("/api/pipeline/all")
@@ -166,11 +166,11 @@ class TestServerEndpoints(unittest.TestCase):
             },
         )
         self.mock_db.get_by_status.side_effect = (
-            lambda s: [downloading_row] if s == "downloading" else []
+            lambda s, **kw: [downloading_row] if s == "downloading" else []
         )
         self.mock_db.count_by_status.return_value = {"downloading": 1}
-        self.mock_db.get_download_history_batch.reset_mock()
-        self.mock_db.get_download_history_batch.return_value = {}
+        self.mock_db.get_latest_download_summaries.reset_mock()
+        self.mock_db.get_latest_download_summaries.return_value = {}
 
         status, data = self._get("/api/pipeline/downloading")
 
@@ -179,11 +179,11 @@ class TestServerEndpoints(unittest.TestCase):
         self.assertEqual(len(data["downloading"]), 1)
         self.assertEqual(data["downloading"][0]["album_title"], "Active Download")
         self.mock_db.get_by_status.assert_called_with("downloading")
-        self.mock_db.get_download_history_batch.assert_any_call([201])
+        self.mock_db.get_latest_download_summaries.assert_any_call([201])
 
         self.mock_db.get_by_status.side_effect = None
         self.mock_db.get_by_status.return_value = []
-        self.mock_db.get_download_history_batch.reset_mock()
+        self.mock_db.get_latest_download_summaries.reset_mock()
         self.mock_db.count_by_status.return_value = {
             "wanted": 0, "imported": 1, "manual": 0}
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -9,7 +9,7 @@ import { state } from './state.js';
 import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow, closeVaFallback } from './browse.js';
 import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
-import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter } from './pipeline.js';
+import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter, onPipelineSearchInput } from './pipeline.js';
 import { loadLongTail, setLongTailBand, onLongTailSearchInput, toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue, longTailAcceptSibling, longTailSetIntent, longTailSetImported, longTailDeleteRequest } from './long_tail.js';
 import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { loadDecisions, dsPreset, runSimulator } from './decisions.js';
@@ -165,6 +165,7 @@ Object.assign(window, {
   loadPipelineDashboard,
   setPipelineView,
   setFilter,
+  onPipelineSearchInput,
   renderPipeline,
   toggleCoverageMatchGraph,
   toggleDetail,

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -37,6 +37,7 @@ export async function loadPipeline() {
   try {
     // U10: opt-in toggle persists in localStorage. Default: filtered.
     const includeReplaced = localStorage.getItem('pipeline.includeReplaced') === 'true';
+    clearPipelineSearch();
     const url = `${API}/api/pipeline/all${includeReplaced ? '?include_replaced=true' : ''}`;
     const r = await fetch(url);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -130,7 +131,22 @@ export async function loadPipelineDashboard() {
  */
 export function setFilter(f) {
   state.pipelineFilter = f;
+  // Filter and search are mutually exclusive: clicking a count card
+  // abandons the active search so the clicked filter actually shows.
+  clearPipelineSearch();
   renderPipeline();
+}
+
+/**
+ * Reset the server-side search state (input text + results). Bumps the
+ * in-flight token so a fetch resolving late discards itself.
+ * @returns {void}
+ */
+export function clearPipelineSearch() {
+  state.pipelineSearchQuery = '';
+  state.pipelineSearchResults = null;
+  pipelineSearchToken += 1;
+  if (pipelineSearchTimer != null) clearTimeout(pipelineSearchTimer);
 }
 
 /**
@@ -168,30 +184,6 @@ export function renderPipeline() {
   const counts = data.counts || {};
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
 
-  let items = [];
-  if (state.pipelineFilter === 'all') {
-    items = [...(data.wanted || []), ...(data.downloading || []), ...(data.imported || []), ...(data.manual || [])];
-  } else if (state.pipelineFilter === 'wanted') {
-    // Downloading is a sub-state of wanted — same album, mid-acquisition.
-    // The status badge on each row still distinguishes them visually.
-    items = [...(data.wanted || []), ...(data.downloading || [])];
-  } else {
-    items = data[state.pipelineFilter] || [];
-  }
-
-  // Group by artist
-  const byArtist = {};
-  for (const item of items) {
-    const artist = item.artist_name || 'Unknown';
-    if (!byArtist[artist]) byArtist[artist] = [];
-    byArtist[artist].push(item);
-  }
-  // Sort artists alphabetically, albums by year within each
-  const artists = Object.keys(byArtist).sort((a, b) => a.localeCompare(b));
-  for (const a of artists) {
-    byArtist[a].sort((x, y) => (x.year || 0) - (y.year || 0));
-  }
-
   // Wanted bucket includes downloading — mid-acquisition is a sub-state
   // of wanted. The status badge on each row keeps them visually distinct.
   const wantedTotal = (counts.wanted || 0) + (counts.downloading || 0);
@@ -213,6 +205,64 @@ export function renderPipeline() {
         </div>
       </div>
     </div>
+    <div class="lt-search">
+      <input type="text" id="pipeline-search-input" class="lt-search-input"
+        placeholder="Search every request by artist or album…"
+        value="${esc(state.pipelineSearchQuery || '')}"
+        oninput="window.onPipelineSearchInput(this.value)">
+    </div>
+    <div id="pipeline-list">${renderPipelineListBody()}</div>
+  `;
+}
+
+/**
+ * Build the artist-grouped list body for the current filter (or the
+ * active server-side search results). Kept separate from
+ * renderPipeline so a search keystroke can repaint only #pipeline-list
+ * and the input keeps focus/caret.
+ *
+ * @returns {string}
+ */
+function renderPipelineListBody() {
+  const data = state.pipelineData || {};
+  const searching = state.pipelineSearchResults != null;
+
+  let items = [];
+  if (searching) {
+    items = state.pipelineSearchResults || [];
+  } else if (state.pipelineFilter === 'all') {
+    items = [...(data.wanted || []), ...(data.downloading || []), ...(data.imported || []), ...(data.manual || [])];
+  } else if (state.pipelineFilter === 'wanted') {
+    // Downloading is a sub-state of wanted — same album, mid-acquisition.
+    // The status badge on each row still distinguishes them visually.
+    items = [...(data.wanted || []), ...(data.downloading || [])];
+  } else {
+    items = data[state.pipelineFilter] || [];
+  }
+
+  // The imported bucket is a recency window (#426); say so whenever the
+  // truncated bucket is part of the current view.
+  const showsImported = !searching
+    && (state.pipelineFilter === 'imported' || state.pipelineFilter === 'all');
+  const truncationNote = showsImported && data.imported_truncated
+    ? `<div class="loading">Showing the ${(data.imported || []).length} most recent of ${data.imported_total} imported — search above to find the rest.</div>`
+    : '';
+
+  // Group by artist
+  const byArtist = {};
+  for (const item of items) {
+    const artist = item.artist_name || 'Unknown';
+    if (!byArtist[artist]) byArtist[artist] = [];
+    byArtist[artist].push(item);
+  }
+  // Sort artists alphabetically, albums by year within each
+  const artists = Object.keys(byArtist).sort((a, b) => a.localeCompare(b));
+  for (const a of artists) {
+    byArtist[a].sort((x, y) => (x.year || 0) - (y.year || 0));
+  }
+
+  return `
+    ${truncationNote}
     ${artists.map(artist => `
       <div class="p-group-header" onclick="this.nextElementSibling.classList.toggle('collapsed')">
         ${esc(artist)} <span style="color:#555;font-weight:400;">${byArtist[artist].length}</span>
@@ -221,8 +271,51 @@ export function renderPipeline() {
         ${byArtist[artist].map(item => renderPipelineItem(item)).join('')}
       </div>
     `).join('')}
-    ${artists.length === 0 ? '<div class="loading">No items</div>' : ''}
+    ${artists.length === 0 ? `<div class="loading">${searching ? 'No matches' : 'No items'}</div>` : ''}
   `;
+}
+
+// Module-scoped debounce + stale-response token for the server-side
+// pipeline search (#426). web.md: fetch-on-input UIs must stamp
+// requests and discard stale responses before rendering.
+let pipelineSearchTimer = null;
+let pipelineSearchToken = 0;
+const PIPELINE_SEARCH_DEBOUNCE_MS = 250;
+
+/**
+ * Handle a keystroke in the pipeline search box: debounce, fetch
+ * server-side results across every status, repaint only the list body.
+ * @param {string} value
+ * @returns {void}
+ */
+export function onPipelineSearchInput(value) {
+  const q = String(value == null ? '' : value);
+  state.pipelineSearchQuery = q;
+  if (pipelineSearchTimer != null) clearTimeout(pipelineSearchTimer);
+  const repaint = () => {
+    const listEl = document.getElementById('pipeline-list');
+    if (listEl) listEl.innerHTML = renderPipelineListBody();
+  };
+  if (q.trim().length < 2) {
+    state.pipelineSearchResults = null;
+    repaint();
+    return;
+  }
+  pipelineSearchTimer = /** @type {any} */ (setTimeout(async () => {
+    const token = ++pipelineSearchToken;
+    try {
+      const r = await fetch(`${API}/api/pipeline/search?q=${encodeURIComponent(q.trim())}`);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      if (token !== pipelineSearchToken) return;
+      state.pipelineSearchResults = data.items || [];
+      repaint();
+    } catch (e) {
+      if (token !== pipelineSearchToken) return;
+      state.pipelineSearchResults = [];
+      repaint();
+    }
+  }, PIPELINE_SEARCH_DEBOUNCE_MS));
 }
 
 function renderPipelineNav() {
@@ -1064,6 +1157,8 @@ export const __test__ = {
   renderMatchRateChart,
   renderPeerBrowseHeavyQueries,
   renderPeersCard,
+  renderPipelineListBody,
+  clearPipelineSearch,
   renderPipelineNav,
   renderWantedTrendCard,
   renderWantedTrendChart,

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -33,7 +33,7 @@ import { invalidateActiveRgs } from './active_rgs.js';
  * @property {string} query             Current search-box substring filter.
  */
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineSearchQuery: string, pipelineSearchResults: Array<Object>|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
@@ -44,6 +44,8 @@ export const state = {
   browseSubView: 'discography',
   browseCache: {},
   pipelineData: null,
+  pipelineSearchQuery: '',
+  pipelineSearchResults: null,
   pipelineDashboardData: null,
   pipelineView: 'queue',
   pipelineFilter: 'wanted',

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -352,19 +352,30 @@ def get_pipeline_recent(h, params: dict[str, list[str]]) -> None:
     h._json({"recent": serialized})
 
 
-def _attach_latest_download_history(
+def _attach_latest_download_summaries(
     items: list[dict],
-    history_batch: dict[int, list[dict]],
+    summaries: dict[int, dict],
 ) -> list[dict]:
+    """Stamp each request row with its newest download's verdict fields.
+
+    ``summaries`` comes from ``get_latest_download_summaries`` — one
+    latest row + a count per request, never the full history (#426).
+    """
     for item in items:
-        history = history_batch.get(item["id"], [])
-        if history:
-            last = build_download_history_row(history[0])
+        summary = summaries.get(int(str(item["id"])))
+        if summary:
+            last = build_download_history_row(summary["latest"])
             item["last_verdict"] = last.verdict
             item["last_outcome"] = last.outcome
             item["last_username"] = last.soulseek_username
-            item["download_count"] = len(history)
+            item["download_count"] = summary["count"]
     return items
+
+
+# The imported cohort is the whole library backfill (~7K rows and
+# growing) — the queue serves a recency window plus server-side search
+# instead of the full list (#426).
+IMPORTED_RECENT_LIMIT = 100
 
 
 def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
@@ -383,16 +394,39 @@ def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
     if include_replaced:
         statuses = statuses + ("replaced",)
     for status in statuses:
-        rows = [s._serialize_row(r) for r in s._db().get_by_status(status)]
+        if status == "imported":
+            db_rows = s._db().get_by_status(
+                "imported", limit=IMPORTED_RECENT_LIMIT, newest_first=True)
+        else:
+            db_rows = s._db().get_by_status(status)
+        rows = [s._serialize_row(r) for r in db_rows]
         status_items[status] = rows
         all_ids.extend([int(str(r["id"])) for r in rows])
-    history_batch = s._db().get_download_history_batch(all_ids)
+    summaries = s._db().get_latest_download_summaries(all_ids)
     for status in statuses:
-        all_data[status] = _attach_latest_download_history(
+        all_data[status] = _attach_latest_download_summaries(
             status_items[status],
-            history_batch,
+            summaries,
         )
+    all_data["imported_total"] = int(counts.get("imported", 0))
+    all_data["imported_truncated"] = (
+        int(counts.get("imported", 0)) > IMPORTED_RECENT_LIMIT
+    )
     h._json(all_data)
+
+
+def get_pipeline_search(h, params: dict[str, list[str]]) -> None:
+    """Operator search over artist/album across every status (#426)."""
+    s = _server()
+    query = params.get("q", [""])[0]
+    rows = [s._serialize_row(r) for r in s._db().search_requests(query)]
+    ids = [int(str(r["id"])) for r in rows]
+    summaries = s._db().get_latest_download_summaries(ids)
+    h._json({
+        "query": query,
+        "items": _attach_latest_download_summaries(rows, summaries),
+        "total": len(rows),
+    })
 
 
 def get_pipeline_downloading(h, params: dict[str, list[str]]) -> None:
@@ -400,14 +434,14 @@ def get_pipeline_downloading(h, params: dict[str, list[str]]) -> None:
     counts = s._db().count_by_status()
     rows = [s._serialize_row(r) for r in s._db().get_by_status("downloading")]
     ids = [int(str(r["id"])) for r in rows]
-    history_batch = s._db().get_download_history_batch(ids)
+    summaries = s._db().get_latest_download_summaries(ids)
     youtube_ingest = [
         s._serialize_row(r)
         for r in s._db().list_active_youtube_rescues(limit=50)
     ]
     h._json({
         "counts": counts,
-        "downloading": _attach_latest_download_history(rows, history_batch),
+        "downloading": _attach_latest_download_summaries(rows, summaries),
         "youtube_ingest": youtube_ingest,
     })
 
@@ -2765,6 +2799,7 @@ GET_ROUTES: dict[str, object] = {
     "/api/pipeline/status": get_pipeline_status,
     "/api/pipeline/recent": get_pipeline_recent,
     "/api/pipeline/all": get_pipeline_all,
+    "/api/pipeline/search": get_pipeline_search,
     "/api/pipeline/downloading": get_pipeline_downloading,
     "/api/pipeline/dashboard": get_pipeline_dashboard,
     "/api/pipeline/constants": get_pipeline_constants,
@@ -2838,9 +2873,16 @@ GET_DESCRIPTIONS: dict[str, str] = {
         "download-history enrichment."
     ),
     "/api/pipeline/all": (
-        "All pipeline requests bucketed by status; latest download "
-        "history attached per row. include_replaced=true opts in to "
-        "frozen audit rows."
+        "Pipeline requests bucketed by status; latest download summary "
+        "attached per row. The imported bucket is a recency window "
+        "(newest 100; imported_total/imported_truncated flag the cap) — "
+        "use /api/pipeline/search for the rest. include_replaced=true "
+        "opts in to frozen audit rows."
+    ),
+    "/api/pipeline/search": (
+        "Operator search over artist/album across every status "
+        "(?q=substring, case-insensitive); latest download summary "
+        "attached per row."
     ),
     "/api/pipeline/downloading": (
         "Pipeline requests currently in the downloading status, plus "


### PR DESCRIPTION
## Why

`/api/pipeline/all` measured **8–10s / 16 MB**: every `album_requests` row serialized (6,828 of 8,380 are the imported library-backfill cohort), plus the **entire download_log history** (28,807 rows with `validation_result`/`import_result` JSONB) fetched via `get_download_history_batch` — of which the route kept exactly `history[0]` and `len(history)` per request. Operator decision on #426: the imported list is unscrollable anyway — recent-N plus search (by artist, sometimes release) is the wanted UX.

## What

- **`get_latest_download_summaries(request_ids)`** — `DISTINCT ON (request_id)` newest row (evidence overlay intact) + a JSONB-free `COUNT` aggregate. `/api/pipeline/all` and `/api/pipeline/downloading` use it; `/api/pipeline/recent` deliberately keeps the full batch (it needs the first *success* row, and only spans 20 requests).
- **Imported = recency window**: newest 100 by `updated_at`, with `imported_total` / `imported_truncated` in the payload and a truncation note in the UI.
- **`GET /api/pipeline/search?q=`** — case-insensitive substring over artist/album across every status (LIKE wildcards escaped — `100%` matches the artist named `100% Wool`, not everything), queue-ordered, latest summary attached. **CLI twin:** `pipeline-cli list [status] --search <q>`, with status narrowing pushed into SQL so the LIMIT can't silently under-report.
- **Queue UI**: search box with 250ms debounce + module-scoped stale-response token (web.md fetch-on-input rule); keystrokes repaint only `#pipeline-list` so the input keeps focus; count-card clicks clear the search (mutually exclusive); refresh resets stale results.

## Review findings (adversarial pass) fixed pre-commit

1. **P2:** switching the status filter mid-search left stale search results rendered under a freshly-highlighted filter — `setFilter` now clears search state (pinned by JS test).
2. **P2:** `list <status> --search` post-filtered in Python *after* the SQL LIMIT, silently under-reporting on common tokens — status now narrows in SQL.

The reviewer verified the `DISTINCT ON` construction, type-keying across the summary attach, LIKE/ESCAPE handling, XSS escaping, truncation math, and that `/recent` was correctly left alone.

## Testing

Real-PG tests for all three DB methods (LIKE-escape round-trip, evidence overlay survival, recency-window ordering); fake mirrors + self-tests; contract tests for the search route, the imported-window call shape, and route-audit classification; CLI tests incl. SQL-side status narrowing; JS unit tests for the list body, truncation note, and search-clear. Full suite 4,378 green, pyright 0 errors, vulture clean.

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)