### PR TITLE
test(web): migrate library + mutations beets mocks — ratchet baseline empty (#445)

### DIFF
--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -549,8 +549,8 @@ def scan_web_harness_overrides() -> Dict[str, int]:
 # === Web beets-MagicMock ratchet (#445 item 1) ===
 #
 # The #430 migration covered the pipeline DB; the browse / library /
-# pipeline contract tests still configure MagicMock shapes for the
-# OTHER stateful collaborator — ``BeetsDB``. Those mocks evaded the
+# pipeline contract tests historically configured MagicMock shapes for
+# the OTHER stateful collaborator — ``BeetsDB``. Those mocks evaded the
 # stateful-assign heuristic purely by variable naming: ``mock_beets``,
 # ``self._beets`` and ``self.beets`` don't match ``STATEFUL_VAR_NAMES``
 # (same evasion class the r1 ratchet review caught for ``mock_db``).
@@ -586,10 +586,10 @@ def scan_web_harness_overrides() -> Dict[str, int]:
 _WEB_BEETS_MOCK_RE = re.compile(
     r"\bmock_beets\w*|self\._beets\b|self\.beets\b")
 
-WEB_BEETS_MOCK_BASELINE: Dict[str, int] = {
-    os.path.join("web", "test_routes_library.py"): 31,
-    os.path.join("web", "test_routes_pipeline_mutations.py"): 19,
-}
+# EMPTY — the #445 item 1 migration is complete (ratchet + four
+# migration batches). The ratchet stays armed at zero: any reintroduced
+# beets-mock variable name in tests/web fails the audit immediately.
+WEB_BEETS_MOCK_BASELINE: Dict[str, int] = {}
 
 
 def count_beets_mock_overrides(text: str) -> int:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -63,7 +63,12 @@ from lib.pipeline_db import (ActiveSearchPlan, BACKOFF_BASE_MINUTES,
 from lib.quality import (
     AlbumQualityEvidence,
 )
-from lib.release_identity import ReleaseIdentity, normalize_release_id
+from lib.beets_db import ReleaseLocation
+from lib.release_identity import (
+    ReleaseIdentity,
+    detect_release_source,
+    normalize_release_id,
+)
 from lib.validation_envelope import WrongMatchTriageAudit
 from lib.search_classification import (
     SearchSummary as _SearchSummary,
@@ -5729,6 +5734,16 @@ class FakeBeetsDB:
         self._mbid_detail: dict[str, dict[str, Any]] = {}
         self._albums_by_artist: dict[str, list[dict[str, Any]]] = {}
         self.list_release_identities_calls: int = 0
+        self._library_albums: list[dict[str, Any]] = []
+        self._album_detail: dict[int, dict[str, Any]] = {}
+        self.search_albums_calls: list[tuple[str, int]] = []
+        self.get_recent_calls: list[int] = []
+        self.get_album_detail_calls: list[int] = []
+        self._locate_queue: list[ReleaseLocation] = []
+        self.locate_calls: list[str] = []
+        self._min_bitrate: dict[str, int | None] = {}
+        self._min_bitrate_default: int | None = None
+        self.get_min_bitrate_calls: list[str] = []
 
     # --- Seeding helpers ---
 
@@ -5768,6 +5783,48 @@ class FakeBeetsDB:
         self._tracks_by_release[release_id] = [
             copy.deepcopy(t) for t in tracks]
 
+    def set_library_albums(self, rows: list[dict[str, Any]]) -> None:
+        """Seed the album table backing ``search_albums``/``get_recent``."""
+        self._library_albums = [copy.deepcopy(r) for r in rows]
+
+    def set_album_detail(self, album_id: int, detail: dict[str, Any]) -> None:
+        self._album_detail[album_id] = copy.deepcopy(detail)
+
+    def set_min_bitrate(self, release_id: str, kbps: int | None) -> None:
+        """Seed a per-release min bitrate. Keys are normalized like
+        production's locate-backed lookup. The release must also be
+        present (album ids seeded, explicit album_exists, or the
+        default) — ``get_min_bitrate`` gates on presence first."""
+        self._min_bitrate[normalize_release_id(release_id)] = kbps
+
+    def queue_locate_results(self, entries: list[ReleaseLocation]) -> None:
+        """Queue ``locate()`` outcomes for before/after-mutation flows.
+
+        Ban-source observes presence around a ``beet remove`` that runs
+        behind a patched subprocess, so the fake's seed stores can't
+        change mid-flow — the queue models the external mutation.
+        Entries are consumed in order; the last entry repeats. An
+        ``exact`` entry with empty selectors gets them auto-filled from
+        the queried id's shape at call time (the locate contract derives
+        selectors from the ID). With an empty queue, ``locate`` is
+        state-derived from the ``set_album_ids_for_release`` store.
+
+        Production-impossible locations are rejected up front: an
+        ``exact`` hit always carries a real int album_id, and ``absent``
+        is always ``(None, ())`` (lib/beets_db.py::locate).
+        """
+        for entry in entries:
+            if entry.kind == "exact":
+                assert (isinstance(entry.album_id, int)
+                        and not isinstance(entry.album_id, bool)), (
+                    f"exact ReleaseLocation needs an int album_id, got "
+                    f"{entry.album_id!r} — production cannot construct this")
+            else:
+                assert entry.album_id is None and entry.selectors == (), (
+                    f"absent ReleaseLocation is always (None, ()), got "
+                    f"({entry.album_id!r}, {entry.selectors!r})")
+        self._locate_queue = list(entries)
+
     # --- Real-method surface ---
 
     def _album_ids_lookup(self, release_id: str) -> list[int] | None:
@@ -5787,17 +5844,27 @@ class FakeBeetsDB:
                 return ids
         return None
 
-    def album_exists(self, release_id: str) -> bool:
-        self.album_exists_calls.append(release_id)
+    def _presence(self, release_id: str) -> bool:
+        """Current presence per the locate seam (issue #121).
+
+        Production answers ``album_exists`` / ``get_min_bitrate`` via
+        ``locate``; the fake's equivalent precedence is: queued locate
+        head (the most explicit model of "current state around an
+        external mutation") → explicit ``set_album_exists`` seed →
+        seeded album ids → the ``_album_exists_default``.
+        """
+        if self._locate_queue:
+            return self._locate_queue[0].kind == "exact"
         if release_id in self._album_exists:
             return self._album_exists[release_id]
-        # Production derives presence and album-id mapping from one
-        # seam (issue #121) — a release seeded with album ids IS in
-        # the library. An explicit set_album_exists seed still wins.
         ids = self._album_ids_lookup(release_id)
         if ids:
             return True
         return self._album_exists_default
+
+    def album_exists(self, release_id: str) -> bool:
+        self.album_exists_calls.append(release_id)
+        return self._presence(release_id)
 
     def check_mbids(self, mbids: list[str]) -> set[str]:
         self.check_mbids_calls.append(list(mbids))
@@ -5870,6 +5937,88 @@ class FakeBeetsDB:
         if self._album_ids_lookup(key):
             return []
         return None
+
+    def search_albums(
+        self, query: str, limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Mirror of ``BeetsDB.search_albums`` over the seeded album
+        table: case-insensitive substring on artist/album, ordered by
+        (artist, year, album), LIMIT applied after ordering."""
+        self.search_albums_calls.append((query, limit))
+        q = query.lower()
+        hits = [
+            a for a in self._library_albums
+            if q in str(a.get("artist", "")).lower()
+            or q in str(a.get("album", "")).lower()
+        ]
+        hits.sort(key=lambda a: (
+            str(a.get("artist", "")), a.get("year") or 0,
+            str(a.get("album", ""))))
+        return [copy.deepcopy(a) for a in hits[:limit]]
+
+    def get_recent(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Mirror of ``BeetsDB.get_recent`` — ``added`` DESC, NULLs last
+        (SQLite DESC ordering), LIMIT applied after ordering."""
+        self.get_recent_calls.append(limit)
+        rows = sorted(
+            self._library_albums,
+            key=lambda a: (a.get("added") is not None, a.get("added") or 0),
+            reverse=True)
+        return [copy.deepcopy(a) for a in rows[:limit]]
+
+    def get_album_detail(self, album_id: int) -> dict[str, Any] | None:
+        """Mirror of ``BeetsDB.get_album_detail`` — None when missing."""
+        self.get_album_detail_calls.append(album_id)
+        detail = self._album_detail.get(album_id)
+        return copy.deepcopy(detail) if detail is not None else None
+
+    @staticmethod
+    def _selectors_for(release_id: str) -> tuple[str, ...]:
+        """Selector tuple for an exact hit, derived from the id shape —
+        mirrors the dispatch in ``BeetsDB.locate`` (issue #121)."""
+        key = normalize_release_id(release_id)
+        if detect_release_source(key) == "discogs":
+            return (f"discogs_albumid:{key}", f"mb_albumid:{key}")
+        return (f"mb_albumid:{key}",)
+
+    def locate(self, release_id: str) -> ReleaseLocation:
+        """Mirror of ``BeetsDB.locate`` — the issue-#121 presence seam.
+
+        Queued results (``queue_locate_results``) win; otherwise the
+        answer is state-derived: exact hit iff the release has seeded
+        album ids, with selectors derived from the id shape.
+        """
+        self.locate_calls.append(release_id)
+        if self._locate_queue:
+            entry = (self._locate_queue.pop(0)
+                     if len(self._locate_queue) > 1
+                     else self._locate_queue[0])
+            if entry.kind == "exact" and not entry.selectors:
+                return ReleaseLocation(
+                    kind="exact", album_id=entry.album_id,
+                    selectors=self._selectors_for(release_id))
+            return entry
+        key = normalize_release_id(release_id)
+        ids = self._album_ids_lookup(key)
+        if ids:
+            return ReleaseLocation(
+                kind="exact", album_id=ids[0],
+                selectors=self._selectors_for(key))
+        return ReleaseLocation(kind="absent", album_id=None, selectors=())
+
+    def get_min_bitrate(self, mb_release_id: str) -> int | None:
+        """Mirror of ``BeetsDB.get_min_bitrate`` (kbps; None = no row).
+
+        Production resolves presence through ``locate`` first and
+        returns None for an absent release, so the fake gates on
+        ``_presence`` before consulting the (normalized-key) seed
+        store / ``_min_bitrate_default``.
+        """
+        self.get_min_bitrate_calls.append(mb_release_id)
+        if not self._presence(mb_release_id):
+            return None
+        key = normalize_release_id(mb_release_id)
+        return self._min_bitrate.get(key, self._min_bitrate_default)
 
     def get_album_info(
         self, mb_release_id: str, _cfg: Any = None,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -4373,6 +4373,142 @@ class TestFakeBeetsDB(unittest.TestCase):
         self.assertEqual(beets.get_album_ids_by_mbids(["mbid-x"]),
                          {"mbid-x": 5})
 
+    def test_search_albums_substring_matches_artist_or_album(self) -> None:
+        # Real query: LIKE %q% COLLATE NOCASE on albumartist OR album,
+        # ORDER BY albumartist, year, album, LIMIT.
+        beets = FakeBeetsDB()
+        beets.set_library_albums([
+            {"id": 2, "album": "Zeta", "artist": "B Artist", "year": 2020,
+             "added": 10.0},
+            {"id": 1, "album": "Alpha", "artist": "A Artist", "year": 2020,
+             "added": 20.0},
+            {"id": 3, "album": "Unrelated", "artist": "Nobody", "year": 2020,
+             "added": 30.0},
+        ])
+        out = beets.search_albums("aRtIsT")
+        self.assertEqual([a["id"] for a in out], [1, 2])
+        self.assertEqual(beets.search_albums("artist", limit=1)[0]["id"], 1)
+        self.assertEqual(beets.search_albums_calls,
+                         [("aRtIsT", 100), ("artist", 1)])
+
+    def test_get_recent_sorts_by_added_desc(self) -> None:
+        beets = FakeBeetsDB()
+        beets.set_library_albums([
+            {"id": 1, "album": "Old", "artist": "X", "added": 10.0},
+            {"id": 2, "album": "New", "artist": "X", "added": 30.0},
+            {"id": 3, "album": "Never stamped", "artist": "X", "added": None},
+        ])
+        out = beets.get_recent(limit=2)
+        self.assertEqual([a["id"] for a in out], [2, 1])
+        # NULL added sorts last under DESC (SQLite ordering).
+        self.assertEqual(
+            [a["id"] for a in beets.get_recent(limit=3)], [2, 1, 3])
+        self.assertEqual(beets.get_recent_calls, [2, 3])
+
+    def test_locate_state_derived_from_album_id_seeds(self) -> None:
+        from lib.beets_db import ReleaseLocation
+
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release(
+            "11111111-1111-1111-1111-111111111111", [4])
+        beets.set_album_ids_for_release("12856590", [9])
+        loc = beets.locate("11111111-1111-1111-1111-111111111111")
+        self.assertEqual(loc, ReleaseLocation(
+            kind="exact", album_id=4,
+            selectors=("mb_albumid:11111111-1111-1111-1111-111111111111",)))
+        # Discogs numeric shape → both selector columns, normalized id.
+        loc = beets.locate("0012856590")
+        self.assertEqual(loc, ReleaseLocation(
+            kind="exact", album_id=9,
+            selectors=("discogs_albumid:12856590",
+                       "mb_albumid:12856590")))
+        self.assertEqual(
+            beets.locate("unseeded-mbid"),
+            ReleaseLocation(kind="absent", album_id=None, selectors=()))
+        self.assertEqual(
+            beets.locate_calls,
+            ["11111111-1111-1111-1111-111111111111", "0012856590",
+             "unseeded-mbid"])
+
+    def test_locate_queue_consumes_in_order_and_repeats_last(self) -> None:
+        from lib.beets_db import ReleaseLocation
+
+        beets = FakeBeetsDB()
+        beets.queue_locate_results([
+            ReleaseLocation(kind="exact", album_id=1, selectors=()),
+            ReleaseLocation(kind="absent", album_id=None, selectors=()),
+        ])
+        first = beets.locate("mbid-x")
+        # Empty selectors on an exact entry auto-fill from the queried
+        # id's shape at call time.
+        self.assertEqual(first.kind, "exact")
+        self.assertEqual(first.selectors, ("mb_albumid:mbid-x",))
+        self.assertEqual(beets.locate("mbid-x").kind, "absent")
+        self.assertEqual(beets.locate("mbid-x").kind, "absent")
+
+    def test_get_min_bitrate_seeded_and_default(self) -> None:
+        beets = FakeBeetsDB()
+        beets._album_exists_default = True  # presence gate (see below)
+        beets.set_min_bitrate("mbid-1", 245)
+        self.assertEqual(beets.get_min_bitrate("mbid-1"), 245)
+        beets._min_bitrate_default = 320
+        self.assertEqual(beets.get_min_bitrate("mbid-2"), 320)
+        self.assertEqual(beets.get_min_bitrate_calls,
+                         ["mbid-1", "mbid-2"])
+
+    def test_get_min_bitrate_gates_on_presence_like_production(self) -> None:
+        # Production resolves presence via locate first — an absent
+        # release returns None no matter what; bitrate keys normalize.
+        from lib.beets_db import ReleaseLocation
+
+        beets = FakeBeetsDB()
+        beets._min_bitrate_default = 320
+        self.assertIsNone(beets.get_min_bitrate("mbid-absent"))
+        beets.set_album_ids_for_release("12856590", [7])
+        beets.set_min_bitrate("12856590", 245)
+        self.assertEqual(beets.get_min_bitrate("0012856590"), 245)
+        # Queued locate head models "current" state — after a queued
+        # removal lands at absent, min_bitrate goes None with it.
+        beets.queue_locate_results([
+            ReleaseLocation(kind="absent", album_id=None, selectors=())])
+        self.assertIsNone(beets.get_min_bitrate("0012856590"))
+        self.assertFalse(beets.album_exists("0012856590"))
+
+    def test_locate_queue_rejects_impossible_locations(self) -> None:
+        from lib.beets_db import ReleaseLocation
+
+        beets = FakeBeetsDB()
+        with self.assertRaises(AssertionError):
+            beets.queue_locate_results([ReleaseLocation(
+                kind="exact", album_id=None, selectors=())])
+        with self.assertRaises(AssertionError):
+            beets.queue_locate_results([ReleaseLocation(
+                kind="absent", album_id=None,
+                selectors=("mb_albumid:x",))])
+
+    def test_locate_queue_passes_explicit_selectors_verbatim(self) -> None:
+        from lib.beets_db import ReleaseLocation
+
+        beets = FakeBeetsDB()
+        entry = ReleaseLocation(
+            kind="exact", album_id=3,
+            selectors=("discogs_albumid:9", "mb_albumid:9"))
+        beets.queue_locate_results([entry])
+        self.assertEqual(beets.locate("9"), entry)
+
+    def test_get_album_detail_keyed_by_album_id(self) -> None:
+        beets = FakeBeetsDB()
+        beets.set_album_detail(7, {"id": 7, "album": "A", "tracks": []})
+        detail = beets.get_album_detail(7)
+        assert detail is not None
+        self.assertEqual(detail["album"], "A")
+        detail["album"] = "mutated"
+        got = beets.get_album_detail(7)
+        assert got is not None
+        self.assertEqual(got["album"], "A")
+        self.assertIsNone(beets.get_album_detail(8))
+        self.assertEqual(beets.get_album_detail_calls, [7, 7, 8])
+
     def test_get_album_ids_by_mbids_derives_from_release_id_seeds(self) -> None:
         # Shares the set_album_ids_for_release seed store so presence
         # and album-id mapping can't disagree (the paired-consistency

--- a/tests/web/test_routes_library.py
+++ b/tests/web/test_routes_library.py
@@ -18,7 +18,7 @@ from tests.web._harness import (
     _FakeDbWebServerCase,
 )
 
-from tests.fakes import FakeCursor, FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakeCursor, FakePipelineDB
 from tests.helpers import make_request_row
 
 
@@ -85,8 +85,8 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         self._srv = srv
         self._orig_beets = srv._beets
         self._orig_beets_db_path = srv.beets_db_path
-        self.beets = MagicMock()
-        srv._beets = self.beets
+        self.beets_db = FakeBeetsDB()
+        srv._beets = self.beets_db
         self.db.seed_request(make_request_row(
             id=42,
             status="wanted",
@@ -143,16 +143,21 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
 
     def _configure_beets_delete_mock(
         self,
-        mock_beets_cls: MagicMock,
+        beets_cls: MagicMock,
         *,
         delete_side_effect: object | None = None,
     ) -> None:
-        beets = mock_beets_cls.return_value.__enter__.return_value
-        beets.get_album_detail.return_value = {"id": 7}
+        """The class patch swaps the BeetsDB constructor for a seeded
+        FakeBeetsDB; ``delete_album`` stays a MagicMock attr — it is the
+        allowlisted SQLite-write + file-delete leaf seam, not a query
+        collaborator."""
+        fake = FakeBeetsDB()
+        fake.set_album_detail(7, {"id": 7})
+        beets_cls.return_value = fake
         if delete_side_effect is not None:
-            mock_beets_cls.delete_album.side_effect = delete_side_effect
+            beets_cls.delete_album.side_effect = delete_side_effect
             return
-        mock_beets_cls.delete_album.return_value = (
+        beets_cls.delete_album.return_value = (
             "Test Album",
             "Test Artist",
             ["/music/Test Artist/Test Album/01 Track.mp3"],
@@ -178,7 +183,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         }]))
 
     def test_beets_search_contract(self):
-        self.beets.search_albums.return_value = [self._album()]
+        self.beets_db.set_library_albums([self._album()])
         self._queue_pipeline_overlay_row(min_bitrate=900)
         status, data = self._get("/api/beets/search?q=test")
 
@@ -191,7 +196,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(data["albums"][0]["min_bitrate"], 900000)
 
     def test_beets_recent_contract(self):
-        self.beets.get_recent.return_value = [self._album()]
+        self.beets_db.set_library_albums([self._album()])
         self._queue_pipeline_overlay_row(min_bitrate=900)
         status, data = self._get("/api/beets/recent")
 
@@ -206,7 +211,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         detail["artpath"] = "/music/Test Artist/Test Album/cover.jpg"
         detail["path"] = "/music/Test Artist/Test Album"
         detail["tracks"] = [self._track()]
-        self.beets.get_album_detail.return_value = detail
+        self.beets_db.set_album_detail(7, detail)
 
         status, data = self._get("/api/beets/album/7")
 
@@ -233,7 +238,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         detail["artpath"] = "/music/Test Artist/Test Album/cover.jpg"
         detail["path"] = "/music/Test Artist/Test Album"
         detail["tracks"] = [self._track()]
-        self.beets.get_album_detail.return_value = detail
+        self.beets_db.set_album_detail(7, detail)
         self.db.seed_request(make_request_row(
             id=43,
             status="wanted",
@@ -273,7 +278,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
                 "title": None,
             }
         ]
-        self.beets.get_album_detail.return_value = detail
+        self.beets_db.set_album_detail(7, detail)
 
         status, data = self._get("/api/beets/album/7")
 
@@ -292,7 +297,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         track = self._track()
         del track["format"]
         detail["tracks"] = [track]
-        self.beets.get_album_detail.return_value = detail
+        self.beets_db.set_album_detail(7, detail)
 
         status, data = self._get("/api/beets/album/7")
 
@@ -307,13 +312,13 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_contract(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
     ):
         self._srv.beets_db_path = "/tmp/beets.db"
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {"id": 7, "confirm": "DELETE"})
 
@@ -327,7 +332,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_explicit_pipeline_request(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -336,7 +341,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {
             "id": 7,
@@ -357,7 +362,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_pipeline_request_by_release_id_fallback(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -369,7 +374,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         self.db.seed_request(make_request_row(
             id=99, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {
             "id": 7,
@@ -389,7 +394,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_pipeline_request_by_uppercase_release_id(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -401,7 +406,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         self.db.seed_request(make_request_row(
             id=98, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {
             "id": 7,
@@ -421,7 +426,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_without_purge_pipeline_leaves_request_intact(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -430,7 +435,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
         self.db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {
             "id": 7,
@@ -448,13 +453,13 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purge_with_no_pipeline_context_is_noop(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
     ):
         self._srv.beets_db_path = "/tmp/beets.db"
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {
             "id": 7,
@@ -475,7 +480,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_purges_discogs_request_by_numeric_release_id_fallback(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -487,7 +492,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
             discogs_release_id="12856590",
             status="imported",
         ))
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
 
         status, data = self._post("/api/beets/delete", {
             "id": 7,
@@ -507,13 +512,13 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_pipeline_failure_aborts_before_beets_delete(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
     ):
         self._srv.beets_db_path = "/tmp/beets.db"
-        self._configure_beets_delete_mock(mock_beets_cls)
+        self._configure_beets_delete_mock(beets_cls)
         failing_db = _FailingDeleteDB()
         failing_db.seed_request(make_request_row(
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
@@ -530,7 +535,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
 
         self.assertEqual(status, 500)
         self.assertIn("error", data)
-        mock_beets_cls.delete_album.assert_not_called()
+        beets_cls.delete_album.assert_not_called()
 
     @patch("lib.library_delete_service.os.path.isdir", return_value=False)
     @patch("lib.library_delete_service.os.path.isfile", return_value=False)
@@ -538,7 +543,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
     @patch("lib.beets_db.BeetsDB")
     def test_beets_delete_failure_after_pipeline_purge_returns_targeted_error(
         self,
-        mock_beets_cls,
+        beets_cls,
         _mock_exists,
         _mock_isfile,
         _mock_isdir,
@@ -548,7 +553,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
             id=42, status="imported", mb_release_id=self.RELEASE_ID,
         ))
         self._configure_beets_delete_mock(
-            mock_beets_cls,
+            beets_cls,
             delete_side_effect=OSError("boom"),
         )
 

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -19,7 +19,7 @@ from tests.web._harness import (
     _FakeDbWebServerCase,
 )
 
-from tests.fakes import FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_request_row
 
 
@@ -856,60 +856,43 @@ class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
         import web.server as srv
         self._srv = srv
         self._orig_beets = srv._beets
-        # Beets stub: update() only hits this via album_exists / get_min_bitrate.
+        # Beets fake: update() only hits this via album_exists / get_min_bitrate.
         # A live beets DB is the usual preceding state for a requeue.
-        self._beets = MagicMock()
-        self._beets.album_exists.return_value = True
-        self._beets.get_min_bitrate.return_value = 320
+        self.beets_db = FakeBeetsDB()
+        self.beets_db._album_exists_default = True
+        self.beets_db._min_bitrate_default = 320
         # Ban-source now also calls ``get_item_paths`` for the bad-rip
-        # hash-capture step (plan 2026-04-29-005, U4). Default to "no
-        # tracks" so legacy ban-source tests don't trip over the new
-        # gate; tests that exercise hash capture override this.
-        self._beets.get_item_paths.return_value = []
-        # Ban-source now routes through ``BeetsDB.locate`` (issue #121).
-        # Default the mock to 'album present before and removed after'
+        # hash-capture step (plan 2026-04-29-005, U4). The fake defaults
+        # to "no tracks" so legacy ban-source tests don't trip over the
+        # new gate; tests that exercise hash capture seed item paths.
+        # Ban-source routes through ``BeetsDB.locate`` (issue #121).
+        # Default the queue to 'album present before and removed after'
         # so the legacy `album_exists.side_effect = [True, False]`
         # tests read as "exact → absent" in the new vocabulary.
         # Individual tests override this via ``_set_locate_sequence``.
         self._set_locate_sequence([
-            ("exact", 1, ()),  # selectors filled per-test via helper
+            ("exact", 1, ()),  # selectors auto-filled by the fake
             ("absent", None, ()),
         ])
-        srv._beets = self._beets
+        srv._beets = self.beets_db
 
     def _set_locate_sequence(
             self, results: list[tuple[str, object, tuple]]) -> None:
-        """Program ``self._beets.locate`` to return a sequence of results.
-
-        Each tuple is ``(kind, album_id, selectors)``. Yields one
-        ReleaseLocation-shaped SimpleNamespace per call; extra calls
-        reuse the final entry. Kept local to this test class because
-        ban-source is the main caller that reasons about the before /
-        after pair.
-        """
-        from types import SimpleNamespace
-        results_copy = list(results)
-
-        def _side_effect(release_id, *_args, **_kwargs):
-            if not results_copy:
-                return SimpleNamespace(kind="absent", album_id=None, selectors=())
-            kind, album_id, selectors = (
-                results_copy[0] if len(results_copy) == 1
-                else results_copy.pop(0))
-            # Auto-fill selectors for 'exact' when the test left them blank
-            # — the locate seam's contract is that selectors are driven by
-            # the ID shape, so it's OK for tests to defer to it.
-            if kind == "exact" and not selectors:
-                from lib.release_identity import detect_release_source
-                if detect_release_source(str(release_id)) == "discogs":
-                    selectors = (f"discogs_albumid:{release_id}",
-                                 f"mb_albumid:{release_id}")
-                else:
-                    selectors = (f"mb_albumid:{release_id}",)
-            return SimpleNamespace(
-                kind=kind, album_id=album_id, selectors=selectors)
-
-        self._beets.locate.side_effect = _side_effect
+        """Queue ``(kind, album_id, selectors)`` locate outcomes on the
+        fake. Extra calls reuse the final entry; blank selectors on an
+        'exact' entry are auto-filled from the queried id's shape by
+        the fake (the locate contract derives them from the ID)."""
+        from lib.beets_db import ReleaseLocation
+        entries: list[ReleaseLocation] = []
+        for kind, album_id, selectors in results:
+            assert kind in ("exact", "absent"), kind
+            # No coercion — queue_locate_results rejects
+            # production-impossible (kind, album_id, selectors) combos.
+            entries.append(ReleaseLocation(
+                kind="exact" if kind == "exact" else "absent",
+                album_id=album_id,  # type: ignore[arg-type]
+                selectors=tuple(selectors)))
+        self.beets_db.queue_locate_results(entries)
 
     def tearDown(self) -> None:
         self._srv._beets = self._orig_beets
@@ -978,7 +961,7 @@ class TestUserRequeueOverridePreservation(_FakeDbWebServerCase):
     def test_upgrade_omits_min_bitrate_when_beets_lookup_misses(
             self, mock_transition):
         """Missing Beets quality data must not clear the existing DB baseline."""
-        self._beets.get_min_bitrate.return_value = None
+        self.beets_db._min_bitrate_default = None
         self.db.seed_request(make_request_row(
             id=1704, status="imported", min_bitrate=320,
             mb_release_id=self.RELEASE_ID,
@@ -1266,16 +1249,12 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         import web.server as srv
         self._srv = srv
         self._orig_beets = srv._beets
-        self._beets = MagicMock()
-        # Default: no tracks — individual tests override.
-        self._beets.get_item_paths.return_value = []
-        # locate seam returns "absent" so ``remove_and_reset_release``
-        # is a no-op unless overridden per-test.
-        from types import SimpleNamespace
-        self._beets.locate.return_value = SimpleNamespace(
-            kind="absent", album_id=None, selectors=()
-        )
-        srv._beets = self._beets
+        self.beets_db = FakeBeetsDB()
+        # Defaults: no tracks (tests seed item paths), and locate is
+        # state-derived — nothing seeded means "absent", so
+        # ``remove_and_reset_release`` is a no-op unless a test seeds
+        # album ids or queues locate results.
+        srv._beets = self.beets_db
 
         self.db.seed_request(make_request_row(
             id=1704, status="imported", mb_release_id=self.RELEASE_ID,
@@ -1299,10 +1278,10 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         # the uploader from the real download_log.
         self.db.log_download(
             1704, outcome="success", soulseek_username="Hxrco")
-        self._beets.get_item_paths.return_value = [
+        self.beets_db.set_item_paths(self.RELEASE_ID, [
             (1, "/mnt/Music/Beets/A/track-01.flac"),
             (2, "/mnt/Music/Beets/A/track-02.flac"),
-        ]
+        ])
         # Distinct digests per call so the route inserts both rows.
         mock_hash.side_effect = [self.HASH_A, self.HASH_B]
 
@@ -1356,11 +1335,11 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         """
         self.db.log_download(
             1704, outcome="success", soulseek_username="Hxrco")
-        self._beets.get_item_paths.return_value = [
+        self.beets_db.set_item_paths(self.RELEASE_ID, [
             (1, "/mnt/Music/Beets/A/track-01.flac"),
             (2, "/mnt/Music/Beets/A/track-02.flac"),
             (3, "/mnt/Music/Beets/A/track-03.flac"),
-        ]
+        ])
         # Track 2 raises; tracks 1 and 3 succeed.
         from lib.audio_hash import AudioHashError
         mock_hash.side_effect = [
@@ -1397,9 +1376,9 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         ``reported_username=None`` (the bytes are still protected).
         """
         # No successful download on record — nothing seeded.
-        self._beets.get_item_paths.return_value = [
+        self.beets_db.set_item_paths(self.RELEASE_ID, [
             (1, "/mnt/Music/Beets/A/track-01.mp3"),
-        ]
+        ])
         mock_hash.return_value = self.HASH_A
 
         status, data = self._post(
@@ -1435,7 +1414,7 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         """
         self.db.log_download(
             1704, outcome="success", soulseek_username="Hxrco")
-        self._beets.get_item_paths.return_value = []
+        # No item paths seeded — the fake returns [] for the release.
 
         status, data = self._post(
             "/api/pipeline/ban-source",
@@ -1482,8 +1461,8 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         # No mutation of any kind.
         self.assertEqual(self.db.denylist, [])
         self.assertEqual(self.db.bad_audio_hashes, [])
-        self._beets.get_item_paths.assert_not_called()
-        self._beets.locate.assert_not_called()
+        self.assertEqual(self.beets_db.get_item_paths_calls, [])
+        self.assertEqual(self.beets_db.locate_calls, [])
 
         # The active set is queued OR running — flip the job to the
         # state the importer worker would hold and re-assert the 409.
@@ -1515,9 +1494,9 @@ class TestBanSourceBadRipExtensions(_FakeDbWebServerCase):
         """
         self.db.log_download(
             1704, outcome="success", soulseek_username="Hxrco")
-        self._beets.get_item_paths.return_value = [
+        self.beets_db.set_item_paths(self.RELEASE_ID, [
             (1, "/mnt/Music/Beets/A/track-01.flac"),
-        ]
+        ])
         mock_hash.return_value = self.HASH_A
 
         # First click inserts the hash for real...


### PR DESCRIPTION
PR 3 of the #445 series — the final migration batch. `WEB_BEETS_MOCK_BASELINE` is now permanently empty and armed at zero.

## What moved

- `test_routes_library.py` (31): `self.beets = MagicMock()` → seeded `self.beets_db = FakeBeetsDB()` (the documented uncounted name); search/recent/detail configured returns → seeds. Delete tests keep the allowlisted `lib.beets_db.BeetsDB` class patch but their instance side is a real seeded fake; `delete_album` stays a leaf stub (SQLite-write + file-delete seam).
- `test_routes_pipeline_mutations.py` (19): both classes' `self._beets = MagicMock()` → seeded fakes; `_set_locate_sequence` is now a thin adapter over a typed locate-queue API (the SimpleNamespace `side_effect` machinery is gone); `assert_not_called` pins → recorder-list equality.

## FakeBeetsDB extensions (dual-review hardened)

- **`locate`** — `queue_locate_results(list[ReleaseLocation])` for before/after-mutation flows (consumed in order, last repeats, exact-with-empty-selectors auto-filled from the queried id's shape) + a state-derived default from the album-ids store. Production-impossible locations (exact without int album_id; absent with selectors) are rejected at queue time.
- **Presence seam coupling** — `album_exists` and `get_min_bitrate` answer through one `_presence` helper (queued locate head → explicit seed → album-ids store → default), closing the gap both reviewers flagged: the fake could previously report a removed album's bitrate, a state production's locate-derived lookups cannot produce.
- **`search_albums` / `get_recent` / `get_album_detail`** — NOCASE substring + (artist, year, album) ordering; added DESC with NULLs last; id-keyed detail. Self-tests for every branch.

The deliberate impossible-looking dedupe fixture in mutations (item paths present + locate absent — documented in-test as isolating the (hash, format) dedupe) survives intact; both reviewers verified the routing didn't change.

Full suite 4,444 tests OK; pyright 0 errors.

Closes the item 1 migration of #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)