### PR TITLE
feat(nix): U7 — pipelineDb.createLocally + actionable assertions

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -30,7 +30,8 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |
 | `slskd.hostUrl` | `http://localhost:5030` | slskd HTTP base URL. |
-| `pipelineDb.dsn` | (required) | PostgreSQL DSN. |
+| `pipelineDb.dsn` | `null` | PostgreSQL DSN. Required unless `createLocally`. |
+| `pipelineDb.createLocally` | `false` | Provision local PostgreSQL: role + database named after `cfg.user`, unix-socket peer auth (no password material anywhere), socket DSN default, migrate unit ordered after postgresql.service. doc2 keeps `false` + its nspawn DSN. |
 | `redis.{enable,host,port,maxmemory}` | enabled, `127.0.0.1:6379`, `2gb` | App-owned local Redis server for the pipeline peer cache and web metadata cache. Uses `allkeys-lru`. |
 | `peerCache.{ttlSeconds,speedTtlSeconds,redisConnectTimeoutMs,redisOperationTimeoutMs}` | 7d, 24h, 200ms, 100ms | Redis TTL and timeout settings rendered into `[Peer Cache]`. |
 | `beetsValidation.{enable,distanceThreshold,stagingDir,trackingFile,verifiedLosslessTarget}` | sensible defaults | Beets validation config. |
@@ -115,6 +116,8 @@ github:abl030/cratedigger
 ├── devShells.<system>.default         ← test/dev environment (same pinned nixpkgs)
 ├── checks.<system>.moduleVm           ← NixOS VM test (boots module against ephemeral postgres)
 ├── checks.<system>.packageSetPin      ← eval guard: default packageSet = own lock; override honoured
+├── checks.<system>.moduleAssertions   ← eval guard: friendly required-option messages; doc2 + stranger shapes clean
+├── checks.<system>.apiBaseDerivation  ← eval guard: beets musicbrainz block derives from musicbrainz.apiBase
 └── checks.<system>.beetsMirrorPatches ← beets mirror knobs patch/don't-patch as configured
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,57 @@
           assert (overridden.cratediggerEscapeHatchMarker or "") == "consumer-pkgs";
           pkgs.runCommand "cratedigger-packageset-pin-ok" { } "touch $out";
 
+        # U7/R11: required options fail with actionable messages naming the
+        # option — verified on MESSAGE CONTENT (tryEval would lose it).
+        # Also pins both DB postures: bare enable trips the dsn-or-
+        # createLocally assertion; a fully-set external-DSN config (the
+        # doc2 shape) and a createLocally config both eval with zero
+        # failing assertions.
+        moduleAssertions = let
+          evalAssertions = extra: (nixpkgs.lib.nixosSystem {
+            modules = [ self.nixosModules.default {
+              nixpkgs.pkgs = import nixpkgs { inherit system; };
+              services.cratedigger.enable = true;
+            } extra ];
+          }).config.assertions;
+          # Scope to our own assertions — a minimal nixosSystem also fails
+          # NixOS's fileSystems/bootloader assertions, which aren't ours.
+          failingMsgs = extra: builtins.filter
+            (m: nixpkgs.lib.hasPrefix "services.cratedigger" m)
+            (map (a: a.message)
+              (builtins.filter (a: !a.assertion) (evalAssertions extra)));
+          bare = failingMsgs { };
+          hasMsg = needle: builtins.any (m: nixpkgs.lib.hasInfix needle m) bare;
+          doc2Shape = failingMsgs {
+            services.cratedigger = {
+              slskd.apiKeyFile = "/run/secrets/slskd-key";
+              slskd.downloadDir = "/mnt/music/slskd";
+              pipelineDb.dsn = "postgresql://cratedigger@10.20.0.11:5432/cratedigger";
+              beetsValidation = {
+                stagingDir = "/mnt/music/incoming";
+                trackingFile = "/mnt/music/incoming/tracking.jsonl";
+              };
+            };
+          };
+          strangerShape = failingMsgs {
+            services.cratedigger = {
+              slskd.apiKeyFile = "/etc/slskd-key";
+              slskd.downloadDir = "/srv/slskd";
+              pipelineDb.createLocally = true;
+              beetsValidation = {
+                stagingDir = "/srv/incoming";
+                trackingFile = "/srv/incoming/tracking.jsonl";
+              };
+            };
+          };
+        in
+          assert hasMsg "slskd.apiKeyFile";
+          assert hasMsg "slskd.downloadDir";
+          assert hasMsg "pipelineDb.createLocally = true";
+          assert doc2Shape == [ ];
+          assert strangerShape == [ ];
+          pkgs.runCommand "cratedigger-module-assertions-ok" { } "touch $out";
+
         # KTD6 derivation, asserted on rendered VALUES (not source text):
         # the beets musicbrainz block flips host/https/ratelimit for a
         # mirror origin vs the public default. Eval-only.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -18,6 +18,15 @@
   cfg = config.services.cratedigger;
   src = cfg.src;
 
+  # Every unit/wrapper interpolates the DSN; guard it so a missing value
+  # yields the actionable message even if string coercion is forced before
+  # the module assertions run. createLocally mkDefaults this option to the
+  # local unix socket (peer auth as cfg.user — no password material, KTD5).
+  pipelineDsn =
+    if cfg.pipelineDb.dsn != null
+    then cfg.pipelineDb.dsn
+    else throw "services.cratedigger.pipelineDb.dsn is not set: either set it to your PostgreSQL connection string, or set services.cratedigger.pipelineDb.createLocally = true to provision a local database.";
+
   # The one beets (tier-2 plan U3, R4): pinned package + full built-in
   # plugin closure, with the mirror patches applied only when the operator
   # sets the knobs. This same derivation is the python library in pythonEnv
@@ -192,13 +201,13 @@
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pythonEnv}/bin/python ${src}/scripts/pipeline_cli.py \
-      --dsn "${cfg.pipelineDb.dsn}" "$@"
+      --dsn "${pipelineDsn}" "$@"
   '';
 
   pipelineMigrate = pkgs.writeShellScriptBin "pipeline-migrate" ''
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pythonEnv}/bin/python ${src}/scripts/migrate_db.py \
-      --dsn "${cfg.pipelineDb.dsn}" \
+      --dsn "${pipelineDsn}" \
       --migrations-dir "${src}/migrations" "$@"
   '';
 
@@ -206,14 +215,14 @@
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pyRunner} ${src}/scripts/importer.py \
-      --dsn "${cfg.pipelineDb.dsn}" "$@"
+      --dsn "${pipelineDsn}" "$@"
   '';
 
   previewWorkerPkg = pkgs.writeShellScriptBin "cratedigger-import-preview-worker" ''
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pyRunner} ${src}/scripts/import_preview_worker.py \
-      --dsn "${cfg.pipelineDb.dsn}" \
+      --dsn "${pipelineDsn}" \
       --workers ${toString cfg.importer.previewWorkers} "$@"
   '';
 
@@ -227,7 +236,7 @@
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pyRunner} ${src}/web/server.py \
       --port ${toString cfg.web.port} \
-      --dsn "${cfg.pipelineDb.dsn}" \
+      --dsn "${pipelineDsn}" \
       --beets-db "${cfg.web.beetsDb}" \
       --redis-host "${cfg.web.redis.host}" \
       --redis-port ${toString cfg.web.redis.port} \
@@ -246,9 +255,9 @@
     export PATH="${pkgs.yt-dlp}/bin:${runtimePath}:$PATH"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pyRunner} ${src}/scripts/youtube_ingest_worker.py \
-      --dsn "${cfg.pipelineDb.dsn}" \
+      --dsn "${pipelineDsn}" \
       --temp-dir "${cfg.youtubeIngest.tempDir}" \
-      --staging-dir "${cfg.beetsValidation.stagingDir}" \
+      --staging-dir "${toString cfg.beetsValidation.stagingDir}" \
       --poll-interval ${toString cfg.youtubeIngest.pollIntervalSeconds} \
       ${optionalString (cfg.youtubeIngest.sourceAddress != "") ''--source-address "${cfg.youtubeIngest.sourceAddress}" ''}"$@"
   '';
@@ -261,7 +270,7 @@
     export PATH="${runtimePath}:$PATH"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
     exec ${pyRunner} ${src}/scripts/run_unfindable_detection.py \
-      --dsn "${cfg.pipelineDb.dsn}" "$@"
+      --dsn "${pipelineDsn}" "$@"
   '';
 
   # [Quality Ranks] section — declarative mirror of QualityRankConfig.defaults().
@@ -293,10 +302,10 @@
   # world-readable (see absence of chmod/chgrp in preStartScript).
   configTemplate = pkgs.writeText "cratedigger-config.ini" ''
     [Slskd]
-    api_key_file = ${cfg.slskd.apiKeyFile}
+    api_key_file = ${toString cfg.slskd.apiKeyFile}
     host_url = ${cfg.slskd.hostUrl}
     url_base = ${cfg.slskd.urlBase}
-    download_dir = ${cfg.slskd.downloadDir}
+    download_dir = ${toString cfg.slskd.downloadDir}
     delete_searches = ${if cfg.slskd.deleteSearches then "True" else "False"}
     stalled_timeout = ${toString cfg.slskd.stalledTimeout}
     remote_queue_timeout = ${toString cfg.slskd.remoteQueueTimeout}
@@ -344,8 +353,8 @@
     enabled = ${if cfg.beetsValidation.enable then "True" else "False"}
     harness_path = ${cfg.beetsValidation.harnessPath}
     distance_threshold = ${toString cfg.beetsValidation.distanceThreshold}
-    staging_dir = ${cfg.beetsValidation.stagingDir}
-    tracking_file = ${cfg.beetsValidation.trackingFile}
+    staging_dir = ${toString cfg.beetsValidation.stagingDir}
+    tracking_file = ${toString cfg.beetsValidation.trackingFile}
     verified_lossless_target = ${cfg.beetsValidation.verifiedLosslessTarget}
 
     [MusicBrainz]
@@ -357,7 +366,7 @@
     ${qualityRanksSection}
     [Pipeline DB]
     enabled = ${if cfg.pipelineDb.enable then "True" else "False"}
-    dsn = ${cfg.pipelineDb.dsn}
+    dsn = ${pipelineDsn}
 
     [Peer Cache]
     redis_host = ${cfg.redis.host}
@@ -449,7 +458,7 @@
   # restart command is configurable so non-systemd slskd setups still work.
   slskdHealthCheck = pkgs.writeShellScript "cratedigger-slskd-healthcheck" ''
     set -euo pipefail
-    api_key=$(${pkgs.coreutils}/bin/cat "${cfg.slskd.apiKeyFile}")
+    api_key=$(${pkgs.coreutils}/bin/cat "${toString cfg.slskd.apiKeyFile}")
     status=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $api_key" "${cfg.slskd.hostUrl}/api/v0/server" 2>/dev/null || echo '{}')
     connected=$(echo "$status" | ${pkgs.jq}/bin/jq -r '.isConnected // false')
     logged_in=$(echo "$status" | ${pkgs.jq}/bin/jq -r '.isLoggedIn // false')
@@ -640,7 +649,8 @@ in {
 
     slskd = {
       apiKeyFile = mkOption {
-        type = types.path;
+        type = types.nullOr types.path;
+        default = null;
         description = ''
           Path to a file containing the slskd API key (raw, no envvar prefix).
           Must be readable by services.cratedigger.user. Use sops/agenix or any
@@ -665,7 +675,8 @@ in {
         description = "slskd URL prefix when behind a reverse proxy.";
       };
       downloadDir = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
+        default = null;
         description = "Directory slskd downloads land in.";
       };
       deleteSearches = mkOption {
@@ -690,10 +701,29 @@ in {
         default = true;
         description = "Use the pipeline DB as album source (currently the only supported mode).";
       };
+      createLocally = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Provision PostgreSQL on this host (services.postgresql +
+          ensureDatabases/ensureUsers). The ensure-role and database are
+          named after services.cratedigger.user, so unix-socket PEER
+          authentication works by construction — no password material
+          anywhere (KTD5). The DSN defaults to the local socket and
+          cratedigger-db-migrate is ordered after postgresql.service so
+          first boot cannot race the database. The operator's external-DB
+          setup (createLocally = false + an explicit dsn) is unchanged.
+        '';
+      };
       dsn = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
+        default = null;
         example = "postgresql://cratedigger@localhost/cratedigger";
-        description = "PostgreSQL connection string for the pipeline DB.";
+        description = ''
+          PostgreSQL connection string for the pipeline DB. Required
+          unless pipelineDb.createLocally = true (which defaults it to
+          the local unix socket).
+        '';
       };
     };
 
@@ -919,12 +949,14 @@ in {
         description = "Maximum beets match distance to accept (0.0 = perfect, 1.0 = no match).";
       };
       stagingDir = mkOption {
-        type = types.str;
-        description = "Directory to stage validated albums for beets import.";
+        type = types.nullOr types.str;
+        default = null;
+        description = "Directory to stage validated albums for beets import. Required when beetsValidation.enable.";
       };
       trackingFile = mkOption {
-        type = types.str;
-        description = "JSONL file tracking beets validation results.";
+        type = types.nullOr types.str;
+        default = null;
+        description = "JSONL file tracking beets validation results. Required when beetsValidation.enable.";
       };
       verifiedLosslessTarget = mkOption {
         type = types.str;
@@ -1211,6 +1243,37 @@ in {
   config = mkIf cfg.enable {
     assertions = [
       {
+        assertion = cfg.slskd.apiKeyFile != null;
+        message = "services.cratedigger.slskd.apiKeyFile is not set: point it at a file containing your slskd API key (readable by services.cratedigger.user).";
+      }
+      {
+        assertion = cfg.slskd.downloadDir != null;
+        message = "services.cratedigger.slskd.downloadDir is not set: point it at the directory slskd downloads land in (slskd's directories.downloads).";
+      }
+      {
+        assertion = cfg.pipelineDb.createLocally || cfg.pipelineDb.dsn != null;
+        message = "services.cratedigger.pipelineDb: set either pipelineDb.dsn (external PostgreSQL) or pipelineDb.createLocally = true (provision a local database with peer auth).";
+      }
+      {
+        assertion = !cfg.beetsValidation.enable || (cfg.beetsValidation.stagingDir != null && cfg.beetsValidation.trackingFile != null);
+        message = "services.cratedigger.beetsValidation: enable requires stagingDir (where validated albums stage for import) and trackingFile (JSONL validation log).";
+      }
+      {
+        # The rescue worker stages into the same beets Incoming root; an
+        # unset stagingDir would silently render --staging-dir "" and
+        # strand rescues under the state dir.
+        assertion = !cfg.youtubeIngest.enable || cfg.beetsValidation.stagingDir != null;
+        message = "services.cratedigger.youtubeIngest: enable requires beetsValidation.stagingDir (rescues stage under its auto-import/ child).";
+      }
+      {
+        assertion = lib.hasPrefix "http://" cfg.musicbrainz.apiBase || lib.hasPrefix "https://" cfg.musicbrainz.apiBase;
+        message = "services.cratedigger.musicbrainz.apiBase must be an origin URL (scheme://host[:port], no path), e.g. https://musicbrainz.org or http://192.168.1.35:5200.";
+      }
+      {
+        assertion = cfg.discogs.apiBase == null || lib.hasPrefix "http://" cfg.discogs.apiBase || lib.hasPrefix "https://" cfg.discogs.apiBase;
+        message = "services.cratedigger.discogs.apiBase must be an origin URL (scheme://host[:port]) when set, e.g. https://discogs.ablz.au.";
+      }
+      {
         assertion = !cfg.notifiers.meelo.enable || (cfg.notifiers.meelo.usernameFile != null && cfg.notifiers.meelo.passwordFile != null && cfg.notifiers.meelo.url != "");
         message = "services.cratedigger.notifiers.meelo: enable requires url, usernameFile, and passwordFile";
       }
@@ -1257,6 +1320,25 @@ in {
       ++ optional cfg.youtubeIngest.enable
         "d ${cfg.youtubeIngest.tempDir} 0755 ${cfg.user} ${cfg.group} -";
 
+    # Local PostgreSQL (stranger ergonomics, KTD5): role + database named
+    # after cfg.user so unix-socket peer auth works with zero credentials
+    # (ensureDBOwnership requires database name == role name). The DSN
+    # defaults to the socket; nothing for the *File secret pattern to
+    # carry, no pg_hba loosening.
+    services.postgresql = mkIf cfg.pipelineDb.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.user ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+    services.cratedigger.pipelineDb.dsn = mkIf cfg.pipelineDb.createLocally (
+      lib.mkDefault "postgresql:///${cfg.user}?host=/run/postgresql"
+    );
+
     services.cratedigger.web.redis.host = lib.mkDefault cfg.redis.host;
     services.cratedigger.web.redis.port = lib.mkDefault cfg.redis.port;
     # One concept, one value: the config.ini [Beets] directory follows the
@@ -1293,13 +1375,18 @@ in {
     systemd.services.cratedigger-db-migrate = {
       description = "Apply Cratedigger pipeline DB schema migrations";
       wantedBy = ["multi-user.target"];
+      # With a locally-provisioned DB, first boot must not race PostgreSQL
+      # (this ordering used to live only in the VM test's hand-rolled
+      # node — now the module owns it, U7/R10).
+      after = optional cfg.pipelineDb.createLocally "postgresql.service";
+      requires = optional cfg.pipelineDb.createLocally "postgresql.service";
       restartIfChanged = true;
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
         User = cfg.user;
         Group = cfg.group;
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${pipelineMigrate}/bin/pipeline-migrate";
       };
     };
@@ -1323,7 +1410,7 @@ in {
         Group = cfg.group;
         UMask = "0000";
         ExecStartPre = lib.optional cfg.healthCheck.enable slskdHealthCheck ++ [preStartScript];
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${cratediggerPkg}/bin/cratedigger";
         WorkingDirectory = cfg.stateDir;
         # Defense-in-depth (issue #212 R13): if anything escapes the
@@ -1380,7 +1467,7 @@ in {
         # outage should fail the unit fast rather than write
         # garbage probe-failed rows for every cohort member.
         ExecStartPre = lib.optional cfg.healthCheck.enable slskdHealthCheck ++ [preStartScript];
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${unfindableDetectionPkg}/bin/cratedigger-unfindable";
         WorkingDirectory = cfg.stateDir;
         # Generous cap: a 100-row batch over a slow slskd is roughly
@@ -1427,7 +1514,7 @@ in {
         Group = cfg.group;
         UMask = "0000";
         ExecStartPre = [preStartScript];
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${importerPkg}/bin/cratedigger-importer";
         WorkingDirectory = cfg.stateDir;
         Restart = "on-failure";
@@ -1452,7 +1539,7 @@ in {
         Group = cfg.group;
         UMask = "0000";
         ExecStartPre = [preStartScript];
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${previewWorkerPkg}/bin/cratedigger-import-preview-worker";
         WorkingDirectory = cfg.stateDir;
         Restart = "on-failure";
@@ -1496,7 +1583,7 @@ in {
         User = cfg.user;
         Group = cfg.group;
         UMask = "0000";
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${youtubeIngestWorkerPkg}/bin/cratedigger-youtube-ingest";
         WorkingDirectory = cfg.stateDir;
         Restart = "on-failure";
@@ -1517,7 +1604,7 @@ in {
         ExecStart = "${webPkg}/bin/cratedigger-web";
         Restart = "on-failure";
         RestartSec = 5;
-        Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}";
+        Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
       };
     };
   };

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -60,22 +60,6 @@ pkgs.testers.nixosTest {
   nodes.machine = { config, lib, pkgs, ... }: {
     imports = [ cratediggerModule ];
 
-    services.postgresql = {
-      enable = true;
-      ensureDatabases = [ "cratedigger" ];
-      ensureUsers = [
-        {
-          name = "cratedigger";
-          ensureDBOwnership = true;
-        }
-      ];
-      authentication = lib.mkOverride 10 ''
-        local all all              trust
-        host  all all 127.0.0.1/32 trust
-        host  all all ::1/128      trust
-      '';
-    };
-
     # Fake slskd API key — never actually called because healthCheck is off.
     environment.etc."cratedigger/slskd-api-key" = {
       text = "test-api-key-do-not-use\n";
@@ -95,7 +79,11 @@ pkgs.testers.nixosTest {
         apiKeyFile = "/etc/cratedigger/slskd-api-key";
         downloadDir = "/var/lib/cratedigger-downloads";
       };
-      pipelineDb.dsn = "postgresql://cratedigger@localhost/cratedigger";
+      # Stranger posture (U7/R10): the module provisions PostgreSQL —
+      # role + database named after cfg.user (root here), unix-socket
+      # peer auth, DSN defaulted to the socket. No hand-rolled postgres
+      # block, no manual unit ordering, no password material anywhere.
+      pipelineDb.createLocally = true;
       beetsValidation = {
         enable = false;
         stagingDir = "/var/lib/cratedigger-staging";
@@ -127,17 +115,10 @@ pkgs.testers.nixosTest {
       healthCheck.enable = false;
     };
 
-    # Order our migrate unit after postgres comes up.
-    systemd.services.cratedigger-db-migrate = {
-      after = [ "postgresql.service" ];
-      requires = [ "postgresql.service" ];
-    };
-    systemd.services.cratedigger.after = [ "postgresql.service" ];
-    systemd.services.cratedigger.wants = [ "postgresql.service" ];
-    systemd.services.cratedigger-web.after = [ "postgresql.service" ];
-    systemd.services.cratedigger-web.wants = [ "postgresql.service" ];
-    systemd.services.cratedigger-youtube-ingest.after = [ "postgresql.service" ];
-    systemd.services.cratedigger-youtube-ingest.wants = [ "postgresql.service" ];
+    # NO manual postgres ordering: the module owns
+    # cratedigger-db-migrate's after/requires on postgresql.service when
+    # createLocally is set, and every app unit requires the migrate unit —
+    # transitively serialising first boot behind PostgreSQL.
 
     # Speed up the VM
     virtualisation.memorySize = 2048;
@@ -155,7 +136,7 @@ pkgs.testers.nixosTest {
     assert state == "active", f"migrator unit not active: {state}"
 
     # Migrations recorded
-    out = machine.succeed("sudo -u postgres psql cratedigger -At -c 'SELECT version FROM schema_migrations ORDER BY version'")
+    out = machine.succeed("sudo -u postgres psql root -At -c 'SELECT version FROM schema_migrations ORDER BY version'")
     versions = [v.strip() for v in out.strip().split() if v.strip()]
     assert "1" in versions, f"baseline migration missing, got {versions}"
     assert "2" in versions, f"002 migration missing, got {versions}"
@@ -190,7 +171,18 @@ pkgs.testers.nixosTest {
     machine.succeed("systemctl show -p After cratedigger-web.service | grep -q redis-cratedigger.service")
     machine.succeed("systemctl show -p Wants cratedigger-web.service | grep -q redis-cratedigger.service")
 
-    # pipeline-cli on PATH and connects
+    # Peer auth by construction (KTD5): the socket DSN carries no
+    # password, and none exists in the rendered config or unit files.
+    machine.succeed("grep -q 'dsn = postgresql:///root?host=/run/postgresql' /var/lib/cratedigger/config.ini")
+    # (password_file *keys* are fine — they are the #117 *File pattern;
+    # what must not exist is an actual credential value.)
+    machine.fail("grep -Eqi 'password *= *[^ ]|pgpassword' /var/lib/cratedigger/config.ini")
+    machine.succeed(
+        "systemctl show cratedigger-db-migrate -p Environment"
+        " | grep -q 'PIPELINE_DB_DSN=postgresql:///root?host=/run/postgresql'"
+    )
+
+    # pipeline-cli on PATH and connects (over the peer-auth socket)
     machine.succeed("pipeline-cli list wanted")
 
     # Web UI listens

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -84,7 +84,7 @@ class TestImporterServiceContract(unittest.TestCase):
         self.assertIn('after = ["cratedigger-db-migrate.service"]', text)
         self.assertIn('requires = ["cratedigger-db-migrate.service"]', text)
         self.assertIn('ExecStart = "${importerPkg}/bin/cratedigger-importer"', text)
-        self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
+        self.assertIn('Environment = "PIPELINE_DB_DSN=${pipelineDsn}"', text)
         self.assertIn("WorkingDirectory = cfg.stateDir", text)
 
     def test_importer_service_restarts_on_switch(self) -> None:
@@ -138,7 +138,7 @@ class TestImporterServiceContract(unittest.TestCase):
         self.assertIn('after = ["cratedigger-db-migrate.service"]', text)
         self.assertIn('requires = ["cratedigger-db-migrate.service"]', text)
         self.assertIn('ExecStart = "${previewWorkerPkg}/bin/cratedigger-import-preview-worker"', text)
-        self.assertIn('Environment = "PIPELINE_DB_DSN=${cfg.pipelineDb.dsn}"', text)
+        self.assertIn('Environment = "PIPELINE_DB_DSN=${pipelineDsn}"', text)
 
 
 class TestPinnedPackageSetContract(unittest.TestCase):
@@ -287,6 +287,32 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
         self.assertIn('default = "musicbrainz.org";', text)
         # ratelimit 1 for public MB; the mirror override arrives via U6.
         self.assertIn("ratelimit", text)
+
+
+class TestCreateLocallyContract(unittest.TestCase):
+    """pipelineDb.createLocally (tier-2 plan U7, R10/KTD5): local postgres
+    with peer auth by construction — role + database named after cfg.user,
+    socket DSN default, migrate unit ordered after postgresql.service."""
+
+    def test_provisioning_block(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("services.postgresql = mkIf cfg.pipelineDb.createLocally", text)
+        self.assertIn("ensureDatabases = [ cfg.user ];", text)
+        self.assertIn("name = cfg.user;", text)
+        self.assertIn("ensureDBOwnership = true;", text)
+        self.assertIn('lib.mkDefault "postgresql:///${cfg.user}?host=/run/postgresql"', text)
+
+    def test_migrate_ordered_after_local_postgres(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('after = optional cfg.pipelineDb.createLocally "postgresql.service";', text)
+        self.assertIn('requires = optional cfg.pipelineDb.createLocally "postgresql.service";', text)
+
+    def test_dsn_guard_gives_actionable_error(self) -> None:
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("pipelineDsn =", text)
+        self.assertIn("pipelineDb.createLocally = true", text)
+        # No unit interpolates the raw nullable option.
+        self.assertNotIn("${cfg.pipelineDb.dsn}", text)
 
 
 class TestApiBaseThreading(unittest.TestCase):


### PR DESCRIPTION
Tier-2 packaging plan U7 (R10, R11 / KTD5).

- `pipelineDb.createLocally`: local PostgreSQL with role + database named after `cfg.user` (ensureDBOwnership requires db == role) — unix-socket peer auth by construction, zero password material anywhere. DSN mkDefaults to `postgresql:///<user>?host=/run/postgresql`; `cratedigger-db-migrate` gains `after`/`requires postgresql.service` (the ordering that previously lived only in the VM test node now belongs to the module).
- Friendly failures: `slskd.apiKeyFile`/`downloadDir`, `beetsValidation.stagingDir`/`trackingFile` (when enabled — and when `youtubeIngest.enable`, per review), `pipelineDb.dsn` xor `createLocally`, apiBase origin-URL coherence. The DSN also has an interpolation-time guard so the actionable message wins regardless of eval order.
- New `checks.<system>.moduleAssertions`: asserts the assertion **messages** on a bare enable, and zero failing cratedigger assertions for both the doc2 external-DSN shape and the createLocally stranger shape (doc2 path pinned unchanged).
- moduleVm reshaped: hand-rolled postgres + manual ordering deleted; `createLocally = true`, socket-DSN asserts in config.ini + unit Environment, no credential values (the `*File` keys stay).

Opus review: doc2 wrapper verified unbroken (all nullOr conversions compatible, no new assertion trips); DSN URI form confirmed canonical libpq; `root` role legal; no fixpoint hazard; one LOW fixed (youtubeIngest without stagingDir would have silently staged rescues under stateDir). Review also flagged for U12: the wrapper must set `musicbrainz.apiBase`/`discogs.apiBase` at cutover — recorded in the deploy notes.

Verified: moduleVm green in createLocally posture, moduleAssertions green, full suite + pyright clean in the pinned shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)