### PR TITLE
refactor(cli): split routes_meta._build_parser per command family (#521)

### DIFF
--- a/scripts/pipeline_cli/album_requests.py
+++ b/scripts/pipeline_cli/album_requests.py
@@ -6,7 +6,9 @@
 needs.
 """
 
+import argparse
 import json
+import os
 import sys
 import urllib.error
 import urllib.request
@@ -494,3 +496,66 @@ def cmd_set_intent(db, args):
         action = "lossless on disk" if target_format else "default (pipeline decides)"
         print(f"  [{args.id}] {label}: {action} "
               f"(target_format: {old_target} → {target_format})")
+
+
+def add_album_requests_subparsers(sub: argparse._SubParsersAction) -> None:
+    """Add ``list`` / ``add`` / ``status`` / ``disk-coverage`` / ``retry`` /
+    ``cancel`` / ``set`` / ``set-intent`` (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions)."""
+    # list
+    p_list = sub.add_parser("list", help="List album requests")
+    p_list.add_argument("filter_status", nargs="?", help="Filter by status")
+    p_list.add_argument(
+        "--search",
+        help="Case-insensitive substring match on artist or album "
+             "(mirrors GET /api/pipeline/search)",
+    )
+
+    # add
+    p_add = sub.add_parser("add", help="Add a new request by MBID or Discogs ID")
+    p_add.add_argument("mbid", help="MusicBrainz release UUID or Discogs numeric release ID")
+    p_add.add_argument("--source", default="request", choices=["request", "redownload", "manual"],
+                       help="Source type (default: request)")
+
+    # status
+    sub.add_parser("status", help="Show counts by status")
+
+    # disk-coverage
+    p_disk = sub.add_parser(
+        "disk-coverage",
+        help="Show which active pipeline rows are actually present in beets",
+    )
+    p_disk.add_argument(
+        "--beets-db",
+        default=os.environ.get("BEETS_DB", "/mnt/virtio/Music/beets-library.db"),
+        help="Path to beets SQLite DB (default: BEETS_DB or production path)",
+    )
+    p_disk.add_argument(
+        "--counts-only",
+        action="store_true",
+        help="Suppress the off-disk row list and print counts only",
+    )
+    p_disk.add_argument(
+        "--include-inverse",
+        action="store_true",
+        help="Also include beets albums with no active pipeline row",
+    )
+
+    # retry
+    p_retry = sub.add_parser("retry", help="Reset a failed request to wanted")
+    p_retry.add_argument("id", type=int, help="Request ID")
+
+    # cancel
+    p_cancel = sub.add_parser("cancel", help="Cancel a request (set to skipped)")
+    p_cancel.add_argument("id", type=int, help="Request ID")
+
+    # set
+    p_set = sub.add_parser("set", help="Change the status of a request")
+    p_set.add_argument("id", type=int, help="Request ID")
+    p_set.add_argument("status", choices=VALID_STATUSES, help="New status")
+
+    # set-intent
+    p_intent = sub.add_parser("set-intent", help="Toggle lossless-on-disk for a request")
+    p_intent.add_argument("id", type=int, help="Request ID")
+    p_intent.add_argument("intent", choices=["lossless", "default"],
+                          help="'lossless' = keep lossless on disk, 'default' = pipeline decides")

--- a/scripts/pipeline_cli/beets_distance.py
+++ b/scripts/pipeline_cli/beets_distance.py
@@ -3,6 +3,7 @@
 Real beets-distance between a download_log's failed_path and an MBID.
 """
 
+import argparse
 import json
 
 from scripts.pipeline_cli._format import _json_default
@@ -104,3 +105,18 @@ def cmd_beets_distance(db, args):
     if result.outcome == "mb_lookup_failed":
         return 5
     return 1
+
+
+def add_beets_distance_subparser(sub: argparse._SubParsersAction) -> None:
+    """Add ``beets-distance`` (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions)."""
+    p_bd = sub.add_parser(
+        "beets-distance",
+        help="Real beets-distance between a download_log's audio and an MBID "
+             "(refuses if MBID is outside the request's release group)")
+    p_bd.add_argument("download_log_id", type=int,
+                      help="download_log row id (see `pipeline-cli show <req>`)")
+    p_bd.add_argument("mbid",
+                      help="Candidate release id — MB UUID or Discogs numeric id")
+    p_bd.add_argument("--json", action="store_true",
+                      help="Print structured JSON instead of text")

--- a/scripts/pipeline_cli/imports.py
+++ b/scripts/pipeline_cli/imports.py
@@ -6,6 +6,7 @@ stage a local folder as a request, list recent queue jobs, and preview
 whether an import would pass without actually running one.
 """
 
+import argparse
 import json
 import os
 import sys
@@ -274,3 +275,66 @@ def cmd_import_preview(db, args):
 
     _print_preview_result(result, json_output=args.json)
     return 0
+
+
+def add_imports_subparsers(sub: argparse._SubParsersAction) -> None:
+    """Add ``force-import`` / ``manual-import`` / ``import-jobs`` /
+    ``import-preview`` (#521 carve out of ``routes_meta._build_parser``,
+    verbatim argument definitions)."""
+    # force-import
+    p_force = sub.add_parser("force-import", help="Force-import a rejected download by download_log ID")
+    p_force.add_argument("download_log_id", type=int, help="Download log ID")
+    p_force.add_argument("--verified-lossless-target",
+                         help="Override the runtime verified-lossless target for this import")
+
+    # manual-import
+    p_manual = sub.add_parser("manual-import", help="Import a local folder as a pipeline request")
+    p_manual.add_argument("id", type=int, help="Pipeline request ID")
+    p_manual.add_argument("path", help="Path to album folder")
+    p_manual.add_argument("--verified-lossless-target",
+                          help="Override the runtime verified-lossless target for this import")
+
+    # import-jobs
+    p_jobs = sub.add_parser("import-jobs", help="List recent import queue jobs")
+    p_jobs.add_argument("--status", choices=["queued", "running", "completed", "failed"])
+    p_jobs.add_argument("--limit", type=int, default=20)
+
+    # import-preview
+    p_preview = sub.add_parser("import-preview", help="Preview whether an import would pass")
+    p_preview.add_argument("--download-log-id", type=int,
+                           help="Preview the failed_path from a download_log row")
+    p_preview.add_argument("--request-id", type=int,
+                           help="Request ID for --path preview")
+    p_preview.add_argument("--path", help="Preview a real folder for a request")
+    p_preview.add_argument("--no-force", action="store_true",
+                           help="Do not pass --force to import_one.py preview")
+    p_preview.add_argument("--values", action="store_true",
+                           help="Preview typed override values instead of a real folder")
+    p_preview.add_argument("--values-json",
+                           help="JSON object with ImportPreviewValues fields")
+    p_preview.add_argument("--json", action="store_true",
+                           help="Print the common preview result as JSON")
+    p_preview.add_argument("--is-flac", action="store_true", default=None)
+    p_preview.add_argument("--min-bitrate", type=int)
+    p_preview.add_argument("--is-cbr", action="store_true", default=None)
+    p_preview.add_argument("--is-vbr", action="store_true", default=None)
+    p_preview.add_argument("--avg-bitrate", type=int)
+    p_preview.add_argument("--spectral-grade", choices=SPECTRAL_GRADE_CHOICES)
+    p_preview.add_argument("--spectral-bitrate", type=int)
+    p_preview.add_argument("--existing-min-bitrate", type=int)
+    p_preview.add_argument("--existing-avg-bitrate", type=int)
+    p_preview.add_argument("--existing-spectral-bitrate", type=int)
+    p_preview.add_argument("--existing-spectral-grade", choices=SPECTRAL_GRADE_CHOICES)
+    p_preview.add_argument("--override-min-bitrate", type=int)
+    p_preview.add_argument("--existing-format")
+    p_preview.add_argument("--existing-is-cbr", action="store_true", default=None)
+    p_preview.add_argument("--post-conversion-min-bitrate", type=int)
+    p_preview.add_argument("--converted-count", type=int)
+    p_preview.add_argument("--verified-lossless", action="store_true", default=None)
+    p_preview.add_argument("--verified-lossless-target")
+    p_preview.add_argument("--target-format")
+    p_preview.add_argument("--new-format")
+    p_preview.add_argument("--audio-check-mode")
+    p_preview.add_argument("--audio-corrupt", action="store_true", default=None)
+    p_preview.add_argument("--import-mode")
+    p_preview.add_argument("--has-nested-audio", action="store_true", default=None)

--- a/scripts/pipeline_cli/long_tail.py
+++ b/scripts/pipeline_cli/long_tail.py
@@ -5,6 +5,7 @@ on-disk quality and stamped with ``in_flight_rescue``. Counterpart of
 ``GET /api/pipeline/long-tail`` (U1).
 """
 
+import argparse
 import json
 import sys
 
@@ -149,3 +150,22 @@ def cmd_long_tail(db, args, *, band_fn=None):
         ))
     print(f"  ({len(result.rows)} rows)")
     return 0
+
+
+def add_long_tail_subparser(sub: argparse._SubParsersAction) -> None:
+    """Add ``long-tail`` (#521 carve out of ``routes_meta._build_parser``,
+    verbatim argument definitions)."""
+    p_long_tail = sub.add_parser(
+        "long-tail",
+        help="Long-tail worklist — wanted cohort pre-banded by on-disk "
+             "quality (missing / QualityRank / unknown) + in_flight_rescue")
+    p_long_tail.add_argument(
+        "--band", default=None,
+        help="Filter to a single band: missing | transparent | excellent "
+             "| good | acceptable | poor | unknown")
+    p_long_tail.add_argument(
+        "--id", type=int, default=None,
+        help="Band a single request by id (post-action refetch); "
+             "exits 2 if not found / not wanted")
+    p_long_tail.add_argument("--json", action="store_true",
+                             help="Print structured JSON instead of text")

--- a/scripts/pipeline_cli/quality.py
+++ b/scripts/pipeline_cli/quality.py
@@ -5,6 +5,8 @@ current quality state. ``repair-spectral`` — find and fix albums stuck
 by stale ``current_spectral_bitrate`` (issue #18).
 """
 
+import argparse
+
 from lib import transitions
 from scripts.pipeline_cli._format import _fmt_br
 
@@ -456,3 +458,17 @@ def cmd_repair_spectral(db, args):
 
     print(f"\nRepaired {repaired} album(s)." if not args.dry_run
           else f"\n[DRY RUN] Would repair {len(candidates)} album(s).")
+
+
+def add_quality_subparsers(sub: argparse._SubParsersAction) -> None:
+    """Add ``quality`` / ``repair-spectral`` (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions)."""
+    # quality
+    p_quality = sub.add_parser("quality", help="Show quality state and simulate decisions")
+    p_quality.add_argument("id", type=int, help="Request ID")
+
+    # repair-spectral
+    p_repair = sub.add_parser("repair-spectral",
+                              help="Fix albums stuck by stale current_spectral_bitrate (#18)")
+    p_repair.add_argument("--dry-run", action="store_true",
+                          help="Show what would be repaired without changing anything")

--- a/scripts/pipeline_cli/query.py
+++ b/scripts/pipeline_cli/query.py
@@ -3,6 +3,7 @@
 Debugging read-only SQL escape hatch — ``pipeline-cli query <sql>``.
 """
 
+import argparse
 import json
 import sys
 from datetime import date, datetime, time
@@ -91,3 +92,11 @@ def cmd_query(db, args):
     for line in _render_query_table(rows, columns):
         print(line)
     return None
+
+
+def add_query_subparser(sub: argparse._SubParsersAction) -> None:
+    """Add ``query`` (#521 carve out of ``routes_meta._build_parser``,
+    verbatim argument definitions)."""
+    p_query = sub.add_parser("query", help="Run a read-only SQL query for debugging")
+    p_query.add_argument("sql", help="SQL query string, or '-' to read SQL from stdin")
+    p_query.add_argument("--json", action="store_true", help="Print rows as JSON")

--- a/scripts/pipeline_cli/replace.py
+++ b/scripts/pipeline_cli/replace.py
@@ -4,6 +4,7 @@ Supersede a request with a new row at a different release id in the
 same release group / master. Counterpart of the Replace web action.
 """
 
+import argparse
 import json
 
 from scripts.pipeline_cli._format import _json_default
@@ -101,3 +102,19 @@ def cmd_replace(db, args):
     if result.outcome in (RESULT_TRANSIENT, RESULT_MIRROR_UNCONFIGURED):
         return 5
     return 1
+
+
+def add_replace_subparser(sub: argparse._SubParsersAction) -> None:
+    """Add ``replace`` (#521 carve out of ``routes_meta._build_parser``,
+    verbatim argument definitions)."""
+    p_replace = sub.add_parser(
+        "replace",
+        help="Supersede a request with a new row at a different release id "
+             "in the same release group/master (same pathway as the source)")
+    p_replace.add_argument("id", type=int, help="Source request ID")
+    p_replace.add_argument(
+        "--to", dest="target_mb_release_id", required=True,
+        help="Target release id — MB UUID or Discogs numeric id; must "
+             "share the source's pathway and release group/master")
+    p_replace.add_argument("--json", action="store_true",
+                           help="Print structured JSON instead of text")

--- a/scripts/pipeline_cli/routes_meta.py
+++ b/scripts/pipeline_cli/routes_meta.py
@@ -1,19 +1,32 @@
-"""pipeline-cli argparse construction + self-documentation (#495 carve).
+"""pipeline-cli argparse construction + self-documentation (#495 carve;
+per-family split #521).
 
-``_build_parser`` builds the entire subcommand tree (pure argparse
-construction — no handler-function references, so this module has no
-dependency on the command-family modules). ``cmd_routes`` walks that same
-parser to self-document the CLI surface, mirroring ``GET /api/_index`` on
-the web side.
+``_build_parser`` builds the entire subcommand tree. The actual
+``sub.add_parser(...)`` argument definitions are colocated with each
+command family's handler module (``add_<family>_subparsers`` functions);
+this module just creates the top-level parser + subparsers object and
+calls each family's builder in turn — the "shared registry" every family
+plugs into, mirroring ``cli.py``'s dispatch dict. ``cmd_routes`` walks
+the assembled parser to self-document the CLI surface, mirroring
+``GET /api/_index`` on the web side.
 """
 
 import argparse
 import json
-import os
 
 from lib.pipeline_db import DEFAULT_DSN
-from scripts.pipeline_cli.imports import SPECTRAL_GRADE_CHOICES
-from scripts.pipeline_cli.album_requests import VALID_STATUSES
+from scripts.pipeline_cli.album_requests import add_album_requests_subparsers
+from scripts.pipeline_cli.beets_distance import add_beets_distance_subparser
+from scripts.pipeline_cli.imports import add_imports_subparsers
+from scripts.pipeline_cli.long_tail import add_long_tail_subparser
+from scripts.pipeline_cli.quality import add_quality_subparsers
+from scripts.pipeline_cli.query import add_query_subparser
+from scripts.pipeline_cli.replace import add_replace_subparser
+from scripts.pipeline_cli.search_plan import add_search_plan_subparser
+from scripts.pipeline_cli.show import add_show_subparser
+from scripts.pipeline_cli.triage import add_triage_subparser
+from scripts.pipeline_cli.wrong_match import add_wrong_match_subparsers
+from scripts.pipeline_cli.youtube import add_youtube_subparsers
 
 
 def _build_parser() -> tuple[
@@ -31,380 +44,46 @@ def _build_parser() -> tuple[
     parser.add_argument("--dsn", default=DEFAULT_DSN, help="PostgreSQL connection string")
     sub = parser.add_subparsers(dest="command")
 
-    # list
-    p_list = sub.add_parser("list", help="List album requests")
-    p_list.add_argument("filter_status", nargs="?", help="Filter by status")
-    p_list.add_argument(
-        "--search",
-        help="Case-insensitive substring match on artist or album "
-             "(mirrors GET /api/pipeline/search)",
-    )
-
-    # add
-    p_add = sub.add_parser("add", help="Add a new request by MBID or Discogs ID")
-    p_add.add_argument("mbid", help="MusicBrainz release UUID or Discogs numeric release ID")
-    p_add.add_argument("--source", default="request", choices=["request", "redownload", "manual"],
-                       help="Source type (default: request)")
+    # list / add / status / disk-coverage / retry / cancel / set / set-intent
+    add_album_requests_subparsers(sub)
 
     # query
-    p_query = sub.add_parser("query", help="Run a read-only SQL query for debugging")
-    p_query.add_argument("sql", help="SQL query string, or '-' to read SQL from stdin")
-    p_query.add_argument("--json", action="store_true", help="Print rows as JSON")
-
-    # status
-    sub.add_parser("status", help="Show counts by status")
-
-    # disk-coverage
-    p_disk = sub.add_parser(
-        "disk-coverage",
-        help="Show which active pipeline rows are actually present in beets",
-    )
-    p_disk.add_argument(
-        "--beets-db",
-        default=os.environ.get("BEETS_DB", "/mnt/virtio/Music/beets-library.db"),
-        help="Path to beets SQLite DB (default: BEETS_DB or production path)",
-    )
-    p_disk.add_argument(
-        "--counts-only",
-        action="store_true",
-        help="Suppress the off-disk row list and print counts only",
-    )
-    p_disk.add_argument(
-        "--include-inverse",
-        action="store_true",
-        help="Also include beets albums with no active pipeline row",
-    )
-
-    # retry
-    p_retry = sub.add_parser("retry", help="Reset a failed request to wanted")
-    p_retry.add_argument("id", type=int, help="Request ID")
-
-    # cancel
-    p_cancel = sub.add_parser("cancel", help="Cancel a request (set to skipped)")
-    p_cancel.add_argument("id", type=int, help="Request ID")
-
-    # set
-    p_set = sub.add_parser("set", help="Change the status of a request")
-    p_set.add_argument("id", type=int, help="Request ID")
-    p_set.add_argument("status", choices=VALID_STATUSES, help="New status")
+    add_query_subparser(sub)
 
     # show
-    p_show = sub.add_parser("show", help="Show full details of a request")
-    p_show.add_argument("id", type=int, help="Request ID")
+    add_show_subparser(sub)
 
-    # search-plan
-    p_sp = sub.add_parser(
-        "search-plan",
-        help="Inspect persisted search plans (read-only, U6)")
-    sp_sub = p_sp.add_subparsers(dest="search_plan_command")
-    p_sp_show = sp_sub.add_parser(
-        "show",
-        help="Show active/failed plans, cursor, items, provenance, "
-             "legacy logs for one request")
-    p_sp_show.add_argument("id", type=int, help="Request ID")
-    p_sp_show.add_argument("--json", action="store_true",
-                            help="Print structured JSON instead of text")
-    p_sp_show.add_argument("--no-stats", action="store_true",
-                            dest="no_stats",
-                            help="Suppress per-slot/query usefulness stats")
-    p_sp_regen = sp_sub.add_parser(
-        "regenerate",
-        help="Regenerate the search plan for a request (U8)")
-    p_sp_regen.add_argument("id", type=int, help="Request ID")
-    p_sp_regen.add_argument("--prepend-artist", action="store_true",
-                             dest="prepend_artist", default=None,
-                             help="Prepend artist name to album title in "
-                             "generated queries (overrides config; absent "
-                             "means use config's album_prepend_artist)")
-    p_sp_regen.add_argument("--json", action="store_true",
-                             help="Print structured JSON instead of text")
-    p_sp_advance = sp_sub.add_parser(
-        "advance",
-        help="Forward-only operator advance of the cursor (e.g. skip "
-             "collapsed default-strategy slots on a self-titled release)")
-    p_sp_advance.add_argument("id", type=int, help="Request ID")
-    sp_target = p_sp_advance.add_mutually_exclusive_group(required=True)
-    sp_target.add_argument(
-        "--to-ordinal", type=int, dest="to_ordinal",
-        help="Absolute target ordinal in [0, plan_item_count)")
-    sp_target.add_argument(
-        "--to-strategy", dest="to_strategy",
-        help="Strategy prefix; advance to the first plan item past the "
-             "current cursor whose strategy starts with this string "
-             "(e.g. `track`, `unwild_year`)")
-    p_sp_advance.add_argument("--json", action="store_true",
-                              help="Print structured JSON instead of text")
-    p_sp_dry_run = sp_sub.add_parser(
-        "dry-run",
-        help="Run the generator against the request's snapshot without "
-             "persisting (U6 simulator)")
-    p_sp_dry_run.add_argument("id", type=int, help="Request ID")
-    p_sp_dry_run.add_argument("--prepend-artist", action="store_true",
-                              dest="prepend_artist", default=None,
-                              help="Prepend artist name to album title in "
-                              "generated queries (overrides config; absent "
-                              "means use config's album_prepend_artist)")
-    p_sp_dry_run.add_argument("--json", action="store_true",
-                              help="Print structured JSON instead of text")
-    p_sp_saturation = sp_sub.add_parser(
-        "saturation",
-        help="Show per-request saturation rate + pre-filter skip total "
-             "over the recent search_log window (U7 telemetry)")
-    p_sp_saturation.add_argument("id", type=int, help="Request ID")
-    p_sp_saturation.add_argument(
-        "--window-days", type=int, default=None, dest="window_days",
-        help="Window in days; defaults to 14; valid range [1, 90]")
-    p_sp_saturation.add_argument(
-        "--json", action="store_true",
-        help="Print structured JSON instead of text")
-    p_sp_history = sp_sub.add_parser(
-        "history",
-        help="Cursor-paginated read of one request's search_log rows "
-             "(per-attempt forensics)")
-    p_sp_history.add_argument("id", type=int, help="Request ID")
-    p_sp_history.add_argument(
-        "--limit", type=int, default=None,
-        help="Rows per page; defaults to 50; valid range [1, 200]")
-    p_sp_history.add_argument(
-        "--before-id", type=int, default=None, dest="before_id",
-        help="Resume cursor: pass the previous page's next_before_id")
-    p_sp_history.add_argument("--json", action="store_true",
-                              help="Print structured JSON instead of text")
+    # search-plan (+ nested show/regenerate/advance/dry-run/saturation/history)
+    p_sp = add_search_plan_subparser(sub)
 
-    # triage (U16) — operator-facing composition of unfindable + field-quality
-    # + search-forensics. Wraps ``lib.triage_service`` (U15). Nested under a
-    # subparser for the same reason ``search-plan`` is: the per-request view
-    # and the cohort list share enough state to benefit from a shared
-    # namespace, and the convention is consistent with the rest of this CLI.
-    p_triage_op = sub.add_parser(
-        "triage",
-        help="Operator triage (U16) — compose unfindable + field-quality + "
-             "search-forensics for one request, or list a cohort by filter")
-    tr_sub = p_triage_op.add_subparsers(dest="triage_command")
-
-    p_tr_show = tr_sub.add_parser(
-        "show",
-        help="Per-request triage composition (request meta + unfindable + "
-             "field-quality + search forensics + last 10 search_log rows). "
-             "Note: subcommand form mirrors `search-plan show <id>`; bare "
-             "`triage <id>` is not accepted.")
-    p_tr_show.add_argument("id", type=int, help="Request ID")
-    p_tr_show.add_argument("--json", action="store_true",
-                            help="Print structured JSON instead of text")
-
-    p_tr_list = tr_sub.add_parser(
-        "list",
-        help="Cohort listing by filter spec")
-    p_tr_list.add_argument(
-        "--filter", default="all",
-        help="Filter spec: all | unfindable[:<category>] | "
-             "data_quality[:<field>] | data_quality:status=<status> | "
-             "data_quality:reason=<code> | search_not_converting")
-    p_tr_list.add_argument(
-        "--limit", type=int, default=50,
-        help="Page size (default 50)")
-    p_tr_list.add_argument(
-        "--after", type=int, default=None,
-        help="Resume cursor: last request_id from prior page")
-    p_tr_list.add_argument("--json", action="store_true",
-                            help="Print structured JSON instead of text")
+    # triage (+ nested show/list)
+    p_triage_op = add_triage_subparser(sub)
 
     # long-tail
-    p_long_tail = sub.add_parser(
-        "long-tail",
-        help="Long-tail worklist — wanted cohort pre-banded by on-disk "
-             "quality (missing / QualityRank / unknown) + in_flight_rescue")
-    p_long_tail.add_argument(
-        "--band", default=None,
-        help="Filter to a single band: missing | transparent | excellent "
-             "| good | acceptable | poor | unknown")
-    p_long_tail.add_argument(
-        "--id", type=int, default=None,
-        help="Band a single request by id (post-action refetch); "
-             "exits 2 if not found / not wanted")
-    p_long_tail.add_argument("--json", action="store_true",
-                             help="Print structured JSON instead of text")
+    add_long_tail_subparser(sub)
 
-    # quality
-    p_quality = sub.add_parser("quality", help="Show quality state and simulate decisions")
-    p_quality.add_argument("id", type=int, help="Request ID")
+    # quality / repair-spectral
+    add_quality_subparsers(sub)
 
-    # set-intent
-    p_intent = sub.add_parser("set-intent", help="Toggle lossless-on-disk for a request")
-    p_intent.add_argument("id", type=int, help="Request ID")
-    p_intent.add_argument("intent", choices=["lossless", "default"],
-                          help="'lossless' = keep lossless on disk, 'default' = pipeline decides")
+    # force-import / manual-import / import-jobs / import-preview
+    add_imports_subparsers(sub)
 
-    # force-import
-    p_force = sub.add_parser("force-import", help="Force-import a rejected download by download_log ID")
-    p_force.add_argument("download_log_id", type=int, help="Download log ID")
-    p_force.add_argument("--verified-lossless-target",
-                         help="Override the runtime verified-lossless target for this import")
-
-    # manual-import
-    p_manual = sub.add_parser("manual-import", help="Import a local folder as a pipeline request")
-    p_manual.add_argument("id", type=int, help="Pipeline request ID")
-    p_manual.add_argument("path", help="Path to album folder")
-    p_manual.add_argument("--verified-lossless-target",
-                          help="Override the runtime verified-lossless target for this import")
-
-    # import-jobs
-    p_jobs = sub.add_parser("import-jobs", help="List recent import queue jobs")
-    p_jobs.add_argument("--status", choices=["queued", "running", "completed", "failed"])
-    p_jobs.add_argument("--limit", type=int, default=20)
-
-    # import-preview
-    p_preview = sub.add_parser("import-preview", help="Preview whether an import would pass")
-    p_preview.add_argument("--download-log-id", type=int,
-                           help="Preview the failed_path from a download_log row")
-    p_preview.add_argument("--request-id", type=int,
-                           help="Request ID for --path preview")
-    p_preview.add_argument("--path", help="Preview a real folder for a request")
-    p_preview.add_argument("--no-force", action="store_true",
-                           help="Do not pass --force to import_one.py preview")
-    p_preview.add_argument("--values", action="store_true",
-                           help="Preview typed override values instead of a real folder")
-    p_preview.add_argument("--values-json",
-                           help="JSON object with ImportPreviewValues fields")
-    p_preview.add_argument("--json", action="store_true",
-                           help="Print the common preview result as JSON")
-    p_preview.add_argument("--is-flac", action="store_true", default=None)
-    p_preview.add_argument("--min-bitrate", type=int)
-    p_preview.add_argument("--is-cbr", action="store_true", default=None)
-    p_preview.add_argument("--is-vbr", action="store_true", default=None)
-    p_preview.add_argument("--avg-bitrate", type=int)
-    p_preview.add_argument("--spectral-grade", choices=SPECTRAL_GRADE_CHOICES)
-    p_preview.add_argument("--spectral-bitrate", type=int)
-    p_preview.add_argument("--existing-min-bitrate", type=int)
-    p_preview.add_argument("--existing-avg-bitrate", type=int)
-    p_preview.add_argument("--existing-spectral-bitrate", type=int)
-    p_preview.add_argument("--existing-spectral-grade", choices=SPECTRAL_GRADE_CHOICES)
-    p_preview.add_argument("--override-min-bitrate", type=int)
-    p_preview.add_argument("--existing-format")
-    p_preview.add_argument("--existing-is-cbr", action="store_true", default=None)
-    p_preview.add_argument("--post-conversion-min-bitrate", type=int)
-    p_preview.add_argument("--converted-count", type=int)
-    p_preview.add_argument("--verified-lossless", action="store_true", default=None)
-    p_preview.add_argument("--verified-lossless-target")
-    p_preview.add_argument("--target-format")
-    p_preview.add_argument("--new-format")
-    p_preview.add_argument("--audio-check-mode")
-    p_preview.add_argument("--audio-corrupt", action="store_true", default=None)
-    p_preview.add_argument("--import-mode")
-    p_preview.add_argument("--has-nested-audio", action="store_true", default=None)
-
-    # wrong-match-triage
-    p_triage = sub.add_parser(
-        "wrong-match-triage",
-        help="Clean the full Wrong Matches queue using existing evidence",
-    )
-    p_triage.add_argument("--apply", action="store_true",
-                          help="Allow destructive full-queue cleanup")
-    p_triage.add_argument("--json", action="store_true")
-
-    # wrong-match-delete
-    p_wm_delete = sub.add_parser(
-        "wrong-match-delete",
-        help="Delete one visible Wrong Matches source folder",
-    )
-    p_wm_delete.add_argument("download_log_id", type=int)
-    p_wm_delete.add_argument("--apply", action="store_true",
-                             help="Allow destructive source deletion")
-    p_wm_delete.add_argument("--json", action="store_true")
-
-    # wrong-match-delete-group
-    p_wm_delete_group = sub.add_parser(
-        "wrong-match-delete-group",
-        help="Delete visible Wrong Matches source folders for one request",
-    )
-    p_wm_delete_group.add_argument("request_id", type=int)
-    p_wm_delete_group.add_argument("--apply", action="store_true",
-                                   help="Allow destructive source deletion")
-    p_wm_delete_group.add_argument("--json", action="store_true")
-
-    # repair-spectral
-    p_repair = sub.add_parser("repair-spectral",
-                              help="Fix albums stuck by stale current_spectral_bitrate (#18)")
-    p_repair.add_argument("--dry-run", action="store_true",
-                          help="Show what would be repaired without changing anything")
+    # wrong-match-triage / wrong-match-delete / wrong-match-delete-group
+    add_wrong_match_subparsers(sub)
 
     # replace
-    p_replace = sub.add_parser(
-        "replace",
-        help="Supersede a request with a new row at a different release id "
-             "in the same release group/master (same pathway as the source)")
-    p_replace.add_argument("id", type=int, help="Source request ID")
-    p_replace.add_argument(
-        "--to", dest="target_mb_release_id", required=True,
-        help="Target release id — MB UUID or Discogs numeric id; must "
-             "share the source's pathway and release group/master")
-    p_replace.add_argument("--json", action="store_true",
-                           help="Print structured JSON instead of text")
+    add_replace_subparser(sub)
 
     # beets-distance
-    p_bd = sub.add_parser(
-        "beets-distance",
-        help="Real beets-distance between a download_log's audio and an MBID "
-             "(refuses if MBID is outside the request's release group)")
-    p_bd.add_argument("download_log_id", type=int,
-                      help="download_log row id (see `pipeline-cli show <req>`)")
-    p_bd.add_argument("mbid",
-                      help="Candidate release id — MB UUID or Discogs numeric id")
-    p_bd.add_argument("--json", action="store_true",
-                      help="Print structured JSON instead of text")
+    add_beets_distance_subparser(sub)
 
-    # youtube-album (U7): MBID/Discogs ID → YT Music album matrix.
-    # Counterpart of ``GET /api/youtube-album`` (U8).
-    p_ya = sub.add_parser(
-        "youtube-album",
-        help="Resolve MBID/Discogs ID → YouTube Music album matrix "
-             "(auto-widens to release group; N×M beets distances per "
-             "YT sibling × MB sibling)",
-    )
-    p_ya.add_argument(
-        "identifier",
-        help="MB release/release-group MBID OR Discogs release/master ID "
-             "(service auto-discriminates via leaf-then-group fallback)",
-    )
-    p_ya.add_argument(
-        "--refresh", action="store_true",
-        help="Bypass BOTH the durable cache (youtube_album_mappings) "
-             "AND the in-process Redis HTTP accelerator, forcing a "
-             "fresh YouTube Music fetch. The fresh response is then "
-             "written back to both layers. (Default: serve from cache.)",
-    )
-    p_ya.add_argument(
-        "--json", action="store_true",
-        help="Print structured JSON instead of human-readable matrix",
-    )
-
-    # youtube-rescue (U4): submit a YouTube Music rescue ingest for one
-    # request. Counterpart of ``POST /api/pipeline/<id>/youtube-rescue``
-    # (U5). Both surfaces wrap ``YoutubeIngestService.submit``.
-    p_yr = sub.add_parser(
-        "youtube-rescue",
-        help="Submit a YouTube Music rescue ingest for one request "
-             "(requires a resolver mapping; emits a youtube_running "
-             "download_log row).",
-    )
-    p_yr.add_argument(
-        "request_id", type=int,
-        help="album_requests.id to attach the rescue to",
-    )
-    p_yr.add_argument(
-        "browse_id",
-        help="YouTube Music browse_id (e.g. MPREb_...); must already "
-             "be cached in youtube_album_mappings for this request's "
-             "release group",
-    )
-    p_yr.add_argument(
-        "--json", action="store_true",
-        help="Print structured JSON ({outcome, download_log_id, detail}) "
-             "instead of plain text.",
-    )
+    # youtube-album / youtube-rescue
+    add_youtube_subparsers(sub)
 
     # routes (U18 step 3): self-document the CLI surface. Mirrors
     # ``GET /api/_index`` on the web side; both are read-only and zero-arg.
+    # Stays inline here (rather than its own family module) since it's
+    # the self-documentation command for this very module.
     p_routes = sub.add_parser(
         "routes",
         help="Self-document the CLI surface — every subcommand, "

--- a/scripts/pipeline_cli/search_plan.py
+++ b/scripts/pipeline_cli/search_plan.py
@@ -6,6 +6,7 @@ over persisted search plans. All wrap ``lib.search_plan_service`` (CLI ⇄
 API surface symmetry, CLAUDE.md).
 """
 
+import argparse
 import json
 
 from scripts.pipeline_cli._format import _json_default
@@ -493,3 +494,93 @@ def cmd_search_plan_history(db, args):
             print(f"  Error message:     {result.error_message}")
 
     return _search_plan_exit_code(result.outcome)
+
+
+def add_search_plan_subparser(
+    sub: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Add ``search-plan`` + its nested subcommands (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions).
+
+    Returns the ``search-plan`` subparser itself so ``main()`` can print
+    its help when invoked without a nested subcommand (mirrors the
+    ``triage`` no-subcommand handling).
+    """
+    p_sp = sub.add_parser(
+        "search-plan",
+        help="Inspect persisted search plans (read-only, U6)")
+    sp_sub = p_sp.add_subparsers(dest="search_plan_command")
+    p_sp_show = sp_sub.add_parser(
+        "show",
+        help="Show active/failed plans, cursor, items, provenance, "
+             "legacy logs for one request")
+    p_sp_show.add_argument("id", type=int, help="Request ID")
+    p_sp_show.add_argument("--json", action="store_true",
+                            help="Print structured JSON instead of text")
+    p_sp_show.add_argument("--no-stats", action="store_true",
+                            dest="no_stats",
+                            help="Suppress per-slot/query usefulness stats")
+    p_sp_regen = sp_sub.add_parser(
+        "regenerate",
+        help="Regenerate the search plan for a request (U8)")
+    p_sp_regen.add_argument("id", type=int, help="Request ID")
+    p_sp_regen.add_argument("--prepend-artist", action="store_true",
+                             dest="prepend_artist", default=None,
+                             help="Prepend artist name to album title in "
+                             "generated queries (overrides config; absent "
+                             "means use config's album_prepend_artist)")
+    p_sp_regen.add_argument("--json", action="store_true",
+                             help="Print structured JSON instead of text")
+    p_sp_advance = sp_sub.add_parser(
+        "advance",
+        help="Forward-only operator advance of the cursor (e.g. skip "
+             "collapsed default-strategy slots on a self-titled release)")
+    p_sp_advance.add_argument("id", type=int, help="Request ID")
+    sp_target = p_sp_advance.add_mutually_exclusive_group(required=True)
+    sp_target.add_argument(
+        "--to-ordinal", type=int, dest="to_ordinal",
+        help="Absolute target ordinal in [0, plan_item_count)")
+    sp_target.add_argument(
+        "--to-strategy", dest="to_strategy",
+        help="Strategy prefix; advance to the first plan item past the "
+             "current cursor whose strategy starts with this string "
+             "(e.g. `track`, `unwild_year`)")
+    p_sp_advance.add_argument("--json", action="store_true",
+                              help="Print structured JSON instead of text")
+    p_sp_dry_run = sp_sub.add_parser(
+        "dry-run",
+        help="Run the generator against the request's snapshot without "
+             "persisting (U6 simulator)")
+    p_sp_dry_run.add_argument("id", type=int, help="Request ID")
+    p_sp_dry_run.add_argument("--prepend-artist", action="store_true",
+                              dest="prepend_artist", default=None,
+                              help="Prepend artist name to album title in "
+                              "generated queries (overrides config; absent "
+                              "means use config's album_prepend_artist)")
+    p_sp_dry_run.add_argument("--json", action="store_true",
+                              help="Print structured JSON instead of text")
+    p_sp_saturation = sp_sub.add_parser(
+        "saturation",
+        help="Show per-request saturation rate + pre-filter skip total "
+             "over the recent search_log window (U7 telemetry)")
+    p_sp_saturation.add_argument("id", type=int, help="Request ID")
+    p_sp_saturation.add_argument(
+        "--window-days", type=int, default=None, dest="window_days",
+        help="Window in days; defaults to 14; valid range [1, 90]")
+    p_sp_saturation.add_argument(
+        "--json", action="store_true",
+        help="Print structured JSON instead of text")
+    p_sp_history = sp_sub.add_parser(
+        "history",
+        help="Cursor-paginated read of one request's search_log rows "
+             "(per-attempt forensics)")
+    p_sp_history.add_argument("id", type=int, help="Request ID")
+    p_sp_history.add_argument(
+        "--limit", type=int, default=None,
+        help="Rows per page; defaults to 50; valid range [1, 200]")
+    p_sp_history.add_argument(
+        "--before-id", type=int, default=None, dest="before_id",
+        help="Resume cursor: pass the previous page's next_before_id")
+    p_sp_history.add_argument("--json", action="store_true",
+                              help="Print structured JSON instead of text")
+    return p_sp

--- a/scripts/pipeline_cli/show.py
+++ b/scripts/pipeline_cli/show.py
@@ -6,6 +6,7 @@ forensics summary), download history (+ import-result rendering), and
 denylisted users.
 """
 
+import argparse
 import json
 
 import msgspec
@@ -302,3 +303,10 @@ def cmd_show(db, args):
         print(f"\n  Denylisted Users ({len(denied)}):")
         for d in denied:
             print(f"    {d['username']}: {d['reason']}")
+
+
+def add_show_subparser(sub: argparse._SubParsersAction) -> None:
+    """Add ``show`` (#521 carve out of ``routes_meta._build_parser``,
+    verbatim argument definitions)."""
+    p_show = sub.add_parser("show", help="Show full details of a request")
+    p_show.add_argument("id", type=int, help="Request ID")

--- a/scripts/pipeline_cli/triage.py
+++ b/scripts/pipeline_cli/triage.py
@@ -11,6 +11,7 @@ thin wrapper around ``lib.triage_service``; the matching HTTP routes
 status-code mapping.
 """
 
+import argparse
 import json
 import sys
 
@@ -320,3 +321,52 @@ def cmd_triage_list(db, args):
             f"--limit={limit} --after={next_after}"
         )
     return 0
+
+
+def add_triage_subparser(
+    sub: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Add ``triage`` + its nested subcommands (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions).
+
+    Returns the ``triage`` subparser itself so ``main()`` can print its
+    help when invoked without a nested subcommand.
+    """
+    # triage (U16) — operator-facing composition of unfindable + field-quality
+    # + search-forensics. Wraps ``lib.triage_service`` (U15). Nested under a
+    # subparser for the same reason ``search-plan`` is: the per-request view
+    # and the cohort list share enough state to benefit from a shared
+    # namespace, and the convention is consistent with the rest of this CLI.
+    p_triage_op = sub.add_parser(
+        "triage",
+        help="Operator triage (U16) — compose unfindable + field-quality + "
+             "search-forensics for one request, or list a cohort by filter")
+    tr_sub = p_triage_op.add_subparsers(dest="triage_command")
+
+    p_tr_show = tr_sub.add_parser(
+        "show",
+        help="Per-request triage composition (request meta + unfindable + "
+             "field-quality + search forensics + last 10 search_log rows). "
+             "Note: subcommand form mirrors `search-plan show <id>`; bare "
+             "`triage <id>` is not accepted.")
+    p_tr_show.add_argument("id", type=int, help="Request ID")
+    p_tr_show.add_argument("--json", action="store_true",
+                            help="Print structured JSON instead of text")
+
+    p_tr_list = tr_sub.add_parser(
+        "list",
+        help="Cohort listing by filter spec")
+    p_tr_list.add_argument(
+        "--filter", default="all",
+        help="Filter spec: all | unfindable[:<category>] | "
+             "data_quality[:<field>] | data_quality:status=<status> | "
+             "data_quality:reason=<code> | search_not_converting")
+    p_tr_list.add_argument(
+        "--limit", type=int, default=50,
+        help="Page size (default 50)")
+    p_tr_list.add_argument(
+        "--after", type=int, default=None,
+        help="Resume cursor: last request_id from prior page")
+    p_tr_list.add_argument("--json", action="store_true",
+                            help="Print structured JSON instead of text")
+    return p_triage_op

--- a/scripts/pipeline_cli/wrong_match.py
+++ b/scripts/pipeline_cli/wrong_match.py
@@ -5,6 +5,7 @@
 folders for one request).
 """
 
+import argparse
 import json
 import sys
 
@@ -164,3 +165,37 @@ def _wrong_match_delete_group_exit_code(summary) -> int:
     if outcomes & {OUTCOME_SKIPPED_INVALID_ROW, OUTCOME_SKIPPED_NOT_VISIBLE}:
         return 2
     return 1
+
+
+def add_wrong_match_subparsers(sub: argparse._SubParsersAction) -> None:
+    """Add ``wrong-match-triage`` / ``wrong-match-delete`` /
+    ``wrong-match-delete-group`` (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions)."""
+    # wrong-match-triage
+    p_triage = sub.add_parser(
+        "wrong-match-triage",
+        help="Clean the full Wrong Matches queue using existing evidence",
+    )
+    p_triage.add_argument("--apply", action="store_true",
+                          help="Allow destructive full-queue cleanup")
+    p_triage.add_argument("--json", action="store_true")
+
+    # wrong-match-delete
+    p_wm_delete = sub.add_parser(
+        "wrong-match-delete",
+        help="Delete one visible Wrong Matches source folder",
+    )
+    p_wm_delete.add_argument("download_log_id", type=int)
+    p_wm_delete.add_argument("--apply", action="store_true",
+                             help="Allow destructive source deletion")
+    p_wm_delete.add_argument("--json", action="store_true")
+
+    # wrong-match-delete-group
+    p_wm_delete_group = sub.add_parser(
+        "wrong-match-delete-group",
+        help="Delete visible Wrong Matches source folders for one request",
+    )
+    p_wm_delete_group.add_argument("request_id", type=int)
+    p_wm_delete_group.add_argument("--apply", action="store_true",
+                                   help="Allow destructive source deletion")
+    p_wm_delete_group.add_argument("--json", action="store_true")

--- a/scripts/pipeline_cli/youtube.py
+++ b/scripts/pipeline_cli/youtube.py
@@ -5,6 +5,7 @@ distance matrix. ``youtube-rescue`` — submit a rescue ingest for one
 request. Both wrap the U7/U4 service layer (CLI ⇄ API surface symmetry).
 """
 
+import argparse
 import sys
 
 import msgspec
@@ -263,3 +264,57 @@ def cmd_youtube_rescue(db, args, *, service_factory=None):
                 )
 
     return YOUTUBE_INGEST_EXIT_CODE.get(result.outcome, 1)
+
+
+def add_youtube_subparsers(sub: argparse._SubParsersAction) -> None:
+    """Add ``youtube-album`` / ``youtube-rescue`` (#521 carve out of
+    ``routes_meta._build_parser``, verbatim argument definitions)."""
+    # youtube-album (U7): MBID/Discogs ID → YT Music album matrix.
+    # Counterpart of ``GET /api/youtube-album`` (U8).
+    p_ya = sub.add_parser(
+        "youtube-album",
+        help="Resolve MBID/Discogs ID → YouTube Music album matrix "
+             "(auto-widens to release group; N×M beets distances per "
+             "YT sibling × MB sibling)",
+    )
+    p_ya.add_argument(
+        "identifier",
+        help="MB release/release-group MBID OR Discogs release/master ID "
+             "(service auto-discriminates via leaf-then-group fallback)",
+    )
+    p_ya.add_argument(
+        "--refresh", action="store_true",
+        help="Bypass BOTH the durable cache (youtube_album_mappings) "
+             "AND the in-process Redis HTTP accelerator, forcing a "
+             "fresh YouTube Music fetch. The fresh response is then "
+             "written back to both layers. (Default: serve from cache.)",
+    )
+    p_ya.add_argument(
+        "--json", action="store_true",
+        help="Print structured JSON instead of human-readable matrix",
+    )
+
+    # youtube-rescue (U4): submit a YouTube Music rescue ingest for one
+    # request. Counterpart of ``POST /api/pipeline/<id>/youtube-rescue``
+    # (U5). Both surfaces wrap ``YoutubeIngestService.submit``.
+    p_yr = sub.add_parser(
+        "youtube-rescue",
+        help="Submit a YouTube Music rescue ingest for one request "
+             "(requires a resolver mapping; emits a youtube_running "
+             "download_log row).",
+    )
+    p_yr.add_argument(
+        "request_id", type=int,
+        help="album_requests.id to attach the rescue to",
+    )
+    p_yr.add_argument(
+        "browse_id",
+        help="YouTube Music browse_id (e.g. MPREb_...); must already "
+             "be cached in youtube_album_mappings for this request's "
+             "release group",
+    )
+    p_yr.add_argument(
+        "--json", action="store_true",
+        help="Print structured JSON ({outcome, download_log_id, detail}) "
+             "instead of plain text.",
+    )


### PR DESCRIPTION
Closes #521

## Summary
- `scripts/pipeline_cli/routes_meta.py::_build_parser` was a ~400-line monolith constructing the entire argparse tree in one function, disconnected from the per-family handler modules the #495 CLI package split already created.
- Each command-family module now owns an `add_<family>_subparsers(sub)` function holding that family's `sub.add_parser(...)` blocks, moved verbatim. `_build_parser` now just builds the top-level parser + subparsers object and calls each family's builder in sequence.
- `routes_meta.py` shrank from 539 to ~130 lines; the `routes` subcommand stays inline there since it's the self-documentation command for that very module.

## Verification (mechanical, behavior-preserving carve)
- Captured the full assembled argparse tree (every subcommand's option strings, dest, type, default, choices, help, nargs, required) before and after via a throwaway dump-and-diff script — **zero diff**.
- `nix-shell --run "pyright"` — 0 errors, 0 warnings.
- `nix-shell --run "bash scripts/run_tests.sh"` — full suite green (4730 tests, exit 0), including the dead-code (vulture) sweep and `tests.test_pipeline_cli` (181 tests).

## Grouping (command → family module)
- `album_requests.py`: list, add, status, disk-coverage, retry, cancel, set, set-intent
- `query.py`: query
- `show.py`: show
- `search_plan.py`: search-plan (+ nested show/regenerate/advance/dry-run/saturation/history) — returns the subparser `main()` needs for no-subcommand help
- `triage.py`: triage (+ nested show/list) — same return-subparser pattern
- `long_tail.py`: long-tail
- `quality.py`: quality, repair-spectral
- `imports.py`: force-import, manual-import, import-jobs, import-preview
- `wrong_match.py`: wrong-match-triage, wrong-match-delete, wrong-match-delete-group
- `replace.py`: replace
- `beets_distance.py`: beets-distance
- `youtube.py`: youtube-album, youtube-rescue
- `routes` stays inline in `routes_meta.py`

## Test plan
- [x] Parser-structure diff (before/after) is zero
- [x] `nix-shell --run "pyright"` clean
- [x] `nix-shell --run "bash scripts/run_tests.sh"` green
- [x] `nix-shell --run "python3 -m unittest tests.test_pipeline_cli -v"` green