### PR TITLE
feat(nix): U2 — module builds from cratedigger's own flake.lock

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -2,6 +2,8 @@
 
 The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosModules.default` in `flake.nix`. It is generic and homelab-agnostic: every secret is a `*File` path, the DB is a `dsn` string, no sops/nspawn/reverse-proxy assumptions.
 
+The flake export is a wrapper that pins the module's package set to **cratedigger's own flake.lock**: the runtime python env (and beets) is built from the nixpkgs rev cratedigger's test suite ran against, not the consumer's nixpkgs. This costs a second nixpkgs evaluation on the consumer host. The escape hatch is `services.cratedigger.packageSet = pkgs;` (or any package set) — setting it forfeits the tested-closure guarantee: your beets/python may then drift from what the suite and the real-beets contract test verified, which is exactly the dev/prod skew that shipped the 2026-06-29 beets 2.12 import breakage.
+
 `~/nixosconfig/modules/nixos/services/cratedigger.nix` is a thin homelab wrapper (~150 lines) that imports the upstream module and adds:
 - sops-nix per-key secret materialization (`cratedigger-secrets-split` oneshot — see below)
 - the nspawn PostgreSQL container for the pipeline DB
@@ -15,6 +17,7 @@ The upstream module lives in this repo at `nix/module.nix`, exposed via `nixosMo
 | `enable` | `false` | Master switch |
 | `user` / `group` | `"root"` | Service identity. Default root because slskd downloads + beets need broad fs access. |
 | `src` | `../.` | Path to cratedigger source tree. Defaults to this flake's repo root. |
+| `packageSet` | cratedigger's own locked nixpkgs (via the flake export) | Package set for the runtime closure. Override = escape hatch, forfeits the tested-closure guarantee. |
 | `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |
@@ -99,9 +102,10 @@ If you don't use sops or have one key per encrypted file, skip the splitter and 
 
 ```
 github:abl030/cratedigger
-├── nixosModules.default              ← upstream NixOS module
-├── devShells.<system>.default         ← test/dev environment
-└── checks.<system>.moduleVm           ← NixOS VM test (boots module against ephemeral postgres)
+├── nixosModules.default              ← upstream NixOS module (pins packageSet to this flake's lock)
+├── devShells.<system>.default         ← test/dev environment (same pinned nixpkgs)
+├── checks.<system>.moduleVm           ← NixOS VM test (boots module against ephemeral postgres)
+└── checks.<system>.packageSetPin      ← eval guard: default packageSet = own lock; override honoured
 ```
 
 ## Validating before deploy

--- a/flake.nix
+++ b/flake.nix
@@ -23,17 +23,54 @@
         default = import ./nix/shell.nix { inherit pkgs; };
       });
 
-      nixosModules.default = ./nix/module.nix;
+      # The module is exported as a wrapper that pins its package set to
+      # cratedigger's OWN flake.lock (tier-2 plan U2 / KTD1): the runtime
+      # closure — python env, beets — is the one the test suite verified,
+      # independent of the consumer's nixpkgs. mkDefault so a consumer
+      # setting services.cratedigger.packageSet (the escape hatch) wins.
+      # Cost: a second nixpkgs evaluation on the consumer host — the
+      # standard trade for closure fidelity.
+      nixosModules.default = { config, lib, pkgs, ... }: {
+        imports = [ ./nix/module.nix ];
+        services.cratedigger.packageSet = lib.mkDefault (import nixpkgs {
+          system = pkgs.stdenv.hostPlatform.system;
+        });
+      };
 
       checks = forLinux ({ pkgs, system }: {
         # Boots a NixOS VM with the upstream module enabled against an
         # ephemeral postgres + a stubbed slskd. Verifies: migrator runs,
         # config.ini is rendered correctly, cratedigger-web responds.
+        # Consumes the wrapped export — the same thing consumers import.
         moduleVm = import ./nix/tests/module-vm.nix {
           inherit pkgs system;
-          cratediggerModule = ./nix/module.nix;
+          cratediggerModule = self.nixosModules.default;
           cratediggerSrc = ./.;
         };
+
+        # Eval-level guard for the packageSet threading. The "consumer" is
+        # simulated with a marked nixpkgs instantiation installed as the
+        # system's ambient pkgs (nixpkgs.pkgs) — so a regression of the
+        # wrapper to `packageSet = lib.mkDefault pkgs` (consumer's set)
+        # makes the default inherit the marker and fails the first assert.
+        # Pure evaluation — only the option value is forced, so no required
+        # options are needed.
+        packageSetPin = let
+          markedPkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (final: prev: { cratediggerEscapeHatchMarker = "consumer-pkgs"; }) ];
+          };
+          evalWith = extraModule: (nixpkgs.lib.nixosSystem {
+            modules = [ self.nixosModules.default { nixpkgs.pkgs = markedPkgs; } extraModule ];
+          }).config.services.cratedigger.packageSet;
+          pinned = evalWith { };
+          overridden = evalWith { services.cratedigger.packageSet = markedPkgs; };
+          expected = import nixpkgs { inherit system; };
+        in
+          assert !(pinned ? cratediggerEscapeHatchMarker);
+          assert pinned.path == expected.path;
+          assert (overridden.cratediggerEscapeHatchMarker or "") == "consumer-pkgs";
+          pkgs.runCommand "cratedigger-packageset-pin-ok" { } "touch $out";
       });
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -18,8 +18,11 @@
   cfg = config.services.cratedigger;
   src = cfg.src;
 
-  # Same python env the dev shell uses — single source of truth.
-  cratedigger = pkgs.callPackage ./package.nix {};
+  # Same python env the dev shell uses — single source of truth. Built from
+  # cfg.packageSet (the flake export pins it to cratedigger's own flake.lock,
+  # tier-2 plan U2/R1) so the runtime closure matches what the test suite ran
+  # against, not whatever nixpkgs the consumer happens to be on.
+  cratedigger = cfg.packageSet.callPackage ./package.nix {};
   pythonEnv = cratedigger.pythonEnv;
 
   pyRunner = "${pythonEnv}/bin/python";
@@ -317,6 +320,22 @@ in {
       default = ../.;
       defaultText = lib.literalExpression "../.";
       description = "Path to the cratedigger source tree. Defaults to this flake's repo root.";
+    };
+
+    packageSet = mkOption {
+      type = types.pkgs;
+      default = pkgs;
+      defaultText = lib.literalExpression "pkgs";
+      description = ''
+        Package set used to build cratedigger's runtime closure (the python
+        env, and from it the pinned beets). When this module is imported via
+        the flake's `nixosModules.default`, this is pinned to the nixpkgs
+        from cratedigger's own flake.lock — the rev the test suite and the
+        real-beets contract test ran against. Setting it explicitly is the
+        deliberate escape hatch for consumers who refuse the second nixpkgs
+        evaluation; doing so forfeits the tested-closure guarantee (your
+        beets/python may drift from what cratedigger's suite verified).
+      '';
     };
 
     user = mkOption {
@@ -942,7 +961,7 @@ in {
       requires = ["cratedigger-db-migrate.service"];
       restartIfChanged = false;
       # Deliberately exclude pythonEnv: it ships a `beet` binary (because
-      # `pkgs.beets` is in pythonEnv for the dev shell + tests), and putting
+      # the packageSet's beets is in pythonEnv for the dev shell + tests), and putting
       # it on PATH shadows whatever `beet` the consumer has provisioned for
       # the harness wrapper to find. The python interpreter is invoked via
       # absolute path inside cratediggerPkg / pipelineCli, so it doesn't need

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULE_NIX = REPO_ROOT / "nix" / "module.nix"
+FLAKE_NIX = REPO_ROOT / "flake.nix"
 
 
 class TestPythonPathCarriesOnlyRepoRoot(unittest.TestCase):
@@ -138,6 +139,41 @@ class TestImporterServiceContract(unittest.TestCase):
         self.assertIn('requires = ["cratedigger-db-migrate.service"]', text)
         self.assertIn('ExecStart = "${previewWorkerPkg}/bin/cratedigger-import-preview-worker"', text)
         self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
+
+
+class TestPinnedPackageSetContract(unittest.TestCase):
+    """The runtime closure builds from cratedigger's own flake.lock, not the
+    consumer's nixpkgs (tier-2 plan U2, R1 / KTD1).
+
+    ``nix/module.nix`` must build its python env from ``cfg.packageSet``
+    (defaulting to the ambient ``pkgs`` so the file stays importable
+    standalone), and ``flake.nix`` must export ``nixosModules.default`` as a
+    wrapper that pins ``packageSet`` to the flake's own locked nixpkgs. A
+    consumer setting ``packageSet`` explicitly is the deliberate escape
+    hatch — it forfeits the tested-closure guarantee.
+    """
+
+    def test_module_builds_package_from_packageSet(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("packageSet = mkOption", text)
+        self.assertIn("cratedigger = cfg.packageSet.callPackage ./package.nix {};", text)
+        self.assertNotIn("pkgs.callPackage ./package.nix", text)
+
+    def test_flake_export_pins_packageSet_to_own_lock(self) -> None:
+        text = FLAKE_NIX.read_text(encoding="utf-8")
+        self.assertIn("nixosModules.default", text)
+        self.assertIn("imports = [ ./nix/module.nix ];", text)
+        self.assertIn(
+            "services.cratedigger.packageSet = lib.mkDefault", text,
+            "flake.nix must pin packageSet via mkDefault so a consumer's "
+            "explicit packageSet (the escape hatch) still wins",
+        )
+        self.assertIn("pkgs.stdenv.hostPlatform.system", text)
+
+    def test_moduleVm_consumes_the_wrapped_export(self) -> None:
+        """The VM gate must exercise what consumers actually import."""
+        text = FLAKE_NIX.read_text(encoding="utf-8")
+        self.assertIn("cratediggerModule = self.nixosModules.default;", text)
 
 
 class TestOwnedRedisContract(unittest.TestCase):


### PR DESCRIPTION
Tier-2 packaging plan U2 (R1 / KTD1).

- `nixosModules.default` is now a wrapper closing over the flake's own nixpkgs: `services.cratedigger.packageSet` defaults (mkDefault) to cratedigger's locked rev for the consumer's `hostPlatform.system`. The consumer's nixpkgs no longer determines the runtime closure.
- `nix/module.nix` builds `package.nix` from `cfg.packageSet`; stays importable standalone (option default = ambient pkgs). Explicit `packageSet` is the documented escape hatch (forfeits the tested-closure guarantee).
- New `checks.<system>.packageSetPin`: eval guard that simulates a consumer via `nixpkgs.pkgs = <marked instantiation>` and asserts the default packageSet does NOT inherit the consumer set (negative-tested: regressing the wrapper to `mkDefault pkgs` fails the check) and that an override is honoured.
- moduleVm now consumes the wrapped export — the same module consumers import.
- `tests/test_nix_module.py` literal-assertion coverage for the threading; docs updated.

Verified: moduleVm green with the wrapped export, packageSetPin green (and RED under deliberate regression), full suite + pyright clean in the pinned shell. Opus review: MEDIUM finding (tautological pin assert) fixed via the consumer-marker approach; downstream homelab wrapper confirmed unaffected (doesn't set packageSet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)