### PR TITLE
refactor: type the slskd downloads envelope — second slice (#507)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -52,7 +52,7 @@ from lib.import_queue import (
     automation_import_dedupe_key,
     automation_import_payload,
 )
-from lib.slskd_client import TransferSnapshot
+from lib.slskd_client import DownloadUser, TransferSnapshot
 from lib.slskd_transfers import (
     _all_files_remotely_queued,
     _get_all_downloads_snapshot,
@@ -793,7 +793,7 @@ def _poll_one_active_download(
     row: dict[str, Any],
     db: DownloadDB,
     ctx: CratediggerContext,
-    cycle_snapshot: Any,
+    cycle_snapshot: list[DownloadUser],
 ) -> None:
     """Process one ``downloading`` row.
 

--- a/lib/quality/repair.py
+++ b/lib/quality/repair.py
@@ -7,8 +7,17 @@ slskd transfers no downloading row owns). Pure move: every definition is
 AST-identical to the current monolith.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Deferred: lib.slskd_client -> lib.config -> lib.quality (this
+    # package's __init__) -> lib.quality.repair would otherwise be a
+    # circular import at module load time. DownloadUser is only used for
+    # the find_slskd_orphans() type annotation, never constructed here.
+    from lib.slskd_client import DownloadUser
 
 
 # --- Repair / orphan detection (pure functions) ---
@@ -105,7 +114,7 @@ class SlskdOrphanTransfer:
 
 
 def find_slskd_orphans(
-    downloads: list[dict[str, Any]],
+    downloads: list[DownloadUser],
     db_rows: list[dict[str, Any]],
 ) -> list[SlskdOrphanTransfer]:
     """Detect live slskd transfers no downloading row owns. Pure — no I/O.
@@ -118,7 +127,8 @@ def find_slskd_orphans(
 
     Args:
         downloads: slskd ``transfers.get_all_downloads()`` snapshot
-            (username → directories → files groups).
+            (username → directories → files groups), already decoded via
+            ``lib.slskd_client.parse_downloads_envelope`` (issue #507).
         db_rows: album_requests rows (must include status,
             active_download_state).
 
@@ -142,20 +152,20 @@ def find_slskd_orphans(
 
     orphans: list[SlskdOrphanTransfer] = []
     for user_group in downloads:
-        username = user_group.get("username", "")
-        for directory in user_group.get("directories", []):
-            for transfer in directory.get("files", []):
-                transfer_state = str(transfer.get("state", ""))
+        username = user_group.username
+        for directory in user_group.directories:
+            for transfer in directory.files:
+                transfer_state = transfer.state
                 if transfer_state.startswith("Completed"):
                     continue
-                filename = transfer.get("filename")
+                filename = transfer.filename
                 if not filename:
                     continue
                 if (username, filename) in owned:
                     continue
                 orphans.append(SlskdOrphanTransfer(
                     username=username,
-                    transfer_id=str(transfer.get("id", "")),
+                    transfer_id=transfer.id,
                     filename=filename,
                     state=transfer_state,
                 ))

--- a/lib/slskd_client.py
+++ b/lib/slskd_client.py
@@ -137,6 +137,110 @@ def parse_transfer_snapshot(raw: dict[str, Any]) -> TransferSnapshot | None:
         return None
 
 
+class DownloadDirectory(msgspec.Struct, rename="camel", frozen=True):
+    """One directory grouping within a downloads-envelope user entry
+    (issue #507): a ``directory`` label plus its file transfers. Reuses
+    ``TransferSnapshot`` for each file — the envelope's per-file shape is
+    identical to the one #468 already modeled at the
+    ``DownloadFile.status`` boundary, so there is no second file-level
+    type to keep in sync."""
+
+    directory: str = ""
+    files: list[TransferSnapshot] = msgspec.field(default_factory=list)
+
+
+class DownloadUser(msgspec.Struct, rename="camel", frozen=True):
+    """One user-group row of ``SlskdTransfersApi.get_all_downloads()`` —
+    the outermost level of the nested user->directories->files envelope
+    (issue #507, the second slice: #468 typed the per-file
+    ``TransferSnapshot`` leaf but deliberately left this envelope
+    untouched, per its own first-slice scope note)."""
+
+    username: str = ""
+    directories: list[DownloadDirectory] = msgspec.field(default_factory=list)
+
+
+def _parse_download_directory(raw: Any) -> DownloadDirectory | None:
+    """Convert one directory entry, salvaging valid files from an entry
+    that also contains malformed ones.
+
+    Each file is decoded independently via ``parse_transfer_snapshot``
+    (the same #468 decoder) so one poison file doesn't drop its
+    siblings — a directory can hold many in-flight files for the same
+    peer, and losing status on all of them because one row is malformed
+    would be a much bigger blast radius than the single file it actually
+    affects.
+    """
+    if not isinstance(raw, dict):
+        logger.warning(
+            "slskd downloads envelope: skipping malformed directory "
+            "entry (type=%s)", type(raw).__name__)
+        return None
+    files: list[TransferSnapshot] = []
+    for file_raw in raw.get("files") or []:
+        parsed = (
+            parse_transfer_snapshot(file_raw)
+            if isinstance(file_raw, dict) else None
+        )
+        if parsed is not None:
+            files.append(parsed)
+        elif not isinstance(file_raw, dict):
+            logger.warning(
+                "slskd downloads envelope: skipping non-dict file entry "
+                "(type=%s)", type(file_raw).__name__)
+    directory = raw.get("directory", "")
+    return DownloadDirectory(
+        directory=directory if isinstance(directory, str) else "",
+        files=files,
+    )
+
+
+def _parse_download_user(raw: Any) -> DownloadUser | None:
+    """Convert one user-group row, salvaging valid directories from a row
+    that also contains malformed ones (issue #507)."""
+    if not isinstance(raw, dict):
+        logger.warning(
+            "slskd downloads envelope: skipping malformed user-group "
+            "row (type=%s)", type(raw).__name__)
+        return None
+    directories: list[DownloadDirectory] = []
+    for dir_raw in raw.get("directories") or []:
+        parsed = _parse_download_directory(dir_raw)
+        if parsed is not None:
+            directories.append(parsed)
+    username = raw.get("username", "")
+    return DownloadUser(
+        username=username if isinstance(username, str) else "",
+        directories=directories,
+    )
+
+
+def parse_downloads_envelope(raw: list[Any]) -> list[DownloadUser]:
+    """Decode the ``get_all_downloads()`` envelope (issue #507): the
+    nested user->directories->files shape ``SlskdTransfersApi
+    .get_all_downloads()`` returns, typed end-to-end so poll/repair code
+    no longer walks raw dicts — #468 typed the per-file
+    ``TransferSnapshot`` leaf but deliberately left this envelope
+    untouched, per its own first-slice scope note.
+
+    Tolerant at every level, mirroring #468's ``parse_transfer_snapshot``
+    tolerance: a malformed file entry is dropped (via that same
+    decoder), a malformed directory or user-group row is dropped and
+    logged. One bad entry anywhere in the tree degrades to "no status
+    this cycle" for just that entry — the same signal already used for
+    "no matching transfer found" (``match_transfer`` returning ``None``)
+    — it never aborts the whole poll cycle for every other in-flight
+    download. This runs inside the 5-minute poll loop against a bulk
+    snapshot shared by every in-flight album.
+    """
+    users: list[DownloadUser] = []
+    for row in raw:
+        parsed = _parse_download_user(row)
+        if parsed is not None:
+            users.append(parsed)
+    return users
+
+
 DOWNLOAD_FILE_COMPLETE = "DownloadFileComplete"
 DOWNLOAD_DIRECTORY_COMPLETE = "DownloadDirectoryComplete"
 
@@ -178,8 +282,10 @@ class SlskdClient:
 
     Method names and return shapes deliberately mirror the retired
     `slskd-api` surface (dict/list returns for the legacy endpoints) so
-    call sites migrate mechanically; the events endpoint — the new wire
-    boundary — returns typed Structs.
+    call sites migrate mechanically. The events endpoint and
+    ``transfers.get_all_downloads()`` are the wire boundaries that have
+    since been typed (issues #146, #468/#507 respectively) — both return
+    typed Structs instead of raw dict/list.
     """
 
     def __init__(
@@ -252,11 +358,11 @@ class SlskdTransfersApi:
         )
         return True
 
-    def get_all_downloads(self, includeRemoved: bool = False) -> list[dict[str, Any]]:
+    def get_all_downloads(self, includeRemoved: bool = False) -> list[DownloadUser]:
         response = self._client._request(
             "GET", "/transfers/downloads/",
             params={"includeRemoved": includeRemoved})
-        return response.json()
+        return parse_downloads_envelope(response.json())
 
     def cancel_download(self, username: str, id: str, remove: bool = False) -> bool:
         self._client._request(

--- a/lib/slskd_transfers.py
+++ b/lib/slskd_transfers.py
@@ -17,7 +17,7 @@ from typing import Any, Literal, TYPE_CHECKING
 
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.processing_paths import path_is_within_root
-from lib.slskd_client import parse_transfer_snapshot
+from lib.slskd_client import DownloadUser, TransferSnapshot
 
 if TYPE_CHECKING:
     from lib.context import CratediggerContext
@@ -125,8 +125,8 @@ def _delete_completed_payloads(
             pass  # Non-empty (shared with another album) or already gone.
 
 
-def slskd_download_status(downloads: list[Any], *,
-                          snapshot: list[dict[str, Any]]) -> bool:
+def slskd_download_status(downloads: list[DownloadFile], *,
+                          snapshot: list[DownloadUser]) -> bool:
     """Get status of each download file by matching locally against the
     pre-fetched bulk poll-cycle snapshot (issue #508: every caller already
     has one — there is no per-file API fallback)."""
@@ -135,9 +135,7 @@ def slskd_download_status(downloads: list[Any], *,
         try:
             transfer = match_transfer(snapshot, file.filename, username=file.username)
             if transfer is not None:
-                file.status = parse_transfer_snapshot(transfer)
-                if file.status is None:
-                    ok = False
+                file.status = transfer
             else:
                 file.status = None
                 ok = False
@@ -198,7 +196,7 @@ def slskd_enqueue_with_outcome(
     max_wait = 10.0
     interval = 1.0
     elapsed = 0.0
-    download_list: list[dict[str, Any]] | None = None
+    download_list: list[DownloadUser] | None = None
 
     while elapsed < max_wait:
         time.sleep(interval)
@@ -256,10 +254,12 @@ def slskd_do_enqueue(username: str, files: list[dict[str, Any]],
     return outcome.downloads
 
 
-def downloads_all_done(downloads: list[Any]) -> tuple[bool, list[Any] | None, int]:
+def downloads_all_done(
+    downloads: list[DownloadFile],
+) -> tuple[bool, list[DownloadFile] | None, int]:
     """Check status of all files. Returns (all_done, error_list_or_none, remote_queue_count)."""
     all_done = True
-    error_list: list[Any] = []
+    error_list: list[DownloadFile] = []
     remote_queue = 0
     for file in downloads:
         if file.status is not None:
@@ -279,7 +279,9 @@ def downloads_all_done(downloads: list[Any]) -> tuple[bool, list[Any] | None, in
     return all_done, error_list if error_list else None, remote_queue
 
 
-def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) -> bool:
+def _all_files_remotely_queued(
+    downloads: list[DownloadFile], remote_queue_count: int,
+) -> bool:
     """Return True when every tracked file is still queued on the remote peer.
 
     This is intentionally separate from stalled transfer detection: a file that has
@@ -295,13 +297,13 @@ def _all_files_remotely_queued(downloads: list[Any], remote_queue_count: int) ->
 # === Transfer ID re-derivation ===
 
 def match_transfer_id(
-    downloads: dict[str, Any] | list[dict[str, Any]],
+    downloads: DownloadUser | list[DownloadUser],
     target_filename: str,
     username: str | None = None,
 ) -> str | None:
     """Find the slskd transfer ID for a filename in slskd download responses.
 
-    downloads may be a single-user transfer dict or the list returned by
+    downloads may be a single user-group entry or the list returned by
     slskd.transfers.get_all_downloads(). When a list is provided, username
     narrows the search to one peer.
     Returns the transfer ID string, or None if not found.
@@ -309,7 +311,7 @@ def match_transfer_id(
     transfer = match_transfer(downloads, target_filename, username=username)
     if transfer is None:
         return None
-    return transfer.get("id", "")
+    return transfer.id
 
 
 def _parse_transfer_timestamp(value: Any) -> datetime:
@@ -328,23 +330,23 @@ def _parse_transfer_timestamp(value: Any) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
-def _transfer_latest_timestamp(transfer: dict[str, Any]) -> datetime:
+def _transfer_latest_timestamp(transfer: TransferSnapshot) -> datetime:
     return max(
-        _parse_transfer_timestamp(transfer.get("endedAt")),
-        _parse_transfer_timestamp(transfer.get("startedAt")),
-        _parse_transfer_timestamp(transfer.get("enqueuedAt")),
-        _parse_transfer_timestamp(transfer.get("requestedAt")),
+        _parse_transfer_timestamp(transfer.ended_at),
+        _parse_transfer_timestamp(transfer.started_at),
+        _parse_transfer_timestamp(transfer.enqueued_at),
+        _parse_transfer_timestamp(transfer.requested_at),
     )
 
 
-def _transfer_priority(transfer: dict[str, Any]) -> tuple[int, int, datetime]:
+def _transfer_priority(transfer: TransferSnapshot) -> tuple[int, int, datetime]:
     """Rank duplicate transfer snapshots for the same username+filename.
 
     Prefer active transfers over terminal ones. Among terminal snapshots,
     prefer successful completions over cancelled/errored attempts, and then
     pick the newest lifecycle timestamp.
     """
-    state = str(transfer.get("state", ""))
+    state = transfer.state
     is_terminal = state.startswith("Completed,")
     is_success = state == "Completed, Succeeded"
     latest_ts = _transfer_latest_timestamp(transfer)
@@ -352,12 +354,12 @@ def _transfer_priority(transfer: dict[str, Any]) -> tuple[int, int, datetime]:
 
 
 def _is_terminal_transfer_before(
-    transfer: dict[str, Any],
+    transfer: TransferSnapshot,
     not_before: str | None,
 ) -> bool:
     if not_before is None:
         return False
-    state = str(transfer.get("state", ""))
+    state = transfer.state
     if not state.startswith("Completed,"):
         return False
     threshold = _parse_transfer_timestamp(not_before)
@@ -368,19 +370,19 @@ def _is_terminal_transfer_before(
 
 
 def match_transfer(
-    downloads: dict[str, Any] | list[dict[str, Any]],
+    downloads: DownloadUser | list[DownloadUser],
     target_filename: str,
     username: str | None = None,
-) -> dict[str, Any] | None:
+) -> TransferSnapshot | None:
     """Find the best slskd transfer snapshot for a username+filename pair."""
     groups = downloads if isinstance(downloads, list) else [downloads]
-    candidates: list[dict[str, Any]] = []
+    candidates: list[TransferSnapshot] = []
     for group in groups:
-        if username is not None and group.get("username") not in (None, "", username):
+        if username is not None and group.username not in ("", username):
             continue
-        for directory in group.get("directories", []):
-            for slskd_file in directory.get("files", []):
-                if slskd_file.get("filename") == target_filename:
+        for directory in group.directories:
+            for slskd_file in directory.files:
+                if slskd_file.filename == target_filename:
                     candidates.append(slskd_file)
 
     if not candidates:
@@ -393,7 +395,7 @@ def _get_all_downloads_snapshot(
     *,
     purpose: str,
     include_removed: bool = True,
-) -> list[dict[str, Any]] | None:
+) -> list[DownloadUser] | None:
     """Fetch the full slskd download snapshot via the bulk endpoint.
 
     The username-scoped endpoint is unreliable for some valid peer names
@@ -406,18 +408,11 @@ def _get_all_downloads_snapshot(
     states itself), so it passes False to trim the payload.
     """
     try:
-        downloads = slskd_client.transfers.get_all_downloads(
+        return slskd_client.transfers.get_all_downloads(
             includeRemoved=include_removed)
     except Exception:
         logger.warning(f"Failed to get all downloads for {purpose}", exc_info=True)
         return None
-
-    if not isinstance(downloads, list):
-        logger.warning("Unexpected get_all_downloads() response type %s",
-                       type(downloads).__name__)
-        return None
-
-    return downloads
 
 
 def converge_slskd_orphans(ctx: CratediggerContext) -> int:
@@ -472,7 +467,7 @@ def rederive_transfer_ids(
     entry: GrabListEntry,
     slskd_client: Any,
     *,
-    snapshot: list[dict[str, Any]] | None = None,
+    snapshot: list[DownloadUser] | None = None,
     not_before: str | None = None,
 ) -> bool:
     """Re-derive slskd transfer IDs for all files in a GrabListEntry.
@@ -498,10 +493,9 @@ def rederive_transfer_ids(
         ):
             transfer = None
         if transfer is not None:
-            f.id = transfer.get("id", "")
-            state = str(transfer.get("state", ""))
-            if state.startswith("Completed,"):
-                f.status = parse_transfer_snapshot(transfer)
+            f.id = transfer.id
+            if transfer.state.startswith("Completed,"):
+                f.status = transfer
             else:
                 f.status = None
         else:

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -34,6 +34,7 @@ from lib.processing_paths import directory_has_entries
 from lib.quality import (OrphanInfo, SlskdOrphanTransfer, find_inconsistencies,
                          find_orphaned_downloads, find_slskd_orphans,
                          suggest_repair)
+from lib.slskd_client import DownloadUser
 
 # No hardcoded fallback (#479): the nspawn DB has moved before (last time to
 # 10.20.0.11) and a baked-in IP silently dials a dead host forever after the
@@ -41,8 +42,10 @@ from lib.quality import (OrphanInfo, SlskdOrphanTransfer, find_inconsistencies,
 DEFAULT_DSN = os.environ.get("PIPELINE_DB_DSN")
 
 
-def _fetch_slskd_downloads(host: str, api_key: str) -> list[dict[str, Any]]:
-    """Fetch the raw slskd ``get_all_downloads()`` snapshot (live transfers only).
+def _fetch_slskd_downloads(host: str, api_key: str) -> list[DownloadUser]:
+    """Fetch the ``get_all_downloads()`` snapshot (live transfers only),
+    already typed via ``lib.slskd_client.parse_downloads_envelope``
+    (issue #507).
 
     Kept as its own network seam so ``_collect_issues`` can derive BOTH the
     forward orphan view (``_active_transfer_pairs``) and the inverse
@@ -52,22 +55,18 @@ def _fetch_slskd_downloads(host: str, api_key: str) -> list[dict[str, Any]]:
     """
     from lib.slskd_client import SlskdClient
     client = SlskdClient(host=host, api_key=api_key)
-    downloads: Any = client.transfers.get_all_downloads(includeRemoved=False)
-    if not isinstance(downloads, list):
-        return []
-    return downloads
+    return client.transfers.get_all_downloads(includeRemoved=False)
 
 
-def _active_transfer_pairs(downloads: list[dict[str, Any]]) -> set[tuple[str, str]]:
+def _active_transfer_pairs(downloads: list[DownloadUser]) -> set[tuple[str, str]]:
     """Flatten a slskd downloads snapshot to (username, filename) pairs. Pure."""
     pairs: set[tuple[str, str]] = set()
     for user_group in downloads:
-        username = user_group.get("username", "")
-        for d in user_group.get("directories", []):
-            for f in d.get("files", []):
-                fname = f.get("filename")
-                if fname:
-                    pairs.add((username, fname))
+        username = user_group.username
+        for d in user_group.directories:
+            for f in d.files:
+                if f.filename:
+                    pairs.add((username, f.filename))
     return pairs
 
 

--- a/tests/fakes/slskd.py
+++ b/tests/fakes/slskd.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import copy
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    from lib.slskd_client import DownloadUser
 
 @dataclass
 class EnqueueCall:
@@ -41,12 +44,17 @@ class FakeSlskdTransfers:
             raise self.enqueue_error
         return self.enqueue_result
 
-    def get_all_downloads(self, includeRemoved: bool = False) -> list[dict[str, Any]]:
+    def get_all_downloads(self, includeRemoved: bool = False) -> list[DownloadUser]:
+        from lib.slskd_client import DownloadUser, parse_downloads_envelope
         self.get_all_downloads_calls.append(includeRemoved)
         self._api.call_log.append("transfers.get_all_downloads")
         if self.get_all_downloads_error is not None:
             raise self.get_all_downloads_error
-        return self._api._next_download_snapshot()
+        # Mirror production's decode exactly (test-fidelity Rule B):
+        # SlskdTransfersApi.get_all_downloads() runs the raw JSON through
+        # parse_downloads_envelope() before returning — the fake must do
+        # the same so tests exercise the identical typed shape (#507).
+        return parse_downloads_envelope(self._api._next_download_snapshot())
 
     def cancel_download(self, username: str, id: str,
                         remove: bool = False) -> bool:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,7 +33,7 @@ from lib.quality import (
     VerifiedLosslessProof,
 )
 from lib.quality_evidence import snapshot_fingerprint
-from lib.slskd_client import TransferSnapshot
+from lib.slskd_client import DownloadDirectory, DownloadUser, TransferSnapshot
 
 
 def make_request_row(**overrides: Any) -> dict[str, Any]:
@@ -343,6 +343,24 @@ def make_transfer_snapshot(**overrides: Any) -> TransferSnapshot:
     defaults: dict[str, Any] = {"state": "Completed, Succeeded"}
     defaults.update(overrides)
     return TransferSnapshot(**defaults)
+
+
+def make_download_directory(**overrides: Any) -> DownloadDirectory:
+    """Build a DownloadDirectory — one directory row of the
+    get_all_downloads() envelope (issue #507) — with an empty file list
+    by default."""
+    defaults: dict[str, Any] = {"directory": "user1\\Music", "files": []}
+    defaults.update(overrides)
+    return DownloadDirectory(**defaults)
+
+
+def make_download_user(**overrides: Any) -> DownloadUser:
+    """Build a DownloadUser — one user-group row of the
+    get_all_downloads() envelope (issue #507) — with an empty directory
+    list by default."""
+    defaults: dict[str, Any] = {"username": "user1", "directories": []}
+    defaults.update(overrides)
+    return DownloadUser(**defaults)
 
 
 def make_grab_list_entry(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -24,7 +24,9 @@ from lib.download_processing import Materialized, MaterializeFailed, Materialize
 from lib.slskd_client import TransferSnapshot
 from tests.helpers import (
     make_ctx_with_fake_db,
+    make_download_directory,
     make_download_file,
+    make_download_user,
     make_grab_list_entry,
     make_request_row,
     make_transfer_snapshot,
@@ -34,37 +36,6 @@ from tests.fakes import FakePipelineDB, FakePipelineDBSource, FakeSlskdAPI
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
-
-
-def _make_transfer_mock(filename="01 - Track.mp3", username="user1",
-                        bitRate=320, sampleRate=44100, bitDepth=None,
-                        isVariableBitRate=None, file_dir="user1\\Music",
-                        size=5000000, bytes_transferred=None, last_state=None):
-    """Build a mock slskd transfer object with runtime state attributes.
-
-    Use this ONLY for tests that want a bare MagicMock transfer object
-    (``status``/``bytes_transferred``/``last_state``/``import_path`` are
-    all real ``DownloadFile`` fields as of #468). For tests that only need
-    DownloadFile fields, use make_download_file() from tests.helpers instead.
-    """
-    f = MagicMock()
-    f.filename = filename
-    f.username = username
-    f.bitRate = bitRate
-    f.sampleRate = sampleRate
-    f.bitDepth = bitDepth
-    f.isVariableBitRate = isVariableBitRate
-    f.file_dir = file_dir
-    f.size = size
-    f.id = "file-id-1"
-    f.status = None
-    f.retry = None
-    f.bytes_transferred = bytes_transferred
-    f.last_state = last_state
-    f.import_path = None
-    f.disk_no = None
-    f.disk_count = None
-    return f
 
 
 def _make_ctx(cfg=None, slskd=None, pipeline_db_source=None):
@@ -354,7 +325,7 @@ class TestDownloadsAllDone(unittest.TestCase):
 
     def test_all_succeeded(self):
         from lib.slskd_transfers import downloads_all_done
-        files = [_make_transfer_mock(), _make_transfer_mock()]
+        files = [make_download_file(), make_download_file()]
         files[0].status = make_transfer_snapshot(state="Completed, Succeeded")
         files[1].status = make_transfer_snapshot(state="Completed, Succeeded")
         done, problems, queued = downloads_all_done(files)
@@ -364,7 +335,7 @@ class TestDownloadsAllDone(unittest.TestCase):
 
     def test_one_errored(self):
         from lib.slskd_transfers import downloads_all_done
-        files = [_make_transfer_mock(), _make_transfer_mock()]
+        files = [make_download_file(), make_download_file()]
         files[0].status = make_transfer_snapshot(state="Completed, Succeeded")
         files[1].status = make_transfer_snapshot(state="Completed, Errored")
         done, problems, queued = downloads_all_done(files)
@@ -376,7 +347,7 @@ class TestDownloadsAllDone(unittest.TestCase):
 
     def test_queued_remotely(self):
         from lib.slskd_transfers import downloads_all_done
-        files = [_make_transfer_mock(), _make_transfer_mock()]
+        files = [make_download_file(), make_download_file()]
         files[0].status = make_transfer_snapshot(state="Completed, Succeeded")
         files[1].status = make_transfer_snapshot(state="Queued, Remotely")
         done, problems, queued = downloads_all_done(files)
@@ -395,7 +366,7 @@ class TestDownloadsAllDone(unittest.TestCase):
             "Completed, Aborted",
         ]
         for state in error_states:
-            files = [_make_transfer_mock()]
+            files = [make_download_file()]
             files[0].status = make_transfer_snapshot(state=state)
             done, problems, _ = downloads_all_done(files)
             self.assertFalse(done, f"state={state} should not be done")
@@ -403,7 +374,7 @@ class TestDownloadsAllDone(unittest.TestCase):
 
     def test_none_status_skipped(self):
         from lib.slskd_transfers import downloads_all_done
-        files = [_make_transfer_mock()]
+        files = [make_download_file()]
         files[0].status = None
         done, problems, queued = downloads_all_done(files)
         # None status means we can't confirm done
@@ -586,15 +557,16 @@ class TestSlskdDownloadStatus(unittest.TestCase):
         """When snapshot is provided, use match_transfer instead of per-file API."""
         from lib.slskd_transfers import slskd_download_status
         f = make_download_file(filename="Music\\01 - Track.mp3", username="user1")
-        snapshot = [{
-            "username": "user1",
-            "directories": [{"files": [{
-                "filename": "Music\\01 - Track.mp3",
-                "id": "file-id-1",
-                "state": "Completed, Succeeded",
-                "size": 5000000,
-            }]}],
-        }]
+        snapshot = [make_download_user(username="user1", directories=[
+            make_download_directory(directory="", files=[
+                make_transfer_snapshot(
+                    filename="Music\\01 - Track.mp3",
+                    id="file-id-1",
+                    state="Completed, Succeeded",
+                    size=5000000,
+                ),
+            ]),
+        ])]
         ok = slskd_download_status([f], snapshot=snapshot)
         self.assertTrue(ok)
         self.assertIsNotNone(f.status)
@@ -605,21 +577,10 @@ class TestSlskdDownloadStatus(unittest.TestCase):
         """When snapshot doesn't contain the file, status is None, returns False."""
         from lib.slskd_transfers import slskd_download_status
         f = make_download_file(filename="Music\\missing.mp3", username="user1")
-        snapshot = [{"username": "user1", "directories": [{"files": []}]}]
+        snapshot = [make_download_user(username="user1", directories=[
+            make_download_directory(directory="", files=[]),
+        ])]
         ok = slskd_download_status([f], snapshot=snapshot)
-        self.assertFalse(ok)
-        self.assertIsNone(f.status)
-
-    def test_malformed_snapshot_entry_sets_none(self):
-        """A snapshot entry with an unexpected shape (e.g. ``directories``
-        not a list of dicts) hits the generic except-Exception branch:
-        status cleared and ok=False. Repointed from the retired
-        per-file-API error test (#508 — that branch is gone)."""
-        from lib.slskd_transfers import slskd_download_status
-        f = make_download_file(filename="Music\\01 - Track.mp3", username="user1")
-        snapshot = [{"username": "user1", "directories": "not-a-list"}]
-        with self.assertLogs("cratedigger", level="ERROR"):
-            ok = slskd_download_status([f], snapshot=snapshot)
         self.assertFalse(ok)
         self.assertIsNone(f.status)
 
@@ -996,54 +957,49 @@ class TestMatchTransferId(unittest.TestCase):
 
     def test_exact_filename_match(self):
         from lib.slskd_transfers import match_transfer_id
-        downloads = {
-            "directories": [{
-                "directory": "user\\Music",
-                "files": [
-                    {"filename": "user\\Music\\01.flac", "id": "abc-123"},
-                    {"filename": "user\\Music\\02.flac", "id": "def-456"},
-                ],
-            }],
-        }
+        downloads = make_download_user(directories=[
+            make_download_directory(directory="user\\Music", files=[
+                make_transfer_snapshot(filename="user\\Music\\01.flac", id="abc-123"),
+                make_transfer_snapshot(filename="user\\Music\\02.flac", id="def-456"),
+            ]),
+        ])
         result = match_transfer_id(downloads, "user\\Music\\01.flac")
         self.assertEqual(result, "abc-123")
 
     def test_not_found(self):
         from lib.slskd_transfers import match_transfer_id
-        downloads = {"directories": [{"directory": "user\\Music", "files": []}]}
+        downloads = make_download_user(directories=[
+            make_download_directory(directory="user\\Music", files=[]),
+        ])
         result = match_transfer_id(downloads, "user\\Music\\missing.flac")
         self.assertIsNone(result)
 
     def test_multi_directory(self):
         from lib.slskd_transfers import match_transfer_id
-        downloads = {
-            "directories": [
-                {"directory": "d1", "files": [
-                    {"filename": "d1\\01.flac", "id": "id-1"},
-                ]},
-                {"directory": "d2", "files": [
-                    {"filename": "d2\\01.flac", "id": "id-2"},
-                ]},
-            ],
-        }
+        downloads = make_download_user(directories=[
+            make_download_directory(directory="d1", files=[
+                make_transfer_snapshot(filename="d1\\01.flac", id="id-1"),
+            ]),
+            make_download_directory(directory="d2", files=[
+                make_transfer_snapshot(filename="d2\\01.flac", id="id-2"),
+            ]),
+        ])
         result = match_transfer_id(downloads, "d2\\01.flac")
         self.assertEqual(result, "id-2")
 
     def test_bulk_downloads_respects_username(self):
         from lib.slskd_transfers import match_transfer_id
         downloads = [
-            {
-                "username": "Mr. Odd",
-                "directories": [{"directory": "a", "files": [
-                    {"filename": "shared\\01.flac", "id": "wrong-id"},
-                ]}],
-            },
-            {
-                "username": "Miick Starr",
-                "directories": [{"directory": "b", "files": [
-                    {"filename": "shared\\01.flac", "id": "right-id"},
-                ]}],
-            },
+            make_download_user(username="Mr. Odd", directories=[
+                make_download_directory(directory="a", files=[
+                    make_transfer_snapshot(filename="shared\\01.flac", id="wrong-id"),
+                ]),
+            ]),
+            make_download_user(username="Miick Starr", directories=[
+                make_download_directory(directory="b", files=[
+                    make_transfer_snapshot(filename="shared\\01.flac", id="right-id"),
+                ]),
+            ]),
         ]
         result = match_transfer_id(
             downloads,
@@ -1055,52 +1011,50 @@ class TestMatchTransferId(unittest.TestCase):
     def test_bulk_downloads_prefers_active_over_old_completed(self):
         from lib.slskd_transfers import match_transfer
         downloads = [
-            {
-                "username": "user1",
-                "directories": [{"directory": "d", "files": [
-                    {
-                        "filename": "shared\\01.flac",
-                        "id": "completed-id",
-                        "state": "Completed, Succeeded",
-                        "endedAt": "2026-04-03T21:00:00+00:00",
-                    },
-                    {
-                        "filename": "shared\\01.flac",
-                        "id": "active-id",
-                        "state": "InProgress",
-                        "startedAt": "2026-04-03T22:00:00+00:00",
-                    },
-                ]}],
-            },
+            make_download_user(username="user1", directories=[
+                make_download_directory(directory="d", files=[
+                    make_transfer_snapshot(
+                        filename="shared\\01.flac",
+                        id="completed-id",
+                        state="Completed, Succeeded",
+                        ended_at="2026-04-03T21:00:00+00:00",
+                    ),
+                    make_transfer_snapshot(
+                        filename="shared\\01.flac",
+                        id="active-id",
+                        state="InProgress",
+                        started_at="2026-04-03T22:00:00+00:00",
+                    ),
+                ]),
+            ]),
         ]
         result = match_transfer(downloads, "shared\\01.flac", username="user1")
         assert result is not None
-        self.assertEqual(result["id"], "active-id")
+        self.assertEqual(result.id, "active-id")
 
     def test_bulk_downloads_prefers_latest_successful_attempt(self):
         from lib.slskd_transfers import match_transfer
         downloads = [
-            {
-                "username": "user1",
-                "directories": [{"directory": "d", "files": [
-                    {
-                        "filename": "shared\\01.flac",
-                        "id": "old-cancelled",
-                        "state": "Completed, Cancelled",
-                        "endedAt": "2026-04-03T20:00:00+00:00",
-                    },
-                    {
-                        "filename": "shared\\01.flac",
-                        "id": "new-succeeded",
-                        "state": "Completed, Succeeded",
-                        "endedAt": "2026-04-03T21:00:00+00:00",
-                    },
-                ]}],
-            },
+            make_download_user(username="user1", directories=[
+                make_download_directory(directory="d", files=[
+                    make_transfer_snapshot(
+                        filename="shared\\01.flac",
+                        id="old-cancelled",
+                        state="Completed, Cancelled",
+                        ended_at="2026-04-03T20:00:00+00:00",
+                    ),
+                    make_transfer_snapshot(
+                        filename="shared\\01.flac",
+                        id="new-succeeded",
+                        state="Completed, Succeeded",
+                        ended_at="2026-04-03T21:00:00+00:00",
+                    ),
+                ]),
+            ]),
         ]
         result = match_transfer(downloads, "shared\\01.flac", username="user1")
         assert result is not None
-        self.assertEqual(result["id"], "new-succeeded")
+        self.assertEqual(result.id, "new-succeeded")
 
 
 class TestRederiveTransferIds(unittest.TestCase):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1588,15 +1588,25 @@ class TestFakePipelineDBSearchPlanContract(unittest.TestCase):
 
 class TestFakeSlskdAPI(unittest.TestCase):
     def test_get_downloads_returns_queued_snapshots(self):
+        """#507: get_all_downloads() now runs the raw JSON snapshot through
+        parse_downloads_envelope(), the same as production — mirroring the
+        real decode is the point (test-fidelity Rule B)."""
+        from lib.slskd_client import parse_downloads_envelope
         first = [{"username": "user1", "directories": [{"files": []}]}]
         second = [{"username": "user1", "directories": [{"files": [
             {"filename": "track.mp3", "id": "tid-1"},
         ]}]}]
         slskd = FakeSlskdAPI(download_snapshots=[first, second])
 
-        self.assertEqual(slskd.transfers.get_all_downloads(includeRemoved=True), first)
-        self.assertEqual(slskd.transfers.get_all_downloads(includeRemoved=True), second)
-        self.assertEqual(slskd.transfers.get_all_downloads(includeRemoved=True), second)
+        self.assertEqual(
+            slskd.transfers.get_all_downloads(includeRemoved=True),
+            parse_downloads_envelope(first))
+        self.assertEqual(
+            slskd.transfers.get_all_downloads(includeRemoved=True),
+            parse_downloads_envelope(second))
+        self.assertEqual(
+            slskd.transfers.get_all_downloads(includeRemoved=True),
+            parse_downloads_envelope(second))
         self.assertEqual(slskd.transfers.get_all_downloads_calls, [True, True, True])
 
     def test_records_enqueue_and_cancel_calls(self):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -9,6 +9,7 @@ from lib.quality import (
     find_slskd_orphans,
     suggest_repair,
 )
+from tests.helpers import make_download_directory, make_download_user, make_transfer_snapshot
 
 
 class TestFindInconsistencies(unittest.TestCase):
@@ -222,14 +223,12 @@ class TestFindSlskdOrphans(unittest.TestCase):
     def _snapshot(username="peer1", directory="Music\\Album",
                   filename="Music\\Album\\01 - Track.flac",
                   transfer_id="t-1", state="InProgress"):
-        return [{
-            "username": username,
-            "directories": [{
-                "directory": directory,
-                "files": [{"filename": filename, "id": transfer_id,
-                           "state": state}],
-            }],
-        }]
+        return [make_download_user(username=username, directories=[
+            make_download_directory(directory=directory, files=[
+                make_transfer_snapshot(
+                    filename=filename, id=transfer_id, state=state),
+            ]),
+        ])]
 
     @staticmethod
     def _owning_row(status="downloading", username="peer1",
@@ -294,15 +293,16 @@ class TestFindSlskdOrphans(unittest.TestCase):
         self.assertEqual(len(orphans), 1)
 
     def test_missing_state_treated_as_live(self):
-        snapshot = self._snapshot()
-        del snapshot[0]["directories"][0]["files"][0]["state"]
+        # state="" is TransferSnapshot's own default — mirrors an entry
+        # where slskd omitted the field entirely (issue #507: the
+        # envelope's file entries decode through the same Struct).
+        snapshot = self._snapshot(state="")
         orphans = find_slskd_orphans(snapshot, [])
         self.assertEqual(len(orphans), 1)
         self.assertEqual(orphans[0].state, "")
 
     def test_file_without_filename_skipped(self):
-        snapshot = self._snapshot()
-        del snapshot[0]["directories"][0]["files"][0]["filename"]
+        snapshot = self._snapshot(filename="")
         orphans = find_slskd_orphans(snapshot, [])
         self.assertEqual(orphans, [])
 

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 from lib.quality import OrphanInfo, SlskdOrphanTransfer
 from scripts import repair
 from tests.fakes import FakePipelineDB
+from tests.helpers import make_download_directory, make_download_user, make_transfer_snapshot
 
 
 class TestCmdFix(unittest.TestCase):
@@ -49,6 +50,47 @@ class TestCmdFix(unittest.TestCase):
         self.assertEqual(transition.target_status, "wanted")
         self.assertEqual(transition.from_status, "downloading")
         self.assertIn("Reset to wanted", stdout.getvalue())
+
+
+class TestActiveTransferPairs(unittest.TestCase):
+    """#507: _active_transfer_pairs walks the typed downloads envelope."""
+
+    def test_flattens_nested_envelope_to_pairs(self) -> None:
+        downloads = [
+            make_download_user(username="peer1", directories=[
+                make_download_directory(directory="Music\\Album", files=[
+                    make_transfer_snapshot(filename="Music\\Album\\01.flac"),
+                    make_transfer_snapshot(filename="Music\\Album\\02.flac"),
+                ]),
+            ]),
+            make_download_user(username="peer2", directories=[
+                make_download_directory(directory="Music\\Other", files=[
+                    make_transfer_snapshot(filename="Music\\Other\\01.flac"),
+                ]),
+            ]),
+        ]
+
+        pairs = repair._active_transfer_pairs(downloads)
+
+        self.assertEqual(pairs, {
+            ("peer1", "Music\\Album\\01.flac"),
+            ("peer1", "Music\\Album\\02.flac"),
+            ("peer2", "Music\\Other\\01.flac"),
+        })
+
+    def test_file_without_filename_excluded(self) -> None:
+        downloads = [
+            make_download_user(username="peer1", directories=[
+                make_download_directory(directory="d", files=[
+                    make_transfer_snapshot(filename=""),
+                ]),
+            ]),
+        ]
+
+        self.assertEqual(repair._active_transfer_pairs(downloads), set())
+
+    def test_empty_downloads_returns_empty_set(self) -> None:
+        self.assertEqual(repair._active_transfer_pairs([]), set())
 
 
 class TestCollectIssues(unittest.TestCase):
@@ -236,17 +278,15 @@ class TestCollectIssuesSlskdOrphanReport(unittest.TestCase):
     """
 
     RAW_SNAPSHOT = [
-        {
-            "username": "peer1",
-            "directories": [{
-                "directory": "Music\\Orphan",
-                "files": [{
-                    "id": "t-orphan",
-                    "filename": "Music\\Orphan\\01.flac",
-                    "state": "InProgress",
-                }],
-            }],
-        },
+        make_download_user(username="peer1", directories=[
+            make_download_directory(directory="Music\\Orphan", files=[
+                make_transfer_snapshot(
+                    id="t-orphan",
+                    filename="Music\\Orphan\\01.flac",
+                    state="InProgress",
+                ),
+            ]),
+        ]),
     ]
 
     @patch("scripts.repair._fetch_slskd_downloads", return_value=RAW_SNAPSHOT)

--- a/tests/test_slskd_client.py
+++ b/tests/test_slskd_client.py
@@ -23,6 +23,8 @@ import msgspec
 import requests
 
 from lib.slskd_client import (
+    DownloadDirectory,
+    DownloadUser,
     SlskdClient,
     SlskdDownloadDirectoryCompleteEvent,
     SlskdDownloadFileCompleteEvent,
@@ -30,6 +32,7 @@ from lib.slskd_client import (
     TransferSnapshot,
     decode_download_directory_complete,
     decode_download_file_complete,
+    parse_downloads_envelope,
     parse_transfer_snapshot,
 )
 
@@ -320,7 +323,12 @@ class TestTransfersEndpoints(SlskdClientTestCase):
 
         downloads = self.client.transfers.get_all_downloads(includeRemoved=True)
 
-        self.assertEqual(downloads, DOWNLOADS_FIXTURE)
+        self.assertEqual(downloads, parse_downloads_envelope(DOWNLOADS_FIXTURE))
+        self.assertIsInstance(downloads[0], DownloadUser)
+        self.assertEqual(downloads[0].username, "FourTwenty")
+        self.assertEqual(
+            downloads[0].directories[0].files[0].id,
+            "1839fe97-46dd-4351-9ada-4422a57f9f7a")
         self.assertEqual(
             self.last_request()["query"], {"includeRemoved": ["True"]})
 
@@ -598,6 +606,95 @@ class TestTransferSnapshot(unittest.TestCase):
         self.assertEqual(snap.state, "Completed, Errored")
         self.assertEqual(snap.id, "")
         self.assertEqual(snap.bytes_transferred, 0)
+
+
+class TestDownloadsEnvelope(unittest.TestCase):
+    """#507: type the get_all_downloads() nested user->directories->files
+    envelope end-to-end — the second slice #468 deliberately left raw.
+    """
+
+    def test_parses_nested_fixture_into_typed_structs(self):
+        users = parse_downloads_envelope(DOWNLOADS_FIXTURE)
+
+        self.assertEqual(len(users), 1)
+        self.assertIsInstance(users[0], DownloadUser)
+        self.assertEqual(users[0].username, "FourTwenty")
+        self.assertIsInstance(users[0].directories[0], DownloadDirectory)
+        self.assertEqual(
+            users[0].directories[0].directory,
+            "Music\\Rock\\Led Zeppelin\\1969 - Led Zeppelin II")
+        file = users[0].directories[0].files[0]
+        self.assertIsInstance(file, TransferSnapshot)
+        self.assertEqual(file.id, "1839fe97-46dd-4351-9ada-4422a57f9f7a")
+        self.assertEqual(file.state, "Queued, Remotely")
+
+    def test_empty_envelope_returns_empty_list(self):
+        self.assertEqual(parse_downloads_envelope([]), [])
+
+    def test_missing_directories_defaults_to_empty_list(self):
+        users = parse_downloads_envelope([{"username": "solo"}])
+
+        self.assertEqual(users, [DownloadUser(username="solo", directories=[])])
+
+    def test_malformed_file_entry_dropped_sibling_survives(self):
+        # RED-boundary guard: one bad file (bytesTransferred as a string)
+        # must not drop its sibling file in the same directory — mirrors
+        # #468's parse_transfer_snapshot per-entry tolerance, but at finer
+        # granularity than a whole user-group row so one poison file in a
+        # peer's payload can't blind the poll to every other in-flight
+        # file that same peer is also transferring.
+        raw = [{
+            "username": "peer1",
+            "directories": [{
+                "directory": "Music\\Album",
+                "files": [
+                    {"filename": "good.flac", "id": "ok-1",
+                     "state": "InProgress"},
+                    {"filename": "bad.flac", "id": "bad-1",
+                     "bytesTransferred": "not-a-number"},
+                ],
+            }],
+        }]
+
+        users = parse_downloads_envelope(raw)
+
+        files = users[0].directories[0].files
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0].filename, "good.flac")
+
+    def test_malformed_directory_entry_dropped_sibling_survives(self):
+        raw = [{
+            "username": "peer1",
+            "directories": [
+                "not-a-directory-dict",
+                {"directory": "Music\\Good", "files": [
+                    {"filename": "01.flac", "id": "id-1"},
+                ]},
+            ],
+        }]
+
+        users = parse_downloads_envelope(raw)
+
+        self.assertEqual(len(users[0].directories), 1)
+        self.assertEqual(users[0].directories[0].directory, "Music\\Good")
+
+    def test_malformed_user_row_dropped_sibling_survives(self):
+        raw = [
+            "not-a-user-dict",
+            {"username": "peer2", "directories": []},
+        ]
+
+        users = parse_downloads_envelope(raw)
+
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0].username, "peer2")
+
+    def test_unknown_fields_at_every_level_are_ignored(self):
+        # slskd's directory row also carries fileCount (see DOWNLOADS_FIXTURE)
+        # — an unmodeled field must not trip decoding at any level.
+        users = parse_downloads_envelope(DOWNLOADS_FIXTURE)
+
+        self.assertEqual(users[0].directories[0].files[0].size, 113325058)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Second slice of #468's deferred scope: types `SlskdTransfersApi.get_all_downloads()`'s nested `user -> directories -> files` envelope end-to-end, so the remaining raw-dict walkers become attribute access.

- **`lib/slskd_client.py`**: new `DownloadDirectory`/`DownloadUser` msgspec Structs (reusing `TransferSnapshot` for the file level — no second file-shape to maintain) and `parse_downloads_envelope()`, decoded once at `get_all_downloads()`. Tolerant at every level, mirroring #468's `parse_transfer_snapshot`: a malformed file entry is dropped via that same decoder, a malformed directory or user-group row is dropped and logged. One bad entry anywhere in the tree degrades to "no status this cycle" for just that entry — never aborts the whole 5-minute poll cycle for every other in-flight download.
- **`lib/slskd_transfers.py`**: `match_transfer`, `match_transfer_id`, `_transfer_priority`, `_transfer_latest_timestamp`, `_is_terminal_transfer_before`, `_get_all_downloads_snapshot`, `rederive_transfer_ids`, `slskd_download_status` all consume/return typed Structs now. Since decode happens once at the client boundary, the two call sites that used to re-decode a matched transfer via `parse_transfer_snapshot` now just assign the already-typed `TransferSnapshot` directly.
- **`lib/quality/repair.py::find_slskd_orphans`**: walks `DownloadUser` attributes instead of nested `.get()` chains. `DownloadUser` is imported `TYPE_CHECKING`-only to avoid a circular import (`lib.slskd_client -> lib.config -> lib.quality -> lib.quality.repair`).
- **`scripts/repair.py`**: `_fetch_slskd_downloads`/`_active_transfer_pairs` (the issue referred to this as `_get_slskd_active_transfers`, renamed by #479 before this work started) walk `DownloadUser` attributes too; the `isinstance(list)` defensive check is dropped since the client boundary now guarantees the shape.
- Ride-along type tightening (#468 recon note): `downloads_all_done`/`slskd_download_status`/`_all_files_remotely_queued` now take `list[DownloadFile]` instead of `list[Any]`, and `_poll_one_active_download`'s `cycle_snapshot` param is `list[DownloadUser]` instead of `Any`.

### Test infrastructure
- `tests/fakes/slskd.py::FakeSlskdTransfers.get_all_downloads()` now runs the same `parse_downloads_envelope()` production uses (test-fidelity Rule B — the fake mirrors the real decode contract) instead of returning the raw dict snapshot verbatim.
- `tests/helpers.py`: new `make_download_directory`/`make_download_user` builders, reusing the existing `make_transfer_snapshot` for the file level.
- Dict-literal fixtures across `tests/test_download.py::TestMatchTransferId`, `tests/test_repair.py::TestFindSlskdOrphans`, and `tests/test_repair_cli.py` move to the new builders.
- `tests/test_download.py`'s `_make_transfer_mock` (a hand-rolled `MagicMock` duplicating `DownloadFile`) is replaced with the existing `make_download_file()` builder — pyright's tightened `downloads_all_done` signature caught it as an unnecessary MagicMock stand-in for a real dataclass.
- `TestSlskdDownloadStatus::test_malformed_snapshot_entry_sets_none` is removed: the malformed-`directories` shape it exercised can no longer be constructed as a well-formed `list[DownloadUser]` snapshot. That coverage now lives in `tests/test_slskd_client.py::TestDownloadsEnvelope`, which proves the decode boundary drops malformed entries before they ever reach `match_transfer`.
- New `tests/test_repair_cli.py::TestActiveTransferPairs` — `_active_transfer_pairs` had no direct unit coverage before this PR.

### Decode-error policy (per issue's explicit requirement)
One malformed row anywhere in the envelope — file, directory, or user-group — is dropped with a `logger.warning` and the rest of the snapshot is still returned. This **cannot** abort the 5-minute poll cycle: it degrades to "no status this cycle" for the one affected entry, the same signal already used for "no matching transfer found" (`match_transfer` returning `None`). RED tests for this live in `tests/test_slskd_client.py::TestDownloadsEnvelope` (`test_malformed_file_entry_dropped_sibling_survives`, `test_malformed_directory_entry_dropped_sibling_survives`, `test_malformed_user_row_dropped_sibling_survives`).

### Interaction with #479 item 3 (not in scope)
#479 item 3 wants `_get_all_downloads_snapshot` to trim the `includeRemoved` payload. This PR's decode boundary (`parse_downloads_envelope`) sits entirely inside `get_all_downloads()` and operates on whatever JSON the server returns — it doesn't assume payload size or care whether `includeRemoved` is `True` or `False`. A future payload trim is orthogonal and won't need to touch the decode logic.

## Test plan
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — 4712 tests, OK (verified after each of the two commits in isolation, and on the final combined state)
- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings on the full repo
- [x] `nix-shell --run "bash scripts/find_dead_code.sh"` — no dead code found
- [x] `nix flake check` (pre-push hook) — all checks passed, including the module VM boot gate
- [x] Verified every `.get(...)`/subscript walker in the functions the issue lists (`match_transfer`, `match_transfer_id`, `_transfer_priority`, `_transfer_latest_timestamp`, `_is_terminal_transfer_before`, `find_slskd_orphans`, `_fetch_slskd_downloads`/`_active_transfer_pairs`) is now attribute access; the only remaining raw-dict access to the envelope shape lives inside `parse_downloads_envelope`'s own helpers — exactly the one decode site the wire-boundary rule calls for.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)