### PR TITLE
test: exclude .claude/worktrees from repo-tree-walking audits

### DIFF
--- a/tests/test_beets_album_op.py
+++ b/tests/test_beets_album_op.py
@@ -252,10 +252,16 @@ class TestBeetOpArgvIsCentralised(unittest.TestCase):
         "tests/test_disambiguation.py",
     })
 
-    # Directories ignored entirely (not Python source we own):
+    # Directories ignored entirely (not Python source we own).
+    # ``.claude`` holds agent git worktrees (``.claude/worktrees/``) —
+    # nested checkouts of this repo. Without pruning it, ``os.walk`` from
+    # REPO_ROOT descends into every stale worktree and flags their copies
+    # of allowlisted files (whose paths aren't in ALLOWED_FILES), failing
+    # this test in a shared checkout. Same class of bug as the pyright
+    # ``.claude/worktrees`` exclude (#520).
     IGNORE_DIRS = {
         ".git", "__pycache__", ".venv", "venv", "result",
-        "node_modules", ".mypy_cache", ".pytest_cache",
+        "node_modules", ".mypy_cache", ".pytest_cache", ".claude",
     }
 
     def test_allowlist_entries_still_exist(self) -> None:

--- a/tests/test_lint_no_is_on_enum.py
+++ b/tests/test_lint_no_is_on_enum.py
@@ -25,9 +25,14 @@ import unittest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Directories to skip entirely.
+# Directories to skip entirely. ``.claude`` holds agent git worktrees
+# (``.claude/worktrees/``) — nested checkouts of this repo; without
+# pruning it, ``os.walk`` from REPO_ROOT scans thousands of stale
+# worktree ``.py`` files every run. Same class as the pyright
+# ``.claude/worktrees`` exclude (#520).
 SKIP_DIRS = {
     ".git", "__pycache__", ".pytest_cache", "node_modules", "fixtures",
+    ".claude",
 }
 
 # Files/paths allowed to use `is EnumMember`. Add here with a comment


### PR DESCRIPTION
## Problem
Two audits walk `REPO_ROOT` with `os.walk` + a skip-set of dir basenames, but neither skipped `.claude` — so they descended into `.claude/worktrees/` (agent git worktrees = nested checkouts of this repo):
- `tests/test_beets_album_op.py::test_no_file_outside_allowlist_constructs_beet_argv` (`IGNORE_DIRS`) — **failed** in a shared checkout with stale worktrees, flagging worktree copies of allowlisted files (`lib/beets_album_op.py`, `tests/test_release_cleanup.py`) whose worktree-relative paths aren't in `ALLOWED_FILES`. Zero real main-tree violations.
- `tests/test_lint_no_is_on_enum.py::_iter_python_files` (`SKIP_DIRS`) — latent: silently scanned all worktree `.py` every run.

This is the same class as the pyright `.claude/worktrees` exclude (#520) — surfaced by the final green-together run of the #512/#521/#536/#537 batch.

## Fix
Add `.claude` to both skip-sets (with a comment).

## Proof
Walking the shared checkout (34 worktrees) crawls **10874** `.claude/worktrees` `.py` files with the old skip-set, **0** with the new. Full suite EXIT=0 (4735), pyright 0, both modified audits still pass and still scan the real tree.

The other repo-walking tests are safe — they scan specific `lib`/`harness`/`scripts`/`web`/`tests` roots, not `.claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)