### PR TITLE
refactor(db): single source of truth for the download_log outcome taxonomy

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -56,6 +56,7 @@ from lib.staged_album import StagedAlbum
 
 if TYPE_CHECKING:
     from lib.context import CratediggerContext
+    from lib.pipeline_db import DownloadLogOutcome
 
 logger = logging.getLogger("cratedigger")
 
@@ -95,7 +96,7 @@ class DownloadDB(transitions.TransitionsDB, Protocol):
         *,
         soulseek_username: str | None = None,
         filetype: str | None = None,
-        outcome: str | None = None,
+        outcome: DownloadLogOutcome | None = None,
         error_message: str | None = None,
     ) -> int: ...
 

--- a/lib/import_dispatch.py
+++ b/lib/import_dispatch.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     from lib.config import CratediggerConfig
     from lib.grab_list import GrabListEntry
     from lib.sidecar_service import SidecarDB, SidecarWriteResult
-    from lib.pipeline_db import PipelineDB
+    from lib.pipeline_db import DownloadLogOutcome, PipelineDB
     from lib.quality import AudioQualityMeasurement, QualityRankConfig
 
 logger = logging.getLogger("cratedigger")
@@ -1066,7 +1066,7 @@ def _do_mark_done(
     distance: float,
     scenario: str | None,
     dest_path: str | None,
-    outcome_label: str = "success",
+    outcome_label: DownloadLogOutcome = "success",
     detail: str | None = None,
     imported_path: str | None = None,
     clear_stale_v0_probe: bool = True,
@@ -1275,7 +1275,7 @@ def _record_rejection_and_maybe_requeue(
     error: str | None,
     *,
     requeue: bool = True,
-    outcome_label: str = "rejected",
+    outcome_label: DownloadLogOutcome = "rejected",
     search_filetype_override: str | None = None,
     validation_result: str | None = None,
     staged_path: str | None = None,
@@ -1690,7 +1690,7 @@ def dispatch_import_core(
     scenario: str = "auto_import",
     files: Sequence[object] | None = None,
     cfg: "CratediggerConfig | None" = None,
-    outcome_label: str = "success",
+    outcome_label: DownloadLogOutcome = "success",
     requeue_on_failure: bool = True,
     cooled_down_users: set[str] | None = None,
     source_dirs: list[str] | None = None,
@@ -2414,7 +2414,7 @@ def dispatch_import_from_db(
     failed_path: str,
     *,
     force: bool = False,
-    outcome_label: str = "force_import",
+    outcome_label: DownloadLogOutcome = "force_import",
     source_username: str | None = None,
     source_dirs: list[str] | None = None,
     import_job_id: int | None = None,
@@ -2492,7 +2492,7 @@ def _dispatch_import_from_db_locked(
     failed_path: str,
     *,
     force: bool,
-    outcome_label: str,
+    outcome_label: DownloadLogOutcome,
     source_username: str | None,
     source_dirs: list[str] | None,
     import_job_id: int | None,

--- a/lib/pipeline_db/__init__.py
+++ b/lib/pipeline_db/__init__.py
@@ -5,7 +5,11 @@ previously top-level name, and ``import lib.pipeline_db`` exposes the
 composed ``PipelineDB`` class.
 """
 from lib.pipeline_db._db import PipelineDB
-from lib.pipeline_db.download_log import DownloadLogCounts
+from lib.pipeline_db.download_log import (
+    DOWNLOAD_LOG_OUTCOMES,
+    DownloadLogCounts,
+    DownloadLogOutcome,
+)
 from lib.pipeline_db._shared import (
     ADVISORY_LOCK_NAMESPACE_IMPORT,
     ADVISORY_LOCK_NAMESPACE_IMPORTER,
@@ -105,7 +109,9 @@ __all__ = [
     "DASHBOARD_WANTED_TREND_WINDOWS",
     "DASHBOARD_WINDOWS",
     "DEFAULT_DSN",
+    "DOWNLOAD_LOG_OUTCOMES",
     "DownloadLogCounts",
+    "DownloadLogOutcome",
     "DryRunPlanClassification",
     "MbidCollisionError",
     "NonConsumingAttemptInput",

--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -2,7 +2,7 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Literal, get_args
 import msgspec
 import psycopg2
 import psycopg2.extras
@@ -11,6 +11,21 @@ from lib.pipeline_db._shared import (
     BACKOFF_BASE_MINUTES,
     BACKOFF_MAX_MINUTES,
 )
+
+# Canonical ``download_log.outcome`` taxonomy — the Python mirror of the
+# ``download_log_outcome_check`` CHECK constraint (latest definition:
+# migrations/042). Two sync points only: this Literal and the migration
+# SQL; ``tests/test_migrator.py`` pins them together. Writers get pyright
+# enforcement at the call site instead of a CheckViolation in production
+# (the failure mode that shipped twice on 2026-07-02: 'error' from the
+# #146 grace escape and the latent 'user_offline' from lib/enqueue.py).
+DownloadLogOutcome = Literal[
+    "success", "rejected", "failed", "timeout",
+    "force_import", "manual_import", "curator_ban",
+    "measurement_failed", "user_offline",
+    "youtube_running", "youtube_success", "youtube_failed",
+]
+DOWNLOAD_LOG_OUTCOMES: frozenset[str] = frozenset(get_args(DownloadLogOutcome))
 
 from lib.pipeline_db._core import _PipelineDBBase
 from lib.validation_envelope import (
@@ -117,7 +132,7 @@ class _DownloadLogMixin(_PipelineDBBase):
                      beets_scenario: str | None = None,
                      beets_detail: str | None = None,
                      valid: bool | None = None,
-                     outcome: str | None = None,
+                     outcome: DownloadLogOutcome | None = None,
                      staged_path: str | None = None,
                      error_message: str | None = None,
                      bitrate: int | None = None,

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -33,6 +33,7 @@ from lib.import_queue import (
     validate_status,
 )
 from lib.pipeline_db import (ActiveSearchPlan, BACKOFF_BASE_MINUTES,
+                             DOWNLOAD_LOG_OUTCOMES,
                              BACKOFF_MAX_MINUTES, BadAudioHashInput,
                              BadAudioHashRow, ConsumedAttemptInput,
                              ConsumedAttemptResult, CURSOR_UPDATE_ADVANCED,
@@ -77,17 +78,6 @@ from tests.fakes.rows import (
     SearchLogRow,
     UserCooldownRow,
 )
-
-# Mirror of download_log_outcome_check (migrations/042). Keep in sync when
-# a migration widens the constraint — the fake must reject exactly what
-# production rejects (test-fidelity Rule A/B).
-DOWNLOAD_LOG_OUTCOMES = frozenset({
-    "success", "rejected", "failed", "timeout",
-    "force_import", "manual_import", "curator_ban",
-    "measurement_failed", "user_offline",
-    "youtube_running", "youtube_success", "youtube_failed",
-})
-
 
 @dataclass
 class _FakeSearchPlanRow:

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -14,6 +14,7 @@ import msgspec
 from lib.beets_db import AlbumInfo
 from lib.config import CratediggerConfig
 from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+from lib.pipeline_db import DownloadLogOutcome
 from lib.quality import (
     AlbumQualityV0Metric,
     AudioQualityMeasurement,
@@ -100,7 +101,8 @@ def _patch_beets_album(album_path: str | None, *, min_bitrate: int = 128):
 class TestDispatchCoreOrchestration(unittest.TestCase):
     """Orchestration tests — assert domain state via FakePipelineDB."""
 
-    def _dispatch(self, ir=None, force=False, outcome_label="success",
+    def _dispatch(self, ir=None, force=False,
+                  outcome_label: DownloadLogOutcome = "success",
                   requeue_on_failure=True, override_min_bitrate=None,
                   source_username=None, target_format=None,
                   verified_lossless_target="",

--- a/tests/test_do_mark.py
+++ b/tests/test_do_mark.py
@@ -7,6 +7,7 @@ call shapes.
 
 import unittest
 
+from lib.pipeline_db import DownloadLogOutcome
 from lib.quality import DownloadInfo, SpectralMeasurement
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
@@ -15,7 +16,8 @@ from tests.helpers import make_request_row
 class TestDoMarkDone(unittest.TestCase):
     """_do_mark_done must transition to imported, log download, handle spectral state."""
 
-    def _call(self, dl_info=None, outcome_label="success", **kwargs):
+    def _call(self, dl_info=None,
+              outcome_label: DownloadLogOutcome = "success", **kwargs):
         from lib.import_dispatch import _do_mark_done
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
@@ -106,7 +108,8 @@ class TestDoMarkDone(unittest.TestCase):
 class TestRecordRejectionAndMaybeRequeue(unittest.TestCase):
     """Rejection recording must log failure and optionally requeue."""
 
-    def _call(self, requeue=True, outcome_label="rejected",
+    def _call(self, requeue=True,
+              outcome_label: DownloadLogOutcome = "rejected",
               search_filetype_override=None, dl_info=None,
               validation_result=None, staged_path=None):
         from lib.import_dispatch import _record_rejection_and_maybe_requeue

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -5,6 +5,7 @@ the ephemeral PostgreSQL fixture from ``conftest.py``.
 """
 
 import os
+import pathlib
 import sys
 import tempfile
 import unittest
@@ -3156,6 +3157,35 @@ class TestActiveYoutubeImportRequestSchema(unittest.TestCase):
         finally:
             self._exec("DELETE FROM import_jobs WHERE request_id = %s", (rid,))
             self._exec("DELETE FROM album_requests WHERE id = %s", (rid,))
+
+
+class TestDownloadLogOutcomeTaxonomySync(unittest.TestCase):
+    """Pin lib.pipeline_db.DOWNLOAD_LOG_OUTCOMES to the migration SQL.
+
+    The CHECK constraint and the Python Literal are the only two sync
+    points for the download_log outcome taxonomy; this test fails when a
+    migration widens the constraint without the Literal (or vice versa).
+    """
+
+    def test_literal_matches_latest_migration_check(self):
+        import re
+        from lib.migrator import DEFAULT_MIGRATIONS_DIR
+        from lib.pipeline_db import DOWNLOAD_LOG_OUTCOMES
+
+        pattern = re.compile(
+            r"ADD CONSTRAINT download_log_outcome_check\s*"
+            r"CHECK \(outcome IN \(([^;]+)\)\)",
+            re.DOTALL,
+        )
+        latest_values = None
+        for path in sorted(pathlib.Path(DEFAULT_MIGRATIONS_DIR).glob("*.sql")):
+            match = pattern.search(path.read_text())
+            if match:
+                latest_values = frozenset(
+                    re.findall(r"'([a-z_]+)'", match.group(1)))
+        assert latest_values is not None, (
+            "no migration defines download_log_outcome_check")
+        self.assertEqual(DOWNLOAD_LOG_OUTCOMES, latest_values)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -21,6 +21,7 @@ import psycopg2
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 from tests.helpers import make_album_quality_evidence
+from lib.pipeline_db import DownloadLogOutcome  # noqa: E402
 
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
@@ -3860,7 +3861,9 @@ class TestUserCooldowns(unittest.TestCase):
 
     def test_check_and_apply_cooldown_mixed_no_trigger(self):
         """3 timeouts + 2 successes → no cooldown."""
-        for outcome in ["timeout", "timeout", "success", "timeout", "success"]:
+        outcomes: list[DownloadLogOutcome] = [
+            "timeout", "timeout", "success", "timeout", "success"]
+        for outcome in outcomes:
             self.db.log_download(request_id=self.req1, soulseek_username="mixeduser",
                                  outcome=outcome)
         result = self.db.check_and_apply_cooldown("mixeduser")


### PR DESCRIPTION
Follow-up to PRs #472/#473. The outcome vocabulary lived in three places (CHECK constraint, hand-synced fake mirror, bare string literals at writers); both of yesterday's production crashes were writers inventing values the constraint rejects.

- `DownloadLogOutcome` Literal + derived `DOWNLOAD_LOG_OUTCOMES` frozenset in `lib/pipeline_db/download_log.py`, exported from the package.
- `PipelineDB.log_download`, the `DownloadDB` protocol, and every `outcome_label` signature in `lib/import_dispatch.py` take the Literal — a typo'd outcome is now a pyright error, not a prod CheckViolation.
- `FakePipelineDB` imports the canonical set for its runtime mirror (param stays `str` so the self-test can drive the rejection path).
- New `tests/test_migrator.py` guard parses the latest `download_log_outcome_check` definition from `migrations/*.sql` and asserts set equality with the Literal — the two remaining sync points cannot drift silently.

No runtime behavior change. Full suite 4580 OK, pyright 0 errors, dead-code clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)