### PR TITLE
feat(db): promote inline raw-SQL seams to named PipelineDB methods (#445 item 2)

### DIFF
--- a/lib/pipeline_db/__init__.py
+++ b/lib/pipeline_db/__init__.py
@@ -5,6 +5,7 @@ previously top-level name, and ``import lib.pipeline_db`` exposes the
 composed ``PipelineDB`` class.
 """
 from lib.pipeline_db._db import PipelineDB
+from lib.pipeline_db.download_log import DownloadLogCounts
 from lib.pipeline_db._shared import (
     ADVISORY_LOCK_NAMESPACE_IMPORT,
     ADVISORY_LOCK_NAMESPACE_IMPORTER,
@@ -104,6 +105,7 @@ __all__ = [
     "DASHBOARD_WANTED_TREND_WINDOWS",
     "DASHBOARD_WINDOWS",
     "DEFAULT_DSN",
+    "DownloadLogCounts",
     "DryRunPlanClassification",
     "MbidCollisionError",
     "NonConsumingAttemptInput",

--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -1,5 +1,6 @@
 """download_log audit rows and wrong-match bookkeeping."""
 import json
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 import msgspec
@@ -20,8 +21,61 @@ from lib.validation_envelope import (
 )
 
 
+@dataclass(frozen=True)
+class DownloadLogCounts:
+    """Aggregate counts behind the Recents tab's filter chips +
+    found-search enqueue rates (#445 item 2)."""
+
+    total: int
+    imported: int
+    matches_24h: int
+    matches_6h: int
+
+
 class _DownloadLogMixin(_PipelineDBBase):
     """download_log audit rows and wrong-match bookkeeping."""
+
+    def get_download_log_counts(self) -> DownloadLogCounts:
+        """One-query aggregate: download_log totals plus found-search
+        counts in the 24h/6h windows. The CROSS JOIN of two single-row
+        aggregates always returns exactly one row."""
+        cur = self._execute("""
+            WITH download_counts AS (
+                SELECT
+                    COUNT(*) AS total,
+                    COUNT(*) FILTER (
+                        WHERE outcome IN ('success', 'force_import')
+                    ) AS imported
+                FROM download_log
+            ),
+            match_counts AS (
+                SELECT
+                    COUNT(*) FILTER (
+                        WHERE outcome = 'found'
+                          AND created_at >= NOW() - INTERVAL '24 hours'
+                    )::int AS matches_24h,
+                    COUNT(*) FILTER (
+                        WHERE outcome = 'found'
+                          AND created_at >= NOW() - INTERVAL '6 hours'
+                    )::int AS matches_6h
+                FROM search_log
+            )
+            SELECT
+                download_counts.total,
+                download_counts.imported,
+                match_counts.matches_24h,
+                match_counts.matches_6h
+            FROM download_counts
+            CROSS JOIN match_counts
+        """)
+        row = cur.fetchone()
+        assert row is not None, "CROSS JOIN of aggregates always yields a row"
+        return DownloadLogCounts(
+            total=row["total"],
+            imported=row["imported"],
+            matches_24h=row["matches_24h"],
+            matches_6h=row["matches_6h"],
+        )
 
 
     def get_log(self, limit: int = 50,

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -83,6 +83,32 @@ class _RequestsMixin(_PipelineDBBase):
         return dict(row) if row else None
 
 
+    def get_pipeline_overlay(
+        self, mbids: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Map mb_release_id → badge-overlay info for the browse /
+        library views (#445 item 2 — formerly inline SQL in
+        ``web/overlay.py::check_pipeline``)."""
+        if not mbids:
+            return {}
+        placeholders = ",".join(["%s"] * len(mbids))
+        cur = self._execute(
+            f"SELECT id, mb_release_id, status, search_filetype_override, "
+            f"target_format, min_bitrate "
+            f"FROM album_requests WHERE mb_release_id IN ({placeholders})",
+            tuple(mbids),
+        )
+        return {
+            r["mb_release_id"]: {
+                "id": r["id"],
+                "status": r["status"],
+                "search_filetype_override": r["search_filetype_override"],
+                "target_format": r["target_format"],
+                "min_bitrate": r["min_bitrate"],
+            }
+            for r in cur.fetchall()
+        }
+
     def get_request_by_mb_release_id(self, mb_release_id: str) -> dict[str, Any] | None:
         cur = self._execute(
             "SELECT * FROM album_requests WHERE mb_release_id = %s", (mb_release_id,)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -46,7 +46,8 @@ from lib.pipeline_db import (ActiveSearchPlan, BACKOFF_BASE_MINUTES,
                              BadAudioHashRow, ConsumedAttemptInput,
                              ConsumedAttemptResult, CURSOR_UPDATE_ADVANCED,
                              CURSOR_UPDATE_STALE, CURSOR_UPDATE_UNCHANGED,
-                             CURSOR_UPDATE_WRAPPED, DryRunPlanClassification,
+                             CURSOR_UPDATE_WRAPPED, DownloadLogCounts,
+                             DryRunPlanClassification,
                              NonConsumingAttemptInput,
                              PLAN_STATUS_ACTIVE, PLAN_STATUS_FAILED_DETERMINISTIC,
                              PLAN_STATUS_FAILED_TRANSIENT,
@@ -3365,6 +3366,55 @@ class FakePipelineDB:
         if limit is not None:
             eligible = eligible[:int(limit)]
         return [copy.deepcopy(r) for r in eligible]
+
+    def get_download_log_counts(self) -> DownloadLogCounts:
+        """Mirror of ``PipelineDB.get_download_log_counts`` — computed
+        from the fake's real ``download_logs``/``search_logs`` state,
+        never queued (#445 item 2). Parity with the production SQL is
+        pinned by ``tests/test_pipeline_db.py::TestGetDownloadLogCounts``.
+        """
+        now = _utcnow()
+        total = len(self.download_logs)
+        imported = sum(
+            1 for e in self.download_logs
+            if e.outcome in ("success", "force_import"))
+        found_24h = sum(
+            1 for e in self.search_logs
+            if e.outcome == "found"
+            and self._as_utc(e.created_at) >= now - timedelta(hours=24))
+        found_6h = sum(
+            1 for e in self.search_logs
+            if e.outcome == "found"
+            and self._as_utc(e.created_at) >= now - timedelta(hours=6))
+        return DownloadLogCounts(
+            total=total, imported=imported,
+            matches_24h=found_24h, matches_6h=found_6h)
+
+    def get_pipeline_overlay(
+        self, mbids: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Mirror of ``PipelineDB.get_pipeline_overlay`` — projects the
+        overlay fields straight from seeded request rows (#445 item 2).
+        Parity pinned by ``TestGetPipelineOverlay``."""
+        wanted = {str(m) for m in mbids}
+        out: dict[str, dict[str, Any]] = {}
+        for r in self._requests.values():
+            raw = r.get("mb_release_id")
+            # Production's column is TEXT — compare and key by the str
+            # form (a None mbid must never stringify into a match).
+            if raw is None:
+                continue
+            mbid = str(raw)
+            if mbid in wanted:
+                out[mbid] = {
+                    "id": r["id"],
+                    "status": r.get("status"),
+                    "search_filetype_override":
+                        r.get("search_filetype_override"),
+                    "target_format": r.get("target_format"),
+                    "min_bitrate": r.get("min_bitrate"),
+                }
+        return out
 
     def get_log(self, limit: int = 50,
                 outcome_filter: str | None = None,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -5309,6 +5309,52 @@ class TestFakeCursor(unittest.TestCase):
         self.assertIsNone(cur.fetchone())
 
 
+class TestFakeDownloadLogCounts(unittest.TestCase):
+    """State-derived mirror of PipelineDB.get_download_log_counts —
+    parity with the real SQL is pinned in tests/test_pipeline_db.py."""
+
+    def test_counts_derive_from_logged_state(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+        db.log_download(1, outcome="success")
+        db.log_download(1, outcome="force_import")
+        db.log_download(1, outcome="rejected")
+        db.log_search(1, outcome="found")
+        db.log_search(1, outcome="found")
+        db.log_search(1, outcome="error")
+        # Age one found-row out of the 6h window only, one out of both.
+        db.search_logs[0].created_at -= timedelta(hours=12)
+        db.log_search(1, outcome="found")
+        db.search_logs[-1].created_at -= timedelta(days=2)
+
+        counts = db.get_download_log_counts()
+        self.assertEqual(counts.total, 3)
+        self.assertEqual(counts.imported, 2)
+        self.assertEqual(counts.matches_24h, 2)
+        self.assertEqual(counts.matches_6h, 1)
+
+
+class TestFakeGetPipelineOverlay(unittest.TestCase):
+    def test_projects_overlay_fields_from_seeded_requests(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=7, mb_release_id="mbid-1", status="wanted",
+            search_filetype_override="lossless", min_bitrate=900))
+        db.seed_request(make_request_row(id=8, mb_release_id="mbid-2"))
+        info = db.get_pipeline_overlay(["mbid-1", "mbid-unknown"])
+        self.assertEqual(set(info), {"mbid-1"})
+        self.assertEqual(info["mbid-1"], {
+            "id": 7, "status": "wanted",
+            "search_filetype_override": "lossless",
+            "target_format": None, "min_bitrate": 900,
+        })
+
+    def test_empty_mbids_short_circuits(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=7, mb_release_id="mbid-1"))
+        self.assertEqual(db.get_pipeline_overlay([]), {})
+
+
 class TestFakeRequestUniqueMbReleaseId(unittest.TestCase):
     """The fake mirrors migrations/001's UNIQUE on album_requests.mb_release_id.
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -8009,5 +8009,135 @@ class TestDashboardFakeParity(unittest.TestCase):
         )
 
 
+@requires_postgres
+class TestGetDownloadLogCounts(unittest.TestCase):
+    """#445 item 2 — the /api/pipeline/log counts aggregate, promoted
+    from inline route SQL to a named PipelineDB method."""
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_empty_tables_yield_zero_counts(self):
+        counts = self.db.get_download_log_counts()
+        self.assertEqual(
+            (counts.total, counts.imported,
+             counts.matches_24h, counts.matches_6h),
+            (0, 0, 0, 0))
+
+    def test_counts_aggregate_downloads_and_found_searches(self):
+        rid = self.db.add_request(
+            mb_release_id="counts-mbid-1", artist_name="A",
+            album_title="B", source="request")
+        self.db.log_download(rid, outcome="success")
+        self.db.log_download(rid, outcome="force_import")
+        self.db.log_download(rid, outcome="rejected")
+        self.db.log_search(rid, outcome="found")
+        self.db.log_search(rid, outcome="found")
+        self.db.log_search(rid, outcome="error")
+        # Age one found-row out of the 6h window but not the 24h one.
+        self.db._execute(
+            "UPDATE search_log SET created_at = NOW() - INTERVAL '12 hours' "
+            "WHERE id = (SELECT MIN(id) FROM search_log "
+            "            WHERE outcome = 'found')")
+        # And one found-row out of BOTH windows.
+        self.db.log_search(rid, outcome="found")
+        self.db._execute(
+            "UPDATE search_log SET created_at = NOW() - INTERVAL '2 days' "
+            "WHERE id = (SELECT MAX(id) FROM search_log)")
+
+        counts = self.db.get_download_log_counts()
+        self.assertEqual(counts.total, 3)
+        self.assertEqual(counts.imported, 2)
+        self.assertEqual(counts.matches_24h, 2)
+        self.assertEqual(counts.matches_6h, 1)
+
+    def test_fake_parity_on_identical_state(self):
+        from tests.fakes import FakePipelineDB
+
+        fake = FakePipelineDB()
+        for db in (self.db, fake):
+            rid = db.add_request(
+                mb_release_id="parity-mbid-1", artist_name="A",
+                album_title="B", source="request")
+            db.log_download(rid, outcome="success")
+            db.log_download(rid, outcome="timeout")
+            db.log_search(rid, outcome="found")
+            db.log_search(rid, outcome="no_results")
+        real = self.db.get_download_log_counts()
+        mirrored = fake.get_download_log_counts()
+        self.assertEqual(
+            (real.total, real.imported, real.matches_24h, real.matches_6h),
+            (mirrored.total, mirrored.imported,
+             mirrored.matches_24h, mirrored.matches_6h),
+            "FakePipelineDB's counts mirror drifted from the real SQL — "
+            "fix the fake (tests/fakes.py), never the production SQL, "
+            "unless the SQL change is the point of your PR.")
+
+
+@requires_postgres
+class TestGetPipelineOverlay(unittest.TestCase):
+    """#445 item 2 — web/overlay.py::check_pipeline's inline SQL,
+    promoted to a named PipelineDB method."""
+
+    def setUp(self):
+        self.db = make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_empty_mbids_short_circuits(self):
+        self.assertEqual(self.db.get_pipeline_overlay([]), {})
+
+    def test_maps_known_mbids_with_overlay_fields(self):
+        rid = self.db.add_request(
+            mb_release_id="overlay-mbid-1", artist_name="A",
+            album_title="B", source="request")
+        self.db.update_request_fields(
+            rid, min_bitrate=900, search_filetype_override="lossless")
+
+        info = self.db.get_pipeline_overlay(
+            ["overlay-mbid-1", "overlay-mbid-unknown"])
+
+        self.assertEqual(set(info), {"overlay-mbid-1"})
+        row = info["overlay-mbid-1"]
+        self.assertEqual(row["id"], rid)
+        self.assertEqual(row["status"], "wanted")
+        self.assertEqual(row["search_filetype_override"], "lossless")
+        self.assertIsNone(row["target_format"])
+        self.assertEqual(row["min_bitrate"], 900)
+
+    def test_fake_parity_on_identical_state(self):
+        from tests.fakes import FakePipelineDB
+
+        fake = FakePipelineDB()
+        rids: dict[int, int] = {}
+        for db in (self.db, fake):
+            rid = db.add_request(
+                mb_release_id="overlay-parity-1", artist_name="A",
+                album_title="B", source="request")
+            db.update_request_fields(rid, min_bitrate=320)
+            db.add_request(
+                mb_release_id="overlay-parity-2", artist_name="C",
+                album_title="D", source="request", status="manual")
+            rids[id(db)] = rid
+        mbids = ["overlay-parity-1", "overlay-parity-2", "nope"]
+        real = self.db.get_pipeline_overlay(mbids)
+        mirrored = fake.get_pipeline_overlay(mbids)
+        # The PG sequence isn't reset between tests, so ids differ by
+        # backend — pin each backend's id mapping, compare the rest.
+        self.assertEqual(real["overlay-parity-1"]["id"], rids[id(self.db)])
+        self.assertEqual(mirrored["overlay-parity-1"]["id"], rids[id(fake)])
+        strip = lambda o: {m: {k: v for k, v in row.items() if k != "id"}
+                           for m, row in o.items()}
+        self.assertEqual(
+            strip(real), strip(mirrored),
+            "FakePipelineDB's overlay mirror drifted from the real SQL — "
+            "fix the fake (tests/fakes.py), never the production SQL, "
+            "unless the SQL change is the point of your PR.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -10,7 +10,8 @@ import unittest
 
 from web import overlay
 
-from tests.fakes import FakeBeetsDB, FakeCursor, FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakePipelineDB
+from tests.helpers import make_request_row
 
 
 class TestSerializeRow(unittest.TestCase):
@@ -30,17 +31,12 @@ class TestCheckPipeline(unittest.TestCase):
     def test_empty_mbids_short_circuits(self):
         db = FakePipelineDB()
         self.assertEqual(overlay.check_pipeline(db, []), {})
-        self.assertEqual(db.execute_calls, [])
 
     def test_returns_info_keyed_by_mbid(self):
         db = FakePipelineDB()
-        db.queue_execute_results(FakeCursor([
-            {
-                "id": 7, "mb_release_id": "mbid-1", "status": "wanted",
-                "search_filetype_override": "lossless",
-                "target_format": None, "min_bitrate": 900,
-            },
-        ]))
+        db.seed_request(make_request_row(
+            id=7, mb_release_id="mbid-1", status="wanted",
+            search_filetype_override="lossless", min_bitrate=900))
         info = overlay.check_pipeline(db, ["mbid-1", "mbid-2"])
         self.assertEqual(set(info), {"mbid-1"})
         self.assertEqual(info["mbid-1"]["id"], 7)
@@ -57,13 +53,9 @@ class TestEnrichWithPipeline(unittest.TestCase):
 
     def test_wanted_with_override_marks_upgrade_queued(self):
         db = FakePipelineDB()
-        db.queue_execute_results(FakeCursor([
-            {
-                "id": 7, "mb_release_id": "mbid-1", "status": "wanted",
-                "search_filetype_override": "lossless",
-                "target_format": None, "min_bitrate": None,
-            },
-        ]))
+        db.seed_request(make_request_row(
+            id=7, mb_release_id="mbid-1", status="wanted",
+            search_filetype_override="lossless", min_bitrate=None))
         albums: list[dict[str, object]] = [
             {"mb_albumid": "mbid-1"}, {"mb_albumid": "other"}]
         overlay.enrich_with_pipeline(db, albums)

--- a/tests/web/test_routes_library.py
+++ b/tests/web/test_routes_library.py
@@ -18,7 +18,7 @@ from tests.web._harness import (
     _FakeDbWebServerCase,
 )
 
-from tests.fakes import FakeBeetsDB, FakeCursor, FakePipelineDB
+from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_request_row
 
 
@@ -163,28 +163,16 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
             ["/music/Test Artist/Test Album/01 Track.mp3"],
         )
 
-    def _queue_pipeline_overlay_row(self, *, min_bitrate: int | None) -> None:
-        """Queue the row ``web.overlay.check_pipeline``'s raw SQL would
-        return for request 42 (the overlay goes through ``_execute``,
-        which the fake cannot interpret — the queued cursor IS the
-        query result). The legacy MagicMock harness silently fed this
-        path an empty magic cursor, so enrichment never ran in tests.
-
-        The cursor row is PROJECTED from the seeded request, mutated
-        first, so the two representations of request 42 cannot
-        contradict each other (in production they are the same row)."""
+    def _set_overlay_min_bitrate(self, *, min_bitrate: int | None) -> None:
+        """Raise request 42's pipeline floor — the overlay now flows
+        through ``PipelineDB.get_pipeline_overlay`` and the fake's
+        state-derived mirror reads the seeded row directly (#445
+        item 2; the queued-cursor projection helper is gone)."""
         self.db.update_request_fields(42, min_bitrate=min_bitrate)
-        req = self.db.request(42)
-        self.db.queue_execute_results(FakeCursor([{
-            k: req.get(k)
-            for k in ("id", "mb_release_id", "status",
-                      "search_filetype_override", "target_format",
-                      "min_bitrate")
-        }]))
 
     def test_beets_search_contract(self):
         self.beets_db.set_library_albums([self._album()])
-        self._queue_pipeline_overlay_row(min_bitrate=900)
+        self._set_overlay_min_bitrate(min_bitrate=900)
         status, data = self._get("/api/beets/search?q=test")
 
         self.assertEqual(status, 200)
@@ -197,7 +185,7 @@ class TestBeetsRouteContracts(_FakeDbWebServerCase):
 
     def test_beets_recent_contract(self):
         self.beets_db.set_library_albums([self._album()])
-        self._queue_pipeline_overlay_row(min_bitrate=900)
+        self._set_overlay_min_bitrate(min_bitrate=900)
         status, data = self._get("/api/beets/recent")
 
         self.assertEqual(status, 200)

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tests.web._harness import _FakeDbWebServerCase
 
-from tests.fakes import FakeCursor, FakePipelineDB
+from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 
 
@@ -43,15 +43,20 @@ class TestServerEndpoints(_FakeDbWebServerCase):
             actual_min_bitrate=320, valid=True,
         )
 
-    def _queue_log_counts(self, *, total: int = 1, imported: int = 1,
-                          matches_24h: int = 3, matches_6h: int = 1) -> None:
-        """The /api/pipeline/log counts come from one raw-SQL aggregate
-        the fake cannot interpret — the queued cursor IS that query's
-        result row. Unqueued calls degrade to all-zero counts."""
-        self.db.queue_execute_results(FakeCursor([{
-            "total": total, "imported": imported,
-            "matches_24h": matches_24h, "matches_6h": matches_6h,
-        }]))
+    def _seed_log_counts_state(self) -> None:
+        """Real rows behind /api/pipeline/log counts: setUp's one
+        success row + these make total=7, imported=2; three recent
+        found-searches, one aged past the 6h window (#445 item 2 —
+        the counts flow through PipelineDB.get_download_log_counts
+        and the fake's state-derived mirror, no queued cursor)."""
+        from datetime import timedelta
+
+        self.db.log_download(100, outcome="force_import")
+        for _ in range(5):
+            self.db.log_download(100, outcome="rejected")
+        for _ in range(3):
+            self.db.log_search(100, outcome="found")
+        self.db.search_logs[0].created_at -= timedelta(hours=12)
 
     # --- GET endpoints ---
 
@@ -121,8 +126,7 @@ class TestServerEndpoints(_FakeDbWebServerCase):
             {e["outcome"] for e in data["log"]}, {"success", "rejected"})
 
     def test_pipeline_log_counts_structure(self):
-        self._queue_log_counts(total=7, imported=2,
-                               matches_24h=3, matches_6h=1)
+        self._seed_log_counts_state()
         status, data = self._get("/api/pipeline/log")
         self.assertEqual(status, 200)
         counts = data["counts"]
@@ -132,13 +136,17 @@ class TestServerEndpoints(_FakeDbWebServerCase):
         for key in ("matches_per_hour_24h", "matches_per_hour_6h"):
             self.assertIn(key, counts)
             self.assertIsInstance(counts[key], (int, float))
-        # The queued aggregate row actually flowed into the payload.
+        # The seeded rows actually flowed into the payload.
         self.assertEqual(counts["all"], 7)
         self.assertEqual(counts["imported"], 2)
         # rejected (5) is coprime with matches_24h (3) so a wiring swap
-        # cannot pass by numeric coincidence.
+        # cannot pass by numeric coincidence; 24h (3) ≠ 6h (2) so a
+        # window transposition cannot either.
         self.assertEqual(counts["rejected"], 5)
+        self.assertEqual(counts["matches_24h"], 3)
+        self.assertEqual(counts["matches_6h"], 2)
         self.assertAlmostEqual(counts["matches_per_hour_24h"], 3 / 24)
+        self.assertAlmostEqual(counts["matches_per_hour_6h"], 2 / 6)
 
     def test_pipeline_status(self):
         status, data = self._get("/api/pipeline/status")

--- a/web/overlay.py
+++ b/web/overlay.py
@@ -21,7 +21,9 @@ class OverlayPipelineDB(Protocol):
     """The slice of PipelineDB the overlay consumes (per-consumer
     protocol, the #409 pattern — FakePipelineDB satisfies it too)."""
 
-    def _execute(self, sql: str, params: tuple = ()) -> Any: ...
+    def get_pipeline_overlay(
+        self, mbids: list[str],
+    ) -> dict[str, dict[str, Any]]: ...
 
 
 class OverlayBeetsDB(Protocol):
@@ -80,22 +82,7 @@ def check_pipeline(pdb: "OverlayPipelineDB | None", mbids) -> dict:
     """Check which MBIDs are already in the pipeline DB. Returns dict of mbid → info."""
     if not mbids or pdb is None:
         return {}
-    placeholders = ",".join(["%s"] * len(mbids))
-    cur = pdb._execute(
-        f"SELECT id, mb_release_id, status, search_filetype_override, target_format, min_bitrate "
-        f"FROM album_requests WHERE mb_release_id IN ({placeholders})",
-        tuple(mbids),
-    )
-    return {
-        r["mb_release_id"]: {
-            "id": r["id"],
-            "status": r["status"],
-            "search_filetype_override": r["search_filetype_override"],
-            "target_format": r["target_format"],
-            "min_bitrate": r["min_bitrate"],
-        }
-        for r in cur.fetchall()
-    }
+    return pdb.get_pipeline_overlay([str(m) for m in mbids])
 
 
 def enrich_with_pipeline(

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -242,50 +242,17 @@ def get_pipeline_log(h, params: dict[str, list[str]]) -> None:
         item["wrong_match_triage_detail"] = classified.wrong_match_triage_detail
         result.append(item)
     # Count recents filters plus found-search enqueue rates (single query).
-    count_cur = _server()._db()._execute("""
-        WITH download_counts AS (
-            SELECT
-                COUNT(*) AS total,
-                COUNT(*) FILTER (
-                    WHERE outcome IN ('success', 'force_import')
-                ) AS imported
-            FROM download_log
-        ),
-        match_counts AS (
-            SELECT
-                COUNT(*) FILTER (
-                    WHERE outcome = 'found'
-                      AND created_at >= NOW() - INTERVAL '24 hours'
-                )::int AS matches_24h,
-                COUNT(*) FILTER (
-                    WHERE outcome = 'found'
-                      AND created_at >= NOW() - INTERVAL '6 hours'
-                )::int AS matches_6h
-            FROM search_log
-        )
-        SELECT
-            download_counts.total,
-            download_counts.imported,
-            match_counts.matches_24h,
-            match_counts.matches_6h
-        FROM download_counts
-        CROSS JOIN match_counts
-    """)
-    count_row = count_cur.fetchone()
-    total = count_row["total"] if count_row else 0
-    imported_c = count_row["imported"] if count_row else 0
-    matches_24h = count_row.get("matches_24h", 0) if count_row else 0
-    matches_6h = count_row.get("matches_6h", 0) if count_row else 0
+    counts = _server()._db().get_download_log_counts()
     h._json({
         "log": result,
         "counts": {
-            "all": total,
-            "imported": imported_c,
-            "rejected": total - imported_c,
-            "matches_24h": matches_24h,
-            "matches_6h": matches_6h,
-            "matches_per_hour_24h": matches_24h / 24,
-            "matches_per_hour_6h": matches_6h / 6,
+            "all": counts.total,
+            "imported": counts.imported,
+            "rejected": counts.total - counts.imported,
+            "matches_24h": counts.matches_24h,
+            "matches_6h": counts.matches_6h,
+            "matches_per_hour_24h": counts.matches_24h / 24,
+            "matches_per_hour_6h": counts.matches_6h / 6,
         },
     })
 


### PR DESCRIPTION
PR 4 of the #445 series — the accepted-with-rationale ADV-6 follow-up from the #430 batch 3 review, now a real fix.

## The problem

`get_pipeline_log`'s counts aggregate and `web/overlay.py::check_pipeline` ran inline `_execute` SQL, so:
- Contract tests hand-fed `FakeCursor` rows via `queue_execute_results` with position-coupled queue semantics.
- The route carried `if count_row else 0` branches production can never take (CROSS JOIN of aggregates always returns one row).
- The fake could hold real `download_logs`/`search_logs` while serializing `counts.all == 0` — an impossible production state.

## The fix

- **`PipelineDB.get_download_log_counts()`** — the aggregate moved verbatim (Codex verified zero SQL drift); returns a frozen `DownloadLogCounts` dataclass; dead route branches deleted.
- **`PipelineDB.get_pipeline_overlay(mbids)`** — the overlay SELECT moved verbatim; `OverlayPipelineDB` protocol narrows from `_execute` to the named method (every handle passed as the overlay DB — web server thread-locals, dev server, test harness — has it).
- **Honest fake mirrors** computed from `download_logs`/`search_logs`/seeded requests, with tz-normalized window comparisons (the dashboard mirror's `_as_utc` convention) and a None-guarded TEXT-faithful mbid comparison.
- **Rule-A real-PG round-trips + fake-parity tests** for both methods, plus fake self-tests.
- **All `FakeCursor` queueing deleted from the consumers** — overlay unit tests and library contract tests seed request rows; the endpoint counts test seeds real rows and now pins both window legs (24h=3 ≠ 6h=2, so a transposition can't pass).

## Review

Both engines ran per the playbook. Codex: no SQL drift, CROSS JOIN assert sound, no caller breakage, seeding arithmetic correct; one pre-existing (unchanged) int-vs-str note in `web/routes/_overlay.py`. Adversarial: contributed the `_as_utc` normalization, the None guard, and the 6h-leg assertions — all applied.

Full suite 4,453 tests OK; pyright 0 errors.

Part of #445 (item 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)