### PR TITLE
refactor: unify the two staged-path-readiness deciders

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -11,7 +11,6 @@ lib/slskd_events.py.
 from __future__ import annotations
 
 import logging
-import os
 from datetime import datetime, timezone
 from contextlib import AbstractContextManager
 from typing import (Any, Callable, Protocol, TYPE_CHECKING, assert_never,
@@ -26,10 +25,10 @@ from lib.download_processing import (
     CompletionResult,
     Materialized,
     MaterializeFailed,
+    MaterializeGuarded,
     MaterializeResult,
-    _abandon_request_scoped_auto_import,
     _canonical_import_folder_path,
-    _log_post_move_resume_blocked,
+    _evaluate_staged_path_readiness,
     _materialize_processing_dir,
     process_completed_album,
 )
@@ -617,7 +616,25 @@ def _processing_path_ready_for_importer(
     db: DownloadDB,
     ctx: CratediggerContext,
 ) -> bool:
-    """Fail closed before enqueueing a job that cannot resume local files."""
+    """Fail closed before enqueueing a job that cannot resume local files.
+
+    Thin wrapper around the ONE shared staged-path-readiness decision
+    (``lib.download_processing._evaluate_staged_path_readiness``, issue
+    #509) — the same decision ``_materialize_processing_dir`` uses for
+    its own non-canonical branch, so this pre-enqueue gate and the
+    materialize step it precedes can never drift apart again. This
+    wrapper only translates the tagged result into this caller's
+    ``bool`` contract and applies this gate's own, deliberately
+    different reaction to failure: an IMMEDIATE reset to 'wanted', not
+    the grace-windowed retry/reset ``materialize_failure_action``
+    applies when the same tag surfaces later from
+    ``_enqueue_completed_processing``'s own materialize call. That
+    difference is intentional and tested (``test_poll_missing_
+    persisted_current_path_resets_to_wanted``) — this gate exists to
+    fail closed before even attempting a heavier materialize/enqueue,
+    not to duplicate the grace window a first materialize attempt
+    already earned.
+    """
     if state.processing_started_at is None or state.current_path is None:
         return True
 
@@ -630,79 +647,22 @@ def _processing_path_ready_for_importer(
         staging_dir=ctx.cfg.beets_staging_dir,
         slskd_download_dir=ctx.cfg.slskd_download_dir,
     )
-    subprocess_started = state.import_subprocess_started_at is not None
-    if (
-        current_path_location.kind == "request_scoped_auto_import_staged"
-        and subprocess_started
-    ):
-        _abandon_request_scoped_auto_import(
-            entry,
-            request_id=request_id,
-            current_path=state.current_path,
-            current_path_kind=current_path_location.kind,
-            db=db,
-            detail=(
-                "Abandoned interrupted auto-import; queued for redownload"
-            ),
-        )
-        return False
-
-    if not os.path.isdir(state.current_path):
-        # The canonical processing folder may not exist yet. The importer
-        # materializes it from the completed slskd files as its first step.
-        if current_path_location.kind == "canonical":
-            return True
-        if current_path_location.blocks_post_move_retry and subprocess_started:
-            _log_post_move_resume_blocked(
-                entry,
-                current_path=state.current_path,
-                detail=(
-                    "already lives at the request-scoped auto-import "
-                    "staged path but the directory is missing. "
-                    "Automatic retry is disabled because beets may "
-                    "already have consumed the staged folder; manual "
-                    "recovery is required."
-                ),
-            )
-            return False
-        logger.error("Current staged path missing: %s", state.current_path)
-        transitions.finalize_request(
-            db,
-            request_id,
-            transitions.RequestTransition.to_wanted(
-                from_status="downloading",
-                attempt_type="download",
-            ),
-        )
-        return False
-
-    staged_album = StagedAlbum.from_entry(entry, default_path=state.current_path)
-    staged_album.bind_import_paths(entry.files)
-    missing_paths: list[str] = []
-    for file in entry.files:
-        import_path = file.import_path
-        if import_path is not None and not os.path.isfile(import_path):
-            missing_paths.append(import_path)
-    if not missing_paths:
+    if current_path_location.kind == "canonical":
+        # The canonical processing folder may not exist yet — the
+        # importer materializes it from the completed slskd files as
+        # its first step. Nothing to check here.
         return True
 
-    if current_path_location.blocks_post_move_retry and subprocess_started:
-        _log_post_move_resume_blocked(
-            entry,
-            current_path=state.current_path,
-            detail=(
-                "already lives at the request-scoped auto-import "
-                f"staged path but tracked files are missing ({', '.join(missing_paths)}). "
-                "Automatic retry is disabled because import may "
-                "already have started; manual recovery is required."
-            ),
-        )
+    staged_album = StagedAlbum.from_entry(entry, default_path=state.current_path)
+    result = _evaluate_staged_path_readiness(
+        entry, staged_album, current_path_location, db,
+    )
+    if isinstance(result, Materialized):
+        return True
+    if isinstance(result, MaterializeGuarded):
         return False
 
-    logger.error(
-        "Current staged path is missing tracked files: %s",
-        ", ".join(missing_paths),
-    )
+    assert isinstance(result, MaterializeFailed)
     transitions.finalize_request(
         db,
         request_id,

--- a/lib/download_processing.py
+++ b/lib/download_processing.py
@@ -18,7 +18,7 @@ import shutil
 from dataclasses import dataclass
 from typing import Any, Callable, TYPE_CHECKING
 
-from lib.download_recovery import classify_processing_path
+from lib.download_recovery import ProcessingPathLocation, classify_processing_path
 from lib.grab_list import GrabListEntry
 from lib.dispatch import (DispatchOutcome, QualityGateFn,
                           _build_download_info,
@@ -116,7 +116,10 @@ class MaterializeGuarded:
 
 
 MaterializeResult = Materialized | MaterializeFailed | MaterializeGuarded
-"""Return type of ``_materialize_processing_dir``."""
+"""Return type of ``_materialize_processing_dir`` and
+``_evaluate_staged_path_readiness`` (issue #509 — the shared staged-path
+resume decision the former's non-canonical branch delegates to, and
+``lib.download._processing_path_ready_for_importer`` also consumes)."""
 
 
 @dataclass(frozen=True)
@@ -544,6 +547,152 @@ def _abandon_request_scoped_auto_import(
         return False
 
 
+def _evaluate_staged_path_readiness(
+    album_data: GrabListEntry,
+    staged_album: StagedAlbum,
+    current_path_location: ProcessingPathLocation,
+    db: DownloadDB | None,
+) -> MaterializeResult:
+    """Decide whether a NON-canonical staged path is safe to resume.
+
+    The ONE "is this staged /Incoming path safe to resume into the
+    importer" decision (issue #509). Before this, the same checks
+    (missing-dir handling, the ``blocks_post_move_retry``/
+    ``blocks_auto_import_dispatch`` guards, the abandon-and-reset call)
+    were expressed twice: here, and again in
+    ``lib.download._processing_path_ready_for_importer``. The two copies
+    had drifted — the poller's copy was missing the
+    ``blocks_auto_import_dispatch`` guard entirely, and computed
+    subprocess-start evidence as a plain in-memory bool
+    (``state.import_subprocess_started_at is not None``) instead of this
+    module's fail-safe tri-state DB read
+    (``_request_import_subprocess_started`` — ``None`` when ownership is
+    unverifiable, which callers must treat the same as "started").
+
+    Both callers now go through this one function; only their REACTION
+    to the tag still differs, because it's a genuinely different,
+    caller-owned policy rather than a duplicated decision:
+    ``_enqueue_completed_processing`` applies the grace-windowed
+    retry/reset policy in ``materialize_failure_action``, while the
+    poller's own pre-enqueue gate (``_processing_path_ready_for_importer``)
+    resets immediately on ``MaterializeFailed`` — its own long-standing,
+    tested "fail closed before even trying to enqueue" behavior.
+
+    Callers must already have excluded ``current_path_location.kind ==
+    "canonical"`` — that branch performs the real event-stamp/move work
+    in ``_materialize_processing_dir`` and has no equivalent here.
+    """
+    request_id = album_data.db_request_id
+    subprocess_started = _request_import_subprocess_started(db, request_id)
+
+    if current_path_location.kind == "request_scoped_auto_import_staged":
+        if subprocess_started is True:
+            handled = _abandon_request_scoped_auto_import(
+                album_data,
+                request_id=request_id,
+                current_path=staged_album.current_path,
+                current_path_kind=current_path_location.kind,
+                db=db,
+                detail=(
+                    "Abandoned interrupted auto-import; queued for "
+                    "redownload"
+                ),
+            )
+            if handled:
+                return MaterializeFailed(
+                    reason="abandoned_interrupted_auto_import")
+            return MaterializeGuarded(
+                detail="abandon_blocked_release_lock_or_probe_unknown")
+        if subprocess_started is None:
+            _log_post_move_resume_blocked(
+                album_data,
+                current_path=staged_album.current_path,
+                detail=(
+                    "already lives at the request-scoped auto-import "
+                    "staged path but import ownership could not be "
+                    "verified; manual recovery is required."
+                ),
+            )
+            return MaterializeGuarded(
+                detail="ownership_unverifiable_request_scoped_staged")
+
+    if not os.path.isdir(staged_album.current_path):
+        if (
+            current_path_location.blocks_post_move_retry
+            and subprocess_started is not False
+        ):
+            _log_post_move_resume_blocked(
+                album_data,
+                current_path=staged_album.current_path,
+                detail=(
+                    "already lives at the request-scoped auto-import "
+                    "staged path but the directory is missing. "
+                    "Automatic retry is disabled because beets may "
+                    "already have consumed the staged folder; manual "
+                    "recovery is required."
+                ),
+            )
+            return MaterializeGuarded(
+                detail="post_move_dir_missing_resume_blocked")
+        logger.error(f"Current staged path missing: {staged_album.current_path}")
+        return MaterializeFailed(reason="staged_path_missing")
+
+    staged_album.bind_import_paths(album_data.files)
+    missing_paths: list[str] = []
+    for file in album_data.files:
+        import_path = file.import_path
+        assert import_path is not None
+        if not os.path.isfile(import_path):
+            missing_paths.append(import_path)
+    if missing_paths:
+        if (
+            current_path_location.blocks_post_move_retry
+            and subprocess_started is not False
+        ):
+            _log_post_move_resume_blocked(
+                album_data,
+                current_path=staged_album.current_path,
+                detail=(
+                    "already lives at the request-scoped auto-import "
+                    f"staged path but tracked files are missing ({', '.join(missing_paths)}). "
+                    "Automatic retry is disabled because import may "
+                    "already have started; manual recovery is required."
+                ),
+            )
+            return MaterializeGuarded(
+                detail="post_move_files_missing_resume_blocked")
+        logger.error(
+            "Current staged path is missing tracked files: %s",
+            ", ".join(missing_paths),
+        )
+        return MaterializeFailed(reason="staged_path_missing_tracked_files")
+
+    if (
+        current_path_location.blocks_auto_import_dispatch
+        and subprocess_started is not False
+    ):
+        detail = (
+            "already lives at the request-scoped auto-import staged "
+            "path. Automatic retry is disabled to avoid duplicate "
+            "import; manual recovery is required."
+        )
+        if current_path_location.kind == "legacy_shared_staged":
+            detail = (
+                "already lives at the legacy shared staged path. "
+                "Automatic retry is disabled because the path is "
+                "ambiguous across editions; manual recovery is required."
+            )
+        _log_post_move_resume_blocked(
+            album_data,
+            current_path=staged_album.current_path,
+            detail=detail,
+        )
+        return MaterializeGuarded(detail="auto_import_dispatch_blocked_post_move")
+
+    album_data.import_folder = staged_album.current_path
+    return Materialized()
+
+
 def _materialize_processing_dir(
     album_data: GrabListEntry,
     staged_album: StagedAlbum,
@@ -581,110 +730,9 @@ def _materialize_processing_dir(
     )
 
     if current_path_location.kind != "canonical":
-        subprocess_started = _request_import_subprocess_started(
-            db, request_id)
-        if current_path_location.kind == "request_scoped_auto_import_staged":
-            if subprocess_started is True:
-                handled = _abandon_request_scoped_auto_import(
-                    album_data,
-                    request_id=request_id,
-                    current_path=staged_album.current_path,
-                    current_path_kind=current_path_location.kind,
-                    db=db,
-                    detail=(
-                        "Abandoned interrupted auto-import; queued for "
-                        "redownload"
-                    ),
-                )
-                if handled:
-                    return MaterializeFailed(
-                        reason="abandoned_interrupted_auto_import")
-                return MaterializeGuarded(
-                    detail="abandon_blocked_release_lock_or_probe_unknown")
-            if subprocess_started is None:
-                _log_post_move_resume_blocked(
-                    album_data,
-                    current_path=staged_album.current_path,
-                    detail=(
-                        "already lives at the request-scoped auto-import "
-                        "staged path but import ownership could not be "
-                        "verified; manual recovery is required."
-                    ),
-                )
-                return MaterializeGuarded(
-                    detail="ownership_unverifiable_request_scoped_staged")
-        if not os.path.isdir(staged_album.current_path):
-            if (
-                current_path_location.blocks_post_move_retry
-                and subprocess_started is not False
-            ):
-                _log_post_move_resume_blocked(
-                    album_data,
-                    current_path=staged_album.current_path,
-                    detail=(
-                        "already lives at the request-scoped auto-import "
-                        "staged path but the directory is missing. "
-                        "Automatic retry is disabled because beets may "
-                        "already have consumed the staged folder; manual "
-                        "recovery is required."
-                    ),
-                )
-                return MaterializeGuarded(
-                    detail="post_move_dir_missing_resume_blocked")
-            logger.error(f"Current staged path missing: {staged_album.current_path}")
-            return MaterializeFailed(reason="staged_path_missing")
-        staged_album.bind_import_paths(album_data.files)
-        missing_paths: list[str] = []
-        for file in album_data.files:
-            import_path = file.import_path
-            assert import_path is not None
-            if not os.path.isfile(import_path):
-                missing_paths.append(import_path)
-        if missing_paths:
-            if (
-                current_path_location.blocks_post_move_retry
-                and subprocess_started is not False
-            ):
-                _log_post_move_resume_blocked(
-                    album_data,
-                    current_path=staged_album.current_path,
-                    detail=(
-                        "already lives at the request-scoped auto-import "
-                        f"staged path but tracked files are missing ({', '.join(missing_paths)}). "
-                        "Automatic retry is disabled because import may "
-                        "already have started; manual recovery is required."
-                    ),
-                )
-                return MaterializeGuarded(
-                    detail="post_move_files_missing_resume_blocked")
-            logger.error(
-                "Current staged path is missing tracked files: %s",
-                ", ".join(missing_paths),
-            )
-            return MaterializeFailed(reason="staged_path_missing_tracked_files")
-        if (
-            current_path_location.blocks_auto_import_dispatch
-            and subprocess_started is not False
-        ):
-            detail = (
-                "already lives at the request-scoped auto-import staged "
-                "path. Automatic retry is disabled to avoid duplicate "
-                "import; manual recovery is required."
-            )
-            if current_path_location.kind == "legacy_shared_staged":
-                detail = (
-                    "already lives at the legacy shared staged path. "
-                    "Automatic retry is disabled because the path is "
-                    "ambiguous across editions; manual recovery is required."
-                )
-            _log_post_move_resume_blocked(
-                album_data,
-                current_path=staged_album.current_path,
-                detail=detail,
-            )
-            return MaterializeGuarded(detail="auto_import_dispatch_blocked_post_move")
-        album_data.import_folder = staged_album.current_path
-        return Materialized()
+        return _evaluate_staged_path_readiness(
+            album_data, staged_album, current_path_location, db,
+        )
 
     # Pre-flight: every file must carry a stamped, on-disk local_path from
     # slskd's DownloadFileComplete event — or already-moved evidence at the

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3571,6 +3571,131 @@ class TestPollActiveDownloads(unittest.TestCase):
             self.assertEqual(fake_db.status_history, [])
             self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
+    def test_poll_canonical_dir_present_file_missing_defers_to_grace_not_reset(self):
+        """Issue #509 third divergence (intentional, safer): canonical
+        current_path, dir EXISTS but the tracked file is absent AND
+        unstamped.
+
+        OLD ``_processing_path_ready_for_importer`` reached its
+        missing-files branch and IMMEDIATELY reset the request to
+        'wanted'. The unified gate short-circuits ``kind == 'canonical'``
+        -> ready and lets ``_materialize_processing_dir`` own the
+        decision: it recovers from the slskd event stamp if present, else
+        returns ``MaterializeFailed(event_path_missing)`` which
+        ``materialize_failure_action`` treats as a grace-windowed retry.
+        So the request stays 'downloading' within the grace window —
+        NOT a wrongful immediate reset — consistent with the grace
+        policy the enqueue path already applied to canonical materialize
+        failures. This case is only reachable via manual FS interference
+        / an exquisitely-timed partial move (``StagedAlbum.move_to``
+        rmtrees the source and repoints current_path in the normal flow).
+        """
+        from lib.download import poll_active_downloads
+        from lib.processing_paths import canonical_processing_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_root = os.path.join(tmpdir, "downloads")
+            canonical_path = canonical_processing_path(
+                artist="Test Artist",
+                title="Test Album",
+                year="2020",
+                slskd_download_dir=download_root,
+            )
+            # Dir EXISTS (empty) but the tracked file is absent.
+            os.makedirs(canonical_path)
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": canonical_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000,
+                     # Unstamped: no event-stamped local_path, so
+                     # materialize cannot recover -> event_path_missing.
+                     "local_path": None},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = download_root
+
+            poll_active_downloads(ctx)
+
+            # Stays downloading within grace — NOT reset to wanted.
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertEqual(fake_db.status_history, [])
+            # Materialize failed within grace -> no job enqueued, no reset.
+            self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 0)
+            self.assertEqual(fake_db.download_logs, [])
+
+    def test_poll_canonical_file_missing_gate_and_materialize_agree(self):
+        """Parity for the #509 third divergence: on the exact
+        canonical-dir-present / file-missing / unstamped fixture, the
+        poller's gate (``_processing_path_ready_for_importer``) and
+        ``_materialize_processing_dir`` AGREE — neither does an immediate
+        reset. The gate reports ready (delegating the real decision), and
+        materialize returns the grace-eligible ``MaterializeFailed``. The
+        request row is left 'downloading' by both.
+        """
+        from lib.download import (
+            _processing_path_ready_for_importer,
+            reconstruct_grab_list_entry,
+        )
+        from lib.download_processing import (
+            MaterializeFailed,
+            _materialize_processing_dir,
+        )
+        from lib.processing_paths import canonical_processing_path
+        from lib.quality import ActiveDownloadState
+        from lib.staged_album import StagedAlbum
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_root = os.path.join(tmpdir, "downloads")
+            canonical_path = canonical_processing_path(
+                artist="Test Artist",
+                title="Test Album",
+                year="2020",
+                slskd_download_dir=download_root,
+            )
+            os.makedirs(canonical_path)
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": canonical_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000,
+                     "local_path": None},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = download_root
+
+            raw = fake_db.request(1)["active_download_state"]
+            assert isinstance(raw, dict)
+            state = ActiveDownloadState.from_raw(raw)
+            entry = reconstruct_grab_list_entry(fake_db.request(1), state)
+
+            # Gate: canonical short-circuit -> ready, and it does NOT reset.
+            ready = _processing_path_ready_for_importer(
+                entry, 1, state, fake_db, ctx)
+            self.assertTrue(ready)
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+
+            # Materialize on the same fixture: grace-eligible failure,
+            # again NOT an immediate reset.
+            assert state.current_path is not None
+            staged_album = StagedAlbum.from_entry(
+                entry, default_path=state.current_path)
+            result = _materialize_processing_dir(entry, staged_album, ctx)
+            self.assertIsInstance(result, MaterializeFailed)
+            assert isinstance(result, MaterializeFailed)
+            self.assertEqual(result.reason, "event_path_missing")
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+
     def test_poll_post_move_staged_path_without_validation_queues(self):
         """Staged retries are queued for importer ownership."""
         from lib.download import poll_active_downloads

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Any, TYPE_CHECKING, cast
 
 from lib.download_processing import Materialized, MaterializeFailed, MaterializeGuarded
+from lib.download_recovery import ProcessingPathKind, ProcessingPathLocation
 from lib.slskd_client import TransferSnapshot
 from tests.helpers import (
     make_ctx_with_fake_db,
@@ -2125,6 +2126,157 @@ class TestMaterializeFailureAction(unittest.TestCase):
                     expected)
 
 
+class TestEvaluateStagedPathReadiness(unittest.TestCase):
+    """Pure decision table for the ONE shared "staged path safe to resume"
+    decision (issue #509) — previously duplicated between
+    ``_materialize_processing_dir`` and
+    ``lib.download._processing_path_ready_for_importer``, which had
+    drifted (a missing ``blocks_auto_import_dispatch`` guard on the
+    poller side, and two different ways of reading subprocess-start
+    evidence). Both callers now route through
+    ``_evaluate_staged_path_readiness``; this table pins its branches
+    directly, independent of either caller's own reaction to the tag.
+    """
+
+    def _seed_and_build(
+        self,
+        tmpdir: str,
+        *,
+        kind: ProcessingPathKind,
+        dir_exists: bool,
+        files_present: bool,
+        subprocess_started_at: str | None,
+        seed_row: bool = True,
+        request_id: int = 1,
+    ):
+        from lib.staged_album import StagedAlbum
+
+        current_path = os.path.join(tmpdir, "staged")
+        entry = make_grab_list_entry(
+            files=[make_download_file(filename="01 - Track.flac")],
+            db_request_id=request_id,
+            db_source="request",
+            mb_release_id="test-mbid-509",
+        )
+        staged_album = StagedAlbum(current_path=current_path, request_id=request_id)
+        if dir_exists:
+            os.makedirs(current_path, exist_ok=True)
+        if files_present:
+            dest = staged_album.import_path_for(entry.files[0])
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "w") as fp:
+                fp.write("fake audio")
+        location = ProcessingPathLocation(path=current_path, kind=kind)
+
+        db = FakePipelineDB()
+        if seed_row:
+            state = {
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                "current_path": current_path,
+                "import_subprocess_started_at": subprocess_started_at,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01 - Track.flac",
+                     "file_dir": "user1\\Music", "size": 1000},
+                ],
+            }
+            db.seed_request(make_request_row(
+                id=request_id,
+                status="downloading",
+                mb_release_id="test-mbid-509",
+                active_download_state=state,
+            ))
+        return entry, staged_album, location, db
+
+    CASES = [
+        # (desc, kind, dir_exists, files_present, subprocess_started_at,
+        #  seed_row, expected_type, expected_attr)
+        ("post_validation_dir_missing_not_blocked",
+         "request_scoped_post_validation_staged", False, False, None, True,
+         MaterializeFailed, "staged_path_missing"),
+        ("post_validation_files_present_ready",
+         "request_scoped_post_validation_staged", True, True, None, True,
+         Materialized, None),
+        ("post_validation_files_missing_not_blocked",
+         "request_scoped_post_validation_staged", True, False, None, True,
+         MaterializeFailed, "staged_path_missing_tracked_files"),
+        ("legacy_shared_dir_missing_not_blocked_by_post_move_guard",
+         "legacy_shared_staged", False, False, None, True,
+         MaterializeFailed, "staged_path_missing"),
+        ("legacy_shared_files_present_dispatch_blocked_when_subprocess_true",
+         "legacy_shared_staged", True, True, _utc_now_iso(), True,
+         MaterializeGuarded, "auto_import_dispatch_blocked_post_move"),
+        ("legacy_shared_files_present_allowed_when_subprocess_false",
+         "legacy_shared_staged", True, True, None, True,
+         Materialized, None),
+        ("auto_import_staged_dir_missing_not_blocked_when_subprocess_false",
+         "request_scoped_auto_import_staged", False, False, None, True,
+         MaterializeFailed, "staged_path_missing"),
+        ("auto_import_staged_subprocess_unknown_guards_immediately",
+         "request_scoped_auto_import_staged", False, False, None, False,
+         MaterializeGuarded, "ownership_unverifiable_request_scoped_staged"),
+        ("auto_import_staged_files_missing_not_blocked_when_subprocess_false",
+         "request_scoped_auto_import_staged", True, False, None, True,
+         MaterializeFailed, "staged_path_missing_tracked_files"),
+        ("auto_import_staged_files_present_ready_when_subprocess_false",
+         "request_scoped_auto_import_staged", True, True, None, True,
+         Materialized, None),
+    ]
+
+    def test_decision_table(self):
+        for (desc, kind, dir_exists, files_present, subprocess_started_at,
+             seed_row, expected_type, expected_attr) in self.CASES:
+            with self.subTest(desc=desc):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    from lib.download_processing import (
+                        _evaluate_staged_path_readiness,
+                    )
+                    entry, staged_album, location, db = self._seed_and_build(
+                        tmpdir,
+                        kind=kind,
+                        dir_exists=dir_exists,
+                        files_present=files_present,
+                        subprocess_started_at=subprocess_started_at,
+                        seed_row=seed_row,
+                    )
+                    result = _evaluate_staged_path_readiness(
+                        entry, staged_album, location, db,
+                    )
+                    self.assertIsInstance(result, expected_type)
+                    if expected_attr is not None:
+                        if isinstance(result, MaterializeFailed):
+                            self.assertEqual(result.reason, expected_attr)
+                        elif isinstance(result, MaterializeGuarded):
+                            self.assertEqual(result.detail, expected_attr)
+                        else:
+                            self.fail(
+                                f"result {result!r} has no reason/detail "
+                                "to compare")
+
+    def test_abandon_success_resets_via_shared_decision(self):
+        """kind=auto-import-staged + subprocess started + abandon commits
+        cleanly: the shared decision reports ``MaterializeFailed`` (the
+        caller's cue to treat this as a completed self-heal, not a
+        guarded manual-recovery case) and the DB row is already reset."""
+        from lib.download_processing import _evaluate_staged_path_readiness
+        with tempfile.TemporaryDirectory() as tmpdir:
+            entry, staged_album, location, db = self._seed_and_build(
+                tmpdir,
+                kind="request_scoped_auto_import_staged",
+                dir_exists=True,
+                files_present=False,
+                subprocess_started_at=_utc_now_iso(),
+            )
+            result = _evaluate_staged_path_readiness(
+                entry, staged_album, location, db,
+            )
+            self.assertIsInstance(result, MaterializeFailed)
+            assert isinstance(result, MaterializeFailed)
+            self.assertEqual(result.reason, "abandoned_interrupted_auto_import")
+            self.assertEqual(db.request(1)["status"], "wanted")
+
+
 class TestPollActiveDownloads(unittest.TestCase):
     """Test poll_active_downloads() — core polling function."""
 
@@ -3777,6 +3929,53 @@ class TestPollActiveDownloads(unittest.TestCase):
                 "Subprocess never launched + missing files = stale "
                 "crash residue; must reset to wanted, not block forever.",
             )
+
+    def test_poll_legacy_wedge_row_with_files_present_resumes_via_shared_decision(self):
+        """Counterpart to the missing-file case above: when the tracked
+        file IS present and the subprocess never launched, the poller's
+        readiness gate must permit resume — proving it shares the exact
+        "2026-05-04 wedge" verdict with ``_materialize_processing_dir``
+        (pinned directly, through the OTHER caller, by
+        ``TestPostMoveResumeBlockGuard.test_legacy_wedge_permits_retry``
+        in tests/test_integration_slices.py). Issue #509: before the
+        unification this was reachable through the poller path too, but
+        via a second, independently-written copy of the same guard.
+        """
+        from lib.download import poll_active_downloads
+        from lib.processing_paths import stage_to_ai_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_root = os.path.join(tmpdir, "staging")
+            resumed_path = stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir=staging_root,
+                request_id=1,
+                auto_import=True,
+            )
+            os.makedirs(resumed_path)
+            with open(os.path.join(resumed_path, "01.flac"), "w") as fp:
+                fp.write("audio")
+            row = self._make_downloading_row(state_dict={
+                "filetype": "flac",
+                "enqueued_at": _utc_now_iso(),
+                "processing_started_at": _utc_now_iso(),
+                # NO ``import_subprocess_started_at`` — legacy wedge shape.
+                "current_path": resumed_path,
+                "files": [
+                    {"username": "user1", "filename": "user1\\Music\\01.flac",
+                     "file_dir": "user1\\Music", "size": 30000000},
+                ],
+            })
+            ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
+            cfg = cast(Any, ctx.cfg)
+            cfg.beets_staging_dir = staging_root
+
+            poll_active_downloads(ctx)
+
+            self.assertEqual(fake_db.request(1)["status"], "downloading")
+            self.assertEqual(fake_db.status_history, [])
+            self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
     def test_poll_no_redownload_window(self):
         """Album stays 'downloading' while queued for importer."""

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -3991,6 +3991,32 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
         self.assertEqual(len(moved), 1)
         self.assertTrue(moved[0].startswith("abandoned_auto_import"))
 
+    def test_readiness_gate_agrees_with_materialize_on_legacy_wedge(self):
+        """Issue #509: the poller's pre-enqueue gate
+        (``_processing_path_ready_for_importer``) and
+        ``_materialize_processing_dir`` above now share ONE decision
+        (``_evaluate_staged_path_readiness``). Same wedge shape
+        (subprocess never launched) through the OTHER caller must reach
+        the same verdict: ready, not blocked.
+        """
+        from lib.download import _processing_path_ready_for_importer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            entry, request_id, state, db, ctx, staged_path = (
+                self._setup_wedged_request(
+                    tmpdir, import_subprocess_started_at=None))
+
+            ready = _processing_path_ready_for_importer(
+                entry, request_id, state, db, ctx)
+
+        self.assertTrue(
+            ready,
+            "Legacy wedged row (subprocess never launched) must be "
+            "reported ready by the poller's own gate too — it shares "
+            "the materialize path's decision now.",
+        )
+        self.assertEqual(db.request(request_id)["status"], "downloading")
+
 
 class TestSearchWatchdogSlice(unittest.TestCase):
     """End-to-end slice for issue #212: parallel-search-executor's


### PR DESCRIPTION
Closes #509

## Summary

`lib/download.py::_processing_path_ready_for_importer` (the poller's pre-enqueue gate) and `lib/download_processing.py::_materialize_processing_dir`'s non-canonical branch (the materialize step it precedes) independently implemented "is this staged `/Incoming` path safe to resume into the importer." They had drifted since #474 gave both call sites the `MaterializeResult` tagged union. This PR extracts the shared decision into one pure function, `_evaluate_staged_path_readiness` (`lib/download_processing.py`), and routes both callers through it — deleting the second, drifted copy. Only each caller's own *reaction* to the resulting tag still differs, and that's a documented, tested, caller-owned policy, not a duplicated check.

## The drift found (and how it was reconciled)

Line-by-line diff of the two "before" implementations surfaced **three** behavior deltas. The first two were verified end-state-inert (reviewer-confirmed). The third is a genuine, intentional behavior change made safer by the unification — documented below, not silent.

1. **Missing guard on the poller side (latent, inert).** `_materialize_processing_dir` checked `current_path_location.blocks_auto_import_dispatch` (blocks retry when the path is `request_scoped_auto_import_staged` or `legacy_shared_staged` and dir+files are otherwise fully present) — `_processing_path_ready_for_importer` never had this check at all. In practice this was latent, not a live bug: the poller's gate returning `True` for this case just fell through to `_enqueue_completed_processing`, which called `_materialize_processing_dir` a moment later and caught it there — so the end state (`downloading`, no job enqueued) was the same either way, just via a redundant round-trip. Reconciliation: the shared function now includes this guard, so the poller's gate catches it directly.

2. **Two different ways of reading subprocess-start evidence (inert).** `_materialize_processing_dir` calls `_request_import_subprocess_started(db, request_id)` — a fresh, fail-safe **tri-state** DB read (`True`/`False`/`None`, where `None` means "unverifiable, treat as started"). `_processing_path_ready_for_importer` instead read `state.import_subprocess_started_at is not None` — a plain **bool** off the in-memory `ActiveDownloadState` already loaded that poll cycle. I verified no existing test scenario could ever observe these two methods disagreeing (the in-memory `state` is always the same row snapshot the DB read would return within the same cycle), so the shared function now always uses the tri-state DB read — strictly more conservative (fails closed on DB errors/row-not-found), and removes the second, weaker evidence source entirely.

3. **Canonical file-missing → grace, not immediate reset (INTENTIONAL, safer, consistency-restoring — found in review).** Case: `current_path == canonical`, `processing_started_at` set, no active import job, the canonical dir **exists** but the tracked file is **absent** at `import_path`. The OLD `_processing_path_ready_for_importer` fell through to its missing-files branch and **immediately reset the request to `wanted`**. The NEW gate short-circuits `kind == "canonical" → return True` before any file check, so the row proceeds to `_enqueue_completed_processing → _materialize_processing_dir`'s canonical branch, which **recovers from the slskd event stamp** if present, else returns `MaterializeFailed(event_path_missing)` — which `materialize_failure_action` treats as a **grace-windowed retry (≤1h) then reset**, not an immediate reset.

   This is kept deliberately, for three reasons: (a) it is **strictly safer** — recover-or-grace never does a wrongful immediate reset of a row whose file may simply be mid-flight; (b) it makes the poller gate **consistent** with the grace-window policy `_enqueue_completed_processing` already applied to canonical materialize failures (before this, the gate and the enqueue path disagreed on the same canonical failure); and (c) the scenario is only reachable via manual FS interference / an exquisitely-timed partial move — in the normal flow `StagedAlbum.move_to` rmtrees the source and repoints `current_path`, so a canonical dir with a missing tracked file doesn't arise. It ships **tested**, not silent (see the two new tests below).

## What deliberately did NOT change

Both callers' **reaction** to a `MaterializeFailed` tag stays different, because it's a real, tested, caller-owned policy rather than an accidental duplication:

| | `_processing_path_ready_for_importer` (poller pre-enqueue gate) | `_enqueue_completed_processing` (via `_materialize_processing_dir`) |
|---|---|---|
| On `Materialized` | proceed (`True`) | proceed to enqueue |
| On `MaterializeGuarded` | leave alone (`False`, no side effect) | leave alone ("leave" via `materialize_failure_action`) |
| On `MaterializeFailed` | **immediate** reset to `wanted` | **grace-windowed** retry (`PROCESSING_MATERIALIZE_GRACE_S`, 1h) then reset |

The immediate-reset behavior on the poller's gate is intentional for the *non-canonical* staged paths it evaluates (post-validation / legacy-shared / auto-import residue) and already had test coverage locking it in (`test_poll_missing_persisted_current_path_resets_to_wanted`, `test_poll_post_move_staged_missing_file_resets_when_subprocess_never_started`). Note this only applies once the gate actually calls `_evaluate_staged_path_readiness` — i.e. for non-canonical `current_path`. For canonical `current_path` the gate short-circuits to ready and never resets (that's divergence #3 above). The gate only fires on a **retry** cycle (`state.processing_started_at` already set from a prior attempt), specifically to fail closed *before* re-attempting a heavier materialize/enqueue on a genuinely-lost staged folder.

## Test evidence

- RED: `tests/test_download.py::TestEvaluateStagedPathReadiness` (new pure-function subTest table, 10 cases + a dedicated abandon-success case) failed with `ImportError` before the function existed.
- GREEN after implementation; full suite green.
- Orchestration test: `TestPollActiveDownloads::test_poll_legacy_wedge_row_with_files_present_resumes_via_shared_decision` — asserts domain state (`status` stays `downloading`, one import job queued) for the poller path resuming a legacy-wedge row through the shared decision.
- Integration slice: `tests/test_integration_slices.py::TestPostMoveResumeBlockGuard::test_readiness_gate_agrees_with_materialize_on_legacy_wedge` — calls `_processing_path_ready_for_importer` directly against the same wedge fixture the existing `test_legacy_wedge_permits_retry` (which calls `_materialize_processing_dir`) uses, proving both callers now agree.
- **Divergence #3 pins (review follow-up):**
  - `TestPollActiveDownloads::test_poll_canonical_dir_present_file_missing_defers_to_grace_not_reset` — orchestration through `poll_active_downloads` on the exact case: canonical dir present, tracked file absent, unstamped. Asserts domain state — request stays `downloading` (within grace), empty `status_history` (no immediate reset), no job enqueued, no download_log. OLD code would have reset to `wanted` here.
  - `TestPollActiveDownloads::test_poll_canonical_file_missing_gate_and_materialize_agree` — parity: on the same fixture, the gate reports ready (delegating, not resetting) and `_materialize_processing_dir` returns `MaterializeFailed(event_path_missing)`; both leave the row `downloading`.
- `nix-shell --run "bash scripts/run_tests.sh"` — full suite green (4709 tests).
- `nix-shell --run "pyright"` — 0 errors, full repo.
- `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code (both `_abandon_request_scoped_auto_import` and `_log_post_move_resume_blocked` remain reachable via the new shared function; the now-unused `import os` in `lib/download.py` was removed).
- Pre-push `nix flake check` (VM boot gate + eval guards + CLI bundle) passed on push — no `--no-verify` needed.

## Test plan

- [x] New pure-function subTest table for `_evaluate_staged_path_readiness`
- [x] Orchestration test asserting domain state through the poller path
- [x] Integration slice proving both callers agree on the same fixture
- [x] Divergence #3 (canonical file-missing → grace) pinned by orchestration + parity tests
- [x] Full suite + pyright + dead-code sweep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
