### PR TITLE
feat(search): route Various Artists tokens to artist pins, not title terms

### DIFF
--- a/lib/va_identity.py
+++ b/lib/va_identity.py
@@ -27,6 +27,53 @@ existing wanted cohort.
 
 from __future__ import annotations
 
+import re
+
 MB_VA_ARTIST_MBID: str = "89ad4ac3-39f7-470e-963a-56509c546377"
 
 DISCOGS_VA_ARTIST_ID: str = "194"
+
+_VA_PHRASE_RE = re.compile(r"\bvarious\s+artists\b", re.IGNORECASE)
+_EMPTY_BRACKETS_RE = re.compile(r"\(\s*\)|\[\s*\]")
+
+# Lucene boolean operators (uppercase-only in Lucene syntax) left
+# dangling at the remainder's edges after the phrase strip — e.g.
+# "best of AND Various Artists" → "best of AND". The MB builder wraps
+# the remainder in `arid:… AND (…)`, so an edge operator the raw
+# passthrough tolerated would now sit inside a group. Interior
+# operators stay: they were valid before the strip and still are.
+_DANGLING_OPERATORS = frozenset({"AND", "OR", "NOT", "&&", "||"})
+
+
+def split_va_query(query: str) -> tuple[str, bool]:
+    """Split free-text search input into (remainder, va_detected).
+
+    Strips every "Various Artists" phrase from the query so the browse
+    search builders can route the VA intent to an artist-id pin instead
+    of letting the tokens AND into the title match (#199 — on both
+    mirrors the tokens can never match a title, so pre-fix VA queries
+    returned zero or junk results).
+
+    A bare "various" only counts when it is the entire query: "Various
+    Positions" and "Various Blends" are real title/artist strings that
+    must pass through untouched. Bracket pairs emptied by the strip
+    ("Rock Christmas (Various Artists)") are removed so the remainder
+    stays a clean title query.
+    """
+    stripped, n_hits = _VA_PHRASE_RE.subn(" ", query)
+    if n_hits == 0:
+        if query.strip().lower() == "various":
+            return "", True
+        return query, False
+    # Fix-point: removing an inner empty pair can empty its outer pair
+    # ("((Various Artists))" → "(( ))" → "( )" → "").
+    while True:
+        stripped, n_brackets = _EMPTY_BRACKETS_RE.subn(" ", stripped)
+        if n_brackets == 0:
+            break
+    tokens = stripped.split()
+    while tokens and tokens[0] in _DANGLING_OPERATORS:
+        tokens.pop(0)
+    while tokens and tokens[-1] in _DANGLING_OPERATORS:
+        tokens.pop()
+    return " ".join(tokens), True

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import unittest
+import urllib.parse
 from unittest.mock import patch, MagicMock
 
 import msgspec
@@ -261,6 +262,82 @@ class TestSearchReleases(unittest.TestCase):
         self.assertTrue(cache_key.startswith("discogs:search:releases:"))
         self.assertIn(f":#{len(long_query)}:", cache_key)
         self.assertLess(len(cache_key), len(f"discogs:search:releases:{long_query}"))
+
+
+class TestSearchReleasesVaRewrite(unittest.TestCase):
+    """VA-token handling in the Discogs title search (#199).
+
+    The dump's VA artist (id 194) has no name row, so "Various Artists"
+    tokens can never match — pre-fix they ANDed into the title match and
+    returned zero results. The fix strips the tokens from the title param
+    and floats VA-credited rows to the top of the result list.
+    """
+
+    # Non-VA single first, VA-credited compilation second — mirrors the
+    # live "Rock Christmas" ranking where 7" singles outrank VA comps.
+    SEARCH_DATA = {
+        "results": [
+            {
+                "id": 9830575,
+                "title": "Rock Around The Christmas Tree",
+                "master_id": None,
+                "primary_type": "Other",
+                "score": 0.26,
+                "released": "1957",
+                "artists": [{"id": 5567902, "name": "Jack Harrell"}],
+            },
+            {
+                "id": 32457180,
+                "title": "Rock Christmas (The Very Best Of)",
+                "master_id": 3673686,
+                "master_title": "Rock Christmas (The Very Best Of)",
+                "master_first_released": "1992",
+                "primary_type": "Album",
+                "score": 0.10,
+                "released": "2024",
+                "artists": [{"id": 194, "name": "Various"}],
+            },
+        ],
+    }
+
+    def _requested_title(self, mock_urlopen):
+        url = mock_urlopen.call_args[0][0].full_url
+        qs = urllib.parse.urlparse(url).query
+        return urllib.parse.parse_qs(qs)["title"][0]
+
+    def test_va_query_strips_tokens_from_title_param(self):
+        with _mock_urlopen(self.SEARCH_DATA) as m:
+            search_releases("Rock Christmas Various Artists")
+        self.assertEqual(self._requested_title(m), "Rock Christmas")
+
+    def test_va_query_floats_va_credited_results_first(self):
+        with _mock_urlopen(self.SEARCH_DATA):
+            results = search_releases("Rock Christmas Various Artists")
+        self.assertEqual(results[0]["artist_id"], "194")
+        self.assertEqual(results[0]["title"], "Rock Christmas (The Very Best Of)")
+        self.assertEqual(results[1]["artist_name"], "Jack Harrell")
+
+    def test_plain_query_preserves_mirror_order(self):
+        with _mock_urlopen(self.SEARCH_DATA):
+            results = search_releases("Rock Christmas")
+        self.assertEqual(results[0]["artist_name"], "Jack Harrell")
+        self.assertEqual(results[1]["artist_id"], "194")
+
+    def test_va_only_query_keeps_raw_title(self):
+        # No title remainder after the strip — keep the raw passthrough
+        # rather than sending an empty title to the mirror.
+        with _mock_urlopen(self.SEARCH_DATA) as m:
+            search_releases("Various Artists")
+        self.assertEqual(self._requested_title(m), "Various Artists")
+
+    def test_cache_key_shares_stripped_query_with_plain_search(self):
+        # The mirror fetch for "Rock Christmas Various Artists" is the
+        # same as for "Rock Christmas"; the VA boost is applied after
+        # memoization so both queries share one cache entry.
+        with patch("web.discogs._cache.memoize_meta", return_value=[]) as memo:
+            search_releases("Rock Christmas Various Artists")
+        self.assertEqual(memo.call_args[0][0],
+                         "discogs:search:releases:Rock Christmas")
 
 
 class TestSearchArtists(unittest.TestCase):

--- a/tests/test_mb_api.py
+++ b/tests/test_mb_api.py
@@ -1,0 +1,107 @@
+"""Seam tests for web/mb.py search builders.
+
+Mirrors the urlopen-mock pattern of tests/test_discogs_api.py: patch the
+leaf urllib seam and assert on the URL the builder constructs. The VA
+rewrite cases are the RED tests for issue #199 — a query carrying
+"Various Artists" tokens must pin `arid:<VA MBID>` instead of letting
+Lucene treat the tokens as title terms.
+"""
+
+import json
+import unittest
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+from lib.va_identity import MB_VA_ARTIST_MBID
+from web.mb import search_release_groups
+
+
+def _mock_urlopen(response_data):
+    """Patch web.mb's urlopen to return canned JSON; capture the Request."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(response_data).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return patch("web.mb.urllib.request.urlopen", return_value=mock_resp)
+
+
+_EMPTY = {"releases": []}
+
+_ONE_RELEASE = {
+    "releases": [
+        {
+            "id": "rel-1",
+            "title": "Rock Christmas: The Very Best Of",
+            "score": 100,
+            "date": "2024",
+            "release-group": {
+                "id": "rg-1",
+                "title": "Rock Christmas: The Very Best Of",
+                "primary-type": "Album",
+                "first-release-date": "2024",
+            },
+            "artist-credit": [
+                {"artist": {"id": MB_VA_ARTIST_MBID, "name": "Various Artists",
+                            "disambiguation": "add compilations to this artist"}},
+            ],
+        },
+    ],
+}
+
+
+def _requested_query(mock_urlopen: MagicMock) -> str:
+    """Extract the decoded ?query= value from the captured Request."""
+    url = mock_urlopen.call_args[0][0].full_url
+    qs = urllib.parse.urlparse(url).query
+    return urllib.parse.parse_qs(qs)["query"][0]
+
+
+class TestSearchReleaseGroupsVaRewrite(unittest.TestCase):
+    def test_va_query_pins_arid_and_strips_tokens(self) -> None:
+        with _mock_urlopen(_EMPTY) as m:
+            search_release_groups("Rock Christmas Various Artists")
+        q = _requested_query(m)
+        self.assertEqual(q, f"arid:{MB_VA_ARTIST_MBID} AND (Rock Christmas)")
+
+    def test_plain_query_passes_through_unchanged(self) -> None:
+        with _mock_urlopen(_EMPTY) as m:
+            search_release_groups("Rock Christmas")
+        self.assertEqual(_requested_query(m), "Rock Christmas")
+
+    def test_va_only_query_falls_back_to_raw(self) -> None:
+        # "Various Artists" alone leaves no title remainder; an arid-only
+        # pin would return 25 arbitrary VA releases, which is no more
+        # useful than today's behaviour — keep the raw passthrough.
+        with _mock_urlopen(_EMPTY) as m:
+            search_release_groups("Various Artists")
+        self.assertEqual(_requested_query(m), "Various Artists")
+
+    def test_title_containing_various_is_not_rewritten(self) -> None:
+        with _mock_urlopen(_EMPTY) as m:
+            search_release_groups("Various Positions")
+        self.assertEqual(_requested_query(m), "Various Positions")
+
+    def test_cache_key_uses_effective_query(self) -> None:
+        # Pre-fix VA queries cached junk/empty results under the raw
+        # string; keying on the rewritten query bypasses those entries.
+        with patch("web.mb._cache.memoize_meta", return_value=[]) as memo:
+            search_release_groups("Rock Christmas Various Artists")
+        key = memo.call_args[0][0]
+        self.assertEqual(
+            key,
+            "mb:search:release_groups:"
+            f"arid:{MB_VA_ARTIST_MBID} AND (Rock Christmas)",
+        )
+
+    def test_va_results_normalized_like_plain_results(self) -> None:
+        with _mock_urlopen(_ONE_RELEASE):
+            results = search_release_groups("Rock Christmas Various Artists")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], "rg-1")
+        self.assertEqual(results[0]["artist_name"], "Various Artists")
+        self.assertEqual(results[0]["primary_type"], "Album")
+        self.assertEqual(results[0]["score"], 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_va_identity.py
+++ b/tests/test_va_identity.py
@@ -1,0 +1,50 @@
+"""Tests for lib/va_identity.py — split_va_query()."""
+
+import unittest
+
+from lib.va_identity import split_va_query
+
+
+class TestSplitVaQuery(unittest.TestCase):
+    """Free-text VA-token detection for the browse search builders (#199)."""
+
+    CASES = [
+        # (desc, query, expected_remainder, expected_va)
+        ("phrase trailing", "Rock Christmas Various Artists", "Rock Christmas", True),
+        ("phrase leading", "Various Artists Rock Christmas", "Rock Christmas", True),
+        ("phrase mid-query", "Rock Various Artists Christmas", "Rock Christmas", True),
+        ("case insensitive", "rock christmas VARIOUS artists", "rock christmas", True),
+        ("parenthesised phrase", "Rock Christmas (Various Artists)", "Rock Christmas", True),
+        ("bracketed phrase", "Rock Christmas [Various Artists]", "Rock Christmas", True),
+        ("phrase only", "Various Artists", "", True),
+        ("bare various exact", "various", "", True),
+        ("bare various exact mixed case", "Various", "", True),
+        ("no va tokens", "Rock Christmas", "Rock Christmas", False),
+        # "Various <word>" is a real title shape (Leonard Cohen's
+        # "Various Positions") — only the full phrase or an exact bare
+        # "various" counts as VA intent.
+        ("leonard cohen guard", "Various Positions", "Various Positions", False),
+        ("trailing bare various untouched", "Rock Christmas Various", "Rock Christmas Various", False),
+        ("artist named various-ish", "Various Blends", "Various Blends", False),
+        ("whitespace collapsed", "Rock   Various Artists   Christmas", "Rock Christmas", True),
+        # Stripping must not leave the remainder more Lucene-hostile
+        # than the raw query was: dangling boolean operators at the
+        # edges are trimmed, and bracket pairs emptied by the strip are
+        # removed to a fix-point (nested pairs included).
+        ("trailing dangling AND trimmed", "best of AND Various Artists", "best of", True),
+        ("leading dangling OR trimmed", "Various Artists OR holiday", "holiday", True),
+        ("interior AND preserved", "Rock AND Roll Various Artists", "Rock AND Roll", True),
+        ("lowercase and is a term, kept", "this and that Various Artists", "this and that", True),
+        ("nested brackets fixpoint", "Christmas ((Various Artists))", "Christmas", True),
+    ]
+
+    def test_split_va_query(self) -> None:
+        for desc, query, expected_remainder, expected_va in self.CASES:
+            with self.subTest(desc=desc):
+                remainder, is_va = split_va_query(query)
+                self.assertEqual(remainder, expected_remainder)
+                self.assertEqual(is_va, expected_va)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -39,7 +39,10 @@ LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS = 20
 # comparison against `artist_id` fields, which are always normalised to str.
 # Single declaration site at ``lib/va_identity.py`` — re-exported here so
 # the existing ``from web.discogs import VA_ARTIST_ID`` imports keep working.
-from lib.va_identity import DISCOGS_VA_ARTIST_ID as VA_ARTIST_ID  # noqa: E402
+from lib.va_identity import (  # noqa: E402
+    DISCOGS_VA_ARTIST_ID as VA_ARTIST_ID,
+    split_va_query,
+)
 
 
 def _get(url: str, *, timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS) -> dict:
@@ -147,7 +150,19 @@ def search_releases(query: str) -> list[dict]:
     Deduplicates by master_id (like MB's release-group dedup) and surfaces
     master-level metadata (master_title, master_first_released, primary_type, score)
     that the mirror provides on each search hit.
+
+    "Various Artists" tokens are stripped from the title match (#199) —
+    the dump's VA artist (id 194) has no name row, so the tokens can
+    never match and pre-fix VA queries returned zero results. The mirror
+    fetch then equals the bare-title search (one shared cache entry);
+    the VA intent is honoured post-cache by floating VA-credited rows to
+    the top. Full artist-id pinning needs an ``artist_id`` filter on the
+    mirror's /api/search — tracked in #199 as discogs-api follow-up.
     """
+    remainder, is_va = split_va_query(query)
+    if is_va and remainder:
+        query = remainder
+
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         data = _get(f"{DISCOGS_API_BASE}/api/search?title={q}&per_page=25")
@@ -177,7 +192,10 @@ def search_releases(query: str) -> list[dict]:
         return results
 
     cache_query = _search_cache_query_part(query)
-    return _cache.memoize_meta(f"discogs:search:releases:{cache_query}", _fetch)
+    results = _cache.memoize_meta(f"discogs:search:releases:{cache_query}", _fetch)
+    if is_va:
+        results = sorted(results, key=lambda r: r.get("artist_id") != VA_ARTIST_ID)
+    return results
 
 
 def search_artists(query: str) -> list[dict]:

--- a/web/mb.py
+++ b/web/mb.py
@@ -29,7 +29,10 @@ USER_AGENT = "cratedigger-web/1.0"
 # (the MB artist→release-group endpoint takes ~23s for VA). Single
 # declaration site at ``lib/va_identity.py`` — re-exported here so the
 # existing ``from web.mb import VA_ARTIST_MBID`` imports keep working.
-from lib.va_identity import MB_VA_ARTIST_MBID as VA_ARTIST_MBID  # noqa: E402
+from lib.va_identity import (  # noqa: E402
+    MB_VA_ARTIST_MBID as VA_ARTIST_MBID,
+    split_va_query,
+)
 
 
 def _get(url):
@@ -53,7 +56,17 @@ def search_release_groups(query):
 
     Uses /release search (not /release-group) because the local MB mirror's
     search index only covers releases.
+
+    "Various Artists" tokens in the query are rewritten to a Lucene
+    ``arid:`` pin on the canonical VA artist (#199) — as title terms they
+    only match albums literally titled "Various Artists". A VA-only query
+    (no title remainder) keeps the raw passthrough: an arid-only pin
+    would return 25 arbitrary VA releases, no more useful than today.
     """
+    remainder, is_va = split_va_query(query)
+    if is_va and remainder:
+        query = f"arid:{VA_ARTIST_MBID} AND ({remainder})"
+
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         data = _get(f"{MB_API_BASE}/release?query={q}&fmt=json&limit=25")


### PR DESCRIPTION
Closes #199 (as narrowed by the 2026-06-13 triage comment: this is suggested fix #1, the only piece scoped to this repo; ranking tuning lives in `abl030/discogs-api`, and the badge/chip asks were de-fanged by the add-by-ID escape hatch that already shipped).

## What

`Rock Christmas Various Artists` returned **zero results** on Discogs and 25 title-matched junk rows on MB, because "Various Artists" can never match a title on either mirror. New pure helper `split_va_query()` in `lib/va_identity.py` (the existing VA-identity declaration site) detects and strips the VA phrase; both search builders route the intent properly:

- **MB (full fix):** `search_release_groups` rewrites to `arid:<VA MBID> AND (<remainder>)`. Verified live: the target comp ("Rock Christmas: The Very Best Of", Various Artists) ranks score=100 position 1 — the issue's RED criterion was position ≤ 5.
- **Discogs (partial fix):** `search_releases` strips the tokens (mirror fetch = bare-title search, one shared cache entry) and floats VA-credited rows (`artist_id == 194`) to the top post-cache. Verified live: positions 1–8 are now all VA comps where pre-fix there were zero results. Full artist-id pinning needs an `artist_id` filter on the mirror's Rust `/api/search` (probed live: `artist_id=` ignored, `artist=Various` matches nothing — the VA artist row is absent from the CC0 dump by design).

## Guards

- "Various Positions" (Leonard Cohen) and "Various Blends" pass through untouched — bare "various" only counts as a whole query.
- VA-only queries (empty remainder) keep the raw passthrough.
- Review-gate findings fixed: empty-bracket removal runs to a fix-point for nested pairs, and dangling Lucene boolean operators at the remainder's edges are trimmed (probed the mirror: it parses leniently either way, so this is robustness, not a 500 fix).
- MB cache keys use the rewritten query, so 24h-stale pre-fix junk entries are bypassed; Discogs VA and bare-title queries deliberately share one cache entry with the boost applied post-cache.

## Tests

19 new: `tests/test_va_identity.py` (pure subTest table), `tests/test_mb_api.py` (new seam-test module mirroring `test_discogs_api.py`'s urlopen-mock pattern), `TestSearchReleasesVaRewrite` in `tests/test_discogs_api.py`. Full suite 4466 OK, pyright 0/0/0. Live-verified against both mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)