### PR TITLE
fix: repair/convergence small follow-ups from #278

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -1,6 +1,6 @@
 # Pipeline DB Schema (key fields + JSONB audit blobs)
 
-The pipeline DB is PostgreSQL. DSN: `192.168.100.11:5432/cratedigger`. Access via `pipeline-cli` on doc2, or from doc1 via `ssh doc2 'pipeline-cli ...'`.
+The pipeline DB is PostgreSQL. DSN: `10.20.0.11:5432/cratedigger`. Access via `pipeline-cli` on doc2, or from doc1 via `ssh doc2 'pipeline-cli ...'`.
 
 Full schema lives in `migrations/*.sql`. This doc covers the fields that appear in debugging and the JSONB audit blobs.
 

--- a/lib/slskd_transfers.py
+++ b/lib/slskd_transfers.py
@@ -397,15 +397,22 @@ def _get_all_downloads_snapshot(
     slskd_client: Any,
     *,
     purpose: str,
+    include_removed: bool = True,
 ) -> list[dict[str, Any]] | None:
     """Fetch the full slskd download snapshot via the bulk endpoint.
 
     The username-scoped endpoint is unreliable for some valid peer names
     containing spaces/punctuation, so monitoring code uses the bulk list and
     matches locally instead.
+
+    ``include_removed`` defaults to True because most callers (poll,
+    re-derivation) need terminal transfers as evidence. The #278 orphan
+    convergence only reasons about live transfers (it skips ``Completed*``
+    states itself), so it passes False to trim the payload.
     """
     try:
-        downloads = slskd_client.transfers.get_all_downloads(includeRemoved=True)
+        downloads = slskd_client.transfers.get_all_downloads(
+            includeRemoved=include_removed)
     except Exception:
         logger.warning(f"Failed to get all downloads for {purpose}", exc_info=True)
         return None
@@ -438,7 +445,8 @@ def converge_slskd_orphans(ctx: CratediggerContext) -> int:
     from lib.quality import find_slskd_orphans
 
     downloads = _get_all_downloads_snapshot(
-        ctx.slskd, purpose="orphan-transfer convergence")
+        ctx.slskd, purpose="orphan-transfer convergence",
+        include_removed=False)
     if downloads is None:
         return 0
     db = ctx.pipeline_db_source._get_db()

--- a/scripts/cleanup_ghost_imported.py
+++ b/scripts/cleanup_ghost_imported.py
@@ -20,10 +20,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from lib.beets_db import BeetsDB
 from lib.pipeline_db import PipelineDB
 
-DEFAULT_DSN = os.environ.get(
-    "PIPELINE_DB_DSN",
-    "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
-)
+# No hardcoded fallback (#479): the nspawn DB has moved before (last time
+# to 10.20.0.11) and a baked-in IP silently dials a dead host forever
+# after the next move. Fail loud in main() instead of guessing.
+DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN")
 
 
 def _row_release_id(row: dict[str, Any]) -> str:
@@ -93,6 +93,11 @@ def main() -> int:
     mode.add_argument("--apply", action="store_true",
                       help="Delete matching ghost imported rows")
     args = parser.parse_args()
+    if not args.dsn:
+        parser.error(
+            "no DSN: set PIPELINE_DB_DSN or pass --dsn "
+            "(no hardcoded fallback — issue #479)"
+        )
 
     db = PipelineDB(args.dsn)
     try:

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -24,10 +24,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.migrator import DEFAULT_MIGRATIONS_DIR, apply_migrations
 
-DEFAULT_DSN = os.environ.get(
-    "PIPELINE_DB_DSN",
-    "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
-)
+# No hardcoded fallback (#479): the nspawn DB has moved before (last time
+# to 10.20.0.11) and a baked-in IP silently dials a dead host forever
+# after the next move. Fail loud in main() instead of guessing.
+DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN")
 
 
 def main() -> int:
@@ -35,7 +35,7 @@ def main() -> int:
     parser.add_argument(
         "--dsn",
         default=DEFAULT_DSN,
-        help="PostgreSQL DSN (default from PIPELINE_DB_DSN env or prod URL)",
+        help="PostgreSQL DSN (default from PIPELINE_DB_DSN env)",
     )
     parser.add_argument(
         "--migrations-dir",
@@ -43,6 +43,11 @@ def main() -> int:
         help=f"Directory containing NNN_name.sql files (default: {DEFAULT_MIGRATIONS_DIR})",
     )
     args = parser.parse_args()
+    if not args.dsn:
+        parser.error(
+            "no DSN: set PIPELINE_DB_DSN or pass --dsn "
+            "(no hardcoded fallback — issue #479)"
+        )
 
     logging.basicConfig(
         level=logging.INFO,

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from dataclasses import dataclass
 from typing import Any, Callable
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -30,22 +31,36 @@ from lib.download_recovery import (find_blocked_processing_path_issues,
 from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE, PipelineDB,
                              release_id_to_lock_key)
 from lib.processing_paths import directory_has_entries
-from lib.quality import (OrphanInfo, find_inconsistencies,
-                         find_orphaned_downloads, suggest_repair)
+from lib.quality import (OrphanInfo, SlskdOrphanTransfer, find_inconsistencies,
+                         find_orphaned_downloads, find_slskd_orphans,
+                         suggest_repair)
 
-DEFAULT_DSN = os.environ.get(
-    "PIPELINE_DB_DSN",
-    "postgresql://cratedigger@192.168.100.11:5432/cratedigger",
-)
+# No hardcoded fallback (#479): the nspawn DB has moved before (last time to
+# 10.20.0.11) and a baked-in IP silently dials a dead host forever after the
+# next move. Fail loud in main() instead of guessing.
+DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN")
 
-def _get_slskd_active_transfers(host: str, api_key: str) -> set[tuple[str, str]]:
-    """Fetch active (username, filename) pairs from slskd API."""
+
+def _fetch_slskd_downloads(host: str, api_key: str) -> list[dict[str, Any]]:
+    """Fetch the raw slskd ``get_all_downloads()`` snapshot (live transfers only).
+
+    Kept as its own network seam so ``_collect_issues`` can derive BOTH the
+    forward orphan view (``_active_transfer_pairs``) and the inverse
+    slskd-side orphan report (``lib.quality.find_slskd_orphans``) from one
+    fetch, instead of flattening to pairs and discarding the raw structure
+    the way this used to (#479 item 1).
+    """
     from lib.slskd_client import SlskdClient
     client = SlskdClient(host=host, api_key=api_key)
     downloads: Any = client.transfers.get_all_downloads(includeRemoved=False)
-    pairs: set[tuple[str, str]] = set()
     if not isinstance(downloads, list):
-        return pairs
+        return []
+    return downloads
+
+
+def _active_transfer_pairs(downloads: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    """Flatten a slskd downloads snapshot to (username, filename) pairs. Pure."""
+    pairs: set[tuple[str, str]] = set()
     for user_group in downloads:
         username = user_group.get("username", "")
         for d in user_group.get("directories", []):
@@ -54,6 +69,22 @@ def _get_slskd_active_transfers(host: str, api_key: str) -> set[tuple[str, str]]
                 if fname:
                     pairs.add((username, fname))
     return pairs
+
+
+@dataclass(frozen=True)
+class CollectedIssues:
+    """Result of ``_collect_issues`` (#479): actionable DB issues, plus a
+    read-only report of slskd-side orphans (live transfers no
+    ``downloading`` row owns).
+
+    ``slskd_orphans`` is informational only — ``cmd_fix`` never acts on it.
+    The #278 convergence (``lib.slskd_transfers.converge_slskd_orphans``,
+    run every cycle before search) is the only thing that ever cancels
+    these; it self-heals on its own next pass regardless of whether anyone
+    reads this report.
+    """
+    issues: list[OrphanInfo]
+    slskd_orphans: list[SlskdOrphanTransfer]
 
 
 def _dedupe_issues(issues: list[OrphanInfo]) -> list[OrphanInfo]:
@@ -128,7 +159,7 @@ def _collect_issues(
     *,
     find_orphaned_fn: "Callable[..., list[OrphanInfo]]" = find_orphaned_downloads,
     find_blocked_recovery_fn: "Callable[..., list[Any]]" = find_blocked_recovery_issues,
-) -> list:
+) -> CollectedIssues:
     """Collect all issues: DB inconsistencies + optional orphaned downloads.
 
     The two ``find_*_fn`` kwargs are dependency-injection seams. Production
@@ -140,10 +171,15 @@ def _collect_issues(
     issues = find_inconsistencies(rows)
     if slskd_host and slskd_key:
         try:
-            active = _get_slskd_active_transfers(slskd_host, slskd_key)
+            downloads = _fetch_slskd_downloads(slskd_host, slskd_key)
         except Exception as e:
             print(f"  slskd: could not check orphans: {e}")
-            return _dedupe_issues(issues)
+            return CollectedIssues(issues=_dedupe_issues(issues), slskd_orphans=[])
+
+        active = _active_transfer_pairs(downloads)
+        # Inverse direction (#278/#479): live transfers no downloading row
+        # owns. Report-only — nothing here ever cancels a transfer.
+        slskd_orphans = find_slskd_orphans(downloads, rows)
 
         orphans = find_orphaned_fn(
             rows,
@@ -156,7 +192,8 @@ def _collect_issues(
             cfg = read_runtime_config()
         except Exception as e:
             print(f"  slskd: could not load runtime config for local-path checks: {e}")
-            return _dedupe_issues(issues)
+            return CollectedIssues(
+                issues=_dedupe_issues(issues), slskd_orphans=slskd_orphans)
 
         blocked_processing_path_issues: list[OrphanInfo] = []
         blocked_recovery_issues: list[OrphanInfo] = []
@@ -216,39 +253,66 @@ def _collect_issues(
             and not blocked_recovery_issues
         ):
             print(f"  slskd: checked {len(active)} active transfers, no orphans.")
-        return issues
+        return CollectedIssues(issues=issues, slskd_orphans=slskd_orphans)
 
     downloading = [r for r in rows if r["status"] == "downloading"
                    and r.get("active_download_state")]
     if downloading:
         print(f"  Note: {len(downloading)} downloading row(s) — pass "
               "--slskd-host/--slskd-key to check for orphans.")
-    return _dedupe_issues(issues)
+    return CollectedIssues(issues=_dedupe_issues(issues), slskd_orphans=[])
+
+
+def _print_slskd_orphan_report(slskd_orphans: list[SlskdOrphanTransfer]) -> None:
+    """Report-only (#479 item 1): live slskd transfers no ``downloading``
+    row owns. Never triggers a cancel — the #278 convergence
+    (``lib.slskd_transfers.converge_slskd_orphans``) is the only thing
+    that reaps these, on its own next cycle.
+    """
+    if not slskd_orphans:
+        return
+    print(
+        f"slskd-side orphans (read-only, {len(slskd_orphans)}): live "
+        "transfer(s) with no owning downloading row. The #278 "
+        "convergence cancels these automatically next cycle — no action "
+        "needed here.\n"
+    )
+    for orphan in slskd_orphans:
+        print(f"  user={orphan.username!r} file={orphan.filename!r} "
+              f"state={orphan.state!r} id={orphan.transfer_id}")
+    print()
 
 
 def cmd_scan(db: PipelineDB, slskd_host: str | None = None,
              slskd_key: str | None = None) -> list:
     """Scan for inconsistencies and print them."""
-    issues = _collect_issues(db, slskd_host, slskd_key)
+    collected = _collect_issues(db, slskd_host, slskd_key)
+    issues = collected.issues
 
     if not issues:
         print("No inconsistencies found.")
-        return []
+    else:
+        print(f"Found {len(issues)} inconsistency(ies):\n")
+        for issue in issues:
+            repair = suggest_repair(issue)
+            print(f"  [{issue.request_id}] {issue.issue_type}: {issue.detail}")
+            print(f"         → suggested: {repair.action} — {repair.detail}")
+            print()
 
-    print(f"Found {len(issues)} inconsistency(ies):\n")
-    for issue in issues:
-        repair = suggest_repair(issue)
-        print(f"  [{issue.request_id}] {issue.issue_type}: {issue.detail}")
-        print(f"         → suggested: {repair.action} — {repair.detail}")
-        print()
-
+    _print_slskd_orphan_report(collected.slskd_orphans)
     return issues
 
 
 def cmd_fix(db: PipelineDB, slskd_host: str | None = None,
             slskd_key: str | None = None) -> None:
-    """Apply suggested repairs."""
-    issues = _collect_issues(db, slskd_host, slskd_key)
+    """Apply suggested repairs.
+
+    Only ``collected.issues`` is actionable here. ``collected.slskd_orphans``
+    is deliberately ignored — it's a read-only report (see ``cmd_scan``);
+    the #278 convergence is the only path that ever cancels a slskd
+    transfer.
+    """
+    issues = _collect_issues(db, slskd_host, slskd_key).issues
 
     if not issues:
         print("No inconsistencies found. Nothing to fix.")
@@ -296,6 +360,11 @@ def main():
     sub.add_parser("fix", help="Apply suggested repairs")
 
     args = parser.parse_args()
+    if not args.dsn:
+        parser.error(
+            "no DSN: set PIPELINE_DB_DSN or pass --dsn "
+            "(no hardcoded fallback — issue #479)"
+        )
     if not args.command:
         parser.print_help()
         sys.exit(1)

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -392,9 +392,12 @@ _LEAF_SEAM_PATTERNS = [
     re.compile(r"^scripts\.pipeline_cli\._resolve_failed_path$"),
 
     # scripts.repair helpers that wrap external boundaries.
-    # ``_get_slskd_active_transfers`` is a thin slskd HTTP call;
-    # ``_get_all_rows`` runs a single SELECT against the pipeline DB.
-    re.compile(r"^scripts\.repair\._get_slskd_active_transfers$"),
+    # ``_fetch_slskd_downloads`` is a thin slskd HTTP call (#479 rename of
+    # the former ``_get_slskd_active_transfers``, which flattened to pairs
+    # inline — now split so the raw snapshot survives for
+    # ``find_slskd_orphans`` too); ``_get_all_rows`` runs a single SELECT
+    # against the pipeline DB.
+    re.compile(r"^scripts\.repair\._fetch_slskd_downloads$"),
     re.compile(r"^scripts\.repair\._get_all_rows$"),
 
     # DB connection reconnect — network/socket boundary.

--- a/tests/fixtures/test_config.ini
+++ b/tests/fixtures/test_config.ini
@@ -47,7 +47,7 @@ tracking_file = /mnt/virtio/Music/Re-download/beets-validated.jsonl
 
 [Pipeline DB]
 enabled = True
-dsn = postgresql://cratedigger@192.168.100.11:5432/cratedigger
+dsn = postgresql://cratedigger@10.20.0.11:5432/cratedigger
 
 [Meelo]
 url = http://192.168.1.29:5001

--- a/tests/test_cleanup_ghost_imported.py
+++ b/tests/test_cleanup_ghost_imported.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 """Tests for scripts/cleanup_ghost_imported.py."""
 
+import io
 import os
 import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.beets_db import BeetsDB
+from scripts import cleanup_ghost_imported
 from scripts.cleanup_ghost_imported import classify_imported_rows
 
 
@@ -101,6 +105,21 @@ class TestCleanupGhostImported(unittest.TestCase):
 
         self.assertEqual(ghosts, [])
         self.assertEqual([row["id"] for row in manual_review], [7])
+
+
+class TestDefaultDsnFailsLoud(unittest.TestCase):
+    """#479 item 2: no hardcoded fallback — fail loud instead."""
+
+    @patch.object(cleanup_ghost_imported, "DEFAULT_DSN", None)
+    def test_main_fails_loud_when_dsn_is_not_configured(self) -> None:
+        with patch.object(sys, "argv", ["cleanup_ghost_imported.py"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as cm:
+                    cleanup_ghost_imported.main()
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("PIPELINE_DB_DSN", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -285,7 +285,7 @@ class TestConfigFromIni(unittest.TestCase):
 
     def test_pipeline_db_dsn(self):
         self.assertEqual(self.cfg.pipeline_db_dsn,
-                         "postgresql://cratedigger@192.168.100.11:5432/cratedigger")
+                         "postgresql://cratedigger@10.20.0.11:5432/cratedigger")
 
     # --- Meelo ---
     def test_meelo_url(self):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -4421,6 +4421,18 @@ class TestConvergeSlskdOrphans(unittest.TestCase):
         self.assertEqual(calls[0].username, "peer2")
         self.assertEqual(calls[0].id, "t-orphan")
 
+    def test_snapshot_fetch_excludes_removed_transfers(self):
+        """#479 item 3: convergence only needs live transfers — trim the
+        payload by requesting includeRemoved=False (it filters
+        Completed* itself, so removed/terminal history is dead weight)."""
+        from lib.slskd_transfers import converge_slskd_orphans
+        slskd = self._seed_slskd()
+        ctx = self._make_ctx(slskd, rows=[self._owning_row()])
+
+        converge_slskd_orphans(ctx)
+
+        self.assertEqual(slskd.transfers.get_all_downloads_calls, [False])
+
     def test_no_downloading_rows_cancels_stranded_transfer(self):
         """The Replace scenario: zero downloading rows, one live transfer."""
         from lib.slskd_transfers import converge_slskd_orphans

--- a/tests/test_migrate_db.py
+++ b/tests/test_migrate_db.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Tests for scripts/migrate_db.py CLI wiring."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stderr
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts import migrate_db
+
+
+class TestDefaultDsnFailsLoud(unittest.TestCase):
+    """#479 item 2: no hardcoded fallback — fail loud instead."""
+
+    @patch.object(migrate_db, "DEFAULT_DSN", None)
+    def test_main_fails_loud_when_dsn_is_not_configured(self) -> None:
+        with patch.object(sys, "argv", ["migrate_db.py"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as cm:
+                    migrate_db.main()
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("PIPELINE_DB_DSN", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -6,7 +6,7 @@ import io
 import os
 import sys
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from typing import Any, cast
 
-from lib.quality import OrphanInfo
+from lib.quality import OrphanInfo, SlskdOrphanTransfer
 from scripts import repair
 from tests.fakes import FakePipelineDB
 
@@ -28,13 +28,16 @@ class TestCmdFix(unittest.TestCase):
         mock_finalize,
     ) -> None:
         db = FakePipelineDB()
-        mock_collect_issues.return_value = [
-            OrphanInfo(
-                request_id=17,
-                issue_type="orphaned_download",
-                detail="transfers gone",
-            )
-        ]
+        mock_collect_issues.return_value = repair.CollectedIssues(
+            issues=[
+                OrphanInfo(
+                    request_id=17,
+                    issue_type="orphaned_download",
+                    detail="transfers gone",
+                )
+            ],
+            slskd_orphans=[],
+        )
 
         stdout = io.StringIO()
         with redirect_stdout(stdout):
@@ -119,38 +122,39 @@ class TestCollectIssues(unittest.TestCase):
         self.assertIsNone(result)
         self.assertIn("could not probe auto-import lock for request 17", stdout.getvalue())
 
-    @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
+    @patch("scripts.repair._fetch_slskd_downloads", return_value=[])
     @patch("scripts.repair.read_runtime_config", side_effect=RuntimeError("cfg boom"))
     @patch("scripts.repair._get_all_rows", return_value=[])
     def test_collect_issues_reports_runtime_config_failure_separately(
         self,
         _mock_get_rows,
         _mock_read_runtime_config,
-        _mock_active_transfers,
+        _mock_fetch_downloads,
     ) -> None:
         stdout = io.StringIO()
 
         with redirect_stdout(stdout):
-            issues = repair._collect_issues(
+            collected = repair._collect_issues(
                 MagicMock(),
                 slskd_host="http://slskd",
                 slskd_key="secret",
             )
 
-        self.assertEqual(issues, [])
+        self.assertEqual(collected.issues, [])
+        self.assertEqual(collected.slskd_orphans, [])
         self.assertIn(
             "could not load runtime config for local-path checks: cfg boom",
             stdout.getvalue(),
         )
 
-    @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
+    @patch("scripts.repair._fetch_slskd_downloads", return_value=[])
     @patch("scripts.repair.read_runtime_config", side_effect=RuntimeError("cfg boom"))
     @patch("scripts.repair._get_all_rows", return_value=[])
     def test_collect_issues_keeps_orphans_when_runtime_config_load_fails(
         self,
         _mock_get_rows,
         _mock_read_runtime_config,
-        _mock_active_transfers,
+        _mock_fetch_downloads,
     ) -> None:
         orphans = [
             OrphanInfo(
@@ -162,15 +166,15 @@ class TestCollectIssues(unittest.TestCase):
 
         stdout = io.StringIO()
         with redirect_stdout(stdout):
-            issues = repair._collect_issues(
+            collected = repair._collect_issues(
                 MagicMock(),
                 slskd_host="http://slskd",
                 slskd_key="secret",
                 find_orphaned_fn=lambda rows, active, existing_local_paths=None: orphans,
             )
 
-        self.assertEqual(len(issues), 1)
-        self.assertEqual(issues[0].issue_type, "orphaned_download")
+        self.assertEqual(len(collected.issues), 1)
+        self.assertEqual(collected.issues[0].issue_type, "orphaned_download")
         self.assertIn(
             "could not load runtime config for local-path checks: cfg boom",
             stdout.getvalue(),
@@ -180,14 +184,14 @@ class TestCollectIssues(unittest.TestCase):
         "scripts.repair.find_blocked_processing_path_issues",
         side_effect=PermissionError("perm boom"),
     )
-    @patch("scripts.repair._get_slskd_active_transfers", return_value=set())
+    @patch("scripts.repair._fetch_slskd_downloads", return_value=[])
     @patch("scripts.repair.read_runtime_config")
     @patch("scripts.repair._get_all_rows", return_value=[])
     def test_collect_issues_keeps_orphans_when_local_path_probe_fails(
         self,
         _mock_get_rows,
         mock_read_runtime_config,
-        _mock_active_transfers,
+        _mock_fetch_downloads,
         _mock_find_blocked_processing,
     ) -> None:
         mock_read_runtime_config.return_value = SimpleNamespace(
@@ -204,7 +208,7 @@ class TestCollectIssues(unittest.TestCase):
 
         stdout = io.StringIO()
         with redirect_stdout(stdout):
-            issues = repair._collect_issues(
+            collected = repair._collect_issues(
                 MagicMock(),
                 slskd_host="http://slskd",
                 slskd_key="secret",
@@ -212,12 +216,155 @@ class TestCollectIssues(unittest.TestCase):
                 find_blocked_recovery_fn=lambda *args, **kwargs: [],
             )
 
-        self.assertEqual(len(issues), 1)
-        self.assertEqual(issues[0].issue_type, "orphaned_download")
+        self.assertEqual(len(collected.issues), 1)
+        self.assertEqual(collected.issues[0].issue_type, "orphaned_download")
         self.assertIn(
             "could not inspect local recovery paths: perm boom",
             stdout.getvalue(),
         )
+
+
+class TestCollectIssuesSlskdOrphanReport(unittest.TestCase):
+    """#479 item 1: scan surfaces slskd-side orphans (read-only).
+
+    ``find_slskd_orphans`` runs for real against the same raw snapshot
+    ``_fetch_slskd_downloads`` already fetched for the forward
+    (``orphaned_download``) check — no second network round-trip, and no
+    ``fix`` action is derived from it (the #278 convergence in
+    ``lib.slskd_transfers.converge_slskd_orphans`` is the only thing that
+    ever cancels these).
+    """
+
+    RAW_SNAPSHOT = [
+        {
+            "username": "peer1",
+            "directories": [{
+                "directory": "Music\\Orphan",
+                "files": [{
+                    "id": "t-orphan",
+                    "filename": "Music\\Orphan\\01.flac",
+                    "state": "InProgress",
+                }],
+            }],
+        },
+    ]
+
+    @patch("scripts.repair._fetch_slskd_downloads", return_value=RAW_SNAPSHOT)
+    @patch("scripts.repair.read_runtime_config")
+    @patch("scripts.repair._get_all_rows", return_value=[])
+    def test_collect_issues_derives_slskd_orphans_from_the_same_snapshot(
+        self,
+        _mock_get_rows,
+        mock_read_runtime_config,
+        _mock_fetch_downloads,
+    ) -> None:
+        mock_read_runtime_config.return_value = SimpleNamespace(
+            beets_staging_dir="/tmp/staging",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        collected = repair._collect_issues(
+            MagicMock(),
+            slskd_host="http://slskd",
+            slskd_key="secret",
+            find_blocked_recovery_fn=lambda *args, **kwargs: [],
+        )
+
+        self.assertEqual(collected.issues, [])
+        self.assertEqual(len(collected.slskd_orphans), 1)
+        orphan = collected.slskd_orphans[0]
+        self.assertEqual(orphan.username, "peer1")
+        self.assertEqual(orphan.transfer_id, "t-orphan")
+        self.assertEqual(orphan.filename, "Music\\Orphan\\01.flac")
+        self.assertEqual(orphan.state, "InProgress")
+
+    @patch("scripts.repair._fetch_slskd_downloads", return_value=[])
+    @patch("scripts.repair._get_all_rows", return_value=[])
+    def test_collect_issues_reports_no_slskd_orphans_without_slskd_args(
+        self,
+        _mock_get_rows,
+        _mock_fetch_downloads,
+    ) -> None:
+        collected = repair._collect_issues(MagicMock(), None, None)
+
+        self.assertEqual(collected.slskd_orphans, [])
+        _mock_fetch_downloads.assert_not_called()
+
+
+class TestCmdScanSlskdOrphanReport(unittest.TestCase):
+    """#479 item 1: cmd_scan prints the slskd orphan report read-only."""
+
+    @patch("scripts.repair._collect_issues")
+    def test_scan_prints_slskd_orphans_without_touching_actionable_issues(
+        self, mock_collect,
+    ) -> None:
+        mock_collect.return_value = repair.CollectedIssues(
+            issues=[],
+            slskd_orphans=[
+                SlskdOrphanTransfer(
+                    username="peer1",
+                    transfer_id="t-orphan",
+                    filename="Music\\Orphan\\01.flac",
+                    state="InProgress",
+                ),
+            ],
+        )
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            issues = repair.cmd_scan(cast(Any, FakePipelineDB()))
+
+        output = stdout.getvalue()
+        self.assertEqual(issues, [])
+        self.assertIn("peer1", output)
+        self.assertIn("t-orphan", output)
+        self.assertIn("read-only", output.lower())
+
+    @patch("scripts.repair._collect_issues")
+    def test_scan_slskd_orphan_report_does_not_affect_returned_issues(
+        self, mock_collect,
+    ) -> None:
+        mock_collect.return_value = repair.CollectedIssues(
+            issues=[
+                OrphanInfo(
+                    request_id=17,
+                    issue_type="orphaned_download",
+                    detail="transfers gone",
+                ),
+            ],
+            slskd_orphans=[
+                SlskdOrphanTransfer(
+                    username="peer1",
+                    transfer_id="t-orphan",
+                    filename="Music\\Orphan\\01.flac",
+                    state="InProgress",
+                ),
+            ],
+        )
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            issues = repair.cmd_scan(cast(Any, FakePipelineDB()))
+
+        # The read-only slskd-orphan report is additive — it never changes
+        # the actionable issue list cmd_fix would later consume.
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].request_id, 17)
+
+
+class TestDefaultDsnFailsLoud(unittest.TestCase):
+    """#479 item 2: no hardcoded fallback — fail loud instead."""
+
+    @patch.object(repair, "DEFAULT_DSN", None)
+    def test_main_fails_loud_when_dsn_is_not_configured(self) -> None:
+        with patch.object(sys, "argv", ["repair.py", "scan"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as cm:
+                    repair.main()
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("PIPELINE_DB_DSN", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/web/server.py
+++ b/web/server.py
@@ -4,7 +4,7 @@
 Browse MusicBrainz, add releases to the pipeline DB, view status.
 
 Usage:
-    python3 web/server.py --port 8085 --dsn postgresql://cratedigger@192.168.100.11/cratedigger
+    python3 web/server.py --port 8085 --dsn postgresql://cratedigger@10.20.0.11/cratedigger
 """
 
 import os


### PR DESCRIPTION
## Summary

Three small follow-ups surfaced while building the #278 orphan-transfer convergence (PR #478):

1. **`scripts/repair.py scan` now reports slskd-side orphans read-only.** The forward direction (`orphaned_download`: DB row with no slskd transfer) was already operator-visible; the inverse direction added in #278 (`lib.quality.find_slskd_orphans`) was convergence-only and invisible until the operator saw 3 transfers get cancelled with no prior warning. `_collect_issues` now keeps the raw slskd snapshot (instead of flattening straight to `(username, filename)` pairs and discarding it) and derives both views from it — no second network round-trip. `cmd_scan` prints a distinct "read-only" section; `cmd_fix` deliberately ignores it. No `fix` action exists for this — the #278 convergence (`converge_slskd_orphans`) remains the only thing that ever cancels a transfer.
2. **Dropped the stale hardcoded `192.168.100.11` DSN fallback.** The nspawn DB moved to `10.20.0.11`; the old fallback silently dialed a dead host. `scripts/repair.py`, `scripts/migrate_db.py`, and `scripts/cleanup_ghost_imported.py` all had the identical stale literal — all three now fail loud via `parser.error()` when `PIPELINE_DB_DSN` is unset and `--dsn` wasn't passed, so a future DB move can't silently go stale again. Also fixed the same literal in `web/server.py`'s usage docstring, `docs/pipeline-db-schema.md`, and the `test_config.py` fixture.
3. **`lib/slskd_transfers.py::_get_all_downloads_snapshot` gained `include_removed: bool = True`.** `converge_slskd_orphans()` passes `False` since it only reasons about live transfers (it already filters `Completed*` states client-side). Pure payload trim, behavior identical.

## Test plan

- [x] RED-first: added failing tests for the scan slskd-orphan report, the DSN fail-loud behavior (3 scripts), and the `include_removed=False` kwarg wiring; confirmed each failed against the pre-change code, then implemented and confirmed green.
- [x] `nix-shell --run "pyright"` — 0 errors across the full repo.
- [x] `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code.
- [x] `node --check web/js/*.js` and every `tests/test_js_*.mjs` — all pass.
- [x] `nix-shell --run "python3 -m unittest discover -s tests -t . -v"` — 4694 tests, OK (no real FAIL/ERROR entries; the grep hits are expected `logger.error(...)` lines from negative-path test scenarios).
- [x] Opus review pass on the diff (correctness, read-only guarantee, fail-loud behavior, kwarg wiring) — findings fixed before this PR.
- [x] Pre-push `nix flake check` passed.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)