### PR TITLE
test(web): #430 batch 2 — replace + search_plan migrated, sys.path shadowing class killed

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -528,7 +528,6 @@ WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "test_routes_imports.py"): 71,
     os.path.join("web", "test_routes_pipeline.py"): 66,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 100,
-    os.path.join("web", "test_routes_pipeline_replace.py"): 27,
     os.path.join("web", "test_routes_pipeline_search_plan.py"): 42,
     os.path.join("web", "test_server_endpoints.py"): 53,
 }

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -528,7 +528,6 @@ WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "test_routes_imports.py"): 71,
     os.path.join("web", "test_routes_pipeline.py"): 66,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 100,
-    os.path.join("web", "test_routes_pipeline_search_plan.py"): 42,
     os.path.join("web", "test_server_endpoints.py"): 53,
 }
 

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 # Bootstrap ephemeral PostgreSQL if available
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_evidence_rekey_migration.py
+++ b/tests/test_evidence_rekey_migration.py
@@ -30,7 +30,7 @@ import unittest
 import uuid
 from typing import Sequence
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))

--- a/tests/test_force_import.py
+++ b/tests/test_force_import.py
@@ -14,7 +14,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 # Bootstrap ephemeral PostgreSQL if available
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -6263,7 +6263,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
 # ``python3 -m unittest tests.test_integration_slices`` directly would skip
 # (conftest is only auto-loaded by pytest discovery).
 import sys as _u7_sys
-_u7_sys.path.insert(0, os.path.dirname(__file__))
+_u7_sys.path.append(os.path.dirname(__file__))
 import conftest as _u7_conftest  # noqa: F401  # boots ephemeral PG + sets DSN
 
 

--- a/tests/test_lambda_audit.py
+++ b/tests/test_lambda_audit.py
@@ -19,7 +19,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from _lambda_audit import ALLOWLIST, iter_test_files, scan_file, scan_tree  # noqa: E402
 
 

--- a/tests/test_long_tail_service.py
+++ b/tests/test_long_tail_service.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 import msgspec
 
 # Bootstrap ephemeral PostgreSQL if available (sets TEST_DB_DSN).
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401,E402
 
 from lib.long_tail_service import (  # noqa: E402

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import unittest
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -21,8 +21,8 @@ import unittest
 # web.server`` resolve ``web`` to tests/web in module-order-dependent
 # ways (the package shadows the real one whenever no earlier import
 # already registered repo-root ``web`` in sys.modules).
-sys.path.insert(0, os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..")))
 from tests._mock_audit_scanner import (
     WEB_HARNESS_MOCK_BASELINE,
     count_harness_overrides,
@@ -55,6 +55,63 @@ class TestStatefulMockAudit(unittest.TestCase):
             "Replace each flagged usage with a typed fake, kwarg-DI seam, "
             "or real-input call.\n\n"
             + "\n".join(lines)
+        )
+
+
+class TestSysPathAudit(unittest.TestCase):
+    """Ban front-of-sys.path inserts of a test directory.
+
+    ``sys.path.insert(0, <tests dir>)`` makes ``tests/web`` shadow the
+    real ``web`` package for any later ``import web.server`` that runs
+    before something else has registered repo-root ``web`` in
+    sys.modules — module-order-dependent ModuleNotFoundErrors that the
+    full discovery run masks. ``sys.path.append`` resolves the same
+    bare imports (``conftest``, ``_lambda_audit``) without ever
+    out-ranking the repo root. Repo-root inserts (the
+    ``join(dirname, "..")`` shape) are fine and not matched.
+    """
+
+    # Matches a dirname-chain applied directly to __file__ (optionally
+    # through abspath); the chain depth decides which directory lands
+    # at the front of sys.path.
+    _FRONT_INSERT_RE = __import__("re").compile(
+        r"sys\.path\.insert\(\s*\d+\s*,\s*"
+        r"((?:os\.path\.dirname\(\s*)+)(?:os\.path\.abspath\(\s*)?__file__")
+
+    def test_no_front_inserts_of_test_dirs(self) -> None:
+        offenders: list[str] = []
+        from tests._mock_audit_scanner import TESTS_DIR
+        for dirpath, dirnames, filenames in os.walk(TESTS_DIR):
+            dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+            for fname in sorted(filenames):
+                if not fname.endswith(".py"):
+                    continue
+                path = os.path.join(dirpath, fname)
+                rel = os.path.relpath(path, TESTS_DIR)
+                if rel == "test_mock_audit.py":
+                    continue  # mentions the pattern in its own source
+                with open(path, encoding="utf-8") as f:
+                    for lineno, line in enumerate(f, 1):
+                        m = self._FRONT_INSERT_RE.search(line)
+                        if not m:
+                            continue
+                        # Resolve which directory the dirname-chain
+                        # yields for THIS file; only inserts that put
+                        # a directory inside tests/ at the front are
+                        # the shadowing hazard (repo-root inserts are
+                        # fine).
+                        depth = m.group(1).count("os.path.dirname(")
+                        target = os.path.abspath(path)
+                        for _ in range(depth):
+                            target = os.path.dirname(target)
+                        if target == TESTS_DIR or target.startswith(
+                                TESTS_DIR + os.sep):
+                            offenders.append(f"  - {rel}:{lineno}")
+        self.assertFalse(
+            offenders,
+            "Front-of-sys.path insert of a test directory — use "
+            "sys.path.append instead (tests/web must never shadow the "
+            "real web package):\n" + "\n".join(offenders),
         )
 
 

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -16,8 +16,14 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _mock_audit_scanner import (
+# Import through the ``tests`` package, NOT via a tests-dir sys.path
+# insert — putting tests/ at sys.path[0] makes a later ``import
+# web.server`` resolve ``web`` to tests/web in module-order-dependent
+# ways (the package shadows the real one whenever no earlier import
+# already registered repo-root ``web`` in sys.modules).
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), ".."))
+from tests._mock_audit_scanner import (
     WEB_HARNESS_MOCK_BASELINE,
     count_harness_overrides,
     iter_scan_paths,

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -13,7 +13,7 @@ from unittest.mock import patch, MagicMock
 import msgspec
 
 # Bootstrap ephemeral PostgreSQL if available
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 import psycopg2
 
 # Bootstrap ephemeral PostgreSQL if available
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 from tests.helpers import make_album_quality_evidence
 

--- a/tests/test_pipeline_db_column_contract.py
+++ b/tests/test_pipeline_db_column_contract.py
@@ -25,7 +25,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
 from lib.pipeline_db import (

--- a/tests/test_slskd_http_pool.py
+++ b/tests/test_slskd_http_pool.py
@@ -107,7 +107,7 @@ class TestSlskdHttpPoolSizing(unittest.TestCase):
         # import conftest do so as `import conftest` (no package prefix), so
         # match that.
         import sys
-        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        sys.path.append(os.path.dirname(os.path.abspath(__file__)))
         import conftest
 
         slskd_api = conftest._real_slskd_api

--- a/tests/test_web_dev_server.py
+++ b/tests/test_web_dev_server.py
@@ -12,7 +12,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — bootstraps TEST_DB_DSN for the live-db test
 
 from scripts.web_dev_server import DevConfig, DevHandler, DevHTTPServer

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -13,11 +13,12 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tests.web._harness import _assert_required_fields, _WebServerCase
+from tests.web._harness import _assert_required_fields, _FakeDbWebServerCase
+from tests.helpers import make_request_row
 
 
 
-class TestReplacedFilterContract(_WebServerCase):
+class TestReplacedFilterContract(_FakeDbWebServerCase):
     """U10 backend tests for the ``?include_replaced`` query parameter
     on pipeline + wrong-matches list endpoints, plus the descendant_*
     fields surfaced from ``post_pipeline_add`` when the existing row is
@@ -25,47 +26,42 @@ class TestReplacedFilterContract(_WebServerCase):
     """
 
     def setUp(self) -> None:
-        # Default mock for the supersede-lookup so the add-flow tests
-        # below can override per-test.
-        self.mock_db.get_request_by_replaces_request_id.return_value = None
+        super().setUp()
+        # One active row + one frozen audit row — the filter contract
+        # is about which of these the list endpoints surface.
+        self.db.seed_request(make_request_row(
+            id=1, status="wanted",
+            mb_release_id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+        ))
+        self.db.seed_request(make_request_row(
+            id=42, status="replaced",
+            mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ))
 
     def test_pipeline_all_default_excludes_replaced(self):
-        captured: list[tuple[str, ...]] = []
-        def fake_get_by_status(status, **kw):
-            captured.append((status,))
-            return []
-        self.mock_db.get_by_status.side_effect = fake_get_by_status
-        self.mock_db.count_by_status.return_value = {}
-        self.mock_db.get_download_history_batch.return_value = {}
-        status, _ = self._get("/api/pipeline/all")
+        status, data = self._get("/api/pipeline/all")
         self.assertEqual(status, 200)
-        statuses = [c[0] for c in captured]
-        self.assertNotIn("replaced", statuses)
+        self.assertNotIn("replaced", data)
+        self.assertEqual(
+            [r["id"] for r in data["wanted"]], [1],
+        )
 
     def test_pipeline_all_include_replaced_true_fetches_replaced(self):
-        captured: list[tuple[str, ...]] = []
-        def fake_get_by_status(status, **kw):
-            captured.append((status,))
-            return []
-        self.mock_db.get_by_status.side_effect = fake_get_by_status
-        self.mock_db.count_by_status.return_value = {}
-        self.mock_db.get_download_history_batch.return_value = {}
-        status, _ = self._get("/api/pipeline/all?include_replaced=true")
+        status, data = self._get("/api/pipeline/all?include_replaced=true")
         self.assertEqual(status, 200)
-        statuses = [c[0] for c in captured]
-        self.assertIn("replaced", statuses)
+        self.assertIn("replaced", data)
+        self.assertEqual(
+            [r["id"] for r in data["replaced"]], [42],
+        )
 
     def test_post_pipeline_add_with_replaced_existing_surfaces_descendant(self):
-        # The harness routes get_request_by_release_id through
-        # get_request_by_mb_release_id (see _make_server), so mock that.
-        self.mock_db.get_request_by_mb_release_id.return_value = {
-            "id": 42, "status": "replaced",
-            "mb_release_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        }
-        self.mock_db.get_request_by_replaces_request_id.return_value = {
-            "id": 99, "status": "wanted",
-            "mb_release_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        }
+        # Request 42 (seeded replaced in setUp) was superseded by 99 —
+        # the descendant chain the add-flow surfaces.
+        self.db.seed_request(make_request_row(
+            id=99, status="wanted",
+            mb_release_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            replaces_request_id=42,
+        ))
         status, data = self._post(
             "/api/pipeline/add",
             {"mb_release_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
@@ -77,10 +73,10 @@ class TestReplacedFilterContract(_WebServerCase):
         self.assertEqual(data["descendant_status"], "wanted")
 
     def test_post_pipeline_add_with_non_replaced_existing_omits_descendant(self):
-        self.mock_db.get_request_by_mb_release_id.return_value = {
-            "id": 42, "status": "wanted",
-            "mb_release_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        }
+        self.db.seed_request(make_request_row(
+            id=42, status="wanted",
+            mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ))
         status, data = self._post(
             "/api/pipeline/add",
             {"mb_release_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
@@ -90,7 +86,7 @@ class TestReplacedFilterContract(_WebServerCase):
         self.assertNotIn("descendant_request_id", data)
 
 
-class TestPipelineReplaceContract(_WebServerCase):
+class TestPipelineReplaceContract(_FakeDbWebServerCase):
     """Contract for ``POST /api/pipeline/<id>/replace`` plus the two
     auxiliary endpoints (``GET /api/pipeline/requests-by-rg/<rg>`` and
     ``GET /api/pipeline/active-rgs``).
@@ -120,6 +116,7 @@ class TestPipelineReplaceContract(_WebServerCase):
     }
 
     def setUp(self) -> None:
+        super().setUp()
         from lib.config import CratediggerConfig
         import configparser
         cp = configparser.RawConfigParser()
@@ -296,14 +293,12 @@ class TestPipelineReplaceContract(_WebServerCase):
         mock_svc.assert_not_called()
 
     def test_requests_by_rg_returns_200_with_required_fields(self):
-        self.mock_db.list_requests_in_release_group.return_value = [
-            {
-                "id": 42, "mb_release_id": "old-uuid",
-                "mb_release_group_id": "rg-1",
-                "status": "wanted",
-                "artist_name": "Pet Grief", "album_title": "X",
-            },
-        ]
+        self.db.seed_request(make_request_row(
+            id=42, mb_release_id="old-uuid",
+            mb_release_group_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            status="wanted",
+            artist_name="Pet Grief", album_title="X",
+        ))
         status, data = self._get(
             "/api/pipeline/requests-by-rg/"
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -318,7 +313,6 @@ class TestPipelineReplaceContract(_WebServerCase):
         )
 
     def test_requests_by_rg_empty_list(self):
-        self.mock_db.list_requests_in_release_group.return_value = []
         status, data = self._get(
             "/api/pipeline/requests-by-rg/"
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -327,21 +321,31 @@ class TestPipelineReplaceContract(_WebServerCase):
         self.assertEqual(data["requests"], [])
 
     def test_active_rgs_returns_sorted_list(self):
-        self.mock_db.list_active_release_group_ids.return_value = {
-            "rg-bbbb", "rg-aaaa",
-        }
+        self.db.seed_request(make_request_row(
+            id=1, status="wanted", mb_release_id="m-1",
+            mb_release_group_id="rg-bbbb",
+        ))
+        self.db.seed_request(make_request_row(
+            id=2, status="imported", mb_release_id="m-2",
+            mb_release_group_id="rg-aaaa",
+        ))
+        # Replaced rows are frozen audit — their RG must NOT count as
+        # active.
+        self.db.seed_request(make_request_row(
+            id=3, status="replaced", mb_release_id="m-3",
+            mb_release_group_id="rg-cccc",
+        ))
         status, data = self._get("/api/pipeline/active-rgs")
         self.assertEqual(status, 200)
         self.assertEqual(data["release_group_ids"], ["rg-aaaa", "rg-bbbb"])
 
     def test_active_rgs_empty(self):
-        self.mock_db.list_active_release_group_ids.return_value = set()
         status, data = self._get("/api/pipeline/active-rgs")
         self.assertEqual(status, 200)
         self.assertEqual(data["release_group_ids"], [])
 
 
-class TestPipelineResolveRgContract(_WebServerCase):
+class TestPipelineResolveRgContract(_FakeDbWebServerCase):
     """Contract for ``POST /api/pipeline/<id>/resolve-rg``.
 
     Lazy-backfill ``mb_release_group_id`` for legacy rows. The Replace
@@ -359,20 +363,19 @@ class TestPipelineResolveRgContract(_WebServerCase):
         "request_id", "mb_release_group_id", "status",
     }
 
-    def setUp(self) -> None:
-        # _WebServerCase shares ``mock_db`` across tests in the class via
-        # setUpClass; reset call counts here so per-test assertions don't
-        # see stale calls from earlier tests in the same class.
-        self.mock_db.reset_mock()
+    def _seed(self, rg: str | None,
+              mb_release_id: str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+              ) -> None:
+        self.db.seed_request(make_request_row(
+            id=42, status="wanted",
+            mb_release_id=mb_release_id,
+            mb_release_group_id=rg,
+        ))
 
     def test_resolve_rg_already_set_returns_200(self):
         """Idempotent: row already has a RG → return it untouched
         and do NOT hit the MB mirror or write to the DB."""
-        self.mock_db.get_request.return_value = {
-            "id": 42,
-            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-            "mb_release_group_id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
-        }
+        self._seed("rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr")
         with patch("web.mb.get_release") as mock_mb:
             status, data = self._post(
                 "/api/pipeline/42/resolve-rg", {},
@@ -388,15 +391,14 @@ class TestPipelineResolveRgContract(_WebServerCase):
             "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
         )
         mock_mb.assert_not_called()
-        self.mock_db.update_request_fields.assert_not_called()
+        self.assertEqual(
+            self.db.request(42)["mb_release_group_id"],
+            "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
+        )
 
     def test_resolve_rg_lazy_backfill_happy_path_returns_200(self):
         """Row has no RG → MB lookup → UPDATE row → 200."""
-        self.mock_db.get_request.return_value = {
-            "id": 42,
-            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-            "mb_release_group_id": None,
-        }
+        self._seed(None)
         with patch(
             "web.mb.get_release",
             return_value={"release_group_id": "rrrr-rrrr-rrrr"},
@@ -416,12 +418,12 @@ class TestPipelineResolveRgContract(_WebServerCase):
         mock_mb.assert_called_once_with(
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", fresh=False,
         )
-        self.mock_db.update_request_fields.assert_called_once_with(
-            42, mb_release_group_id="rrrr-rrrr-rrrr",
+        # The lazy backfill landed on the row itself.
+        self.assertEqual(
+            self.db.request(42)["mb_release_group_id"], "rrrr-rrrr-rrrr",
         )
 
     def test_resolve_rg_not_found_returns_404(self):
-        self.mock_db.get_request.return_value = None
         with patch("web.mb.get_release") as mock_mb:
             status, data = self._post(
                 "/api/pipeline/9999/resolve-rg", {},
@@ -438,11 +440,7 @@ class TestPipelineResolveRgContract(_WebServerCase):
     def test_resolve_rg_no_release_group_returns_422(self):
         """MB returns a payload but no release_group_id (e.g. mirror
         anomaly, or a release whose RG is missing upstream)."""
-        self.mock_db.get_request.return_value = {
-            "id": 42,
-            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-            "mb_release_group_id": None,
-        }
+        self._seed(None)
         with patch(
             "web.mb.get_release",
             return_value={"release_group_id": None},
@@ -456,15 +454,11 @@ class TestPipelineResolveRgContract(_WebServerCase):
             "resolve-rg 422 response",
         )
         self.assertEqual(data["status"], "no_release_group")
-        self.mock_db.update_request_fields.assert_not_called()
+        self.assertIsNone(self.db.request(42)["mb_release_group_id"])
 
     def test_resolve_rg_discogs_release_id_returns_422(self):
         """Numeric Discogs release id → 422 short-circuit, no MB hit."""
-        self.mock_db.get_request.return_value = {
-            "id": 42,
-            "mb_release_id": "12345",
-            "mb_release_group_id": None,
-        }
+        self._seed(None, mb_release_id="12345")
         with patch("web.mb.get_release") as mock_mb:
             status, data = self._post(
                 "/api/pipeline/42/resolve-rg", {},
@@ -472,16 +466,12 @@ class TestPipelineResolveRgContract(_WebServerCase):
         self.assertEqual(status, 422)
         self.assertEqual(data["status"], "non_mb_release_id")
         mock_mb.assert_not_called()
-        self.mock_db.update_request_fields.assert_not_called()
+        self.assertIsNone(self.db.request(42)["mb_release_group_id"])
 
     def test_resolve_rg_transient_returns_503(self):
         """Network blip / timeout → 503 retryable."""
         from urllib.error import URLError
-        self.mock_db.get_request.return_value = {
-            "id": 42,
-            "mb_release_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-            "mb_release_group_id": None,
-        }
+        self._seed(None)
         with patch(
             "web.mb.get_release",
             side_effect=URLError("connection refused"),
@@ -495,7 +485,7 @@ class TestPipelineResolveRgContract(_WebServerCase):
             "resolve-rg 503 response",
         )
         self.assertEqual(data["status"], "transient")
-        self.mock_db.update_request_fields.assert_not_called()
+        self.assertIsNone(self.db.request(42)["mb_release_group_id"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -395,6 +395,9 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
             self.db.request(42)["mb_release_group_id"],
             "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
         )
+        # No write at all — not even a redundant same-value UPDATE
+        # (the fake records every update_request_fields call).
+        self.assertEqual(self.db.update_request_fields_calls, [])
 
     def test_resolve_rg_lazy_backfill_happy_path_returns_200(self):
         """Row has no RG → MB lookup → UPDATE row → 200."""
@@ -455,6 +458,7 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
         )
         self.assertEqual(data["status"], "no_release_group")
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
+        self.assertEqual(self.db.update_request_fields_calls, [])
 
     def test_resolve_rg_discogs_release_id_returns_422(self):
         """Numeric Discogs release id → 422 short-circuit, no MB hit."""
@@ -467,6 +471,7 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
         self.assertEqual(data["status"], "non_mb_release_id")
         mock_mb.assert_not_called()
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
+        self.assertEqual(self.db.update_request_fields_calls, [])
 
     def test_resolve_rg_transient_returns_503(self):
         """Network blip / timeout → 503 retryable."""
@@ -486,6 +491,7 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
         )
         self.assertEqual(data["status"], "transient")
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
+        self.assertEqual(self.db.update_request_fields_calls, [])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/web/test_routes_pipeline_search_plan.py
+++ b/tests/web/test_routes_pipeline_search_plan.py
@@ -5,25 +5,24 @@ Split from tests/test_web_server.py (#408). Shared harness in
 tests/web/_harness.py.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import json
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tests.web._harness import _assert_required_fields, _WebServerCase
+from tests.web._harness import _assert_required_fields, _FakeDbWebServerCase
 
-from lib.pipeline_db import SearchPlanProvenance
 from tests.helpers import make_request_row
 
 
-class TestPipelineSearchPlanContract(_WebServerCase):
+class TestPipelineSearchPlanContract(_FakeDbWebServerCase):
     """U6 contract for ``GET /api/pipeline/<id>/search-plan``.
 
     The frontend doesn't consume this in v1, but the route must be
@@ -86,161 +85,91 @@ class TestPipelineSearchPlanContract(_WebServerCase):
         "result_count", "elapsed_s", "final_state",
     }
 
-    def _wire_inspection(
-        self,
-        *,
-        request_status: str = "wanted",
-        request_id: int = 100,
-        active: object = None,
-        latest_failed_deterministic: object = None,
-        latest_failed_transient: object = None,
-        superseded_count: int = 0,
-        legacy_log_count: int = 0,
-        legacy_head_history: list[dict] | None = None,
-    ) -> None:
-        from lib.pipeline_db import (
-            SearchPlanInspection,
-            SearchPlanStats,
-            SearchPlanStatsBucket,
-            CACHE_ATTRIBUTION_CYCLE_ONLY,
-        )
-        from tests.helpers import make_request_row
-        self.mock_db.get_request.return_value = make_request_row(
-            id=request_id, status=request_status,
-        )
-        self.mock_db.get_search_history.reset_mock()
-        self.mock_db.get_legacy_search_log_summary.reset_mock()
-        self.mock_db.get_search_plan_stats_history.reset_mock()
-        self.mock_db.get_search_plan_inspection.return_value = (
-            SearchPlanInspection(
-                request_id=request_id,
-                active=active,  # type: ignore[arg-type]
-                latest_failed_deterministic=latest_failed_deterministic,  # type: ignore[arg-type]
-                latest_failed_transient=latest_failed_transient,  # type: ignore[arg-type]
-                superseded_count=superseded_count,
-                legacy_search_log_count=legacy_log_count,
-            ))
-        self.mock_db.get_legacy_search_log_summary.return_value = (
-            legacy_log_count, legacy_head_history or [])
-        self.mock_db.get_search_plan_stats_history.return_value = []
-        empty_bucket = SearchPlanStatsBucket(
-            slots=[], query_groups=[], legacy_bucket=None,
-            cache_attribution_level=CACHE_ATTRIBUTION_CYCLE_ONLY,
-            cache_per_search_available=False,
-        )
-        self.mock_db.get_search_plan_stats.return_value = SearchPlanStats(
-            request_id=request_id,
-            current=empty_bucket,
-            superseded_and_legacy=empty_bucket,
-        )
+    def _seed_request(self, *, request_id: int = 100,
+                      status: str = "wanted") -> None:
+        self.db.seed_request(make_request_row(id=request_id, status=status))
 
-    def _make_active(
-        self, *,
-        generator_id: str = "search-plan/2026-05-25-1",
-        items_count: int = 2,
-        next_ordinal: int = 0,
-        cycle_count: int = 0,
-        plan_provenance: SearchPlanProvenance | None = None,
-    ):
-        from datetime import datetime, timezone
-        from lib.pipeline_db import (
-            ActiveSearchPlan, SearchPlanItemRow, SearchPlanRow,
-            SearchPlanMetadataSnapshot, SearchPlanItemProvenance,
-            SearchPlanProvenance,
-        )
-        plan = SearchPlanRow(
-            id=11, request_id=100, generator_id=generator_id,
-            status="active", failure_class=None,
-            metadata_snapshot=SearchPlanMetadataSnapshot(artist_name="X"),
-            provenance=plan_provenance,
-            error_message=None, superseded_at=None,
-            superseded_by_plan_id=None,
-            created_at=datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc),
-        )
-        items = [
-            SearchPlanItemRow(
-                id=1000 + i, plan_id=11, ordinal=i,
+    def _plan_items(self, items_count: int = 2):
+        from lib.pipeline_db import SearchPlanItemInput
+        return [
+            SearchPlanItemInput(
+                ordinal=i,
                 strategy=("default" if i == 0 else f"strategy_{i}"),
                 query=f"q{i}", canonical_query_key=f"k{i}",
                 repeat_group=("default-3" if i == 0 else None),
-                provenance=SearchPlanItemProvenance(values={"src": "gen"}) if i == 0 else None,
+                provenance={"src": "gen"} if i == 0 else None,
             )
             for i in range(items_count)
         ]
-        return ActiveSearchPlan(
-            plan=plan, items=items,
-            next_ordinal=next_ordinal, cycle_count=cycle_count,
+
+    def _seed_active_plan(
+        self, *,
+        generator_id: str = "search-plan/2026-05-25-1",
+        items_count: int = 2,
+        plan_provenance: dict | None = None,
+    ) -> int:
+        return self.db.create_successful_search_plan(
+            request_id=100, generator_id=generator_id,
+            items=self._plan_items(items_count),
+            metadata_snapshot={"artist_name": "X"},
+            provenance=plan_provenance,
         )
 
-    def _make_failed_plan(
+    def _seed_failed_plan(
         self, *,
-        plan_id: int,
-        status: str,
+        transient: bool,
         failure_class: str,
         error_message: str = "boom",
         generator_id: str = "search-plan/2026-05-19-1",
-    ):
-        from datetime import datetime, timezone
-        from lib.pipeline_db import SearchPlanRow, SearchPlanProvenance
-        return SearchPlanRow(
-            id=plan_id, request_id=100, generator_id=generator_id,
-            status=status, failure_class=failure_class,
-            metadata_snapshot=None,
-            provenance=SearchPlanProvenance(values={"reason": failure_class}),
-            error_message=error_message, superseded_at=None,
-            superseded_by_plan_id=None,
-            created_at=datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc),
+    ) -> int:
+        return self.db.create_failed_search_plan(
+            request_id=100, generator_id=generator_id,
+            failure_class=failure_class, error_message=error_message,
+            transient=transient,
+            provenance={"reason": failure_class},
         )
 
-    def tearDown(self) -> None:
-        # Reset mocks so other suites in this class don't see leakage.
-        from tests.helpers import make_request_row
-        self.mock_db.get_request.return_value = make_request_row(
-            id=100, status="imported", min_bitrate=320,
-            imported_path="/mnt/virtio/Music/Beets/Test",
-        )
-        self.mock_db.get_legacy_search_log_summary.return_value = (0, [])
-        self.mock_db.get_search_plan_stats_history.return_value = []
-        self.mock_db.get_search_plan_inspection.reset_mock(
-            return_value=True, side_effect=True)
-        self.mock_db.get_search_plan_stats.reset_mock(
-            return_value=True, side_effect=True)
+    def _seed_legacy_logs(self, n: int) -> None:
+        """Plan-less search_log rows — the fake counts plan_id IS NULL
+        rows as legacy, same as production."""
+        for i in range(1, n + 1):
+            self.db.log_search(
+                100, query=f"q{i}",
+                outcome=("found" if i % 2 == 0 else "no_match"),
+                variant="v1", result_count=(5 if i % 2 == 0 else 0),
+                elapsed_s=float(i), final_state="Completed",
+            )
 
     # -- happy path: active + failures + legacy logs --
 
     def test_search_plan_route_returns_full_inspection_payload(self):
-        from lib.pipeline_db import SearchPlanProvenance
-        active = self._make_active(plan_provenance=SearchPlanProvenance(values={
-            "omitted_candidates": [{"q": "x", "why": "low_entropy"}],
-            "dropped_low_entropy_tokens": ["the", "and"],
-        }))
-        det = self._make_failed_plan(
-            plan_id=22, status="failed_deterministic",
-            failure_class="no_runnable_query",
-            error_message="all queries dropped")
-        trans = self._make_failed_plan(
-            plan_id=23, status="failed_transient",
-            failure_class="resolver_unavailable",
-            error_message="resolver 503")
-        self._wire_inspection(
-            active=active,
-            latest_failed_deterministic=det,
-            latest_failed_transient=trans,
-            superseded_count=2,
-            legacy_log_count=5,
-            legacy_head_history=[
-                {"id": 1, "request_id": 100, "outcome": "no_match",
-                 "variant": "v1", "query": "q1", "result_count": 0,
-                 "elapsed_s": 1.0, "final_state": "Completed",
-                 "created_at": "2026-04-01T00:00:00+00:00",
-                 "plan_id": None},
-                {"id": 2, "request_id": 100, "outcome": "found",
-                 "variant": "v1", "query": "q2", "result_count": 5,
-                 "elapsed_s": 2.0, "final_state": "Completed",
-                 "created_at": "2026-04-02T00:00:00+00:00",
-                 "plan_id": None},
-            ],
+        self._seed_request()
+        # Three real generations: two get superseded, the third is the
+        # current active plan — superseded_count comes from real rows.
+        self._seed_active_plan()
+        self.db.supersede_search_plan_with_replacement(
+            request_id=100, generator_id="search-plan/2026-05-25-1",
+            items=self._plan_items(),
+            metadata_snapshot={"artist_name": "X"},
         )
+        self.db.supersede_search_plan_with_replacement(
+            request_id=100, generator_id="search-plan/2026-05-25-1",
+            items=self._plan_items(),
+            metadata_snapshot={"artist_name": "X"},
+            provenance={
+                "omitted_candidates": [{"q": "x", "why": "low_entropy"}],
+                "dropped_low_entropy_tokens": ["the", "and"],
+            },
+        )
+        self._seed_failed_plan(
+            transient=False, failure_class="no_runnable_query",
+            error_message="all queries dropped")
+        self._seed_failed_plan(
+            transient=True, failure_class="resolver_unavailable",
+            error_message="resolver 503")
+        # 7 plan-less rows: the head must cap at the route's limit of 5
+        # while the count reflects all 7.
+        self._seed_legacy_logs(7)
 
         status, data = self._get("/api/pipeline/100/search-plan")
 
@@ -284,11 +213,10 @@ class TestPipelineSearchPlanContract(_WebServerCase):
         _assert_required_fields(
             self, data["legacy_logs"], self.LEGACY_LOGS_REQUIRED_FIELDS,
             "search-plan legacy_logs")
-        self.assertEqual(data["legacy_logs"]["count"], 5)
-        self.mock_db.get_legacy_search_log_summary.assert_called_once_with(
-            100, limit=5)
-        self.mock_db.get_search_plan_stats_history.assert_called_once_with(100)
-        self.mock_db.get_search_history.assert_not_called()
+        self.assertEqual(data["legacy_logs"]["count"], 7)
+        # The head is capped at the route's limit (5) even though all
+        # 7 rows are counted — pins the limit the route passes down.
+        self.assertEqual(len(data["legacy_logs"]["head"]), 5)
         for row in data["legacy_logs"]["head"]:
             _assert_required_fields(
                 self, row, self.LEGACY_HEAD_REQUIRED_FIELDS,
@@ -315,7 +243,6 @@ class TestPipelineSearchPlanContract(_WebServerCase):
     # -- 404 missing request --
 
     def test_search_plan_missing_request_returns_404_with_error_body(self):
-        self.mock_db.get_request.return_value = None
         status, data = self._get("/api/pipeline/9999/search-plan")
         self.assertEqual(status, 404)
         self.assertIn("error", data)
@@ -323,12 +250,9 @@ class TestPipelineSearchPlanContract(_WebServerCase):
     # -- request with no plan at all (transient failure) --
 
     def test_search_plan_no_active_plan_with_only_transient_failure(self):
-        trans = self._make_failed_plan(
-            plan_id=23, status="failed_transient",
-            failure_class="resolver_unavailable")
-        self._wire_inspection(
-            active=None, latest_failed_transient=trans,
-        )
+        self._seed_request()
+        self._seed_failed_plan(
+            transient=True, failure_class="resolver_unavailable")
         status, data = self._get("/api/pipeline/100/search-plan")
         self.assertEqual(status, 200)
         self.assertIsNone(data["active_plan"])
@@ -339,22 +263,8 @@ class TestPipelineSearchPlanContract(_WebServerCase):
     # -- legacy logs section is non-empty when only legacy rows exist --
 
     def test_search_plan_surfaces_legacy_logs_when_no_plan_context(self):
-        self._wire_inspection(
-            active=None,
-            legacy_log_count=2,
-            legacy_head_history=[
-                {"id": 1, "request_id": 100, "outcome": "no_match",
-                 "variant": "v1", "query": "q1", "result_count": 0,
-                 "elapsed_s": 0.5, "final_state": "Completed",
-                 "created_at": "2026-04-01T00:00:00+00:00",
-                 "plan_id": None},
-                {"id": 2, "request_id": 100, "outcome": "no_results",
-                 "variant": "v2", "query": "q2", "result_count": 0,
-                 "elapsed_s": 0.6, "final_state": "Completed",
-                 "created_at": "2026-04-02T00:00:00+00:00",
-                 "plan_id": None},
-            ],
-        )
+        self._seed_request()
+        self._seed_legacy_logs(2)
         status, data = self._get("/api/pipeline/100/search-plan")
         self.assertEqual(status, 200)
         self.assertEqual(data["legacy_logs"]["count"], 2)
@@ -363,8 +273,8 @@ class TestPipelineSearchPlanContract(_WebServerCase):
     # -- generator id drift: active plan but stale generator id --
 
     def test_search_plan_flags_generator_id_mismatch_when_stale(self):
-        active = self._make_active(generator_id="search-plan/2026-01-01-old")
-        self._wire_inspection(active=active)
+        self._seed_request()
+        self._seed_active_plan(generator_id="search-plan/2026-01-01-old")
         status, data = self._get("/api/pipeline/100/search-plan")
         self.assertEqual(status, 200)
         self.assertTrue(data["currentness"]["has_active_plan"])
@@ -375,7 +285,7 @@ class TestPipelineSearchPlanContract(_WebServerCase):
             "search-plan/2026-01-01-old")
 
 
-class TestPipelineSearchPlanDryRunContract(_WebServerCase):
+class TestPipelineSearchPlanDryRunContract(_FakeDbWebServerCase):
     """U6 contract for ``GET /api/pipeline/<id>/search-plan/dry-run``.
 
     Read-only generator simulator. The route wraps
@@ -410,20 +320,19 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
     }
 
     def setUp(self) -> None:
-        from tests.helpers import make_request_row
-        self.mock_db.get_request.return_value = make_request_row(
+        super().setUp()
+        self.db.seed_request(make_request_row(
             id=100, status="wanted",
             artist_name="Radiohead", album_title="Kid A",
             year=2008, release_group_year=2000,
-        )
-        self.mock_db.get_tracks.return_value = [
+        ))
+        self.db.set_tracks(100, [
             {"disc_number": 1, "track_number": 1,
              "title": "Everything In Its Right Place"},
             {"disc_number": 1, "track_number": 2, "title": "Kid A"},
             {"disc_number": 1, "track_number": 3,
              "title": "The National Anthem"},
-        ]
-        self.mock_db.get_active_search_plan.return_value = None
+        ])
         # Route reads runtime config — patch to a default CratediggerConfig.
         from lib.config import CratediggerConfig
         import configparser
@@ -437,9 +346,6 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
 
     def tearDown(self) -> None:
         self._cfg_patcher.stop()
-        self.mock_db.get_active_search_plan.reset_mock(
-            return_value=True, side_effect=True)
-        self.mock_db.get_tracks.return_value = []
 
     def test_dry_run_happy_path_returns_200_with_required_fields(self):
         status, data = self._get(
@@ -473,14 +379,18 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
         # When an active plan exists, the response flags
         # would_supersede_active=True so operators understand the
         # current plan would be replaced by a real regeneration call.
-        self.mock_db.get_active_search_plan.return_value = MagicMock()
+        from lib.pipeline_db import SearchPlanItemInput
+        self.db.create_successful_search_plan(
+            request_id=100, generator_id="search-plan/2026-05-25-1",
+            items=[SearchPlanItemInput(
+                ordinal=0, strategy="default", query="radiohead kid a")],
+        )
         status, data = self._get(
             "/api/pipeline/100/search-plan/dry-run")
         self.assertEqual(status, 200)
         self.assertTrue(data["would_supersede_active"])
 
     def test_dry_run_request_not_found_returns_404(self):
-        self.mock_db.get_request.return_value = None
         status, data = self._get(
             "/api/pipeline/9999/search-plan/dry-run")
         self.assertEqual(status, 404)
@@ -497,7 +407,7 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
     def test_dry_run_request_with_no_tracks_succeeds(self):
         # Generator handles empty tracks — emits a plan without
         # track-fallback slots; the dry-run reflects exactly that.
-        self.mock_db.get_tracks.return_value = []
+        self.db.set_tracks(100, [])
         status, data = self._get(
             "/api/pipeline/100/search-plan/dry-run")
         self.assertEqual(status, 200)
@@ -513,17 +423,14 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
             f"{strategies}")
 
     def test_dry_run_does_not_persist_or_write_plan_rows(self):
-        # The simulator must never call into create_successful_search_plan
-        # / supersede_search_plan_with_replacement / create_failed_search_plan.
-        self.mock_db.create_successful_search_plan.reset_mock()
-        self.mock_db.supersede_search_plan_with_replacement.reset_mock()
-        self.mock_db.create_failed_search_plan.reset_mock()
+        # The simulator must never persist anything: after the call the
+        # fake's plan store is still empty and the request has no
+        # active plan — the domain version of "no write methods ran".
         status, _ = self._get(
             "/api/pipeline/100/search-plan/dry-run")
         self.assertEqual(status, 200)
-        self.mock_db.create_successful_search_plan.assert_not_called()
-        self.mock_db.supersede_search_plan_with_replacement.assert_not_called()
-        self.mock_db.create_failed_search_plan.assert_not_called()
+        self.assertEqual(self.db.search_plans, {})
+        self.assertIsNone(self.db.get_active_search_plan(100))
 
     def test_dry_run_carries_current_generator_id(self):
         from lib.search import SEARCH_PLAN_GENERATOR_ID
@@ -537,7 +444,7 @@ class TestPipelineSearchPlanDryRunContract(_WebServerCase):
             data["plan"]["generator_id"], SEARCH_PLAN_GENERATOR_ID)
 
 
-class TestPipelineSearchPlanSaturationContract(_WebServerCase):
+class TestPipelineSearchPlanSaturationContract(_FakeDbWebServerCase):
     """U7 contract for ``GET /api/pipeline/<id>/search-plan/saturation``.
 
     Read-only telemetry aggregator. The route wraps
@@ -560,18 +467,13 @@ class TestPipelineSearchPlanSaturationContract(_WebServerCase):
     }
 
     def setUp(self) -> None:
-        from tests.helpers import make_request_row
-        # Production-shape mock: use real datetime + UUID values on the
-        # request row so the JSON encoder path is exercised end-to-end.
-        # The route does not consult timestamps directly, but the
-        # ``get_request`` call walks through the JSON encoder boundary
-        # if anything else does — keep the row shape honest.
+        super().setUp()
         import uuid
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=100, status="wanted",
             artist_name="Radiohead", album_title="Kid A",
             mb_release_id=str(uuid.uuid4()),
-        )
+        ))
         # Route reads runtime config — patch to a default config.
         from lib.config import CratediggerConfig
         import configparser
@@ -582,22 +484,30 @@ class TestPipelineSearchPlanSaturationContract(_WebServerCase):
             return_value=CratediggerConfig.from_ini(cp),
         )
         self._cfg_patcher.start()
-        # Default saturation summary — happy-path scenario.
-        from lib.pipeline_db import SaturationSummary
-        self.mock_db.get_saturation_summary.return_value = SaturationSummary(
-            total_searches=30,
-            saturated_searches=10,
-            saturation_rate=10 / 30,
-            total_pre_filter_skips=50,
-            window_days=14,
-        )
 
     def tearDown(self) -> None:
         self._cfg_patcher.stop()
-        self.mock_db.get_saturation_summary.reset_mock(
-            return_value=True, side_effect=True)
+
+    def _seed_search_logs(self, *, total: int, saturated: int,
+                          skips_total: int) -> None:
+        """Real search_log rows the fake's get_saturation_summary
+        aggregates: ``LimitReached`` in final_state counts as
+        saturated; pre_filter_skip_count sums."""
+        per, rem = divmod(skips_total, total)
+        for i in range(total):
+            self.db.log_search(
+                100, query=f"q{i}", outcome="no_match",
+                final_state=(
+                    "Completed, LimitReached" if i < saturated
+                    else "Completed"),
+                pre_filter_skip_count=per + (1 if i < rem else 0),
+            )
+
+    def _age_last_log(self, days: int) -> None:
+        self.db.search_logs[-1].created_at -= timedelta(days=days)
 
     def test_happy_path_returns_200_with_required_fields(self):
+        self._seed_search_logs(total=30, saturated=10, skips_total=50)
         status, data = self._get(
             "/api/pipeline/100/search-plan/saturation")
         self.assertEqual(status, 200)
@@ -613,13 +523,7 @@ class TestPipelineSearchPlanSaturationContract(_WebServerCase):
         self.assertIsNone(data["error_message"])
 
     def test_empty_window_is_200_with_zeros_not_404(self):
-        # Found-but-quiet: request exists, window is just empty.
-        from lib.pipeline_db import SaturationSummary
-        self.mock_db.get_saturation_summary.return_value = SaturationSummary(
-            total_searches=0, saturated_searches=0,
-            saturation_rate=0.0, total_pre_filter_skips=0,
-            window_days=14,
-        )
+        # Found-but-quiet: request exists, no search_log rows at all.
         status, data = self._get(
             "/api/pipeline/100/search-plan/saturation")
         self.assertEqual(status, 200)
@@ -629,7 +533,6 @@ class TestPipelineSearchPlanSaturationContract(_WebServerCase):
         self.assertEqual(data["total_searches"], 0)
 
     def test_request_not_found_returns_404(self):
-        self.mock_db.get_request.return_value = None
         status, data = self._get(
             "/api/pipeline/9999/search-plan/saturation")
         self.assertEqual(status, 404)
@@ -642,24 +545,24 @@ class TestPipelineSearchPlanSaturationContract(_WebServerCase):
         self.assertEqual(data["total_searches"], 0)
         self.assertEqual(data["saturation_rate"], 0.0)
         self.assertIn("error", data)
-        # The DB aggregator must NOT be called when the request row
-        # itself is missing — wastes a query and risks misleading zeros.
-        self.mock_db.get_saturation_summary.assert_not_called()
 
     def test_window_days_query_string_propagates_to_service(self):
-        from lib.pipeline_db import SaturationSummary
-        self.mock_db.get_saturation_summary.return_value = SaturationSummary(
-            total_searches=5, saturated_searches=1,
-            saturation_rate=0.2, total_pre_filter_skips=3,
-            window_days=7,
-        )
+        self._seed_search_logs(total=5, saturated=1, skips_total=3)
+        # One older row inside the default 14d window but OUTSIDE the
+        # requested 7d window — if the route failed to propagate
+        # window_days to the aggregator, this row would inflate the
+        # totals below.
+        self.db.log_search(
+            100, query="old", outcome="no_match", final_state="Completed")
+        self._age_last_log(10)
         status, data = self._get(
             "/api/pipeline/100/search-plan/saturation?window_days=7")
         self.assertEqual(status, 200)
         self.assertEqual(data["window_days"], 7)
-        # The aggregator was called with the requested window.
-        self.mock_db.get_saturation_summary.assert_called_with(
-            100, window_days=7)
+        self.assertEqual(data["total_searches"], 5)
+        self.assertEqual(data["saturated_searches"], 1)
+        self.assertAlmostEqual(data["saturation_rate"], 0.2)
+        self.assertEqual(data["total_pre_filter_skips"], 3)
 
     def test_invalid_window_days_non_int_returns_400(self):
         status, data = self._get(
@@ -675,13 +578,19 @@ class TestPipelineSearchPlanSaturationContract(_WebServerCase):
         self.assertEqual(data["outcome"], "input_invalid")
 
     def test_default_window_is_14_when_omitted(self):
+        # The 10-day-old row IS inside the default 14d window — the
+        # complement of the 7d propagation test above.
+        self.db.log_search(
+            100, query="old", outcome="no_match", final_state="Completed")
+        self._age_last_log(10)
         status, data = self._get(
             "/api/pipeline/100/search-plan/saturation")
         self.assertEqual(status, 200)
         self.assertEqual(data["window_days"], 14)
+        self.assertEqual(data["total_searches"], 1)
 
 
-class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
+class TestPipelineSearchPlanRegenerateContract(_FakeDbWebServerCase):
     """U8 contract for ``POST /api/pipeline/<id>/search-plan/regenerate``.
 
     The endpoint must wrap ``SearchPlanService.generate_for_request``
@@ -713,10 +622,10 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
         )
 
     def setUp(self) -> None:
-        from tests.helpers import make_request_row
-        self.mock_db.get_request.return_value = make_request_row(
+        super().setUp()
+        self.db.seed_request(make_request_row(
             id=100, status="wanted",
-        )
+        ))
         # The route reads the runtime config — patch it to a default.
         from lib.config import CratediggerConfig
         import configparser
@@ -747,10 +656,9 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
         self.assertEqual(data["request_status"], "wanted")
 
     def test_regenerate_success_for_imported_request_marks_not_executable(self):
-        from tests.helpers import make_request_row
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=100, status="imported",
-        )
+        ))
         with self._patch_service(outcome="success", plan_id=99):
             status, data = self._post(
                 "/api/pipeline/100/search-plan/regenerate", {})
@@ -760,7 +668,6 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
         self.assertEqual(data["request_status"], "imported")
 
     def test_regenerate_request_not_found_returns_404(self):
-        self.mock_db.get_request.return_value = None
         with self._patch_service(outcome="request_not_found"):
             status, data = self._post(
                 "/api/pipeline/9999/search-plan/regenerate", {})
@@ -885,7 +792,7 @@ class TestPipelineSearchPlanRegenerateContract(_WebServerCase):
         mock_gen.assert_not_called()
 
 
-class TestPipelineSearchPlanAdvanceContract(_WebServerCase):
+class TestPipelineSearchPlanAdvanceContract(_FakeDbWebServerCase):
     """Contract for ``POST /api/pipeline/<id>/search-plan/advance``.
 
     The endpoint wraps ``SearchPlanService.advance_for_request``. Both
@@ -909,6 +816,7 @@ class TestPipelineSearchPlanAdvanceContract(_WebServerCase):
     }
 
     def setUp(self) -> None:
+        super().setUp()
         from lib.config import CratediggerConfig
         import configparser
         cp = configparser.RawConfigParser()
@@ -1044,7 +952,7 @@ class TestPipelineSearchPlanAdvanceContract(_WebServerCase):
         mock_adv.assert_not_called()
 
 
-class TestPipelineSearchPlanHistoryContract(_WebServerCase):
+class TestPipelineSearchPlanHistoryContract(_FakeDbWebServerCase):
     """Contract for ``GET /api/pipeline/<id>/search-plan/history``.
 
     The endpoint wraps ``SearchPlanService.history_for_request``. Both
@@ -1062,6 +970,7 @@ class TestPipelineSearchPlanHistoryContract(_WebServerCase):
     HISTORY_REQUIRED_FIELDS = {"request_id", "rows", "next_before_id"}
 
     def setUp(self) -> None:
+        super().setUp()
         from lib.config import CratediggerConfig
         import configparser
         cp = configparser.RawConfigParser()

--- a/tests/web/test_server_threading.py
+++ b/tests/web/test_server_threading.py
@@ -20,7 +20,7 @@ import time
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import conftest  # noqa: F401 — sets TEST_DB_DSN for the per-thread test
 
 from tests.web._harness import _WebServerCase


### PR DESCRIPTION
Batch 2 of #430 (batch 1: #440). Migrates `test_routes_pipeline_replace.py` (27→0) and `test_routes_pipeline_search_plan.py` (42→0) to the bare-`FakePipelineDB` harness; remaining baseline: `_harness.py` 39, imports 71, pipeline 66, mutations 100, endpoints 53.

## Highlights

- **Replace module**: the `include_replaced` filter tests seed one wanted + one replaced row and assert which rows `/api/pipeline/all` actually surfaces (was: capturing status strings passed to a `side_effect`). Resolve-rg tests assert the row's `mb_release_group_id` after the call AND that `update_request_fields_calls == []` on no-write paths (the fake's call log restores the dropped `assert_not_called` at full strength). Active-rgs now pins that replaced rows' RGs don't count as active — previously untested.
- **Search-plan module**: inspection scenarios **create real plans** through the fake's production-mirroring write API (`create_successful_search_plan`, two `supersede_search_plan_with_replacement` generations, `create_failed_search_plan`) and real `log_search` rows — `superseded_count`, legacy count/head-capping, and currentness booleans are all computed, not injected. The saturation window test plants a 10-day-old log row that would inflate the totals if `window_days=7` failed to propagate — strictly stronger than the old `assert_called_with`. Dry-run's "never persists" asserts the plan store stays empty (covers all three write methods at once).
- **sys.path shadowing class killed** (r1 adversarial finding): every `sys.path.insert(0, <tests dir>)` in the tree is now `append` — `tests/web` can never shadow the real `web` package again (`python3 -m unittest tests.test_mock_audit tests.web.test_X` used to fail in module-order-dependent ways). `TestSysPathAudit` resolves each dirname-chain insert to its actual target directory and bans front-inserts of test dirs; it caught a real offender (`test_server_threading`) on its first run while correctly passing the repo-root `dirname(dirname(...))` shape. `import conftest` stays bare everywhere per the documented single-instance contract.

## Documented equivalence trades (r1 ADV-3/4/5)

- `get_search_plan_stats_history.assert_called_once_with(100)` (prefetch batching) and the saturation-404 `assert_not_called` (query economy) were internal-optimization pins, not operator contracts; payload shape + zero-filled 404 body remain fully asserted.
- `created_at` rewinding on `SearchLogRow` is the fake's documented seeding seam; no helper promoted until a second consumer exists.

## Review trail

| Round | Reviewer | Findings | Resolution |
|-------|----------|----------|------------|
| r1 | Same-engine adversarial | 1 MEDIUM (piecemeal sys.path fix), 3 LOW, 2 NIT | MEDIUM fixed structurally (append conversion + TestSysPathAudit); ADV-2 no-write pins restored via the fake's call log; ADV-6 normpath; ADV-3/4/5 documented equivalences (see review commit body) |
| r2 | Codex partner (`codex exec review --base main`) | none | — |

- [x] Full suite 4403 tests OK; pyright 0 errors full-repo
- [x] Ratchet entries deleted for both modules; migrated files contain zero `mock_db` occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)