### PR TITLE
chore(download): MANIFEST-TRACE instrumentation for multi-disc under-capture RCA

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -241,6 +241,13 @@ def reconstruct_grab_list_entry(
             local_path=f.local_path,
         ))
     year = request.get("year")
+    from lib.import_manifest import manifest_trace_summary
+    logger.info(
+        "MANIFEST-TRACE reconstruct request=%s %s current_path=%s",
+        request["id"],
+        manifest_trace_summary(files),
+        state.current_path,
+    )
     return GrabListEntry(
         album_id=request["id"],
         files=files,

--- a/lib/download_processing.py
+++ b/lib/download_processing.py
@@ -30,7 +30,9 @@ from lib.import_evidence import (
     ensure_candidate_evidence_for_action,
 )
 from lib.import_manifest import (
+    audio_relative_paths,
     check_audio_manifest,
+    manifest_trace_summary,
     move_failed_import_curated,
     tracked_audio_paths_for_downloads,
 )
@@ -701,6 +703,16 @@ def _materialize_processing_dir(
     """Ensure ``staged_album.current_path`` holds the album's local files."""
     canonical_path = _canonical_import_folder_path(
         album_data, ctx.cfg.slskd_download_dir)
+    logger.info(
+        "MANIFEST-TRACE materialize request=%s %s canonical_exists=%s "
+        "canonical_existing_audio=%s current_path=%s canonical=%r",
+        album_data.db_request_id,
+        manifest_trace_summary(album_data.files),
+        os.path.isdir(canonical_path),
+        len(audio_relative_paths(canonical_path)),
+        staged_album.current_path,
+        canonical_path,
+    )
     db = (ctx.pipeline_db_source._get_db()
           if ctx.pipeline_db_source is not None else None)
     request_id = album_data.db_request_id
@@ -946,6 +958,14 @@ def _process_beets_validation(
     manifest_ok, manifest_detail = _check_staged_audio_manifest(
         album_data,
         staged_album,
+    )
+    logger.info(
+        "MANIFEST-TRACE check request=%s ok=%s %s actual_audio=%s path=%s",
+        album_data.db_request_id,
+        manifest_ok,
+        manifest_trace_summary(album_data.files),
+        len(audio_relative_paths(current_path)),
+        current_path,
     )
     if not manifest_ok:
         return _reject_request_auto_import(

--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -1170,6 +1170,16 @@ def try_multi_enqueue(
         )
         disk["source"] = (username, directory, match_result.file_dir)
         count_found += 1
+        logger.info(
+            "MANIFEST-TRACE multidisc-match request=%s disc=%s/%s user=%s "
+            "disc_files=%s file_dir=%r",
+            _album_request_id(album),
+            disk["disk_no"],
+            total,
+            username,
+            len(files_to_enqueue),
+            match_result.file_dir,
+        )
     if count_found == total:
         planned_downloads: list[DownloadFile] = []
         for disk in split_release:
@@ -1337,6 +1347,15 @@ def try_multi_enqueue(
                     candidates=tuple(accumulated),
                     pre_filter_skip_count=pre_filter_skips[0],
                 )
+        logger.info(
+            "MANIFEST-TRACE multidisc-enqueue request=%s enqueued_discs=%s/%s "
+            "planned_files=%s accepted_files=%s",
+            _album_request_id(album),
+            enqueued,
+            total,
+            len(planned_downloads),
+            len(all_downloads),
+        )
         if enqueued == total:
             if not _persist_claimed_download_state(claim, all_downloads, ctx):
                 cancel_and_delete(all_downloads, ctx)
@@ -1417,6 +1436,18 @@ def _try_filetype(
 
         if attempt.matched:
             assert attempt.downloads is not None
+            from lib.import_manifest import manifest_trace_summary
+            logger.info(
+                "MANIFEST-TRACE grab-accept request=%s album=%r filetype=%s "
+                "%s release_tracks=%s release_media=%s path=%s",
+                album.db_request_id,
+                album.title,
+                allowed_filetype,
+                manifest_trace_summary(attempt.downloads),
+                getattr(release, "track_count", "?"),
+                len(release.media),
+                "multi" if len(release.media) > 1 else "single",
+            )
             grab_entry = GrabListEntry(
                 album_id=album_id,
                 files=attempt.downloads,

--- a/lib/import_manifest.py
+++ b/lib/import_manifest.py
@@ -79,6 +79,26 @@ def _allocate_leftover_target(src_path: str) -> str:
     return target_path
 
 
+def manifest_trace_summary(files: Iterable["DownloadFile"]) -> str:
+    """One-line disc-coverage summary of a download manifest (log-only).
+
+    Renders ``files=<n> discs={<disk_no>:<count>,...}`` so ``MANIFEST-TRACE``
+    log lines expose, at each lifecycle seam, whether a multi-disc grab is
+    under-covering (issue: partial-disc manifest → false ``untracked_audio``).
+    Purely diagnostic — never influences a decision.
+    """
+    file_list = list(files)
+    counts: dict[Any, int] = {}
+    for file in file_list:
+        key = getattr(file, "disk_no", None)
+        counts[key] = counts.get(key, 0) + 1
+    disc_str = ",".join(
+        f"{key}:{counts[key]}"
+        for key in sorted(counts, key=lambda value: (value is None, value))
+    )
+    return f"files={len(file_list)} discs={{{disc_str}}}"
+
+
 def audio_relative_paths(root: str) -> list[str]:
     """Return relative audio paths under ``root`` in stable order."""
     paths: list[str] = []


### PR DESCRIPTION
Log-only instrumentation to close the RCA on false `untracked_audio` rejects of complete multi-disc releases (canonical case: request 2812, *The Mighty Boosh — The Complete Radio Series*, a 3-disc/62-track box repeatedly rejected as `untracked_audio` with 42 "extra" files).

## Why
Static analysis + disk forensics proved the grab manifest reaches validation covering **only one disc** of the box (extra = Disk 1 + Disk 3), but could **not reproduce the shrink** — the enqueue code reads as 62-or-nothing, yet the disk (quarantine folders) shows manifests of 42, then 20, then 20 across Jul 3/5/7. The reduction is real and non-deterministic. These seams capture manifest disc-coverage at every lifecycle stage so the next live re-grab reveals exactly where 62 becomes 20.

## What
`manifest_trace_summary(files)` → `files=<n> discs={<disk_no>:<count>}`, emitted as `MANIFEST-TRACE` at six seams:
- `grab-accept` (`enqueue._try_filetype`) — manifest at grab time
- `multidisc-match` / `multidisc-enqueue` (`try_multi_enqueue`) — per-disc match + partial-enqueue tally
- `reconstruct` (`download.reconstruct_grab_list_entry`) — manifest entering completion
- `materialize` (`download_processing._materialize_processing_dir`) — **canonical-folder reuse + pre-existing audio count** (accumulation signal)
- `check` (`download_processing._process_beets_validation`) — manifest vs on-disk at the reject

## Safety
- No behaviour change; purely observability. `pyright` 0 errors, full suite green (4748 tests).
- **Deliberately does NOT delete or clean any on-disk state.** The existing slskd-dir clutter (8,362 loose files, orphaned `CD 01`/`CD 03` disc folders) is a *suspected input* to the bug and must be preserved to reproduce with logging active.

Part of the RCA → refactor → reaper plan tracked in the covering issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)