### PR TITLE
refactor: relocate lib/quality/repair.py to lib/repair.py (#512)

### DIFF
--- a/lib/quality/__init__.py
+++ b/lib/quality/__init__.py
@@ -5,9 +5,11 @@ works for every X callers/tests imported from the monolith. Submodule
 docstrings say what lives where; the decision twins live in
 ``lib.quality.pipeline`` (parity contract — keep them together).
 
-Refreshed onto main post-split to also carry ``SlskdOrphanTransfer`` /
-``find_slskd_orphans`` (issue #278), added to the monolith after the
-original #477 split landed.
+The orphan/repair cluster (``OrphanInfo``, ``RepairAction``,
+``SlskdOrphanTransfer``, ``find_orphaned_downloads``,
+``find_inconsistencies``, ``suggest_repair``, ``find_slskd_orphans``) was
+parked here by the #477 split even though it isn't quality-decision logic;
+relocated to ``lib.repair`` (issue #512).
 """
 
 from lib.quality.wire_types import (
@@ -180,15 +182,6 @@ from lib.quality.pipeline import (
     full_pipeline_decision_from_evidence,
     override_bitrate_from_current_evidence,
 )
-from lib.quality.repair import (
-    OrphanInfo,
-    RepairAction,
-    SlskdOrphanTransfer,
-    find_inconsistencies,
-    find_orphaned_downloads,
-    find_slskd_orphans,
-    suggest_repair,
-)
 
 __all__ = [
     "AUDIO_EXTENSIONS",
@@ -230,7 +223,6 @@ __all__ = [
     "MeasurementFailure",
     "MeasurementFailureReason",
     "MovedSibling",
-    "OrphanInfo",
     "PostflightInfo",
     "ProvisionalLosslessDecisionInput",
     "ProvisionalLosslessDecisionResult",
@@ -246,9 +238,7 @@ __all__ = [
     "QualityRank",
     "QualityRankConfig",
     "RankBitrateMetric",
-    "RepairAction",
     "SPECTRAL_TRANSCODE_GRADES",
-    "SlskdOrphanTransfer",
     "SpectralDetail",
     "SpectralMeasurement",
     "TRANSCODE_MIN_BITRATE_KBPS",
@@ -306,9 +296,6 @@ __all__ = [
     "extract_usernames",
     "file_identity",
     "filetype_matches",
-    "find_inconsistencies",
-    "find_orphaned_downloads",
-    "find_slskd_orphans",
     "full_pipeline_decision",
     "full_pipeline_decision_from_evidence",
     "gate_rank",
@@ -339,7 +326,6 @@ __all__ = [
     "should_cooldown",
     "spectral_gate_trigger",
     "spectral_import_decision",
-    "suggest_repair",
     "top_candidates",
     "top_candidates_with_skip_split",
     "transcode_detection",

--- a/lib/repair.py
+++ b/lib/repair.py
@@ -1,10 +1,12 @@
-"""Orphan/inconsistency detection + repair suggestions (parked here by #477; not quality logic).
+"""Orphan/inconsistency detection + repair suggestions.
 
-Extracted verbatim from the monolithic ``lib/quality.py`` (issue #477),
-refreshed onto main to also carry ``SlskdOrphanTransfer`` /
+Originally extracted verbatim from the monolithic ``lib/quality.py`` (issue
+#477), which parked it under ``lib/quality/`` even though it isn't
+quality-decision logic; refreshed to also carry ``SlskdOrphanTransfer`` /
 ``find_slskd_orphans`` (issue #278, the inverse orphan direction — live
-slskd transfers no downloading row owns). Pure move: every definition is
-AST-identical to the current monolith.
+slskd transfers no downloading row owns); relocated to this top-level
+module (issue #512). Pure moves both times: every definition here is
+AST-identical to its prior incarnation.
 """
 
 from __future__ import annotations
@@ -13,10 +15,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    # Deferred: lib.slskd_client -> lib.config -> lib.quality (this
-    # package's __init__) -> lib.quality.repair would otherwise be a
-    # circular import at module load time. DownloadUser is only used for
-    # the find_slskd_orphans() type annotation, never constructed here.
+    # DownloadUser is only used for the find_slskd_orphans() type
+    # annotation, never constructed here — deferred so this module doesn't
+    # need lib.slskd_client at runtime import time.
     from lib.slskd_client import DownloadUser
 
 

--- a/lib/slskd_transfers.py
+++ b/lib/slskd_transfers.py
@@ -432,7 +432,7 @@ def converge_slskd_orphans(ctx: CratediggerContext) -> int:
     logged and the remaining orphans are still attempted. Returns the
     number of transfers successfully cancelled.
     """
-    from lib.quality import find_slskd_orphans
+    from lib.repair import find_slskd_orphans
 
     downloads = _get_all_downloads_snapshot(
         ctx.slskd, purpose="orphan-transfer convergence",

--- a/scripts/repair.py
+++ b/scripts/repair.py
@@ -31,9 +31,9 @@ from lib.download_recovery import (find_blocked_processing_path_issues,
 from lib.pipeline_db import (ADVISORY_LOCK_NAMESPACE_RELEASE, PipelineDB,
                              release_id_to_lock_key)
 from lib.processing_paths import directory_has_entries
-from lib.quality import (OrphanInfo, SlskdOrphanTransfer, find_inconsistencies,
-                         find_orphaned_downloads, find_slskd_orphans,
-                         suggest_repair)
+from lib.repair import (OrphanInfo, SlskdOrphanTransfer, find_inconsistencies,
+                        find_orphaned_downloads, find_slskd_orphans,
+                        suggest_repair)
 from lib.slskd_client import DownloadUser
 
 # No hardcoded fallback (#479): the nspawn DB has moved before (last time to
@@ -49,7 +49,7 @@ def _fetch_slskd_downloads(host: str, api_key: str) -> list[DownloadUser]:
 
     Kept as its own network seam so ``_collect_issues`` can derive BOTH the
     forward orphan view (``_active_transfer_pairs``) and the inverse
-    slskd-side orphan report (``lib.quality.find_slskd_orphans``) from one
+    slskd-side orphan report (``lib.repair.find_slskd_orphans``) from one
     fetch, instead of flattening to pairs and discarding the raw structure
     the way this used to (#479 item 1).
     """

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from lib.quality import (
+from lib.repair import (
     OrphanInfo,
     find_inconsistencies,
     find_orphaned_downloads,

--- a/tests/test_repair_cli.py
+++ b/tests/test_repair_cli.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from typing import Any, cast
 
-from lib.quality import OrphanInfo, SlskdOrphanTransfer
+from lib.repair import OrphanInfo, SlskdOrphanTransfer
 from scripts import repair
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_download_directory, make_download_user, make_transfer_snapshot


### PR DESCRIPTION
## Summary
- Pure move (`git mv`): `lib/quality/repair.py` → `lib/repair.py`. The orphan/inconsistency-detection + repair-suggestion cluster (`OrphanInfo`, `RepairAction`, `SlskdOrphanTransfer`, `find_orphaned_downloads`, `find_inconsistencies`, `suggest_repair`, `find_slskd_orphans`) was parked under `lib/quality/` by the #477 monolith split even though it isn't quality-decision logic.
- Removed the re-export block + `__all__` entries from `lib/quality/__init__.py` — no deprecated compat shim (single-operator repo, `.claude/rules/scope.md`).
- Repointed every caller directly at `lib.repair`: `lib/slskd_transfers.py`, `scripts/repair.py`, `tests/test_repair.py`, `tests/test_repair_cli.py`.
- Zero behavior change. AST-identity verified: all 7 moved definitions produce byte-identical `ast.dump()` output before/after (only module-level docstrings/comments changed, never function bodies).

Closes #512

## Test plan
- [x] `nix-shell --run "pyright"` → 0 errors, 0 warnings
- [x] `nix-shell --run "bash scripts/run_tests.sh"` → exit 0, 4730 tests, `OK` (includes the vulture dead-code sweep: "No dead code found")
- [x] AST-identity check: `ast.dump()` on all 7 moved definitions (`OrphanInfo`, `RepairAction`, `SlskdOrphanTransfer`, `find_orphaned_downloads`, `find_inconsistencies`, `suggest_repair`, `find_slskd_orphans`) matches exactly between old and new location
- [x] Grepped repo-wide for remaining `lib.quality` repair-symbol imports and `lib/quality/repair` doc references — none left (dated `docs/plans/*` left untouched per instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)