### PR TITLE
feat(nix): U4 — module renders beets config.yaml into BEETSDIR

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -20,6 +20,10 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `packageSet` | cratedigger's own locked nixpkgs (via the flake export) | Package set for the runtime closure. Override = escape hatch, forfeits the tested-closure guarantee. |
 | `beets.discogsMirrorUrl` | `null` | When set, build-time-patches the beets discogs plugin to hit this mirror instead of api.discogs.com. |
 | `beets.lrclibUrl` | `null` | When set, build-time-patches the beets lyrics plugin's LRCLIB base to this URL. |
+| `beets.discogsTokenFile` | `null` | `*File` secret (issue #117): materialized into `${stateDir}/beets/secrets.yaml` (0400) + `include:` in the rendered config. Null = placeholder token (plugins load cleanly; public-Discogs lookups are token-required). |
+| `beetsConfig.{directory,library}` | production values | Rendered into the module-owned `config.yaml`. `beetsDirectory` (config.ini) follows `beetsConfig.directory` by default. |
+| `beetsConfig.fetchart.{maxwidth,minwidth}` | `500` / `300` | Load-bearing: library size (embedded art × every track) and the Meelo black-box floor. |
+| `beetsConfig.musicbrainz.{host,https,ratelimit}` | `musicbrainz.org` / `true` / `1` | Public-MB stranger default (functional but slow); the operator points these at the local mirror. |
 | `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |
@@ -58,6 +62,7 @@ Three options under `services.cratedigger.searchSettings.*` control the slskd se
 1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, zstandard) from the pinned `packageSet`. The beets in that env is the cratedigger-owned derivation (`nix/beets.nix`) — one store path serving the python library (`lib/beets_distance.py`), the `cratedigger-beet` wrapper (which pins `BEETSDIR` at `${stateDir}/beets`), and — from U5 — the harness.
 2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `scripts/importer.py` / `scripts/import_preview_worker.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH.
 3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path. App units render through an atomic temp-file-and-rename step because importer, preview, web, and timer-driven services can start concurrently after migrations.
+3b. Renders the beets `config.yaml` into `${stateDir}/beets/` (BEETSDIR) the same way. `import.duplicate_keys.album: [mb_albumid, discogs_albumid]` (the Palo Santo data-loss invariant), the plugin list, and the path templates are fixed literals — NOT options. Only `beetsConfig.*` (directory, library, fetchart widths, musicbrainz host/https/ratelimit) is operator-tunable. With `beets.discogsTokenFile` set, `secrets.yaml` (0400) is materialized next to it and included.
 4. Enables `redis-cratedigger.service` by default with bounded memory and `allkeys-lru`.
 5. Pre-start: health-check slskd → render config.ini → start `cratedigger.py`.
 

--- a/harness/beets_harness.py
+++ b/harness/beets_harness.py
@@ -251,9 +251,11 @@ def _assert_duplicate_keys_include_mb_albumid(cfg) -> None:
             "cross-MBID sibling destruction via find_duplicates — the "
             "2026-04-20 Palo Santo bug. Extra mutable keys like albumartist or "
             "album make same-release upgrades miss Beets' duplicate callback, "
-            "so replacement would not be atomic. Fix the `duplicate_keys` "
-            "block under `import:` in ~/.config/beets/config.yaml (or the "
-            "equivalent Nix module)."
+            "so replacement would not be atomic. The config is rendered by "
+            "the cratedigger NixOS module into ${stateDir}/beets/config.yaml "
+            "(BEETSDIR) — duplicate_keys is a hard-coded literal there "
+            "(nix/module.nix, tier-2 plan R5), so if this fires the rendered "
+            "file was bypassed or hand-edited."
         )
         print(msg, file=sys.stderr)
         sys.exit(1)

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -30,8 +30,116 @@
   };
 
   # Config dir every beets consumer resolves via BEETSDIR (beets' native
-  # config-dir override). U4 renders config.yaml into it.
+  # config-dir override). preStart renders config.yaml (and, when a token
+  # file is configured, secrets.yaml) into it.
   beetsConfigDir = "${cfg.stateDir}/beets";
+
+  # The module owns beets config.yaml (tier-2 plan U4, R5). The attrset
+  # mirrors the production config exactly (source of truth: the operator's
+  # live HM-rendered ~/.config/beets/config.yaml, 2026-07-03); the U12
+  # cutover gate diffs the rendered file against it, so change values here
+  # only in lockstep with production intent.
+  #
+  # HARD-CODED, not options:
+  #   - import.duplicate_keys.album = [mb_albumid discogs_albumid] — the
+  #     Palo Santo data-loss invariant. Beets reads it strictly from
+  #     config["import"]["duplicate_keys"]; a top-level duplicate_keys is
+  #     silently ignored and re-enables cross-MBID sibling destruction.
+  #     NEVER expose this as an option.
+  #   - plugins — fixed production list; musicbrainz must be present or
+  #     beets returns 0 candidates for everything.
+  #   - paths / asciify_paths — path-affecting keys; drift here plus the
+  #     importer's post-import `beet move` reproduces the 2026-05-18
+  #     asciify mass-split (1,178 albums).
+  beetsSettings = let
+    bc = cfg.beetsConfig;
+  in {
+    directory = bc.directory;
+    library = bc.library;
+    asciify_paths = true;
+    clutter = ["Thumbs.DB" "Thumbs.db" ".DS_Store" "*.jpg" "*.png" "AlbumArt*" "Folder.*" "desktop.ini"];
+    import = {
+      copy = false;
+      write = true;
+      move = true;
+      timid = false;
+      incremental = true;
+      incremental_skip_later = true;
+      log = "${dirOf bc.library}/beets-import.log";
+      languages = ["en"];
+      duplicate_keys = {
+        album = ["mb_albumid" "discogs_albumid"];
+        item = ["artist" "title"];
+      };
+    };
+    paths = {
+      default = "$albumartist/$year - $album%aunique{albumartist album,albumtype year label catalognum albumdisambig releasegroupdisambig short_mbid}/$track $title";
+      singleton = "Non-Album/$artist/$title";
+      comp = "Compilations/$album%aunique{albumartist album,albumtype year label catalognum albumdisambig releasegroupdisambig short_mbid}/$track $title";
+    };
+    item_fields.short_mbid = "mb_albumid[:8] if mb_albumid else ''";
+    album_fields.short_mbid = "mb_albumid[:8] if mb_albumid else ''";
+    musicbrainz = {
+      host = bc.musicbrainz.host;
+      https = bc.musicbrainz.https;
+      ratelimit = bc.musicbrainz.ratelimit;
+    };
+    match = {
+      ignore_video_tracks = false;
+      strong_rec_thresh = 0.10;
+      medium_rec_thresh = 0.25;
+      preferred = {
+        countries = ["AU" "US" "GB|UK"];
+        media = ["Digital Media|File" "CD"];
+        original_year = true;
+      };
+    };
+    plugins = "musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline";
+    chroma.auto = false;
+    fetchart = {
+      auto = true;
+      minwidth = bc.fetchart.minwidth;
+      maxwidth = bc.fetchart.maxwidth;
+      quality = 75;
+      high_resolution = false;
+      sources = ["coverart" "itunes" "amazon" "albumart" "cover_art_url" "filesystem"];
+    };
+    embedart.auto = true;
+    scrub.auto = true;
+    lyrics = {
+      auto = true;
+      synced = true;
+      sources = ["lrclib"];
+    };
+    lastgenre = {
+      auto = true;
+      count = 3;
+      source = "album";
+      canonical = true;
+      separator = ", ";
+      force = false;
+    };
+    the = {
+      a = true;
+      the = true;
+    };
+  } // (
+    if cfg.beets.discogsTokenFile != null then {
+      # Real token: issue #117 *File pattern — preStart materializes
+      # secrets.yaml (0400) next to config.yaml; the world-readable
+      # config.yaml carries only the include.
+      include = ["secrets.yaml"];
+    } else {
+      # Tokenless stranger default (R7): any non-empty user_token makes
+      # the discogs plugin skip its interactive OAuth flow at load, so
+      # every plugin loads cleanly offline. Public-Discogs lookups with
+      # this placeholder are documented token-required (they 401 per-use;
+      # beets logs and falls back to MB candidates).
+      discogs.user_token = "cratedigger-placeholder-token";
+    }
+  );
+
+  beetsConfigTemplate = (pkgs.formats.yaml {}).generate "cratedigger-beets-config.yaml" beetsSettings;
 
   # Same python env the dev shell uses — single source of truth. Built from
   # cfg.packageSet (the flake export pins it to cratedigger's own flake.lock,
@@ -280,6 +388,45 @@
     ${pkgs.coreutils}/bin/mv -f "$tmp" "$config_dir/config.ini"
     trap - EXIT
     rm -f "$config_dir/.cratedigger.lock"
+
+    # Beets config (tier-2 plan U4): atomic render into BEETSDIR, same
+    # temp-file-and-rename dance as config.ini because the importer,
+    # preview worker and timer-driven oneshot can start concurrently.
+    beets_dir="${beetsConfigDir}"
+    mkdir -p "$beets_dir"
+    tmp_yaml="$(${pkgs.coreutils}/bin/mktemp "$beets_dir/.config.yaml.XXXXXX")"
+    trap '${pkgs.coreutils}/bin/rm -f "$tmp_yaml"' EXIT
+    ${pkgs.coreutils}/bin/cp ${beetsConfigTemplate} "$tmp_yaml"
+    ${pkgs.coreutils}/bin/chmod 0644 "$tmp_yaml"
+    ${pkgs.coreutils}/bin/mv -f "$tmp_yaml" "$beets_dir/config.yaml"
+    trap - EXIT
+    ${optionalString (cfg.beets.discogsTokenFile != null) ''
+      # Discogs token: *File pattern (issue #117) — the token lands only
+      # in a 0400 secrets.yaml owned by the service user, never in the
+      # world-readable config.yaml. Bare assignment so a failed cat
+      # (unreadable secret) fails the unit under set -e instead of being
+      # swallowed inside a printf argument.
+      discogs_token="$(${pkgs.coreutils}/bin/cat "${cfg.beets.discogsTokenFile}")"
+      if [ -z "$discogs_token" ]; then
+        # An empty user_token re-enables the discogs plugin's interactive
+        # OAuth flow at load — the exact hazard the placeholder/token
+        # design exists to kill. Fail loud instead of deploying green
+        # with a broken beets.
+        echo "cratedigger: beets.discogsTokenFile (${cfg.beets.discogsTokenFile}) is empty — refusing to render an empty discogs user_token" >&2
+        exit 1
+      fi
+      # YAML single-quoted scalar; embedded single quotes doubled.
+      discogs_token="''${discogs_token//\'/\'\'}"
+      tmp_secrets="$(${pkgs.coreutils}/bin/mktemp "$beets_dir/.secrets.yaml.XXXXXX")"
+      trap '${pkgs.coreutils}/bin/rm -f "$tmp_secrets"' EXIT
+      {
+        echo 'discogs:'
+        echo "  user_token: '$discogs_token'"
+      } > "$tmp_secrets"
+      ${pkgs.coreutils}/bin/chmod 0400 "$tmp_secrets"
+      ${pkgs.coreutils}/bin/mv -f "$tmp_secrets" "$beets_dir/secrets.yaml"
+      trap - EXIT
+    ''}
   '';
 
   # Optional health check for a stuck slskd reconnect loop. Generic — the
@@ -601,6 +748,89 @@ in {
           (substituteInPlace at build time) to this value instead of public
           lrclib.net. Null = stock plugin behaviour.
         '';
+      };
+      discogsTokenFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Path to a file containing a Discogs user token (raw, one line).
+          Same contract as slskd.apiKeyFile (issue #117): must be readable
+          by services.cratedigger.user. When set, preStart materializes it
+          into ''${stateDir}/beets/secrets.yaml (mode 0400) and the rendered
+          config.yaml includes it. When null, a non-empty placeholder token
+          is rendered instead so the discogs plugin loads without its
+          interactive OAuth flow — public-Discogs lookups then fail
+          per-use until a real token is provided (documented
+          token-required).
+        '';
+      };
+    };
+
+    # Operator-tunable subset of the rendered beets config.yaml. Everything
+    # NOT listed here (path templates, duplicate_keys, plugin list, match
+    # weights, ...) is rendered as a fixed production-parity literal — see
+    # beetsSettings above for why.
+    beetsConfig = {
+      directory = mkOption {
+        type = types.str;
+        default = "/mnt/virtio/Music/Beets";
+        description = ''
+          Beets library root (config.yaml `directory:`). Production-matching
+          default (tier-2 plan R5); strangers point this at their music
+          root.
+        '';
+      };
+      library = mkOption {
+        type = types.str;
+        default = "/mnt/virtio/Music/beets-library.db";
+        description = ''
+          Beets library SQLite DB (config.yaml `library:`). The import log
+          renders next to it as beets-import.log. The parent directory must
+          exist at runtime: `beet` prompts interactively ("Create it
+          (Y/n)?") when it's missing, which blocks any non-interactive
+          invocation.
+        '';
+      };
+      fetchart = {
+        maxwidth = mkOption {
+          type = types.int;
+          default = 500;
+          description = ''
+            fetchart maxwidth. Load-bearing: embedded art is duplicated in
+            every track, so width drives library size (500px ≈ 71KB vs
+            1138KB unresized across ~83K tracks = ~85GB saved).
+          '';
+        };
+        minwidth = mkOption {
+          type = types.int;
+          default = 300;
+          description = ''
+            fetchart minwidth. Load-bearing: art under ~2KB renders as
+            black boxes in Meelo — 300px is the observed floor.
+          '';
+        };
+      };
+      musicbrainz = {
+        host = mkOption {
+          type = types.str;
+          default = "musicbrainz.org";
+          description = ''
+            MusicBrainz host for beets (config.yaml `musicbrainz.host`).
+            Default is public MB — functional but rate-limited (~1 req/s).
+            Point at a local mirror (host:port) for production-speed
+            matching; https and ratelimit below must be set coherently.
+          '';
+        };
+        https = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Whether beets talks TLS to musicbrainz.host (true for public MB, typically false for a LAN mirror).";
+        };
+        ratelimit = mkOption {
+          type = types.int;
+          default = 1;
+          description = "beets musicbrainz ratelimit (req/s). 1 for public MB; 100 against a local mirror.";
+        };
       };
     };
 
@@ -980,6 +1210,9 @@ in {
 
     services.cratedigger.web.redis.host = lib.mkDefault cfg.redis.host;
     services.cratedigger.web.redis.port = lib.mkDefault cfg.redis.port;
+    # One concept, one value: the config.ini [Beets] directory follows the
+    # rendered beets config.yaml `directory:` unless explicitly overridden.
+    services.cratedigger.beetsDirectory = lib.mkDefault cfg.beetsConfig.directory;
 
     services.redis.servers.cratedigger = {
       enable = cfg.redis.enable;

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -15,6 +15,45 @@
 # heavyweight fixtures that belong in the python test suite.
 { pkgs, system, cratediggerModule, cratediggerSrc }:
 
+let
+  # Parses the module-rendered beets config and asserts the invariants that
+  # have bitten in production: duplicate_keys nesting (Palo Santo guard),
+  # the fixed plugin list with musicbrainz present (zero-candidates guard),
+  # public-MB stranger defaults, and the tokenless placeholder (no OAuth).
+  pyWithYaml = pkgs.python3.withPackages (ps: [ ps.pyyaml ]);
+  checkRenderedBeetsConfig = pkgs.writeText "check-rendered-beets-config.py" ''
+    import yaml
+
+    with open("/var/lib/cratedigger/beets/config.yaml") as f:
+        cfg = yaml.safe_load(f)
+
+    dk = cfg["import"]["duplicate_keys"]
+    assert dk["album"] == ["mb_albumid", "discogs_albumid"], dk
+    assert dk["item"] == ["artist", "title"], dk
+
+    plugins = cfg["plugins"].split()
+    expected = (
+        "musicbrainz discogs fetchart embedart lyrics lastgenre scrub "
+        "info missing duplicates edit fromfilename ftintitle the inline"
+    ).split()
+    assert plugins == expected, plugins
+
+    mb = cfg["musicbrainz"]
+    assert mb["host"] == "musicbrainz.org", mb
+    assert mb["https"] is True, mb
+    assert mb["ratelimit"] == 1, mb
+
+    # Tokenless stranger posture: placeholder token, no secrets include.
+    assert cfg["discogs"]["user_token"] == "cratedigger-placeholder-token"
+    assert "include" not in cfg, cfg.get("include")
+
+    # Path-affecting keys present and production-shaped.
+    assert cfg["asciify_paths"] is True
+    assert "short_mbid" in cfg["paths"]["default"], cfg["paths"]
+
+    print("BEETS_CONFIG_OK")
+  '';
+in
 pkgs.testers.nixosTest {
   name = "cratedigger-module-vm";
 
@@ -61,6 +100,14 @@ pkgs.testers.nixosTest {
         enable = false;
         stagingDir = "/var/lib/cratedigger-staging";
         trackingFile = "/var/lib/cratedigger-staging/tracking.jsonl";
+      };
+      # Stranger-set beets paths (VM-local). The library's PARENT dir must
+      # exist or `beet` prompts "Create it (Y/n)?" interactively — which
+      # blocks forever under the test driver's backdoor shell. stateDir
+      # exists by tmpfiles, so the library parent is guaranteed.
+      beetsConfig = {
+        directory = "/var/lib/cratedigger-music";
+        library = "/var/lib/cratedigger/beets-library.db";
       };
       web = {
         enable = true;
@@ -197,18 +244,23 @@ pkgs.testers.nixosTest {
     # fails to acquire and returns 0 immediately.
     machine.succeed("cratedigger-youtube-ingest --once")
 
-    # U3 (tier-2): cratedigger owns the beet runtime. cratedigger-beet is
-    # on PATH, resolves BEETSDIR at the module's beets config dir, and the
-    # pinned derivation carries the dependency closure for the FULL
-    # production plugin set — including a tokenless discogs (placeholder
-    # token = no interactive OAuth, no network at load). The config.yaml
-    # written here is a stand-in until U4 renders the real one.
+    # U3+U4 (tier-2): cratedigger owns the beet runtime AND its config.
+    # The module rendered config.yaml into BEETSDIR during ExecStartPre
+    # (the `systemctl start cratedigger.service` above); cratedigger-beet
+    # resolves it and loads the FULL production plugin set — including a
+    # tokenless discogs (placeholder token = no interactive OAuth, no
+    # network at load).
     machine.succeed("command -v cratedigger-beet")
-    machine.succeed("test -d /var/lib/cratedigger/beets")
-    machine.succeed(
-        "printf 'plugins: musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline\\ndiscogs:\\n  user_token: cratedigger-placeholder-token\\n'"
-        + " > /var/lib/cratedigger/beets/config.yaml"
-    )
+    machine.succeed("test -f /var/lib/cratedigger/beets/config.yaml")
+    mode = machine.succeed("stat -c %a /var/lib/cratedigger/beets/config.yaml").strip()
+    assert mode == "644", f"config.yaml should be 0644, got {mode}"
+    # No token file configured -> no secrets.yaml materialized.
+    machine.fail("test -e /var/lib/cratedigger/beets/secrets.yaml")
+
+    # Semantic assertions on the rendered YAML (duplicate_keys nesting,
+    # plugin list, public-MB defaults, placeholder token).
+    machine.succeed("${pyWithYaml}/bin/python3 ${checkRenderedBeetsConfig}")
+
     version_out = machine.succeed("cratedigger-beet version")
     plugins_line = next(
         line for line in version_out.splitlines() if line.startswith("plugins:")
@@ -221,6 +273,5 @@ pkgs.testers.nixosTest {
         assert plugin in loaded, f"plugin {plugin} not loaded: {version_out}"
     # Tokenless/stranger posture: config loads without crash or prompt.
     machine.succeed("cratedigger-beet config > /dev/null")
-    machine.succeed("rm /var/lib/cratedigger/beets/config.yaml")
   '';
 }

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -214,6 +214,65 @@ class TestOwnedBeetsContract(unittest.TestCase):
         self.assertIn("--replace-fail", beets_nix)
 
 
+class TestRenderedBeetsConfigContract(unittest.TestCase):
+    """The module owns beets config.yaml (tier-2 plan U4, R5).
+
+    Rendered into ``${stateDir}/beets/config.yaml`` by the preStart script
+    (atomic mv, same as config.ini). The data-loss invariant
+    ``import.duplicate_keys.album: [mb_albumid, discogs_albumid]`` is a
+    hard-coded literal — no option may expose it (Palo Santo guard moved to
+    first line of defense). The plugin list is fixed, not operator-blankable
+    (the zero-candidates guard: ``musicbrainz`` must be present).
+    """
+
+    PRODUCTION_PLUGINS = (
+        "musicbrainz discogs fetchart embedart lyrics lastgenre scrub "
+        "info missing duplicates edit fromfilename ftintitle the inline"
+    )
+
+    def test_duplicate_keys_is_a_literal_under_import(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('duplicate_keys = {', text)
+        self.assertIn('album = ["mb_albumid" "discogs_albumid"];', text)
+        self.assertIn('item = ["artist" "title"];', text)
+        # No option surface for it — the literal lives in the render
+        # attrset, not in an mkOption default someone can override.
+        self.assertNotIn("duplicateKeys", text)
+
+    def test_plugin_list_is_fixed_and_contains_musicbrainz(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn(f'plugins = "{self.PRODUCTION_PLUGINS}";', text)
+
+    def test_config_yaml_rendered_atomically_into_beetsdir(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('mktemp "$beets_dir/.config.yaml.XXXXXX"', text)
+        self.assertIn('mv -f "$tmp_yaml" "$beets_dir/config.yaml"', text)
+
+    def test_discogs_token_file_pattern(self) -> None:
+        """Real token via issue #117 *File include; placeholder otherwise."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("discogsTokenFile", text)
+        # secrets.yaml materialized 0400 from the *File — the token itself
+        # never lands in the world-readable config.yaml.
+        self.assertIn('chmod 0400 "$tmp_secrets"', text)
+        self.assertIn('mv -f "$tmp_secrets" "$beets_dir/secrets.yaml"', text)
+        # Fail-loud on unreadable/empty token: a bare assignment trips
+        # set -e on cat failure, and an empty token is rejected (an empty
+        # user_token re-enables the discogs interactive OAuth at load).
+        self.assertIn('discogs_token="$(', text)
+        self.assertIn('if [ -z "$discogs_token" ]; then', text)
+        # Tokenless default: non-empty placeholder suppresses the discogs
+        # plugin's interactive OAuth at load (R7).
+        self.assertIn("cratedigger-placeholder-token", text)
+
+    def test_musicbrainz_defaults_are_public(self) -> None:
+        """Stranger default = public MB (functional-but-slow, R13/U4 leg)."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('default = "musicbrainz.org";', text)
+        # ratelimit 1 for public MB; the mirror override arrives via U6.
+        self.assertIn("ratelimit", text)
+
+
 class TestOwnedRedisContract(unittest.TestCase):
     def test_cratedigger_owns_local_redis_server_by_default(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")


### PR DESCRIPTION
Tier-2 packaging plan U4 (R5, R7).

- preStart renders `${stateDir}/beets/config.yaml` atomically from an attrset mirroring the live production config — **verified byte-identical** against doc2's live HM-rendered config when operator values are substituted (same `pkgs.formats.yaml` generator). The U12 layer-(a) equivalence gate is pre-validated.
- Hard-coded literals (NOT options): `import.duplicate_keys.album: [mb_albumid, discogs_albumid]` (Palo Santo guard, now first-line-of-defense), the 15-plugin production list (incl. `inline`, required by the `short_mbid` path templates — the plan's R4 list omitted it; production reality wins), `paths` templates + `asciify_paths` (2026-05-18 mass-split class).
- Options: `beetsConfig.{directory,library}`, `fetchart.{maxwidth,minwidth}`, `musicbrainz.{host,https,ratelimit}` (public-MB stranger default; U6 threads the mirror). `beetsDirectory` follows `beetsConfig.directory` via mkDefault.
- Discogs token: `beets.discogsTokenFile` (issue #117 `*File`) → 0400 `secrets.yaml` + `include:`; tokenless default renders the R7 placeholder token. Fail-loud on unreadable/empty token (empty `user_token` would silently re-enable the plugin's interactive OAuth — Opus review MEDIUM, fixed with bare-assignment read + emptiness guard + quoted YAML scalar).
- Found en route: `beet` prompts "Create it (Y/n)?" interactively when the library parent dir is missing — blocks any non-interactive shell (this is what hung the first VM run for 30 minutes). VM node now models a stranger with VM-local paths; hazard documented on the option.
- Harness `duplicate_keys` guard error text re-pointed at the module render (defense in depth retained).

Verified: moduleVm green (semantic YAML assertions: duplicate_keys nesting, plugin list, public-MB defaults, placeholder token, no secrets.yaml when tokenless), full suite + pyright clean in pinned shell, doc2 byte-parity diff empty, RED→GREEN on the new module contract tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)