### PR TITLE
test(pipeline-db): grow read-projection parity gate to 6 more get_* mirrors (#523)

### DIFF
--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -240,6 +240,7 @@ class FakePipelineDB:
         self._youtube_album_mappings: dict[
             tuple[str, str], list[dict[str, Any]],
         ] = {}
+        self._next_youtube_mapping_id = 0
 
     # --- Seeding ---
 
@@ -2285,10 +2286,33 @@ class FakePipelineDB:
         real implementation wraps DELETE + INSERTs in a single transaction;
         the fake just overwrites the dict slot, which is atomic in the
         single-threaded test context.
+
+        Stamps ``id``, ``release_group_identifier``, ``source``, and
+        ``resolved_at`` onto each stored row. Production's SELECT
+        projection (``PipelineDB.get_youtube_album_mapping``) always
+        includes these DB-assigned columns (``id BIGSERIAL PRIMARY KEY``,
+        ``resolved_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`` — migration
+        034) even though callers never pass them into ``rows``. #523's
+        read-projection parity gate surfaced this: the fake previously
+        echoed the input dict verbatim, four keys short of what
+        production's read returns.
         """
+        stored: list[dict[str, Any]] = []
+        for row in rows:
+            self._next_youtube_mapping_id += 1
+            stored_row = copy.deepcopy(row)
+            stored_row["id"] = self._next_youtube_mapping_id
+            stored_row["release_group_identifier"] = release_group_identifier
+            stored_row["source"] = source
+            stored_row.setdefault("yt_audio_playlist_id", None)
+            stored_row.setdefault("yt_year", None)
+            stored_row.setdefault("album_title", None)
+            stored_row.setdefault("album_artist", None)
+            stored_row["resolved_at"] = _utcnow()
+            stored.append(stored_row)
         self._youtube_album_mappings[
             (release_group_identifier, source)
-        ] = [copy.deepcopy(r) for r in rows]
+        ] = stored
 
     # --- Session lifecycle ---
 
@@ -2344,6 +2368,15 @@ class FakePipelineDB:
             "source_path": source_path,
             "reasoning": reasoning,
             "status": status,
+            # Migration 032 — resolver-populated catalog number; migration
+            # 001 — download-time final container format. Neither is part
+            # of ``AddRequestInput`` (production's INSERT column list), so
+            # a freshly-added real row has both NULL until a later UPDATE
+            # populates them. #523 read-projection parity (get_wanted_
+            # searchable's ``ar.*``) surfaced these as missing from the
+            # fake's row shape.
+            "catalog_number": None,
+            "final_format": None,
             "search_attempts": 0,
             "download_attempts": 0,
             "validation_attempts": 0,

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -4729,6 +4729,46 @@ class TestGetWrongMatches(unittest.TestCase):
         self.assertEqual(row["request_imported_path"],
                          "/mnt/virtio/Music/Beets/Artist/Album")
 
+    def test_get_wrong_matches_keyset_parity(self):
+        """#523 -- fake<->production parity for the widest read projection.
+
+        Seeds the SAME sequence ``_log_rejected`` runs on ``self.db``
+        (real PG) onto a fresh ``FakePipelineDB``, then compares the full
+        21-column wrong-match projection. Reuses
+        ``TestReadProjectionParity._assert_keyset_parity`` -- it is a
+        staticmethod whose first param is the ``TestCase`` instance, so
+        cross-class reuse is safe.
+        """
+        from tests.fakes import FakePipelineDB
+
+        fake = FakePipelineDB()
+        fake_req1 = fake.add_request(
+            mb_release_id="wm-uuid-1", artist_name="Artist 1",
+            album_title="Album 1", source="request")
+
+        self._log_rejected(self.req1, "alice", "/fi/parity-a")
+        fake.log_download(
+            request_id=fake_req1,
+            soulseek_username="alice",
+            outcome="rejected",
+            beets_scenario="high_distance",
+            validation_result=json.dumps({
+                "scenario": "high_distance", "distance": 0.25,
+                "failed_path": "/fi/parity-a",
+            }),
+        )
+
+        real_rows = self.db.get_wrong_matches()
+        fake_rows = fake.get_wrong_matches()
+        self.assertTrue(
+            real_rows, "seeding produced no rows on real PG — "
+            "get_wrong_matches parity would pass vacuously")
+        self.assertTrue(
+            fake_rows, "seeding produced no rows on FakePipelineDB — "
+            "get_wrong_matches parity would pass vacuously")
+        TestReadProjectionParity._assert_keyset_parity(
+            self, real_rows, fake_rows, "get_wrong_matches")
+
 
 @requires_postgres
 class TestBadAudioHashes(unittest.TestCase):
@@ -8605,6 +8645,208 @@ class TestReadProjectionParity(unittest.TestCase):
         self._assert_keyset_parity(
             self, real_rows, fake_rows,
             "get_field_resolutions_for_requests")
+
+    # --- get_wanted_searchable (#523) ----------------------------------------
+
+    def _seed_wanted_searchable_request(
+        self, db: Any, *, mb_release_id: str, generator_id: str,
+    ) -> int:
+        from lib.pipeline_db import SearchPlanItemInput
+
+        rid = db.add_request(
+            "WS Artist", "WS Album", "request", mb_release_id=mb_release_id)
+        db.create_successful_search_plan(
+            request_id=rid, generator_id=generator_id,
+            items=[SearchPlanItemInput(
+                ordinal=0, strategy="default", query="Q")])
+        return rid
+
+    def test_get_wanted_searchable_keyset_parity(self):
+        for db in (self.db, self.fake):
+            self._seed_wanted_searchable_request(
+                db, mb_release_id="ws-parity", generator_id="g-parity")
+
+        real_rows = self.db.get_wanted_searchable("g-parity")
+        fake_rows = self.fake.get_wanted_searchable("g-parity")
+        self.assertTrue(
+            real_rows, "seeding produced no rows on real PG — "
+            "get_wanted_searchable parity would pass vacuously")
+        self.assertTrue(
+            fake_rows, "seeding produced no rows on FakePipelineDB — "
+            "get_wanted_searchable parity would pass vacuously")
+        self._assert_keyset_parity(
+            self, real_rows, fake_rows, "get_wanted_searchable")
+
+    def test_get_wanted_searchable_no_active_plan_empty_branch(self):
+        # A wanted request with no active plan is not execution-eligible
+        # -- both backends must agree on the empty-list contract. This
+        # is the explicit contract being asserted, not the keyset check,
+        # so an empty result here is the expected (non-vacuous) outcome.
+        for db in (self.db, self.fake):
+            db.add_request(
+                "WS Artist", "WS Album (no plan)", "request",
+                mb_release_id="ws-no-plan")
+
+        self.assertEqual(self.db.get_wanted_searchable("g-parity"), [])
+        self.assertEqual(self.fake.get_wanted_searchable("g-parity"), [])
+
+    # --- get_search_summaries_for_requests (#523) ----------------------------
+
+    def _seed_search_summary_request(
+        self, db: Any, *, mb_release_id: str,
+    ) -> int:
+        rid = db.add_request(
+            "Summary Artist", "Summary Album", "request",
+            mb_release_id=mb_release_id)
+        db.log_search(
+            rid, query="q1", outcome="found", result_count=5, elapsed_s=1.0)
+        return rid
+
+    def test_get_search_summaries_for_requests_keyset_parity(self):
+        ids: dict[int, int] = {}
+        for db in (self.db, self.fake):
+            ids[id(db)] = self._seed_search_summary_request(
+                db, mb_release_id="summary-parity-1")
+
+        real_map = self.db.get_search_summaries_for_requests(
+            [ids[id(self.db)]])
+        fake_map = self.fake.get_search_summaries_for_requests(
+            [ids[id(self.fake)]])
+        real_rows = list(real_map.values())
+        fake_rows = list(fake_map.values())
+        self.assertTrue(
+            real_rows, "seeding produced no rows on real PG — "
+            "get_search_summaries_for_requests parity would pass vacuously")
+        self.assertTrue(
+            fake_rows, "seeding produced no rows on FakePipelineDB — "
+            "get_search_summaries_for_requests parity would pass vacuously")
+        self._assert_keyset_parity(
+            self, real_rows, fake_rows, "get_search_summaries_for_requests")
+
+    def test_get_search_summaries_for_requests_empty_input_contract(self):
+        # Contract: an empty id list short-circuits to {} without a query
+        # on both backends -- not a keyset check, the {} equality IS the
+        # assertion.
+        self.assertEqual(self.db.get_search_summaries_for_requests([]), {})
+        self.assertEqual(self.fake.get_search_summaries_for_requests([]), {})
+
+    # --- get_recent_search_log_for_requests (#523) ---------------------------
+
+    def test_get_recent_search_log_for_requests_keyset_parity(self):
+        ids: dict[int, int] = {}
+        for db in (self.db, self.fake):
+            rid = db.add_request(
+                "RecentLog Artist", "RecentLog Album", "request",
+                mb_release_id="recentlog-parity-1")
+            db.log_search(
+                rid, query="q1", outcome="found", result_count=5,
+                elapsed_s=1.0)
+            ids[id(db)] = rid
+
+        real_map = self.db.get_recent_search_log_for_requests(
+            [ids[id(self.db)]], per_request_limit=5)
+        fake_map = self.fake.get_recent_search_log_for_requests(
+            [ids[id(self.fake)]], per_request_limit=5)
+        real_rows = [row for rows in real_map.values() for row in rows]
+        fake_rows = [row for rows in fake_map.values() for row in rows]
+        self.assertTrue(
+            real_rows, "seeding produced no rows on real PG — "
+            "get_recent_search_log_for_requests parity would pass vacuously")
+        self.assertTrue(
+            fake_rows, "seeding produced no rows on FakePipelineDB — "
+            "get_recent_search_log_for_requests parity would pass vacuously")
+        self._assert_keyset_parity(
+            self, real_rows, fake_rows, "get_recent_search_log_for_requests")
+
+    # --- list_active_youtube_rescues (#523) ----------------------------------
+
+    def test_list_active_youtube_rescues_keyset_parity(self):
+        for db in (self.db, self.fake):
+            rid = db.add_request(
+                "Rescue Artist", "Rescue Album", "request",
+                mb_release_id="rescue-parity-1")
+            db.insert_youtube_running(
+                request_id=rid, browse_id="MPREb_parity",
+                audio_playlist_id=None,
+                yt_url="https://example.invalid/parity",
+                expected_track_count=2)
+
+        real_rows = self.db.list_active_youtube_rescues()
+        fake_rows = self.fake.list_active_youtube_rescues()
+        self.assertTrue(
+            real_rows, "seeding produced no rows on real PG — "
+            "list_active_youtube_rescues parity would pass vacuously")
+        self.assertTrue(
+            fake_rows, "seeding produced no rows on FakePipelineDB — "
+            "list_active_youtube_rescues parity would pass vacuously")
+        self._assert_keyset_parity(
+            self, real_rows, fake_rows, "list_active_youtube_rescues")
+
+    def test_list_active_youtube_rescues_empty_branch_parity(self):
+        # Contract: no in-flight rescues -- both return []. This is the
+        # explicit empty contract, not the keyset check.
+        self.assertEqual(self.db.list_active_youtube_rescues(), [])
+        self.assertEqual(self.fake.list_active_youtube_rescues(), [])
+
+    # --- get_youtube_album_mapping (#523, tri-state) -------------------------
+
+    @staticmethod
+    def _youtube_mapping_row(**overrides: Any) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            "yt_browse_id": "MPREb_parity",
+            "yt_audio_playlist_id": "OLAK5uy_parity",
+            "yt_url": "https://music.youtube.com/playlist?list=OLAK5uy_parity",
+            "yt_year": 2020,
+            "yt_track_count": 10,
+            "album_title": "Parity Album",
+            "album_artist": "Parity Artist",
+            "yt_tracks": [
+                {"title": "Track 1", "video_id": "v1",
+                 "length_seconds": 200, "track_number": 1, "disc_number": 1,
+                 "artists": [{"name": "Artist"}]},
+            ],
+            "distances": [
+                {"mbid": "mb-1", "distance": 0.05, "error": None},
+            ],
+        }
+        row.update(overrides)
+        return row
+
+    def test_get_youtube_album_mapping_keyset_parity(self):
+        for db in (self.db, self.fake):
+            db.upsert_youtube_album_mapping(
+                "rg-parity", "mb", [self._youtube_mapping_row()])
+
+        real_rows = self.db.get_youtube_album_mapping("rg-parity", "mb")
+        fake_rows = self.fake.get_youtube_album_mapping("rg-parity", "mb")
+        self.assertTrue(
+            real_rows, "seeding produced no rows on real PG — "
+            "get_youtube_album_mapping parity would pass vacuously")
+        self.assertTrue(
+            fake_rows, "seeding produced no rows on FakePipelineDB — "
+            "get_youtube_album_mapping parity would pass vacuously")
+        assert real_rows is not None and fake_rows is not None
+        self._assert_keyset_parity(
+            self, real_rows, fake_rows, "get_youtube_album_mapping")
+
+    def test_get_youtube_album_mapping_resolved_empty_branch_parity(self):
+        # Contract: upserting an empty matrix stamps the empty-resolution
+        # marker -- both backends return [] (cache HIT), never None.
+        for db in (self.db, self.fake):
+            db.upsert_youtube_album_mapping("rg-parity-empty", "mb", [])
+
+        self.assertEqual(
+            self.db.get_youtube_album_mapping("rg-parity-empty", "mb"), [])
+        self.assertEqual(
+            self.fake.get_youtube_album_mapping("rg-parity-empty", "mb"), [])
+
+    def test_get_youtube_album_mapping_never_resolved_branch_parity(self):
+        # Contract: an unknown (rg, source) pair is a cache MISS -- None
+        # on both backends, distinct from the resolved-empty [] above.
+        self.assertIsNone(
+            self.db.get_youtube_album_mapping("rg-never-resolved", "mb"))
+        self.assertIsNone(
+            self.fake.get_youtube_album_mapping("rg-never-resolved", "mb"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #523.

Direct continuation of #481 item 2 (PR #513), which added `TestReadProjectionParity` in `tests/test_pipeline_db.py` — a real-PG gate asserting key-set equality between production `PipelineDB` SELECT projections and their `FakePipelineDB` hand-mirrored rows. It started with a subset (4 of ~51 `get_*` mirrors) and left "grow the audit list" as the next step. This grows it to six more high-value read mirrors.

**Test-only change** (plus two fake-side drift fixes the new tests surfaced — production SQL untouched).

## Coverage added
New parity tests (extending `TestReadProjectionParity`, plus one on `TestGetWrongMatches`) for:
- `get_wanted_searchable` — seeded via `add_request` + `create_successful_search_plan` (active plan, matching generator id)
- `get_search_summaries_for_requests` — `dict[int, dict]` view read, adapted via `.values()`
- `get_recent_search_log_for_requests` — `dict[int, list[dict]]`, flattened
- `list_active_youtube_rescues` — seeded via `insert_youtube_running`
- `get_youtube_album_mapping` — tri-state: non-empty rows (keyset parity), resolved-empty (`[]`), never-resolved (`None`)
- `get_wrong_matches` — the widest 23-column projection; added to the existing `TestGetWrongMatches`

Every keyset-parity test seeds ≥1 row on **both** the real PG `PipelineDB` and `FakePipelineDB` and **asserts the rows are non-empty before comparing keysets** — so none can pass vacuously (a keyset test over two empty result sets is 0==0 with no keys to compare). Empty/None branches assert the explicit contract (`[]` / `None`) instead.

## Fake drift surfaced and fixed (fake side only)
The parity gate did its job on first run:
- `FakePipelineDB.upsert_youtube_album_mapping` echoed input rows verbatim, four keys short of production's SELECT — now stamps the DB-assigned `id` / `release_group_identifier` / `source` / `resolved_at` (migration 034) onto each stored row.
- `FakePipelineDB.add_request` omitted `catalog_number` (migration 032) and `final_format` (migration 001) — NULL-by-default columns absent from `AddRequestInput`'s INSERT list but present in the real `album_requests` table (and thus in `get_wanted_searchable`'s `ar.*`). Now defaulted to `None`.

Both are self-verifying: `get_wanted_searchable` parity compares against real PG `ar.*`, so the test passing proves the fake's `add_request` row shape now matches the real column set exactly.

## Verification
- `nix-shell --run "pyright"` → 0 errors (full repo).
- Full suite → `Ran 4746 tests ... OK`, no failures, no skips.
- Teeth-check: injecting a bogus key into a fake projection makes the parity test RED-fail naming that exact column, then reverted — the gate catches drift in both directions (it symmetric-diffs the key sets).

## Review
Implemented by a Sonnet subagent against a written plan; reviewed by an independent Opus pass that traced the vacuous-pass guard on every keyset test, confirmed identical cross-backend seeding, and verified both fake fixes against the production projections. Verdict: mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
