### PR TITLE
refactor: post-#282 consolidation (#501)

### DIFF
--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -350,24 +350,14 @@ class MbidReplaceService:
                     ),
                 )
             # Lazy-backfill: resolve the source MBID's RG fresh.
-            try:
-                src_data = self.mb_lookup(source_mbid, fresh=True)
-            except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
-                # Network blip / timeout / malformed JSON — retryable.
-                return ReplaceResult(
-                    outcome=RESULT_TRANSIENT,
-                    request_id=request_id,
-                    error_message=f"MB lookup failed (transient): {exc}",
-                )
-            except Exception as exc:  # noqa: BLE001
-                return ReplaceResult(
-                    outcome=RESULT_TARGET_INVALID,
-                    request_id=request_id,
-                    error_message=(
-                        f"source MBID {source_mbid} could not be "
-                        f"resolved: {exc}"
-                    ),
-                )
+            src_data, err = self._mb_lookup_or_error(
+                source_mbid,
+                request_id=request_id,
+                detail_context=f"source MBID {source_mbid}",
+            )
+            if err is not None:
+                return err
+            assert src_data is not None
             # ``mb_lookup`` is typed dict[str, Any]; ``release_group_id``
             # is None when the mirror doesn't have one.
             source_rg = src_data.get("release_group_id")
@@ -396,26 +386,14 @@ class MbidReplaceService:
             )
 
         # Fresh MB lookup of the target.
-        try:
-            target_data = self.mb_lookup(
-                target_mb_release_id, fresh=True
-            )
-        except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
-            # Network blip / timeout / malformed JSON — retryable.
-            return ReplaceResult(
-                outcome=RESULT_TRANSIENT,
-                request_id=request_id,
-                error_message=f"MB lookup failed (transient): {exc}",
-            )
-        except Exception as exc:  # noqa: BLE001
-            return ReplaceResult(
-                outcome=RESULT_TARGET_INVALID,
-                request_id=request_id,
-                error_message=(
-                    f"target MBID {target_mb_release_id} could not be "
-                    f"resolved: {exc}"
-                ),
-            )
+        target_data, err = self._mb_lookup_or_error(
+            target_mb_release_id,
+            request_id=request_id,
+            detail_context=f"target MBID {target_mb_release_id}",
+        )
+        if err is not None:
+            return err
+        assert target_data is not None
 
         if not target_data:
             return ReplaceResult(
@@ -491,6 +469,54 @@ class MbidReplaceService:
             target_data=target_data,
             new_discogs_release_id=None,
         )
+
+    def _mb_lookup_or_error(
+        self,
+        mbid: str,
+        *,
+        request_id: int,
+        detail_context: str,
+    ) -> tuple[dict[str, Any] | None, ReplaceResult | None]:
+        """Fresh MB-mirror lookup + the two-way exception→outcome mapping
+        shared by the source lazy-backfill and target lookup sites in
+        ``replace_request_mbid``. Mirrors ``_discogs_lookup_or_error``
+        (#501 item 3) — no ``mirror_unconfigured`` branch, since the MB
+        mirror has no analogous "unconfigured" failure mode (public MB is
+        the always-available fallback).
+
+        Returns ``(data, None)`` on success or ``(None, ReplaceResult(...))``
+        on failure. ``detail_context`` names the id being resolved in the
+        generic RESULT_TARGET_INVALID message (e.g. ``"source MBID
+        <id>"`` / ``"target MBID <id>"``), preserving each call site's
+        original wording.
+
+        A network blip / timeout / malformed JSON is RESULT_TRANSIENT
+        (503, retryable); anything else is RESULT_TARGET_INVALID (422)
+        AND logs a warning, so a real bug in the mirror client no longer
+        presents identically to bad operator input.
+        """
+        try:
+            data = self.mb_lookup(mbid, fresh=True)
+        except _TRANSIENT_LOOKUP_EXCEPTIONS as exc:
+            return None, ReplaceResult(
+                outcome=RESULT_TRANSIENT,
+                request_id=request_id,
+                error_message=f"MB lookup failed (transient): {exc}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Replace: unexpected MB lookup error resolving %s "
+                "(request_id=%d): %s: %s",
+                detail_context, request_id, type(exc).__name__, exc,
+            )
+            return None, ReplaceResult(
+                outcome=RESULT_TARGET_INVALID,
+                request_id=request_id,
+                error_message=(
+                    f"{detail_context} could not be resolved: {exc}"
+                ),
+            )
+        return data, None
 
     def _replace_discogs_target(
         self,

--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -36,9 +36,10 @@ import logging
 import os
 import shutil
 import socket
-from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol, runtime_checkable
 from urllib.error import URLError
+
+import msgspec
 
 
 # MB-mirror transient errors — network blips, timeouts, malformed
@@ -55,6 +56,22 @@ _TRANSIENT_LOOKUP_EXCEPTIONS: tuple[type[BaseException], ...] = (
 
 from lib.config import CratediggerConfig
 from lib.release_identity import detect_release_source, normalize_release_id
+from lib.replace_status import (
+    REPLACE_REASON_CROSS_PATHWAY_TARGET,
+    REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
+    REPLACE_REASON_TARGET_NO_RELEASE_GROUP,
+    REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR,
+    REPLACE_REASON_UNRESOLVABLE_TARGET,
+    RESULT_MIRROR_UNCONFIGURED,
+    RESULT_NOT_FOUND,
+    RESULT_REPLACED,
+    RESULT_TARGET_COLLISION_REQUEST,
+    RESULT_TARGET_INVALID,
+    RESULT_TARGET_RELEASE_GROUP_MISMATCH,
+    RESULT_TARGET_SAME_AS_CURRENT,
+    RESULT_TRANSIENT,
+    RESULT_WRONG_STATE,
+)
 from lib.pipeline_db import (
     ADVISORY_LOCK_NAMESPACE_IMPORT,
     MbidCollisionError,
@@ -116,24 +133,12 @@ class MbidReplaceDB(
     ) -> int: ...
 
 
-# Result outcome constants.
-RESULT_REPLACED = "replaced"
-RESULT_NOT_FOUND = "not_found"
-RESULT_WRONG_STATE = "wrong_state"
-RESULT_TARGET_INVALID = "target_invalid"
-RESULT_TARGET_RELEASE_GROUP_MISMATCH = "target_release_group_mismatch"
-RESULT_TARGET_SAME_AS_CURRENT = "target_same_as_current"
-RESULT_TARGET_COLLISION_REQUEST = "target_collision_request"
-RESULT_MIRROR_UNCONFIGURED = "mirror_unconfigured"
-RESULT_TRANSIENT = "transient"
-
-
-@dataclass(frozen=True)
-class ReplaceResult:
+class ReplaceResult(msgspec.Struct, frozen=True):
     """Outcome of a single ``replace_request_mbid`` call.
 
-    ``outcome`` is one of the ``RESULT_*`` constants. Other fields are
-    surfaced conditionally:
+    ``outcome`` is one of the ``RESULT_*`` constants (imported from
+    ``lib.replace_status`` and re-exported here — CLI/API/tests import
+    them from this module). Other fields are surfaced conditionally:
 
     - ``new_request_id``: set on ``RESULT_REPLACED``.
     - ``current_status``: set on ``RESULT_TARGET_COLLISION_REQUEST`` so
@@ -143,6 +148,13 @@ class ReplaceResult:
     - ``descendant_request_id``: set on ``RESULT_WRONG_STATE`` when the
       source row is itself already ``status='replaced'`` — so the UI
       can deep-link to "the new request is at /pipeline/{id}".
+    - ``reason``: set on ``RESULT_TARGET_INVALID`` — one of the
+      ``REPLACE_REASON_*`` constants, distinguishing the several distinct
+      rejections that outcome collapses (#501 item 2). ``error_message``
+      stays free-text for operator-facing detail; ``reason`` is the
+      stable code CLI/API/tests assert on. ``msgspec.Struct`` per the
+      wire-boundary rule (CLI ``--json`` output and the HTTP response
+      body both surface every field).
     - ``warnings``: filesystem-cleanup failures that did NOT roll back
       the DB change (R26 non-fatal semantics).
     """
@@ -153,7 +165,8 @@ class ReplaceResult:
     current_status: str | None = None
     descendant_request_id: int | None = None
     error_message: str | None = None
-    warnings: tuple[str, ...] = field(default_factory=tuple)
+    reason: str | None = None
+    warnings: tuple[str, ...] = ()
 
 
 # Type aliases for the injectable dependencies.
@@ -318,6 +331,7 @@ class MbidReplaceService:
                     f"not a valid same-pathway target for source "
                     f"({source_source})"
                 ),
+                reason=REPLACE_REASON_CROSS_PATHWAY_TARGET,
             )
 
         if source_mbid == target_mb_release_id:
@@ -348,6 +362,7 @@ class MbidReplaceService:
                         f"source MBID {source_mbid!r} could not be "
                         "resolved: source request has no MB release id"
                     ),
+                    reason=REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
                 )
             # Lazy-backfill: resolve the source MBID's RG fresh.
             src_data, err = self._mb_lookup_or_error(
@@ -369,6 +384,7 @@ class MbidReplaceService:
                         f"source MBID {source_mbid} did not resolve to "
                         "a release group on the MB mirror"
                     ),
+                    reason=REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
                 )
 
         # Pre-check collision against the active row set.
@@ -403,6 +419,7 @@ class MbidReplaceService:
                     f"target MBID {target_mb_release_id} returned empty "
                     "payload from MB mirror"
                 ),
+                reason=REPLACE_REASON_UNRESOLVABLE_TARGET,
             )
 
         canonical_mbid = target_data.get("id") or target_mb_release_id
@@ -415,6 +432,7 @@ class MbidReplaceService:
                     f"target MBID {target_mb_release_id} resolved with "
                     "no release_group_id"
                 ),
+                reason=REPLACE_REASON_TARGET_NO_RELEASE_GROUP,
             )
 
         if target_rg != source_rg:
@@ -515,6 +533,7 @@ class MbidReplaceService:
                 error_message=(
                     f"{detail_context} could not be resolved: {exc}"
                 ),
+                reason=REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR,
             )
         return data, None
 
@@ -565,6 +584,7 @@ class MbidReplaceService:
                         "master; nothing to swap to (only the current "
                         "release is a valid target)"
                     ),
+                    reason=REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
                 )
 
         # Pre-check collision against the raw target id (identity-aware).
@@ -599,6 +619,7 @@ class MbidReplaceService:
                     f"target Discogs id {target_mb_release_id} returned "
                     "empty payload from the mirror"
                 ),
+                reason=REPLACE_REASON_UNRESOLVABLE_TARGET,
             )
 
         canonical_id = str(target_data.get("id") or target_mb_release_id)
@@ -611,6 +632,7 @@ class MbidReplaceService:
                     f"target Discogs id {target_mb_release_id} resolved "
                     "with no master"
                 ),
+                reason=REPLACE_REASON_TARGET_NO_RELEASE_GROUP,
             )
 
         if target_master != source_master:
@@ -715,6 +737,7 @@ class MbidReplaceService:
                 error_message=(
                     f"{detail_context} could not be resolved: {exc}"
                 ),
+                reason=REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR,
             )
         return data, None
 

--- a/lib/replace_status.py
+++ b/lib/replace_status.py
@@ -1,0 +1,74 @@
+"""Shared outcome/status string constants for the Replace operator action
+and its lazy release-group/master resolver (``POST .../resolve-rg``).
+
+Both ``lib/mbid_replace_service.py`` (``ReplaceResult.outcome`` /
+``ReplaceResult.reason``) and ``web/routes/pipeline.py::
+post_pipeline_resolve_rg`` (its bare ``status`` field) express failure
+modes as plain strings. Before this module they were declared
+independently at each call site — a rename of one copy (e.g.
+``RESULT_MIRROR_UNCONFIGURED``) could silently diverge from the other
+(resolve-rg's hardcoded ``"mirror_unconfigured"`` literal) without any
+test catching the drift, since they were never the same symbol. Both
+surfaces now import from here (#501 item 2).
+
+``REPLACE_REASON_*`` are typed sub-codes for ``ReplaceResult.reason``,
+distinguishing the different rejections ``RESULT_TARGET_INVALID``
+collapses. ``error_message`` stays free-text for operator-facing detail;
+``reason`` is the stable code CLI/API/tests assert on. Pathway-neutral by
+design (no MB/Discogs adapter asymmetry) — the same reason applies
+whether the failing lookup was against the MB mirror or the Discogs
+mirror:
+
+    cross_pathway_target      target/source pathways differ, or the
+                               target id doesn't parse as either shape
+    source_no_release_group   the source has no release group/master to
+                               anchor siblings against (MB: no RG after
+                               lazy-backfill; Discogs: masterless)
+    unresolvable_target       the target lookup returned no usable data
+                               (empty/falsy payload)
+    target_no_release_group   the target resolved but has no release
+                               group/master (MB: no release_group_id;
+                               Discogs: no master)
+    unexpected_lookup_error   the lookup call itself raised something
+                               that isn't the known transient set — this
+                               ALSO logs a warning, since it may be a
+                               real bug rather than expected bad input
+"""
+
+from __future__ import annotations
+
+# ReplaceResult.outcome constants. See lib/mbid_replace_service.py's
+# module docstring for the full exit-code / HTTP-status convention.
+RESULT_REPLACED = "replaced"
+RESULT_NOT_FOUND = "not_found"
+RESULT_WRONG_STATE = "wrong_state"
+RESULT_TARGET_INVALID = "target_invalid"
+RESULT_TARGET_RELEASE_GROUP_MISMATCH = "target_release_group_mismatch"
+RESULT_TARGET_SAME_AS_CURRENT = "target_same_as_current"
+RESULT_TARGET_COLLISION_REQUEST = "target_collision_request"
+RESULT_MIRROR_UNCONFIGURED = "mirror_unconfigured"
+RESULT_TRANSIENT = "transient"
+
+# ReplaceResult.reason constants — sub-codes for RESULT_TARGET_INVALID.
+REPLACE_REASON_CROSS_PATHWAY_TARGET = "cross_pathway_target"
+REPLACE_REASON_SOURCE_NO_RELEASE_GROUP = "source_no_release_group"
+REPLACE_REASON_UNRESOLVABLE_TARGET = "unresolvable_target"
+REPLACE_REASON_TARGET_NO_RELEASE_GROUP = "target_no_release_group"
+REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR = "unexpected_lookup_error"
+
+# POST /api/pipeline/<id>/resolve-rg status vocabulary
+# (web/routes/pipeline.py::post_pipeline_resolve_rg). Two of these
+# (RESOLVE_STATUS_MIRROR_UNCONFIGURED / RESOLVE_STATUS_TRANSIENT) are
+# deliberately the SAME string values as RESULT_MIRROR_UNCONFIGURED /
+# RESULT_TRANSIENT above — both describe the identical failure mode
+# (Discogs mirror not configured / a network blip) on a sibling operator
+# action, and web/js/replace_picker.js string-matches both vocabularies.
+RESOLVE_STATUS_RESOLVED = "resolved"
+RESOLVE_STATUS_MASTERLESS = "masterless"
+RESOLVE_STATUS_NOT_FOUND = "not_found"
+RESOLVE_STATUS_MISSING_RELEASE_ID = "missing_release_id"
+RESOLVE_STATUS_NON_MB_RELEASE_ID = "non_mb_release_id"
+RESOLVE_STATUS_NO_RELEASE_GROUP = "no_release_group"
+RESOLVE_STATUS_LOOKUP_FAILED = "lookup_failed"
+RESOLVE_STATUS_MIRROR_UNCONFIGURED = RESULT_MIRROR_UNCONFIGURED
+RESOLVE_STATUS_TRANSIENT = RESULT_TRANSIENT

--- a/scripts/pipeline_cli/replace.py
+++ b/scripts/pipeline_cli/replace.py
@@ -10,7 +10,9 @@ from scripts.pipeline_cli._format import _json_default
 
 
 def cmd_replace(db, args):
-    """Supersede a request with a new row at a different MBID.
+    """Supersede a request with a new row at a different release id (an
+    MB release UUID or a Discogs numeric release id — must share the
+    source's pathway and release group/master).
 
     Counterpart of ``POST /api/pipeline/<id>/replace``. Both surfaces
     wrap ``MbidReplaceService.replace_request_mbid`` — keep them in
@@ -19,7 +21,9 @@ def cmd_replace(db, args):
     Exit codes:
       * 0 — ``RESULT_REPLACED``
       * 2 — ``RESULT_NOT_FOUND``
-      * 3 — ``RESULT_TARGET_INVALID``, ``RESULT_TARGET_RELEASE_GROUP_MISMATCH``,
+      * 3 — ``RESULT_TARGET_INVALID`` (``reason`` carries the typed
+            sub-code — see ``lib/replace_status.py``),
+            ``RESULT_TARGET_RELEASE_GROUP_MISMATCH``,
             ``RESULT_TARGET_SAME_AS_CURRENT`` (semantic input violations)
       * 4 — ``RESULT_WRONG_STATE`` (including supersede race —
             double-click landed first; descendant_request_id is set),
@@ -55,6 +59,7 @@ def cmd_replace(db, args):
         "current_status": result.current_status,
         "descendant_request_id": result.descendant_request_id,
         "error_message": result.error_message,
+        "reason": result.reason,
         "warnings": list(result.warnings),
     }
     if getattr(args, "json", False):
@@ -69,6 +74,8 @@ def cmd_replace(db, args):
             print(f"  Holder status:     {result.current_status}")
         if result.descendant_request_id is not None:
             print(f"  Descendant id:     {result.descendant_request_id}")
+        if result.reason is not None:
+            print(f"  Reason:            {result.reason}")
         if result.error_message:
             print(f"  Error message:     {result.error_message}")
         if result.warnings:

--- a/scripts/web_dev_server.py
+++ b/scripts/web_dev_server.py
@@ -252,6 +252,7 @@ class DevHandler(BaseHTTPRequestHandler):
 
     def _serve_live_db_get(self, parsed) -> None:
         import web.server as web_server
+        from web import discogs as _discogs
 
         path = parsed.path.rstrip("/") or "/"
         params = parse_qs(parsed.query)
@@ -266,6 +267,12 @@ class DevHandler(BaseHTTPRequestHandler):
                     fn(self, params, *match.groups())  # type: ignore[operator]
                     return
             self._error("Not found", 404)
+        except _discogs.DiscogsMirrorNotConfigured as exc:
+            # Reuse production's mapping (web/server.py::do_GET) — a
+            # deliberate config posture (no Discogs mirror), not a crash.
+            # Dev sessions should exercise the same 503, not a generic 500
+            # (#501 item 4).
+            self._error(str(exc), 503)
         except Exception as exc:
             web_server.log.exception("dev live-db GET %s failed", path)
             web_server._try_reconnect_db()

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -778,7 +778,6 @@ import {
   pickBestDistance,
   formatDistanceBadge,
   runWithConcurrency,
-  mapDiscogsMasterReleases,
   renderMasterlessNote,
   extractTracklist,
   esc as replaceEsc,
@@ -981,63 +980,14 @@ assertEqual(replaceEsc('<script>'), '&lt;script&gt;', 'esc escapes <');
 assertEqual(replaceEsc('a&b'), 'a&amp;b', 'esc escapes &');
 assertEqual(replaceEsc('"x"'), '&quot;x&quot;', 'esc escapes "');
 
-// ============================================================
-// replace_picker.js — Discogs-pathway Replace (U5)
-// ============================================================
-
-// mapDiscogsMasterReleases — GET /api/discogs/master/<id> payload → the
-// same pressing-row shape GET /api/release-group/<id> already returns
-// for MB (id/title/date/country/format/track_count preserved).
-const discogsMasterPayload = {
-  title: 'Hold Your Colour',
-  type: 'Album',
-  first_release_date: '2005-05-23',
-  artist_credit: 'Pendulum',
-  primary_artist_id: '287459',
-  releases: [
-    {
-      id: '1122334', title: 'Hold Your Colour (CD, Album)', date: '2005-05-23',
-      country: 'UK', status: 'Official', track_count: 13, format: 'CD, Album',
-      media_count: 1, labels: [{ name: 'Breakbeat Kaos' }],
-    },
-    {
-      id: '5566778', title: 'Hold Your Colour (2xLP)', date: '2006-01-01',
-      country: 'US', status: 'Official', track_count: 13, format: 'Vinyl, LP',
-      media_count: 2, labels: [{ name: 'Breakbeat Kaos' }],
-    },
-  ],
-};
-const mappedDiscogs = mapDiscogsMasterReleases(discogsMasterPayload);
-assertEqual(mappedDiscogs.length, 2, 'mapDiscogsMasterReleases preserves release count');
-assertEqual(mappedDiscogs[0].id, '1122334', 'mapDiscogsMasterReleases preserves id');
-assertEqual(mappedDiscogs[0].title, 'Hold Your Colour (CD, Album)', 'mapDiscogsMasterReleases preserves title');
-assertEqual(mappedDiscogs[0].date, '2005-05-23', 'mapDiscogsMasterReleases preserves date');
-assertEqual(mappedDiscogs[0].country, 'UK', 'mapDiscogsMasterReleases preserves country');
-assertEqual(mappedDiscogs[0].format, 'CD, Album', 'mapDiscogsMasterReleases preserves format');
-assertEqual(mappedDiscogs[0].track_count, 13, 'mapDiscogsMasterReleases preserves track_count');
-
-// The mapped rows feed straight into the existing renderPressingsList —
-// current-release marking works identically to the MB path.
-const discogsPressingsHtml = renderPressingsList(mappedDiscogs, '1122334');
-assert(/data-expand-mbid="1122334"[^>]*disabled|disabled[^>]*data-expand-mbid="1122334"/.test(discogsPressingsHtml),
-  'mapDiscogsMasterReleases + renderPressingsList marks the current Discogs release disabled');
-assert(discogsPressingsHtml.includes('current pressing'),
-  'mapDiscogsMasterReleases + renderPressingsList labels the current Discogs release');
-assert(/replace-picker-confirm[^>]*data-mbid="5566778"/.test(discogsPressingsHtml),
-  'mapDiscogsMasterReleases + renderPressingsList renders a pick button for the Discogs sibling');
-
-// Missing fields render through the picker's existing empty/dash handling
-// rather than throwing or leaking `undefined` into the HTML.
-const sparseMapped = mapDiscogsMasterReleases({ releases: [{ id: 999 }] });
-assertEqual(sparseMapped[0].id, '999', 'mapDiscogsMasterReleases coerces numeric id to string');
-assertEqual(sparseMapped[0].title, '', 'mapDiscogsMasterReleases missing title → empty string');
-assertEqual(sparseMapped[0].track_count, 0, 'mapDiscogsMasterReleases missing track_count → 0');
-assert(!renderPressingsList(sparseMapped, 'other').includes('undefined'),
-  'mapDiscogsMasterReleases sparse row never renders "undefined"');
-
-// Absent/malformed payload → empty list, not a throw.
-assertEqual(mapDiscogsMasterReleases(null).length, 0, 'mapDiscogsMasterReleases(null) → []');
-assertEqual(mapDiscogsMasterReleases({}).length, 0, 'mapDiscogsMasterReleases({}) → []');
+// mapDiscogsMasterReleases (the client-side MB/Discogs release-group shape
+// adapter) and its dedicated coverage are deleted (#501 item 1) — GET
+// /api/release-group/<id> now dispatches numeric ids to the Discogs master
+// endpoint server-side (web/routes/browse.py::get_release_group) and
+// returns the identical shape, so replace_picker.js's runStandard needs no
+// anchor-shape branch or client-side mapping at all. Parity is proven
+// server-side by
+// tests/web/test_routes_browse.py::test_release_group_numeric_id_forwards_to_discogs.
 
 // renderMasterlessNote — R2/AE1 copy, pure/DOM-free.
 assert(renderMasterlessNote().toLowerCase().includes('no other pressings'),
@@ -1065,16 +1015,9 @@ assert(renderTracklist(extracted).includes('Slam'),
 assertEqual(extractTracklist({}).length, 0, 'extractTracklist({}) → []');
 assertEqual(extractTracklist(null).length, 0, 'extractTracklist(null) → []');
 
-// Anchor-shape dispatch — the exact predicate replace_picker.js uses to
-// pick /api/release-group/<id> (MB) vs /api/discogs/master/<id>
-// (Discogs). Reuses util.js's detectSource rather than a duplicate
-// isNumericId helper (already exhaustively covered above).
-assertEqual(detectSource('89ad4ac3-39f7-470e-963a-56509c546377') === 'discogs', false,
-  'replace-picker anchor dispatch: UUID anchor is not routed to the Discogs master endpoint');
-assertEqual(detectSource('1122334') === 'discogs', true,
-  'replace-picker anchor dispatch: numeric anchor is routed to the Discogs master endpoint');
-assertEqual(detectSource('not-an-id') === 'discogs', false,
-  'replace-picker anchor dispatch: junk anchor is not routed to the Discogs master endpoint');
+// Anchor-shape dispatch test removed (#501 item 1) — replace_picker.js no
+// longer branches on the anchor's shape client-side; detectSource's own
+// exhaustive coverage lives at the top of this file.
 
 // renderReplaceButton (release_actions.js) — U9
 import { renderReplaceButton } from '../web/js/release_actions.js';

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -399,6 +399,55 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
         result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
 
+    def test_mb_source_lazy_backfill_unexpected_exception_logs_warning(self):
+        """#501 item 3: the MB arm gains the Discogs arm's parity — an
+        unexpected (non-transient) exception during the source
+        lazy-backfill lookup is TARGET_INVALID AND logs a warning, so a
+        real client bug doesn't present identically to expected operator
+        input error (mirrors
+        test_source_lazy_backfill_generic_exception_target_invalid on the
+        Discogs arm)."""
+        db = FakePipelineDB()
+        self._seed_old(db, mb_release_group_id=None)
+
+        def fake_lookup(mbid, *, fresh=False):
+            if mbid == OLD_MBID:
+                raise RuntimeError("MB mirror 500")
+            return _fake_target_payload()
+
+        svc = self._make_service(db, mb_lookup=fake_lookup)
+        with self.assertLogs("lib.mbid_replace_service", level="WARNING") as cm:
+            result = svc.replace_request_mbid(
+                42, target_mb_release_id=NEW_MBID,
+            )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertTrue(
+            any("source" in m.lower() for m in cm.output),
+            f"expected a warning naming the source lookup, got: {cm.output}",
+        )
+
+    def test_mb_target_lookup_unexpected_exception_logs_warning(self):
+        """#501 item 3: mirrors the above for the TARGET lookup site — a
+        previously-untested branch (the MB arm's target-lookup generic
+        exception handler had no outcome OR logging coverage) gains
+        both."""
+        db = FakePipelineDB()
+        self._seed_old(db)
+
+        def fake_lookup(mbid, *, fresh=False):
+            raise RuntimeError("MB mirror 500")
+
+        svc = self._make_service(db, mb_lookup=fake_lookup)
+        with self.assertLogs("lib.mbid_replace_service", level="WARNING") as cm:
+            result = svc.replace_request_mbid(
+                42, target_mb_release_id=NEW_MBID,
+            )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertTrue(
+            any("target" in m.lower() for m in cm.output),
+            f"expected a warning naming the target lookup, got: {cm.output}",
+        )
+
     def test_transient_urlerror(self):
         db = FakePipelineDB()
         self._seed_old(db)

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -22,6 +22,11 @@ from lib.config import CratediggerConfig
 from lib.mbid_replace_service import (
     MbidReplaceService,
     ReplaceResult,
+    REPLACE_REASON_CROSS_PATHWAY_TARGET,
+    REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
+    REPLACE_REASON_TARGET_NO_RELEASE_GROUP,
+    REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR,
+    REPLACE_REASON_UNRESOLVABLE_TARGET,
     RESULT_MIRROR_UNCONFIGURED,
     RESULT_NOT_FOUND,
     RESULT_REPLACED,
@@ -325,6 +330,9 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
                     f"target_invalid (got {result.outcome})",
                 )
                 self.assertIsNotNone(result.error_message)
+                self.assertEqual(
+                    result.reason, REPLACE_REASON_CROSS_PATHWAY_TARGET,
+                )
                 # The MB lookup must NOT have been reached — pre-Phase 0
                 # rejection. We can confirm by checking the request was
                 # never advanced past the validation step (no DB
@@ -385,6 +393,20 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
         )
         result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_TARGET_NO_RELEASE_GROUP)
+
+    def test_target_invalid_target_empty_payload(self):
+        """#501 item 2: the target lookup succeeds but returns a falsy
+        payload (distinct from an unresolvable-with-no-RG payload) —
+        REASON: unresolvable_target."""
+        db = FakePipelineDB()
+        self._seed_old(db)
+        svc = self._make_service(
+            db, mb_lookup=lambda mbid, *, fresh=False: {},
+        )
+        result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_UNRESOLVABLE_TARGET)
 
     def test_target_invalid_source_resolve_failure(self):
         db = FakePipelineDB()
@@ -398,6 +420,30 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
         svc = self._make_service(db, mb_lookup=fake_lookup)
         result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR)
+
+    def test_target_invalid_source_no_release_group_after_lazy_backfill(self):
+        """#501 item 2: the source lazy-backfill lookup succeeds but the
+        MB mirror has no release_group_id for it — REASON:
+        source_no_release_group (the MB-arm analog of a masterless
+        Discogs source)."""
+        db = FakePipelineDB()
+        self._seed_old(db, mb_release_group_id=None)
+
+        def fake_lookup(mbid, *, fresh=False):
+            if mbid == OLD_MBID:
+                return {
+                    "id": OLD_MBID, "title": "Old", "artist_name": "X",
+                    "release_group_id": None, "tracks": [],
+                }
+            return _fake_target_payload()
+
+        svc = self._make_service(db, mb_lookup=fake_lookup)
+        result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(
+            result.reason, REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
+        )
 
     def test_mb_source_lazy_backfill_unexpected_exception_logs_warning(self):
         """#501 item 3: the MB arm gains the Discogs arm's parity — an
@@ -421,6 +467,7 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
                 42, target_mb_release_id=NEW_MBID,
             )
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR)
         self.assertTrue(
             any("source" in m.lower() for m in cm.output),
             f"expected a warning naming the source lookup, got: {cm.output}",
@@ -443,6 +490,7 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
                 42, target_mb_release_id=NEW_MBID,
             )
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR)
         self.assertTrue(
             any("target" in m.lower() for m in cm.output),
             f"expected a warning naming the target lookup, got: {cm.output}",
@@ -869,6 +917,7 @@ class TestReplaceDiscogsArm(_ServiceCase):
             42, target_mb_release_id=NEW_DISCOGS_ID,
         )
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_UNEXPECTED_LOOKUP_ERROR)
         # Source lookup raised first → target lookup never ran.
         self.assertEqual(calls, [OLD_DISCOGS_ID])
         self.assertIsNone(result.new_request_id)
@@ -890,6 +939,7 @@ class TestReplaceDiscogsArm(_ServiceCase):
         svc = self._make_service(db, discogs_lookup=fake_lookup)
         result = svc.replace_request_mbid(42, target_mb_release_id=NEW_MBID)
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_CROSS_PATHWAY_TARGET)
         self.assertFalse(called["hit"])
 
     def test_mb_source_numeric_target_invalid(self):
@@ -902,6 +952,7 @@ class TestReplaceDiscogsArm(_ServiceCase):
             42, target_mb_release_id=NEW_DISCOGS_ID,
         )
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_CROSS_PATHWAY_TARGET)
 
     def test_masterless_source_other_target_rejected(self):
         """AE1 / R10: a masterless Discogs source rejects any target that
@@ -918,6 +969,9 @@ class TestReplaceDiscogsArm(_ServiceCase):
             42, target_mb_release_id=NEW_DISCOGS_ID,
         )
         self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(
+            result.reason, REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
+        )
         assert result.error_message is not None
         self.assertIn("master", result.error_message)
 
@@ -951,6 +1005,44 @@ class TestReplaceDiscogsArm(_ServiceCase):
         self.assertEqual(
             result.outcome, RESULT_TARGET_RELEASE_GROUP_MISMATCH
         )
+
+    def test_discogs_target_no_master(self):
+        """#501 item 2: the Discogs arm's analog of
+        test_target_invalid_missing_rg — target resolves but has no
+        master. REASON: target_no_release_group (pathway-neutral naming;
+        same reason code as the MB arm's missing-release_group_id case)."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=DISCOGS_MASTER)
+        svc = self._make_service(
+            db,
+            discogs_lookup=(
+                lambda rid, *, fresh=False: _fake_discogs_payload(
+                    release_id=NEW_DISCOGS_ID, master=None,
+                )
+            ),
+        )
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(
+            result.reason, REPLACE_REASON_TARGET_NO_RELEASE_GROUP,
+        )
+
+    def test_discogs_target_empty_payload(self):
+        """#501 item 2: the Discogs arm's analog of
+        test_target_invalid_target_empty_payload — the target lookup
+        succeeds but returns a falsy payload. REASON: unresolvable_target."""
+        db = FakePipelineDB()
+        self._seed_discogs(db, master=DISCOGS_MASTER)
+        svc = self._make_service(
+            db, discogs_lookup=lambda rid, *, fresh=False: {},
+        )
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_DISCOGS_ID,
+        )
+        self.assertEqual(result.outcome, RESULT_TARGET_INVALID)
+        self.assertEqual(result.reason, REPLACE_REASON_UNRESOLVABLE_TARGET)
 
     def test_discogs_mirror_unconfigured(self):
         """AE3 / R11: an unconfigured Discogs mirror surfaces its own

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2654,6 +2654,30 @@ class TestCmdReplace(unittest.TestCase):
                 rc, _ = self._run(mock_outcome=outcome)
                 self.assertEqual(rc, 5)
 
+    def test_json_output_includes_reason(self):
+        """#501 item 2: the CLI's --json payload surfaces the new typed
+        ``reason`` field (a REPLACE_REASON_* code) so operators/tooling
+        can assert on the stable code instead of parsing error_message."""
+        rc, out = self._run(
+            mock_outcome="target_invalid",
+            mock_kwargs={
+                "reason": "cross_pathway_target",
+                "error_message": "target ... is not a valid same-pathway target",
+            },
+            json_out=True,
+        )
+        payload = json.loads(out)
+        self.assertEqual(payload["reason"], "cross_pathway_target")
+
+    def test_text_output_includes_reason_line(self):
+        """#501 item 2: the human-readable output also surfaces the
+        reason code when set (target_invalid outcomes only)."""
+        rc, out = self._run(
+            mock_outcome="target_invalid",
+            mock_kwargs={"reason": "cross_pathway_target"},
+        )
+        self.assertIn("cross_pathway_target", out)
+
     def test_numeric_discogs_target_accepted(self):
         """A numeric Discogs id is a valid target on the CLI surface —
         argparse takes ``--to`` as an opaque string; the service

--- a/tests/test_web_dev_server.py
+++ b/tests/test_web_dev_server.py
@@ -161,6 +161,57 @@ class WebDevServerProxyTest(unittest.TestCase):
         self.assertEqual(body, b"bcd")
 
 
+class WebDevServerLiveDbErrorMappingTest(unittest.TestCase):
+    """#501 item 4: the `--data live-db` GET dispatch's generic
+    `except Exception` mapped EVERY route-handler exception to 500,
+    including `DiscogsMirrorNotConfigured` — which production's
+    `web/server.py::do_GET` maps to 503 (a deliberate config posture, not
+    a crash). Dev sessions should exercise the same status code."""
+
+    def setUp(self) -> None:
+        config = DevConfig(
+            data="live-db",
+            scenario="peers",
+            prod_base_url="https://music.ablz.au",
+            dsn=None,
+            beets_db=None,
+            redis_host=None,
+            redis_port=6379,
+        )
+        self.server = DevHTTPServer(("127.0.0.1", 0), DevHandler, config)
+        self.thread = threading.Thread(
+            target=self.server.serve_forever,
+            daemon=True,
+        )
+        self.thread.start()
+        self.base = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def test_discogs_mirror_not_configured_maps_to_503_not_500(self):
+        import web.server as web_server
+        from web.discogs import DiscogsMirrorNotConfigured
+
+        def _raise(h, params):
+            raise DiscogsMirrorNotConfigured("no mirror configured")
+
+        # Throwaway route registration (test-only wiring into the real
+        # route dict, not a mock of our own logic) so the real exception
+        # class flows through the real dispatch path (test-fidelity Rule B).
+        probe_path = "/api/__test_mirror_probe"
+        web_server.Handler._FUNC_GET_ROUTES[probe_path] = _raise
+        self.addCleanup(
+            web_server.Handler._FUNC_GET_ROUTES.pop, probe_path, None,
+        )
+
+        with self.assertRaises(HTTPError) as raised:
+            urlopen(f"{self.base}{probe_path}")
+        self.assertEqual(raised.exception.code, 503)
+
+
 class ConfigureLiveDbReadOnlyTest(unittest.TestCase):
     """`--data live-db` sessions must stay read-only after #427.
 

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -586,6 +586,52 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
                                 "release detail track (discogs forward)")
         self.assertEqual(data["beets_album_id"], 8)
 
+    @patch("web.routes.browse.discogs_api.get_master_releases")
+    def test_release_group_numeric_id_forwards_to_discogs(self, mock_discogs_master):
+        """#501 item 1: a numeric id in the release-group route is a
+        Discogs master id, not an MB release-group UUID — the route
+        must dispatch to the Discogs master endpoint (mirrors
+        test_release_detail_numeric_id_forwards_to_discogs above) rather
+        than firing a doomed MB lookup."""
+        beets_db = FakeBeetsDB()
+        beets_db.set_album_ids_for_release("21491", [8])
+        beets_db.set_mbid_detail("21491", {})
+        mock_discogs_master.return_value = {
+            "title": "OK Computer",
+            "type": "Album",
+            "first_release_date": "1997",
+            "artist_credit": "Radiohead",
+            "primary_artist_id": "3840",
+            "releases": [
+                {
+                    "id": "21491",
+                    "title": "OK Computer",
+                    "date": "1997",
+                    "country": "Europe",
+                    "status": "Official",
+                    "track_count": 12,
+                    "format": "CD",
+                    "media_count": 1,
+                    "labels": [],
+                },
+            ],
+        }
+        with patch("web.server.mb_api") as mock_mb, \
+                patch("web.server.check_beets_library", return_value={"21491"}), \
+                patch("web.server._beets_db", return_value=beets_db), \
+                patch("web.server.check_pipeline",
+                      return_value={"21491": {"id": 42, "status": "wanted"}}):
+            status, data = self._get("/api/release-group/0021491")
+
+        self.assertEqual(status, 200)
+        mock_discogs_master.assert_called_once_with(21491)
+        mock_mb.get_release_group_releases.assert_not_called()
+        _assert_required_fields(self, data, {"releases"},
+                                "release group response (discogs forward)")
+        _assert_required_fields(self, data["releases"][0], self.RELEASE_GROUP_REQUIRED_FIELDS,
+                                "release group release (discogs forward)")
+        self.assertEqual(data["releases"][0]["beets_album_id"], 8)
+
     def test_artist_disambiguate_contract(self):
         fake_releases = [
             {

--- a/tests/web/test_routes_pipeline_replace.py
+++ b/tests/web/test_routes_pipeline_replace.py
@@ -108,7 +108,7 @@ class TestPipelineReplaceContract(_FakeDbWebServerCase):
 
     REPLACE_REQUIRED_FIELDS = {
         "outcome", "request_id", "new_request_id", "current_status",
-        "descendant_request_id", "error_message", "warnings",
+        "descendant_request_id", "error_message", "reason", "warnings",
     }
     REQUESTS_BY_RG_FIELDS = {
         "id", "mb_release_id", "mb_release_group_id", "status",
@@ -206,12 +206,14 @@ class TestPipelineReplaceContract(_FakeDbWebServerCase):
         with self._patch_service(
             outcome="target_invalid", request_id=100,
             error_message="MB lookup empty",
+            reason="unresolvable_target",
         ):
             status, data = self._post(
                 "/api/pipeline/100/replace",
                 {"target_mb_release_id": "bogus"},
             )
         self.assertEqual(status, 422)
+        self.assertEqual(data["reason"], "unresolvable_target")
 
     def test_replace_rg_mismatch_returns_422(self):
         with self._patch_service(

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -24,8 +24,12 @@
  *      `source==='youtube'` ("rescue running" / "last rescue failed: …").
  *   4. Sibling pressings ← `GET /api/release-group/<rg>` (rg read straight
  *      off the cohort row's `mb_release_group_id` — projected by
- *      `_LONG_TAIL_SELECT`, #398; skipped for rows without one, e.g.
- *      Discogs-sourced).
+ *      `_LONG_TAIL_SELECT`, #398; skipped only for rows with no release
+ *      group / master at all. `mb_release_group_id` doubles as the
+ *      Discogs master id for Discogs-sourced rows (KTD-1), and the route
+ *      dispatches numeric ids to the Discogs master endpoint server-side
+ *      (#501 item 1) — a Discogs row with a resolved master gets real
+ *      sibling pressings here too, not a doomed MB lookup).
  *   5. YouTube matrix  ← the four-state shell. Defaults to `never_run`
  *      with a "Check YouTube" button (U5 wires the actual resolver call —
  *      U4 must NOT auto-call the slow, side-effectful resolver GET).
@@ -1505,13 +1509,19 @@ async function loadPipelinePanels(id, token, inFlightFlag) {
 /**
  * Load the sibling-pressings panel from `GET /api/release-group/<rg>`.
  * Independent — a slow / failing release-group renders only this panel's
- * error affordance and never blocks the others. Rows without a release
- * group (Discogs-sourced, or a legacy MB row with none) render an explicit
- * "no sibling data" state rather than firing a doomed fetch (KTD7).
+ * error affordance and never blocks the others. `rgId` doubles as the
+ * Discogs master id for Discogs-sourced rows (KTD-1 — numeric ids share
+ * this column); the route dispatches numeric ids to the Discogs master
+ * endpoint server-side (`web/routes/browse.py::get_release_group`, #501
+ * item 1), so a Discogs row with a resolved master gets REAL sibling
+ * pressings here, not a doomed MB lookup. Rows with no release group /
+ * master at all (masterless Discogs releases, or a legacy MB row with
+ * none) render an explicit "no sibling data" state instead of fetching.
  *
  * @param {number} id
  * @param {number} token
- * @param {string|null} rgId  The request's `mb_release_group_id`, or null.
+ * @param {string|null} rgId  The request's `mb_release_group_id` (MB
+ *   release-group UUID or Discogs numeric master id), or null.
  * @returns {Promise<void>}
  */
 async function loadSiblingsPanel(id, token, rgId) {

--- a/web/js/replace_picker.js
+++ b/web/js/replace_picker.js
@@ -28,23 +28,23 @@
  * release-group analog for a Discogs row is the Discogs master, and the
  * numeric master id lives in the SAME `releaseGroupId` field MB uses
  * (KTD-1 — `lib/field_resolver_service.py::_looks_numeric` convention).
- * `runStandard` branches purely on the anchor's shape (`detectSource`):
- * a UUID anchor keeps the existing `GET /api/release-group/<id>` path
- * byte-for-byte; a numeric anchor fetches `GET /api/discogs/master/<id>`
- * instead and maps its `releases` onto the same pressing-row shape via
- * `mapDiscogsMasterReleases`. `POST .../resolve-rg` returning
- * `status: 'masterless'` (Discogs release with no master) renders the
- * one-element "nothing to swap to" state (R2) via `runMasterless`
- * instead of the generic error path. Tracklist fetches
- * (`fetchTracklist`/`loadSourceTracklist`) need NO branch — `GET
+ * `runStandard` needs NO client-side anchor-shape branch — `GET
+ * /api/release-group/<id>` already forwards numeric ids to the Discogs
+ * master endpoint server-side (`web/routes/browse.py::get_release_group`,
+ * #501 item 1) and returns the identical pressing-row shape
+ * (`web/discogs.py::get_master_releases` deliberately mirrors
+ * `mb.get_release_group_releases()`), proven by
+ * `tests/web/test_routes_browse.py::test_release_group_numeric_id_forwards_to_discogs`.
+ * `POST .../resolve-rg` returning `status: 'masterless'` (Discogs release
+ * with no master) renders the one-element "nothing to swap to" state (R2)
+ * via `runMasterless` instead of the generic error path. Tracklist fetches
+ * (`fetchTracklist`/`loadSourceTracklist`) need NO branch either — `GET
  * /api/release/<id>` already forwards numeric ids to the Discogs mirror
  * server-side (`web/routes/browse.py::get_release`) and returns the
  * identical `tracks` shape (`disc_number/track_number/title/
  * length_seconds`), proven by
  * `tests/web/test_routes_browse.py::test_release_detail_numeric_id_forwards_to_discogs`.
  */
-
-import { detectSource } from './util.js';
 
 /**
  * @typedef {Object} ReplacePickerOptionsStandard
@@ -157,37 +157,6 @@ export function renderPressingsList(releases, sourceMbid) {
     </li>`;
   });
   return `<ul class="replace-picker-list">${rows.join('')}</ul>`;
-}
-
-/**
- * Map a `GET /api/discogs/master/<id>` payload's `releases` array onto the
- * same pressing-row shape (`ReleaseGroupSibling`) `GET /api/release-group/
- * <id>` already returns for MB — field for field: `id`, `title`, `date`,
- * `country`, `status`, `track_count`, `format` (see
- * `web/discogs.py::get_master_releases` vs `web/mb.py::
- * get_release_group_releases`, which already emit identical keys). This
- * mapper exists as the one seam that would catch future drift between the
- * two backends' shapes — it is intentionally NOT a real transformation
- * today. Discogs-only extras (`media_count`, `labels`) are dropped;
- * anything the payload omits falls back to a safe empty value, which
- * `pressingMeta`/`renderPressingsList` already render as blank/dash.
- * Marking the current pressing is unchanged — `renderPressingsList`
- * compares `r.id === sourceMbid` the same way for both sources.
- *
- * @param {{releases?: Array<Object>}|null|undefined} payload
- * @returns {ReleaseGroupSibling[]}
- */
-export function mapDiscogsMasterReleases(payload) {
-  const releases = (payload && Array.isArray(payload.releases)) ? payload.releases : [];
-  return releases.map((r) => ({
-    id: String(r.id ?? ''),
-    title: r.title || '',
-    date: r.date || '',
-    country: r.country || '',
-    status: r.status || '',
-    track_count: typeof r.track_count === 'number' ? r.track_count : 0,
-    format: r.format || '',
-  }));
 }
 
 /**
@@ -525,18 +494,15 @@ async function runStandard(options, showOverlay, close) {
   let sourceMbid = '';
   try {
     // Discogs master ids live in the same field MB release-group ids do
-    // (KTD-1); dispatch on shape rather than threading a second
-    // "pathway" option through the caller.
-    const isDiscogsAnchor = detectSource(releaseGroupId) === 'discogs';
-    const res = await fetch(
-      isDiscogsAnchor
-        ? `/api/discogs/master/${encodeURIComponent(releaseGroupId)}`
-        : `/api/release-group/${encodeURIComponent(releaseGroupId)}`);
+    // (KTD-1). No anchor-shape branch needed here — the route dispatches
+    // numeric ids to the Discogs master endpoint server-side and returns
+    // the identical shape (#501 item 1).
+    const res = await fetch(`/api/release-group/${encodeURIComponent(releaseGroupId)}`);
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
     const body = await res.json();
-    releases = isDiscogsAnchor ? mapDiscogsMasterReleases(body) : (body.releases || []);
+    releases = body.releases || [];
     // Identify the current pressing for the source request (so we can
     // disable that row in the list).
     sourceMbid = await fetchSourceMbid(options.sourceRequestId);

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -229,7 +229,19 @@ def get_artist_disambiguate(h: BaseHTTPRequestHandler, params: dict[str, list[st
 
 def get_release_group(h: BaseHTTPRequestHandler, params: dict[str, list[str]], rg_id: str) -> None:
     srv = _server()
-    data = srv.mb_api.get_release_group_releases(rg_id)
+    normalized_id = normalize_release_id(rg_id) or rg_id.strip()
+    identity = ReleaseIdentity.from_id(normalized_id)
+    if identity and identity.source == "discogs":
+        # A numeric id here is a Discogs master, not an MB release-group
+        # UUID — dispatch server-side the same way get_release() forwards
+        # numeric release ids to get_discogs_release(). get_master_releases
+        # deliberately mirrors mb.get_release_group_releases()'s shape
+        # (web/discogs.py), so get_discogs_master's overlay is the same
+        # contract the frontend already reads for MB rows (#501 item 1).
+        get_discogs_master(h, params, identity.release_id)
+        return
+
+    data = srv.mb_api.get_release_group_releases(normalized_id)
     # Standard toolbar (Remove from beets) and badge renderer (in library
     # + codec-aware rank) read these overlay fields per row, so route
     # them through the shared helper.
@@ -679,7 +691,8 @@ ROUTES: list[RouteRegistration] = [
     ),
     pattern_route(
         "GET", r"^/api/release-group/([a-f0-9-]+)$", get_release_group,
-        "MB release group detail — releases in this group with overlay.",
+        "MB release group detail (auto-routes to the Discogs master "
+        "endpoint for numeric IDs) — releases in this group with overlay.",
         classified=True,
     ),
     pattern_route(

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -51,6 +51,17 @@ from lib.disk_coverage_service import disk_coverage
 from lib.import_preview import ImportPreviewValues, preview_import_from_values
 from lib.release_identity import detect_release_source, normalize_release_id
 from lib.release_cleanup import remove_and_reset_release
+from lib.replace_status import (
+    RESOLVE_STATUS_LOOKUP_FAILED,
+    RESOLVE_STATUS_MASTERLESS,
+    RESOLVE_STATUS_MIRROR_UNCONFIGURED,
+    RESOLVE_STATUS_MISSING_RELEASE_ID,
+    RESOLVE_STATUS_NON_MB_RELEASE_ID,
+    RESOLVE_STATUS_NO_RELEASE_GROUP,
+    RESOLVE_STATUS_NOT_FOUND,
+    RESOLVE_STATUS_RESOLVED,
+    RESOLVE_STATUS_TRANSIENT,
+)
 from lib.util import resolve_failed_path
 from lib.validation_envelope import decode_validation_envelope
 from lib.spectral_check import (HF_DEFICIT_SUSPECT, HF_DEFICIT_MARGINAL,
@@ -681,7 +692,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": None,
-            "status": "not_found",
+            "status": RESOLVE_STATUS_NOT_FOUND,
             "error": f"request {request_id} not found",
         }, status=404)
         return
@@ -691,7 +702,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": existing_rg,
-            "status": "resolved",
+            "status": RESOLVE_STATUS_RESOLVED,
         })
         return
 
@@ -700,7 +711,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": None,
-            "status": "missing_release_id",
+            "status": RESOLVE_STATUS_MISSING_RELEASE_ID,
             "error": (
                 f"request {request_id} has no mb_release_id to resolve"
             ),
@@ -727,7 +738,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": None,
-            "status": "non_mb_release_id",
+            "status": RESOLVE_STATUS_NON_MB_RELEASE_ID,
             "error": (
                 f"request {request_id}.mb_release_id "
                 f"{mb_release_id!r} is neither a MusicBrainz UUID "
@@ -752,7 +763,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
             h._json({
                 "request_id": request_id,
                 "mb_release_group_id": None,
-                "status": "mirror_unconfigured",
+                "status": RESOLVE_STATUS_MIRROR_UNCONFIGURED,
                 "error": f"Discogs mirror not configured: {exc}",
             }, status=503)
             return
@@ -760,7 +771,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
             h._json({
                 "request_id": request_id,
                 "mb_release_group_id": None,
-                "status": "transient",
+                "status": RESOLVE_STATUS_TRANSIENT,
                 "error": f"Discogs lookup failed (transient): {exc}",
             }, status=503)
             return
@@ -768,7 +779,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
             h._json({
                 "request_id": request_id,
                 "mb_release_group_id": None,
-                "status": "lookup_failed",
+                "status": RESOLVE_STATUS_LOOKUP_FAILED,
                 "error": (
                     f"Discogs lookup for {mb_release_id} failed: {exc}"
                 ),
@@ -783,7 +794,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
             h._json({
                 "request_id": request_id,
                 "mb_release_group_id": None,
-                "status": "masterless",
+                "status": RESOLVE_STATUS_MASTERLESS,
             })
             return
 
@@ -791,7 +802,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": master_id,
-            "status": "resolved",
+            "status": RESOLVE_STATUS_RESOLVED,
         })
         return
 
@@ -801,7 +812,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": None,
-            "status": "transient",
+            "status": RESOLVE_STATUS_TRANSIENT,
             "error": f"MB lookup failed (transient): {exc}",
         }, status=503)
         return
@@ -809,7 +820,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": None,
-            "status": "lookup_failed",
+            "status": RESOLVE_STATUS_LOOKUP_FAILED,
             "error": (
                 f"MB lookup for {mb_release_id} failed: {exc}"
             ),
@@ -821,7 +832,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
         h._json({
             "request_id": request_id,
             "mb_release_group_id": None,
-            "status": "no_release_group",
+            "status": RESOLVE_STATUS_NO_RELEASE_GROUP,
             "error": (
                 f"MB release {mb_release_id} has no release_group_id"
             ),
@@ -832,7 +843,7 @@ def post_pipeline_resolve_rg(h, body: dict, req_id_str: str) -> None:
     h._json({
         "request_id": request_id,
         "mb_release_group_id": rg_id,
-        "status": "resolved",
+        "status": RESOLVE_STATUS_RESOLVED,
     })
 
 
@@ -909,6 +920,7 @@ def post_pipeline_replace(h, body: dict, req_id_str: str) -> None:
         "current_status": result.current_status,
         "descendant_request_id": result.descendant_request_id,
         "error_message": result.error_message,
+        "reason": result.reason,
         "warnings": list(result.warnings),
     }
     if result.outcome == RESULT_REPLACED:


### PR DESCRIPTION
## Summary

Closes #501.

Four independent cleanups surfaced during #282 (Discogs-pathway Replace, PR #499/#500). Deduped against #466-#498 — no overlap.

### Item 1 — Server-side pathway dispatch for `GET /api/release-group/<id>`
`web/routes/browse.py::get_release_group`'s regex (`[a-f0-9-]+`) silently matched Discogs numeric master ids and fired a doomed MB lookup for every one — the same asymmetry `get_release()` already closed for `/api/release/<id>`. Numeric ids now dispatch to `get_discogs_master` server-side (`web/discogs.py::get_master_releases` deliberately mirrors `mb.get_release_group_releases()`'s shape).

This fixes a real bug #282 amplified: `web/js/long_tail.js::loadSiblingsPanel` fires `GET /api/release-group/<rg>` unconditionally for every row with a resolved release group/master — since Discogs rows carry the numeric master id in the same `mb_release_group_id` column (KTD-1), post-#282 that's every Discogs row with a resolved master. The long-tail console now gets real sibling pressings for Discogs rows instead of a generic error. Updated the stale docstrings claiming Discogs rows always render a "no sibling data" placeholder.

Also dropped `web/js/replace_picker.js`'s client-side `isDiscogsAnchor` branch and `mapDiscogsMasterReleases` adapter (and its dedicated JS unit tests) — the server-side dispatch makes the client-side MB/Discogs shape adapter redundant, one dispatch site instead of one per JS consumer, honoring "no adapter code between MB and Discogs" at the route layer.

### Item 2 — Typed rejection reasons + shared status constants
`RESULT_TARGET_INVALID` collapsed at least five distinct rejections (cross-pathway target, masterless/RG-less source, unresolvable target, target-resolved-without-master, unexpected lookup exception), distinguishable only by free-text `error_message`. Added a stable `reason` field (a `REPLACE_REASON_*` code, pathway-neutral — same code for MB and Discogs failures of the same shape) to `ReplaceResult` so CLI/API/tests can assert on the code instead of parsing messages.

`ReplaceResult` crosses the JSON boundary on both the CLI `--json` output and the HTTP response body, so it converts from `@dataclass(frozen=True)` to `msgspec.Struct(frozen=True)` per the wire-boundary-types rule while adding the field (mirrors `lib/field_resolver_service.py::ResolverResult`'s `status` + `reason_code` precedent) — additive, no callers break.

New `lib/replace_status.py` centralizes every `RESULT_*` / `REPLACE_REASON_*` / `RESOLVE_STATUS_*` string constant. `POST .../resolve-rg`'s status vocabulary was previously hardcoded independently of the service's `RESULT_*` constants — two of them (`mirror_unconfigured`, `transient`) describe the identical failure mode on a sibling operator action but could silently diverge since they were never the same symbol. Both surfaces now import from one module.

Both `pipeline-cli replace` and `POST /api/pipeline/<id>/replace` surface the new `reason` field (CLI ⇄ API symmetry). Folded in: the `cmd_replace` docstring's stale "different MBID" text (adjacent lines in the docstring this change already touches) — now pathway-neutral, matching the module docstring and the web route's wording.

### Item 3 — MB-arm parity with `_discogs_lookup_or_error`
PR #499 extracted the Discogs arm's duplicated three-way exception→outcome mapping into `_discogs_lookup_or_error`, adding a `logger.warning` on unexpected exceptions so a real client bug stops presenting identically to expected operator input. The MB arm kept its own two inline copies of the analogous two-way mapping. Extracted `_mb_lookup_or_error` mirroring the Discogs helper — same outcomes and messages, but the target-lookup site gains outcome AND logging coverage for the first time (it had neither before).

Landed this refactor *before* item 2 in the implementation (item 2's reason-wiring is cleaner against the now-unified call sites) but keeping the requested commit-per-item structure; see commit order below.

Judgment call: did NOT force-unify `post_pipeline_resolve_rg`'s two MB/Discogs branches into one function — they already read cleanly separately (mirrors the simplify pass's original call on this), and the shared-constants module already kills the vocabulary-drift risk without adding a forced-abstraction layer.

### Item 4 — Small parity/hygiene items
- `scripts/web_dev_server.py::_serve_live_db_get`'s generic exception handler mapped every route-handler exception to 500, including `DiscogsMirrorNotConfigured` — production's `web/server.py::do_GET` catches this specific exception first and maps it to 503 (deliberate config posture, not a crash). Dev sessions now exercise the same 503.
- `cmd_replace` docstring fix folded into item 2's commit (see above) since it's adjacent lines in the same docstring.
- Beets-distance badges for Discogs siblings (`/api/beets-distance/<log>/<id>` is UUID-anchored) — left as a documented deferral per the #282 plan's Scope Boundaries. Not implemented in this PR.

## Commits (in order)
1. `refactor(web): server-side dispatch for GET /api/release-group/<id> (#501 item 1)`
2. `refactor(replace): MB-arm parity with _discogs_lookup_or_error (#501 item 3)`
3. `fix(dev-server): map DiscogsMirrorNotConfigured to 503 in live-db GET dispatch (#501 item 4)`
4. `feat(replace): typed rejection reasons + shared status constants (#501 item 2)`

(Items 3 and 2 are ordered 3-then-2 in the commit log — item 2's reason-wiring builds cleanly on item 3's unified lookup-helper call sites.)

## Explicitly not done (per issue's "Explicitly not proposed")
Cross-pathway replace and the Discogs inverted picker mode stay out (operator-confirmed, unrelated to this PR's scope).

## Test plan
- [x] Full suite: `nix-shell --run "bash scripts/run_tests.sh"` — 4714 tests, OK
- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings
- [x] `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code
- [x] `node --check web/js/*.js` + `node tests/test_js_util.mjs` — 487 passed, 0 failed
- [x] Strict RED/GREEN TDD throughout — every new behavior has a failing test written first (server dispatch, reason field, logger.warning parity, dev-server status mapping)
- [x] `TestRouteContractAudit` passes unchanged (item 1 modifies an existing classified route's dispatch, no new route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)