### PR TITLE
fix(devshell): pin pyright to the dev-shell interpreter so the IDE matches the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.egg-info/
 .mypy_cache/
 .pyright/
+.pyright-venv
 .mcp.json
 .playwright-mcp/
 # Claude Code — only ignore machine-specific files

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -33,5 +33,17 @@ pkgs.mkShell {
     # Echo to stderr so the banner doesn't pollute stdout when callers do
     # ``nix-shell --run "cmd" > out`` (e.g. regenerating the vulture whitelist).
     echo "cratedigger dev shell — run: python3 -m unittest discover -s tests -t . -v" >&2
+
+    # Pin the IDE's pyright to THIS interpreter so in-editor diagnostics match
+    # ``nix-shell --run pyright`` (pyrightconfig.json points venvPath/venv here).
+    # Without it, the editor's pyright falls back to the system python3 — which
+    # lacks psycopg2/msgspec/pydantic/beets/... — and floods the file with
+    # spurious reportMissingImports. Refreshed every shell entry (the store path
+    # changes on ``nix flake update``); registered as an indirect GC root so
+    # ``nix-collect-garbage`` won't sever the symlink.
+    _cd_pyenv="$(${testPythonEnv}/bin/python3 -c 'import sys,os;print(os.path.dirname(os.path.dirname(sys.executable)))')"
+    nix-store --realise "$_cd_pyenv" --indirect --add-root "$PWD/.pyright-venv" >/dev/null 2>&1 \
+      || ln -sfn "$_cd_pyenv" "$PWD/.pyright-venv"
+    unset _cd_pyenv
   '';
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,9 +1,12 @@
 {
   "extraPaths": ["."],
+  "venvPath": ".",
+  "venv": ".pyright-venv",
   "pythonVersion": "3.13",
   "reportMissingImports": "error",
   "exclude": [
     "build",
-    "tools/vulture"
+    "tools/vulture",
+    ".pyright-venv"
   ]
 }


### PR DESCRIPTION
## Problem

The editor's pyright showed a flood of `reportMissingImports` that never appeared under `nix-shell --run pyright`. Root cause: `pyrightconfig.json` had no interpreter pointer, so the IDE's pyright fell back to the system `python3` — which has none of `psycopg2`/`msgspec`/`pydantic`/`beets`/`music_tag`/`slskd_api`. The CLI run was clean only because it inherits the dev-shell env on `PATH`.

## Fix

- **`pyrightconfig.json`** — add `"venvPath": "."` + `"venv": ".pyright-venv"` so pyright resolves imports against the dev-shell env, and add `.pyright-venv` to `exclude` so that symlink is kept out of the *source* walk.
- **`nix/shell.nix`** — the `shellHook` refreshes a `.pyright-venv` symlink to the current dev-shell python on every shell entry (the store path changes on `nix flake update`, so it can't be hardcoded), registered as an indirect GC root so `nix-collect-garbage` won't sever it.
- **`.gitignore`** — ignore `.pyright-venv`.

The `exclude` is load-bearing: without it pyright recursively type-checks the entire env (beets → gstreamer → thousands of files) and hangs for minutes.

## Verification

Standalone pyright with a **clean PATH (system python only — the IDE's situation)** against the repo's real config:
- Before: 5+ `reportMissingImports`.
- After: **0 errors / 0 missing imports**, including repo-internal `from lib.pipeline_db import PipelineDB`.

Full repo via `nix-shell --run pyright`: **`0 errors, 0 warnings, 0 informations`**, `Found 261 source files`, `Find Source Files: 0.02s` (the symlink is excluded from the walk).

Dev-tooling only — no runtime or test code touched.

To activate locally: reload the editor window so it re-reads `pyrightconfig.json`. IDE diagnostics now equal the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)