### PR TITLE
Score beets-distance for Discogs siblings, not just MB

### DIFF
--- a/scripts/pipeline_cli/beets_distance.py
+++ b/scripts/pipeline_cli/beets_distance.py
@@ -16,6 +16,12 @@ def cmd_beets_distance(db, args):
     keep them in sync (see ``CLAUDE.md`` § "CLI ⇄ API surface
     symmetry").
 
+    ``args.mbid`` may be an MB release UUID or a bare Discogs numeric
+    release id (#530 — same dispatch as the API route: numeric ⇒
+    Discogs, mirroring ``browse.py::get_release_group``).
+    ``compute_beets_distance`` is source-agnostic; no MB<->Discogs
+    adapter needed.
+
     Exit codes:
       * 0 — ``ok``
       * 2 — ``download_log_not_found``, ``request_not_found``
@@ -27,13 +33,20 @@ def cmd_beets_distance(db, args):
       * 1 — ``distance_failed`` / unknown outcome
     """
     from lib.beets_distance import compute_beets_distance
+    from lib.release_identity import detect_release_source
+    from web import discogs as discogs_api
     from web import mb as mb_api
+
+    if detect_release_source(args.mbid) == "discogs":
+        get_release_fn = lambda m: discogs_api.get_release(int(m), fresh=False)
+    else:
+        get_release_fn = lambda m: mb_api.get_release(m, fresh=False)
 
     result = compute_beets_distance(
         int(args.download_log_id),
         args.mbid,
         pdb=db,
-        mb_get_release=lambda m: mb_api.get_release(m, fresh=False),
+        mb_get_release=get_release_fn,
         cache=None,
     )
 

--- a/scripts/pipeline_cli/routes_meta.py
+++ b/scripts/pipeline_cli/routes_meta.py
@@ -349,7 +349,7 @@ def _build_parser() -> tuple[
     p_bd.add_argument("download_log_id", type=int,
                       help="download_log row id (see `pipeline-cli show <req>`)")
     p_bd.add_argument("mbid",
-                      help="Candidate MB release UUID")
+                      help="Candidate release id — MB UUID or Discogs numeric id")
     p_bd.add_argument("--json", action="store_true",
                       help="Print structured JSON instead of text")
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2797,6 +2797,51 @@ class TestCmdBeetsDistance(unittest.TestCase):
         self.assertAlmostEqual(payload["distance"], 0.07, places=4)
         self.assertEqual(payload["components"]["album"], 0.0)
 
+    def test_discogs_numeric_id_routes_through_discogs_lookup(self):
+        """A numeric mbid (Discogs sibling) must route through
+        ``discogs_api.get_release``, not ``web.mb.get_release`` — CLI
+        counterpart of the same dispatch fixed in the API route (#530).
+        No new MB<->Discogs adapter: ``compute_beets_distance`` already
+        treats ``release_group_id`` as optional and ``discogs_api.get_release``
+        mirrors ``mb_api.get_release``'s dict shape exactly.
+        """
+        from lib.beets_distance import BeetsDistanceResult
+
+        captured = {}
+
+        def _fake_compute(download_log_id, mbid, *, pdb, mb_get_release,
+                           cache=None, **_kw):
+            captured["mb_get_release"] = mb_get_release
+            return BeetsDistanceResult(
+                outcome="ok", distance=0.05,
+                download_log_id=download_log_id, candidate_mbid=mbid,
+            )
+
+        discogs_release = {
+            "id": "2048516",
+            "title": "Fake Album",
+            "artist_name": "Fake Artist",
+            "artist_id": "999",
+            "release_group_id": None,
+            "tracks": [],
+        }
+        args = SimpleNamespace(download_log_id=100, mbid="2048516", json=False)
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            with patch(
+                "lib.beets_distance.compute_beets_distance",
+                side_effect=_fake_compute,
+            ), patch(
+                "web.discogs.get_release",
+                return_value=discogs_release,
+            ) as discogs_get:
+                rc = pipeline_cli.cmd_beets_distance(MagicMock(), args)
+                self.assertIn("mb_get_release", captured)
+                resolved = captured["mb_get_release"]("2048516")
+                discogs_get.assert_called_once_with(2048516, fresh=False)
+        self.assertEqual(rc, 0)
+        self.assertEqual(resolved, discogs_release)
+
 
 class TestCmdYoutubeAlbum(unittest.TestCase):
     """``pipeline-cli youtube-album`` wraps

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -1484,16 +1484,61 @@ class TestBeetsDistanceRouteContract(_FakeDbWebServerCase):
             status, _ = self._get(f"/api/beets-distance/100/{self.UUID_A}")
         self.assertEqual(status, 500)
 
-    def test_route_pattern_requires_uuid_shape(self):
-        """The route pattern only matches MBID UUIDs — a malformed
-        MBID (e.g. a Discogs numeric id) doesn't even hit the handler.
-
-        This is a route-table contract: keep the regex strict so we
-        never accidentally compute a distance against a non-MB id.
+    def test_route_pattern_rejects_non_id_shapes(self):
+        """The route pattern matches full MB UUIDs and bare Discogs
+        numeric ids (#530) — a shape that is neither (partial UUID,
+        non-numeric junk) doesn't even hit the handler.
         """
-        # Numeric id (Discogs-shaped) — pattern shouldn't match.
-        status, _ = self._get("/api/beets-distance/100/2048516")
+        status, _ = self._get("/api/beets-distance/100/not-a-real-id")
         self.assertEqual(status, 404)
+
+    def test_discogs_numeric_id_routes_through_discogs_lookup(self):
+        """A numeric candidate id (Discogs sibling — e.g. surfaced by the
+        Replace picker against a Discogs-sourced request per #501) must
+        resolve via ``discogs_api.get_release``, not ``mb_api.get_release``
+        (#530). This mirrors ``browse.py``'s numeric-dispatch idiom and
+        the YouTube resolver's ``discogs_get_release`` seam — no new
+        MB<->Discogs adapter: ``compute_beets_distance`` already treats
+        ``release_group_id`` as optional and ``discogs_api.get_release``
+        mirrors ``mb_api.get_release``'s dict shape exactly.
+        """
+        captured = {}
+
+        def _fake_compute(download_log_id, mbid, *, pdb, mb_get_release,
+                           cache=None, **_kw):
+            captured["mb_get_release"] = mb_get_release
+            return self._Result(
+                outcome="ok",
+                distance=0.05,
+                download_log_id=download_log_id,
+                candidate_mbid=mbid,
+            )
+
+        discogs_release = {
+            "id": "2048516",
+            "title": "Fake Album",
+            "artist_name": "Fake Artist",
+            "artist_id": "999",
+            "release_group_id": None,
+            "tracks": [],
+        }
+        with patch(
+            "lib.beets_distance.compute_beets_distance",
+            side_effect=_fake_compute,
+        ), patch(
+            "web.discogs.get_release",
+            return_value=discogs_release,
+        ) as discogs_get:
+            status, data = self._get("/api/beets-distance/100/2048516")
+            self.assertIn("mb_get_release", captured)
+            resolved = captured["mb_get_release"]("2048516")
+            discogs_get.assert_called_once_with(2048516, fresh=False)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["outcome"], "ok")
+        # The handler's mb_get_release seam must be wired to Discogs,
+        # not MB, for a numeric candidate id.
+        self.assertEqual(resolved, discogs_release)
 
 
 if __name__ == "__main__":

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -1994,6 +1994,15 @@ def get_beets_distance(
     thin adapter that maps the typed ``BeetsDistanceResult`` outcomes
     to HTTP status codes per the CLI ⇄ API symmetry rule.
 
+    ``mbid`` may be an MB release UUID or a bare Discogs numeric release
+    id (#530 — Discogs siblings, e.g. surfaced by the Replace picker
+    against a Discogs-sourced request per #501). Dispatch on the id
+    shape the same way ``browse.py::get_release_group`` does: numeric ⇒
+    Discogs. ``compute_beets_distance`` is source-agnostic (the
+    YouTube resolver already scores Discogs releases through it via the
+    same ``get_release``-shaped callable) — no MB<->Discogs adapter
+    needed.
+
     Status-code mapping:
       * 200 — ``ok`` (distance is in ``response.distance``)
       * 404 — ``download_log_not_found`` / ``request_not_found``
@@ -2013,12 +2022,17 @@ def get_beets_distance(
         h._error("Invalid download_log_id")
         return
 
+    if detect_release_source(mbid) == "discogs":
+        get_release_fn = lambda m: discogs_api.get_release(int(m), fresh=False)
+    else:
+        get_release_fn = lambda m: mb_api.get_release(m, fresh=False)
+
     s = _server()
     result = compute_beets_distance(
         download_log_id,
         mbid,
         pdb=s._db(),
-        mb_get_release=lambda m: mb_api.get_release(m, fresh=False),
+        mb_get_release=get_release_fn,
         cache=_RedisFingerprintCache(),
     )
 
@@ -2102,12 +2116,14 @@ ROUTES: list[RouteRegistration] = [
         classified=True,
     ),
     # /api/beets-distance/<download_log_id>/<mbid> — real beets distance
-    # for one (download_log_id, mbid) pair. See get_beets_distance above.
+    # for one (download_log_id, mbid) pair. mbid may be an MB UUID or a
+    # bare Discogs numeric id (#530). See get_beets_distance above.
     pattern_route(
-        "GET", r"^/api/beets-distance/(\d+)/([a-f0-9-]{36})$",
+        "GET", r"^/api/beets-distance/(\d+)/([a-f0-9-]{36}|\d+)$",
         get_beets_distance,
-        "Real beets match distance for one (download_log_id, mbid) pair; "
-        "refuses cross-release-group comparisons.",
+        "Real beets match distance for one (download_log_id, mbid) pair "
+        "(mbid may be an MB UUID or a Discogs numeric id); refuses "
+        "cross-release-group comparisons.",
         classified=True,
     ),
     pattern_route(


### PR DESCRIPTION
## Summary
- `GET /api/beets-distance/<download_log_id>/<mbid>` was registered with a UUID-only regex, so a numeric Discogs sibling id 404'd before reaching the handler — the Replace picker's per-pressing distance fan-out (`replace_picker.js::loadDistances`) silently produced no badge for Discogs siblings (surfaced by `browse.py::get_release_group`'s numeric dispatch, #501).
- Widened the route regex (`([a-f0-9-]{36}|\d+)`) and dispatch `get_beets_distance`'s `mb_get_release` seam on id shape via the already-imported `lib.release_identity.detect_release_source` — numeric ⇒ `discogs_api.get_release`, mirroring `browse.py`'s existing idiom.
- Mirrored the same dispatch in the `pipeline-cli beets-distance` counterpart for CLI ⇄ API symmetry.
- `compute_beets_distance` needed **no changes** — it already treats `release_group_id` as optional and `discogs_api.get_release` mirrors `mb_api.get_release`'s dict shape exactly (the same seam the YouTube resolver already scores Discogs releases through). No MB↔Discogs adapter code was added.
- No frontend change needed: `replace_picker.js` already fires `/api/beets-distance/<log>/<id>` for every sibling pressing regardless of source once `browse.py` returns Discogs siblings — the route relaxation alone unblocks it. (The long-tail siblings panel is a separate, read-only view that doesn't call beets-distance at all yet, and its "Accept a sibling" action stays MB-only per KTD7 — out of scope here.)

Closes #530

## Test plan
- [x] RED: added `test_discogs_numeric_id_routes_through_discogs_lookup` in `tests/web/test_routes_pipeline.py` and `tests/test_pipeline_cli.py`; confirmed both failed against the pre-change UUID-only regex / MB-only dispatch (404 at the route level / real MB-mirror network call in the CLI test).
- [x] GREEN: both pass after the regex widen + dispatch change.
- [x] Replaced `test_route_pattern_requires_uuid_shape` (asserted numeric ids 404'd) with `test_route_pattern_rejects_non_id_shapes`, which still guards the regex against genuinely malformed ids (partial UUID / non-numeric junk).
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — full suite green (exit 0, 4730 tests).
- [x] `nix-shell --run "pyright"` — 0 errors, 0 warnings.
- [x] `node --check web/js/*.js` — passes (no JS changes were needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)