### PR TITLE
feat: U5 — delete every Home-Manager beets coupling (BEETSDIR + config seams)

### DIFF
--- a/harness/beets_harness.py
+++ b/harness/beets_harness.py
@@ -30,13 +30,20 @@ if TYPE_CHECKING:
     from beets.importer.tasks import ImportTask
 
 
-# Append-only JSONL log of every beets album mutation the harness drives.
-# Captures MBID swaps that bypass cratedigger's pipeline DB — e.g. the
-# tagging-workspace fix_reissues/fix_undated scripts that drive this harness
-# with --search-id to intentionally retag existing albums. Without this log,
-# those mutations are invisible to cratedigger's audit trail (see the 04-14
-# Lucksmiths case). Located next to the library so it survives host rebuilds.
-MUTATIONS_LOG_PATH = "/mnt/virtio/Music/.harness-mutations.jsonl"
+def _mutations_log_path() -> str:
+    """Append-only JSONL log of every beets album mutation the harness drives.
+
+    Captures MBID swaps that bypass cratedigger's pipeline DB — e.g. the
+    tagging-workspace fix_reissues/fix_undated scripts that drive this
+    harness with --search-id to intentionally retag existing albums.
+    Without this log, those mutations are invisible to cratedigger's audit
+    trail (see the 04-14 Lucksmiths case). Derived from the configured
+    library path (next to it, so it survives host rebuilds and follows
+    whatever library the module-rendered BEETSDIR config points at —
+    tier-2 plan U5, no hardcoded operator paths).
+    """
+    lib_path = config["library"].as_filename()
+    return os.path.join(os.path.dirname(lib_path), ".harness-mutations.jsonl")
 
 
 # Redirect beets logging to stderr so stdout stays clean for JSON protocol
@@ -211,10 +218,12 @@ def _mbid_swap_event(task, candidate) -> dict | None:
     }
 
 
-def _append_mutation_log(event: dict, log_path: str = MUTATIONS_LOG_PATH) -> None:
+def _append_mutation_log(event: dict, log_path: str | None = None) -> None:
     """Append one JSONL event. Never raises — the audit log must not break
     the import itself. Failures are logged to stderr for operator visibility."""
     try:
+        if log_path is None:
+            log_path = _mutations_log_path()
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(event) + "\n")
     except OSError as e:

--- a/harness/run_beets_harness.sh
+++ b/harness/run_beets_harness.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Wrapper to run beets_harness.py inside the Nix-managed beets Python environment.
+# Runs beets_harness.py on the cratedigger-pinned beets python env.
 #
 # Usage:
 #   ./harness/run_beets_harness.sh /mnt/virtio/Music/AI/SomeArtist/SomeAlbum
@@ -7,41 +7,28 @@
 #
 # The harness communicates over stdin/stdout using newline-delimited JSON.
 # Beets logs go to stderr.
+#
+# The interpreter comes from CRATEDIGGER_BEETS_PYTHON — exported by
+# lib/util.py::beets_subprocess_env() from the runtime config's
+# [Beets] python key (rendered by the NixOS module from the pinned beets
+# env), or by the dev shell's shellHook. The harness resolves its beets
+# config via BEETSDIR (set by the same env helper) — never a per-user
+# ~/.config/beets. The Home-Manager-era wrapper archaeology (grepping the
+# HM beet wrapper's internals for its interpreter and site-packages) is
+# gone (tier-2 plan R6): a missing interpreter is an actionable error,
+# not a silent fallback to whatever profile exists on the host.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HARNESS="$SCRIPT_DIR/beets_harness.py"
 
-# Resolve the beet wrapper to find its Python environment
-BEET_BIN="$(command -v beet 2>/dev/null || echo "/etc/profiles/per-user/abl030/bin/beet")"
-
-if [[ ! -x "$BEET_BIN" ]]; then
-    echo "Error: beet not found at $BEET_BIN" >&2
+if [[ -z "${CRATEDIGGER_BEETS_PYTHON:-}" ]]; then
+    echo "Error: CRATEDIGGER_BEETS_PYTHON is not set. It is exported by" >&2
+    echo "beets_subprocess_env() from [Beets] python in config.ini (the" >&2
+    echo "NixOS module renders it), or by the dev shell. There is no" >&2
+    echo "Home Manager fallback." >&2
     exit 1
 fi
 
-# Follow the wrapper chain to find .beet-wrapped
-BEET_WRAPPED="$(grep -oP '(?<=exec -a "\$0" ")[^"]+' "$BEET_BIN")"
-if [[ -z "$BEET_WRAPPED" ]]; then
-    echo "Error: could not extract .beet-wrapped path from $BEET_BIN" >&2
-    exit 1
-fi
-
-# Get the Python interpreter from .beet-wrapped's shebang
-PYTHON="$(head -1 "$BEET_WRAPPED" | sed 's/^#!//')"
-if [[ ! -x "$PYTHON" ]]; then
-    echo "Error: Python not found at $PYTHON" >&2
-    exit 1
-fi
-
-# Extract the site-packages list from the functools.reduce line in .beet-wrapped
-# and build PYTHONPATH from it
-PYTHONPATH="$(sed -n '3p' "$BEET_WRAPPED" \
-    | grep -oP "'/nix/store/[^']+/site-packages'" \
-    | tr -d "'" \
-    | paste -sd: -)"
-
-export PYTHONPATH
-
-exec "$PYTHON" "$HARNESS" "$@"
+exec "$CRATEDIGGER_BEETS_PYTHON" "$HARNESS" "$@"

--- a/lib/beets_album_op.py
+++ b/lib/beets_album_op.py
@@ -170,7 +170,19 @@ def _run_beet_op(
     # the per-call cost is a dict lookup.
     from lib.util import beet_bin, beets_subprocess_env
 
-    argv: list[str] = [beet_bin(), verb, "-a"]
+    try:
+        # Config-resolution (tier-2 U5): both helpers raise an actionable
+        # RuntimeError when the beets runtime keys are unset. Fold that
+        # into the typed failure so this function's "never raises"
+        # contract holds for callers built around BeetsOpFailure.
+        beet = beet_bin()
+        beets_env = beets_subprocess_env()
+    except RuntimeError as exc:
+        msg = str(exc)
+        log.warning("beets_album_op: beet %s %s %s", verb, selector, msg)
+        return BeetsOpFailure(reason="exception", detail=msg, selector=selector)
+
+    argv: list[str] = [beet, verb, "-a"]
     if verb == "remove" and delete_files:
         argv.append("-d")
     argv.append(selector)
@@ -185,7 +197,7 @@ def _run_beet_op(
         proc = sp.run(
             argv,
             capture_output=True, text=True, errors="replace", timeout=timeout,
-            env=beets_subprocess_env(),
+            env=beets_env,
             input="y\n",
         )
     except sp.TimeoutExpired as exc:

--- a/lib/config.py
+++ b/lib/config.py
@@ -136,6 +136,15 @@ class CratediggerConfig:
     # See docs/solutions/runtime-errors/plex-partial-scan-silent-200.md.
     beets_directory: str = ""
 
+    # Module-rendered beets runtime (tier-2 plan U5, R6). The NixOS module
+    # renders these into config.ini so every beets subprocess resolves the
+    # SAME pinned interpreter/binary and the SAME rendered config dir
+    # (BEETSDIR) — no Home-Manager per-user profile involved anywhere.
+    # Empty string -> unset (dev shells / tests provide env fallbacks).
+    beets_config_dir: str = ""
+    beet_binary: str = ""
+    beets_python: str = ""
+
     # --- Quality Ranks (codec-aware comparison model, issue #60) ---
     quality_ranks: QualityRankConfig = field(default_factory=QualityRankConfig.defaults)
 
@@ -316,6 +325,9 @@ class CratediggerConfig:
             # Top-level `[Beets]` section (separate from `[Beets Validation]`
             # which exists for legacy reasons). Empty string → unset.
             beets_directory=get("Beets", "directory", ""),
+            beets_config_dir=get("Beets", "config_dir", ""),
+            beet_binary=get("Beets", "beet_binary", ""),
+            beets_python=get("Beets", "python", ""),
             # Quality Ranks — codec-aware comparison policy. Missing section
             # yields the default QualityRankConfig (see lib/quality.py).
             quality_ranks=QualityRankConfig.from_ini(config),
@@ -375,7 +387,7 @@ def read_runtime_config(config_path: str | None = None) -> CratediggerConfig:
     is a deployment bug — usually config.ini's mode is too restrictive for
     the calling user. Silently returning empty config previously masked
     issue #117 (force-import via pipeline-cli failed with cryptic
-    "/home/abl030/import_one.py not found" because beets_harness_path was
+    "import_one.py not found" (bad user-home path) because beets_harness_path was
     empty). Surfacing the real cause beats the silent path-resolution
     fallout downstream.
     """

--- a/lib/permissions.py
+++ b/lib/permissions.py
@@ -3,7 +3,8 @@
 Issue #84: beets creates directories via `os.mkdir()` with no explicit mode,
 which means the resulting mode is `0o777 & ~umask`. Even though the systemd
 service runs with `UMask=0000`, something in the subprocess chain
-(import_one.py → run_beets_harness.sh → .beet-wrapped → beets) intermittently
+(import_one.py → run_beets_harness.sh → beets; the HM-era wrapper
+chain at the time) intermittently
 resets the umask, producing `0o755` artist/album directories that block any
 other user (abl030) from running beets commands against the library.
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -55,38 +55,54 @@ def parse_mb_first_release_year(data: dict[str, Any]) -> int | None:
 
 
 def beet_bin() -> str:
-    """Locate the ``beet`` executable, preferring PATH.
+    """Locate the ``beet`` executable.
 
     Single source of truth for "where does ``beet`` live" across every
     subprocess callsite (release_cleanup remove, force-import, diagnostics,
-    etc). Before this helper, ``release_cleanup``
-    used the literal ``"beet"`` and relied on parent PATH resolution
-    while ``harness/import_one.py`` had its own ``shutil.which("beet")
-    or <hardcoded path>`` fallback — Codex (PR #131 round 1 P3) flagged
-    the inconsistency after the pre-flight removal path started
-    routing through ``release_cleanup`` from the harness, where the
-    systemd-narrowed PATH (coreutils/findutils/grep/sed only) does not
-    include ``/etc/profiles/per-user/abl030/bin``.
+    etc). Precedence:
 
-    Resolved at CALL time (not import time) so tests that patch
-    ``shutil.which`` see the patched value.
+      1. ``[Beets] beet_binary`` from the runtime config.ini — rendered by
+         the NixOS module with the pinned env's ``beet`` (nix/beets.nix),
+         so production always runs the beets the test suite verified.
+      2. ``beet`` on PATH (dev shells; the pinned dev shell provides the
+         same derivation).
+
+    There is deliberately NO per-user-profile fallback (tier-2 plan R6):
+    a missing beet is an actionable configuration error, never a silent
+    revert to whatever Home Manager profile happens to exist on the host.
+
+    Resolved at CALL time (not import time) so tests that patch config or
+    ``shutil.which`` see the patched values.
     """
-    return (shutil.which("beet")
-            or "/etc/profiles/per-user/abl030/bin/beet")
+    from lib.config import read_runtime_config
+    configured = read_runtime_config().beet_binary
+    if configured:
+        return configured
+    found = shutil.which("beet")
+    if found:
+        return found
+    raise RuntimeError(
+        "beet binary not found: set [Beets] beet_binary in config.ini "
+        "(services.cratedigger renders it from the pinned beets env) or "
+        "put `beet` on PATH. There is no Home Manager fallback."
+    )
 
 
 def beets_subprocess_env() -> dict[str, str]:
     """Env for subprocesses that invoke beets (directly or via the harness
-    and import_one.py). Single source of truth for the HOME override.
+    and import_one.py). Single source of truth for how a beets subprocess
+    finds its config and interpreter.
 
-    Beets resolves its config from `$HOME/.config/beets/config.yaml`. The
-    cratedigger systemd service runs as root with HOME=/root; the Nix Home
-    Manager beets config (including the Discogs plugin token and the patched
-    base URL for the local Discogs mirror) lives at /home/abl030/.config/.
-    Without the override, the Discogs plugin silently returns 0 candidates
-    for every --search-id <numeric_id> → scenario=mbid_not_found on every
-    Discogs validation. This hit every Blueline Medic - Apology Wars
-    attempt (download_log 3604–3616) post-PR #100.
+    Sets ``BEETSDIR`` (beets' native config-dir override) at the
+    module-rendered config dir from ``[Beets] config_dir`` in the runtime
+    config.ini, and ``CRATEDIGGER_BEETS_PYTHON`` (the pinned interpreter the
+    harness wrapper execs) from ``[Beets] python``. Pre-set environment
+    values act as the dev/test fallback when the runtime config doesn't
+    carry the keys. The Home-Manager-era ``HOME=/home/<user>`` impersonation
+    is gone (tier-2 plan R6): an unset config dir raises an actionable
+    error instead of silently letting beets fall back to the invoking
+    user's ~/.config/beets — the misconfig class behind the 2026-06-29
+    breakage and the Blueline Medic 0-candidates incident.
 
     Every subprocess that runs beets must use this env:
       - lib/beets.py::beets_validate (harness for validation)
@@ -94,10 +110,26 @@ def beets_subprocess_env() -> dict[str, str]:
       - harness/import_one.py (launches the harness + `beet move`)
       - web/routes/pipeline.py (ban-source `beet remove`)
 
-    os.environ is snapshotted at CALL time, not import time, so tests that
-    patch the environment see the patched values.
+    os.environ and the runtime config are read at CALL time, not import
+    time, so tests that patch either see the patched values.
     """
-    return {**os.environ, "HOME": "/home/abl030"}
+    from lib.config import read_runtime_config
+    cfg = read_runtime_config()
+    env = {**os.environ}
+    beetsdir = cfg.beets_config_dir or env.get("BEETSDIR", "")
+    if not beetsdir:
+        raise RuntimeError(
+            "beets config dir is not set: set [Beets] config_dir in "
+            "config.ini (services.cratedigger renders it at "
+            "<stateDir>/beets) or export BEETSDIR. Refusing to launch a "
+            "beets subprocess that would silently fall back to the "
+            "invoking user's ~/.config/beets."
+        )
+    env["BEETSDIR"] = beetsdir
+    beets_python = cfg.beets_python or env.get("CRATEDIGGER_BEETS_PYTHON", "")
+    if beets_python:
+        env["CRATEDIGGER_BEETS_PYTHON"] = beets_python
+    return env
 
 
 # === Filesystem utilities ===

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -219,6 +219,11 @@
 
   webPkg = pkgs.writeShellScriptBin "cratedigger-web" ''
     export PATH="${runtimePath}:$PATH"
+    # cratedigger-web imports beets IN-PROCESS (lib/beets_distance.py);
+    # BEETSDIR points that import at the module-rendered config so
+    # Replace-picker distances use the same match config the importer
+    # sees (previously it silently read the invoking user's defaults).
+    export BEETSDIR="${beetsConfigDir}"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pyRunner} ${src}/web/server.py \
       --port ${toString cfg.web.port} \
@@ -329,6 +334,9 @@
 
     [Beets]
     directory = ${cfg.beetsDirectory}
+    config_dir = ${beetsConfigDir}
+    beet_binary = ${pythonEnv}/bin/beet
+    python = ${pythonEnv}/bin/python
 
     [Beets Validation]
     enabled = ${if cfg.beetsValidation.enable then "True" else "False"}
@@ -1247,14 +1255,12 @@ in {
       wants = redisServiceUnits;
       requires = ["cratedigger-db-migrate.service"];
       restartIfChanged = false;
-      # Deliberately exclude pythonEnv: it ships a `beet` binary (because
-      # the packageSet's beets is in pythonEnv for the dev shell + tests), and putting
-      # it on PATH shadows whatever `beet` the consumer has provisioned for
-      # the harness wrapper to find. The python interpreter is invoked via
-      # absolute path inside cratediggerPkg / pipelineCli, so it doesn't need
-      # to be on PATH. The harness wrapper at harness/run_beets_harness.sh
-      # uses `command -v beet` to find a beets installation that already
-      # has the consumer's plugins/config (e.g. home-manager).
+      # Deliberately exclude pythonEnv from PATH: the python interpreter is
+      # invoked via absolute path inside the wrappers, and every beets
+      # consumer resolves the pinned interpreter/binary from the rendered
+      # [Beets] config keys (config_dir / beet_binary / python) rather than
+      # PATH lookup — keeping PATH lean avoids ever re-introducing an
+      # ambient-beet dependency (tier-2 plan R6).
       path = [pkgs.bash pkgs.coreutils pkgs.gnugrep pkgs.gnused pkgs.curl pkgs.jq pkgs.ffmpeg pkgs.mp3val pkgs.flac pkgs.sox];
       serviceConfig = {
         Type = "oneshot";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -65,5 +65,12 @@ pkgs.mkShell {
     # the next shell entry. Same pattern as .pyright-venv.
     nix-store --realise ${pkgs.path} --indirect --add-root "$PWD/.nixpkgs-src" >/dev/null 2>&1 \
       || ln -sfn ${pkgs.path} "$PWD/.nixpkgs-src"
+
+    # The harness wrapper (harness/run_beets_harness.sh) execs this
+    # interpreter. In production the NixOS module renders [Beets] python
+    # into config.ini and beets_subprocess_env() exports it; in the dev
+    # shell the test env's python IS the pinned beets env, so export it
+    # directly. No Home Manager fallback exists (tier-2 plan R6).
+    export CRATEDIGGER_BEETS_PYTHON="${testPythonEnv}/bin/python3"
   '';
 }

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -174,6 +174,11 @@ pkgs.testers.nixosTest {
     assert mode == "644", f"config.ini should be 0644, got {mode}"
     machine.succeed("grep -q 'enabled = False' /var/lib/cratedigger/config.ini")  # beets disabled
     machine.succeed("grep -q '\\[Quality Ranks\\]' /var/lib/cratedigger/config.ini")
+    # U5 (tier-2): the module renders the beets runtime keys so every
+    # beets subprocess resolves the pinned interpreter + rendered config.
+    machine.succeed("grep -q 'config_dir = /var/lib/cratedigger/beets' /var/lib/cratedigger/config.ini")
+    machine.succeed("grep -q 'beet_binary = /nix/store/' /var/lib/cratedigger/config.ini")
+    machine.succeed("grep -q 'python = /nix/store/' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q '\\[Peer Cache\\]' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q 'redis_host = 127.0.0.1' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q 'ttl_seconds = 604800' /var/lib/cratedigger/config.ini")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,24 @@
+"""Test-suite environment defaults.
+
+``beets_subprocess_env()`` (tier-2 plan U5, R6) refuses to build a beets
+subprocess env without a config dir — production renders [Beets]
+config_dir; dev/test provides BEETSDIR. Tests mock the subprocess leaf
+(sp.run/sp.Popen) but the env helper runs for real before it, so give the
+whole suite a deterministic BEETSDIR default here. Tests that assert the
+unset-raises contract clear it explicitly (patch.dict(clear=True)).
+
+setdefault: a caller-provided BEETSDIR (or a runtime config, which takes
+precedence anyway) is never overridden.
+"""
+
+import os
+import tempfile
+
+# A real (creatable) dir: beets' config.read() makedirs(BEETSDIR) at import
+# in the in-process consumers (lib/beets_distance.py slices), so a
+# nonexistent root path would PermissionError. Fixed path (not mkdtemp) so
+# repeated suite runs reuse one dir instead of accreting temp dirs.
+if "BEETSDIR" not in os.environ:
+    _beetsdir = os.path.join(tempfile.gettempdir(), "cratedigger-test-beetsdir")
+    os.makedirs(_beetsdir, exist_ok=True)
+    os.environ["BEETSDIR"] = _beetsdir

--- a/tests/test_beets_distance.py
+++ b/tests/test_beets_distance.py
@@ -603,7 +603,12 @@ class TestComputeBeetsDistanceWithItemsOverride(unittest.TestCase):
         self.assertLess(r.distance, 0.5)
         self.assertIsNotNone(r.components)
         assert r.components is not None
-        self.assertGreater(len(r.components), 0)
+        # components may be EMPTY here: with stock beets defaults a perfect
+        # synthetic match accrues no penalties. The old assertGreater(len)
+        # only held because the test process inherited the operator's
+        # ~/.config/beets (match.preferred penalties) before tier-2 U5
+        # pinned BEETSDIR — the per-component contract lives in
+        # test_per_component_breakdown_penalises_wrong_title.
         # Override path means no download_log was consulted.
         self.assertIsNone(r.download_log_id)
         self.assertIsNone(r.request_id)

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -1006,7 +1006,12 @@ class TestDispatchFromDbRuntimeConfigSeam(unittest.TestCase):
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
 
-        mock_read.assert_called_once_with()
+        # Dispatch consumes the shared reader (not a bespoke parser). Since
+        # tier-2 U5, beets_subprocess_env() also reads the runtime config
+        # (BEETSDIR / [Beets] keys), so "called at least once, always
+        # zero-arg" is the seam contract — not exactly-once.
+        self.assertGreaterEqual(mock_read.call_count, 1)
+        mock_read.assert_called_with()
 
 
 class TestDispatchFromDbPrecondition(unittest.TestCase):

--- a/tests/test_hm_coupling_guard.py
+++ b/tests/test_hm_coupling_guard.py
@@ -1,0 +1,53 @@
+"""R6 made mechanical: no Home-Manager coupling anywhere in the codebase.
+
+Tier-2 plan U5 deleted every HM seam — the ``HOME=/home/<user>``
+impersonation in ``beets_subprocess_env``, the
+``/etc/profiles/per-user/.../bin/beet`` fallbacks, and the harness's
+``.beet-wrapped`` scraping. "Deleted, not supplemented" only stays true if
+nothing can quietly reintroduce a per-user-profile path, so this guard
+asserts absence across every python/shell source in lib/, harness/,
+scripts/ and web/. Docs and plan files are exempt (history is allowed to
+name the old paths); code is not.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+FORBIDDEN = (
+    "/home/abl030",
+    "/etc/profiles/per-user",
+    ".beet-wrapped",
+)
+
+SOURCE_DIRS = ("lib", "harness", "scripts", "web")
+SOURCE_SUFFIXES = {".py", ".sh"}
+
+
+class TestNoHomeManagerCoupling(unittest.TestCase):
+    def test_no_hm_paths_in_source(self) -> None:
+        offenders: list[str] = []
+        for dirname in SOURCE_DIRS:
+            for path in sorted((REPO_ROOT / dirname).rglob("*")):
+                if path.suffix not in SOURCE_SUFFIXES or not path.is_file():
+                    continue
+                text = path.read_text(encoding="utf-8", errors="replace")
+                for lineno, line in enumerate(text.splitlines(), start=1):
+                    for pattern in FORBIDDEN:
+                        if pattern in line:
+                            offenders.append(
+                                f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}"
+                            )
+        self.assertEqual(
+            offenders, [],
+            "Home-Manager coupling reintroduced (tier-2 plan R6 forbids "
+            "per-user-profile paths in code — beets is module-owned via "
+            "BEETSDIR + [Beets] config keys):\n" + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -265,6 +265,22 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
         # plugin's interactive OAuth at load (R7).
         self.assertIn("cratedigger-placeholder-token", text)
 
+    def test_beets_runtime_keys_rendered_into_config_ini(self) -> None:
+        """[Beets] config_dir / beet_binary / python — the U5 seam values
+        every beets subprocess resolves (BEETSDIR + pinned interpreter)."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("config_dir = ${beetsConfigDir}", text)
+        self.assertIn("beet_binary = ${pythonEnv}/bin/beet", text)
+        self.assertIn("python = ${pythonEnv}/bin/python", text)
+
+    def test_web_wrapper_exports_beetsdir(self) -> None:
+        """cratedigger-web imports beets in-process (beets_distance) —
+        BEETSDIR must point it at the module-rendered config."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        web_start = text.index('writeShellScriptBin "cratedigger-web"')
+        web_block = text[web_start:web_start + 1200]
+        self.assertIn('export BEETSDIR="${beetsConfigDir}"', web_block)
+
     def test_musicbrainz_defaults_are_public(self) -> None:
         """Stranger default = public MB (functional-but-slow, R13/U4 leg)."""
         text = MODULE_NIX.read_text(encoding="utf-8")

--- a/tests/test_run_beets_harness_script.py
+++ b/tests/test_run_beets_harness_script.py
@@ -1,0 +1,100 @@
+"""Contract tests for harness/run_beets_harness.sh (tier-2 plan U5).
+
+The wrapper is a two-liner now: exec ``$CRATEDIGGER_BEETS_PYTHON`` on
+beets_harness.py. These tests pin the production launch shape — the
+interpreter comes from the env (exported by ``beets_subprocess_env()``
+from the module-rendered config), the harness resolves its beets config
+via BEETSDIR, and a missing interpreter is an actionable error rather
+than a silent fallback to a Home Manager profile.
+
+The BEETSDIR test runs the REAL harness on the REAL beets (dev-shell
+python) — it proves the whole chain production uses: wrapper → pinned
+interpreter → beets config.read() honouring BEETSDIR → the Palo Santo
+duplicate_keys guard evaluating the module-rendered config shape.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "harness" / "run_beets_harness.sh"
+
+
+class TestRunBeetsHarnessScript(unittest.TestCase):
+    def test_missing_interpreter_is_actionable_error(self) -> None:
+        env = {k: v for k, v in os.environ.items()
+               if k != "CRATEDIGGER_BEETS_PYTHON"}
+        proc = subprocess.run(
+            [str(SCRIPT), "--help"],
+            env=env, capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        self.assertIn("CRATEDIGGER_BEETS_PYTHON", proc.stderr)
+        self.assertIn("config.ini", proc.stderr)
+
+    def test_execs_the_given_interpreter(self) -> None:
+        """The wrapper adds nothing but the exec — argv reaches the harness
+        unchanged on the interpreter we point it at."""
+        proc = subprocess.run(
+            [str(SCRIPT), "--help"],
+            env={**os.environ, "CRATEDIGGER_BEETS_PYTHON": sys.executable},
+            capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--search-id", proc.stdout)
+
+    def test_harness_reads_beets_config_from_BEETSDIR(self) -> None:
+        """Launch exactly as production does (wrapper + env) against a
+        BEETSDIR whose config VIOLATES the duplicate_keys invariant: the
+        harness must read THAT config (not ~/.config/beets) and die with
+        the Palo Santo guard's message."""
+        with tempfile.TemporaryDirectory() as beetsdir:
+            with open(os.path.join(beetsdir, "config.yaml"), "w",
+                      encoding="utf-8") as f:
+                f.write("library: {}/lib.db\n".format(beetsdir))
+            proc = subprocess.run(
+                [str(SCRIPT), "--pretend", beetsdir],
+                env={**os.environ,
+                     "CRATEDIGGER_BEETS_PYTHON": sys.executable,
+                     "BEETSDIR": beetsdir},
+                capture_output=True, text=True, input="",
+            )
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        self.assertIn("duplicate_keys.album must be exactly", proc.stderr)
+
+    def test_harness_accepts_module_shaped_config(self) -> None:
+        """Same launch, but the BEETSDIR carries the module-rendered
+        duplicate_keys shape — the guard passes and the harness proceeds
+        past config validation (empty dir -> clean run, no albums)."""
+        with tempfile.TemporaryDirectory() as beetsdir, \
+                tempfile.TemporaryDirectory() as emptydir:
+            with open(os.path.join(beetsdir, "config.yaml"), "w",
+                      encoding="utf-8") as f:
+                f.write(
+                    "library: {}/lib.db\n"
+                    "directory: {}/music\n"
+                    "import:\n"
+                    "  duplicate_keys:\n"
+                    "    album: [mb_albumid, discogs_albumid]\n"
+                    "    item: [artist, title]\n".format(beetsdir, beetsdir)
+                )
+            proc = subprocess.run(
+                [str(SCRIPT), "--pretend", emptydir],
+                env={**os.environ,
+                     "CRATEDIGGER_BEETS_PYTHON": sys.executable,
+                     "BEETSDIR": beetsdir},
+                capture_output=True, text=True, input="",
+                timeout=120,
+            )
+        self.assertNotIn("duplicate_keys.album must be exactly", proc.stderr)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1098,44 +1098,131 @@ class TestPlexAddedAtPinClient(unittest.TestCase):
 class TestBeetsSubprocessEnv(unittest.TestCase):
     """beets_subprocess_env() is the single source of truth for the env dict
     used by every subprocess that invokes beets (directly or via the harness
-    / import_one.py). Beets reads `~/.config/beets/config.yaml`; when cratedigger
-    runs as the systemd service (root, HOME=/root), the Nix Home Manager
-    beets config isn't there and the Discogs plugin returns 0 candidates for
-    every --search-id. See live failures in download_log for Blueline Medic.
+    / import_one.py). It resolves BEETSDIR (beets' config-dir override) from
+    the runtime config's [Beets] config_dir — the module-rendered config —
+    with a pre-set env BEETSDIR as the dev/test fallback. The Home-Manager
+    HOME impersonation is gone (tier-2 plan R6): unset config dir raises an
+    actionable error instead of silently reading ~/.config/beets.
     """
 
-    def test_helper_exists_and_returns_dict(self) -> None:
-        from lib.util import beets_subprocess_env
-        env = beets_subprocess_env()
-        self.assertIsInstance(env, dict)
+    def _with_runtime_config(self, ini_text: str):
+        """Context: a temp runtime config.ini as the active config."""
+        import contextlib
+        import tempfile
 
-    def test_home_overridden_to_home_manager_profile(self) -> None:
-        """HOME must point to the user profile where beets config lives,
-        regardless of what HOME is in the caller's environment."""
+        @contextlib.contextmanager
+        def cm():
+            with tempfile.TemporaryDirectory() as d:
+                path = os.path.join(d, "config.ini")
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(ini_text)
+                with patch.dict(os.environ,
+                                {"CRATEDIGGER_RUNTIME_CONFIG": path},
+                                clear=False):
+                    yield
+        return cm()
+
+    def test_beetsdir_comes_from_runtime_config(self) -> None:
         from lib.util import beets_subprocess_env
-        with patch.dict(os.environ, {"HOME": "/root"}, clear=False):
+        with self._with_runtime_config(
+            "[Beets]\nconfig_dir = /var/lib/cratedigger/beets\n"
+        ):
             env = beets_subprocess_env()
-        self.assertEqual(env["HOME"], "/home/abl030")
+        self.assertEqual(env["BEETSDIR"], "/var/lib/cratedigger/beets")
+
+    def test_config_wins_over_preset_env(self) -> None:
+        from lib.util import beets_subprocess_env
+        with self._with_runtime_config(
+            "[Beets]\nconfig_dir = /from/config\n"
+        ), patch.dict(os.environ, {"BEETSDIR": "/from/env"}, clear=False):
+            env = beets_subprocess_env()
+        self.assertEqual(env["BEETSDIR"], "/from/config")
+
+    def test_env_beetsdir_is_the_dev_fallback(self) -> None:
+        from lib.util import beets_subprocess_env
+        with self._with_runtime_config("[Slskd]\nhost_url = http://x\n"), \
+                patch.dict(os.environ, {"BEETSDIR": "/from/env"}, clear=False):
+            env = beets_subprocess_env()
+        self.assertEqual(env["BEETSDIR"], "/from/env")
+
+    def test_unset_config_dir_raises_actionable_error(self) -> None:
+        """No silent fallback to the invoking user's ~/.config/beets."""
+        from lib.util import beets_subprocess_env
+        with self._with_runtime_config("[Slskd]\nhost_url = http://x\n"):
+            no_beetsdir = {k: v for k, v in os.environ.items()
+                           if k != "BEETSDIR"}
+            with patch.dict(os.environ, no_beetsdir, clear=True):
+                with self.assertRaises(RuntimeError) as ctx:
+                    beets_subprocess_env()
+        self.assertIn("[Beets] config_dir", str(ctx.exception))
+
+    def test_no_home_override_remains(self) -> None:
+        """The HOME=/home/<user> impersonation is deleted, not supplemented."""
+        from lib.util import beets_subprocess_env
+        with self._with_runtime_config(
+            "[Beets]\nconfig_dir = /cfg\n"
+        ), patch.dict(os.environ, {"HOME": "/root"}, clear=False):
+            env = beets_subprocess_env()
+        self.assertEqual(env["HOME"], "/root")
+
+    def test_beets_python_exported_from_config(self) -> None:
+        from lib.util import beets_subprocess_env
+        with self._with_runtime_config(
+            "[Beets]\nconfig_dir = /cfg\npython = /nix/store/x/bin/python\n"
+        ):
+            env = beets_subprocess_env()
+        self.assertEqual(env["CRATEDIGGER_BEETS_PYTHON"], "/nix/store/x/bin/python")
 
     def test_inherits_other_env_vars(self) -> None:
-        """Non-HOME vars pass through unchanged — PATH, PYTHONPATH etc. must
-        still reach the subprocess."""
         from lib.util import beets_subprocess_env
         sentinel = "CRATEDIGGER_TEST_SENTINEL_VAR_XYZ"
-        with patch.dict(os.environ, {sentinel: "present"}, clear=False):
+        with self._with_runtime_config(
+            "[Beets]\nconfig_dir = /cfg\n"
+        ), patch.dict(os.environ, {sentinel: "present"}, clear=False):
             env = beets_subprocess_env()
         self.assertEqual(env.get(sentinel), "present")
 
-    def test_picks_up_environ_at_call_time(self) -> None:
-        """Not a frozen module-level snapshot — os.environ is read fresh
-        each call so test-time patching works and any late-set var shows up."""
-        from lib.util import beets_subprocess_env
-        with patch.dict(os.environ, {"LATE_BOUND_VAR": "first"}, clear=False):
-            env1 = beets_subprocess_env()
-        with patch.dict(os.environ, {"LATE_BOUND_VAR": "second"}, clear=False):
-            env2 = beets_subprocess_env()
-        self.assertEqual(env1["LATE_BOUND_VAR"], "first")
-        self.assertEqual(env2["LATE_BOUND_VAR"], "second")
+
+class TestBeetBin(unittest.TestCase):
+    """beet_bin(): configured [Beets] beet_binary wins; PATH is the dev
+    fallback; there is NO per-user-profile fallback (tier-2 plan R6)."""
+
+    def _with_runtime_config(self, ini_text: str):
+        import contextlib
+        import tempfile
+
+        @contextlib.contextmanager
+        def cm():
+            with tempfile.TemporaryDirectory() as d:
+                path = os.path.join(d, "config.ini")
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(ini_text)
+                with patch.dict(os.environ,
+                                {"CRATEDIGGER_RUNTIME_CONFIG": path},
+                                clear=False):
+                    yield
+        return cm()
+
+    def test_configured_binary_wins(self) -> None:
+        from lib.util import beet_bin
+        with self._with_runtime_config(
+            "[Beets]\nbeet_binary = /nix/store/x/bin/beet\n"
+        ), patch("shutil.which", return_value="/usr/bin/beet"):
+            self.assertEqual(beet_bin(), "/nix/store/x/bin/beet")
+
+    def test_path_fallback(self) -> None:
+        from lib.util import beet_bin
+        with self._with_runtime_config("[Slskd]\nhost_url = http://x\n"), \
+                patch("shutil.which", return_value="/dev-shell/bin/beet"):
+            self.assertEqual(beet_bin(), "/dev-shell/bin/beet")
+
+    def test_missing_everywhere_raises_actionable_error(self) -> None:
+        from lib.util import beet_bin
+        with self._with_runtime_config("[Slskd]\nhost_url = http://x\n"), \
+                patch("shutil.which", return_value=None):
+            with self.assertRaises(RuntimeError) as ctx:
+                beet_bin()
+        self.assertIn("beet_binary", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tier-2 packaging plan U5 (R6): every HM coupling deleted, not supplemented.

- `beets_subprocess_env()`: `BEETSDIR` from `[Beets] config_dir` (module-rendered; env fallback for dev/test), `CRATEDIGGER_BEETS_PYTHON` from `[Beets] python`. The `HOME=/home/abl030` impersonation is gone; unset config dir raises an actionable error instead of silently reading `~/.config/beets`.
- `beet_bin()`: `[Beets] beet_binary` (pinned beet) > PATH > actionable error. `/etc/profiles/per-user` fallback gone.
- `harness/run_beets_harness.sh`: `exec $CRATEDIGGER_BEETS_PYTHON beets_harness.py` — all `.beet-wrapped` scraping gone.
- Mutations log derived from the configured beets library path (was a hardcoded `/mnt/virtio` literal).
- Module renders the three `[Beets]` keys; `cratedigger-web` exports `BEETSDIR` (in-process `beets_distance` now reads the rendered match config — Replace-picker distances flagged for the U12 sanity check).
- Grep-guard test forbids `/home/abl030`, `/etc/profiles/per-user`, `.beet-wrapped` in lib/ harness/ scripts/ web/ (caught two stale docstrings on first run). Script-contract tests run the REAL harness against BEETSDIR configs — the Palo Santo guard fires against a violating config; the module shape passes.
- Suite-wide `BEETSDIR` test default in `tests/__init__.py` (beets `config.read()` makedirs it). Two tests updated — one only ever passed because the test process inherited the operator's `~/.config/beets`, exactly the skew this unit kills.

Opus review: no correctness gaps in the production chains (all four traced: poll-cycle validate, importer→import_one→harness, web ban-source, operator CLI force-import); LOW findings fixed (stale HM comment in module.nix, `beets_album_op` never-raises contract folds resolution errors into `BeetsOpFailure`, fixed-path test BEETSDIR).

Verified: full suite 4622 green + pyright clean in pinned shell, moduleVm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)