### PR TITLE
feat(dashboard): Disk Coverage card with out-of-band drift rows

### DIFF
--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -114,7 +114,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
     }
     DASHBOARD_REQUIRED_FIELDS = {
         "generated_at", "redis", "searches", "cycles", "coverage",
-        "peers", "plan_readiness",
+        "peers", "plan_readiness", "disk_coverage",
     }
     DASHBOARD_SEARCH_WINDOW_FIELDS = {
         "label", "hours", "searches", "distinct_requests",
@@ -279,6 +279,53 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         _assert_required_fields(
             self, data["inverse"][0], self.DISK_COVERAGE_INVERSE_FIELDS,
             "disk coverage inverse row")
+
+    def test_pipeline_dashboard_disk_coverage_contract(self):
+        import web.server as srv
+
+        self.db.seed_request(make_request_row(
+            id=9101, status="imported", mb_release_id="dash-on-disk",
+        ))
+        self.db.seed_request(make_request_row(
+            id=9102, status="imported", mb_release_id="dash-drifted",
+            artist_name="Drift Artist", album_title="Drift Album",
+        ))
+        self.db.seed_request(make_request_row(
+            id=9103, status="wanted", mb_release_id="dash-not-yet",
+        ))
+        self.db.seed_request(make_request_row(
+            id=9104, status="downloading", mb_release_id="dash-in-flight",
+        ))
+        beets = FakeBeetsDB()
+        beets.set_album_exists("dash-on-disk", True)
+        # The class setUp baseline (id=100, imported) must read as
+        # on-disk so it doesn't pollute the drift assertion below.
+        beets.set_album_exists(self.db.request(100)["mb_release_id"], True)
+
+        with patch.object(srv, "_beets_db", return_value=beets):
+            status, data = self._get("/api/pipeline/dashboard")
+
+        self.assertEqual(status, 200)
+        dc = data["disk_coverage"]
+        _assert_required_fields(
+            self, dc, {"counts", "drift_rows"},
+            "pipeline dashboard disk coverage")
+        _assert_required_fields(
+            self, dc["counts"], self.DISK_COVERAGE_COUNT_FIELDS,
+            "pipeline dashboard disk coverage counts")
+        # Only off-disk `imported` rows are drift — wanted (not yet
+        # acquired), downloading (in flight), and manual (staged for
+        # review) are all expected to be absent from beets.
+        self.assertEqual([r["id"] for r in dc["drift_rows"]], [9102])
+        _assert_required_fields(
+            self, dc["drift_rows"][0], self.DISK_COVERAGE_ROW_FIELDS,
+            "pipeline dashboard drift row")
+
+    def test_pipeline_dashboard_disk_coverage_null_without_beets(self):
+        status, data = self._get("/api/pipeline/dashboard")
+
+        self.assertEqual(status, 200)
+        self.assertIsNone(data["disk_coverage"])
 
     def test_pipeline_log_surfaces_wrong_match_triage_audit(self):
         self.db.log_download(

--- a/web/js/pipeline_dashboard.js
+++ b/web/js/pipeline_dashboard.js
@@ -31,6 +31,7 @@ export function renderPipelineDashboard(navHtml) {
     <div class="dashboard-grid">
       ${renderRedisCard(redis)}
       ${renderCoverageCard(coverageWithRates)}
+      ${renderDiskCoverageCard(data.disk_coverage)}
       ${renderWantedTrendCard(coverageWithRates.wanted_trend || {})}
       ${renderPeersCard(peers)}
       ${renderSearchCard(searches)}
@@ -174,6 +175,39 @@ function renderRedisCard(redis) {
         <div class="metric-row"><span>Expires</span><strong>${formatCount(redis.expires_count)}</strong></div>
         <div class="metric-row"><span>Avg TTL</span><strong>${formatHoursFromMs(redis.avg_ttl_ms)}</strong></div>
         <div class="metric-row"><span>Frag</span><strong>${formatDecimal(redis.fragmentation_ratio)}</strong></div>
+      </div>
+    </div>
+  `;
+}
+
+function renderDiskCoverageCard(dc) {
+  if (!dc) {
+    return `
+    <div class="dashboard-card">
+      <div class="dashboard-card-title">Disk Coverage</div>
+      <div class="metric-list">
+        <div class="metric-row"><span>Beets DB</span><strong class="metric-muted">unavailable</strong></div>
+      </div>
+    </div>
+  `;
+  }
+  const c = dc.counts || {};
+  const drift = Array.isArray(dc.drift_rows) ? dc.drift_rows : [];
+  const wantedOffDisk = (c.off_disk_by_status || {}).wanted || 0;
+  const driftClass = drift.length > 0 ? 'metric-bad' : 'metric-good';
+  const driftRowsHtml = drift.map(r => `
+        <div class="metric-row">
+          <span>#${r.id} ${esc(r.artist_name || '?')} — ${esc(r.album_title || '?')}</span>
+          <strong class="metric-bad">${esc(r.status)}</strong>
+        </div>`).join('');
+  return `
+    <div class="dashboard-card">
+      <div class="dashboard-card-title">Disk Coverage</div>
+      <div class="metric-list">
+        <div class="metric-row"><span>On disk</span><strong>${formatCount(c.on_disk_total)} / ${formatCount(c.active_total)}</strong></div>
+        <div class="metric-row"><span>Wanted (not yet acquired)</span><strong class="metric-muted">${formatCount(wantedOffDisk)}</strong></div>
+        <div class="metric-row"><span>Drift (imported, missing from beets)</span><strong class="${driftClass}">${formatCount(drift.length)}</strong></div>
+        ${driftRowsHtml}
       </div>
     </div>
   `;

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -41,6 +41,7 @@ from lib.quality import (QUALITY_LOSSLESS, QUALITY_UPGRADE_TIERS,
                          should_clear_lossless_search_override,
                          top_candidates,
                          get_decision_tree)
+from lib.disk_coverage_service import disk_coverage
 from lib.import_preview import ImportPreviewValues, preview_import_from_values
 from lib.release_identity import detect_release_source, normalize_release_id
 from lib.release_cleanup import remove_and_reset_release
@@ -418,7 +419,31 @@ def get_pipeline_dashboard(h, params: dict[str, list[str]]) -> None:
     s = _server()
     data = s._db().get_pipeline_dashboard_metrics()
     data["redis"] = cache_api.redis_metrics()
+    data["disk_coverage"] = _dashboard_disk_coverage(s)
     h._json(data)
+
+
+def _dashboard_disk_coverage(s) -> dict[str, object] | None:
+    """Pipeline-vs-beets coverage block for the dashboard, or None when
+    no beets DB is configured.
+
+    Only ``imported`` claims beets presence, so ``drift_rows`` carries
+    off-disk ``imported`` rows only (a release that vanished from beets
+    is the Lucksmiths-class out-of-band drift signal). Off-disk wanted
+    (not yet acquired), downloading (in flight), and manual (staged for
+    review) rows are lifecycle-normal, not drift."""
+    beets = s._beets_db()
+    if beets is None:
+        return None
+    result = disk_coverage(s._db(), beets, include_rows=True)
+    return {
+        "counts": msgspec.to_builtins(result.counts),
+        "drift_rows": [
+            msgspec.to_builtins(row)
+            for row in (result.off_disk or [])
+            if row.status == "imported"
+        ],
+    }
 
 
 def _runtime_rank_config():


### PR DESCRIPTION
## Summary

Issues #148/#149 triage follow-up: the operator asked for the forgotten `disk-coverage` machinery to be surfaced on the dashboard.

- `GET /api/pipeline/dashboard` now embeds a `disk_coverage` block: `counts` (from the existing `lib/disk_coverage_service`) + `drift_rows`
- **Drift = off-disk `imported` rows only.** Off-disk `wanted` (not yet acquired), `downloading` (in flight), and `manual` (staged for review) are lifecycle-normal absences, not drift — without this filter the card would false-positive on every in-flight download
- New **Disk Coverage** card on the Pipeline dashboard: on-disk/active totals, wanted-not-yet-acquired count (muted), drift count (red when non-zero) with per-row detail
- `disk_coverage: null` when no beets DB is configured; card renders "unavailable"

## Performance / caching decision

Measured on live doc2 data (8,420 active requests): the coverage computation costs **~370ms**; the dashboard today is ~200ms and loads only on tab-open + manual Refresh (no polling). Shipped inline with **no cache** — a TTL cache would serve the exact signal this card exists for (Lucksmiths-class out-of-band drift) stale, and #101 already removed response caching from this app.

## Live validation

Running the underlying query on production surfaced one genuine drift row: request **1704** (Blueline Medic — *A Working Title in Green*), status `imported`, release absent from beets.

## Tests

- Contract: `disk_coverage` added to `DASHBOARD_REQUIRED_FIELDS`; new tests pin the counts/drift-row shapes, the imported-only drift filter (downloading row excluded), and the no-beets null case (RED first, then GREEN)
- Full suite: 4,573 tests OK; pyright 0 errors; `node --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)