### PR TITLE
cleanup: dead IMPORT_ONE + stale mock-audit entry (deletion subset of #521)

### DIFF
--- a/lib/field_resolver_service.py
+++ b/lib/field_resolver_service.py
@@ -1240,7 +1240,7 @@ def detect_va_compilation(
 #
 # ``resolve_all`` is the single entry point the web add path
 # (``web/routes/pipeline.py::post_pipeline_add``) and the CLI add path
-# (``scripts/pipeline_cli.py::cmd_add``) call after they have a freshly
+# (``scripts/pipeline_cli/album_requests.py::cmd_add``) call after they have a freshly
 # inserted ``album_requests`` row id and the upstream release payload(s)
 # in hand. It:
 #
@@ -1365,7 +1365,7 @@ def resolve_all(
     """Run all field resolvers inline at enqueue with a wall-clock budget.
 
     Called from ``web/routes/pipeline.py::post_pipeline_add`` and from
-    ``scripts/pipeline_cli.py::cmd_add`` after the new ``album_requests``
+    ``scripts/pipeline_cli/album_requests.py::cmd_add`` after the new ``album_requests``
     row has been inserted (so ``request["id"]`` is real and the FK in
     ``album_request_field_resolutions`` is satisfiable). The caller then
     updates the row with the returned values (proceed-with-NULL where
@@ -1589,7 +1589,7 @@ def resolve_all(
 #
 # Single canonical implementation of the "result → update_request_fields"
 # mapping. Web (``web/routes/pipeline.py::_resolve_and_update_after_add``)
-# and CLI (``scripts/pipeline_cli.py::_resolve_and_update_after_add``)
+# and CLI (``scripts/pipeline_cli/album_requests.py::_resolve_and_update_after_add``)
 # previously each carried a near-identical copy. The transient deploy
 # one-shot (``docs/search-plan-iter2-deploy.md`` § 3.2) also benefits —
 # its inline ``updates`` dict-building is the same shape.

--- a/lib/youtube_ingest_service.py
+++ b/lib/youtube_ingest_service.py
@@ -432,8 +432,9 @@ def _default_mb_track_count(_mbid: str) -> Optional[int]:
     bare ``YoutubeIngestService(pdb)`` without an MB-wiring fail fast
     at the first precheck/gate rather than silently passing a
     ``None`` MB count through. The production callers (CLI in
-    ``scripts/pipeline_cli.py``, HTTP route in ``web/routes/youtube.py``)
-    go through :func:`default_youtube_ingest_service_factory` which wires
+    ``scripts/pipeline_cli/youtube.py``, HTTP route in
+    ``web/routes/youtube.py``) go through
+    :func:`default_youtube_ingest_service_factory` which wires
     the live MB-mirror flavour. Tests inject a fake that returns canned
     values.
     """
@@ -453,8 +454,8 @@ def default_mb_track_count_from_mirror(mbid: str) -> Optional[int]:
     ``track_count_precheck_failed`` and the operator escalates.
 
     Shared by both production callers (CLI in
-    ``scripts/pipeline_cli.py::cmd_youtube_rescue`` and HTTP route in
-    ``web/routes/youtube.py::post_pipeline_youtube_rescue``) per CLI ⇄
+    ``scripts/pipeline_cli/youtube.py::cmd_youtube_rescue`` and HTTP route
+    in ``web/routes/youtube.py::post_pipeline_youtube_rescue``) per CLI ⇄
     API symmetry — duplicating the helper across the two wrappers would
     let them drift in subtle ways (different timeout, different cache
     behaviour). Tests inject a fake instead of calling this helper.
@@ -475,7 +476,7 @@ def default_youtube_ingest_service_factory(pdb: _PipelineDB) -> "YoutubeIngestSe
 
     Wires the live MB-mirror ``mb_track_count_fn`` (other ports retain
     their library-side production defaults). Both
-    ``scripts/pipeline_cli.py::cmd_youtube_rescue`` and
+    ``scripts/pipeline_cli/youtube.py::cmd_youtube_rescue`` and
     ``web/routes/youtube.py::post_pipeline_youtube_rescue`` call this
     so the two surfaces share one wiring per CLI ⇄ API symmetry. Tests
     inject a service via ``service_factory=`` (CLI) or patch the

--- a/scripts/pipeline_cli/__init__.py
+++ b/scripts/pipeline_cli/__init__.py
@@ -107,7 +107,6 @@ from scripts.pipeline_cli.quality import (
     cmd_repair_spectral,
 )
 from scripts.pipeline_cli.imports import (
-    IMPORT_ONE,
     SLSKD_DOWNLOAD_DIRS,
     SPECTRAL_GRADE_CHOICES,
     _preview_values_from_args,
@@ -160,7 +159,6 @@ from scripts.pipeline_cli.routes_meta import (
 from scripts.pipeline_cli.cli import PipelineDB, main
 
 __all__ = [
-    "IMPORT_ONE",
     "OUTCOME_EXIT_CODE",
     "PipelineDB",
     "SLSKD_DOWNLOAD_DIRS",

--- a/scripts/pipeline_cli/imports.py
+++ b/scripts/pipeline_cli/imports.py
@@ -28,10 +28,6 @@ from scripts.pipeline_cli.quality import _load_runtime_rank_config
 
 SPECTRAL_GRADE_CHOICES = ("genuine", "marginal", "suspect", "likely_transcode")
 
-# ``scripts/pipeline_cli/imports.py`` -> repo root is two levels up (the
-# original monolith at ``scripts/pipeline_cli.py`` only needed one).
-IMPORT_ONE = os.path.join(os.path.dirname(__file__), "..", "..", "harness", "import_one.py")
-
 # Known slskd download dirs to resolve old relative failed_paths against
 SLSKD_DOWNLOAD_DIRS = ["/mnt/virtio/music/slskd"]
 

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -395,7 +395,6 @@ _LEAF_SEAM_PATTERNS = [
 
     # MusicBrainz / Discogs API fetch helpers — HTTP boundary.
     re.compile(r"^scripts\.pipeline_cli\.album_requests\.fetch_mb_release$"),
-    re.compile(r"^scripts\.pipeline_cli\.fetch_mb_release_group_year$"),
     re.compile(r"^lib\.\w+\.fetch_mb_release$"),
 
     # scripts.pipeline_cli loaders — each is a thin wrapper around a

--- a/web/routes/youtube.py
+++ b/web/routes/youtube.py
@@ -2,7 +2,7 @@
 
 Single GET endpoint, ``/api/youtube-album?identifier=<id>&refresh=<bool>``,
 that wraps ``lib.youtube_album_service.resolve_youtube_album``. The CLI
-counterpart (U7) lives at ``scripts/pipeline_cli.py::cmd_youtube_album``;
+counterpart (U7) lives at ``scripts/pipeline_cli/youtube.py::cmd_youtube_album``;
 both surfaces share the same service + outcome vocabulary per
 ``CLAUDE.md`` § "CLI ⇄ API surface symmetry".
 
@@ -65,7 +65,7 @@ class _RedisYoutubeCache:
     ``youtube:album:youtube:album:<browse_id>`` keys).
 
     Mirrors ``_RedisFingerprintCache`` in ``web/routes/pipeline.py``
-    (and ``scripts/pipeline_cli.py::_RedisYoutubeCache`` on the CLI
+    (and ``scripts/pipeline_cli/youtube.py::_RedisYoutubeCache`` on the CLI
     side) — bytes get/set with a long sentinel TTL. Falls back to a
     no-op when Redis is unavailable so single-shot dev shells still
     work without the in-process accelerator.
@@ -110,7 +110,7 @@ def _build_youtube_client():
     Lazy-imports ``requests``, ``urllib3``, and ``ytmusicapi`` so the
     web server's startup cost stays low and unrelated routes don't
     pay for unused HTTP machinery. Mirrors
-    ``scripts/pipeline_cli.py::_build_youtube_client``.
+    ``scripts/pipeline_cli/youtube.py::_build_youtube_client``.
 
     Returns a ``(yt_client, session)`` tuple so the caller can close
     the session in a ``finally`` block — without that, every YT route


### PR DESCRIPTION
## Summary

Deletion-only subset of #521 — three small, independently-confirmed-dead cleanups:

1. **Dead `IMPORT_ONE`** — `scripts/pipeline_cli/imports.py` defined `IMPORT_ONE` (a path to `harness/import_one.py`) and re-exported it from `scripts/pipeline_cli/__init__.py`, but no function body referenced it. Confirmed dead via `grep -rn "IMPORT_ONE" scripts/ lib/ web/ tests/ harness/ cratedigger.py` — only the definition + the two `__init__.py` lines matched. Removed the definition and both `__init__.py` references; `os` is still used elsewhere in `imports.py` so its import stays.
2. **Stale mock-audit allowlist entry** — `tests/_mock_audit_scanner.py` allowlisted `scripts.pipeline_cli.fetch_mb_release_group_year`, a symbol that exists nowhere in the repo (confirmed via repo-wide grep). Removed the one `re.compile(...)` line; the shared "MusicBrainz / Discogs API fetch helpers" comment covers the remaining two entries so it was left in place.
3. **Cosmetic docstring drift** — `lib/youtube_ingest_service.py`, `lib/field_resolver_service.py`, and `web/routes/youtube.py` still referenced the pre-#495 monolith path `scripts/pipeline_cli.py::cmd_X`. Updated each reference to the real module the command now lives in under the `scripts/pipeline_cli/` package (e.g. `scripts/pipeline_cli/youtube.py::cmd_youtube_rescue`, `scripts/pipeline_cli/album_requests.py::cmd_add`).

## Explicitly out of scope (deferred, not touched here)

- The `_build_parser` split (~400 lines) in `scripts/pipeline_cli/routes_meta.py`.
- The `_load_runtime_rank_config` relocation.

Closes #521 (deletion subset only — the two items above remain open under #521 or a follow-up).

## Test plan

- [x] `nix-shell --run "bash scripts/run_tests.sh"` — exit 0, `OK` (4728 tests; suite includes the dead-code sweep, `tests/test_mock_audit.py`, `tests/test_pipeline_cli.py`)
- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings, 0 informations (full repo)
- [x] Repo-wide grep confirms `IMPORT_ONE` and `fetch_mb_release_group_year` are fully gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)