### PR TITLE
refactor(web): consolidate long-tail console state into one Map (#481 item 1)

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -23,6 +23,7 @@ node tests/test_js_history.mjs || exit 1
 node tests/test_js_pipeline.mjs || exit 1
 node tests/test_js_pipeline_dashboard.mjs || exit 1
 node tests/test_js_wrong_matches.mjs || exit 1
+node tests/test_js_long_tail_console.mjs || exit 1
 echo ""
 
 # Dead-code sweep — fails fast on new vulture findings before the slow

--- a/tests/test_js_long_tail_console.mjs
+++ b/tests/test_js_long_tail_console.mjs
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for web/js/long_tail.js's console-state consolidation (#481
+ * item 1) — the pure open/close/prune/canStart/settle transition helpers
+ * over the single `Map<id, ConsoleState>` that replaced eight parallel
+ * module-scoped structures (a token Map, five in-flight guard Sets, a
+ * YouTube-result cache Map, and `state.longTail.open`).
+ *
+ * Every helper takes the map explicitly, so these tests build their own
+ * fresh `Map` per scenario rather than touching the module's real
+ * `consoleStates` singleton (exercised separately, as a DOM-free no-op
+ * check, in tests/test_js_util.mjs).
+ *
+ * Run with: node tests/test_js_long_tail_console.mjs
+ */
+
+import { __test__ } from '../web/js/long_tail.js';
+
+const {
+  consoleOpen,
+  consoleClose,
+  consolePrune,
+  consoleCanStart,
+  consoleSettle,
+  consoleClearGuards,
+  consoleToken,
+  consoleIsStale,
+  consoleIsOpen,
+  consoleYoutubeResult,
+  consoleSetYoutubeResult,
+  consoleOpenIds,
+} = __test__;
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, msg) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+function assertEqual(actual, expected, msg) {
+  if (actual === expected) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// --- consoleOpen / consoleClose / consoleIsOpen / consoleToken ---
+console.log('consoleOpen / consoleClose / consoleIsOpen / consoleToken');
+{
+  const map = new Map();
+  assertEqual(consoleIsOpen(map, 1), false, 'an untracked id is not open');
+  assertEqual(consoleToken(map, 1), 0, 'an untracked id has token 0');
+
+  const t1 = consoleOpen(map, 1);
+  assertEqual(t1, 1, 'consoleOpen returns the new (bumped) token');
+  assertEqual(consoleIsOpen(map, 1), true, 'consoleOpen marks the row open');
+  assertEqual(consoleToken(map, 1), 1, 'consoleToken reflects the just-opened token');
+
+  const t2 = consoleOpen(map, 1);
+  assertEqual(t2, 2, 're-opening bumps the token again');
+  assertEqual(consoleIsOpen(map, 1), true, 're-opening keeps the row open');
+
+  const t3 = consoleClose(map, 1);
+  assertEqual(t3, 3, 'consoleClose also bumps the token');
+  assertEqual(consoleIsOpen(map, 1), false, 'consoleClose marks the row closed');
+
+  // Closing a row that was never opened still creates a well-formed entry
+  // (mirrors the old `consoleTokens.set(id, (consoleTokens.get(id)||0)+1)`
+  // behaviour — collapsing a console the toggle handler never had to
+  // pre-open must not throw).
+  const freshClose = consoleClose(map, 99);
+  assertEqual(freshClose, 1, 'closing a never-opened id still bumps from 0');
+  assertEqual(consoleIsOpen(map, 99), false, 'a closed-only id reads as not open');
+
+  // Two rows are independent.
+  const map2 = new Map();
+  consoleOpen(map2, 5);
+  assertEqual(consoleToken(map2, 6), 0, 'a different id is unaffected by another id\'s open');
+}
+
+// --- consolePrune: the ONE prune function for BOTH call sites ---
+console.log('consolePrune');
+{
+  // Site shape 1: loadLongTail's fresh-cohort intersect — keep = cohort ids.
+  const map = new Map();
+  consoleOpen(map, 1);
+  consoleOpen(map, 2);
+  consoleOpen(map, 3);
+  consoleSetYoutubeResult(map, 2, { outcome: 'ok' });
+  consoleCanStart(map, 3, 'resolve');
+
+  const cohortIds = new Set([1, 3]);
+  consolePrune(map, (id) => cohortIds.has(id));
+  assertEqual(map.has(1), true, 'consolePrune keeps an id present in the cohort');
+  assertEqual(map.has(2), false, 'consolePrune drops an id absent from the cohort');
+  assertEqual(map.has(3), true, 'consolePrune keeps another cohort id');
+  // Dropping id 2 removed its ENTIRE state atomically — token, open flag,
+  // and (had it had one) its cached YouTube result — in one call. This is
+  // the bug class #481 item 1 kills: no second structure to forget.
+  assertEqual(consoleYoutubeResult(map, 2), null,
+    'consolePrune drops the cached YouTube result along with everything else for a pruned id');
+  // The kept id's OTHER state (in-flight guard) survived untouched.
+  assertEqual(consoleCanStart(map, 3, 'resolve'), false,
+    'consolePrune leaves a kept id\'s in-flight guard untouched');
+
+  // Site shape 2: removeRowFromCohort's single-row drop — keep = "not this id".
+  const map3 = new Map();
+  consoleOpen(map3, 10);
+  consoleOpen(map3, 11);
+  consolePrune(map3, (id) => id !== 10);
+  assertEqual(map3.has(10), false, 'consolePrune (single-row shape) drops exactly the removed id');
+  assertEqual(map3.has(11), true, 'consolePrune (single-row shape) leaves every other id untouched');
+}
+
+// --- consoleCanStart / consoleSettle: the double-fire guard pair ---
+console.log('consoleCanStart / consoleSettle');
+{
+  const map = new Map();
+  assertEqual(consoleCanStart(map, 5, 'resolve'), true,
+    'consoleCanStart: nothing outstanding → may start (and marks it started)');
+  assertEqual(consoleCanStart(map, 5, 'resolve'), false,
+    'consoleCanStart: an outstanding call for the same id+action → suppressed');
+  // A DIFFERENT action on the same id is independent — this is the whole
+  // point of naming actions instead of five separate Sets colliding on id.
+  assertEqual(consoleCanStart(map, 5, 'submit'), true,
+    'consoleCanStart: a different action on the same id is independent');
+  // A different id is independent too.
+  assertEqual(consoleCanStart(map, 6, 'resolve'), true,
+    'consoleCanStart: a different id is independent');
+
+  consoleSettle(map, 5, 'resolve');
+  assertEqual(consoleCanStart(map, 5, 'resolve'), true,
+    'consoleSettle clears the guard so a later call may start again');
+  // Settling one action does not clear a sibling action's guard.
+  assertEqual(consoleCanStart(map, 5, 'submit'), false,
+    'consoleSettle only clears the named action, not every action for the id');
+
+  // Settling an id with no tracked state at all is a safe no-op (the row
+  // may have been pruned while its fetch was outstanding).
+  consoleSettle(map, 12345, 'resolve');
+  assertEqual(map.has(12345), false, 'consoleSettle does not fabricate state for an untracked id');
+}
+
+// --- consoleClearGuards: LT-R1, sweeps every in-flight flag for one id ---
+console.log('consoleClearGuards');
+{
+  const map = new Map();
+  consoleOpen(map, 7);
+  consoleCanStart(map, 7, 'resolve');
+  consoleCanStart(map, 7, 'submit');
+  consoleCanStart(map, 7, 'intent');
+  consoleSetYoutubeResult(map, 7, { outcome: 'ok' });
+
+  consoleClearGuards(map, 7);
+  assertEqual(consoleCanStart(map, 7, 'resolve'), true,
+    'consoleClearGuards releases the resolve guard');
+  assertEqual(consoleCanStart(map, 7, 'submit'), true,
+    'consoleClearGuards releases the submit guard');
+  assertEqual(consoleCanStart(map, 7, 'intent'), true,
+    'consoleClearGuards releases the intent guard');
+  // LT-R1 clears guards WITHOUT touching open/youtubeResult — only the
+  // explicit toggle path calls this, never the #398 restore path.
+  assertEqual(consoleIsOpen(map, 7), true,
+    'consoleClearGuards does not touch the open flag');
+  assertEqual(consoleYoutubeResult(map, 7).outcome, 'ok',
+    'consoleClearGuards does not touch the cached YouTube result');
+
+  // A never-tracked id is a safe no-op.
+  consoleClearGuards(map, 999);
+  assertEqual(map.has(999), false, 'consoleClearGuards does not fabricate state for an untracked id');
+}
+
+// --- consoleYoutubeResult / consoleSetYoutubeResult: the #398 cache ---
+console.log('consoleYoutubeResult / consoleSetYoutubeResult');
+{
+  const map = new Map();
+  assertEqual(consoleYoutubeResult(map, 1), null, 'an untracked id has no cached result');
+  consoleSetYoutubeResult(map, 1, { outcome: 'ok', youtube_releases: [] });
+  assertEqual(consoleYoutubeResult(map, 1).outcome, 'ok', 'caches the settled resolver result');
+  // #398 fidelity: closing (collapsing) the console must NOT drop the cache
+  // — a later reopen restores the matrix instead of resetting to never_run.
+  consoleOpen(map, 1);
+  consoleClose(map, 1);
+  assertEqual(consoleYoutubeResult(map, 1).outcome, 'ok',
+    'consoleClose preserves the cached YouTube result (#398)');
+}
+
+// --- consoleOpenIds: drives restoreLongTailConsoles ---
+console.log('consoleOpenIds');
+{
+  const map = new Map();
+  consoleOpen(map, 1);
+  consoleOpen(map, 2);
+  consoleOpen(map, 3);
+  consoleClose(map, 2);
+  assertEqual(JSON.stringify(consoleOpenIds(map)), JSON.stringify([1, 3]),
+    'consoleOpenIds lists only ids currently marked open');
+  assertEqual(consoleOpenIds(new Map()).length, 0, 'consoleOpenIds on an empty map is empty');
+}
+
+// --- The two deliberate token semantics, made explicit (#481 item 1) ---
+console.log('consoleToken (resolver-settle) vs consoleIsStale (panel-paint)');
+{
+  const map = new Map();
+  const capturedToken = consoleOpen(map, 1);  // e.g. a panel fetch fires here.
+  assertEqual(consoleIsStale(map, 1, capturedToken), false,
+    'consoleIsStale: not stale immediately after the captured token was issued');
+  assertEqual(consoleToken(map, 1), capturedToken,
+    'consoleToken: matches the captured token before anything else happens');
+
+  // The operator collapses and reopens the console (or a #398 restore
+  // re-creates it) while a fetch stamped with `capturedToken` is still
+  // outstanding.
+  consoleClose(map, 1);
+  consoleOpen(map, 1);
+
+  // Panel-paint semantic: a fetch stamped with the OLD captured token must
+  // discard — the console it was fired against no longer exists.
+  assertEqual(consoleIsStale(map, 1, capturedToken), true,
+    'consoleIsStale: a fetch stamped with the captured token is stale after a reopen');
+
+  // Resolver-settle semantic: the YouTube resolver instead re-reads the
+  // CURRENT token at paint time (not the captured one) — because its panel
+  // container is per-row, so whatever console exists now is the only one it
+  // can paint into, including one re-created by a restore mid-flight.
+  const liveToken = consoleToken(map, 1);
+  assert(liveToken !== capturedToken,
+    'consoleToken: the current token has moved on from what was captured at fire time');
+  assertEqual(consoleIsStale(map, 1, liveToken), false,
+    'consoleIsStale: re-reading the CURRENT token (the resolver-settle pattern) is never stale');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -1320,14 +1320,14 @@ console.log('long_tail.js __test__');
   // --- renderLongTailBody: the three list states (DOM-free string paint) ---
   const { renderLongTailBody } = longTailTest;
   // Empty cohort -> empty-cohort affordance, never blank.
-  state.longTail = { rows: [], band: null, query: '', open: new Set() };
+  state.longTail = { rows: [], band: null, query: '' };
   const emptyCohort = renderLongTailBody();
   assert(
     emptyCohort.includes('No wanted releases in the long tail'),
     'renderLongTailBody empty cohort shows the empty-cohort affordance',
   );
   // Populated cohort -> tab strip + rows for the default (Missing) band.
-  state.longTail = { rows: cohort, band: null, query: '', open: new Set() };
+  state.longTail = { rows: cohort, band: null, query: '' };
   const populated = renderLongTailBody();
   assert(
     populated.includes('lt-band-tabs') && populated.includes('lt-search-input'),
@@ -1344,7 +1344,7 @@ console.log('long_tail.js __test__');
   );
   // Empty-band -> a search filters the selected band to zero; the
   // affordance + cross-band hint show, never a blank area.
-  state.longTail = { rows: cohort, band: 'missing', query: 'hecker', open: new Set() };
+  state.longTail = { rows: cohort, band: 'missing', query: 'hecker' };
   const emptyBand = renderLongTailBody();
   assert(
     emptyBand.includes('No Missing releases match'),
@@ -1355,7 +1355,7 @@ console.log('long_tail.js __test__');
     'renderLongTailBody empty-band surfaces the cross-band match hint',
   );
   // Reset shared state so later tests are not affected.
-  state.longTail = { rows: null, band: null, query: '', open: new Set() };
+  state.longTail = { rows: null, band: null, query: '' };
 }
 
 // --- long_tail.js action console pure helpers (U4) ---
@@ -1612,7 +1612,6 @@ console.log('long_tail.js __test__ (U5 rescue flow)');
     youtubeBestDistance,
     youtubeRescueTargets,
     rescueOutcomeCopy,
-    canStartInFlight,
     renderYoutubeBody,
     renderRescueConfirm,
   } = longTailTest;
@@ -1730,15 +1729,9 @@ console.log('long_tail.js __test__ (U5 rescue flow)');
   // null result → generic error, never throws.
   assertEqual(rescueOutcomeCopy(null).tone, 'error', 'rescueOutcomeCopy null → error tone (no throw)');
 
-  // --- canStartInFlight: double-fire guard predicate ---
-  const inFlightSet = new Set();
-  assertEqual(canStartInFlight(inFlightSet, 5), true,
-    'canStartInFlight: nothing outstanding → may start');
-  inFlightSet.add(5);
-  assertEqual(canStartInFlight(inFlightSet, 5), false,
-    'canStartInFlight: an outstanding call for the id → suppressed (double-fire guard)');
-  assertEqual(canStartInFlight(inFlightSet, 6), true,
-    'canStartInFlight: a different id is independent');
+  // The double-fire guard predicate is now `consoleCanStart` (part of the
+  // #481 item 1 console-state consolidation) — covered in
+  // tests/test_js_long_tail_console.mjs, not here.
 
   // --- renderRescueConfirm: reuses the .confirm-box shell ---
   const confirm = renderRescueConfirm(11, 'MPREb_x', { artist_name: 'Smog', album_title: 'Knock Knock' });
@@ -1874,20 +1867,23 @@ console.log('long_tail.js __test__ (U6 secondary actions)');
     'renderActionsBar: MB row with no release group disables accept-sibling');
 }
 
-// --- long_tail.js #398 console-persistence state ---
-console.log('long_tail.js console persistence (#398)');
+// --- long_tail.js #398 / #481 item 1 console-persistence state ---
+console.log('long_tail.js console persistence (#398 / #481 item 1)');
 {
-  // The open-console set must be initialised on the shared state — the
-  // restore path (and the toggle bookkeeping) read it unconditionally.
-  assert(state.longTail.open instanceof Set,
-    'state.longTail.open is a Set (open-console ids persist across re-renders)');
+  // Open-console tracking lives in the module-scoped `consoleStates` map
+  // (#481 item 1 — no longer on shared state; see tests/test_js_long_tail_console.mjs
+  // for the pure open/close/prune/canStart/settle transition coverage).
+  const { consoleStates } = longTailTest;
+  assert(consoleStates instanceof Map,
+    'consoleStates is a Map (open-console ids persist across re-renders)');
   // The DOM-side entry points are no-ops outside a browser — must not throw
-  // when the module is imported into the Node test runner.
+  // when the module is imported into the Node test runner, and must not
+  // fabricate console state for a row nobody opened.
   const { restoreLongTailConsoles, toggleLongTailDetail } = await import('../web/js/long_tail.js');
   restoreLongTailConsoles();
   toggleLongTailDetail(1);
-  assert(state.longTail.open.size === 0,
-    'DOM-side no-ops leave the open-console set untouched in Node');
+  assert(consoleStates.size === 0,
+    'DOM-side no-ops leave consoleStates untouched in Node');
 }
 
 // --- Summary ---

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -35,9 +35,9 @@
  *   1. "Check YouTube" (`checkYoutube`) — replaces U4's placeholder. Calls
  *      the SLOW, SIDE-EFFECTFUL resolver GET
  *      (`GET /api/youtube-album?identifier=<mb_release_id>`), disables the
- *      button + shows in-progress, GUARDS double-fire (a module-scoped
- *      `resolveInFlight` Set keyed by request id — a second click while
- *      outstanding fires nothing), and STAMPS the fetch with a per-row
+ *      button + shows in-progress, GUARDS double-fire
+ *      (`consoleCanStart(consoleStates, id, 'resolve')` — a second click
+ *      while outstanding fires nothing), and STAMPS the fetch with a per-row
  *      console token so a stale result (operator collapsed the console or
  *      moved to another row) never paints. On return the YouTube panel is
  *      re-rendered via `youtubeSectionState`: `resolved_with_matrix` →
@@ -85,16 +85,33 @@
  * no optimistic band moves, no polling. Set-imported / Delete remove just
  * the acted-on row's DOM nodes (it leaves the cohort); the confirmed Replace
  * closes the console and full-cohort refetches. Open consoles survive every
- * list re-render: `state.longTail.open` tracks expanded rows and
+ * list re-render: `consoleStates` tracks each row's open flag and
  * `restoreLongTailConsoles` re-opens them after the DOM wipe (#398).
+ *
+ * #481 item 1 (this unit): the console-state consolidation. Every per-row
+ * bookkeeping structure the console needs — the fetch token, the five
+ * action double-fire guards, the cached YouTube resolver result, and the
+ * open/closed flag — used to live in eight parallel module-scoped
+ * structures (plus `state.longTail.open` on shared state) with two
+ * independent prune sites that each had to remember to sweep every one of
+ * them (the #480 review caught two "forgot to prune one" instances — an
+ * open-set leak on full refetch, a stale resolver cache). `consoleStates`
+ * (a single `Map<id, ConsoleState>`) replaces all eight; five pure
+ * transition helpers (`consoleOpen`/`consoleClose`/`consolePrune`/
+ * `consoleCanStart`/`consoleSettle`) are the only way to mutate it, and
+ * `consolePrune` is the ONE prune function called from both former prune
+ * sites. The two deliberate token semantics from U5 are now explicit,
+ * separately named functions rather than comment-only: `consoleIsStale`
+ * (panel-paint — discard against the token CAPTURED at fetch time) vs.
+ * `consoleToken` (resolver-settle — read the CURRENT token at paint time).
  *
  * Pure / DOM-free helpers (band ordering, tab derivation, in-band search
  * filtering, cross-band match count, YouTube state classifier, console
- * emphasis selector) are exported via `__test__` for the Node unit suite.
- * The classifier + emphasis selector live in `util.js` (the shared pure
- * home) and are re-exported through `__test__` here for convenience.
- * Rendering and fetch live alongside them but never leak into the pure
- * helpers.
+ * emphasis selector, and the #481 console-state transitions) are exported
+ * via `__test__` for the Node unit suite. The classifier + emphasis
+ * selector live in `util.js` (the shared pure home) and are re-exported
+ * through `__test__` here for convenience. Rendering and fetch live
+ * alongside them but never leak into the pure helpers.
  *
  * Shape mirrors `web/js/search_plan.js` / `web/js/recents.js`:
  * `// @ts-check`, ES6 module, JSDoc on exports, the
@@ -510,15 +527,11 @@ export async function loadLongTail() {
     if (token !== longTailRequestToken) return;
     const rows = Array.isArray(data.results) ? data.results : [];
     state.longTail.rows = rows;
-    // Prune console-open marks (and cached resolver results) for rows that
-    // left the wanted cohort — imported out-of-band, replaced, deleted.
+    // Prune console state for rows that left the wanted cohort — imported
+    // out-of-band, replaced, deleted. One map, one prune function (#481
+    // item 1) — the fresh-cohort intersect.
     const cohortIds = new Set(rows.map((r) => r && r.id));
-    for (const openId of [...state.longTail.open]) {
-      if (!cohortIds.has(openId)) {
-        state.longTail.open.delete(openId);
-        youtubeResolveResults.delete(openId);
-      }
-    }
+    consolePrune(consoleStates, (id) => cohortIds.has(id));
     const tabs = deriveBandTabs(rows);
     // Pick a default band when none selected or the prior selection is
     // gone from the new cohort.
@@ -610,15 +623,263 @@ export function onLongTailSearchInput(value) {
 // source and patch only that panel's container. A per-row token guard
 // discards a console fetch that resolves after the operator has clicked a
 // different row (or re-collapsed this one).
+//
+// #481 item 1: all per-row console bookkeeping — the fetch token, the
+// five action double-fire guards (resolve/submit/intent/import/delete),
+// the cached YouTube resolver result, and the open/closed flag — used to
+// live in eight parallel module-scoped structures (plus `state.longTail.
+// open` on shared state) with two independent prune sites that each had to
+// remember to sweep every one of them. The #480 review caught two
+// "forgot to prune one" instances that shape produced. `consoleStates`
+// below is the single `Map<id, ConsoleState>` replacing all eight; the
+// five pure transition helpers (`consoleOpen`/`consoleClose`/
+// `consolePrune`/`consoleCanStart`/`consoleSettle`) are the only way to
+// mutate it, and `consolePrune` is the ONE prune function called from both
+// sites (`removeRowFromCohort`, `loadLongTail`'s fresh-cohort intersect).
 
 /**
- * Per-row console-fetch token. Bumped every time a row's console is
- * (re)opened so a slow panel fetch that resolves against a stale console
- * is discarded before it paints. Keyed by `album_requests.id`.
+ * Per-row console state — the single source of truth for everything the
+ * action console needs to track per `album_requests.id`. Replaces the
+ * eight parallel structures #481 item 1 called out (fetch token, five
+ * in-flight guard Sets, the YouTube-result cache, and the open-console
+ * Set) with one `Map<id, ConsoleState>` entry per row.
  *
- * @type {Map<number, number>}
+ * @typedef {Object} ConsoleState
+ * @property {boolean} open  Is this row's console currently expanded?
+ * @property {number} token  Per-row console-fetch token, bumped on every
+ *   {@link consoleOpen} / {@link consoleClose} so a panel fetch stamped
+ *   with a stale token is discarded before it paints ({@link consoleIsStale}).
+ * @property {Object|null} youtubeResult  The row's cached YouTube resolver
+ *   result (from a prior Check YouTube this session), so a console restore
+ *   after a list re-render doesn't reset a resolved matrix back to
+ *   `never_run` (#398).
+ * @property {Set<string>} inFlight  Action names (`'resolve'`, `'submit'`,
+ *   `'intent'`, `'import'`, `'delete'`) with an outstanding request —
+ *   double-fire guards, gated by {@link consoleCanStart} /
+ *   {@link consoleSettle}.
  */
-const consoleTokens = new Map();
+
+/**
+ * Per-row console state, keyed by `album_requests.id`. The single map
+ * backing every pure transition helper below — see the header comment for
+ * the eight-structures-to-one consolidation this replaces.
+ *
+ * @type {Map<number, ConsoleState>}
+ */
+const consoleStates = new Map();
+
+/**
+ * Get (creating if absent) the console-state entry for `id`. Every mutator
+ * below routes through this so a row's first touch — whichever action
+ * fires first — always finds a well-formed entry. Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {ConsoleState}
+ */
+function ensureConsoleState(map, id) {
+  let entry = map.get(id);
+  if (!entry) {
+    entry = { open: false, token: 0, youtubeResult: null, inFlight: new Set() };
+    map.set(id, entry);
+  }
+  return entry;
+}
+
+/**
+ * Open (or re-open) a row's console. Bumps the token so a panel fetch fired
+ * against a stale console (operator collapsed/reopened while it was
+ * outstanding) is discarded on resolve, and marks the row open. Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {number} The new token — stamp the panel fetches this open fires.
+ */
+export function consoleOpen(map, id) {
+  const entry = ensureConsoleState(map, id);
+  entry.open = true;
+  entry.token += 1;
+  return entry.token;
+}
+
+/**
+ * Close a row's console. Bumps the token (same discard effect as
+ * {@link consoleOpen}) and marks the row closed, but deliberately leaves
+ * `inFlight` and `youtubeResult` untouched: an outstanding action keeps its
+ * double-fire guard across a collapse (LT-R1 is a SEPARATE, explicit clear —
+ * see {@link consoleClearGuards}), and the cached resolver result survives so
+ * a later reopen restores the matrix instead of resetting to `never_run`
+ * (#398). Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {number} The new token.
+ */
+export function consoleClose(map, id) {
+  const entry = ensureConsoleState(map, id);
+  entry.open = false;
+  entry.token += 1;
+  return entry.token;
+}
+
+/**
+ * Drop every row's console state whose id does NOT satisfy `keep`. The
+ * ONE prune function called from BOTH prune sites — `loadLongTail`'s
+ * fresh-cohort intersect (`keep = (id) => cohortIds.has(id)`) and
+ * `removeRowFromCohort`'s single-row drop (`keep = (id) => id !== removedId`).
+ * Removing an id drops its ENTIRE row state atomically — open flag, token,
+ * cached YouTube result, in-flight guards — in one call, so there is no
+ * longer a second (or third…) structure a future change can forget to sweep
+ * (#481 item 1). Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {(id: number) => boolean} keep
+ * @returns {void}
+ */
+export function consolePrune(map, keep) {
+  for (const id of [...map.keys()]) {
+    if (!keep(id)) map.delete(id);
+  }
+}
+
+/**
+ * Atomic check-and-set double-fire guard for one row's named action
+ * (`'resolve'` | `'submit'` | `'intent'` | `'import'` | `'delete'`). Returns
+ * `true` and marks the action in-flight when none was outstanding for this
+ * id; returns `false` (no mutation) when one already was. Pair with
+ * {@link consoleSettle} in a `try/finally` around the async call. Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function consoleCanStart(map, id, action) {
+  const entry = ensureConsoleState(map, id);
+  if (entry.inFlight.has(action)) return false;
+  entry.inFlight.add(action);
+  return true;
+}
+
+/**
+ * Clear one row's named action in-flight flag — the `finally` counterpart
+ * of {@link consoleCanStart}. No-op when the row has no tracked state
+ * (already pruned — e.g. the row left the cohort while its fetch was
+ * outstanding). Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @param {string} action
+ * @returns {void}
+ */
+export function consoleSettle(map, id, action) {
+  const entry = map.get(id);
+  if (entry) entry.inFlight.delete(action);
+}
+
+/**
+ * Clear EVERY in-flight action guard for one row (LT-R1) — called when the
+ * operator (re)opens or collapses THIS row's console via
+ * {@link toggleLongTailDetail}, so a console destroyed mid-flight doesn't
+ * leave a stale guard silently dead-ing the fresh console's buttons until an
+ * orphaned fetch settles. Deliberately NOT called by
+ * {@link restoreLongTailConsoles} — an outstanding operation keeps its
+ * double-fire protection across a list re-render (#398 fidelity). Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {void}
+ */
+export function consoleClearGuards(map, id) {
+  const entry = map.get(id);
+  if (entry) entry.inFlight.clear();
+}
+
+/**
+ * The row's CURRENT console token — the resolver-settle semantic. Used to
+ * paint the YouTube panel against whatever console exists NOW (even one
+ * re-created by a #398 restore while the resolver fetch was outstanding),
+ * never the token captured when the fetch fired. Contrast
+ * {@link consoleIsStale}, the panel-paint semantic, which discards against
+ * the CAPTURED token instead. Returns `0` for an untracked id (never
+ * opened, or already pruned). Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {number}
+ */
+export function consoleToken(map, id) {
+  const entry = map.get(id);
+  return entry ? entry.token : 0;
+}
+
+/**
+ * Stale-discard predicate for a panel fetch stamped with `capturedToken` at
+ * fire time — the panel-paint semantic (contrast {@link consoleToken}, the
+ * resolver-settle semantic). `true` means the console has moved on
+ * (reopened, closed, or pruned) since the fetch fired, and the result must
+ * be discarded rather than painted. Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @param {number} capturedToken
+ * @returns {boolean}
+ */
+export function consoleIsStale(map, id, capturedToken) {
+  return consoleToken(map, id) !== capturedToken;
+}
+
+/**
+ * Is this row's console currently marked open? Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {boolean}
+ */
+export function consoleIsOpen(map, id) {
+  const entry = map.get(id);
+  return entry != null && entry.open === true;
+}
+
+/**
+ * The row's cached YouTube resolver result, or `null` if none settled yet.
+ * Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @returns {Object|null}
+ */
+export function consoleYoutubeResult(map, id) {
+  const entry = map.get(id);
+  return entry ? entry.youtubeResult : null;
+}
+
+/**
+ * Cache a row's settled YouTube resolver result (#398 restore cache). Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @param {number} id
+ * @param {Object|null} result
+ * @returns {void}
+ */
+export function consoleSetYoutubeResult(map, id, result) {
+  ensureConsoleState(map, id).youtubeResult = result;
+}
+
+/**
+ * Every id currently marked open, in insertion order — drives
+ * {@link restoreLongTailConsoles}. Pure.
+ *
+ * @param {Map<number, ConsoleState>} map
+ * @returns {number[]}
+ */
+export function consoleOpenIds(map) {
+  const ids = [];
+  for (const [id, entry] of map) {
+    if (entry.open) ids.push(id);
+  }
+  return ids;
+}
 
 /**
  * Visible-row cap for the Soulseek peers panel before the "show all"
@@ -1191,7 +1452,7 @@ function renderActionsBar(row) {
  */
 function patchPanel(id, name, token, html) {
   if (typeof document === 'undefined') return;
-  if (consoleTokens.get(id) !== token) return;  // stale console — discard.
+  if (consoleIsStale(consoleStates, id, token)) return;  // stale console — discard.
   const panel = document.getElementById(`lt-panel-${name}-${id}`);
   if (!panel) return;
   const body = panel.querySelector('.lt-panel-body');
@@ -1290,10 +1551,11 @@ function consoleRow(id) {
  * per-row token stamps the fetch so a stale console (operator clicked
  * another row, or re-collapsed this one) is discarded before it paints.
  *
- * The open/closed state is tracked in `state.longTail.open` so a list
- * re-render (post-action single-row patch, band switch, search repaint)
- * can restore expanded consoles via {@link restoreLongTailConsoles}
- * instead of collapsing them (#398 / KTD8 fidelity).
+ * The open/closed state is tracked in `consoleStates` (the row's `open`
+ * flag) so a list re-render (post-action single-row patch, band switch,
+ * search repaint) can restore expanded consoles via
+ * {@link restoreLongTailConsoles} instead of collapsing them (#398 / KTD8
+ * fidelity).
  *
  * @param {number} id  album_requests.id
  * @returns {void}
@@ -1305,12 +1567,12 @@ export function toggleLongTailDetail(id) {
   // Re-opening or collapsing this console: drop stale action guards so the
   // fresh console's buttons aren't silently dead from a prior mid-flight op
   // (LT-R1). Any outstanding fetch's result is still token-discarded below.
-  clearActionGuards(id);
+  consoleClearGuards(consoleStates, id);
   if (el.classList.contains('open')) {
     el.classList.remove('open');
-    state.longTail.open.delete(id);
-    // Bump the token so any in-flight panel fetch is discarded on resolve.
-    consoleTokens.set(id, (consoleTokens.get(id) || 0) + 1);
+    // Bumps the token (any in-flight panel fetch is discarded on resolve)
+    // and marks the row closed.
+    consoleClose(consoleStates, id);
     return;
   }
   openConsole(id, el);
@@ -1318,19 +1580,17 @@ export function toggleLongTailDetail(id) {
 
 /**
  * Open one row's console: render the shell, mark it open in
- * `state.longTail.open`, and fire the independent panel loads. Shared by
- * the row-click toggle and the post-re-render restore path. DOM-side.
+ * `consoleStates`, and fire the independent panel loads. Shared by the
+ * row-click toggle and the post-re-render restore path. DOM-side.
  *
  * @param {number} id  album_requests.id
  * @param {HTMLElement} el  The row's `.lt-detail` container.
  * @returns {void}
  */
 function openConsole(id, el) {
-  const token = (consoleTokens.get(id) || 0) + 1;
-  consoleTokens.set(id, token);
-  state.longTail.open.add(id);
+  const token = consoleOpen(consoleStates, id);
   const row = consoleRow(id) || { id };
-  el.innerHTML = renderConsoleShell(row, youtubeResolveResults.get(id) || null);
+  el.innerHTML = renderConsoleShell(row, consoleYoutubeResult(consoleStates, id));
   el.classList.add('open');
   const inFlightFlag = !!row.in_flight_rescue;
   // Independent panel loads — no Promise.all, no shared await. One panel's
@@ -1361,7 +1621,7 @@ function openConsole(id, el) {
  */
 export function restoreLongTailConsoles() {
   if (typeof document === 'undefined') return;
-  for (const id of state.longTail.open) {
+  for (const id of consoleOpenIds(consoleStates)) {
     const el = document.getElementById(`lt-detail-${id}`);
     if (!el || el.classList.contains('open')) continue;
     openConsole(id, el);
@@ -1469,81 +1729,12 @@ export function rescueOutcomeCopy(result) {
 }
 
 /**
- * Request ids with an outstanding resolver GET. Guards the slow,
- * side-effectful Check-YouTube call against double-fire: a second click
- * while one is outstanding fires nothing.
- *
- * @type {Set<number>}
- */
-const resolveInFlight = new Set();
-
-/**
- * Last resolver result per request id, kept for the session so a console
- * restore after a list re-render re-renders the YouTube panel from the
- * already-fetched result instead of resetting it to `never_run` (#398).
- * Pruned with the row (`removeRowFromCohort`). Superseded in place by the
- * next Check YouTube / Re-check.
- *
- * @type {Map<number, Object>}
- */
-const youtubeResolveResults = new Map();
-
-/**
- * Request ids with an outstanding rescue-submit POST. Guards the confirm →
- * submit step against double-fire.
- *
- * @type {Set<number>}
- */
-const submitInFlight = new Set();
-
-/**
- * Request ids with an outstanding set-intent POST. Guards the intent toggle
- * against double-fire (two rapid clicks racing opposite intents at the DB).
- *
- * @type {Set<number>}
- */
-const intentInFlight = new Set();
-
-/**
  * True while a rescue confirm overlay is open. The overlay mounts into the
  * single shared modal host, so a second `pickYoutubeRescue` would overwrite
  * the first overlay's DOM and orphan its promise — this boolean serialises
  * them (one confirm at a time).
  */
 let rescueConfirmOpen = false;
-
-/**
- * Clear any stale per-id action guards when a console is (re)opened or
- * collapsed (LT-R1). The guards' `finally` blocks delete on settle, but a
- * console destroyed mid-flight (collapse/reopen, list re-render) would
- * otherwise leave a stale entry that silently no-ops the re-opened button
- * until the orphaned fetch settles. The outstanding fetch's result is still
- * token-discarded; clearing just re-enables the fresh console's buttons (a
- * duplicate resolver call hits the server-side cache, so it's harmless).
- *
- * @param {number} id
- * @returns {void}
- */
-function clearActionGuards(id) {
-  resolveInFlight.delete(id);
-  submitInFlight.delete(id);
-  intentInFlight.delete(id);
-  importInFlight.delete(id);
-  deleteInFlight.delete(id);
-}
-
-/**
- * Double-fire predicate for the resolver GET. Pure. `true` when a Check
- * YouTube call may START for this id (none outstanding); `false` when one
- * is already in flight (the click is suppressed).
- *
- * @param {Set<number>} inFlight  The in-flight id set.
- * @param {number} id
- * @returns {boolean}
- */
-export function canStartInFlight(inFlight, id) {
-  return !inFlight.has(id);
-}
 
 /**
  * Re-render just the YouTube panel body for one row's open console, guarded
@@ -1564,18 +1755,19 @@ function patchYoutubePanel(id, token, result) {
  * re-renders the YouTube panel with the fresh classification.
  *
  * Guards:
- *   * Double-fire — a module-scoped `resolveInFlight` Set keyed by request
- *     id; a second click while outstanding returns immediately.
+ *   * Double-fire — `consoleCanStart(consoleStates, id, 'resolve')`; a
+ *     second click while outstanding returns immediately.
  *   * Disabled button — the live "Check YouTube" / "Retry" button is
  *     disabled + relabelled while outstanding so the operator sees progress
  *     and can't re-click it.
  *
- * The settled result is cached in `youtubeResolveResults` and painted
- * against the row's CURRENT console token (not the one captured at fire
- * time): the panel container is per-row, so the only console it can paint
- * into is this row's — including one re-created by a #398 restore while
- * the fetch was outstanding. A collapsed console's hidden DOM may be
- * touched; harmless, since reopening re-renders the shell (from the cache).
+ * The settled result is cached via {@link consoleSetYoutubeResult} and
+ * painted against the row's CURRENT console token ({@link consoleToken} —
+ * not the one captured at fire time): the panel container is per-row, so
+ * the only console it can paint into is this row's — including one
+ * re-created by a #398 restore while the fetch was outstanding. A
+ * collapsed console's hidden DOM may be touched; harmless, since reopening
+ * re-renders the shell (from the cache).
  *
  * The resolver identifier is the request's `mb_release_id` (an MB release
  * MBID or a Discogs release id) — the same id the resolver's
@@ -1586,19 +1778,20 @@ function patchYoutubePanel(id, token, result) {
  * @returns {Promise<void>}
  */
 export async function checkYoutube(id) {
-  if (!canStartInFlight(resolveInFlight, id)) return;  // double-fire guard.
+  if (!consoleCanStart(consoleStates, id, 'resolve')) return;  // double-fire guard.
   const row = consoleRow(id);
   const identifier = row && row.mb_release_id ? String(row.mb_release_id) : '';
-  // Paint against the row's CURRENT token, re-read at paint time: the
-  // youtube panel container is per-row, so any console this can reach is
-  // this row's — including one re-created by a #398 restore mid-fetch.
-  const currentToken = () => consoleTokens.get(id) || 0;
+  // Paint against the row's CURRENT token, re-read at paint time (the
+  // resolver-settle semantic — see consoleToken's docstring): the youtube
+  // panel container is per-row, so any console this can reach is this
+  // row's — including one re-created by a #398 restore mid-fetch.
+  const currentToken = () => consoleToken(consoleStates, id);
   if (!identifier) {
     patchYoutubePanel(id, currentToken(), /** @type {any} */ (
       { outcome: 'transient', error_message: 'No release identifier on this request.' }));
+    consoleSettle(consoleStates, id, 'resolve');
     return;
   }
-  resolveInFlight.add(id);
   setYoutubeChecking(id);
   try {
     const r = await fetch(
@@ -1613,13 +1806,13 @@ export async function checkYoutube(id) {
     } catch (_e) {
       result = { outcome: 'transient', error_message: `HTTP ${r.status}` };
     }
-    youtubeResolveResults.set(id, result);
+    consoleSetYoutubeResult(consoleStates, id, result);
     patchYoutubePanel(id, currentToken(), result);
   } catch (_e) {
     patchYoutubePanel(id, currentToken(), /** @type {any} */ (
       { outcome: 'transient', error_message: 'Could not reach the resolver. Retry.' }));
   } finally {
-    resolveInFlight.delete(id);
+    consoleSettle(consoleStates, id, 'resolve');
   }
 }
 
@@ -1755,8 +1948,7 @@ export async function pickYoutubeRescue(id, browseId) {
  * @returns {Promise<void>}
  */
 async function submitYoutubeRescue(id, browseId) {
-  if (!canStartInFlight(submitInFlight, id)) return;  // double-fire guard.
-  submitInFlight.add(id);
+  if (!consoleCanStart(consoleStates, id, 'submit')) return;  // double-fire guard.
   try {
     let result;
     try {
@@ -1779,7 +1971,7 @@ async function submitYoutubeRescue(id, browseId) {
     // away the operator's scroll position. The "rescue running" badge
     // reconciles on the next manual Refresh.
   } finally {
-    submitInFlight.delete(id);
+    consoleSettle(consoleStates, id, 'submit');
   }
 }
 
@@ -1797,8 +1989,8 @@ async function submitYoutubeRescue(id, browseId) {
  *
  * The re-render does NOT collapse the acted-on row's console (or any
  * other): `renderPipeline`'s long-tail paint ends with
- * {@link restoreLongTailConsoles}, which re-opens every console in
- * `state.longTail.open` against the fresh DOM (#398).
+ * {@link restoreLongTailConsoles}, which re-opens every console marked
+ * open in `consoleStates` against the fresh DOM (#398).
  *
  * @param {number} id
  * @returns {Promise<void>}
@@ -1848,10 +2040,10 @@ function patchRowInCohort(id, fresh) {
  * @returns {void}
  */
 function removeRowFromCohort(id) {
-  // The row is gone for good — prune its console-open mark and cached
-  // resolver result so a later re-render doesn't resurrect either.
-  state.longTail.open.delete(id);
-  youtubeResolveResults.delete(id);
+  // The row is gone for good — prune its ENTIRE console state (open flag,
+  // token, cached resolver result, in-flight guards) in one call. One map,
+  // one prune function (#481 item 1) — the single-row drop.
+  consolePrune(consoleStates, (rowId) => rowId !== id);
   const rows = Array.isArray(state.longTail.rows) ? state.longTail.rows : null;
   if (!rows) return;
   const idx = rows.findIndex((r) => r && r.id === id);
@@ -1970,22 +2162,6 @@ export function buildAcceptSiblingOptions(row) {
 }
 
 /**
- * Request ids with an outstanding "Set imported" POST. Guards the button
- * against double-fire.
- *
- * @type {Set<number>}
- */
-const importInFlight = new Set();
-
-/**
- * Request ids with an outstanding "Delete request" POST. Guards the button
- * against double-fire.
- *
- * @type {Set<number>}
- */
-const deleteInFlight = new Set();
-
-/**
  * Accept-a-sibling-pressing handler (U6). Opens the existing Replace picker
  * (standard mode) for the row's MB release group; the picker owns the
  * sibling list + confirm + `POST .../replace`. On a CONFIRMED Replace the
@@ -2057,8 +2233,7 @@ function closeConsole(id) {
   if (typeof document === 'undefined') return;
   const el = document.getElementById(`lt-detail-${id}`);
   if (el) el.classList.remove('open');
-  state.longTail.open.delete(id);
-  consoleTokens.set(id, (consoleTokens.get(id) || 0) + 1);
+  consoleClose(consoleStates, id);
 }
 
 /**
@@ -2075,8 +2250,7 @@ function closeConsole(id) {
 export async function longTailSetIntent(id) {
   const row = consoleRow(id);
   if (!row) return;
-  if (!canStartInFlight(intentInFlight, id)) return;  // double-fire guard.
-  intentInFlight.add(id);
+  if (!consoleCanStart(consoleStates, id, 'intent')) return;  // double-fire guard.
   const intent = intentToggleTarget(row.target_format);
   try {
     let data;
@@ -2104,7 +2278,7 @@ export async function longTailSetIntent(id) {
     // off the authoritative refetched row.
     await refetchLongTailRow(id);
   } finally {
-    intentInFlight.delete(id);
+    consoleSettle(consoleStates, id, 'intent');
   }
 }
 
@@ -2120,8 +2294,7 @@ export async function longTailSetIntent(id) {
  * @returns {Promise<void>}
  */
 export async function longTailSetImported(id) {
-  if (!canStartInFlight(importInFlight, id)) return;  // double-fire guard.
-  importInFlight.add(id);
+  if (!consoleCanStart(consoleStates, id, 'import')) return;  // double-fire guard.
   try {
     let data;
     try {
@@ -2145,7 +2318,7 @@ export async function longTailSetImported(id) {
     removeRowFromCohort(id);
     removeRowElement(id);
   } finally {
-    importInFlight.delete(id);
+    consoleSettle(consoleStates, id, 'import');
   }
 }
 
@@ -2165,8 +2338,7 @@ export async function longTailDeleteRequest(id) {
       && !confirm(`Delete request #${id}? This removes the wanted request entirely.`)) {
     return;
   }
-  if (!canStartInFlight(deleteInFlight, id)) return;  // double-fire guard.
-  deleteInFlight.add(id);
+  if (!consoleCanStart(consoleStates, id, 'delete')) return;  // double-fire guard.
   try {
     let status = 0;
     let data;
@@ -2199,7 +2371,7 @@ export async function longTailDeleteRequest(id) {
       toast((data && data.error) || `Delete failed (HTTP ${status})`, true);
     }
   } finally {
-    deleteInFlight.delete(id);
+    consoleSettle(consoleStates, id, 'delete');
   }
 }
 
@@ -2230,8 +2402,21 @@ export const __test__ = {
   youtubeBestDistance,
   youtubeRescueTargets,
   rescueOutcomeCopy,
-  canStartInFlight,
   renderRescueConfirm,
+  // #481 item 1 — the console-state Map + its five pure transition helpers.
+  consoleStates,
+  consoleOpen,
+  consoleClose,
+  consolePrune,
+  consoleCanStart,
+  consoleSettle,
+  consoleClearGuards,
+  consoleToken,
+  consoleIsStale,
+  consoleIsOpen,
+  consoleYoutubeResult,
+  consoleSetYoutubeResult,
+  consoleOpenIds,
   // U6 — secondary action pure helpers.
   canAcceptSibling,
   acceptDisabledReason,

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -26,16 +26,18 @@ import { invalidateActiveRgs } from './active_rgs.js';
  * `wanted` cohort fetched once (KTD2 — one banded fetch, client-side
  * tab/search filtering); `band` is the selected band tab (`null` until
  * the first fetch picks a default); `query` is the live search box value.
- * `open` is the set of request ids whose action console is expanded —
- * persisted here so a list re-render (post-action single-row patch, band
- * switch, search repaint) can restore open consoles instead of collapsing
- * them (#398 / KTD8 fidelity).
+ *
+ * The per-row "is this console expanded" flag (and every other per-row
+ * console bookkeeping — fetch token, action double-fire guards, cached
+ * YouTube resolver result) lives in `long_tail.js`'s module-scoped
+ * `consoleStates` map, not here — #481 item 1 consolidated it out of
+ * shared state (it was read only within `long_tail.js`) alongside seven
+ * other parallel structures into one `Map<id, ConsoleState>`.
  *
  * @typedef {Object} LongTailState
  * @property {Array<Object>|null} rows  The fetched cohort, or `null` before the first load.
  * @property {string|null} band         Selected band tab, or `null` (no selection yet).
  * @property {string} query             Current search-box substring filter.
- * @property {Set<number>} open         Ids of rows with an expanded console.
  */
 
 /** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineSearchQuery: string, pipelineSearchResults: Array<Object>|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
@@ -59,9 +61,9 @@ export const state = {
   pipelineDailyMatchGraphOpen: false,
   // Long-tail triage worklist (U3). `rows` null until the first fetch;
   // `band` null until the cohort's default band is picked; `query` is
-  // the live in-band search-box filter; `open` tracks expanded consoles
-  // across re-renders (#398).
-  longTail: { rows: null, band: null, query: '', open: new Set() },
+  // the live in-band search-box filter. Expanded-console tracking lives in
+  // long_tail.js's `consoleStates` map (#481 item 1), not here.
+  longTail: { rows: null, band: null, query: '' },
   recentsCounts: {
     all: 0,
     imported: 0,


### PR DESCRIPTION
## Summary

Addresses #481 (item 1). Items 2 (fake↔prod read-projection parity gate) and 3 (routes split) are separate PRs; the issue closes after item 3.

- The action console in `web/js/long_tail.js` tracked per-request-id state in **eight parallel module-scoped structures**: a fetch-token `Map`, five in-flight guard `Set`s (`resolveInFlight`/`submitInFlight`/`intentInFlight`/`importInFlight`/`deleteInFlight`), a YouTube-resolver-result cache `Map`, and `state.longTail.open` on shared state — plus `clearActionGuards` (existed solely to sweep five of them) and **two** prune sites (`removeRowFromCohort`, `loadLongTail`'s fresh-cohort intersect) that each had to remember every structure. This was a live bug class: the #480 review caught two "forgot to prune one" instances (an open-set leak on full refetch, a stale resolver cache).
- Replaces all eight with **one `Map<id, ConsoleState>`** (`consoleStates`), mutated only through five pure transition helpers exported via `__test__`: `consoleOpen` / `consoleClose` / `consolePrune` / `consoleCanStart` / `consoleSettle` (plus `consoleClearGuards` for the LT-R1 explicit-clear case, distinct from the #398 restore path which deliberately does NOT clear guards).
- `consolePrune` is the **one** prune function now called from both former prune sites (`loadLongTail`'s fresh-cohort intersect via a `keep` predicate over cohort ids; `removeRowFromCohort`'s single-row drop via `id !== removedId`). Removing an id now drops its entire row state atomically — no more "forgot the second structure."
- The two deliberate token semantics from U5 are now explicit, separately named functions instead of comment-only: `consoleIsStale` (panel-paint — discard against the token **captured** at fetch time) vs. `consoleToken` (resolver-settle — read the **current** token at paint time).
- `state.longTail.open` is removed from shared state (`web/js/state.js`) — it was read only within `long_tail.js`, so it's now fully internal to the module's `consoleStates` map.
- Behaviour is unchanged; this is a consolidation, not a redesign. The optional extraction into `web/js/long_tail_console.js` (mentioned in the issue as optional) was **not** done — see Suggestions in the implementation notes.

## Test plan

- [x] `node --check web/js/*.js`
- [x] Every `tests/test_js_*.mjs` passes, including new `tests/test_js_long_tail_console.mjs` (RED-first pure-function coverage for `open`/`close`/`prune`/`canStart`/`settle`, plus the two token semantics)
- [x] `tests/test_js_util.mjs`'s existing long-tail coverage updated to the new shape (no `state.longTail.open`, no `canStartInFlight`)
- [x] New test wired into `scripts/run_tests.sh`
- [x] `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code
- [x] `nix-shell --run "python3 -m unittest discover -s tests -t . -v"` — 4686 tests, OK
- [x] `nix-shell --run "pyright"` — 0 errors
- [x] `nix flake check` (pre-push hook) — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)