### PR TITLE
refactor(nix): consolidate beets option surface into services.cratedigger.beets.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ You need: **NixOS**, **slskd** (`services.slskd` is in nixpkgs), and disk for mu
               downloadDir = "/srv/music/slskd-downloads";
             };
             pipelineDb.createLocally = true;   # local postgres, peer auth, no passwords
-            beetsConfig = {
+            beets.config = {
               directory = "/srv/music/library";
               library = "/srv/music/beets-library.db";
             };
-            beetsValidation = {
+            beets.validation = {
               stagingDir = "/srv/music/incoming";
               trackingFile = "/srv/music/beets-validated.jsonl";
             };
@@ -109,8 +109,8 @@ Out of the box, MusicBrainz matching uses **public musicbrainz.org** (works, rat
 | Mirror | Without it | Option | Sample |
 |---|---|---|---|
 | MusicBrainz | Functional but ~1 req/s | `musicbrainz.apiBase` | [`examples/musicbrainz-mirror.nix`](examples/musicbrainz-mirror.nix) |
-| Discogs | Discogs browse off; MB browse unaffected | `discogs.apiBase` + `beets.discogsMirrorUrl` | [`examples/discogs-mirror.nix`](examples/discogs-mirror.nix) |
-| LRCLIB (lyrics) | Public lrclib.net | `beets.lrclibUrl` | — |
+| Discogs | Discogs browse off; MB browse unaffected | `discogs.apiBase` + `beets.package.discogsMirrorUrl` | [`examples/discogs-mirror.nix`](examples/discogs-mirror.nix) |
+| LRCLIB (lyrics) | Public lrclib.net | `beets.package.lrclibUrl` | — |
 
 The full account (sizes, replication tokens, degraded-mode math) is in [`docs/mirrors.md`](docs/mirrors.md).
 

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -18,7 +18,7 @@ When Cratedigger downloads an album and it passes validation, beets is what actu
 ## Version & Installation
 
 - **Owned by cratedigger** (tier-2 packaging): the beets package, plugin closure, config, binary and library are all provisioned by cratedigger's own NixOS module from cratedigger's own flake.lock. There is no Home Manager beets anymore.
-- **Package**: `nix/beets.nix` — the pinned `python3Packages.beets` with the full built-in plugin closure. Mirror patches (Discogs mirror, local LRCLIB) are opt-in module knobs (`services.cratedigger.beets.discogsMirrorUrl` / `beets.lrclibUrl`), applied via `substituteInPlace` with `--replace-fail` as the drift alarm.
+- **Package**: `nix/beets.nix` — the pinned `python3Packages.beets` with the full built-in plugin closure. Mirror patches (Discogs mirror, local LRCLIB) are opt-in module knobs (`services.cratedigger.beets.package.discogsMirrorUrl` / `beets.package.lrclibUrl`), applied via `substituteInPlace` with `--replace-fail` as the drift alarm.
 - **Binary**: `cratedigger-beet` on the system PATH — the canonical manual-ops beet for the library cratedigger manages. It pins `BEETSDIR` at the module-rendered config, so operator invocations and pipeline subprocesses always read the SAME config.
 - **One store path everywhere**: the python library (`lib/beets_distance.py` in cratedigger-web), the dev shell, the harness interpreter, and `cratedigger-beet` all reference the same beets derivation. The real-beets contract test (`tests/test_harness_beets2_contract.py`) runs against exactly the beets production runs.
 
@@ -29,10 +29,10 @@ In modern beets (2.x), `musicbrainz` is a **plugin** that must be explicitly lis
 ## Configuration
 
 **Rendered config**: `/var/lib/cratedigger/beets/config.yaml` (BEETSDIR; rendered by the module's preStart — do NOT edit, it is overwritten on every service start)
-**Secrets**: `/var/lib/cratedigger/beets/secrets.yaml` (0400; materialized from `services.cratedigger.beets.discogsTokenFile`, included via beets `include:`)
+**Secrets**: `/var/lib/cratedigger/beets/secrets.yaml` (0400; materialized from `services.cratedigger.beets.package.discogsTokenFile`, included via beets `include:`)
 
 To change the config:
-1. Tunables (`beetsConfig.{directory,library}`, fetchart widths, `musicbrainz.*` via `musicbrainz.apiBase`) are module options — set them in the nixosconfig wrapper. Everything else (path templates, `duplicate_keys`, the plugin list) is a fixed literal in cratedigger's `nix/module.nix` `beetsSettings` — change it there, in this repo, with the U12-style rendered-config diff in mind.
+1. Tunables (`beets.config.{directory,library}`, fetchart widths, `musicbrainz.*` via `musicbrainz.apiBase`) are module options — set them in the nixosconfig wrapper. Everything else (path templates, `duplicate_keys`, the plugin list) is a fixed literal in cratedigger's `nix/module.nix` `beetsSettings` — change it there, in this repo, with the U12-style rendered-config diff in mind.
 2. Deploy via the normal flake flow (`.claude/rules/deploy.md`).
 3. Verify: `ssh doc2 'cat /var/lib/cratedigger/beets/config.yaml'` after the next service start.
 

--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -10,8 +10,8 @@ without it, and how the operator's instances are stood up.
 | Dependency | Without it | With it | Module option |
 |---|---|---|---|
 | MusicBrainz mirror | Works against public MB — functional but ~1 req/s | Production-speed matching (ratelimit 100) | `services.cratedigger.musicbrainz.apiBase` |
-| Discogs mirror | Discogs **browse is off** (clear 503); MB browse unaffected | Discogs search/artist/master/release browse + numeric-ID validation | `services.cratedigger.discogs.apiBase` + `beets.discogsMirrorUrl` |
-| LRCLIB instance | Lyrics fetched from public lrclib.net | Local lyrics lookups | `services.cratedigger.beets.lrclibUrl` |
+| Discogs mirror | Discogs **browse is off** (clear 503); MB browse unaffected | Discogs search/artist/master/release browse + numeric-ID validation | `services.cratedigger.discogs.apiBase` + `beets.package.discogsMirrorUrl` |
+| LRCLIB instance | Lyrics fetched from public lrclib.net | Local lyrics lookups | `services.cratedigger.beets.package.lrclibUrl` |
 | slskd | Nothing works — it's the Soulseek client | — | `services.slskd` exists in nixpkgs; point `slskd.hostUrl`/`apiKeyFile`/`downloadDir` at it |
 
 ## Public-MusicBrainz degraded mode (supported)
@@ -68,17 +68,17 @@ nspawn container on doc2, served at `https://discogs.ablz.au`).
 same pattern as this repo's tier-2 work) lives in the discogs-api repo.
 
 Wire it up: `services.cratedigger.discogs.apiBase` (browse) and
-`services.cratedigger.beets.discogsMirrorUrl` (build-time patch of the
+`services.cratedigger.beets.package.discogsMirrorUrl` (build-time patch of the
 beets discogs plugin, so *imports* also hit the mirror). The beets
 plugin additionally wants a Discogs user token via
-`beets.discogsTokenFile` (issue #117 `*File` pattern); tokenless installs
+`beets.package.discogsTokenFile` (issue #117 `*File` pattern); tokenless installs
 get a placeholder that keeps plugin load clean — public-Discogs lookups
 are then token-required.
 
 ## LRCLIB (optional)
 
 The operator runs a local LRCLIB instance (`http://192.168.1.35:3300`).
-`services.cratedigger.beets.lrclibUrl = "http://<host>:3300/api"`
+`services.cratedigger.beets.package.lrclibUrl = "http://<host>:3300/api"`
 build-time-patches the beets lyrics plugin at that base. Unset = public
 lrclib.net (stock behaviour).
 

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -18,13 +18,13 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `user` / `group` | `"root"` | Service identity. Default root because slskd downloads + beets need broad fs access. |
 | `src` | `../.` | Path to cratedigger source tree. Defaults to this flake's repo root. |
 | `packageSet` | cratedigger's own locked nixpkgs (via the flake export) | Package set for the runtime closure. Override = escape hatch, forfeits the tested-closure guarantee. |
-| `beets.discogsMirrorUrl` | `null` | When set, build-time-patches the beets discogs plugin to hit this mirror instead of api.discogs.com. |
-| `beets.lrclibUrl` | `null` | When set, build-time-patches the beets lyrics plugin's LRCLIB base to this URL. |
-| `beets.discogsTokenFile` | `null` | `*File` secret (issue #117): materialized into `${stateDir}/beets/secrets.yaml` (0400) + `include:` in the rendered config. Null = placeholder token (plugins load cleanly; public-Discogs lookups are token-required). |
-| `beetsConfig.{directory,library}` | production values | Rendered into the module-owned `config.yaml`. `beetsDirectory` (config.ini) follows `beetsConfig.directory` by default. |
-| `beetsConfig.fetchart.{maxwidth,minwidth}` | `500` / `300` | Load-bearing: library size (embedded art × every track) and the Meelo black-box floor. |
-| `beetsConfig.musicbrainz.{host,https,ratelimit}` | derived from `musicbrainz.apiBase` | mkDefault-derived (mirror ⇒ host:port/http/ratelimit 100; public ⇒ musicbrainz.org/https/1); override to pin explicitly. |
-| `musicbrainz.apiBase` | `https://musicbrainz.org` | ONE MB origin for web/mb.py (`--mb-api`), pipeline-cli lookups, and the rendered beets musicbrainz block (KTD6). Public default is functional but ~1 req/s. |
+| `beets.package.discogsMirrorUrl` | `null` | When set, build-time-patches the beets discogs plugin to hit this mirror instead of api.discogs.com. |
+| `beets.package.lrclibUrl` | `null` | When set, build-time-patches the beets lyrics plugin's LRCLIB base to this URL. |
+| `beets.package.discogsTokenFile` | `null` | `*File` secret (issue #117): materialized into `${stateDir}/beets/secrets.yaml` (0400) + `include:` in the rendered config. Null = placeholder token (plugins load cleanly; public-Discogs lookups are token-required). |
+| `beets.config.{directory,library}` | production values | Rendered into the module-owned `config.yaml`. `beets.directory` (config.ini) follows `beets.config.directory` by default. |
+| `beets.config.fetchart.{maxwidth,minwidth}` | `500` / `300` | Load-bearing: library size (embedded art × every track) and the Meelo black-box floor. |
+| `beets.config.musicbrainz.{host,https,ratelimit}` | derived from `musicbrainz.apiBase` | mkDefault-derived (mirror ⇒ host:port/http/ratelimit 100; public ⇒ musicbrainz.org/https/1); override to pin explicitly. |
+| `musicbrainz.apiBase` | `https://musicbrainz.org` | ONE MB origin for web/mb.py (via config.ini, read at `cratedigger-web` startup), pipeline-cli lookups, and the rendered beets musicbrainz block (KTD6). Public default is functional but ~1 req/s. |
 | `discogs.apiBase` | `null` | Discogs mirror origin. Mirror-REQUIRED: unset ⇒ Discogs browse off with a 503 mirror-required message (public api.discogs.com does not serve this API shape). |
 | `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
@@ -34,7 +34,7 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `pipelineDb.createLocally` | `false` | Provision local PostgreSQL: role + database named after `cfg.user`, unix-socket peer auth (no password material anywhere), socket DSN default, migrate unit ordered after postgresql.service. doc2 keeps `false` + its nspawn DSN. |
 | `redis.{enable,host,port,maxmemory}` | enabled, `127.0.0.1:6379`, `2gb` | App-owned local Redis server for the pipeline peer cache and web metadata cache. Uses `allkeys-lru`. |
 | `peerCache.{ttlSeconds,speedTtlSeconds,redisConnectTimeoutMs,redisOperationTimeoutMs}` | 7d, 24h, 200ms, 100ms | Redis TTL and timeout settings rendered into `[Peer Cache]`. |
-| `beetsValidation.{enable,distanceThreshold,stagingDir,trackingFile,verifiedLosslessTarget}` | sensible defaults | Beets validation config. |
+| `beets.validation.{enable,distanceThreshold,stagingDir,trackingFile,verifiedLosslessTarget}` | sensible defaults | Beets validation config. |
 | `web.{enable,port,beetsDb,redis.host,redis.port}` | port=8085 | Web UI config. `web.redis.*` follows the shared app Redis defaults unless explicitly overridden. |
 | `notifiers.meelo.{enable,url,usernameFile,passwordFile}` | disabled | Meelo notifier. |
 | `notifiers.plex.{enable,url,tokenFile,librarySectionId,pathMap}` | disabled | Plex notifier. |
@@ -65,7 +65,7 @@ Three options under `services.cratedigger.searchSettings.*` control the slskd se
 1. Builds a Python environment with dependencies (`nix/package.nix`: psycopg2, music-tag, beets, msgspec, redis, zstandard) from the pinned `packageSet`. The beets in that env is the cratedigger-owned derivation (`nix/beets.nix`) — one store path serving the python library (`lib/beets_distance.py`), the `cratedigger-beet` wrapper (which pins `BEETSDIR` at `${stateDir}/beets`), and — from U5 — the harness.
 2. Wraps `cratedigger.py` / `pipeline_cli.py` / `migrate_db.py` / `scripts/importer.py` / `scripts/import_preview_worker.py` / `web/server.py` in shell scripts with ffmpeg, sox, mp3val, flac in PATH.
 3. Renders `/var/lib/cratedigger/config.ini` at boot from option values, sed-substituting credentials read from each `*File` path. App units render through an atomic temp-file-and-rename step because importer, preview, web, and timer-driven services can start concurrently after migrations.
-3b. Renders the beets `config.yaml` into `${stateDir}/beets/` (BEETSDIR) the same way. `import.duplicate_keys.album: [mb_albumid, discogs_albumid]` (the Palo Santo data-loss invariant), the plugin list, and the path templates are fixed literals — NOT options. Only `beetsConfig.*` (directory, library, fetchart widths, musicbrainz host/https/ratelimit) is operator-tunable. With `beets.discogsTokenFile` set, `secrets.yaml` (0400) is materialized next to it and included.
+3b. Renders the beets `config.yaml` into `${stateDir}/beets/` (BEETSDIR) the same way. `import.duplicate_keys.album: [mb_albumid, discogs_albumid]` (the Palo Santo data-loss invariant), the plugin list, and the path templates are fixed literals — NOT options. Only `beets.config.*` (directory, library, fetchart widths, musicbrainz host/https/ratelimit) is operator-tunable. With `beets.package.discogsTokenFile` set, `secrets.yaml` (0400) is materialized next to it and included.
 4. Enables `redis-cratedigger.service` by default with bounded memory and `allkeys-lru`.
 5. Pre-start: health-check slskd → render config.ini → start `cratedigger.py`.
 

--- a/docs/plex-primer.md
+++ b/docs/plex-primer.md
@@ -115,7 +115,7 @@ The path-shape concerns are configurable; nothing is hardcoded:
 | Nothing configured | (warning logged) | Plex receives a relative path and silently no-ops |
 
 Via the Nix module, the equivalent options are
-`services.cratedigger.beetsDirectory` and
+`services.cratedigger.beets.directory` and
 `services.cratedigger.notifiers.plex.pathMap`.
 
 ## API Access

--- a/examples/cratedigger.nix
+++ b/examples/cratedigger.nix
@@ -54,11 +54,11 @@
     # --- Beets: cratedigger owns the package, config, and binary ------
     # `cratedigger-beet` lands on your PATH for manual ops (run it with
     # sudo — the service runs as root by default).
-    beetsConfig = {
+    beets.config = {
       directory = "/srv/music/library";          # where tagged albums live
       library = "/srv/music/beets-library.db";   # parent dir must exist
     };
-    beetsValidation = {
+    beets.validation = {
       stagingDir = "/srv/music/incoming";        # validated albums stage here
       trackingFile = "/srv/music/beets-validated.jsonl";
     };
@@ -78,7 +78,7 @@
     #
     # musicbrainz.apiBase = "http://mb-mirror.lan:5200";
     # discogs.apiBase = "http://discogs-mirror.lan:8086";
-    # beets = {
+    # beets.package = {
     #   discogsMirrorUrl = "http://discogs-mirror.lan:8086";
     #   lrclibUrl = "http://lrclib.lan:3300/api";
     #   # Discogs user token (https://www.discogs.com/settings/developers),

--- a/examples/discogs-mirror.nix
+++ b/examples/discogs-mirror.nix
@@ -13,7 +13,7 @@
 #
 # Wire cratedigger at it with:
 #   services.cratedigger.discogs.apiBase = "http://localhost:8086";
-#   services.cratedigger.beets.discogsMirrorUrl = "http://localhost:8086";
+#   services.cratedigger.beets.package.discogsMirrorUrl = "http://localhost:8086";
 #
 # Two units:
 #   discogs-import.service/.timer — monthly oneshot: download the latest

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
               slskd.apiKeyFile = "/run/secrets/slskd-key";
               slskd.downloadDir = "/mnt/music/slskd";
               pipelineDb.dsn = "postgresql://cratedigger@10.20.0.11:5432/cratedigger";
-              beetsValidation = {
+              beets.validation = {
                 stagingDir = "/mnt/music/incoming";
                 trackingFile = "/mnt/music/incoming/tracking.jsonl";
               };
@@ -134,7 +134,7 @@
               slskd.apiKeyFile = "/etc/slskd-key";
               slskd.downloadDir = "/srv/slskd";
               pipelineDb.createLocally = true;
-              beetsValidation = {
+              beets.validation = {
                 stagingDir = "/srv/incoming";
                 trackingFile = "/srv/incoming/tracking.jsonl";
               };
@@ -158,7 +158,7 @@
               services.cratedigger.enable = true;
               services.cratedigger.musicbrainz.apiBase = apiBase;
             } ];
-          }).config.services.cratedigger.beetsConfig.musicbrainz;
+          }).config.services.cratedigger.beets.config.musicbrainz;
           mirror = evalMb "http://192.168.1.35:5200";
           public = evalMb "https://musicbrainz.org";
         in

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -34,8 +34,8 @@
   # harness interpreter joins in U5.
   beetsEnv = import ./beets.nix {
     pkgs = cfg.packageSet;
-    discogsMirrorUrl = cfg.beets.discogsMirrorUrl;
-    lrclibUrl = cfg.beets.lrclibUrl;
+    discogsMirrorUrl = cfg.beets.package.discogsMirrorUrl;
+    lrclibUrl = cfg.beets.package.lrclibUrl;
   };
 
   # Config dir every beets consumer resolves via BEETSDIR (beets' native
@@ -61,7 +61,7 @@
   #     importer's post-import `beet move` reproduces the 2026-05-18
   #     asciify mass-split (1,178 albums).
   beetsSettings = let
-    bc = cfg.beetsConfig;
+    bc = cfg.beets.config;
   in {
     directory = bc.directory;
     library = bc.library;
@@ -133,7 +133,7 @@
       the = true;
     };
   } // (
-    if cfg.beets.discogsTokenFile != null then {
+    if cfg.beets.package.discogsTokenFile != null then {
       # Real token: issue #117 *File pattern — preStart materializes
       # secrets.yaml (0400) next to config.yaml; the world-readable
       # config.yaml carries only the include.
@@ -234,14 +234,20 @@
     # sees (previously it silently read the invoking user's defaults).
     export BEETSDIR="${beetsConfigDir}"
     export PYTHONPATH="${src}''${PYTHONPATH:+:$PYTHONPATH}"
+    # MB/Discogs API bases are NOT passed here (issue #497): config.ini's
+    # [MusicBrainz]/[Discogs] api_base is the ONE production source, read at
+    # startup via configure_api_bases_from_runtime_config(). The
+    # --mb-api/--discogs-api flags still exist on web/server.py for
+    # dev-only overrides for a manual `cratedigger-web` invocation — the module
+    # deliberately stops passing them so there is no second path to keep
+    # in sync with config.ini.
     exec ${pyRunner} ${src}/web/server.py \
       --port ${toString cfg.web.port} \
       --dsn "${pipelineDsn}" \
       --beets-db "${cfg.web.beetsDb}" \
       --redis-host "${cfg.web.redis.host}" \
       --redis-port ${toString cfg.web.redis.port} \
-      --mb-api "${cfg.musicbrainz.apiBase}/ws/2" \
-      ${optionalString (cfg.discogs.apiBase != null) ''--discogs-api "${cfg.discogs.apiBase}" ''}"$@"
+      "$@"
   '';
 
   # YouTube-rescue ingest drainer — see scripts/youtube_ingest_worker.py.
@@ -257,7 +263,7 @@
     exec ${pyRunner} ${src}/scripts/youtube_ingest_worker.py \
       --dsn "${pipelineDsn}" \
       --temp-dir "${cfg.youtubeIngest.tempDir}" \
-      --staging-dir "${toString cfg.beetsValidation.stagingDir}" \
+      --staging-dir "${toString cfg.beets.validation.stagingDir}" \
       --poll-interval ${toString cfg.youtubeIngest.pollIntervalSeconds} \
       ${optionalString (cfg.youtubeIngest.sourceAddress != "") ''--source-address "${cfg.youtubeIngest.sourceAddress}" ''}"$@"
   '';
@@ -344,18 +350,18 @@
     extensions_whitelist = ${concatStringsSep "," cfg.downloadSettings.extensionsWhitelist}
 
     [Beets]
-    directory = ${cfg.beetsDirectory}
+    directory = ${cfg.beets.directory}
     config_dir = ${beetsConfigDir}
     beet_binary = ${pythonEnv}/bin/beet
     python = ${pythonEnv}/bin/python
 
     [Beets Validation]
-    enabled = ${if cfg.beetsValidation.enable then "True" else "False"}
-    harness_path = ${cfg.beetsValidation.harnessPath}
-    distance_threshold = ${toString cfg.beetsValidation.distanceThreshold}
-    staging_dir = ${toString cfg.beetsValidation.stagingDir}
-    tracking_file = ${toString cfg.beetsValidation.trackingFile}
-    verified_lossless_target = ${cfg.beetsValidation.verifiedLosslessTarget}
+    enabled = ${if cfg.beets.validation.enable then "True" else "False"}
+    harness_path = ${cfg.beets.validation.harnessPath}
+    distance_threshold = ${toString cfg.beets.validation.distanceThreshold}
+    staging_dir = ${toString cfg.beets.validation.stagingDir}
+    tracking_file = ${toString cfg.beets.validation.trackingFile}
+    verified_lossless_target = ${cfg.beets.validation.verifiedLosslessTarget}
 
     [MusicBrainz]
     api_base = ${cfg.musicbrainz.apiBase}
@@ -425,19 +431,19 @@
     ${pkgs.coreutils}/bin/chmod 0644 "$tmp_yaml"
     ${pkgs.coreutils}/bin/mv -f "$tmp_yaml" "$beets_dir/config.yaml"
     trap - EXIT
-    ${optionalString (cfg.beets.discogsTokenFile != null) ''
+    ${optionalString (cfg.beets.package.discogsTokenFile != null) ''
       # Discogs token: *File pattern (issue #117) — the token lands only
       # in a 0400 secrets.yaml owned by the service user, never in the
       # world-readable config.yaml. Bare assignment so a failed cat
       # (unreadable secret) fails the unit under set -e instead of being
       # swallowed inside a printf argument.
-      discogs_token="$(${pkgs.coreutils}/bin/cat "${cfg.beets.discogsTokenFile}")"
+      discogs_token="$(${pkgs.coreutils}/bin/cat "${cfg.beets.package.discogsTokenFile}")"
       if [ -z "$discogs_token" ]; then
         # An empty user_token re-enables the discogs plugin's interactive
         # OAuth flow at load — the exact hazard the placeholder/token
         # design exists to kill. Fail loud instead of deploying green
         # with a broken beets.
-        echo "cratedigger: beets.discogsTokenFile (${cfg.beets.discogsTokenFile}) is empty — refusing to render an empty discogs user_token" >&2
+        echo "cratedigger: beets.package.discogsTokenFile (${cfg.beets.package.discogsTokenFile}) is empty — refusing to render an empty discogs user_token" >&2
         exit 1
       fi
       # YAML single-quoted scalar; embedded single quotes doubled.
@@ -772,43 +778,171 @@ in {
       };
     };
 
+    # ONE beets option tree (issue #497): package build-time knobs
+    # (beets.package.*), the operator-tunable subset of the rendered
+    # config.yaml (beets.config.*), the config.ini [Beets] directory
+    # (beets.directory), and the pipeline validation gate (beets.validation.*)
+    # all live under services.cratedigger.beets.*. Everything under
+    # beets.config NOT listed here (path templates, duplicate_keys, plugin
+    # list, match weights, ...) is rendered as a fixed production-parity
+    # literal — see beetsSettings above for why.
     beets = {
-      discogsMirrorUrl = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "https://discogs.ablz.au";
+      package = {
+        discogsMirrorUrl = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "https://discogs.ablz.au";
+          description = ''
+            When set, the beets discogs plugin's client is patched
+            (substituteInPlace at build time) to use this base URL instead of
+            public api.discogs.com. Null = stock plugin behaviour (public
+            Discogs, token required for lookups — see the discogs token
+            handling in the rendered beets config).
+          '';
+        };
+        lrclibUrl = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "http://192.168.1.35:3300/api";
+          description = ''
+            When set, the beets lyrics plugin's LRCLIB base URL is patched
+            (substituteInPlace at build time) to this value instead of public
+            lrclib.net. Null = stock plugin behaviour.
+          '';
+        };
+        discogsTokenFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            Path to a file containing a Discogs user token (raw, one line).
+            Same contract as slskd.apiKeyFile (issue #117): must be readable
+            by services.cratedigger.user. When set, preStart materializes it
+            into ''${stateDir}/beets/secrets.yaml (mode 0400) and the rendered
+            config.yaml includes it. When null, a non-empty placeholder token
+            is rendered instead so the discogs plugin loads without its
+            interactive OAuth flow — public-Discogs lookups then fail
+            per-use until a real token is provided (documented
+            token-required).
+          '';
+        };
+      };
+
+      config = {
+        directory = mkOption {
+          type = types.str;
+          default = "/mnt/virtio/Music/Beets";
+          description = ''
+            Beets library root (config.yaml `directory:`). Production-matching
+            default (tier-2 plan R5); strangers point this at their music
+            root.
+          '';
+        };
+        library = mkOption {
+          type = types.str;
+          default = "/mnt/virtio/Music/beets-library.db";
+          description = ''
+            Beets library SQLite DB (config.yaml `library:`). The import log
+            renders next to it as beets-import.log. The parent directory must
+            exist at runtime: `beet` prompts interactively ("Create it
+            (Y/n)?") when it's missing, which blocks any non-interactive
+            invocation.
+          '';
+        };
+        fetchart = {
+          maxwidth = mkOption {
+            type = types.int;
+            default = 500;
+            description = ''
+              fetchart maxwidth. Load-bearing: embedded art is duplicated in
+              every track, so width drives library size (500px ≈ 71KB vs
+              1138KB unresized across ~83K tracks = ~85GB saved).
+            '';
+          };
+          minwidth = mkOption {
+            type = types.int;
+            default = 300;
+            description = ''
+              fetchart minwidth. Load-bearing: art under ~2KB renders as
+              black boxes in Meelo — 300px is the observed floor.
+            '';
+          };
+        };
+        musicbrainz = {
+          host = mkOption {
+            type = types.str;
+            default = "musicbrainz.org";
+            description = ''
+              MusicBrainz host for beets (config.yaml `musicbrainz.host`).
+              Default is public MB — functional but rate-limited (~1 req/s).
+              Point at a local mirror (host:port) for production-speed
+              matching; https and ratelimit below must be set coherently.
+            '';
+          };
+          https = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether beets talks TLS to musicbrainz.host (true for public MB, typically false for a LAN mirror).";
+          };
+          ratelimit = mkOption {
+            type = types.int;
+            default = 1;
+            description = "beets musicbrainz ratelimit (req/s). 1 for public MB; 100 against a local mirror.";
+          };
+        };
+      };
+
+      # config.ini [Beets] directory. Follows beets.config.directory by
+      # default (mkDefault'd in the config block below).
+      directory = mkOption {
+        type = types.str;
+        default = "";
+        example = "/mnt/virtio/Music/Beets";
         description = ''
-          When set, the beets discogs plugin's client is patched
-          (substituteInPlace at build time) to use this base URL instead of
-          public api.discogs.com. Null = stock plugin behaviour (public
-          Discogs, token required for lookups — see the discogs token
-          handling in the rendered beets config).
+          Absolute path to the beets library root (matches `directory:` in
+          ~/.config/beets/config.yaml). Beets stores file paths in its SQLite
+          DB as relative to this root, so consumers that perform host-side
+          filesystem ops (cleanup_disambiguation_orphans) or send absolute
+          paths to external services (trigger_plex_scan on bare-metal Plex)
+          need to absolutize against this root.
+
+          Optional but recommended. Leave empty if you provide an equivalent
+          absolute prefix via notifiers.plex.pathMap (Docker remap form
+          `/host/beets:/container/path`).
         '';
       };
-      lrclibUrl = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "http://192.168.1.35:3300/api";
-        description = ''
-          When set, the beets lyrics plugin's LRCLIB base URL is patched
-          (substituteInPlace at build time) to this value instead of public
-          lrclib.net. Null = stock plugin behaviour.
-        '';
-      };
-      discogsTokenFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        description = ''
-          Path to a file containing a Discogs user token (raw, one line).
-          Same contract as slskd.apiKeyFile (issue #117): must be readable
-          by services.cratedigger.user. When set, preStart materializes it
-          into ''${stateDir}/beets/secrets.yaml (mode 0400) and the rendered
-          config.yaml includes it. When null, a non-empty placeholder token
-          is rendered instead so the discogs plugin loads without its
-          interactive OAuth flow — public-Discogs lookups then fail
-          per-use until a real token is provided (documented
-          token-required).
-        '';
+
+      validation = {
+        enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Validate every download against MusicBrainz via beets before import.";
+        };
+        harnessPath = mkOption {
+          type = types.str;
+          default = "${cfg.src}/harness/run_beets_harness.sh";
+          defaultText = lib.literalExpression "\${cfg.src}/harness/run_beets_harness.sh";
+          description = "Path to the beets harness wrapper script.";
+        };
+        distanceThreshold = mkOption {
+          type = types.float;
+          default = 0.15;
+          description = "Maximum beets match distance to accept (0.0 = perfect, 1.0 = no match).";
+        };
+        stagingDir = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Directory to stage validated albums for beets import. Required when beets.validation.enable.";
+        };
+        trackingFile = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "JSONL file tracking beets validation results. Required when beets.validation.enable.";
+        };
+        verifiedLosslessTarget = mkOption {
+          type = types.str;
+          default = "";
+          description = "Target format after verified lossless (e.g. 'opus 128', 'mp3 v2'). Empty = keep V0.";
+        };
       };
     };
 
@@ -820,10 +954,12 @@ in {
         description = ''
           MusicBrainz API origin (scheme://host[:port], no path) — ONE value
           threaded to all three consumers (tier-2 plan U6/KTD6): web/mb.py
-          (via cratedigger-web --mb-api), pipeline-cli release lookups, and
-          the rendered beets musicbrainz.{host,https,ratelimit}. Public MB
-          default is functional but rate-limited (~1 req/s); point at a
-          local mirror for production-speed matching.
+          (via config.ini [MusicBrainz] api_base, read at cratedigger-web
+          startup by configure_api_bases_from_runtime_config()), pipeline-cli
+          release lookups, and the rendered beets
+          musicbrainz.{host,https,ratelimit}. Public MB default is functional
+          but rate-limited (~1 req/s); point at a local mirror for
+          production-speed matching.
         '';
       };
     };
@@ -840,128 +976,8 @@ in {
           Null = Discogs browse off (clear 503 mirror-required message);
           MusicBrainz browse is unaffected. The beets discogs plugin's own
           public-Discogs path (used by imports) is separate — see
-          beets.discogsMirrorUrl for its mirror knob.
+          beets.package.discogsMirrorUrl for its mirror knob.
         '';
-      };
-    };
-
-    # Operator-tunable subset of the rendered beets config.yaml. Everything
-    # NOT listed here (path templates, duplicate_keys, plugin list, match
-    # weights, ...) is rendered as a fixed production-parity literal — see
-    # beetsSettings above for why.
-    beetsConfig = {
-      directory = mkOption {
-        type = types.str;
-        default = "/mnt/virtio/Music/Beets";
-        description = ''
-          Beets library root (config.yaml `directory:`). Production-matching
-          default (tier-2 plan R5); strangers point this at their music
-          root.
-        '';
-      };
-      library = mkOption {
-        type = types.str;
-        default = "/mnt/virtio/Music/beets-library.db";
-        description = ''
-          Beets library SQLite DB (config.yaml `library:`). The import log
-          renders next to it as beets-import.log. The parent directory must
-          exist at runtime: `beet` prompts interactively ("Create it
-          (Y/n)?") when it's missing, which blocks any non-interactive
-          invocation.
-        '';
-      };
-      fetchart = {
-        maxwidth = mkOption {
-          type = types.int;
-          default = 500;
-          description = ''
-            fetchart maxwidth. Load-bearing: embedded art is duplicated in
-            every track, so width drives library size (500px ≈ 71KB vs
-            1138KB unresized across ~83K tracks = ~85GB saved).
-          '';
-        };
-        minwidth = mkOption {
-          type = types.int;
-          default = 300;
-          description = ''
-            fetchart minwidth. Load-bearing: art under ~2KB renders as
-            black boxes in Meelo — 300px is the observed floor.
-          '';
-        };
-      };
-      musicbrainz = {
-        host = mkOption {
-          type = types.str;
-          default = "musicbrainz.org";
-          description = ''
-            MusicBrainz host for beets (config.yaml `musicbrainz.host`).
-            Default is public MB — functional but rate-limited (~1 req/s).
-            Point at a local mirror (host:port) for production-speed
-            matching; https and ratelimit below must be set coherently.
-          '';
-        };
-        https = mkOption {
-          type = types.bool;
-          default = true;
-          description = "Whether beets talks TLS to musicbrainz.host (true for public MB, typically false for a LAN mirror).";
-        };
-        ratelimit = mkOption {
-          type = types.int;
-          default = 1;
-          description = "beets musicbrainz ratelimit (req/s). 1 for public MB; 100 against a local mirror.";
-        };
-      };
-    };
-
-    beetsDirectory = mkOption {
-      type = types.str;
-      default = "";
-      example = "/mnt/virtio/Music/Beets";
-      description = ''
-        Absolute path to the beets library root (matches `directory:` in
-        ~/.config/beets/config.yaml). Beets stores file paths in its SQLite
-        DB as relative to this root, so consumers that perform host-side
-        filesystem ops (cleanup_disambiguation_orphans) or send absolute
-        paths to external services (trigger_plex_scan on bare-metal Plex)
-        need to absolutize against this root.
-
-        Optional but recommended. Leave empty if you provide an equivalent
-        absolute prefix via notifiers.plex.pathMap (Docker remap form
-        `/host/beets:/container/path`).
-      '';
-    };
-
-    beetsValidation = {
-      enable = mkOption {
-        type = types.bool;
-        default = true;
-        description = "Validate every download against MusicBrainz via beets before import.";
-      };
-      harnessPath = mkOption {
-        type = types.str;
-        default = "${cfg.src}/harness/run_beets_harness.sh";
-        defaultText = lib.literalExpression "\${cfg.src}/harness/run_beets_harness.sh";
-        description = "Path to the beets harness wrapper script.";
-      };
-      distanceThreshold = mkOption {
-        type = types.float;
-        default = 0.15;
-        description = "Maximum beets match distance to accept (0.0 = perfect, 1.0 = no match).";
-      };
-      stagingDir = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "Directory to stage validated albums for beets import. Required when beetsValidation.enable.";
-      };
-      trackingFile = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "JSONL file tracking beets validation results. Required when beetsValidation.enable.";
-      };
-      verifiedLosslessTarget = mkOption {
-        type = types.str;
-        default = "";
-        description = "Target format after verified lossless (e.g. 'opus 128', 'mp3 v2'). Empty = keep V0.";
       };
     };
 
@@ -1255,15 +1271,15 @@ in {
         message = "services.cratedigger.pipelineDb: set either pipelineDb.dsn (external PostgreSQL) or pipelineDb.createLocally = true (provision a local database with peer auth).";
       }
       {
-        assertion = !cfg.beetsValidation.enable || (cfg.beetsValidation.stagingDir != null && cfg.beetsValidation.trackingFile != null);
-        message = "services.cratedigger.beetsValidation: enable requires stagingDir (where validated albums stage for import) and trackingFile (JSONL validation log).";
+        assertion = !cfg.beets.validation.enable || (cfg.beets.validation.stagingDir != null && cfg.beets.validation.trackingFile != null);
+        message = "services.cratedigger.beets.validation: enable requires stagingDir (where validated albums stage for import) and trackingFile (JSONL validation log).";
       }
       {
         # The rescue worker stages into the same beets Incoming root; an
         # unset stagingDir would silently render --staging-dir "" and
         # strand rescues under the state dir.
-        assertion = !cfg.youtubeIngest.enable || cfg.beetsValidation.stagingDir != null;
-        message = "services.cratedigger.youtubeIngest: enable requires beetsValidation.stagingDir (rescues stage under its auto-import/ child).";
+        assertion = !cfg.youtubeIngest.enable || cfg.beets.validation.stagingDir != null;
+        message = "services.cratedigger.youtubeIngest: enable requires beets.validation.stagingDir (rescues stage under its auto-import/ child).";
       }
       {
         assertion = lib.hasPrefix "http://" cfg.musicbrainz.apiBase || lib.hasPrefix "https://" cfg.musicbrainz.apiBase;
@@ -1343,14 +1359,14 @@ in {
     services.cratedigger.web.redis.port = lib.mkDefault cfg.redis.port;
     # One concept, one value: the config.ini [Beets] directory follows the
     # rendered beets config.yaml `directory:` unless explicitly overridden.
-    services.cratedigger.beetsDirectory = lib.mkDefault cfg.beetsConfig.directory;
+    services.cratedigger.beets.directory = lib.mkDefault cfg.beets.config.directory;
 
     # One MB value, three consumers (U6/KTD6): the rendered beets
     # musicbrainz block derives from musicbrainz.apiBase — mirror =>
     # host:port / plain http / ratelimit 100 (the harness --upstream
     # block's inverse); public => musicbrainz.org / https / ratelimit 1.
     # mkDefault so an operator can still pin the beets block explicitly.
-    services.cratedigger.beetsConfig.musicbrainz = let
+    services.cratedigger.beets.config.musicbrainz = let
       mbHost = lib.removePrefix "https://" (lib.removePrefix "http://" cfg.musicbrainz.apiBase);
       mbPublic = mbHost == "musicbrainz.org";
     in {

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -3,7 +3,7 @@
 # every `nix flake check`.
 #
 # Posture: pipelineDb.createLocally = true (module-provisioned postgres,
-# peer auth, no hand-rolled DB block), beetsValidation ON, VM-local beets
+# peer auth, no hand-rolled DB block), beets.validation ON, VM-local beets
 # paths, NO mirror knobs (public-MB defaults), no secrets beyond the
 # stubbed slskd key.
 #
@@ -90,7 +90,7 @@ pkgs.testers.nixosTest {
       # Stranger posture (U10/R12): beets validation ON — the full
       # rendered-config surface (config.ini beets keys + config.yaml) is
       # what a real first boot produces.
-      beetsValidation = {
+      beets.validation = {
         enable = true;
         stagingDir = "/var/lib/cratedigger-staging";
         trackingFile = "/var/lib/cratedigger-staging/tracking.jsonl";
@@ -99,7 +99,7 @@ pkgs.testers.nixosTest {
       # exist or `beet` prompts "Create it (Y/n)?" interactively — which
       # blocks forever under the test driver's backdoor shell. stateDir
       # exists by tmpfiles, so the library parent is guaranteed.
-      beetsConfig = {
+      beets.config = {
         directory = "/var/lib/cratedigger-music";
         library = "/var/lib/cratedigger/beets-library.db";
       };

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -190,8 +190,8 @@ class TestOwnedBeetsContract(unittest.TestCase):
         text = MODULE_NIX.read_text(encoding="utf-8")
         self.assertIn("beetsEnv = import ./beets.nix {", text)
         self.assertIn("pkgs = cfg.packageSet;", text)
-        self.assertIn("discogsMirrorUrl = cfg.beets.discogsMirrorUrl;", text)
-        self.assertIn("lrclibUrl = cfg.beets.lrclibUrl;", text)
+        self.assertIn("discogsMirrorUrl = cfg.beets.package.discogsMirrorUrl;", text)
+        self.assertIn("lrclibUrl = cfg.beets.package.lrclibUrl;", text)
         self.assertIn(
             "cratedigger = cfg.packageSet.callPackage ./package.nix { beetsPackage = beetsEnv; };",
             text,
@@ -212,6 +212,25 @@ class TestOwnedBeetsContract(unittest.TestCase):
         self.assertIn("discogsMirrorUrl ? null", beets_nix)
         self.assertIn("lrclibUrl ? null", beets_nix)
         self.assertIn("--replace-fail", beets_nix)
+
+    def test_beets_option_tree_is_consolidated(self) -> None:
+        """Issue #497: ONE beets option tree —
+        beets.{package,config,directory,validation} — not four separate
+        beets/beetsConfig/beetsValidation/beetsDirectory groups. No aliases,
+        no compat shims (scope.md): the old flat option names must be
+        entirely gone. (``beetsConfigDir``/``beetsConfigTemplate`` are
+        unrelated internal let-bindings for the rendered-config path/file —
+        not part of the option surface — so they're excluded here.)"""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("beets = {", text)
+        self.assertIn("package = {", text)
+        self.assertIn("config = {", text)
+        self.assertIn("validation = {", text)
+        self.assertNotIn("cfg.beetsConfig", text)
+        self.assertNotIn("beetsConfig = {", text)
+        self.assertNotIn("services.cratedigger.beetsConfig", text)
+        self.assertNotIn("beetsValidation", text)
+        self.assertNotIn("beetsDirectory", text)
 
 
 class TestRenderedBeetsConfigContract(unittest.TestCase):
@@ -332,14 +351,27 @@ class TestApiBaseThreading(unittest.TestCase):
         idx = text.index("discogs = {")
         self.assertIn("default = null;", text[idx:idx + 800])
 
-    def test_web_wrapper_passes_both_bases(self) -> None:
+    def test_web_wrapper_does_not_pass_api_base_flags(self) -> None:
+        """Issue #497: config.ini is the ONE production source for the MB/
+        Discogs API bases (read at startup via
+        configure_api_bases_from_runtime_config()). The module must not also
+        pass --mb-api/--discogs-api on the actual ExecStart invocation —
+        that was a second path carrying the same two values, which is
+        exactly the double-plumbing this consolidation removes. The flags
+        themselves stay on web/server.py for a manual dev-only override,
+        and a comment nearby is allowed to
+        mention them by name — only the invocation argv is asserted here."""
         text = MODULE_NIX.read_text(encoding="utf-8")
-        self.assertIn('--mb-api "${cfg.musicbrainz.apiBase}/ws/2"', text)
-        self.assertIn('--discogs-api "${cfg.discogs.apiBase}"', text)
+        web_start = text.index('writeShellScriptBin "cratedigger-web"')
+        exec_start = text.index("exec ${pyRunner} ${src}/web/server.py", web_start)
+        exec_end = text.index("'';", exec_start)
+        exec_block = text[exec_start:exec_end]
+        self.assertNotIn("--mb-api", exec_block)
+        self.assertNotIn("--discogs-api", exec_block)
 
     def test_beets_musicbrainz_derives_from_the_one_value(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")
-        self.assertIn("services.cratedigger.beetsConfig.musicbrainz = let", text)
+        self.assertIn("services.cratedigger.beets.config.musicbrainz = let", text)
         self.assertIn('mbHost = lib.removePrefix "https://" (lib.removePrefix "http://" cfg.musicbrainz.apiBase);', text)
         self.assertIn("ratelimit = lib.mkDefault (if mbPublic then 1 else 100);", text)
 

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -28,8 +28,11 @@ from web import cache as _cache
 # /api/masters/<id>, ...) and the msgspec response Structs are the Rust
 # Discogs mirror's shape — public api.discogs.com does not serve them, so
 # there is no functional public fallback. None = Discogs browse is off;
-# the server wires this from `cratedigger-web --discogs-api`
-# (services.cratedigger.discogs.apiBase).
+# the server wires this from config.ini [Discogs] api_base via
+# configure_api_bases_from_runtime_config() at cratedigger-web startup
+# (services.cratedigger.discogs.apiBase; issue #497 dropped the module's
+# --discogs-api flag in favor of config.ini as the one production source
+# — the flag itself survives as a dev-only override).
 DISCOGS_API_BASE: str | None = None
 
 
@@ -46,9 +49,8 @@ def _api_base() -> str:
         raise DiscogsMirrorNotConfigured(
             "Discogs browse requires a Discogs mirror: this API speaks the "
             "Rust mirror's endpoint shape, which public api.discogs.com "
-            "does not serve. Set services.cratedigger.discogs.apiBase "
-            "(cratedigger-web --discogs-api). Without a mirror, browse via "
-            "MusicBrainz only."
+            "does not serve. Set services.cratedigger.discogs.apiBase. "
+            "Without a mirror, browse via MusicBrainz only."
         )
     return DISCOGS_API_BASE
 USER_AGENT = "cratedigger-web/1.0"

--- a/web/mb.py
+++ b/web/mb.py
@@ -23,8 +23,12 @@ from web import cache as _cache
 
 # Default: public MusicBrainz (functional but rate-limited ~1 req/s).
 # Production points this at the local mirror via the module's
-# services.cratedigger.musicbrainz.apiBase -> `cratedigger-web --mb-api`
-# (tier-2 plan U6, R13/KTD6). The value includes the /ws/2 prefix.
+# services.cratedigger.musicbrainz.apiBase -> config.ini [MusicBrainz]
+# api_base -> configure_api_bases_from_runtime_config() at cratedigger-web
+# startup (tier-2 plan U6, R13/KTD6; issue #497 dropped the module's
+# --mb-api flag in favor of config.ini as the one production source — the
+# flag itself survives as a dev-only override). The value includes the
+# /ws/2 prefix.
 MB_API_BASE = "https://musicbrainz.org/ws/2"
 USER_AGENT = "cratedigger-web/1.0"
 

--- a/web/server.py
+++ b/web/server.py
@@ -528,9 +528,14 @@ def main():
     parser.add_argument("--port", type=int, default=8085)
     parser.add_argument("--dsn", default=os.environ.get("PIPELINE_DB_DSN", "postgresql://cratedigger@localhost/cratedigger"))
     parser.add_argument("--beets-db", default="/mnt/virtio/Music/beets-library.db")
-    parser.add_argument("--mb-api", default=None, help="MusicBrainz API base URL (full base incl. /ws/2)")
+    parser.add_argument("--mb-api", default=None,
+                        help="MusicBrainz API base URL (full base incl. /ws/2). Dev-only override — "
+                             "production reads config.ini [MusicBrainz] api_base (issue #497); the "
+                             "NixOS module does not pass this flag.")
     parser.add_argument("--discogs-api", default=None,
-                        help="Discogs mirror base URL (mirror-required; unset = Discogs browse off)")
+                        help="Discogs mirror base URL (mirror-required; unset = Discogs browse off). "
+                             "Dev-only override — production reads config.ini [Discogs] api_base "
+                             "(issue #497); the NixOS module does not pass this flag.")
     parser.add_argument("--redis-host", default=None, help="Redis host for caching (optional)")
     parser.add_argument("--redis-port", type=int, default=6379)
     args = parser.parse_args()
@@ -548,8 +553,11 @@ def main():
         # prefix in the helper or flush `meta:*` manually during deploy.
         cache.invalidate_pattern("web:*")
 
-    # API bases: runtime config first (shared startup wiring — the same
-    # call pipeline-cli and the youtube worker make), explicit flags win.
+    # API bases: config.ini is the ONE production source (issue #497 —
+    # the NixOS module no longer passes --mb-api/--discogs-api). Runtime
+    # config is read first (shared startup wiring — the same call
+    # pipeline-cli and the youtube worker make); the flags are a dev-only
+    # override for a manual invocation and win when set.
     # Config carries ORIGINS; the flag carries the full MB base incl.
     # /ws/2 (KTD6). Discogs stays unset without a mirror — web/discogs.py
     # then serves a clear 503 mirror-required (R13).


### PR DESCRIPTION
## Summary

- Renames the module's four separate beets-ish option groups (`beets.*`, `beetsConfig.*`, `beetsValidation.*`, `beetsDirectory`) into ONE coherent tree: `services.cratedigger.beets.{package,config,directory,validation}.*`. No aliases, no compat shims — the old flat names are removed entirely (`.claude/rules/scope.md`).
- Collapses the double-path API-base plumbing: `cratedigger-web`'s wrapper no longer passes `--mb-api`/`--discogs-api` (it previously threaded the same two `config.ini` values onto argv, carrying them twice). `config.ini` is now the ONE production source (`configure_api_bases_from_runtime_config()` at startup); the CLI flags themselves stay on `web/server.py` as dev-only overrides for a manual invocation.
- Updated in the same commit: `nix/module.nix`, `flake.nix` (eval-guard shapes), `nix/tests/module-vm.nix`, `examples/cratedigger.nix`, `examples/discogs-mirror.nix`, `docs/nixos-module.md`, `docs/beets-primer.md`, `docs/mirrors.md`, `docs/plex-primer.md`, `README.md`, `tests/test_nix_module.py`, and the `web/server.py`/`web/mb.py`/`web/discogs.py` comments/help-text that referenced the old flags.
- Rendered `config.yaml`/`config.ini` output is byte-identical — only option *names* moved. Did not split `nix/module.nix` into `nix/module/*` files (judgment call per the issue — the rename didn't touch enough of the file's structure to justify it).

Closes #497

**DEPLOY NOTE:** the homelab wrapper at `~/nixosconfig/modules/nixos/services/cratedigger.nix` (not in this repo) sets `beetsConfig`/`beetsValidation`/`beetsDirectory`/`beets.discogsMirrorUrl` etc. today and will fail to eval against the new module until it's updated to the `beets.{package,config,directory,validation}.*` shape at deploy time. This PR does not touch nixosconfig and does not deploy — that's the operator's leg at rollout.

## Test plan

- [x] `nix build .#checks.x86_64-linux.moduleVm` — passes (stranger-boot VM gate, byte-parity assertions on rendered `config.ini`/`config.yaml`)
- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings
- [x] `node --check web/js/*.js` — passes
- [x] every `tests/test_js_*.mjs` — all green (1231 assertions across files)
- [x] `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code
- [x] `nix-shell --run "python3 -m unittest discover -s tests -t . -v"` — 4687 tests, OK (including all 31 `tests/test_nix_module.py` contract tests, three new/updated for this PR)
- [x] `git push` — pre-push hook's `nix flake check` (moduleVm + eval guards + CLI bundle) passed
- [x] Independent Opus review pass (no bugs found; rename verified complete and byte-parity verified by tracing every interpolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)