### PR TITLE
fix(events): grace escape crashed on download_log outcome CHECK (#146)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -555,7 +555,7 @@ def _enqueue_completed_processing(
                 request_id=request_id,
                 soulseek_username=dl_info.username,
                 filetype=dl_info.filetype,
-                outcome="error",
+                outcome="failed",
                 error_message=detail,
             )
             transitions.finalize_request(

--- a/migrations/042_download_log_user_offline_outcome.sql
+++ b/migrations/042_download_log_user_offline_outcome.sql
@@ -1,0 +1,16 @@
+-- Widen download_log_outcome_check to include 'user_offline'.
+--
+-- lib/enqueue.py writes outcome='user_offline' for verified peer-offline
+-- enqueue rejections (the pooyork incident handling), but the CHECK
+-- constraint was never widened — the write raised CheckViolation the
+-- moment the path fired (prod has zero user_offline rows). Caught on
+-- 2026-07-02 when FakePipelineDB.log_download started mirroring this
+-- constraint (test-fidelity Rule A) after the #146 phase-3 grace escape
+-- shipped the same class of bug with outcome='error'.
+
+ALTER TABLE download_log DROP CONSTRAINT IF EXISTS download_log_outcome_check;
+ALTER TABLE download_log ADD CONSTRAINT download_log_outcome_check
+    CHECK (outcome IN ('success', 'rejected', 'failed', 'timeout',
+                       'force_import', 'manual_import', 'curator_ban',
+                       'measurement_failed', 'user_offline',
+                       'youtube_running', 'youtube_success', 'youtube_failed'));

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -78,6 +78,17 @@ from tests.fakes.rows import (
     UserCooldownRow,
 )
 
+# Mirror of download_log_outcome_check (migrations/042). Keep in sync when
+# a migration widens the constraint — the fake must reject exactly what
+# production rejects (test-fidelity Rule A/B).
+DOWNLOAD_LOG_OUTCOMES = frozenset({
+    "success", "rejected", "failed", "timeout",
+    "force_import", "manual_import", "curator_ban",
+    "measurement_failed", "user_offline",
+    "youtube_running", "youtube_success", "youtube_failed",
+})
+
+
 @dataclass
 class _FakeSearchPlanRow:
     """In-memory mirror of a search_plans row."""
@@ -1251,6 +1262,16 @@ class FakePipelineDB:
             raise psycopg2.errors.NotNullViolation(
                 'null value in column "request_id" of relation '
                 '"download_log" violates not-null constraint'
+            )
+        if outcome is not None and outcome not in DOWNLOAD_LOG_OUTCOMES:
+            # Mirror download_log_outcome_check (migration 037) — a fake
+            # that accepts any string shipped an outcome production
+            # rejects (#146 phase-3 grace escape, 2026-07-02).
+            import psycopg2.errors
+
+            raise psycopg2.errors.CheckViolation(
+                'new row for relation "download_log" violates check '
+                f'constraint "download_log_outcome_check" (outcome={outcome!r})'
             )
         new_log_id = self._mint_download_log_id()
         auxiliary: dict[str, Any] = {

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2396,7 +2396,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.request(1)["status"], "wanted")
         self.assertEqual(fake_db._import_jobs, [])
         self.assertEqual(len(fake_db.download_logs), 1)
-        self.assertEqual(fake_db.download_logs[0].outcome, "error")
+        self.assertEqual(fake_db.download_logs[0].outcome, "failed")
         self.assertIn("EVENT-PATH MISSING", "\n".join(logs.output))
 
     def test_poll_active_all_complete_uses_async_preview_gate(self):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -555,6 +555,16 @@ class TestFakePipelineDB(unittest.TestCase):
         self.assertEqual(db.plex_added_at_pins[0]["status"], "done")
         self.assertEqual(db.plex_added_at_pins[0]["reconciled_at"], now)
 
+    def test_log_download_rejects_non_canonical_outcome(self):
+        """Mirror of download_log_outcome_check — the fake must reject
+        exactly what production rejects (test-fidelity Rule A/B; the
+        #146 grace escape shipped outcome='error' past a permissive
+        fake and crashed on the real CHECK constraint)."""
+        import psycopg2.errors
+        db = FakePipelineDB()
+        with self.assertRaises(psycopg2.errors.CheckViolation):
+            db.log_download(42, outcome="error")
+
     def test_assert_log_passes(self):
         db = FakePipelineDB()
         log_id = db.log_download(42, outcome="success", soulseek_username="user1")
@@ -3687,7 +3697,7 @@ class TestFakeRecentSuccessfulUploader(unittest.TestCase):
     def test_returns_none_when_no_successful_log(self):
         db = FakePipelineDB()
         db.log_download(42, soulseek_username="bob", outcome="rejected")
-        db.log_download(42, soulseek_username="alice", outcome="error")
+        db.log_download(42, soulseek_username="alice", outcome="failed")
         self.assertIsNone(db.get_recent_successful_uploader(42))
 
     def test_returns_most_recent_success(self):

--- a/tests/test_wrong_matches_cleanup.py
+++ b/tests/test_wrong_matches_cleanup.py
@@ -341,7 +341,7 @@ class TestWrongMatchDeleteService(unittest.TestCase):
             log_id = self._log_download(
                 db,
                 failed_path=source,
-                outcome="accepted",
+                outcome="success",
             )
 
             result = delete_wrong_match(db, log_id, require_visible=True)


### PR DESCRIPTION
Post-deploy verification of PR #472 caught the phase-3 self-heal inert in prod: the grace escape wrote `outcome='error'`, which `download_log_outcome_check` rejects — `log_download` raised CheckViolation, the per-row guard swallowed it, and the reset-to-wanted never ran (the three pre-bootstrap rows stayed `downloading`).

- Escape now writes the canonical `'failed'`.
- **Structural fix (test-fidelity Rule A):** `FakePipelineDB.log_download` mirrors the outcome CHECK constraint, self-tested. The mirror immediately caught a second latent instance: `lib/enqueue.py` writes `outcome='user_offline'` (pooyork peer-offline handling) but the constraint was never widened — prod has zero such rows because the write crashes when the path fires. Migration 042 widens the CHECK to include `'user_offline'`.
- Two test fixtures that leaned on the permissive fake move to canonical outcomes.

Verification: full suite 4579 OK (incl. migrator), pyright 0 errors, dead-code clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)