### PR TITLE
feat: U6 — MB + Discogs API bases become configuration

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -23,7 +23,9 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `beets.discogsTokenFile` | `null` | `*File` secret (issue #117): materialized into `${stateDir}/beets/secrets.yaml` (0400) + `include:` in the rendered config. Null = placeholder token (plugins load cleanly; public-Discogs lookups are token-required). |
 | `beetsConfig.{directory,library}` | production values | Rendered into the module-owned `config.yaml`. `beetsDirectory` (config.ini) follows `beetsConfig.directory` by default. |
 | `beetsConfig.fetchart.{maxwidth,minwidth}` | `500` / `300` | Load-bearing: library size (embedded art × every track) and the Meelo black-box floor. |
-| `beetsConfig.musicbrainz.{host,https,ratelimit}` | `musicbrainz.org` / `true` / `1` | Public-MB stranger default (functional but slow); the operator points these at the local mirror. |
+| `beetsConfig.musicbrainz.{host,https,ratelimit}` | derived from `musicbrainz.apiBase` | mkDefault-derived (mirror ⇒ host:port/http/ratelimit 100; public ⇒ musicbrainz.org/https/1); override to pin explicitly. |
+| `musicbrainz.apiBase` | `https://musicbrainz.org` | ONE MB origin for web/mb.py (`--mb-api`), pipeline-cli lookups, and the rendered beets musicbrainz block (KTD6). Public default is functional but ~1 req/s. |
+| `discogs.apiBase` | `null` | Discogs mirror origin. Mirror-REQUIRED: unset ⇒ Discogs browse off with a 503 mirror-required message (public api.discogs.com does not serve this API shape). |
 | `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,28 @@
           assert (overridden.cratediggerEscapeHatchMarker or "") == "consumer-pkgs";
           pkgs.runCommand "cratedigger-packageset-pin-ok" { } "touch $out";
 
+        # KTD6 derivation, asserted on rendered VALUES (not source text):
+        # the beets musicbrainz block flips host/https/ratelimit for a
+        # mirror origin vs the public default. Eval-only.
+        apiBaseDerivation = let
+          evalMb = apiBase: (nixpkgs.lib.nixosSystem {
+            modules = [ self.nixosModules.default {
+              nixpkgs.pkgs = import nixpkgs { inherit system; };
+              services.cratedigger.enable = true;
+              services.cratedigger.musicbrainz.apiBase = apiBase;
+            } ];
+          }).config.services.cratedigger.beetsConfig.musicbrainz;
+          mirror = evalMb "http://192.168.1.35:5200";
+          public = evalMb "https://musicbrainz.org";
+        in
+          assert mirror.host == "192.168.1.35:5200";
+          assert mirror.https == false;
+          assert mirror.ratelimit == 100;
+          assert public.host == "musicbrainz.org";
+          assert public.https == true;
+          assert public.ratelimit == 1;
+          pkgs.runCommand "cratedigger-api-base-derivation-ok" { } "touch $out";
+
         # nix/beets.nix mirror knobs: with the knobs set, the built plugin
         # files carry the mirror URLs; with them unset, stock upstream URLs.
         # `--replace-fail` inside beets.nix is the primary drift alarm (the

--- a/lib/config.py
+++ b/lib/config.py
@@ -145,6 +145,14 @@ class CratediggerConfig:
     beet_binary: str = ""
     beets_python: str = ""
 
+    # One MB value, three consumers (tier-2 plan U6 / KTD6): web/mb.py,
+    # pipeline-cli lookups, and the rendered beets musicbrainz.* block all
+    # derive from this origin (scheme://host[:port], no path). Public MB
+    # default = functional-but-slow stranger posture.
+    musicbrainz_api_base: str = "https://musicbrainz.org"
+    # Discogs is mirror-REQUIRED (R13): empty = Discogs browse off.
+    discogs_api_base: str = ""
+
     # --- Quality Ranks (codec-aware comparison model, issue #60) ---
     quality_ranks: QualityRankConfig = field(default_factory=QualityRankConfig.defaults)
 
@@ -328,6 +336,8 @@ class CratediggerConfig:
             beets_config_dir=get("Beets", "config_dir", ""),
             beet_binary=get("Beets", "beet_binary", ""),
             beets_python=get("Beets", "python", ""),
+            musicbrainz_api_base=get("MusicBrainz", "api_base", "https://musicbrainz.org"),
+            discogs_api_base=get("Discogs", "api_base", ""),
             # Quality Ranks — codec-aware comparison policy. Missing section
             # yields the default QualityRankConfig (see lib/quality.py).
             quality_ranks=QualityRankConfig.from_ini(config),

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -230,7 +230,9 @@
       --dsn "${cfg.pipelineDb.dsn}" \
       --beets-db "${cfg.web.beetsDb}" \
       --redis-host "${cfg.web.redis.host}" \
-      --redis-port ${toString cfg.web.redis.port} "$@"
+      --redis-port ${toString cfg.web.redis.port} \
+      --mb-api "${cfg.musicbrainz.apiBase}/ws/2" \
+      ${optionalString (cfg.discogs.apiBase != null) ''--discogs-api "${cfg.discogs.apiBase}" ''}"$@"
   '';
 
   # YouTube-rescue ingest drainer — see scripts/youtube_ingest_worker.py.
@@ -345,6 +347,12 @@
     staging_dir = ${cfg.beetsValidation.stagingDir}
     tracking_file = ${cfg.beetsValidation.trackingFile}
     verified_lossless_target = ${cfg.beetsValidation.verifiedLosslessTarget}
+
+    [MusicBrainz]
+    api_base = ${cfg.musicbrainz.apiBase}
+
+    [Discogs]
+    api_base = ${if cfg.discogs.apiBase != null then cfg.discogs.apiBase else ""}
 
     ${qualityRanksSection}
     [Pipeline DB]
@@ -770,6 +778,39 @@ in {
           interactive OAuth flow — public-Discogs lookups then fail
           per-use until a real token is provided (documented
           token-required).
+        '';
+      };
+    };
+
+    musicbrainz = {
+      apiBase = mkOption {
+        type = types.str;
+        default = "https://musicbrainz.org";
+        example = "http://192.168.1.35:5200";
+        description = ''
+          MusicBrainz API origin (scheme://host[:port], no path) — ONE value
+          threaded to all three consumers (tier-2 plan U6/KTD6): web/mb.py
+          (via cratedigger-web --mb-api), pipeline-cli release lookups, and
+          the rendered beets musicbrainz.{host,https,ratelimit}. Public MB
+          default is functional but rate-limited (~1 req/s); point at a
+          local mirror for production-speed matching.
+        '';
+      };
+    };
+
+    discogs = {
+      apiBase = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "https://discogs.ablz.au";
+        description = ''
+          Discogs mirror origin. Mirror-REQUIRED (R13): web/discogs.py
+          speaks the Rust mirror's endpoint shape, which public
+          api.discogs.com does not serve — there is no public fallback.
+          Null = Discogs browse off (clear 503 mirror-required message);
+          MusicBrainz browse is unaffected. The beets discogs plugin's own
+          public-Discogs path (used by imports) is separate — see
+          beets.discogsMirrorUrl for its mirror knob.
         '';
       };
     };
@@ -1221,6 +1262,20 @@ in {
     # One concept, one value: the config.ini [Beets] directory follows the
     # rendered beets config.yaml `directory:` unless explicitly overridden.
     services.cratedigger.beetsDirectory = lib.mkDefault cfg.beetsConfig.directory;
+
+    # One MB value, three consumers (U6/KTD6): the rendered beets
+    # musicbrainz block derives from musicbrainz.apiBase — mirror =>
+    # host:port / plain http / ratelimit 100 (the harness --upstream
+    # block's inverse); public => musicbrainz.org / https / ratelimit 1.
+    # mkDefault so an operator can still pin the beets block explicitly.
+    services.cratedigger.beetsConfig.musicbrainz = let
+      mbHost = lib.removePrefix "https://" (lib.removePrefix "http://" cfg.musicbrainz.apiBase);
+      mbPublic = mbHost == "musicbrainz.org";
+    in {
+      host = lib.mkDefault mbHost;
+      https = lib.mkDefault (lib.hasPrefix "https://" cfg.musicbrainz.apiBase);
+      ratelimit = lib.mkDefault (if mbPublic then 1 else 100);
+    };
 
     services.redis.servers.cratedigger = {
       enable = cfg.redis.enable;

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -179,6 +179,8 @@ pkgs.testers.nixosTest {
     machine.succeed("grep -q 'config_dir = /var/lib/cratedigger/beets' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q 'beet_binary = /nix/store/' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q 'python = /nix/store/' /var/lib/cratedigger/config.ini")
+    # U6 (tier-2): one MB value, rendered for the python consumers too.
+    machine.succeed("grep -q 'api_base = https://musicbrainz.org' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q '\\[Peer Cache\\]' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q 'redis_host = 127.0.0.1' /var/lib/cratedigger/config.ini")
     machine.succeed("grep -q 'ttl_seconds = 604800' /var/lib/cratedigger/config.ini")

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -86,7 +86,16 @@ from lib.youtube_ingest_service import (
     default_youtube_ingest_service_factory,
 )
 
-MB_API = "http://192.168.1.35:5200/ws/2"
+def _mb_api() -> str:
+    """MusicBrainz WS/2 base — one config value, three consumers (KTD6).
+
+    Reads [MusicBrainz] api_base from the runtime config (rendered by the
+    NixOS module; public musicbrainz.org default) instead of a second
+    hardcoded mirror URL drifting from web/mb.py's.
+    """
+    from lib.config import read_runtime_config
+    from web.api_bases import mb_ws2_base
+    return mb_ws2_base(read_runtime_config().musicbrainz_api_base)
 SPECTRAL_GRADE_CHOICES = ("genuine", "marginal", "suspect", "likely_transcode")
 
 
@@ -154,7 +163,7 @@ def fetch_mb_release(mb_release_id):
     even though MB has the data.
     """
     url = (
-        f"{MB_API}/release/{mb_release_id}"
+        f"{_mb_api()}/release/{mb_release_id}"
         f"?inc=recordings+artist-credits+media+release-groups+labels&fmt=json"
     )
     req = urllib.request.Request(url)
@@ -3714,6 +3723,13 @@ def cmd_routes(db, args) -> int:
 
 
 def main():
+    # Mirror origins for every web.mb / web.discogs consumer in this
+    # process (add --discogs, youtube-album, distance, Replace, field
+    # resolution). Without this, the CLI silently runs against public MB
+    # and an unset Discogs base (tier-2 U6 wiring).
+    from web.api_bases import configure_api_bases_from_runtime_config
+    configure_api_bases_from_runtime_config()
+
     parser, p_sp, p_triage_op = _build_parser()
     args = parser.parse_args()
     if not args.command:

--- a/scripts/youtube_ingest_worker.py
+++ b/scripts/youtube_ingest_worker.py
@@ -616,6 +616,12 @@ def run_loop(
 
 
 def main(argv: Iterable[str] | None = None) -> int:
+    # This worker's track-count gate resolves releases via web.mb (and
+    # Discogs-sourced requests via web.discogs) — wire the mirror origins
+    # from the runtime config like every headless consumer (tier-2 U6).
+    from web.api_bases import configure_api_bases_from_runtime_config
+    configure_api_bases_from_runtime_config()
+
     parser = argparse.ArgumentParser(
         description="Drain the YouTube-rescue ingest queue",
     )

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -11,6 +11,21 @@ import msgspec
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import web.discogs
+
+
+def setUpModule() -> None:
+    # These tests exercise the REAL web/discogs.py with urlopen patched.
+    # Since tier-2 U6 the module ships with NO default base (Discogs is
+    # mirror-required, R13) — give the suite a synthetic mirror origin so
+    # URL construction proceeds; assertions check paths, not the origin.
+    web.discogs.DISCOGS_API_BASE = "https://discogs-mirror.test"
+
+
+def tearDownModule() -> None:
+    web.discogs.DISCOGS_API_BASE = None
+
+
 from web.discogs import (
     _parse_duration,
     _parse_position,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9044,6 +9044,14 @@ class TestFieldResolverSlice(unittest.TestCase):
             resolve_release_group_year,
         )
         from tests.fakes import FakePipelineDB
+        import web.discogs
+
+        # Mirror-required since tier-2 U6; urlopen is patched below, so a
+        # synthetic origin suffices for the real-client round trip.
+        base_p = patch.object(web.discogs, "DISCOGS_API_BASE",
+                              "https://discogs-mirror.test")
+        base_p.start()
+        self.addCleanup(base_p.stop)
 
         # Captured shape from the Discogs mirror's
         # /api/masters/<id> endpoint.

--- a/tests/test_mirror_contracts.py
+++ b/tests/test_mirror_contracts.py
@@ -100,6 +100,13 @@ class _MirrorContractCase(unittest.TestCase):
         set_p.start()
         self.addCleanup(get_p.stop)
         self.addCleanup(set_p.stop)
+        # Discogs is mirror-required since tier-2 U6 (no default base).
+        # These contract tests patch urlopen — only the exception contract
+        # is under test, so any synthetic origin works.
+        base_p = patch.object(discogs, "DISCOGS_API_BASE",
+                              "https://discogs-mirror.test")
+        base_p.start()
+        self.addCleanup(base_p.stop)
 
 
 class TestMBAdapterContract(_MirrorContractCase):

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -289,6 +289,35 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
         self.assertIn("ratelimit", text)
 
 
+class TestApiBaseThreading(unittest.TestCase):
+    """One MB value, three consumers (tier-2 plan U6 / KTD6); Discogs is
+    mirror-required with no public default (R13)."""
+
+    def test_config_ini_renders_api_bases(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("[MusicBrainz]", text)
+        self.assertIn("api_base = ${cfg.musicbrainz.apiBase}", text)
+        self.assertIn("[Discogs]", text)
+
+    def test_mb_default_is_public_and_discogs_has_none(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('default = "https://musicbrainz.org";', text)
+        # discogs.apiBase: nullOr with null default — mirror-required.
+        idx = text.index("discogs = {")
+        self.assertIn("default = null;", text[idx:idx + 800])
+
+    def test_web_wrapper_passes_both_bases(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('--mb-api "${cfg.musicbrainz.apiBase}/ws/2"', text)
+        self.assertIn('--discogs-api "${cfg.discogs.apiBase}"', text)
+
+    def test_beets_musicbrainz_derives_from_the_one_value(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("services.cratedigger.beetsConfig.musicbrainz = let", text)
+        self.assertIn('mbHost = lib.removePrefix "https://" (lib.removePrefix "http://" cfg.musicbrainz.apiBase);', text)
+        self.assertIn("ratelimit = lib.mkDefault (if mbPublic then 1 else 100);", text)
+
+
 class TestOwnedRedisContract(unittest.TestCase):
     def test_cratedigger_owns_local_redis_server_by_default(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -55,6 +55,33 @@ def make_db():
     return db
 
 
+class TestMbApiBase(unittest.TestCase):
+    """KTD6: pipeline-cli's MB lookups read [MusicBrainz] api_base from the
+    runtime config instead of carrying a second hardcoded mirror URL."""
+
+    def test_mb_api_reads_runtime_config(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "config.ini")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("[MusicBrainz]\napi_base = http://mb-mirror.test:5200\n")
+            with patch.dict(os.environ,
+                            {"CRATEDIGGER_RUNTIME_CONFIG": path},
+                            clear=False):
+                self.assertEqual(pipeline_cli._mb_api(),
+                                 "http://mb-mirror.test:5200/ws/2")
+
+    def test_mb_api_defaults_to_public(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "config.ini")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("[Slskd]\nhost_url = http://x\n")
+            with patch.dict(os.environ,
+                            {"CRATEDIGGER_RUNTIME_CONFIG": path},
+                            clear=False):
+                self.assertEqual(pipeline_cli._mb_api(),
+                                 "https://musicbrainz.org/ws/2")
+
+
 class TestCmdAdd(unittest.TestCase):
     def setUp(self):
         self.db = make_db()

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -649,6 +649,22 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
         "artist_id", "artist_name", "release_groups",
     }
 
+    def test_discogs_routes_return_503_mirror_required_when_base_unset(self):
+        """R13: no mirror configured -> a clear mirror-required 503 from the
+        REAL web/discogs.py (raised at URL construction, before any network),
+        not a broken upstream fetch. Discogs browse is mirror-required; MB
+        browse is unaffected."""
+        for path in ("/api/discogs/search?q=test",
+                     "/api/discogs/artist/3840",
+                     "/api/discogs/master/21491",
+                     "/api/discogs/release/21491",
+                     "/api/discogs/label/search?q=warp",
+                     "/api/discogs/label/757"):
+            with self.subTest(path=path):
+                status, data = self._get(path)
+                self.assertEqual(status, 503, data)
+                self.assertIn("mirror", data["error"].lower())
+
     def test_discogs_search_release_contract(self):
         with patch("web.routes.browse.discogs_api") as mock_dg:
             mock_dg.search_releases.return_value = [

--- a/web/api_bases.py
+++ b/web/api_bases.py
@@ -1,0 +1,37 @@
+"""Process-startup wiring for the mirror API bases (tier-2 plan U6/KTD6).
+
+``web/mb.py`` and ``web/discogs.py`` hold their bases as module globals.
+``cratedigger-web`` sets them in ``web/server.py::main()`` (flags win over
+config), but they are ALSO imported by headless processes — pipeline-cli
+(add --discogs, youtube-album, distance, Replace, field resolution) and
+the youtube-ingest worker. Every such entry point must call
+``configure_api_bases_from_runtime_config()`` at startup, or it silently
+runs against the module defaults (public MB / Discogs-unset) instead of
+the operator's mirrors.
+"""
+
+from __future__ import annotations
+
+PUBLIC_MB_ORIGIN = "https://musicbrainz.org"
+
+
+def mb_ws2_base(origin: str) -> str:
+    """WS/2 base from an MB origin (scheme://host[:port], no path)."""
+    return (origin or PUBLIC_MB_ORIGIN).rstrip("/") + "/ws/2"
+
+
+def configure_api_bases_from_runtime_config() -> None:
+    """Point web.mb / web.discogs at the runtime config's mirror origins.
+
+    Reads [MusicBrainz] api_base and [Discogs] api_base from the runtime
+    config.ini (rendered by the NixOS module). Missing config soft-fails
+    to the stranger posture: public MB, Discogs browse off.
+    """
+    import web.discogs
+    import web.mb
+    from lib.config import read_runtime_config
+
+    cfg = read_runtime_config()
+    web.mb.MB_API_BASE = mb_ws2_base(cfg.musicbrainz_api_base)
+    if cfg.discogs_api_base:
+        web.discogs.DISCOGS_API_BASE = cfg.discogs_api_base

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -1,6 +1,6 @@
 """Discogs mirror API helpers — shared between pipeline_cli and web server.
 
-All queries hit the local Discogs mirror at DISCOGS_API_BASE.
+All queries hit the local Discogs mirror (DISCOGS_API_BASE; mirror-required, see _api_base).
 Response shapes are normalized to match what the frontend expects,
 mirroring web/mb.py where possible.
 
@@ -24,7 +24,33 @@ import msgspec
 
 from web import cache as _cache
 
-DISCOGS_API_BASE = "https://discogs.ablz.au"
+# Mirror-REQUIRED (tier-2 plan U6, R13): these endpoints (/api/search,
+# /api/masters/<id>, ...) and the msgspec response Structs are the Rust
+# Discogs mirror's shape — public api.discogs.com does not serve them, so
+# there is no functional public fallback. None = Discogs browse is off;
+# the server wires this from `cratedigger-web --discogs-api`
+# (services.cratedigger.discogs.apiBase).
+DISCOGS_API_BASE: str | None = None
+
+
+class DiscogsMirrorNotConfigured(RuntimeError):
+    """Raised at URL-construction time when no Discogs mirror is configured.
+
+    web/server.py maps this to a 503 with the message, so browse callers
+    get a clear mirror-required response instead of a broken upstream
+    fetch."""
+
+
+def _api_base() -> str:
+    if not DISCOGS_API_BASE:
+        raise DiscogsMirrorNotConfigured(
+            "Discogs browse requires a Discogs mirror: this API speaks the "
+            "Rust mirror's endpoint shape, which public api.discogs.com "
+            "does not serve. Set services.cratedigger.discogs.apiBase "
+            "(cratedigger-web --discogs-api). Without a mirror, browse via "
+            "MusicBrainz only."
+        )
+    return DISCOGS_API_BASE
 USER_AGENT = "cratedigger-web/1.0"
 SEARCH_CACHE_QUERY_PREFIX_CHARS = 200
 DEFAULT_HTTP_TIMEOUT_SECONDS = 60
@@ -168,7 +194,7 @@ def search_releases(query: str) -> list[dict]:
 
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(effective_query)
-        url = f"{DISCOGS_API_BASE}/api/search?title={q}&per_page=25"
+        url = f"{_api_base()}/api/search?title={q}&per_page=25"
         if va_pin:
             url += f"&artist_id={VA_ARTIST_ID}"
         data = _get(url)
@@ -214,7 +240,7 @@ def search_artists(query: str) -> list[dict]:
     """
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
-        data = _get(f"{DISCOGS_API_BASE}/api/artists?name={q}&per_page=20")
+        data = _get(f"{_api_base()}/api/artists?name={q}&per_page=20")
         return [
             {
                 "id": str(r["id"]),
@@ -287,7 +313,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
         page = 1
         while True:
             data = _get(
-                f"{DISCOGS_API_BASE}/api/artists/{artist_id}/masters?per_page=100&page={page}"
+                f"{_api_base()}/api/artists/{artist_id}/masters?per_page=100&page={page}"
             )
             results = data.get("results", [])
             if not results:
@@ -301,7 +327,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             page += 1
 
         appearances = _get(
-            f"{DISCOGS_API_BASE}/api/artists/{artist_id}/appearances"
+            f"{_api_base()}/api/artists/{artist_id}/appearances"
         )
         for r in appearances.get("results", []):
             entry = _normalize_artist_master_entry(r)
@@ -318,7 +344,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
 def get_master_releases(master_id: int) -> dict:
     """Get all releases (pressings) for a master. Mirrors mb.get_release_group_releases()."""
     def _fetch() -> dict:
-        data = _get(f"{DISCOGS_API_BASE}/api/masters/{master_id}")
+        data = _get(f"{_api_base()}/api/masters/{master_id}")
         releases = []
         for r in data.get("releases", []):
             formats = r.get("formats", [])
@@ -355,7 +381,7 @@ def get_release(release_id: int, *, fresh: bool = False) -> dict:
     artist/title/track data into `album_requests` / `request_tracks`.
     """
     def _fetch() -> dict:
-        data = _get(f"{DISCOGS_API_BASE}/api/releases/{release_id}")
+        data = _get(f"{_api_base()}/api/releases/{release_id}")
         artists = data.get("artists", [])
         artist_name = _primary_artist_name(artists)
         artist_id = _primary_artist_id(artists)
@@ -394,7 +420,7 @@ def get_release(release_id: int, *, fresh: bool = False) -> dict:
 def get_artist_name(artist_id: int) -> str:
     """Look up an artist's name by Discogs ID."""
     def _fetch() -> str:
-        data = _get(f"{DISCOGS_API_BASE}/api/artists/{artist_id}")
+        data = _get(f"{_api_base()}/api/artists/{artist_id}")
         return data.get("name", "")
 
     return _cache.memoize_meta(f"discogs:artist:{artist_id}:name", _fetch)
@@ -595,7 +621,7 @@ def search_labels(query: str, *, page: int = 1, per_page: int = 25) -> list[Labe
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         raw = _get(
-            f"{DISCOGS_API_BASE}/api/labels"
+            f"{_api_base()}/api/labels"
             f"?name={q}&page={page}&per_page={per_page}"
         )
         decoded = msgspec.convert(raw, type=_DiscogsLabelSearchResponse)
@@ -618,7 +644,7 @@ def get_label(label_id: int | str) -> LabelEntity:
     label_id_str = _assert_discogs_label_id(label_id)
 
     def _fetch() -> dict:
-        raw = _get(f"{DISCOGS_API_BASE}/api/labels/{label_id_str}")
+        raw = _get(f"{_api_base()}/api/labels/{label_id_str}")
         decoded = msgspec.convert(raw, type=_DiscogsLabelDetail)
         return msgspec.to_builtins(_label_entity_from_detail(decoded))
 
@@ -646,7 +672,7 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
     def _fetch() -> dict:
         sub_flag = "true" if include_sublabels else "false"
         raw = _get(
-            f"{DISCOGS_API_BASE}/api/labels/{label_id_str}/releases"
+            f"{_api_base()}/api/labels/{label_id_str}/releases"
             f"?include_sublabels={sub_flag}&page={page}&per_page={per_page}",
             timeout=(
                 LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS

--- a/web/mb.py
+++ b/web/mb.py
@@ -1,6 +1,6 @@
 """MusicBrainz API helpers — shared between pipeline_cli and web server.
 
-All queries hit the local MB mirror at MB_API_BASE. The pure-metadata
+All queries hit the MusicBrainz API at MB_API_BASE (public MB by default; the local mirror in production). The pure-metadata
 responses are memoized via `cache.memoize_meta()` at 24h TTL so the
 web UI can render multiple cards per page without hammering the mirror.
 
@@ -21,7 +21,11 @@ import urllib.error
 # separate from the pipeline's peer-cache implementation.
 from web import cache as _cache
 
-MB_API_BASE = "http://192.168.1.35:5200/ws/2"
+# Default: public MusicBrainz (functional but rate-limited ~1 req/s).
+# Production points this at the local mirror via the module's
+# services.cratedigger.musicbrainz.apiBase -> `cratedigger-web --mb-api`
+# (tier-2 plan U6, R13/KTD6). The value includes the /ws/2 prefix.
+MB_API_BASE = "https://musicbrainz.org/ws/2"
 USER_AGENT = "cratedigger-web/1.0"
 
 # Canonical Various Artists MBID. Used by the resolver and the browse-tab

--- a/web/server.py
+++ b/web/server.py
@@ -51,6 +51,7 @@ if __name__ == "__main__" or "web.server" not in sys.modules:
     sys.modules["web.server"] = sys.modules[__name__]
 
 from web import cache as cache
+from web import discogs as _discogs
 from web import mb as mb_api
 from web import overlay as _overlay
 from lib.beets_db import BeetsDB
@@ -428,6 +429,11 @@ class Handler(BaseHTTPRequestHandler):
             # body-write attempt to a dead socket.
             log.warning("Client disconnect on GET %s: %s", path, type(e).__name__)
             self.close_connection = True
+        except _discogs.DiscogsMirrorNotConfigured as e:
+            # Deliberate config posture, not a crash: no Discogs mirror ->
+            # Discogs browse is off (tier-2 plan R13). 503 with the
+            # actionable message, no DB reconnect churn.
+            self._error(str(e), 503)
         except Exception as e:
             log.exception("GET %s failed", path)
             _try_reconnect_db()
@@ -478,6 +484,10 @@ class Handler(BaseHTTPRequestHandler):
             # handled here.
             log.warning("Client disconnect on POST %s: %s", path, type(e).__name__)
             self.close_connection = True
+        except _discogs.DiscogsMirrorNotConfigured as e:
+            # Deliberate config posture (no Discogs mirror) — clean 503,
+            # no DB reconnect churn (R13).
+            self._error(str(e), 503)
         except Exception as e:
             log.exception("POST %s failed", path)
             _try_reconnect_db()
@@ -518,7 +528,9 @@ def main():
     parser.add_argument("--port", type=int, default=8085)
     parser.add_argument("--dsn", default=os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger"))
     parser.add_argument("--beets-db", default="/mnt/virtio/Music/beets-library.db")
-    parser.add_argument("--mb-api", default=None, help="MusicBrainz API base URL")
+    parser.add_argument("--mb-api", default=None, help="MusicBrainz API base URL (full base incl. /ws/2)")
+    parser.add_argument("--discogs-api", default=None,
+                        help="Discogs mirror base URL (mirror-required; unset = Discogs browse off)")
     parser.add_argument("--redis-host", default=None, help="Redis host for caching (optional)")
     parser.add_argument("--redis-port", type=int, default=6379)
     args = parser.parse_args()
@@ -536,8 +548,17 @@ def main():
         # prefix in the helper or flush `meta:*` manually during deploy.
         cache.invalidate_pattern("web:*")
 
+    # API bases: runtime config first (shared startup wiring — the same
+    # call pipeline-cli and the youtube worker make), explicit flags win.
+    # Config carries ORIGINS; the flag carries the full MB base incl.
+    # /ws/2 (KTD6). Discogs stays unset without a mirror — web/discogs.py
+    # then serves a clear 503 mirror-required (R13).
+    from web.api_bases import configure_api_bases_from_runtime_config
+    configure_api_bases_from_runtime_config()
     if args.mb_api:
         mb_api.MB_API_BASE = args.mb_api
+    if args.discogs_api:
+        _discogs.DISCOGS_API_BASE = args.discogs_api
 
     global _db_dsn
     _db_dsn = args.dsn


### PR DESCRIPTION
Tier-2 packaging plan U6 (R13 / KTD6).

- One MB value, three consumers: `[MusicBrainz] api_base` (origin; public default) feeds `web/mb.py` (module passes `--mb-api <origin>/ws/2`; server also wires from config), `pipeline-cli` lookups (`_mb_api()` kills the second hardcoded mirror copy), and the rendered beets `musicbrainz.{host,https,ratelimit}` — now mkDefault-**derived** from the same origin (mirror ⇒ host:port/http/100; public ⇒ musicbrainz.org/https/1), value-asserted by the new eval check `checks.apiBaseDerivation`.
- Discogs is mirror-REQUIRED: no default base; `_api_base()` raises `DiscogsMirrorNotConfigured` at URL construction and the server maps it to a clear 503 in **both** do_GET and do_POST. Contract test covers all six discogs GET routes incl. labels.
- **Headless consumers wired too** (Opus review HIGH): `web/api_bases.py::configure_api_bases_from_runtime_config()` runs at startup of `pipeline-cli` and the youtube-ingest worker — without it, `pipeline-cli add --discogs` would have been fully broken and the worker's track-count gate would have silently flipped to public MB on doc2. The review also caught that my do_POST 503 edit had silently no-op'd (indent mismatch in a scripted replace) — fixed and verified.
- No hardcoded `192.168.1.35:5200` / `discogs.ablz.au` remains in code.

Verified: full suite 4629 green + pyright clean (pinned shell), moduleVm green, `apiBaseDerivation` + all flake eval checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)