### PR TITLE
fix(tooling): playwright MCP works headless on doc1

### DIFF
--- a/.claude/agents/playwright.md
+++ b/.claude/agents/playwright.md
@@ -11,11 +11,11 @@ model: opus
 
 You are a browser-automation agent driving Microsoft's Playwright MCP server via `scripts/mcp-playwright.sh`.
 
-**Display mode is auto-detected:** the wrapper picks headed vs headless based on whether `DISPLAY`/`WAYLAND_DISPLAY` is set. On a graphical workstation you're driving a visible Chromium window; on a server or SSH session you're headless. Either way, treat the a11y tree as your source of truth — the user can't always see the window, and headless runs obviously have no screen.
+**You are almost certainly headless.** Development happens on doc1, a headless VM: the wrapper auto-selects `--headless` when `DISPLAY`/`WAYLAND_DISPLAY` is unset, and the browser is the nixpkgs-bundled Chromium (`PLAYWRIGHT_BROWSERS_PATH` points into the nix store — do not look for browsers in `~/.cache/ms-playwright`, and never run `playwright install`). Headed CDP-attach mode exists only on desktops running the `playwright-chromium` launcher. Treat the a11y tree as your source of truth; nobody is watching a window.
 
-Observe state with `browser_snapshot` (DOM a11y tree — primary interaction surface) and `browser_take_screenshot` (PNG — for visual diffs or reporting). Always snapshot before acting and after navigating.
+Observe state with `browser_snapshot` (DOM a11y tree — primary interaction surface) and `browser_take_screenshot` (PNG — works fine headless; use for visual diffs or reporting). Always snapshot before acting and after navigating.
 
-**Profile is persistent**, so cookies and logged-in sessions survive between MCP sessions. To force a clean state, delete `~/.cache/ms-playwright/mcp-*`.
+**Profile is persistent**, so cookies and logged-in sessions survive between MCP sessions. To force a clean state, delete `~/.cache/ms-playwright/mcp-*` (profiles live there even though the browsers themselves come from the nix store).
 
 ## Tools (deferred — use ToolSearch with +playwright to load)
 

--- a/docs/playwright-mcp.md
+++ b/docs/playwright-mcp.md
@@ -1,10 +1,33 @@
 # Playwright MCP (Web UI Testing)
 
-The Playwright MCP server provides browser automation tools for testing the web UI at `https://music.ablz.au`. Configured in `.mcp.json` (not committed — platform-specific). Use `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_fill_form`, `browser_console_messages`, etc.
+The Playwright MCP server provides browser automation tools for testing the web UI at `https://music.ablz.au`. Use `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_fill_form`, `browser_console_messages`, etc.
+
+**The `playwright` agent needs no `.mcp.json`** — its frontmatter (`.claude/agents/playwright.md`) declares its own MCP server via `scripts/mcp-playwright.sh`, which spawns fresh on every agent invocation. `.mcp.json` (gitignored, per-machine) is only needed to expose the browser tools to the main session.
 
 ## Setup
 
-### Windows laptop
+### Linux / doc1 (primary dev host, headless)
+
+Everything comes from Nix — no npm, no `playwright install`:
+
+- `playwright-mcp` (nixpkgs) is installed via home-manager (`nixosconfig modules/home-manager/services/claude-code.nix`). Its wrapper exports `PLAYWRIGHT_BROWSERS_PATH` into the nix store, so browsers are bundled and patched for NixOS. Do not download browsers into `~/.cache/ms-playwright` — non-Nix binaries fail with missing shared libraries (`libglib-2.0.so.0`).
+- `scripts/mcp-playwright.sh` resolves the server binary by either name (`playwright-mcp` from nixpkgs, `mcp-server-playwright` from npm) and auto-selects `--headless` when `DISPLAY`/`WAYLAND_DISPLAY` is unset — which is always, on doc1.
+- Optional `.mcp.json` for main-session tools:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "/home/abl030/cratedigger/scripts/mcp-playwright.sh",
+      "args": []
+    }
+  }
+}
+```
+
+Smoke check after a nixpkgs bump: `scripts/mcp-playwright.sh` should start and answer an MCP `initialize` over stdio; the bundled browser is at `$PLAYWRIGHT_BROWSERS_PATH/chromium-*/chrome-linux64/chrome`.
+
+### Windows laptop (headed, legacy)
 
 Node.js installed via scoop. `.mcp.json` must use absolute paths because scoop shims aren't in the Claude Code process PATH:
 
@@ -23,23 +46,6 @@ Requires:
 1. `scoop install nodejs`
 2. `npm install -g @playwright/mcp@latest` (with PATH set)
 3. `npx playwright install chromium` to download the browser binary (~183MB, stored in `%LOCALAPPDATA%\ms-playwright\`)
-
-### Linux (doc1)
-
-Use npx directly — Node.js is available system-wide:
-
-```json
-{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    }
-  }
-}
-```
-
-First run will auto-install the package. You may still need `npx playwright install chromium` for the browser binary.
 
 ## Usage notes
 

--- a/scripts/mcp-playwright.sh
+++ b/scripts/mcp-playwright.sh
@@ -21,11 +21,27 @@
 # Extra flags from the agent's mcpServers.args are appended via "$@".
 set -euo pipefail
 
+# The server binary name differs by packaging: nixpkgs installs
+# `playwright-mcp` (doc1 and other NixOS hosts, via home-manager);
+# the upstream npm package installs `mcp-server-playwright`.
+MCP_BIN=""
+for candidate in playwright-mcp mcp-server-playwright; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    MCP_BIN="$candidate"
+    break
+  fi
+done
+if [[ -z "$MCP_BIN" ]]; then
+  echo "mcp-playwright.sh: neither playwright-mcp (nixpkgs) nor" \
+       "mcp-server-playwright (npm) found on PATH" >&2
+  exit 127
+fi
+
 CDP_PORT="${PLAYWRIGHT_MCP_CDP_PORT:-9222}"
 CDP_ENDPOINT="http://127.0.0.1:${CDP_PORT}"
 
 if curl -sf --max-time 1 "${CDP_ENDPOINT}/json/version" >/dev/null 2>&1; then
-  exec mcp-server-playwright --cdp-endpoint "${CDP_ENDPOINT}" "$@"
+  exec "$MCP_BIN" --cdp-endpoint "${CDP_ENDPOINT}" "$@"
 fi
 
 mode=()
@@ -37,4 +53,4 @@ elif [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
   mode=(--headless)
 fi
 
-exec mcp-server-playwright "${mode[@]}" "$@"
+exec "$MCP_BIN" "${mode[@]}" "$@"


### PR DESCRIPTION
## Summary

The playwright agent now works on doc1: every agent spawn previously died with exit 127 before the MCP handshake because `scripts/mcp-playwright.sh` exec'd `mcp-server-playwright` (the upstream npm bin name) while nixpkgs installs the server as `playwright-mcp`. The wrapper now resolves whichever name exists on PATH — doc1 carries both across profiles (`playwright-mcp` 0.0.76 system, `mcp-server-playwright` 0.0.56 home-manager) and the resolution order prefers the newer nixpkgs name.

Everything else already worked and needed no change: headless auto-detection (no `DISPLAY` on doc1) and the nix-store browser bundle via `PLAYWRIGHT_BROWSERS_PATH`.

The agent definition and `docs/playwright-mcp.md` are updated for the doc1-headless reality: browsers come from the nix store (never `playwright install` / `~/.cache/ms-playwright`), doc1 is the primary documented setup, Windows headed mode kept as legacy.

## Validation

Stdio smoke through the fixed wrapper on doc1: MCP `initialize` returns a clean handshake (`serverInfo: Playwright`), `tools/list` exposes the full 21-tool `browser_*` surface, and a headless `browser_navigate` to `https://music.ablz.au` succeeds using the nix-bundled Chromium (`Google Chrome for Testing 148.0.7778.96`). One remaining machine-local step (not repo content): approve the `playwright` MCP server once in the `claude` TUI so sessions load it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
