### PR TITLE
fix(convert): scale ffmpeg conversion timeout to source duration

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -22,6 +22,7 @@ Exit codes:
 
 import argparse
 import json
+import math
 import os
 import select
 import signal
@@ -734,10 +735,15 @@ def _temp_v0_probe(
                 *V0_SPEC.metadata_args,
                 "-y", out_path,
             ]
+            # Same duration-scaled budget as convert_lossless — a flat 300s
+            # makes this probe loop measurement_failed forever on long-form
+            # tracks (the 24h "7 Skies H3") for keep-lossless requests.
+            probe_timeout = _conversion_timeout_seconds(
+                _probe_duration_seconds(src_path))
             try:
                 result = subprocess.run(
                     cmd, capture_output=True, text=True, errors="replace",
-                    timeout=300)
+                    timeout=probe_timeout)
             except subprocess.TimeoutExpired:
                 failed += 1
                 continue
@@ -793,6 +799,54 @@ def _probe_source_channels(path: str) -> int | None:
     if isinstance(channels, int) and channels > 0:
         return channels
     return None
+
+
+def _probe_duration_seconds(path: str) -> float | None:
+    """Read total playback duration (seconds) from an audio file via mutagen.
+
+    Returns the float duration or ``None`` if the probe fails. mutagen reads
+    the stream header (FLAC STREAMINFO etc.), not the whole file, so this is
+    cheap even for multi-GB sources. Used to scale the ffmpeg conversion
+    timeout to track length — see ``_conversion_timeout_seconds``.
+    """
+    try:
+        from mutagen import File as _MutagenFile  # type: ignore[import-untyped,attr-defined]  # pyright: ignore[reportPrivateImportUsage]
+    except ImportError:
+        return None
+    try:
+        mf = _MutagenFile(path)
+    except Exception:
+        return None
+    if mf is None:
+        return None
+    length = getattr(getattr(mf, "info", None), "length", None)
+    if isinstance(length, (int, float)) and length > 0:
+        return float(length)
+    return None
+
+
+# Conversion timeout budget — a flat 300s is fine for songs but guarantees a
+# TimeoutExpired on long-form single tracks (the 24-hour Flaming Lips
+# "7 Skies H3" cannot transcode to V0 in 5 minutes, so request 4873 looped
+# measurement_failed forever). Scale the budget to the source duration:
+# assume the encoder sustains at least ~4x realtime, add fixed headroom, and
+# floor at 300s so normal-length tracks are unaffected. The budget is only a
+# ceiling — fast encodes finish well under it; it just lets slow/huge ones
+# complete instead of being killed mid-stream.
+_CONVERSION_TIMEOUT_FLOOR_S = 300
+_CONVERSION_MIN_REALTIME_FACTOR = 4
+_CONVERSION_TIMEOUT_HEADROOM_S = 120
+
+
+def _conversion_timeout_seconds(duration_s: float | None) -> int:
+    """ffmpeg conversion budget (seconds) scaled to source duration (pure)."""
+    if duration_s is None or duration_s <= 0:
+        return _CONVERSION_TIMEOUT_FLOOR_S
+    scaled = (
+        math.ceil(duration_s / _CONVERSION_MIN_REALTIME_FACTOR)
+        + _CONVERSION_TIMEOUT_HEADROOM_S
+    )
+    return max(_CONVERSION_TIMEOUT_FLOOR_S, scaled)
 
 
 def convert_lossless(album_path: str, spec: ConversionSpec,
@@ -868,15 +922,17 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
                "-c:a", spec.codec, *spec.codec_args,
                *spec.metadata_args,
                "-y", temp_out_path]
+        conv_timeout = _conversion_timeout_seconds(
+            _probe_duration_seconds(src_path))
         try:
             # errors="replace" so non-UTF-8 bytes in ffmpeg stderr (e.g.
             # CP1252-tagged FLAC Vorbis comments echoed in verbose output)
             # don't raise UnicodeDecodeError during capture and crash the
             # whole import — request 580 (78 Saab — Crossed Lines) hit this.
             result = subprocess.run(cmd, capture_output=True, text=True,
-                                    errors="replace", timeout=300)
+                                    errors="replace", timeout=conv_timeout)
         except subprocess.TimeoutExpired:
-            print(f"  [FAIL] {fname}: ffmpeg timed out after 300s",
+            print(f"  [FAIL] {fname}: ffmpeg timed out after {conv_timeout}s",
                   file=sys.stderr)
             if os.path.exists(temp_out_path):
                 os.remove(temp_out_path)

--- a/tests/test_conversion_e2e.py
+++ b/tests/test_conversion_e2e.py
@@ -15,6 +15,8 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 HARNESS_DIR = os.path.join(ROOT_DIR, "harness")
@@ -65,6 +67,47 @@ class TestAudioFixtures(unittest.TestCase):
             for p in paths:
                 self.assertTrue(os.path.exists(p))
                 self.assertTrue(p.endswith(".flac"))
+
+
+# ============================================================================
+# Conversion-timeout wiring — the duration-scaled budget must reach ffmpeg
+# ============================================================================
+
+class TestConversionTimeoutWiring(unittest.TestCase):
+    """Guard the wiring (not just the pure helper): a long-form source must
+    cause convert_lossless to pass a scaled timeout to subprocess.run, so a
+    regression back to a flat constant is caught. Request 4873 (24h track)."""
+
+    def test_scaled_timeout_reaches_ffmpeg(self):
+        from harness.import_one import (
+            convert_lossless, V0_SPEC,
+            _conversion_timeout_seconds, _probe_duration_seconds,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            album = os.path.join(d, "album")
+            os.makedirs(album)
+            flac = os.path.join(album, "01 long.flac")
+            # > 716s break-even so the budget exceeds the 300s floor and the
+            # assertion actually exercises the scaled branch.
+            make_test_flac(flac, duration=800)
+            expected = _conversion_timeout_seconds(
+                _probe_duration_seconds(flac))
+            self.assertGreater(
+                expected, 300, "fixture must exercise the scaled branch")
+
+            captured = {}
+
+            def _fake_run(*_args, **kwargs):
+                captured["timeout"] = kwargs.get("timeout")
+                # returncode!=0 short-circuits the post-conversion file ops;
+                # we only care that the timeout was computed and forwarded.
+                return SimpleNamespace(returncode=1, stderr="", stdout="")
+
+            with mock.patch("harness.import_one.subprocess.run",
+                            side_effect=_fake_run):
+                convert_lossless(album, V0_SPEC, keep_source=True)
+
+            self.assertEqual(captured.get("timeout"), expected)
 
 
 # ============================================================================

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -334,6 +334,49 @@ class TestConversionDecision(unittest.TestCase):
         self.assertFalse(r.is_terminal)
 
 
+# ============================================================================
+# _conversion_timeout_seconds — duration-scaled ffmpeg budget (request 4873)
+# ============================================================================
+
+class TestConversionTimeoutSeconds(unittest.TestCase):
+    """The conversion timeout must scale with source duration so long-form
+    single tracks (the 24-hour "7 Skies H3") get enough budget to transcode,
+    while normal-length tracks keep the 300s floor (pure)."""
+
+    # (description, duration_seconds, expected_timeout)
+    CASES = [
+        ("none probe -> floor", None, 300),
+        ("zero duration -> floor", 0, 300),
+        ("negative duration -> floor", -5.0, 300),
+        ("4-minute song -> floor", 240.0, 300),
+        ("12-minute boundary -> floor", 720.0, 300),
+        ("20-minute track -> scaled", 1200.0, 420),
+        ("1-hour set -> scaled", 3600.0, 1020),
+        ("2-hour set -> scaled", 7200.0, 1920),
+        ("24-hour 7 Skies H3 -> scaled", 86400.0, 21720),
+    ]
+
+    def test_timeout_scaling(self):
+        from harness.import_one import _conversion_timeout_seconds
+        for desc, duration, expected in self.CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    _conversion_timeout_seconds(duration), expected)
+
+    def test_long_track_exceeds_flat_300s_floor(self):
+        """Regression guard: the 24h track that looped measurement_failed
+        forever must now get a budget far above the old flat 300s."""
+        from harness.import_one import _conversion_timeout_seconds
+        self.assertGreater(_conversion_timeout_seconds(86400.0), 300)
+
+    def test_probe_duration_missing_file_returns_none(self):
+        """The probe must degrade to None (caller falls back to the floor),
+        never raise, on an unreadable path."""
+        from harness.import_one import _probe_duration_seconds
+        self.assertIsNone(
+            _probe_duration_seconds("/nonexistent/does-not-exist.flac"))
+
+
 class TestM4aAlacDetection(unittest.TestCase):
     """ALAC .m4a detection gates lossless conversion."""
 


### PR DESCRIPTION
## Problem

Request **4873** — The Flaming Lips "24 Hour Song Skull", a single **24-hour track**. The library copy is MP3 320; this is an upgrade-to-lossless request. A complete **7.6 GB FLAC downloaded successfully**, but the request looped `measurement_failed` forever (28 download_log rows) and could never import.

Root cause: `convert_lossless` (the preview worker's V0-probe transcode) and the twin path `_temp_v0_probe` both ran ffmpeg with a hardcoded `timeout=300`. A 24-hour FLAC cannot encode to MP3 V0 in 5 minutes → `TimeoutExpired` → `conversion_failed` → `measurement_failed`, every cycle. Each cycle also copytree'd 7.6 GB and burned 5 min of ffmpeg for nothing.

## Why not just skip the transcode

The V0 probe **must** run the real transcode — it measures the resulting bitrate to distinguish a genuine lossless source from one upsampled-from-lossy. Skipping it would delete the probe. So the fix scales the budget instead of removing the work.

## Fix

`timeout = max(300, ceil(duration_s / 4) + 120)` — assume the encoder sustains ≥4× realtime, plus headroom, floored at 300 s so normal-length tracks are unaffected. A 24 h track gets ~6 h; a 2 h set ~32 min; songs keep 300 s. Applied to **both** transcode paths (`convert_lossless` and `_temp_v0_probe`, the keep-lossless V0 probe — the second site was caught in review).

- `_probe_duration_seconds` — mutagen header read, cheap on multi-GB files
- `_conversion_timeout_seconds` — pure, duration-scaled budget
- Tests: pure `subTest` table (None/zero/negative/floor/boundary/1h/2h/24h) + a real-FLAC wiring seam test asserting the scaled timeout actually reaches `subprocess.run`

This self-heals request 4873: the staged FLAC now converts within budget, the V0 probe succeeds, evidence persists, and the importer decides.

## Verification
- `pyright` clean (0/0/0)
- Full suite: 4472 tests OK, no failures, no skips, dead-code sweep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)