### PR TITLE
fix(quality): keep ALAC-in-m4a V0 anchor instead of stripping it on import

### DIFF
--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -943,7 +943,25 @@ def propagate_candidate_evidence_to_current(
         and library_codec is not None
         and source_codec != library_codec
     )
-    source_is_lossless = source_codec in LOSSLESS_CODECS if source_codec else False
+    # ``codec`` is labelled by container extension (snapshot_audio_files), so
+    # ``.m4a`` records ``"m4a"`` for BOTH lossless ALAC and lossy AAC — the
+    # container string alone cannot prove the source was lossless. The
+    # authoritative signal is the candidate's V0 probe lineage: the harness
+    # only grinds a ``lossless_source`` probe after ffprobe confirms a
+    # lossless container (ALAC/FLAC/WAV). Trust that lineage so an
+    # ALAC-in-m4a anchor survives the transcode instead of being stripped as
+    # if it were AAC — otherwise the next candidate sees no comparable probe
+    # and imports for free, ratcheting the V0 anchor downward (request 5219,
+    # Fred again.. *Actual Life 3*: 253 ALAC anchor wiped, 239 FLAC imported).
+    source_v0 = candidate_evidence.v0_metric
+    source_has_lossless_v0_lineage = (
+        source_v0 is not None
+        and source_v0.source_lineage == V0_SOURCE_LINEAGE_LOSSLESS_SOURCE
+    )
+    source_is_lossless = (
+        (source_codec in LOSSLESS_CODECS if source_codec else False)
+        or source_has_lossless_v0_lineage
+    )
     strip_source_fields = is_transcode and not source_is_lossless
 
     candidate_measurement = candidate_evidence.measurement

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -7926,6 +7926,253 @@ class TestU10PostImportEvidencePropagation(unittest.TestCase):
             self.assertEqual(new_evidence.codec, "mp3")
             self.assertEqual(new_evidence.container, "mp3")
 
+    def test_transcoded_alac_m4a_to_opus_propagates_source_evidence(self):
+        """ALAC-in-m4a source → Opus library: source-side evidence propagates.
+
+        Live regression — request 5219 (Fred again.. *Actual Life 3*), peer
+        ``denleschae``. ALAC is lossless, but ``snapshot_audio_files`` labels
+        codec by extension, so an ``.m4a`` file records ``codec="m4a"``.
+        ``"m4a"`` is not in ``LOSSLESS_CODECS`` ``{flac, alac, wav}``, so the
+        codec-only lossless gate misread the ALAC source as a lossy transcode
+        and STRIPPED the candidate's V0 probe (avg 253) onto NULL. The next
+        FLAC candidate (avg 239) then saw "no comparable source probe", imported
+        unconditionally, and regressed the library's V0 anchor 253 → 239.
+
+        The authoritative "was this source lossless?" signal is the candidate's
+        V0 probe lineage (``lossless_source`` — the harness only grinds a
+        lossless-source probe after ffprobe confirms ALAC). Propagation must
+        honour that signal, not the noisy container string. Positive sibling of
+        ``test_transcoded_flac_to_v0_propagates_source_evidence``; the m4a
+        container that carries a lossless-source V0 probe is the only difference.
+        """
+        from lib.import_dispatch import _refresh_current_evidence_after_import
+        from lib.quality import AlbumQualityV0Metric
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=5219, mb_release_id="mbid-alac-m4a"))
+
+        with tempfile.TemporaryDirectory() as source_dir, \
+                tempfile.TemporaryDirectory() as library_dir:
+            self._stage_audio(source_dir, filenames=["01 - source.m4a"])
+            self._stage_audio(library_dir, filenames=["01 - Library.opus"])
+
+            from lib.quality_evidence import snapshot_audio_files
+            candidate_files = snapshot_audio_files(source_dir)
+            # snapshot_audio_files labels codec by extension: an ALAC-in-m4a
+            # source records codec="m4a", exactly as production stored it
+            # (album_quality_evidence row 24558).
+            self.assertEqual(candidate_files[0].codec, "m4a")
+
+            # The harness only emits a lossless_source V0 lineage after
+            # ffprobe confirms the .m4a holds ALAC — this is the truth-of-
+            # source anchor the gate must trust.
+            v0_metric = AlbumQualityV0Metric(
+                min_bitrate_kbps=192,
+                avg_bitrate_kbps=253,
+                median_bitrate_kbps=250,
+                source_lineage="lossless_source",
+                source_provenance="lossless_source",
+            )
+            candidate_measurement = AudioQualityMeasurement(
+                min_bitrate_kbps=192,
+                avg_bitrate_kbps=253,
+                median_bitrate_kbps=250,
+                format="ALAC",
+                is_cbr=False,
+                spectral_grade="likely_transcode",
+                spectral_bitrate_kbps=96,
+                verified_lossless=False,
+                was_converted_from="m4a",
+            )
+            from lib.quality import AlbumQualityEvidence
+            from datetime import datetime, timezone
+            from lib.quality_evidence import snapshot_fingerprint
+            candidate_evidence = AlbumQualityEvidence(
+                mb_release_id="mbid-alac-m4a",
+                snapshot_fingerprint=snapshot_fingerprint(candidate_files),
+                source_path=source_dir,
+                measurement=candidate_measurement,
+                measured_at=datetime(2026, 6, 16, 23, 53, 0, tzinfo=timezone.utc),
+                files=candidate_files,
+                codec="m4a",
+                container="m4a",
+                storage_format="m4a",
+                target_format="opus",
+                v0_metric=v0_metric,
+                verified_lossless_proof=None,
+                audio_corrupt=False,
+                folder_layout="flat",
+                audio_file_count=len(candidate_files),
+                filetype_band="lossless",
+                matched_bad_audio_hash_id=None,
+                matched_bad_audio_hash_path=None,
+            )
+            db.upsert_album_quality_evidence(candidate_evidence)
+            persisted_candidate = db.find_album_quality_evidence(
+                mb_release_id="mbid-alac-m4a",
+                snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
+            )
+            assert persisted_candidate is not None
+
+            beets_info = AlbumInfo(
+                album_id=5,
+                track_count=1,
+                min_bitrate_kbps=102,
+                avg_bitrate_kbps=128,
+                median_bitrate_kbps=128,
+                is_cbr=False,
+                album_path=library_dir,
+                format="Opus",
+            )
+            with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                _refresh_current_evidence_after_import(
+                    db,  # type: ignore[arg-type]
+                    request_id=5219,
+                    mb_release_id="mbid-alac-m4a",
+                    quality_ranks=None,
+                    source_candidate=persisted_candidate,
+                    import_result=make_import_result(
+                        decision="provisional_lossless_upgrade",
+                        new_min_bitrate=102,
+                    ),
+                )
+
+            request_row = db.request(5219)
+            new_evidence_id = request_row["current_evidence_id"]
+            self.assertIsNotNone(new_evidence_id)
+            new_evidence = db.load_album_quality_evidence_by_id(new_evidence_id)
+            assert new_evidence is not None
+
+            # ALAC is lossless — the V0 probe lineage and spectral grade
+            # describe the upstream lossless source and MUST survive the
+            # transcode to Opus, so the next candidate compares against the
+            # 253 anchor instead of importing for free.
+            self.assertEqual(
+                new_evidence.v0_metric, v0_metric,
+                "ALAC-m4a V0 probe lineage was stripped — anchor lost",
+            )
+            self.assertEqual(
+                new_evidence.measurement.spectral_grade, "likely_transcode")
+            self.assertEqual(new_evidence.measurement.spectral_bitrate_kbps, 96)
+
+            # Bitrate / format still reflect the Opus output from album_info.
+            self.assertEqual(new_evidence.measurement.format, "Opus")
+            self.assertEqual(new_evidence.codec, "opus")
+
+    def test_transcoded_aac_m4a_to_opus_strips_source_evidence(self):
+        """AAC-in-m4a source → Opus library: source-side evidence is STRIPPED.
+
+        Negative sibling of
+        ``test_transcoded_alac_m4a_to_opus_propagates_source_evidence``. Both
+        sources record ``codec="m4a"`` (the container is ambiguous), so the
+        gate must NOT key on the container string — it must key on the V0
+        probe lineage. AAC is lossy, so the harness emits a
+        ``native_lossy_research`` lineage (never ``lossless_source``), and the
+        source-side fields must be stripped exactly as for an MP3 source. This
+        proves the fix admits ALAC-m4a without widening the gate to admit every
+        ``.m4a`` (which would re-import AAC junk as a lossless anchor).
+        """
+        from lib.import_dispatch import _refresh_current_evidence_after_import
+        from lib.quality import AlbumQualityV0Metric
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=146, mb_release_id="mbid-aac-m4a"))
+
+        with tempfile.TemporaryDirectory() as source_dir, \
+                tempfile.TemporaryDirectory() as library_dir:
+            self._stage_audio(source_dir, filenames=["01 - source.m4a"])
+            self._stage_audio(library_dir, filenames=["01 - Library.opus"])
+
+            from lib.quality_evidence import snapshot_audio_files
+            candidate_files = snapshot_audio_files(source_dir)
+            self.assertEqual(candidate_files[0].codec, "m4a")
+
+            # Lossy AAC → native_lossy_research lineage (NOT lossless_source).
+            v0_metric = AlbumQualityV0Metric(
+                min_bitrate_kbps=210,
+                avg_bitrate_kbps=240,
+                median_bitrate_kbps=235,
+                source_lineage="native_lossy_research",
+                source_provenance="native_lossy_research",
+            )
+            candidate_measurement = AudioQualityMeasurement(
+                min_bitrate_kbps=256,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=256,
+                format="AAC",
+                is_cbr=False,
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=256,
+                verified_lossless=False,
+                was_converted_from=None,
+            )
+            from lib.quality import AlbumQualityEvidence
+            from datetime import datetime, timezone
+            from lib.quality_evidence import snapshot_fingerprint
+            candidate_evidence = AlbumQualityEvidence(
+                mb_release_id="mbid-aac-m4a",
+                snapshot_fingerprint=snapshot_fingerprint(candidate_files),
+                source_path=source_dir,
+                measurement=candidate_measurement,
+                measured_at=datetime(2026, 6, 16, 23, 53, 0, tzinfo=timezone.utc),
+                files=candidate_files,
+                codec="m4a",
+                container="m4a",
+                storage_format="m4a",
+                target_format="opus",
+                v0_metric=v0_metric,
+                verified_lossless_proof=None,
+                audio_corrupt=False,
+                folder_layout="flat",
+                audio_file_count=len(candidate_files),
+                filetype_band="aac",
+                matched_bad_audio_hash_id=55,
+                matched_bad_audio_hash_path="/some/known/bad.m4a",
+            )
+            db.upsert_album_quality_evidence(candidate_evidence)
+            persisted_candidate = db.find_album_quality_evidence(
+                mb_release_id="mbid-aac-m4a",
+                snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
+            )
+            assert persisted_candidate is not None
+
+            beets_info = AlbumInfo(
+                album_id=6,
+                track_count=1,
+                min_bitrate_kbps=119,
+                avg_bitrate_kbps=128,
+                median_bitrate_kbps=125,
+                is_cbr=False,
+                album_path=library_dir,
+                format="Opus",
+            )
+            with patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
+                _refresh_current_evidence_after_import(
+                    db,  # type: ignore[arg-type]
+                    request_id=146,
+                    mb_release_id="mbid-aac-m4a",
+                    quality_ranks=None,
+                    source_candidate=persisted_candidate,
+                    import_result=make_import_result(
+                        decision="import", new_min_bitrate=119,
+                    ),
+                )
+
+            request_row = db.request(146)
+            new_evidence_id = request_row["current_evidence_id"]
+            self.assertIsNotNone(new_evidence_id)
+            new_evidence = db.load_album_quality_evidence_by_id(new_evidence_id)
+            assert new_evidence is not None
+
+            # Lossy m4a source: every source-side field stripped onto NULL.
+            self.assertIsNone(new_evidence.v0_metric)
+            self.assertIsNone(new_evidence.measurement.spectral_grade)
+            self.assertIsNone(new_evidence.measurement.spectral_bitrate_kbps)
+            self.assertIsNone(new_evidence.matched_bad_audio_hash_id)
+            self.assertIsNone(new_evidence.matched_bad_audio_hash_path)
+            self.assertEqual(new_evidence.measurement.format, "Opus")
+            self.assertEqual(new_evidence.codec, "opus")
+
     def test_transcoded_mp3_to_opus_strips_source_evidence(self):
         """AE5: non-lossless-source transcoded import does NOT propagate
         source-side evidence.

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -155,11 +155,14 @@ console.log('renderDownloadHistoryItem() renders lossless V0 probe with inline (
     'lossless probe omits the noisy kind suffix');
 }
 
-console.log('renderDownloadHistoryItem() falls back to existing min bitrate for V0 probe (was X) when existing has no V0 probe');
+console.log('renderDownloadHistoryItem() omits the V0 probe (was X) suffix when existing has no comparable V0 probe');
 {
-  // Lossless candidate upgrading a lossy library album — the existing
-  // side has no V0 probe but does have a min bitrate. Show that as the
-  // "(was X)" comparison rather than dropping it entirely.
+  // Lossless candidate over a library album with no recorded V0 probe.
+  // The V0-probe row must NOT borrow the existing raw min bitrate as a
+  // "(was X)" — painting a V0-probe avg next to a container min reads as
+  // a fake upgrade ("260kbps avg (was 192kbps)" mixes two metrics). The
+  // min-vs-min comparison still renders on the Bitrate row, so nothing is
+  // lost.
   const html = renderDownloadHistoryItem({
     outcome: 'success',
     soulseek_username: 'awellregulatedabbey',
@@ -175,9 +178,14 @@ console.log('renderDownloadHistoryItem() falls back to existing min bitrate for 
 
   assertContains(html, 'class="p-hist-label">V0 probe</span>',
     'V0 probe row present');
-  assertContains(html, '260kbps avg', 'candidate V0 probe avg rendered');
+  // The V0-probe value cell carries the candidate alone — no fabricated
+  // "(was X)". A precise cell match (not a whole-HTML substring) so the
+  // Bitrate row's legitimate "(was 192kbps)" cannot leak into this assertion.
+  assertContains(html, '<span class="p-hist-value">260kbps avg</span>',
+    'V0 probe value has no (was X) suffix when existing has no V0 probe');
+  // The legitimate min-vs-min comparison still renders on the Bitrate row.
   assertContains(html, 'class="p-hist-was">(was 192kbps)',
-    'V0 probe (was X) falls back to existing min bitrate when no existing V0 probe');
+    'Bitrate row keeps the apples-to-apples min comparison');
 }
 
 console.log('renderDownloadHistoryItem() drops the V0 probe row for non-lossless candidates');

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -104,23 +104,22 @@ export function renderDownloadHistoryItem(h) {
   // backend policy decisions, but redundant with the Bitrate row in
   // the UI, where the same number already appears.
   //
-  // For the "(was X)" suffix, prefer the existing-side V0 probe avg
-  // (a true apples-to-apples comparison when the library album was
-  // also lossless) but fall back to the existing raw min bitrate when
-  // that's the only "before" data we have. The fallback isn't strictly
-  // the same metric, but the operator still wants to see what the
-  // library album was before this candidate showed up.
+  // The "(was X)" suffix is V0-probe-avg vs V0-probe-avg only — a true
+  // apples-to-apples comparison against the library album's recorded
+  // lossless-source probe. We deliberately do NOT fall back to the
+  // existing raw min bitrate: painting a V0-probe avg next to a
+  // container min bitrate reads as a fake upgrade (e.g. "239kbps avg
+  // (was 92kbps)" compares two different metrics). When there's no
+  // comparable existing probe, the row shows the candidate alone; the
+  // Bitrate row below already carries the min-vs-min comparison.
   if (
     h.v0_probe_avg_bitrate
     && h.v0_probe_kind === 'lossless_source_v0'
   ) {
     const candidate = formatV0Probe(h.v0_probe_avg_bitrate, h.v0_probe_kind);
-    let was = null;
-    if (h.existing_v0_probe_avg_bitrate) {
-      was = `${esc(h.existing_v0_probe_avg_bitrate)}kbps avg`;
-    } else if (h.existing_min_bitrate) {
-      was = `${esc(h.existing_min_bitrate)}kbps`;
-    }
+    const was = h.existing_v0_probe_avg_bitrate
+      ? `${esc(h.existing_v0_probe_avg_bitrate)}kbps avg`
+      : null;
     rows.push(['V0 probe', withWas(candidate, was)]);
   }
 


### PR DESCRIPTION
## The bug — the V0 probe doesn't carry through

On request **5219** (Fred again.. *Actual Life 3*), every lossless-container copy on Soulseek is a fake-lossless (~96kbps lossy audio wrapped in FLAC/ALAC; spectral grades `likely_transcode ~96kbps`). The provisional-lossless lane holds the library at the best V0-probe-avg seen and only replaces when a candidate beats it by >5kbps — ratcheting **upward**. It held a **245** anchor for ~10 days, correctly rejecting 12 candidates (239–248). Then it regressed:

| time | peer | source | probe | existing anchor | result |
|------|------|--------|------|------|--------|
| 06-16 23:53 | denleschae | **m4a (ALAC)** | 253 | 245 | imported |
| 06-17 00:42 | fliphkd21 | flac | 239 | **NULL** | imported (no anchor!) |

The library ended up **worse** (239) than the 245 it held for 10 days.

## Root cause (confirmed in evidence rows)

`propagate_candidate_evidence_to_current` gates source-side fields (`v0_metric`, spectral, bad-hash) on `source_codec in LOSSLESS_CODECS` (`{flac, alac, wav}`). But `AlbumQualityEvidence.codec` is labelled by **container extension** (`snapshot_audio_files`), so an ALAC-in-m4a file records `codec="m4a"`. `"m4a"` ∉ `LOSSLESS_CODECS`, so a genuinely-lossless ALAC source was misread as a lossy transcode and its V0 probe was **stripped to NULL** on the post-import library row. The next candidate then saw no comparable anchor and imported unconditionally.

Production evidence rows prove it:
```
24558  codec=m4a   v0_avg=253   lineage=lossless_source  <- denleschae ALAC candidate
24560  codec=opus  v0_avg=NULL                           <- its post-import row: STRIPPED
24565  codec=opus  v0_avg=239                            <- fliphkd21 flac (not stripped; regressed anchor)
```

## The fix

Trust the candidate's **V0 probe lineage** (`lossless_source`) as the authoritative "was the source lossless" signal — the harness only grinds that probe after ffprobe confirms a lossless container (ALAC/FLAC/WAV) — instead of the noisy container-extension `codec` string. This brings propagation into line with the already-correct `_lossless_source_from_evidence` helper. AAC-in-m4a (lossy) never receives a `lossless_source` probe, so it still strips correctly.

**UI:** dropped the misleading `existing_min_bitrate` fallback in the Recents V0-probe `(was X)` suffix, which painted a V0-probe avg next to a raw container min and read as a fake upgrade (`239kbps avg (was 92kbps)`).

## Tests (RED-first, real import code via `_refresh_current_evidence_after_import`)

- `test_transcoded_alac_m4a_to_opus_propagates_source_evidence` — the bug (RED → GREEN)
- `test_transcoded_aac_m4a_to_opus_strips_source_evidence` — negative sibling: lossy m4a with the same `codec="m4a"` still strips, proving the gate keys on **lineage**, not the container
- updated the stale JS history fallback test to pin the new contract (it had been passing by substring leakage from the Bitrate row)

Full suite 4468 ✓ · pyright 0 errors ✓ · JS 52 ✓ · reviewed by ce-correctness-reviewer.

## Follow-up (operational, after deploy)
Un-denylist the highest-probe peer **denleschae** (253, ALAC) on request 5219 so the pipeline re-fetches it as the new anchor (with this fix the 253 lineage will now persist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
