### PR TITLE
chore(web): deterministic per-thread conn close + stale web.md rule fix (#435)

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -10,7 +10,7 @@ paths:
 - Route handlers in `web/routes/*.py` — server.py is routing/cache/main only (~450 lines)
 - Beets queries via `lib/beets_db.py` `BeetsDB` class — never raw `sqlite3.connect()` in handlers
 - MusicBrainz queries through local mirror at `http://192.168.1.35:5200` via `web/mb.py`
-- Redis cache: MB data 24h TTL, beets/pipeline 5min TTL, explicit invalidation on POST mutations
+- Redis cache: `meta:` namespace only — pure MB/Discogs mirror metadata, 24h TTL via `memoize_meta` in `web/mb.py`/`web/discogs.py`. The routing-level response cache was REMOVED by #101 (it baked pipeline overlay state into cached responses); do not reintroduce response caching or reference `cache_api.cached(...)` — it no longer exists
 - Static JS served at `/js/*.js` — `node --check` validates syntax in CI
 - Fetch-on-input UI must stamp requests with a module-scoped in-flight token and discard stale responses before rendering
 - The web UI reads download_log JSONB columns (import_result, validation_result) — use the typed field names from the dataclasses, not arbitrary strings

--- a/tests/web/test_server_threading.py
+++ b/tests/web/test_server_threading.py
@@ -215,6 +215,28 @@ class TestPerThreadDbHandles(unittest.TestCase):
             # inherit a closed handle.
             srv._thread_state.db = None
 
+    def test_finish_closes_this_threads_handles_deterministically(self):
+        """#435: connection teardown closes the thread-local psycopg2
+        handle instead of leaving it to GC. Injected shared handles are
+        out of scope (the dev server / harness own those)."""
+        srv = self._srv
+        srv._db_dsn = TEST_DSN
+        srv.db = None
+
+        handle = srv._db()
+        self.assertFalse(handle.conn.closed)
+        srv._close_thread_handles()
+        self.assertTrue(handle.conn.closed)
+        self.assertIsNone(getattr(srv._thread_state, "db", None))
+
+    def test_close_thread_handles_leaves_injected_handle_alone(self):
+        srv = self._srv
+        srv._db_dsn = None
+        sentinel = object()
+        srv.db = sentinel  # type: ignore[assignment]
+        srv._close_thread_handles()
+        self.assertIs(srv.db, sentinel)
+
     def test_injected_handle_is_shared_across_threads(self):
         srv = self._srv
         srv._db_dsn = None

--- a/web/server.py
+++ b/web/server.py
@@ -133,6 +133,30 @@ def _beets_db() -> BeetsDB | None:
     return handle
 
 
+def _close_thread_handles() -> None:
+    """Close and drop this thread's DB handles.
+
+    Called from ``Handler.finish()`` — under ``ThreadingHTTPServer``
+    one thread serves one connection, so connection-close IS
+    thread-death and this releases the psycopg2/sqlite handles
+    deterministically instead of waiting on GC (#435). Injected shared
+    handles (``db``/``_beets`` — tests, dev server) are never touched."""
+    handle = getattr(_thread_state, "db", None)
+    if handle is not None:
+        try:
+            handle.close()
+        except Exception:
+            pass
+        _thread_state.db = None
+    beets_handle = getattr(_thread_state, "beets", None)
+    if beets_handle is not None:
+        try:
+            beets_handle.close()
+        except Exception:
+            pass
+        _thread_state.beets = None
+
+
 def _serialize_row(row: dict[str, object]) -> dict[str, object]:
     """Serialize a DB row dict — convert datetime objects to ISO strings."""
     result: dict[str, object] = {}
@@ -501,6 +525,16 @@ class Handler(BaseHTTPRequestHandler):
             # See do_GET: never reuse the socket after an error response.
             self.close_connection = True
             self._error(str(e), 500)
+
+    def finish(self):
+        """Connection teardown: release this thread's DB handles.
+
+        Runs once per connection (after the keep-alive loop ends), which
+        under ThreadingHTTPServer is the moment the worker thread dies."""
+        try:
+            super().finish()
+        finally:
+            _close_thread_handles()
 
     def do_OPTIONS(self):
         self.send_response(200)


### PR DESCRIPTION
Two small cleanups from the 2026-06-12 retrospective (#435):

1. **`Handler.finish()` closes thread-local DB handles.** Under `ThreadingHTTPServer` one thread serves one connection, so connection teardown is thread death — the psycopg2/sqlite handles now close deterministically there instead of waiting on GC finalizers (the residual risk flagged in #428's review). Injected shared handles (test harness, dev server live-db) are explicitly out of scope. Pinned by two new tests.

2. **`.claude/rules/web.md` cache line updated** — it still described the routing-level Redis response cache removed by #101, and that stale text misled the #227 plan-of-record into prescribing a `cache_api.cached(...)` wrapper that no longer exists.

Suite 4,380 green, pyright 0.

Closes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)