### PR TITLE
fix(sidecar): write cratedigger.json world-readable (0644)

### DIFF
--- a/lib/sidecar_service.py
+++ b/lib/sidecar_service.py
@@ -121,6 +121,13 @@ def write_sidecar_for_request(
     return SidecarWriteResult(OUTCOME_WRITTEN, path)
 
 
+# World-readable: the sidecar exists to be read by other processes and peers
+# (slskd reshare, the operator, other Cratedigger instances). mkstemp creates
+# 0600, which would make the file useless for that purpose, so widen it to the
+# conventional 0644 for a generated read-only metadata file.
+_SIDECAR_FILE_MODE = 0o644
+
+
 def _atomic_write_bytes(path: str, data: bytes) -> None:
     """Write ``data`` to ``path`` via a same-dir temp file + ``os.replace``."""
     directory = os.path.dirname(path)
@@ -130,6 +137,7 @@ def _atomic_write_bytes(path: str, data: bytes) -> None:
     try:
         with os.fdopen(fd, "wb") as fh:
             fh.write(data)
+        os.chmod(tmp_path, _SIDECAR_FILE_MODE)
         os.replace(tmp_path, path)
     except BaseException:
         try:

--- a/tests/test_sidecar_service.py
+++ b/tests/test_sidecar_service.py
@@ -135,6 +135,16 @@ class TestWriteSidecarHappyPath(_SidecarServiceCase):
         self.assertEqual(result.outcome, "written")
         self.assertIsNone(self._read_sidecar().source_username)
 
+    def test_written_file_is_world_readable(self):
+        # The sidecar exists to be read by other processes/peers — mkstemp's
+        # default 0600 would defeat that. Must land world-readable (0644).
+        self._seed_current_evidence(self._verified_lossless_evidence())
+        result = write_sidecar_for_request(
+            self.db, self.beets, REQUEST_ID, mb_release_id=MBID
+        )
+        assert result.path is not None
+        self.assertEqual(os.stat(result.path).st_mode & 0o777, 0o644)
+
 
 class TestImportDispatchSidecarHook(_SidecarServiceCase):
     """The importer success hook writes the sidecar via the shared service."""


### PR DESCRIPTION
Follow-up to #459. `tempfile.mkstemp` hardcodes mode `0600`, so every sidecar landed root-only-readable — defeating the feature's purpose (slskd reshare, the operator, and other Cratedigger instances must read it; the audio beside it is `0664`). chmod the temp file to `0644` before the atomic rename.

Caught in live verification of the backfill (the 3910 written files were `-rw------- root:root`). After merge+deploy, the idempotent backfill re-run overwrites them with the correct mode.

- `tests/test_sidecar_service.py::test_written_file_is_world_readable` asserts the mode.
- Full suite: 4493 OK; pyright 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)