### PR TITLE
refactor: typed CompletionResult/MaterializeResult for completion-processing ownership (#474)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -14,10 +14,19 @@ import logging
 import os
 from datetime import datetime, timezone
 from contextlib import AbstractContextManager
-from typing import Any, Callable, Protocol, TYPE_CHECKING, runtime_checkable
+from typing import (Any, Callable, Protocol, TYPE_CHECKING, assert_never,
+                    runtime_checkable)
 
 
 from lib.download_processing import (
+    Completed,
+    CompletionDeferred,
+    CompletionDispatched,
+    CompletionFailed,
+    CompletionResult,
+    Materialized,
+    MaterializeFailed,
+    MaterializeResult,
     _abandon_request_scoped_auto_import,
     _canonical_import_folder_path,
     _log_post_move_resume_blocked,
@@ -36,7 +45,7 @@ from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          decide_download_action,
                          extract_usernames)
 from lib import transitions
-from lib.dispatch import DispatchOutcome, _build_download_info
+from lib.dispatch import _build_download_info
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
     ImportJob,
@@ -380,8 +389,8 @@ def _run_completed_processing(
     ctx: CratediggerContext,
     *,
     import_job_id: int,
-    process_album_fn: "Callable[..., bool | DispatchOutcome | None] | None" = None,
-) -> bool | DispatchOutcome | None:
+    process_album_fn: "Callable[..., CompletionResult] | None" = None,
+) -> CompletionResult:
     """Run or resume local post-download processing for a completed album.
 
     ``process_album_fn`` is an opt-in DI seam for tests that exercise the
@@ -403,7 +412,7 @@ def _run_completed_processing(
         _persist_updated_download_state(db, request_id, entry, state)
 
     try:
-        outcome = _process(
+        result = _process(
             entry,
             [],
             ctx,
@@ -412,34 +421,29 @@ def _run_completed_processing(
     except Exception:
         logger.exception(f"Error processing completed download {entry.artist} - {entry.title} "
                          f"— will retry local processing next cycle")
-        return None
+        return CompletionDeferred(detail="unhandled_exception_during_local_processing")
 
-    # Ownership return from ``process_completed_album``:
-    # - True  → processing succeeded; flip to 'imported' if status is
-    #   still 'downloading'.
-    # - False → a non-deferred failure path returned; reset to
-    #   'wanted' only if the request row is still 'downloading'.
-    # - DispatchOutcome → dispatch/finalization already owned request
+    # Ownership return from ``process_completed_album`` (see
+    # ``CompletionResult`` in lib/download_processing.py):
+    # - Completed           → processing succeeded; flip to 'imported' if
+    #   status is still 'downloading'.
+    # - CompletionFailed    → a non-deferred failure path returned; reset
+    #   to 'wanted' only if the request row is still 'downloading'.
+    # - CompletionDispatched → dispatch/finalization already owned request
     #   transitions; return the summary to the queue owner only.
-    # - None  → leave the row untouched. This covers release-lock
-    #   contention, guarded post-move staged paths, and ownership-less
-    #   request rejects that require manual recovery. Do NOT touch state
-    #   here.
-    if outcome is None:
-        return None
+    # - CompletionDeferred  → leave the row untouched. This covers
+    #   release-lock contention, guarded post-move staged paths, and
+    #   ownership-less request rejects that require manual recovery. Do
+    #   NOT touch state here.
+    if isinstance(result, CompletionDeferred):
+        return result
 
-    if isinstance(outcome, DispatchOutcome):
-        return outcome
+    if isinstance(result, CompletionDispatched):
+        return result
 
-    if outcome is not True and outcome is not False:
-        raise TypeError(
-            "process_completed_album returned unsupported outcome "
-            f"{type(outcome).__name__}"
-        )
-
-    refreshed = db.get_request(request_id)
-    if refreshed and refreshed["status"] == "downloading":
-        if outcome is True:
+    if isinstance(result, Completed):
+        refreshed = db.get_request(request_id)
+        if refreshed and refreshed["status"] == "downloading":
             logger.info(f"  process_completed_album succeeded without "
                         f"setting status — setting imported")
             transitions.finalize_request(
@@ -449,7 +453,11 @@ def _run_completed_processing(
                     from_status="downloading",
                 ),
             )
-        elif outcome is False:
+        return result
+
+    if isinstance(result, CompletionFailed):
+        refreshed = db.get_request(request_id)
+        if refreshed and refreshed["status"] == "downloading":
             logger.warning(f"  process_completed_album failed without "
                            f"setting status — resetting to wanted")
             transitions.finalize_request(
@@ -460,7 +468,9 @@ def _run_completed_processing(
                     attempt_type="download",
                 ),
             )
-    return outcome
+        return result
+
+    assert_never(result)
 
 
 def _active_import_job_for_request(
@@ -470,23 +480,25 @@ def _active_import_job_for_request(
 
 
 def materialize_failure_action(
-    materialized: bool | None,
+    materialized: MaterializeResult,
     processing_started_at: str | None,
     now: datetime,
     *,
     grace_seconds: int = PROCESSING_MATERIALIZE_GRACE_S,
 ) -> str:
-    """Decide what the poller does with a non-True materialize outcome.
+    """Decide what the poller does with a non-``Materialized`` outcome.
 
-    - ``"leave"`` — ``None`` marks guarded paths needing manual recovery;
-      NEVER auto-reset those, regardless of age.
-    - ``"retry"`` — ``False`` within the grace window retries next cycle
-      (covers the benign completion-vs-event-write race, which resolves
-      on the next ingest).
-    - ``"reset"`` — ``False`` past the grace window self-heals the
-      request back to 'wanted' for re-download.
+    - ``"leave"`` — ``MaterializeGuarded`` marks paths needing manual
+      recovery; NEVER auto-reset those, regardless of age. (Also the
+      no-op answer if ``materialized`` is actually ``Materialized`` —
+      callers only invoke this after already excluding that case.)
+    - ``"retry"`` — ``MaterializeFailed`` within the grace window retries
+      next cycle (covers the benign completion-vs-event-write race,
+      which resolves on the next ingest).
+    - ``"reset"`` — ``MaterializeFailed`` past the grace window self-heals
+      the request back to 'wanted' for re-download.
     """
-    if materialized is not False:
+    if not isinstance(materialized, MaterializeFailed):
         return "leave"
     if processing_started_at is None:
         return "retry"
@@ -530,7 +542,7 @@ def _enqueue_completed_processing(
         ),
     )
     materialized = _materialize_processing_dir(entry, staged_album, ctx)
-    if materialized is not True:
+    if not isinstance(materialized, Materialized):
         action = materialize_failure_action(
             materialized,
             state.processing_started_at,

--- a/lib/download_processing.py
+++ b/lib/download_processing.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+from dataclasses import dataclass
 from typing import Any, Callable, TYPE_CHECKING
 
 from lib.download_recovery import classify_processing_path
@@ -66,6 +67,102 @@ _ABANDON_PATH_PRESENT = "present"
 _ABANDON_PATH_ABSENT = "absent"
 _ABANDON_PATH_UNKNOWN = "unknown"
 
+
+# === Tagged results for the completion-processing ownership protocol (#474) ===
+#
+# ``_materialize_processing_dir`` and ``process_completed_album`` used to
+# return an anonymous ``bool | None`` / ``bool | DispatchOutcome | None``
+# union where ``None`` meant "leave the row untouched" — a convention
+# documented only in ~30-line comment blocks at each call site. These
+# frozen dataclasses name each outcome so pyright can exhaustiveness-check
+# every consumer (``match``/``isinstance`` + ``typing.assert_never``)
+# instead of relying on identity comparisons against ``True``/``False``/
+# ``None``. Never persisted — plain ``@dataclass``, not ``msgspec.Struct``
+# (see CLAUDE.md "Wire-boundary types").
+
+
+@dataclass(frozen=True)
+class Materialized:
+    """``_materialize_processing_dir`` succeeded: the album's tracked files
+    are present at ``staged_album.current_path`` (materialized this call,
+    or resumed from a prior crashed attempt). Historical bare ``True``."""
+
+
+@dataclass(frozen=True)
+class MaterializeFailed:
+    """A local-only materialize failure (missing event stamp, a file-move
+    error, a vanished staged directory/file, a failed ``mkdir``). The
+    caller retries within the materialize grace window, then self-heals
+    the request back to ``wanted``. Historical bare ``False``.
+
+    ``reason`` is a short, machine-stable diagnostic code — consumers
+    must branch on the type tag, never on this string.
+    """
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class MaterializeGuarded:
+    """Ownership/resume ambiguity: leave the row untouched (an active
+    release lock, unverifiable subprocess-start evidence, a post-move
+    resume block). Historical bare ``None``.
+
+    ``detail`` is diagnostic only — consumers must branch on the type
+    tag, never on this string.
+    """
+
+    detail: str
+
+
+MaterializeResult = Materialized | MaterializeFailed | MaterializeGuarded
+"""Return type of ``_materialize_processing_dir``."""
+
+
+@dataclass(frozen=True)
+class Completed:
+    """``process_completed_album`` succeeded without producing a dispatch
+    summary — no validation configured, or the redownload path already
+    called ``mark_done`` directly. Caller finalizes to ``imported`` only
+    if the request row is still ``downloading``. Historical bare ``True``.
+    """
+
+
+@dataclass(frozen=True)
+class CompletionFailed:
+    """A non-dispatch local failure (materialization failed). Caller
+    resets to ``wanted`` only if the request row is still ``downloading``.
+    Historical bare ``False``.
+    """
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class CompletionDispatched:
+    """The validation/dispatch path already owned the request transition.
+
+    ``outcome`` is an import summary for the queue owner ONLY — it must
+    NEVER drive a fallback status transition. Historical raw
+    ``DispatchOutcome`` return value.
+    """
+
+    outcome: DispatchOutcome
+
+
+@dataclass(frozen=True)
+class CompletionDeferred:
+    """The path intentionally left request state untouched: release-lock
+    contention, a guarded post-move staged path, or an ownership-less
+    reject needing manual recovery. Caller must NOT touch status.
+    Historical bare ``None``.
+    """
+
+    detail: str
+
+
+CompletionResult = Completed | CompletionFailed | CompletionDispatched | CompletionDeferred
+"""Return type of ``process_completed_album`` / ``_run_completed_processing``."""
 
 
 def _run_post_rejection_wrong_match_cleanup(
@@ -455,7 +552,7 @@ def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
     ctx: CratediggerContext,
-) -> bool | None:
+) -> MaterializeResult:
     """Ensure ``staged_album.current_path`` holds the album's local files."""
     canonical_path = _canonical_import_folder_path(
         album_data, ctx.cfg.slskd_download_dir)
@@ -476,7 +573,7 @@ def _materialize_processing_dir(
                 "verified; manual recovery is required."
             ),
         )
-        return None
+        return MaterializeGuarded(detail="missing_db_request_id_for_request_scoped_staged")
     current_path_location = classify_processing_path(
         current_path=staged_album.current_path,
         artist=album_data.artist,
@@ -503,7 +600,11 @@ def _materialize_processing_dir(
                         "redownload"
                     ),
                 )
-                return False if handled else None
+                if handled:
+                    return MaterializeFailed(
+                        reason="abandoned_interrupted_auto_import")
+                return MaterializeGuarded(
+                    detail="abandon_blocked_release_lock_or_probe_unknown")
             if subprocess_started is None:
                 _log_post_move_resume_blocked(
                     album_data,
@@ -514,7 +615,8 @@ def _materialize_processing_dir(
                         "verified; manual recovery is required."
                     ),
                 )
-                return None
+                return MaterializeGuarded(
+                    detail="ownership_unverifiable_request_scoped_staged")
         if not os.path.isdir(staged_album.current_path):
             if (
                 current_path_location.blocks_post_move_retry
@@ -531,9 +633,10 @@ def _materialize_processing_dir(
                         "recovery is required."
                     ),
                 )
-                return None
+                return MaterializeGuarded(
+                    detail="post_move_dir_missing_resume_blocked")
             logger.error(f"Current staged path missing: {staged_album.current_path}")
-            return False
+            return MaterializeFailed(reason="staged_path_missing")
         staged_album.bind_import_paths(album_data.files)
         missing_paths: list[str] = []
         for file in album_data.files:
@@ -556,12 +659,13 @@ def _materialize_processing_dir(
                         "already have started; manual recovery is required."
                     ),
                 )
-                return None
+                return MaterializeGuarded(
+                    detail="post_move_files_missing_resume_blocked")
             logger.error(
                 "Current staged path is missing tracked files: %s",
                 ", ".join(missing_paths),
             )
-            return False
+            return MaterializeFailed(reason="staged_path_missing_tracked_files")
         if (
             current_path_location.blocks_auto_import_dispatch
             and subprocess_started is not False
@@ -582,9 +686,9 @@ def _materialize_processing_dir(
                 current_path=staged_album.current_path,
                 detail=detail,
             )
-            return None
+            return MaterializeGuarded(detail="auto_import_dispatch_blocked_post_move")
         album_data.import_folder = staged_album.current_path
-        return True
+        return Materialized()
 
     # Pre-flight: every file must carry a stamped, on-disk local_path from
     # slskd's DownloadFileComplete event — or already-moved evidence at the
@@ -618,7 +722,7 @@ def _materialize_processing_dir(
             len(missing_stamps),
             "; ".join(missing_stamps),
         )
-        return False
+        return MaterializeFailed(reason="event_path_missing")
 
     rm_dirs: list[str] = []
     moved_files_history: list[tuple[str, str]] = []
@@ -637,7 +741,7 @@ def _materialize_processing_dir(
                 canonical_path,
                 album_data.db_request_id,
             )
-            return False
+            return MaterializeFailed(reason="staging_dir_create_failed")
 
     for file in album_data.files:
         dst_file = file.import_path
@@ -667,7 +771,7 @@ def _materialize_processing_dir(
                 os.rmdir(canonical_path)
             except OSError:
                 logger.warning(f"Could not remove temp import directory {canonical_path}")
-            return False
+            return MaterializeFailed(reason="file_move_failed")
 
     for rm_dir in rm_dirs:
         if os.path.abspath(rm_dir) == os.path.abspath(canonical_path):
@@ -679,7 +783,7 @@ def _materialize_processing_dir(
 
     album_data.import_folder = staged_album.current_path
     staged_album.persist_current_path(db)
-    return True
+    return Materialized()
 
 
 def _check_staged_audio_manifest(
@@ -714,18 +818,22 @@ def process_completed_album(
     validate_fn: "Callable[..., DispatchOutcome | None] | None" = None,
     handle_valid_fn: "Callable[..., DispatchOutcome | None] | None" = None,
     dispatch_fn: "Callable[..., DispatchOutcome | None] | None" = None,
-) -> "bool | DispatchOutcome | None":
+) -> CompletionResult:
     """Process a fully-downloaded album: move files, tag, validate, stage/import.
 
-    Returns the local processing result:
-    - ``True`` — local non-dispatch processing succeeded. Outer caller may
-      finalize only if the request row is still ``downloading``.
-    - ``False`` — local non-dispatch processing failed. Outer caller resets
-      to ``wanted`` only if the request row is still ``downloading``.
-    - ``DispatchOutcome`` — the validation / dispatch path already owned the
-      request transition and produced an import summary for the queue owner.
-    - ``None`` — the validation / dispatch path intentionally left state
-      untouched for retry / manual recovery. Outer caller must NOT touch status.
+    Returns the local processing result (see ``CompletionResult`` variants):
+    - ``Completed`` — local non-dispatch processing succeeded. Outer caller
+      may finalize to ``imported`` only if the request row is still
+      ``downloading``. Historical bare ``True``.
+    - ``CompletionFailed`` — local non-dispatch processing failed. Outer
+      caller resets to ``wanted`` only if the request row is still
+      ``downloading``. Historical bare ``False``.
+    - ``CompletionDispatched`` — the validation / dispatch path already owned
+      the request transition; ``.outcome`` is an import summary for the
+      queue owner only. Historical raw ``DispatchOutcome``.
+    - ``CompletionDeferred`` — the validation / dispatch path intentionally
+      left state untouched for retry / manual recovery. Outer caller must
+      NOT touch status. Historical bare ``None``.
     """
     staged_album = StagedAlbum.from_entry(
         album_data,
@@ -733,8 +841,11 @@ def process_completed_album(
             album_data, ctx.cfg.slskd_download_dir),
     )
     materialized = _materialize_processing_dir(album_data, staged_album, ctx)
-    if materialized is not True:
-        return materialized
+    if isinstance(materialized, MaterializeFailed):
+        return CompletionFailed(reason=materialized.reason)
+    if isinstance(materialized, MaterializeGuarded):
+        return CompletionDeferred(detail=materialized.detail)
+    assert isinstance(materialized, Materialized)
 
     logger.info(f"Processing completed download: {album_data.artist} - {album_data.title}")
     if ctx.cfg.beets_validation_enabled and album_data.mb_release_id:
@@ -749,16 +860,16 @@ def process_completed_album(
         )
         if outcome is not None:
             if outcome.deferred:
-                # Release-lock contention. Propagate ``None`` so
-                # ``_run_completed_processing`` leaves the request's
+                # Release-lock contention. Propagate ``CompletionDeferred``
+                # so ``_run_completed_processing`` leaves the request's
                 # status, active_download_state, and staged files
                 # untouched for the next cycle to retry.
-                return None
-            # DispatchOutcome is an import summary only. Return it so the
+                return CompletionDeferred(detail=outcome.message)
+            # DispatchOutcome is an import summary only. Wrap it so the
             # importer queue can record the real terminal job outcome, but do
             # not let it drive fallback request-status transitions below.
-            return outcome
-    return True
+            return CompletionDispatched(outcome=outcome)
+    return Completed()
 
 
 def _process_beets_validation(

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -136,7 +136,7 @@ def _materialize_automation_preview_path(
     """Ensure automation preview has the same stable folder importer uses."""
     from lib.config import read_runtime_config
     from lib.download import reconstruct_grab_list_entry
-    from lib.download_processing import _materialize_processing_dir
+    from lib.download_processing import Materialized, _materialize_processing_dir
     from lib.staged_album import StagedAlbum
 
     cfg = read_runtime_config()
@@ -153,7 +153,7 @@ def _materialize_automation_preview_path(
         default_path=canonical_path,
     )
     materialized = _materialize_processing_dir(entry, staged_album, ctx)
-    if materialized is not True:
+    if not isinstance(materialized, Materialized):
         raise ValueError(
             f"Album request {request_id} could not be materialized for preview"
         )

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -10,7 +10,7 @@ import shutil
 import socket
 import sys
 import time
-from typing import Any
+from typing import Any, assert_never
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
@@ -23,6 +23,13 @@ from lib.dispatch import (
     DISPATCH_CODE_REQUEUE_FAILED,
     DISPATCH_CODE_REQUEUED_FOR_PREVIEW,
     DispatchOutcome,
+)
+from lib.download_processing import (
+    Completed,
+    CompletionDeferred,
+    CompletionDispatched,
+    CompletionFailed,
+    CompletionResult,
 )
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
@@ -225,6 +232,35 @@ def _build_runtime_context(db: PipelineDB):
     return CratediggerContext(cfg=cfg, slskd=None, pipeline_db_source=source)
 
 
+def _dispatch_outcome_from_completion(
+    result: CompletionResult,
+    *,
+    deferred_message: str,
+    completed_message: str,
+    failed_message: str,
+) -> DispatchOutcome:
+    """Map the completion-processing tag to the queue's DispatchOutcome.
+
+    Both ``execute_automation_import_job`` and ``execute_youtube_import_job``
+    drive the same completion-processing protocol (issue #474) and need to
+    report the same four outcomes back to the importer queue; this is the
+    single conversion so the two callers don't duplicate the match.
+    """
+    if isinstance(result, CompletionDeferred):
+        return DispatchOutcome(
+            success=False,
+            message=deferred_message,
+            deferred=True,
+        )
+    if isinstance(result, CompletionDispatched):
+        return result.outcome
+    if isinstance(result, Completed):
+        return DispatchOutcome(success=True, message=completed_message)
+    if isinstance(result, CompletionFailed):
+        return DispatchOutcome(success=False, message=failed_message)
+    assert_never(result)
+
+
 def execute_automation_import_job(
     db: PipelineDB,
     job: ImportJob,
@@ -268,24 +304,13 @@ def execute_automation_import_job(
     finally:
         if created_ctx:
             runtime_ctx.pipeline_db_source.close()
-    if result is None:
-        return DispatchOutcome(
-            success=False,
-            message=(
-                "Automation import was deferred or requires manual recovery"
-            ),
-            deferred=True,
-        )
-    if isinstance(result, DispatchOutcome):
-        return result
-    if result:
-        return DispatchOutcome(
-            success=True,
-            message="Automation import processing completed",
-        )
-    return DispatchOutcome(
-        success=False,
-        message="Automation import processing failed",
+    return _dispatch_outcome_from_completion(
+        result,
+        deferred_message=(
+            "Automation import was deferred or requires manual recovery"
+        ),
+        completed_message="Automation import processing completed",
+        failed_message="Automation import processing failed",
     )
 
 
@@ -381,7 +406,7 @@ def execute_youtube_import_job(
     created_ctx = ctx is None
     runtime_ctx = ctx or _build_runtime_context(db)
     try:
-        outcome = process_completed_album(
+        result = process_completed_album(
             entry,
             [],
             runtime_ctx,
@@ -391,24 +416,13 @@ def execute_youtube_import_job(
         if created_ctx:
             runtime_ctx.pipeline_db_source.close()
 
-    if outcome is None:
-        return DispatchOutcome(
-            success=False,
-            message=(
-                "YouTube import was deferred or requires manual recovery"
-            ),
-            deferred=True,
-        )
-    if isinstance(outcome, DispatchOutcome):
-        return outcome
-    if outcome:
-        return DispatchOutcome(
-            success=True,
-            message="YouTube import processing completed",
-        )
-    return DispatchOutcome(
-        success=False,
-        message="YouTube import processing failed",
+    return _dispatch_outcome_from_completion(
+        result,
+        deferred_message=(
+            "YouTube import was deferred or requires manual recovery"
+        ),
+        completed_message="YouTube import processing completed",
+        failed_message="YouTube import processing failed",
     )
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -20,6 +20,7 @@ import time
 from datetime import datetime, timezone, timedelta
 from typing import Any, TYPE_CHECKING, cast
 
+from lib.download_processing import Materialized, MaterializeFailed, MaterializeGuarded
 from lib.slskd_client import TransferSnapshot
 from tests.helpers import (
     make_ctx_with_fake_db,
@@ -1300,8 +1301,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
     """Test process_completed_album return ownership."""
 
     def test_returns_true_on_success(self):
-        """Successful file move + processing returns True."""
-        from lib.download_processing import process_completed_album
+        """Successful file move + processing returns Completed."""
+        from lib.download_processing import Completed, process_completed_album
         import tempfile, os
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create source file
@@ -1320,13 +1321,13 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             cfg.slskd_download_dir = tmpdir
             cfg.beets_validation_enabled = False
             result = process_completed_album(album, [], ctx, import_job_id=1)
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
 
     def test_dispatch_outcome_summary_is_returned_to_queue_owner(
         self,
     ):
         """Auto-import summaries must survive for the importer queue result."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionDispatched, process_completed_album
         from lib.dispatch import DispatchOutcome
         import tempfile, os
 
@@ -1359,7 +1360,8 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 album, [], ctx, import_job_id=1, validate_fn=_stub_validate,
             )
 
-            self.assertIs(result, stub_outcome)
+            assert isinstance(result, CompletionDispatched)
+            self.assertIs(result.outcome, stub_outcome)
             self.assertEqual(len(validate_calls), 1)
 
     @patch("lib.beets.beets_validate")
@@ -1368,8 +1370,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
         mock_beets_validate,
     ):
         """Validation rejections must fail the queue job, not look completed."""
-        from lib.download_processing import process_completed_album
-        from lib.dispatch import DispatchOutcome
+        from lib.download_processing import CompletionDispatched, process_completed_album
         from lib.quality import ValidationResult
         import tempfile
 
@@ -1418,11 +1419,12 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            assert isinstance(result, DispatchOutcome)
-            self.assertFalse(result.success)
-            self.assertFalse(result.deferred)
+            assert isinstance(result, CompletionDispatched)
+            outcome = result.outcome
+            self.assertFalse(outcome.success)
+            self.assertFalse(outcome.deferred)
             self.assertEqual(
-                result.message,
+                outcome.message,
                 "Rejected: high_distance - distance=0.1919",
             )
             source = ctx.pipeline_db_source
@@ -1430,9 +1432,9 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             self.assertEqual(len(source.reject_and_requeue_calls), 1)
 
     def test_returns_false_on_file_move_failure(self):
-        """A mid-album move failure returns False and rolls back the
-        already-moved files to their stamped sources."""
-        from lib.download_processing import process_completed_album
+        """A mid-album move failure returns CompletionFailed and rolls back
+        the already-moved files to their stamped sources."""
+        from lib.download_processing import CompletionFailed, process_completed_album
         import tempfile, os
         with tempfile.TemporaryDirectory() as tmpdir:
             src_dir = os.path.join(tmpdir, "Music")
@@ -1467,14 +1469,14 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                 result = process_completed_album(
                     album, [], ctx, import_job_id=1)
 
-            self.assertFalse(result)
+            self.assertIsInstance(result, CompletionFailed)
             # Rollback restored the first file to its stamped source.
             self.assertTrue(os.path.exists(srcs[0]))
             self.assertTrue(os.path.exists(srcs[1]))
 
     def test_resumes_from_persisted_current_path(self):
         """A post-move retry must process the persisted current_path, not slskd."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             resumed_path = os.path.join(tmpdir, "staging", "Artist", "Album")
@@ -1504,13 +1506,13 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(files[0].import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
     def test_resumes_multi_disc_from_persisted_current_path(self):
         """Resume must preserve the staged multi-disc filenames on disk."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             resumed_path = os.path.join(tmpdir, "staging", "Artist", "Album")
@@ -1542,13 +1544,13 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(file.import_path, resumed_file)
             self.assertTrue(os.path.exists(resumed_file))
 
     def test_persists_canonical_current_path_for_fresh_materialization(self):
         """The first local materialization must persist the canonical path to DB."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             fake_db = FakePipelineDB()
@@ -1583,7 +1585,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(
                 fake_db.request(42)["active_download_state"]["current_path"],
                 os.path.join(tmpdir, "downloads", "Artist - Album (2024)"),
@@ -1595,7 +1597,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
         mock_beets_validate,
     ):
         """Post-move auto-import retries must stop before re-dispatch."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionDeferred, process_completed_album
         from lib.quality import ValidationResult
         from lib.processing_paths import stage_to_ai_path
         import tempfile
@@ -1645,7 +1647,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                     dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
                 )
 
-            self.assertIsNone(result)
+            self.assertIsInstance(result, CompletionDeferred)
             self.assertEqual(dispatch_calls, [])
             self.assertIn("POST-MOVE RESUME BLOCKED", "\n".join(logs.output))
 
@@ -1653,7 +1655,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
         self,
     ):
         """Request-scoped auto-import staging without request id must stay blocked."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionDeferred, process_completed_album
         from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1692,14 +1694,14 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
             with self.assertLogs("cratedigger", level="ERROR") as logs:
                 result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertIsNone(result)
+            self.assertIsInstance(result, CompletionDeferred)
             self.assertIn("missing db_request_id", "\n".join(logs.output))
 
     def test_post_validation_staged_path_without_request_id_still_resumes(
         self,
     ):
         """Post-validation staging remains resumable without the auto-import guard."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         from lib.processing_paths import stage_to_ai_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1738,7 +1740,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(album.files[0].import_path, resumed_file)
 
     @patch("lib.beets.beets_validate")
@@ -1747,7 +1749,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
         mock_beets_validate,
     ):
         """Legacy shared staged retries must stop before validation reruns."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionDeferred, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             staging_root = os.path.join(tmpdir, "staging")
@@ -1784,14 +1786,14 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
                     dispatch_fn=lambda **kw: dispatch_calls.append(kw) or None,
                 )
 
-            self.assertIsNone(result)
+            self.assertIsInstance(result, CompletionDeferred)
             mock_beets_validate.assert_not_called()
             self.assertEqual(dispatch_calls, [])
             self.assertIn("legacy shared staged path", "\n".join(logs.output))
 
     def test_returns_false_when_persisted_current_path_missing_dir(self):
         """Resume must fail closed when the persisted directory no longer exists."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionFailed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             album = make_grab_list_entry(
@@ -1812,11 +1814,11 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertFalse(result)
+            self.assertIsInstance(result, CompletionFailed)
 
     def test_returns_false_when_persisted_current_path_missing_file(self):
         """Resume dir must contain every tracked file before processing continues."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionFailed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             resumed_path = os.path.join(tmpdir, "staging", "Artist", "Album")
@@ -1840,7 +1842,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertFalse(result)
+            self.assertIsInstance(result, CompletionFailed)
 
 
 class TestHandleValidResultMissingMbid(unittest.TestCase):
@@ -1926,7 +1928,7 @@ class TestEventPathMaterialization(unittest.TestCase):
         # slskd placed the file at an arbitrary event-reported location
         # with a collision suffix; the move follows the stamp and the
         # destination keeps the clean remote basename.
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             event_path = os.path.join(
@@ -1939,14 +1941,14 @@ class TestEventPathMaterialization(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertFalse(os.path.exists(event_path))
             self.assertEqual(self._moved(tmpdir), [self.FNAME])
 
     def test_stamped_forward_slash_remote_path_keeps_basename(self):
         # Destination basename extraction accepts slash-normalized remote
         # paths regardless of where the stamped source lives.
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             src = os.path.join(tmpdir, "Kid A", self.FNAME)
@@ -1969,14 +1971,14 @@ class TestEventPathMaterialization(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(self._moved(tmpdir), [self.FNAME])
 
     def test_unstamped_file_is_hard_failure(self):
         # No event was ever ingested for this file (pre-bootstrap
         # completion or cursor gap) — hard failure with diagnostics, no
         # guessing at on-disk locations.
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionFailed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             # File IS on disk at the historical inferred location — the
@@ -1991,7 +1993,7 @@ class TestEventPathMaterialization(unittest.TestCase):
                 result = process_completed_album(
                     album, [], ctx, import_job_id=1)
 
-            self.assertFalse(result)
+            self.assertIsInstance(result, CompletionFailed)
             self.assertTrue(os.path.exists(src))
             joined = "\n".join(logs.output)
             self.assertIn("EVENT-PATH MISSING", joined)
@@ -2000,7 +2002,7 @@ class TestEventPathMaterialization(unittest.TestCase):
     def test_stale_stamp_without_dst_is_hard_failure(self):
         # Stamped path vanished and the destination has no already-moved
         # copy — hard failure, diagnostics name the stale stamp.
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionFailed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             album, ctx = self._album(
@@ -2010,7 +2012,7 @@ class TestEventPathMaterialization(unittest.TestCase):
                 result = process_completed_album(
                     album, [], ctx, import_job_id=1)
 
-            self.assertFalse(result)
+            self.assertIsInstance(result, CompletionFailed)
             joined = "\n".join(logs.output)
             self.assertIn("EVENT-PATH MISSING", joined)
             self.assertIn("stale_stamp", joined)
@@ -2019,7 +2021,7 @@ class TestEventPathMaterialization(unittest.TestCase):
         """One stamped file, one unstamped: the pre-flight check fails the
         album BEFORE any move, so the stamped file stays at its event
         location — no move-then-rollback churn."""
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import CompletionFailed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             event_src = os.path.join(
@@ -2052,7 +2054,7 @@ class TestEventPathMaterialization(unittest.TestCase):
                 result = process_completed_album(
                     album, [], ctx, import_job_id=1)
 
-            self.assertFalse(result)
+            self.assertIsInstance(result, CompletionFailed)
             self.assertTrue(os.path.exists(event_src))
             self.assertIn("EVENT-PATH MISSING", "\n".join(logs.output))
             dst_dir = os.path.join(tmpdir, "Radiohead - Kid A (2000)")
@@ -2062,7 +2064,7 @@ class TestEventPathMaterialization(unittest.TestCase):
     def test_already_moved_resume_still_skips(self):
         # Crash-resume: dst exists, the stamped source is gone. The file
         # counts as already moved; processing succeeds.
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             dst_dir = os.path.join(tmpdir, "Radiohead - Kid A (2000)")
@@ -2074,13 +2076,13 @@ class TestEventPathMaterialization(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(self._moved(tmpdir), [self.FNAME])
 
     def test_unstamped_already_moved_resume_still_skips(self):
         # Even an unstamped file counts as already moved when the
         # destination copy exists — pre-flight must not hard-fail it.
-        from lib.download_processing import process_completed_album
+        from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             dst_dir = os.path.join(tmpdir, "Radiohead - Kid A (2000)")
@@ -2091,25 +2093,44 @@ class TestEventPathMaterialization(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
-            self.assertTrue(result)
+            self.assertIsInstance(result, Completed)
             self.assertEqual(self._moved(tmpdir), [self.FNAME])
 
 
 class TestMaterializeFailureAction(unittest.TestCase):
-    """Pure decision table for the poller's materialize-failure escape."""
+    """Pure decision table for the poller's materialize-failure escape.
+
+    Cases pin the ownership-protocol tags (#474): ``MaterializeGuarded``
+    (historical bare ``None``) always "leave"s regardless of age;
+    ``MaterializeFailed`` (historical bare ``False``) "retry"s within
+    the grace window and "reset"s past it; ``Materialized`` (historical
+    bare ``True``) also "leave"s — callers only invoke this function
+    after already excluding the success case, but the no-op answer must
+    still hold so a future caller that skips the exclusion check fails
+    safe rather than auto-resetting a successful materialization.
+    """
 
     NOW = datetime(2026, 7, 2, 12, 0, 0, tzinfo=timezone.utc)
     OLD = (NOW - timedelta(hours=2)).isoformat()
     FRESH = (NOW - timedelta(minutes=5)).isoformat()
 
     CASES = [
-        ("none_fresh_leaves", None, FRESH, "leave"),
-        ("none_old_leaves_manual_recovery_alone", None, OLD, "leave"),
-        ("false_fresh_retries", False, FRESH, "retry"),
-        ("false_old_resets", False, OLD, "reset"),
-        ("false_no_start_retries", False, None, "retry"),
-        ("false_unparseable_start_retries", False, "not-a-date", "retry"),
-        ("naive_timestamp_treated_utc", False,
+        ("guarded_fresh_leaves",
+         MaterializeGuarded(detail="release_lock_held"), FRESH, "leave"),
+        ("guarded_old_leaves_manual_recovery_alone",
+         MaterializeGuarded(detail="release_lock_held"), OLD, "leave"),
+        ("materialized_leaves_as_no_op_safety_net",
+         Materialized(), OLD, "leave"),
+        ("failed_fresh_retries",
+         MaterializeFailed(reason="staged_path_missing"), FRESH, "retry"),
+        ("failed_old_resets",
+         MaterializeFailed(reason="staged_path_missing"), OLD, "reset"),
+        ("failed_no_start_retries",
+         MaterializeFailed(reason="staged_path_missing"), None, "retry"),
+        ("failed_unparseable_start_retries",
+         MaterializeFailed(reason="staged_path_missing"), "not-a-date", "retry"),
+        ("naive_timestamp_treated_utc",
+         MaterializeFailed(reason="staged_path_missing"),
          (NOW - timedelta(hours=2)).replace(tzinfo=None).isoformat(), "reset"),
     ]
 

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -16,6 +16,7 @@ from lib.dispatch import (
     DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
     DispatchOutcome,
 )
+from lib.download_processing import Completed, CompletionDispatched
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
     IMPORT_JOB_FORCE,
@@ -1191,7 +1192,7 @@ class TestImporterWorker(unittest.TestCase):
 
         with patch(
             "lib.download._run_completed_processing",
-            return_value=True,
+            return_value=Completed(),
         ) as processing:
             updated = importer.process_claimed_job(
                 cast(Any, db),
@@ -1234,7 +1235,8 @@ class TestImporterWorker(unittest.TestCase):
 
         with patch(
             "lib.download._run_completed_processing",
-            return_value=DispatchOutcome(True, "Imported by dispatch"),
+            return_value=CompletionDispatched(
+                outcome=DispatchOutcome(True, "Imported by dispatch")),
         ) as processing:
             updated = importer.process_claimed_job(
                 cast(Any, db),
@@ -1278,7 +1280,8 @@ class TestImporterWorker(unittest.TestCase):
 
         with patch(
             "lib.download._run_completed_processing",
-            return_value=DispatchOutcome(False, "Pre-import gate rejected"),
+            return_value=CompletionDispatched(
+                outcome=DispatchOutcome(False, "Pre-import gate rejected")),
         ):
             updated = importer.process_claimed_job(
                 cast(Any, db),
@@ -2557,7 +2560,8 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
 
             with patch(
                 "lib.download_processing.process_completed_album",
-                return_value=DispatchOutcome(True, "Imported by dispatch"),
+                return_value=CompletionDispatched(
+                    outcome=DispatchOutcome(True, "Imported by dispatch")),
             ) as proc:
                 updated = importer.process_claimed_job(
                     cast(Any, db),
@@ -2672,7 +2676,7 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
 
             with patch(
                 "lib.download_processing.process_completed_album",
-                return_value=True,
+                return_value=Completed(),
             ):
                 updated = importer.process_claimed_job(
                     cast(Any, db),
@@ -2715,7 +2719,7 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
             self._mark_importable(db, job)
             claimed = self._claim(db)
 
-            def _run_real_finalize(*args: Any, **kwargs: Any) -> DispatchOutcome:
+            def _run_real_finalize(*args: Any, **kwargs: Any) -> CompletionDispatched:
                 # Mirror the production seam: dispatch_import_from_db
                 # would call finalize_request(to_imported) on auto-import
                 # success. That call routes to mark_imported_with_rescue.
@@ -2726,7 +2730,7 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
                         from_status="wanted",
                     ),
                 )
-                return DispatchOutcome(True, "Imported")
+                return CompletionDispatched(outcome=DispatchOutcome(True, "Imported"))
 
             with patch(
                 "lib.download_processing.process_completed_album",
@@ -2775,7 +2779,7 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
             self._mark_importable(db, job)
             claimed = self._claim(db)
 
-            def _run_real_finalize(*args: Any, **kwargs: Any) -> DispatchOutcome:
+            def _run_real_finalize(*args: Any, **kwargs: Any) -> CompletionDispatched:
                 transitions.finalize_request(
                     cast(Any, db),
                     42,
@@ -2783,7 +2787,8 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
                         from_status="manual",
                     ),
                 )
-                return DispatchOutcome(True, "Imported from manual")
+                return CompletionDispatched(
+                    outcome=DispatchOutcome(True, "Imported from manual"))
 
             with patch(
                 "lib.download_processing.process_completed_album",
@@ -2828,8 +2833,8 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
             # Simulate a wrong-matches reject from the pipeline.
             with patch(
                 "lib.download_processing.process_completed_album",
-                return_value=DispatchOutcome(
-                    False, "Rejected: high_distance"),
+                return_value=CompletionDispatched(outcome=DispatchOutcome(
+                    False, "Rejected: high_distance")),
             ):
                 updated = importer.process_claimed_job(
                     cast(Any, db),
@@ -2865,11 +2870,11 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
 
             with patch(
                 "lib.download_processing.process_completed_album",
-                return_value=DispatchOutcome(
+                return_value=CompletionDispatched(outcome=DispatchOutcome(
                     False,
                     "Quality pipeline rejected",
                     code=DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
-                ),
+                )),
             ):
                 updated = importer.process_claimed_job(
                     cast(Any, db),
@@ -2922,7 +2927,8 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
 
             with patch(
                 "lib.download_processing.process_completed_album",
-                return_value=DispatchOutcome(True, "ok"),
+                return_value=CompletionDispatched(
+                    outcome=DispatchOutcome(True, "ok")),
             ) as proc:
                 importer.process_claimed_job(
                     cast(Any, db),

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2521,7 +2521,9 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
 
 
 class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
-    """The ``process_completed_album`` return ownership seam.
+    """The ``process_completed_album`` return ownership seam (#474 tagged
+    ``CompletionResult``: ``Completed`` / ``CompletionFailed`` /
+    ``CompletionDispatched`` / ``CompletionDeferred``).
 
     Pre-#133 this was a 2-way ``bool``: True → flip to ``imported``,
     False → reset to ``wanted``. That binary misclassified release-
@@ -2531,11 +2533,11 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
     Codex R3 P2/P3 then flagged that the reset clobbered spectral
     state and staged files.
 
-    The proper seam separates local bool fallback, ``None`` deferred
-    retry, and ``DispatchOutcome`` queue summaries. These tests pin the
-    branching at
-    ``_run_completed_processing`` so a future refactor can't silently
-    collapse dispatch ownership into bool fallback transitions.
+    The proper seam separates local non-dispatch success/failure,
+    deferred retry, and dispatch queue summaries onto distinct tags.
+    These tests pin the branching at ``_run_completed_processing`` so a
+    future refactor can't silently collapse dispatch ownership into
+    fallback status transitions.
     """
 
     def _ctx(self, db: FakePipelineDB):
@@ -2553,11 +2555,12 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             files=[])
 
     def test_deferred_outcome_leaves_status_downloading(self):
-        """``process_completed_album`` returning ``None`` must NOT touch
-        the request's status. The next ``poll_active_downloads`` cycle
-        will re-enter via status='downloading'.
+        """``process_completed_album`` returning ``CompletionDeferred`` must
+        NOT touch the request's status. The next ``poll_active_downloads``
+        cycle will re-enter via status='downloading'.
         """
         from lib import download as dl_mod
+        from lib.download_processing import CompletionDeferred
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42, status="downloading",
@@ -2566,7 +2569,8 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: None,
+            process_album_fn=lambda *_a, **_kw: CompletionDeferred(
+                detail="release_lock_contention"),
         )
         self.assertEqual(db.request(42)["status"], "downloading")
         # Spectral untouched.
@@ -2576,39 +2580,44 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         # apply_transition at all.
         self.assertEqual(db.status_history, [])
 
-    def test_true_outcome_flips_to_imported(self):
-        """Happy path: ``process_completed_album`` returns ``True`` and
+    def test_completed_outcome_flips_to_imported(self):
+        """Happy path: ``process_completed_album`` returns ``Completed`` and
         status was 'downloading' → flip to 'imported'."""
         from lib import download as dl_mod
+        from lib.download_processing import Completed
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: True,
+            process_album_fn=lambda *_a, **_kw: Completed(),
         )
         self.assertEqual(db.request(42)["status"], "imported")
 
-    def test_false_outcome_resets_to_wanted_with_attempt(self):
-        """Failure: ``process_completed_album`` returns ``False`` →
-        reset to 'wanted' with an attempt increment (genuine failure
+    def test_completion_failed_resets_to_wanted_with_attempt(self):
+        """Failure: ``process_completed_album`` returns ``CompletionFailed``
+        → reset to 'wanted' with an attempt increment (genuine failure
         DOES deserve a backoff-scored attempt)."""
         from lib import download as dl_mod
+        from lib.download_processing import CompletionFailed
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: False,
+            process_album_fn=lambda *_a, **_kw: CompletionFailed(
+                reason="staged_path_missing"),
         )
         self.assertEqual(db.request(42)["status"], "wanted")
 
-    def test_false_outcome_after_inner_rejection_does_not_double_transition(self):
+    def test_completion_failed_after_inner_rejection_does_not_double_transition(self):
         """If ``process_completed_album`` already requeued the row, the outer
-        ``False`` branch must not apply a second reset-to-wanted transition.
+        ``CompletionFailed`` branch must not apply a second
+        reset-to-wanted transition.
         """
         from lib import download as dl_mod
         from lib import transitions
+        from lib.download_processing import CompletionFailed
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
@@ -2621,7 +2630,7 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
                     from_status="downloading",
                 ),
             )
-            return False
+            return CompletionFailed(reason="beets_validation_rejected")
 
         dl_mod._run_completed_processing(
             self._entry(),
@@ -2637,9 +2646,12 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         self.assertEqual(db.status_history, [(42, "wanted")])
 
     def test_dispatch_outcome_does_not_drive_fallback_transition(self):
-        """Dispatch summaries are queue results, not fallback bool outcomes."""
+        """Dispatch summaries are queue results, not fallback status
+        transitions — ``CompletionDispatched`` passes the wrapped
+        ``DispatchOutcome`` straight through untouched."""
         from lib import download as dl_mod
         from lib.dispatch import DispatchOutcome
+        from lib.download_processing import CompletionDispatched
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
@@ -2648,23 +2660,60 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             message="Pre-import gate rejected",
         )
 
-        with patch.object(
-            dl_mod,
-            "process_completed_album",
-            return_value=dispatch_outcome,
-        ):
-            outcome = dl_mod._run_completed_processing(
-                self._entry(),
-                42,
-                self._state(),
-                db,
-                self._ctx(db),
-                import_job_id=1,
-            )
+        result = dl_mod._run_completed_processing(
+            self._entry(),
+            42,
+            self._state(),
+            db,
+            self._ctx(db),
+            import_job_id=1,
+            process_album_fn=lambda *_a, **_kw: CompletionDispatched(
+                outcome=dispatch_outcome),
+        )
 
-        self.assertIs(outcome, dispatch_outcome)
+        assert isinstance(result, CompletionDispatched)
+        self.assertIs(result.outcome, dispatch_outcome)
         self.assertEqual(db.request(42)["status"], "downloading")
         self.assertEqual(db.status_history, [])
+
+    def test_real_process_completed_album_success_flips_to_imported(self):
+        """Integration slice: no DI stub — the REAL ``process_completed_album``
+        (materialize + validation-disabled path) runs through
+        ``_run_completed_processing`` end to end, and the ``Completed`` tag
+        it returns drives the status flip to 'imported'."""
+        from lib import download as dl_mod
+        from tests.helpers import make_download_file
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = os.path.join(tmpdir, "source_dir")
+            os.makedirs(src_dir)
+            src_file = os.path.join(src_dir, "01 - Track.mp3")
+            with open(src_file, "w") as f:
+                f.write("fake audio")
+
+            files = [make_download_file(
+                filename="source_dir\\01 - Track.mp3",
+                file_dir="source_dir",
+            )]
+            files[0].local_path = src_file
+            entry = self._entry()
+            entry.files = files
+            entry.mb_release_id = ""
+
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(id=42, status="downloading"))
+            ctx = self._ctx(db)
+            ctx.cfg.slskd_download_dir = tmpdir
+            ctx.cfg.beets_validation_enabled = False
+
+            result = dl_mod._run_completed_processing(
+                entry, 42, self._state(), db, ctx, import_job_id=1,
+            )
+
+        from lib.download_processing import Completed
+        self.assertIsInstance(result, Completed)
+        self.assertEqual(db.request(42)["status"], "imported")
+
 
 class TestBadAudioHashSlice(unittest.TestCase):
     """Integration slice: bad-audio-hash gate inside ``measure_preimport_state``.
@@ -3882,7 +3931,7 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
         Exercises ``_materialize_processing_dir`` (the actual fire site
         seen in production logs at ``lib/download.py:583``).
         """
-        from lib.download_processing import _materialize_processing_dir
+        from lib.download_processing import Materialized, _materialize_processing_dir
         from lib.staged_album import StagedAlbum
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -3893,12 +3942,13 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
             result = _materialize_processing_dir(
                 entry, staged_album, ctx)
 
-        self.assertIs(
-            result, True,
+        self.assertIsInstance(
+            result, Materialized,
             "Legacy wedged row (subprocess never launched) must "
-            "materialize the existing files for retry. Returning None "
-            "perpetuates the 2026-05-04 wedge: every cycle requeues a "
-            "job that fails in <50ms with POST-MOVE RESUME BLOCKED.",
+            "materialize the existing files for retry. Returning "
+            "MaterializeGuarded perpetuates the 2026-05-04 wedge: every "
+            "cycle requeues a job that fails in <50ms with POST-MOVE "
+            "RESUME BLOCKED.",
         )
         # And ``import_folder`` must be wired to the staged path so the
         # downstream tag-write/beets-validate sequence picks the files up.
@@ -3910,7 +3960,7 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
         attempt, preserves leftover files under failed_imports, and
         resets the request for a clean redownload.
         """
-        from lib.download_processing import _materialize_processing_dir
+        from lib.download_processing import MaterializeFailed, _materialize_processing_dir
         from lib.staged_album import StagedAlbum
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -3928,9 +3978,9 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
             )
             moved = os.listdir(failed_parent)
 
-        self.assertIs(
+        self.assertIsInstance(
             result,
-            False,
+            MaterializeFailed,
             "Subprocess-started residue must not retry in place; it should "
             "abandon and let the next search/download cycle own recovery.",
         )


### PR DESCRIPTION
## Summary

Replaces the anonymous `bool | DispatchOutcome | None` / `bool | None` unions returned by `process_completed_album` and `_materialize_processing_dir` with tagged frozen dataclasses, so pyright can exhaustiveness-check every consumer instead of relying on isinstance/identity ladders on bools. Pure-shape refactor — zero intended behaviour change.

Closes #474

## Old → new value mapping

**`_materialize_processing_dir` → `MaterializeResult`**

| Historical | New tag | Meaning |
|---|---|---|
| `True` | `Materialized()` | Files are present at the staged path; caller proceeds |
| `False` | `MaterializeFailed(reason: str)` | Local failure — poller retries within grace window, then resets to `wanted` |
| `None` | `MaterializeGuarded(detail: str)` | Ownership ambiguous — leave the row untouched, NEVER auto-reset |

**`process_completed_album` / `_run_completed_processing` → `CompletionResult`**

| Historical | New tag | Meaning |
|---|---|---|
| `True` | `Completed()` | Local success, no dispatch summary — caller finalizes to `imported` iff row still `downloading` |
| `False` | `CompletionFailed(reason: str)` | Local failure — caller resets to `wanted` iff row still `downloading` |
| raw `DispatchOutcome` | `CompletionDispatched(outcome: DispatchOutcome)` | Dispatch already owned the transition; `.outcome` is a queue-only summary, never drives a fallback transition |
| `None` | `CompletionDeferred(detail: str)` | Intentionally left untouched (release-lock contention, guarded post-move path, ownership-less reject) |

`reason`/`detail` fields are diagnostic only (consumers branch on the type tag, never the string). The original `logger.error(...)` diagnostics at each return site in `lib/download_processing.py` are unchanged, so nothing is lost.

## Blast radius

- `lib/download_processing.py` — defines the tagged types; `_materialize_processing_dir` and `process_completed_album` now return them (every historical return site mapped 1:1).
- `lib/download.py` — `_run_completed_processing` matches on `CompletionResult` ending in `assert_never`; `materialize_failure_action` takes `MaterializeResult`; `_enqueue_completed_processing` matches on `MaterializeResult`.
- `scripts/importer.py` — new shared `_dispatch_outcome_from_completion` helper (ending in `assert_never`) replaces two duplicated isinstance ladders in `execute_automation_import_job` / `execute_youtube_import_job`.
- `scripts/import_preview_worker.py` — `_materialize_automation_preview_path` updated to the new tag.
- Tests updated to assert on tags instead of identity: `tests/test_download.py` (`TestProcessCompletedAlbumReturnOwnership`, `TestEventPathMaterialization`, `TestMaterializeFailureAction`), `tests/test_import_queue.py` (automation + YouTube dispatcher tests), `tests/test_integration_slices.py` (`TestRunCompletedProcessingOutcomeBranching` + the two `_materialize_processing_dir` wedge-guard slices). Added one new integration slice (`test_real_process_completed_album_success_flips_to_imported`) that exercises the real `_run_completed_processing` → real `process_completed_album` → tag → status-transition path with no DI stub.

## Confirming zero behaviour change

- Every historical `True`/`False`/`None`/raw-`DispatchOutcome` return site was traced and mapped value-by-value (including the tricky `return False if handled else None` abandon branch, and the `outcome.deferred` split inside `process_completed_album`'s validation block).
- The poller's materialize-grace escape (`materialize_failure_action`) preserves the exact "leave" (guarded)/"retry"/"reset" (failed, grace-window-gated) decision table.
- **Exhaustiveness guard verified live**: temporarily added a bogus variant to the `CompletionResult` union (no consumer update) and confirmed `pyright` flagged both `assert_never` call sites (`lib/download.py`, `scripts/importer.py`) with a type error before reverting.
- Adversarial Opus review of the full diff: PASS, no bugs/missed consumers/weakened tests found.

## Test plan

- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings (full repo)
- [x] `nix-shell --run "python3 -m unittest discover -s tests -t ."` — 4664 tests, OK
- [x] `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code
- [x] JS syntax check + all `tests/test_js_*.mjs` — all green
- [x] Exhaustiveness guard manually verified (see above)
- [x] Pre-push `nix flake check` (VM boot gate + eval guards + CLI bundle) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)