### PR TITLE
test(web): #430 batch 3 — endpoints + pipeline migrated, dashboard fake becomes a parity-gated read-model mirror

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -526,7 +526,6 @@ _HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
 WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "_harness.py"): 39,
     os.path.join("web", "test_routes_imports.py"): 71,
-    os.path.join("web", "test_routes_pipeline.py"): 66,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 100,
 }
 

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -528,7 +528,6 @@ WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "test_routes_imports.py"): 71,
     os.path.join("web", "test_routes_pipeline.py"): 66,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 100,
-    os.path.join("web", "test_server_endpoints.py"): 53,
 }
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3828,13 +3828,19 @@ class FakePipelineDB:
         cutoff = now - timedelta(hours=hours)
         rows = [e for e in self.search_logs
                 if self._as_utc(e.created_at) >= cutoff]
-        outcomes = {"found": 0, "no_match": 0, "no_results": 0,
-                    "exhausted": 0, "errors": 0}
-        for e in rows:
-            if e.outcome in outcomes:
-                outcomes[e.outcome] += 1
-            else:
-                outcomes["errors"] += 1
+        # Errors bucket mirrors the SQL FILTER exactly: only timeout /
+        # error / empty_query count — an unknown outcome counts toward
+        # ``searches`` but no bucket.
+        outcomes = {
+            "found": sum(1 for e in rows if e.outcome == "found"),
+            "no_match": sum(1 for e in rows if e.outcome == "no_match"),
+            "no_results": sum(
+                1 for e in rows if e.outcome == "no_results"),
+            "exhausted": sum(1 for e in rows if e.outcome == "exhausted"),
+            "errors": sum(
+                1 for e in rows
+                if e.outcome in ("timeout", "error", "empty_query")),
+        }
         elapsed = sorted(
             e.elapsed_s for e in rows if e.elapsed_s is not None)
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -4199,14 +4199,24 @@ class FakePipelineDB:
                     self._dashboard_cycle_window("24h", 24, now),
                     self._dashboard_cycle_window("6h", 6, now),
                 ],
+                # Production: ORDER BY created_at DESC LIMIT 12 — NOT
+                # insertion order (rows seeded with explicit
+                # completed_at values must sort by their timestamps).
                 "recent": [
-                    self._dashboard_cycle_row(r)
-                    for r in reversed(self.cycle_metrics[-12:])
-                ],
-                "outliers": [
                     self._dashboard_cycle_row(r)
                     for r in sorted(
                         self.cycle_metrics,
+                        key=lambda row: self._as_utc(row["created_at"]),
+                        reverse=True,
+                    )[:12]
+                ],
+                # Production restricts outliers to the last 24 hours.
+                "outliers": [
+                    self._dashboard_cycle_row(r)
+                    for r in sorted(
+                        (row for row in self.cycle_metrics
+                         if self._as_utc(row["created_at"])
+                         >= now - timedelta(hours=24)),
                         key=lambda row: row["cycle_total_s"],
                         reverse=True,
                     )[:8]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3858,7 +3858,7 @@ class FakePipelineDB:
             "cursor_wraps": sum(
                 1 for e in rows if e.cursor_update_status == "wrapped"),
             "stale_completions": sum(
-                1 for e in rows if e.execution_stage == "stale_completion"),
+                1 for e in rows if e.cursor_update_status == "stale"),
             "non_consuming": sum(
                 1 for e in rows if e.attempt_consumed is False),
             "cache_attribution_level": "cycle_only",
@@ -3905,147 +3905,214 @@ class FakePipelineDB:
         }
 
     def _dashboard_cycle_row(self, row: dict[str, Any]) -> dict[str, Any]:
-        out = dict(row)
-        for key in ("started_at", "created_at"):
-            value = out.get(key)
-            out[key] = value.isoformat() if isinstance(value, datetime) else value
-        return out
+        """Mirror ``PipelineDB._serialize_dashboard_cycle_row`` exactly:
+        fixed key set, ``cycle_searches_watchdog_killed`` renamed to
+        ``watchdog_kills``, cache hit/miss + wanted_total columns NOT
+        emitted, timestamps isoformatted."""
+        def _iso(value: Any) -> str | None:
+            return value.isoformat() if isinstance(value, datetime) else value
+        return {
+            "id": int(row["id"]),
+            "started_at": _iso(row.get("started_at")),
+            "created_at": _iso(row.get("created_at")),
+            "cycle_total_s": float(row["cycle_total_s"]),
+            "browse_time_s": float(row["browse_time_s"]),
+            "match_time_s": float(row["match_time_s"]),
+            "search_time_s": float(row["search_time_s"]),
+            "watchdog_kills": int(row["cycle_searches_watchdog_killed"]),
+            "find_download_queued": int(row["find_download_queued"]),
+            "find_download_completed": int(row["find_download_completed"]),
+            "find_download_drain_time_s": float(
+                row["find_download_drain_time_s"]),
+            "cache_errors": int(row["cache_errors"]),
+            "cache_write_errors": int(row["cache_write_errors"]),
+            "cache_fuse_tripped": int(row["cache_fuse_tripped"]),
+            "peers_browsed": int(row["peers_browsed"]),
+            "peers_browsed_lazy": int(row["peers_browsed_lazy"]),
+            "fanout_waves": int(row["fanout_waves"]),
+        }
 
     def _dashboard_coverage(self, now: datetime) -> dict[str, Any]:
-        wanted_ids = {
-            int(r["id"]) for r in self._requests.values()
+        """Mirror the production coverage CTEs: backlog = wanted +
+        downloading; suspects = searched-in-24h rows ordered
+        (searches_24h DESC, searches_6h DESC, id ASC) LIMIT 12 with
+        reset_24h counting the HISTORICAL ``exhausted`` outcome and
+        problem_24h restricted to timeout/error/empty_query;
+        stale_wanted = ALL backlog rows ordered last_search_at ASC
+        NULLS FIRST LIMIT 12 (recently-searched rows included); the
+        match-rate series are DENSE generate_series mirrors (24 hourly /
+        28 daily zero-filled buckets); matches_* ride the wanted CTE
+        cross-join, so an empty backlog reports 0 matches even when
+        found rows exist."""
+        backlog = {
+            int(r["id"]): r for r in self._requests.values()
             if r.get("status") in ("wanted", "downloading")
         }
-        last_search: dict[int, datetime] = {}
+
+        # One pass over search_log per request: rollup of windowed
+        # outcome counts + last_search_at.
+        rollup: dict[int, dict[str, Any]] = {}
+        cutoff_24h = now - timedelta(hours=24)
+        cutoff_6h = now - timedelta(hours=6)
         for e in self.search_logs:
             at = self._as_utc(e.created_at)
-            prev = last_search.get(e.request_id)
-            if prev is None or at > prev:
-                last_search[e.request_id] = at
+            r = rollup.setdefault(e.request_id, {
+                "last_search_at": None, "searches_24h": 0, "searches_6h": 0,
+                "found_24h": 0, "no_match_24h": 0, "no_results_24h": 0,
+                "reset_24h": 0, "problem_24h": 0,
+            })
+            if r["last_search_at"] is None or at > r["last_search_at"]:
+                r["last_search_at"] = at
+            if at >= cutoff_24h:
+                r["searches_24h"] += 1
+                if e.outcome == "found":
+                    r["found_24h"] += 1
+                elif e.outcome == "no_match":
+                    r["no_match_24h"] += 1
+                elif e.outcome == "no_results":
+                    r["no_results_24h"] += 1
+                elif e.outcome == "exhausted":
+                    r["reset_24h"] += 1
+                elif e.outcome in ("timeout", "error", "empty_query"):
+                    r["problem_24h"] += 1
+            if at >= cutoff_6h:
+                r["searches_6h"] += 1
 
-        def _searched_within(hours: int) -> set[int]:
-            cutoff = now - timedelta(hours=hours)
-            return {rid for rid in wanted_ids
-                    if last_search.get(rid) is not None
-                    and last_search[rid] >= cutoff}
-
-        def _searches_within(hours: int) -> list[SearchLogRow]:
-            cutoff = now - timedelta(hours=hours)
-            return [e for e in self.search_logs
-                    if e.request_id in wanted_ids
-                    and self._as_utc(e.created_at) >= cutoff]
-
-        searched_24h = _searched_within(24)
-        searched_6h = _searched_within(6)
-        active_24h = _searches_within(24)
-        active_6h = _searches_within(6)
+        searched_24h = sum(
+            1 for rid in backlog
+            if rollup.get(rid, {}).get("searches_24h", 0) > 0)
+        searched_6h = sum(
+            1 for rid in backlog
+            if rollup.get(rid, {}).get("searches_6h", 0) > 0)
+        active_24h = sum(
+            rollup.get(rid, {}).get("searches_24h", 0) for rid in backlog)
+        active_6h = sum(
+            rollup.get(rid, {}).get("searches_6h", 0) for rid in backlog)
 
         found_rows = [e for e in self.search_logs if e.outcome == "found"]
+        if backlog:
+            matches_24h = sum(
+                1 for e in found_rows
+                if self._as_utc(e.created_at) >= cutoff_24h)
+            matches_6h = sum(
+                1 for e in found_rows
+                if self._as_utc(e.created_at) >= cutoff_6h)
+        else:
+            # Production's summary SQL cross-joins match_rates against
+            # the wanted CTE — zero backlog rows mean the aggregates
+            # COALESCE to 0 regardless of found rows.
+            matches_24h = 0
+            matches_6h = 0
 
-        def _matches_within(hours: int) -> int:
-            cutoff = now - timedelta(hours=hours)
-            return sum(1 for e in found_rows
-                       if self._as_utc(e.created_at) >= cutoff)
-
-        # Hourly buckets (24h) / daily buckets (28d), non-empty only —
-        # mirrors the SQL GROUP BY which never emits zero rows.
-        hourly: dict[datetime, int] = {}
-        daily: dict[datetime, int] = {}
+        # Dense bucket mirrors of generate_series + LEFT JOIN.
+        hour_anchor = now.replace(minute=0, second=0, microsecond=0)
+        hourly_counts: dict[datetime, int] = {}
+        day_anchor = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        daily_counts: dict[datetime, int] = {}
         for e in found_rows:
             at = self._as_utc(e.created_at)
-            if at >= now - timedelta(hours=24):
-                bucket = at.replace(minute=0, second=0, microsecond=0)
-                hourly[bucket] = hourly.get(bucket, 0) + 1
-            if at >= now - timedelta(days=28):
-                day = at.replace(hour=0, minute=0, second=0, microsecond=0)
-                daily[day] = daily.get(day, 0) + 1
+            hourly_counts[at.replace(minute=0, second=0, microsecond=0)] = (
+                hourly_counts.get(
+                    at.replace(minute=0, second=0, microsecond=0), 0) + 1)
+            daily_counts[at.replace(
+                hour=0, minute=0, second=0, microsecond=0)] = (
+                daily_counts.get(at.replace(
+                    hour=0, minute=0, second=0, microsecond=0), 0) + 1)
+        series_24h = []
+        for i in range(23, -1, -1):
+            bucket = hour_anchor - timedelta(hours=i)
+            n = hourly_counts.get(bucket, 0)
+            series_24h.append({
+                "bucket_start": bucket.isoformat(),
+                "matches": n,
+                "matches_per_hour": n,
+            })
+        series_28d = []
+        for i in range(27, -1, -1):
+            bucket = day_anchor - timedelta(days=i)
+            n = daily_counts.get(bucket, 0)
+            series_28d.append({
+                "bucket_start": bucket.isoformat(),
+                "matches": n,
+                "matches_per_day": n,
+            })
 
-        per_request_24h: dict[int, int] = {}
-        for e in active_24h:
-            per_request_24h[e.request_id] = (
-                per_request_24h.get(e.request_id, 0) + 1)
-        top10 = sorted(per_request_24h.values(), reverse=True)[:10]
-        top_10_share = (sum(top10) / len(active_24h)) if active_24h else None
-
-        def _request_outcome_counts(rid: int, hours: int) -> dict[str, int]:
-            cutoff = now - timedelta(hours=hours)
-            rows = [e for e in self.search_logs
-                    if e.request_id == rid
-                    and self._as_utc(e.created_at) >= cutoff]
-            known = ("found", "no_match", "no_results", "reset")
-            counts = {f"{k}_{hours}h": sum(
-                1 for e in rows if e.outcome == k) for k in known}
-            counts[f"problem_{hours}h"] = sum(
-                1 for e in rows if e.outcome not in known)
-            return counts
-
-        def _suspect_row(rid: int) -> dict[str, Any]:
-            req = self._requests.get(rid, {})
-            at = last_search.get(rid)
+        def _request_row(rid: int) -> dict[str, Any]:
+            req = backlog[rid]
+            r = rollup.get(rid, {})
+            at = r.get("last_search_at")
             return {
                 "request_id": rid,
                 "artist_name": req.get("artist_name"),
                 "album_title": req.get("album_title"),
                 "status": req.get("status"),
                 "last_search_at": at.isoformat() if at else None,
-                "searches_24h": per_request_24h.get(rid, 0),
-                "searches_6h": sum(
-                    1 for e in active_6h if e.request_id == rid),
-                **{k: v for k, v in
-                   _request_outcome_counts(rid, 24).items()
-                   if k != "reset_24h" and k != "problem_24h"},
-                "reset_24h": _request_outcome_counts(rid, 24)["reset_24h"],
-                "problem_24h": _request_outcome_counts(rid, 24)["problem_24h"],
+                "searches_24h": int(r.get("searches_24h", 0)),
+                "searches_6h": int(r.get("searches_6h", 0)),
+                "found_24h": int(r.get("found_24h", 0)),
+                "no_match_24h": int(r.get("no_match_24h", 0)),
+                "no_results_24h": int(r.get("no_results_24h", 0)),
+                "reset_24h": int(r.get("reset_24h", 0)),
+                "problem_24h": int(r.get("problem_24h", 0)),
             }
 
         suspects = [
-            _suspect_row(rid)
-            for rid, n in sorted(per_request_24h.items(),
-                                 key=lambda kv: kv[1], reverse=True)
-            if n >= 2
-        ][:10]
+            _request_row(rid)
+            for rid in sorted(
+                (rid for rid in backlog
+                 if rollup.get(rid, {}).get("searches_24h", 0) > 0),
+                key=lambda rid: (
+                    -rollup[rid]["searches_24h"],
+                    -rollup[rid]["searches_6h"],
+                    rid,
+                ),
+            )
+        ][:12]
+
+        def _stale_sort_key(rid: int):
+            at = rollup.get(rid, {}).get("last_search_at")
+            req = backlog[rid]
+            created = self._as_utc(_as_datetime(req.get("created_at")))
+            # NULLS FIRST: never-searched rows sort before everything.
+            return (at is not None, at or created, created, rid)
 
         stale = []
-        for rid in sorted(wanted_ids):
-            at = last_search.get(rid)
-            if at is not None and at >= now - timedelta(hours=24):
-                continue
-            row = _suspect_row(rid)
+        for rid in sorted(backlog, key=_stale_sort_key)[:12]:
+            row = _request_row(rid)
+            at = rollup.get(rid, {}).get("last_search_at")
             row["hours_since_search"] = (
                 (now - at).total_seconds() / 3600 if at else None)
             stale.append(row)
 
+        top_10_searches = sum(r["searches_24h"] for r in suspects[:10])
+        top_10_share = (top_10_searches / active_24h) if active_24h else 0
+
         oldest = None
-        searched_ats = [last_search[rid] for rid in wanted_ids
-                        if rid in last_search]
+        searched_ats = [
+            rollup[rid]["last_search_at"] for rid in backlog
+            if rid in rollup and rollup[rid]["last_search_at"] is not None
+        ]
         if searched_ats:
             oldest = min(searched_ats).isoformat()
 
         return {
-            "wanted_total": len(wanted_ids),
-            "wanted_searched_24h": len(searched_24h),
-            "wanted_searched_6h": len(searched_6h),
-            "wanted_unsearched_24h": len(wanted_ids) - len(searched_24h),
-            "wanted_unsearched_6h": len(wanted_ids) - len(searched_6h),
+            "wanted_total": len(backlog),
+            "wanted_searched_24h": searched_24h,
+            "wanted_searched_6h": searched_6h,
+            "wanted_unsearched_24h": max(len(backlog) - searched_24h, 0),
+            "wanted_unsearched_6h": max(len(backlog) - searched_6h, 0),
             "wanted_never_searched": sum(
-                1 for rid in wanted_ids if rid not in last_search),
-            "active_wanted_searches_24h": len(active_24h),
-            "active_wanted_searches_6h": len(active_6h),
+                1 for rid in backlog
+                if rollup.get(rid, {}).get("last_search_at") is None),
+            "active_wanted_searches_24h": active_24h,
+            "active_wanted_searches_6h": active_6h,
             "oldest_last_search_at": oldest,
-            "matches_24h": _matches_within(24),
-            "matches_6h": _matches_within(6),
-            "matches_per_hour_24h": _matches_within(24) / 24,
-            "matches_per_hour_6h": _matches_within(6) / 6,
-            "match_rate_series_24h": [
-                {"bucket_start": bucket.isoformat(), "matches": n,
-                 "matches_per_hour": n}
-                for bucket, n in sorted(hourly.items())
-            ],
-            "match_rate_series_28d": [
-                {"bucket_start": day.isoformat(), "matches": n,
-                 "matches_per_day": n}
-                for day, n in sorted(daily.items())
-            ],
+            "matches_24h": matches_24h,
+            "matches_6h": matches_6h,
+            "matches_per_hour_24h": matches_24h / 24,
+            "matches_per_hour_6h": matches_6h / 6,
+            "match_rate_series_24h": series_24h,
+            "match_rate_series_28d": series_28d,
             "wanted_trend": self._dashboard_wanted_trend(
                 self._current_wanted_total()),
             "top_10_share_24h": top_10_share,
@@ -4054,13 +4121,23 @@ class FakePipelineDB:
         }
 
     def _dashboard_heavy_queries(self, now: datetime) -> list[dict[str, Any]]:
+        """Mirror ``_dashboard_peer_browse_heavy_queries``: rows with
+        (peers_browsed + peers_browsed_lazy) > 0 in the last 24h,
+        ordered (peer_dirs DESC, fanout_waves DESC, created_at DESC,
+        id DESC), LIMIT 12, with the production serializer's int/float
+        coercions (result_count never None)."""
         cutoff = now - timedelta(hours=24)
         rows = [e for e in self.search_logs
                 if self._as_utc(e.created_at) >= cutoff
-                and (e.peers_browsed or e.browse_time_s)]
-        rows.sort(key=lambda e: e.browse_time_s, reverse=True)
+                and (e.peers_browsed + e.peers_browsed_lazy) > 0]
+        rows.sort(key=lambda e: (
+            -(e.peers_browsed + e.peers_browsed_lazy),
+            -e.fanout_waves,
+            -self._as_utc(e.created_at).timestamp(),
+            -e.id,
+        ))
         out: list[dict[str, Any]] = []
-        for e in rows[:10]:
+        for e in rows[:12]:
             req = self._requests.get(e.request_id, {})
             out.append({
                 "search_log_id": e.id,
@@ -4073,14 +4150,16 @@ class FakePipelineDB:
                 "query": e.query,
                 "variant": e.variant,
                 "outcome": e.outcome,
-                "result_count": e.result_count,
-                "elapsed_s": e.elapsed_s,
-                "browse_time_s": e.browse_time_s,
-                "match_time_s": e.match_time_s,
-                "peers_browsed": e.peers_browsed,
-                "peers_browsed_lazy": e.peers_browsed_lazy,
-                "peer_dirs": e.peers_browsed + e.peers_browsed_lazy,
-                "fanout_waves": e.fanout_waves,
+                "result_count": int(e.result_count or 0),
+                "elapsed_s": float(e.elapsed_s)
+                if e.elapsed_s is not None else None,
+                "browse_time_s": float(e.browse_time_s or 0.0),
+                "match_time_s": float(e.match_time_s or 0.0),
+                "peers_browsed": int(e.peers_browsed or 0),
+                "peers_browsed_lazy": int(e.peers_browsed_lazy or 0),
+                "peer_dirs": int(
+                    (e.peers_browsed or 0) + (e.peers_browsed_lazy or 0)),
+                "fanout_waves": int(e.fanout_waves or 0),
             })
         return out
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3816,34 +3816,324 @@ class FakePipelineDB:
             },
         }
 
+    @staticmethod
+    def _as_utc(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def _dashboard_search_window(
+        self, label: str, hours: int, now: datetime,
+    ) -> dict[str, Any]:
+        cutoff = now - timedelta(hours=hours)
+        rows = [e for e in self.search_logs
+                if self._as_utc(e.created_at) >= cutoff]
+        outcomes = {"found": 0, "no_match": 0, "no_results": 0,
+                    "exhausted": 0, "errors": 0}
+        for e in rows:
+            if e.outcome in outcomes:
+                outcomes[e.outcome] += 1
+            else:
+                outcomes["errors"] += 1
+        elapsed = sorted(
+            e.elapsed_s for e in rows if e.elapsed_s is not None)
+
+        def _pct(p: float) -> float | None:
+            if not elapsed:
+                return None
+            return elapsed[min(len(elapsed) - 1, int(len(elapsed) * p))]
+
+        return {
+            "label": label,
+            "hours": hours,
+            "searches": len(rows),
+            "distinct_requests": len({e.request_id for e in rows}),
+            "searches_per_hour": len(rows) / hours,
+            "searches_per_24h": len(rows) / hours * 24,
+            "avg_elapsed_s": (sum(elapsed) / len(elapsed)) if elapsed else None,
+            "median_elapsed_s": _pct(0.5),
+            "p95_elapsed_s": _pct(0.95),
+            "max_elapsed_s": elapsed[-1] if elapsed else None,
+            "outcomes": outcomes,
+            "cursor_wraps": sum(
+                1 for e in rows if e.cursor_update_status == "wrapped"),
+            "stale_completions": sum(
+                1 for e in rows if e.execution_stage == "stale_completion"),
+            "non_consuming": sum(
+                1 for e in rows if e.attempt_consumed is False),
+            "cache_attribution_level": "cycle_only",
+        }
+
+    def _dashboard_cycle_window(
+        self, label: str, hours: int, now: datetime,
+    ) -> dict[str, Any]:
+        cutoff = now - timedelta(hours=hours)
+        rows = [r for r in self.cycle_metrics
+                if self._as_utc(r["created_at"]) >= cutoff]
+        totals = sorted(float(r["cycle_total_s"]) for r in rows)
+        searches = sorted(float(r["search_time_s"]) for r in rows)
+
+        def _pct(values: list[float], p: float) -> float | None:
+            if not values:
+                return None
+            return values[min(len(values) - 1, int(len(values) * p))]
+
+        return {
+            "label": label,
+            "hours": hours,
+            "cycles": len(rows),
+            "avg_cycle_s": (sum(totals) / len(totals)) if totals else None,
+            "median_cycle_s": _pct(totals, 0.5),
+            "p95_cycle_s": _pct(totals, 0.95),
+            "max_cycle_s": totals[-1] if totals else None,
+            "median_search_s": _pct(searches, 0.5),
+            "watchdog_kills": sum(
+                int(r["cycle_searches_watchdog_killed"]) for r in rows),
+            "find_download_queued": sum(
+                int(r["find_download_queued"]) for r in rows),
+            "find_download_completed": sum(
+                int(r["find_download_completed"]) for r in rows),
+            "cache_errors": sum(int(r["cache_errors"]) for r in rows),
+            "cache_write_errors": sum(
+                int(r["cache_write_errors"]) for r in rows),
+            "cache_fuse_tripped": sum(
+                int(r["cache_fuse_tripped"]) for r in rows),
+            "peers_browsed": sum(int(r["peers_browsed"]) for r in rows),
+            "peers_browsed_lazy": sum(
+                int(r["peers_browsed_lazy"]) for r in rows),
+            "fanout_waves": sum(int(r["fanout_waves"]) for r in rows),
+        }
+
+    def _dashboard_cycle_row(self, row: dict[str, Any]) -> dict[str, Any]:
+        out = dict(row)
+        for key in ("started_at", "created_at"):
+            value = out.get(key)
+            out[key] = value.isoformat() if isinstance(value, datetime) else value
+        return out
+
+    def _dashboard_coverage(self, now: datetime) -> dict[str, Any]:
+        wanted_ids = {
+            int(r["id"]) for r in self._requests.values()
+            if r.get("status") in ("wanted", "downloading")
+        }
+        last_search: dict[int, datetime] = {}
+        for e in self.search_logs:
+            at = self._as_utc(e.created_at)
+            prev = last_search.get(e.request_id)
+            if prev is None or at > prev:
+                last_search[e.request_id] = at
+
+        def _searched_within(hours: int) -> set[int]:
+            cutoff = now - timedelta(hours=hours)
+            return {rid for rid in wanted_ids
+                    if last_search.get(rid) is not None
+                    and last_search[rid] >= cutoff}
+
+        def _searches_within(hours: int) -> list[SearchLogRow]:
+            cutoff = now - timedelta(hours=hours)
+            return [e for e in self.search_logs
+                    if e.request_id in wanted_ids
+                    and self._as_utc(e.created_at) >= cutoff]
+
+        searched_24h = _searched_within(24)
+        searched_6h = _searched_within(6)
+        active_24h = _searches_within(24)
+        active_6h = _searches_within(6)
+
+        found_rows = [e for e in self.search_logs if e.outcome == "found"]
+
+        def _matches_within(hours: int) -> int:
+            cutoff = now - timedelta(hours=hours)
+            return sum(1 for e in found_rows
+                       if self._as_utc(e.created_at) >= cutoff)
+
+        # Hourly buckets (24h) / daily buckets (28d), non-empty only —
+        # mirrors the SQL GROUP BY which never emits zero rows.
+        hourly: dict[datetime, int] = {}
+        daily: dict[datetime, int] = {}
+        for e in found_rows:
+            at = self._as_utc(e.created_at)
+            if at >= now - timedelta(hours=24):
+                bucket = at.replace(minute=0, second=0, microsecond=0)
+                hourly[bucket] = hourly.get(bucket, 0) + 1
+            if at >= now - timedelta(days=28):
+                day = at.replace(hour=0, minute=0, second=0, microsecond=0)
+                daily[day] = daily.get(day, 0) + 1
+
+        per_request_24h: dict[int, int] = {}
+        for e in active_24h:
+            per_request_24h[e.request_id] = (
+                per_request_24h.get(e.request_id, 0) + 1)
+        top10 = sorted(per_request_24h.values(), reverse=True)[:10]
+        top_10_share = (sum(top10) / len(active_24h)) if active_24h else None
+
+        def _request_outcome_counts(rid: int, hours: int) -> dict[str, int]:
+            cutoff = now - timedelta(hours=hours)
+            rows = [e for e in self.search_logs
+                    if e.request_id == rid
+                    and self._as_utc(e.created_at) >= cutoff]
+            known = ("found", "no_match", "no_results", "reset")
+            counts = {f"{k}_{hours}h": sum(
+                1 for e in rows if e.outcome == k) for k in known}
+            counts[f"problem_{hours}h"] = sum(
+                1 for e in rows if e.outcome not in known)
+            return counts
+
+        def _suspect_row(rid: int) -> dict[str, Any]:
+            req = self._requests.get(rid, {})
+            at = last_search.get(rid)
+            return {
+                "request_id": rid,
+                "artist_name": req.get("artist_name"),
+                "album_title": req.get("album_title"),
+                "status": req.get("status"),
+                "last_search_at": at.isoformat() if at else None,
+                "searches_24h": per_request_24h.get(rid, 0),
+                "searches_6h": sum(
+                    1 for e in active_6h if e.request_id == rid),
+                **{k: v for k, v in
+                   _request_outcome_counts(rid, 24).items()
+                   if k != "reset_24h" and k != "problem_24h"},
+                "reset_24h": _request_outcome_counts(rid, 24)["reset_24h"],
+                "problem_24h": _request_outcome_counts(rid, 24)["problem_24h"],
+            }
+
+        suspects = [
+            _suspect_row(rid)
+            for rid, n in sorted(per_request_24h.items(),
+                                 key=lambda kv: kv[1], reverse=True)
+            if n >= 2
+        ][:10]
+
+        stale = []
+        for rid in sorted(wanted_ids):
+            at = last_search.get(rid)
+            if at is not None and at >= now - timedelta(hours=24):
+                continue
+            row = _suspect_row(rid)
+            row["hours_since_search"] = (
+                (now - at).total_seconds() / 3600 if at else None)
+            stale.append(row)
+
+        oldest = None
+        searched_ats = [last_search[rid] for rid in wanted_ids
+                        if rid in last_search]
+        if searched_ats:
+            oldest = min(searched_ats).isoformat()
+
+        return {
+            "wanted_total": len(wanted_ids),
+            "wanted_searched_24h": len(searched_24h),
+            "wanted_searched_6h": len(searched_6h),
+            "wanted_unsearched_24h": len(wanted_ids) - len(searched_24h),
+            "wanted_unsearched_6h": len(wanted_ids) - len(searched_6h),
+            "wanted_never_searched": sum(
+                1 for rid in wanted_ids if rid not in last_search),
+            "active_wanted_searches_24h": len(active_24h),
+            "active_wanted_searches_6h": len(active_6h),
+            "oldest_last_search_at": oldest,
+            "matches_24h": _matches_within(24),
+            "matches_6h": _matches_within(6),
+            "matches_per_hour_24h": _matches_within(24) / 24,
+            "matches_per_hour_6h": _matches_within(6) / 6,
+            "match_rate_series_24h": [
+                {"bucket_start": bucket.isoformat(), "matches": n,
+                 "matches_per_hour": n}
+                for bucket, n in sorted(hourly.items())
+            ],
+            "match_rate_series_28d": [
+                {"bucket_start": day.isoformat(), "matches": n,
+                 "matches_per_day": n}
+                for day, n in sorted(daily.items())
+            ],
+            "wanted_trend": self._dashboard_wanted_trend(
+                self._current_wanted_total()),
+            "top_10_share_24h": top_10_share,
+            "top_loop_suspects": suspects,
+            "stale_wanted": stale,
+        }
+
+    def _dashboard_heavy_queries(self, now: datetime) -> list[dict[str, Any]]:
+        cutoff = now - timedelta(hours=24)
+        rows = [e for e in self.search_logs
+                if self._as_utc(e.created_at) >= cutoff
+                and (e.peers_browsed or e.browse_time_s)]
+        rows.sort(key=lambda e: e.browse_time_s, reverse=True)
+        out: list[dict[str, Any]] = []
+        for e in rows[:10]:
+            req = self._requests.get(e.request_id, {})
+            out.append({
+                "search_log_id": e.id,
+                "request_id": e.request_id,
+                "mb_release_id": req.get("mb_release_id"),
+                "artist_name": req.get("artist_name"),
+                "album_title": req.get("album_title"),
+                "status": req.get("status"),
+                "created_at": self._as_utc(e.created_at).isoformat(),
+                "query": e.query,
+                "variant": e.variant,
+                "outcome": e.outcome,
+                "result_count": e.result_count,
+                "elapsed_s": e.elapsed_s,
+                "browse_time_s": e.browse_time_s,
+                "match_time_s": e.match_time_s,
+                "peers_browsed": e.peers_browsed,
+                "peers_browsed_lazy": e.peers_browsed_lazy,
+                "peer_dirs": e.peers_browsed + e.peers_browsed_lazy,
+                "fanout_waves": e.fanout_waves,
+            })
+        return out
+
     def get_pipeline_dashboard_metrics(
         self,
         *,
         plan_generator_id: str | None = None,
     ) -> dict[str, Any]:
+        """Python mirror of the production dashboard read-model.
+
+        Aggregates real seeded telemetry (``search_logs``,
+        ``cycle_metrics``, ``peer_observations``, request rows) into the
+        same envelope ``PipelineDB.get_pipeline_dashboard_metrics``
+        emits, with every timestamp isoformatted exactly like the
+        production ``_isoformat_or_none`` boundary (datetimes leaking
+        here 500 the dashboard route's json.dumps). Percentiles use a
+        simple nearest-rank cut — close enough for contract tests; the
+        production SQL is the authority on exact statistics.
+        """
         if plan_generator_id is None:
             from lib.search import SEARCH_PLAN_GENERATOR_ID
             plan_generator_id = SEARCH_PLAN_GENERATOR_ID
+        now = _utcnow()
         peers = self.get_peer_metrics()
-        peers["heavy_queries"] = []
+        peers["heavy_queries"] = self._dashboard_heavy_queries(now)
         peers["heavy_query_hours"] = 24
         return {
-            "generated_at": _utcnow().isoformat(),
-            "searches": {"windows": []},
+            "generated_at": now.isoformat(),
+            "searches": {
+                "windows": [
+                    self._dashboard_search_window("24h", 24, now),
+                    self._dashboard_search_window("6h", 6, now),
+                ],
+            },
             "cycles": {
-                "windows": [],
-                "recent": list(reversed(self.cycle_metrics[-12:])),
-                "outliers": sorted(
-                    self.cycle_metrics,
-                    key=lambda row: row["cycle_total_s"],
-                    reverse=True,
-                )[:8],
+                "windows": [
+                    self._dashboard_cycle_window("24h", 24, now),
+                    self._dashboard_cycle_window("6h", 6, now),
+                ],
+                "recent": [
+                    self._dashboard_cycle_row(r)
+                    for r in reversed(self.cycle_metrics[-12:])
+                ],
+                "outliers": [
+                    self._dashboard_cycle_row(r)
+                    for r in sorted(
+                        self.cycle_metrics,
+                        key=lambda row: row["cycle_total_s"],
+                        reverse=True,
+                    )[:8]
+                ],
             },
-            "coverage": {
-                "wanted_trend": self._dashboard_wanted_trend(
-                    self._current_wanted_total(),
-                ),
-            },
+            "coverage": self._dashboard_coverage(now),
             "peers": peers,
             "plan_readiness": self.get_search_plan_readiness(plan_generator_id),
         }

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -12,8 +12,8 @@ import sys
 import unittest
 from unittest.mock import patch, MagicMock
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "harness"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "harness"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 
 def _make_harness_proc(messages: list[dict]) -> MagicMock:

--- a/tests/test_evidence_rekey_migration.py
+++ b/tests/test_evidence_rekey_migration.py
@@ -33,7 +33,7 @@ from typing import Sequence
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 import psycopg2  # noqa: E402
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -5025,6 +5025,12 @@ class TestFakeDashboardMirror(unittest.TestCase):
         self.assertEqual(len(suspects), 1)
         self.assertEqual(suspects[0]["reset_24h"], 1)
         self.assertEqual(suspects[0]["problem_24h"], 1)
+        # Search-window errors bucket mirrors the SQL FILTER: the
+        # unknown outcome counts toward searches but NO bucket.
+        win24 = payload["searches"]["windows"][0]
+        self.assertEqual(win24["searches"], 3)
+        self.assertEqual(win24["outcomes"]["errors"], 1)
+        self.assertEqual(win24["outcomes"]["exhausted"], 1)
 
     def test_stale_wanted_includes_recently_searched_and_caps_at_12(self):
         """Production's stale panel is the 12 oldest-searched backlog

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -4927,6 +4927,67 @@ class TestFakePipelineDBYoutubeIngest(unittest.TestCase):
         )
 
 
+class TestFakeDashboardMirror(unittest.TestCase):
+    """The dashboard read-model mirror aggregates real seeded telemetry
+    and must emit a fully JSON-serializable envelope (production
+    isoformats every timestamp at the _isoformat_or_none boundary —
+    a raw datetime here 500s the dashboard route)."""
+
+    def _seeded_db(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        db.record_cycle_metrics(
+            cycle_total_s=300.0, search_time_s=240.0, peers_browsed=8,
+            find_download_queued=4, find_download_completed=4,
+            wanted_total=10,
+        )
+        db.log_search(
+            1, query="q", outcome="found", result_count=5, elapsed_s=2.0,
+            variant="v1", final_state="Completed", browse_time_s=42.0,
+            peers_browsed=110, peers_browsed_lazy=5, fanout_waves=6,
+        )
+        db.log_search(1, query="q2", outcome="no_match", elapsed_s=1.0)
+        db.record_peer_observations(["peer-a", "peer-b"])
+        return db
+
+    def test_envelope_is_json_serializable_with_seeded_telemetry(self):
+        import json
+        db = self._seeded_db()
+        payload = db.get_pipeline_dashboard_metrics()
+        json.dumps(payload)  # raises TypeError on any leaked datetime
+
+    def test_windows_and_coverage_aggregate_seeded_rows(self):
+        db = self._seeded_db()
+        payload = db.get_pipeline_dashboard_metrics()
+        win24 = payload["searches"]["windows"][0]
+        self.assertEqual(win24["label"], "24h")
+        self.assertEqual(win24["searches"], 2)
+        self.assertEqual(win24["outcomes"]["found"], 1)
+        self.assertEqual(win24["outcomes"]["no_match"], 1)
+        cov = payload["coverage"]
+        self.assertEqual(cov["matches_24h"], 1)
+        self.assertEqual(cov["wanted_total"], 1)
+        self.assertEqual(cov["wanted_searched_24h"], 1)
+        self.assertEqual(len(cov["match_rate_series_24h"]), 1)
+        self.assertEqual(cov["match_rate_series_24h"][0]["matches"], 1)
+        # Heavy-query panel surfaces the browse-heavy row.
+        heavy = payload["peers"]["heavy_queries"]
+        self.assertEqual(len(heavy), 1)
+        self.assertEqual(heavy[0]["peers_browsed"], 110)
+        self.assertEqual(heavy[0]["peer_dirs"], 115)
+        cyc24 = payload["cycles"]["windows"][0]
+        self.assertEqual(cyc24["cycles"], 1)
+        self.assertEqual(cyc24["find_download_queued"], 4)
+
+    def test_empty_db_emits_complete_envelope(self):
+        import json
+        payload = FakePipelineDB().get_pipeline_dashboard_metrics()
+        json.dumps(payload)
+        self.assertEqual(payload["searches"]["windows"][0]["searches"], 0)
+        self.assertEqual(payload["coverage"]["wanted_total"], 0)
+        self.assertEqual(payload["peers"]["heavy_queries"], [])
+
+
 class TestFakeCursor(unittest.TestCase):
     """FakeCursor pairs with FakePipelineDB.queue_execute_results for
     raw-SQL seams (web.overlay.check_pipeline et al.). Consumption

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -4968,8 +4968,12 @@ class TestFakeDashboardMirror(unittest.TestCase):
         self.assertEqual(cov["matches_24h"], 1)
         self.assertEqual(cov["wanted_total"], 1)
         self.assertEqual(cov["wanted_searched_24h"], 1)
-        self.assertEqual(len(cov["match_rate_series_24h"]), 1)
-        self.assertEqual(cov["match_rate_series_24h"][0]["matches"], 1)
+        # Production zero-fills the series via generate_series — DENSE:
+        # always exactly 24 hourly / 28 daily buckets.
+        self.assertEqual(len(cov["match_rate_series_24h"]), 24)
+        self.assertEqual(len(cov["match_rate_series_28d"]), 28)
+        self.assertEqual(
+            sum(pt["matches"] for pt in cov["match_rate_series_24h"]), 1)
         # Heavy-query panel surfaces the browse-heavy row.
         heavy = payload["peers"]["heavy_queries"]
         self.assertEqual(len(heavy), 1)
@@ -4986,6 +4990,71 @@ class TestFakeDashboardMirror(unittest.TestCase):
         self.assertEqual(payload["searches"]["windows"][0]["searches"], 0)
         self.assertEqual(payload["coverage"]["wanted_total"], 0)
         self.assertEqual(payload["peers"]["heavy_queries"], [])
+        # Dense zero-filled series even with zero telemetry.
+        self.assertEqual(
+            len(payload["coverage"]["match_rate_series_24h"]), 24)
+        self.assertEqual(
+            len(payload["coverage"]["match_rate_series_28d"]), 28)
+        # Never null — production emits 0 when there are no searches.
+        self.assertEqual(payload["coverage"]["top_10_share_24h"], 0)
+
+    def test_cycle_rows_use_production_serializer_keys(self):
+        """recent/outliers rows carry the renamed watchdog_kills key and
+        NOT the raw cycle_metrics column names production never emits."""
+        db = self._seeded_db()
+        payload = db.get_pipeline_dashboard_metrics()
+        recent = payload["cycles"]["recent"]
+        self.assertEqual(len(recent), 1)
+        row = recent[0]
+        self.assertIn("watchdog_kills", row)
+        self.assertNotIn("cycle_searches_watchdog_killed", row)
+        self.assertNotIn("cache_pos_hits", row)
+        self.assertNotIn("wanted_total", row)
+        self.assertIsInstance(row["created_at"], str)
+
+    def test_exhausted_outcome_counts_as_reset_in_suspects(self):
+        """Production's reset_24h counts the HISTORICAL ``exhausted``
+        outcome; problem_24h is restricted to timeout/error/empty_query."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        db.log_search(1, query="q", outcome="exhausted")
+        db.log_search(1, query="q", outcome="timeout")
+        db.log_search(1, query="q", outcome="some_unknown_outcome")
+        payload = db.get_pipeline_dashboard_metrics()
+        suspects = payload["coverage"]["top_loop_suspects"]
+        self.assertEqual(len(suspects), 1)
+        self.assertEqual(suspects[0]["reset_24h"], 1)
+        self.assertEqual(suspects[0]["problem_24h"], 1)
+
+    def test_stale_wanted_includes_recently_searched_and_caps_at_12(self):
+        """Production's stale panel is the 12 oldest-searched backlog
+        rows ordered last_search_at ASC NULLS FIRST — recently-searched
+        rows are included, never-searched rows sort first."""
+        db = FakePipelineDB()
+        for rid in range(1, 15):
+            db.seed_request(make_request_row(id=rid, status="wanted"))
+        db.log_search(1, query="q", outcome="no_match")  # searched 1h ago
+        payload = db.get_pipeline_dashboard_metrics()
+        stale = payload["coverage"]["stale_wanted"]
+        self.assertEqual(len(stale), 12)
+        # Never-searched rows lead; the searched row sorts last and IS
+        # eligible (it would be excluded only by the LIMIT, with 14
+        # backlog rows it falls off the end).
+        self.assertIsNone(stale[0]["last_search_at"])
+        self.assertNotIn(1, [r["request_id"] for r in stale])
+
+    def test_heavy_queries_lazy_only_rows_qualify(self):
+        """The filter is (peers_browsed + peers_browsed_lazy) > 0 — a
+        lazy-only browse row qualifies; result_count coerces to int."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        db.log_search(1, query="lazy", outcome="no_match",
+                      peers_browsed_lazy=7)
+        payload = db.get_pipeline_dashboard_metrics()
+        heavy = payload["peers"]["heavy_queries"]
+        self.assertEqual(len(heavy), 1)
+        self.assertEqual(heavy[0]["peer_dirs"], 7)
+        self.assertEqual(heavy[0]["result_count"], 0)
 
 
 class TestFakeCursor(unittest.TestCase):

--- a/tests/test_force_import.py
+++ b/tests/test_force_import.py
@@ -17,9 +17,9 @@ from unittest.mock import patch, MagicMock
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "harness"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "harness"))
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -12,7 +12,7 @@ import unittest
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 import psycopg2  # noqa: E402
 

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -77,6 +77,17 @@ class TestSysPathAudit(unittest.TestCase):
     _FRONT_INSERT_RE = __import__("re").compile(
         r"sys\.path\.insert\(\s*\d+\s*,\s*"
         r"((?:os\.path\.dirname\(\s*)+)(?:os\.path\.abspath\(\s*)?__file__")
+    # Front-inserts of repo source dirs (lib/, web/, scripts/) shadow
+    # same-named top-level packages — lib/beets.py out-ranks the real
+    # ``beets`` package (the issue #95 dual-load footgun conftest.py
+    # documents). tests/web/_harness.py is the one DELIBERATE exception:
+    # it reproduces production's PYTHONPATH ambiguity on purpose (see
+    # TestPipelineRouteDirectEquivalence) and protects itself by eagerly
+    # importing the real ``beets`` first.
+    _SOURCE_DIR_INSERT_RE = __import__("re").compile(
+        r'sys\.path\.insert\(\s*\d+\s*,\s*os\.path\.join\('
+        r'os\.path\.dirname\(__file__\),\s*"\.\."(?:,\s*"\.\.")?,'
+        r'\s*"(?:lib|web|scripts|harness)"\)')
 
     def test_no_front_inserts_of_test_dirs(self) -> None:
         offenders: list[str] = []
@@ -92,6 +103,12 @@ class TestSysPathAudit(unittest.TestCase):
                     continue  # mentions the pattern in its own source
                 with open(path, encoding="utf-8") as f:
                     for lineno, line in enumerate(f, 1):
+                        if (self._SOURCE_DIR_INSERT_RE.search(line)
+                                and rel != os.path.join(
+                                    "web", "_harness.py")):
+                            offenders.append(
+                                f"  - {rel}:{lineno} (source-dir insert)")
+                            continue
                         m = self._FRONT_INSERT_RE.search(line)
                         if not m:
                             continue

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 from tests.helpers import make_album_quality_evidence
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -7930,5 +7930,84 @@ class TestGetByStatusRecentWindow(unittest.TestCase):
         self.assertEqual(len(rows), 1)
 
 
+@requires_postgres
+class TestDashboardFakeParity(unittest.TestCase):
+    """Structural parity gate: FakePipelineDB's dashboard mirror vs the
+    real PostgreSQL read-model on identically-seeded telemetry.
+
+    The fake's get_pipeline_dashboard_metrics is a ~300-line Python
+    mirror of ~700 lines of SQL; this test makes drift mechanical
+    instead of review-archaeological. Both sides are seeded through the
+    SAME writer calls, then the payloads are compared as SHAPES —
+    recursive dict key sets, list lengths, first-element shapes, and
+    leaf type categories (null / bool / num / str). Values are not
+    compared (timestamps and rates are time-anchored); a key rename, a
+    dropped panel, a sparse-vs-dense series, or a None-vs-0 leaf all
+    fail loudly.
+    """
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    @staticmethod
+    def _seed(db: Any) -> None:
+        rid = db.add_request(
+            "Parity Artist", "Parity Album", "request",
+            mb_release_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        )
+        db.log_search(
+            rid, query="found q", outcome="found", result_count=5,
+            elapsed_s=2.0, variant="v1", final_state="Completed",
+            browse_time_s=42.0, match_time_s=1.0, peers_browsed=110,
+            peers_browsed_lazy=5, fanout_waves=6,
+        )
+        db.log_search(rid, query="loop", outcome="no_match", elapsed_s=1.0)
+        db.log_search(rid, query="old style", outcome="exhausted")
+        db.record_cycle_metrics(
+            cycle_total_s=300.0, browse_time_s=20.0, match_time_s=10.0,
+            search_time_s=240.0, peers_browsed=8, fanout_waves=2,
+            find_download_queued=4, find_download_completed=4,
+            wanted_total=10,
+        )
+        db.record_peer_observations(["peer-a", "peer-b"])
+
+    @classmethod
+    def _shape(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {k: cls._shape(v) for k, v in sorted(value.items())}
+        if isinstance(value, list):
+            head = cls._shape(value[0]) if value else None
+            return ("list", len(value), head)
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "bool"
+        if isinstance(value, (int, float)):
+            return "num"
+        if isinstance(value, str):
+            return "str"
+        return type(value).__name__
+
+    def test_fake_dashboard_shape_matches_real_pg(self):
+        from tests.fakes import FakePipelineDB
+        self._seed(self.db)
+        fake = FakePipelineDB()
+        self._seed(fake)
+
+        real_shape = self._shape(self.db.get_pipeline_dashboard_metrics())
+        fake_shape = self._shape(fake.get_pipeline_dashboard_metrics())
+
+        self.assertEqual(
+            real_shape, fake_shape,
+            "FakePipelineDB's dashboard mirror drifted from the real "
+            "PostgreSQL read-model — fix the fake (tests/fakes.py), "
+            "never the production SQL, unless the SQL change is the "
+            "point of your PR.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spectral_check.py
+++ b/tests/test_spectral_check.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 
 class TestParseRmsFromStat(unittest.TestCase):

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -23,7 +23,7 @@ import unittest
 from typing import Any
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "web"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -174,10 +174,15 @@ class _FakeDbWebServerCase(_WebServerCase):
 
     db: FakePipelineDB
 
+    #: Override in subclasses that need a typed failure-injecting
+    #: FakePipelineDB subclass (e.g. raising connection errors from a
+    #: specific method) — still a stateful fake, never a MagicMock.
+    DB_FACTORY: type[FakePipelineDB] = FakePipelineDB
+
     def setUp(self) -> None:
         super().setUp()
         import web.server as srv
-        self.db = FakePipelineDB()
+        self.db = self.DB_FACTORY()
         patcher = patch.object(srv, "db", self.db)
         patcher.start()
         self.addCleanup(patcher.stop)

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -5,7 +5,6 @@ Split from tests/test_web_server.py (#408). Shared harness in
 tests/web/_harness.py.
 """
 
-import copy
 from datetime import datetime, timezone
 import os
 import sys
@@ -18,17 +17,15 @@ import msgspec
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import (
-    _MOCK_PIPELINE_REQUEST,
     _assert_required_fields,
-    _WebServerCase,
+    _FakeDbWebServerCase,
     _fresh_triage_runner,
 )
 
-from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
 
-class TestPipelineRouteContracts(_WebServerCase):
+class TestPipelineRouteContracts(_FakeDbWebServerCase):
     """Contract tests for frontend-consumed pipeline GET routes."""
 
     PIPELINE_ITEM_REQUIRED_FIELDS = {
@@ -198,22 +195,26 @@ class TestPipelineRouteContracts(_WebServerCase):
     }
 
     def setUp(self) -> None:
-        self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
-        self.mock_db.get_tracks.return_value = [
-            {"disc_number": 1, "track_number": 1, "title": "Track", "length_seconds": 180},
-        ]
-        self.mock_db.get_wanted.return_value = [
-            make_request_row(id=101, status="wanted", source="request"),
-        ]
-        self.mock_db.count_by_status.return_value = {
-            "wanted": 1, "downloading": 0, "imported": 1, "manual": 0,
-        }
-        self.mock_db.get_by_status.side_effect = None
-        self.mock_db.get_by_status.return_value = []
-        self.mock_db.get_download_history_batch.return_value = {}
-        self.mock_db.get_latest_download_summaries.return_value = {}
-        self.mock_db.get_recent.return_value = []
-        self.mock_db.get_track_counts.return_value = {}
+        super().setUp()
+        # The detail/log fixtures: one imported request with a track and
+        # a real success download row, plus one wanted request.
+        self.db.seed_request(make_request_row(
+            id=100, status="imported", min_bitrate=320,
+            imported_path="/mnt/virtio/Music/Beets/Test",
+        ))
+        self.db.set_tracks(100, [
+            {"disc_number": 1, "track_number": 1, "title": "Track",
+             "length_seconds": 180},
+        ])
+        self.db.log_download(
+            100, outcome="success", beets_scenario="strong_match",
+            beets_distance=0.012, soulseek_username="testuser",
+            filetype="mp3", bitrate=320000, actual_filetype="mp3",
+            actual_min_bitrate=320, valid=True,
+        )
+        self.db.seed_request(make_request_row(
+            id=101, status="wanted", source="request",
+        ))
 
     def test_pipeline_log_contract(self):
         status, data = self._get("/api/pipeline/log")
@@ -237,8 +238,7 @@ class TestPipelineRouteContracts(_WebServerCase):
         from tests.fakes import FakeBeetsDB
         import web.server as srv
 
-        fake = self.mock_db._fake
-        fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=9001, status="wanted", mb_release_id="disk-missing-mbid",
             artist_name="Missing Artist", album_title="Missing Album",
         ))
@@ -282,16 +282,10 @@ class TestPipelineRouteContracts(_WebServerCase):
             "disk coverage inverse row")
 
     def test_pipeline_log_surfaces_wrong_match_triage_audit(self):
-        original_log = copy.deepcopy(self.mock_db.get_log.return_value)
-        row = copy.deepcopy(self.mock_db.get_log.return_value[0])
-        row.update({
-            "outcome": "rejected",
-            "beets_scenario": "high_distance",
-            "beets_distance": 0.190,
-            "soulseek_username": "moundsofass",
-            "album_title": "For Screening Purposes Only",
-            "artist_name": "Test Icicles",
-            "validation_result": {
+        self.db.log_download(
+            100, outcome="rejected", beets_scenario="high_distance",
+            beets_distance=0.190, soulseek_username="moundsofass",
+            validation_result={
                 "scenario": "wrong_match",
                 "wrong_match_triage": {
                     "action": "deleted_reject",
@@ -301,13 +295,9 @@ class TestPipelineRouteContracts(_WebServerCase):
                     "stage_chain": ["mp3_spectral:reject"],
                 },
             },
-        })
-        self.mock_db.get_log.return_value = [row]
+        )
 
-        try:
-            status, data = self._get("/api/pipeline/log")
-        finally:
-            self.mock_db.get_log.return_value = original_log
+        status, data = self._get("/api/pipeline/log")
 
         self.assertEqual(status, 200)
         item = data["log"][0]
@@ -328,9 +318,8 @@ class TestPipelineRouteContracts(_WebServerCase):
                                 "pipeline status wanted item")
 
     def test_pipeline_all_contract(self):
-        row = make_request_row(id=201, status="wanted", album_title="Wanted Album")
-        self.mock_db.get_by_status.side_effect = (
-            lambda s, **kw: [row] if s == "wanted" else [])
+        self.db.seed_request(make_request_row(
+            id=201, status="wanted", album_title="Wanted Album"))
 
         status, data = self._get("/api/pipeline/all")
 
@@ -344,36 +333,36 @@ class TestPipelineRouteContracts(_WebServerCase):
     def test_pipeline_all_imported_is_a_recency_window(self):
         """#426: the imported bucket is capped (newest first) and the
         payload flags the truncation so the UI can say so."""
+        from datetime import timedelta
         from web.routes.pipeline import IMPORTED_RECENT_LIMIT
-        row = make_request_row(id=301, status="imported",
-                               album_title="Imported Album")
-        calls = []
-
-        def _by_status(s, **kw):
-            calls.append((s, kw))
-            return [row] if s == "imported" else []
-
-        self.mock_db.get_by_status.side_effect = _by_status
-        self.mock_db.count_by_status.return_value = {
-            "wanted": 0, "imported": IMPORTED_RECENT_LIMIT + 50, "manual": 0,
-        }
+        # setUp already seeded one imported row (id=100); add enough to
+        # exceed the cap by 10. Stagger updated_at so newest-first
+        # ordering is observable.
+        base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        for i in range(IMPORTED_RECENT_LIMIT + 10):
+            self.db.seed_request(make_request_row(
+                id=1000 + i, status="imported",
+                album_title=f"Imported {i}",
+                updated_at=base + timedelta(minutes=i),
+            ))
 
         status, data = self._get("/api/pipeline/all")
 
         self.assertEqual(status, 200)
-        self.assertEqual(data["imported_total"], IMPORTED_RECENT_LIMIT + 50)
+        self.assertEqual(data["imported_total"], IMPORTED_RECENT_LIMIT + 11)
         self.assertTrue(data["imported_truncated"])
-        imported_call = next(c for c in calls if c[0] == "imported")
-        self.assertEqual(imported_call[1],
-                         {"limit": IMPORTED_RECENT_LIMIT, "newest_first": True})
+        # The bucket is capped at the limit, newest first.
+        self.assertEqual(len(data["imported"]), IMPORTED_RECENT_LIMIT)
+        self.assertEqual(data["imported"][0]["album_title"],
+                         f"Imported {IMPORTED_RECENT_LIMIT + 9}")
 
     SEARCH_REQUIRED_FIELDS = {"query", "items", "total"}
 
     def test_pipeline_search_contract(self):
-        row = make_request_row(id=401, status="imported",
-                               artist_name="The Mountain Goats",
-                               album_title="Tallahassee")
-        self.mock_db.search_requests.return_value = [row]
+        self.db.seed_request(make_request_row(
+            id=401, status="imported",
+            artist_name="The Mountain Goats",
+            album_title="Tallahassee"))
 
         status, data = self._get("/api/pipeline/search?q=mountain")
 
@@ -387,12 +376,50 @@ class TestPipelineRouteContracts(_WebServerCase):
                                 "pipeline search item")
 
     def test_pipeline_search_blank_query_is_empty(self):
-        self.mock_db.search_requests.return_value = []
         status, data = self._get("/api/pipeline/search")
         self.assertEqual(status, 200)
         self.assertEqual(data["items"], [])
 
+    def _seed_dashboard_telemetry(self) -> None:
+        """Real telemetry rows for every [0]-indexed dashboard assertion:
+        cycle metrics (windows + wanted-trend samples), found/loop search
+        logs (match-rate series, heavy queries, loop suspects), and peer
+        observations (totals + days)."""
+        from datetime import timedelta
+        base = datetime.now(timezone.utc)
+        self.db.record_cycle_metrics(
+            cycle_total_s=300.0, browse_time_s=20.0, match_time_s=10.0,
+            search_time_s=240.0, peers_browsed=8, fanout_waves=2,
+            find_download_queued=4, find_download_completed=4,
+            completed_at=base - timedelta(hours=2), wanted_total=12,
+        )
+        self.db.record_cycle_metrics(
+            cycle_total_s=320.0, browse_time_s=22.0, match_time_s=11.0,
+            search_time_s=250.0, peers_browsed=9, fanout_waves=3,
+            find_download_queued=3, find_download_completed=3,
+            completed_at=base - timedelta(minutes=5), wanted_total=10,
+        )
+        # One found search (match-rate series) + enough no_match rows on
+        # the wanted request to register as a loop suspect, with browse
+        # telemetry so the heavy-queries panel has a row.
+        self.db.log_search(
+            101, query="found query", outcome="found", result_count=5,
+            elapsed_s=2.0, variant="v1", final_state="Completed",
+            browse_time_s=42.0, match_time_s=1.0, peers_browsed=110,
+            peers_browsed_lazy=5, fanout_waves=6,
+        )
+        for i in range(4):
+            self.db.log_search(
+                101, query=f"loop {i}", outcome="no_match",
+                result_count=500, elapsed_s=12.0, variant="track_0",
+                final_state="Completed", browse_time_s=42.0,
+                match_time_s=1.0, peers_browsed=110, peers_browsed_lazy=5,
+                fanout_waves=6,
+            )
+        self.db.record_peer_observations(["peer-a", "peer-b", "peer-c"])
+
     def test_pipeline_dashboard_contract(self):
+        self._seed_dashboard_telemetry()
         status, data = self._get("/api/pipeline/dashboard")
 
         self.assertEqual(status, 200)
@@ -521,7 +548,8 @@ class TestPipelineRouteContracts(_WebServerCase):
         """When the latest search_log row has candidates, the route emits the
         full slice (up to 20) by (matched_tracks DESC, avg_ratio DESC) via
         msgspec.to_builtins."""
-        candidates_blob = [
+        from lib.quality import CandidateScore
+        candidates_blob = msgspec.convert([
             {"username": "u1", "dir": "A", "filetype": "flac",
              "matched_tracks": 26, "total_tracks": 26, "avg_ratio": 0.95,
              "missing_titles": [], "file_count": 26},
@@ -534,19 +562,14 @@ class TestPipelineRouteContracts(_WebServerCase):
             {"username": "u4", "dir": "D", "filetype": "flac",
              "matched_tracks": 20, "total_tracks": 26, "avg_ratio": 0.99,
              "missing_titles": ["a", "b"], "file_count": 20},
-        ]
-        self.mock_db.get_search_history.return_value = [{
-            "id": 99, "request_id": 100, "query": "*rtist Album",
-            "result_count": 100, "elapsed_s": 1.2, "outcome": "no_match",
-            "created_at": "2026-04-29T00:00:00+00:00",
-            "candidates": candidates_blob,
-            "variant": "v3_artist_only", "final_state": "Completed",
-        }]
+        ], type=list[CandidateScore])
+        self.db.log_search(
+            100, query="*rtist Album", result_count=100, elapsed_s=1.2,
+            outcome="no_match", candidates=candidates_blob,
+            variant="v3_artist_only", final_state="Completed",
+        )
 
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_search_history.return_value = []
+        status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
         last = data["last_search"]
@@ -568,24 +591,20 @@ class TestPipelineRouteContracts(_WebServerCase):
     def test_pipeline_detail_caps_top_candidates_at_twenty(self):
         """U2: the peers panel widened from 3 to the full stored cap (20). A
         search row with >20 candidates surfaces exactly 20, still ranked."""
-        blob = [
+        from lib.quality import CandidateScore
+        blob = msgspec.convert([
             {"username": f"u{i:02d}", "dir": f"D{i}", "filetype": "flac",
              "matched_tracks": 26, "total_tracks": 26,
              "avg_ratio": 1.0 - i / 100.0,
              "missing_titles": [], "file_count": 26}
             for i in range(25)
-        ]
-        self.mock_db.get_search_history.return_value = [{
-            "id": 99, "request_id": 100, "query": "q",
-            "result_count": 100, "elapsed_s": 1.0, "outcome": "no_match",
-            "created_at": "2026-04-29T00:00:00+00:00",
-            "candidates": blob,
-            "variant": "v3_artist_only", "final_state": "Completed",
-        }]
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_search_history.return_value = []
+        ], type=list[CandidateScore])
+        self.db.log_search(
+            100, query="q", result_count=100, elapsed_s=1.0,
+            outcome="no_match", candidates=blob,
+            variant="v3_artist_only", final_state="Completed",
+        )
+        status, data = self._get("/api/pipeline/100")
         self.assertEqual(status, 200)
         top = data["last_search"]["top_candidates"]
         self.assertEqual(len(top), 20)
@@ -595,16 +614,12 @@ class TestPipelineRouteContracts(_WebServerCase):
 
     def test_pipeline_detail_handles_null_candidates_gracefully(self):
         """Historical search_log row with NULL candidates → top_candidates=[]."""
-        self.mock_db.get_search_history.return_value = [{
-            "id": 1, "request_id": 100, "query": "q",
-            "result_count": None, "elapsed_s": None, "outcome": "timeout",
-            "created_at": "2026-04-29T00:00:00+00:00",
-            "candidates": None, "variant": None, "final_state": None,
-        }]
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_search_history.return_value = []
+        self.db.log_search(
+            100, query="q", result_count=None, elapsed_s=None,
+            outcome="timeout", candidates=None,
+            variant=None, final_state=None,
+        )
+        status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
         self.assertIsNotNone(data["last_search"])
@@ -613,17 +628,12 @@ class TestPipelineRouteContracts(_WebServerCase):
 
     def test_pipeline_detail_handles_empty_candidates_list(self):
         """Latest search row with an empty candidates list → top_candidates=[]."""
-        self.mock_db.get_search_history.return_value = [{
-            "id": 1, "request_id": 100, "query": "q",
-            "result_count": 0, "elapsed_s": 0.5, "outcome": "no_results",
-            "created_at": "2026-04-29T00:00:00+00:00",
-            "candidates": [], "variant": "v2_artist_album_no_year",
-            "final_state": "Completed",
-        }]
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_search_history.return_value = []
+        self.db.log_search(
+            100, query="q", result_count=0, elapsed_s=0.5,
+            outcome="no_results", candidates=[],
+            variant="v2_artist_album_no_year", final_state="Completed",
+        )
+        status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
         self.assertEqual(data["last_search"]["top_candidates"], [])
@@ -637,18 +647,17 @@ class TestPipelineRouteContracts(_WebServerCase):
         try/except msgspec.ValidationError; the web route must do the same so
         a corrupt row does not 500 the detail page.
         """
-        self.mock_db.get_search_history.return_value = [{
-            "id": 7, "request_id": 100, "query": "q",
-            "result_count": 5, "elapsed_s": 0.5, "outcome": "no_match",
-            "created_at": "2026-04-29T00:00:00+00:00",
-            # Wrong shape — missing every required CandidateScore field.
-            "candidates": [{"foo": "bar"}],
-            "variant": "v2_artist_album_no_year", "final_state": "Completed",
-        }]
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_search_history.return_value = []
+        import json as _json
+        self.db.log_search(
+            100, query="q", result_count=5, elapsed_s=0.5,
+            outcome="no_match", candidates=[],
+            variant="v2_artist_album_no_year", final_state="Completed",
+        )
+        # Corrupt the stored JSONB in place — historical rows whose
+        # shape predates CandidateScore. The fake stores the encoded
+        # JSON string exactly like the real column.
+        self.db.search_logs[-1].candidates = _json.dumps([{"foo": "bar"}])
+        status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
         self.assertIsNotNone(data["last_search"])
@@ -658,26 +667,18 @@ class TestPipelineRouteContracts(_WebServerCase):
 
     def test_pipeline_detail_surfaces_manual_reason(self):
         """manual_reason='search_exhausted' is exposed on the detail response."""
-        row = copy.deepcopy(_MOCK_PIPELINE_REQUEST)
-        row["manual_reason"] = "search_exhausted"
-        row["status"] = "manual"
-        self.mock_db.get_request.return_value = row
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
+        self.db.update_request_fields(
+            100, status="manual", manual_reason="search_exhausted")
+        status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
         self.assertEqual(data["manual_reason"], "search_exhausted")
 
     def test_pipeline_detail_history_surfaces_wrong_match_triage_audit(self):
-        original_history = copy.deepcopy(self.mock_db.get_download_history.return_value)
-        row = copy.deepcopy(self.mock_db.get_download_history.return_value[0])
-        row.update({
-            "outcome": "rejected",
-            "beets_scenario": "high_distance",
-            "beets_distance": 0.190,
-            "validation_result": {
+        self.db.log_download(
+            100, outcome="rejected", beets_scenario="high_distance",
+            beets_distance=0.190,
+            validation_result={
                 "wrong_match_triage": {
                     "action": "deleted_reject",
                     "reason": "requeue_upgrade",
@@ -686,13 +687,8 @@ class TestPipelineRouteContracts(_WebServerCase):
                     "stage_chain": ["stage1_spectral:reject"],
                 },
             },
-        })
-        self.mock_db.get_download_history.return_value = [row]
-
-        try:
-            status, data = self._get("/api/pipeline/100")
-        finally:
-            self.mock_db.get_download_history.return_value = original_history
+        )
+        status, data = self._get("/api/pipeline/100")
 
         self.assertEqual(status, 200)
         item = data["history"][0]
@@ -704,11 +700,16 @@ class TestPipelineRouteContracts(_WebServerCase):
                          ["stage1_spectral:reject"])
 
     def test_pipeline_recent_contract(self):
-        row = make_request_row(id=202, status="imported", album_title="Recent Album")
-        history = copy.deepcopy(self.mock_db.get_download_history.return_value[0])
-        self.mock_db.get_recent.return_value = [row]
-        self.mock_db.get_track_counts.return_value = {202: 11}
-        self.mock_db.get_download_history_batch.return_value = {202: [history]}
+        self.db.seed_request(make_request_row(
+            id=202, status="imported", album_title="Recent Album"))
+        self.db.set_tracks(202, [
+            {"disc_number": 1, "track_number": n, "title": f"T{n}"}
+            for n in range(1, 12)
+        ])
+        self.db.log_download(
+            202, outcome="success", beets_scenario="strong_match",
+            beets_distance=0.01, soulseek_username="testuser",
+        )
 
         status, data = self._get("/api/pipeline/recent")
 
@@ -733,12 +734,13 @@ class TestPipelineRouteContracts(_WebServerCase):
         even if a shim would have returned 12 tracks (mocked here with
         ``create=True`` so the test is RED against the current code).
         """
-        row = make_request_row(
+        self.db.seed_request(make_request_row(
             id=303, status="imported", album_title="Recent Album",
-            mb_release_id="no-such-id-in-beets")
-        self.mock_db.get_recent.return_value = [row]
-        self.mock_db.get_track_counts.return_value = {303: 8}
-        self.mock_db.get_download_history_batch.return_value = {}
+            mb_release_id="no-such-id-in-beets"))
+        self.db.set_tracks(303, [
+            {"disc_number": 1, "track_number": n, "title": f"T{n}"}
+            for n in range(1, 9)
+        ])
 
         status, data = self._get("/api/pipeline/recent")
         self.assertEqual(status, 200)
@@ -837,7 +839,7 @@ class TestPipelineRouteContracts(_WebServerCase):
 
         runner.join(timeout=5)
         mock_cleanup.assert_called_once_with(
-            self.mock_db,
+            self.db,
             confirm_all_wrong_matches=True,
         )
 
@@ -912,7 +914,17 @@ class TestPipelineRouteContracts(_WebServerCase):
         self.assertIn("confirm_all_wrong_matches", data.get("message") or data.get("error") or "")
         mock_cleanup.assert_not_called()
 
+    def _enqueue_force_job(self) -> int:
+        job = self.db.enqueue_import_job(
+            "force_import", request_id=100,
+            dedupe_key="force_import:download_log:42",
+            payload={"failed_path": "/tmp/Test Album"},
+            message="Import queued",
+        )
+        return job.id
+
     def test_import_jobs_contract(self):
+        self._enqueue_force_job()
         status, data = self._get("/api/import-jobs")
 
         self.assertEqual(status, 200)
@@ -921,7 +933,8 @@ class TestPipelineRouteContracts(_WebServerCase):
                                 "import jobs item")
 
     def test_import_job_detail_contract(self):
-        status, data = self._get("/api/import-jobs/77")
+        job_id = self._enqueue_force_job()
+        status, data = self._get(f"/api/import-jobs/{job_id}")
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, {"job"}, "import job detail response")
@@ -929,6 +942,7 @@ class TestPipelineRouteContracts(_WebServerCase):
                                 "import job detail")
 
     def test_import_jobs_timeline_contract(self):
+        self._enqueue_force_job()
         status, data = self._get("/api/import-jobs/timeline")
 
         self.assertEqual(status, 200)
@@ -938,7 +952,9 @@ class TestPipelineRouteContracts(_WebServerCase):
                                 "import jobs timeline item")
         _assert_required_fields(self, data["jobs"][0], {"artist_name", "album_title"},
                                 "import jobs timeline identity")
-        self.mock_db.list_import_job_timeline.assert_called_once_with(limit=50)
+        # The identity join resolved through the seeded request row.
+        self.assertEqual(data["jobs"][0]["artist_name"],
+                         self.db.request(100)["artist_name"])
 
     def test_import_jobs_rejects_invalid_filters(self):
         status, data = self._get("/api/import-jobs?status=bad")
@@ -1040,7 +1056,7 @@ def _kwargs_to_query(kwargs: dict) -> str:
     return "&".join(parts)
 
 
-class TestPipelineRouteDirectEquivalence(_WebServerCase):
+class TestPipelineRouteDirectEquivalence(_FakeDbWebServerCase):
     """Every pure-function web route must return the same value as a
     direct call to the underlying library function with equivalent inputs.
 
@@ -1237,7 +1253,7 @@ class TestApplyPipelineBitrateOverride(unittest.TestCase):
         self.assertNotIn("upgrade_queued", album)
 
 
-class TestBeetsDistanceRouteContract(_WebServerCase):
+class TestBeetsDistanceRouteContract(_FakeDbWebServerCase):
     """Contract for ``GET /api/beets-distance/<download_log_id>/<mbid>``.
 
     Service-layer correctness is covered by ``tests.test_beets_distance``.
@@ -1278,7 +1294,7 @@ class TestBeetsDistanceRouteContract(_WebServerCase):
     UUID_B = "12345678-1234-1234-1234-123456789abc"
 
     def setUp(self) -> None:
-        self.mock_db.reset_mock()
+        super().setUp()
         from lib.beets_distance import BeetsDistanceResult
         self._Result = BeetsDistanceResult
 
@@ -1414,7 +1430,7 @@ class TestBeetsDistanceRouteContract(_WebServerCase):
         self.assertEqual(status, 404)
 
 
-class TestTriageRouteContracts(_WebServerCase):
+class TestTriageRouteContracts(_FakeDbWebServerCase):
     """U17 contracts for ``GET /api/triage/<id>`` and ``GET /api/triage/list``.
 
     Both endpoints wrap ``lib.triage_service`` (U15) — the same service
@@ -1425,8 +1441,8 @@ class TestTriageRouteContracts(_WebServerCase):
     ⇄ API surface symmetry).
 
     Tests drive the real ``compose_triage_for_request`` and
-    ``list_triage`` paths against a real :class:`FakePipelineDB`
-    (reached via ``self.mock_db._fake``) — no service-layer mocking,
+    ``list_triage`` paths against the per-test :class:`FakePipelineDB`
+    (``self.db``) — no service-layer mocking,
     per ``code-quality.md`` § MOCKS: LEAF-SEAM ONLY. Seeded rows use
     production-shape values: ``datetime.datetime`` for timestamps via
     ``make_request_row``'s defaults, real ``FieldResolutionRow`` /
@@ -1452,51 +1468,6 @@ class TestTriageRouteContracts(_WebServerCase):
 
     LIST_REQUIRED_FIELDS = {"results", "next_after", "page_size", "filter"}
 
-    # MagicMock attribute names whose pre-set ``.return_value`` /
-    # ``.side_effect`` from ``_make_server`` would short-circuit a call
-    # to the wrapped fake. We need the triage path to hit the fresh
-    # FakePipelineDB on every method ``compose_triage_for_request`` /
-    # ``list_triage`` touches, so each test resets the relevant child
-    # mocks to forwarding ``side_effect`` lambdas that call through to
-    # the fresh backing fake.
-    _TRIAGE_DB_METHODS = (
-        "get_request",
-        "list_triage_page",
-        "get_field_resolutions_for_requests",
-        "get_search_summaries_for_requests",
-        "get_recent_search_log_for_requests",
-    )
-
-    def setUp(self) -> None:
-        # Each test gets its own FakePipelineDB so seeded rows from one
-        # test never bleed into the next. Re-wrap the harness so the
-        # MagicMock layer keeps recording but `._fake` points at the
-        # fresh fake.
-        fresh = FakePipelineDB()
-        self._old_backing = self.mock_db._fake
-        self.mock_db._mock_wraps = fresh
-        self.mock_db._fake = fresh
-        # Snapshot the pre-existing child-mock state for the methods
-        # the triage service touches, then force them to forward to the
-        # fresh fake. Without this, _make_server's static
-        # ``mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST``
-        # would short-circuit every composed triage to request_id=100.
-        self._triage_method_state: dict[str, MagicMock] = {}
-        for name in self._TRIAGE_DB_METHODS:
-            self._triage_method_state[name] = getattr(self.mock_db, name)
-            forwarder = MagicMock(side_effect=getattr(fresh, name))
-            setattr(self.mock_db, name, forwarder)
-
-    def tearDown(self) -> None:
-        for name, prev in self._triage_method_state.items():
-            setattr(self.mock_db, name, prev)
-        self.mock_db._mock_wraps = self._old_backing
-        self.mock_db._fake = self._old_backing
-
-    @property
-    def _fake(self) -> "FakePipelineDB":
-        return self.mock_db._fake
-
     # --- /api/triage/<id> -------------------------------------------------
 
     def test_show_returns_200_with_required_fields_and_roundtrips(self):
@@ -1505,7 +1476,7 @@ class TestTriageRouteContracts(_WebServerCase):
         through ``msgspec.convert(payload, type=TriageResult)`` — the
         wire-boundary contract per CLI ⇄ API symmetry."""
         from lib.triage_service import TriageResult
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=4242,
             artist_name="Triage Artist",
             album_title="Triage Album",
@@ -1562,14 +1533,14 @@ class TestTriageRouteContracts(_WebServerCase):
         """A seeded unfindable request shows up under
         ``filter=unfindable`` with the documented envelope shape."""
         from lib.triage_service import TriageResult
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=10, artist_name="Stuck Artist",
             unfindable_category="artist_absent",
             unfindable_categorised_at=datetime(2026, 5, 20, tzinfo=timezone.utc),
         ))
         # Decoy row without any unfindable signal — must NOT appear in
         # the filtered cohort.
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=11, artist_name="Healthy Artist", status="imported",
         ))
 
@@ -1597,15 +1568,15 @@ class TestTriageRouteContracts(_WebServerCase):
         actually writes."""
         # Seeded request A: has a release_group_year resolution in the
         # sticky 4xx-client bucket — matches.
-        self._fake.seed_request(make_request_row(id=20))
-        self._fake.record_field_resolution(
+        self.db.seed_request(make_request_row(id=20))
+        self.db.record_field_resolution(
             request_id=20, field_name="release_group_year",
             status="unresolved_4xx_client", reason_code="http_400",
         )
         # Seeded request B: has a field resolution but a different
         # status bucket — must NOT appear.
-        self._fake.seed_request(make_request_row(id=21))
-        self._fake.record_field_resolution(
+        self.db.seed_request(make_request_row(id=21))
+        self.db.record_field_resolution(
             request_id=21, field_name="catalog_number",
             status="unresolved_mirror_unavailable",
             reason_code="ConnectionError",
@@ -1627,14 +1598,14 @@ class TestTriageRouteContracts(_WebServerCase):
         ``reason_code`` column (HTTP code specifier — http_400,
         http_410, http_422, etc.)."""
         # Seeded request A: 4xx-client status, reason_code=http_400 — matches.
-        self._fake.seed_request(make_request_row(id=22))
-        self._fake.record_field_resolution(
+        self.db.seed_request(make_request_row(id=22))
+        self.db.record_field_resolution(
             request_id=22, field_name="release_group_year",
             status="unresolved_4xx_client", reason_code="http_400",
         )
         # Seeded request B: 4xx-client status but reason_code=http_410 — excluded.
-        self._fake.seed_request(make_request_row(id=23))
-        self._fake.record_field_resolution(
+        self.db.seed_request(make_request_row(id=23))
+        self.db.record_field_resolution(
             request_id=23, field_name="catalog_number",
             status="unresolved_4xx_client", reason_code="http_410",
         )
@@ -1668,7 +1639,7 @@ class TestTriageRouteContracts(_WebServerCase):
         """When the page is exactly ``limit`` long the response carries
         ``next_after`` = last request_id so the operator can paginate."""
         for rid in (30, 31, 32):
-            self._fake.seed_request(make_request_row(
+            self.db.seed_request(make_request_row(
                 id=rid, status="imported",
             ))
 
@@ -1684,7 +1655,7 @@ class TestTriageRouteContracts(_WebServerCase):
     def test_list_default_filter_when_query_string_omitted(self):
         """Missing ``filter=`` defaults to ``all`` so a bare hit on
         ``/api/triage/list`` is meaningful."""
-        self._fake.seed_request(make_request_row(id=40, status="imported"))
+        self.db.seed_request(make_request_row(id=40, status="imported"))
 
         status, data = self._get("/api/triage/list")
 
@@ -1709,7 +1680,7 @@ class TestTriageRouteContracts(_WebServerCase):
         self.assertIn("error", data)
 
 
-class TestLongTailRouteContracts(_WebServerCase):
+class TestLongTailRouteContracts(_FakeDbWebServerCase):
     """U1 contract for ``GET /api/pipeline/long-tail``.
 
     Wraps ``lib.long_tail_service.list_long_tail`` — the same service
@@ -1734,41 +1705,15 @@ class TestLongTailRouteContracts(_WebServerCase):
     }
     ENVELOPE_REQUIRED_FIELDS = {"results", "band", "count"}
 
-    _LONG_TAIL_DB_METHODS = (
-        "get_long_tail_cohort",
-        "get_long_tail_request",
-    )
-
-    def setUp(self) -> None:
-        fresh = FakePipelineDB()
-        self._old_backing = self.mock_db._fake
-        self.mock_db._mock_wraps = fresh
-        self.mock_db._fake = fresh
-        self._lt_method_state: dict[str, MagicMock] = {}
-        for name in self._LONG_TAIL_DB_METHODS:
-            self._lt_method_state[name] = getattr(self.mock_db, name)
-            forwarder = MagicMock(side_effect=getattr(fresh, name))
-            setattr(self.mock_db, name, forwarder)
-
-    def tearDown(self) -> None:
-        for name, prev in self._lt_method_state.items():
-            setattr(self.mock_db, name, prev)
-        self.mock_db._mock_wraps = self._old_backing
-        self.mock_db._fake = self._old_backing
-
-    @property
-    def _fake(self) -> "FakePipelineDB":
-        return self.mock_db._fake
-
     def test_missing_row_bands_missing_and_imported_absent(self):
         """AE1 at the HTTP boundary: a wanted row with no beets album
         bands ``missing``; an imported request is absent from the
         result. (No beets configured → everything Missing.)"""
         from lib.long_tail_service import LongTailRow
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1",
             artist_name="Vanishing", album_title="Lost"))
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=2, status="imported", mb_release_id="rel-2"))
 
         status, data = self._get("/api/pipeline/long-tail")
@@ -1794,7 +1739,7 @@ class TestLongTailRouteContracts(_WebServerCase):
         seam is patched to report the release in-library with a
         lossless detail row."""
         import web.server as srv
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1"))
 
         mock_beets = MagicMock()
@@ -1814,7 +1759,7 @@ class TestLongTailRouteContracts(_WebServerCase):
     def test_unknown_band_when_in_library_but_unrankable(self):
         """In-library but no detail / unrankable → ``unknown``, not
         ``missing``."""
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1"))
 
         mock_beets = MagicMock()
@@ -1828,9 +1773,9 @@ class TestLongTailRouteContracts(_WebServerCase):
         self.assertEqual(data["results"][0]["band"], "unknown")
 
     def test_in_flight_rescue_stamped(self):
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1"))
-        self._fake.insert_youtube_running(
+        self.db.insert_youtube_running(
             request_id=1, browse_id="MPREb_z", audio_playlist_id=None,
             yt_url="https://music.youtube.com/playlist?list=z",
             expected_track_count=10,
@@ -1840,9 +1785,9 @@ class TestLongTailRouteContracts(_WebServerCase):
         self.assertTrue(data["results"][0]["in_flight_rescue"])
 
     def test_band_filter_narrows_result(self):
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1"))
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=2, status="wanted", mb_release_id="rel-2"))
         # No beets → both Missing.
         status, data = self._get("/api/pipeline/long-tail?band=missing")
@@ -1863,7 +1808,7 @@ class TestLongTailRouteContracts(_WebServerCase):
     def test_single_id_returns_one_banded_row(self):
         """KTD8: ``?id=`` returns just that request's authoritative band."""
         from lib.long_tail_service import LongTailRow
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id="rel-42",
             artist_name="One", album_title="Row"))
         status, data = self._get("/api/pipeline/long-tail?id=42")
@@ -1876,7 +1821,7 @@ class TestLongTailRouteContracts(_WebServerCase):
         self.assertEqual(row.band, "missing")
 
     def test_single_id_404_when_not_wanted(self):
-        self._fake.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id="rel-42"))
         status, data = self._get("/api/pipeline/long-tail?id=42")
         self.assertEqual(status, 404)

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -915,9 +915,14 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         mock_cleanup.assert_not_called()
 
     def _enqueue_force_job(self) -> int:
+        from lib.import_queue import force_import_dedupe_key
+        log_id = self.db.log_download(
+            100, outcome="rejected", soulseek_username="baduser",
+            validation_result={"failed_path": "/tmp/Test Album"},
+        )
         job = self.db.enqueue_import_job(
             "force_import", request_id=100,
-            dedupe_key="force_import:download_log:42",
+            dedupe_key=force_import_dedupe_key(log_id),
             payload={"failed_path": "/tmp/Test Album"},
             message="Import queued",
         )
@@ -955,6 +960,18 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         # The identity join resolved through the seeded request row.
         self.assertEqual(data["jobs"][0]["artist_name"],
                          self.db.request(100)["artist_name"])
+
+    def test_import_jobs_timeline_caps_at_50(self):
+        """The route hardcodes limit=50 — seed 51 jobs, count the page."""
+        for i in range(51):
+            self.db.enqueue_import_job(
+                "force_import", request_id=100,
+                dedupe_key=f"force_import:download_log:{i}",
+                payload={"failed_path": f"/tmp/a{i}"},
+            )
+        status, data = self._get("/api/import-jobs/timeline")
+        self.assertEqual(status, 200)
+        self.assertEqual(len(data["jobs"]), 50)
 
     def test_import_jobs_rejects_invalid_filters(self):
         status, data = self._get("/api/import-jobs?status=bad")

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -106,6 +106,10 @@ class TestServerEndpoints(_FakeDbWebServerCase):
         status, data = self._get("/api/pipeline/log?limit=5000")
         self.assertEqual(status, 200)
         self.assertEqual(len(data["log"]), 500)
+        # And the no-param default is 50 — same seeded rows.
+        status, data = self._get("/api/pipeline/log")
+        self.assertEqual(status, 200)
+        self.assertEqual(len(data["log"]), 50)
 
     def test_pipeline_log_filter_invalid_ignored(self):
         self.db.log_download(100, outcome="rejected",
@@ -117,7 +121,7 @@ class TestServerEndpoints(_FakeDbWebServerCase):
             {e["outcome"] for e in data["log"]}, {"success", "rejected"})
 
     def test_pipeline_log_counts_structure(self):
-        self._queue_log_counts(total=5, imported=2,
+        self._queue_log_counts(total=7, imported=2,
                                matches_24h=3, matches_6h=1)
         status, data = self._get("/api/pipeline/log")
         self.assertEqual(status, 200)
@@ -129,9 +133,11 @@ class TestServerEndpoints(_FakeDbWebServerCase):
             self.assertIn(key, counts)
             self.assertIsInstance(counts[key], (int, float))
         # The queued aggregate row actually flowed into the payload.
-        self.assertEqual(counts["all"], 5)
+        self.assertEqual(counts["all"], 7)
         self.assertEqual(counts["imported"], 2)
-        self.assertEqual(counts["rejected"], 3)
+        # rejected (5) is coprime with matches_24h (3) so a wiring swap
+        # cannot pass by numeric coincidence.
+        self.assertEqual(counts["rejected"], 5)
         self.assertAlmostEqual(counts["matches_per_hour_24h"], 3 / 24)
 
     def test_pipeline_status(self):
@@ -222,6 +228,23 @@ class TestServerEndpoints(_FakeDbWebServerCase):
         self.assertEqual(rescue["album_title"], "YT Album")
         self.assertEqual(rescue["youtube_metadata"]["browse_id"], "yt-browse")
         self.assertEqual(rescue["request_status"], "wanted")
+
+    def test_pipeline_downloading_caps_youtube_ingest_at_50(self):
+        """The route hardcodes limit=50 on list_active_youtube_rescues —
+        one running rescue per request (partial unique index), so 51
+        requests with running ingests page down to 50."""
+        for i in range(51):
+            rid = 300 + i
+            self.db.seed_request(make_request_row(
+                id=rid, status="wanted", mb_release_id=f"yt-{rid}"))
+            self.db.insert_youtube_running(
+                request_id=rid, browse_id=f"b{rid}",
+                audio_playlist_id=None, yt_url=f"https://yt/{rid}",
+                expected_track_count=2,
+            )
+        status, data = self._get("/api/pipeline/downloading")
+        self.assertEqual(status, 200)
+        self.assertEqual(len(data["youtube_ingest"]), 50)
 
     def test_pipeline_detail(self):
         status, data = self._get("/api/pipeline/100")

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -541,7 +541,11 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
     """
 
     DB_FACTORY = _RaisingUpdateFieldsDB
-    db: "_RaisingUpdateFieldsDB"
+
+    @property
+    def raising_db(self) -> _RaisingUpdateFieldsDB:
+        assert isinstance(self.db, _RaisingUpdateFieldsDB)
+        return self.db
 
     def setUp(self):
         super().setUp()
@@ -552,7 +556,10 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
             search_filetype_override="lossless",
         ))
 
-    def _post(self, path, body):
+    def _post_may_disconnect(self, path, body):
+        """Like ``_post`` but tolerates connection-level failures —
+        exactly what the wedge produces server-side. Tests assert on
+        server-side observable state, not on the client response."""
         url = f"{self.base}{path}"
         data = json.dumps(body).encode()
         req = Request(url, data=data, headers={"Content-Type": "application/json"})
@@ -562,10 +569,6 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
         except HTTPError as e:
             return e.code, json.loads(e.read())
         except Exception:
-            # Connection-level failures (which is exactly what the wedge
-            # produces server-side) surface client-side as URLError or
-            # similar. Tests assert on server-side observable state, not
-            # on the client response.
             return None, None
 
     def _assert_no_reconnect_no_traceback(self, mock_reconnect, log_records, kind):
@@ -604,27 +607,27 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
     def test_brokenpipe_during_post_does_not_trigger_reconnect(self, mock_reconnect):
         """Wedge regression: BrokenPipeError reaches the typed except
         clause first, never the catch-all that reconnects."""
-        self.db.update_error = BrokenPipeError(32, "Broken pipe")
+        self.raising_db.update_error = BrokenPipeError(32, "Broken pipe")
         with self.assertLogs("cratedigger-web", level="WARNING") as cm:
-            self._post("/api/pipeline/set-intent",
+            self._post_may_disconnect("/api/pipeline/set-intent",
                        {"id": 100, "intent": "default"})
         self._assert_no_reconnect_no_traceback(mock_reconnect, cm.records, "BrokenPipeError")
 
     @patch("web.server._try_reconnect_db")
     def test_connection_reset_during_post_does_not_trigger_reconnect(self, mock_reconnect):
         """Sibling disconnect class — same handling expected."""
-        self.db.update_error = ConnectionResetError(104, "Connection reset by peer")
+        self.raising_db.update_error = ConnectionResetError(104, "Connection reset by peer")
         with self.assertLogs("cratedigger-web", level="WARNING") as cm:
-            self._post("/api/pipeline/set-intent",
+            self._post_may_disconnect("/api/pipeline/set-intent",
                        {"id": 100, "intent": "default"})
         self._assert_no_reconnect_no_traceback(mock_reconnect, cm.records, "ConnectionResetError")
 
     @patch("web.server._try_reconnect_db")
     def test_connection_aborted_during_post_does_not_trigger_reconnect(self, mock_reconnect):
         """Sibling disconnect class — same handling expected."""
-        self.db.update_error = ConnectionAbortedError(103, "Software caused connection abort")
+        self.raising_db.update_error = ConnectionAbortedError(103, "Software caused connection abort")
         with self.assertLogs("cratedigger-web", level="WARNING") as cm:
-            self._post("/api/pipeline/set-intent",
+            self._post_may_disconnect("/api/pipeline/set-intent",
                        {"id": 100, "intent": "default"})
         self._assert_no_reconnect_no_traceback(mock_reconnect, cm.records, "ConnectionAbortedError")
 
@@ -634,9 +637,9 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
         the catch-all and trigger _try_reconnect_db. The narrowing must
         not change behaviour for real DB errors."""
         import psycopg2
-        self.db.update_error = psycopg2.OperationalError("simulated PG outage")
+        self.raising_db.update_error = psycopg2.OperationalError("simulated PG outage")
         with self.assertLogs("cratedigger-web", level="ERROR") as cm:
-            status, _ = self._post("/api/pipeline/set-intent",
+            status, _ = self._post_may_disconnect("/api/pipeline/set-intent",
                                    {"id": 100, "intent": "default"})
         # Real DB error → catch-all fires → reconnect attempted.
         self.assertEqual(
@@ -661,9 +664,9 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
         (e.g. ValueError) still hits the catch-all. Narrowing this
         further (so non-DB exceptions skip the reconnect) is explicitly
         out of scope per the plan — see follow-up #234."""
-        self.db.update_error = ValueError("simulated handler bug")
+        self.raising_db.update_error = ValueError("simulated handler bug")
         with self.assertLogs("cratedigger-web", level="ERROR") as cm:
-            status, _ = self._post("/api/pipeline/set-intent",
+            status, _ = self._post_may_disconnect("/api/pipeline/set-intent",
                                    {"id": 100, "intent": "default"})
         self.assertEqual(
             mock_reconnect.call_count, 1,
@@ -689,7 +692,7 @@ class TestClientDisconnectHandling(_FakeDbWebServerCase):
             # assertLogs requires at least one record; a trivial DEBUG log
             # ensures the context manager is satisfied even on a quiet path.
             logging.getLogger("cratedigger-web").debug("test marker: normal POST path")
-            status, _ = self._post("/api/pipeline/set-intent",
+            status, _ = self._post_may_disconnect("/api/pipeline/set-intent",
                                    {"id": 100, "intent": "default"})
         self.assertEqual(mock_reconnect.call_count, 0)
         disconnect_warnings = [

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -5,7 +5,6 @@ Split from tests/test_web_server.py (#408). Shared harness in
 tests/web/_harness.py.
 """
 
-from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -18,42 +17,41 @@ from urllib.error import HTTPError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tests.web._harness import _MOCK_PIPELINE_REQUEST, _make_server
+from tests.web._harness import _FakeDbWebServerCase
 
+from tests.fakes import FakeCursor, FakePipelineDB
 from tests.helpers import make_request_row
 
 
-class TestServerEndpoints(unittest.TestCase):
+class TestServerEndpoints(_FakeDbWebServerCase):
     """Test HTTP endpoints return expected status and structure."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.server, cls.port, cls.mock_db = _make_server()
-        cls.base = f"http://127.0.0.1:{cls.port}"
+    def setUp(self) -> None:
+        super().setUp()
+        self.db.seed_request(make_request_row(
+            id=100, status="imported", min_bitrate=320,
+            imported_path="/mnt/virtio/Music/Beets/Test",
+        ))
+        self.db.set_tracks(100, [
+            {"disc_number": 1, "track_number": 1, "title": "Track",
+             "length_seconds": 180},
+        ])
+        self.db.log_download(
+            100, outcome="success", beets_scenario="strong_match",
+            beets_distance=0.012, soulseek_username="testuser",
+            filetype="mp3", bitrate=320000, actual_filetype="mp3",
+            actual_min_bitrate=320, valid=True,
+        )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-
-    def _get(self, path: str) -> tuple[int, dict]:
-        """GET a path and return (status, json)."""
-        url = f"{self.base}{path}"
-        try:
-            resp = urlopen(url)
-            return resp.status, json.loads(resp.read())
-        except HTTPError as e:
-            return e.code, json.loads(e.read())
-
-    def _post(self, path: str, body: dict) -> tuple[int, dict]:
-        """POST JSON and return (status, json)."""
-        url = f"{self.base}{path}"
-        data = json.dumps(body).encode()
-        req = Request(url, data=data, headers={"Content-Type": "application/json"})
-        try:
-            resp = urlopen(req)
-            return resp.status, json.loads(resp.read())
-        except HTTPError as e:
-            return e.code, json.loads(e.read())
+    def _queue_log_counts(self, *, total: int = 1, imported: int = 1,
+                          matches_24h: int = 3, matches_6h: int = 1) -> None:
+        """The /api/pipeline/log counts come from one raw-SQL aggregate
+        the fake cannot interpret — the queued cursor IS that query's
+        result row. Unqueued calls degrade to all-zero counts."""
+        self.db.queue_execute_results(FakeCursor([{
+            "total": total, "imported": imported,
+            "matches_24h": matches_24h, "matches_6h": matches_6h,
+        }]))
 
     # --- GET endpoints ---
 
@@ -75,33 +73,52 @@ class TestServerEndpoints(unittest.TestCase):
                 self.assertIn(key, entry, f"Missing key '{key}' in log entry")
 
     def test_pipeline_log_filter_imported(self):
+        self.db.log_download(100, outcome="rejected",
+                             soulseek_username="rejuser")
         status, data = self._get("/api/pipeline/log?outcome=imported")
         self.assertEqual(status, 200)
-        self.assertIn("log", data)
-        # Verify the DB was called with the filter
-        self.mock_db.get_log.assert_called_with(limit=50, outcome_filter="imported")
+        self.assertTrue(data["log"])
+        self.assertEqual(
+            {e["outcome"] for e in data["log"]}, {"success"},
+            "imported filter must drop the rejected row")
 
     def test_pipeline_log_filter_rejected(self):
+        self.db.log_download(100, outcome="rejected",
+                             soulseek_username="rejuser")
         status, data = self._get("/api/pipeline/log?outcome=rejected")
         self.assertEqual(status, 200)
-        self.mock_db.get_log.assert_called_with(limit=50, outcome_filter="rejected")
+        self.assertEqual(
+            {e["outcome"] for e in data["log"]}, {"rejected"},
+            "rejected filter must drop the success row")
 
     def test_pipeline_log_limit_param(self):
-        status, data = self._get("/api/pipeline/log?outcome=rejected&limit=300")
+        self.db.log_download(100, outcome="rejected")
+        self.db.log_download(100, outcome="rejected")
+        status, data = self._get("/api/pipeline/log?outcome=rejected&limit=1")
         self.assertEqual(status, 200)
-        self.mock_db.get_log.assert_called_with(limit=300, outcome_filter="rejected")
+        self.assertEqual(len(data["log"]), 1)
 
     def test_pipeline_log_limit_param_is_capped(self):
+        # 501 extra rows + the setUp row = 502 total; the route must
+        # cap ?limit=5000 to 500 rows.
+        for _ in range(501):
+            self.db.log_download(100, outcome="success")
         status, data = self._get("/api/pipeline/log?limit=5000")
         self.assertEqual(status, 200)
-        self.mock_db.get_log.assert_called_with(limit=500, outcome_filter=None)
+        self.assertEqual(len(data["log"]), 500)
 
     def test_pipeline_log_filter_invalid_ignored(self):
+        self.db.log_download(100, outcome="rejected",
+                             soulseek_username="rejuser")
         status, data = self._get("/api/pipeline/log?outcome=badvalue")
         self.assertEqual(status, 200)
-        self.mock_db.get_log.assert_called_with(limit=50, outcome_filter=None)
+        # Invalid filter is ignored — BOTH outcomes are returned.
+        self.assertEqual(
+            {e["outcome"] for e in data["log"]}, {"success", "rejected"})
 
     def test_pipeline_log_counts_structure(self):
+        self._queue_log_counts(total=5, imported=2,
+                               matches_24h=3, matches_6h=1)
         status, data = self._get("/api/pipeline/log")
         self.assertEqual(status, 200)
         counts = data["counts"]
@@ -111,6 +128,11 @@ class TestServerEndpoints(unittest.TestCase):
         for key in ("matches_per_hour_24h", "matches_per_hour_6h"):
             self.assertIn(key, counts)
             self.assertIsInstance(counts[key], (int, float))
+        # The queued aggregate row actually flowed into the payload.
+        self.assertEqual(counts["all"], 5)
+        self.assertEqual(counts["imported"], 2)
+        self.assertEqual(counts["rejected"], 3)
+        self.assertAlmostEqual(counts["matches_per_hour_24h"], 3 / 24)
 
     def test_pipeline_status(self):
         status, data = self._get("/api/pipeline/status")
@@ -127,36 +149,29 @@ class TestServerEndpoints(unittest.TestCase):
 
     def test_pipeline_status_includes_downloading(self):
         """count_by_status includes downloading when albums are downloading."""
-        self.mock_db.count_by_status.return_value = {
-            "wanted": 3, "downloading": 2, "imported": 10, "manual": 1}
+        for rid in (201, 202):
+            self.db.seed_request(make_request_row(
+                id=rid, status="downloading", mb_release_id=f"dl-{rid}",
+            ))
         status, data = self._get("/api/pipeline/status")
         self.assertEqual(status, 200)
         self.assertEqual(data["counts"]["downloading"], 2)
-        # Restore
-        self.mock_db.count_by_status.return_value = {"wanted": 0, "imported": 1, "manual": 0}
 
     def test_pipeline_all_includes_downloading(self):
         """get_pipeline_all returns downloading albums in the response."""
-        downloading_row = make_request_row(
+        self.db.seed_request(make_request_row(
             id=200, album_title="Downloading Album", artist_name="DL Artist",
             mb_release_id="dl-uuid", status="downloading",
             active_download_state={"filetype": "flac", "enqueued_at": "now", "files": []},
-        )
-        self.mock_db.get_by_status.side_effect = lambda s, **kw: [downloading_row] if s == "downloading" else []
-        self.mock_db.count_by_status.return_value = {"downloading": 1}
-        self.mock_db.get_download_history_batch.return_value = {}
+        ))
         status, data = self._get("/api/pipeline/all")
         self.assertEqual(status, 200)
         self.assertIn("downloading", data)
         self.assertEqual(len(data["downloading"]), 1)
         self.assertEqual(data["downloading"][0]["album_title"], "Downloading Album")
-        # Restore
-        self.mock_db.get_by_status.side_effect = None
-        self.mock_db.get_by_status.return_value = []
-        self.mock_db.count_by_status.return_value = {"wanted": 0, "imported": 1, "manual": 0}
 
     def test_pipeline_downloading_returns_current_downloads_only(self):
-        downloading_row = make_request_row(
+        self.db.seed_request(make_request_row(
             id=201, album_title="Active Download", artist_name="DL Artist",
             mb_release_id="dl-uuid", status="downloading",
             active_download_state={
@@ -164,50 +179,38 @@ class TestServerEndpoints(unittest.TestCase):
                 "enqueued_at": "2026-05-05T12:00:00+00:00",
                 "files": [{"username": "peer", "bytes_transferred": 1, "size": 2}],
             },
+        ))
+        # A prior rejected attempt — its summary must be stamped onto the
+        # downloading row (the real get_latest_download_summaries path).
+        self.db.log_download(
+            201, outcome="rejected", soulseek_username="peer",
+            beets_scenario="high_distance",
         )
-        self.mock_db.get_by_status.side_effect = (
-            lambda s, **kw: [downloading_row] if s == "downloading" else []
-        )
-        self.mock_db.count_by_status.return_value = {"downloading": 1}
-        self.mock_db.get_latest_download_summaries.reset_mock()
-        self.mock_db.get_latest_download_summaries.return_value = {}
 
         status, data = self._get("/api/pipeline/downloading")
 
         self.assertEqual(status, 200)
         self.assertEqual(data["counts"]["downloading"], 1)
         self.assertEqual(len(data["downloading"]), 1)
-        self.assertEqual(data["downloading"][0]["album_title"], "Active Download")
-        self.mock_db.get_by_status.assert_called_with("downloading")
-        self.mock_db.get_latest_download_summaries.assert_any_call([201])
-
-        self.mock_db.get_by_status.side_effect = None
-        self.mock_db.get_by_status.return_value = []
-        self.mock_db.get_latest_download_summaries.reset_mock()
-        self.mock_db.count_by_status.return_value = {
-            "wanted": 0, "imported": 1, "manual": 0}
+        row = data["downloading"][0]
+        self.assertEqual(row["album_title"], "Active Download")
+        # Request 100 (imported, from setUp) must NOT appear here.
+        self.assertNotIn(100, [r["id"] for r in data["downloading"]])
+        self.assertEqual(row["last_outcome"], "rejected")
+        self.assertEqual(row["last_username"], "peer")
 
     def test_pipeline_downloading_includes_active_youtube_ingest(self):
-        self.mock_db.get_by_status.side_effect = None
-        self.mock_db.get_by_status.return_value = []
-        self.mock_db.count_by_status.return_value = {"downloading": 0}
-        self.mock_db.get_download_history_batch.return_value = {}
-        self.mock_db.list_active_youtube_rescues.return_value = [{
-            "download_log_id": 301,
-            "request_id": 202,
-            "source": "youtube",
-            "outcome": "youtube_running",
-            "youtube_metadata": {
-                "browse_id": "yt-browse",
-                "expected_track_count": 2,
-                "yt_url": "https://music.youtube.com/playlist?list=abc",
-            },
-            "created_at": datetime(2026, 5, 28, tzinfo=timezone.utc),
-            "artist_name": "YT Artist",
-            "album_title": "YT Album",
-            "mb_release_id": "yt-mbid",
-            "request_status": "wanted",
-        }]
+        self.db.seed_request(make_request_row(
+            id=202, status="wanted", artist_name="YT Artist",
+            album_title="YT Album", mb_release_id="yt-mbid",
+        ))
+        log_id = self.db.insert_youtube_running(
+            request_id=202,
+            browse_id="yt-browse",
+            audio_playlist_id=None,
+            yt_url="https://music.youtube.com/playlist?list=abc",
+            expected_track_count=2,
+        )
 
         status, data = self._get("/api/pipeline/downloading")
 
@@ -215,17 +218,10 @@ class TestServerEndpoints(unittest.TestCase):
         self.assertEqual(data["downloading"], [])
         self.assertEqual(len(data["youtube_ingest"]), 1)
         rescue = data["youtube_ingest"][0]
-        self.assertEqual(rescue["download_log_id"], 301)
+        self.assertEqual(rescue["download_log_id"], log_id)
         self.assertEqual(rescue["album_title"], "YT Album")
         self.assertEqual(rescue["youtube_metadata"]["browse_id"], "yt-browse")
-        self.assertTrue(rescue["created_at"].startswith("2026-05-28T00:00:00"))
-        self.mock_db.list_active_youtube_rescues.assert_called_with(limit=50)
-
-        self.mock_db.get_by_status.return_value = []
-        self.mock_db.list_active_youtube_rescues.return_value = []
-        self.mock_db.get_download_history_batch.reset_mock()
-        self.mock_db.count_by_status.return_value = {
-            "wanted": 0, "imported": 1, "manual": 0}
+        self.assertEqual(rescue["request_status"], "wanted")
 
     def test_pipeline_detail(self):
         status, data = self._get("/api/pipeline/100")
@@ -239,11 +235,8 @@ class TestServerEndpoints(unittest.TestCase):
             self.assertIn("downloaded_label", data["history"][0])
 
     def test_pipeline_detail_not_found(self):
-        self.mock_db.get_request.return_value = None
         status, data = self._get("/api/pipeline/999")
         self.assertEqual(status, 404)
-        # Restore
-        self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
 
     def test_unknown_get_returns_404(self):
         status, data = self._get("/api/nonexistent")
@@ -291,46 +284,52 @@ class TestServerEndpoints(unittest.TestCase):
     def test_post_force_import_passes_source_username(self, _mock_resolve):
         from lib.import_queue import IMPORT_JOB_FORCE, force_import_dedupe_key
 
-        self.mock_db.get_download_log_entry.return_value = {
-            "id": 42,
-            "request_id": 100,
-            "soulseek_username": "baduser",
-            "validation_result": {
+        log_id = self.db.log_download(
+            100, outcome="rejected", soulseek_username="baduser",
+            validation_result={
                 "failed_path": "/tmp/Test Album",
                 "scenario": "high_distance",
                 "source_dirs": ["baduser\\Artist\\Album"],
             },
-        }
+        )
 
-        status, data = self._post("/api/pipeline/force-import", {"download_log_id": 42})
+        status, data = self._post(
+            "/api/pipeline/force-import", {"download_log_id": log_id})
 
         self.assertEqual(status, 202)
         self.assertEqual(data["status"], "queued")
-        self.assertEqual(data["artist"], _MOCK_PIPELINE_REQUEST["artist_name"])
-        self.assertEqual(data["album"], _MOCK_PIPELINE_REQUEST["album_title"])
-        self.mock_db.enqueue_import_job.assert_called_once()
-        args, kwargs = self.mock_db.enqueue_import_job.call_args
-        self.assertEqual(args, (IMPORT_JOB_FORCE,))
-        self.assertEqual(kwargs["request_id"], 100)
-        self.assertEqual(kwargs["dedupe_key"], force_import_dedupe_key(42))
-        self.assertEqual(kwargs["payload"]["failed_path"], "/tmp/Test Album")
-        self.assertEqual(kwargs["payload"]["source_username"], "baduser")
-        self.assertEqual(kwargs["payload"]["source_dirs"], ["baduser\\Artist\\Album"])
+        req = self.db.request(100)
+        self.assertEqual(data["artist"], req["artist_name"])
+        self.assertEqual(data["album"], req["album_title"])
+        # The job landed in the real import queue with the full payload.
+        jobs = self.db.list_import_jobs()
+        self.assertEqual(len(jobs), 1)
+        job = jobs[0]
+        self.assertEqual(job.job_type, IMPORT_JOB_FORCE)
+        self.assertEqual(job.request_id, 100)
+        self.assertEqual(job.dedupe_key, force_import_dedupe_key(log_id))
+        self.assertEqual(job.payload["failed_path"], "/tmp/Test Album")
+        self.assertEqual(job.payload["source_username"], "baduser")
+        self.assertEqual(job.payload["source_dirs"], ["baduser\\Artist\\Album"])
 
     def test_post_set_intent_default_clears_stale_lossless_override(self):
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=100, status="wanted", artist_name="Test Artist",
             album_title="Test Album", target_format="lossless",
             search_filetype_override="lossless",
-        )
-        self.mock_db.update_request_fields.reset_mock()
+        ))
         status, data = self._post("/api/pipeline/set-intent",
                                   {"id": 100, "intent": "default"})
         self.assertEqual(status, 200)
         self.assertFalse(data["requeued"])
-        self.mock_db.update_request_fields.assert_called_once_with(
-            100, target_format=None, search_filetype_override=None)
-        self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
+        # Both stale fields cleared on the row itself.
+        row = self.db.request(100)
+        self.assertIsNone(row["target_format"])
+        self.assertIsNone(row["search_filetype_override"])
+        self.assertEqual(
+            self.db.update_request_fields_calls,
+            [(100, {"target_format": None,
+                    "search_filetype_override": None})])
 
     def test_post_set_intent_invalid(self):
         """POST /api/pipeline/set-intent with bad intent returns 400."""
@@ -499,7 +498,22 @@ class TestFuzzyShimRemoved(unittest.TestCase):
         )
 
 
-class TestClientDisconnectHandling(unittest.TestCase):
+class _RaisingUpdateFieldsDB(FakePipelineDB):
+    """update_request_fields raises ``update_error`` when set —
+    deterministic stand-in for a client disconnect (or DB error)
+    surfacing mid-handler."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.update_error: Exception | None = None
+
+    def update_request_fields(self, request_id: int, **fields: object) -> None:
+        if self.update_error is not None:
+            raise self.update_error
+        super().update_request_fields(request_id, **fields)
+
+
+class TestClientDisconnectHandling(_FakeDbWebServerCase):
     """Issue #233 wedge regression: client closes mid-response.
 
     Before this fix, a BrokenPipeError raised inside do_GET/do_POST
@@ -517,27 +531,26 @@ class TestClientDisconnectHandling(unittest.TestCase):
     in both do_GET and do_POST. Disconnect errors get a single WARNING
     log line and a clean return — no DB reconnect, no second body-write.
 
-    These tests inject the exception via ``mock_db.<method>.side_effect``
-    rather than via raw-socket mid-body close. The mechanism is the same
-    code path (typed except clause inside do_POST's try block); the
-    side_effect approach is deterministic where raw-socket timing is
+    These tests inject the exception via a typed FakePipelineDB
+    subclass whose ``update_request_fields`` raises on demand, rather
+    than via raw-socket mid-body close. The mechanism is the same code
+    path (typed except clause inside do_POST's try block); the
+    injection approach is deterministic where raw-socket timing is
     flaky on localhost. R3 regression-guard tests confirm the existing
     catch-all still fires for real handler errors.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.server, cls.port, cls.mock_db = _make_server()
-        cls.base = f"http://127.0.0.1:{cls.port}"
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
+    DB_FACTORY = _RaisingUpdateFieldsDB
+    db: "_RaisingUpdateFieldsDB"
 
     def setUp(self):
-        # Ensure each test starts with a clean side_effect.
-        self.mock_db.update_request_fields.side_effect = None
-        self.mock_db.update_request_fields.return_value = None
+        super().setUp()
+        # set-intent "default" on a wanted row reaches the
+        # update_request_fields write — the injection point.
+        self.db.seed_request(make_request_row(
+            id=100, status="wanted", target_format="lossless",
+            search_filetype_override="lossless",
+        ))
 
     def _post(self, path, body):
         url = f"{self.base}{path}"
@@ -591,7 +604,7 @@ class TestClientDisconnectHandling(unittest.TestCase):
     def test_brokenpipe_during_post_does_not_trigger_reconnect(self, mock_reconnect):
         """Wedge regression: BrokenPipeError reaches the typed except
         clause first, never the catch-all that reconnects."""
-        self.mock_db.update_request_fields.side_effect = BrokenPipeError(32, "Broken pipe")
+        self.db.update_error = BrokenPipeError(32, "Broken pipe")
         with self.assertLogs("cratedigger-web", level="WARNING") as cm:
             self._post("/api/pipeline/set-intent",
                        {"id": 100, "intent": "default"})
@@ -600,7 +613,7 @@ class TestClientDisconnectHandling(unittest.TestCase):
     @patch("web.server._try_reconnect_db")
     def test_connection_reset_during_post_does_not_trigger_reconnect(self, mock_reconnect):
         """Sibling disconnect class — same handling expected."""
-        self.mock_db.update_request_fields.side_effect = ConnectionResetError(104, "Connection reset by peer")
+        self.db.update_error = ConnectionResetError(104, "Connection reset by peer")
         with self.assertLogs("cratedigger-web", level="WARNING") as cm:
             self._post("/api/pipeline/set-intent",
                        {"id": 100, "intent": "default"})
@@ -609,7 +622,7 @@ class TestClientDisconnectHandling(unittest.TestCase):
     @patch("web.server._try_reconnect_db")
     def test_connection_aborted_during_post_does_not_trigger_reconnect(self, mock_reconnect):
         """Sibling disconnect class — same handling expected."""
-        self.mock_db.update_request_fields.side_effect = ConnectionAbortedError(103, "Software caused connection abort")
+        self.db.update_error = ConnectionAbortedError(103, "Software caused connection abort")
         with self.assertLogs("cratedigger-web", level="WARNING") as cm:
             self._post("/api/pipeline/set-intent",
                        {"id": 100, "intent": "default"})
@@ -621,7 +634,7 @@ class TestClientDisconnectHandling(unittest.TestCase):
         the catch-all and trigger _try_reconnect_db. The narrowing must
         not change behaviour for real DB errors."""
         import psycopg2
-        self.mock_db.update_request_fields.side_effect = psycopg2.OperationalError("simulated PG outage")
+        self.db.update_error = psycopg2.OperationalError("simulated PG outage")
         with self.assertLogs("cratedigger-web", level="ERROR") as cm:
             status, _ = self._post("/api/pipeline/set-intent",
                                    {"id": 100, "intent": "default"})
@@ -648,7 +661,7 @@ class TestClientDisconnectHandling(unittest.TestCase):
         (e.g. ValueError) still hits the catch-all. Narrowing this
         further (so non-DB exceptions skip the reconnect) is explicitly
         out of scope per the plan — see follow-up #234."""
-        self.mock_db.update_request_fields.side_effect = ValueError("simulated handler bug")
+        self.db.update_error = ValueError("simulated handler bug")
         with self.assertLogs("cratedigger-web", level="ERROR") as cm:
             status, _ = self._post("/api/pipeline/set-intent",
                                    {"id": 100, "intent": "default"})
@@ -668,7 +681,7 @@ class TestClientDisconnectHandling(unittest.TestCase):
     def test_normal_post_no_reconnect_no_warning(self, mock_reconnect):
         """Happy path regression guard: a successful POST does not
         trigger any reconnect or disconnect-warning side effects."""
-        # mock_db.set_intent_for_request returns True by default per setUp.
+        # No update_error set — the fake's real write path runs.
         # Use assertNoLogs (Python 3.10+) to assert no WARNING/ERROR records.
         # Some logger setups still emit INFO; we only care that no WARNING
         # for "Client disconnect" appears and no ERROR is emitted.

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -380,7 +380,10 @@ class TestServerEndpoints(_FakeDbWebServerCase):
         if data["log"]:
             created = data["log"][0].get("created_at")
             self.assertIsInstance(created, str)
-            self.assertIn("2026", created)
+            # ISO-8601 round-trip — no fixed-year assertion (the seeded
+            # row carries the fake's "now", which outlives 2026).
+            from datetime import datetime as _dt
+            _dt.fromisoformat(created)
 
 
     def test_disambiguate_endpoint(self):


### PR DESCRIPTION
Batch 3 of #430 (batches 1-2: #440, #441). Migrates `test_server_endpoints.py` (53→0) and `test_routes_pipeline.py` (66→0). Remaining baseline: `_harness.py` 39, imports 71, mutations 100.

## The headline: the dashboard fake is now a real read-model mirror with a mechanical parity gate

The dashboard contract test previously asserted against a 290-line hand-built metrics dict in the harness — zero production semantics. `FakePipelineDB.get_pipeline_dashboard_metrics` was a partial stub (windows hardcoded `[]`, no coverage aggregation, raw datetime leaks that 500'd the route the moment real telemetry was seeded). It's now a full Python mirror of `lib/pipeline_db/dashboard.py`: search/cycle windows with the exact SQL FILTER semantics (errors = timeout/error/empty_query only; `reset_24h` = historical `exhausted`; `stale_completions` via `cursor_update_status`), dense `generate_series`-style zero-filled match-rate series (24/28 buckets), production serializer key sets (`watchdog_kills` rename, fixed cycle-row columns), loop-suspect/stale-wanted cohorts with production ordering + LIMIT 12, heavy-queries panel with the `(peers_browsed + lazy) > 0` filter and coercions.

**`TestDashboardFakeParity`** (real-PG suite) seeds identical telemetry through the shared writer API into both `PipelineDB` and `FakePipelineDB` and compares recursive payload *shapes* (key sets, list lengths, first-element shapes, leaf type categories). Key renames, dropped panels, sparse-vs-dense series, and None-vs-0 leaves now fail mechanically instead of waiting for review archaeology.

## Other fidelity wins

- get_log filter/limit/cap pins became row-counting assertions (502-row seed → 500 cap, default 50); timeline + youtube-ingest caps pinned with 51-row seeds
- force-import asserts the job in the real import queue (dedupe key derived from the actual log row)
- `DB_FACTORY` hook on `_FakeDbWebServerCase`: `TestClientDisconnectHandling` runs a typed `_RaisingUpdateFieldsDB` instead of MagicMock side_effects
- Triage + LongTail classes deleted their 30-line forwarding-shim scaffolding — the per-test fake gives them isolation for free
- Killed the **source-dir sys.path shadow class** (sibling of batch 2's tests-dir fix): ten front-inserts of `lib`/`web`/`scripts`/`harness` converted to append (`lib/beets.py` could shadow the real `beets` package — the issue-#95 dual-load footgun). `TestSysPathAudit` now bans the pattern; `tests/web/_harness.py` is the one documented exemption (deliberate ambiguity reproduction for `TestPipelineRouteDirectEquivalence`).

## Review trail

| Round | Reviewer | Findings | Resolution |
|-------|----------|----------|------------|
| r1 | Same-engine adversarial | 2 HIGH (sparse-vs-dense series with a backwards comment; cycle-row serializer drift), 4 MEDIUM, 3 LOW, 3 NIT | All fixed in `review(r1 adversarial)` with pinning self-tests; the parity gate closes the "300 lines of Python tracking 700 lines of SQL" residual risk structurally. ADV-6 (log-counts FakeCursor seam) accepted with rationale — promoting the route's inline SQL to a named DB method is a production refactor that doesn't belong in a tests-only PR. |
| r2 | Codex partner | 2 P2 (cycles.recent ordering + outlier 24h window; post-2026 timestamp assertion) | Fixed in `review(r2 codex)`; follow-through surfaced the source-dir shadow class. |
| r3 | Codex partner | 1 P2 (errors bucket counted unknown outcomes; SQL counts only timeout/error/empty_query) | Fixed + pinned in `review(r3 codex)`. |
| r4 | Codex partner | none | Converged. |

- [x] Full suite 4413 tests OK (incl. real-PG parity gate); pyright 0 errors full-repo
- [x] Ratchet entries deleted for both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)