### PR TITLE
test(web): #430 batch 1 — FakePipelineDB harness mode, 4 modules migrated, ratchet baseline

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -522,7 +522,6 @@ _WEB_HARNESS_OVERRIDE_RE = re.compile(
 WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "_harness.py"): 31,
     os.path.join("web", "test_routes_imports.py"): 63,
-    os.path.join("web", "test_routes_library.py"): 4,
     os.path.join("web", "test_routes_pipeline.py"): 59,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 98,
     os.path.join("web", "test_routes_pipeline_replace.py"): 26,

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -521,15 +521,12 @@ _WEB_HARNESS_OVERRIDE_RE = re.compile(
 
 WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "_harness.py"): 31,
-    os.path.join("web", "test_routes_browse.py"): 4,
     os.path.join("web", "test_routes_imports.py"): 63,
     os.path.join("web", "test_routes_library.py"): 4,
     os.path.join("web", "test_routes_pipeline.py"): 59,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 98,
     os.path.join("web", "test_routes_pipeline_replace.py"): 26,
     os.path.join("web", "test_routes_pipeline_search_plan.py"): 42,
-    os.path.join("web", "test_routes_youtube.py"): 1,
-    os.path.join("web", "test_server_cache.py"): 3,
     os.path.join("web", "test_server_endpoints.py"): 51,
 }
 

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -490,3 +490,62 @@ def scan_tree() -> Dict[str, Dict[str, int]]:
         if counts:
             result[rel] = counts
     return result
+
+
+# === Web-harness MagicMock ratchet (#430) ===
+#
+# The tests/web contract harness historically injected a MagicMock
+# pipeline DB (now ``MagicMock(wraps=FakePipelineDB)``), so contract
+# tests pass whenever the mock's shape matches the assertion's shape —
+# production query semantics never enter the loop. Issue #430 migrates
+# the harness and every per-route test to a bare ``FakePipelineDB``,
+# route-module by route-module.
+#
+# This ratchet pins the per-file count of remaining MagicMock-harness
+# usage lines (``mock_db.<attr>`` configuration/assertion sites and
+# ``_pipeline_db_test_harness(`` construction sites). The audit test
+# requires the live counts to match this baseline EXACTLY:
+#
+# - a count above baseline fails — new tests must seed FakePipelineDB
+#   state instead of configuring mock returns, even in unmigrated files
+# - a count below baseline fails — shrink the entry here in the same
+#   commit so the baseline always reflects reality
+# - a file at zero must have NO entry; delete the line when a module
+#   finishes migrating
+#
+# The migration is done when this dict is empty.
+
+_WEB_HARNESS_OVERRIDE_RE = re.compile(
+    r"\bmock_db\.|\b_pipeline_db_test_harness\s*\("
+)
+
+WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
+    os.path.join("web", "_harness.py"): 31,
+    os.path.join("web", "test_routes_browse.py"): 4,
+    os.path.join("web", "test_routes_imports.py"): 63,
+    os.path.join("web", "test_routes_library.py"): 4,
+    os.path.join("web", "test_routes_pipeline.py"): 59,
+    os.path.join("web", "test_routes_pipeline_mutations.py"): 98,
+    os.path.join("web", "test_routes_pipeline_replace.py"): 26,
+    os.path.join("web", "test_routes_pipeline_search_plan.py"): 42,
+    os.path.join("web", "test_routes_youtube.py"): 1,
+    os.path.join("web", "test_server_cache.py"): 3,
+    os.path.join("web", "test_server_endpoints.py"): 51,
+}
+
+
+def scan_web_harness_overrides() -> Dict[str, int]:
+    """Count MagicMock-harness usage lines per ``tests/web`` file."""
+    counts: Dict[str, int] = {}
+    web_prefix = "web" + os.sep
+    for rel, path in iter_scan_paths():
+        if not rel.startswith(web_prefix):
+            continue
+        n = 0
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                if _WEB_HARNESS_OVERRIDE_RE.search(line):
+                    n += 1
+        if n:
+            counts[rel] = n
+    return counts

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -502,9 +502,14 @@ def scan_tree() -> Dict[str, Dict[str, int]]:
 # route-module by route-module.
 #
 # This ratchet pins the per-file count of remaining MagicMock-harness
-# usage lines (``mock_db.<attr>`` configuration/assertion sites and
-# ``_pipeline_db_test_harness(`` construction sites). The audit test
-# requires the live counts to match this baseline EXACTLY:
+# usage OCCURRENCES: every ``mock_db`` reference in a ``tests/web``
+# file (dotted, aliased, passed bare — aliasing the mock away is the
+# evasion the occurrence count exists to close) plus every
+# ``_pipeline_db_test_harness`` reference in ANY scanned test file
+# (the transitional wrapped-MagicMock constructor must not leak
+# outside tests/web where the per-file mock_db count can't see it).
+# The audit test requires the live counts to match this baseline
+# EXACTLY:
 #
 # - a count above baseline fails — new tests must seed FakePipelineDB
 #   state instead of configuring mock returns, even in unmigrated files
@@ -515,33 +520,41 @@ def scan_tree() -> Dict[str, Dict[str, int]]:
 #
 # The migration is done when this dict is empty.
 
-_WEB_HARNESS_OVERRIDE_RE = re.compile(
-    r"\bmock_db\.|\b_pipeline_db_test_harness\s*\("
-)
+_WEB_HARNESS_MOCK_DB_RE = re.compile(r"\bmock_db\b")
+_HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
 
 WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
-    os.path.join("web", "_harness.py"): 31,
-    os.path.join("web", "test_routes_imports.py"): 63,
-    os.path.join("web", "test_routes_pipeline.py"): 59,
-    os.path.join("web", "test_routes_pipeline_mutations.py"): 98,
-    os.path.join("web", "test_routes_pipeline_replace.py"): 26,
+    os.path.join("web", "_harness.py"): 39,
+    os.path.join("web", "test_routes_imports.py"): 71,
+    os.path.join("web", "test_routes_pipeline.py"): 66,
+    os.path.join("web", "test_routes_pipeline_mutations.py"): 100,
+    os.path.join("web", "test_routes_pipeline_replace.py"): 27,
     os.path.join("web", "test_routes_pipeline_search_plan.py"): 42,
-    os.path.join("web", "test_server_endpoints.py"): 51,
+    os.path.join("web", "test_server_endpoints.py"): 53,
 }
 
 
+def count_harness_overrides(text: str, *, web_file: bool) -> int:
+    """Count MagicMock-harness usage occurrences in one file's text.
+
+    ``mock_db`` references only count inside ``tests/web`` files (the
+    name has no meaning elsewhere); ``_pipeline_db_test_harness``
+    references count everywhere the scanner walks.
+    """
+    n = len(_HARNESS_CTOR_RE.findall(text))
+    if web_file:
+        n += len(_WEB_HARNESS_MOCK_DB_RE.findall(text))
+    return n
+
+
 def scan_web_harness_overrides() -> Dict[str, int]:
-    """Count MagicMock-harness usage lines per ``tests/web`` file."""
+    """Count MagicMock-harness usage occurrences per test file."""
     counts: Dict[str, int] = {}
     web_prefix = "web" + os.sep
     for rel, path in iter_scan_paths():
-        if not rel.startswith(web_prefix):
-            continue
-        n = 0
         with open(path, encoding="utf-8") as f:
-            for line in f:
-                if _WEB_HARNESS_OVERRIDE_RE.search(line):
-                    n += 1
+            n = count_harness_overrides(
+                f.read(), web_file=rel.startswith(web_prefix))
         if n:
             counts[rel] = n
     return counts

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1067,7 +1067,10 @@ class FakePipelineDB:
         # arguments for assertion.
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
         self._execute_queue: list[Any] = []
-        self._execute_default: Any = None
+        # Production ``_execute`` always returns a cursor — an unqueued
+        # call degrades to "query ran, zero rows" instead of a None
+        # that detonates as AttributeError at the caller's fetchall().
+        self._execute_default: Any = FakeCursor()
         # U15 triage N+1 guard: every triage-bound bulk getter increments
         # its counter exactly once per call. ``list_triage`` is bounded
         # to four entries (one page + three bulk getters) regardless of
@@ -1114,7 +1117,8 @@ class FakePipelineDB:
 
         Records the call and returns the next entry from
         ``queue_execute_results``. If the queue is empty, returns
-        ``self._execute_default`` (defaults to ``None``)."""
+        ``self._execute_default`` (an empty :class:`FakeCursor` —
+        mirrors production's "query ran, zero rows" contract)."""
         self.execute_calls.append((sql, params))
         if not self._execute_queue:
             return self._execute_default
@@ -5207,16 +5211,22 @@ class FakeCursor:
     code under test goes through ``PipelineDB._execute`` directly
     (e.g. ``web.overlay.check_pipeline``) — the fake cannot interpret
     SQL, so the test supplies the rows the query would return.
+
+    Mirrors real psycopg2 consumption semantics (test-fidelity Rule B):
+    ``fetchone`` advances and returns ``None`` when exhausted;
+    ``fetchall`` drains and returns only the remainder. A
+    ``while cur.fetchone():`` consumer must terminate.
     """
 
     def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
         self._rows = list(rows) if rows else []
 
     def fetchall(self) -> list[dict[str, Any]]:
-        return self._rows
+        rows, self._rows = self._rows, []
+        return rows
 
     def fetchone(self) -> dict[str, Any] | None:
-        return self._rows[0] if self._rows else None
+        return self._rows.pop(0) if self._rows else None
 
 
 class FakeBeetsDB:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5200,6 +5200,25 @@ class FakePipelineDBSource:
         self.close_calls += 1
 
 
+class FakeCursor:
+    """Minimal DB-API cursor stand-in for raw-SQL seams.
+
+    Pair with :meth:`FakePipelineDB.queue_execute_results` when the
+    code under test goes through ``PipelineDB._execute`` directly
+    (e.g. ``web.overlay.check_pipeline``) — the fake cannot interpret
+    SQL, so the test supplies the rows the query would return.
+    """
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self._rows = list(rows) if rows else []
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._rows[0] if self._rows else None
+
+
 class FakeBeetsDB:
     """In-memory fake for ``lib.beets_db.BeetsDB`` — minimal surface.
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -266,10 +266,11 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertIs(raised.exception, boom)
 
     def test_execute_with_empty_queue_returns_default(self):
-        """Empty queue returns ``None`` so tests that don't care about the
-        cursor result can still call ``_execute`` without setup."""
+        """Empty queue returns an empty cursor (production's "query ran,
+        zero rows" shape) so tests that don't care about the cursor
+        result can still call ``_execute`` without setup."""
         db = FakePipelineDB()
-        self.assertIsNone(db._execute("SELECT 1"))
+        self.assertEqual(db._execute("SELECT 1").fetchall(), [])
         self.assertEqual(db.execute_calls, [("SELECT 1", ())])
 
     def test_record_attempt_updates_retry_metadata(self):
@@ -4928,15 +4929,32 @@ class TestFakePipelineDBYoutubeIngest(unittest.TestCase):
 
 class TestFakeCursor(unittest.TestCase):
     """FakeCursor pairs with FakePipelineDB.queue_execute_results for
-    raw-SQL seams (web.overlay.check_pipeline et al.)."""
+    raw-SQL seams (web.overlay.check_pipeline et al.). Consumption
+    semantics mirror real psycopg2 cursors (test-fidelity Rule B)."""
 
     def test_fetchall_returns_rows(self):
         rows = [{"id": 1}, {"id": 2}]
         self.assertEqual(FakeCursor(rows).fetchall(), rows)
 
-    def test_fetchone_returns_first_row_or_none(self):
-        self.assertEqual(FakeCursor([{"id": 1}]).fetchone(), {"id": 1})
+    def test_fetchone_consumes_like_a_real_cursor(self):
+        cur = FakeCursor([{"id": 1}, {"id": 2}])
+        self.assertEqual(cur.fetchone(), {"id": 1})
+        self.assertEqual(cur.fetchone(), {"id": 2})
+        self.assertIsNone(cur.fetchone())
         self.assertIsNone(FakeCursor().fetchone())
+
+    def test_fetchall_after_fetchone_returns_remainder(self):
+        cur = FakeCursor([{"id": 1}, {"id": 2}, {"id": 3}])
+        cur.fetchone()
+        self.assertEqual(cur.fetchall(), [{"id": 2}, {"id": 3}])
+        self.assertEqual(cur.fetchall(), [])
+
+    def test_while_fetchone_loop_terminates(self):
+        cur = FakeCursor([{"id": 1}, {"id": 2}])
+        drained = []
+        while (row := cur.fetchone()) is not None:
+            drained.append(row)
+        self.assertEqual(len(drained), 2)
 
     def test_empty_default_fetchall(self):
         self.assertEqual(FakeCursor().fetchall(), [])
@@ -4946,6 +4964,15 @@ class TestFakeCursor(unittest.TestCase):
         db.queue_execute_results(FakeCursor([{"id": 7}]))
         cur = db._execute("SELECT 1", ())
         self.assertEqual(cur.fetchall(), [{"id": 7}])
+
+    def test_unqueued_execute_returns_empty_cursor_not_none(self):
+        """Production _execute always returns a cursor; the unqueued
+        fake degrades to "query ran, zero rows" instead of a None that
+        AttributeErrors at the caller's fetchall()."""
+        db = FakePipelineDB()
+        cur = db._execute("SELECT 1", ())
+        self.assertEqual(cur.fetchall(), [])
+        self.assertIsNone(cur.fetchone())
 
 
 if __name__ == "__main__":

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -10,7 +10,13 @@ from zoneinfo import ZoneInfo
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.pipeline_db import PipelineDB, RequestSpectralStateUpdate
 from lib.quality import SpectralMeasurement, ValidationResult
-from tests.fakes import FakeBeetsDB, FakePipelineDB, FakeSlskdAPI, FakeYTMusic
+from tests.fakes import (
+    FakeBeetsDB,
+    FakeCursor,
+    FakePipelineDB,
+    FakeSlskdAPI,
+    FakeYTMusic,
+)
 from tests.helpers import (
     make_album_quality_evidence,
     make_download_file,
@@ -4918,6 +4924,28 @@ class TestFakePipelineDBYoutubeIngest(unittest.TestCase):
         self.assertEqual(
             {r["source"] for r in batch[42]}, {"slskd", "youtube"},
         )
+
+
+class TestFakeCursor(unittest.TestCase):
+    """FakeCursor pairs with FakePipelineDB.queue_execute_results for
+    raw-SQL seams (web.overlay.check_pipeline et al.)."""
+
+    def test_fetchall_returns_rows(self):
+        rows = [{"id": 1}, {"id": 2}]
+        self.assertEqual(FakeCursor(rows).fetchall(), rows)
+
+    def test_fetchone_returns_first_row_or_none(self):
+        self.assertEqual(FakeCursor([{"id": 1}]).fetchone(), {"id": 1})
+        self.assertIsNone(FakeCursor().fetchone())
+
+    def test_empty_default_fetchall(self):
+        self.assertEqual(FakeCursor().fetchall(), [])
+
+    def test_queued_through_fake_pipeline_db_execute(self):
+        db = FakePipelineDB()
+        db.queue_execute_results(FakeCursor([{"id": 7}]))
+        cur = db._execute("SELECT 1", ())
+        self.assertEqual(cur.fetchall(), [{"id": 7}])
 
 
 if __name__ == "__main__":

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -19,6 +19,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _mock_audit_scanner import (
     WEB_HARNESS_MOCK_BASELINE,
+    count_harness_overrides,
     iter_scan_paths,
     scan_tree,
     scan_web_harness_overrides,
@@ -60,6 +61,32 @@ class TestWebHarnessMockRatchet(unittest.TestCase):
     means a migration landed and the baseline entry must drop with it.
     """
 
+    def test_counter_pins_evasion_shapes(self) -> None:
+        """Document exactly what the ratchet counts — occurrences, not
+        lines, including alias/bare-reference shapes that a dotted-only
+        regex would miss (the r1 adversarial-review evasion vectors)."""
+        cases = [
+            ("dotted config", "self.mock_db.get_log.return_value = []", 1),
+            ("alias assignment", "m = self.mock_db", 1),
+            ("getattr reflection", "getattr(self.mock_db, name)", 1),
+            ("bare positional arg", "helper(self.mock_db, x)", 1),
+            ("two occurrences one line",
+             "mock_db.a.return_value = 1; mock_db.b.side_effect = e", 2),
+            ("substring does not count", "my_mock_database = 1", 0),
+            ("harness ctor", "db = _pipeline_db_test_harness()", 1),
+        ]
+        for desc, line, expected in cases:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    count_harness_overrides(line, web_file=True), expected)
+        # mock_db is only meaningful inside tests/web; the transitional
+        # wrapped-MagicMock constructor is counted EVERYWHERE so it
+        # cannot leak outside tests/web unseen.
+        self.assertEqual(count_harness_overrides(
+            "self.mock_db.get_log()", web_file=False), 0)
+        self.assertEqual(count_harness_overrides(
+            "db = _pipeline_db_test_harness()", web_file=False), 1)
+
     def test_counts_match_baseline_exactly(self) -> None:
         current = scan_web_harness_overrides()
         problems: list[str] = []
@@ -68,13 +95,13 @@ class TestWebHarnessMockRatchet(unittest.TestCase):
             base = WEB_HARNESS_MOCK_BASELINE.get(rel, 0)
             if cur > base:
                 problems.append(
-                    f"  - {rel}: {base} → {cur} MagicMock-harness lines. "
+                    f"  - {rel}: {base} → {cur} MagicMock-harness occurrences. "
                     "New tests must seed FakePipelineDB state (see "
                     "tests/fakes.py), not configure mock_db returns."
                 )
             elif cur < base:
                 problems.append(
-                    f"  - {rel}: {base} → {cur} MagicMock-harness lines. "
+                    f"  - {rel}: {base} → {cur} MagicMock-harness occurrences. "
                     "Migration progress — shrink WEB_HARNESS_MOCK_BASELINE "
                     "in tests/_mock_audit_scanner.py to match"
                     + (" (delete the entry)." if cur == 0 else ".")

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -17,7 +17,12 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _mock_audit_scanner import iter_scan_paths, scan_tree
+from _mock_audit_scanner import (
+    WEB_HARNESS_MOCK_BASELINE,
+    iter_scan_paths,
+    scan_tree,
+    scan_web_harness_overrides,
+)
 
 
 class TestStatefulMockAudit(unittest.TestCase):
@@ -44,6 +49,41 @@ class TestStatefulMockAudit(unittest.TestCase):
             "or real-input call.\n\n"
             + "\n".join(lines)
         )
+
+
+class TestWebHarnessMockRatchet(unittest.TestCase):
+    """Ratchet for the #430 MagicMock → FakePipelineDB harness migration.
+
+    Per-file counts of remaining MagicMock-harness usage in ``tests/web``
+    must match ``WEB_HARNESS_MOCK_BASELINE`` exactly: growth means a new
+    test leaned on mock shapes instead of FakePipelineDB state; shrink
+    means a migration landed and the baseline entry must drop with it.
+    """
+
+    def test_counts_match_baseline_exactly(self) -> None:
+        current = scan_web_harness_overrides()
+        problems: list[str] = []
+        for rel in sorted(set(current) | set(WEB_HARNESS_MOCK_BASELINE)):
+            cur = current.get(rel, 0)
+            base = WEB_HARNESS_MOCK_BASELINE.get(rel, 0)
+            if cur > base:
+                problems.append(
+                    f"  - {rel}: {base} → {cur} MagicMock-harness lines. "
+                    "New tests must seed FakePipelineDB state (see "
+                    "tests/fakes.py), not configure mock_db returns."
+                )
+            elif cur < base:
+                problems.append(
+                    f"  - {rel}: {base} → {cur} MagicMock-harness lines. "
+                    "Migration progress — shrink WEB_HARNESS_MOCK_BASELINE "
+                    "in tests/_mock_audit_scanner.py to match"
+                    + (" (delete the entry)." if cur == 0 else ".")
+                )
+        if problems:
+            self.fail(
+                "Web-harness MagicMock ratchet (#430) out of sync with "
+                "WEB_HARNESS_MOCK_BASELINE:\n" + "\n".join(problems)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -10,17 +10,7 @@ import unittest
 
 from web import overlay
 
-from tests.fakes import FakeBeetsDB, FakePipelineDB
-
-
-class _Cursor:
-    """Minimal cursor stand-in for FakePipelineDB.queue_execute_results."""
-
-    def __init__(self, rows):
-        self._rows = rows
-
-    def fetchall(self):
-        return self._rows
+from tests.fakes import FakeBeetsDB, FakeCursor, FakePipelineDB
 
 
 class TestSerializeRow(unittest.TestCase):
@@ -44,7 +34,7 @@ class TestCheckPipeline(unittest.TestCase):
 
     def test_returns_info_keyed_by_mbid(self):
         db = FakePipelineDB()
-        db.queue_execute_results(_Cursor([
+        db.queue_execute_results(FakeCursor([
             {
                 "id": 7, "mb_release_id": "mbid-1", "status": "wanted",
                 "search_filetype_override": "lossless",
@@ -67,7 +57,7 @@ class TestEnrichWithPipeline(unittest.TestCase):
 
     def test_wanted_with_override_marks_upgrade_queued(self):
         db = FakePipelineDB()
-        db.queue_execute_results(_Cursor([
+        db.queue_execute_results(FakeCursor([
             {
                 "id": 7, "mb_release_id": "mbid-1", "status": "wanted",
                 "search_filetype_override": "lossless",

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import unittest
 from http.server import HTTPServer, ThreadingHTTPServer
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
@@ -143,6 +143,35 @@ class _WebServerCase(unittest.TestCase):
             return resp.status, json.loads(resp.read())
         except HTTPError as e:
             return e.code, json.loads(e.read())
+
+
+class _FakeDbWebServerCase(_WebServerCase):
+    """Contract-test base with a bare per-test :class:`FakePipelineDB`.
+
+    Migration target for #430. ``setUp`` installs a fresh fake as
+    ``web.server.db`` (the same module-global swap production uses for
+    DSN-less handles — ``_db()`` returns it directly), so every test
+    starts from empty typed state. Tests seed what they need
+    (``self.db.seed_request(...)``, ``self.db.log_download(...)``,
+    ``self.db.update_status(...)``) and assertions hit the fake's real
+    query semantics — there is no MagicMock layer to shape-match.
+
+    The inherited class-level ``mock_db`` (legacy MagicMock harness)
+    must not be touched in subclasses; the ratchet in
+    ``tests/_mock_audit_scanner.py`` enforces this textually, and any
+    accidental use is inert anyway because ``web.server.db`` points at
+    ``self.db`` for the duration of the test.
+    """
+
+    db: FakePipelineDB
+
+    def setUp(self) -> None:
+        super().setUp()
+        import web.server as srv
+        self.db = FakePipelineDB()
+        patcher = patch.object(srv, "db", self.db)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
 
 def _fresh_triage_runner(case: unittest.TestCase):

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """Shared HTTP test harness for the web route contract tests (#408).
 
-Starts a real HTTP server on a random port with mocked DB; the
-``tests/web/test_*.py`` modules verify response codes, JSON structure,
-and error handling against it. One harness, no per-class copies.
+Starts a real HTTP server on a random port; the ``tests/web/test_*.py``
+modules verify response codes, JSON structure, and error handling
+against it. Two base classes during the #430 migration:
+
+- :class:`_FakeDbWebServerCase` — per-test bare ``FakePipelineDB``.
+  Subclass THIS for new and migrated modules.
+- :class:`_WebServerCase` — legacy class-level MagicMock-wrapped DB
+  with canned ``.return_value`` defaults. Dies when the ratchet
+  baseline in ``tests/_mock_audit_scanner.py`` is empty.
 """
 
 import copy
@@ -157,10 +163,13 @@ class _FakeDbWebServerCase(_WebServerCase):
     query semantics — there is no MagicMock layer to shape-match.
 
     The inherited class-level ``mock_db`` (legacy MagicMock harness)
-    must not be touched in subclasses; the ratchet in
-    ``tests/_mock_audit_scanner.py`` enforces this textually, and any
-    accidental use is inert anyway because ``web.server.db`` points at
-    ``self.db`` for the duration of the test.
+    must not be touched in subclasses — the ratchet in
+    ``tests/_mock_audit_scanner.py`` is the guard that enforces this.
+    Note the textual guard is load-bearing: configuration of the
+    disconnected mock fails loudly at the route, but a negative
+    assertion (``assert_not_called``) against it would pass VACUOUSLY
+    (the mock genuinely receives no calls), so don't rely on runtime
+    behaviour to catch accidental use.
     """
 
     db: FakePipelineDB

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -205,8 +205,9 @@ def _pipeline_db_test_harness(fake: "FakePipelineDB | None" = None) -> MagicMock
     state-based assertions remain available via the underlying fake.
 
     Tests can reach the underlying fake through the ``_fake`` attribute on
-    the mock (or by accepting the helper's return value directly in
-    bespoke harnesses such as the ``failing_db`` site).
+    the mock. Transitional (#430): migrated route modules subclass
+    :class:`_FakeDbWebServerCase` instead; this helper dies with the last
+    ratchet entry in ``tests/_mock_audit_scanner.py``.
     """
     backing = fake if fake is not None else FakePipelineDB()
     harness = MagicMock(wraps=backing)

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -17,14 +17,14 @@ from urllib.error import HTTPError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tests.web._harness import _assert_required_fields, _WebServerCase
+from tests.web._harness import _assert_required_fields, _FakeDbWebServerCase
 
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 from web.library_album_row import LibraryAlbumRow
 
 
-class TestBrowseRouteContracts(_WebServerCase):
+class TestBrowseRouteContracts(_FakeDbWebServerCase):
     """Contract tests for browse and MusicBrainz-backed routes."""
 
     ARTIST_SEARCH_REQUIRED_FIELDS = {"id", "name", "disambiguation"}
@@ -511,9 +511,9 @@ class TestBrowseRouteContracts(_WebServerCase):
         mock_beets.get_album_ids_by_mbids.return_value = {self.RELEASE_ID: 7}
         mock_beets.check_mbids_detail.return_value = {self.RELEASE_ID: {}}
         mock_beets.get_tracks_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id=self.RELEASE_ID,
-        )
+        ))
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.server.check_beets_library", return_value={self.RELEASE_ID}), \
                 patch("web.server._beets_db", return_value=mock_beets):
@@ -533,9 +533,9 @@ class TestBrowseRouteContracts(_WebServerCase):
         mock_beets.get_album_ids_by_mbids.return_value = {"12856590": 8}
         mock_beets.check_mbids_detail.return_value = {"12856590": {}}
         mock_beets.get_tracks_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_discogs_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id="12856590", discogs_release_id="12856590",
-        )
+        ))
         mock_discogs_get.return_value = {
             "id": "12856590",
             "title": "Discogs Album",
@@ -606,7 +606,7 @@ class TestBrowseRouteContracts(_WebServerCase):
                                 "disambiguate track")
 
 
-class TestDiscogsBrowseRouteContracts(_WebServerCase):
+class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
     """Contract tests for Discogs browse routes."""
 
     DISCOGS_SEARCH_REQUIRED_FIELDS = {
@@ -720,8 +720,6 @@ class TestDiscogsBrowseRouteContracts(_WebServerCase):
         mock_beets.get_album_ids_by_mbids.return_value = {"83182": 10}
         mock_beets.check_mbids_detail.return_value = {"83182": {}}
         mock_beets.get_tracks_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
         with patch("web.routes.browse.discogs_api") as mock_dg, \
                 patch("web.server.check_beets_library", return_value={"83182"}), \
                 patch("web.server._beets_db", return_value=mock_beets):
@@ -749,7 +747,7 @@ class TestDiscogsBrowseRouteContracts(_WebServerCase):
         self.assertEqual(data["beets_album_id"], 10)
 
 
-class TestSearchByIdResolveContract(_WebServerCase):
+class TestSearchByIdResolveContract(_FakeDbWebServerCase):
     """Contract tests for /api/browse/resolve — the search-by-ID resolver."""
 
     REQUIRED_FIELDS = {

--- a/tests/web/test_routes_library.py
+++ b/tests/web/test_routes_library.py
@@ -163,11 +163,18 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         return for request 42 (the overlay goes through ``_execute``,
         which the fake cannot interpret — the queued cursor IS the
         query result). The legacy MagicMock harness silently fed this
-        path an empty magic cursor, so enrichment never ran in tests."""
+        path an empty magic cursor, so enrichment never ran in tests.
+
+        The cursor row is PROJECTED from the seeded request, mutated
+        first, so the two representations of request 42 cannot
+        contradict each other (in production they are the same row)."""
+        self.db.update_request_fields(42, min_bitrate=min_bitrate)
+        req = self.db.request(42)
         self.db.queue_execute_results(FakeCursor([{
-            "id": 42, "mb_release_id": self.RELEASE_ID, "status": "wanted",
-            "search_filetype_override": None, "target_format": None,
-            "min_bitrate": min_bitrate,
+            k: req.get(k)
+            for k in ("id", "mb_release_id", "status",
+                      "search_filetype_override", "target_format",
+                      "min_bitrate")
         }]))
 
     def test_beets_search_contract(self):
@@ -325,28 +332,24 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
         self._configure_beets_delete_mock(mock_beets_cls)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-                "purge_pipeline": True,
-                "pipeline_id": 42,
-                "release_id": self.RELEASE_ID,
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "pipeline_id": 42,
+            "release_id": self.RELEASE_ID,
+        })
 
         self.assertEqual(status, 200)
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 42)
-        self.assertIsNone(fake_db.get_request(42))
+        self.assertIsNone(self.db.get_request(42))
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -359,27 +362,26 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        # Drop the setUp-seeded request 42 (same RELEASE_ID) so the
+        # release-id fallback can only resolve to this test's row.
+        self.db.delete_request(42)
+        self.db.seed_request(make_request_row(
             id=99, status="imported", mb_release_id=self.RELEASE_ID,
         ))
         self._configure_beets_delete_mock(mock_beets_cls)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-                "purge_pipeline": True,
-                "release_id": self.RELEASE_ID,
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "release_id": self.RELEASE_ID,
+        })
 
         self.assertEqual(status, 200)
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 99)
-        self.assertIsNone(fake_db.get_request(99))
+        self.assertIsNone(self.db.get_request(99))
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -392,27 +394,26 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        # Drop the setUp-seeded request 42 (same RELEASE_ID) so the
+        # release-id fallback can only resolve to this test's row.
+        self.db.delete_request(42)
+        self.db.seed_request(make_request_row(
             id=98, status="imported", mb_release_id=self.RELEASE_ID,
         ))
         self._configure_beets_delete_mock(mock_beets_cls)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-                "purge_pipeline": True,
-                "release_id": self.RELEASE_ID.upper(),
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "release_id": self.RELEASE_ID.upper(),
+        })
 
         self.assertEqual(status, 200)
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 98)
-        self.assertIsNone(fake_db.get_request(98))
+        self.assertIsNone(self.db.get_request(98))
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -425,25 +426,21 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
         self._configure_beets_delete_mock(mock_beets_cls)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+        })
 
         self.assertEqual(status, 200)
         self.assertFalse(data["pipeline_deleted"])
         self.assertIsNone(data["pipeline_id"])
-        self.assertIsNotNone(fake_db.get_request(42))
+        self.assertIsNotNone(self.db.get_request(42))
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -456,22 +453,21 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
         self._configure_beets_delete_mock(mock_beets_cls)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-                "purge_pipeline": True,
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+        })
 
         self.assertEqual(status, 200)
         self.assertFalse(data["pipeline_deleted"])
         self.assertIsNone(data["pipeline_id"])
+        # The setUp-seeded request is untouched — no pipeline context
+        # in the body means no purge, even with purge_pipeline=True.
+        self.assertIsNotNone(self.db.get_request(42))
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -484,11 +480,8 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=77,
             mb_release_id=None,
             discogs_release_id="12856590",
@@ -496,18 +489,17 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         ))
         self._configure_beets_delete_mock(mock_beets_cls)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-                "purge_pipeline": True,
-                "release_id": "12856590",
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "release_id": "12856590",
+        })
 
         self.assertEqual(status, 200)
         self.assertTrue(data["pipeline_deleted"])
         self.assertEqual(data["pipeline_id"], 77)
-        self.assertIsNone(fake_db.get_request(77))
+        self.assertIsNone(self.db.get_request(77))
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -520,8 +512,6 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
         self._configure_beets_delete_mock(mock_beets_cls)
         failing_db = _FailingDeleteDB()
@@ -529,7 +519,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
 
-        with patch.object(srv, "db", failing_db):
+        with patch.object(self._srv, "db", failing_db):
             status, data = self._post("/api/beets/delete", {
                 "id": 7,
                 "confirm": "DELETE",
@@ -553,11 +543,8 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         _mock_isfile,
         _mock_isdir,
     ):
-        import web.server as srv
-
         self._srv.beets_db_path = "/tmp/beets.db"
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
         self._configure_beets_delete_mock(
@@ -565,18 +552,17 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
             delete_side_effect=OSError("boom"),
         )
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post("/api/beets/delete", {
-                "id": 7,
-                "confirm": "DELETE",
-                "purge_pipeline": True,
-                "pipeline_id": 42,
-                "release_id": self.RELEASE_ID,
-            })
+        status, data = self._post("/api/beets/delete", {
+            "id": 7,
+            "confirm": "DELETE",
+            "purge_pipeline": True,
+            "pipeline_id": 42,
+            "release_id": self.RELEASE_ID,
+        })
 
         self.assertEqual(status, 500)
         self.assertIn("Pipeline request was removed", data["error"])
-        self.assertIsNone(fake_db.get_request(42))
+        self.assertIsNone(self.db.get_request(42))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/web/test_routes_library.py
+++ b/tests/web/test_routes_library.py
@@ -15,15 +15,22 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import (
     _assert_required_fields,
-    _WebServerCase,
-    _pipeline_db_test_harness,
+    _FakeDbWebServerCase,
 )
 
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakeCursor, FakePipelineDB
 from tests.helpers import make_request_row
 
 
-class TestBeetsRouteContracts(_WebServerCase):
+class _FailingDeleteDB(FakePipelineDB):
+    """delete_request raises — pins purge-failure ordering (no beets
+    delete may run after the pipeline purge fails)."""
+
+    def delete_request(self, request_id: int) -> None:
+        raise RuntimeError("boom")
+
+
+class TestBeetsRouteContracts(_FakeDbWebServerCase):
     """Contract tests for frontend-consumed beets library routes."""
 
     ALBUM_REQUIRED_FIELDS = {
@@ -72,6 +79,7 @@ class TestBeetsRouteContracts(_WebServerCase):
     RG_ID = "11111111-1111-1111-1111-111111111111"
 
     def setUp(self) -> None:
+        super().setUp()
         import web.server as srv
 
         self._srv = srv
@@ -79,13 +87,21 @@ class TestBeetsRouteContracts(_WebServerCase):
         self._orig_beets_db_path = srv.beets_db_path
         self.beets = MagicMock()
         srv._beets = self.beets
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=42,
             status="wanted",
             mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
+        ))
+        # One real success row so album-detail download_history flows
+        # through the fake's get_download_history query semantics.
+        self.db.log_download(
+            42, outcome="success", beets_scenario="strong_match",
+            beets_distance=0.012, soulseek_username="testuser",
+            filetype="mp3", bitrate=320000, was_converted=False,
+            actual_filetype="mp3", actual_min_bitrate=320,
+            slskd_filetype="mp3", slskd_bitrate=320000, valid=True,
         )
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
 
     def tearDown(self) -> None:
         self._srv._beets = self._orig_beets
@@ -142,25 +158,41 @@ class TestBeetsRouteContracts(_WebServerCase):
             ["/music/Test Artist/Test Album/01 Track.mp3"],
         )
 
+    def _queue_pipeline_overlay_row(self, *, min_bitrate: int | None) -> None:
+        """Queue the row ``web.overlay.check_pipeline``'s raw SQL would
+        return for request 42 (the overlay goes through ``_execute``,
+        which the fake cannot interpret — the queued cursor IS the
+        query result). The legacy MagicMock harness silently fed this
+        path an empty magic cursor, so enrichment never ran in tests."""
+        self.db.queue_execute_results(FakeCursor([{
+            "id": 42, "mb_release_id": self.RELEASE_ID, "status": "wanted",
+            "search_filetype_override": None, "target_format": None,
+            "min_bitrate": min_bitrate,
+        }]))
+
     def test_beets_search_contract(self):
         self.beets.search_albums.return_value = [self._album()]
-        with patch("web.server.check_pipeline", return_value={}):
-            status, data = self._get("/api/beets/search?q=test")
+        self._queue_pipeline_overlay_row(min_bitrate=900)
+        status, data = self._get("/api/beets/search?q=test")
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, {"albums"}, "beets search response")
         _assert_required_fields(self, data["albums"][0], self.ALBUM_REQUIRED_FIELDS,
                                 "beets search album")
+        # Pipeline enrichment ran for real: 900 kbps pipeline floor
+        # overrides the album's 320000 bps beets value.
+        self.assertEqual(data["albums"][0]["min_bitrate"], 900000)
 
     def test_beets_recent_contract(self):
         self.beets.get_recent.return_value = [self._album()]
-        with patch("web.server.check_pipeline", return_value={}):
-            status, data = self._get("/api/beets/recent")
+        self._queue_pipeline_overlay_row(min_bitrate=900)
+        status, data = self._get("/api/beets/recent")
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, {"albums"}, "beets recent response")
         _assert_required_fields(self, data["albums"][0], self.ALBUM_REQUIRED_FIELDS,
                                 "beets recent album")
+        self.assertEqual(data["albums"][0]["min_bitrate"], 900000)
 
     def test_beets_album_detail_contract(self):
         detail = self._album()
@@ -195,11 +227,16 @@ class TestBeetsRouteContracts(_WebServerCase):
         detail["path"] = "/music/Test Artist/Test Album"
         detail["tracks"] = [self._track()]
         self.beets.get_album_detail.return_value = detail
-        self.mock_db.get_request_by_discogs_release_id.return_value = make_request_row(
-            id=42,
+        self.db.seed_request(make_request_row(
+            id=43,
             status="wanted",
             mb_release_id="12856590",
             discogs_release_id="12856590",
+        ))
+        self.db.log_download(
+            43, outcome="success", beets_scenario="strong_match",
+            beets_distance=0.012, soulseek_username="testuser",
+            filetype="mp3", actual_filetype="mp3", actual_min_bitrate=320,
         )
 
         status, data = self._get("/api/beets/album/7")
@@ -487,13 +524,10 @@ class TestBeetsRouteContracts(_WebServerCase):
 
         self._srv.beets_db_path = "/tmp/beets.db"
         self._configure_beets_delete_mock(mock_beets_cls)
-        # Wrap a real FakePipelineDB so unmocked methods fall through to
-        # typed state — same rationale as ``_pipeline_db_test_harness``.
-        failing_db = _pipeline_db_test_harness()
-        failing_db.get_request.return_value = make_request_row(
+        failing_db = _FailingDeleteDB()
+        failing_db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
-        )
-        failing_db.delete_request.side_effect = RuntimeError("boom")
+        ))
 
         with patch.object(srv, "db", failing_db):
             status, data = self._post("/api/beets/delete", {

--- a/tests/web/test_routes_youtube.py
+++ b/tests/web/test_routes_youtube.py
@@ -17,11 +17,11 @@ from urllib.error import HTTPError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tests.web._harness import _assert_required_fields, _WebServerCase
+from tests.web._harness import _assert_required_fields, _FakeDbWebServerCase
 
 
 
-class TestYoutubeRouteContracts(_WebServerCase):
+class TestYoutubeRouteContracts(_FakeDbWebServerCase):
     """U8 contract for ``GET /api/youtube-album?identifier=<id>``.
 
     Mirrors the CLI surface ``pipeline-cli youtube-album`` (U7); the
@@ -77,7 +77,7 @@ class TestYoutubeRouteContracts(_WebServerCase):
     UUID_B = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
 
     def setUp(self) -> None:
-        self.mock_db.reset_mock()
+        super().setUp()
         from lib.youtube_album_service import (
             ResolvedDistance,
             ResolvedYoutubeRelease,
@@ -389,7 +389,7 @@ class TestYoutubeRouteContracts(_WebServerCase):
         )
 
 
-class TestPipelineYoutubeRescueContract(_WebServerCase):
+class TestPipelineYoutubeRescueContract(_FakeDbWebServerCase):
     """U5 contract for ``POST /api/pipeline/<id>/youtube-rescue``.
 
     The endpoint wraps ``YoutubeIngestService.submit``. Both the CLI

--- a/tests/web/test_server_cache.py
+++ b/tests/web/test_server_cache.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tests.web._harness import _WebServerCase
+from tests.web._harness import _FakeDbWebServerCase, _WebServerCase
 
 from tests.helpers import make_request_row
 
@@ -68,7 +68,7 @@ class TestOverlayNotBakedIntoRoutingCache(_WebServerCase):
             f"outside the web UI's POST paths. Offenders: {sorted(leaked)}")
 
 
-class _CachedServerCase(_WebServerCase):
+class _CachedServerCase(_FakeDbWebServerCase):
     """Shared harness: _WebServerCase but with a FakeRedis wired up so we
     can observe routing-cache behaviour in isolation. Pre-fix this would
     exhibit the stale-badge bug; post-fix it proves the overlay recomputes."""
@@ -104,6 +104,7 @@ class TestReleaseEndpointReflectsPipelineWrite(_CachedServerCase):
     RELEASE_ID = "c6cd62c4-da2a-4a89-a219-adba66d6c7d4"
 
     def setUp(self) -> None:
+        super().setUp()
         # Clear any state left behind by a previous test that shares the
         # FakeRedis instance, so each scenario starts cold. `_redis` is
         # typed `object | None` on the module; narrow to FakeRedis here.
@@ -126,18 +127,16 @@ class TestReleaseEndpointReflectsPipelineWrite(_CachedServerCase):
     def test_release_reflects_external_status_write(self) -> None:
         """Pipeline writes status='downloading' directly to Postgres
         between two GETs. The second GET must see 'downloading'."""
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id=self.RELEASE_ID,
-        )
+        ))
         first = self._call_release_detail()
         self.assertEqual(first["pipeline_status"], "wanted")
 
         # Simulate cratedigger pipeline flipping status outside the web UI.
         # No POST to /api/cache/invalidate, no web-UI cache-group flush —
         # this is the exact sequence that produced the stale-badge bug.
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
-            id=42, status="downloading", mb_release_id=self.RELEASE_ID,
-        )
+        self.db.update_status(42, "downloading")
         second = self._call_release_detail()
         self.assertEqual(
             second["pipeline_status"], "downloading",
@@ -149,9 +148,9 @@ class TestReleaseEndpointReflectsPipelineWrite(_CachedServerCase):
         """Same bug for the in_library flag. After an album is imported
         the 'in_library' flag flips true in beets; a second GET within
         the cache window must reflect that without an explicit flush."""
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
-        )
+        ))
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.server.check_beets_library", return_value=set()):
             mock_mb.get_release.return_value = {
@@ -217,6 +216,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
     ]
 
     def setUp(self) -> None:
+        super().setUp()
         from tests.test_web_cache import FakeRedis
         fake = self._cache._redis
         assert isinstance(fake, FakeRedis)


### PR DESCRIPTION
First batch of #430 — migrating the `tests/web` contract harness off the MagicMock pipeline DB onto the stateful `FakePipelineDB`, with a ratchet that makes the migration self-enforcing.

## Why

Both adversarial review passes on 2026-06-12 (#428's P1, #429's testing gap) hit the same root cause: `tests/web/_harness.py` injects a MagicMock DB, so contract tests pass whenever the mock's shape matches the assertion's shape — production query semantics never enter the loop. This is the `.claude/rules/test-fidelity.md` meta-pattern, structurally embedded in the harness.

## What

1. **Ratchet** (`tests/_mock_audit_scanner.py` + `tests/test_mock_audit.py`): `WEB_HARNESS_MOCK_BASELINE` pins per-file occurrence counts of `mock_db` references (tests/web) and `_pipeline_db_test_harness` references (everywhere). Exact-match: growth fails the audit, shrink forces the baseline entry to drop in the same commit. **The migration is done when the dict is empty.** Counter semantics pinned by a subTest table covering the alias/bare-reference evasion shapes.
2. **`_FakeDbWebServerCase`** (`tests/web/_harness.py`): per-test fresh bare `FakePipelineDB` installed as `web.server.db` (the production DSN-less module-global swap). Tests seed state (`seed_request`, `log_download`, `update_status`) and assert against the fake's real query semantics.
3. **Four modules migrated** (baseline entries deleted): `test_routes_youtube.py`, `test_server_cache.py`, `test_routes_browse.py`, `test_routes_library.py`. Notable upgrades in fidelity:
   - the #101 stale-badge regression now flips status via `db.update_status(42, "downloading")` — the actual "pipeline writes directly to Postgres" sequence
   - library search/recent now **prove** pipeline enrichment runs: the legacy MagicMock cursor silently iterated empty so `web.overlay.check_pipeline`'s raw-SQL path never executed in tests (the `check_pipeline` patch in those tests was dead weight); they now queue a `FakeCursor` row projected from the seeded request and assert the 900 kbps pipeline floor lands as `min_bitrate=900000`
   - purge-failure ordering pinned via a typed `_FailingDeleteDB(FakePipelineDB)` subclass instead of `side_effect`
4. **Shared `FakeCursor`** in `tests/fakes.py` (promoted from `test_web_overlay.py`'s private `_Cursor`, with self-tests): psycopg2 consumption parity — `fetchone` advances, `fetchall` drains, `while cur.fetchone():` terminates. `FakePipelineDB._execute` unqueued default is now an empty cursor ("query ran, zero rows") instead of a None that 500s opaquely.

## Remaining (subsequent PRs)

Baseline: `_harness.py` 39, `test_routes_imports.py` 71, `test_routes_pipeline.py` 66, `test_routes_pipeline_mutations.py` 100, `test_routes_pipeline_replace.py` 27, `test_routes_pipeline_search_plan.py` 42, `test_server_endpoints.py` 53. The legacy `_WebServerCase` mock defaults and `_pipeline_db_test_harness` die with the last entry.

**Known residual risks** (documented, deliberate):
- A new tests/web file can still subclass legacy `_WebServerCase` and lean on `_make_server`'s class-level mock defaults with zero counted occurrences — closed only when the legacy harness is deleted at the end of the series.
- Per-test `patch.object(srv, "db", ...)` lifetime vs background work: theoretical for these synchronous routes, but the `test_routes_imports.py` migration (TriageRunner sweeps) must account for handler threads outliving a test.

## Acceptance checklist

- [x] Full suite green (4402 tests, `OK`), including the three gates (JS, dead-code, unittest)
- [x] `nix-shell --run pyright` — 0 errors full-repo
- [x] Ratchet RED-proven both directions (growth fail + shrink fail observed during development)
- [x] Migrated modules contain zero `mock_db` / `_pipeline_db_test_harness` occurrences
- [x] Same-engine adversarial pre-review: 1 HIGH + 2 MEDIUM found, all fixed with pinning tests (see review-fix commit)
- [x] Codex partner review (`codex exec review --base main`): no findings

Closes nothing yet — #430 stays open until the baseline dict is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)