### PR TITLE
fix(tests): isolate test_import_queue from lib.download import-order race

### DIFF
--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -46,6 +46,30 @@ from tests.helpers import (
 )
 
 
+def setUpModule() -> None:
+    """Force a real, unmocked import of ``lib.download`` up front (#511).
+
+    ``lib/download.py`` binds its module-level ``process_completed_album``
+    name at import time via a ``from lib.download_processing import ...``
+    statement. Several tests below reach that import lazily for the first
+    time (via ``scripts.importer.execute_youtube_import_job``'s own
+    deferred ``from lib.download import ...``) while a mock-patch context
+    on ``lib.download_processing``'s own ``process_completed_album``
+    attribute is active. Python caches module imports, so whichever call
+    site imports ``lib.download`` FIRST permanently decides what its
+    module-level name refers to — if that first import happens mid-patch,
+    the mock gets baked in forever; the patch's own restore on exit only
+    resets the OTHER module's attribute, which this separately-bound name
+    never observes again. That silently broke ``TestImporterWorker``'s
+    automation-import tests (which rely on ``lib.download``'s real
+    function), whenever this module ran standalone, because
+    ``TestExecuteYoutubeImportJob`` sorts before ``TestImporterWorker`` and
+    got there first. Importing it here, before any test or patch runs,
+    makes the real binding deterministic regardless of test order.
+    """
+    import lib.download  # noqa: F401
+
+
 # Migration 021 helpers — seed evidence and wire the FK chain that
 # production reads through.
 def _seed_candidate_for_download_log(db, log_id: int, *, mb_release_id: str,


### PR DESCRIPTION
Closes #511

## Root cause

`lib/download.py` binds its module-level `process_completed_album` name at
import time via a `from lib.download_processing import ...` statement.
Because Python caches module imports (`sys.modules`), that statement only
ever *executes* once per process — the first time anything triggers
`lib.download`'s import (directly, or lazily, e.g. via
`scripts.importer.execute_youtube_import_job`'s own deferred
`from lib.download import ...`).

Several `TestExecuteYoutubeImportJob` tests wrap that lazy import inside a
mock-patch context on `lib.download_processing`'s own
`process_completed_album` attribute. When `tests/test_import_queue.py` runs
standalone (`python3 -m unittest tests.test_import_queue`), no earlier test
has imported `lib.download` yet, and `TestExecuteYoutubeImportJob` sorts
alphabetically before `TestImporterWorker` — so `lib.download`'s **first
ever** import happens *while the mock is active*, permanently binding the
mock into `lib.download`'s own namespace. The mock-patch's own restore on
exit only resets `lib.download_processing`'s attribute; it can never reach
`lib.download`'s already-resolved, separately-bound name.

Later, `TestImporterWorker::test_requeued_automation_job_abandons_interrupted_auto_import`
exercises the automation-import path through `lib.download._run_completed_processing`,
whose default dispatch target resolves to the now-poisoned module-level
name — so the real "abandon interrupted auto-import" logic never runs; the
job is instead reported "completed" via the stale mock's canned return
value, tripping the assertion (`'completed' != 'failed'`).

Under full-suite discovery this is invisible because an earlier test module
(`tests/test_cooldown.py`, which sorts before `test_import_queue.py`)
imports `lib.download` first, safely, with no mock active — so by the time
`TestExecuteYoutubeImportJob` runs, the real function is already
permanently bound and immune to the later patches.

## Fix

Test-only change. Added `setUpModule()` to `tests/test_import_queue.py`
that eagerly, unconditionally imports `lib.download` before any test or
patch in the module runs — removing the import-order race entirely rather
than depending on some other file happening to import it first. This
matches the existing `setUpModule`/`tearDownModule` precedent already used
elsewhere in this test suite (`tests/test_youtube_album_service.py`,
`tests/test_discogs_api.py`).

No production code changed.

## Test plan

- [x] RED: confirmed standalone `python3 -m unittest tests.test_import_queue`
      failed on unmodified `main` with `AssertionError: 'completed' != 'failed'`
- [x] Bisected the leak to `TestExecuteYoutubeImportJob`'s
      `with patch("lib.download_processing.process_completed_album", ...)`
      tests via runtime instrumentation (confirmed `lib.download.process_completed_album`
      was a stale `MagicMock` at the point of failure)
- [x] GREEN: standalone module run, 3x in a row, all `EXIT=0`
- [x] Full suite (`scripts/run_tests.sh`): `EXIT=0`
- [x] `pyright`: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)