### PR TITLE
docs: tier-2 README rewrite + sample mirror/consumer modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Cratedigger
 
-A quality-obsessed music acquisition pipeline. Searches Soulseek via [slskd](https://github.com/slskd/slskd), validates downloads against [MusicBrainz](https://musicbrainz.org/) or [Discogs](https://www.discogs.com/) via [beets](https://beets.io/), and curates a library toward verified lossless sources — automatically.
+A quality-obsessed music acquisition pipeline. Searches Soulseek via [slskd](https://github.com/slskd/slskd), validates every download against a specific [MusicBrainz](https://musicbrainz.org/) or [Discogs](https://www.discogs.com/) release via [beets](https://beets.io/), and curates a library toward verified lossless sources — automatically.
 
 Cratedigger doesn't just download albums. It siphons the best available quality out of Soulseek over time: downloading, verifying via spectral analysis, converting, comparing against what's already on disk, and re-queuing for upgrades when better sources appear.
 
-> This project was originally inspired by [mrusse/soularr](https://github.com/mrusse/soularr), a clever script that connected Lidarr with Soulseek. Cratedigger has since diverged into its own thing — PostgreSQL pipeline DB, beets validation, spectral quality verification, async downloads, a web UI — but the original idea of bridging Soulseek into a music library workflow came from mrusse's work. Thank you.
->
-> If you'd like to support the original author: [buy mrusse a coffee](https://ko-fi.com/mrusse).
+It is an **archival tool first**: requests point at exact pressings (a specific release ID, never a "close enough" sibling), the system never stops searching for what it hasn't found, and nothing irreversible ever happens without the operator. Much of the long tail it hunts is genuinely vanishing — the peer who had it logs off, and that's that.
+
+> This project was originally inspired by [mrusse/soularr](https://github.com/mrusse/soularr). Cratedigger has since diverged into its own thing — PostgreSQL pipeline DB, beets validation, spectral quality verification, async downloads, a web UI — but the original idea of bridging Soulseek into a music library workflow came from mrusse's work. If you appreciate that idea, [buy mrusse a coffee](https://ko-fi.com/mrusse).
 
 ## How it works
 
@@ -33,600 +33,136 @@ Pipeline DB (PostgreSQL)           |                       |
       |  source=request            |                       |
       |    spectral analysis       |                       |
       |    FLAC->V0 conversion     |                       |
-      |    quality gate            |  auto-import -------->| -> /Beets
+      |    quality gate            |  auto-import -------->| -> library
       |                            |                       |
       |  source=redownload         |                       |
       |    stage to /Incoming      |  (manual review)      |
-      |                            |                       |
-      |  ImportResult + ValidationResult JSON               |
-      |<---------------------------------------------------+
 ```
 
 ## Features
 
-- **PostgreSQL pipeline DB** as the sole source of truth for album requests, download state, and quality history
-- **Web UI** (`music.ablz.au`) for browsing local MusicBrainz and Discogs mirrors with a source toggle, and adding albums
-- **Beets validation** -- every download validated against the target release ID (MusicBrainz UUID or Discogs numeric) before import
-- **Auto-import** with FLAC->V0 conversion (or configurable target: Opus, MP3 V2, AAC, FLAC on disk), spectral analysis, and quality gating
-- **Async downloads** -- non-blocking: enqueue downloads, persist state to DB, poll on next run. Downloads span multiple 5-minute cycles.
-- **Parallel Soulseek searches** -- `ThreadPoolExecutor` fires all searches concurrently
-- **Spectral quality verification** -- sox-based transcode detection catches fake FLACs and upsampled MP3s
-- **Quality upgrade system** -- automatically re-queues albums when better sources become available. CBR -> lossless -> verified V0.
-- **User cooldowns** -- global, temporary cooldowns for Soulseek users who consistently timeout or fail (5 consecutive failures = 3-day cooldown)
-- **Force-import** -- manually import rejected downloads via CLI or web API
-- **Wrong Matches auto-triage** -- rejected wrong-match folders are previewed immediately; clear rejects are deleted and audited, importable/uncertain candidates stay visible
-- **Full audit trail** -- every decision stored as queryable JSONB in PostgreSQL
-- **Typed decision pipeline** -- pure functions in `quality.py`, typed dataclasses throughout, pyright enforced
-- **Discogs as first-class citizen** -- browse, add, and import Discogs releases through the same pipeline as MusicBrainz. Beets auto-routes numeric IDs to the Discogs plugin; local Discogs mirror eliminates external API dependencies.
-- **Comprehensive test suite** -- 1500+ tests (`nix-shell --run "bash scripts/run_tests.sh"`) with a 4-category taxonomy (pure / seam / orchestration / integration slice), shared `FakePipelineDB`/`FakeSlskdAPI` fakes, builders for typed data, and a route contract audit guard that fails at test time if a new web endpoint is added without frontend contract coverage
+- **Strict pressing identity** — every request targets one release ID; validation rejects anything that isn't that exact pressing
+- **PostgreSQL pipeline DB** as the sole source of truth for requests, download state, and quality history (full JSONB audit trail)
+- **Web UI** for browsing MusicBrainz and Discogs and adding albums to the pipeline
+- **Spectral quality verification** — sox-based transcode detection catches fake FLACs and upsampled MP3s
+- **Quality upgrade system** — automatically re-queues albums when better sources appear (CBR → lossless → verified target format)
+- **Async, parallel operation** — searches fan out concurrently; downloads span 5-minute cycles without blocking
+- **Persisted search plans** with escalation (wildcarded queries → exact → per-track) and long-tail "unfindable" triage
+- **Owned beets runtime** — the module ships a pinned beets with the full plugin closure and renders its config; your library's path layout is protected by config invariants tested in a VM on every `nix flake check`
+- **Operator surface twice over** — every action exists as both a `pipeline-cli` subcommand and a web API endpoint
+- **User cooldowns, force-import, wrong-match triage, YouTube rescue** for the long tail
 
-## Request Retry Backoff
+## Running it (NixOS)
 
-Cratedigger distinguishes between:
+Cratedigger is a Nix flake with a NixOS module. It deliberately builds its runtime (python env + beets) from **its own flake.lock** — the exact closure its test suite ran against — not your system's nixpkgs.
 
-- `status = 'wanted'` -- the request is still active in the pipeline
-- `eligible for search now` -- `status = 'wanted'` **and** `next_retry_after <= now()`
-
-`get_wanted()` only returns rows that are both wanted and due. A request can
-therefore sit in the wanted bucket while being intentionally skipped for a few
-hours.
-
-Retry-worthy failures call `record_attempt()` and set a shared per-request
-`next_retry_after` timestamp. There are three counters:
-
-- `search_attempts` -- search miss / enqueue failure
-- `download_attempts` -- download timeout or local move/processing failure
-- `validation_attempts` -- auto-import rejection that requeues the album
-
-The counters are separate, but the retry clock is shared. The most recent
-recorded failure overwrites `next_retry_after` for the request.
-
-Today this backoff is hardcoded in Python (`BACKOFF_BASE_MINUTES = 30`,
-`BACKOFF_MAX_MINUTES = 360`) and is **not yet tunable via the NixOS module**.
-The schedule is exponential and capped at 6 hours:
-
-| Attempt count | Delay before next search |
-|---|---|
-| 1 | 30 minutes |
-| 2 | 60 minutes |
-| 3 | 120 minutes |
-| 4 | 240 minutes |
-| 5 | 360 minutes |
-| 6 | 360 minutes |
-| 7+ | 360 minutes (6 hour cap) |
-
-That means a repeatedly failing request is retried at roughly:
-`t0`, `t0+30m`, `t0+1h30m`, `t0+3h30m`, `t0+7h30m`, then every 6 hours after
-the cap kicks in.
-
-Operator requeues go back to `wanted` without backoff. `reset_to_wanted()`
-clears all three counters and nulls `next_retry_after` by default, so
-upgrade/requeue paths from already-imported albums become eligible again
-immediately. Automatic download failures preserve the existing counters and
-record the failed attempt, so backoff continues to grow.
-
-This is separate from **user cooldowns**. Backoff is per album request; user
-cooldowns are global per Soulseek user.
-
-## Install
-
-Cratedigger ships as a Nix flake. The repo provides:
-
-- `nixosModules.default` — the NixOS module (systemd units, configTemplate, options surface)
-- `packages.<system>.slskd-api` — the `slskd-api` PyPI build (not in nixpkgs)
-- `devShells.<system>.default` — dev environment for running tests
-- `checks.<system>.moduleVm` — NixOS VM test booting the module against an ephemeral postgres
-
-Add it to your flake:
+You need: **NixOS**, **slskd** (`services.slskd` is in nixpkgs), and disk for music. PostgreSQL is provisioned for you.
 
 ```nix
 {
   inputs.cratedigger.url = "github:abl030/cratedigger";
+
   outputs = { self, nixpkgs, cratedigger, ... }: {
     nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
       modules = [
         cratedigger.nixosModules.default
-        ({ config, ... }: {
+        {
           services.cratedigger = {
             enable = true;
             slskd = {
-              apiKeyFile = "/run/secrets/slskd-api-key";   # raw key, one line
-              downloadDir = "/var/lib/slskd/downloads";
+              apiKeyFile = "/var/lib/secrets/slskd-api-key";  # raw key, one line
+              downloadDir = "/srv/music/slskd-downloads";
             };
-            pipelineDb.dsn = "postgresql://cratedigger@localhost/cratedigger";
+            pipelineDb.createLocally = true;   # local postgres, peer auth, no passwords
+            beetsConfig = {
+              directory = "/srv/music/library";
+              library = "/srv/music/beets-library.db";
+            };
             beetsValidation = {
-              enable = true;
-              stagingDir = "/srv/music/Incoming";
+              stagingDir = "/srv/music/incoming";
               trackingFile = "/srv/music/beets-validated.jsonl";
             };
             web = {
-              enable = true;
+              enable = true;                    # UI on :8085
               beetsDb = "/srv/music/beets-library.db";
             };
           };
-        })
+        }
       ];
     };
   };
 }
 ```
 
-You provide: PostgreSQL (the module just takes a DSN), slskd, and a secrets backend that materializes `*File` paths the module reads. The module owns a local Redis server by default for the pipeline peer cache and web metadata cache (`redis-cratedigger.service`, `maxmemory=3gb`, `allkeys-lru`). The module defaults to running as root because slskd downloads land outside any service-user home and beets needs broad filesystem access; override `services.cratedigger.user` once you've set up the surrounding permissions.
+A complete, commented version of this (including slskd itself) is [`examples/cratedigger.nix`](examples/cratedigger.nix). Misconfigurations fail at eval time with messages that name the option to set. The module runs as root by default (Soulseek downloads and the library live outside any service user's home) — override `services.cratedigger.user` if you've arranged permissions.
 
-Try it without committing:
+`cratedigger-beet` lands on your PATH as the canonical beets binary for the managed library (run it with sudo). The operator CLI is also available without installing anything:
 
 ```bash
-nix develop github:abl030/cratedigger        # dev shell with deps
-nix run github:abl030/cratedigger#slskd-api  # build the slskd-api package
-nix flake check github:abl030/cratedigger    # boot the VM check
+nix run github:abl030/cratedigger#pipeline-cli -- --help
 ```
 
-For homelab consumers (sops-nix, nspawn DB containers, reverse proxies), see `~/nixosconfig/modules/nixos/services/cratedigger.nix` for a worked example wrapping this module.
+### Mirrors (optional, recommended for speed)
 
-## Quality decision pipeline
+Out of the box, MusicBrainz matching uses **public musicbrainz.org** (works, rate-limited ~1 req/s) and **Discogs browse is off** (the web UI is MB-only; you get a clear 503 explaining why). Local mirrors remove both limits:
 
-All quality decisions are pure functions in `lib/quality.py` with full unit test coverage:
-
-1. **`spectral_import_decision()`** -- Pre-import: should we import this CBR download?
-2. **`import_quality_decision()`** -- Is this an upgrade or downgrade? Genuine FLAC->V0 always wins.
-3. **`transcode_detection()`** -- Post-FLAC-conversion: was the FLAC a transcode?
-4. **`quality_gate_decision()`** -- Post-import: accept, or re-queue for better quality?
-5. **`determine_verified_lossless()`** -- Single source of truth for verified lossless status.
-6. **`should_cooldown()`** -- Global user cooldown: skip users with 5+ consecutive failures for 3 days.
-
-## Tuning the quality rank model
-
-Every threshold, enum, and per-codec band in the rank model is tunable via Nix options on the deployment side. The runtime parses them from `[Quality Ranks]` in `/var/lib/cratedigger/config.ini`, which is regenerated on every `nixos-rebuild switch` from the Nix module. Full rationale and per-band justification lives in [`docs/quality-ranks.md`](docs/quality-ranks.md); this section is the tuning reference.
-
-### Where to tune
-
-All options live under `services.cratedigger.qualityRanks.*` and are declared by the upstream NixOS module at [`nix/module.nix`](nix/module.nix) in this repo. Set them anywhere in your NixOS config that imports `cratedigger.nixosModules.default` — typically a host config or a homelab wrapper. The `[Quality Ranks]` section of `config.ini` is regenerated from these options on every `nixos-rebuild switch`; Cratedigger picks up the new values on its next 5-min timer fire.
-
-**Source of truth**: `QualityRankConfig.defaults()` in `lib/quality.py`, pinned by `TestQualityRankConfigDefaults` in `tests/test_quality_decisions.py`. The Nix options mirror those defaults for declarative visibility -- you should be able to open `cratedigger.nix` and read your current policy without grepping Python. Drift between Python and Nix is caught at cratedigger test time: bump a default in either repo, the pin test fails and reminds you to update the other.
-
-### Nix-exposed options
-
-**Policy scalars:**
-
-| Option | Type | Default | Meaning |
+| Mirror | Without it | Option | Sample |
 |---|---|---|---|
-| `gateMinRank` | enum (`unknown`, `poor`, `acceptable`, `good`, `excellent`, `transparent`, `lossless`) | `"excellent"` | Minimum rank an imported album must reach before the quality gate accepts it. Below this → re-queue for upgrade. Raise to tighten (reject more albums); lower to accept lower-quality sources. |
-| `bitrateMetric` | enum (`min`, `avg`, `median`) | `"avg"` | Which per-album bitrate statistic feeds rank classification. `avg` is robust to VBR per-track variance. `median` is outlier-resistant -- prefer when albums commonly have quiet intros/hidden tracks/skits that skew `avg`. `min` is legacy and penalizes legitimately-encoded lo-fi VBR. See `docs/quality-ranks.md` "When to prefer median". |
-| `withinRankToleranceKbps` | int | `5` | Same-rank equivalence window in kbps. Two bare-codec measurements in the same rank tier within this tolerance are "equivalent"; outside it, one is "better"/"worse". |
+| MusicBrainz | Functional but ~1 req/s | `musicbrainz.apiBase` | [`examples/musicbrainz-mirror.nix`](examples/musicbrainz-mirror.nix) |
+| Discogs | Discogs browse off; MB browse unaffected | `discogs.apiBase` + `beets.discogsMirrorUrl` | [`examples/discogs-mirror.nix`](examples/discogs-mirror.nix) |
+| LRCLIB (lyrics) | Public lrclib.net | `beets.lrclibUrl` | — |
 
-**Per-codec band tables** (`bands.<codec>.{transparent,excellent,good,acceptable}`, all in kbps, used when the format hint is a bare codec string like `"MP3"` rather than an explicit label like `"mp3 v0"`):
+The full account (sizes, replication tokens, degraded-mode math) is in [`docs/mirrors.md`](docs/mirrors.md).
 
-| Codec | transparent | excellent | good | acceptable | Notes |
-|---|---|---|---|---|---|
-| `bands.opus`   | 112 | 88  | 64  | 48  | Unconstrained Opus VBR averages 120-135 kbps typical / 95-150 kbps per track. 112 leaves headroom for sparse material; 88 matches Opus 96 hydrogenaudio quality. |
-| `bands.mp3Vbr` | 245 | 210 | 170 | 130 | `excellent=210` preserves the legacy `QUALITY_MIN_BITRATE_KBPS=210` gate threshold. V0 typically averages 220-260; V2 ~190 → `good=170`. **`excellent` also feeds `transcode_detection()` as the spectral-fallback threshold** (#66) so lowering it implicitly lowers what counts as "credible V0" when spectral is unavailable. |
-| `bands.mp3Cbr` | 320 | 256 | 192 | 128 | Unverifiable CBR is only `transparent` at 320 because we can't prove a CBR file came from lossless source. Below that → requeue for a FLAC source to re-verify. |
-| `bands.aac`    | 192 | 144 | 112 | 80  | Hydrogenaudio consensus places the "no meaningful quality gain above here" ceiling for music at 192 kbps. |
-
-Leaving every option at its default produces exactly `QualityRankConfig.defaults()` -- the defaults above are the shipping values.
-
-### Collection fields (NOT exposed via Nix -- edit `lib/quality.py` directly)
-
-Three fields are part of the rank model but are NOT surfaced as Nix options because they're rarely-if-ever retuned outside of development. They live on `QualityRankConfig` in `lib/quality.py`, are parseable from `[Quality Ranks]` as CSV (see #65), and default to sensible values. If you want to tune them, the cleanest path is editing the dataclass defaults and updating `TestQualityRankConfigDefaults` to pin the new values. Extending `nix/module.nix` to render them is a trivial follow-up if you find yourself retuning them often.
-
-- **`mp3_vbr_levels`** -- 10-tuple mapping LAME V-levels to ranks (V0..V9). The V-level is an **explicit label contract** -- when a download advertises `"mp3 v0"`, the rank model reads V0 from this tuple and bypasses `bands.mp3Vbr` entirely. This is why a 207 kbps lo-fi V0 still classifies as TRANSPARENT: the V0 label beats the 210 threshold.
-
-  **Default ladder**: `V0=TRANSPARENT, V1-V2=EXCELLENT, V3-V4=GOOD, V5-V9=ACCEPTABLE`
-
-  **When to retune**: tighten if you don't trust LAME's claim that V2 is transparent (move V1/V2 to EXCELLENT → GOOD). Loosen if you encode at V4 locally and want your own rips to pass the gate (move V4 up to EXCELLENT).
-
-- **`lossless_codecs`** -- set of codec identity strings that **short-circuit to LOSSLESS** regardless of measured bitrate. Checked against the first whitespace-separated token of the format hint during rank classification. If the format hint starts with any of these, the rank model skips bitrate-based classification entirely and returns LOSSLESS.
-
-  **Default**: `{"flac", "lossless", "alac", "wav"}`
-
-  **When to retune**: add `"ape"`, `"dsf"`, or `"wavpack"` if your library carries them. Remove nothing -- removing entries is a footgun that would reclassify genuine lossless files as UNKNOWN.
-
-- **`mixed_format_precedence`** -- ordered tuple used by `_reduce_album_format()` when an album on disk has tracks in multiple codecs (rare -- usually a manually-merged album). Walked in order; the first codec that appears on the album becomes the album's canonical codec for rank classification. Order matters.
-
-  **Default**: `("mp3", "aac", "opus", "flac")` -- worst codec wins, so a mixed FLAC+MP3 album classifies as MP3 (conservative).
-
-  **When to retune**: reverse to `("flac", "opus", "aac", "mp3")` if you'd rather have mixed-format albums classified by the *best* codec on disk (less conservative -- you'll accept more as "good enough"). The default is the conservative choice for a curated library.
-
-### How to tune and deploy
-
-The exact deploy flow depends on where you set the options. For a host config that imports `cratedigger.nixosModules.default` directly:
+### Verifying before you trust it
 
 ```bash
-$EDITOR hosts/<your-host>/configuration.nix   # tweak services.cratedigger.qualityRanks.*
-git commit -am "cratedigger: retune <what>" && git push
-sudo nixos-rebuild switch --flake .
+nix flake check github:abl030/cratedigger
 ```
 
-For the abl030 homelab (this project's reference deployment):
+boots a NixOS VM in the stranger posture — local postgres, rendered beets config, public-MB defaults — and asserts the invariants that have historically eaten libraries (beets `duplicate_keys` nesting, the plugin list, path templates). The same check gates every push to this repo via a pre-push hook; known-good states are tagged `vYYYY.MM.DD`.
+
+## Quality pipeline in one paragraph
+
+Every download is validated against its exact target release (beets match distance ≤ 0.15), spectrally analysed (sox), converted (FLAC→V0 by default, or a configured `verifiedLosslessTarget` like `opus 128`), and compared against what's already on disk before beets imports it. All decisions are pure functions in `lib/quality.py` with a CLI simulator (`pipeline-cli quality <id>`); every outcome lands as queryable JSONB in the pipeline DB. Details: [docs/quality-ranks.md](docs/quality-ranks.md), [docs/quality-verification.md](docs/quality-verification.md).
+
+| Config value for `verifiedLosslessTarget` | Output | Notes |
+|---|---|---|
+| `opus 128` / `opus 96` | `.opus` | ~half V0's bitrate at equivalent quality |
+| `mp3 v0` / `mp3 v2` / `mp3 192` | `.mp3` | LAME VBR/CBR |
+| `aac 128` | `.m4a` | Apple ecosystem |
+| *(empty)* | `.mp3` | keep V0 — the default |
+
+## Request retry backoff
+
+A request can be `wanted` while intentionally skipped for a few hours: retry-worthy failures (search miss, download timeout, rejected import) set a shared exponential `next_retry_after` (30 min base, 6 h cap), and `get_wanted()` only returns rows that are due. Search, download, and validation attempts are counted separately; the retry clock is shared. The backoff is currently hardcoded (`BACKOFF_BASE_MINUTES = 30`, `BACKOFF_MAX_MINUTES = 360`), not module-tunable.
+
+## Going deeper
+
+| Topic | Where |
+|---|---|
+| Every module option | [docs/nixos-module.md](docs/nixos-module.md) |
+| Mirrors: setup + degraded modes | [docs/mirrors.md](docs/mirrors.md) |
+| Beets ownership, harness, config invariants | [docs/beets-primer.md](docs/beets-primer.md) |
+| Quality model + tuning the rank bands | [docs/quality-ranks.md](docs/quality-ranks.md), [docs/quality-verification.md](docs/quality-verification.md) |
+| Search plans, escalation, unfindable triage | [docs/persisted-search-plans-rollout.md](docs/persisted-search-plans-rollout.md), [docs/search-plan-iter2-deploy.md](docs/search-plan-iter2-deploy.md) |
+| Pipeline DB schema + audit blobs | [docs/pipeline-db-schema.md](docs/pipeline-db-schema.md) |
+| Debugging a decision (`pipeline-cli show/quality/debug-download`) | [docs/debugging-cli.md](docs/debugging-cli.md) |
+| Web UI internals + dev server | [docs/webui-primer.md](docs/webui-primer.md), [docs/web-dev-server.md](docs/web-dev-server.md) |
+| Post-import notifiers (Meelo / Plex / Jellyfin) | [docs/meelo-primer.md](docs/meelo-primer.md), [docs/plex-primer.md](docs/plex-primer.md) |
+
+## Development
 
 ```bash
-# On doc1 — has git push credentials for nixosconfig
-cd ~/nixosconfig
-$EDITOR hosts/doc2/configuration.nix          # tweak services.cratedigger.qualityRanks.*
-git commit -am "cratedigger: retune <what>" && git push
-ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
+nix-shell --run "bash scripts/run_tests.sh"   # full suite (~2 min): JS, dead-code sweep, 4600+ python tests
+nix-shell --run "pyright"                     # 0 errors, enforced
 ```
 
-### How to verify the new config is live
-
-1. **Read the generated file** -- `ssh doc2 'sudo cat /var/lib/cratedigger/config.ini | grep -A 30 "\[Quality Ranks\]"'`. The section should show the exact values from your Nix edit.
-
-2. **Check the runtime picks them up** -- `ssh doc2 'pipeline-cli quality <any_request_id>'`. The output prints the active `gate_min_rank`, `bitrate_metric`, and thresholds the simulator is using. Mismatch means Cratedigger hasn't restarted since the rebuild (it's a 5-min timer) -- wait a cycle or `sudo systemctl start cratedigger --no-block`.
-
-3. **Visual confirmation** -- open the [Decisions tab at music.ablz.au](https://music.ablz.au). The top of the tab renders three pills (**Gate min rank** / **Bitrate metric** / **Within-rank tolerance**) pulled from the same `_runtime_rank_config()` snapshot. If your tuning is live, the pills show the new values (#68). The transcode stage rule threshold also reflects `bands.mp3Vbr.excellent` live, since `get_decision_tree()` threads `cfg` through (#75).
-
-### The search filter is deliberately permissive
-
-The `[Search Settings] allowed_filetypes` list in `config.ini` (exposed as `services.cratedigger.searchSettings.allowedFiletypes` on the upstream module) is a **priority-ordered preference list**, not a quality gate. It decides which codecs Cratedigger prefers when multiple options exist for the same album and drives peer selection within each tier; it does NOT decide whether a file is "good enough". That call belongs to the rank model.
-
-**Current production list** (top-to-bottom priority):
-
-```
-mp3 v0,mp3 320,flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,aac,opus,ogg,mp3,wav
-```
-
-**How it actually works** (in `cratedigger.py:_build_search_cache` → `lib/enqueue.py:_try_filetype`):
-
-1. slskd returns every peer that has a file matching the raw text query "artist album". No filetype restriction on the wire — the codec preference is applied locally.
-2. `_build_search_cache()` walks each file and buckets it into the **first tier it matches**. Files that match zero tiers are dropped.
-3. `_try_filetype()` walks tiers in list order. For each tier, it sorts peers by upload speed (descending) and enqueues the first peer with a complete album directory.
-4. If no tier has a complete album, the fallback catch-all unions all tiers the peer already matched — it does NOT rescue files that matched no tier at all.
-
-**Why the high-quality tiers lead**: `mp3 v0` and `mp3 320` sit at the top because the curation philosophy in `CLAUDE.md` says "MP3 V0 is efficient TRANSPARENT MP3; take it if available". FLAC sample-rate tiers follow so hi-res FLAC beats CD-quality FLAC. ALAC comes before the lossy codecs because it's lossless. AAC/Opus/OGG get specific tiers before the bare-codec fallbacks so preferred lossy codecs have priority.
-
-**Why the bare-codec tiers at the end**: `aac`, `opus`, `ogg`, `mp3`, `wav` with no quality qualifier match any bitrate/bitdepth for that codec. They exist so that **any audio file the rank model understands reaches the rank model**. The rank model then handles the real decision via:
-
-- `quality_rank()` → codec-specific band classification from `cfg.{opus,aac,mp3_vbr,mp3_cbr}.{transparent,excellent,good,acceptable}`
-- `import_quality_decision()` → accepts imports unconditionally when there's no existing album, rejects downgrades against existing albums
-- `quality_gate_decision()` → accepts or `requeue_upgrade` based on rank vs `cfg.gate_min_rank`
-- Spectral verification via `spectral_import_decision()` for MP3/CBR
-- Transcode detection via `transcode_detection()` for FLAC→V0 conversions
-
-**The design intent**: low-quality placeholder imports for new requests that have nothing else, followed by automatic upgrade cycles as better sources appear on Soulseek. An obscure album that only exists as MP3 V4 gets imported at V4, then upgrades to FLAC if/when a lossless seeder shows up. No silent "no match found" blind spots.
-
-**When to tune this list**:
-
-- **Reorder the preferred tiers** if you want a different curation philosophy. E.g. moving `flac 16/44.1` above `mp3 v0` means "always prefer FLAC even though it's 5x bigger". Current order prefers space-efficient transparent MP3.
-- **Remove a bare-codec fallback tier** if you want the search filter to enforce a codec floor. E.g. removing `opus` means Opus 128 is invisible again, matching the pre-2026-04-11 behavior.
-- **Add format/bitrate-specific tiers** if you want to promote or demote specific subsets. E.g. inserting `opus 128+` between `alac` and the bare-codec fallbacks would prefer Opus 128 before falling through to AAC/OGG.
-
-**Exposed as `services.cratedigger.searchSettings.allowedFiletypes`** (a `listOf str`). Set it on the host config that imports the upstream module to override the default list above.
-
-### Where the docs live
-
-- [`docs/quality-ranks.md`](docs/quality-ranks.md) -- the full rank model rationale: rank ladder, codec resolution order, band table justification, bitrate metric tradeoffs, when to prefer median.
-- [`docs/quality-verification.md`](docs/quality-verification.md) -- spectral cliff detection methodology and tuning history.
-- `lib/quality.py:QualityRankConfig` -- the dataclass, with docstrings next to each default.
-- `tests/test_quality_decisions.py:TestQualityRankConfigDefaults` -- pin tests that fail loudly on any drift.
-- `lib/quality.py:file_identity()` / `filetype_matches()` / `parse_filetype_config()` -- the search-side filetype spec model that backs `allowed_filetypes`.
-
-### Search loop tunables
-
-Three Nix options control the slskd search window and the plan-driven
-escalation ladder. All live under `services.cratedigger.searchSettings.*`
-and render into `[Search Settings]` in `config.ini`. See
-[`docs/pipeline-db-schema.md`](docs/pipeline-db-schema.md#persisted-search-plans-migration-014)
-for the full plan/cursor schema and
-[`docs/parallel-search.md`](docs/parallel-search.md#plan-driven-execution-post-2026-05-cutover)
-for how Phase 2 picks the next slot.
-
-| Option | Default | Maps to | What it caps |
-|--------|---------|---------|--------------|
-| `searchResponseLimit` | `1000` | slskd `responseLimit` | Number of peer responses slskd buffers per search. Raising this gives the matcher more peer diversity. Caps at this value when peers stop responding. |
-| `searchFileLimit` | `50000` | slskd `fileLimit` | Total files across all peer responses. Multi-disc / OST / compilation searches fill this fast (each peer holds 50+ tracks); the slskd-api default of 10000 terminates such searches in ~3s, possibly before the right peer responds. |
-| `searchEscalationThreshold` | `5` | (cratedigger only) | Number of repeated default slots the generator emits at the head of every plan before stepping into `unwild`, optional `unwild_year`, and up to three track slots. See `lib/search.py` (`SEARCH_PLAN_GENERATOR_ID` and the pure plan generator). |
-
-**What you cannot tune from here**: the per-search `searchTimeout` is fixed at 30s by slskd itself (see `cfg.search_timeout` in `config.ini`, but slskd ignores values above 30000ms). The dominant cycle cost is searches running to that timeout because vague variants don't fill the response/file caps. Issue #196 tracks options to remove this ceiling.
-
-### Inspecting and regenerating a request's search plan
-
-```bash
-# Read-only: show the active plan, cursor, cycle count, items, and
-# legacy logs for a request.
-pipeline-cli search-plan show <request_id>            # human output
-pipeline-cli search-plan show <request_id> --json     # machine output
-
-# Mutating: regenerate the plan from current metadata. Allowed for any
-# status; only `wanted` requests with a successful current plan are
-# executable. A successful regeneration resets cursor / cycle to 0 --
-# don't run this on active requests just to inspect.
-pipeline-cli search-plan regenerate <request_id>
-```
-
-API equivalents (`/api/pipeline/<id>/search-plan` GET,
-`/api/pipeline/<id>/search-plan/regenerate` POST) live in
-`web/routes/pipeline.py`. The dashboard summary at
-`/api/pipeline/dashboard` exposes plan-readiness counts (searchable /
-legacy / failed-deterministic / failed-transient / no-plan) and
-plan-driven cycle-wrap metrics in addition to the historical search
-outcomes. See [`docs/persisted-search-plans-rollout.md`](docs/persisted-search-plans-rollout.md)
-for operator verification.
-
-## Audit trail
-
-Every download stores two JSONB blobs in `download_log` for complete auditability:
-
-**`import_result`** -- from `import_one.py` via `ImportResult` dataclass:
-- Decision (import/downgrade/transcode_upgrade/transcode_downgrade/error)
-- Per-track spectral analysis (grade, HF deficit, cliff detection per track)
-- Conversion details (FLAC->V0 or configurable target format, post-conversion bitrate)
-- Quality comparison (new vs existing bitrate, verified_lossless flag)
-- Postflight verification (beets ID, track count, imported path)
-
-**`validation_result`** -- from `beets_validate()` via `ValidationResult` dataclass:
-- Full beets candidate list with distance breakdown per component (album, artist, tracks, media, source, year...)
-- Track mapping: which local file matched which MusicBrainz track
-- Local file list (path, title, bitrate, format) vs MB track list (title, length, track_id)
-- Beets recommendation confidence level
-- Soulseek username, download folder, failed_path (used by force-import), denylisted users, corrupt files
-
-```sql
--- Why was this rejected?
-SELECT validation_result->'candidates'->0->'distance_breakdown',
-       import_result->>'decision',
-       import_result->'spectral'->>'grade'
-FROM download_log WHERE id = <id>;
-
--- Which tracks matched?
-SELECT m->'item'->>'title' as local, m->'track'->>'title' as mb
-FROM download_log, jsonb_array_elements(validation_result->'candidates'->0->'mapping') AS m
-WHERE id = <id>;
-```
-
-All types are fully typed dataclasses with pyright enforcement and JSON round-trip serialization:
-`ImportResult`, `ValidationResult`, `CandidateSummary`, `HarnessItem`, `HarnessTrackInfo`, `TrackMapping`, `DownloadInfo`, `AlbumInfo`, `ActiveDownloadState`, `ActiveDownloadFileState`, `CooldownConfig`.
-
-## Pipeline CLI diagnostics
-
-`pipeline-cli` already has the pipeline DB connection configured, so use it for ad-hoc debugging instead of hand-rolling `psql` or Python one-offs.
-
-```bash
-# Inline SQL (runs in a read-only DB session)
-pipeline-cli query "SELECT id, status, artist_name, album_title FROM album_requests WHERE status = 'wanted' LIMIT 5"
-
-# Multi-line SQL without shell quoting
-pipeline-cli query - <<'SQL'
-SELECT id, artist_name, album_title, min_bitrate, current_spectral_bitrate
-FROM album_requests
-WHERE current_spectral_bitrate IS NOT NULL
-ORDER BY updated_at DESC
-LIMIT 10
-SQL
-
-# JSON output for scripting
-pipeline-cli query --json "SELECT id, outcome, import_result FROM download_log ORDER BY id DESC LIMIT 3"
-```
-
-## MusicBrainz mirror
-
-All MusicBrainz lookups hit a local mirror at `http://192.168.1.35:5200` (doc2), not the public API. This avoids rate limits and provides sub-second response times. The mirror runs [musicbrainz-docker](https://github.com/metabrainz/musicbrainz-docker) and replicates nightly.
-
-```bash
-# Search releases
-curl -s "http://192.168.1.35:5200/ws/2/release?query=artist:radiohead+AND+release:ok+computer&fmt=json"
-
-# Get release with tracks
-curl -s "http://192.168.1.35:5200/ws/2/release/<MBID>?inc=recordings+media&fmt=json"
-```
-
-## Verified lossless target format
-
-After verifying a FLAC download is genuine (via spectral analysis + V0 conversion), the pipeline can convert to a configurable target format instead of keeping V0. Set via the upstream module:
-
-```nix
-services.cratedigger.beetsValidation.verifiedLosslessTarget = "opus 128";
-```
-
-This renders into `[Beets Validation] verified_lossless_target = opus 128` in the runtime `config.ini`.
-
-Supported formats:
-
-| Config value | ffmpeg codec | Output | Notes |
-|---|---|---|---|
-| `opus 128` | libopus VBR 128kbps | `.opus` | ~half the bitrate of V0 at equivalent quality |
-| `opus 96` | libopus VBR 96kbps | `.opus` | Good for space-constrained libraries |
-| `mp3 v0` | LAME VBR quality 0 | `.mp3` | Same as default (no target needed) |
-| `mp3 v2` | LAME VBR quality 2 | `.mp3` | ~190kbps, smaller than V0 |
-| `mp3 192` | LAME CBR 192kbps | `.mp3` | Fixed bitrate |
-| `aac 128` | AAC VBR 128kbps | `.m4a` | Apple ecosystem |
-| *(empty)* | *(none)* | `.mp3` | Keep V0 — the default |
-
-The V0 verification step always runs first regardless of target format. Genuineness is judged by `transcode_detection()`: spectral cliff analysis is authoritative when available (suspect grade → transcode, genuine/marginal → not), and the post-conversion V0 bitrate is a fallback only when spectral is unavailable. The fallback threshold defaults to `cfg.mp3_vbr.excellent` (210 kbps) and tracks retuning of `[Quality Ranks]` automatically. Only after verification does the target conversion run from the original FLAC. If the FLAC is a transcode, the target conversion is skipped and V0 is kept.
-
-## Notifiers (Meelo / Plex / Jellyfin)
-
-After a successful auto-import, Cratedigger fires a best-effort library-refresh POST to each configured downstream media server so newly-imported albums appear without a manual rescan. Each notifier is independent and disabled by default. Failures are logged and non-fatal: a broken Plex will never block a successful beets import.
-
-Configure via the upstream module:
-
-```nix
-services.cratedigger.notifiers = {
-  meelo = {
-    enable = true;
-    url = "https://meelo.example.com";
-    usernameFile = "/run/secrets/meelo-username";
-    passwordFile = "/run/secrets/meelo-password";
-  };
-  plex = {
-    enable = true;
-    url = "https://plex.example.com";
-    tokenFile = "/run/secrets/plex-token";
-    librarySectionId = 3;
-    pathMap = "/srv/music/Beets:/data/music";   # optional, scopes refresh to one path
-  };
-  jellyfin = {
-    enable = true;
-    url = "https://jellyfin.example.com";
-    tokenFile = "/run/secrets/jellyfin-token";
-  };
-};
-```
-
-The module renders the `[Meelo]` / `[Plex]` / `[Jellyfin]` sections of `config.ini` from these options at boot, sed-substituting credentials read from each `*File` path. The typed fields + `from_config` wiring live in [`lib/config.py`](lib/config.py); the HTTP calls themselves are `trigger_meelo_scan()` / `trigger_plex_scan()` / `trigger_jellyfin_scan()` in [`lib/util.py`](lib/util.py), dispatched from `lib/dispatch/` under the `trigger_notifiers` flag on `DispatchAction`. Jellyfin's `library_id` is optional — leave it unset to trigger a full refresh.
-
-## Running tests
-
-```bash
-nix-shell --run "bash scripts/run_tests.sh"    # full suite, saves to /tmp/cratedigger-test-output.txt
-nix-shell --run "python3 -m unittest tests.<module> -v"  # single module
-```
-
-## Frontend development server
-
-Use the local live-reload server when iterating on `web/index.html` or
-`web/js/*.js`. It serves the checked-out frontend files and backs `/api/*`
-from one of three read-only data sources:
-
-```bash
-# Deterministic fixture data, no network or DB required
-nix-shell --run "python3 scripts/web_dev_server.py --data fixture --scenario peer_dirs --port 8096"
-
-# Local frontend files against any remote read-only backend
-nix-shell --run "python3 scripts/web_dev_server.py --data prod-api --prod-base-url http://127.0.0.1:18096 --port 8096"
-
-# On the backend host only: local route code against a live DB session
-PIPELINE_DB_DSN=postgresql://cratedigger@127.0.0.1:15432/cratedigger \
-  nix-shell --run "python3 scripts/web_dev_server.py --data live-db --host 127.0.0.1 --port 8096"
-```
-
-`prod-api` is a generic proxy mode despite the historical name. Point
-`--prod-base-url` at `https://music.ablz.au`, another dev server, or an SSH
-forwarded port.
-
-For Wrong Matches and other file-backed views, `live-db` must run on a host
-that can open the real download folders on disk. PostgreSQL access alone is not
-enough because the explorer and audio endpoints read files directly. In the
-current homelab, `doc1` and `doc2` can act as backend hosts; a laptop usually
-cannot.
-
-Canonical "works from anywhere with SSH" flow:
-
-```bash
-# 1. On a backend host that can see the files, start the live-db server.
-#    If that host needs a DB tunnel first, expose doc2's PostgreSQL locally:
-ssh -N -L 15432:192.168.100.11:5432 doc2
-PIPELINE_DB_DSN=postgresql://cratedigger@127.0.0.1:15432/cratedigger \
-  nix-shell --run "python3 scripts/web_dev_server.py --data live-db --host 127.0.0.1 --port 8096"
-
-# 2. From your local machine, tunnel the remote backend back to localhost.
-ssh -N -L 18096:127.0.0.1:8096 <backend-host>
-
-# 3. Serve your checked-out frontend files locally against that backend.
-nix-shell --run "python3 scripts/web_dev_server.py --data prod-api --prod-base-url http://127.0.0.1:18096 --host 127.0.0.1 --port 8096"
-```
-
-Open <http://127.0.0.1:8096>. The page gets a small dev badge and reloads
-automatically when `web/index.html`, `web/js/*.js`, or the active fixture JSON
-changes. Mutating API requests are blocked in all modes; `live-db` also sets
-the PostgreSQL session to `default_transaction_read_only=on`. The `prod-api`
-proxy forwards `Range` requests, so in-browser audio playback and seek work
-through the tunnel.
-
-The test layer follows a 4-category taxonomy documented in `.claude/rules/code-quality.md`:
-
-- **Pure function tests** — direct input → output, exhaustive subTest tables for decision matrices
-- **Seam tests** — interface boundaries (subprocess argv, route contract fields, SQL shape)
-- **Orchestration tests** — assert domain state via `FakePipelineDB`/`FakeSlskdAPI`, not mock call shapes
-- **Integration slices** — real code paths in `tests/test_integration_slices.py`, minimal patching, required for every high-risk orchestration boundary
-
-Shared infrastructure lives in `tests/fakes.py` (stateful fakes) and `tests/helpers.py` (typed data builders + the `patch_dispatch_externals()` context manager). New web routes must be classified in `TestRouteContractAudit.CLASSIFIED_ROUTES` — the suite fails at test time if a route is added without contract coverage.
-
-## Deployment
-
-Deployed via NixOS. The upstream module at [`nix/module.nix`](nix/module.nix) builds a Python environment with dependencies and registers the runtime systemd units:
-
-- `cratedigger-db-migrate.service` — oneshot, runs the schema migrator (`scripts/migrate_db.py`) on every `nixos-rebuild switch`. `restartIfChanged = true` + `RemainAfterExit = true` so it always re-evaluates when the unit derivation changes but doesn't re-run between cycles.
-- `redis-cratedigger.service` — app-owned Redis server for peer cache and web metadata cache. The pipeline/web units want and start after it, but do not require it; Redis failures degrade to cold-cache behavior.
-- `cratedigger.service` — oneshot pipeline run, triggered by `cratedigger.timer`. Runs healthcheck → prestart (renders `config.ini`) → `cratedigger.py`. `restartIfChanged = false` so deploys don't restart it mid-cycle; the next timer fire picks up the new code.
-- `cratedigger.timer` — starts the next cycle 1 second after the previous
-  oneshot exits by default (`services.cratedigger.timer.onUnitInactiveSec`).
-- `cratedigger-importer.service` — long-running serial importer that drains `import_jobs` whose async preview stage marked them importable. When the async preview gate is disabled, newly queued jobs are marked importable immediately.
-- `cratedigger-import-preview-worker.service` — optional long-running async preview worker enabled by `services.cratedigger.importer.preview.enable = true`. It defaults to `services.cratedigger.importer.previewWorkers = 2`, claims queued preview work, and runs validation/spectral/measurement preview before the importer sees the job.
-- `cratedigger-web.service` — long-running web UI bound to `services.cratedigger.web.port` (default 8085).
-
-`cratedigger.service`, `cratedigger-importer.service`, `cratedigger-import-preview-worker.service` when enabled, and `cratedigger-web.service` all require the migrate unit, so the app cannot start against an un-migrated DB. These units can start in parallel after migration; their prestart renders `/var/lib/cratedigger/config.ini` through an atomic temp-file-and-rename step so concurrent service starts do not race on the shared config file.
-
-To deploy a new revision:
-
-```bash
-# 1. Push your cratedigger changes
-cd /path/to/cratedigger && git push
-
-# 2. Update the flake input on the consumer side
-cd /path/to/your-nixos-config
-nix flake update cratedigger              # or whatever you named the input
-git commit -am "cratedigger: bump" && git push
-
-# 3. Rebuild
-sudo nixos-rebuild switch --flake .       # or via --flake github:user/repo#host
-```
-
-`restartIfChanged = false` on `cratedigger.service` means the deploy completes without restarting an in-flight cycle; the next 5-min timer fire runs the new code.
-
-For the first Redis peer-cache deploy, run it as a controlled single-cycle rollout:
-
-```bash
-sudo systemctl stop cratedigger.timer
-sudo nixos-rebuild switch --flake .#HOST
-systemctl is-active redis-cratedigger.service
-redis-cli -p 6379 CONFIG GET maxmemory-policy
-grep -A8 '^\[Peer Cache\]' /var/lib/cratedigger/config.ini
-sudo systemctl start cratedigger.service
-journalctl -u cratedigger.service -n 80 --no-pager | grep 'Cratedigger cycle complete'
-redis-cli -p 6379 --scan --pattern 'peer_*' | wc -l
-sudo systemctl start cratedigger.timer
-```
-
-Expected: Redis is `active`, `maxmemory-policy` is `allkeys-lru`, config contains `redis_host = 127.0.0.1`, the first cycle may be cold, and later summaries should show nonzero `cache_pos_hits` or `cache_neg_hits` with `cache_errors=0 cache_fuse_tripped=0 cache_write_errors=0`. Stop and roll back if any cache error counter is nonzero after Redis is active, if key growth is explosive for your cycle volume, or if matches/downloads regress. The old `cratedigger_cache.json` is intentionally left on disk but new code no longer reads or writes it.
-
-Rollback:
-
-```bash
-sudo systemctl stop cratedigger.timer cratedigger.service
-sudo nixos-rebuild switch --flake .#HOST --rollback
-# Optional when bad Redis writes are suspected:
-redis-cli -p 6379 --scan --pattern 'peer_dir:*' | xargs -r redis-cli -p 6379 DEL
-redis-cli -p 6379 --scan --pattern 'peer_dir_neg:*' | xargs -r redis-cli -p 6379 DEL
-redis-cli -p 6379 --scan --pattern 'peer_speed:*' | xargs -r redis-cli -p 6379 DEL
-redis-cli -p 6379 --scan --pattern 'peer_dir_count:*' | xargs -r redis-cli -p 6379 DEL
-sudo systemctl start cratedigger.service
-stat /var/lib/cratedigger/cratedigger_cache.json
-sudo systemctl start cratedigger.timer
-```
-
-After deploying importer queue changes, check:
-
-```bash
-systemctl status cratedigger-db-migrate cratedigger-import-preview-worker cratedigger-importer
-journalctl -u cratedigger-import-preview-worker -u cratedigger-importer -n 100 --no-pager
-```
-
-With preview enabled, healthy state is: migrations applied, the preview worker
-running, queued jobs moving from `preview_status='waiting'` to `would_import`
-or a terminal preview failure, and the importer only claiming `would_import`
-jobs.
-If `services.cratedigger.importer.preview.enable = false`, the preview worker
-is intentionally absent and new jobs should enter the queue as
-`preview_status='would_import'` with `preview_message='Preview gate disabled'`.
-
-### Schema migrations
-
-Schema lives in `migrations/NNN_name.sql`, applied by a tiny custom migrator (`lib/migrator.py`) that tracks applied versions in a `schema_migrations` table. The deploy systemd unit `cratedigger-db-migrate.service` (oneshot, `restartIfChanged = true`) runs the migrator on every `nixos-rebuild switch` BEFORE the app services start. The app services `requires` the migrate unit, so a failed migration blocks the app from coming up against an inconsistent schema.
-
-To add a schema change:
-
-1. Drop a new file in `migrations/` named `NNN_describe_change.sql` (next number).
-2. Plain SQL — each file runs in its own transaction, exactly once per DB. No `IF NOT EXISTS` guards needed.
-3. Test it: `nix-shell --run "python3 -m unittest tests.test_migrator -v"`
-4. Commit, push, deploy. The migrator picks it up automatically.
-
-`PipelineDB` itself never runs DDL — it expects the schema to already be current. The migration unit is the only path.
+The dev shell resolves the same pinned nixpkgs as the module and production — one beets everywhere; `tests/test_harness_beets2_contract.py` runs the real beets so version drift fails the suite instead of production.
 
 ## Credits
 
-This project grew out of [mrusse/soularr](https://github.com/mrusse/soularr) by [Michael Russell](https://github.com/mrusse) -- the original idea of bridging Soulseek into a music library workflow. If you appreciate that idea, [buy mrusse a coffee](https://ko-fi.com/mrusse).
-
-**Libraries**: [slskd-api](https://github.com/bigoulours/slskd-python-api), [music-tag](https://github.com/KristoforMaynworWormo/music-tag), [psycopg2](https://www.psycopg.org/), [beets](https://beets.io/)
+This project grew out of [mrusse/soularr](https://github.com/mrusse/soularr) by [Michael Russell](https://github.com/mrusse). **Libraries**: [beets](https://beets.io/), [psycopg2](https://www.psycopg.org/), [msgspec](https://jcristharif.com/msgspec/), [music-tag](https://github.com/KristoforMaynworWormo/music-tag).
 
 ## License
 

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -41,7 +41,7 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `notifiers.jellyfin.{enable,url,tokenFile}` | disabled | Jellyfin notifier. |
 | `healthCheck.{enable,onFailureCommand}` | enabled, no recovery | Pre-cycle slskd healthcheck. `onFailureCommand` runs to recover (e.g. `systemctl restart slskd.service`). |
 | `releaseSettings.*` / `searchSettings.*` / `downloadSettings.*` | match config.ini defaults | Pipeline tunables. See "Search loop tunables" below for the trio that caps the slskd search window. |
-| `qualityRanks.*` | mirror of `QualityRankConfig.defaults()` | See README § "Tuning the quality rank model". |
+| `qualityRanks.*` | mirror of `QualityRankConfig.defaults()` | See docs/quality-ranks.md § "Tuning reference (Nix options)". |
 | `timer.{enable,onBootSec,onUnitInactiveSec}` | 1s after exit | Cycle frequency. |
 | `importer.enable` | `true` | Long-lived serial importer that drains queued import work. |
 | `importer.preview.enable` | `false` | Enable the async preview gate. When disabled, new import jobs are marked importable immediately for backward-compatible draining. |

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -345,3 +345,87 @@ every request) and waiting for the next `cratedigger.timer` fire (5 min).
 - Issue #60 (this PR)
 - Issue #31 — original quality pipeline bugs that drove this rewrite
 - `docs/opus-encoding.md` — Opus 128 rationale and listening test references
+
+## Tuning reference (Nix options)
+
+> Relocated from the README (tier-2 doc run, 2026-07-04) — this is the operational tuning reference; the sections above are the model rationale.
+
+Every threshold, enum, and per-codec band in the rank model is tunable via Nix options on the deployment side. The runtime parses them from `[Quality Ranks]` in `/var/lib/cratedigger/config.ini`, which is regenerated on every `nixos-rebuild switch` from the Nix module. Full rationale and per-band justification lives in [`docs/quality-ranks.md`](docs/quality-ranks.md); this section is the tuning reference.
+
+### Where to tune
+
+All options live under `services.cratedigger.qualityRanks.*` and are declared by the upstream NixOS module at [`nix/module.nix`](nix/module.nix) in this repo. Set them anywhere in your NixOS config that imports `cratedigger.nixosModules.default` — typically a host config or a homelab wrapper. The `[Quality Ranks]` section of `config.ini` is regenerated from these options on every `nixos-rebuild switch`; Cratedigger picks up the new values on its next 5-min timer fire.
+
+**Source of truth**: `QualityRankConfig.defaults()` in `lib/quality.py`, pinned by `TestQualityRankConfigDefaults` in `tests/test_quality_decisions.py`. The Nix options mirror those defaults for declarative visibility -- you should be able to open `cratedigger.nix` and read your current policy without grepping Python. Drift between Python and Nix is caught at cratedigger test time: bump a default in either repo, the pin test fails and reminds you to update the other.
+
+### Nix-exposed options
+
+**Policy scalars:**
+
+| Option | Type | Default | Meaning |
+|---|---|---|---|
+| `gateMinRank` | enum (`unknown`, `poor`, `acceptable`, `good`, `excellent`, `transparent`, `lossless`) | `"excellent"` | Minimum rank an imported album must reach before the quality gate accepts it. Below this → re-queue for upgrade. Raise to tighten (reject more albums); lower to accept lower-quality sources. |
+| `bitrateMetric` | enum (`min`, `avg`, `median`) | `"avg"` | Which per-album bitrate statistic feeds rank classification. `avg` is robust to VBR per-track variance. `median` is outlier-resistant -- prefer when albums commonly have quiet intros/hidden tracks/skits that skew `avg`. `min` is legacy and penalizes legitimately-encoded lo-fi VBR. See `docs/quality-ranks.md` "When to prefer median". |
+| `withinRankToleranceKbps` | int | `5` | Same-rank equivalence window in kbps. Two bare-codec measurements in the same rank tier within this tolerance are "equivalent"; outside it, one is "better"/"worse". |
+
+**Per-codec band tables** (`bands.<codec>.{transparent,excellent,good,acceptable}`, all in kbps, used when the format hint is a bare codec string like `"MP3"` rather than an explicit label like `"mp3 v0"`):
+
+| Codec | transparent | excellent | good | acceptable | Notes |
+|---|---|---|---|---|---|
+| `bands.opus`   | 112 | 88  | 64  | 48  | Unconstrained Opus VBR averages 120-135 kbps typical / 95-150 kbps per track. 112 leaves headroom for sparse material; 88 matches Opus 96 hydrogenaudio quality. |
+| `bands.mp3Vbr` | 245 | 210 | 170 | 130 | `excellent=210` preserves the legacy `QUALITY_MIN_BITRATE_KBPS=210` gate threshold. V0 typically averages 220-260; V2 ~190 → `good=170`. **`excellent` also feeds `transcode_detection()` as the spectral-fallback threshold** (#66) so lowering it implicitly lowers what counts as "credible V0" when spectral is unavailable. |
+| `bands.mp3Cbr` | 320 | 256 | 192 | 128 | Unverifiable CBR is only `transparent` at 320 because we can't prove a CBR file came from lossless source. Below that → requeue for a FLAC source to re-verify. |
+| `bands.aac`    | 192 | 144 | 112 | 80  | Hydrogenaudio consensus places the "no meaningful quality gain above here" ceiling for music at 192 kbps. |
+
+Leaving every option at its default produces exactly `QualityRankConfig.defaults()` -- the defaults above are the shipping values.
+
+### Collection fields (NOT exposed via Nix -- edit `lib/quality.py` directly)
+
+Three fields are part of the rank model but are NOT surfaced as Nix options because they're rarely-if-ever retuned outside of development. They live on `QualityRankConfig` in `lib/quality.py`, are parseable from `[Quality Ranks]` as CSV (see #65), and default to sensible values. If you want to tune them, the cleanest path is editing the dataclass defaults and updating `TestQualityRankConfigDefaults` to pin the new values. Extending `nix/module.nix` to render them is a trivial follow-up if you find yourself retuning them often.
+
+- **`mp3_vbr_levels`** -- 10-tuple mapping LAME V-levels to ranks (V0..V9). The V-level is an **explicit label contract** -- when a download advertises `"mp3 v0"`, the rank model reads V0 from this tuple and bypasses `bands.mp3Vbr` entirely. This is why a 207 kbps lo-fi V0 still classifies as TRANSPARENT: the V0 label beats the 210 threshold.
+
+  **Default ladder**: `V0=TRANSPARENT, V1-V2=EXCELLENT, V3-V4=GOOD, V5-V9=ACCEPTABLE`
+
+  **When to retune**: tighten if you don't trust LAME's claim that V2 is transparent (move V1/V2 to EXCELLENT → GOOD). Loosen if you encode at V4 locally and want your own rips to pass the gate (move V4 up to EXCELLENT).
+
+- **`lossless_codecs`** -- set of codec identity strings that **short-circuit to LOSSLESS** regardless of measured bitrate. Checked against the first whitespace-separated token of the format hint during rank classification. If the format hint starts with any of these, the rank model skips bitrate-based classification entirely and returns LOSSLESS.
+
+  **Default**: `{"flac", "lossless", "alac", "wav"}`
+
+  **When to retune**: add `"ape"`, `"dsf"`, or `"wavpack"` if your library carries them. Remove nothing -- removing entries is a footgun that would reclassify genuine lossless files as UNKNOWN.
+
+- **`mixed_format_precedence`** -- ordered tuple used by `_reduce_album_format()` when an album on disk has tracks in multiple codecs (rare -- usually a manually-merged album). Walked in order; the first codec that appears on the album becomes the album's canonical codec for rank classification. Order matters.
+
+  **Default**: `("mp3", "aac", "opus", "flac")` -- worst codec wins, so a mixed FLAC+MP3 album classifies as MP3 (conservative).
+
+  **When to retune**: reverse to `("flac", "opus", "aac", "mp3")` if you'd rather have mixed-format albums classified by the *best* codec on disk (less conservative -- you'll accept more as "good enough"). The default is the conservative choice for a curated library.
+
+### How to tune and deploy
+
+The exact deploy flow depends on where you set the options. For a host config that imports `cratedigger.nixosModules.default` directly:
+
+```bash
+$EDITOR hosts/<your-host>/configuration.nix   # tweak services.cratedigger.qualityRanks.*
+git commit -am "cratedigger: retune <what>" && git push
+sudo nixos-rebuild switch --flake .
+```
+
+For the abl030 homelab (this project's reference deployment):
+
+```bash
+# On doc1 — has git push credentials for nixosconfig
+cd ~/nixosconfig
+$EDITOR hosts/doc2/configuration.nix          # tweak services.cratedigger.qualityRanks.*
+git commit -am "cratedigger: retune <what>" && git push
+ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
+```
+
+### How to verify the new config is live
+
+1. **Read the generated file** -- `ssh doc2 'sudo cat /var/lib/cratedigger/config.ini | grep -A 30 "\[Quality Ranks\]"'`. The section should show the exact values from your Nix edit.
+
+2. **Check the runtime picks them up** -- `ssh doc2 'pipeline-cli quality <any_request_id>'`. The output prints the active `gate_min_rank`, `bitrate_metric`, and thresholds the simulator is using. Mismatch means Cratedigger hasn't restarted since the rebuild (it's a 5-min timer) -- wait a cycle or `sudo systemctl start cratedigger --no-block`.
+
+3. **Visual confirmation** -- open the [Decisions tab at music.ablz.au](https://music.ablz.au). The top of the tab renders three pills (**Gate min rank** / **Bitrate metric** / **Within-rank tolerance**) pulled from the same `_runtime_rank_config()` snapshot. If your tuning is live, the pills show the new values (#68). The transcode stage rule threshold also reflects `bands.mp3Vbr.excellent` live, since `get_decision_tree()` threads `cfg` through (#75).
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Examples — sample NixOS configs
+
+These are **samples, not supported products** (cratedigger is tier-2:
+reproducible and runnable by a competent NixOS stranger, with no
+versioned-upgrade or support promises). Copy them into your own config
+and adapt paths, hostnames, and secrets handling.
+
+| File | What it stands up |
+|---|---|
+| [`cratedigger.nix`](cratedigger.nix) | Cratedigger itself — the minimal working consumer config. Start here. |
+| [`musicbrainz-mirror.nix`](musicbrainz-mirror.nix) | A local MusicBrainz mirror (upstream musicbrainz-docker under podman). Optional — cratedigger works against public MB, just slower. |
+| [`discogs-mirror.nix`](discogs-mirror.nix) | The Discogs mirror (Rust JSON API over PostgreSQL, loaded from the monthly CC0 dumps). Optional — without it, Discogs browse is off and MB browse carries the UI. |
+
+What you always need besides cratedigger: **slskd** (`services.slskd`
+exists in nixpkgs) and somewhere for music to live. PostgreSQL is
+provisioned for you by `pipelineDb.createLocally = true`.
+
+The honest account of what each mirror buys you (and the degraded modes
+without them) is in [`docs/mirrors.md`](../docs/mirrors.md).

--- a/examples/cratedigger.nix
+++ b/examples/cratedigger.nix
@@ -1,0 +1,97 @@
+# SAMPLE — minimal cratedigger consumer config.
+#
+# Add the flake input and import this module (adapt paths to taste):
+#
+#   inputs.cratedigger.url = "github:abl030/cratedigger";
+#   ...
+#   nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+#     modules = [
+#       cratedigger.nixosModules.default
+#       ./examples/cratedigger.nix      # <- this file, adapted
+#     ];
+#   };
+#
+# The module builds its runtime (python env + beets) from CRATEDIGGER'S
+# OWN flake.lock — the exact closure its test suite ran against — not
+# your nixpkgs. That costs one extra nixpkgs evaluation and is the whole
+# point; `services.cratedigger.packageSet` is the escape hatch if you
+# refuse the trade.
+{ config, pkgs, ... }:
+
+{
+  # ---------------------------------------------------------------------
+  # slskd — the Soulseek client cratedigger drives. Bring your own
+  # credentials; the API key must also land in the file cratedigger reads
+  # (slskd.apiKeyFile below). See `services.slskd` options in nixpkgs.
+  # ---------------------------------------------------------------------
+  services.slskd = {
+    enable = true;
+    domain = null;
+    settings = {
+      shares.directories = [ "/srv/music/library" ];
+      directories.downloads = "/srv/music/slskd-downloads";
+    };
+    # slskd reads SLSKD_SLSK_USERNAME / SLSKD_SLSK_PASSWORD / SLSKD_API_KEY
+    # from this env file. Any secrets backend works; a root-owned file is
+    # the floor.
+    environmentFile = "/var/lib/secrets/slskd.env";
+  };
+
+  services.cratedigger = {
+    enable = true;
+
+    # --- The two things you must always provide -----------------------
+    slskd = {
+      # Raw API key, one line, readable by the cratedigger user (root by
+      # default). Same value slskd itself was given above.
+      apiKeyFile = "/var/lib/secrets/slskd-api-key";
+      downloadDir = "/srv/music/slskd-downloads";
+    };
+
+    # --- Database: provisioned locally, peer auth, zero passwords -----
+    pipelineDb.createLocally = true;
+
+    # --- Beets: cratedigger owns the package, config, and binary ------
+    # `cratedigger-beet` lands on your PATH for manual ops (run it with
+    # sudo — the service runs as root by default).
+    beetsConfig = {
+      directory = "/srv/music/library";          # where tagged albums live
+      library = "/srv/music/beets-library.db";   # parent dir must exist
+    };
+    beetsValidation = {
+      stagingDir = "/srv/music/incoming";        # validated albums stage here
+      trackingFile = "/srv/music/beets-validated.jsonl";
+    };
+
+    # --- Web UI (album browser + request manager) ---------------------
+    web = {
+      enable = true;
+      port = 8085;
+      beetsDb = "/srv/music/beets-library.db";
+    };
+
+    # --- Mirrors: all optional ----------------------------------------
+    # Without any of this, MusicBrainz browse/matching uses public
+    # musicbrainz.org (works, rate-limited ~1 req/s) and Discogs browse
+    # is off with a clear 503. See docs/mirrors.md and the sibling
+    # examples for standing the mirrors up.
+    #
+    # musicbrainz.apiBase = "http://mb-mirror.lan:5200";
+    # discogs.apiBase = "http://discogs-mirror.lan:8086";
+    # beets = {
+    #   discogsMirrorUrl = "http://discogs-mirror.lan:8086";
+    #   lrclibUrl = "http://lrclib.lan:3300/api";
+    #   # Discogs user token (https://www.discogs.com/settings/developers),
+    #   # raw, one line. Without it, public-Discogs lookups during import
+    #   # fail per-use (everything still loads cleanly).
+    #   discogsTokenFile = "/var/lib/secrets/discogs-token";
+    # };
+  };
+
+  # The staging/library parents must exist; the module manages only its
+  # own state dir.
+  systemd.tmpfiles.rules = [
+    "d /srv/music 0775 root root -"
+    "d /srv/music/incoming 0775 root root -"
+  ];
+}

--- a/examples/discogs-mirror.nix
+++ b/examples/discogs-mirror.nix
@@ -1,0 +1,109 @@
+# SAMPLE — the Discogs mirror: a Rust JSON API over PostgreSQL, loaded
+# from the monthly CC0 XML dumps (data.discogs.com). ~19M releases;
+# plan ~100GB of disk for postgres + dumps.
+#
+# This is a distilled version of the operator's production deployment
+# (which uses an nspawn postgres container + sops). It builds the
+# `discogs-api` project from source; add the input to your flake:
+#
+#   inputs.discogs-api-src = {
+#     url = "github:abl030/discogs-api";
+#     flake = false;
+#   };
+#
+# Wire cratedigger at it with:
+#   services.cratedigger.discogs.apiBase = "http://localhost:8086";
+#   services.cratedigger.beets.discogsMirrorUrl = "http://localhost:8086";
+#
+# Two units:
+#   discogs-import.service/.timer — monthly oneshot: download the latest
+#     dumps, parse, COPY into postgres (idempotent: drops + recreates)
+#   discogs-api.service           — long-running axum HTTP server
+{ config, lib, pkgs, inputs, ... }:
+
+let
+  discogsPkg = pkgs.rustPlatform.buildRustPackage {
+    pname = "discogs-api";
+    version = "0.1.0";
+    src = inputs.discogs-api-src;
+    cargoLock.lockFile = "${inputs.discogs-api-src}/Cargo.lock";
+    nativeBuildInputs = [ pkgs.pkg-config ];
+    buildInputs = [ pkgs.openssl ];
+  };
+
+  # Local postgres over the unix socket, role + db named "discogs",
+  # peer auth — no password material (same pattern cratedigger's
+  # pipelineDb.createLocally uses).
+  dsn = "postgresql:///discogs?host=/run/postgresql";
+  dumpDir = "/var/lib/discogs-mirror/dumps";
+  apiPort = 8086;
+in
+{
+  services.postgresql = {
+    enable = true;
+    ensureDatabases = [ "discogs" ];
+    ensureUsers = [
+      {
+        name = "discogs";
+        ensureDBOwnership = true;
+      }
+    ];
+  };
+
+  users.users.discogs = {
+    isSystemUser = true;
+    group = "discogs";
+  };
+  users.groups.discogs = { };
+
+  systemd.tmpfiles.rules = [
+    "d /var/lib/discogs-mirror 0755 discogs discogs -"
+    "d ${dumpDir} 0755 discogs discogs -"
+  ];
+
+  systemd.services.discogs-import = {
+    description = "Discogs dump importer (monthly)";
+    after = [ "postgresql.service" "network-online.target" ];
+    requires = [ "postgresql.service" ];
+    wants = [ "network-online.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "discogs";
+      Group = "discogs";
+      # The import takes hours on first run (streaming-parses multi-GB
+      # XML); it is idempotent, so on-failure retry is safe.
+      TimeoutStartSec = "12h";
+      Restart = "on-failure";
+      RestartSec = "30min";
+      ExecStart = "${discogsPkg}/bin/discogs-import --dsn ${dsn} --dump-dir ${dumpDir}";
+    };
+  };
+
+  systemd.timers.discogs-import = {
+    description = "Monthly Discogs dump import";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      # Dumps publish at the start of each month; the 2nd avoids racing
+      # the upload.
+      OnCalendar = "*-*-02 04:00:00";
+      Persistent = true;
+    };
+  };
+
+  systemd.services.discogs-api = {
+    description = "Discogs mirror JSON API";
+    after = [ "postgresql.service" ];
+    requires = [ "postgresql.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "simple";
+      User = "discogs";
+      Group = "discogs";
+      ExecStart = "${discogsPkg}/bin/discogs-api --dsn ${dsn} --port ${toString apiPort}";
+      Restart = "on-failure";
+      RestartSec = 5;
+      NoNewPrivileges = true;
+      ProtectSystem = "strict";
+    };
+  };
+}

--- a/examples/musicbrainz-mirror.nix
+++ b/examples/musicbrainz-mirror.nix
@@ -1,0 +1,72 @@
+# SAMPLE — a local MusicBrainz mirror on NixOS.
+#
+# The supported way to run an MB mirror is upstream's compose stack:
+#   https://github.com/metabrainz/musicbrainz-docker
+# (postgres + WS/2 web service + search indexes + live replication).
+# There is no nixpkgs-native MB mirror; this sample shows the shape of
+# wrapping the upstream stack in a podman-compose systemd unit, which is
+# how the operator's production mirror runs. Expect to spend real time
+# on the initial data import (~100GB+, hours to days) — read upstream's
+# README first. The long-term plan in this project is `mb-api`, a Rust
+# reimplementation of the WS/2 subset cratedigger uses; until that
+# exists, upstream's stack is the mirror.
+#
+# What you need:
+#   1. A checkout of musicbrainz-docker (pin it — a flake input with
+#      flake = false works well).
+#   2. A (free) MetaBrainz replication token for hourly replication:
+#      https://metabrainz.org/supporters/account-type
+#   3. Disk: ~100GB+ for the database and search indexes.
+#
+# Wire cratedigger at it with:
+#   services.cratedigger.musicbrainz.apiBase = "http://localhost:5200";
+# (one value — web browse, pipeline-cli, and the rendered beets
+# musicbrainz block all derive from it; ratelimit flips to 100
+# automatically for a non-public host.)
+{ config, lib, pkgs, inputs, ... }:
+
+let
+  # Pin upstream: inputs.musicbrainz-docker = { url = "github:metabrainz/musicbrainz-docker"; flake = false; };
+  composeDir = "/var/lib/musicbrainz-docker";
+  # Upstream compose exposes the web service on 5000 by default; the
+  # operator maps it to 5200. Set via compose overrides (see upstream's
+  # `admin/configure` and compose override docs).
+  port = 5200;
+in
+{
+  virtualisation.podman = {
+    enable = true;
+    defaultNetwork.settings.dns_enabled = true;
+  };
+
+  # One-time setup (manual, from upstream's README — the initial import
+  # is an interactive, hours-long operation and does not belong in a
+  # systemd unit):
+  #   cp -r ${toString inputs.musicbrainz-docker or "<musicbrainz-docker checkout>"} ${composeDir}
+  #   cd ${composeDir}
+  #   admin/configure add publishing-db-port   # and any other overrides
+  #   echo "MB_REPLICATION_TOKEN=<token>" >> .env
+  #   podman-compose build
+  #   podman-compose run --rm musicbrainz createdb.sh -fetch   # the big one
+  #   podman-compose run --rm indexer python -m sir reindex    # search indexes
+
+  # Day-2: the stack as a unit. Replication runs inside the stack (cron
+  # in the musicbrainz container) once the token is configured.
+  systemd.services.musicbrainz-mirror = {
+    description = "MusicBrainz mirror (upstream musicbrainz-docker via podman-compose)";
+    after = [ "network-online.target" "podman.service" ];
+    wants = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+    path = [ pkgs.podman pkgs.podman-compose ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      WorkingDirectory = composeDir;
+      ExecStart = "${pkgs.podman-compose}/bin/podman-compose up -d";
+      ExecStop = "${pkgs.podman-compose}/bin/podman-compose down";
+      TimeoutStartSec = "10min";
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [ port ];
+}


### PR DESCRIPTION
Full doc run for tier-2 usability (operator request):

- **README**: 633 → ~190 lines, quickstart-first. Flake snippet with `createLocally` + friendly eval failures, mirrors matrix with honest degraded modes, `nix run` CLI, stranger-boot VM gate. Stale content fixed (`slskd-api` package ref, hardcoded mirror URLs, HM-era prose). Deep sections became `docs/` pointers; the quality-rank tuning reference was **relocated** to `docs/quality-ranks.md` (not deleted) with pointers updated.
- **examples/** (new, samples-not-products): `cratedigger.nix` (complete minimal consumer incl. slskd), `discogs-mirror.nix` (Rust mirror distilled to plain postgres + importer timer + API), `musicbrainz-mirror.nix` (skeleton around upstream musicbrainz-docker via podman-compose, manual import steps documented).
- All examples parse; push ran the full pre-push `nix flake check` (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)