### PR TITLE
feat(nix): U8 — packages.default CLI bundle + flake version

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -112,13 +112,16 @@ If you don't use sops or have one key per encrypted file, skip the splitter and 
 
 ```
 github:abl030/cratedigger
+├── packages.<system>.default          ← operator CLI bundle (pipeline-cli, pipeline-migrate) — `nix run .#pipeline-cli`
+├── apps.<system>.pipeline-cli         ← `nix run github:abl030/cratedigger#pipeline-cli -- --help`
 ├── nixosModules.default              ← upstream NixOS module (pins packageSet to this flake's lock)
 ├── devShells.<system>.default         ← test/dev environment (same pinned nixpkgs)
 ├── checks.<system>.moduleVm           ← NixOS VM test (boots module against ephemeral postgres)
 ├── checks.<system>.packageSetPin      ← eval guard: default packageSet = own lock; override honoured
 ├── checks.<system>.moduleAssertions   ← eval guard: friendly required-option messages; doc2 + stranger shapes clean
 ├── checks.<system>.apiBaseDerivation  ← eval guard: beets musicbrainz block derives from musicbrainz.apiBase
-└── checks.<system>.beetsMirrorPatches ← beets mirror knobs patch/don't-patch as configured
+├── checks.<system>.beetsMirrorPatches ← beets mirror knobs patch/don't-patch as configured
+└── checks.<system>.packageDefault     ← the CLI bundle builds (`nix run` stays green)
 ```
 
 ## Validating before deploy

--- a/flake.nix
+++ b/flake.nix
@@ -18,9 +18,30 @@
         inherit system;
         pkgs = import nixpkgs { inherit system; };
       });
+      version = "0-unstable-"
+        + (builtins.substring 0 8 (self.lastModifiedDate or "19700101"))
+        + (if self ? shortRev then "-${self.shortRev}" else "-dirty");
     in {
       devShells = forAllSystems ({ pkgs, ... }: {
         default = import ./nix/shell.nix { inherit pkgs; };
+      });
+
+      # Tag-based versions are not readable in pure flake eval, so the
+      # version above is date+rev (sortable, unique per commit); release
+      # tags (vYYYY.MM.DD, U9) record verified states in git itself.
+      packages = forAllSystems ({ pkgs, ... }: rec {
+        default = import ./nix/wrappers.nix {
+          inherit pkgs version;
+          src = ./.;
+        };
+        cratedigger = default;
+      });
+
+      apps = forAllSystems ({ system, ... }: {
+        pipeline-cli = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/pipeline-cli";
+        };
       });
 
       # The module is exported as a wrapper that pins its package set to
@@ -42,6 +63,10 @@
         # ephemeral postgres + a stubbed slskd. Verifies: migrator runs,
         # config.ini is rendered correctly, cratedigger-web responds.
         # Consumes the wrapped export — the same thing consumers import.
+        # `nix flake check` must build the CLI bundle (U8): a stranger's
+        # `nix run .#pipeline-cli` is only as green as this check.
+        packageDefault = self.packages.${system}.default;
+
         moduleVm = import ./nix/tests/module-vm.nix {
           inherit pkgs system;
           cratediggerModule = self.nixosModules.default;

--- a/nix/wrappers.nix
+++ b/nix/wrappers.nix
@@ -1,0 +1,47 @@
+# Standalone CLI wrapper bundle for `nix run` / `nix profile install`
+# (tier-2 plan U8, R8 / KTD4).
+#
+# Deliberately NOT a buildPythonApplication: the repo is flat (no
+# __init__.py in lib/scripts/harness, sys.path bootstraps in entry points,
+# vulture/unittest/pyright all assume repo-root layout), so the package
+# output is the same writeShellScriptBin shape the NixOS module uses —
+# pinned interpreter + PYTHONPATH=<repo root> only (the lib/beets.py
+# shadow hazard forbids subdirectories).
+#
+# Only the operator-facing CLI surfaces are bundled. The daemons
+# (cratedigger loop, importer, web, workers) are the NixOS module's job —
+# they need rendered config and systemd ordering, not `nix run`.
+{ pkgs, src ? ../., version ? "0-unstable-dirty" }:
+
+let
+  cratedigger = pkgs.callPackage ./package.nix { };
+  pythonEnv = cratedigger.pythonEnv;
+
+  runtimePath = pkgs.lib.makeBinPath [
+    pkgs.coreutils
+    pkgs.ffmpeg
+    pkgs.sox
+    pkgs.flac
+    pkgs.mp3val
+  ];
+
+  mkCliTool = name: script: pkgs.writeShellScriptBin name ''
+    export PATH="${runtimePath}:$PATH"
+    export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
+    exec ${pythonEnv}/bin/python ${src}/${script} "$@"
+  '';
+in
+pkgs.symlinkJoin {
+  name = "cratedigger-${version}";
+  pname = "cratedigger";
+  inherit version;
+  paths = [
+    # DSN via --dsn / PIPELINE_DB_DSN, same contract as everywhere else.
+    (mkCliTool "pipeline-cli" "scripts/pipeline_cli.py")
+    (mkCliTool "pipeline-migrate" "scripts/migrate_db.py")
+  ];
+  meta = {
+    description = "Cratedigger operator CLI (pipeline-cli, pipeline-migrate)";
+    mainProgram = "pipeline-cli";
+  };
+}


### PR DESCRIPTION
Tier-2 packaging plan U8 (R8 / KTD4).

- `nix/wrappers.nix`: operator CLI bundle (`pipeline-cli`, `pipeline-migrate`) as writeShellScriptBin wrappers over the pinned pythonEnv (symlinkJoin, `pname`/`version` attrs). Flat layout stays — no pyproject/src migration (KTD4's rationale: `lib/beets.py` shadow hazard + vulture/unittest/pyright root-layout assumptions). Daemons stay module-only.
- `nix run .#pipeline-cli -- --help` exits 0 from a clean clone; `apps.<system>.pipeline-cli` exposed.
- `version = 0-unstable-<date>-<shortRev>` (tags unreadable in pure flake eval; U9's vYYYY.MM.DD tags record verified states in git).
- `checks.<system>.packageDefault` puts the bundle on `nix flake check` (gated by U9's pre-push hook).

Verified: build + version eval + `nix run` all green; module contract tests green (no `.py` touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)