### PR TITLE
refactor: ActiveDownloadState/ActiveDownloadFileState → msgspec.Struct (#467)

### DIFF
--- a/lib/quality.py
+++ b/lib/quality.py
@@ -538,9 +538,18 @@ class SpectralMeasurement:
 # Download info — typed replacement for the untyped dl_info dict
 # ---------------------------------------------------------------------------
 
-@dataclass
-class ActiveDownloadFileState:
-    """Per-file state persisted for active downloads."""
+class ActiveDownloadFileState(msgspec.Struct, omit_defaults=True):
+    """Per-file state persisted for active downloads.
+
+    Wire boundary: the ``album_requests.active_download_state`` JSONB column
+    (nested under ``ActiveDownloadState.files``). ``omit_defaults=True``
+    reproduces the pre-refactor "absent key when None" shape for the optional
+    fields (``disk_no``, ``disk_count``, ``last_state``, ``local_path``). The
+    hand-rolled encoder additionally always emitted ``retry_count`` and
+    ``bytes_transferred`` even at ``0``; those are now omitted at ``0`` and
+    the strict decoder restores the ``0`` default — lossless both ways.
+    See issue #467.
+    """
     username: str
     filename: str           # Full soulseek path (backslashes)
     file_dir: str           # Download directory on source user's system
@@ -556,52 +565,20 @@ class ActiveDownloadFileState:
     # each event is consumed exactly once.
     local_path: str | None = None
 
-    def to_dict(self) -> dict[str, object]:
-        d: dict[str, object] = {
-            "username": self.username,
-            "filename": self.filename,
-            "file_dir": self.file_dir,
-            "size": self.size,
-            "retry_count": self.retry_count,
-            "bytes_transferred": self.bytes_transferred,
-        }
-        if self.disk_no is not None:
-            d["disk_no"] = self.disk_no
-        if self.disk_count is not None:
-            d["disk_count"] = self.disk_count
-        if self.last_state is not None:
-            d["last_state"] = self.last_state
-        if self.local_path is not None:
-            d["local_path"] = self.local_path
-        return d
 
-    @staticmethod
-    def from_dict(d: dict[str, object]) -> "ActiveDownloadFileState":
-        return ActiveDownloadFileState(
-            username=str(d["username"]),
-            filename=str(d["filename"]),
-            file_dir=str(d["file_dir"]),
-            size=int(d["size"]),  # type: ignore[arg-type]
-            disk_no=int(d["disk_no"]) if d.get("disk_no") is not None else None,  # type: ignore[arg-type]
-            disk_count=int(d["disk_count"]) if d.get("disk_count") is not None else None,  # type: ignore[arg-type]
-            retry_count=int(d.get("retry_count", 0)),  # type: ignore[arg-type]
-            bytes_transferred=int(d.get("bytes_transferred", 0)),  # type: ignore[arg-type]
-            last_state=(
-                str(d["last_state"])
-                if d.get("last_state") is not None
-                else None
-            ),
-            local_path=(
-                str(d["local_path"])
-                if d.get("local_path") is not None
-                else None
-            ),
-        )
+class ActiveDownloadState(msgspec.Struct, omit_defaults=True):
+    """State persisted to DB for an album being actively downloaded.
 
-
-@dataclass
-class ActiveDownloadState:
-    """State persisted to DB for an album being actively downloaded."""
+    Wire boundary: the ``album_requests.active_download_state`` JSONB column.
+    Decode happens at exactly one site — ``from_dict`` / ``from_json``
+    (``msgspec.convert`` / ``msgspec.json.decode``) — which strict-validates
+    field types, so int-vs-str drift raises ``msgspec.ValidationError``
+    instead of being silently coerced (as the old ``int(d["size"])`` decoder
+    did). ``omit_defaults=True`` reproduces the old "absent key when None"
+    shape for the optional timestamp fields; ``current_path`` is now omitted
+    when ``None`` (the hand-rolled encoder emitted it as ``null``) — the
+    strict decoder restores ``None`` either way. See issue #467.
+    """
     filetype: str                         # "flac", "mp3 v0", etc.
     enqueued_at: str                      # ISO8601 UTC timestamp
     files: list[ActiveDownloadFileState]
@@ -617,55 +594,15 @@ class ActiveDownloadState:
     current_path: str | None = None
 
     def to_json(self) -> str:
-        data: dict[str, object] = {
-            "filetype": self.filetype,
-            "enqueued_at": self.enqueued_at,
-            "files": [f.to_dict() for f in self.files],
-        }
-        if self.last_progress_at is not None:
-            data["last_progress_at"] = self.last_progress_at
-        if self.processing_started_at is not None:
-            data["processing_started_at"] = self.processing_started_at
-        if self.import_subprocess_started_at is not None:
-            data["import_subprocess_started_at"] = (
-                self.import_subprocess_started_at
-            )
-        data["current_path"] = self.current_path
-        return json.dumps(data)
+        return msgspec.json.encode(self).decode()
 
     @staticmethod
     def from_dict(d: dict[str, object]) -> "ActiveDownloadState":
-        files_raw = d.get("files")
-        assert isinstance(files_raw, list)
-        return ActiveDownloadState(
-            filetype=str(d["filetype"]),
-            enqueued_at=str(d["enqueued_at"]),
-            files=[ActiveDownloadFileState.from_dict(f) for f in files_raw],
-            last_progress_at=(
-                str(d["last_progress_at"])
-                if d.get("last_progress_at") is not None
-                else None
-            ),
-            processing_started_at=(
-                str(d["processing_started_at"])
-                if d.get("processing_started_at") is not None
-                else None
-            ),
-            import_subprocess_started_at=(
-                str(d["import_subprocess_started_at"])
-                if d.get("import_subprocess_started_at") is not None
-                else None
-            ),
-            current_path=(
-                str(d["current_path"])
-                if d.get("current_path") is not None
-                else None
-            ),
-        )
+        return msgspec.convert(d, type=ActiveDownloadState)
 
     @staticmethod
     def from_json(s: str) -> "ActiveDownloadState":
-        return ActiveDownloadState.from_dict(json.loads(s))
+        return msgspec.json.decode(s, type=ActiveDownloadState)
 
 
 @dataclass

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -23,7 +23,7 @@ import configparser
 import json
 import unittest
 from dataclasses import replace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from cratedigger import TrackRecord
@@ -656,18 +656,18 @@ class TestDownloadOwnershipPreclaim(unittest.TestCase):
             candidates=[],
         )
 
+        # Capture the row as observed at the moment slskd is called. Assertions
+        # must NOT live inside this closure: production wraps the enqueue call
+        # in a broad try/except (lib/enqueue.py::_leave_claim_for_poll_recovery)
+        # that swallows any exception once the claim has landed, so an
+        # AssertionError raised here would be masked and the test would pass
+        # regardless. Assert in the test body instead.
+        observed: dict[str, Any] = {}
+
         def fake_enqueue(*, username, files, file_dir, ctx):
             row = db.request(1)
-            self.assertEqual(row["status"], "downloading")
-            state = json.loads(row["active_download_state"])
-            self.assertEqual(state["filetype"], "flac")
-            self.assertEqual(state["files"][0]["username"], "u00")
-            self.assertEqual(
-                state["files"][0]["filename"],
-                "Music\\u00\\Album\\01.flac",
-            )
-            self.assertIn("current_path", state)
-            self.assertIsNone(state["current_path"])
+            observed["status"] = row["status"]
+            observed["state"] = json.loads(row["active_download_state"])
             return SlskdEnqueueOutcome(status="accepted", downloads=[
                 DownloadFile(
                     filename=files[0]["filename"],
@@ -687,6 +687,19 @@ class TestDownloadOwnershipPreclaim(unittest.TestCase):
         self.assertTrue(attempt.matched)
         self.assertEqual(db.status_history, [(1, "downloading")])
         self.assertEqual(db.request(1)["status"], "downloading")
+        # The claim landed BEFORE slskd was called: fake_enqueue saw the row
+        # already downloading with the planned state.
+        self.assertEqual(observed["status"], "downloading")
+        self.assertEqual(observed["state"]["filetype"], "flac")
+        self.assertEqual(observed["state"]["files"][0]["username"], "u00")
+        self.assertEqual(
+            observed["state"]["files"][0]["filename"],
+            "Music\\u00\\Album\\01.flac",
+        )
+        # current_path is unset at claim time (before slskd returns transfer
+        # IDs). The msgspec encoder omits it when None (issue #467), so read it
+        # via .get() as production does.
+        self.assertIsNone(observed["state"].get("current_path"))
 
     def test_process_death_after_claim_leaves_planned_state_owned(self):
         cfg = _make_cfg(browse_top_k=20)

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -9,6 +9,8 @@ import os
 import sys
 import unittest
 
+import msgspec
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.quality import (
@@ -1247,31 +1249,46 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(j["files"][0]["last_state"], "InProgress")
 
     def test_active_download_file_state_local_path_round_trip(self):
-        """local_path (issue #146 phase 1) survives to_dict/from_dict; absent
-        key deserializes to None (pre-141 rows have no local_path)."""
-        from lib.quality import ActiveDownloadFileState
-        stamped = ActiveDownloadFileState(
-            username="user1",
-            filename="user1\\Music\\01.flac",
-            file_dir="user1\\Music",
-            size=30000000,
-            local_path="/dl/Album/01_638827305447447018.flac",
-        )
-        d = stamped.to_dict()
-        self.assertEqual(d["local_path"], "/dl/Album/01_638827305447447018.flac")
-        restored = ActiveDownloadFileState.from_dict(d)
-        self.assertEqual(
-            restored.local_path, "/dl/Album/01_638827305447447018.flac")
+        """local_path (issue #146 phase 1) survives the state wire round-trip;
+        absent key deserializes to None (pre-141 rows have no local_path).
 
-        unstamped = ActiveDownloadFileState(
-            username="user1",
-            filename="user1\\Music\\01.flac",
-            file_dir="user1\\Music",
-            size=30000000,
+        Files are only ever (de)serialized as part of the parent state, so
+        the round-trip is exercised through ``ActiveDownloadState`` — the one
+        wire boundary — rather than via a file-level helper."""
+        from lib.quality import ActiveDownloadState, ActiveDownloadFileState
+        stamped = ActiveDownloadState(
+            filetype="flac", enqueued_at="2026-04-03T12:00:00+00:00",
+            files=[ActiveDownloadFileState(
+                username="user1",
+                filename="user1\\Music\\01.flac",
+                file_dir="user1\\Music",
+                size=30000000,
+                local_path="/dl/Album/01_638827305447447018.flac",
+            )],
         )
-        d = unstamped.to_dict()
-        self.assertNotIn("local_path", d)
-        self.assertIsNone(ActiveDownloadFileState.from_dict(d).local_path)
+        j = json.loads(stamped.to_json())
+        self.assertEqual(
+            j["files"][0]["local_path"],
+            "/dl/Album/01_638827305447447018.flac")
+        restored = ActiveDownloadState.from_json(stamped.to_json())
+        self.assertEqual(
+            restored.files[0].local_path,
+            "/dl/Album/01_638827305447447018.flac")
+
+        unstamped = ActiveDownloadState(
+            filetype="flac", enqueued_at="2026-04-03T12:00:00+00:00",
+            files=[ActiveDownloadFileState(
+                username="user1",
+                filename="user1\\Music\\01.flac",
+                file_dir="user1\\Music",
+                size=30000000,
+            )],
+        )
+        j = json.loads(unstamped.to_json())
+        self.assertNotIn("local_path", j["files"][0])
+        self.assertIsNone(
+            ActiveDownloadState.from_json(
+                unstamped.to_json()).files[0].local_path)
 
     def test_active_download_state_from_json(self):
         """Deserialize, verify all fields."""
@@ -1389,7 +1406,10 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertIsNone(f.last_state)
 
     def test_active_download_state_missing_current_path_defaults_none(self):
-        """Pre-refactor rows without current_path still deserialize."""
+        """Rows without current_path still deserialize to None, and a None
+        current_path is now omitted from the wire (issue #467: the msgspec
+        encoder omits defaults; the hand-rolled encoder emitted ``null``).
+        Both shapes decode to the same struct — see the decode-compat test."""
         from lib.quality import ActiveDownloadState
         raw = json.dumps({
             "filetype": "flac",
@@ -1401,7 +1421,7 @@ class TestActiveDownloadState(unittest.TestCase):
         self.assertEqual(state.filetype, "flac")
         self.assertEqual(state.enqueued_at, "2026-04-03T12:00:00+00:00")
         self.assertEqual(state.files, [])
-        self.assertIsNone(json.loads(state.to_json())["current_path"])
+        self.assertNotIn("current_path", json.loads(state.to_json()))
 
     def test_active_download_state_enqueued_at_iso(self):
         """Verify ISO8601 datetime format."""
@@ -1416,6 +1436,132 @@ class TestActiveDownloadState(unittest.TestCase):
         from datetime import datetime, timezone
         dt = datetime.fromisoformat(j["enqueued_at"])
         self.assertEqual(dt.tzinfo, timezone.utc)
+
+    # --- issue #467: msgspec wire-boundary contract -----------------------
+
+    def _full_state(self):
+        from lib.quality import ActiveDownloadState, ActiveDownloadFileState
+        return ActiveDownloadState(
+            filetype="flac",
+            enqueued_at="2026-04-03T12:00:00+00:00",
+            last_progress_at="2026-04-03T12:01:00+00:00",
+            processing_started_at="2026-04-03T12:02:00+00:00",
+            import_subprocess_started_at="2026-04-03T12:04:00+00:00",
+            current_path="/tmp/staged/user1/Album",
+            files=[ActiveDownloadFileState(
+                username="user1", filename="user1\\Music\\01.flac",
+                file_dir="user1\\Music", size=30000000,
+                disk_no=2, disk_count=3, retry_count=5,
+                bytes_transferred=8192, last_state="InProgress",
+                local_path="/dl/Album/01.flac")],
+        )
+
+    def _minimal_state(self):
+        from lib.quality import ActiveDownloadState, ActiveDownloadFileState
+        return ActiveDownloadState(
+            filetype="flac", enqueued_at="2026-04-03T12:00:00+00:00",
+            files=[ActiveDownloadFileState(
+                username="u", filename="f", file_dir="d", size=100)])
+
+    # The exact wire the hand-rolled (@dataclass) encoder produced, captured
+    # from the pre-refactor code and frozen here as the legacy contract.
+    LEGACY_FULL_WIRE = {
+        "current_path": "/tmp/staged/user1/Album",
+        "enqueued_at": "2026-04-03T12:00:00+00:00",
+        "files": [{
+            "bytes_transferred": 8192, "disk_count": 3, "disk_no": 2,
+            "file_dir": "user1\\Music", "filename": "user1\\Music\\01.flac",
+            "last_state": "InProgress", "local_path": "/dl/Album/01.flac",
+            "retry_count": 5, "size": 30000000, "username": "user1"}],
+        "filetype": "flac",
+        "import_subprocess_started_at": "2026-04-03T12:04:00+00:00",
+        "last_progress_at": "2026-04-03T12:01:00+00:00",
+        "processing_started_at": "2026-04-03T12:02:00+00:00",
+    }
+    LEGACY_MINIMAL_WIRE = {
+        "current_path": None,
+        "enqueued_at": "2026-04-03T12:00:00+00:00",
+        "files": [{
+            "bytes_transferred": 0, "file_dir": "d", "filename": "f",
+            "retry_count": 0, "size": 100, "username": "u"}],
+        "filetype": "flac",
+    }
+
+    def test_wire_full_state_identical_to_legacy(self):
+        """A fully-populated state encodes byte-for-value identically to the
+        legacy hand-rolled encoder — no fields at their default, so
+        omit_defaults changes nothing."""
+        self.assertEqual(
+            json.loads(self._full_state().to_json()), self.LEGACY_FULL_WIRE)
+
+    def test_wire_minimal_state_omits_default_keys(self):
+        """A minimal state omits the keys the msgspec encoder now drops at
+        their default: file retry_count/bytes_transferred (were emitted as 0)
+        and state current_path (was emitted as null). This is the documented
+        issue #467 wire diff — the omitted keys all restore to their defaults
+        on decode."""
+        wire = json.loads(self._minimal_state().to_json())
+        self.assertNotIn("current_path", wire)
+        self.assertNotIn("retry_count", wire["files"][0])
+        self.assertNotIn("bytes_transferred", wire["files"][0])
+        # The non-default fields are still present.
+        self.assertEqual(wire["filetype"], "flac")
+        self.assertEqual(wire["files"][0]["size"], 100)
+
+    def test_minimal_legacy_and_new_wire_decode_equal(self):
+        """Decode-compat both ways: the legacy minimal wire (with
+        current_path=null, retry_count=0, bytes_transferred=0 present) and the
+        new minimal wire (those keys omitted) decode to the *same* struct. The
+        wire diff is therefore lossless."""
+        from lib.quality import ActiveDownloadState
+        legacy = ActiveDownloadState.from_json(json.dumps(self.LEGACY_MINIMAL_WIRE))
+        new = ActiveDownloadState.from_json(self._minimal_state().to_json())
+        self.assertEqual(legacy, new)
+        # And the load-bearing defaults are what we expect.
+        self.assertIsNone(new.current_path)
+        self.assertEqual(new.files[0].retry_count, 0)
+        self.assertEqual(new.files[0].bytes_transferred, 0)
+
+    def test_from_dict_decodes_live_prod_row_shape(self):
+        """The exact shape of a live album_requests.active_download_state row
+        (int fields as JSON numbers, retry_count present as 0, disk fields
+        present) decodes strictly with types preserved."""
+        from lib.quality import ActiveDownloadState
+        row = {
+            "filetype": "flac",
+            "enqueued_at": "2026-06-01T00:00:00+00:00",
+            "current_path": None,
+            "files": [{
+                "bytes_transferred": 63570957, "disk_count": 3, "disk_no": 1,
+                "file_dir": "peer\\Music", "filename": "peer\\Music\\01.flac",
+                "last_state": "Completed, Succeeded", "retry_count": 0,
+                "size": 63570957, "username": "peer"}],
+        }
+        state = ActiveDownloadState.from_dict(row)
+        f = state.files[0]
+        self.assertEqual(f.size, 63570957)
+        self.assertEqual(f.bytes_transferred, 63570957)
+        self.assertEqual(f.disk_no, 1)
+        self.assertEqual(f.disk_count, 3)
+        self.assertEqual(f.retry_count, 0)
+        self.assertEqual(f.last_state, "Completed, Succeeded")
+        self.assertIsNone(state.current_path)
+
+    def test_from_dict_rejects_string_size_wire_drift(self):
+        """int-vs-str drift at the wire boundary is caught, not coerced. The
+        hand-rolled decoder ran int(d['size']) and laundered a str; msgspec's
+        strict decode raises ValidationError instead (the regression guard
+        that makes the boundary worth having)."""
+        from lib.quality import ActiveDownloadState
+        drifted = {
+            "filetype": "flac",
+            "enqueued_at": "2026-06-01T00:00:00+00:00",
+            "files": [{
+                "username": "peer", "filename": "f", "file_dir": "d",
+                "size": "63570957"}],
+        }
+        with self.assertRaises(msgspec.ValidationError):
+            ActiveDownloadState.from_dict(drifted)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -195,7 +195,10 @@ class TestDownloadOwnershipPreclaimRecoverySlice(unittest.TestCase):
         self.assertTrue(attempt.matched)
         self.assertEqual(db.request(1)["status"], "downloading")
         planned_state = db.request(1)["active_download_state"]
-        self.assertIsNone(planned_state["current_path"])
+        # current_path is unset at enqueue time; the msgspec encoder omits it
+        # when None (issue #467), so read it the way production does — via
+        # .get(), which yields None whether the key is absent or null.
+        self.assertIsNone(planned_state.get("current_path"))
 
         poll_slskd = FakeSlskdAPI(downloads=[{
             "username": "u00",


### PR DESCRIPTION
Closes #467

## What

`ActiveDownloadState` and `ActiveDownloadFileState` in `lib/quality.py` are the (de)serialization contract for the `album_requests.active_download_state` JSONB column, but were hand-rolled `@dataclass`es with field-by-field `to_dict`/`from_dict`/`to_json`/`from_json` full of `str()`/`int()` coercions and `# type: ignore[arg-type]` comments. Per the wire-boundary rule (`.claude/rules/code-quality.md` § "Wire-boundary types") they should be `msgspec.Struct` with `msgspec.json.encode` / `msgspec.convert` at the boundary.

- Both classes → `msgspec.Struct(omit_defaults=True)`; field names/order/defaults unchanged, so all ~dozen construction sites (`build_active_download_state`, `scripts/importer.py` synthetic state, `_youtube_active_download_files`, tests) are untouched.
- `to_json()` → `msgspec.json.encode(self).decode()`; `from_dict` → `msgspec.convert(d, type=cls)`; `from_json` → `msgspec.json.decode(s, type=cls)`. Decode at exactly one site.
- Deleted the now-vestigial `ActiveDownloadFileState.to_dict`/`from_dict` — msgspec recurses into nested structs automatically (only the old `State` encoder called them). Vulture confirms no orphans.
- **Secondary win:** the old `from_dict` laundered type drift (`size=int(d["size"])`); the strict `msgspec.convert` now raises `msgspec.ValidationError` at the boundary instead (issue #99 class of bug).

## Wire-shape verification

Captured the old encoder's exact output first and pinned both shapes as fixtures (`LEGACY_FULL_WIRE` / `LEGACY_MINIMAL_WIRE` in `TestActiveDownloadState`).

- **Fully-populated state: byte-for-value identical** to the legacy encoder (no field at its default → `omit_defaults` changes nothing). Asserted by `test_wire_full_state_identical_to_legacy`.
- **Minimal state: 3 documented wire diffs** — `omit_defaults=True` omits keys the hand-rolled encoder always emitted:
  | field | old wire (minimal) | new wire (minimal) |
  |---|---|---|
  | file `retry_count` | `0` (present) | omitted |
  | file `bytes_transferred` | `0` (present) | omitted |
  | state `current_path` | `null` (present) | omitted |

  Live prod rows show `retry_count` present as `0` and `current_path` present as `null`, so this is a genuine diff — sanctioned by the issue via "prove decode-compat both ways and note the wire diff explicitly."

### Why the diff is safe (decode-compatible both ways)

- **New decodes old:** the strict decoder applies field defaults (`0` / `None`) — a live prod row (ints as JSON numbers, `retry_count: 0`, `current_path: null`, disk fields present) decodes cleanly. Asserted by `test_from_dict_decodes_live_prod_row_shape`.
- **Old-style reads new:** every raw-JSONB consumer reads these via `dict.get()` (`None` whether the key is absent or `null`) — `lib/download_recovery.py`, `lib/quality.py`, etc. The old decoder used `.get("retry_count", 0)` / `.get("current_path")`, so absent and null converge.
- **SQL/mutations unaffected:** `abandon_auto_import_request` (`active_download_state->>'current_path' = %s`) only fires when `import_subprocess_started_at IS NOT NULL`, by which point `current_path` is a concrete non-null path (emitted identically by both encoders); the `IS NOT NULL` clause on `import_subprocess_started_at` behaves identically (old encoder also omitted it when None). Both `jsonb_set` stamp paths in `lib/pipeline_db/requests.py` use `create_missing=true`.
- `test_minimal_legacy_and_new_wire_decode_equal` asserts the legacy minimal wire and the new minimal wire decode to the **same** struct.

## Tests

- New: `test_wire_full_state_identical_to_legacy`, `test_wire_minimal_state_omits_default_keys`, `test_minimal_legacy_and_new_wire_decode_equal`, `test_from_dict_decodes_live_prod_row_shape`, `test_from_dict_rejects_string_size_wire_drift` (RED wire-drift → `msgspec.ValidationError`).
- Carried over: existing `TestActiveDownloadState` coverage passes; the `current_path`/`local_path` wire assertions updated to the new shape and rerouted through the state wire.
- Two raw-dict `current_path` test reads (`tests/test_integration_slices.py`, `tests/test_enqueue_fanout.py`) switched to `.get()` to match how production reads them; the enqueue-claim assertion was additionally **hoisted out of a swallowed slskd `side_effect`** (production wraps the enqueue call in a broad try/except once the claim lands, so assertions inside the fake never gated) so it now actually gates.

**Verification:** full suite 4663 tests OK (0 failures/errors); `pyright` 0 errors; vulture no dead code; JS gates green; `nix flake check` passed on push (VM boot gate).

Left out: nothing deferred — `#468` (TransferSnapshot) is a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)