### PR TITLE
feat(discogs): pin artist_id=194 for VA search instead of token-strip

### DIFF
--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -269,23 +269,13 @@ class TestSearchReleasesVaRewrite(unittest.TestCase):
 
     The dump's VA artist (id 194) has no name row, so "Various Artists"
     tokens can never match — pre-fix they ANDed into the title match and
-    returned zero results. The fix strips the tokens from the title param
-    and floats VA-credited rows to the top of the result list.
+    returned zero results. The fix strips the tokens from the title and
+    pins the mirror's ``artist_id=194`` exact filter so the mirror itself
+    returns only VA-credited releases.
     """
 
-    # Non-VA single first, VA-credited compilation second — mirrors the
-    # live "Rock Christmas" ranking where 7" singles outrank VA comps.
     SEARCH_DATA = {
         "results": [
-            {
-                "id": 9830575,
-                "title": "Rock Around The Christmas Tree",
-                "master_id": None,
-                "primary_type": "Other",
-                "score": 0.26,
-                "released": "1957",
-                "artists": [{"id": 5567902, "name": "Jack Harrell"}],
-            },
             {
                 "id": 32457180,
                 "title": "Rock Christmas (The Very Best Of)",
@@ -300,44 +290,55 @@ class TestSearchReleasesVaRewrite(unittest.TestCase):
         ],
     }
 
-    def _requested_title(self, mock_urlopen):
+    def _requested_qs(self, mock_urlopen) -> dict:
         url = mock_urlopen.call_args[0][0].full_url
-        qs = urllib.parse.urlparse(url).query
-        return urllib.parse.parse_qs(qs)["title"][0]
+        return urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
 
-    def test_va_query_strips_tokens_from_title_param(self):
+    def test_va_query_strips_tokens_and_pins_artist_id(self):
         with _mock_urlopen(self.SEARCH_DATA) as m:
             search_releases("Rock Christmas Various Artists")
-        self.assertEqual(self._requested_title(m), "Rock Christmas")
+        qs = self._requested_qs(m)
+        self.assertEqual(qs["title"][0], "Rock Christmas")
+        self.assertEqual(qs["artist_id"][0], "194")
 
-    def test_va_query_floats_va_credited_results_first(self):
-        with _mock_urlopen(self.SEARCH_DATA):
-            results = search_releases("Rock Christmas Various Artists")
-        self.assertEqual(results[0]["artist_id"], "194")
-        self.assertEqual(results[0]["title"], "Rock Christmas (The Very Best Of)")
-        self.assertEqual(results[1]["artist_name"], "Jack Harrell")
+    def test_plain_query_sends_no_artist_id(self):
+        with _mock_urlopen(self.SEARCH_DATA) as m:
+            search_releases("Rock Christmas")
+        qs = self._requested_qs(m)
+        self.assertEqual(qs["title"][0], "Rock Christmas")
+        self.assertNotIn("artist_id", qs)
 
-    def test_plain_query_preserves_mirror_order(self):
-        with _mock_urlopen(self.SEARCH_DATA):
-            results = search_releases("Rock Christmas")
-        self.assertEqual(results[0]["artist_name"], "Jack Harrell")
-        self.assertEqual(results[1]["artist_id"], "194")
-
-    def test_va_only_query_keeps_raw_title(self):
+    def test_va_only_query_keeps_raw_title_and_no_pin(self):
         # No title remainder after the strip — keep the raw passthrough
-        # rather than sending an empty title to the mirror.
+        # rather than pinning artist_id with an empty title (which would
+        # make the mirror scan every one of artist 194's releases).
         with _mock_urlopen(self.SEARCH_DATA) as m:
             search_releases("Various Artists")
-        self.assertEqual(self._requested_title(m), "Various Artists")
+        qs = self._requested_qs(m)
+        self.assertEqual(qs["title"][0], "Various Artists")
+        self.assertNotIn("artist_id", qs)
 
-    def test_cache_key_shares_stripped_query_with_plain_search(self):
-        # The mirror fetch for "Rock Christmas Various Artists" is the
-        # same as for "Rock Christmas"; the VA boost is applied after
-        # memoization so both queries share one cache entry.
+    def _cache_key_for(self, query: str) -> str:
         with patch("web.discogs._cache.memoize_meta", return_value=[]) as memo:
-            search_releases("Rock Christmas Various Artists")
-        self.assertEqual(memo.call_args[0][0],
-                         "discogs:search:releases:Rock Christmas")
+            search_releases(query)
+        return memo.call_args[0][0]
+
+    def test_va_query_uses_distinct_cache_key(self):
+        # The artist_id-pinned fetch is a different upstream query than
+        # the bare-title fetch, so it must NOT collide with the plain
+        # "Rock Christmas" cache entry.
+        va_key = self._cache_key_for("Rock Christmas Various Artists")
+        plain_key = self._cache_key_for("Rock Christmas")
+        self.assertNotEqual(va_key, plain_key)
+        self.assertTrue(va_key.startswith("discogs:search:releases:"))
+
+    def test_va_flag_cannot_be_forged_by_user_text(self):
+        # The va discriminator sits before the user query text, so a plain
+        # query crafted to look like the VA key's tail must not collide.
+        va_key = self._cache_key_for("Rock Christmas Various Artists")
+        for adversarial in ("Rock Christmas:va", "va=1:Rock Christmas",
+                            "Rock Christmas va=1"):
+            self.assertNotEqual(self._cache_key_for(adversarial), va_key)
 
 
 class TestSearchArtists(unittest.TestCase):

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -151,21 +151,27 @@ def search_releases(query: str) -> list[dict]:
     master-level metadata (master_title, master_first_released, primary_type, score)
     that the mirror provides on each search hit.
 
-    "Various Artists" tokens are stripped from the title match (#199) —
-    the dump's VA artist (id 194) has no name row, so the tokens can
-    never match and pre-fix VA queries returned zero results. The mirror
-    fetch then equals the bare-title search (one shared cache entry);
-    the VA intent is honoured post-cache by floating VA-credited rows to
-    the top. Full artist-id pinning needs an ``artist_id`` filter on the
-    mirror's /api/search — tracked in #199 as discogs-api follow-up.
+    "Various Artists" tokens are stripped from the title and routed to
+    the mirror's ``artist_id`` exact filter (#199) — the dump's VA artist
+    (id 194) has no name row, so the tokens can never match the text
+    index and pre-fix VA queries returned zero results. Pinning
+    ``artist_id=194`` makes the mirror return only VA-credited releases.
+    The pinned fetch is a distinct upstream query, so it gets its own
+    cache entry (the bare-title fetch returns a different, unfiltered
+    set). A VA query with no title remainder ("Various Artists" alone)
+    keeps the raw passthrough — an artist_id pin with no title would make
+    the mirror scan every one of artist 194's releases.
     """
     remainder, is_va = split_va_query(query)
-    if is_va and remainder:
-        query = remainder
+    va_pin = is_va and bool(remainder)
+    effective_query = remainder if va_pin else query
 
     def _fetch() -> list[dict]:
-        q = urllib.parse.quote(query)
-        data = _get(f"{DISCOGS_API_BASE}/api/search?title={q}&per_page=25")
+        q = urllib.parse.quote(effective_query)
+        url = f"{DISCOGS_API_BASE}/api/search?title={q}&per_page=25"
+        if va_pin:
+            url += f"&artist_id={VA_ARTIST_ID}"
+        data = _get(url)
         seen_master: set[int] = set()
         results = []
         for r in data.get("results", []):
@@ -191,11 +197,13 @@ def search_releases(query: str) -> list[dict]:
             })
         return results
 
-    cache_query = _search_cache_query_part(query)
-    results = _cache.memoize_meta(f"discogs:search:releases:{cache_query}", _fetch)
-    if is_va:
-        results = sorted(results, key=lambda r: r.get("artist_id") != VA_ARTIST_ID)
-    return results
+    # The va flag sits in a FIXED position before the (unbounded) user
+    # query text, so a plain query can never forge the VA-pinned key by
+    # ending in the discriminator — the two fetches hit different upstream
+    # URLs and must never share a cache entry.
+    cache_query = _search_cache_query_part(effective_query)
+    cache_key = f"discogs:search:releases:va={int(va_pin)}:{cache_query}"
+    return _cache.memoize_meta(cache_key, _fetch)
 
 
 def search_artists(query: str) -> list[dict]:


### PR DESCRIPTION
Completes the Discogs half of #199. Pairs with the just-deployed `discogs-api` change ([abl030/discogs-api@430350e](https://github.com/abl030/discogs-api/commit/430350e)) that added an `artist_id` exact-filter to `/api/search`.

## What

The earlier #199 PR (#454) shipped a stopgap on the Discogs side: strip the "Various Artists" tokens from the title and float VA-credited rows client-side. That was a partial fix because the mirror still returned the full unfiltered set. Now that the mirror accepts `artist_id`, this upgrades to a real server-side pin:

- VA query with a title remainder → `GET /api/search?title=<remainder>&artist_id=194`. The mirror returns **only** VA-credited releases.
- Distinct cache entry: the pinned fetch is a different upstream query than the bare-title fetch. The `va=0`/`va=1` flag sits in a **fixed position before** the user query text so a crafted plain query (e.g. one ending in `:va`) can't forge the VA key — a cache-poisoning path the reviewer caught and that's now guarded by `test_va_flag_cannot_be_forged_by_user_text`.
- Removed the post-cache `sorted()` VA-float — the mirror filters now, so client-side reordering is dead.
- VA-only queries ("Various Artists" alone) keep the raw passthrough: pinning `artist_id` with no title would make the mirror scan all ~260k of artist 194's releases.

## Verification (live, post-mirror-deploy)

`title=Rock+Christmas&artist_id=194` against the deployed mirror returns 260 VA-credited releases (41 distinct masters); without the pin, the top results are 1950s 7" singles by Jack Harrell et al. The target comp's specific *ranking* within the VA set (it lands mid-list) is the separate ranking concern (#199 finding #2) — out of scope here; this PR fixes the filter, which is what took VA search from "0 results / impossible" to "VA comps only."

Full suite 4466 OK, pyright 0/0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)