### PR TITLE
refactor: kill the dual-module-load ambiguity — one canonical import name per module (#445 item 3)

### DIFF
--- a/docs/solutions/architecture/service-first-then-glue.md
+++ b/docs/solutions/architecture/service-first-then-glue.md
@@ -163,14 +163,16 @@ look like this by default. If it doesn't, that's the smell.
 ## Caveats
 
 - The eager `from beets import library` at module load time is
-  non-obvious. It exists because `tests/test_web_server.py` adds
-  `tests/../lib` to sys.path early in the test session, which then
-  shadows the upstream `beets` package whenever something lazy-imports
-  it later. Eager-at-load wins because the module is loaded before any
-  test fixture can pollute sys.path. The fix that actually mattered
-  was adding `ps.beets` to the production pythonEnv in
-  `nix/package.nix` so the eager import works in prod too — see PR
-  #287.
+  non-obvious. Historically it guarded against the web test harness
+  adding `lib/` to sys.path early in the test session, which shadowed
+  the upstream `beets` package with `lib/beets.py` whenever something
+  lazy-imported it later. Those inserts were removed with #445 item 3
+  (every module now loads under exactly one canonical name —
+  `tests/test_no_dual_load.py` and `TestSysPathAudit` enforce it), but
+  the eager import stays: it pins the upstream package once at load
+  time. The fix that actually mattered was adding `ps.beets` to the
+  production pythonEnv in `nix/package.nix` so the eager import works
+  in prod too — see PR #287.
 
 - The cross-RG guardrail passes through when the request's release
   group is null (legacy rows). Documented as `_StubPDB`-driven test

--- a/lib/beets_distance.py
+++ b/lib/beets_distance.py
@@ -46,17 +46,17 @@ from typing import Callable, Optional, Protocol, Sequence
 
 import msgspec
 
-# Eager beets imports. Lazy-loading was tempting (the module is heavy
-# and quality_evidence/measurement do the same), but a sibling
-# ``tests/web/_harness.py`` adds ``lib/`` to sys.path early
-# in the test session, which then shadows the upstream ``beets``
-# package whenever we lazily ``from beets import library`` later. By
-# importing eagerly here we lock in the right module at this file's
-# load time, before any test fixture can prepend lib/ to sys.path.
-from beets import library as _beets_library  # noqa: E402
-from beets.autotag import distance as _beets_distance_mod  # noqa: E402
-from beets.autotag import hooks as _beets_hooks  # noqa: E402
-from beets.autotag import match as _beets_match_mod  # noqa: E402
+# Eager beets imports — deliberate. The module is heavy, but importing
+# at load time pins the upstream ``beets`` package once; lazy imports
+# inside call paths would re-resolve ``beets`` against whatever
+# sys.path looks like at call time. (Historically this guarded against
+# tests/web/_harness.py putting ``lib/`` on sys.path so ``lib/beets.py``
+# shadowed the real package — that insert is gone, and
+# tests/test_no_dual_load.py now bans the ambiguity outright.)
+from beets import library as _beets_library
+from beets.autotag import distance as _beets_distance_mod
+from beets.autotag import hooks as _beets_hooks
+from beets.autotag import match as _beets_match_mod
 
 from lib.validation_envelope import decode_validation_envelope
 

--- a/lib/beets_distance.py
+++ b/lib/beets_distance.py
@@ -47,12 +47,13 @@ from typing import Callable, Optional, Protocol, Sequence
 import msgspec
 
 # Eager beets imports — deliberate. The module is heavy, but importing
-# at load time pins the upstream ``beets`` package once; lazy imports
-# inside call paths would re-resolve ``beets`` against whatever
-# sys.path looks like at call time. (Historically this guarded against
-# tests/web/_harness.py putting ``lib/`` on sys.path so ``lib/beets.py``
-# shadowed the real package — that insert is gone, and
-# tests/test_no_dual_load.py now bans the ambiguity outright.)
+# at load time pins the upstream ``beets`` package before anything can
+# pollute sys.path (the first import wins; later sys.path mutations
+# can't rebind a name already in sys.modules). Historically this
+# guarded against tests/web/_harness.py putting ``lib/`` on sys.path so
+# ``lib/beets.py`` shadowed the real package — that insert is gone, and
+# tests/test_no_dual_load.py + TestSysPathAudit ban the ambiguity
+# outright.
 from beets import library as _beets_library
 from beets.autotag import distance as _beets_distance_mod
 from beets.autotag import hooks as _beets_hooks

--- a/lib/quality.py
+++ b/lib/quality.py
@@ -1515,13 +1515,15 @@ def _selected_bitrate(m: AudioQualityMeasurement,
     Keeps the metric dispatch in one place — compare_quality does not
     peek into m.avg / m.median / m.min directly.
     """
-    # Use `==` not `is`: RankBitrateMetric is a StrEnum, and the project
-    # has modules that get loaded under two names (``lib.quality`` and
-    # ``quality`` via the PYTHONPATH ``lib`` entry). When a cfg constructed
-    # in one module is compared with an enum member from the other, they
-    # are equal by string value but NOT the same object. Identity-compare
-    # here silently fell through to min_bitrate, breaking the AVG policy
-    # in the web simulator for VBR albums (issue #93 post-deploy probe).
+    # Use `==` not `is`: RankBitrateMetric is a StrEnum. Historically the
+    # project loaded modules under two names (``lib.quality`` and bare
+    # ``quality`` via a PYTHONPATH ``lib`` entry) — an enum member from
+    # one copy compared equal by string value but NOT identical to the
+    # other's, so identity-compare silently fell through to min_bitrate,
+    # breaking the AVG policy in the web simulator for VBR albums (issue
+    # #93 post-deploy probe). The dual-load is gone (#445 item 3; pinned
+    # by tests/test_no_dual_load.py), but `==` remains the correct
+    # comparison for a StrEnum either way.
     if cfg.bitrate_metric == RankBitrateMetric.AVG and m.avg_bitrate_kbps is not None:
         return m.avg_bitrate_kbps
     if (cfg.bitrate_metric == RankBitrateMetric.MEDIAN

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -10,7 +10,6 @@ sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tagging-workspace", "scripts"))
 
 from album_source import AlbumRecord, DatabaseSource
 from lib.grab_list import GrabListEntry, DownloadFile

--- a/tests/test_beets_distance.py
+++ b/tests/test_beets_distance.py
@@ -372,10 +372,11 @@ class TestBeetsDistanceIntegrationSlice(unittest.TestCase):
     def setUpClass(cls) -> None:
         # Read the fixture's real length once so MB tracks line up
         # with whatever the on-disk file actually decodes to. Import
-        # via ``lib.beets_distance`` which holds an eager reference to
-        # the upstream ``beets.library`` module — guards against the
-        # sys.path leak where other tests inject ``tests/../lib`` and
-        # shadow the real ``beets`` package.
+        # via ``lib.beets_distance``, which pins the upstream
+        # ``beets.library`` module eagerly at load time. (Historically
+        # this also guarded against tests injecting ``tests/../lib``
+        # onto sys.path and shadowing the real ``beets`` package —
+        # those inserts are gone and TestSysPathAudit bans the class.)
         from lib.beets_distance import _beets_library
         item = _beets_library.Item.from_path(FIXTURE_FLAC)
         cls.fixture_length = float(item.get("length") or 1.0)

--- a/tests/test_conversion_e2e.py
+++ b/tests/test_conversion_e2e.py
@@ -19,7 +19,6 @@ import unittest
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
 sys.path.insert(0, ROOT_DIR)
-sys.path.insert(0, HARNESS_DIR)
 
 from tests.audio_fixtures import make_test_flac, make_test_album, get_bitrate_kbps
 

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -12,8 +12,6 @@ import sys
 import unittest
 from unittest.mock import patch, MagicMock
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "harness"))
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 
 def _make_harness_proc(messages: list[dict]) -> MagicMock:

--- a/tests/test_evidence_rekey_migration.py
+++ b/tests/test_evidence_rekey_migration.py
@@ -33,7 +33,6 @@ from typing import Sequence
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 import psycopg2  # noqa: E402
 

--- a/tests/test_force_import.py
+++ b/tests/test_force_import.py
@@ -17,9 +17,6 @@ from unittest.mock import patch, MagicMock
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "scripts"))
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "harness"))
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -22,7 +22,6 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
 
 sys.path.insert(0, ROOT_DIR)
-sys.path.insert(0, HARNESS_DIR)
 
 from tests.fakes import FakeBeetsDB, FakePipelineDB  # noqa: E402
 

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -12,7 +12,6 @@ import unittest
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 import psycopg2  # noqa: E402
 

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -62,39 +62,61 @@ class TestStatefulMockAudit(unittest.TestCase):
 
 
 class TestSysPathAudit(unittest.TestCase):
-    """Ban front-of-sys.path inserts of a test directory.
+    """Ban every sys.path mutation that can shadow a real package.
 
-    ``sys.path.insert(0, <tests dir>)`` makes ``tests/web`` shadow the
-    real ``web`` package for any later ``import web.server`` that runs
-    before something else has registered repo-root ``web`` in
-    sys.modules — module-order-dependent ModuleNotFoundErrors that the
-    full discovery run masks. ``sys.path.append`` resolves the same
-    bare imports (``conftest``, ``_lambda_audit``) without ever
-    out-ranking the repo root. Repo-root inserts (the
-    ``join(dirname, "..")`` shape) are fine and not matched.
+    The audit resolves each ``<anything>.path.insert/append(...)`` call
+    in tests/ via the AST — folding ``os.path.join/dirname/abspath/
+    normpath`` chains and simple module-level variable assignments, so
+    naming the directory through a variable is not an evasion. The
+    policy (no exceptions — the tests/web/_harness.py inserts that
+    deliberately reproduced the dual-load ambiguity were removed with
+    #445 item 3; production strips its script-dir entry too, see
+    tests/test_no_dual_load.py):
+
+    - the repo root may be inserted or appended (how ``from lib.X``
+      resolves in standalone module runs);
+    - the tests/ dir (or a subdir) may only be APPENDED — a front
+      insert makes ``tests/web`` shadow the real ``web`` package in
+      module-order-dependent ways that full discovery masks;
+    - any other directory (lib/, web/, scripts/, harness/, anything
+      out-of-repo) is banned outright: it makes repo modules importable
+      under bare second names — the issue #95 / PR #94 dual-load class;
+    - a target the folder can't resolve is banned too: use a literal
+      ``os.path`` shape the audit can prove safe.
     """
 
-    # Matches a dirname-chain applied directly to __file__ (optionally
-    # through abspath); the chain depth decides which directory lands
-    # at the front of sys.path.
-    _FRONT_INSERT_RE = __import__("re").compile(
-        r"sys\.path\.insert\(\s*\d+\s*,\s*"
-        r"((?:os\.path\.dirname\(\s*)+)(?:os\.path\.abspath\(\s*)?__file__")
-    # Front-inserts of repo source dirs (lib/, web/, scripts/) shadow
-    # same-named top-level packages — lib/beets.py out-ranks the real
-    # ``beets`` package (the issue #95 dual-load footgun conftest.py
-    # documents). No exceptions: the tests/web/_harness.py inserts that
-    # deliberately reproduced the ambiguity were removed with #445
-    # item 3 (production now strips its script-dir entry too — see
-    # tests/test_no_dual_load.py).
-    _SOURCE_DIR_INSERT_RE = __import__("re").compile(
-        r'sys\.path\.insert\(\s*\d+\s*,\s*os\.path\.join\('
-        r'os\.path\.dirname\(__file__\),\s*"\.\."(?:,\s*"\.\.")?,'
-        r'\s*"(?:lib|web|scripts|harness)"\)')
+    @staticmethod
+    def _fold(node, file_path: str, env: dict[str, str]) -> str | None:
+        """Constant-fold a string expression: literals, ``__file__``,
+        previously-folded module-level names, and os.path calls."""
+        import ast
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            if node.id == "__file__":
+                return os.path.abspath(file_path)
+            return env.get(node.id)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            func = node.func
+            if (isinstance(func.value, ast.Attribute)
+                    and isinstance(func.value.value, ast.Name)
+                    and func.value.value.id == "os"
+                    and func.value.attr == "path"
+                    and func.attr in ("join", "dirname", "abspath",
+                                      "normpath")):
+                args = [TestSysPathAudit._fold(a, file_path, env)
+                        for a in node.args]
+                if any(a is None for a in args):
+                    return None
+                fn = getattr(os.path, func.attr)
+                return fn(*args)
+        return None
 
-    def test_no_front_inserts_of_test_dirs(self) -> None:
+    def test_no_shadowing_sys_path_mutations(self) -> None:
+        import ast
         offenders: list[str] = []
         from tests._mock_audit_scanner import TESTS_DIR
+        repo_root = os.path.dirname(TESTS_DIR)
         for dirpath, dirnames, filenames in os.walk(TESTS_DIR):
             dirnames[:] = [d for d in dirnames if d != "__pycache__"]
             for fname in sorted(filenames):
@@ -102,34 +124,48 @@ class TestSysPathAudit(unittest.TestCase):
                     continue
                 path = os.path.join(dirpath, fname)
                 rel = os.path.relpath(path, TESTS_DIR)
-                if rel == "test_mock_audit.py":
-                    continue  # mentions the pattern in its own source
                 with open(path, encoding="utf-8") as f:
-                    for lineno, line in enumerate(f, 1):
-                        if self._SOURCE_DIR_INSERT_RE.search(line):
-                            offenders.append(
-                                f"  - {rel}:{lineno} (source-dir insert)")
-                            continue
-                        m = self._FRONT_INSERT_RE.search(line)
-                        if not m:
-                            continue
-                        # Resolve which directory the dirname-chain
-                        # yields for THIS file; only inserts that put
-                        # a directory inside tests/ at the front are
-                        # the shadowing hazard (repo-root inserts are
-                        # fine).
-                        depth = m.group(1).count("os.path.dirname(")
-                        target = os.path.abspath(path)
-                        for _ in range(depth):
-                            target = os.path.dirname(target)
-                        if target == TESTS_DIR or target.startswith(
-                                TESTS_DIR + os.sep):
-                            offenders.append(f"  - {rel}:{lineno}")
+                    tree = ast.parse(f.read(), filename=path)
+                # Module-level NAME = <foldable str expr> assignments.
+                env: dict[str, str] = {}
+                for stmt in tree.body:
+                    if (isinstance(stmt, ast.Assign)
+                            and len(stmt.targets) == 1
+                            and isinstance(stmt.targets[0], ast.Name)):
+                        folded = self._fold(stmt.value, path, env)
+                        if folded is not None:
+                            env[stmt.targets[0].id] = folded
+                for node in ast.walk(tree):
+                    if not (isinstance(node, ast.Call)
+                            and isinstance(node.func, ast.Attribute)
+                            and node.func.attr in ("insert", "append")
+                            and isinstance(node.func.value, ast.Attribute)
+                            and node.func.value.attr == "path"):
+                        continue
+                    is_insert = node.func.attr == "insert"
+                    dir_arg = node.args[1] if is_insert else node.args[0]
+                    target = self._fold(dir_arg, path, env)
+                    if target is None:
+                        offenders.append(
+                            f"  - {rel}:{node.lineno} (unresolvable "
+                            "sys.path target — use a literal os.path "
+                            "shape the audit can fold)")
+                        continue
+                    target = os.path.normpath(os.path.abspath(target))
+                    if target == repo_root:
+                        continue
+                    in_tests = (target == TESTS_DIR
+                                or target.startswith(TESTS_DIR + os.sep))
+                    if in_tests and not is_insert:
+                        continue
+                    kind = ("front-insert of a tests/ dir" if in_tests
+                            else f"non-root dir {target!r}")
+                    offenders.append(f"  - {rel}:{node.lineno} ({kind})")
         self.assertFalse(
             offenders,
-            "Front-of-sys.path insert of a test directory — use "
-            "sys.path.append instead (tests/web must never shadow the "
-            "real web package):\n" + "\n".join(offenders),
+            "sys.path mutation that can shadow a real package (issue "
+            "#95 dual-load class). Only the repo root may be inserted; "
+            "tests/ dirs may only be appended:\n" + "\n".join(offenders),
         )
 
 

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -83,10 +83,10 @@ class TestSysPathAudit(unittest.TestCase):
     # Front-inserts of repo source dirs (lib/, web/, scripts/) shadow
     # same-named top-level packages — lib/beets.py out-ranks the real
     # ``beets`` package (the issue #95 dual-load footgun conftest.py
-    # documents). tests/web/_harness.py is the one DELIBERATE exception:
-    # it reproduces production's PYTHONPATH ambiguity on purpose (see
-    # TestPipelineRouteDirectEquivalence) and protects itself by eagerly
-    # importing the real ``beets`` first.
+    # documents). No exceptions: the tests/web/_harness.py inserts that
+    # deliberately reproduced the ambiguity were removed with #445
+    # item 3 (production now strips its script-dir entry too — see
+    # tests/test_no_dual_load.py).
     _SOURCE_DIR_INSERT_RE = __import__("re").compile(
         r'sys\.path\.insert\(\s*\d+\s*,\s*os\.path\.join\('
         r'os\.path\.dirname\(__file__\),\s*"\.\."(?:,\s*"\.\.")?,'
@@ -106,9 +106,7 @@ class TestSysPathAudit(unittest.TestCase):
                     continue  # mentions the pattern in its own source
                 with open(path, encoding="utf-8") as f:
                     for lineno, line in enumerate(f, 1):
-                        if (self._SOURCE_DIR_INSERT_RE.search(line)
-                                and rel != os.path.join(
-                                    "web", "_harness.py")):
+                        if self._SOURCE_DIR_INSERT_RE.search(line):
                             offenders.append(
                                 f"  - {rel}:{lineno} (source-dir insert)")
                             continue

--- a/tests/test_native_codec_label.py
+++ b/tests/test_native_codec_label.py
@@ -25,7 +25,6 @@ import unittest
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
 sys.path.insert(0, ROOT_DIR)
-sys.path.insert(0, HARNESS_DIR)
 
 
 def _make_audio(path: str, codec_args: list[str], duration: int = 1) -> None:

--- a/tests/test_no_dual_load.py
+++ b/tests/test_no_dual_load.py
@@ -24,15 +24,24 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 # Modules that live under a package directory and whose bare name would
 # collide with the prefixed name if the package dir were on PYTHONPATH.
-# Each entry is (package, module_file_stem).
+# Each entry is (package, dotted_module_stem) — the walk descends into
+# subpackages so e.g. ("web", "routes.pipeline") guards the bare
+# ``routes.pipeline`` vs ``web.routes.pipeline`` pair too.
 PACKAGE_MODULES: list[tuple[str, str]] = []
 for pkg in ("lib", "web", "harness", "scripts"):
     pkg_dir = os.path.join(REPO_ROOT, pkg)
     if not os.path.isdir(pkg_dir):
         continue
-    for entry in os.listdir(pkg_dir):
-        if entry.endswith(".py") and entry != "__init__.py":
-            PACKAGE_MODULES.append((pkg, entry[:-3]))
+    for dirpath, dirnames, filenames in os.walk(pkg_dir):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        rel_dir = os.path.relpath(dirpath, pkg_dir)
+        prefix = "" if rel_dir == "." else rel_dir.replace(os.sep, ".") + "."
+        if prefix:
+            # The subpackage itself is a collidable bare name.
+            PACKAGE_MODULES.append((pkg, prefix.rstrip(".")))
+        for entry in sorted(filenames):
+            if entry.endswith(".py") and entry != "__init__.py":
+                PACKAGE_MODULES.append((pkg, prefix + entry[:-3]))
 
 
 def _run_entrypoint_and_dump_modules(bootstrap_code: str) -> set[str]:
@@ -112,22 +121,28 @@ class TestNoDualLoad(unittest.TestCase):
         name. server.py must strip its own directory from sys.path at
         import time so the bare names are never resolvable."""
         bootstrap = (
-            "import sys, os\n"
-            "web_dir = os.path.abspath('web')\n"
+            "import sys, os, tempfile\n"
+            "web_dir = os.path.realpath(os.path.abspath('web'))\n"
+            # A sentinel entry pins the negative-space contract: the
+            # strip must never remove anything OTHER than web/.
+            "sentinel = tempfile.mkdtemp(prefix='cd-syspath-sentinel-')\n"
+            "sys.path.insert(0, sentinel)\n"
             # Simulate script-mode boot: web/ at sys.path[0].
             "sys.path.insert(0, web_dir)\n"
             "import web.server\n"
             "live = [p for p in sys.path\n"
-            "        if os.path.abspath(p or os.getcwd()) == web_dir]\n"
+            "        if os.path.realpath(p or os.getcwd()) == web_dir]\n"
             "assert not live, f'web/ still on sys.path: {sys.path}'\n"
+            "assert sentinel in sys.path, 'strip removed a non-web entry'\n"
             # The structural consequence: bare web-module names must not
             # be importable at all.
-            "try:\n"
-            "    import routes  # noqa: F401\n"
-            "except ImportError:\n"
-            "    pass\n"
-            "else:\n"
-            "    raise AssertionError('bare `routes` is importable')\n"
+            "for bare in ('routes', 'mb', 'cache', 'overlay'):\n"
+            "    try:\n"
+            "        __import__(bare)\n"
+            "    except ImportError:\n"
+            "        pass\n"
+            "    else:\n"
+            "        raise AssertionError(f'bare {bare!r} is importable')\n"
         )
         modules = _run_entrypoint_and_dump_modules(bootstrap)
         offenders = _dual_loaded(modules)

--- a/tests/test_no_dual_load.py
+++ b/tests/test_no_dual_load.py
@@ -103,6 +103,39 @@ class TestNoDualLoad(unittest.TestCase):
             "contains the repo root, and every import uses its prefixed form."
         )
 
+    def test_web_server_strips_script_dir_from_sys_path(self):
+        """Production boots ``web/server.py`` as a script (via the Nix
+        wrapper's ``coverage run .../web/server.py``), so Python puts the
+        ``web/`` directory itself at ``sys.path[0]``. With that entry
+        live, one bare import anywhere (``import mb``, ``from routes
+        import ...``) silently double-loads a web module under a second
+        name. server.py must strip its own directory from sys.path at
+        import time so the bare names are never resolvable."""
+        bootstrap = (
+            "import sys, os\n"
+            "web_dir = os.path.abspath('web')\n"
+            # Simulate script-mode boot: web/ at sys.path[0].
+            "sys.path.insert(0, web_dir)\n"
+            "import web.server\n"
+            "live = [p for p in sys.path\n"
+            "        if os.path.abspath(p or os.getcwd()) == web_dir]\n"
+            "assert not live, f'web/ still on sys.path: {sys.path}'\n"
+            # The structural consequence: bare web-module names must not
+            # be importable at all.
+            "try:\n"
+            "    import routes  # noqa: F401\n"
+            "except ImportError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise AssertionError('bare `routes` is importable')\n"
+        )
+        modules = _run_entrypoint_and_dump_modules(bootstrap)
+        offenders = _dual_loaded(modules)
+        self.assertEqual(
+            offenders, [],
+            f"Modules loaded under both bare and prefixed names: {offenders}."
+        )
+
     def test_cratedigger_main_no_dual_load(self):
         """Booting cratedigger.py must not load any module twice."""
         bootstrap = (

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -22,7 +22,6 @@ sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 from tests.helpers import make_album_quality_evidence
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 

--- a/tests/test_spectral_check.py
+++ b/tests/test_spectral_check.py
@@ -10,7 +10,6 @@ from unittest.mock import patch, MagicMock
 
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
 
 
 class TestParseRmsFromStat(unittest.TestCase):

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -23,7 +23,6 @@ import unittest
 from typing import Any
 
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "web"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 

--- a/tests/web/_harness.py
+++ b/tests/web/_harness.py
@@ -21,18 +21,6 @@ from urllib.error import HTTPError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-# Eager import: lib.beets_distance pins the real ``beets`` package
-# (see lib/beets_distance.py:49-55) — we must trigger it *before* the
-# next two ``sys.path.insert`` calls add ``lib/`` ahead of site-
-# packages, otherwise downstream imports of lib.youtube_album_service
-# (which imports lib.beets_distance lazily inside the route handler)
-# fail with "cannot import name 'library' from 'beets'" because
-# ``beets`` would resolve to ``lib/beets.py``.
-import lib.beets_distance  # noqa: F401,E402
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "web"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
-
 from tests.fakes import FakePipelineDB
 
 # Production-shaped ``validation_result`` template for wrong-match

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -360,8 +360,6 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "artist_credit": "Radiohead",
             "primary_artist_id": "3840",
         }
-        # server.py loads routes via `from routes import browse` (sys.path hack),
-        # so the canonical module is `routes.browse`, not `web.routes.browse`.
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.routes.browse.discogs_api") as mock_dg:
             mock_mb.search_artists.return_value = [{"id": self.ARTIST_ID, "name": "Radiohead"}]

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -1087,9 +1087,10 @@ class TestPipelineRouteDirectEquivalence(_FakeDbWebServerCase):
     the response had the right keys with plausible values. Equivalence
     tests catch the divergence that contract tests can't see.
 
-    ``tests/web/_harness.py`` puts ``lib/`` on sys.path, reproducing the
-    same PYTHONPATH ambiguity production has. A future regression of the
-    original dual-load bug would fail this test.
+    The dual-load ambiguity itself is gone (#445 item 3: one canonical
+    import name per module, enforced by tests/test_no_dual_load.py and
+    TestSysPathAudit), but the equivalence contract this test pins is
+    independent of how a divergence arises — keep it.
     """
 
     # Scenario table — each is a direct-call kwargs dict. The helper

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -735,9 +735,9 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
 
     # -- fresh=True seam (Codex review on issue #101) ----------------
 
-    @patch("routes.pipeline.mb_api.get_release_group_year",
+    @patch("web.routes.pipeline.mb_api.get_release_group_year",
            return_value=2024)
-    @patch("routes.pipeline.mb_api.get_release")
+    @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_add_mb_fetches_release_fresh(
         self, mock_get_release, _mock_rgy,
     ):
@@ -772,7 +772,7 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
             self.assertEqual(call.args, ("fresh-add-mbid",))
             self.assertEqual(call.kwargs, {"fresh": True})
 
-    @patch("routes.pipeline.discogs_api.get_release")
+    @patch("web.routes.pipeline.discogs_api.get_release")
     def test_pipeline_add_discogs_fetches_release_fresh(self, mock_get_release):
         """POST /api/pipeline/add (Discogs) MUST bypass the 24h meta cache."""
         mock_get_release.return_value = {
@@ -798,7 +798,7 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
             self.assertEqual(call.kwargs, {"fresh": True})
 
     @patch("web.routes.pipeline.finalize_request")
-    @patch("routes.pipeline.mb_api.get_release")
+    @patch("web.routes.pipeline.mb_api.get_release")
     def test_pipeline_upgrade_new_mb_fetches_release_fresh(
             self, mock_get_release, _mock_transition):
         """POST /api/pipeline/upgrade creating a brand-new MB request
@@ -818,7 +818,7 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", fresh=True)
 
     @patch("web.routes.pipeline.finalize_request")
-    @patch("routes.pipeline.discogs_api.get_release")
+    @patch("web.routes.pipeline.discogs_api.get_release")
     def test_pipeline_upgrade_new_discogs_fetches_release_fresh(
             self, mock_get_release, _mock_transition):
         """POST /api/pipeline/upgrade creating a brand-new Discogs request

--- a/web/server.py
+++ b/web/server.py
@@ -26,6 +26,17 @@ logging.basicConfig(
 )
 log = logging.getLogger("cratedigger-web")
 
+# Script-mode Python puts this file's directory (web/) at sys.path[0]
+# (production boots `coverage run .../web/server.py`), which makes every
+# web module importable under a bare second name (`import mb`, `from
+# routes import ...`) — the issue #95 / PR #94 dual-load bug class, where
+# two copies of the same class break `is` and isinstance across the
+# boundary. Strip it so each module has exactly one canonical name.
+_WEB_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path[:] = [
+    p for p in sys.path if os.path.abspath(p or os.getcwd()) != _WEB_DIR
+]
+
 # Ensure repo root is importable when run as __main__ so `from lib.X` /
 # `from web.X` resolve without relying on PYTHONPATH.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/web/server.py
+++ b/web/server.py
@@ -7,14 +7,32 @@ Usage:
     python3 web/server.py --port 8085 --dsn postgresql://cratedigger@192.168.100.11/cratedigger
 """
 
+import os
+import sys
+
+# Script-mode Python puts this file's directory (web/) at sys.path[0]
+# (production boots `coverage run .../web/server.py`), which makes every
+# web module importable under a bare second name (`import mb`, `from
+# routes import ...`) — the issue #95 / PR #94 dual-load bug class, where
+# two copies of the same class break `is` and isinstance across the
+# boundary. Strip it (realpath: a symlink-aliased spelling of web/ must
+# not survive the filter) before ANY other import so each module has
+# exactly one canonical name.
+_WEB_DIR = os.path.realpath(os.path.dirname(os.path.abspath(__file__)))
+sys.path[:] = [
+    p for p in sys.path if os.path.realpath(p or os.getcwd()) != _WEB_DIR
+]
+
+# Ensure repo root is importable when run as __main__ so `from lib.X` /
+# `from web.X` resolve without relying on PYTHONPATH.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import argparse
 import json
 import logging
-import os
 import re
 import shutil
 import sqlite3
-import sys
 import threading
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
@@ -25,21 +43,6 @@ logging.basicConfig(
     level=logging.INFO,
 )
 log = logging.getLogger("cratedigger-web")
-
-# Script-mode Python puts this file's directory (web/) at sys.path[0]
-# (production boots `coverage run .../web/server.py`), which makes every
-# web module importable under a bare second name (`import mb`, `from
-# routes import ...`) — the issue #95 / PR #94 dual-load bug class, where
-# two copies of the same class break `is` and isinstance across the
-# boundary. Strip it so each module has exactly one canonical name.
-_WEB_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path[:] = [
-    p for p in sys.path if os.path.abspath(p or os.getcwd()) != _WEB_DIR
-]
-
-# Ensure repo root is importable when run as __main__ so `from lib.X` /
-# `from web.X` resolve without relying on PYTHONPATH.
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Ensure this module is importable as 'web.server' even when run as __main__,
 # so route modules can `from web import server` and get the same instance.


### PR DESCRIPTION
Final item of the #445 series. Closes the dual-module-load ambiguity (the PR #94 / issue #95 bug class: the same file loaded as both `quality` and `lib.quality`, `is EnumMember` comparing False across the boundary).

## Live probe first (per the issue)

gdb-injected `PyRun_SimpleString` sys.modules dump from the **running** production web process on doc2 (993 modules): every cratedigger module already loads under exactly one canonical name (`web.*` / `lib.*`; `web.server`↔`__main__` is a deliberate same-object alias). **But** production boots `coverage run .../web/server.py` as a script, so `sys.path[0]` is the `web/` directory itself — the hazard was one bare import away. The actual dual-loading happened in tests: `tests/web/_harness.py` deliberately front-inserted `web/` and `lib/`.

## What changed

- **`web/server.py`** strips its own directory from `sys.path` before ANY other import (realpath-safe, never touches other entries — both pinned by a sentinel in the new test). One canonical name per module is now structural, not conventional.
- **`tests/test_no_dual_load.py`**: new subprocess regression test boots `web.server` with the script-mode path shape and asserts the entry is stripped, a sentinel survives, bare `routes`/`mb`/`cache`/`overlay` are unimportable, and no module appears under two names. `PACKAGE_MODULES` now walks subpackages (`routes.pipeline`, `pipeline_db.requests`).
- **`tests/web/_harness.py`**: the deliberate `web/`+`lib/` inserts and the eager `lib.beets_distance` shadow-shield are gone. The five `patch("routes.pipeline...")` targets rewritten to `web.routes.pipeline...` (equivalence: both names resolved `mb_api`/`discogs_api` to the same shared `web.mb`/`web.discogs` module objects, so the patched seam is unchanged).
- **`TestSysPathAudit` rewritten as an AST resolver** — folds `os.path` chains, `__file__`, and simple module-level variables, so variable-target inserts and `append` are no longer evasions. Policy with zero exemptions: repo root may be inserted; tests/ dirs append-only; source dirs / out-of-repo / unresolvable targets banned. The RED run flushed out **14 dead source-dir sys.path mutations across 11 test files** (none load-bearing — all imports already prefixed).
- **Stale docs reframed as historical**: `lib/quality.py` `_selected_bitrate` `==` rationale, `lib/beets_distance.py` eager-import rationale, `test_beets_distance` setUpClass comment, `service-first-then-glue.md` caveat, `TestPipelineRouteDirectEquivalence` docstring (the equivalence contract outlives the ambiguity that motivated it).

## Acceptance checklist

- [x] Live `sys.modules` probe on doc2 before touching anything
- [x] RED→GREEN: script-mode strip test failed before the server.py change, passes after
- [x] RED→GREEN: AST audit flagged exactly the 13 surviving dead mutations, zero false positives; passes after deletion
- [x] `TestSysPathAudit` has no exemptions; `tests/web/_harness.py` inserts gone
- [x] Full suite 4,454 tests OK; pyright 0 errors; dead-code sweep clean
- [x] Adversarial same-engine review (r1): 1 HIGH, 1 MEDIUM, 4 LOW, 2 NIT — all fixed (see review commits) or documented (web_dev_server strip no-op equivalence in 20005fd body)
- [x] Codex partner review: "I did not find a discrete regression introduced by this diff."

Part of #445 (item 3 — the last open item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)