### PR TITLE
feat(replace): Discogs-pathway Replace via master-anchored picker

### DIFF
--- a/docs/plans/2026-07-04-001-feat-discogs-pathway-replace-plan.md
+++ b/docs/plans/2026-07-04-001-feat-discogs-pathway-replace-plan.md
@@ -1,0 +1,273 @@
+---
+title: Discogs-Pathway Replace - Plan
+type: feat
+date: 2026-07-04
+topic: discogs-pathway-replace
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Discogs-Pathway Replace - Plan
+
+## Goal Capsule
+
+- **Objective:** Extend the Replace operator action to Discogs-pathway requests — a Discogs-master-anchored sibling picker with the same supersede/audit semantics MB Replace already has.
+- **Product authority:** GitHub issue #282, scoped and confirmed by the operator; Product Contract below is the confirmed scope.
+- **Product Contract preservation:** unchanged from the brainstorm except (a) R10-R11 added — service-level guardrails surfaced by flow analysis (master-mismatch gate, mirror-unconfigured outcome); (b) the Outstanding Question (persist vs live-lookup master anchor) is resolved into KTD-1 and the section removed; (c) R6 clarified in review — parity is with MB Replace's supersede (base identity, no resolver re-run), not the full add flow.
+- **Open blockers:** None.
+- **Stop conditions:** Any change that would touch MB Replace behavior beyond routing (R3), or that requires a new `album_requests` column, contradicts this plan — stop and surface rather than improvise.
+
+---
+
+## Product Contract
+
+### Summary
+
+Recreate Replace for Discogs-pathway requests: from a stuck Discogs request, the operator opens a picker of the other pressings of the same album (siblings under the release's Discogs master), picks one, and the request is superseded with the same audit chain as MB Replace. Same-pathway only; nothing new conceptually.
+
+### Problem Frame
+
+Replace shipped MB-only (#279/#280). A Discogs-pathway request — a numeric Discogs id — fails at two gates: the target must be a UUID-shaped MBID, and source release-group resolution has no Discogs branch. The #280 backfill skipped 124 Discogs rows as "non-MB id; no release-group concept", so those requests have no first-class repoint path at all.
+
+The operator job this serves is simple: "we keep downloading the wrong release for this request — show me the other pressings of this album." Pendulum's *Hold Your Colour* is the canonical case: many pressings, and the one the request anchors on is not the one Soulseek peers actually carry. An operator action that exists for one pathway and not the other is also exactly the MB/Discogs adapter asymmetry the project doctrine forbids.
+
+### Key Decisions
+
+- **Discogs master is the release-group analog.** The picker anchors on the source release's master, the same way MB anchors on the release group. Production precedent: the YouTube resolver already enumerates Discogs siblings via the master and treats it as the RG analog.
+- **Same-pathway siblings only; lists are never merged.** MB and Discogs are disjoint ID spaces, and the resolver precedent deliberately keeps their sibling lists separate. A Discogs row's picker shows Discogs releases only.
+- **Minimum recreation, no rework.** The existing MB Replace machinery (service, picker, supersede semantics) is extended, not refactored or simplified.
+- **Masterless releases inherit the orphan shape.** A Discogs release with no master gets a one-element sibling list (itself), not an error — matching how the YouTube resolver handles the same case.
+
+### Requirements
+
+**Picker**
+
+- R1. A Discogs-pathway request's Replace picker lists the sibling releases of the source release's Discogs master — other pressings of the same album, Discogs releases only.
+- R2. A masterless Discogs release yields a picker containing only the current release, presented as "nothing to swap to" rather than an error.
+- R3. MB-pathway picker behavior is unchanged.
+
+**Replace action**
+
+- R4. Replace accepts a Discogs release id as target when the source request is Discogs-pathway; a target from the other pathway is rejected as invalid.
+- R5. Supersede semantics are identical to MB Replace: the old row flips to `replaced` (terminal, frozen audit), the new row is created as `wanted` pointing back via `replaces_request_id`, and the next pipeline cycle rebuilds derived state.
+- R6. The superseded-into row carries complete Discogs identity — `mb_release_id` and `discogs_release_id` dual-written as the add flow writes them; resolver-derived fields (`is_va_compilation`, `release_group_year`, `catalog_number`, `track_artist`) are not re-resolved, matching MB Replace's supersede.
+- R7. Strict pressing identity holds: the new request anchors on exactly the Discogs release id the operator picked — no substitution, no sibling fallback.
+
+**Service guardrails**
+
+- R10. The service rejects a Discogs target that is not a sibling of the source's master (the Discogs analog of MB's release-group-mismatch gate), so a caller bypassing the picker cannot cross albums. A masterless source rejects every target other than itself.
+- R11. An unconfigured Discogs mirror surfaces as its own outcome — distinct from "invalid target" and from "transient" — so the operator sees "mirror not set up", not "your pick was bad".
+
+**Surface parity**
+
+- R8. The action exists on both `pipeline-cli` and the web API, wrapping the same service method with matched exit-code/status-code mappings.
+- R9. The web Replace picker works from a Discogs-pathway request row; its backing sibling-enumeration route accepts Discogs ids (today it rejects numeric ids with 422).
+
+### Key Flows
+
+- F1. Repoint a stuck Discogs request
+  - **Trigger:** Operator notices a Discogs request repeatedly downloading or rejecting the wrong release.
+  - **Steps:** Operator opens Replace on the request; the picker enumerates the master's sibling pressings; operator picks one; the service supersedes the row; the pipeline's next cycle searches the new pressing.
+  - **Outcome:** Old row frozen as `replaced` audit, new `wanted` row back-linked, no manual DB surgery.
+  - **Covers:** R1, R4, R5, R6, R7.
+
+### Acceptance Examples
+
+- AE1. **Covers R2, R10.** Given a Discogs-pathway request whose release has no master, when the operator opens Replace, then the picker shows only the current release; any submitted target other than the current release is rejected. The operator's fallback is delete-and-re-add via browse.
+- AE2. **Covers R4.** Given a Discogs-pathway request, when the operator submits an MB UUID as the replacement target, then the action is rejected as invalid — cross-pathway replace is not supported.
+- AE3. **Covers R11.** Given a host with no Discogs mirror configured, when the operator attempts Replace on a Discogs request, then the outcome names the missing mirror (HTTP 503 / CLI exit 5), not an invalid-target error.
+
+### Success Criteria
+
+- Every Discogs-pathway request in the pipeline DB — including the 124 rows the #280 backfill skipped — can be replaced through the picker, except masterless releases, which correctly present as having no siblings.
+
+### Scope Boundaries
+
+- Cross-pathway replace (Discogs↔MB, scenario (c) in #282) — out. Delete-and-re-add via browse covers the rare pathway jump, at the acknowledged cost of the `replaces_request_id` audit link.
+- Mixed-pathway picker (showing MB and Discogs candidates together) — out; lists are never merged.
+- Refactoring or simplifying the existing MB Replace machinery — out; this issue only recreates the action for the second pathway.
+- Special handling for upstream Discogs rename/merge in dump rebuilds (scenario (b)) — no dedicated machinery; Replace itself is the remedy when it happens.
+- The picker's inverted mode (`requests-by-rg`) for Discogs — deferred to follow-up; standard mode covers the operator job.
+- Beets-distance badges for Discogs siblings — the `/api/beets-distance` route is UUID-anchored, so the badge silently doesn't render on Discogs rows; widening it is deferred to follow-up. Tracklist comparison remains the pressing-selection aid.
+
+### Dependencies / Assumptions
+
+- The Discogs mirror is required for master sibling enumeration, consistent with Discogs browse being mirror-required today (R11 covers the unconfigured case).
+- Pathway is inferred from the id's shape (UUID vs numeric, `lib/release_identity.py::detect_release_source`); this inference is authoritative for routing the service branch and validating targets.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD-1. **The master anchor lives in `mb_release_group_id` — no new column, no migration, no deploy one-shot, no add-flow change.** Numeric Discogs master ids in that column are an established convention: `lib/field_resolver_service.py::_looks_numeric` exists to dispatch on exactly this ("historical rows where Discogs was the source carry the numeric master id in that column"), and the field resolver already persists the master for new Discogs adds — both add paths run `_resolve_and_update_after_add`, whose RG resolver writes the Discogs master (from `web/discogs.py::get_release`'s `release_group_id` key, `web/discogs.py:406`) into `mb_release_group_id` when NULL (`lib/field_resolver_service.py:497-509, 1642-1646`). Only legacy rows (and resolver-timeout rows) lack it, and the Replace service's existing lazy-backfill branch (resolve-then-persist when the column is NULL) gains a Discogs arm — so the 124 legacy rows resolve themselves on first Replace with no backfill.
+- KTD-2. **Extend `MbidReplaceService`; no parallel service.** One service, branching on `detect_release_source(source_mbid)`. The target gate becomes pathway-aware: UUID target requires MB source, numeric target requires Discogs source (R4); everything after the lookups (mismatch check, collision check, supersede, warnings) stays shared. Follows `docs/solutions/architecture/service-first-then-glue.md`: guardrails before IO, injected lookup collaborators, wrappers stay thin.
+- KTD-3. **The Discogs lookup is an injected collaborator, mirroring `mb_lookup`.** The service gains a `discogs_lookup` constructor parameter defaulting to `web.discogs.get_release`, so tests fake it with real exception contracts (`HTTPError`/`URLError`, per test-fidelity Rule B) instead of patching module internals.
+- KTD-4. **Supersede dual-writes Discogs identity.** `supersede_request_mbid` gains a `new_discogs_release_id` parameter; for a Discogs replace the new row gets `mb_release_id = discogs_id` AND `discogs_release_id = discogs_id`, matching the add flow. The dual-write is load-bearing twice over: `mb_release_id`'s UNIQUE constraint is the only DB-level collision safety net (`discogs_release_id` has none), and beets validation for Discogs rows queries both `mb_albumid` and `discogs_albumid` (`lib/beets_db.py:184-268`).
+- KTD-5. **`DiscogsMirrorNotConfigured` maps to its own outcome** (`mirror_unconfigured` → HTTP 503 / CLI exit 5). Without an explicit catch it falls into the generic handler and reads as `target_invalid` — misleading, per flow analysis. 503/5 fits the existing convention (service unavailable) while the outcome string tells the operator it's a config gap, not a retry.
+- KTD-6. **Collision checks go identity-aware in the Discogs branch only.** The Discogs arm's collision pre-check and canonical-redirect re-check use the existing identity-aware `get_request_by_release_id` (`lib/pipeline_db/requests.py:128-151`); the MB branch's `get_request_by_mb_release_id` call sites stay untouched, honoring the no-MB-behavior-change stop condition. The dual-write (KTD-4) keeps the `mb_release_id` UNIQUE-constraint safety net intact for both pathways.
+- KTD-7. **The picker reuses `GET /api/discogs/master/<id>`.** The route already exists for browse (`web/routes/browse.py:311`, wrapping `get_master_releases`) and is already classified in the route audit. `replace_picker.js` branches on the resolved anchor's shape: UUID → `/api/release-group/<id>`, numeric → `/api/discogs/master/<id>`. `post_pipeline_resolve_rg` loses its numeric-id 422 and instead resolves+persists the master for Discogs rows (same lazy-backfill contract as MB), returning a distinct `masterless` status when the release has no master.
+
+### Assumptions
+
+- The `target_mb_release_id` field name is reused for numeric Discogs targets on both surfaces (least churn; the service dispatches on id shape, not the parameter name). Renaming the wire field is not worth the drift.
+- Discogs mirror 404 on a nonexistent numeric id surfaces as transient (inherited: `HTTPError` subclasses `URLError`, which is in `_TRANSIENT_LOOKUP_EXCEPTIONS`) — same behavior as the MB path today; not changed by this plan.
+- Persisting numeric master ids into `mb_release_group_id` for newly added Discogs requests is safe for existing consumers: the field resolver dispatches on shape by design, and the YouTube services classify by release-id shape before trusting the column. U2 verifies this with a targeted check of `mb_release_group_id` consumers rather than assuming.
+
+### High-Level Technical Design
+
+Target-validation gate after the change (the service's decision order — guardrails before IO):
+
+```mermaid
+flowchart TB
+  A[replace_request_mbid] --> B{source row found + status wanted/manual?}
+  B -->|no| X1[not_found / wrong_state]
+  B -->|yes| C{detect_release_source of source vs target}
+  C -->|shapes differ| X2[target_invalid - cross-pathway]
+  C -->|both MB| D[mb_lookup path - unchanged]
+  C -->|both Discogs| E{source mb_release_group_id set?}
+  E -->|no| F[lazy backfill: discogs_lookup source id -> master id, persist]
+  F -->|no master| X3[reject: masterless source, target != source]
+  E -->|yes| G[discogs_lookup target id]
+  F -->|master found| G
+  G -->|DiscogsMirrorNotConfigured| X4[mirror_unconfigured 503]
+  G -->|HTTPError/URLError| X5[transient 503]
+  G --> H{target master == source master?}
+  H -->|no| X6[target_release_group_mismatch]
+  H -->|yes| I[collision check via get_request_by_release_id]
+  I --> J[supersede: dual-write mb_release_id + discogs_release_id, master into mb_release_group_id]
+```
+
+---
+
+## Implementation Units
+
+### U1. Supersede carries Discogs identity
+
+- **Goal:** `supersede_request_mbid` can populate `discogs_release_id` on the new row, with the write proven against real PG.
+- **Requirements:** R5, R6.
+- **Dependencies:** none.
+- **Files:** `lib/pipeline_db/requests.py`, `lib/mbid_replace_service.py` (the `MbidReplaceDB` protocol signature), `tests/fakes/pipeline_db.py`, `tests/test_fakes.py`, `tests/test_pipeline_db.py`.
+- **Approach:** Add `new_discogs_release_id: str | None` to `supersede_request_mbid` (production INSERT column list at `lib/pipeline_db/requests.py:307-322`, protocol at `lib/mbid_replace_service.py:93-105`, fake at `tests/fakes/pipeline_db.py:2395-2469`). Forward-only: MB callers pass `None`.
+- **Execution note:** Rule A red-first — no real-PG round-trip test exists for supersede at all today. Write the round-trip test asserting *every* input field (not just the new one) is readable back, watch it fail on `discogs_release_id`, then add the column to the INSERT.
+- **Test scenarios:**
+  - Real-PG round-trip (`@requires_postgres`, model on `tests/test_pipeline_db.py` Rule A shape): supersede with `new_discogs_release_id="12345"` → new row's `discogs_release_id`, `mb_release_id`, `mb_release_group_id`, artist/title/year/country, `replaces_request_id`, status all read back exactly; old row is `replaced`.
+  - Same round-trip with `new_discogs_release_id=None` (MB path) → column is NULL, everything else unchanged.
+  - `FakePipelineDB` parity self-test in `tests/test_fakes.py`: fake threads the new field identically.
+- **Verification:** round-trip test red before the INSERT change, green after; `TestReplaceDBProtocolParity` still passes for both DB implementations.
+
+### U2. Pin the add flow's master-anchor persistence
+
+- **Goal:** Prove with tests that new Discogs adds already persist the master id into `mb_release_group_id` via the field resolver — no add-flow code change (a second write in `add_request` would be a parallel code path).
+- **Requirements:** R1 (anchor availability), KTD-1.
+- **Dependencies:** none.
+- **Files:** `tests/test_field_resolver_service.py` (or the resolver's existing test module).
+- **Approach:** The RG resolver already writes the Discogs master to `mb_release_group_id` when NULL after both add paths (`lib/field_resolver_service.py:497-509, 1642-1646`). If existing resolver tests don't pin the Discogs-master case, add the missing assertions; if they do, cite them and this unit collapses to verification. Grep `mb_release_group_id` consumers once to confirm no UUID-shape assumption breaks (the Assumptions section records the expected answer).
+- **Test scenarios:**
+  - RG resolver on a numeric-id row whose Discogs lookup returns `release_group_id="98765"` → `mb_release_group_id="98765"` written (skip if an equivalent assertion already exists).
+  - Masterless release (`release_group_id=None`) → column stays NULL, no error.
+- **Verification:** resolver tests green; a fresh Discogs add on the dev server shows the master id via `pipeline-cli show`.
+
+### U3. Service: Discogs replace branch
+
+- **Goal:** `MbidReplaceService.replace_request_mbid` completes the full outcome matrix for Discogs-pathway sources.
+- **Requirements:** R4, R5, R6, R7, R10, R11.
+- **Dependencies:** U1 (supersede parameter). U2 is verification-only; the lazy backfill covers rows without the anchor.
+- **Files:** `lib/mbid_replace_service.py`, `tests/test_mbid_replace_service.py`, `scripts/pipeline_cli.py` (`cmd_replace` outcome→exit-code map), `web/routes/pipeline.py` (`post_pipeline_replace` outcome→status map), `tests/test_pipeline_cli.py`, `tests/web/test_routes_pipeline_replace.py`.
+- **Approach:** Per the HTD flowchart. Replace the step-0a UUID gate with a pathway-aware gate: `detect_release_source(target)` must be valid and equal `detect_release_source(source_mbid)`, else `RESULT_TARGET_INVALID`. Add injected `discogs_lookup` (default `web.discogs.get_release`) beside `mb_lookup`. Discogs arm: lazy-backfill source master from `discogs_lookup(source_id)["release_group_id"]` (persist like the MB backfill); masterless source → reject any target ≠ source; target lookup via `discogs_lookup(target_id, fresh=True)`; master equality reuses the existing mismatch outcome; catch `DiscogsMirrorNotConfigured` → new `RESULT_MIRROR_UNCONFIGURED`; supersede call passes `new_discogs_release_id=canonical_id` and the master as `new_mb_release_group_id`. In the Discogs arm only, run the collision pre-check and canonical-redirect re-check through the identity-aware `get_request_by_release_id` (KTD-6); MB call sites stay on `get_request_by_mb_release_id`. Wrapper updates are mechanical: `mirror_unconfigured` → HTTP 503 / exit 5.
+- **Execution note:** Test-first against the outcome matrix — extend `TestReplaceOutcomeMatrix` one red scenario at a time; fakes for `discogs_lookup` must raise real `urllib.error.HTTPError`/`URLError` on failure paths (Rule B), never return `None`.
+- **Test scenarios (extend `tests/test_mbid_replace_service.py`):**
+  - Happy path: Discogs source with persisted master, sibling target → `replaced`; supersede received dual identity + master; old row `replaced`, `replaces_request_id` set (assert against `FakePipelineDB` state).
+  - Lazy backfill: source with NULL `mb_release_group_id`, `discogs_lookup` returns master → backfill persisted, replace proceeds (mirror of `test_release_group_mismatch_after_lazy_backfill`).
+  - Covers AE2: Discogs source + UUID target → `target_invalid`; MB source + numeric target → `target_invalid`.
+  - Covers AE1: masterless source (lookup returns `release_group_id=None`) + any other target → rejected; target == source → `target_same_as_current`.
+  - Master mismatch: target's master ≠ source's master → `target_release_group_mismatch` (R10).
+  - Covers AE3: `discogs_lookup` raises `DiscogsMirrorNotConfigured` → `mirror_unconfigured`.
+  - Transient: `discogs_lookup` raises `URLError` → `transient` (Rule B exception classes).
+  - Collision: another active row already holds the target Discogs id → `target_collision_request`, via the identity-aware lookup.
+  - MB regression row: the existing matrix untouched and green (R3).
+  - CLI wrapper: `mirror_unconfigured` → exit 5; numeric target accepted by argparse (exit-code map test).
+  - API contract: `mirror_unconfigured` → 503 with required fields; numeric target passes the pydantic body (status-code map test).
+- **Verification:** full outcome matrix green; `pipeline-cli replace <discogs-row> --to <sibling-id>` works against the dev DB.
+
+### U4. resolve-rg resolves Discogs masters
+
+- **Goal:** `POST /api/pipeline/<id>/resolve-rg` resolves and persists the master anchor for Discogs rows instead of 422ing on numeric ids.
+- **Requirements:** R9, R2 (masterless signalling).
+- **Dependencies:** U2 (shared persistence convention).
+- **Files:** `web/routes/pipeline.py` (`post_pipeline_resolve_rg`, lines ~1108-1186), `tests/web/test_routes_pipeline_replace.py`.
+- **Approach:** In the numeric-id branch (today's 422), call `discogs_api.get_release(source_id)`: master found → persist to `mb_release_group_id`, return 200 `{status:"resolved", mb_release_group_id:<master>}` (same payload shape as MB); no master → 200 `{status:"masterless"}` so the picker renders the one-element state instead of an error; `DiscogsMirrorNotConfigured` → 503. No new route, so no route-audit entry; the existing 422 contract test (`test_resolve_rg_discogs_release_id_returns_422`) is replaced with the new contract (note the equivalence in the commit message).
+- **Test scenarios:**
+  - Discogs row, master exists → 200 resolved, fake DB row updated with the master id.
+  - Discogs row, masterless → 200 `masterless`, row untouched.
+  - Discogs row, mirror unconfigured → 503.
+  - MB row behavior unchanged (existing tests stay green).
+- **Verification:** `tests/web/test_routes_pipeline_replace.py` green; route audit unchanged.
+
+### U5. Picker enumerates Discogs siblings
+
+- **Goal:** The Replace picker works end-to-end from a Discogs request row.
+- **Requirements:** R1, R2, R3, R7.
+- **Dependencies:** U3 (pathway-aware replace endpoint for submit), U4 (resolve-rg contract).
+- **Files:** `web/js/replace_picker.js`, `web/js/util.js` (pure mapping helper if extracted), `tests/test_js_util.mjs`.
+- **Approach:** After resolve-rg, branch on the anchor: UUID → existing `GET /api/release-group/<id>`; numeric → `GET /api/discogs/master/<id>` (existing browse route), mapping its `releases` payload (`id, title, date, country, format, track_count, labels`) onto the picker's row shape. Branch the tracklist fetches the same way: `fetchTracklist`/`loadSourceTracklist` call `GET /api/release/<mbid>` unconditionally today — route numeric ids to `GET /api/discogs/release/<id>` and map its `tracks` shape, or every row-expand and the reference panel errors on Discogs rows. `masterless` status → render the current release only with the "nothing to swap to" note (R2). Submit path unchanged — `POST /api/pipeline/<id>/replace` with the picked numeric id in `target_mb_release_id`. Mirror-error responses ride the picker's existing generic error state. The beets-distance badge (`/api/beets-distance/<log>/<mbid>`, UUID-anchored route) will silently not render for Discogs siblings — accepted and deferred (see Scope Boundaries), not a bug.
+- **Execution note:** Keep the payload-mapping function pure and Node-testable; the JS suite has no DOM.
+- **Test scenarios:**
+  - Pure mapping: a `get_master_releases`-shaped payload maps to picker rows preserving id/title/date/country/format; current release is marked.
+  - Pure mapping: a Discogs `get_release`-shaped `tracks` payload maps to the picker's tracklist shape (the row-expand comparison view).
+  - Covers AE1: `masterless` resolve-rg response yields the one-element render state.
+  - `node --check web/js/*.js` passes (syntax gate).
+- **Verification:** JS tests green; manual dev-server pass via `scripts/web_dev_server.py --data live-db` showing siblings for a real Discogs row.
+
+### U6. Live smoke and rescan parity
+
+- **Goal:** Prove the shipped flow on doc2 against real data, including one of the 124 legacy rows.
+- **Requirements:** Success Criteria; R5.
+- **Dependencies:** U3, U4, U5 deployed.
+- **Files:** none (operator verification; deploy per `.claude/rules/deploy.md`).
+- **Approach:** Deploy via `/deploy`. Playwright smoke on `music.ablz.au`: open Replace on a Discogs-pathway request (small/obscure artist), confirm sibling list renders, execute one real replace on a legacy row (NULL `mb_release_group_id`) to exercise the lazy backfill live, verify old row `replaced` + new row `wanted` with dual identity via `pipeline-cli show`. Institutional lesson: a structurally identical mirror-backed feature (MB search-by-id) shipped green-but-broken on mocks alone; the live smoke is not optional.
+- **Test expectation:** none — live verification unit; the suite coverage lives in U1-U5.
+- **Verification:** replaced row visible in the UI's replaced filter; `rescued_at`/audit columns intact; tag the verified state per deploy rules.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Applies to |
+|---|---|---|
+| Full suite (JS syntax + JS tests + vulture + unittest, includes real-PG tests) | `nix-shell --run "bash scripts/run_tests.sh"` then grep `^FAIL\|^ERROR` in `/tmp/cratedigger-test-output.txt` | U1-U5 |
+| Type check, whole repo, zero errors | `nix-shell --run "pyright"` | U1-U5 |
+| Single-module loop during dev | `nix-shell --run "python3 -m unittest tests.test_mbid_replace_service -v"` (and peers) | U1, U3, U4 |
+| Route audit self-check | included in the suite (`tests/web/test_route_audit.py`) | U4, U5 |
+| Live smoke | Playwright against `music.ablz.au` + `pipeline-cli show`/`query` on doc2 | U6 |
+
+No `nix/module.nix` changes are planned, so the `moduleVm` check is not required; the pre-push hook (`nix flake check`) still gates the push.
+
+---
+
+## Definition of Done
+
+- All of U1-U5 landed; full suite green with zero skips; pyright zero errors on the whole repo.
+- MB Replace outcome matrix untouched and green (R3).
+- The Rule A supersede round-trip test exists and passes against real PG.
+- U6 live verification complete: one legacy Discogs row (previously unreplaceable) replaced end-to-end on doc2, lazy backfill observed, audit chain intact.
+- No abandoned experimental code in the diff; the plan's guardrails (no new column, no parallel service, no MB behavior change) hold.
+- PR merged via "Create a merge commit"; deploy verified and tagged per `.claude/rules/deploy.md`.
+
+---
+
+## Sources / Research
+
+- `lib/mbid_replace_service.py` — outcome constants (109-116), UUID target gate (250-260), source-RG resolution + lazy backfill (299-343), target lookup (359-401), mismatch gate (403-411), supersede call (507-517), protocol (93-105).
+- `web/routes/pipeline.py` — Discogs add branch dual-write, `mb_release_group_id=None` (1464-1541); `post_pipeline_resolve_rg` numeric-id 422 (1108-1186); `post_pipeline_replace` (1241).
+- `web/discogs.py` — `get_master_releases` (344-372), `get_release` master→`release_group_id` remap (406), `DiscogsMirrorNotConfigured` (44-53).
+- `lib/field_resolver_service.py` — `_looks_numeric` and the numeric-master-in-`mb_release_group_id` convention (153-167, 318-345); the RG resolver that persists the master on add (497-509, 1642-1646).
+- `lib/beets_db.py` (184-268) and `harness/import_one.py` (170-208) — dual-column Discogs identity lookups downstream of supersede.
+- `lib/pipeline_db/requests.py` — supersede INSERT (307-322), `get_request_by_release_id` (128-151).
+- `web/routes/browse.py:311` — existing `GET /api/discogs/master/<id>` route; classified in `tests/web/test_route_audit.py`.
+- `tests/test_mbid_replace_service.py`, `tests/web/test_routes_pipeline_replace.py`, `tests/test_pipeline_cli.py`, `tests/fakes/pipeline_db.py:2395-2469` — test surfaces to extend.
+- `docs/solutions/architecture/service-first-then-glue.md`, `docs/solutions/testing/contract-test-mocks-must-mirror-production-shape.md`, `docs/solutions/testing/mocked-contract-tests-miss-helper-mirror-integration-bugs.md`, `.claude/rules/test-fidelity.md` — the patterns U1/U3/U6 follow.
+- `docs/plans/2026-05-18-001-feat-replace-operator-action-plan.md` — the original MB Replace plan.

--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -16,11 +16,17 @@ Outcome → exit code / HTTP status convention (matches
     target_release_group_mismatch  422 / 3
     target_same_as_current         422 / 3
     target_collision_request       409 / 4
+    mirror_unconfigured            503 / 5
     transient                      503 / 5
 
-See ``docs/plans/2026-05-18-001-feat-replace-operator-action-plan.md``
-and ``docs/brainstorms/2026-05-18-replace-operator-action-requirements.md``
-for the full design.
+Both MusicBrainz and Discogs sources flow through this one service; the
+pathway is inferred from the id's shape (``detect_release_source``). MB×MB
+is the original path, unchanged; Discogs×Discogs anchors on the source's
+Discogs master (numeric id in ``mb_release_group_id``, KTD-1).
+
+See ``docs/plans/2026-07-04-001-feat-discogs-pathway-replace-plan.md`` and
+``docs/plans/2026-05-18-001-feat-replace-operator-action-plan.md`` for the
+full design.
 """
 
 from __future__ import annotations
@@ -30,7 +36,6 @@ import logging
 import os
 import shutil
 import socket
-import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol, runtime_checkable
 from urllib.error import URLError
@@ -49,6 +54,7 @@ _TRANSIENT_LOOKUP_EXCEPTIONS: tuple[type[BaseException], ...] = (
 )
 
 from lib.config import CratediggerConfig
+from lib.release_identity import detect_release_source, normalize_release_id
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_IMPORT,
     MbidCollisionError,
@@ -86,6 +92,10 @@ class MbidReplaceDB(
         self, mb_release_id: str,
     ) -> dict[str, Any] | None: ...
 
+    def get_request_by_release_id(
+        self, release_id: object | None,
+    ) -> dict[str, Any] | None: ...
+
     def get_request_by_replaces_request_id(
         self, replaced_id: int,
     ) -> dict[str, Any] | None: ...
@@ -114,6 +124,7 @@ RESULT_TARGET_INVALID = "target_invalid"
 RESULT_TARGET_RELEASE_GROUP_MISMATCH = "target_release_group_mismatch"
 RESULT_TARGET_SAME_AS_CURRENT = "target_same_as_current"
 RESULT_TARGET_COLLISION_REQUEST = "target_collision_request"
+RESULT_MIRROR_UNCONFIGURED = "mirror_unconfigured"
 RESULT_TRANSIENT = "transient"
 
 
@@ -150,6 +161,12 @@ MBLookup = Callable[..., dict[str, Any]]
 """Signature: ``mb_lookup(mbid, *, fresh: bool=False) -> dict``. The
 default is ``web.mb.get_release``; tests inject a fake."""
 
+DiscogsLookup = Callable[..., dict[str, Any]]
+"""Signature: ``discogs_lookup(release_id: int, *, fresh: bool=False) ->
+dict``. The default is ``web.discogs.get_release``; tests inject a fake
+that raises the real ``HTTPError``/``URLError``/``DiscogsMirrorNotConfigured``
+on failure paths (test-fidelity Rule B)."""
+
 BeetsDBFactory = Callable[[], Any]
 """Zero-arg callable returning a ``BeetsDB`` instance. Default uses
 ``lib.beets_db.BeetsDB`` against the configured library path."""
@@ -160,6 +177,15 @@ def _default_mb_lookup(mbid: str, *, fresh: bool = False) -> dict[str, Any]:
     doesn't pull in ``web.mb``'s urllib transport at import time."""
     from web.mb import get_release
     return get_release(mbid, fresh=fresh)
+
+
+def _default_discogs_lookup(
+    release_id: int, *, fresh: bool = False,
+) -> dict[str, Any]:
+    """Default Discogs-mirror lookup. Imported lazily so the service
+    module doesn't pull in ``web.discogs``'s transport at import time."""
+    from web.discogs import get_release
+    return get_release(release_id, fresh=fresh)
 
 
 def _default_beets_db_factory() -> Any:
@@ -183,6 +209,7 @@ class MbidReplaceService:
         slskd: Any = None,
         beets_db_factory: BeetsDBFactory | None = None,
         mb_lookup: MBLookup | None = None,
+        discogs_lookup: DiscogsLookup | None = None,
         search_plan_service: SearchPlanService | None = None,
     ) -> None:
         self.db = db
@@ -193,6 +220,7 @@ class MbidReplaceService:
         self.slskd = slskd
         self.beets_db_factory = beets_db_factory or _default_beets_db_factory
         self.mb_lookup = mb_lookup or _default_mb_lookup
+        self.discogs_lookup = discogs_lookup or _default_discogs_lookup
         self.search_plan_service = (
             search_plan_service or SearchPlanService(db, config)
         )
@@ -240,26 +268,6 @@ class MbidReplaceService:
             "Replace: request_id=%d target_mb_release_id=%s",
             request_id, target_mb_release_id,
         )
-        # Step 0a — defense-in-depth UUID validation. The route regex
-        # (``^/api/pipeline/(\d+)/replace$`` + JSON body) and CLI
-        # argparse handle most malformed input upstream, but the service
-        # is the contract boundary and a malformed MBID has nothing to
-        # do downstream — the MB mirror lookup would error out anyway.
-        # Reject early with a clean message so the operator sees
-        # ``target_invalid`` (422 / exit 3) instead of a stack trace or
-        # an opaque mirror failure.
-        try:
-            uuid.UUID(str(target_mb_release_id))
-        except (ValueError, TypeError, AttributeError):
-            return ReplaceResult(
-                outcome=RESULT_TARGET_INVALID,
-                request_id=request_id,
-                error_message=(
-                    f"target_mb_release_id {target_mb_release_id!r} is "
-                    "not a valid UUID"
-                ),
-            )
-
         # Phase 0 — validate.
         source = self.db.get_request(request_id)
         if source is None:
@@ -287,6 +295,31 @@ class MbidReplaceService:
             )
 
         source_mbid = source.get("mb_release_id")
+
+        # Pathway-aware target gate (replaces the old step-0a UUID gate).
+        # The target must be a valid release id in the SAME identity space
+        # as the source: UUID target ⇒ MB source, numeric target ⇒ Discogs
+        # source. A cross-pathway target (or an unparseable id) is
+        # RESULT_TARGET_INVALID — cross-pathway Replace is out of scope
+        # (R4 / AE2). ``detect_release_source`` is the single authority for
+        # the pathway (KTD-2); the branch below dispatches on the source's
+        # own shape, so MB×MB flows through the original path untouched.
+        source_source = detect_release_source(source_mbid)
+        target_source = detect_release_source(target_mb_release_id)
+        if (
+            target_source not in ("musicbrainz", "discogs")
+            or target_source != source_source
+        ):
+            return ReplaceResult(
+                outcome=RESULT_TARGET_INVALID,
+                request_id=request_id,
+                error_message=(
+                    f"target {target_mb_release_id!r} ({target_source}) is "
+                    f"not a valid same-pathway target for source "
+                    f"({source_source})"
+                ),
+            )
+
         if source_mbid == target_mb_release_id:
             return ReplaceResult(
                 outcome=RESULT_TARGET_SAME_AS_CURRENT,
@@ -295,6 +328,11 @@ class MbidReplaceService:
                     "target MBID equals the source request's current "
                     "MBID"
                 ),
+            )
+
+        if source_source == "discogs":
+            return self._replace_discogs_target(
+                request_id, source, source_mbid, target_mb_release_id,
             )
 
         source_rg = source.get("mb_release_group_id")
@@ -445,6 +483,215 @@ class MbidReplaceService:
                     ),
                 )
 
+        return self._finalize_replace(
+            request_id,
+            source_mbid=source_mbid,
+            canonical_mbid=canonical_mbid,
+            target_rg=target_rg,
+            target_data=target_data,
+            new_discogs_release_id=None,
+        )
+
+    def _replace_discogs_target(
+        self,
+        request_id: int,
+        source: dict[str, Any],
+        source_mbid: str | None,
+        target_mb_release_id: str,
+    ) -> ReplaceResult:
+        """Discogs arm of Phase 0 — mirror of the MB decision order
+        (guardrails before IO), then delegate to the shared Phase 1-5.
+
+        Reached only when both the source and target are Discogs-pathway
+        (numeric) ids and the target differs from the source. The source's
+        Discogs master lives in ``mb_release_group_id`` (numeric, KTD-1);
+        legacy rows with a NULL master lazy-resolve it via a fresh lookup
+        of the source id (no persist needed — the old row is about to
+        freeze, and the superseded-into row carries the master directly).
+        Collision checks go through the identity-aware
+        ``get_request_by_release_id`` (KTD-6); the MB arm's call sites stay
+        on ``get_request_by_mb_release_id``.
+        """
+        from web.discogs import DiscogsMirrorNotConfigured
+
+        normalized_target = normalize_release_id(target_mb_release_id)
+        target_id_num = int(normalized_target)
+
+        # Resolve the source master (guardrail before the target IO).
+        source_master = source.get("mb_release_group_id")
+        if not source_master:
+            try:
+                src_data = self.discogs_lookup(
+                    int(normalize_release_id(source_mbid)), fresh=True,
+                )
+            except DiscogsMirrorNotConfigured as exc:
+                return ReplaceResult(
+                    outcome=RESULT_MIRROR_UNCONFIGURED,
+                    request_id=request_id,
+                    error_message=f"Discogs mirror not configured: {exc}",
+                )
+            except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
+                return ReplaceResult(
+                    outcome=RESULT_TRANSIENT,
+                    request_id=request_id,
+                    error_message=(
+                        f"Discogs lookup failed (transient): {exc}"
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001
+                return ReplaceResult(
+                    outcome=RESULT_TARGET_INVALID,
+                    request_id=request_id,
+                    error_message=(
+                        f"source Discogs id {source_mbid} could not be "
+                        f"resolved: {exc}"
+                    ),
+                )
+            source_master = src_data.get("release_group_id")
+            if not source_master:
+                # Masterless source: the only valid target is the source
+                # itself, already caught by RESULT_TARGET_SAME_AS_CURRENT
+                # upstream. Any other target crosses albums (AE1 / R10).
+                return ReplaceResult(
+                    outcome=RESULT_TARGET_INVALID,
+                    request_id=request_id,
+                    error_message=(
+                        f"source Discogs release {source_mbid} has no "
+                        "master; nothing to swap to (only the current "
+                        "release is a valid target)"
+                    ),
+                )
+
+        # Pre-check collision against the raw target id (identity-aware).
+        existing = self.db.get_request_by_release_id(target_mb_release_id)
+        if existing is not None and int(existing["id"]) != request_id:
+            return ReplaceResult(
+                outcome=RESULT_TARGET_COLLISION_REQUEST,
+                request_id=request_id,
+                current_status=existing.get("status"),
+                error_message=(
+                    f"target Discogs id {target_mb_release_id} is already "
+                    f"used by request {existing['id']} "
+                    f"(status={existing.get('status')!r})"
+                ),
+            )
+
+        # Fresh Discogs lookup of the target.
+        try:
+            target_data = self.discogs_lookup(target_id_num, fresh=True)
+        except DiscogsMirrorNotConfigured as exc:
+            return ReplaceResult(
+                outcome=RESULT_MIRROR_UNCONFIGURED,
+                request_id=request_id,
+                error_message=f"Discogs mirror not configured: {exc}",
+            )
+        except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
+            return ReplaceResult(
+                outcome=RESULT_TRANSIENT,
+                request_id=request_id,
+                error_message=f"Discogs lookup failed (transient): {exc}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ReplaceResult(
+                outcome=RESULT_TARGET_INVALID,
+                request_id=request_id,
+                error_message=(
+                    f"target Discogs id {target_mb_release_id} could not "
+                    f"be resolved: {exc}"
+                ),
+            )
+
+        if not target_data:
+            return ReplaceResult(
+                outcome=RESULT_TARGET_INVALID,
+                request_id=request_id,
+                error_message=(
+                    f"target Discogs id {target_mb_release_id} returned "
+                    "empty payload from the mirror"
+                ),
+            )
+
+        canonical_id = str(target_data.get("id") or target_mb_release_id)
+        target_master = target_data.get("release_group_id")
+        if not target_master:
+            return ReplaceResult(
+                outcome=RESULT_TARGET_INVALID,
+                request_id=request_id,
+                error_message=(
+                    f"target Discogs id {target_mb_release_id} resolved "
+                    "with no master"
+                ),
+            )
+
+        if target_master != source_master:
+            return ReplaceResult(
+                outcome=RESULT_TARGET_RELEASE_GROUP_MISMATCH,
+                request_id=request_id,
+                error_message=(
+                    f"target master {target_master} does not match source "
+                    f"master {source_master}"
+                ),
+            )
+
+        # Canonical-redirect re-check (mirror the MB arm): if the mirror
+        # returned a different canonical id, re-check collision against it
+        # and (defensively) against the source.
+        if canonical_id != normalized_target:
+            if canonical_id == normalize_release_id(source_mbid):
+                return ReplaceResult(
+                    outcome=RESULT_TARGET_COLLISION_REQUEST,
+                    request_id=request_id,
+                    current_status=source.get("status"),
+                    error_message=(
+                        f"target Discogs id {target_mb_release_id} "
+                        f"redirects to canonical {canonical_id} which is "
+                        "the source's current id"
+                    ),
+                )
+            existing_canon = self.db.get_request_by_release_id(canonical_id)
+            if (
+                existing_canon is not None
+                and int(existing_canon["id"]) != request_id
+            ):
+                return ReplaceResult(
+                    outcome=RESULT_TARGET_COLLISION_REQUEST,
+                    request_id=request_id,
+                    current_status=existing_canon.get("status"),
+                    error_message=(
+                        f"target redirects to canonical {canonical_id} "
+                        f"held by request {existing_canon['id']} "
+                        f"(status={existing_canon.get('status')!r})"
+                    ),
+                )
+
+        return self._finalize_replace(
+            request_id,
+            source_mbid=source_mbid,
+            canonical_mbid=canonical_id,
+            target_rg=target_master,
+            target_data=target_data,
+            new_discogs_release_id=canonical_id,
+        )
+
+    def _finalize_replace(
+        self,
+        request_id: int,
+        *,
+        source_mbid: str | None,
+        canonical_mbid: str,
+        target_rg: str,
+        target_data: dict[str, Any],
+        new_discogs_release_id: str | None,
+    ) -> ReplaceResult:
+        """Phases 1-5 — the mutation half, shared by the MB and Discogs
+        arms once the target identity is resolved and validated.
+
+        Acquires the IMPORT advisory lock, captures pre-supersede state,
+        atomically supersedes the row (dual-writing
+        ``new_discogs_release_id`` for the Discogs pathway; ``None`` for
+        MB), runs non-fatal filesystem cleanup under the lock, then
+        regenerates the search plan and fires the rescans OUTSIDE the lock.
+        """
         # Phase 1 — acquire IMPORT advisory lock. See docs/advisory-locks.md.
         # We acquire BEFORE re-reading the source row so the importer
         # worker cannot finish (and flip status / set imported_path)
@@ -515,6 +762,7 @@ class MbidReplaceService:
                     new_year=target_data.get("year"),
                     new_country=target_data.get("country"),
                     new_tracks=list(target_data.get("tracks") or []),
+                    new_discogs_release_id=new_discogs_release_id,
                 )
             except MbidCollisionError as exc:
                 return ReplaceResult(

--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -512,41 +512,20 @@ class MbidReplaceService:
         ``get_request_by_release_id`` (KTD-6); the MB arm's call sites stay
         on ``get_request_by_mb_release_id``.
         """
-        from web.discogs import DiscogsMirrorNotConfigured
-
         normalized_target = normalize_release_id(target_mb_release_id)
         target_id_num = int(normalized_target)
 
         # Resolve the source master (guardrail before the target IO).
         source_master = source.get("mb_release_group_id")
         if not source_master:
-            try:
-                src_data = self.discogs_lookup(
-                    int(normalize_release_id(source_mbid)), fresh=True,
-                )
-            except DiscogsMirrorNotConfigured as exc:
-                return ReplaceResult(
-                    outcome=RESULT_MIRROR_UNCONFIGURED,
-                    request_id=request_id,
-                    error_message=f"Discogs mirror not configured: {exc}",
-                )
-            except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
-                return ReplaceResult(
-                    outcome=RESULT_TRANSIENT,
-                    request_id=request_id,
-                    error_message=(
-                        f"Discogs lookup failed (transient): {exc}"
-                    ),
-                )
-            except Exception as exc:  # noqa: BLE001
-                return ReplaceResult(
-                    outcome=RESULT_TARGET_INVALID,
-                    request_id=request_id,
-                    error_message=(
-                        f"source Discogs id {source_mbid} could not be "
-                        f"resolved: {exc}"
-                    ),
-                )
+            src_data, err = self._discogs_lookup_or_error(
+                int(normalize_release_id(source_mbid)),
+                request_id=request_id,
+                detail_context=f"source Discogs id {source_mbid}",
+            )
+            if err is not None:
+                return err
+            assert src_data is not None
             source_master = src_data.get("release_group_id")
             if not source_master:
                 # Masterless source: the only valid target is the source
@@ -577,29 +556,14 @@ class MbidReplaceService:
             )
 
         # Fresh Discogs lookup of the target.
-        try:
-            target_data = self.discogs_lookup(target_id_num, fresh=True)
-        except DiscogsMirrorNotConfigured as exc:
-            return ReplaceResult(
-                outcome=RESULT_MIRROR_UNCONFIGURED,
-                request_id=request_id,
-                error_message=f"Discogs mirror not configured: {exc}",
-            )
-        except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
-            return ReplaceResult(
-                outcome=RESULT_TRANSIENT,
-                request_id=request_id,
-                error_message=f"Discogs lookup failed (transient): {exc}",
-            )
-        except Exception as exc:  # noqa: BLE001
-            return ReplaceResult(
-                outcome=RESULT_TARGET_INVALID,
-                request_id=request_id,
-                error_message=(
-                    f"target Discogs id {target_mb_release_id} could not "
-                    f"be resolved: {exc}"
-                ),
-            )
+        target_data, err = self._discogs_lookup_or_error(
+            target_id_num,
+            request_id=request_id,
+            detail_context=f"target Discogs id {target_mb_release_id}",
+        )
+        if err is not None:
+            return err
+        assert target_data is not None
 
         if not target_data:
             return ReplaceResult(
@@ -672,6 +636,61 @@ class MbidReplaceService:
             target_data=target_data,
             new_discogs_release_id=canonical_id,
         )
+
+    def _discogs_lookup_or_error(
+        self,
+        release_id_num: int,
+        *,
+        request_id: int,
+        detail_context: str,
+    ) -> tuple[dict[str, Any] | None, ReplaceResult | None]:
+        """Fresh Discogs-mirror lookup + the three-way exception→outcome
+        mapping shared by the source lazy-backfill and target lookup sites
+        in ``_replace_discogs_target``.
+
+        Returns ``(data, None)`` on success or ``(None, ReplaceResult(...))``
+        on failure. ``detail_context`` names the id being resolved in the
+        generic RESULT_TARGET_INVALID message (e.g. ``"source Discogs id
+        1001"`` / ``"target Discogs id 1002"``), preserving each call
+        site's original wording.
+
+        The three failure classes mirror the MB arm: an unconfigured
+        mirror is RESULT_MIRROR_UNCONFIGURED (503), a network blip /
+        timeout / malformed JSON is RESULT_TRANSIENT (503, retryable),
+        and anything else is RESULT_TARGET_INVALID (422). The generic
+        branch ALSO logs a warning so a real bug in the mirror client no
+        longer presents identically to bad operator input.
+        """
+        from web.discogs import DiscogsMirrorNotConfigured
+
+        try:
+            data = self.discogs_lookup(release_id_num, fresh=True)
+        except DiscogsMirrorNotConfigured as exc:
+            return None, ReplaceResult(
+                outcome=RESULT_MIRROR_UNCONFIGURED,
+                request_id=request_id,
+                error_message=f"Discogs mirror not configured: {exc}",
+            )
+        except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
+            return None, ReplaceResult(
+                outcome=RESULT_TRANSIENT,
+                request_id=request_id,
+                error_message=f"Discogs lookup failed (transient): {exc}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Replace: unexpected Discogs lookup error resolving %s "
+                "(request_id=%d): %s: %s",
+                detail_context, request_id, type(exc).__name__, exc,
+            )
+            return None, ReplaceResult(
+                outcome=RESULT_TARGET_INVALID,
+                request_id=request_id,
+                error_message=(
+                    f"{detail_context} could not be resolved: {exc}"
+                ),
+            )
+        return data, None
 
     def _finalize_replace(
         self,

--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -102,6 +102,7 @@ class MbidReplaceDB(
         new_year: int | None,
         new_country: str | None,
         new_tracks: list[dict[str, Any]],
+        new_discogs_release_id: str | None = None,
     ) -> int: ...
 
 

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -244,6 +244,7 @@ class _RequestsMixin(_PipelineDBBase):
         new_year: int | None,
         new_country: str | None,
         new_tracks: list[dict[str, Any]],
+        new_discogs_release_id: str | None = None,
     ) -> int:
         """Atomically supersede ``old_request_id`` with a new row.
 
@@ -257,6 +258,9 @@ class _RequestsMixin(_PipelineDBBase):
         3. ``INSERT`` a new ``album_requests`` row with the target MBID,
            ``status='wanted'``, ``replaces_request_id=old_request_id``,
            and the source inherited from the old row.
+           ``new_discogs_release_id`` is dual-written for the Discogs-pathway
+           Replace (the new row carries both the MB and Discogs identity, as
+           the add flow writes them); MB callers pass ``None``.
         4. ``INSERT`` the new row's ``album_tracks`` rows.
 
         Returns the new request_id.
@@ -309,10 +313,11 @@ class _RequestsMixin(_PipelineDBBase):
                         INSERT INTO album_requests (
                             mb_release_id, mb_release_group_id, mb_artist_id,
                             artist_name, album_title, year, country,
+                            discogs_release_id,
                             source, status, replaces_request_id,
                             created_at, updated_at
                         ) VALUES (
-                            %s, %s, %s, %s, %s, %s, %s, %s,
+                            %s, %s, %s, %s, %s, %s, %s, %s, %s,
                             'wanted', %s, %s, %s
                         )
                         RETURNING id
@@ -325,6 +330,7 @@ class _RequestsMixin(_PipelineDBBase):
                             new_album_title,
                             new_year,
                             new_country,
+                            new_discogs_release_id,
                             old_source,
                             old_request_id,
                             now,

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -3517,12 +3517,13 @@ def _build_parser() -> tuple[
     # replace
     p_replace = sub.add_parser(
         "replace",
-        help="Supersede a request with a new row at a different MBID "
-             "in the same release group")
+        help="Supersede a request with a new row at a different release id "
+             "in the same release group/master (same pathway as the source)")
     p_replace.add_argument("id", type=int, help="Source request ID")
     p_replace.add_argument(
         "--to", dest="target_mb_release_id", required=True,
-        help="Target MB release ID (must share the source's release group)")
+        help="Target release id — MB UUID or Discogs numeric id; must "
+             "share the source's pathway and release group/master")
     p_replace.add_argument("--json", action="store_true",
                            help="Print structured JSON instead of text")
 

--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -2000,11 +2000,13 @@ def cmd_replace(db, args):
       * 4 — ``RESULT_WRONG_STATE`` (including supersede race —
             double-click landed first; descendant_request_id is set),
             ``RESULT_TARGET_COLLISION_REQUEST``
-      * 5 — ``RESULT_TRANSIENT`` (retryable; MB-mirror unreachable etc.)
+      * 5 — ``RESULT_TRANSIENT`` (retryable; mirror unreachable etc.),
+            ``RESULT_MIRROR_UNCONFIGURED`` (Discogs mirror not configured)
     """
     from lib.config import read_runtime_config
     from lib.mbid_replace_service import (
         MbidReplaceService,
+        RESULT_MIRROR_UNCONFIGURED,
         RESULT_NOT_FOUND,
         RESULT_REPLACED,
         RESULT_TARGET_COLLISION_REQUEST,
@@ -2065,7 +2067,7 @@ def cmd_replace(db, args):
         RESULT_TARGET_COLLISION_REQUEST,
     ):
         return 4
-    if result.outcome == RESULT_TRANSIENT:
+    if result.outcome in (RESULT_TRANSIENT, RESULT_MIRROR_UNCONFIGURED):
         return 5
     return 1
 

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -2404,6 +2404,7 @@ class FakePipelineDB:
         new_year: int | None,
         new_country: str | None,
         new_tracks: list[dict[str, Any]],
+        new_discogs_release_id: str | None = None,
     ) -> int:
         """In-memory mirror of ``PipelineDB.supersede_request_mbid``.
 
@@ -2449,6 +2450,7 @@ class FakePipelineDB:
             mb_release_id=new_mb_release_id,
             mb_release_group_id=new_mb_release_group_id,
             mb_artist_id=new_mb_artist_id,
+            discogs_release_id=new_discogs_release_id,
             year=new_year,
             country=new_country,
             status="wanted",

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -2364,6 +2364,44 @@ class TestFakeSupersedeRequestMbid(unittest.TestCase):
         self.assertEqual(new["source"], "request")  # inherited
         self.assertEqual(len(db.get_tracks(new_id)), 2)
 
+    def test_discogs_release_id_threaded_onto_new_row(self):
+        # U1: a Discogs-pathway supersede dual-writes discogs_release_id onto
+        # the new row — the fake must thread it identically to real PG.
+        db = self._seed_old()
+        new_id = db.supersede_request_mbid(
+            42,
+            new_mb_release_id="new-mbid",
+            new_mb_release_group_id="rg-1",
+            new_mb_artist_id="art-1",
+            new_artist_name="Pet Grief",
+            new_album_title="New Album",
+            new_year=2025,
+            new_country="JP",
+            new_discogs_release_id="12345",
+            new_tracks=[],
+        )
+        new = db.get_request(new_id)
+        assert new is not None
+        self.assertEqual(new["discogs_release_id"], "12345")
+
+    def test_discogs_release_id_defaults_to_none(self):
+        # MB Replace omits new_discogs_release_id — the new row's column is None.
+        db = self._seed_old()
+        new_id = db.supersede_request_mbid(
+            42,
+            new_mb_release_id="new-mbid",
+            new_mb_release_group_id="rg-1",
+            new_mb_artist_id="art-1",
+            new_artist_name="Pet Grief",
+            new_album_title="New Album",
+            new_year=2025,
+            new_country="JP",
+            new_tracks=[],
+        )
+        new = db.get_request(new_id)
+        assert new is not None
+        self.assertIsNone(new["discogs_release_id"])
+
     def test_imported_path_cleared_on_old_row(self):
         db = self._seed_old()
         db.supersede_request_mbid(

--- a/tests/test_field_resolver_service.py
+++ b/tests/test_field_resolver_service.py
@@ -1036,6 +1036,87 @@ class TestResolveAll(unittest.TestCase):
         self.assertEqual(result.release_group_id, "rg-master-id")
         self.assertEqual(result.catalog_number, "CAT-7")
 
+    def test_discogs_master_persisted_into_mb_release_group_id_via_apply(self):
+        """KTD-1 pin (docs/plans/2026-07-04-001-feat-discogs-pathway-replace-plan.md
+        U2): new Discogs adds already persist the Discogs master id into
+        ``mb_release_group_id`` through ``resolve_all`` +
+        ``apply_resolve_all_result`` — the mechanism the Discogs-pathway
+        Replace picker anchors on. Chains both halves together; the two
+        halves were previously only pinned in isolation
+        (``test_discogs_release_fetched_at_most_once_per_invocation`` for
+        the resolver, ``test_writes_release_group_id_when_existing_is_none``
+        for the generic write helper)."""
+        from lib.field_resolver_service import resolve_all
+
+        db = FakePipelineDB()
+        req = _request(
+            id=803,
+            mb_release_id=None,
+            mb_release_group_id=None,
+            discogs_release_id="900555",
+        )
+
+        discogs_payload = {
+            "id": "900555",
+            "title": "Album",
+            "artist_id": "12345",
+            "release_group_id": "98765",
+            "tracks": [],
+            "labels": [],
+        }
+
+        result = resolve_all(
+            req, db,
+            discogs_release_payload=discogs_payload,
+            discogs_get_master_year=lambda _id: 2010,
+            discogs_get_release=lambda _rid, *, fresh=True: discogs_payload,
+        )
+        self.assertEqual(result.release_group_id, "98765")
+
+        apply_resolve_all_result(
+            db, 803, result, existing_mb_release_group_id=None,
+        )
+        _req_id, fields = db.update_request_fields_calls[-1]
+        self.assertEqual(fields["mb_release_group_id"], "98765")
+
+    def test_discogs_masterless_release_leaves_mb_release_group_id_unwritten(self):
+        """AE1/R2 companion: a masterless Discogs release resolves
+        ``release_group_id=None`` and the write helper must neither write
+        the column nor raise — matching the YouTube resolver's orphan-shape
+        handling for the same case."""
+        from lib.field_resolver_service import resolve_all
+
+        db = FakePipelineDB()
+        req = _request(
+            id=804,
+            mb_release_id=None,
+            mb_release_group_id=None,
+            discogs_release_id="900777",
+        )
+
+        discogs_payload = {
+            "id": "900777",
+            "title": "Album",
+            "artist_id": "12345",
+            "release_group_id": None,
+            "tracks": [],
+            "labels": [],
+        }
+
+        result = resolve_all(
+            req, db,
+            discogs_release_payload=discogs_payload,
+            discogs_get_master_year=lambda _id: None,
+            discogs_get_release=lambda _rid, *, fresh=True: discogs_payload,
+        )
+        self.assertIsNone(result.release_group_id)
+
+        apply_resolve_all_result(
+            db, 804, result, existing_mb_release_group_id=None,
+        )
+        _req_id, fields = db.update_request_fields_calls[-1]
+        self.assertNotIn("mb_release_group_id", fields)
+
     def test_va_detection_via_canonical_mbid(self):
         """Rule 1: primary-artist MBID matches the canonical VA id."""
         from lib.field_resolver_service import resolve_all

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -778,6 +778,9 @@ import {
   pickBestDistance,
   formatDistanceBadge,
   runWithConcurrency,
+  mapDiscogsMasterReleases,
+  renderMasterlessNote,
+  extractTracklist,
   esc as replaceEsc,
 } from '../web/js/replace_picker.js';
 
@@ -977,6 +980,101 @@ assertEqual(
 assertEqual(replaceEsc('<script>'), '&lt;script&gt;', 'esc escapes <');
 assertEqual(replaceEsc('a&b'), 'a&amp;b', 'esc escapes &');
 assertEqual(replaceEsc('"x"'), '&quot;x&quot;', 'esc escapes "');
+
+// ============================================================
+// replace_picker.js — Discogs-pathway Replace (U5)
+// ============================================================
+
+// mapDiscogsMasterReleases — GET /api/discogs/master/<id> payload → the
+// same pressing-row shape GET /api/release-group/<id> already returns
+// for MB (id/title/date/country/format/track_count preserved).
+const discogsMasterPayload = {
+  title: 'Hold Your Colour',
+  type: 'Album',
+  first_release_date: '2005-05-23',
+  artist_credit: 'Pendulum',
+  primary_artist_id: '287459',
+  releases: [
+    {
+      id: '1122334', title: 'Hold Your Colour (CD, Album)', date: '2005-05-23',
+      country: 'UK', status: 'Official', track_count: 13, format: 'CD, Album',
+      media_count: 1, labels: [{ name: 'Breakbeat Kaos' }],
+    },
+    {
+      id: '5566778', title: 'Hold Your Colour (2xLP)', date: '2006-01-01',
+      country: 'US', status: 'Official', track_count: 13, format: 'Vinyl, LP',
+      media_count: 2, labels: [{ name: 'Breakbeat Kaos' }],
+    },
+  ],
+};
+const mappedDiscogs = mapDiscogsMasterReleases(discogsMasterPayload);
+assertEqual(mappedDiscogs.length, 2, 'mapDiscogsMasterReleases preserves release count');
+assertEqual(mappedDiscogs[0].id, '1122334', 'mapDiscogsMasterReleases preserves id');
+assertEqual(mappedDiscogs[0].title, 'Hold Your Colour (CD, Album)', 'mapDiscogsMasterReleases preserves title');
+assertEqual(mappedDiscogs[0].date, '2005-05-23', 'mapDiscogsMasterReleases preserves date');
+assertEqual(mappedDiscogs[0].country, 'UK', 'mapDiscogsMasterReleases preserves country');
+assertEqual(mappedDiscogs[0].format, 'CD, Album', 'mapDiscogsMasterReleases preserves format');
+assertEqual(mappedDiscogs[0].track_count, 13, 'mapDiscogsMasterReleases preserves track_count');
+
+// The mapped rows feed straight into the existing renderPressingsList —
+// current-release marking works identically to the MB path.
+const discogsPressingsHtml = renderPressingsList(mappedDiscogs, '1122334');
+assert(/data-expand-mbid="1122334"[^>]*disabled|disabled[^>]*data-expand-mbid="1122334"/.test(discogsPressingsHtml),
+  'mapDiscogsMasterReleases + renderPressingsList marks the current Discogs release disabled');
+assert(discogsPressingsHtml.includes('current pressing'),
+  'mapDiscogsMasterReleases + renderPressingsList labels the current Discogs release');
+assert(/replace-picker-confirm[^>]*data-mbid="5566778"/.test(discogsPressingsHtml),
+  'mapDiscogsMasterReleases + renderPressingsList renders a pick button for the Discogs sibling');
+
+// Missing fields render through the picker's existing empty/dash handling
+// rather than throwing or leaking `undefined` into the HTML.
+const sparseMapped = mapDiscogsMasterReleases({ releases: [{ id: 999 }] });
+assertEqual(sparseMapped[0].id, '999', 'mapDiscogsMasterReleases coerces numeric id to string');
+assertEqual(sparseMapped[0].title, '', 'mapDiscogsMasterReleases missing title → empty string');
+assertEqual(sparseMapped[0].track_count, 0, 'mapDiscogsMasterReleases missing track_count → 0');
+assert(!renderPressingsList(sparseMapped, 'other').includes('undefined'),
+  'mapDiscogsMasterReleases sparse row never renders "undefined"');
+
+// Absent/malformed payload → empty list, not a throw.
+assertEqual(mapDiscogsMasterReleases(null).length, 0, 'mapDiscogsMasterReleases(null) → []');
+assertEqual(mapDiscogsMasterReleases({}).length, 0, 'mapDiscogsMasterReleases({}) → []');
+
+// renderMasterlessNote — R2/AE1 copy, pure/DOM-free.
+assert(renderMasterlessNote().toLowerCase().includes('no other pressings'),
+  'renderMasterlessNote explains there is nothing to swap to');
+
+// extractTracklist — GET /api/release/<id> (or /api/discogs/release/<id>,
+// same shape) payload → the tracklist array `fetchTracklist` hands to
+// renderTracklist. No MB/Discogs branch needed: both backends already
+// emit identical track objects (disc_number/track_number/title/
+// length_seconds), proven server-side by
+// test_release_detail_numeric_id_forwards_to_discogs.
+const discogsReleasePayload = {
+  id: '1122334',
+  title: 'Hold Your Colour (CD, Album)',
+  tracks: [
+    { disc_number: 1, track_number: 1, title: 'Slam', length_seconds: 245 },
+    { disc_number: 1, track_number: 2, title: 'Voyager', length_seconds: 260 },
+  ],
+};
+const extracted = extractTracklist(discogsReleasePayload);
+assertEqual(extracted.length, 2, 'extractTracklist preserves track count');
+assertEqual(extracted[0].title, 'Slam', 'extractTracklist preserves track title');
+assert(renderTracklist(extracted).includes('Slam'),
+  'extractTracklist output renders through the existing renderTracklist');
+assertEqual(extractTracklist({}).length, 0, 'extractTracklist({}) → []');
+assertEqual(extractTracklist(null).length, 0, 'extractTracklist(null) → []');
+
+// Anchor-shape dispatch — the exact predicate replace_picker.js uses to
+// pick /api/release-group/<id> (MB) vs /api/discogs/master/<id>
+// (Discogs). Reuses util.js's detectSource rather than a duplicate
+// isNumericId helper (already exhaustively covered above).
+assertEqual(detectSource('89ad4ac3-39f7-470e-963a-56509c546377') === 'discogs', false,
+  'replace-picker anchor dispatch: UUID anchor is not routed to the Discogs master endpoint');
+assertEqual(detectSource('1122334') === 'discogs', true,
+  'replace-picker anchor dispatch: numeric anchor is routed to the Discogs master endpoint');
+assertEqual(detectSource('not-an-id') === 'discogs', false,
+  'replace-picker anchor dispatch: junk anchor is not routed to the Discogs master endpoint');
 
 // renderReplaceButton (release_actions.js) — U9
 import { renderReplaceButton } from '../web/js/release_actions.js';

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -40,9 +40,10 @@ from tests.fakes import FakePipelineDB, FakeSlskdAPI
 from tests.helpers import make_request_row
 
 
-# NOTE: must be parseable by ``uuid.UUID`` — the service rejects
-# malformed MBIDs at the boundary with RESULT_TARGET_INVALID. Keep the
-# repeated-digit pattern for at-a-glance reading of test scenarios.
+# NOTE: must be a valid MB release id per ``detect_release_source``
+# (lib/release_identity.py regex) — the service rejects malformed MBIDs
+# at the boundary with RESULT_TARGET_INVALID. Keep the repeated-digit
+# pattern for at-a-glance reading of test scenarios.
 OLD_MBID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 NEW_MBID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 RG_ID = "11111111-1111-1111-1111-111111111111"
@@ -743,6 +744,88 @@ class TestReplaceDiscogsArm(_ServiceCase):
         self.assertEqual(result.outcome, RESULT_REPLACED)
         # Lazy-backfill issued a fresh lookup of the source id.
         self.assertIn(OLD_DISCOGS_ID, calls)
+
+    def test_source_lazy_backfill_mirror_unconfigured(self):
+        """SOURCE lazy-backfill lookup (masterless legacy row) surfaces
+        RESULT_MIRROR_UNCONFIGURED when the source-master resolution hits
+        an unconfigured Discogs mirror — the target lookup is never
+        reached and no supersede occurs (Rule B: the real
+        ``DiscogsMirrorNotConfigured`` is raised)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=None)
+        calls: list[str] = []
+
+        def fake_lookup(rid, *, fresh=False):
+            calls.append(str(rid))
+            if str(rid) == OLD_DISCOGS_ID:
+                raise DiscogsMirrorNotConfigured("no mirror")
+            return _fake_discogs_payload()
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_MIRROR_UNCONFIGURED)
+        # Source lookup raised first → target lookup never ran.
+        self.assertEqual(calls, [OLD_DISCOGS_ID])
+        # No supersede: old row untouched, no descendant.
+        self.assertIsNone(result.new_request_id)
+        old = db.get_request(42)
+        assert old is not None
+        self.assertEqual(old["status"], "wanted")
+
+    def test_source_lazy_backfill_transient_urlerror(self):
+        """SOURCE lazy-backfill lookup classifies a network blip as
+        RESULT_TRANSIENT (retryable), not RESULT_TARGET_INVALID — the
+        source id is already known-good; the mirror was just unreachable
+        (Rule B: the real ``URLError`` is raised). No supersede occurs."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=None)
+        calls: list[str] = []
+
+        def fake_lookup(rid, *, fresh=False):
+            calls.append(str(rid))
+            if str(rid) == OLD_DISCOGS_ID:
+                raise URLError("connection refused")
+            return _fake_discogs_payload()
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TRANSIENT)
+        # Source lookup raised first → target lookup never ran.
+        self.assertEqual(calls, [OLD_DISCOGS_ID])
+        self.assertIsNone(result.new_request_id)
+        old = db.get_request(42)
+        assert old is not None
+        self.assertEqual(old["status"], "wanted")
+
+    def test_source_lazy_backfill_generic_exception_target_invalid(self):
+        """SOURCE lazy-backfill lookup maps an unexpected error to
+        RESULT_TARGET_INVALID (the generic branch, which also logs a
+        warning). Target lookup never runs and no supersede occurs."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=None)
+        calls: list[str] = []
+
+        def fake_lookup(rid, *, fresh=False):
+            calls.append(str(rid))
+            if str(rid) == OLD_DISCOGS_ID:
+                raise RuntimeError("Discogs mirror 500")
+            return _fake_discogs_payload()
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        # Source lookup raised first → target lookup never ran.
+        self.assertEqual(calls, [OLD_DISCOGS_ID])
+        self.assertIsNone(result.new_request_id)
+        old = db.get_request(42)
+        assert old is not None
+        self.assertEqual(old["status"], "wanted")
 
     def test_discogs_source_uuid_target_invalid(self):
         """AE2: a UUID target against a Discogs source is cross-pathway →

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -22,6 +22,7 @@ from lib.config import CratediggerConfig
 from lib.mbid_replace_service import (
     MbidReplaceService,
     ReplaceResult,
+    RESULT_MIRROR_UNCONFIGURED,
     RESULT_NOT_FOUND,
     RESULT_REPLACED,
     RESULT_TARGET_COLLISION_REQUEST,
@@ -31,6 +32,7 @@ from lib.mbid_replace_service import (
     RESULT_TRANSIENT,
     RESULT_WRONG_STATE,
 )
+from web.discogs import DiscogsMirrorNotConfigured
 from lib.pipeline_db import MbidCollisionError, SupersedeRaceError
 from lib.release_cleanup import ReleaseCleanupResult
 from lib.wrong_match_delete_service import WrongMatchDeleteSummary
@@ -45,6 +47,15 @@ OLD_MBID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 NEW_MBID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 RG_ID = "11111111-1111-1111-1111-111111111111"
 OTHER_RG_ID = "22222222-2222-2222-2222-222222222222"
+
+# Discogs-pathway fixtures — numeric release ids; the master anchor lives
+# in ``mb_release_group_id`` as a numeric id (KTD-1). A Discogs source row
+# dual-writes the numeric id into both ``mb_release_id`` and
+# ``discogs_release_id`` (KTD-4), as the add flow does.
+OLD_DISCOGS_ID = "1001"
+NEW_DISCOGS_ID = "1002"
+DISCOGS_MASTER = "5000"
+OTHER_DISCOGS_MASTER = "6000"
 
 
 def _empty_wrong_match_summary(_db, request_id: int) -> WrongMatchDeleteSummary:
@@ -98,6 +109,37 @@ def _fake_target_payload(
     }
 
 
+def _fake_discogs_payload(
+    *,
+    release_id: str = NEW_DISCOGS_ID,
+    master: str | None = DISCOGS_MASTER,
+    artist_name: str = "Pet Grief",
+    title: str = "New Pressing",
+    artist_id: str | None = "art-d-1",
+    year: int | None = 2025,
+    country: str | None = "JP",
+    tracks: list[dict] | None = None,
+) -> dict:
+    """Mirror of ``web.discogs.get_release``'s normalized shape.
+
+    ``master`` maps to the ``release_group_id`` key (the mirror remaps
+    ``master_id`` there); ``None`` models a masterless release.
+    """
+    return {
+        "id": str(release_id),
+        "title": title,
+        "artist_name": artist_name,
+        "artist_id": artist_id,
+        "release_group_id": master,
+        "year": year,
+        "country": country,
+        "tracks": tracks if tracks is not None else [
+            {"disc_number": 1, "track_number": 1, "title": "T1"},
+            {"disc_number": 1, "track_number": 2, "title": "T2"},
+        ],
+    }
+
+
 class _ServiceCase(unittest.TestCase):
     """Shared scaffolding for MbidReplaceService tests."""
 
@@ -131,17 +173,57 @@ class _ServiceCase(unittest.TestCase):
         db.seed_request(row)
         return request_id
 
+    def _seed_discogs(
+        self,
+        db: FakePipelineDB,
+        *,
+        request_id: int = 42,
+        status: str = "wanted",
+        master: str | None = DISCOGS_MASTER,
+        release_id: str = OLD_DISCOGS_ID,
+        imported_path: str | None = None,
+        source: str = "request",
+    ) -> int:
+        """Seed a Discogs-pathway source row.
+
+        The numeric release id is dual-written into both ``mb_release_id``
+        and ``discogs_release_id`` (KTD-4); the numeric master lives in
+        ``mb_release_group_id`` (KTD-1). ``master=None`` models a legacy row
+        that predates master persistence (the lazy-backfill target).
+        """
+        row = make_request_row(
+            id=request_id,
+            mb_release_id=release_id,
+            discogs_release_id=release_id,
+            mb_release_group_id=master,
+            mb_artist_id="art-d-1",
+            artist_name="Pet Grief",
+            album_title="Old Pressing",
+            year=2024,
+            country="US",
+            status=status,
+            imported_path=imported_path,
+            source=source,
+        )
+        db.seed_request(row)
+        return request_id
+
     def _make_service(
         self,
         db: FakePipelineDB,
         *,
         mb_lookup=None,
+        discogs_lookup=None,
         search_plan_service=None,
         beets_db_factory=None,
         cfg: CratediggerConfig | None = None,
     ) -> MbidReplaceService:
         if mb_lookup is None:
             mb_lookup = lambda mbid, *, fresh=False: _fake_target_payload()
+        if discogs_lookup is None:
+            discogs_lookup = (
+                lambda rid, *, fresh=False: _fake_discogs_payload()
+            )
         if search_plan_service is None:
             search_plan_service = MagicMock()
         if beets_db_factory is None:
@@ -152,8 +234,41 @@ class _ServiceCase(unittest.TestCase):
             slskd=FakeSlskdAPI(),
             beets_db_factory=beets_db_factory,
             mb_lookup=mb_lookup,
+            discogs_lookup=discogs_lookup,
             search_plan_service=search_plan_service,
         )
+
+    def _patch_externals(self):
+        """Patch the five external edges (beets removal, wrong-match
+        cleanup, and the three rescan notifiers) and register cleanup via
+        ``self.addCleanup``. Returns the patched mocks as a list so tests
+        can assert on them. Scoped per-test — unlike ``patch.stopall``
+        which would stop EVERY active patch in the process."""
+        patches = [
+            patch(
+                "lib.mbid_replace_service.remove_and_reset_release",
+                MagicMock(return_value=ReleaseCleanupResult(
+                    beets_removed=True,
+                    absent_after=True,
+                    selector_failures=(),
+                )),
+            ),
+            patch(
+                "lib.mbid_replace_service.delete_wrong_match_group",
+                MagicMock(side_effect=_empty_wrong_match_summary),
+            ),
+            patch("lib.mbid_replace_service.trigger_meelo_scan", MagicMock()),
+            patch("lib.mbid_replace_service.trigger_plex_scan", MagicMock()),
+            patch(
+                "lib.mbid_replace_service.trigger_jellyfin_scan",
+                MagicMock(),
+            ),
+        ]
+        mocks = []
+        for p in patches:
+            mocks.append(p.start())
+            self.addCleanup(p.stop)
+        return mocks
 
     def _assert_slskd_untouched(self, slskd: object) -> None:
         """Assert FakeSlskdAPI recorded zero calls across every surface.
@@ -553,42 +668,221 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
         )
 
 
+class TestReplaceDiscogsArm(_ServiceCase):
+    """Discogs-pathway Replace (U3): the full outcome matrix for a
+    numeric Discogs source. The MB arm is exercised separately and must
+    stay byte-for-byte unchanged (R3)."""
+
+    def test_discogs_happy_path_dual_writes_identity(self):
+        """Discogs source with a persisted master + sibling target →
+        replaced. The superseded-into row carries dual identity (KTD-4):
+        ``mb_release_id`` AND ``discogs_release_id`` both hold the picked
+        canonical id, and the numeric master lands in
+        ``mb_release_group_id``."""
+        self._patch_externals()
+        db = FakePipelineDB()
+        self._seed_discogs(db, status="wanted")
+        plan_svc = MagicMock()
+        svc = self._make_service(
+            db,
+            search_plan_service=plan_svc,
+            discogs_lookup=(
+                lambda rid, *, fresh=False: _fake_discogs_payload(
+                    release_id=NEW_DISCOGS_ID, master=DISCOGS_MASTER,
+                )
+            ),
+        )
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_REPLACED)
+        assert result.new_request_id is not None
+        # Old row frozen as replaced audit.
+        old = db.get_request(42)
+        assert old is not None
+        self.assertEqual(old["status"], "replaced")
+        # New row born wanted, back-linked, with dual identity + master.
+        new = db.get_request(result.new_request_id)
+        assert new is not None
+        self.assertEqual(new["status"], "wanted")
+        self.assertEqual(new["replaces_request_id"], 42)
+        self.assertEqual(new["mb_release_id"], NEW_DISCOGS_ID)
+        self.assertEqual(new["discogs_release_id"], NEW_DISCOGS_ID)
+        self.assertEqual(new["mb_release_group_id"], DISCOGS_MASTER)
+        plan_svc.generate_for_request.assert_called_once_with(
+            result.new_request_id, regenerate=False,
+        )
+        self._assert_slskd_untouched(svc.slskd)
+
+    def test_discogs_lazy_backfill_source_master(self):
+        """Source row with a NULL master (legacy row): the source id is
+        looked up fresh to resolve the master, then the replace proceeds
+        (mirror of ``test_release_group_mismatch_after_lazy_backfill``,
+        happy variant). No persistence of the source master is required —
+        the superseded-into row carries the master via the supersede
+        call, and the old row is about to freeze."""
+        self._patch_externals()
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=None)
+        calls: list[str] = []
+
+        def fake_lookup(rid, *, fresh=False):
+            calls.append(str(rid))
+            if str(rid) == OLD_DISCOGS_ID:
+                return _fake_discogs_payload(
+                    release_id=OLD_DISCOGS_ID, master=DISCOGS_MASTER,
+                )
+            return _fake_discogs_payload(
+                release_id=NEW_DISCOGS_ID, master=DISCOGS_MASTER,
+            )
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_REPLACED)
+        # Lazy-backfill issued a fresh lookup of the source id.
+        self.assertIn(OLD_DISCOGS_ID, calls)
+
+    def test_discogs_source_uuid_target_invalid(self):
+        """AE2: a UUID target against a Discogs source is cross-pathway →
+        target_invalid (never reaches the mirror)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db)
+        called = {"hit": False}
+
+        def fake_lookup(rid, *, fresh=False):
+            called["hit"] = True
+            return _fake_discogs_payload()
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertFalse(called["hit"])
+
+    def test_mb_source_numeric_target_invalid(self):
+        """AE2 (mirror direction): a numeric Discogs target against an MB
+        source is cross-pathway → target_invalid."""
+        db = FakePipelineDB()
+        self._seed_old(db)
+        svc = self._make_service(db)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+
+    def test_masterless_source_other_target_rejected(self):
+        """AE1 / R10: a masterless Discogs source rejects any target that
+        is not the source itself."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=None)
+
+        def fake_lookup(rid, *, fresh=False):
+            # Source resolves masterless; target never reached.
+            return _fake_discogs_payload(release_id=str(rid), master=None)
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        assert result.error_message is not None
+        self.assertIn("master", result.error_message)
+
+    def test_masterless_source_same_target_same_as_current(self):
+        """AE1: a masterless source with target == source is caught by the
+        shared same-as-current gate (before the arm runs)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=None)
+        svc = self._make_service(db)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=OLD_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_SAME_AS_CURRENT)
+
+    def test_discogs_master_mismatch(self):
+        """R10: target's master ≠ source's master → release-group mismatch
+        (reuses the shared MB mismatch outcome)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=DISCOGS_MASTER)
+        svc = self._make_service(
+            db,
+            discogs_lookup=(
+                lambda rid, *, fresh=False: _fake_discogs_payload(
+                    release_id=NEW_DISCOGS_ID, master=OTHER_DISCOGS_MASTER,
+                )
+            ),
+        )
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(
+            result.outcome, RESULT_TARGET_RELEASE_GROUP_MISMATCH
+        )
+
+    def test_discogs_mirror_unconfigured(self):
+        """AE3 / R11: an unconfigured Discogs mirror surfaces its own
+        outcome — distinct from target_invalid and transient (Rule B: the
+        real ``DiscogsMirrorNotConfigured`` is raised)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=DISCOGS_MASTER)
+
+        def fake_lookup(rid, *, fresh=False):
+            raise DiscogsMirrorNotConfigured("no mirror")
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_MIRROR_UNCONFIGURED)
+
+    def test_discogs_transient_urlerror(self):
+        """A network blip on the Discogs lookup is retryable → transient
+        (Rule B: the real ``URLError`` is raised)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=DISCOGS_MASTER)
+
+        def fake_lookup(rid, *, fresh=False):
+            raise URLError("connection refused")
+
+        svc = self._make_service(db, discogs_lookup=fake_lookup)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TRANSIENT)
+
+    def test_discogs_collision_via_identity_lookup(self):
+        """KTD-6: an active row already holding the target Discogs id (in
+        ``discogs_release_id``) is a collision — found via the
+        identity-aware ``get_request_by_release_id``, NOT
+        ``get_request_by_mb_release_id`` (the holder's ``mb_release_id``
+        deliberately differs)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=DISCOGS_MASTER)
+        db.seed_request(make_request_row(
+            id=43, mb_release_id="9999",
+            discogs_release_id=NEW_DISCOGS_ID,
+            mb_release_group_id=DISCOGS_MASTER, status="downloading",
+        ))
+        svc = self._make_service(
+            db,
+            discogs_lookup=(
+                lambda rid, *, fresh=False: _fake_discogs_payload(
+                    release_id=NEW_DISCOGS_ID, master=DISCOGS_MASTER,
+                )
+            ),
+        )
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_COLLISION_REQUEST)
+        self.assertEqual(result.current_status, "downloading")
+
+
 class TestReplaceHappyPath(_ServiceCase):
     """Cover RESULT_REPLACED + ordering invariants + the Pet Grief
-    merged-upstream case (target redirects to canonical)."""
-
-    def _patch_externals(self):
-        """Patch the five external edges and register cleanup via
-        ``self.addCleanup``. Returns the patched mocks as a tuple so
-        tests can assert on them. Scoped per-test — unlike
-        ``patch.stopall`` which would stop EVERY active patch in the
-        process (including any unrelated patch the test runner is
-        holding) and is a known footgun on shared mocks."""
-        patches = [
-            patch(
-                "lib.mbid_replace_service.remove_and_reset_release",
-                MagicMock(return_value=ReleaseCleanupResult(
-                    beets_removed=True,
-                    absent_after=True,
-                    selector_failures=(),
-                )),
-            ),
-            patch(
-                "lib.mbid_replace_service.delete_wrong_match_group",
-                MagicMock(side_effect=_empty_wrong_match_summary),
-            ),
-            patch("lib.mbid_replace_service.trigger_meelo_scan", MagicMock()),
-            patch("lib.mbid_replace_service.trigger_plex_scan", MagicMock()),
-            patch(
-                "lib.mbid_replace_service.trigger_jellyfin_scan",
-                MagicMock(),
-            ),
-        ]
-        mocks = []
-        for p in patches:
-            mocks.append(p.start())
-            self.addCleanup(p.stop)
-        return mocks
+    merged-upstream case (target redirects to canonical). ``_patch_externals``
+    is inherited from ``_ServiceCase``."""
 
     def _replace(self, *, old_status="wanted", **service_kwargs):
         db = FakePipelineDB()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2646,9 +2646,25 @@ class TestCmdReplace(unittest.TestCase):
                 rc, _ = self._run(mock_outcome=outcome)
                 self.assertEqual(rc, 4)
 
-    def test_exit_5_on_transient(self):
-        rc, _ = self._run(mock_outcome="transient")
-        self.assertEqual(rc, 5)
+    def test_exit_5_on_transient_and_mirror_unconfigured(self):
+        # mirror_unconfigured (Discogs mirror not set up) shares exit 5
+        # with transient — both are service-unavailable/retryable.
+        for outcome in ("transient", "mirror_unconfigured"):
+            with self.subTest(outcome=outcome):
+                rc, _ = self._run(mock_outcome=outcome)
+                self.assertEqual(rc, 5)
+
+    def test_numeric_discogs_target_accepted(self):
+        """A numeric Discogs id is a valid target on the CLI surface —
+        argparse takes ``--to`` as an opaque string; the service
+        dispatches on id shape, not the wire param name."""
+        rc, out = self._run(
+            mock_outcome="replaced",
+            mock_kwargs={"new_request_id": 99},
+            target_mbid="1002",
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("99", out)
 
     def test_json_output_carries_full_payload(self):
         rc, out = self._run(

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -102,6 +102,100 @@ class TestAddRequestRoundTrip(unittest.TestCase):
 
 
 @requires_postgres
+class TestSupersedeRequestMbidRoundTrip(unittest.TestCase):
+    """Rule A round-trip for supersede_request_mbid (U1 — Discogs-pathway
+    Replace). Every field the supersede INSERT writes onto the new row must
+    read back unchanged through real PG, and the old row must flip to the
+    frozen 'replaced' audit state. Before U1 there was NO real-PG round-trip
+    for supersede at all, so the new discogs_release_id column had no guard
+    against being dropped at the SQL seam — exactly the album_title class
+    Rule A targets."""
+
+    def _seed_old(self, db) -> int:
+        return db.add_request(
+            artist_name="Pendulum",
+            album_title="Hold Your Colour (old pressing)",
+            source="request",
+            mb_release_id="old-mbid",
+            mb_release_group_id="rg-old",
+            mb_artist_id="art-old",
+            year=2005,
+            country="AU",
+            status="wanted",
+        )
+
+    def test_supersede_round_trip_with_discogs_id(self):
+        db = make_db()
+        old_id = self._seed_old(db)
+        new_id = db.supersede_request_mbid(
+            old_id,
+            new_mb_release_id="new-mbid",
+            new_mb_release_group_id="rg-new",
+            new_mb_artist_id="art-new",
+            new_artist_name="Pendulum",
+            new_album_title="Hold Your Colour (target pressing)",
+            new_year=2007,
+            new_country="JP",
+            new_discogs_release_id="12345",
+            new_tracks=[
+                {"disc_number": 1, "track_number": 1, "title": "Prelude"},
+                {"disc_number": 1, "track_number": 2, "title": "Slam"},
+            ],
+        )
+        expected = {
+            "mb_release_id": "new-mbid",
+            "mb_release_group_id": "rg-new",
+            "mb_artist_id": "art-new",
+            "artist_name": "Pendulum",
+            "album_title": "Hold Your Colour (target pressing)",
+            "year": 2007,
+            "country": "JP",
+            "discogs_release_id": "12345",
+            "replaces_request_id": old_id,
+            "status": "wanted",
+            "source": "request",  # inherited from the old row
+        }
+        new = db.get_request(new_id)
+        self.assertIsNotNone(new)
+        assert new is not None
+        for col, val in expected.items():
+            self.assertEqual(
+                new[col], val,
+                f"supersede field {col!r} did not round-trip through PG")
+        # The old row is the frozen 'replaced' audit row.
+        old = db.get_request(old_id)
+        assert old is not None
+        self.assertEqual(old["status"], "replaced")
+
+    def test_supersede_round_trip_mb_path_discogs_id_null(self):
+        # MB Replace passes new_discogs_release_id=None — the column must be
+        # NULL, everything else unchanged.
+        db = make_db()
+        old_id = self._seed_old(db)
+        new_id = db.supersede_request_mbid(
+            old_id,
+            new_mb_release_id="new-mbid-mb",
+            new_mb_release_group_id="rg-new",
+            new_mb_artist_id="art-new",
+            new_artist_name="Pendulum",
+            new_album_title="Hold Your Colour",
+            new_year=2007,
+            new_country="JP",
+            new_discogs_release_id=None,
+            new_tracks=[],
+        )
+        new = db.get_request(new_id)
+        assert new is not None
+        self.assertIsNone(new["discogs_release_id"])
+        self.assertEqual(new["mb_release_id"], "new-mbid-mb")
+        self.assertEqual(new["status"], "wanted")
+        self.assertEqual(new["replaces_request_id"], old_id)
+        old = db.get_request(old_id)
+        assert old is not None
+        self.assertEqual(old["status"], "replaced")
+
+
+@requires_postgres
 class TestPlexAddedAtPinsRoundTrip(unittest.TestCase):
     """Rule A round-trip for the Plex addedAt pin store (migration 040).
     Every field the writer persists must read back unchanged through real PG —

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -127,6 +127,10 @@ class TestSupersedeRequestMbidRoundTrip(unittest.TestCase):
     def test_supersede_round_trip_with_discogs_id(self):
         db = make_db()
         old_id = self._seed_old(db)
+        new_tracks = [
+            {"disc_number": 1, "track_number": 1, "title": "Prelude"},
+            {"disc_number": 1, "track_number": 2, "title": "Slam"},
+        ]
         new_id = db.supersede_request_mbid(
             old_id,
             new_mb_release_id="new-mbid",
@@ -137,10 +141,7 @@ class TestSupersedeRequestMbidRoundTrip(unittest.TestCase):
             new_year=2007,
             new_country="JP",
             new_discogs_release_id="12345",
-            new_tracks=[
-                {"disc_number": 1, "track_number": 1, "title": "Prelude"},
-                {"disc_number": 1, "track_number": 2, "title": "Slam"},
-            ],
+            new_tracks=new_tracks,
         )
         expected = {
             "mb_release_id": "new-mbid",
@@ -166,6 +167,13 @@ class TestSupersedeRequestMbidRoundTrip(unittest.TestCase):
         old = db.get_request(old_id)
         assert old is not None
         self.assertEqual(old["status"], "replaced")
+        # album_tracks for the new row must round-trip through the same
+        # getter the rest of the pipeline reads tracks back with.
+        tracks = db.get_tracks(new_id)
+        self.assertEqual(
+            [(t["disc_number"], t["track_number"], t["title"]) for t in tracks],
+            [(t["disc_number"], t["track_number"], t["title"]) for t in new_tracks],
+        )
 
     def test_supersede_round_trip_mb_path_discogs_id_null(self):
         # MB Replace passes new_discogs_release_id=None — the column must be

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -501,16 +501,86 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
         self.assertEqual(self.db.update_request_fields_calls, [])
 
-    def test_resolve_rg_discogs_release_id_returns_422(self):
-        """Numeric Discogs release id → 422 short-circuit, no MB hit."""
+    # U4 (docs/plans/2026-07-04-001-feat-discogs-pathway-replace-plan.md):
+    # a numeric Discogs release id used to short-circuit with a 422
+    # ("non_mb_release_id") before ever touching a mirror. R9 removes
+    # that short-circuit — the route now resolves (and persists) the
+    # Discogs master the same way the MB branch resolves the release
+    # group, via the same ``update_request_fields`` DB method. The 422
+    # equivalence: today's behavior asserted no mirror call and a 422;
+    # the replacement scenarios below assert a resolved/masterless 200
+    # (or a 503 on mirror trouble) with a real Discogs mirror call.
+
+    def test_resolve_rg_discogs_master_found_returns_200_and_persists(self):
+        """Discogs row, master exists → 200 resolved, row updated with
+        the master id via the same DB method the MB branch uses."""
         self._seed(None, mb_release_id="12345")
-        with patch("web.mb.get_release") as mock_mb:
+        with patch(
+            "web.discogs.get_release",
+            return_value={"id": "12345", "release_group_id": "98765"},
+        ) as mock_discogs:
             status, data = self._post(
                 "/api/pipeline/42/resolve-rg", {},
             )
-        self.assertEqual(status, 422)
-        self.assertEqual(data["status"], "non_mb_release_id")
-        mock_mb.assert_not_called()
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg discogs master-found response",
+        )
+        self.assertEqual(data["status"], "resolved")
+        self.assertEqual(data["mb_release_group_id"], "98765")
+        mock_discogs.assert_called_once_with(12345, fresh=True)
+        self.assertEqual(
+            self.db.request(42)["mb_release_group_id"], "98765",
+        )
+
+    def test_resolve_rg_discogs_masterless_returns_200_untouched(self):
+        """Discogs row, no master → 200 'masterless' (R2), row left
+        untouched — not an error shape."""
+        self._seed(None, mb_release_id="12345")
+        with patch(
+            "web.discogs.get_release",
+            return_value={"id": "12345", "release_group_id": None},
+        ):
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 200)
+        self.assertEqual(data["status"], "masterless")
+        self.assertIsNone(self.db.request(42)["mb_release_group_id"])
+        self.assertEqual(self.db.update_request_fields_calls, [])
+
+    def test_resolve_rg_discogs_mirror_unconfigured_returns_503(self):
+        """AE3 / R11: unconfigured mirror is its own outcome, distinct
+        from a lookup failure or an invalid target."""
+        from web.discogs import DiscogsMirrorNotConfigured
+        self._seed(None, mb_release_id="12345")
+        with patch(
+            "web.discogs.get_release",
+            side_effect=DiscogsMirrorNotConfigured("no mirror configured"),
+        ):
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 503)
+        self.assertEqual(data["status"], "mirror_unconfigured")
+        self.assertIsNone(self.db.request(42)["mb_release_group_id"])
+        self.assertEqual(self.db.update_request_fields_calls, [])
+
+    def test_resolve_rg_discogs_transient_returns_503(self):
+        """Network blip on the Discogs mirror → 503 retryable (mirrors
+        the MB transient mapping)."""
+        from urllib.error import URLError
+        self._seed(None, mb_release_id="12345")
+        with patch(
+            "web.discogs.get_release",
+            side_effect=URLError("connection refused"),
+        ):
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 503)
+        self.assertEqual(data["status"], "transient")
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
         self.assertEqual(self.db.update_request_fields_calls, [])
 

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -546,6 +546,10 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
                 "/api/pipeline/42/resolve-rg", {},
             )
         self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg discogs masterless response",
+        )
         self.assertEqual(data["status"], "masterless")
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
         self.assertEqual(self.db.update_request_fields_calls, [])
@@ -563,6 +567,10 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
                 "/api/pipeline/42/resolve-rg", {},
             )
         self.assertEqual(status, 503)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg discogs mirror-unconfigured response",
+        )
         self.assertEqual(data["status"], "mirror_unconfigured")
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
         self.assertEqual(self.db.update_request_fields_calls, [])
@@ -580,7 +588,32 @@ class TestPipelineResolveRgContract(_FakeDbWebServerCase):
                 "/api/pipeline/42/resolve-rg", {},
             )
         self.assertEqual(status, 503)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg discogs transient response",
+        )
         self.assertEqual(data["status"], "transient")
+        self.assertIsNone(self.db.request(42)["mb_release_group_id"])
+        self.assertEqual(self.db.update_request_fields_calls, [])
+
+    def test_resolve_rg_discogs_lookup_failed_returns_422(self):
+        """Non-transient, non-mirror-config Discogs failure (e.g. a
+        malformed payload) falls into the generic lookup_failed branch —
+        422, not 503 — and leaves the row untouched."""
+        self._seed(None, mb_release_id="12345")
+        with patch(
+            "web.discogs.get_release",
+            side_effect=KeyError("malformed payload"),
+        ):
+            status, data = self._post(
+                "/api/pipeline/42/resolve-rg", {},
+            )
+        self.assertEqual(status, 422)
+        _assert_required_fields(
+            self, data, self.RESOLVE_RG_REQUIRED_FIELDS,
+            "resolve-rg discogs lookup-failed response",
+        )
+        self.assertEqual(data["status"], "lookup_failed")
         self.assertIsNone(self.db.request(42)["mb_release_group_id"])
         self.assertEqual(self.db.update_request_fields_calls, [])
 

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -103,7 +103,7 @@ class TestPipelineReplaceContract(_FakeDbWebServerCase):
       * 409 — RESULT_WRONG_STATE, RESULT_TARGET_COLLISION_REQUEST
       * 422 — RESULT_TARGET_INVALID, RESULT_TARGET_RELEASE_GROUP_MISMATCH,
               RESULT_TARGET_SAME_AS_CURRENT
-      * 503 — RESULT_TRANSIENT
+      * 503 — RESULT_TRANSIENT, RESULT_MIRROR_UNCONFIGURED
     """
 
     REPLACE_REQUIRED_FIELDS = {
@@ -265,6 +265,47 @@ class TestPipelineReplaceContract(_FakeDbWebServerCase):
         self.assertIsNone(data["new_request_id"])
         self.assertIsNone(data["current_status"])
         self.assertIsNone(data["descendant_request_id"])
+
+    def test_replace_mirror_unconfigured_returns_503(self):
+        """503 also maps to RESULT_MIRROR_UNCONFIGURED — the Discogs
+        mirror is not configured on this host (R11 / AE3). The operator
+        sees "mirror not set up", distinct from target_invalid (422) and
+        transient. The response carries the full required-fields contract
+        so the frontend renders it uniformly."""
+        with self._patch_service(
+            outcome="mirror_unconfigured", request_id=100,
+            error_message="Discogs mirror not configured",
+        ):
+            status, data = self._post(
+                "/api/pipeline/100/replace",
+                {"target_mb_release_id": "1002"},
+            )
+        self.assertEqual(status, 503)
+        _assert_required_fields(
+            self, data, self.REPLACE_REQUIRED_FIELDS,
+            "replace 503 mirror_unconfigured response",
+        )
+        self.assertEqual(data["outcome"], "mirror_unconfigured")
+        self.assertEqual(
+            data["error_message"], "Discogs mirror not configured",
+        )
+        self.assertIsNone(data["new_request_id"])
+
+    def test_replace_numeric_discogs_target_passes_body(self):
+        """A numeric Discogs id passes the pydantic body (the wire param
+        stays ``target_mb_release_id``; the service dispatches on shape).
+        The service is patched, so this pins the route accepts the body
+        and returns the mapped success status."""
+        with self._patch_service(
+            outcome="replaced", request_id=100, new_request_id=200,
+        ):
+            status, data = self._post(
+                "/api/pipeline/100/replace",
+                {"target_mb_release_id": "1002"},
+            )
+        self.assertEqual(status, 200)
+        self.assertEqual(data["outcome"], "replaced")
+        self.assertEqual(data["new_request_id"], 200)
 
     def test_replace_missing_target_returns_400(self):
         from unittest.mock import patch as _patch

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -23,7 +23,28 @@
  *
  * The module is callable from cross-module onclick handlers via the
  * `window.openReplacePicker` binding installed in main.js.
+ *
+ * Discogs-pathway anchors (feat/discogs-pathway-replace, U5): the
+ * release-group analog for a Discogs row is the Discogs master, and the
+ * numeric master id lives in the SAME `releaseGroupId` field MB uses
+ * (KTD-1 — `lib/field_resolver_service.py::_looks_numeric` convention).
+ * `runStandard` branches purely on the anchor's shape (`detectSource`):
+ * a UUID anchor keeps the existing `GET /api/release-group/<id>` path
+ * byte-for-byte; a numeric anchor fetches `GET /api/discogs/master/<id>`
+ * instead and maps its `releases` onto the same pressing-row shape via
+ * `mapDiscogsMasterReleases`. `POST .../resolve-rg` returning
+ * `status: 'masterless'` (Discogs release with no master) renders the
+ * one-element "nothing to swap to" state (R2) via `runMasterless`
+ * instead of the generic error path. Tracklist fetches
+ * (`fetchTracklist`/`loadSourceTracklist`) need NO branch — `GET
+ * /api/release/<id>` already forwards numeric ids to the Discogs mirror
+ * server-side (`web/routes/browse.py::get_release`) and returns the
+ * identical `tracks` shape (`disc_number/track_number/title/
+ * length_seconds`), proven by
+ * `tests/web/test_routes_browse.py::test_release_detail_numeric_id_forwards_to_discogs`.
  */
+
+import { detectSource } from './util.js';
 
 /**
  * @typedef {Object} ReplacePickerOptionsStandard
@@ -139,6 +160,51 @@ export function renderPressingsList(releases, sourceMbid) {
 }
 
 /**
+ * Map a `GET /api/discogs/master/<id>` payload's `releases` array onto the
+ * same pressing-row shape (`ReleaseGroupSibling`) `GET /api/release-group/
+ * <id>` already returns for MB — field for field: `id`, `title`, `date`,
+ * `country`, `status`, `track_count`, `format` (see
+ * `web/discogs.py::get_master_releases` vs `web/mb.py::
+ * get_release_group_releases`, which already emit identical keys). This
+ * mapper exists as the one seam that would catch future drift between the
+ * two backends' shapes — it is intentionally NOT a real transformation
+ * today. Discogs-only extras (`media_count`, `labels`) are dropped;
+ * anything the payload omits falls back to a safe empty value, which
+ * `pressingMeta`/`renderPressingsList` already render as blank/dash.
+ * Marking the current pressing is unchanged — `renderPressingsList`
+ * compares `r.id === sourceMbid` the same way for both sources.
+ *
+ * @param {{releases?: Array<Object>}|null|undefined} payload
+ * @returns {ReleaseGroupSibling[]}
+ */
+export function mapDiscogsMasterReleases(payload) {
+  const releases = (payload && Array.isArray(payload.releases)) ? payload.releases : [];
+  return releases.map((r) => ({
+    id: String(r.id ?? ''),
+    title: r.title || '',
+    date: r.date || '',
+    country: r.country || '',
+    status: r.status || '',
+    track_count: typeof r.track_count === 'number' ? r.track_count : 0,
+    format: r.format || '',
+  }));
+}
+
+/**
+ * Explanatory note for the masterless-source state (R2 / AE1) — the
+ * source Discogs release has no master on file, so there are no sibling
+ * pressings to switch to. Rendered above the one-element pressings list
+ * (current release only, disabled) built via the existing
+ * `renderPressingsList` — no new list-rendering logic needed, just the
+ * copy explaining why the list has one row.
+ *
+ * @returns {string}
+ */
+export function renderMasterlessNote() {
+  return '<p style="color:#888;">This release has no Discogs master on file — there are no other pressings to switch to.</p>';
+}
+
+/**
  * Format seconds → "m:ss". Returns empty string for null/undefined/NaN.
  *
  * @param {number|null|undefined} secs
@@ -160,6 +226,26 @@ export function formatLength(secs) {
  * @property {string} [title]
  * @property {number|null} [length_seconds]
  */
+
+/**
+ * Extract the tracklist array from a `GET /api/release/<id>` payload.
+ *
+ * No MB/Discogs branch needed here: `GET /api/release/<id>` already
+ * forwards numeric ids to the Discogs mirror server-side
+ * (`web/routes/browse.py::get_release` → `get_discogs_release`) and both
+ * backends emit `tracks` in the identical shape (`disc_number`/
+ * `track_number`/`title`/`length_seconds` — compare
+ * `web/mb.py::_strip_release` and `web/discogs.py::get_release`). This
+ * helper is the one seam that would catch a future field-name drift
+ * between the two backends instead of silently rendering a blank
+ * tracklist.
+ *
+ * @param {{tracks?: TracklistTrack[]}|null|undefined} payload
+ * @returns {TracklistTrack[]}
+ */
+export function extractTracklist(payload) {
+  return (payload && Array.isArray(payload.tracks)) ? payload.tracks : [];
+}
 
 /**
  * Render a compact tracklist. Disc headers only appear when there is
@@ -390,6 +476,14 @@ async function runStandard(options, showOverlay, close) {
         `/api/pipeline/${options.sourceRequestId}/resolve-rg`,
         { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
       const body = await res.json();
+      // R2/AE1: a masterless Discogs release is not an error — render the
+      // one-element "nothing to swap to" state instead of falling into
+      // the generic failure branch below (which would otherwise read
+      // `mb_release_group_id: null` as a failure).
+      if (res.ok && body.status === 'masterless') {
+        await runMasterless(options, showOverlay, close);
+        return;
+      }
       if (!res.ok || !body.mb_release_group_id) {
         const msg = body.error || `HTTP ${res.status}`;
         showOverlay(`${renderStandardHeader(options.sourceLabel || '')}
@@ -414,12 +508,19 @@ async function runStandard(options, showOverlay, close) {
   let releases;
   let sourceMbid = '';
   try {
-    const res = await fetch(`/api/release-group/${encodeURIComponent(releaseGroupId)}`);
+    // Discogs master ids live in the same field MB release-group ids do
+    // (KTD-1); dispatch on shape rather than threading a second
+    // "pathway" option through the caller.
+    const isDiscogsAnchor = detectSource(releaseGroupId) === 'discogs';
+    const res = await fetch(
+      isDiscogsAnchor
+        ? `/api/discogs/master/${encodeURIComponent(releaseGroupId)}`
+        : `/api/release-group/${encodeURIComponent(releaseGroupId)}`);
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
     const body = await res.json();
-    releases = body.releases || [];
+    releases = isDiscogsAnchor ? mapDiscogsMasterReleases(body) : (body.releases || []);
     // Identify the current pressing for the source request (so we can
     // disable that row in the list).
     const detail = await fetch(`/api/pipeline/${options.sourceRequestId}`);
@@ -476,6 +577,45 @@ async function runStandard(options, showOverlay, close) {
   loadDistances(modal, options.sourceRequestId, releases).catch((err) => {
     console.warn('replace-picker distance overlay failed:', err);
   });
+}
+
+/**
+ * R2/AE1 — a masterless Discogs source has no siblings to swap to. Renders
+ * the current release as the sole (disabled) row via the existing
+ * `renderPressingsList`, with `renderMasterlessNote()` explaining why —
+ * not an error state, just nothing to pick. There is no submit path here:
+ * `renderPressingsList` already omits the "Use this pressing" button for
+ * the current/disabled row, so the operator's only action is Cancel.
+ *
+ * @param {ReplacePickerOptionsStandard} options
+ * @param {(html: string) => void} showOverlay
+ * @param {(r: ReplacePickerResult) => void} close
+ */
+async function runMasterless(options, showOverlay, close) {
+  const sourceLabel = options.sourceLabel || `request #${options.sourceRequestId}`;
+  showOverlay(`${renderStandardHeader(sourceLabel)}
+    <p>Loading current release…</p>`);
+
+  let sourceMbid = '';
+  try {
+    const detail = await fetch(`/api/pipeline/${options.sourceRequestId}`);
+    if (detail.ok) {
+      const drow = await detail.json();
+      sourceMbid = (drow.request && drow.request.mb_release_id) || drow.mb_release_id || '';
+    }
+  } catch (err) {
+    // Non-fatal — falls through to the id-less row below; the picker
+    // still communicates "nothing to swap to" even without the id.
+  }
+
+  const releases = sourceMbid ? [{ id: sourceMbid, title: sourceLabel }] : [];
+  showOverlay(`${renderStandardHeader(sourceLabel)}
+    ${renderMasterlessNote()}
+    ${renderPressingsList(releases, sourceMbid)}
+    <div class="replace-picker-cancel-bar">
+      <button class="btn" id="replace-picker-cancel">Cancel</button>
+    </div>`);
+  bindCancel(close);
 }
 
 /**
@@ -589,7 +729,7 @@ function fetchTracklist(mbid) {
     .then(async (res) => {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = await res.json();
-      return { tracks: body.tracks || [] };
+      return { tracks: extractTracklist(body) };
     });
   tracklistCache.set(mbid, p);
   // If the fetch rejects, drop the cache entry so retries are possible.

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -459,6 +459,22 @@ export async function openReplacePicker(options) {
 }
 
 /**
+ * Fetch the source request's release id, unwrapping the pipeline detail
+ * envelope. The endpoint wraps the row under `request` — a flat read
+ * returned `undefined`, leaving the id blank (which the picker silently
+ * tolerated because it only drove the "disable current pressing" visual).
+ * Fixed when we started depending on it for the reference tracklist.
+ * @param {number|string} requestId
+ * @returns {Promise<string>} '' when the fetch fails or the id is absent
+ */
+async function fetchSourceMbid(requestId) {
+  const detail = await fetch(`/api/pipeline/${requestId}`);
+  if (!detail.ok) return '';
+  const drow = await detail.json();
+  return (drow.request && drow.request.mb_release_id) || drow.mb_release_id || '';
+}
+
+/**
  * @param {ReplacePickerOptionsStandard} options
  * @param {(html: string) => void} showOverlay
  * @param {(r: ReplacePickerResult) => void} close
@@ -523,16 +539,7 @@ async function runStandard(options, showOverlay, close) {
     releases = isDiscogsAnchor ? mapDiscogsMasterReleases(body) : (body.releases || []);
     // Identify the current pressing for the source request (so we can
     // disable that row in the list).
-    const detail = await fetch(`/api/pipeline/${options.sourceRequestId}`);
-    if (detail.ok) {
-      const drow = await detail.json();
-      // The pipeline detail endpoint wraps the row under `request` —
-      // a flat read returned `undefined`, leaving sourceMbid blank
-      // (which the picker silently tolerated because it only drove the
-      // "disable current pressing" visual). Fixed when we started
-      // depending on it for the reference tracklist.
-      sourceMbid = (drow.request && drow.request.mb_release_id) || drow.mb_release_id || '';
-    }
+    sourceMbid = await fetchSourceMbid(options.sourceRequestId);
   } catch (err) {
     showOverlay(`${renderStandardHeader(options.sourceLabel || '')}
       <p style="color:#f66;">Failed to load release group: ${esc(String(err))}</p>
@@ -598,11 +605,7 @@ async function runMasterless(options, showOverlay, close) {
 
   let sourceMbid = '';
   try {
-    const detail = await fetch(`/api/pipeline/${options.sourceRequestId}`);
-    if (detail.ok) {
-      const drow = await detail.json();
-      sourceMbid = (drow.request && drow.request.mb_release_id) || drow.mb_release_id || '';
-    }
+    sourceMbid = await fetchSourceMbid(options.sourceRequestId);
   } catch (err) {
     // Non-fatal — falls through to the id-less row below; the picker
     // still communicates "nothing to swap to" even without the id.

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1119,14 +1119,24 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
     already has a non-null RG the route returns it untouched (no
     redundant MB hit because ``get_release(fresh=False)`` is cache-served).
 
+    MB rows resolve the release group via the MB mirror. Discogs rows
+    (numeric ``mb_release_id``) resolve the release's Discogs master
+    instead — the release-group analog (KTD-1) — and persist it into
+    the same ``mb_release_group_id`` column via the same
+    ``update_request_fields`` call the MB branch uses.
+
     Status-code mapping:
-      * 200 — ``status='resolved'`` (RG found; row updated or already set)
+      * 200 — ``status='resolved'`` (RG/master found; row updated or
+              already set) or ``status='masterless'`` (Discogs release
+              has no master; row left untouched — R2, the picker
+              renders the one-element "nothing to swap to" state
+              instead of an error)
       * 404 — request id does not exist
-      * 422 — MB lookup returned no release_group_id (e.g. the row's
-              ``mb_release_id`` is a numeric Discogs id, or the upstream
-              MB release has no RG attached)
-      * 503 — transient MB-mirror error (timeout, network, malformed
-              JSON) — retryable
+      * 422 — MB lookup returned no release_group_id (the upstream MB
+              release has no RG attached)
+      * 503 — transient mirror error (timeout, network, malformed
+              JSON) — retryable — or ``status='mirror_unconfigured'``
+              when the Discogs mirror isn't configured (R11)
     """
     try:
         request_id = int(req_id_str)
@@ -1166,33 +1176,86 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         }, status=422)
         return
 
-    # MB release ids are UUIDs; numeric ids are Discogs and have no
-    # release-group concept here. Surface 422 so the picker can show a
-    # clean error rather than letting the mirror return 404 / 500.
-    try:
-        import uuid as _uuid
-        _uuid.UUID(str(mb_release_id))
-    except (ValueError, TypeError, AttributeError):
-        h._json({
-            "request_id": request_id,
-            "mb_release_group_id": None,
-            "status": "non_mb_release_id",
-            "error": (
-                f"request {request_id}.mb_release_id "
-                f"{mb_release_id!r} is not a MusicBrainz UUID"
-            ),
-        }, status=422)
-        return
-
-    # MB-mirror transient errors (network, JSON decode) are retryable.
-    # See ``lib/mbid_replace_service.py::_TRANSIENT_LOOKUP_EXCEPTIONS``
-    # for the rationale and the same exception set.
+    # Mirror transient errors (network, JSON decode) are retryable, on
+    # either mirror. See
+    # ``lib/mbid_replace_service.py::_TRANSIENT_LOOKUP_EXCEPTIONS`` for
+    # the rationale and the same exception set.
     import socket as _socket
     from urllib.error import URLError
     transient: tuple[type[BaseException], ...] = (
         URLError, TimeoutError, _socket.timeout, ConnectionError,
         json.JSONDecodeError,
     )
+
+    # MB release ids are UUIDs; numeric ids are Discogs-pathway, whose
+    # release-group analog is the Discogs master (KTD-1: the numeric
+    # master id lives in this same column, per the
+    # ``lib/field_resolver_service.py::_looks_numeric`` convention).
+    try:
+        import uuid as _uuid
+        _uuid.UUID(str(mb_release_id))
+    except (ValueError, TypeError, AttributeError):
+        try:
+            discogs_id_num = int(mb_release_id)
+        except (TypeError, ValueError):
+            h._json({
+                "request_id": request_id,
+                "mb_release_group_id": None,
+                "status": "non_mb_release_id",
+                "error": (
+                    f"request {request_id}.mb_release_id "
+                    f"{mb_release_id!r} is neither a MusicBrainz UUID "
+                    "nor a numeric Discogs id"
+                ),
+            }, status=422)
+            return
+
+        from web.discogs import DiscogsMirrorNotConfigured
+
+        # Bypass the 24h meta cache — this write path can persist the
+        # resolved master into the pipeline DB, same rationale as the
+        # add flow's ``fresh=True`` calls above.
+        try:
+            discogs_data = discogs_api.get_release(
+                discogs_id_num, fresh=True,
+            )
+        except DiscogsMirrorNotConfigured as exc:
+            h._json({
+                "request_id": request_id,
+                "mb_release_group_id": None,
+                "status": "mirror_unconfigured",
+                "error": f"Discogs mirror not configured: {exc}",
+            }, status=503)
+            return
+        except transient as exc:
+            h._json({
+                "request_id": request_id,
+                "mb_release_group_id": None,
+                "status": "transient",
+                "error": f"Discogs lookup failed (transient): {exc}",
+            }, status=503)
+            return
+
+        master_id = (
+            discogs_data.get("release_group_id")
+            if isinstance(discogs_data, dict) else None
+        )
+        if not master_id:
+            h._json({
+                "request_id": request_id,
+                "mb_release_group_id": None,
+                "status": "masterless",
+            })
+            return
+
+        db.update_request_fields(request_id, mb_release_group_id=master_id)
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": master_id,
+            "status": "resolved",
+        })
+        return
+
     try:
         data = mb_api.get_release(mb_release_id, fresh=False)
     except transient as exc:

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1191,24 +1191,22 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
     # release-group analog is the Discogs master (KTD-1: the numeric
     # master id lives in this same column, per the
     # ``lib/field_resolver_service.py::_looks_numeric`` convention).
-    try:
-        import uuid as _uuid
-        _uuid.UUID(str(mb_release_id))
-    except (ValueError, TypeError, AttributeError):
-        try:
-            discogs_id_num = int(mb_release_id)
-        except (TypeError, ValueError):
-            h._json({
-                "request_id": request_id,
-                "mb_release_group_id": None,
-                "status": "non_mb_release_id",
-                "error": (
-                    f"request {request_id}.mb_release_id "
-                    f"{mb_release_id!r} is neither a MusicBrainz UUID "
-                    "nor a numeric Discogs id"
-                ),
-            }, status=422)
-            return
+    release_source = detect_release_source(mb_release_id)
+    if release_source == "unknown":
+        h._json({
+            "request_id": request_id,
+            "mb_release_group_id": None,
+            "status": "non_mb_release_id",
+            "error": (
+                f"request {request_id}.mb_release_id "
+                f"{mb_release_id!r} is neither a MusicBrainz UUID "
+                "nor a numeric Discogs id"
+            ),
+        }, status=422)
+        return
+
+    if release_source == "discogs":
+        discogs_id_num = int(normalize_release_id(mb_release_id))
 
         from web.discogs import DiscogsMirrorNotConfigured
 
@@ -1234,6 +1232,16 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
                 "status": "transient",
                 "error": f"Discogs lookup failed (transient): {exc}",
             }, status=503)
+            return
+        except Exception as exc:  # noqa: BLE001
+            h._json({
+                "request_id": request_id,
+                "mb_release_group_id": None,
+                "status": "lookup_failed",
+                "error": (
+                    f"Discogs lookup for {mb_release_id} failed: {exc}"
+                ),
+            }, status=422)
             return
 
         master_id = (
@@ -1309,7 +1317,9 @@ def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
     ``MbidReplaceService.replace_request_mbid`` — keep them in sync (see
     ``CLAUDE.md`` § "CLI ⇄ API surface symmetry").
 
-    Body: ``{"target_mb_release_id": "<mbid>"}``.
+    Body: ``{"target_mb_release_id": "<id>"}`` — an MB release UUID or a
+    Discogs numeric release id; must share the source's pathway (MB or
+    Discogs) and release group/master.
 
     Status-code mapping mirrors the CLI exit codes:
       * 200 — ``RESULT_REPLACED``
@@ -3045,7 +3055,8 @@ POST_PATTERN_DESCRIPTIONS: list[tuple[re.Pattern[str], str]] = [
      "(by ordinal or strategy prefix)."),
     (re.compile(r"^/api/pipeline/(\d+)/replace$"),
      "Supersede the source request with a new row at a different "
-     "MBID in the same release group."),
+     "release id (MB UUID or Discogs numeric id) in the same "
+     "release group/master, same pathway as the source."),
     (re.compile(r"^/api/pipeline/(\d+)/resolve-rg$"),
      "Lazy-backfill mb_release_group_id for a legacy request row."),
 ]

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1258,11 +1258,13 @@ def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
               ``RESULT_TARGET_COLLISION_REQUEST``
       * 422 — ``RESULT_TARGET_INVALID``, ``RESULT_TARGET_RELEASE_GROUP_MISMATCH``,
               ``RESULT_TARGET_SAME_AS_CURRENT``
-      * 503 — ``RESULT_TRANSIENT`` (MB-mirror unreachable etc.)
+      * 503 — ``RESULT_TRANSIENT`` (mirror unreachable etc.) or
+              ``RESULT_MIRROR_UNCONFIGURED`` (Discogs mirror not configured)
     """
     from lib.config import read_runtime_config
     from lib.mbid_replace_service import (
         MbidReplaceService,
+        RESULT_MIRROR_UNCONFIGURED,
         RESULT_NOT_FOUND,
         RESULT_REPLACED,
         RESULT_TARGET_COLLISION_REQUEST,
@@ -1327,8 +1329,8 @@ def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
         payload["error"] = result.error_message or "Semantic violation"
         h._json(payload, status=422)
         return
-    if result.outcome == RESULT_TRANSIENT:
-        payload["error"] = result.error_message or "Transient; retry"
+    if result.outcome in (RESULT_TRANSIENT, RESULT_MIRROR_UNCONFIGURED):
+        payload["error"] = result.error_message or "Service unavailable; retry"
         h._json(payload, status=503)
         return
     h._error(f"Unknown replace outcome: {result.outcome}", 500)


### PR DESCRIPTION
## Summary

A Discogs-pathway request can now be repointed at another pressing of the same album through the Replace action — previously any numeric Discogs id hit the service's UUID gate and returned `target_invalid`, leaving the 124 Discogs rows skipped by the #280 backfill with no first-class repoint path. The picker anchors on the release's Discogs **master** (the release-group analog), lists its sibling pressings, and supersedes with the same frozen-audit chain MB Replace uses. Same-pathway only; MB behavior is byte-for-byte unchanged.

Fixes #282. Plan: `docs/plans/2026-07-04-001-feat-discogs-pathway-replace-plan.md`.

## Design decisions

- **The master anchor lives in `mb_release_group_id` — no new column, no migration, no backfill.** Numeric master ids in that column are an established convention (`field_resolver_service._looks_numeric` dispatches on it), and the field resolver already persists the master for new Discogs adds. Legacy rows lazy-resolve on first Replace via the service's existing backfill branch, now with a Discogs arm.
- **One service, no parallel path.** `MbidReplaceService` branches internally on `detect_release_source`; the target gate is pathway-aware (UUID target ⇒ MB source, numeric ⇒ Discogs source, mismatch ⇒ `target_invalid`). The Discogs lookup is an injected collaborator mirroring `mb_lookup`.
- **Supersede dual-writes identity** (`mb_release_id` + `discogs_release_id`), matching the add flow — this keeps the `mb_release_id` UNIQUE constraint as the concurrent-replace collision net and keeps beets' dual-column lookups working on the new row.
- **`mirror_unconfigured` is a first-class outcome** (HTTP 503 / CLI exit 5) so a missing Discogs mirror reads as a config gap, not a bad pick. Masterless releases render a one-element "nothing to swap to" picker per the YouTube resolver's orphan precedent, and the service rejects every target but the release itself.
- **The picker reuses the existing `GET /api/discogs/master/<id>` browse route**; resolve-rg now resolves and persists masters for numeric ids (200 `resolved` / 200 `masterless` / 503) instead of 422ing. Deliberately deferred: cross-pathway replace, the inverted picker mode for Discogs, and beets-distance badges on Discogs siblings.

## Validation

- Full suite: 4,658 tests OK (zero skips); whole-repo pyright 0 errors; `node --check` clean.
- First-ever real-PG round-trip for `supersede_request_mbid` (Rule A), including `album_tracks` read-back; failure-path fakes raise the real `DiscogsMirrorNotConfigured`/`URLError` classes (Rule B).
- Multi-persona review (correctness/adversarial on Opus + an independent Codex cross-model pass) found zero logic defects; all 7 validated findings (test coverage + doc drift) applied on-branch.
- Live verification (plan U6) happens post-merge on doc2: replace one legacy NULL-master Discogs row end-to-end, then tag per deploy rules. The dev harness blocks mutating flows by design, so the picker's happy path was HTTP-smoked locally and is finally proven live.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
