### PR TITLE
fix(download): resolve process_completed_album at call time (#536)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -17,6 +17,7 @@ from typing import (Any, Callable, Protocol, TYPE_CHECKING, assert_never,
                     runtime_checkable)
 
 
+from lib import download_processing
 from lib.download_processing import (
     Completed,
     CompletionDeferred,
@@ -30,7 +31,6 @@ from lib.download_processing import (
     _canonical_import_folder_path,
     _evaluate_staged_path_readiness,
     _materialize_processing_dir,
-    process_completed_album,
 )
 from lib.download_recovery import (
     classify_processing_path,
@@ -396,9 +396,16 @@ def _run_completed_processing(
     outer transition flow without going through the full
     ``process_completed_album`` body. Defaults to the real production
     function so callers in ``scripts/importer.py`` are unchanged.
+
+    The default is resolved via the ``download_processing`` module
+    reference (not a from-import binding) so that patching
+    ``lib.download_processing.process_completed_album`` in tests is
+    honored here at call time, regardless of import order (#536).
     """
     _process = (
-        process_album_fn if process_album_fn is not None else process_completed_album
+        process_album_fn
+        if process_album_fn is not None
+        else download_processing.process_completed_album
     )
 
     if state.processing_started_at is None:

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -46,30 +46,6 @@ from tests.helpers import (
 )
 
 
-def setUpModule() -> None:
-    """Force a real, unmocked import of ``lib.download`` up front (#511).
-
-    ``lib/download.py`` binds its module-level ``process_completed_album``
-    name at import time via a ``from lib.download_processing import ...``
-    statement. Several tests below reach that import lazily for the first
-    time (via ``scripts.importer.execute_youtube_import_job``'s own
-    deferred ``from lib.download import ...``) while a mock-patch context
-    on ``lib.download_processing``'s own ``process_completed_album``
-    attribute is active. Python caches module imports, so whichever call
-    site imports ``lib.download`` FIRST permanently decides what its
-    module-level name refers to — if that first import happens mid-patch,
-    the mock gets baked in forever; the patch's own restore on exit only
-    resets the OTHER module's attribute, which this separately-bound name
-    never observes again. That silently broke ``TestImporterWorker``'s
-    automation-import tests (which rely on ``lib.download``'s real
-    function), whenever this module ran standalone, because
-    ``TestExecuteYoutubeImportJob`` sorts before ``TestImporterWorker`` and
-    got there first. Importing it here, before any test or patch runs,
-    makes the real binding deterministic regardless of test order.
-    """
-    import lib.download  # noqa: F401
-
-
 # Migration 021 helpers — seed evidence and wire the FK chain that
 # production reads through.
 def _seed_candidate_for_download_log(db, log_id: int, *, mb_release_id: str,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2714,6 +2714,34 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         self.assertIsInstance(result, Completed)
         self.assertEqual(db.request(42)["status"], "imported")
 
+    def test_default_process_album_fn_honors_patched_download_processing(self):
+        """Regression guard (#536): with no ``process_album_fn`` override,
+        ``_run_completed_processing`` must resolve ``process_completed_album``
+        from ``lib.download_processing`` at call time. Before #536 that
+        default was captured once via a from-import at ``lib.download``
+        import time, so patching the leaf seam here — the same seam
+        production tests already patch elsewhere — silently had no effect
+        on this call site.
+        """
+        from lib import download as dl_mod
+        from lib.download_processing import Completed
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+
+        with patch(
+            "lib.download_processing.process_completed_album",
+            return_value=Completed(),
+        ) as patched:
+            result = dl_mod._run_completed_processing(
+                self._entry(), 42, self._state(), db, self._ctx(db),
+                import_job_id=1,
+            )
+
+        patched.assert_called_once()
+        self.assertIsInstance(result, Completed)
+        self.assertEqual(db.request(42)["status"], "imported")
+
 
 class TestBadAudioHashSlice(unittest.TestCase):
     """Integration slice: bad-audio-hash gate inside ``measure_preimport_state``.


### PR DESCRIPTION
Closes #536

## Summary
- `lib/download.py` bound `process_completed_album` via a module-level from-import, so patching `lib.download_processing.process_completed_album` in tests never affected `lib.download`'s own call site — and if `lib.download` was first imported mid-patch, the mock got baked in permanently for the rest of the process. This was the root cause of the #511 symptom, previously worked around with a `setUpModule()` in `tests/test_import_queue.py` that force-imported `lib.download` before any patch could run.
- Fixed at the root: `lib/download.py` now does `from lib import download_processing` and resolves the default via `download_processing.process_completed_album` at call time inside `_run_completed_processing`, so patching the leaf seam is honored regardless of import order. Production behavior is unchanged — `download_processing.process_completed_album` is the same function object in production; only patchability differs.
- Removed the now-redundant `setUpModule()` workaround from `tests/test_import_queue.py` per the single-operator/no-kept-workarounds rule.
- Added a regression guard in `tests/test_integration_slices.py::TestRunCompletedProcessingOutcomeBranching::test_default_process_album_fn_honors_patched_download_processing` that patches `lib.download_processing.process_completed_album` with no `process_album_fn` override and asserts the patch is actually invoked.

## Verification
- RED: reverted just the `lib/download.py` fix (kept `setUpModule` removed) — `tests/test_import_queue.py` standalone reproduced the exact original symptom `AssertionError: 'completed' != 'failed'`, and the new guard test failed with `Expected 'process_completed_album' to have been called once. Called 0 times.`
- GREEN: reapplied the fix — both failures resolved.
- `tests/test_import_queue.py` passes standalone 3x (EXIT=0 each) and under full-suite discovery.
- Full suite: `nix-shell --run "bash scripts/run_tests.sh"` → `Ran 4731 tests ... OK`, EXIT=0.
- `nix-shell --run "pyright"` → `0 errors, 0 warnings, 0 informations`.

## Test plan
- [x] Guard test fails against the old from-import binding (RED)
- [x] Guard test passes with the fix (GREEN)
- [x] `tests/test_import_queue.py` standalone x3 + under discover, all green
- [x] Full suite green
- [x] Pyright clean (full repo)