### PR TITLE
feat(nix): U1 — pin dev shell to flake.lock nixpkgs; beets 2.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .mypy_cache/
 .pyright/
 .pyright-venv
+.nixpkgs-src
 .mcp.json
 .playwright-mcp/
 # Claude Code — only ignore machine-specific files

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,21 @@
-{ pkgs ? import <nixpkgs> {} }:
+# Plain `nix-shell` resolves the flake-locked nixpkgs, NOT the host's
+# <nixpkgs> channel. One pinned rev everywhere (dev shell, flake checks,
+# module) is the tier-2 packaging invariant: the real-beets contract test
+# only guards drift if it runs against the beets production will run.
+# `nix develop` gets the same pin via flake.nix; this shim covers the
+# `nix-shell --run "..."` path every rule and script uses. The fetched
+# tarball is GC-rooted from the shellHook (.nixpkgs-src) so
+# nix-collect-garbage doesn't force a re-download.
+{ pkgs ? import (
+    let
+      lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+      node = lock.nodes.${lock.nodes.${lock.root}.inputs.nixpkgs}.locked;
+    in
+    builtins.fetchTarball {
+      url = "https://github.com/${node.owner}/${node.repo}/archive/${node.rev}.tar.gz";
+      sha256 = node.narHash;
+    }
+  ) {} }:
 
 let
   cratedigger = import ./package.nix { inherit pkgs; };
@@ -42,5 +59,11 @@ pkgs.mkShell {
     nix-store --realise "$_cd_pyenv" --indirect --add-root "$PWD/.pyright-venv" >/dev/null 2>&1 \
       || ln -sfn "$_cd_pyenv" "$PWD/.pyright-venv"
     unset _cd_pyenv
+
+    # GC-root the pinned nixpkgs source tree (fetched by the flake.lock
+    # shim above) so nix-collect-garbage doesn't force a re-download on
+    # the next shell entry. Same pattern as .pyright-venv.
+    nix-store --realise ${pkgs.path} --indirect --add-root "$PWD/.nixpkgs-src" >/dev/null 2>&1 \
+      || ln -sfn ${pkgs.path} "$PWD/.nixpkgs-src"
   '';
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,6 +7,7 @@
   "exclude": [
     "build",
     "tools/vulture",
-    ".pyright-venv"
+    ".pyright-venv",
+    ".nixpkgs-src"
   ]
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
 # Back-compat shim — delegates to nix/shell.nix so there's one definition.
-# Prefer `nix develop` (uses the flake-pinned nixpkgs); `nix-shell` still works
-# but uses whatever <nixpkgs> resolves to in your channel.
-import ./nix/shell.nix { pkgs = import <nixpkgs> {}; }
+# No explicit pkgs: nix/shell.nix's default resolves the flake-locked
+# nixpkgs (via a flake.lock-reading fetchTarball), so plain `nix-shell`
+# and `nix develop` consume the same pinned rev — never the host channel.
+import ./nix/shell.nix {}


### PR DESCRIPTION
Tier-2 packaging plan U1 (docs/plans/2026-07-03-001-feat-tier2-packaging-plan.md). Requirements R2/R3.

- `nix flake update`: nixpkgs 2026-04-14 (beets 2.8.0) → 2026-06-29 (**beets 2.12.0**, python 3.13.13). Prod HM beets is 2.12, so pinning is now a lateral move, not a downgrade.
- `nix/shell.nix` default `pkgs` becomes a flake.lock-reading `fetchTarball` shim; root `shell.nix` drops its explicit `pkgs = import <nixpkgs> {}` so plain `nix-shell` — the path every rule and script uses — resolves the locked rev.
- Pinned nixpkgs tree GC-rooted at `.nixpkgs-src` (same pattern as `.pyright-venv`); gitignored + pyright-excluded.

Verified:
- Full suite green in the pinned shell (4598 tests, 0 skipped), including `tests/test_harness_beets2_contract.py` — the real-beets drift gate now runs against the beets prod will run.
- Pyright 0 errors repo-wide.
- `nix-shell` and `nix develop` resolve the identical python env store path; `.nixpkgs-src` points at the fetchTarball source (pin provably in effect, not the host channel).
- Opus review completed; its HIGH finding (root `shell.nix` overriding the pin) fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)