### PR TITLE
tooling: exclude .claude/worktrees from pyright, glob JS test suites

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,6 +8,7 @@
     "build",
     "tools/vulture",
     ".pyright-venv",
-    ".nixpkgs-src"
+    ".nixpkgs-src",
+    ".claude/worktrees"
   ]
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,17 +13,13 @@ done
 echo "All JS files OK"
 echo ""
 
-# JS unit tests
+# JS unit tests — glob so every tests/test_js_*.mjs on disk runs; a manual
+# list drifted silently before (issue #520: test_js_grouping.mjs,
+# test_js_library.mjs, test_js_release_actions.mjs were never run).
 echo "=== JS unit tests ==="
-node tests/test_js_util.mjs || exit 1
-node tests/test_js_decisions.mjs || exit 1
-node tests/test_js_search_plan.mjs || exit 1
-node tests/test_js_recents.mjs || exit 1
-node tests/test_js_history.mjs || exit 1
-node tests/test_js_pipeline.mjs || exit 1
-node tests/test_js_pipeline_dashboard.mjs || exit 1
-node tests/test_js_wrong_matches.mjs || exit 1
-node tests/test_js_long_tail_console.mjs || exit 1
+for f in tests/test_js_*.mjs; do
+  node "$f" || exit 1
+done
 echo ""
 
 # Dead-code sweep — fails fast on new vulture findings before the slow


### PR DESCRIPTION
## Summary
- `pyrightconfig.json`: add `.claude/worktrees` to `exclude` so the shared checkout's `nix-shell --run "pyright"` doesn't crawl every stale worktree checkout (thousands of extra `.py` files, previously pinned a core with a runaway watcher).
- `scripts/run_tests.sh`: replace the hardcoded `tests/test_js_*.mjs` list with a glob (`for f in tests/test_js_*.mjs; do node "$f" || exit 1; done`) so every JS suite on disk is always reached by the gate. The hardcoded list had silently drifted — `test_js_grouping.mjs`, `test_js_library.mjs`, and `test_js_release_actions.mjs` existed but were never run.

Closes #520

## Investigation (issue's JS-suite half)
- STEP A: `ls tests/test_js_*.mjs` (12 files) vs the old hardcoded list (9 files) confirmed exactly the three omissions the issue named.
- STEP B: ran each un-run suite standalone via `nix-shell --run "node tests/<file>.mjs"` — all three passed (grouping: 32 passed, library: 5 passed, release_actions: 51 passed).
- STEP C: since all three passed, converted the hardcoded list to a glob (the safe branch of the issue's decision tree). Did not add the optional audit-test mirror of `test_skip_audit.py` — the glob itself structurally eliminates the drift class (no separate list to fall out of sync), so a bash-content-scanning Python test would add complexity for little marginal value. Noted as a possible follow-up only.

## Test plan
- [x] `nix-shell --run "pyright"` → `0 errors, 0 warnings, 0 informations`
- [x] `pyrightconfig.json` parses as valid JSON
- [x] `nix-shell --run "bash scripts/run_tests.sh"` (edited script) → exit 0, `Ran 4728 tests ... OK`, all JS suites (12/12) report "N passed, 0 failed"