### PR TITLE
refactor(db): compose history SQL from named parts (#433)

### DIFF
--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -250,17 +250,24 @@ class _DownloadLogMixin(_PipelineDBBase):
     # ``dl.*`` automatically projects ``source`` and ``youtube_metadata``
     # (migration 037) onto every consumer; no additional column list
     # change is needed here.
-    _DOWNLOAD_LOG_HISTORY_SELECT = """
-        SELECT
+    # History queries compose from these two named parts so variants
+    # (plain SELECT vs DISTINCT ON) build explicitly instead of
+    # string-replacing tokens inside a finished statement (#433).
+    _DOWNLOAD_LOG_HISTORY_COLUMNS = """
             dl.*,
             e.spectral_grade        AS _evidence_spectral_grade,
             e.spectral_bitrate_kbps AS _evidence_spectral_bitrate,
             e.v0_source_lineage     AS _evidence_v0_probe_kind,
             e.v0_avg_bitrate_kbps   AS _evidence_v0_probe_avg_bitrate
+    """
+    _DOWNLOAD_LOG_HISTORY_FROM = """
         FROM download_log dl
         LEFT JOIN album_quality_evidence e
             ON e.id = dl.candidate_evidence_id
     """
+    _DOWNLOAD_LOG_HISTORY_SELECT = (
+        "SELECT" + _DOWNLOAD_LOG_HISTORY_COLUMNS + _DOWNLOAD_LOG_HISTORY_FROM
+    )
 
     # Evidence stores lineage as ``lossless_source`` / ``native_lossy_research``;
     # download_log.v0_probe_kind stores the wire-shaped kind
@@ -357,11 +364,9 @@ class _DownloadLogMixin(_PipelineDBBase):
         ids = [int(r) for r in request_ids]
         latest_cur = self._execute(
             "SELECT * FROM ("
-            + self._DOWNLOAD_LOG_HISTORY_SELECT.replace(
-                "SELECT",
-                "SELECT DISTINCT ON (dl.request_id)",
-                1,
-            )
+            "SELECT DISTINCT ON (dl.request_id)"
+            + self._DOWNLOAD_LOG_HISTORY_COLUMNS
+            + self._DOWNLOAD_LOG_HISTORY_FROM
             + " WHERE dl.request_id = ANY(%s)"
             " ORDER BY dl.request_id, dl.id DESC"
             ") latest",


### PR DESCRIPTION
`get_latest_download_summaries` (#429) built its `DISTINCT ON` variant by string-replacing the first `SELECT` token inside the finished `_DOWNLOAD_LOG_HISTORY_SELECT` — a silent landmine for the first person to add a subquery to that constant. Now `_DOWNLOAD_LOG_HISTORY_COLUMNS` + `_DOWNLOAD_LOG_HISTORY_FROM` are named parts both consumers compose explicitly.

No behavior change. Existing real-PG tests (`TestLatestDownloadSummaries`, `TestDownloadLog`) pin both query shapes; full suite 4,380 green, pyright 0.

Closes #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)