### PR TITLE
feat(nix): U3 — cratedigger-owned beets + plugin closure + cratedigger-beet

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -18,6 +18,8 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `user` / `group` | `"root"` | Service identity. Default root because slskd downloads + beets need broad fs access. |
 | `src` | `../.` | Path to cratedigger source tree. Defaults to this flake's repo root. |
 | `packageSet` | cratedigger's own locked nixpkgs (via the flake export) | Package set for the runtime closure. Override = escape hatch, forfeits the tested-closure guarantee. |
+| `beets.discogsMirrorUrl` | `null` | When set, build-time-patches the beets discogs plugin to hit this mirror instead of api.discogs.com. |
+| `beets.lrclibUrl` | `null` | When set, build-time-patches the beets lyrics plugin's LRCLIB base to this URL. |
 | `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |
@@ -53,7 +55,7 @@ Three options under `services.cratedigger.searchSettings.*` control the slskd se
 
 ## What the module does
 
-1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, zstandard).
+1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, zstandard) from the pinned `packageSet`. The beets in that env is the cratedigger-owned derivation (`nix/beets.nix`) — one store path serving the python library (`lib/beets_distance.py`), the `cratedigger-beet` wrapper (which pins `BEETSDIR` at `${stateDir}/beets`), and — from U5 — the harness.
 2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `scripts/importer.py` / `scripts/import_preview_worker.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH.
 3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path. App units render through an atomic temp-file-and-rename step because importer, preview, web, and timer-driven services can start concurrently after migrations.
 4. Enables `redis-cratedigger.service` by default with bounded memory and `allkeys-lru`.
@@ -105,7 +107,8 @@ github:abl030/cratedigger
 ├── nixosModules.default              ← upstream NixOS module (pins packageSet to this flake's lock)
 ├── devShells.<system>.default         ← test/dev environment (same pinned nixpkgs)
 ├── checks.<system>.moduleVm           ← NixOS VM test (boots module against ephemeral postgres)
-└── checks.<system>.packageSetPin      ← eval guard: default packageSet = own lock; override honoured
+├── checks.<system>.packageSetPin      ← eval guard: default packageSet = own lock; override honoured
+└── checks.<system>.beetsMirrorPatches ← beets mirror knobs patch/don't-patch as configured
 ```
 
 ## Validating before deploy

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,41 @@
           assert pinned.path == expected.path;
           assert (overridden.cratediggerEscapeHatchMarker or "") == "consumer-pkgs";
           pkgs.runCommand "cratedigger-packageset-pin-ok" { } "touch $out";
+
+        # nix/beets.nix mirror knobs: with the knobs set, the built plugin
+        # files carry the mirror URLs; with them unset, stock upstream URLs.
+        # `--replace-fail` inside beets.nix is the primary drift alarm (the
+        # patched build fails if a future beets drops the target strings);
+        # this check additionally pins the unpatched default to stock
+        # behaviour so the knobs can never become always-on.
+        beetsMirrorPatches = let
+          patched = import ./nix/beets.nix {
+            inherit pkgs;
+            discogsMirrorUrl = "https://discogs-mirror.example.test";
+            lrclibUrl = "http://lrclib.example.test/api";
+          };
+          unpatched = import ./nix/beets.nix { inherit pkgs; };
+          # Compose the patched variant into a withPackages env the same way
+          # pythonEnv does in production — the standalone build alone would
+          # leave the real deploy shape (patched beets inside the env) as
+          # the first-ever composition.
+          patchedEnv = pkgs.python3.withPackages (ps: [ patched ]);
+        in pkgs.runCommand "cratedigger-beets-mirror-patches-ok" { } ''
+          set -euo pipefail
+          p_lyrics=$(echo ${patched}/lib/python*/site-packages/beetsplug/lyrics.py)
+          p_discogs=$(echo ${patched}/lib/python*/site-packages/beetsplug/discogs/__init__.py)
+          u_lyrics=$(echo ${unpatched}/lib/python*/site-packages/beetsplug/lyrics.py)
+          u_discogs=$(echo ${unpatched}/lib/python*/site-packages/beetsplug/discogs/__init__.py)
+          grep -q 'BASE_URL = "http://lrclib.example.test/api"' "$p_lyrics"
+          grep -q '_base_url = "https://discogs-mirror.example.test"' "$p_discogs"
+          # Positive stock-URL/stock-line assertions: if the knob defaults
+          # ever became non-null (always-on mirrors), these lines change and
+          # the grep fails — a negated grep would not survive set -e anyway.
+          grep -q 'BASE_URL = "https://lrclib.net/api"' "$u_lyrics"
+          grep -q 'self.discogs_client = Client(USER_AGENT, user_token=user_token)$' "$u_discogs"
+          test -x ${patchedEnv}/bin/beet
+          touch $out
+        '';
       });
     };
 }

--- a/nix/beets.nix
+++ b/nix/beets.nix
@@ -1,0 +1,62 @@
+# The one beets — cratedigger owns the beet runtime (tier-2 plan U3, R4).
+#
+# Returns the pinned nixpkgs' python beets package (python3Packages.beets),
+# which carries every built-in plugin's dependency closure — the production
+# plugin list (musicbrainz discogs fetchart embedart lyrics lastgenre scrub
+# info missing duplicates edit fromfilename ftintitle the inline) is all
+# built-ins, so no pluginOverrides are needed. Because this is the *python
+# package* (pkgs.beets is just `toPythonApplication python3Packages.beets`),
+# the same store path serves all consumers: `pythonEnv` (lib/beets_distance
+# imports the library in cratedigger-web), the dev shell, the
+# `cratedigger-beet` wrapper's `bin/beet`, and — from U5 — the harness
+# interpreter (which today still resolves the consumer's `beet`).
+#
+# The two mirror patches are ported from the operator's Home Manager module
+# (~/nixosconfig/modules/home-manager/services/beets.nix) as opt-in knobs,
+# null/off by default so a stranger gets stock plugin behaviour:
+#   - discogsMirrorUrl: point the discogs plugin's python3-discogs-client at
+#     a Discogs mirror (e.g. https://discogs.ablz.au) instead of
+#     api.discogs.com.
+#   - lrclibUrl: point the lyrics plugin's LRCLIB base at a local instance
+#     (e.g. http://192.168.1.35:3300/api) instead of lrclib.net.
+# `--replace-fail` is the drift alarm: if a future `nix flake update` ships
+# a beets whose plugin source no longer contains these strings, the build
+# fails loudly instead of silently reverting to the public APIs.
+{
+  pkgs,
+  discogsMirrorUrl ? null,
+  lrclibUrl ? null,
+}:
+
+let
+  base = pkgs.python3Packages.beets;
+
+  lrclibPatch = ''
+    substituteInPlace beetsplug/lyrics.py \
+      --replace-fail 'BASE_URL = "https://lrclib.net/api"' \
+                     'BASE_URL = "${lrclibUrl}"'
+  '';
+
+  discogsPatch = ''
+    substituteInPlace beetsplug/discogs/__init__.py \
+      --replace-fail 'self.discogs_client = Client(USER_AGENT, user_token=user_token)' \
+                     'self.discogs_client = Client(USER_AGENT, user_token=user_token); self.discogs_client._base_url = "${discogsMirrorUrl}"' \
+      --replace-fail 'self.discogs_client = Client(USER_AGENT, c_key, c_secret, token, secret)' \
+                     'self.discogs_client = Client(USER_AGENT, c_key, c_secret, token, secret); self.discogs_client._base_url = "${discogsMirrorUrl}"'
+  '';
+
+  postPatch =
+    (if lrclibUrl != null then lrclibPatch else "")
+    + (if discogsMirrorUrl != null then discogsPatch else "");
+in
+if postPatch == "" then
+  base
+else
+  base.overridePythonAttrs (old: {
+    postPatch = (old.postPatch or "") + postPatch;
+    # The patched tree is a private runtime variant; upstream's test suite
+    # (and its network-touching doctests) already ran for the unpatched
+    # base — two URL-literal swaps don't invalidate it, and re-running it
+    # roughly doubles eval-to-deploy time on every mirror-knob change.
+    doCheck = false;
+  })

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -18,12 +18,35 @@
   cfg = config.services.cratedigger;
   src = cfg.src;
 
+  # The one beets (tier-2 plan U3, R4): pinned package + full built-in
+  # plugin closure, with the mirror patches applied only when the operator
+  # sets the knobs. This same derivation is the python library in pythonEnv
+  # (lib/beets_distance.py) and the bin/beet behind cratedigger-beet; the
+  # harness interpreter joins in U5.
+  beetsEnv = import ./beets.nix {
+    pkgs = cfg.packageSet;
+    discogsMirrorUrl = cfg.beets.discogsMirrorUrl;
+    lrclibUrl = cfg.beets.lrclibUrl;
+  };
+
+  # Config dir every beets consumer resolves via BEETSDIR (beets' native
+  # config-dir override). U4 renders config.yaml into it.
+  beetsConfigDir = "${cfg.stateDir}/beets";
+
   # Same python env the dev shell uses — single source of truth. Built from
   # cfg.packageSet (the flake export pins it to cratedigger's own flake.lock,
   # tier-2 plan U2/R1) so the runtime closure matches what the test suite ran
   # against, not whatever nixpkgs the consumer happens to be on.
-  cratedigger = cfg.packageSet.callPackage ./package.nix {};
+  cratedigger = cfg.packageSet.callPackage ./package.nix { beetsPackage = beetsEnv; };
   pythonEnv = cratedigger.pythonEnv;
+
+  # Canonical manual-ops beet for the library cratedigger manages. Pins
+  # BEETSDIR so operator invocations and pipeline subprocesses read the
+  # SAME module-rendered config — never a per-user ~/.config/beets.
+  cratediggerBeet = pkgs.writeShellScriptBin "cratedigger-beet" ''
+    export BEETSDIR="${beetsConfigDir}"
+    exec ${pythonEnv}/bin/beet "$@"
+  '';
 
   pyRunner = "${pythonEnv}/bin/python";
 
@@ -556,6 +579,31 @@ in {
       };
     };
 
+    beets = {
+      discogsMirrorUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "https://discogs.ablz.au";
+        description = ''
+          When set, the beets discogs plugin's client is patched
+          (substituteInPlace at build time) to use this base URL instead of
+          public api.discogs.com. Null = stock plugin behaviour (public
+          Discogs, token required for lookups — see the discogs token
+          handling in the rendered beets config).
+        '';
+      };
+      lrclibUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "http://192.168.1.35:3300/api";
+        description = ''
+          When set, the beets lyrics plugin's LRCLIB base URL is patched
+          (substituteInPlace at build time) to this value instead of public
+          lrclib.net. Null = stock plugin behaviour.
+        '';
+      };
+    };
+
     beetsDirectory = mkOption {
       type = types.str;
       default = "";
@@ -901,7 +949,7 @@ in {
       }
     ];
 
-    environment.systemPackages = [pipelineCli pipelineMigrate importerPkg previewWorkerPkg youtubeIngestWorkerPkg pkgs.postgresql];
+    environment.systemPackages = [pipelineCli pipelineMigrate importerPkg previewWorkerPkg youtubeIngestWorkerPkg cratediggerBeet pkgs.postgresql];
 
     users.users = mkIf (cfg.user != "root") {
       ${cfg.user} = {
@@ -920,7 +968,13 @@ in {
     # / notifiers.*.{username,password,token}File) and retain their own
     # restrictive modes from whatever provisioned them (sops-nix, agenix, etc).
     systemd.tmpfiles.rules =
-      [ "d ${cfg.stateDir} 0755 ${cfg.user} ${cfg.group} -" ]
+      [
+        "d ${cfg.stateDir} 0755 ${cfg.user} ${cfg.group} -"
+        # BEETSDIR for every beets consumer (cratedigger-beet, harness).
+        # U4 renders config.yaml into it; the dir must exist regardless so
+        # the wrapper works on a fresh boot.
+        "d ${beetsConfigDir} 0755 ${cfg.user} ${cfg.group} -"
+      ]
       ++ optional cfg.youtubeIngest.enable
         "d ${cfg.youtubeIngest.tempDir} 0755 ${cfg.user} ${cfg.group} -";
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,16 +1,12 @@
-{ pkgs }:
+{ pkgs, beetsPackage ? import ./beets.nix { inherit pkgs; } }:
 
 let
-  # Production python deps. Includes beets only as a Python library —
-  # ``lib/beets_distance.py`` calls ``beets.autotag.distance`` directly
-  # from cratedigger-web to compute Replace-picker distance scores. The
-  # consumer's ``beet`` CLI is still the source of truth for import:
-  # ``harness/run_beets_harness.sh`` invokes it explicitly with its own
-  # PATH + plugin config, and the systemd unit doesn't put the Nix
-  # ``beet`` binary on the cratedigger user's shell PATH. So adding the
-  # library here does NOT shadow the consumer's binary at import time.
-  # If we ever spawn ``beet`` from the cratedigger process itself, that
-  # invariant breaks and this needs revisiting.
+  # Production python deps. beets is cratedigger-owned (tier-2 plan U3):
+  # ``beetsPackage`` (nix/beets.nix, optionally mirror-patched by the
+  # module) is BOTH the library ``lib/beets_distance.py`` imports from
+  # cratedigger-web AND the ``bin/beet`` behind cratedigger-beet — one
+  # store path for every beets consumer (the harness joins in U5; until
+  # then it still resolves the consumer's ``beet``).
   pythonPackages = ps: [
     ps.psycopg2
     ps.music-tag
@@ -18,7 +14,7 @@ let
     ps.pydantic  # HTTP request-body validation in web/routes/* (issue #343); msgspec stays for internal wire boundaries
     ps.redis     # web UI cache (graceful no-op if redis server is down, but the module must be importable)
     ps.zstandard # peer cache compresses msgpack directory payloads before writing Redis bytes
-    ps.beets     # beets.autotag.distance for /api/beets-distance — library import only
+    beetsPackage # the one beets: autotag.distance library + bin/beet (nix/beets.nix)
     ps.ytmusicapi # YouTube Music album resolver — anonymous `YTMusic()` for search + get_album
   ];
 in {

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -196,5 +196,31 @@ pkgs.testers.nixosTest {
     # and not respawn. The systemd unit holds the lock; this invocation
     # fails to acquire and returns 0 immediately.
     machine.succeed("cratedigger-youtube-ingest --once")
+
+    # U3 (tier-2): cratedigger owns the beet runtime. cratedigger-beet is
+    # on PATH, resolves BEETSDIR at the module's beets config dir, and the
+    # pinned derivation carries the dependency closure for the FULL
+    # production plugin set — including a tokenless discogs (placeholder
+    # token = no interactive OAuth, no network at load). The config.yaml
+    # written here is a stand-in until U4 renders the real one.
+    machine.succeed("command -v cratedigger-beet")
+    machine.succeed("test -d /var/lib/cratedigger/beets")
+    machine.succeed(
+        "printf 'plugins: musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline\\ndiscogs:\\n  user_token: cratedigger-placeholder-token\\n'"
+        + " > /var/lib/cratedigger/beets/config.yaml"
+    )
+    version_out = machine.succeed("cratedigger-beet version")
+    plugins_line = next(
+        line for line in version_out.splitlines() if line.startswith("plugins:")
+    )
+    loaded = {p.strip() for p in plugins_line.split(":", 1)[1].split(",")}
+    for plugin in (
+        "musicbrainz discogs fetchart embedart lyrics lastgenre scrub "
+        "info missing duplicates edit fromfilename ftintitle the inline"
+    ).split():
+        assert plugin in loaded, f"plugin {plugin} not loaded: {version_out}"
+    # Tokenless/stranger posture: config loads without crash or prompt.
+    machine.succeed("cratedigger-beet config > /dev/null")
+    machine.succeed("rm /var/lib/cratedigger/beets/config.yaml")
   '';
 }

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -156,7 +156,7 @@ class TestPinnedPackageSetContract(unittest.TestCase):
     def test_module_builds_package_from_packageSet(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")
         self.assertIn("packageSet = mkOption", text)
-        self.assertIn("cratedigger = cfg.packageSet.callPackage ./package.nix {};", text)
+        self.assertIn("cratedigger = cfg.packageSet.callPackage ./package.nix", text)
         self.assertNotIn("pkgs.callPackage ./package.nix", text)
 
     def test_flake_export_pins_packageSet_to_own_lock(self) -> None:
@@ -174,6 +174,44 @@ class TestPinnedPackageSetContract(unittest.TestCase):
         """The VM gate must exercise what consumers actually import."""
         text = FLAKE_NIX.read_text(encoding="utf-8")
         self.assertIn("cratediggerModule = self.nixosModules.default;", text)
+
+
+class TestOwnedBeetsContract(unittest.TestCase):
+    """Cratedigger owns the beet runtime (tier-2 plan U3, R4 / KTD3).
+
+    One pinned beets derivation (nix/beets.nix, from cfg.packageSet, mirror
+    patches as opt-in knobs) serves pythonEnv, the dev shell, the harness,
+    and the cratedigger-beet wrapper. The wrapper pins BEETSDIR at the
+    module's beets config dir so every consumer reads the same rendered
+    config.
+    """
+
+    def test_module_threads_beets_env_from_packageSet(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("beetsEnv = import ./beets.nix {", text)
+        self.assertIn("pkgs = cfg.packageSet;", text)
+        self.assertIn("discogsMirrorUrl = cfg.beets.discogsMirrorUrl;", text)
+        self.assertIn("lrclibUrl = cfg.beets.lrclibUrl;", text)
+        self.assertIn(
+            "cratedigger = cfg.packageSet.callPackage ./package.nix { beetsPackage = beetsEnv; };",
+            text,
+        )
+
+    def test_cratedigger_beet_wrapper_pins_beetsdir(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('pkgs.writeShellScriptBin "cratedigger-beet"', text)
+        self.assertIn('beetsConfigDir = "${cfg.stateDir}/beets";', text)
+        self.assertIn('export BEETSDIR="${beetsConfigDir}"', text)
+        self.assertIn("exec ${pythonEnv}/bin/beet", text)
+        # On systemPackages as the canonical manual-ops binary.
+        self.assertIn("cratediggerBeet pkgs.postgresql", text)
+
+    def test_mirror_knobs_default_off(self) -> None:
+        """Strangers get stock plugin behaviour — knobs are opt-in."""
+        beets_nix = (REPO_ROOT / "nix" / "beets.nix").read_text(encoding="utf-8")
+        self.assertIn("discogsMirrorUrl ? null", beets_nix)
+        self.assertIn("lrclibUrl ? null", beets_nix)
+        self.assertIn("--replace-fail", beets_nix)
 
 
 class TestOwnedRedisContract(unittest.TestCase):


### PR DESCRIPTION
Tier-2 packaging plan U3 (R4, R7 / KTD3).

- `nix/beets.nix` (new): the one beets — pinned `python3Packages.beets` (all 15 production plugins are built-ins, dep closure included), with the two HM mirror patches ported as opt-in module knobs `beets.discogsMirrorUrl` / `beets.lrclibUrl` (null default = stock behaviour; `--replace-fail` = drift alarm on future flake updates).
- One store path for every beets consumer: pythonEnv's library (`lib/beets_distance.py`), the dev shell, and `bin/beet` behind the new `cratedigger-beet` wrapper (`BEETSDIR=${stateDir}/beets`, on systemPackages). Harness joins in U5.
- R7 decision: tokenless stranger default uses a placeholder `discogs.user_token` — verified all 15 plugins load cleanly offline with zero prompts (without it, plugin load triggers interactive OAuth). Real tokens stay on the issue #117 `*File` pattern (rendered in U4).
- New `checks.<system>.beetsMirrorPatches`: knobs-set ⇒ patched plugin files; knobs-unset ⇒ positive stock-line assertions (a default flip to always-on fails the grep); also composes the patched beets into `withPackages` to exercise the production shape.
- moduleVm: asserts `cratedigger-beet version` loads the exact production plugin set (parsed plugins line) and tokenless `beet config` is clean.

Verified: moduleVm green, beetsMirrorPatches green, full suite + pyright clean in the pinned shell, patch targets confirmed in pinned beets 2.12.0. Opus review: no HIGH/MEDIUM; LOW findings fixed (ineffective negated grep under set -e → positive assertions; present-tense harness claims → U5-future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)