### PR TITLE
test(web): #430 final — delete the legacy MagicMock harness, baseline empty

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -116,12 +116,12 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
 
 ## API Contract Tests
 - Every API endpoint consumed by the frontend must have a contract test in `tests/web/` — one `test_*.py` per `web/routes/*.py` module (e.g. `tests/web/test_routes_pipeline.py` for `web/routes/pipeline.py`)
-- Contract tests use a real `_WebServerCase` harness (HTTPServer on a random port + mocked DB) — see existing `TestPipelineRouteContracts`, `TestBrowseRouteContracts`, etc. as reference patterns
+- Contract tests use the real `_FakeDbWebServerCase` harness (HTTPServer on a random port + a fresh bare `FakePipelineDB` installed as `web.server.db` per test) — see existing `TestPipelineRouteContracts`, `TestBrowseRouteContracts`, etc. as reference patterns. Seed state (`self.db.seed_request(...)`, `self.db.log_download(...)`) and assert against the fake's real query semantics — never configure mock returns (#430; the `WEB_HARNESS_MOCK_BASELINE` ratchet in `tests/_mock_audit_scanner.py` is permanently empty and bans `mock_db` references in tests/web outright)
 - Define a `REQUIRED_FIELDS` set per endpoint — the fields the frontend JS relies on
 - Assert every returned dict includes all required fields via `_assert_required_fields(self, payload, REQUIRED_FIELDS, "label")`
 - When adding a field the frontend needs, add it to `REQUIRED_FIELDS` first (RED), then fix the backend (GREEN)
 - **Every new route MUST be added to `TestRouteContractAudit.CLASSIFIED_ROUTES`** — this is the guard test that introspects `Handler._FUNC_GET_ROUTES`/`_FUNC_POST_ROUTES`/`_FUNC_GET_PATTERNS` and fails if a registered route is unclassified or a stale entry is missing. The audit makes contract coverage self-enforcing — you cannot ship a route without classifying it.
-- The `_WebServerCase` harness in `tests/web/_harness.py` exposes `self._get(path)` and `self._post(path, body)` helpers that hit the real server. Reuse these (subclass `_WebServerCase`) instead of building your own harness — standalone per-class harness copies are exactly the drift #408 removed.
+- The harness in `tests/web/_harness.py` exposes `self._get(path)` and `self._post(path, body)` helpers that hit the real server. Reuse these (subclass `_FakeDbWebServerCase`; set `DB_FACTORY` to a typed `FakePipelineDB` subclass for failure injection) instead of building your own harness — standalone per-class harness copies are exactly the drift #408 removed.
 - **Mock data must mirror production row shape — synthetic int/str dicts are NOT acceptable.** When a contract test mocks a DB-row producer (any `PipelineDB`/`BeetsDB`/`psycopg2.extras.DictRow` source), at least one scenario must populate rows with production-shaped values: `datetime.datetime` for timestamps, `uuid.UUID` for UUIDs, the typed dataclass/`msgspec.Struct` for JSONB columns. Synthetic dicts of `str`/`int` values pass Pyright (`Dict[str, Any]` is permissive) and pass the contract test (mock matches assertion shape) but 500 on the first real call when the JSON encoder hits an unserializable type. This rule has bitten more than once — see `docs/solutions/testing/contract-test-mocks-must-mirror-production-shape.md` (search-plan-history datetime 500) and `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md` (search-by-id MB drift). The escape hatch when row-shape mocking is impractical: pair the contract test with an integration slice in `tests/test_integration_slices.py` that round-trips through real serialization. Every contract test that returns DB rows owes either a production-shaped mock OR a slice — never neither.
 
 ## Logging & Auditability
@@ -197,7 +197,7 @@ Before writing any new code, decide which test types you owe and what infrastruc
 |------------------|-----------|-------------------------|
 | A new pure decision function in `lib/quality.py` | A subTest table covering every branch | `tests/test_quality_decisions.py` patterns |
 | A new dispatch / orchestration path | An orchestration test asserting domain state + an integration slice | `FakePipelineDB`, `patch_dispatch_externals()`, `tests/test_integration_slices.py` |
-| A new web API endpoint | A contract test with `REQUIRED_FIELDS` AND an entry in `TestRouteContractAudit.CLASSIFIED_ROUTES` AND a paired `pipeline-cli` subcommand (CLI ⇄ API symmetry) | `_WebServerCase` + `_assert_required_fields` from `tests/web/_harness.py`, the matching `tests/web/test_routes_<module>.py`, `scripts/pipeline_cli.py` |
+| A new web API endpoint | A contract test with `REQUIRED_FIELDS` AND an entry in `TestRouteContractAudit.CLASSIFIED_ROUTES` AND a paired `pipeline-cli` subcommand (CLI ⇄ API symmetry) | `_FakeDbWebServerCase` + `_assert_required_fields` from `tests/web/_harness.py`, the matching `tests/web/test_routes_<module>.py`, `scripts/pipeline_cli.py` |
 | A new operator action (CLI subcommand or API endpoint) | A service-layer method with a typed `Result`, BOTH a CLI subcommand AND an API endpoint, exit-code and status-code tests for each | `tests/test_<service>.py` for the authoritative coverage; CLI/API tests check the wrapper only |
 | A new slskd interaction | An orchestration test using `FakeSlskdAPI` | `FakeSlskdAPI` from `tests/fakes.py` |
 | A new typed dataclass | A pure test of construction + serialization, and a builder in `tests/helpers.py` if it crosses test boundaries | `tests/helpers.py` |
@@ -270,7 +270,7 @@ Always use these instead of inventing parallel scaffolding:
 - `FakeSlskdAPI` — stateful slskd client: `transfers` (enqueue, get_all_downloads, get_download, cancel_download, queued snapshots), `users` (directory with per-directory results and errors), call recording.
 - `FakePipelineDBSource` — typed PipelineDBSource fake wrapping a `FakePipelineDB`. Use via `make_ctx_with_fake_db(fake_db)` rather than constructing directly.
 
-**`tests/web/`** — per-route-module contract tests mirroring `web/routes/*.py`. Shared harness in `tests/web/_harness.py` (`_WebServerCase` with `_get`/`_post` helpers, `_assert_required_fields`, `_pipeline_db_test_harness`, `_fresh_triage_runner`, `_make_server`); `TestRouteContractAudit` guard in `tests/web/test_route_audit.py`.
+**`tests/web/`** — per-route-module contract tests mirroring `web/routes/*.py`. Shared harness in `tests/web/_harness.py` (`_FakeDbWebServerCase` with a per-test bare `FakePipelineDB` as `self.db`, `_get`/`_post` helpers, `_assert_required_fields`, `_fresh_triage_runner`); `TestRouteContractAudit` guard in `tests/web/test_route_audit.py`.
 
 ### General test rules
 

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -501,31 +501,23 @@ def scan_tree() -> Dict[str, Dict[str, int]]:
 # the harness and every per-route test to a bare ``FakePipelineDB``,
 # route-module by route-module.
 #
-# This ratchet pins the per-file count of remaining MagicMock-harness
-# usage OCCURRENCES: every ``mock_db`` reference in a ``tests/web``
-# file (dotted, aliased, passed bare — aliasing the mock away is the
-# evasion the occurrence count exists to close) plus every
-# ``_pipeline_db_test_harness`` reference in ANY scanned test file
-# (the transitional wrapped-MagicMock constructor must not leak
-# outside tests/web where the per-file mock_db count can't see it).
-# The audit test requires the live counts to match this baseline
-# EXACTLY:
-#
-# - a count above baseline fails — new tests must seed FakePipelineDB
-#   state instead of configuring mock returns, even in unmigrated files
-# - a count below baseline fails — shrink the entry here in the same
-#   commit so the baseline always reflects reality
-# - a file at zero must have NO entry; delete the line when a module
-#   finishes migrating
-#
-# The migration is done when this dict is empty.
+# This ratchet counts MagicMock-harness usage OCCURRENCES: every
+# ``mock_db`` reference in a ``tests/web`` file (dotted, aliased,
+# passed bare — aliasing the mock away is the evasion the occurrence
+# count exists to close) plus every ``_pipeline_db_test_harness``
+# reference in ANY scanned test file. The audit test requires the live
+# counts to match this baseline EXACTLY — and the baseline is now
+# permanently empty: contract tests seed FakePipelineDB state, never
+# configure mock returns.
 
 _WEB_HARNESS_MOCK_DB_RE = re.compile(r"\bmock_db\b")
 _HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
 
-WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {
-    os.path.join("web", "_harness.py"): 39,
-}
+# EMPTY — the #430 migration is complete (PRs #440-#443 + the final
+# harness deletion). The ratchet stays armed at zero: any reintroduced
+# ``mock_db`` reference in tests/web, or ``_pipeline_db_test_harness``
+# reference anywhere, fails the audit immediately.
+WEB_HARNESS_MOCK_BASELINE: Dict[str, int] = {}
 
 
 def count_harness_overrides(text: str, *, web_file: bool) -> int:

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -1,26 +1,21 @@
 #!/usr/bin/env python3
-"""Shared HTTP test harness for the web route contract tests (#408).
+"""Shared HTTP test harness for the web route contract tests (#408, #430).
 
 Starts a real HTTP server on a random port; the ``tests/web/test_*.py``
 modules verify response codes, JSON structure, and error handling
-against it. Two base classes during the #430 migration:
-
-- :class:`_FakeDbWebServerCase` — per-test bare ``FakePipelineDB``.
-  Subclass THIS for new and migrated modules.
-- :class:`_WebServerCase` — legacy class-level MagicMock-wrapped DB
-  with canned ``.return_value`` defaults. Dies when the ratchet
-  baseline in ``tests/_mock_audit_scanner.py`` is empty.
+against it. One harness, no per-class copies, no MagicMock DB: every
+test runs against a fresh, bare :class:`FakePipelineDB` installed as
+``web.server.db`` (the same module-global swap production uses for
+DSN-less handles), so assertions hit the fake's real query semantics.
 """
 
-import copy
-from datetime import datetime, timezone
 import json
 import os
 import sys
 import threading
 import unittest
 from http.server import HTTPServer, ThreadingHTTPServer
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
@@ -38,70 +33,29 @@ import lib.beets_distance  # noqa: F401,E402
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
 
-from lib.import_queue import ImportJob
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_request_row
 
-_MOCK_PIPELINE_REQUEST = make_request_row(
-    id=100, status="imported", min_bitrate=320,
-    imported_path="/mnt/virtio/Music/Beets/Test",
-)
-
-_DEFAULT_WRONG_MATCH_ROW = {
-    "download_log_id": 42,
-    "request_id": 100,
-    "artist_name": "Test Artist",
-    "album_title": "Test Album",
-    "mb_release_id": "abc-123",
-    # Release-group id surfaces in the wrong-matches group payload
-    # so the frontend can render the Replace button (R7).
-    "mb_release_group_id": "rg-abc-123",
+# Production-shaped ``validation_result`` template for wrong-match
+# seeding (the JSONB blob a rejected download_log row carries). Tests
+# deepcopy and override; see test_routes_imports._seed_wrong_match.
+_DEFAULT_WRONG_MATCH_VALIDATION = {
+    "distance": 0.25,
+    "scenario": "high_distance",
+    "detail": "distance too high",
+    "failed_path": "/mnt/virtio/music/slskd/failed_imports/Test",
     "soulseek_username": "testuser",
-    # Per-attempt evidence — surfaced via the LEFT JOIN to
-    # album_quality_evidence in PipelineDB.get_wrong_matches (with
-    # COALESCE against the legacy denorm columns for spectral/V0).
-    "spectral_grade": None,
-    "spectral_bitrate": None,
-    "v0_probe_kind": None,
-    "v0_probe_avg_bitrate": None,
-    "evidence_storage_format": None,
-    "evidence_min_bitrate": None,
-    "evidence_verified_lossless": False,
-    # album_requests quality snapshot (joined in by get_wrong_matches)
-    "request_status": "wanted",
-    "request_min_bitrate": None,
-    "request_verified_lossless": False,
-    "request_current_spectral_grade": None,
-    "request_current_spectral_bitrate": None,
-    "request_imported_path": None,
-    "validation_result": {
+    "candidates": [{
+        "is_target": True,
+        "artist": "Test Artist",
+        "album": "Test Album",
         "distance": 0.25,
-        "scenario": "high_distance",
-        "detail": "distance too high",
-        "failed_path": "/mnt/virtio/music/slskd/failed_imports/Test",
-        "soulseek_username": "testuser",
-        "candidates": [{
-            "is_target": True,
-            "artist": "Test Artist",
-            "album": "Test Album",
-            "distance": 0.25,
-            "distance_breakdown": {"tracks": 0.15, "album": 0.10},
-            "track_count": 10,
-            "mapping": [],
-            "extra_items": [],
-            "extra_tracks": [],
-        }],
-        "items": [{"path": "01 Track.mp3", "title": "Track"}],
-    },
-}
-
-_DEFAULT_WRONG_MATCH_ENTRY = {
-    "id": 42,
-    "request_id": 100,
-    "validation_result": {
-        "failed_path": "/mnt/virtio/music/slskd/failed_imports/Test",
-        "scenario": "high_distance",
-    },
+        "distance_breakdown": {"tracks": 0.15, "album": 0.10},
+        "track_count": 10,
+        "mapping": [],
+        "extra_items": [],
+        "extra_tracks": [],
+    }],
+    "items": [{"path": "01 Track.mp3", "title": "Track"}],
 }
 
 
@@ -116,16 +70,15 @@ def _assert_required_fields(
 
 
 class _WebServerCase(unittest.TestCase):
-    """Shared HTTP test harness for endpoint contract tests."""
+    """Shared HTTP server harness (no DB opinions — see the subclass)."""
 
     server: HTTPServer
     port: int
     base: str
-    mock_db: MagicMock
 
     @classmethod
     def setUpClass(cls):
-        cls.server, cls.port, cls.mock_db = _make_server()
+        cls.server, cls.port = _make_server()
         cls.base = f"http://127.0.0.1:{cls.port}"
 
     @classmethod
@@ -154,22 +107,12 @@ class _WebServerCase(unittest.TestCase):
 class _FakeDbWebServerCase(_WebServerCase):
     """Contract-test base with a bare per-test :class:`FakePipelineDB`.
 
-    Migration target for #430. ``setUp`` installs a fresh fake as
-    ``web.server.db`` (the same module-global swap production uses for
-    DSN-less handles — ``_db()`` returns it directly), so every test
-    starts from empty typed state. Tests seed what they need
-    (``self.db.seed_request(...)``, ``self.db.log_download(...)``,
-    ``self.db.update_status(...)``) and assertions hit the fake's real
-    query semantics — there is no MagicMock layer to shape-match.
-
-    The inherited class-level ``mock_db`` (legacy MagicMock harness)
-    must not be touched in subclasses — the ratchet in
-    ``tests/_mock_audit_scanner.py`` is the guard that enforces this.
-    Note the textual guard is load-bearing: configuration of the
-    disconnected mock fails loudly at the route, but a negative
-    assertion (``assert_not_called``) against it would pass VACUOUSLY
-    (the mock genuinely receives no calls), so don't rely on runtime
-    behaviour to catch accidental use.
+    ``setUp`` installs a fresh fake as ``web.server.db`` (the same
+    module-global swap production uses for DSN-less handles — ``_db()``
+    returns it directly), so every test starts from empty typed state.
+    Tests seed what they need (``self.db.seed_request(...)``,
+    ``self.db.log_download(...)``, ``self.db.update_status(...)``) and
+    assertions hit the fake's real query semantics.
     """
 
     db: FakePipelineDB
@@ -201,445 +144,17 @@ def _fresh_triage_runner(case: unittest.TestCase):
     return runner
 
 
-def _pipeline_db_test_harness(fake: "FakePipelineDB | None" = None) -> MagicMock:
-    """Build the contract-test pipeline-DB harness.
-
-    Returns a MagicMock that ``wraps`` a real :class:`FakePipelineDB`. The
-    fake is the source of truth for state (seeded request rows live there
-    via :meth:`seed_request`); the MagicMock layer records every call so
-    contract tests can keep using ``.return_value = X`` / ``.assert_called_*``
-    overrides without re-engineering ~300 sites in a single PR.
-
-    The audit rule (``code-quality.md`` § MOCKS: LEAF-SEAM ONLY) forbids
-    constructing ``MagicMock()`` directly for ``mock_db`` / ``failing_db``
-    style variables because pure MagicMocks let production code rot
-    unobserved. Wrapping a FakePipelineDB closes that loophole: any call
-    the test does NOT explicitly override falls through to the typed
-    fake, so production code paths still hit real state mutations and
-    state-based assertions remain available via the underlying fake.
-
-    Tests can reach the underlying fake through the ``_fake`` attribute on
-    the mock. Transitional (#430): migrated route modules subclass
-    :class:`_FakeDbWebServerCase` instead; this helper dies with the last
-    ratchet entry in ``tests/_mock_audit_scanner.py``.
-    """
-    backing = fake if fake is not None else FakePipelineDB()
-    harness = MagicMock(wraps=backing)
-    # FakePipelineDB.set_tracks requires every track dict to carry
-    # ``track_number``. The legacy MagicMock harness silently accepted
-    # slimmer test fixtures (``[{"title": "..."}]``); preserve that
-    # behaviour by short-circuiting the write — these contract tests
-    # exercise the route's response shape, not the track-row layout.
-    # Production callers always emit a ``track_number`` field.
-    harness.set_tracks = MagicMock(return_value=None)
-    harness._fake = backing
-    return harness
-
-
 def _make_server():
-    """Create a test server with mocked DB on a random port."""
+    """Create a test server on a random port.
+
+    The boot-time ``web.server.db`` is an empty :class:`FakePipelineDB`
+    — :class:`_FakeDbWebServerCase` shadows it with a fresh fake per
+    test, so the boot fake only serves requests issued outside a test
+    body (there are none in practice).
+    """
     import web.server as srv
-    from lib.release_identity import detect_release_source, normalize_release_id
-    # Mock the pipeline DB. The MagicMock wraps a real FakePipelineDB so
-    # unmocked methods fall through to typed state — see
-    # ``_pipeline_db_test_harness`` for the rationale.
-    mock_db = _pipeline_db_test_harness()
-    mock_db.get_log.return_value = [
-        {
-            "id": 1, "request_id": 100, "outcome": "success",
-            "beets_scenario": "strong_match", "beets_distance": 0.012,
-            "beets_detail": None, "soulseek_username": "testuser",
-            "filetype": "mp3", "bitrate": 320000, "was_converted": False,
-            "original_filetype": None, "actual_filetype": "mp3",
-            "actual_min_bitrate": 320, "slskd_filetype": "mp3",
-            "slskd_bitrate": 320000, "spectral_grade": None,
-            "spectral_bitrate": None, "existing_min_bitrate": None,
-            "existing_spectral_bitrate": None, "valid": True,
-            "error_message": None, "staged_path": None,
-            "download_path": None, "sample_rate": None,
-            "bit_depth": None, "is_vbr": None,
-            "import_result": None, "validation_result": None,
-            "created_at": "2026-03-30T12:00:00+00:00",
-            "album_title": "Test Album", "artist_name": "Test Artist",
-            "mb_release_id": "abc-123", "year": 2024,
-            "country": "US", "request_status": "imported",
-            "request_min_bitrate": 320, "prev_min_bitrate": None,
-            "search_filetype_override": None, "source": "slskd",
-            "request_source": "request",
-        },
-    ]
-    mock_db._execute.return_value = MagicMock(fetchone=MagicMock(return_value={
-        "total": 1,
-        "imported": 1,
-        "matches_24h": 3,
-        "matches_6h": 1,
-    }))
-    mock_db.count_by_status.return_value = {"wanted": 0, "imported": 1, "manual": 0}
-    mock_db.get_by_status.return_value = []
-    mock_db.get_latest_download_summaries.return_value = {}
-    mock_db.search_requests.return_value = []
-    mock_db.get_request.return_value = _MOCK_PIPELINE_REQUEST
-    mock_db.get_tracks.return_value = []
-    mock_db.get_download_history.return_value = [
-        {
-            "id": 1, "request_id": 100, "outcome": "success",
-            "beets_scenario": "strong_match", "beets_distance": 0.012,
-            "soulseek_username": "testuser", "filetype": "mp3",
-            "bitrate": 320000, "was_converted": False,
-            "actual_filetype": "mp3", "actual_min_bitrate": 320,
-            "spectral_grade": None, "spectral_bitrate": None,
-            "existing_min_bitrate": None, "existing_spectral_bitrate": None,
-            "created_at": "2026-03-30T12:00:00+00:00",
-            "error_message": None, "original_filetype": None,
-            "slskd_filetype": "mp3", "slskd_bitrate": 320000,
-            "beets_detail": None, "valid": True,
-            "staged_path": None, "download_path": None,
-            "sample_rate": None, "bit_depth": None, "is_vbr": None,
-            "import_result": None, "validation_result": None,
-            "source": "slskd", "request_source": "request",
-            "youtube_metadata": None,
-        },
-    ]
 
-    mock_db.get_search_history.return_value = []
-    mock_db.get_search_plan_stats_history.return_value = []
-    mock_db.get_legacy_search_log_summary.return_value = (0, [])
-    mock_db.get_pipeline_dashboard_metrics.return_value = {
-        "generated_at": "2026-05-05T00:00:00+00:00",
-        "searches": {
-            "windows": [
-                {
-                    "label": "24h",
-                    "hours": 24,
-                    "searches": 12,
-                    "distinct_requests": 8,
-                    "searches_per_hour": 0.5,
-                    "searches_per_24h": 12,
-                    "avg_elapsed_s": 4.2,
-                    "median_elapsed_s": 3.1,
-                    "p95_elapsed_s": 9.9,
-                    "max_elapsed_s": 11.0,
-                    "outcomes": {
-                        "found": 2,
-                        "no_match": 4,
-                        "no_results": 5,
-                        "exhausted": 0,
-                        "errors": 1,
-                    },
-                    "cursor_wraps": 0,
-                    "stale_completions": 0,
-                    "non_consuming": 1,
-                    "cache_attribution_level": "cycle_only",
-                },
-                {
-                    "label": "6h",
-                    "hours": 6,
-                    "searches": 5,
-                    "distinct_requests": 5,
-                    "searches_per_hour": 0.8333333333,
-                    "searches_per_24h": 20,
-                    "avg_elapsed_s": 3.0,
-                    "median_elapsed_s": 2.8,
-                    "p95_elapsed_s": 5.0,
-                    "max_elapsed_s": 5.5,
-                    "outcomes": {
-                        "found": 1,
-                        "no_match": 1,
-                        "no_results": 3,
-                        "exhausted": 0,
-                        "errors": 0,
-                    },
-                    "cursor_wraps": 0,
-                    "stale_completions": 0,
-                    "non_consuming": 0,
-                    "cache_attribution_level": "cycle_only",
-                },
-            ],
-        },
-        "cycles": {
-            "windows": [
-                {
-                    "label": "24h",
-                    "hours": 24,
-                    "cycles": 10,
-                    "avg_cycle_s": 320.0,
-                    "median_cycle_s": 300.0,
-                    "p95_cycle_s": 700.0,
-                    "max_cycle_s": 900.0,
-                    "median_search_s": 250.0,
-                    "watchdog_kills": 1,
-                    "find_download_queued": 30,
-                    "find_download_completed": 28,
-                    "cache_errors": 0,
-                    "cache_write_errors": 0,
-                    "cache_fuse_tripped": 0,
-                    "peers_browsed": 100,
-                    "peers_browsed_lazy": 2,
-                    "fanout_waves": 20,
-                },
-                {
-                    "label": "6h",
-                    "hours": 6,
-                    "cycles": 3,
-                    "avg_cycle_s": 290.0,
-                    "median_cycle_s": 280.0,
-                    "p95_cycle_s": 360.0,
-                    "max_cycle_s": 380.0,
-                    "median_search_s": 220.0,
-                    "watchdog_kills": 0,
-                    "find_download_queued": 8,
-                    "find_download_completed": 8,
-                    "cache_errors": 0,
-                    "cache_write_errors": 0,
-                    "cache_fuse_tripped": 0,
-                    "peers_browsed": 25,
-                    "peers_browsed_lazy": 0,
-                    "fanout_waves": 6,
-                },
-            ],
-            "recent": [
-                {
-                    "id": 1,
-                    "started_at": "2026-05-05T00:00:00+00:00",
-                    "created_at": "2026-05-05T00:05:00+00:00",
-                    "cycle_total_s": 300.0,
-                    "browse_time_s": 20.0,
-                    "match_time_s": 10.0,
-                    "search_time_s": 240.0,
-                    "watchdog_kills": 0,
-                    "find_download_queued": 4,
-                    "find_download_completed": 4,
-                    "find_download_drain_time_s": 1.0,
-                    "cache_errors": 0,
-                    "cache_write_errors": 0,
-                    "cache_fuse_tripped": 0,
-                    "peers_browsed": 8,
-                    "peers_browsed_lazy": 0,
-                    "fanout_waves": 2,
-                },
-            ],
-            "outliers": [
-                {
-                    "id": 2,
-                    "started_at": "2026-05-04T00:00:00+00:00",
-                    "created_at": "2026-05-04T00:15:00+00:00",
-                    "cycle_total_s": 900.0,
-                    "browse_time_s": 80.0,
-                    "match_time_s": 30.0,
-                    "search_time_s": 760.0,
-                    "watchdog_kills": 1,
-                    "find_download_queued": 2,
-                    "find_download_completed": 1,
-                    "find_download_drain_time_s": 5.0,
-                    "cache_errors": 0,
-                    "cache_write_errors": 0,
-                    "cache_fuse_tripped": 0,
-                    "peers_browsed": 22,
-                    "peers_browsed_lazy": 1,
-                    "fanout_waves": 5,
-                },
-            ],
-        },
-        "coverage": {
-            "wanted_total": 10,
-            "wanted_searched_24h": 8,
-            "wanted_searched_6h": 5,
-            "wanted_unsearched_24h": 2,
-            "wanted_unsearched_6h": 5,
-            "wanted_never_searched": 1,
-            "active_wanted_searches_24h": 12,
-            "active_wanted_searches_6h": 5,
-            "oldest_last_search_at": "2026-05-04T00:00:00+00:00",
-            "matches_24h": 3,
-            "matches_6h": 1,
-            "matches_per_hour_24h": 0.125,
-            "matches_per_hour_6h": 0.1666666667,
-            "match_rate_series_24h": [
-                {
-                    "bucket_start": "2026-05-04T23:00:00+00:00",
-                    "matches": 1,
-                    "matches_per_hour": 1,
-                },
-                {
-                    "bucket_start": "2026-05-05T00:00:00+00:00",
-                    "matches": 2,
-                    "matches_per_hour": 2,
-                },
-            ],
-            "match_rate_series_28d": [
-                {
-                    "bucket_start": "2026-05-04T00:00:00+00:00",
-                    "matches": 1,
-                    "matches_per_day": 1,
-                },
-                {
-                    "bucket_start": "2026-05-05T00:00:00+00:00",
-                    "matches": 2,
-                    "matches_per_day": 2,
-                },
-            ],
-            "wanted_trend": {
-                "current_wanted": 10,
-                "latest_sample_at": "2026-05-05T00:00:00+00:00",
-                "series_24h": [
-                    {
-                        "sampled_at": "2026-05-04T23:00:00+00:00",
-                        "wanted_total": 12,
-                    },
-                    {
-                        "sampled_at": "2026-05-05T00:00:00+00:00",
-                        "wanted_total": 10,
-                        "synthetic": True,
-                    },
-                ],
-                "windows": [
-                    {
-                        "label": "6h",
-                        "hours": 6,
-                        "sample_count": 1,
-                        "start_sample_at": "2026-05-04T23:00:00+00:00",
-                        "end_sample_at": "2026-05-05T00:00:00+00:00",
-                        "start_wanted": 12,
-                        "end_wanted": 10,
-                        "delta": -2,
-                        "delta_per_hour": -2.0,
-                        "drain_per_hour": 2.0,
-                        "eta_hours": 5.0,
-                        "trend": "down",
-                    },
-                ],
-            },
-            "top_10_share_24h": 0.75,
-            "top_loop_suspects": [
-                {
-                    "request_id": 100,
-                    "artist_name": "Test Artist",
-                    "album_title": "Loop Album",
-                    "status": "wanted",
-                    "last_search_at": "2026-05-05T00:00:00+00:00",
-                    "searches_24h": 4,
-                    "searches_6h": 2,
-                    "found_24h": 0,
-                    "no_match_24h": 2,
-                    "no_results_24h": 2,
-                    "reset_24h": 0,
-                    "problem_24h": 0,
-                },
-            ],
-            "stale_wanted": [
-                {
-                    "request_id": 101,
-                    "artist_name": "Test Artist",
-                    "album_title": "Stale Album",
-                    "status": "wanted",
-                    "last_search_at": None,
-                    "hours_since_search": None,
-                    "searches_24h": 0,
-                    "searches_6h": 0,
-                    "found_24h": 0,
-                    "no_match_24h": 0,
-                    "no_results_24h": 0,
-                    "reset_24h": 0,
-                    "problem_24h": 0,
-                },
-            ],
-        },
-        "peers": {
-            "heavy_query_hours": 24,
-            "heavy_queries": [
-                {
-                    "search_log_id": 88,
-                    "request_id": 100,
-                    "mb_release_id": "dash-heavy-mbid",
-                    "artist_name": "Test Artist",
-                    "album_title": "Loop Album",
-                    "status": "wanted",
-                    "created_at": "2026-05-05T00:03:00+00:00",
-                    "query": "loop heavy tokens",
-                    "variant": "track_0",
-                    "outcome": "no_match",
-                    "result_count": 500,
-                    "elapsed_s": 12.0,
-                    "browse_time_s": 42.0,
-                    "match_time_s": 1.0,
-                    "peers_browsed": 110,
-                    "peers_browsed_lazy": 5,
-                    "peer_dirs": 115,
-                    "fanout_waves": 6,
-                },
-            ],
-            "totals": {
-                "known_peers": 220,
-                "new_24h": 80,
-                "seen_24h": 95,
-                "tracked_since": "2026-05-04T00:00:00+00:00",
-            },
-            "days": [
-                {
-                    "date": "2026-05-05",
-                    "new_peers": 22,
-                    "total_peers": 220,
-                },
-            ],
-        },
-        "plan_readiness": {
-            "generator_id": "search-plan/2026-05-19-1",
-            "wanted_total": 10,
-            "wanted_searchable": 7,
-            "wanted_legacy": 1,
-            "wanted_failed_deterministic": 1,
-            "wanted_failed_transient": 1,
-            "wanted_no_plan": 0,
-        },
-    }
-    mock_db.get_wrong_matches.return_value = [copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW)]
-    mock_db.get_download_log_entry.return_value = copy.deepcopy(_DEFAULT_WRONG_MATCH_ENTRY)
-    mock_db.clear_wrong_match_path.return_value = True
-    mock_db.list_requests_by_artist.return_value = []
-    mock_job = ImportJob(
-        id=77,
-        job_type="force_import",
-        status="queued",
-        request_id=100,
-        dedupe_key="force_import:download_log:42",
-        payload={"failed_path": "/tmp/Test Album"},
-        result=None,
-        message="Import queued",
-        error=None,
-        attempts=0,
-        worker_id=None,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
-        started_at=None,
-        heartbeat_at=None,
-        completed_at=None,
-    )
-    mock_db.enqueue_import_job.return_value = mock_job
-    mock_db.get_import_job.return_value = mock_job
-    mock_db.list_import_jobs.return_value = [mock_job]
-    mock_db.list_import_job_timeline.return_value = [mock_job]
-    mock_db.list_active_import_jobs.return_value = []
-    mock_db.count_import_jobs_by_status.return_value = {"queued": 1}
-    # Default to "no active job" / "no successful uploader" so the
-    # bad-rip route's race-check + username-resolution paths take
-    # the happy fall-through unless individual tests override.
-    mock_db.get_active_import_job_for_request.return_value = None
-    mock_db.get_recent_successful_uploader.return_value = None
-    mock_db.add_bad_audio_hashes.return_value = 0
-
-    def _get_request_by_release_id(release_id):
-        normalized = normalize_release_id(release_id)
-        if not normalized:
-            return None
-        if detect_release_source(normalized) == "discogs":
-            req = mock_db.get_request_by_discogs_release_id(normalized)
-            if req:
-                return req
-        return mock_db.get_request_by_mb_release_id(normalized)
-
-    mock_db.get_request_by_release_id.side_effect = _get_request_by_release_id
-
-    srv.db = mock_db
+    srv.db = FakePipelineDB()
     srv.beets_db_path = None  # No beets DB in tests
 
     # Mirror production: ThreadingHTTPServer + the same Handler.
@@ -647,6 +162,4 @@ def _make_server():
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    return server, port, mock_db
-
-
+    return server, port

--- a/tests/web/test_routes_imports.py
+++ b/tests/web/test_routes_imports.py
@@ -19,7 +19,7 @@ from urllib.error import HTTPError
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import (
-    _DEFAULT_WRONG_MATCH_ROW,
+    _DEFAULT_WRONG_MATCH_VALIDATION,
     _assert_required_fields,
     _FakeDbWebServerCase,
     _fresh_triage_runner,
@@ -229,7 +229,7 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
             ))
         elif request_overrides:
             self.db.update_request_fields(request_id, **request_overrides)
-        vr = copy.deepcopy(_DEFAULT_WRONG_MATCH_ROW["validation_result"])
+        vr = copy.deepcopy(_DEFAULT_WRONG_MATCH_VALIDATION)
         vr["failed_path"] = failed_path
         vr["scenario"] = scenario
         vr["distance"] = distance
@@ -637,8 +637,8 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         preview hook (R3 — this feature does not introduce a preview
         workflow).
         """
-        # _DEFAULT_WRONG_MATCH_ROW already has all four evidence fields
-        # set to None; this test pins that the resulting entry mirrors that.
+        # The setUp row carries no evidence; this test pins that the
+        # resulting entry still emits all four keys as None.
         _, data = self._get("/api/wrong-matches")
         entry = data["groups"][0]["entries"][0]
         self.assertEqual(entry["source_dirs"], [])


### PR DESCRIPTION
The terminal PR of the #430 series (#440 → #443). `tests/web/_harness.py` loses `_pipeline_db_test_harness`, the `MagicMock(wraps=...)` layer, and ~300 lines of canned `.return_value` defaults (including the 290-line hand-built dashboard dict). `_make_server` boots an empty `FakePipelineDB` that `_FakeDbWebServerCase` shadows per test; `_WebServerCase` is now purely the HTTP layer.

**`WEB_HARNESS_MOCK_BASELINE` is permanently empty.** The ratchet stays armed at zero: any reintroduced `mock_db` reference in `tests/web`, or `_pipeline_db_test_harness` reference anywhere, fails the audit immediately. This also retires the two last structural traps the migration documented along the way — the vacuous-negative-assertion hazard (a disconnected class-level mock absorbing `assert_not_called`) and the `set_tracks` no-op shim that masked the `album_tracks` NOT NULL contract.

`code-quality.md`'s contract-test sections now describe the fake-backed harness (seed state, assert real query semantics, `DB_FACTORY` for typed failure injection).

## Series summary (the test-fidelity meta-pattern, closed)

#428's P1 and #429's testing gap shared one root cause: contract tests passing whenever a mock's shape matched the assertion's shape. Across five PRs, every `tests/web` contract test now drives production wiring against a stateful fake, and the migration surfaced real fidelity dividends along the way: the dashboard fake became a parity-gated read-model mirror (`TestDashboardFakeParity` vs real PG), the library search/recent tests exposed that pipeline enrichment had never executed in tests, two impossible evidence fixtures were caught by the fake's storage validators, and two whole classes of `sys.path` shadowing landmines were killed with audits.

## Review trail

| Round | Reviewer | Findings | Resolution |
|-------|----------|----------|------------|
| r1 | Codex partner | none | Converged |

- [x] Full suite 4413 tests OK; pyright 0 errors full-repo

Closes #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)