### PR TITLE
refactor(context): broken_user is a set, not a list (#207)

### DIFF
--- a/lib/context.py
+++ b/lib/context.py
@@ -64,7 +64,7 @@ class CratediggerContext:
     search_cache: dict[int, Any] = field(default_factory=dict)
     folder_cache: dict[str, Any] = field(default_factory=dict)
     user_upload_speed: dict[str, int] = field(default_factory=dict)
-    broken_user: list[str] = field(default_factory=list)
+    broken_user: set[str] = field(default_factory=set)
     search_dir_audio_count: dict[str, dict[str, int]] = field(default_factory=dict)
     negative_matches: set[tuple[str, str, int, str]] = field(default_factory=set)
     current_album_cache: dict[int, Any] = field(default_factory=dict)

--- a/lib/matching.py
+++ b/lib/matching.py
@@ -649,7 +649,7 @@ def check_for_match(
             and browse_attempts == len(uncached)
             and len(uncached) == len(dirs_to_try)
         ):
-            ctx.broken_user.append(username)
+            ctx.broken_user.add(username)
             logger.debug(f"All browses failed for {username}, marked as broken")
             return _build_no_match()
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -25,7 +25,7 @@ class TestCratediggerContext(unittest.TestCase):
         self.assertIsInstance(ctx.search_cache, dict)
         self.assertIsInstance(ctx.folder_cache, dict)
         self.assertIsInstance(ctx.user_upload_speed, dict)
-        self.assertIsInstance(ctx.broken_user, list)
+        self.assertIsInstance(ctx.broken_user, set)
         self.assertIsNotNone(ctx.browse_coordinator_lock)
         self.assertEqual(len(ctx.search_cache), 0)
         self.assertEqual(len(ctx.broken_user), 0)
@@ -49,7 +49,7 @@ class TestCratediggerContext(unittest.TestCase):
 
         # Mutating one context's caches should not affect the other
         ctx1.search_cache[42] = {"user1": {}}
-        ctx1.broken_user.append("bad_user")
+        ctx1.broken_user.add("bad_user")
         ctx1.user_upload_speed["user1"] = 50000
 
         self.assertEqual(len(ctx2.search_cache), 0)

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -412,7 +412,7 @@ class TestBrokenUserPerCycle(unittest.TestCase):
             slskd=FakeSlskdAPI(),
             pipeline_db_source=FakePipelineDBSource(),
         )
-        self.assertEqual(ctx.broken_user, [])
+        self.assertEqual(ctx.broken_user, set())
 
 
 class _PrefetchSource(FakePipelineDBSource):

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -533,7 +533,7 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
 
     def test_broken_user_returns_empty_candidates(self) -> None:
         """Broken-user short-circuit returns empty candidates."""
-        self.ctx.broken_user.append(self.username)
+        self.ctx.broken_user.add(self.username)
         result = check_for_match(
             self.tracks, "flac", ["dirA"], self.username, self.ctx,
         )
@@ -552,7 +552,7 @@ class TestCheckForMatchCandidateAccumulation(unittest.TestCase):
 
         self.assertFalse(self._matched(result))
         self.assertEqual(self._candidates(result), [])
-        self.assertEqual(self.ctx.broken_user, [])
+        self.assertEqual(self.ctx.broken_user, set())
         self.assertNotIn((self.username, "dirA", 3, "flac"), self.ctx.negative_matches)
         self.assertEqual(self.ctx.peers_browsed_lazy, 0)
         self.assertEqual(self.ctx.cache_neg_hits, 1)
@@ -1275,7 +1275,7 @@ class TestCheckForMatchRejectionReasonEndToEnd(unittest.TestCase):
     def test_broken_user_short_circuit_returns_none_reason(self) -> None:
         # Broken-user fast-path emits no candidates and no pre-filter
         # skip count → rejection_reason is None (upstream issue).
-        self.ctx.broken_user.append(self.username)
+        self.ctx.broken_user.add(self.username)
         result = check_for_match(
             self.tracks, "flac", ["dirA"], self.username, self.ctx,
         )


### PR DESCRIPTION
Resolves the surviving half of #207 after re-verifying both findings against current code.

## What

`CratediggerContext.broken_user: list[str]` → `set[str]`. The sole append site (`lib/matching.py` all-browses-failed marking) becomes `.add()`; the three `in` lookups are unchanged. Tests updated to pin the set type.

## Why this is all that's left of #207

- **Finding #1 (cycle budget undercount): obsolete.** `browse_cycle_budget_s` / `ctx.cycle_browse_time_s` were deleted by `10d8af3` (2026-05-02 rollback after the budget tanked found rate 13.7% → 2.2%). There is no budget for the lazy browse path to undercount, and lazy time is already counted in `ctx.browse_time_s`. Production data (7d of `search_log`): lazy is 4.6% of 289k browses — irrelevant with no budget to evade.
- **Finding #2 duplicates: already impossible.** The issue's second append site (enqueue.py) was also deleted by `10d8af3`; the remaining one is guarded by the `if username in ctx.broken_user` early-return in `check_for_match`, and all match calls run serially in the wave loop. The set conversion is type hygiene only — it makes the membership-only contract explicit.
- **Performance: immaterial either way.** `broken_user` is per-cycle; list lookups were microseconds against ~58s/cycle of network browse time.

Full suite (4454 tests) + pyright (0 errors) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)