### PR TITLE
test: beets-mock ratchet + FakePipelineDB strictness (#445 items 1+4)

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -544,3 +544,71 @@ def scan_web_harness_overrides() -> Dict[str, int]:
         if n:
             counts[rel] = n
     return counts
+
+
+# === Web beets-MagicMock ratchet (#445 item 1) ===
+#
+# The #430 migration covered the pipeline DB; the browse / library /
+# pipeline contract tests still configure MagicMock shapes for the
+# OTHER stateful collaborator — ``BeetsDB``. Those mocks evaded the
+# stateful-assign heuristic purely by variable naming: ``mock_beets``,
+# ``self._beets`` and ``self.beets`` don't match ``STATEFUL_VAR_NAMES``
+# (same evasion class the r1 ratchet review caught for ``mock_db``).
+#
+# This ratchet counts OCCURRENCES of the beets-mock variable names in
+# ``tests/web`` files: ``mock_beets`` (plus suffixed forms like
+# ``mock_beets_cls``), ``self._beets`` and ``self.beets``. It does NOT
+# count the production attribute ``web.server._beets`` itself —
+# migrated tests still inject a fake via ``srv._beets = fake`` (the
+# same constructor-replacement seam as ``web.server.db``), and
+# ``test_routes_browse``'s real-SQLite class fixture (``cls._beets =
+# BeetsDB(...)``) is legitimate. The audit test requires the live
+# counts to match this baseline EXACTLY — growth fails, and an
+# un-shrunk baseline after a migration also fails, so every migration
+# PR is forced to record its own progress. The replacement is
+# ``FakeBeetsDB`` from ``tests/fakes.py`` (extend it + add a self-test
+# in ``tests/test_fakes.py::TestFakeBeetsDB`` when a route exercises a
+# method it lacks).
+#
+# Known limits (adversarial review of the landing PR):
+# - Name the migrated attribute ``self.beets_db`` (uncounted), NOT
+#   ``self._beets = FakeBeetsDB()`` — the regex counts the name, not
+#   the type, so reusing the mock's name would keep the file's count
+#   inflated and make the failure message lie.
+# - ``cls``-level shapes are uncounted because browse's real-SQLite
+#   fixture legitimately uses ``cls._beets``. Do NOT introduce
+#   ``cls._beets = MagicMock()`` — the general stateful-assign audit
+#   misses it too; it is a review tripwire, not a sanctioned gap.
+# - Shrinking this baseline is only legitimate when the mocks were
+#   replaced with ``FakeBeetsDB`` seeding — aliasing
+#   (``b = self._beets``) also shrinks the count and is an evasion.
+
+_WEB_BEETS_MOCK_RE = re.compile(
+    r"\bmock_beets\w*|self\._beets\b|self\.beets\b")
+
+WEB_BEETS_MOCK_BASELINE: Dict[str, int] = {
+    os.path.join("web", "test_routes_browse.py"): 23,
+    os.path.join("web", "test_routes_labels.py"): 4,
+    os.path.join("web", "test_routes_library.py"): 31,
+    os.path.join("web", "test_routes_pipeline.py"): 6,
+    os.path.join("web", "test_routes_pipeline_mutations.py"): 19,
+}
+
+
+def count_beets_mock_overrides(text: str) -> int:
+    """Count beets-MagicMock variable-name occurrences in one file's text."""
+    return len(_WEB_BEETS_MOCK_RE.findall(text))
+
+
+def scan_web_beets_overrides() -> Dict[str, int]:
+    """Count beets-MagicMock occurrences per ``tests/web`` test file."""
+    counts: Dict[str, int] = {}
+    web_prefix = "web" + os.sep
+    for rel, path in iter_scan_paths():
+        if not rel.startswith(web_prefix):
+            continue
+        with open(path, encoding="utf-8") as f:
+            n = count_beets_mock_overrides(f.read())
+        if n:
+            counts[rel] = n
+    return counts

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1088,9 +1088,67 @@ class FakePipelineDB:
 
     # --- Seeding ---
 
+    def _assert_mb_release_id_unique(
+        self, mb_release_id: Any, exclude_id: int | None = None,
+    ) -> None:
+        """Mirror migrations/001's UNIQUE on album_requests.mb_release_id.
+
+        PG UNIQUE permits any number of NULLs, so ``None`` always passes.
+        Test-fidelity Rule B — the fake must not be more permissive than
+        the real INSERT (#445 item 4).
+        """
+        if mb_release_id is None:
+            return
+        for rid, row in self._requests.items():
+            if rid == exclude_id:
+                continue
+            if row.get("mb_release_id") == mb_release_id:
+                import psycopg2.errors
+
+                raise psycopg2.errors.UniqueViolation(
+                    "duplicate key value violates unique constraint "
+                    f'"album_requests_mb_release_id_key" — mb_release_id '
+                    f"{mb_release_id!r} is already on request {rid}"
+                )
+
+    def _mint_download_log_id(self) -> int:
+        """Advance the download_log id counter, mirroring a PG sequence.
+
+        A sequence-backed PK never regresses and never collides. Tests
+        may pin ids FORWARD (``db._next_download_log_id = 41`` → next id
+        42); rewinding below an existing id is the bug this guard exists
+        to catch — the three log accessors silently disagree on duplicate
+        ids (#445 item 4).
+        """
+        new_id = self._next_download_log_id + 1
+        taken = {entry.id for entry in self.download_logs}
+        if new_id in taken:
+            import psycopg2.errors
+
+            raise psycopg2.errors.UniqueViolation(
+                "duplicate key value violates unique constraint "
+                f'"download_log_pkey" — id {new_id} already exists '
+                "(a test rewound _next_download_log_id)"
+            )
+        if any(existing > new_id for existing in taken):
+            raise AssertionError(
+                f"minted download_log id {new_id} precedes existing ids "
+                f"{sorted(taken)} — production's sequence-backed PK can "
+                "never do that (rewound _next_download_log_id)"
+            )
+        self._next_download_log_id = new_id
+        return new_id
+
     def seed_request(self, row: dict[str, Any]) -> None:
-        """Add a request row to the fake DB. Must include 'id'."""
+        """Add a request row to the fake DB. Must include 'id'.
+
+        Re-seeding an existing id replaces that row (an update); a NEW id
+        carrying a non-NULL ``mb_release_id`` already held by another row
+        raises ``UniqueViolation``, mirroring the production schema.
+        """
         rid = row["id"]
+        self._assert_mb_release_id_unique(
+            row.get("mb_release_id"), exclude_id=rid)
         self._requests[rid] = copy.deepcopy(row)
         if rid > self._next_request_id:
             self._next_request_id = rid
@@ -1989,7 +2047,7 @@ class FakePipelineDB:
                 'null value in column "request_id" of relation '
                 '"download_log" violates not-null constraint'
             )
-        self._next_download_log_id += 1
+        new_log_id = self._mint_download_log_id()
         auxiliary: dict[str, Any] = {
             "download_path": download_path,
             "valid": valid,
@@ -2030,10 +2088,10 @@ class FakePipelineDB:
             error_message=error_message,
             validation_result=validation_result,
             import_result=import_result,
-            id=self._next_download_log_id,
+            id=new_log_id,
             extra=auxiliary,
         ))
-        return self._next_download_log_id
+        return new_log_id
 
     # --- YouTube rescue ingest (mirrors PipelineDB U2 methods) ---
 
@@ -2076,7 +2134,7 @@ class FakePipelineDB:
             from lib.pipeline_db import YoutubeInFlightError as _YIFE
             raise _YIFE(request_id, existing_id)
 
-        self._next_download_log_id += 1
+        new_log_id = self._mint_download_log_id()
         metadata: dict[str, Any] = {
             "yt_url": yt_url,
             "browse_id": browse_id,
@@ -2094,9 +2152,9 @@ class FakePipelineDB:
             outcome="youtube_running",
             source="youtube",
             youtube_metadata=metadata,
-            id=self._next_download_log_id,
+            id=new_log_id,
         ))
-        return self._next_download_log_id
+        return new_log_id
 
     def enqueue_youtube_import_and_mark_success(
         self,
@@ -2765,6 +2823,12 @@ class FakePipelineDB:
         self.update_request_fields_calls.append((request_id, dict(fields)))
         row = self._requests.get(request_id)
         if row:
+            if fields.get("mb_release_id") is not None:
+                # Production's UPDATE hits the same UNIQUE(mb_release_id)
+                # as the INSERT — re-pointing a row at another row's mbid
+                # raises there too (setting a row's own mbid is a no-op).
+                self._assert_mb_release_id_unique(
+                    fields["mb_release_id"], exclude_id=request_id)
             row.update(fields)
             row["updated_at"] = _utcnow()
 
@@ -3039,6 +3103,7 @@ class FakePipelineDB:
         or ``*_attempts`` see the same NULL/0 defaults production
         callers get from PostgreSQL. Codex R7.
         """
+        self._assert_mb_release_id_unique(mb_release_id)
         self._next_request_id += 1
         rid = self._next_request_id
         now = _utcnow()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -109,6 +109,13 @@ def make_request_row(**overrides: Any) -> dict[str, Any]:
         "updated_at": datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     }
     row.update(overrides)
+    if "mb_release_id" not in overrides:
+        # Default derives from the row id (id=1 → "test-mbid-0001") so
+        # multi-row fixtures get distinct mbids and don't collide with
+        # the UNIQUE(mb_release_id) FakePipelineDB enforces (#445 item 4).
+        rid = row["id"]
+        suffix = f"{rid:04d}" if isinstance(rid, int) else str(rid)
+        row["mb_release_id"] = f"test-mbid-{suffix}"
     return row
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2035,7 +2035,8 @@ class TestPollActiveDownloads(unittest.TestCase):
             "album_title": "Test Album",
             "artist_name": "Test Artist",
             "year": 2020,
-            "mb_release_id": "test-mbid",
+            # Per-row mbid — the fake enforces UNIQUE(mb_release_id).
+            "mb_release_id": f"test-mbid-{request_id}",
             "source": "request",
             "search_filetype_override": None,
             "target_format": None,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -5111,5 +5111,140 @@ class TestFakeCursor(unittest.TestCase):
         self.assertIsNone(cur.fetchone())
 
 
+class TestFakeRequestUniqueMbReleaseId(unittest.TestCase):
+    """The fake mirrors migrations/001's UNIQUE on album_requests.mb_release_id.
+
+    Test-fidelity Rule B — the fake must not be more permissive than the
+    real INSERT. Two rows sharing a non-NULL mb_release_id is a state
+    production can never hold (#445 item 4).
+    """
+
+    def test_seed_request_rejects_duplicate_mb_release_id(self):
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, mb_release_id="mbid-dup"))
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.seed_request(make_request_row(id=2, mb_release_id="mbid-dup"))
+
+    def test_seed_request_same_id_reseed_is_an_update(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, mb_release_id="mbid-x", status="wanted"))
+        db.seed_request(make_request_row(
+            id=1, mb_release_id="mbid-x", status="manual"))
+        self.assertEqual(db.request(1)["status"], "manual")
+
+    def test_seed_request_allows_multiple_null_mb_release_ids(self):
+        # PG UNIQUE permits any number of NULLs (Discogs-only rows).
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, mb_release_id=None, discogs_release_id="111"))
+        db.seed_request(make_request_row(
+            id=2, mb_release_id=None, discogs_release_id="222"))
+        self.assertEqual(db.request(2)["discogs_release_id"], "222")
+
+    def test_add_request_rejects_duplicate_mb_release_id(self):
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.add_request("A", "B", "request", mb_release_id="mbid-dup")
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.add_request("C", "D", "request", mb_release_id="mbid-dup")
+
+    def test_add_request_allows_distinct_and_null_mb_release_ids(self):
+        db = FakePipelineDB()
+        db.add_request("A", "B", "request", mb_release_id="mbid-1")
+        db.add_request("C", "D", "request", mb_release_id=None)
+        rid = db.add_request("E", "F", "request", mb_release_id=None)
+        self.assertEqual(db.request(rid)["artist_name"], "E")
+
+    def test_reseed_cannot_steal_another_rows_mb_release_id(self):
+        # exclude_id only exempts the row's OWN id — re-seeding id=1
+        # with an mbid held by row 2 must still raise.
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, mb_release_id="mbid-1"))
+        db.seed_request(make_request_row(id=2, mb_release_id="mbid-2"))
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.seed_request(make_request_row(id=1, mb_release_id="mbid-2"))
+
+    def test_add_request_collides_with_seeded_row(self):
+        # seed_request and add_request share one uniqueness check.
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=7, mb_release_id="mbid-seeded"))
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.add_request("A", "B", "request", mb_release_id="mbid-seeded")
+
+    def test_update_request_fields_rejects_duplicate_mb_release_id(self):
+        # Production's UPDATE hits the same UNIQUE as the INSERT.
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, mb_release_id="mbid-1"))
+        db.seed_request(make_request_row(id=2, mb_release_id="mbid-2"))
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.update_request_fields(2, mb_release_id="mbid-1")
+        self.assertEqual(db.request(2)["mb_release_id"], "mbid-2")
+
+    def test_update_request_fields_setting_own_mbid_is_a_noop(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, mb_release_id="mbid-1"))
+        db.update_request_fields(1, mb_release_id="mbid-1", status="manual")
+        self.assertEqual(db.request(1)["status"], "manual")
+
+
+class TestFakeDownloadLogIdMint(unittest.TestCase):
+    """Minted download_log ids mirror production's sequence-backed PK.
+
+    A test that rewinds ``_next_download_log_id`` below an existing id
+    used to mint duplicates silently — the three accessors then disagree
+    (oldest vs max-id vs insertion order). The mint guard makes that a
+    hard error (#445 item 4; previously a local assert in
+    ``test_routes_imports._seed_wrong_match``).
+    """
+
+    def test_log_download_rejects_rewound_counter_collision(self):
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.log_download(1, outcome="rejected")
+        db._next_download_log_id = 0
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.log_download(1, outcome="rejected")
+
+    def test_log_download_rejects_regressed_id_even_without_collision(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db._next_download_log_id = 4  # pin → next id is 5
+        db.log_download(1, outcome="rejected")
+        db._next_download_log_id = 1  # would mint 2 — a sequence never regresses
+        with self.assertRaises(AssertionError):
+            db.log_download(1, outcome="rejected")
+
+    def test_insert_youtube_running_shares_the_mint_guard(self):
+        import psycopg2.errors
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        db.log_download(1, outcome="rejected")
+        db._next_download_log_id = 0
+        with self.assertRaises(psycopg2.errors.UniqueViolation):
+            db.insert_youtube_running(
+                request_id=1, browse_id="b", audio_playlist_id=None,
+                yt_url="u", expected_track_count=10)
+
+    def test_forward_pinning_still_works(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.log_download(1, outcome="rejected")
+        db._next_download_log_id = 41  # forward pin — ids stay monotonic
+        self.assertEqual(db.log_download(1, outcome="rejected"), 42)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -24,10 +24,13 @@ import unittest
 sys.path.insert(0, os.path.normpath(os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..")))
 from tests._mock_audit_scanner import (
+    WEB_BEETS_MOCK_BASELINE,
     WEB_HARNESS_MOCK_BASELINE,
+    count_beets_mock_overrides,
     count_harness_overrides,
     iter_scan_paths,
     scan_tree,
+    scan_web_beets_overrides,
     scan_web_harness_overrides,
 )
 
@@ -190,6 +193,72 @@ class TestWebHarnessMockRatchet(unittest.TestCase):
             self.fail(
                 "Web-harness MagicMock ratchet (#430) out of sync with "
                 "WEB_HARNESS_MOCK_BASELINE:\n" + "\n".join(problems)
+            )
+
+
+class TestWebBeetsMockRatchet(unittest.TestCase):
+    """Ratchet for the #445 beets-MagicMock → FakeBeetsDB migration.
+
+    Per-file counts of remaining beets-mock variable-name occurrences in
+    ``tests/web`` must match ``WEB_BEETS_MOCK_BASELINE`` exactly: growth
+    means a new test configured beets mock shapes instead of seeding
+    ``FakeBeetsDB`` state; shrink means a migration landed and the
+    baseline entry must drop with it.
+    """
+
+    def test_counter_pins_evasion_shapes(self) -> None:
+        """Document exactly what the ratchet counts — occurrences of the
+        beets-mock variable names, including alias / suffixed / dotted
+        shapes, while leaving the production ``web.server._beets``
+        attribute and real-BeetsDB class fixtures uncounted."""
+        cases = [
+            ("dotted config",
+             "self._beets.album_exists.return_value = True", 1),
+            ("bare assignment", "mock_beets = MagicMock()", 1),
+            ("suffixed patch arg", "mock_beets_cls: MagicMock,", 1),
+            ("alias assignment", "b = self._beets", 1),
+            ("library dotted form", "self.beets.get_recent.return_value", 1),
+            ("injection counts the mock side only",
+             "srv._beets = self.beets", 1),
+            ("two occurrences one line",
+             "srv._beets = self._beets; m = mock_beets", 2),
+            ("production attr alone does not count",
+             "self._orig_beets = srv._beets", 0),
+            ("real-BeetsDB class fixture does not count",
+             "cls._beets = BeetsDB(cls._db_path)", 0),
+            ("beets_db var name does not count (general audit owns it)",
+             "self.beets_db = FakeBeetsDB()", 0),
+        ]
+        for desc, line, expected in cases:
+            with self.subTest(desc=desc):
+                self.assertEqual(count_beets_mock_overrides(line), expected)
+
+    def test_counts_match_baseline_exactly(self) -> None:
+        current = scan_web_beets_overrides()
+        problems: list[str] = []
+        for rel in sorted(set(current) | set(WEB_BEETS_MOCK_BASELINE)):
+            cur = current.get(rel, 0)
+            base = WEB_BEETS_MOCK_BASELINE.get(rel, 0)
+            if cur > base:
+                problems.append(
+                    f"  - {rel}: {base} → {cur} beets-mock occurrences. "
+                    "New tests must seed FakeBeetsDB state (see "
+                    "tests/fakes.py), not configure beets mock returns."
+                )
+            elif cur < base:
+                problems.append(
+                    f"  - {rel}: {base} → {cur} beets-mock occurrences. "
+                    "Migration progress — shrink WEB_BEETS_MOCK_BASELINE "
+                    "in tests/_mock_audit_scanner.py to match"
+                    + (" (delete the entry)." if cur == 0 else ".")
+                    + " Only shrink if the mocks were replaced with "
+                    "FakeBeetsDB seeding — aliasing the mock away is "
+                    "an evasion, not progress."
+                )
+        if problems:
+            self.fail(
+                "Web beets-MagicMock ratchet (#445) out of sync with "
+                "WEB_BEETS_MOCK_BASELINE:\n" + "\n".join(problems)
             )
 
 

--- a/tests/test_youtube_ingest_worker.py
+++ b/tests/test_youtube_ingest_worker.py
@@ -62,10 +62,13 @@ EXPECTED_TRACKS = 10
 
 
 def _seed_wanted_request(pdb: FakePipelineDB, *, request_id: int = 42) -> None:
+    # Per-request mbid (default id 42 keeps MB_REL) — two wanted rows
+    # sharing one mb_release_id is a state production's UNIQUE forbids.
+    mb_release_id = MB_REL if request_id == 42 else f"{MB_REL[:-2]}{request_id}"
     pdb.seed_request(make_request_row(
         id=request_id,
         status="wanted",
-        mb_release_id=MB_REL,
+        mb_release_id=mb_release_id,
         mb_release_group_id=MB_RG,
     ))
 

--- a/tests/web/test_routes_imports.py
+++ b/tests/web/test_routes_imports.py
@@ -237,12 +237,8 @@ class TestWrongMatchesContract(_FakeDbWebServerCase):
         vr["soulseek_username"] = username
         vr.update(validation_overrides or {})
         if download_log_id is not None:
-            taken = {e.id for e in self.db.download_logs}
-            assert download_log_id not in taken and all(
-                existing < download_log_id for existing in taken), (
-                f"pinned log id {download_log_id} collides with or "
-                f"precedes existing ids {sorted(taken)} — production's "
-                "sequence-backed PK can never do that")
+            # Forward pin only — the fake's id-mint guard raises if the
+            # pinned id collides with or precedes an existing id.
             self.db._next_download_log_id = download_log_id - 1
         return self.db.log_download(
             request_id, outcome="rejected", soulseek_username=username,


### PR DESCRIPTION
PR 1 of the #445 series — lands the ratchet before any migration (per the #430 playbook) and folds in the cheap fake-strictness fixes.

## Ratchet (item 1, step 0)

`WEB_BEETS_MOCK_BASELINE` in `tests/_mock_audit_scanner.py` pins per-file occurrence counts of the beets-mock variable names in `tests/web` (`mock_beets*`, `self._beets`, `self.beets` — 83 occurrences across 5 files). `TestWebBeetsMockRatchet` requires an exact match in both directions, so migration PRs are forced to shrink the baseline as they land. The production `web.server._beets` injection seam and browse's real-SQLite `cls._beets` fixture are deliberately uncounted; known evasion limits are documented in the baseline comment block.

## Fake strictness (item 4)

`FakePipelineDB` now mirrors two production constraints it previously ignored:

- **UNIQUE(mb_release_id)** (migrations/001): `seed_request`, `add_request`, and `update_request_fields` raise `UniqueViolation` on a duplicate non-NULL mbid. `make_request_row`'s default mbid now derives from the row id so multi-row fixtures stop colliding by default (id=1 keeps `test-mbid-0001`).
- **Sequence-backed download_log ids**: `log_download` / `insert_youtube_running` mint through a shared guard — `UniqueViolation` on collision, `AssertionError` on regression. The local pinning assert in `_seed_wrong_match` moved into the fake.

The strictness surfaced three impossible fixtures (poll builder sharing one mbid across rows, two wanted rows sharing `MB_REL`, 24 static-default collisions in test_fakes) — fixed in this PR.

## Verification

- Full suite 4,428 tests OK; pyright full repo 0 errors.
- Adversarial review: 5 findings, all addressed (update_request_fields bypass closed + self-tests; insert_youtube_running id asymmetry fixed; ratchet limits documented).
- Codex partner review: no findings; independently verified production UPDATE/supersede hit the same UNIQUE path and that the fake is nowhere stricter than reachable production semantics.

Part of #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)