### PR TITLE
test(web): migrate browse/labels/pipeline beets mocks to FakeBeetsDB (#445 batch 1)

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -587,10 +587,7 @@ _WEB_BEETS_MOCK_RE = re.compile(
     r"\bmock_beets\w*|self\._beets\b|self\.beets\b")
 
 WEB_BEETS_MOCK_BASELINE: Dict[str, int] = {
-    os.path.join("web", "test_routes_browse.py"): 23,
-    os.path.join("web", "test_routes_labels.py"): 4,
     os.path.join("web", "test_routes_library.py"): 31,
-    os.path.join("web", "test_routes_pipeline.py"): 6,
     os.path.join("web", "test_routes_pipeline_mutations.py"): 19,
 }
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5722,6 +5722,9 @@ class FakeBeetsDB:
         self.get_item_paths_calls: list[str] = []
         self.check_mbids_calls: list[list[str]] = []
         self.check_mbids_detail_calls: list[list[str]] = []
+        self.get_album_ids_by_mbids_calls: list[list[str]] = []
+        self.get_tracks_by_mb_release_id_calls: list[str] = []
+        self._tracks_by_release: dict[str, list[dict[str, Any]]] = {}
         self.get_albums_by_artist_calls: list[tuple[str, str]] = []
         self._mbid_detail: dict[str, dict[str, Any]] = {}
         self._albums_by_artist: dict[str, list[dict[str, Any]]] = {}
@@ -5759,11 +5762,42 @@ class FakeBeetsDB:
     def set_release_identities(self, rows: list[dict[str, Any]]) -> None:
         self._release_identities = [copy.deepcopy(r) for r in rows]
 
+    def set_tracks_for_release(
+        self, release_id: str, tracks: list[dict[str, Any]],
+    ) -> None:
+        self._tracks_by_release[release_id] = [
+            copy.deepcopy(t) for t in tracks]
+
     # --- Real-method surface ---
+
+    def _album_ids_lookup(self, release_id: str) -> list[int] | None:
+        """Normalized view of the ``set_album_ids_for_release`` store.
+
+        Production's ``_batch_lookup_album_ids`` runs every input
+        through ``normalize_release_id`` and matches against the stored
+        column value — '0012856590' finds the row stored '12856590'.
+        Returns ``None`` for "release never seeded" vs ``[]`` for
+        "seeded with zero albums".
+        """
+        key = normalize_release_id(release_id)
+        if not key:
+            return None
+        for seeded, ids in self._album_ids_for_release.items():
+            if normalize_release_id(seeded) == key:
+                return ids
+        return None
 
     def album_exists(self, release_id: str) -> bool:
         self.album_exists_calls.append(release_id)
-        return self._album_exists.get(release_id, self._album_exists_default)
+        if release_id in self._album_exists:
+            return self._album_exists[release_id]
+        # Production derives presence and album-id mapping from one
+        # seam (issue #121) — a release seeded with album ids IS in
+        # the library. An explicit set_album_exists seed still wins.
+        ids = self._album_ids_lookup(release_id)
+        if ids:
+            return True
+        return self._album_exists_default
 
     def check_mbids(self, mbids: list[str]) -> set[str]:
         self.check_mbids_calls.append(list(mbids))
@@ -5792,6 +5826,50 @@ class FakeBeetsDB:
         self.get_all_album_ids_for_release_calls.append(release_id)
         return self._album_ids_for_release.get(
             release_id, list(self._album_ids_default))
+
+    def get_album_ids_by_mbids(self, mbids: list[str]) -> dict[str, int]:
+        """Mirror of ``BeetsDB.get_album_ids_by_mbids`` — exact hits only.
+
+        Derives from the ``set_album_ids_for_release`` seed store —
+        shared with ``get_all_album_ids_for_release``, and seeded album
+        ids imply ``album_exists`` — mirroring production's single
+        ``_batch_lookup_album_ids`` seam (issue #121). Inputs and result
+        keys are normalized like production ('0012856590' hits the row
+        seeded '12856590' and the result is keyed '12856590'). First
+        seeded album id wins, matching the exact-hit ``locate`` contract.
+        """
+        self.get_album_ids_by_mbids_calls.append(list(mbids))
+        result: dict[str, int] = {}
+        for mbid in mbids:
+            key = normalize_release_id(mbid)
+            if not key:
+                continue
+            ids = self._album_ids_lookup(key)
+            if ids is None:
+                ids = list(self._album_ids_default)
+            if ids:
+                result[key] = ids[0]
+        return result
+
+    def get_tracks_by_mb_release_id(
+        self, mbid: str,
+    ) -> list[dict[str, Any]] | None:
+        """Mirror of ``BeetsDB.get_tracks_by_mb_release_id``.
+
+        ``None`` only when the release has no exact beets hit — the
+        browse route branches on that. A release seeded with album ids
+        but no tracks returns ``[]`` (production: exact hit always
+        yields a list), so 'album present but tracks None' is not an
+        expressible state.
+        """
+        self.get_tracks_by_mb_release_id_calls.append(mbid)
+        key = normalize_release_id(mbid)
+        for seeded, tracks in self._tracks_by_release.items():
+            if normalize_release_id(seeded) == key:
+                return [copy.deepcopy(t) for t in tracks]
+        if self._album_ids_lookup(key):
+            return []
+        return None
 
     def get_album_info(
         self, mb_release_id: str, _cfg: Any = None,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -4324,6 +4324,68 @@ class TestFakeBeetsDB(unittest.TestCase):
         self.assertEqual(beets.get_albums_by_artist_calls,
                          [("X", "mb-1"), ("Y", "")])
 
+    def test_get_tracks_by_mb_release_id_returns_seeded_or_none(self) -> None:
+        # Real method returns None when locate finds no exact hit —
+        # NOT an empty list (the browse route branches on that).
+        beets = FakeBeetsDB()
+        tracks = [{"title": "T1", "track": 1, "disc": 1, "length": 180,
+                   "format": "MP3", "bitrate": 320000,
+                   "samplerate": 44100, "bitdepth": 16}]
+        beets.set_tracks_for_release("mbid-1", tracks)
+        self.assertEqual(beets.get_tracks_by_mb_release_id("mbid-1"), tracks)
+        self.assertIsNone(beets.get_tracks_by_mb_release_id("mbid-2"))
+        self.assertEqual(beets.get_tracks_by_mb_release_id_calls,
+                         ["mbid-1", "mbid-2"])
+
+    def test_get_tracks_empty_list_when_album_present_without_seeds(self) -> None:
+        # Production: an exact album hit always yields a list (its
+        # items), never None. 'Album present but tracks None' is not a
+        # reachable state, so the fake must not express it either.
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release("mbid-1", [7])
+        self.assertEqual(beets.get_tracks_by_mb_release_id("mbid-1"), [])
+
+    def test_album_id_seeds_imply_presence(self) -> None:
+        # Production derives presence and album-id mapping from one
+        # seam (issue #121) — seeded ids mean the release IS in
+        # library. An explicit set_album_exists seed still wins.
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release("mbid-1", [7])
+        self.assertTrue(beets.album_exists("mbid-1"))
+        self.assertEqual(beets.check_mbids(["mbid-1", "mbid-2"]), {"mbid-1"})
+        beets.set_album_exists("mbid-1", False)
+        self.assertFalse(beets.album_exists("mbid-1"))
+
+    def test_get_album_ids_by_mbids_normalizes_like_production(self) -> None:
+        # _batch_lookup_album_ids normalizes every input and keys the
+        # result by the canonical form — '0012856590' hits the row
+        # stored '12856590'.
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release("12856590", [8])
+        out = beets.get_album_ids_by_mbids(["0012856590"])
+        self.assertEqual(out, {"12856590": 8})
+
+    def test_get_album_ids_by_mbids_honors_album_ids_default(self) -> None:
+        # The shared store's _default affordance applies to both
+        # readers — get_all_album_ids_for_release and this map.
+        beets = FakeBeetsDB()
+        beets._album_ids_default = [5]
+        self.assertEqual(beets.get_album_ids_by_mbids(["mbid-x"]),
+                         {"mbid-x": 5})
+
+    def test_get_album_ids_by_mbids_derives_from_release_id_seeds(self) -> None:
+        # Shares the set_album_ids_for_release seed store so presence
+        # and album-id mapping can't disagree (the paired-consistency
+        # concern from issue #121 the real _batch_lookup_album_ids
+        # exists to solve). Exact hit → first seeded album id.
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release("mbid-1", [17, 18])
+        beets.set_album_ids_for_release("mbid-empty", [])
+        out = beets.get_album_ids_by_mbids(["mbid-1", "mbid-empty", "mbid-2"])
+        self.assertEqual(out, {"mbid-1": 17})
+        self.assertEqual(beets.get_album_ids_by_mbids_calls,
+                         [["mbid-1", "mbid-empty", "mbid-2"]])
+
     def test_album_exists_returns_seeded_value(self) -> None:
         beets = FakeBeetsDB()
         beets.set_album_exists("mbid-1", True)

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -11,7 +11,7 @@ import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from urllib.error import HTTPError
 
 
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import _assert_required_fields, _FakeDbWebServerCase
 
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_request_row
 from web.library_album_row import LibraryAlbumRow
 
@@ -477,12 +477,12 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "track_count": 10,
             "status": "Official",
         }
-        mock_beets = MagicMock()
-        mock_beets.get_album_ids_by_mbids.return_value = {self.RELEASE_ID: 7}
-        mock_beets.check_mbids_detail.return_value = {self.RELEASE_ID: {}}
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release(self.RELEASE_ID, [7])
+        beets_db.set_mbid_detail(self.RELEASE_ID, {})
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.server.check_beets_library", return_value={self.RELEASE_ID}), \
-                patch("web.server._beets_db", return_value=mock_beets), \
+                patch("web.server._beets_db", return_value=beets_db), \
                 patch("web.server.check_pipeline",
                       return_value={self.RELEASE_ID: {"id": 42, "status": "wanted"}}):
             mock_mb.get_release_group_releases.return_value = {"releases": [release]}
@@ -507,16 +507,15 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
                 },
             ],
         }
-        mock_beets = MagicMock()
-        mock_beets.get_album_ids_by_mbids.return_value = {self.RELEASE_ID: 7}
-        mock_beets.check_mbids_detail.return_value = {self.RELEASE_ID: {}}
-        mock_beets.get_tracks_by_mb_release_id.return_value = None
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release(self.RELEASE_ID, [7])
+        beets_db.set_mbid_detail(self.RELEASE_ID, {})
         self.db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id=self.RELEASE_ID,
         ))
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.server.check_beets_library", return_value={self.RELEASE_ID}), \
-                patch("web.server._beets_db", return_value=mock_beets):
+                patch("web.server._beets_db", return_value=beets_db):
             mock_mb.get_release.return_value = release
             status, data = self._get(f"/api/release/{self.RELEASE_ID}")
 
@@ -527,12 +526,39 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
                                 "release detail track")
         self.assertEqual(data["beets_album_id"], 7)
 
+    def test_release_detail_includes_beets_tracks_when_in_library(self):
+        """In-library release with beets item rows → the payload carries
+        ``beets_tracks`` (the per-track format/bitrate table the
+        frontend renders under the release)."""
+        release = {
+            "id": self.RELEASE_ID,
+            "title": "Test Album",
+            "tracks": [{"disc_number": 1, "track_number": 1,
+                        "title": "Track", "length_seconds": 180}],
+        }
+        beets_track = {
+            "title": "Track", "track": 1, "disc": 1, "length": 180.0,
+            "format": "FLAC", "bitrate": 1100000,
+            "samplerate": 44100, "bitdepth": 16,
+        }
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release(self.RELEASE_ID, [7])
+        beets_db.set_mbid_detail(self.RELEASE_ID, {})
+        beets_db.set_tracks_for_release(self.RELEASE_ID, [beets_track])
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value={self.RELEASE_ID}), \
+                patch("web.server._beets_db", return_value=beets_db):
+            mock_mb.get_release.return_value = release
+            status, data = self._get(f"/api/release/{self.RELEASE_ID}")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["beets_tracks"], [beets_track])
+
     @patch("web.routes.browse.discogs_api.get_release")
     def test_release_detail_numeric_id_forwards_to_discogs(self, mock_discogs_get):
-        mock_beets = MagicMock()
-        mock_beets.get_album_ids_by_mbids.return_value = {"12856590": 8}
-        mock_beets.check_mbids_detail.return_value = {"12856590": {}}
-        mock_beets.get_tracks_by_mb_release_id.return_value = None
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release("12856590", [8])
+        beets_db.set_mbid_detail("12856590", {})
         self.db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id="12856590", discogs_release_id="12856590",
         ))
@@ -550,7 +576,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
         }
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.server.check_beets_library", return_value={"12856590"}), \
-                patch("web.server._beets_db", return_value=mock_beets):
+                patch("web.server._beets_db", return_value=beets_db):
             status, data = self._get("/api/release/0012856590")
 
         self.assertEqual(status, 200)
@@ -680,12 +706,12 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
                                 "discogs artist response")
 
     def test_discogs_master_contract(self):
-        mock_beets = MagicMock()
-        mock_beets.get_album_ids_by_mbids.return_value = {"83182": 9}
-        mock_beets.check_mbids_detail.return_value = {"83182": {}}
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release("83182", [9])
+        beets_db.set_mbid_detail("83182", {})
         with patch("web.routes.browse.discogs_api") as mock_dg, \
                 patch("web.server.check_beets_library", return_value={"83182"}), \
-                patch("web.server._beets_db", return_value=mock_beets), \
+                patch("web.server._beets_db", return_value=beets_db), \
                 patch("web.server.check_pipeline", return_value={}):
             mock_dg.get_master_releases.return_value = {
                 "title": "OK Computer",
@@ -716,13 +742,12 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(data["releases"][0]["beets_album_id"], 9)
 
     def test_discogs_release_contract(self):
-        mock_beets = MagicMock()
-        mock_beets.get_album_ids_by_mbids.return_value = {"83182": 10}
-        mock_beets.check_mbids_detail.return_value = {"83182": {}}
-        mock_beets.get_tracks_by_mb_release_id.return_value = None
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release("83182", [10])
+        beets_db.set_mbid_detail("83182", {})
         with patch("web.routes.browse.discogs_api") as mock_dg, \
                 patch("web.server.check_beets_library", return_value={"83182"}), \
-                patch("web.server._beets_db", return_value=mock_beets):
+                patch("web.server._beets_db", return_value=beets_db):
             mock_dg.get_release.return_value = {
                 "id": "83182",
                 "title": "OK Computer",

--- a/tests/web/test_routes_labels.py
+++ b/tests/web/test_routes_labels.py
@@ -8,12 +8,13 @@ tests/web/_harness.py.
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from urllib.error import HTTPError
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
+from tests.fakes import FakeBeetsDB
 from tests.web._harness import _assert_required_fields, _WebServerCase
 
 
@@ -164,11 +165,10 @@ class TestLabelRouteContracts(_WebServerCase):
         were called."""
         held_id = "1001"
         in_pipeline_id = "1002"
-        mock_beets = MagicMock()
-        mock_beets.get_album_ids_by_mbids.return_value = {held_id: 17}
-        mock_beets.check_mbids_detail.return_value = {
-            held_id: {"beets_format": "FLAC", "beets_bitrate": 1100},
-        }
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release(held_id, [17])
+        beets_db.set_mbid_detail(
+            held_id, {"beets_format": "FLAC", "beets_bitrate": 1100})
 
         def _compute_rank(fmt, br):
             return "lossless" if fmt == "FLAC" else "transparent"
@@ -178,7 +178,7 @@ class TestLabelRouteContracts(_WebServerCase):
                       return_value={held_id}), \
                 patch("web.server.check_pipeline",
                       return_value={in_pipeline_id: {"id": 99, "status": "wanted"}}), \
-                patch("web.server._beets_db", return_value=mock_beets), \
+                patch("web.server._beets_db", return_value=beets_db), \
                 patch("web.server.compute_library_rank",
                       side_effect=_compute_rank):
             mock_dg.get_label.return_value = self._make_label_entity()

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -10,7 +10,7 @@ import os
 import sys
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import msgspec
 
@@ -22,6 +22,7 @@ from tests.web._harness import (
     _fresh_triage_runner,
 )
 
+from tests.fakes import FakeBeetsDB
 from tests.helpers import make_request_row
 
 
@@ -235,7 +236,6 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         )
 
     def test_disk_coverage_contract(self):
-        from tests.fakes import FakeBeetsDB
         import web.server as srv
 
         self.db.seed_request(make_request_row(
@@ -259,7 +259,6 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
             "disk coverage off-disk row")
 
     def test_disk_coverage_inverse_contract(self):
-        from tests.fakes import FakeBeetsDB
         import web.server as srv
 
         beets = FakeBeetsDB()
@@ -1755,19 +1754,17 @@ class TestLongTailRouteContracts(_FakeDbWebServerCase):
         classifies Transparent bands ``transparent``. The beets leaf
         seam is patched to report the release in-library with a
         lossless detail row."""
-        import web.server as srv
         self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1"))
 
-        mock_beets = MagicMock()
+        beets_db = FakeBeetsDB()
         # MP3 @ 256 kbps classifies TRANSPARENT in the default rank model
         # (Opus 128 / MP3 V0 are transparent; see docs/quality-ranks.md).
-        mock_beets.check_mbids_detail.return_value = {
-            "rel-1": {"beets_format": "MP3", "beets_bitrate": 256},
-        }
+        beets_db.set_mbid_detail(
+            "rel-1", {"beets_format": "MP3", "beets_bitrate": 256})
         with patch("web.server.check_beets_library",
                    return_value={"rel-1"}), \
-                patch("web.server._beets_db", return_value=mock_beets):
+                patch("web.server._beets_db", return_value=beets_db):
             status, data = self._get("/api/pipeline/long-tail")
 
         self.assertEqual(status, 200)
@@ -1779,11 +1776,10 @@ class TestLongTailRouteContracts(_FakeDbWebServerCase):
         self.db.seed_request(make_request_row(
             id=1, status="wanted", mb_release_id="rel-1"))
 
-        mock_beets = MagicMock()
-        mock_beets.check_mbids_detail.return_value = {}  # no detail row
+        beets_db = FakeBeetsDB()  # no detail row seeded
         with patch("web.server.check_beets_library",
                    return_value={"rel-1"}), \
-                patch("web.server._beets_db", return_value=mock_beets):
+                patch("web.server._beets_db", return_value=beets_db):
             status, data = self._get("/api/pipeline/long-tail")
 
         self.assertEqual(status, 200)


### PR DESCRIPTION
PR 2 of the #445 series — first migration batch against the ratchet #446 landed.

## What moved

`test_routes_labels.py` (4), `test_routes_pipeline.py` (6), and `test_routes_browse.py` (23) — every `mock_beets = MagicMock()` with configured returns is now a seeded `FakeBeetsDB` injected through the same allowlisted `web.server._beets_db` seam. The three files drop out of `WEB_BEETS_MOCK_BASELINE` (remaining: library 31, mutations 19). Assertions unchanged.

## FakeBeetsDB extensions (review-hardened)

Both review engines (adversarial agent + Codex) converged on the same fidelity gaps in the first cut; the landed version fixes all of them:

- `get_album_ids_by_mbids` — derives from the `set_album_ids_for_release` store, normalizes inputs/result keys via `normalize_release_id` like production's `_batch_lookup_album_ids` (leading-zero Discogs ids hit the canonical row and come back canonically keyed), honors `_album_ids_default`.
- `get_tracks_by_mb_release_id` — `None` only for no-exact-hit; album-ids-seeded-but-no-tracks returns `[]`, so "album present but tracks None" (production-unreachable) is inexpressible.
- Seeded album ids now imply `album_exists`/`check_mbids` presence — production's single issue-#121 seam; explicit `set_album_exists` seeds win.
- Self-tests for every branch in `TestFakeBeetsDB`.

## Bonus coverage

New browse contract test pins the `beets_tracks` release-detail branch (frontend's per-track format/bitrate table) that the old `return_value=None` mocks left permanently unexercised — flagged by both reviewers as one seed call away.

Full suite 4,435 tests OK; pyright 0 errors.

Part of #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)