### PR TITLE
test(web): #430 batch 4 — mutations + imports migrated; only the legacy harness remains

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -525,7 +525,6 @@ _HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
 
 WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "_harness.py"): 39,
-    os.path.join("web", "test_routes_imports.py"): 71,
 }
 
 

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -526,7 +526,6 @@ _HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
 WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
     os.path.join("web", "_harness.py"): 39,
     os.path.join("web", "test_routes_imports.py"): 71,
-    os.path.join("web", "test_routes_pipeline_mutations.py"): 100,
 }
 
 

--- a/tests/web/test_routes_imports.py
+++ b/tests/web/test_routes_imports.py
@@ -6,7 +6,6 @@ tests/web/_harness.py.
 """
 
 import copy
-from datetime import datetime, timezone
 import json
 import os
 import sys
@@ -20,21 +19,17 @@ from urllib.error import HTTPError
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import (
-    _MOCK_PIPELINE_REQUEST,
     _DEFAULT_WRONG_MATCH_ROW,
-    _DEFAULT_WRONG_MATCH_ENTRY,
     _assert_required_fields,
-    _WebServerCase,
+    _FakeDbWebServerCase,
     _fresh_triage_runner,
-    _make_server,
 )
 
 from lib.manual_import import FolderInfo
-from lib.import_queue import ImportJob
 from tests.helpers import make_request_row
 
 
-class TestManualImportRouteContracts(_WebServerCase):
+class TestManualImportRouteContracts(_FakeDbWebServerCase):
     """Contract tests for manual import routes."""
 
     FOLDER_REQUIRED_FIELDS = {"name", "path", "artist", "album", "file_count", "match"}
@@ -42,8 +37,11 @@ class TestManualImportRouteContracts(_WebServerCase):
     IMPORT_REQUIRED_FIELDS = {"status", "message", "request_id", "artist", "album"}
 
     def setUp(self) -> None:
-        self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
-        self.mock_db.get_by_status.side_effect = None
+        super().setUp()
+        self.db.seed_request(make_request_row(
+            id=100, status="wanted", mb_release_id="abc-123",
+            artist_name="Test Artist", album_title="Test Album",
+        ))
 
     @patch("web.routes.imports.scan_complete_folder")
     def test_manual_import_scan_contract(self, mock_scan):
@@ -60,15 +58,6 @@ class TestManualImportRouteContracts(_WebServerCase):
             file_count=10,
         )
         mock_scan.return_value = [folder]
-        self.mock_db.get_by_status.return_value = [
-            make_request_row(
-                id=100,
-                status="wanted",
-                mb_release_id="abc-123",
-                artist_name="Test Artist",
-                album_title="Test Album",
-            ),
-        ]
 
         status, data = self._get("/api/manual-import/scan")
 
@@ -97,7 +86,7 @@ class TestManualImportRouteContracts(_WebServerCase):
                                 "manual import response")
 
 
-class TestWrongMatchesContract(unittest.TestCase):
+class TestWrongMatchesContract(_FakeDbWebServerCase):
     """Contract tests: /api/wrong-matches returns grouped-by-release shape.
 
     Issue #113: every rejection with a failed_path must be reachable. The
@@ -106,50 +95,14 @@ class TestWrongMatchesContract(unittest.TestCase):
     collapse by release and expand to per-candidate actions.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.server, cls.port, cls.mock_db = _make_server()
-        cls.base = f"http://127.0.0.1:{cls.port}"
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-
-    def _get(self, path: str) -> tuple[int, dict]:
-        url = f"{self.base}{path}"
-        try:
-            resp = urlopen(url)
-            return resp.status, json.loads(resp.read())
-        except HTTPError as e:
-            return e.code, json.loads(e.read())
-
-    def _post(self, path: str, body: dict) -> tuple[int, dict]:
-        url = f"{self.base}{path}"
-        data = json.dumps(body).encode()
-        req = Request(url, data=data, headers={"Content-Type": "application/json"})
-        try:
-            resp = urlopen(req)
-            return resp.status, json.loads(resp.read())
-        except HTTPError as e:
-            return e.code, json.loads(e.read())
-
     def setUp(self) -> None:
-        self.mock_db.get_request.return_value = copy.deepcopy(_MOCK_PIPELINE_REQUEST)
-        self.mock_db.get_wrong_matches.side_effect = None
-        self.mock_db.get_wrong_matches.return_value = [copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)]
-        self.mock_db.get_download_log_entry.reset_mock()
-        self.mock_db.get_download_log_entry.side_effect = None
-        self.mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
-        self.mock_db.clear_wrong_match_path.reset_mock()
-        self.mock_db.clear_wrong_match_path.return_value = True
-        self.mock_db.clear_wrong_match_paths.reset_mock()
-        self.mock_db.clear_wrong_match_paths.return_value = 1
-        self.mock_db.enqueue_import_job.reset_mock()
-        self.mock_db.enqueue_import_job.side_effect = None
-        self.mock_db.enqueue_import_job.return_value = self._job(
-            77, 100, 42, "/mnt/virtio/music/slskd/failed_imports/Test")
-        self.mock_db.get_download_history_batch.return_value = {}
-        self.mock_db.list_active_import_jobs_for_wrong_match.return_value = []
+        super().setUp()
+        # Default group: request 100 + one rejected row pinned to log id
+        # 42 — the id many URLs / dedupe keys in this class reference.
+        self.default_log_id = self._seed_wrong_match(
+            download_log_id=42, request_id=100, username="testuser",
+            failed_path="/mnt/virtio/music/slskd/failed_imports/Test",
+        )
         # Default: treat every failed_path as existing so the group survives
         # filtering. Individual tests override this to exercise missing-file
         # and mixed-existence cases. Converge deletion is service-backed.
@@ -244,60 +197,95 @@ class TestWrongMatchesContract(unittest.TestCase):
         "source_dirs": list,
     }
 
-    def _row(self, download_log_id: int, request_id: int, username: str,
-             failed_path: str, artist: str = "Test Artist",
-             album: str = "Test Album",
-             mb_release_id: str | None = "abc-123",
-             scenario: str = "high_distance",
-             distance: float = 0.25) -> dict:
-        row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
-        row["download_log_id"] = download_log_id
-        row["request_id"] = request_id
-        row["artist_name"] = artist
-        row["album_title"] = album
-        row["mb_release_id"] = mb_release_id
-        row["soulseek_username"] = username
-        row["validation_result"]["failed_path"] = failed_path
-        row["validation_result"]["scenario"] = scenario
-        row["validation_result"]["distance"] = distance
-        row["validation_result"]["candidates"][0]["distance"] = distance
-        return row
-
-    def _entry(self, download_log_id: int, request_id: int,
-               failed_path: str) -> dict:
-        return {
-            "id": download_log_id,
-            "request_id": request_id,
-            "validation_result": {
-                "failed_path": failed_path,
-                "scenario": "high_distance",
-            },
-        }
-
-    def _job(self, job_id: int, request_id: int, download_log_id: int,
-             failed_path: str, *, deduped: bool = False) -> ImportJob:
-        return ImportJob(
-            id=job_id,
-            job_type="force_import",
-            status="queued",
-            request_id=request_id,
-            dedupe_key=f"force_import:download_log:{download_log_id}",
-            payload={
-                "download_log_id": download_log_id,
-                "failed_path": failed_path,
-            },
-            result=None,
-            message="Import queued",
-            error=None,
-            attempts=0,
-            worker_id=None,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
-            started_at=None,
-            heartbeat_at=None,
-            completed_at=None,
-            deduped=deduped,
+    def _seed_wrong_match(
+        self, *,
+        download_log_id: int | None = None,
+        request_id: int = 100,
+        username: str = "testuser",
+        failed_path: str = "/mnt/virtio/music/slskd/failed_imports/Test",
+        artist: str = "Test Artist",
+        album: str = "Test Album",
+        mb_release_id: str | None = "abc-123",
+        scenario: str = "high_distance",
+        distance: float = 0.25,
+        request_overrides: dict | None = None,
+        validation_overrides: dict | None = None,
+        log_overrides: dict | None = None,
+    ) -> int:
+        """Seed a request + one rejected download_log row that the fake's
+        REAL get_wrong_matches query surfaces (the legacy harness fed the
+        joined row shape straight into a mock). Returns the log id;
+        ``download_log_id`` pins it for tests whose URLs / dedupe keys
+        hardcode ids."""
+        if self.db.get_request(request_id) is None:
+            self.db.seed_request(make_request_row(
+                id=request_id, status="wanted", artist_name=artist,
+                album_title=album, mb_release_id=mb_release_id,
+                mb_release_group_id="rg-abc-123",
+                min_bitrate=None, verified_lossless=False,
+                current_spectral_grade=None,
+                current_spectral_bitrate=None, imported_path=None,
+                **(request_overrides or {}),
+            ))
+        elif request_overrides:
+            self.db.update_request_fields(request_id, **request_overrides)
+        vr = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW["validation_result"])
+        vr["failed_path"] = failed_path
+        vr["scenario"] = scenario
+        vr["distance"] = distance
+        vr["candidates"][0]["distance"] = distance
+        vr["soulseek_username"] = username
+        vr.update(validation_overrides or {})
+        if download_log_id is not None:
+            self.db._next_download_log_id = download_log_id - 1
+        return self.db.log_download(
+            request_id, outcome="rejected", soulseek_username=username,
+            validation_result=vr, **(log_overrides or {}),
         )
+
+    def _seed_entry_evidence(
+        self, log_id: int, *,
+        storage_format: str | None = None,
+        min_bitrate: int | None = None,
+        verified_lossless: bool = False,
+        spectral_grade: str | None = None,
+        spectral_bitrate: int | None = None,
+        v0_probe_kind: str | None = None,
+        v0_probe_avg_bitrate: int | None = None,
+    ) -> None:
+        """Attach a real album_quality_evidence row to a download_log row
+        — the route reads it through the fake's LEFT-JOIN mirror."""
+        from lib.quality import (
+            AlbumQualityV0Metric,
+            AudioQualityMeasurement,
+            VerifiedLosslessProof,
+        )
+        from tests.helpers import make_album_quality_evidence
+        evidence = make_album_quality_evidence(
+            mb_release_id=f"ev-{log_id}",
+            storage_format=storage_format,
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=min_bitrate,
+                format=storage_format,
+                verified_lossless=verified_lossless,
+                spectral_grade=spectral_grade,
+                spectral_bitrate_kbps=spectral_bitrate,
+            ),
+            verified_lossless_proof=VerifiedLosslessProof(
+                proof_origin="test", source="seeded",
+                classifier="contract-test",
+            ) if verified_lossless else None,
+            v0_metric=AlbumQualityV0Metric(
+                avg_bitrate_kbps=v0_probe_avg_bitrate,
+                source_lineage=v0_probe_kind,
+            ) if (v0_probe_kind or v0_probe_avg_bitrate) else None,
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint)
+        assert stored is not None and stored.id is not None
+        self.db.set_download_log_candidate_evidence(log_id, stored.id)
 
     def _cleanup_result(self, log_id: int, *, outcome: str = "deleted"):
         from lib.wrong_match_cleanup_service import (
@@ -395,12 +383,14 @@ class TestWrongMatchesContract(unittest.TestCase):
         from get_wrong_matches() through to the entry dict so the operator
         can eyeball candidates by audio quality.
         """
-        row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
-        row["spectral_grade"] = "suspect"
-        row["spectral_bitrate"] = 320
-        row["v0_probe_kind"] = "lossless_source_v0"
-        row["v0_probe_avg_bitrate"] = 265
-        self.mock_db.get_wrong_matches.return_value = [row]
+        # Legacy denorm columns (evidence rows reject legacy probe
+        # kinds like lossless_source_v0) — the COALESCE path the route
+        # falls back to for pre-evidence rows.
+        self.db.delete_request(100)
+        self._seed_wrong_match(download_log_id=43, log_overrides=dict(
+            spectral_grade="suspect", spectral_bitrate=320,
+            v0_probe_kind="lossless_source_v0", v0_probe_avg_bitrate=265,
+        ))
 
         _, data = self._get("/api/wrong-matches")
         entry = data["groups"][0]["entries"][0]
@@ -410,12 +400,14 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(entry["v0_probe_avg_bitrate"], 265)
 
     def test_entry_surfaces_preserved_source_dirs(self):
-        row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
-        row["validation_result"]["source_dirs"] = [
-            "baduser\\Artist\\Album",
-            "baduser\\Artist\\Album\\CD2",
-        ]
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self.db.delete_request(100)  # replace the setUp row wholesale
+        self._seed_wrong_match(
+            download_log_id=43,
+            validation_overrides={"source_dirs": [
+                "baduser\\Artist\\Album",
+                "baduser\\Artist\\Album\\CD2",
+            ]},
+        )
 
         _, data = self._get("/api/wrong-matches")
         entry = data["groups"][0]["entries"][0]
@@ -430,16 +422,16 @@ class TestWrongMatchesContract(unittest.TestCase):
             with open(track_path, "wb") as handle:
                 handle.write(b"fake mp3 bytes")
 
-            self.mock_db.get_download_log_entry.return_value = {
-                "id": 42,
-                "request_id": 100,
-                "validation_result": {
+            log_id = self.db.log_download(
+                100, outcome="rejected",
+                validation_result={
                     "failed_path": tmpdir,
                     "source_dirs": ["baduser\\Artist\\Album"],
                 },
-            }
+            )
 
-            status, data = self._get("/api/wrong-matches/explorer?download_log_id=42")
+            status, data = self._get(
+                f"/api/wrong-matches/explorer?download_log_id={log_id}")
 
         self.assertEqual(status, 200)
         self.assertEqual(data["status"], "ok")
@@ -447,7 +439,9 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(data["audio_file_count"], 1)
         self.assertEqual(data["files"][0]["relative_path"], "01 - Track.mp3")
         self.assertTrue(data["files"][0]["playable"])
-        self.assertIn("/api/wrong-matches/audio?download_log_id=42", data["files"][0]["stream_url"])
+        self.assertIn(
+            f"/api/wrong-matches/audio?download_log_id={log_id}",
+            data["files"][0]["stream_url"])
 
     def test_wrong_match_explorer_normalizes_raw_id3_tags_and_skips_artwork_frames(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -455,13 +449,10 @@ class TestWrongMatchesContract(unittest.TestCase):
             with open(track_path, "wb") as handle:
                 handle.write(b"fake mp3 bytes")
 
-            self.mock_db.get_download_log_entry.return_value = {
-                "id": 42,
-                "request_id": 100,
-                "validation_result": {
-                    "failed_path": tmpdir,
-                },
-            }
+            log_id = self.db.log_download(
+                100, outcome="rejected",
+                validation_result={"failed_path": tmpdir},
+            )
 
             class _FakeInfo:
                 length = 181.0
@@ -481,7 +472,8 @@ class TestWrongMatchesContract(unittest.TestCase):
                 info = _FakeInfo()
 
             with patch("mutagen.File", return_value=_FakeAudio()):
-                status, data = self._get("/api/wrong-matches/explorer?download_log_id=42")
+                status, data = self._get(
+                    f"/api/wrong-matches/explorer?download_log_id={log_id}")
 
         self.assertEqual(status, 200)
         tags = data["files"][0]["tags"]
@@ -503,10 +495,9 @@ class TestWrongMatchesContract(unittest.TestCase):
                 with open(os.path.join(tmpdir, filename), "wb") as handle:
                     handle.write(b"fake mp3 bytes")
 
-            self.mock_db.get_download_log_entry.return_value = {
-                "id": 42,
-                "request_id": 100,
-                "validation_result": {
+            log_id = self.db.log_download(
+                100, outcome="rejected",
+                validation_result={
                     "failed_path": tmpdir,
                     "candidates": [{
                         "is_target": True,
@@ -526,7 +517,7 @@ class TestWrongMatchesContract(unittest.TestCase):
                         ],
                     }],
                 },
-            }
+            )
 
             class _FakeInfo:
                 length = 181.0
@@ -547,7 +538,8 @@ class TestWrongMatchesContract(unittest.TestCase):
                 return _FakeAudio()
 
             with patch("mutagen.File", side_effect=_fake_audio):
-                status, data = self._get("/api/wrong-matches/explorer?download_log_id=42")
+                status, data = self._get(
+                    f"/api/wrong-matches/explorer?download_log_id={log_id}")
 
         self.assertEqual(status, 200)
         self.assertEqual(data["ordered_by"], "matched")
@@ -573,13 +565,10 @@ class TestWrongMatchesContract(unittest.TestCase):
             with open(track_path, "wb") as handle:
                 handle.write(b"abcdef")
 
-            self.mock_db.get_download_log_entry.return_value = {
-                "id": 42,
-                "request_id": 100,
-                "validation_result": {
-                    "failed_path": tmpdir,
-                },
-            }
+            log_id = self.db.log_download(
+                100, outcome="rejected",
+                validation_result={"failed_path": tmpdir},
+            )
 
             conn = http.client.HTTPConnection(
                 "127.0.0.1", self.port, timeout=10)
@@ -591,7 +580,8 @@ class TestWrongMatchesContract(unittest.TestCase):
                     conn.request(
                         "GET",
                         "/api/wrong-matches/audio"
-                        "?download_log_id=42&path=01%20-%20Track.mp3",
+                        f"?download_log_id={log_id}"
+                        "&path=01%20-%20Track.mp3",
                     )
                     resp = conn.getresponse()
                     self.assertEqual(resp.status, 200)
@@ -611,16 +601,14 @@ class TestWrongMatchesContract(unittest.TestCase):
             with open(track_path, "wb") as handle:
                 handle.write(b"abcdef")
 
-            self.mock_db.get_download_log_entry.return_value = {
-                "id": 42,
-                "request_id": 100,
-                "validation_result": {
-                    "failed_path": tmpdir,
-                },
-            }
+            log_id = self.db.log_download(
+                100, outcome="rejected",
+                validation_result={"failed_path": tmpdir},
+            )
 
             req = Request(
-                f"{self.base}/api/wrong-matches/audio?download_log_id=42&path=01%20-%20Track.mp3",
+                f"{self.base}/api/wrong-matches/audio"
+                f"?download_log_id={log_id}&path=01%20-%20Track.mp3",
                 headers={"Range": "bytes=1-3"},
             )
             with urlopen(req) as resp:
@@ -668,11 +656,10 @@ class TestWrongMatchesContract(unittest.TestCase):
         verified_lossless → entry.verified_lossless, and computes
         quality_rank from format + bitrate via compute_library_rank.
         """
-        row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
-        row["evidence_storage_format"] = "FLAC"
-        row["evidence_min_bitrate"] = 0
-        row["evidence_verified_lossless"] = True
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self._seed_entry_evidence(
+            self.default_log_id,
+            storage_format="FLAC", min_bitrate=0, verified_lossless=True,
+        )
 
         _, data = self._get("/api/wrong-matches")
         entry = data["groups"][0]["entries"][0]
@@ -688,22 +675,23 @@ class TestWrongMatchesContract(unittest.TestCase):
         an evidence-less row. The frontend operator wants the best
         candidate at the top so they can force-import without scrolling.
         """
-        def _row(log_id: int, fmt: str | None, kbps: int | None) -> dict:
-            r = self._row(log_id, 770, f"user{log_id}", f"/fi/p{log_id}",
-                          artist="A", album="B", mb_release_id="mb-x",
-                          distance=0.20)
-            r["evidence_storage_format"] = fmt
-            r["evidence_min_bitrate"] = kbps
-            r["evidence_verified_lossless"] = fmt == "FLAC"
-            return r
+        self.db.delete_request(100)  # drop the setUp group
+        def _seed(log_id: int, fmt: str | None, kbps: int | None) -> None:
+            self._seed_wrong_match(
+                download_log_id=log_id, request_id=770,
+                username=f"user{log_id}", failed_path=f"/fi/p{log_id}",
+                artist="A", album="B", mb_release_id="mb-x",
+                distance=0.20)
+            if fmt is not None:
+                self._seed_entry_evidence(
+                    log_id, storage_format=fmt, min_bitrate=kbps,
+                    verified_lossless=fmt == "FLAC")
 
-        self.mock_db.get_wrong_matches.return_value = [
-            _row(901, None,   None),   # unknown
-            _row(902, "opus", 128),    # transparent
-            _row(903, "MP3",  320),    # transparent
-            _row(904, "FLAC", 0),      # lossless
-            _row(905, "MP3",  192),    # good
-        ]
+        _seed(901, None,   None)   # unknown
+        _seed(902, "opus", 128)    # transparent
+        _seed(903, "MP3",  320)    # transparent
+        _seed(904, "FLAC", 0)      # lossless
+        _seed(905, "MP3",  192)    # good
         with patch("web.routes.imports.resolve_failed_path",
                    side_effect=lambda p: p):
             status, data = self._get("/api/wrong-matches")
@@ -722,11 +710,13 @@ class TestWrongMatchesContract(unittest.TestCase):
 
     def test_multiple_rejections_for_same_request_collapse_to_single_group(self):
         """RED for issue #113: 3 rejections on one request → 1 group with 3 entries."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(3584, 515, "ascalaphid", "/fi/path_9"),
-            self._row(3565, 515, "gatybfb",    "/fi/path_8"),
-            self._row(3559, 515, "jazzush",    "/fi/path_7"),
-        ]
+        self.db.delete_request(100)  # drop the setUp group
+        self._seed_wrong_match(download_log_id=3559, request_id=515,
+                               username="jazzush", failed_path="/fi/path_7")
+        self._seed_wrong_match(download_log_id=3565, request_id=515,
+                               username="gatybfb", failed_path="/fi/path_8")
+        self._seed_wrong_match(download_log_id=3584, request_id=515,
+                               username="ascalaphid", failed_path="/fi/path_9")
         with patch("web.routes.imports.resolve_failed_path",
                    side_effect=lambda p: p):
             status, data = self._get("/api/wrong-matches")
@@ -743,14 +733,16 @@ class TestWrongMatchesContract(unittest.TestCase):
                          "Entries must be ordered newest download_log_id first.")
 
     def test_multiple_releases_return_separate_groups(self):
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(200, 1, "u1", "/fi/a", artist="A1", album="B1",
-                      mb_release_id="mb-1"),
-            self._row(201, 1, "u2", "/fi/b", artist="A1", album="B1",
-                      mb_release_id="mb-1"),
-            self._row(300, 2, "u3", "/fi/c", artist="A2", album="B2",
-                      mb_release_id="mb-2"),
-        ]
+        self.db.delete_request(100)  # drop the setUp group
+        self._seed_wrong_match(download_log_id=200, request_id=1,
+                               username="u1", failed_path="/fi/a",
+                               artist="A1", album="B1", mb_release_id="mb-1")
+        self._seed_wrong_match(download_log_id=201, request_id=1,
+                               username="u2", failed_path="/fi/b",
+                               artist="A1", album="B1", mb_release_id="mb-1")
+        self._seed_wrong_match(download_log_id=300, request_id=2,
+                               username="u3", failed_path="/fi/c",
+                               artist="A2", album="B2", mb_release_id="mb-2")
         with patch("web.routes.imports.resolve_failed_path",
                    side_effect=lambda p: p):
             status, data = self._get("/api/wrong-matches")
@@ -767,13 +759,10 @@ class TestWrongMatchesContract(unittest.TestCase):
                                      "beets_tracks": 12}})
     def test_group_shows_current_quality_when_imported(self, _mock_beets):
         """Imported album: quality_label, quality_rank, verified_lossless reflect on-disk state."""
-        row = self._row(42, 100, "testuser", "/fi/Test")
-        row["request_status"] = "imported"
-        row["request_min_bitrate"] = 207
-        row["request_verified_lossless"] = True
-        row["request_current_spectral_grade"] = "genuine"
-        row["request_imported_path"] = "/mnt/virtio/Music/Beets/Artist/Album"
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self.db.update_request_fields(
+            100, status="imported", min_bitrate=207,
+            verified_lossless=True, current_spectral_grade="genuine",
+            imported_path="/mnt/virtio/Music/Beets/Artist/Album")
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
         self.assertEqual(group["status"], "imported")
@@ -790,11 +779,7 @@ class TestWrongMatchesContract(unittest.TestCase):
 
     def test_group_shows_nothing_on_disk_when_wanted(self):
         """Wanted album: no files in library yet — fields are null, label signals 'not on disk'."""
-        row = self._row(42, 100, "testuser", "/fi/Test")
-        row["request_status"] = "wanted"
-        row["request_min_bitrate"] = None
-        row["request_verified_lossless"] = False
-        self.mock_db.get_wrong_matches.return_value = [row]
+        # setUp's request 100 is already wanted with no on-disk quality.
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
         self.assertEqual(group["status"], "wanted")
@@ -814,13 +799,11 @@ class TestWrongMatchesContract(unittest.TestCase):
         "320k likely_transcode" for a release with nothing on disk and
         force-imports based on false quality data.
         """
-        row = self._row(42, 100, "testuser", "/fi/Test")
-        row["request_status"] = "wanted"
-        row["request_min_bitrate"] = 320                  # stale
-        row["request_verified_lossless"] = False
-        row["request_current_spectral_grade"] = "likely_transcode"  # stale
-        row["request_current_spectral_bitrate"] = 160                # stale
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self.db.update_request_fields(
+            100, status="wanted", min_bitrate=320,            # stale
+            verified_lossless=False,
+            current_spectral_grade="likely_transcode",        # stale
+            current_spectral_bitrate=160)                     # stale
         # No beets mock — _is_in_beets returns False, so every on-disk
         # field in the response should reflect "nothing on disk".
         status, data = self._get("/api/wrong-matches")
@@ -858,14 +841,12 @@ class TestWrongMatchesContract(unittest.TestCase):
         of the album, the honest UI answer is 'not in library' — re-tag
         it or add it to the pipeline.
         """
-        row = self._row(42, 100, "testuser", "/fi/Test",
-                         mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-        row["request_status"] = "imported"
-        row["request_min_bitrate"] = 245
-        row["request_verified_lossless"] = True
-        row["request_current_spectral_grade"] = "genuine"
-        row["request_current_spectral_bitrate"] = None
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self.db.update_request_fields(
+            100, status="imported",
+            mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            min_bitrate=245, verified_lossless=True,
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=None)
 
         status, data = self._get("/api/wrong-matches")
         self.assertEqual(status, 200)
@@ -894,12 +875,10 @@ class TestWrongMatchesContract(unittest.TestCase):
         have returned a match (mocked here with ``create=True`` so the
         test is RED against the current code).
         """
-        row = self._row(42, 100, "testuser", "/fi/Test", mb_release_id=None)
-        row["request_status"] = "imported"
-        row["request_min_bitrate"] = 245
-        row["request_verified_lossless"] = True
-        row["request_current_spectral_grade"] = "genuine"
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self.db.update_request_fields(
+            100, status="imported", mb_release_id=None,
+            min_bitrate=245, verified_lossless=True,
+            current_spectral_grade="genuine")
 
         status, data = self._get("/api/wrong-matches")
         self.assertEqual(status, 200)
@@ -915,33 +894,25 @@ class TestWrongMatchesContract(unittest.TestCase):
         A rejection that happened after a successful import doesn't change what
         beets has — the earlier success is still what's on disk.
         """
-        row = self._row(42, 100, "testuser", "/fi/Test")
-        self.mock_db.get_wrong_matches.return_value = [row]
-        self.mock_db.get_download_history_batch.return_value = {
-            100: [
-                # Newest = rejected (a later force-import attempt that failed).
-                {"id": 999, "outcome": "rejected",
-                 "created_at": "2026-04-19T09:00:00+00:00",
-                 "soulseek_username": "newestuser",
-                 "actual_filetype": "mp3", "actual_min_bitrate": 192,
-                 "beets_scenario": "high_distance"},
-                # Then an older force_import — this is what's actually on disk.
-                {"id": 900, "outcome": "force_import",
-                 "created_at": "2026-04-10T09:00:00+00:00",
-                 "soulseek_username": "forceuser",
-                 "actual_filetype": "mp3", "actual_min_bitrate": 207,
-                 "beets_scenario": "force_import"},
-                {"id": 800, "outcome": "success",
-                 "created_at": "2026-03-10T12:00:00+00:00",
-                 "soulseek_username": "olderuser",
-                 "actual_filetype": "flac", "actual_min_bitrate": 900},
-            ],
-        }
+        # Real history, oldest → newest: success, then a force_import,
+        # then a rejected attempt newest. The summary must pick the
+        # force_import (most recent import), not the newest rejection.
+        self.db.log_download(
+            100, outcome="success", soulseek_username="olderuser",
+            actual_filetype="flac", actual_min_bitrate=900)
+        forced_id = self.db.log_download(
+            100, outcome="force_import", soulseek_username="forceuser",
+            actual_filetype="mp3", actual_min_bitrate=207,
+            beets_scenario="force_import")
+        self.db.log_download(
+            100, outcome="rejected", soulseek_username="newestuser",
+            actual_filetype="mp3", actual_min_bitrate=192,
+            beets_scenario="high_distance")
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
         latest = group["latest_import"]
         self.assertIsNotNone(latest)
-        self.assertEqual(latest["id"], 900,
+        self.assertEqual(latest["id"], forced_id,
                          "Must pick the most recent success/force/manual import, "
                          "not the newest rejection.")
         self.assertEqual(latest["outcome"], "force_import")
@@ -949,37 +920,28 @@ class TestWrongMatchesContract(unittest.TestCase):
 
     def test_group_latest_import_none_when_never_imported(self):
         """Release that has only rejections → latest_import is None."""
-        row = self._row(42, 100, "testuser", "/fi/Test")
-        self.mock_db.get_wrong_matches.return_value = [row]
-        self.mock_db.get_download_history_batch.return_value = {
-            100: [
-                {"id": 999, "outcome": "rejected",
-                 "created_at": "2026-04-19T09:00:00+00:00",
-                 "soulseek_username": "u1"},
-                {"id": 998, "outcome": "timeout",
-                 "created_at": "2026-04-18T09:00:00+00:00",
-                 "soulseek_username": "u2"},
-            ],
-        }
+        self.db.log_download(100, outcome="timeout",
+                             soulseek_username="u2")
+        self.db.log_download(100, outcome="rejected",
+                             soulseek_username="u1")
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
         self.assertIsNone(group["latest_import"])
 
     def test_group_latest_import_none_when_batch_empty(self):
         """Edge case: no history rows at all → latest_import is None."""
-        row = self._row(42, 100, "testuser", "/fi/Test")
-        self.mock_db.get_wrong_matches.return_value = [row]
-        self.mock_db.get_download_history_batch.return_value = {}
+        # Only the setUp rejection exists — no import history at all.
         status, data = self._get("/api/wrong-matches")
         group = data["groups"][0]
         self.assertIsNone(group["latest_import"])
 
     def test_group_dropped_when_no_entries_have_existing_files(self):
         """If every entry's files are gone, the group is excluded from the UI."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(10, 5, "u1", "/gone/a"),
-            self._row(11, 5, "u2", "/gone/b"),
-        ]
+        self.db.delete_request(100)  # drop the setUp group
+        self._seed_wrong_match(download_log_id=10, request_id=5,
+                               username="u1", failed_path="/gone/a")
+        self._seed_wrong_match(download_log_id=11, request_id=5,
+                               username="u2", failed_path="/gone/b")
         with patch("web.routes.imports.resolve_failed_path", return_value=None):
             status, data = self._get("/api/wrong-matches")
         self.assertEqual(status, 200)
@@ -987,10 +949,11 @@ class TestWrongMatchesContract(unittest.TestCase):
 
     def test_group_pending_count_reflects_existing_entries_only(self):
         """pending_count counts entries with files still on disk."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(20, 7, "present", "/on-disk/a"),
-            self._row(21, 7, "missing", "/gone/b"),
-        ]
+        self.db.delete_request(100)  # drop the setUp group
+        self._seed_wrong_match(download_log_id=20, request_id=7,
+                               username="present", failed_path="/on-disk/a")
+        self._seed_wrong_match(download_log_id=21, request_id=7,
+                               username="missing", failed_path="/gone/b")
         with patch("web.routes.imports.resolve_failed_path",
                    side_effect=lambda p: p if p.startswith("/on-disk") else None):
             status, data = self._get("/api/wrong-matches")
@@ -1012,9 +975,9 @@ class TestWrongMatchesContract(unittest.TestCase):
     @patch("web.routes.imports.resolve_failed_path",
            return_value="/mnt/virtio/music/slskd/failed_imports/Test")
     def test_relative_failed_path_uses_resolved_path(self, _mock_resolve):
-        row = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)
-        row["validation_result"]["failed_path"] = "failed_imports/Test"
-        self.mock_db.get_wrong_matches.return_value = [row]
+        self.db.delete_request(100)  # replace the setUp row wholesale
+        self._seed_wrong_match(download_log_id=43,
+                               failed_path="failed_imports/Test")
 
         status, data = self._get("/api/wrong-matches")
 
@@ -1042,7 +1005,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(data["deleted_path"],
                          "/mnt/virtio/music/slskd/failed_imports/Test")
         self.mock_manual_cleanup.assert_called_once_with(
-            self.mock_db,
+            self.db,
             42,
             require_visible=True,
         )
@@ -1069,7 +1032,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(status, 409)
         self.assertEqual(data["error"], "active_import_job")
         self.mock_manual_cleanup.assert_called_once_with(
-            self.mock_db,
+            self.db,
             42,
             require_visible=True,
         )
@@ -1116,7 +1079,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(data["cleared"], 2)
         self.assertEqual(data["deleted_paths"], 2)
         self.assertTrue(data["group_empty"])
-        self.mock_manual_group_cleanup.assert_called_once_with(self.mock_db, 42)
+        self.mock_manual_group_cleanup.assert_called_once_with(self.db, 42)
 
     def test_manual_delete_group_reports_partial_when_rows_are_skipped(self):
         from lib.wrong_match_delete_service import (
@@ -1196,7 +1159,7 @@ class TestWrongMatchesContract(unittest.TestCase):
 
         runner.join(timeout=5)
         mock_cleanup.assert_called_once_with(
-            self.mock_db,
+            self.db,
             confirm_all_wrong_matches=True,
         )
 
@@ -1214,29 +1177,23 @@ class TestWrongMatchesContract(unittest.TestCase):
 
     def test_converge_queues_green_candidates_and_deletes_unmatched(self):
         """Converge queues green rows and deletes high-distance leftovers."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(100, 42, "u1", "/fi/a", distance=0.167),
-            self._row(101, 42, "u2", "/fi/b", distance=0.180),
-            self._row(102, 42, "u3", "/fi/c", distance=0.226),
-            self._row(200, 99, "other", "/fi/other", distance=0.100),
-        ]
-        self.mock_db.get_wrong_matches.return_value[0]["validation_result"]["source_dirs"] = [
-            "u1\\Artist\\Album",
-        ]
-        entries = {
-            100: self._entry(100, 42, "/fi/a"),
-            101: self._entry(101, 42, "/fi/b"),
-            102: self._entry(102, 42, "/fi/c"),
-        }
-        self.mock_db.get_download_log_entry.side_effect = (
-            lambda lid: copy.deepcopy(entries[lid])
-        )
-        self.mock_db.enqueue_import_job.side_effect = [
-            self._job(900, 42, 100, "/fi/a"),
-            self._job(901, 42, 101, "/fi/b"),
-        ]
+        self._seed_wrong_match(
+            download_log_id=100, request_id=42, username="u1",
+            failed_path="/fi/a", distance=0.167,
+            validation_overrides={"source_dirs": ["u1\\Artist\\Album"]})
+        self._seed_wrong_match(
+            download_log_id=101, request_id=42, username="u2",
+            failed_path="/fi/b", distance=0.180)
+        self._seed_wrong_match(
+            download_log_id=102, request_id=42, username="u3",
+            failed_path="/fi/c", distance=0.226)
+        self._seed_wrong_match(
+            download_log_id=200, request_id=99, username="other",
+            failed_path="/fi/other", distance=0.100)
+
         def manual_delete_after_enqueue(_db, log_id, **_kwargs):
-            self.assertEqual(self.mock_db.enqueue_import_job.call_count, 2)
+            # Both green rows were queued BEFORE the unmatched delete ran.
+            self.assertEqual(len(self.db.list_import_jobs()), 2)
             return self._manual_cleanup_result(log_id)
 
         self.mock_manual_cleanup.side_effect = manual_delete_after_enqueue
@@ -1261,41 +1218,38 @@ class TestWrongMatchesContract(unittest.TestCase):
             {item["download_log_id"] for item in data["selected"]},
             {100, 101},
         )
+        jobs = {j.dedupe_key: j for j in self.db.list_import_jobs()}
         self.assertEqual(
-            [call.kwargs["dedupe_key"]
-             for call in self.mock_db.enqueue_import_job.call_args_list],
-            [
+            set(jobs),
+            {
                 "force_import:download_log:100",
                 "force_import:download_log:101",
-            ],
+            },
         )
-        self.mock_db.clear_wrong_match_paths.assert_not_called()
+        # Queued rows stay visible: their failed_path survives.
+        entry_100 = self.db.get_download_log_entry(100)
+        assert entry_100 is not None
         self.assertEqual(
-            self.mock_db.enqueue_import_job.call_args_list[0].kwargs["payload"]["source_dirs"],
+            entry_100["validation_result"]["failed_path"], "/fi/a")
+        self.assertEqual(
+            jobs["force_import:download_log:100"]
+            .payload["source_dirs"],
             ["u1\\Artist\\Album"],
         )
-        self.mock_manual_cleanup.assert_called_once_with(self.mock_db, 102, require_visible=True)
+        self.mock_manual_cleanup.assert_called_once_with(self.db, 102, require_visible=True)
         self.mock_cleanup.assert_not_called()
 
     def test_converge_deletes_unmatched_when_legacy_client_requests_it(self):
         """Legacy true payloads still delete non-green rows while selected rows stay visible."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(100, 42, "u1", "/fi/a", distance=0.167),
-            self._row(101, 42, "u2", "/fi/b", distance=0.180),
-            self._row(102, 42, "u3", "/fi/c", distance=0.226),
-        ]
-        entries = {
-            100: self._entry(100, 42, "/fi/a"),
-            101: self._entry(101, 42, "/fi/b"),
-            102: self._entry(102, 42, "/fi/c"),
-        }
-        self.mock_db.get_download_log_entry.side_effect = (
-            lambda lid: copy.deepcopy(entries[lid])
-        )
-        self.mock_db.enqueue_import_job.side_effect = [
-            self._job(900, 42, 100, "/fi/a"),
-            self._job(901, 42, 101, "/fi/b"),
-        ]
+        self._seed_wrong_match(
+            download_log_id=100, request_id=42, username="u1",
+            failed_path="/fi/a", distance=0.167)
+        self._seed_wrong_match(
+            download_log_id=101, request_id=42, username="u2",
+            failed_path="/fi/b", distance=0.180)
+        self._seed_wrong_match(
+            download_log_id=102, request_id=42, username="u3",
+            failed_path="/fi/c", distance=0.226)
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,
@@ -1308,7 +1262,7 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(data["deleted"], 1)
         self.assertEqual(data["remaining"], 2)
         self.assertFalse(data["group_empty"])
-        self.mock_manual_cleanup.assert_called_once_with(self.mock_db, 102, require_visible=True)
+        self.mock_manual_cleanup.assert_called_once_with(self.db, 102, require_visible=True)
         self.mock_cleanup.assert_not_called()
 
     def test_converge_deletes_unmatched_unconditionally_without_classifier(self):
@@ -1319,18 +1273,12 @@ class TestWrongMatchesContract(unittest.TestCase):
         evidence-based classifier blocked deletion. Converge has already collected
         operator intent; the unmatched row dies.
         """
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(100, 42, "u1", "/fi/a", distance=0.167),
-            self._row(102, 42, "u3", "/fi/c", distance=0.226),
-        ]
-        entries = {
-            100: self._entry(100, 42, "/fi/a"),
-            102: self._entry(102, 42, "/fi/c"),
-        }
-        self.mock_db.get_download_log_entry.side_effect = (
-            lambda lid: copy.deepcopy(entries[lid])
-        )
-        self.mock_db.enqueue_import_job.return_value = self._job(900, 42, 100, "/fi/a")
+        self._seed_wrong_match(
+            download_log_id=100, request_id=42, username="u1",
+            failed_path="/fi/a", distance=0.167)
+        self._seed_wrong_match(
+            download_log_id=102, request_id=42, username="u3",
+            failed_path="/fi/c", distance=0.226)
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,
@@ -1341,14 +1289,14 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(status, 202)
         self.assertEqual(data["deleted"], 1)
         self.assertEqual(data["remaining"], 1)
-        self.mock_manual_cleanup.assert_called_once_with(self.mock_db, 102, require_visible=True)
+        self.mock_manual_cleanup.assert_called_once_with(self.db, 102, require_visible=True)
         self.mock_cleanup.assert_not_called()
 
     def test_converge_skips_missing_green_files(self):
         """A green row with no surviving failed_path is not queued or dismissed."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(100, 42, "u1", "/gone/a", distance=0.167),
-        ]
+        self._seed_wrong_match(
+            download_log_id=100, request_id=42, username="u1",
+            failed_path="/gone/a", distance=0.167)
 
         with patch("web.routes.imports.resolve_failed_path", return_value=None):
             status, data = self._post("/api/wrong-matches/converge", {
@@ -1363,18 +1311,25 @@ class TestWrongMatchesContract(unittest.TestCase):
         self.assertEqual(data["skipped"], [
             {"download_log_id": 100, "reason": "files_missing"},
         ])
-        self.mock_db.enqueue_import_job.assert_not_called()
-        self.mock_db.clear_wrong_match_paths.assert_not_called()
+        self.assertEqual(self.db.list_import_jobs(), [])
+        # The row stays visible — failed_path survives.
+        entry_100 = self.db.get_download_log_entry(100)
+        assert entry_100 is not None
+        self.assertIn("failed_path", entry_100["validation_result"])
         self.mock_cleanup.assert_not_called()
 
     def test_converge_reports_deduped_jobs(self):
         """Existing active force-import jobs still count as selected but remain visible."""
-        self.mock_db.get_wrong_matches.return_value = [
-            self._row(100, 42, "u1", "/fi/a", distance=0.167),
-        ]
-        self.mock_db.get_download_log_entry.return_value = self._entry(100, 42, "/fi/a")
-        self.mock_db.enqueue_import_job.return_value = self._job(
-            900, 42, 100, "/fi/a", deduped=True)
+        self._seed_wrong_match(
+            download_log_id=100, request_id=42, username="u1",
+            failed_path="/fi/a", distance=0.167)
+        # Pre-existing active job with the same dedupe key — converge's
+        # enqueue dedupes against it for real.
+        self.db.enqueue_import_job(
+            "force_import", request_id=42,
+            dedupe_key="force_import:download_log:100",
+            payload={"download_log_id": 100, "failed_path": "/fi/a"},
+        )
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,

--- a/tests/web/test_routes_imports.py
+++ b/tests/web/test_routes_imports.py
@@ -237,6 +237,12 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         vr["soulseek_username"] = username
         vr.update(validation_overrides or {})
         if download_log_id is not None:
+            taken = {e.id for e in self.db.download_logs}
+            assert download_log_id not in taken and all(
+                existing < download_log_id for existing in taken), (
+                f"pinned log id {download_log_id} collides with or "
+                f"precedes existing ids {sorted(taken)} — production's "
+                "sequence-backed PK can never do that")
             self.db._next_download_log_id = download_log_id - 1
         return self.db.log_download(
             request_id, outcome="rejected", soulseek_username=username,
@@ -1179,17 +1185,17 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         """Converge queues green rows and deletes high-distance leftovers."""
         self._seed_wrong_match(
             download_log_id=100, request_id=42, username="u1",
-            failed_path="/fi/a", distance=0.167,
+            failed_path="/fi/a", distance=0.167, mb_release_id="mb-42",
             validation_overrides={"source_dirs": ["u1\\Artist\\Album"]})
         self._seed_wrong_match(
             download_log_id=101, request_id=42, username="u2",
-            failed_path="/fi/b", distance=0.180)
+            failed_path="/fi/b", distance=0.180, mb_release_id="mb-42")
         self._seed_wrong_match(
             download_log_id=102, request_id=42, username="u3",
-            failed_path="/fi/c", distance=0.226)
+            failed_path="/fi/c", distance=0.226, mb_release_id="mb-42")
         self._seed_wrong_match(
             download_log_id=200, request_id=99, username="other",
-            failed_path="/fi/other", distance=0.100)
+            failed_path="/fi/other", distance=0.100, mb_release_id="mb-99")
 
         def manual_delete_after_enqueue(_db, log_id, **_kwargs):
             # Both green rows were queued BEFORE the unmatched delete ran.
@@ -1226,11 +1232,12 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
                 "force_import:download_log:101",
             },
         )
-        # Queued rows stay visible: their failed_path survives.
-        entry_100 = self.db.get_download_log_entry(100)
-        assert entry_100 is not None
-        self.assertEqual(
-            entry_100["validation_result"]["failed_path"], "/fi/a")
+        # EVERY queued row stays visible: failed_path survives on both.
+        for lid, path in ((100, "/fi/a"), (101, "/fi/b")):
+            entry = self.db.get_download_log_entry(lid)
+            assert entry is not None
+            self.assertEqual(
+                entry["validation_result"]["failed_path"], path)
         self.assertEqual(
             jobs["force_import:download_log:100"]
             .payload["source_dirs"],
@@ -1243,13 +1250,13 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         """Legacy true payloads still delete non-green rows while selected rows stay visible."""
         self._seed_wrong_match(
             download_log_id=100, request_id=42, username="u1",
-            failed_path="/fi/a", distance=0.167)
+            failed_path="/fi/a", distance=0.167, mb_release_id="mb-42")
         self._seed_wrong_match(
             download_log_id=101, request_id=42, username="u2",
-            failed_path="/fi/b", distance=0.180)
+            failed_path="/fi/b", distance=0.180, mb_release_id="mb-42")
         self._seed_wrong_match(
             download_log_id=102, request_id=42, username="u3",
-            failed_path="/fi/c", distance=0.226)
+            failed_path="/fi/c", distance=0.226, mb_release_id="mb-42")
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,
@@ -1275,10 +1282,10 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         """
         self._seed_wrong_match(
             download_log_id=100, request_id=42, username="u1",
-            failed_path="/fi/a", distance=0.167)
+            failed_path="/fi/a", distance=0.167, mb_release_id="mb-42")
         self._seed_wrong_match(
             download_log_id=102, request_id=42, username="u3",
-            failed_path="/fi/c", distance=0.226)
+            failed_path="/fi/c", distance=0.226, mb_release_id="mb-42")
 
         status, data = self._post("/api/wrong-matches/converge", {
             "request_id": 42,
@@ -1296,7 +1303,7 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         """A green row with no surviving failed_path is not queued or dismissed."""
         self._seed_wrong_match(
             download_log_id=100, request_id=42, username="u1",
-            failed_path="/gone/a", distance=0.167)
+            failed_path="/gone/a", distance=0.167, mb_release_id="mb-42")
 
         with patch("web.routes.imports.resolve_failed_path", return_value=None):
             status, data = self._post("/api/wrong-matches/converge", {
@@ -1322,7 +1329,7 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         """Existing active force-import jobs still count as selected but remain visible."""
         self._seed_wrong_match(
             download_log_id=100, request_id=42, username="u1",
-            failed_path="/fi/a", distance=0.167)
+            failed_path="/fi/a", distance=0.167, mb_release_id="mb-42")
         # Pre-existing active job with the same dedupe key — converge's
         # enqueue dedupes against it for real.
         self.db.enqueue_import_job(

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -5,7 +5,6 @@ Split from tests/test_web_server.py (#408). Shared harness in
 tests/web/_harness.py.
 """
 
-import copy
 import json
 import os
 import sys
@@ -16,17 +15,27 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import (
-    _MOCK_PIPELINE_REQUEST,
-    _DEFAULT_WRONG_MATCH_ENTRY,
     _assert_required_fields,
-    _WebServerCase,
+    _FakeDbWebServerCase,
 )
 
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
 
-class TestPipelineMutationRouteContracts(_WebServerCase):
+class _RacingDeleteDB(FakePipelineDB):
+    """delete_request races: a superseding descendant lands concurrently,
+    then the FK violation fires — the post-FK walk must see it."""
+
+    def delete_request(self, request_id: int) -> None:
+        import psycopg2.errors
+        self.seed_request(make_request_row(
+            id=250, status="wanted", mb_release_id="race-250",
+            replaces_request_id=request_id))
+        raise psycopg2.errors.ForeignKeyViolation("descendant landed")
+
+
+class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
     """Contract tests for frontend-consumed pipeline mutation routes."""
 
     ADD_REQUIRED_FIELDS = {"status", "id", "artist", "album", "tracks"}
@@ -48,15 +57,14 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
     DELETE_REQUIRED_FIELDS = {"status", "id"}
 
     def setUp(self) -> None:
-        # ``mock_db`` is class-scoped; reset call history so U4's
-        # assertions on ``update_request_fields.call_args_list`` see only
-        # the calls from the current test, not the previous one.
-        self.mock_db.reset_mock()
-        self.mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
-        self.mock_db.get_request_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
-        self.mock_db.add_request.return_value = 501
-        self.mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
+        super().setUp()
+        # Request 100: the lookup target for update/upgrade/set-quality
+        # bodies that pass mb_release_id="abc-123".
+        self.db.seed_request(make_request_row(
+            id=100, status="imported", min_bitrate=320,
+            mb_release_id="abc-123",
+            imported_path="/mnt/virtio/Music/Beets/Test",
+        ))
         # MB add path also calls ``get_release_raw`` (for the resolver's
         # raw payload) alongside the existing ``get_release`` (for slim
         # add_request fields). Class-wide stub so individual tests only
@@ -83,10 +91,12 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "Test Album",
             "year": 2024,
             "country": "US",
-            "tracks": [{"title": "Track"}],
+            "tracks": [{"title": "Track", "track_number": 1,
+                        "disc_number": 1}],
         }
 
-        status, data = self._post("/api/pipeline/add", {"mb_release_id": "abc-123"})
+        status, data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "add-contract-mbid"})
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.ADD_REQUIRED_FIELDS,
@@ -101,8 +111,6 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         """Web add path generates a search plan after `set_tracks()`,
         consistent with the CLI add path. Failures must not break the
         HTTP response."""
-        import web.server as srv
-        fake_db = FakePipelineDB()
         mock_get_release.return_value = {
             "release_group_id": "rg-1",
             "artist_id": "artist-1",
@@ -118,15 +126,14 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             ],
         }
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post(
-                "/api/pipeline/add", {"mb_release_id": "abc-plan-1"})
+        status, data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "abc-plan-1"})
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.ADD_REQUIRED_FIELDS,
                                 "pipeline add response (plan)")
         new_id = data["id"]
-        active = fake_db.get_active_search_plan(new_id)
+        active = self.db.get_active_search_plan(new_id)
         self.assertIsNotNone(active)
         assert active is not None
         from lib.search import SEARCH_PLAN_GENERATOR_ID
@@ -134,11 +141,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(active.next_ordinal, 0)
 
     def test_pipeline_add_exists_contract(self):
-        self.mock_db.get_request_by_mb_release_id.return_value = {
-            "id": 502,
-            "status": "wanted",
-        }
-
+        # Request 100 (setUp) already holds mb_release_id="abc-123".
         status, data = self._post("/api/pipeline/add", {"mb_release_id": "abc-123"})
 
         self.assertEqual(status, 200)
@@ -162,7 +165,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "Kid A",
             "year": 2008,  # reissue
             "country": "US",
-            "tracks": [{"title": "Everything In Its Right Place"}],
+            "tracks": [{"title": "Everything In Its Right Place",
+                        "track_number": 1, "disc_number": 1}],
         }
         mock_rgy.return_value = 2000  # release-group's first year
 
@@ -171,23 +175,20 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_rgy.assert_called_once_with("rg-kid-a")
-        add_kwargs = self.mock_db.add_request.call_args.kwargs
-        self.assertEqual(add_kwargs["year"], 2008)
+        row = self.db.get_request(_data["id"])
+        assert row is not None
+        self.assertEqual(row["year"], 2008)
         # add_request no longer carries release_group_year directly; the
         # resolver service writes it via update_request_fields once the
-        # FK in album_request_field_resolutions is satisfiable.
-        update_calls = self.mock_db.update_request_fields.call_args_list
+        # FK in album_request_field_resolutions is satisfiable. One
+        # write, landed on the row.
         rg_year_writes = [
-            c for c in update_calls
-            if "release_group_year" in c.kwargs
+            c for c in self.db.update_request_fields_calls
+            if "release_group_year" in c[1]
         ]
         self.assertEqual(len(rg_year_writes), 1)
-        self.assertEqual(
-            rg_year_writes[0].kwargs["release_group_year"], 2000,
-        )
-        self.assertEqual(
-            rg_year_writes[0].kwargs.get("is_va_compilation"), False,
-        )
+        self.assertEqual(row["release_group_year"], 2000)
+        self.assertIs(row["is_va_compilation"], False)
 
     @patch("web.routes.pipeline.mb_api.get_release_group_year")
     @patch("web.routes.pipeline.mb_api.get_release")
@@ -203,7 +204,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "Willow",
             "year": 2007,
             "country": "AU",
-            "tracks": [{"title": "And Finally I Can Breathe"}],
+            "tracks": [{"title": "And Finally I Can Breathe",
+                        "track_number": 1, "disc_number": 1}],
         }
         mock_rgy.return_value = 2007
 
@@ -211,17 +213,15 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "/api/pipeline/add", {"mb_release_id": "willow-mbid"})
 
         self.assertEqual(status, 200)
-        add_kwargs = self.mock_db.add_request.call_args.kwargs
-        self.assertEqual(add_kwargs["year"], 2007)
-        update_calls = self.mock_db.update_request_fields.call_args_list
+        row = self.db.get_request(_data["id"])
+        assert row is not None
+        self.assertEqual(row["year"], 2007)
         rg_year_writes = [
-            c for c in update_calls
-            if "release_group_year" in c.kwargs
+            c for c in self.db.update_request_fields_calls
+            if "release_group_year" in c[1]
         ]
         self.assertEqual(len(rg_year_writes), 1)
-        self.assertEqual(
-            rg_year_writes[0].kwargs["release_group_year"], 2007,
-        )
+        self.assertEqual(row["release_group_year"], 2007)
 
     @patch("web.routes.pipeline.mb_api.get_release_group_year")
     @patch("web.routes.pipeline.mb_api.get_release")
@@ -241,7 +241,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "T",
             "year": 2020,
             "country": "US",
-            "tracks": [{"title": "Track"}],
+            "tracks": [{"title": "Track", "track_number": 1,
+                        "disc_number": 1}],
         }
         mock_rgy.return_value = None  # mirror returned 404 / unparseable
 
@@ -251,12 +252,13 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.ADD_REQUIRED_FIELDS,
                                 "pipeline add response (rg 404)")
-        add_kwargs = self.mock_db.add_request.call_args.kwargs
-        self.assertEqual(add_kwargs["year"], 2020)
-        update_calls = self.mock_db.update_request_fields.call_args_list
+        row = self.db.get_request(data["id"])
+        assert row is not None
+        self.assertEqual(row["year"], 2020)
+        self.assertIsNone(row["release_group_year"])
         rg_year_writes = [
-            c for c in update_calls
-            if "release_group_year" in c.kwargs
+            c for c in self.db.update_request_fields_calls
+            if "release_group_year" in c[1]
         ]
         self.assertEqual(rg_year_writes, [],
                          "unresolved rg_year must NOT be written")
@@ -277,7 +279,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "T",
             "year": 2020,
             "country": "US",
-            "tracks": [{"title": "Track"}],
+            "tracks": [{"title": "Track", "track_number": 1,
+                        "disc_number": 1}],
         }
 
         status, _data = self._post(
@@ -285,10 +288,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         mock_rgy.assert_not_called()
-        update_calls = self.mock_db.update_request_fields.call_args_list
         rg_year_writes = [
-            c for c in update_calls
-            if "release_group_year" in c.kwargs
+            c for c in self.db.update_request_fields_calls
+            if "release_group_year" in c[1]
         ]
         self.assertEqual(rg_year_writes, [],
                          "unresolved rg_year must NOT be written")
@@ -316,7 +318,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "Tarantino Presents",
             "year": 2008,
             "country": "US",
-            "tracks": [{"title": "T1"}],
+            "tracks": [{"title": "T1", "track_number": 1,
+                        "disc_number": 1}],
         }
         # Real-VA shape (post-#373): Compilation rg AND per-track
         # artist credits diverge from the album-level credit. The
@@ -340,13 +343,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         status, _data = self._post(
             "/api/pipeline/add", {"mb_release_id": "va-mbid"})
         self.assertEqual(status, 200)
-        update_calls = self.mock_db.update_request_fields.call_args_list
-        va_writes = [
-            c for c in update_calls
-            if c.kwargs.get("is_va_compilation") is True
-        ]
-        self.assertGreaterEqual(len(va_writes), 1,
-                                "is_va_compilation=True must be written")
+        row = self.db.get_request(_data["id"])
+        assert row is not None
+        self.assertTrue(row["is_va_compilation"],
+                        "is_va_compilation=True must land on the row")
 
     @patch("web.routes.pipeline.mb_api.get_release_raw")
     @patch("web.routes.pipeline.mb_api.get_release_group_year")
@@ -360,15 +360,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         — not a normal-shaped plan that would have to wait for the
         next operator regeneration to flip.
 
-        Uses a real ``FakePipelineDB`` because the active plan needs
-        to be fetched after the add lands; ``mock_db`` MagicMock can't
-        round-trip a plan through ``store_search_plan`` /
-        ``get_active_search_plan``.
+        The active plan is fetched after the add lands — the per-test
+        fake round-trips it through the real plan store.
         """
-        import web.server as srv
-        from tests.fakes import FakePipelineDB
-        fake_db = FakePipelineDB()
-
         mock_get_release.return_value = {
             "release_group_id": "rg-va",
             "artist_id": "a-1",
@@ -400,14 +394,13 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         }
         mock_rgy.return_value = 2008
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post(
-                "/api/pipeline/add", {"mb_release_id": "va-plan-mbid"})
+        status, data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "va-plan-mbid"})
         self.assertEqual(status, 200)
 
         new_id = data["id"]
         # VA flag landed.
-        row = fake_db.get_request(new_id)
+        row = self.db.get_request(new_id)
         assert row is not None
         self.assertTrue(row["is_va_compilation"])
 
@@ -416,7 +409,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         # silently passed ``is_va_compilation=False`` into the
         # generator and the plan was the normal-shape (default /
         # literal / literal_flac).
-        active = fake_db.get_active_search_plan(new_id)
+        active = self.db.get_active_search_plan(new_id)
         assert active is not None
         strategies = [item.strategy for item in active.items]
         self.assertTrue(
@@ -450,7 +443,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "Album",
             "year": 2010,
             "country": "GB",
-            "tracks": [{"title": "T1"}],
+            "tracks": [{"title": "T1", "track_number": 1,
+                        "disc_number": 1}],
         }
         # Raw MB JSON shape with label-info present.
         mock_get_raw.return_value = {
@@ -462,12 +456,10 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "/api/pipeline/add", {"mb_release_id": "abc-mbid"})
         self.assertEqual(status, 200)
 
-        catno_writes = [
-            c for c in self.mock_db.update_request_fields.call_args_list
-            if c.kwargs.get("catalog_number") == "STRMRT-001"
-        ]
-        self.assertGreaterEqual(
-            len(catno_writes), 1,
+        row = self.db.get_request(_data["id"])
+        assert row is not None
+        self.assertEqual(
+            row["catalog_number"], "STRMRT-001",
             "resolver-extracted catalog_number must be persisted",
         )
 
@@ -475,12 +467,9 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         """U4 integration: full add-from-web flow against ``FakePipelineDB``
         creates the new row with ``release_group_year`` populated and
         the request reads back correctly."""
-        import web.server as srv
-        fake_db = FakePipelineDB()
         with patch("web.routes.pipeline.mb_api.get_release") as mock_rel, \
              patch("web.routes.pipeline.mb_api.get_release_group_year",
-                   return_value=2000) as mock_rgy, \
-             patch.object(srv, "db", fake_db):
+                   return_value=2000) as mock_rgy:
             mock_rel.return_value = {
                 "release_group_id": "rg-kid-a",
                 "artist_id": "rh-1",
@@ -498,7 +487,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
         self.assertEqual(status, 200)
         new_id = data["id"]
-        row = fake_db.get_request(new_id)
+        row = self.db.get_request(new_id)
         assert row is not None
         self.assertEqual(row["year"], 2008)
         self.assertEqual(row["release_group_year"], 2000)
@@ -507,33 +496,30 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
     def test_pipeline_add_duplicate_does_not_regenerate(self):
         """Duplicate add returns the existing request without generating
         a second plan."""
-        import web.server as srv
-        fake_db = FakePipelineDB()
         # Pre-seed an existing request matching the release id.
-        fake_db.add_request(
+        self.db.add_request(
             mb_release_id="abc-dupe",
             artist_name="Dupe", album_title="Existing", source="request",
         )
-        before = len(fake_db.search_plans)
+        before = len(self.db.search_plans)
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post(
-                "/api/pipeline/add", {"mb_release_id": "abc-dupe"})
+        status, data = self._post(
+            "/api/pipeline/add", {"mb_release_id": "abc-dupe"})
 
         self.assertEqual(status, 200)
         self.assertEqual(data["status"], "exists")
-        self.assertEqual(len(fake_db.search_plans), before)
+        self.assertEqual(len(self.db.search_plans), before)
 
     @patch("web.routes.pipeline.discogs_api.get_release")
     def test_pipeline_add_discogs_contract(self, mock_get_release):
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
         mock_get_release.return_value = {
             "artist_id": "3840",
             "artist_name": "Radiohead",
             "title": "OK Computer",
             "year": 1997,
             "country": "Europe",
-            "tracks": [{"title": "Airbag"}],
+            "tracks": [{"title": "Airbag", "track_number": 1,
+                        "disc_number": 1}],
         }
 
         status, data = self._post("/api/pipeline/add", {"discogs_release_id": "83182"})
@@ -541,16 +527,17 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.ADD_REQUIRED_FIELDS,
                                 "pipeline add discogs response")
-        # Verify both columns populated
-        add_call = self.mock_db.add_request.call_args
-        self.assertEqual(add_call.kwargs["mb_release_id"], "83182")
-        self.assertEqual(add_call.kwargs["discogs_release_id"], "83182")
+        # Verify both columns populated on the persisted row
+        row = self.db.get_request(data["id"])
+        assert row is not None
+        self.assertEqual(row["mb_release_id"], "83182")
+        self.assertEqual(row["discogs_release_id"], "83182")
 
     def test_pipeline_add_discogs_exists_contract(self):
-        self.mock_db.get_request_by_discogs_release_id.return_value = {
-            "id": 503,
-            "status": "imported",
-        }
+        self.db.seed_request(make_request_row(
+            id=503, status="imported",
+            mb_release_id="83182", discogs_release_id="83182",
+        ))
 
         status, data = self._post("/api/pipeline/add", {"discogs_release_id": "83182"})
 
@@ -568,8 +555,6 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
     @patch("web.routes.pipeline.finalize_request")
     def test_pipeline_upgrade_contract(self, _mock_transition):
-        self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
-
         status, data = self._post("/api/pipeline/upgrade", {"mb_release_id": "abc-123"})
 
         self.assertEqual(status, 200)
@@ -583,9 +568,6 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self, mock_mb_get, mock_dg_get, _mock_transition,
     ):
         """Numeric mb_release_id (Discogs) routes to discogs_api, not mb_api."""
-        self.mock_db.get_request_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
-        self.mock_db.add_request.return_value = 999
         mock_dg_get.return_value = {
             "id": "12856590",
             "title": "New.Old.Rare",
@@ -604,16 +586,15 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         mock_dg_get.assert_called_once_with(12856590, fresh=True)
         mock_mb_get.assert_not_called()
         # Confirm Discogs ID is mirrored into both columns for pipeline-compat
-        add_kwargs = self.mock_db.add_request.call_args.kwargs
-        self.assertEqual(add_kwargs["mb_release_id"], "12856590")
-        self.assertEqual(add_kwargs["discogs_release_id"], "12856590")
+        row = self.db.get_request(data["id"])
+        assert row is not None
+        self.assertEqual(row["mb_release_id"], "12856590")
+        self.assertEqual(row["discogs_release_id"], "12856590")
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
                                 "pipeline upgrade response (discogs)")
 
     @patch("web.routes.pipeline.finalize_request")
     def test_pipeline_set_quality_contract(self, _mock_transition):
-        self.mock_db.get_request_by_mb_release_id.return_value = _MOCK_PIPELINE_REQUEST
-
         status, data = self._post(
             "/api/pipeline/set-quality",
             {"mb_release_id": "abc-123", "status": "manual", "min_bitrate": 245},
@@ -627,21 +608,17 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
     def test_pipeline_set_quality_discogs_request_normalizes_and_falls_back(
         self, _mock_transition,
     ):
-        import web.server as srv
-
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=100,
             status="imported",
             mb_release_id="12856590",
             discogs_release_id=None,
         ))
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post(
-                "/api/pipeline/set-quality",
-                {"mb_release_id": " 0012856590 ", "status": "manual", "min_bitrate": 245},
-            )
+        status, data = self._post(
+            "/api/pipeline/set-quality",
+            {"mb_release_id": " 0012856590 ", "status": "manual", "min_bitrate": 245},
+        )
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.SET_QUALITY_REQUIRED_FIELDS,
@@ -649,21 +626,17 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
     @patch("web.routes.pipeline.finalize_request")
     def test_pipeline_upgrade_normalizes_uppercase_uuid(self, mock_transition):
-        import web.server as srv
-
-        fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704,
             status="imported",
             mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             min_bitrate=320,
         ))
 
-        with patch.object(srv, "db", fake_db):
-            status, data = self._post(
-                "/api/pipeline/upgrade",
-                {"mb_release_id": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"},
-            )
+        status, data = self._post(
+            "/api/pipeline/upgrade",
+            {"mb_release_id": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"},
+        )
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.UPGRADE_REQUIRED_FIELDS,
@@ -671,7 +644,8 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         self.assertEqual(mock_transition.call_args.args[1], 1704)
 
     def test_pipeline_set_intent_contract(self):
-        self.mock_db.get_request.return_value = make_request_row(id=100, status="wanted")
+        self.db.seed_request(make_request_row(
+            id=100, status="wanted", mb_release_id="abc-123"))
 
         status, data = self._post("/api/pipeline/set-intent",
                                   {"id": 100, "intent": "lossless"})
@@ -693,20 +667,28 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
 
     @patch("web.routes.pipeline.resolve_failed_path", return_value="/tmp/Test Album")
     def test_pipeline_force_import_contract(self, _mock_resolve):
-        status, data = self._post("/api/pipeline/force-import", {"download_log_id": 42})
+        log_id = self.db.log_download(
+            100, outcome="rejected",
+            validation_result={
+                "failed_path": "/mnt/virtio/music/slskd/failed_imports/Test",
+                "scenario": "high_distance",
+            },
+        )
+        status, data = self._post(
+            "/api/pipeline/force-import", {"download_log_id": log_id})
 
         self.assertEqual(status, 202)
         _assert_required_fields(self, data, self.FORCE_IMPORT_REQUIRED_FIELDS,
                                 "pipeline force-import response")
 
     def test_pipeline_delete_contract(self):
-        # Default: no descendant — delete succeeds.
-        self.mock_db.get_request_by_replaces_request_id.return_value = None
+        # No descendant — delete succeeds and the row is gone.
         status, data = self._post("/api/pipeline/delete", {"id": 100})
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.DELETE_REQUIRED_FIELDS,
                                 "pipeline delete response")
+        self.assertIsNone(self.db.get_request(100))
 
     def test_pipeline_delete_with_descendant_returns_409(self):
         """Deleting a request that has a superseding descendant is
@@ -715,56 +697,38 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         route walks the descendant chain and returns 409 with the
         list of descendant IDs so the operator can prune the lineage
         leaf-first."""
-        # Reset shared-class mock state from prior tests.
-        self.mock_db.delete_request.reset_mock()
-        self.mock_db.delete_request.side_effect = None
-        # Chain: 100 → 200 → 300.
-        def descendant_of(req_id):
-            if req_id == 100:
-                return {"id": 200, "status": "wanted",
-                        "replaces_request_id": 100}
-            if req_id == 200:
-                return {"id": 300, "status": "imported",
-                        "replaces_request_id": 200}
-            return None
-        self.mock_db.get_request_by_replaces_request_id.side_effect = (
-            descendant_of
-        )
+        # Real supersede chain: 100 ← 200 ← 300.
+        self.db.seed_request(make_request_row(
+            id=200, status="wanted", mb_release_id="chain-200",
+            replaces_request_id=100))
+        self.db.seed_request(make_request_row(
+            id=300, status="imported", mb_release_id="chain-300",
+            replaces_request_id=200))
         status, data = self._post("/api/pipeline/delete", {"id": 100})
 
         self.assertEqual(status, 409)
         self.assertIn("error", data)
         self.assertIn("descendant_request_ids", data)
         self.assertEqual(data["descendant_request_ids"], [200, 300])
-        # delete_request must NOT have been called on the route's
-        # happy path when the descendant block fires.
-        self.mock_db.delete_request.assert_not_called()
-        # Clear side_effect for downstream tests.
-        self.mock_db.get_request_by_replaces_request_id.side_effect = None
-        self.mock_db.get_request_by_replaces_request_id.return_value = None
+        # The descendant block fired before any delete — the row
+        # survives.
+        self.assertIsNotNone(self.db.get_request(100))
 
     def test_pipeline_delete_fk_violation_returns_409(self):
-        """Defensive race-window guard: a descendant landed between the
-        route's read and the delete. The FK violation surfaces as 409
-        rather than a 500, mirroring the pre-check shape."""
-        import psycopg2.errors
-        self.mock_db.get_request_by_replaces_request_id.side_effect = [
-            # First call (pre-check) sees no descendant.
-            None,
-            # Second call (post-FK error walk) sees the descendant.
-            {"id": 250, "status": "wanted", "replaces_request_id": 100},
-            # Third call (chain walk) sees no further descendants.
-            None,
-        ]
-        self.mock_db.delete_request.side_effect = (
-            psycopg2.errors.ForeignKeyViolation("descendant landed")
-        )
-        status, data = self._post("/api/pipeline/delete", {"id": 100})
+        """Defensive race-window guard: a descendant lands between the
+        route's read and the delete (modelled by a typed fake whose
+        delete seeds the descendant then raises the FK violation). The
+        violation surfaces as 409 rather than a 500, mirroring the
+        pre-check shape."""
+        import web.server as srv
+        racing = _RacingDeleteDB()
+        racing.seed_request(make_request_row(
+            id=100, status="imported", mb_release_id="abc-123"))
+        with patch.object(srv, "db", racing):
+            status, data = self._post("/api/pipeline/delete", {"id": 100})
         self.assertEqual(status, 409)
         self.assertIn("error", data)
         self.assertEqual(data["descendant_request_ids"], [250])
-        # Reset side_effects for downstream tests.
-        self.mock_db.delete_request.side_effect = None
 
     # -- fresh=True seam (Codex review on issue #101) ----------------
 
@@ -787,11 +751,12 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             "title": "Test Album",
             "year": 2024,
             "country": "US",
-            "tracks": [{"title": "Track"}],
+            "tracks": [{"title": "Track", "track_number": 1,
+                        "disc_number": 1}],
         }
 
         status, _data = self._post("/api/pipeline/add",
-                                   {"mb_release_id": "abc-123"})
+                                   {"mb_release_id": "fresh-add-mbid"})
 
         self.assertEqual(status, 200)
         # ``get_release`` is now called multiple times — once by the
@@ -801,20 +766,20 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         # stale cache snapshot.
         self.assertGreaterEqual(mock_get_release.call_count, 1)
         for call in mock_get_release.call_args_list:
-            self.assertEqual(call.args, ("abc-123",))
+            self.assertEqual(call.args, ("fresh-add-mbid",))
             self.assertEqual(call.kwargs, {"fresh": True})
 
     @patch("routes.pipeline.discogs_api.get_release")
     def test_pipeline_add_discogs_fetches_release_fresh(self, mock_get_release):
         """POST /api/pipeline/add (Discogs) MUST bypass the 24h meta cache."""
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
         mock_get_release.return_value = {
             "artist_id": "3840",
             "artist_name": "Radiohead",
             "title": "OK Computer",
             "year": 1997,
             "country": "Europe",
-            "tracks": [{"title": "Airbag"}],
+            "tracks": [{"title": "Airbag", "track_number": 1,
+                        "disc_number": 1}],
         }
 
         status, _data = self._post("/api/pipeline/add",
@@ -835,9 +800,6 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             self, mock_get_release, _mock_transition):
         """POST /api/pipeline/upgrade creating a brand-new MB request
         MUST bypass the meta cache — same rationale as add."""
-        self.mock_db.get_request_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
-        self.mock_db.add_request.return_value = 999
         mock_get_release.return_value = {
             "artist_id": "a-1", "artist_name": "A", "title": "T",
             "year": 2024, "country": "US", "tracks": [],
@@ -858,9 +820,6 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
             self, mock_get_release, _mock_transition):
         """POST /api/pipeline/upgrade creating a brand-new Discogs request
         MUST bypass the meta cache — same rationale as add."""
-        self.mock_db.get_request_by_mb_release_id.return_value = None
-        self.mock_db.get_request_by_discogs_release_id.return_value = None
-        self.mock_db.add_request.return_value = 999
         mock_get_release.return_value = {
             "id": "12856590", "title": "New.Old.Rare",
             "artist_name": "Blueline Medic", "artist_id": "3640",
@@ -875,7 +834,7 @@ class TestPipelineMutationRouteContracts(_WebServerCase):
         mock_get_release.assert_called_once_with(12856590, fresh=True)
 
 
-class TestUserRequeueOverridePreservation(_WebServerCase):
+class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
     """User-initiated requeue endpoints must preserve a stricter existing
     search_filetype_override — e.g. 'lossless' set by the quality gate after a
     CBR 320 import. Clicking Upgrade or flipping status back to wanted must not
@@ -890,6 +849,7 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     RELEASE_ID = "c6cd62c4-da2a-4a89-a219-adba66d6c7d4"
 
     def setUp(self) -> None:
+        super().setUp()
         import web.server as srv
         self._srv = srv
         self._orig_beets = srv._beets
@@ -966,10 +926,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     @patch("web.routes.pipeline.finalize_request")
     def test_upgrade_preserves_stricter_override(self, mock_transition):
         """Upgrade on an imported album with override='lossless' must keep it."""
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", min_bitrate=320,
+            mb_release_id=self.RELEASE_ID,
             search_filetype_override="lossless",
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/upgrade",
                                     {"mb_release_id": self.RELEASE_ID})
@@ -980,10 +941,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     @patch("web.routes.pipeline.finalize_request")
     def test_upgrade_preserves_narrowed_override(self, mock_transition):
         """Upgrade must preserve a post-downgrade-narrow like 'lossless,mp3 v0'."""
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", min_bitrate=320,
+            mb_release_id=self.RELEASE_ID,
             search_filetype_override="lossless,mp3 v0",
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/upgrade",
                                     {"mb_release_id": self.RELEASE_ID})
@@ -996,10 +958,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         """Upgrade on an imported album with no override falls back to the full ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
 
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", min_bitrate=160,
+            mb_release_id=self.RELEASE_ID,
             search_filetype_override=None,
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/upgrade",
                                     {"mb_release_id": self.RELEASE_ID})
@@ -1013,10 +976,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
             self, mock_transition):
         """Missing Beets quality data must not clear the existing DB baseline."""
         self._beets.get_min_bitrate.return_value = None
-        self.mock_db.get_request_by_mb_release_id.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", min_bitrate=320,
+            mb_release_id=self.RELEASE_ID,
             search_filetype_override="lossless",
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/upgrade",
                                     {"mb_release_id": self.RELEASE_ID})
@@ -1031,11 +995,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     @patch("web.routes.pipeline.finalize_request")
     def test_update_to_wanted_preserves_stricter_override(self, mock_transition):
         """Flipping an imported album back to wanted must preserve 'lossless'."""
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
             search_filetype_override="lossless",
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/update",
                                     {"id": 1704, "status": "wanted"})
@@ -1049,11 +1013,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         """Flipping imported→wanted with no override uses the full upgrade ladder."""
         from lib.quality import QUALITY_UPGRADE_TIERS
 
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=160,
             search_filetype_override=None,
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/update",
                                     {"id": 1704, "status": "wanted"})
@@ -1067,11 +1031,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
     @patch("web.routes.pipeline.finalize_request")
     def test_ban_source_preserves_stricter_override(self, mock_transition):
         """Pin: ban_source already preserves override. Guard against future regression."""
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
             search_filetype_override="lossless",
-        )
+        ))
 
         status, _data = self._post("/api/pipeline/ban-source", {
             "request_id": 1704, "username": "baduser",
@@ -1095,16 +1059,15 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         clear-on-disk-quality. Issue #121 couples both sides via
         ``lib.release_cleanup.remove_and_reset_release``.
         """
-        self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
             returncode=0, stdout="", stderr="")
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
             current_spectral_grade="likely_transcode",
             current_spectral_bitrate=160,
             verified_lossless=False,
-        )
+        ))
         # First locate: was present. Second (after remove): gone.
         self._set_locate_sequence([
             ("exact", 1, ()),
@@ -1117,7 +1080,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         })
 
         self.assertEqual(status, 200)
-        self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
+        # The on-disk quality fields are wiped on the row itself.
+        row = self.db.request(1704)
+        self.assertIsNone(row["current_spectral_grade"])
+        self.assertIsNone(row["current_spectral_bitrate"])
 
     @patch("lib.beets_album_op.sp.run")
     @patch("web.routes.pipeline.finalize_request")
@@ -1132,15 +1098,14 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         user the ban committed but the on-disk remove was incomplete
         (issue #123 PR B).
         """
-        self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
             returncode=1, stdout="", stderr="beet failed")
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
             current_spectral_grade="genuine",
             verified_lossless=True,
-        )
+        ))
         # Album is still there after the remove attempt. Seed the
         # selector tuple so the remove loop has something to iterate.
         self._set_locate_sequence([
@@ -1154,7 +1119,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         })
 
         self.assertEqual(status, 200)
-        self.mock_db.clear_on_disk_quality_fields.assert_not_called()
+        # Album still on disk → the on-disk quality stays accurate.
+        row = self.db.request(1704)
+        self.assertEqual(row["current_spectral_grade"], "genuine")
+        self.assertTrue(row["verified_lossless"])
         # #123 PR B + plan 2026-04-29-005 U4: the non-zero rc now
         # surfaces under ``partial_failures.cleanup_errors`` (the
         # unified shape). Distinguishes "banned cleanly" from
@@ -1177,13 +1145,12 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         every caller that asks 'is this release on disk?' agrees on
         the same selector set.
         """
-        self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
             returncode=0, stdout="", stderr="")
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id="12856590",
             min_bitrate=320,
-        )
+        ))
         # Was there (with BOTH Discogs selectors); after both removes, gone.
         self._set_locate_sequence([
             ("exact", 1, ("discogs_albumid:12856590", "mb_albumid:12856590")),
@@ -1217,16 +1184,15 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         doesn't keep deriving ``--override-min-bitrate`` from phantom
         baselines on the next import attempt.
         """
-        self.mock_db.clear_on_disk_quality_fields.reset_mock()
         mock_subprocess.return_value = MagicMock(
             returncode=0, stdout="", stderr="")
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
             current_spectral_grade="likely_transcode",
             current_spectral_bitrate=160,
             imported_path="/mnt/virtio/Music/Beets/Stale/Path",
-        )
+        ))
         # Album was already gone when ban-source ran (earlier beet rm).
         self._set_locate_sequence([
             ("absent", None, ()),
@@ -1239,7 +1205,10 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         })
 
         self.assertEqual(status, 200)
-        self.mock_db.clear_on_disk_quality_fields.assert_called_once_with(1704)
+        # Phantom baselines wiped on the row itself.
+        row = self.db.request(1704)
+        self.assertIsNone(row["current_spectral_grade"])
+        self.assertIsNone(row["current_spectral_bitrate"])
         # No remove ran — the handler had nothing to remove.
         mock_subprocess.assert_not_called()
 
@@ -1250,13 +1219,12 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
         ``remove_and_reset_release`` deletes them. Without it, there is
         no album to ban — return 400 rather than silently skip.
         """
-        self.mock_db.clear_on_disk_quality_fields.reset_mock()
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported",
             min_bitrate=320,
             current_spectral_grade="genuine",
             verified_lossless=True,
-        )
+        ))
 
         status, data = self._post("/api/pipeline/ban-source", {
             "request_id": 1704, "username": "baduser",
@@ -1265,10 +1233,11 @@ class TestUserRequeueOverridePreservation(_WebServerCase):
 
         self.assertEqual(status, 400)
         self.assertIn("mb_release_id", data.get("error", ""))
-        self.mock_db.clear_on_disk_quality_fields.assert_not_called()
+        row = self.db.request(1704)
+        self.assertEqual(row["current_spectral_grade"], "genuine")
 
 
-class TestBanSourceBadRipExtensions(_WebServerCase):
+class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
     """Plan 2026-04-29-005 U4: bad-rip hash capture + server-side
     username resolution + importer-race 409 + unified
     ``partial_failures`` response shape on ``POST /api/pipeline/ban-source``.
@@ -1281,6 +1250,7 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
     HASH_B = b"\x02" * 32
 
     def setUp(self) -> None:
+        super().setUp()
         import web.server as srv
         self._srv = srv
         self._orig_beets = srv._beets
@@ -1295,19 +1265,10 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         )
         srv._beets = self._beets
 
-        # Reset bad-rip-related mocks so cross-test state doesn't leak.
-        self.mock_db.get_active_import_job_for_request.reset_mock()
-        self.mock_db.get_active_import_job_for_request.return_value = None
-        self.mock_db.get_recent_successful_uploader.reset_mock()
-        self.mock_db.get_recent_successful_uploader.return_value = None
-        self.mock_db.add_bad_audio_hashes.reset_mock()
-        self.mock_db.add_bad_audio_hashes.return_value = 0
-        self.mock_db.add_denylist.reset_mock()
-        self.mock_db.log_download.reset_mock()
-        self.mock_db.get_request.return_value = make_request_row(
+        self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
             min_bitrate=320,
-        )
+        ))
 
     def tearDown(self) -> None:
         self._srv._beets = self._orig_beets
@@ -1322,14 +1283,16 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         download_log, hashes every track via ``hash_audio_content``,
         and persists them with the resolved username (R3, R5, R7).
         """
-        self.mock_db.get_recent_successful_uploader.return_value = "Hxrco"
+        # A prior successful download from Hxrco — the server resolves
+        # the uploader from the real download_log.
+        self.db.log_download(
+            1704, outcome="success", soulseek_username="Hxrco")
         self._beets.get_item_paths.return_value = [
             (1, "/mnt/Music/Beets/A/track-01.flac"),
             (2, "/mnt/Music/Beets/A/track-02.flac"),
         ]
         # Distinct digests per call so the route inserts both rows.
         mock_hash.side_effect = [self.HASH_A, self.HASH_B]
-        self.mock_db.add_bad_audio_hashes.return_value = 2
 
         status, data = self._post(
             "/api/pipeline/ban-source",
@@ -1341,29 +1304,29 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.assertEqual(data["hashes_recorded"], 2)
         # Happy path: no partial_failures on the response.
         self.assertNotIn("partial_failures", data)
-        # add_bad_audio_hashes called with the resolved username + reason.
-        self.mock_db.add_bad_audio_hashes.assert_called_once()
-        call_args = self.mock_db.add_bad_audio_hashes.call_args
-        self.assertEqual(call_args.args[0], 1704)
-        self.assertEqual(call_args.args[1], "Hxrco")
-        self.assertEqual(call_args.args[2], "manually banned via web UI")
-        hashes_arg = call_args.args[3]
-        self.assertEqual(len(hashes_arg), 2)
-        self.assertEqual(hashes_arg[0].hash_value, self.HASH_A)
-        self.assertEqual(hashes_arg[0].audio_format, "flac")
-        self.assertEqual(hashes_arg[1].hash_value, self.HASH_B)
+        # Both hashes persisted with the resolved username + reason.
+        rows = self.db.bad_audio_hashes
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0].request_id, 1704)
+        self.assertEqual(rows[0].reported_username, "Hxrco")
+        self.assertEqual(rows[0].reason, "manually banned via web UI")
+        self.assertEqual(rows[0].hash_value, self.HASH_A)
+        self.assertEqual(rows[0].audio_format, "flac")
+        self.assertEqual(rows[1].hash_value, self.HASH_B)
         # Denylist written for the resolved user.
-        self.mock_db.add_denylist.assert_called_once_with(
-            1704, "Hxrco", "manually banned via web UI"
-        )
-        # #188 follow-up: a download_log row records the ban event.
-        self.mock_db.log_download.assert_called_once()
-        log_kwargs = self.mock_db.log_download.call_args.kwargs
-        self.assertEqual(log_kwargs["request_id"], 1704)
-        self.assertEqual(log_kwargs["soulseek_username"], "Hxrco")
-        self.assertEqual(log_kwargs["outcome"], "curator_ban")
-        self.assertIn("Marked bad rip", log_kwargs["beets_detail"])
-        ban_meta = json.loads(log_kwargs["validation_result"])
+        self.assertEqual(len(self.db.denylist), 1)
+        self.assertEqual(self.db.denylist[0].username, "Hxrco")
+        self.assertEqual(
+            self.db.denylist[0].reason, "manually banned via web UI")
+        # #188 follow-up: a download_log row records the ban event
+        # (newest row after the seeded success).
+        ban_row = self.db.download_logs[-1]
+        self.assertEqual(ban_row.request_id, 1704)
+        self.assertEqual(ban_row.soulseek_username, "Hxrco")
+        self.assertEqual(ban_row.outcome, "curator_ban")
+        assert ban_row.beets_detail is not None
+        self.assertIn("Marked bad rip", ban_row.beets_detail)
+        ban_meta = json.loads(ban_row.validation_result)
         self.assertEqual(ban_meta["scenario"], "curator_ban")
         self.assertEqual(ban_meta["hashes_recorded"], 2)
         self.assertEqual(ban_meta["denylisted_username"], "Hxrco")
@@ -1377,7 +1340,8 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         succeeded count, ``partial_failures.hash_capture_errors``
         names the failed path, denylist + remove + requeue still run.
         """
-        self.mock_db.get_recent_successful_uploader.return_value = "Hxrco"
+        self.db.log_download(
+            1704, outcome="success", soulseek_username="Hxrco")
         self._beets.get_item_paths.return_value = [
             (1, "/mnt/Music/Beets/A/track-01.flac"),
             (2, "/mnt/Music/Beets/A/track-02.flac"),
@@ -1390,7 +1354,6 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
             AudioHashError("ffmpeg failed (rc=1): truncated mp3"),
             self.HASH_B,
         ]
-        self.mock_db.add_bad_audio_hashes.return_value = 2
 
         status, data = self._post(
             "/api/pipeline/ban-source",
@@ -1406,10 +1369,9 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
                          "/mnt/Music/Beets/A/track-02.flac")
         self.assertIn("truncated", errors[0]["reason"])
         # Denylist still runs for the resolved user.
-        self.mock_db.add_denylist.assert_called_once()
-        # ``add_bad_audio_hashes`` called with the two SUCCESSFUL hashes only.
-        hashes_arg = self.mock_db.add_bad_audio_hashes.call_args.args[3]
-        self.assertEqual(len(hashes_arg), 2)
+        self.assertEqual(len(self.db.denylist), 1)
+        # Only the two SUCCESSFUL hashes persisted.
+        self.assertEqual(len(self.db.bad_audio_hashes), 2)
 
     # E1.1 — no successful uploader on record.
     @patch("web.routes.pipeline.hash_audio_content")
@@ -1420,12 +1382,11 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         ``add_denylist`` not called, but hashes ARE recorded with
         ``reported_username=None`` (the bytes are still protected).
         """
-        self.mock_db.get_recent_successful_uploader.return_value = None
+        # No successful download on record — nothing seeded.
         self._beets.get_item_paths.return_value = [
             (1, "/mnt/Music/Beets/A/track-01.mp3"),
         ]
         mock_hash.return_value = self.HASH_A
-        self.mock_db.add_bad_audio_hashes.return_value = 1
 
         status, data = self._post(
             "/api/pipeline/ban-source",
@@ -1437,15 +1398,14 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.assertEqual(data["hashes_recorded"], 1)
         self.assertNotIn("partial_failures", data)
         # #188 follow-up: ban event still logged with NULL username.
-        self.mock_db.log_download.assert_called_once()
-        log_kwargs = self.mock_db.log_download.call_args.kwargs
-        self.assertEqual(log_kwargs["outcome"], "curator_ban")
-        self.assertIsNone(log_kwargs["soulseek_username"])
+        ban_row = self.db.download_logs[-1]
+        self.assertEqual(ban_row.outcome, "curator_ban")
+        self.assertIsNone(ban_row.soulseek_username)
         # Hashes recorded with username=None.
-        call_args = self.mock_db.add_bad_audio_hashes.call_args
-        self.assertIsNone(call_args.args[1])
-        # No denylist call when no user resolved.
-        self.mock_db.add_denylist.assert_not_called()
+        self.assertEqual(len(self.db.bad_audio_hashes), 1)
+        self.assertIsNone(self.db.bad_audio_hashes[0].reported_username)
+        # No denylist entry when no user resolved.
+        self.assertEqual(self.db.denylist, [])
 
     # E1.2 — album not in beets / no track paths.
     @patch("web.routes.pipeline.finalize_request")
@@ -1456,7 +1416,8 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         ``no_tracks_in_beets`` entry; denylist still runs if
         username resolved; no hashes recorded.
         """
-        self.mock_db.get_recent_successful_uploader.return_value = "Hxrco"
+        self.db.log_download(
+            1704, outcome="success", soulseek_username="Hxrco")
         self._beets.get_item_paths.return_value = []
 
         status, data = self._post(
@@ -1472,11 +1433,10 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.assertIsNone(errors[0]["track_path"])
         self.assertEqual(errors[0]["reason"], "no_tracks_in_beets")
         # Denylist still written.
-        self.mock_db.add_denylist.assert_called_once_with(
-            1704, "Hxrco", "manually banned via web UI"
-        )
-        # No add_bad_audio_hashes call (empty list short-circuit).
-        self.mock_db.add_bad_audio_hashes.assert_not_called()
+        self.assertEqual(len(self.db.denylist), 1)
+        self.assertEqual(self.db.denylist[0].username, "Hxrco")
+        # No hashes persisted (empty list short-circuit).
+        self.assertEqual(self.db.bad_audio_hashes, [])
 
     # E1.3 — importer race: 409 before any work.
     def test_importer_busy_returns_409_no_writes(self):
@@ -1484,9 +1444,14 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         ``{error: "importer_busy", retry_after_seconds: 30}``. No
         denylist, no hashes, no beets_db calls.
         """
-        self.mock_db.get_active_import_job_for_request.return_value = {
-            "id": 99, "request_id": 1704, "status": "running",
-        }
+        # An active (queued) import job for the request — the fake's
+        # get_active_import_job_for_request treats queued and running
+        # alike, mirroring the production active-set.
+        self.db.enqueue_import_job(
+            "force_import", request_id=1704,
+            dedupe_key="force_import:download_log:99",
+            payload={"failed_path": "/tmp/Busy Album"},
+        )
 
         status, data = self._post(
             "/api/pipeline/ban-source",
@@ -1498,8 +1463,8 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.assertEqual(data["error"], "importer_busy")
         self.assertEqual(data["retry_after_seconds"], 30)
         # No mutation of any kind.
-        self.mock_db.add_denylist.assert_not_called()
-        self.mock_db.add_bad_audio_hashes.assert_not_called()
+        self.assertEqual(self.db.denylist, [])
+        self.assertEqual(self.db.bad_audio_hashes, [])
         self._beets.get_item_paths.assert_not_called()
         self._beets.locate.assert_not_called()
 
@@ -1512,14 +1477,22 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         the DB layer; ``add_bad_audio_hashes`` returns 0). Response
         is 200 with ``hashes_recorded: 0`` and no ``partial_failures``.
         """
-        self.mock_db.get_recent_successful_uploader.return_value = "Hxrco"
+        self.db.log_download(
+            1704, outcome="success", soulseek_username="Hxrco")
         self._beets.get_item_paths.return_value = [
             (1, "/mnt/Music/Beets/A/track-01.flac"),
         ]
         mock_hash.return_value = self.HASH_A
-        # DB layer returns 0 — every (hash, format) already present.
-        self.mock_db.add_bad_audio_hashes.return_value = 0
 
+        # First click inserts the hash for real...
+        status, data = self._post(
+            "/api/pipeline/ban-source",
+            {"request_id": 1704, "mb_release_id": self.RELEASE_ID},
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(data["hashes_recorded"], 1)
+
+        # ...the second click dedupes on (hash, format) and inserts 0.
         status, data = self._post(
             "/api/pipeline/ban-source",
             {"request_id": 1704, "mb_release_id": self.RELEASE_ID},
@@ -1528,6 +1501,7 @@ class TestBanSourceBadRipExtensions(_WebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(data["hashes_recorded"], 0)
         self.assertNotIn("partial_failures", data)
+        self.assertEqual(len(self.db.bad_audio_hashes), 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -724,6 +724,9 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
         racing = _RacingDeleteDB()
         racing.seed_request(make_request_row(
             id=100, status="imported", mb_release_id="abc-123"))
+        # Re-bind self.db so any assertion in this test targets the
+        # live fake, never setUp's now-shadowed one.
+        self.db = racing
         with patch.object(srv, "db", racing):
             status, data = self._post("/api/pipeline/delete", {"id": 100})
         self.assertEqual(status, 409)
@@ -1080,10 +1083,14 @@ class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
         })
 
         self.assertEqual(status, 200)
-        # The on-disk quality fields are wiped on the row itself.
+        # The full wipe ran (recorder pins the helper, not an inline
+        # partial wipe) and the operator-visible fields are gone.
+        self.assertEqual(self.db.clear_on_disk_quality_fields_calls, [1704])
         row = self.db.request(1704)
         self.assertIsNone(row["current_spectral_grade"])
         self.assertIsNone(row["current_spectral_bitrate"])
+        self.assertFalse(row["verified_lossless"])
+        self.assertIsNone(row["imported_path"])
 
     @patch("lib.beets_album_op.sp.run")
     @patch("web.routes.pipeline.finalize_request")
@@ -1119,7 +1126,8 @@ class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
         })
 
         self.assertEqual(status, 200)
-        # Album still on disk → the on-disk quality stays accurate.
+        # Album still on disk → the wipe must not run at all.
+        self.assertEqual(self.db.clear_on_disk_quality_fields_calls, [])
         row = self.db.request(1704)
         self.assertEqual(row["current_spectral_grade"], "genuine")
         self.assertTrue(row["verified_lossless"])
@@ -1205,10 +1213,13 @@ class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
         })
 
         self.assertEqual(status, 200)
-        # Phantom baselines wiped on the row itself.
+        # Phantom baselines wiped on the row itself — INCLUDING the
+        # stale imported_path that misleads every downstream consumer.
+        self.assertEqual(self.db.clear_on_disk_quality_fields_calls, [1704])
         row = self.db.request(1704)
         self.assertIsNone(row["current_spectral_grade"])
         self.assertIsNone(row["current_spectral_bitrate"])
+        self.assertIsNone(row["imported_path"])
         # No remove ran — the handler had nothing to remove.
         mock_subprocess.assert_not_called()
 
@@ -1233,6 +1244,7 @@ class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
 
         self.assertEqual(status, 400)
         self.assertIn("mb_release_id", data.get("error", ""))
+        self.assertEqual(self.db.clear_on_disk_quality_fields_calls, [])
         row = self.db.request(1704)
         self.assertEqual(row["current_spectral_grade"], "genuine")
 
@@ -1318,9 +1330,11 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         self.assertEqual(self.db.denylist[0].username, "Hxrco")
         self.assertEqual(
             self.db.denylist[0].reason, "manually banned via web UI")
-        # #188 follow-up: a download_log row records the ban event
-        # (newest row after the seeded success).
-        ban_row = self.db.download_logs[-1]
+        # #188 follow-up: EXACTLY ONE download_log row records the ban.
+        ban_rows = [r for r in self.db.download_logs
+                    if r.outcome == "curator_ban"]
+        self.assertEqual(len(ban_rows), 1)
+        ban_row = ban_rows[0]
         self.assertEqual(ban_row.request_id, 1704)
         self.assertEqual(ban_row.soulseek_username, "Hxrco")
         self.assertEqual(ban_row.outcome, "curator_ban")
@@ -1397,8 +1411,11 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         self.assertIsNone(data["username"])
         self.assertEqual(data["hashes_recorded"], 1)
         self.assertNotIn("partial_failures", data)
-        # #188 follow-up: ban event still logged with NULL username.
-        ban_row = self.db.download_logs[-1]
+        # #188 follow-up: EXACTLY ONE ban event, with NULL username.
+        ban_rows = [r for r in self.db.download_logs
+                    if r.outcome == "curator_ban"]
+        self.assertEqual(len(ban_rows), 1)
+        ban_row = ban_rows[0]
         self.assertEqual(ban_row.outcome, "curator_ban")
         self.assertIsNone(ban_row.soulseek_username)
         # Hashes recorded with username=None.
@@ -1468,14 +1485,33 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         self._beets.get_item_paths.assert_not_called()
         self._beets.locate.assert_not_called()
 
+        # The active set is queued OR running — flip the job to the
+        # state the importer worker would hold and re-assert the 409.
+        self.db._import_jobs[0]["status"] = "running"
+        status, data = self._post(
+            "/api/pipeline/ban-source",
+            {"request_id": 1704, "mb_release_id": self.RELEASE_ID,
+             "username": "anyone"},
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(data["error"], "importer_busy")
+
     # E1.6 — idempotency: second click is a no-op insert.
     @patch("web.routes.pipeline.hash_audio_content")
     @patch("web.routes.pipeline.finalize_request")
     def test_idempotent_second_click_records_zero_new_hashes(
             self, _mock_transition, mock_hash):
         """Second call inserts 0 new rows (ON CONFLICT DO NOTHING in
-        the DB layer; ``add_bad_audio_hashes`` returns 0). Response
-        is 200 with ``hashes_recorded: 0`` and no ``partial_failures``.
+        the DB layer). Response is 200 with ``hashes_recorded: 0`` and
+        no ``partial_failures``.
+
+        Modeled timing window: the second click lands BEFORE the first
+        ban's beets removal completes — get_item_paths still returns
+        the track while locate reports absent. That impossible-looking
+        combination is deliberate: it isolates the real (hash, format)
+        dedupe in add_bad_audio_hashes. Do not "fix" the fixture to an
+        emptied library — that reroutes through no_tracks_in_beets and
+        silently loses the dedupe-path coverage.
         """
         self.db.log_download(
             1704, outcome="success", soulseek_username="Hxrco")


### PR DESCRIPTION
Batch 4 of #430 (batches 1-3: #440, #441, #442) — the two biggest modules. `test_routes_pipeline_mutations.py` (100→0) and `test_routes_imports.py` (71→0). **Only `tests/web/_harness.py` (39) remains in the ratchet baseline** — the legacy MagicMock harness deletion is the final PR.

## Highlights

- **Add-flow tests assert persisted rows, not call shapes**: `release_group_year` / `is_va_compilation` / `catalog_number` are read off the actual new row; MB track fixtures now carry `track_number`/`disc_number` because the fake's `set_tracks` enforces the production NOT NULL the legacy harness shimmed away with a no-op mock.
- **Real supersede chains + a typed FK-race fake**: delete tests seed 100 ← 200 ← 300 for real; `_RacingDeleteDB.delete_request` seeds the concurrent descendant then raises `ForeignKeyViolation` — the route's post-FK walk finds a row that actually exists.
- **Ban-source / bad-rip flows** assert `bad_audio_hashes` / denylist / `curator_ban` rows in the fake's stores (exact-count guards), full-wipe semantics via the recorder + operator-visible fields (`imported_path` nulled — previously unasserted), and the idempotency test performs a **real double-click**: the `(hash, format)` dedupe executes instead of arriving as `return_value=0`.
- **Wrong-matches contract tests run the real query**: `_seed_wrong_match` seeds request + rejected `download_log` rows so the DISTINCT-ON collapse, evidence LEFT JOIN, and request join execute. The fake's evidence validators caught two impossible legacy fixtures (verified-lossless without proof provenance; a legacy probe kind on an evidence row — that scenario correctly moved to the legacy denorm columns the COALESCE path serves).
- **Converge** enqueues real force-import jobs (derived dedupe keys, payload `source_dirs` from the seeded row); the deduped path pre-enqueues a colliding job; the operator-authority contract (`cleanup_wrong_match` never called; `delete_wrong_match` is the deletion path) is fully preserved.

## Review trail

| Round | Reviewer | Findings | Resolution |
|-------|----------|----------|------------|
| r1 | Same-engine adversarial | 1 HIGH (ban-source wipe pinned 2 of 7 owned fields), 3 MEDIUM (UNIQUE-violating converge seeds; id-rewind hazard in the seeder; curator_ban count pin), 2 LOW, 1 NIT + 3 gaps | All fixed in `review(r1 adversarial)` — recorder + field pins, distinct mb ids, loud collision guard, exact-count audit rows, both-rows visibility, named timing window, racing-fake rebind, queued AND running importer-busy coverage |
| r2 | Codex partner | none | Converged |

- [x] Full suite 4413 tests OK; pyright 0 errors full-repo
- [x] Both ratchet entries deleted; migrated files contain zero `mock_db` occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)