### PR TITLE
feat: U9 — pre-push nix-flake-check hook + tag convention

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -9,6 +9,8 @@
 - `restartIfChanged = false` on the cratedigger service — deploys don't restart it. The 5-min timer picks up new code on the next cycle. `cratedigger-web` and `cratedigger-db-migrate` use the systemd default and DO restart on switch.
 - Always verify deployed code: `ssh doc2 'grep "<unique string>" /nix/store/*/lib/quality.py 2>/dev/null'`. For module changes: `ssh doc2 'cat /etc/systemd/system/cratedigger.service'` or check the rendered `/var/lib/cratedigger/config.ini`.
 - Before deploying changes to `nix/module.nix`, run the VM check: `nix build .#checks.x86_64-linux.moduleVm`.
+- **Every `nix flake update` in cratedigger must re-run the real-beets drift gate** (`tests/test_harness_beets2_contract.py` inside the re-pinned shell, plus the full suite): since tier-2 packaging, the flake.lock — not the consumer's nixpkgs — decides the beets version production runs. A lock bump is a beets upgrade until proven otherwise.
+- After live verification of a deploy-worthy state, tag it `vYYYY.MM.DD` (suffix `-N` for same-day). The pre-push hook (`scripts/pre-push`, runs `nix flake check`) gates every push; the tag records the verified state.
 - Use the `/deploy` command for the full sequence.
 
 ## Database migrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,12 @@ Why: we hit this on 2026-05-20. The suite was reporting `OK (skipped=56)` for mo
 
 Install with: `ln -sf ../../scripts/pre-commit .git/hooks/pre-commit`. Runs pyright on staged `.py` files.
 
+### Pre-push hook
+
+Install with: `ln -sf ../../scripts/pre-push .git/hooks/pre-push`. Runs `nix flake check` (moduleVm boot gate + eval guards + CLI bundle) before every push — tags are verifiably green without CI (CI stays GitGuardian-only). First run per machine builds the VM (~minutes); later runs are cache hits. Escape hatch: `git push --no-verify`.
+
+**Tag convention:** known-good deployed states are tagged `vYYYY.MM.DD` (suffix `-N` for same-day). Tagging happens AFTER live verification on doc2 — the hook gates the push, the tag records the verified state.
+
 ### Claude Code commands
 
 - `/deploy` — full push → flake update → rebuild → verify sequence

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Git pre-push hook: run `nix flake check` before anything leaves the
+# machine (tier-2 plan U9, R9 — tags are verifiably green without CI;
+# cratedigger's CI is GitGuardian-only by design).
+#
+# Install: ln -sf ../../scripts/pre-push .git/hooks/pre-push
+#
+# Cost: the FIRST run per machine builds the moduleVm (a full NixOS VM
+# boot — several minutes) plus the eval checks and the CLI bundle.
+# Subsequent runs are Nix cache hits unless the relevant inputs changed;
+# a source change re-runs the VM (cratediggerSrc = ./.), which is the
+# point — the tree you push is the tree that booted.
+#
+# Deliberate escape hatch: `git push --no-verify`.
+set -euo pipefail
+
+echo "pre-push: nix flake check (moduleVm + eval guards + CLI bundle)..." >&2
+nix flake check
+echo "pre-push: flake check OK" >&2


### PR DESCRIPTION
Tier-2 packaging plan U9 (R9).

- `scripts/pre-push`: runs `nix flake check` before every push (installed via `ln -sf ../../scripts/pre-push .git/hooks/pre-push`, done on doc1). First-run VM cost + cache-hit behaviour documented in the header; `git push --no-verify` is the escape hatch.
- Tag convention `vYYYY.MM.DD` (suffix `-N` for same-day), cut after live verification — hook gates the push, tag records the verified state.
- `deploy.md`: every `nix flake update` must re-run the real-beets drift gate — the lock now decides the beets prod runs.
- No CI changes (GitGuardian-only stays). The hook's behaviour is `nix flake check` itself — covered by the U8/U10 checks; the full-check green proof lands with U10's gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)