### PR TITLE
test(pipeline-db): self-enforcing read-projection parity audit (#546 W1)

### DIFF
--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -3943,12 +3943,30 @@ class FakePipelineDB:
             if e.request_id == request_id
         ]
 
+    # Production's ``get_search_plan_stats_history`` SELECTs a NARROW,
+    # hand-listed column set (search_plan.py) — it deliberately excludes
+    # ``candidates`` AND the U11 forensics columns (pre_filter_skip_count,
+    # rejection_reason, result_count_uncapped, query_token_count,
+    # query_distinct_token_count, expected_track_count, matcher_score_top1,
+    # query_template) so inspection stats don't drag the wide row. The
+    # fake MUST mirror that exact projection (#546 W1 parity).
+    _SEARCH_PLAN_STATS_HISTORY_KEYS: tuple[str, ...] = (
+        "id", "request_id", "query", "result_count", "elapsed_s", "outcome",
+        "variant", "final_state", "browse_time_s", "match_time_s",
+        "peers_browsed", "peers_browsed_lazy", "fanout_waves",
+        "plan_id", "plan_item_id", "plan_ordinal", "plan_strategy",
+        "plan_canonical_query_key", "plan_repeat_group",
+        "plan_generator_id", "execution_stage", "attempt_consumed",
+        "cursor_update_status", "stale_reason", "plan_cycle_snapshot",
+        "created_at",
+    )
+
     def get_search_plan_stats_history(
         self, request_id: int,
     ) -> list[dict[str, object]]:
         rows = self.get_search_history(request_id)
         return [
-            {k: v for k, v in row.items() if k != "candidates"}
+            {k: row[k] for k in self._SEARCH_PLAN_STATS_HISTORY_KEYS}
             for row in rows
         ]
 

--- a/tests/read_projection_registry.py
+++ b/tests/read_projection_registry.py
@@ -1,0 +1,540 @@
+"""Read-projection parity registry (issue #546 W1).
+
+The write side has ``.claude/rules/test-fidelity.md`` Rule A: every
+``PipelineDB`` write method carries a real-PG round-trip test. The READ
+side has the mirror problem — ``FakePipelineDB`` (``tests/fakes/pipeline_db.py``)
+hand-mirrors production ``SELECT`` projections across ~62 ``get_*`` /
+``list_*`` methods. When the fake's projection drifts from production's
+(a column the fake returns that production doesn't, or vice-versa),
+fake-driven contract tests stay green while the live route 500s or
+renders nulls. #523 found a 2/6 drift rate.
+
+This module is the DATA half of the self-enforcing read-parity audit.
+It has NO test cases and needs NO PostgreSQL — it is a pure
+data/introspection module imported by both:
+
+* the registry-driven parity DRIVER
+  (``tests/test_pipeline_db.py::TestReadProjectionRegistryParity``),
+  which seeds identical state through a real ``PipelineDB`` and a
+  ``FakePipelineDB``, runs each seeder, and asserts key-set parity; and
+* the completeness AUDIT
+  (``tests/test_read_projection_audit.py``), which asserts every read
+  mirror is covered by exactly one of: a registry seeder, an existing
+  hand-written parity test, or the allowlist.
+
+A ``Seeder`` is deliberately backend-agnostic: it takes a db that is
+EITHER a real ``PipelineDB`` OR a ``FakePipelineDB`` (they share the
+same duck-typed surface), seeds identical deterministic state, calls
+exactly ONE read-projection method, and returns the projected rows
+flattened to ``list[dict]``. Only KEYS are compared downstream (ids and
+timestamps are backend-assigned/time-anchored), so seeders must never
+put timestamps or random values in row KEYS. Every seeder must produce
+>= 1 row on BOTH backends — a vacuous parity check is worthless.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+
+# A seeder takes a db (real ``PipelineDB`` or ``FakePipelineDB``), seeds
+# identical state, calls ONE read method, and returns the projected rows
+# flattened to ``list[dict]``.
+Seeder = Callable[[Any], "list[dict[str, Any]]"]
+
+
+# Read verbs whose methods carry a row projection that can drift from
+# production. ``search_``/``find_``/``fetch_`` are here because they run
+# raw SELECTs too (e.g. ``search_requests`` = ``SELECT *`` behind a LIVE
+# route, ``find_youtube_album_mapping_for_release`` = a hand-listed SELECT)
+# — restricting the universe to ``get_``/``list_`` let those escape the
+# audit (the #546 W1 reviewers' F1 finding).
+_READ_METHOD_PREFIXES: "tuple[str, ...]" = (
+    "get_", "list_", "search_", "find_", "fetch_",
+)
+
+
+def enumerate_read_mirrors() -> "list[str]":
+    """Introspect ``FakePipelineDB`` for its public read-projection methods.
+
+    The authoritative universe is every public method whose name starts
+    with one of ``_READ_METHOD_PREFIXES``. ``FakePipelineDB`` is the
+    mirror, so its read surface IS the set of projections that can drift
+    from production.
+
+    Scalar-returning read verbs (``count_*`` → int, ``has_*`` / ``exists_*``
+    → bool) are INTENTIONALLY excluded: they return a bool/int/scalar-map
+    with no row projection, so the SELECT-column-drift class this audit
+    guards against does not apply to them.
+    """
+    from tests.fakes import FakePipelineDB
+
+    return sorted(
+        name
+        for name in dir(FakePipelineDB)
+        if any(name.startswith(p) for p in _READ_METHOD_PREFIXES)
+        and not name.startswith("_")
+    )
+
+
+# --------------------------------------------------------------------------
+# Flattening helpers — normalise the varied read-method return shapes to a
+# flat ``list[dict]`` so the parity driver only compares row key-sets.
+# --------------------------------------------------------------------------
+
+def _one(row: "dict[str, Any] | None") -> "list[dict[str, Any]]":
+    """Single-dict-or-None return → ``[row]`` or ``[]``."""
+    return [row] if row is not None else []
+
+
+def _flatten_map_of_lists(
+    mapping: "dict[Any, list[dict[str, Any]]]",
+) -> "list[dict[str, Any]]":
+    """``dict[key, list[row]]`` return → flat list of the inner rows."""
+    return [row for rows in mapping.values() for row in rows]
+
+
+# --------------------------------------------------------------------------
+# Seeders. Each seeds identical state on whichever backend it is handed,
+# then calls one read method and returns its rows flattened.
+# --------------------------------------------------------------------------
+
+# --- Request-family (album_requests SELECT * projections) -----------------
+
+def _seed_get_request(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="mbrel-get-request")
+    return _one(db.get_request(rid))
+
+
+def _seed_get_request_by_mb_release_id(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="mbrel-parity")
+    return _one(db.get_request_by_mb_release_id("mbrel-parity"))
+
+
+def _seed_get_request_by_discogs_release_id(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        discogs_release_id="12345")
+    return _one(db.get_request_by_discogs_release_id("12345"))
+
+
+def _seed_get_request_by_release_id(db: Any) -> "list[dict[str, Any]]":
+    # A non-UUID / non-numeric id falls back to the mb_release_id lookup on
+    # both backends (identical ReleaseIdentity logic).
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="relid-parity")
+    return _one(db.get_request_by_release_id("relid-parity"))
+
+
+def _seed_get_request_by_replaces_request_id(db: Any) -> "list[dict[str, Any]]":
+    old_id = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="super-old")
+    db.supersede_request_mbid(
+        old_id,
+        new_mb_release_id="super-new",
+        new_mb_release_group_id=None,
+        new_mb_artist_id=None,
+        new_artist_name="Parity Artist",
+        new_album_title="Parity Album (superseded)",
+        new_year=None,
+        new_country=None,
+        new_tracks=[],
+    )
+    return _one(db.get_request_by_replaces_request_id(old_id))
+
+
+def _seed_get_wanted(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="wanted-parity", status="wanted")
+    return list(db.get_wanted())
+
+
+def _seed_get_by_status(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="bystatus-parity", status="wanted")
+    return list(db.get_by_status("wanted"))
+
+
+def _seed_get_recent(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="recent-parity")
+    db.log_download(rid, outcome="success")
+    return list(db.get_recent())
+
+
+def _seed_list_non_replaced_requests(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="nonreplaced-parity")
+    return list(db.list_non_replaced_requests())
+
+
+def _seed_list_requests_by_artist(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="byartist-parity")
+    return list(db.list_requests_by_artist("Parity Artist"))
+
+
+def _seed_list_requests_in_release_group(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="inrg-parity", mb_release_group_id="rg-parity")
+    return list(db.list_requests_in_release_group("rg-parity"))
+
+
+# --- Tracks / downloading / denylist / field-resolution -------------------
+
+def _seed_get_tracks(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="tracks-parity")
+    db.set_tracks(rid, [
+        {"disc_number": 1, "track_number": 1, "title": "T",
+         "length_seconds": 100},
+    ])
+    return list(db.get_tracks(rid))
+
+
+def _seed_get_downloading(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="downloading-parity", status="wanted")
+    db.set_downloading(rid, '{"state":"Queued"}')
+    return list(db.get_downloading())
+
+
+def _seed_get_denylisted_users(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="denylist-parity")
+    db.add_denylist(rid, "peer", "reason")
+    return list(db.get_denylisted_users(rid))
+
+
+def _seed_get_field_resolution(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="fieldres-single-parity")
+    db.record_field_resolution(
+        rid, "catalog_number", "unresolved_404", "http_404")
+    return _one(db.get_field_resolution(rid, "catalog_number"))
+
+
+# --- download_log projections (all share the dl.* history projection) -----
+
+def _seed_get_download_log_entry(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="dlentry-parity")
+    lid = db.log_download(rid, outcome="success")
+    return _one(db.get_download_log_entry(lid))
+
+
+def _seed_get_download_history(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="dlhistory-parity")
+    db.log_download(rid, outcome="success")
+    return list(db.get_download_history(rid))
+
+
+def _seed_get_download_history_batch(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="dlbatch-parity")
+    db.log_download(rid, outcome="success")
+    return _flatten_map_of_lists(db.get_download_history_batch([rid]))
+
+
+def _seed_get_latest_download_summaries(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="dlsummary-parity")
+    db.log_download(rid, outcome="success")
+    summaries = db.get_latest_download_summaries([rid])
+    # Each value is ``{"latest": <download_log row>, "count": n}`` — the
+    # ``latest`` sub-dict is the projection that can drift.
+    return [summary["latest"] for summary in summaries.values()]
+
+
+def _seed_get_log(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="getlog-parity")
+    db.log_download(rid, outcome="success")
+    return list(db.get_log())
+
+
+# --- search_log projections -----------------------------------------------
+
+def _seed_get_search_history(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="searchhist-parity")
+    db.log_search(
+        rid, query="q", outcome="found", result_count=5, elapsed_s=1.0)
+    return list(db.get_search_history(rid))
+
+
+def _seed_get_search_plan_stats_history(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="planstatshist-parity")
+    db.log_search(
+        rid, query="q", outcome="found", result_count=5, elapsed_s=1.0)
+    return list(db.get_search_plan_stats_history(rid))
+
+
+def _seed_get_search_history_page(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="searchpage-parity")
+    db.log_search(
+        rid, query="q", outcome="found", result_count=5, elapsed_s=1.0)
+    # ``.rows`` is a raw search_log SELECT * projection wrapped in a Struct
+    # that does NOT key-validate the inner rows — unwrap it like the
+    # get_download_history_batch map (F4).
+    return list(db.get_search_history_page(rid, limit=10).rows)
+
+
+def _seed_get_legacy_search_log_summary(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="legacysummary-parity")
+    # A plain log_search writes plan_id=NULL — a legacy row.
+    db.log_search(
+        rid, query="q", outcome="found", result_count=5, elapsed_s=1.0)
+    # Returns (count, head-sample rows); the head sample is a narrow
+    # 9-column hand-listed SELECT — the projection to key-compare (F2).
+    return list(db.get_legacy_search_log_summary(rid, limit=10)[1])
+
+
+def _seed_search_requests(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="searchreq-parity")
+    return list(db.search_requests("Parity"))
+
+
+# --- import_jobs projection ------------------------------------------------
+
+def _seed_get_active_import_job_for_request(db: Any) -> "list[dict[str, Any]]":
+    from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="activejob-parity")
+    db.enqueue_import_job(
+        IMPORT_JOB_MANUAL,
+        request_id=rid,
+        dedupe_key=f"manual:{rid}",
+        payload=manual_import_payload(failed_path="/tmp/parity"),
+    )
+    return _one(db.get_active_import_job_for_request(rid))
+
+
+# --- youtube_album_mappings projection ------------------------------------
+
+def _youtube_mapping_row(**overrides: Any) -> "dict[str, Any]":
+    """The upsert-row shape from
+    ``TestReadProjectionParity._youtube_mapping_row`` — duplicated here
+    because the registry module can't reach that test-class staticmethod.
+    """
+    row: "dict[str, Any]" = {
+        "yt_browse_id": "MPREb_parity",
+        "yt_audio_playlist_id": "OLAK5uy_parity",
+        "yt_url": "https://music.youtube.com/playlist?list=OLAK5uy_parity",
+        "yt_year": 2020,
+        "yt_track_count": 10,
+        "album_title": "Parity Album",
+        "album_artist": "Parity Artist",
+        "yt_tracks": [
+            {"title": "Track 1", "video_id": "v1", "length_seconds": 200,
+             "track_number": 1, "disc_number": 1,
+             "artists": [{"name": "Artist"}]},
+        ],
+        "distances": [{"mbid": "mb-1", "distance": 0.05, "error": None}],
+    }
+    row.update(overrides)
+    return row
+
+
+def _seed_find_youtube_album_mapping_for_release(
+    db: Any,
+) -> "list[dict[str, Any]]":
+    db.upsert_youtube_album_mapping(
+        "rg-find-parity", "mb",
+        [_youtube_mapping_row(
+            yt_browse_id="MPREb_find",
+            distances=[{"mbid": "mb-find-1", "distance": 0.05, "error": None}],
+        )])
+    return _one(db.find_youtube_album_mapping_for_release(
+        source="mb", release_id="mb-find-1", browse_id="MPREb_find"))
+
+
+# --- plex pins / unfindable probe -----------------------------------------
+
+def _seed_get_pending_plex_added_at_pins(db: Any) -> "list[dict[str, Any]]":
+    db.add_plex_added_at_pin(
+        imported_path="/x",
+        original_added_at=1700000000,
+        rating_key="rk",
+        request_id=None,
+    )
+    # captured_before must be AFTER the pin's captured_at (stamped NOW()).
+    captured_before = datetime.now(timezone.utc) + timedelta(days=1)
+    return list(db.get_pending_plex_added_at_pins(
+        captured_before=captured_before, limit=100))
+
+
+def _seed_list_unfindable_probe_candidates(db: Any) -> "list[dict[str, Any]]":
+    db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="probe-parity", status="wanted")
+    return list(db.list_unfindable_probe_candidates(
+        limit=10, probe_interval_days=7))
+
+
+# --------------------------------------------------------------------------
+# The registry. One entry per read-projection method newly covered by a
+# seeded keyset-parity check. Methods already covered by a hand-written
+# parity test (get_wrong_matches, get_pipeline_overlay, ...) are NOT here —
+# the audit finds those via AST. Methods with no raw-SELECT row projection
+# (typed Struct returns, scalars, computed metric dicts) are in ALLOWLIST.
+# --------------------------------------------------------------------------
+
+PARITY_REGISTRY: "dict[str, Seeder]" = {
+    # Request-family (album_requests SELECT * projections).
+    "get_request": _seed_get_request,
+    "get_request_by_mb_release_id": _seed_get_request_by_mb_release_id,
+    "get_request_by_discogs_release_id":
+        _seed_get_request_by_discogs_release_id,
+    "get_request_by_release_id": _seed_get_request_by_release_id,
+    "get_request_by_replaces_request_id":
+        _seed_get_request_by_replaces_request_id,
+    "get_wanted": _seed_get_wanted,
+    "get_by_status": _seed_get_by_status,
+    "get_recent": _seed_get_recent,
+    "search_requests": _seed_search_requests,
+    "list_non_replaced_requests": _seed_list_non_replaced_requests,
+    "list_requests_by_artist": _seed_list_requests_by_artist,
+    "list_requests_in_release_group": _seed_list_requests_in_release_group,
+    # Tracks / downloading / denylist / field-resolution.
+    "get_tracks": _seed_get_tracks,
+    "get_downloading": _seed_get_downloading,
+    "get_denylisted_users": _seed_get_denylisted_users,
+    "get_field_resolution": _seed_get_field_resolution,
+    # download_log projections.
+    "get_download_log_entry": _seed_get_download_log_entry,
+    "get_download_history": _seed_get_download_history,
+    "get_download_history_batch": _seed_get_download_history_batch,
+    "get_latest_download_summaries": _seed_get_latest_download_summaries,
+    "get_log": _seed_get_log,
+    # search_log projections.
+    "get_search_history": _seed_get_search_history,
+    "get_search_history_page": _seed_get_search_history_page,
+    "get_search_plan_stats_history": _seed_get_search_plan_stats_history,
+    "get_legacy_search_log_summary": _seed_get_legacy_search_log_summary,
+    # import_jobs projection.
+    "get_active_import_job_for_request":
+        _seed_get_active_import_job_for_request,
+    # youtube_album_mappings projection.
+    "find_youtube_album_mapping_for_release":
+        _seed_find_youtube_album_mapping_for_release,
+    # plex pins / unfindable probe.
+    "get_pending_plex_added_at_pins": _seed_get_pending_plex_added_at_pins,
+    "list_unfindable_probe_candidates": _seed_list_unfindable_probe_candidates,
+}
+
+
+# --------------------------------------------------------------------------
+# The allowlist. Read mirrors that are NOT keyset-parity-checked, each with
+# a one-line rationale. This is the ratchet — it only shrinks. A read mirror
+# belongs here iff it has no raw ``SELECT`` row projection to key-compare:
+#
+#   * Typed Struct/dataclass returns — validated at the msgspec/dataclass
+#     boundary; the caller sees typed attributes, not a dict projection.
+#   * Scalar returns (int / str / list[str] / set[str] / dict[int,int] /
+#     dict[int,dict]) — no per-row column projection.
+#   * Computed-aggregate metric dicts — the key set is statically assembled
+#     in Python, not a raw SELECT column list, so the SELECT-drift class
+#     the parity gate guards against does not apply.
+# --------------------------------------------------------------------------
+
+ALLOWLIST: "dict[str, str]" = {
+    # --- Typed Struct / dataclass returns ---
+    "get_active_search_plan":
+        "typed ActiveSearchPlan | None return (wraps a PersistedSearchPlan "
+        "in .plan) — validated at the dataclass boundary, no dict "
+        "projection to key-compare",
+    "get_import_job":
+        "typed ImportJob return — msgspec/dataclass boundary, no dict "
+        "projection",
+    "get_saturation_summary":
+        "typed SaturationSummary return — computed aggregate, no row "
+        "projection",
+    "get_search_plan_inspection":
+        "typed inspection dataclass return — no raw SELECT dict projection",
+    "get_search_plan_stats":
+        "typed SearchPlanStats return — computed aggregate, no row "
+        "projection",
+    "get_unfindable_search_log_signal":
+        "typed UnfindableSearchLogSignal return — computed aggregate, no "
+        "row projection",
+    "list_active_import_jobs":
+        "list[ImportJob] — typed dataclass rows, no dict projection",
+    "list_active_import_jobs_for_wrong_match":
+        "list[ImportJob] — typed dataclass rows, no dict projection",
+    "list_import_job_timeline":
+        "list[ImportJob] — typed dataclass rows, no dict projection",
+    "list_import_jobs":
+        "list[ImportJob] — typed dataclass rows, no dict projection",
+    "list_search_plan_classification_for_requests":
+        "typed classification dataclass values — no raw SELECT dict "
+        "projection",
+    "list_wanted_for_plan_reconciliation":
+        "typed reconciliation-row dataclass return — no dict projection",
+    "find_active_youtube_import_job":
+        "typed ImportJob | None return — validated at the msgspec boundary",
+    "find_album_quality_evidence":
+        "typed AlbumQualityEvidence Struct return — validated at the "
+        "msgspec boundary",
+    # --- Scalar returns ---
+    "get_cooled_down_users":
+        "list[str] usernames — scalar, no row projection",
+    "get_download_log_candidate_evidence_id":
+        "int | None FK scalar — no row projection",
+    "get_import_job_candidate_evidence_id":
+        "int | None FK scalar — no row projection",
+    "get_recent_successful_uploader":
+        "str | None username — scalar, no row projection",
+    "get_request_current_evidence_id":
+        "int | None FK scalar — no row projection",
+    "get_track_counts":
+        "dict[int,int] request_id → count — scalar aggregate, no row "
+        "projection",
+    "find_orphan_youtube_running":
+        "scalar list[int] return — no row projection",
+    "list_active_release_group_ids":
+        "set[str] release-group ids — scalar, no row projection",
+    # --- Computed-aggregate metric dicts ---
+    "get_peer_metrics":
+        "computed peer-telemetry metric dict — key set assembled in "
+        "Python, not a raw SELECT column list",
+    "get_pipeline_dashboard_metrics":
+        "computed dashboard metric dict — key set assembled in Python, "
+        "not a raw SELECT column list",
+    "get_search_plan_readiness":
+        "computed readiness metric dict — key set assembled in Python, "
+        "not a raw SELECT column list",
+}

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -8849,5 +8849,52 @@ class TestReadProjectionParity(unittest.TestCase):
             self.fake.get_youtube_album_mapping("rg-never-resolved", "mb"))
 
 
+@requires_postgres
+class TestReadProjectionRegistryParity(unittest.TestCase):
+    """#546 W1 — registry-driven read-projection parity gate.
+
+    ``TestReadProjectionParity`` (above) is the hand-written half: one
+    ``test_*`` method per covered projection. This class is the
+    self-enforcing half — it iterates ``PARITY_REGISTRY`` from
+    ``tests/read_projection_registry.py`` and runs every registered
+    seeder against a fresh real ``PipelineDB`` and a fresh
+    ``FakePipelineDB``, asserting key-set parity for each. Adding a
+    seeder to the registry is all it takes to gate a new mirror; the
+    companion audit (``tests/test_read_projection_audit.py``) forces
+    every ``FakePipelineDB`` read method into the registry, the
+    hand-written coverage, or the allowlist.
+
+    Reuses ``TestReadProjectionParity._assert_keyset_parity`` — a
+    staticmethod whose first argument is the ``TestCase`` instance, so
+    cross-class reuse is safe.
+    """
+
+    def test_every_registered_mirror_has_keyset_parity(self):
+        from tests.fakes import FakePipelineDB
+        from tests.read_projection_registry import PARITY_REGISTRY
+
+        for method_name, seeder in sorted(PARITY_REGISTRY.items()):
+            with self.subTest(method=method_name):
+                real_db = make_db()
+                try:
+                    fake_db = FakePipelineDB()
+                    real_rows = seeder(real_db)
+                    fake_rows = seeder(fake_db)
+                    self.assertTrue(
+                        real_rows,
+                        f"{method_name}: seeder produced no rows on real "
+                        f"PG — parity would pass vacuously; fix the seeder "
+                        f"in tests/read_projection_registry.py")
+                    self.assertTrue(
+                        fake_rows,
+                        f"{method_name}: seeder produced no rows on "
+                        f"FakePipelineDB — parity would pass vacuously; fix "
+                        f"the seeder in tests/read_projection_registry.py")
+                    TestReadProjectionParity._assert_keyset_parity(
+                        self, real_rows, fake_rows, method_name)
+                finally:
+                    real_db.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_read_projection_audit.py
+++ b/tests/test_read_projection_audit.py
@@ -1,0 +1,222 @@
+"""Read-projection parity completeness audit (issue #546 W1).
+
+The read-side mirror of ``tests/test_pipeline_db_write_audit.py``. Where
+the write audit makes every ``PipelineDB`` write method carry a Rule A
+round-trip test, this audit makes every ``FakePipelineDB`` READ
+projection (``get_*`` / ``list_*``) carry a fake<->production key-set
+parity check — OR be explicitly allowlisted with a one-line rationale.
+
+The authoritative universe is ``enumerate_read_mirrors()`` (every public
+read method on ``FakePipelineDB``). Each mirror MUST fall into exactly
+one bucket:
+
+  (a) a key in ``PARITY_REGISTRY`` — a registry seeder drives it through
+      ``TestReadProjectionRegistryParity``;
+  (b) a hand-written parity test in ``tests/test_pipeline_db.py`` that
+      calls ``db.<method>()`` inside a parity-shaped test (detected by
+      AST across ALL classes in that file); or
+  (c) a key in ``ALLOWLIST`` — no raw ``SELECT`` row projection to
+      key-compare (typed Struct return, scalar, or computed metric dict).
+
+A mirror in none of the three fails the audit with actionable guidance:
+add a registry seeder or an allowlist entry. This makes the whole read
+surface self-enforcing — a new ``FakePipelineDB`` read method can't ship
+without landing in a bucket, so #524/#525-class drift can't recur.
+
+Like the write audit, ``tests/test_pipeline_db.py`` is parsed as TEXT
+via ``ast`` (path derived from ``__file__``) — never imported, because
+importing it bootstraps ephemeral PostgreSQL.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+from tests.read_projection_registry import (
+    ALLOWLIST,
+    PARITY_REGISTRY,
+    enumerate_read_mirrors,
+)
+
+
+def _find_parity_tests_for_method(
+    method_name: str, tree: ast.Module,
+) -> "list[str]":
+    """Return parity test functions in ``tree`` that exercise ``method_name``.
+
+    A test qualifies as a parity test for ``method_name`` when its body
+    either:
+
+      * calls ``<x>.<method_name>(...)`` at least TWICE (once per backend —
+        the ``self.db`` real-PG call and the ``self.fake`` / ``fake`` call
+        every hand-written parity test makes), OR
+      * passes ``<method_name>``'s result INTO ``_assert_keyset_parity(...)``
+        — either a direct inline ``_assert_keyset_parity(self, db.M(), ...)``
+        call, or a variable bound from a call to ``M`` and then passed as an
+        argument.
+
+    Pure name-based acceptance (``"parity" in test.name``) is deliberately
+    REJECTED — it let a name-only smoke test or a setup-only mention count
+    as coverage, looser than the write-side sibling
+    (``tests/test_pipeline_db_write_audit.py``). Requiring two real call
+    sites (or an actual result-into-comparator flow) keeps the heuristic
+    strictly tighter while still registering all 13 existing hand-covered
+    methods across ``TestReadProjectionParity``, ``TestGetWrongMatches``,
+    ``TestGetPipelineOverlay``, ``TestSlskdEventCursorRoundTrip`` and
+    ``TestGetDownloadLogCounts``.
+    """
+
+    def _is_call_to_method(sub: ast.AST) -> bool:
+        return (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == method_name
+        )
+
+    hits: "list[str]" = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+
+        # (a) Count call sites of ``<x>.<method_name>(...)``.
+        call_count = sum(
+            1 for sub in ast.walk(node) if _is_call_to_method(sub))
+
+        # Names bound from an expression that contains a call to ``M``
+        # (covers ``rows = db.M()`` and ``rows = list(db.M())``).
+        m_bound_names: "set[str]" = set()
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Assign) and any(
+                _is_call_to_method(v) for v in ast.walk(sub.value)
+            ):
+                for target in sub.targets:
+                    if isinstance(target, ast.Name):
+                        m_bound_names.add(target.id)
+
+        # (b) Is ``M``'s result passed into ``_assert_keyset_parity(...)``?
+        passed_into_assert = False
+        for sub in ast.walk(node):
+            if not (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "_assert_keyset_parity"
+            ):
+                continue
+            for arg in sub.args:
+                if _is_call_to_method(arg):
+                    passed_into_assert = True
+                if isinstance(arg, ast.Name) and arg.id in m_bound_names:
+                    passed_into_assert = True
+
+        if call_count >= 2 or passed_into_assert:
+            hits.append(node.name)
+    return hits
+
+
+class TestReadProjectionAudit(unittest.TestCase):
+    """Every ``FakePipelineDB`` read mirror lands in exactly one bucket.
+
+    Add a new ``get_*`` / ``list_*`` / ``search_*`` / ``find_*`` /
+    ``fetch_*`` method to ``FakePipelineDB`` ⇒ the audit fails until you
+    either:
+      1. Add a registry seeder in ``tests/read_projection_registry.py``
+         (preferred for any raw-SELECT row projection), OR
+      2. Add an ``ALLOWLIST`` entry there with a one-line rationale (for
+         typed Struct / scalar / computed-metric returns), OR
+      3. Add a hand-written parity test in ``tests/test_pipeline_db.py``.
+
+    There is no fourth option — a new read mirror without a bucket is the
+    #523 drift class waiting to recur.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Parse tests/test_pipeline_db.py once as TEXT — never import it
+        # (that bootstraps ephemeral PostgreSQL). Derive the path from this
+        # file's own location so it survives lib.pipeline_db being a package.
+        test_path = (
+            pathlib.Path(__file__).resolve().parent / "test_pipeline_db.py"
+        )
+        cls._test_tree = ast.parse(test_path.read_text())
+
+    def test_every_read_mirror_is_covered(self) -> None:
+        uncovered: "list[str]" = []
+        for name in enumerate_read_mirrors():
+            if name in PARITY_REGISTRY:
+                continue
+            if name in ALLOWLIST:
+                continue
+            if _find_parity_tests_for_method(name, self._test_tree):
+                continue
+            uncovered.append(name)
+        self.assertEqual(
+            uncovered, [],
+            msg=(
+                "These FakePipelineDB read mirrors have no fake<->production "
+                "key-set parity coverage (#546 W1). For each, EITHER add a "
+                "registry seeder to PARITY_REGISTRY in "
+                "tests/read_projection_registry.py (preferred for a raw "
+                "SELECT row projection) OR add an ALLOWLIST entry there with "
+                "a one-line rationale (typed Struct / scalar / computed "
+                "metric return):\n  - " + "\n  - ".join(sorted(uncovered))
+            ),
+        )
+
+    def test_registry_entries_match_real_methods(self) -> None:
+        """Catch stale registry keys — a method renamed or deleted but
+        left with a dangling seeder."""
+        real_methods = set(enumerate_read_mirrors())
+        stale = [name for name in PARITY_REGISTRY if name not in real_methods]
+        self.assertEqual(
+            stale, [],
+            msg=(
+                "PARITY_REGISTRY contains stale entries that don't match any "
+                "current FakePipelineDB read method:\n  - "
+                + "\n  - ".join(sorted(stale))
+            ),
+        )
+
+    def test_allowlist_entries_match_real_methods(self) -> None:
+        """Catch stale allowlist entries — a method renamed or deleted but
+        left with a dangling allowlist row."""
+        real_methods = set(enumerate_read_mirrors())
+        stale = [name for name in ALLOWLIST if name not in real_methods]
+        self.assertEqual(
+            stale, [],
+            msg=(
+                "ALLOWLIST contains stale entries that don't match any "
+                "current FakePipelineDB read method:\n  - "
+                + "\n  - ".join(sorted(stale))
+            ),
+        )
+
+    def test_allowlist_rationales_are_non_empty(self) -> None:
+        empty = [name for name, reason in ALLOWLIST.items()
+                 if not reason.strip()]
+        self.assertEqual(
+            empty, [],
+            msg=(
+                "ALLOWLIST entries must carry a one-line rationale:\n  - "
+                + "\n  - ".join(sorted(empty))
+            ),
+        )
+
+    def test_no_method_both_allowlisted_and_registered(self) -> None:
+        """A method must be in exactly one of PARITY_REGISTRY / ALLOWLIST —
+        never both (that would be contradictory bucketing)."""
+        both = sorted(set(PARITY_REGISTRY) & set(ALLOWLIST))
+        self.assertEqual(
+            both, [],
+            msg=(
+                "These methods are in BOTH PARITY_REGISTRY and ALLOWLIST — "
+                "pick one bucket (a seeded parity check OR an allowlist "
+                "rationale):\n  - " + "\n  - ".join(both)
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the W1 item of #546. **W1+W2 were slated as one PR; W2 turned out to already exist** (`tests/test_pipeline_db_write_audit.py`, shipped June 12 — the issue author didn't know), so this PR is W1 alone. W3/W4 remain as their own PRs.

## Problem
`FakePipelineDB` hand-mirrors production `SELECT` projections across **67** read methods. Before this, only ~13 carried a fake↔production keyset-parity test, and that set was **grown by hand** (#481 seeded 4, #523 added 6). #523 found a **2/6 drift rate** in the methods it touched — a lot of latent "fake-green while the live route 500s / renders nulls" bugs, the exact class `.claude/rules/test-fidelity.md` exists to kill. The hand-grow approach guaranteed a #524/#525/… forever.

## What this does
Makes the whole read surface **self-enforcing** — the read-side mirror of Rule A (write round-trips) and of the write-side `test_pipeline_db_write_audit.py`.

- **`tests/read_projection_registry.py`** — `enumerate_read_mirrors()` introspects FakePipelineDB's `get_*`/`list_*`/`search_*`/`find_*`/`fetch_*` surface (scalar verbs `count_*`/`has_*` intentionally excluded — no row projection). `PARITY_REGISTRY` = 29 backend-agnostic seeders (seed identical state on a real `PipelineDB` OR `FakePipelineDB`, call one read method, return rows flattened to `list[dict]`). `ALLOWLIST` = 25 entries (typed-Struct / scalar / computed-metric returns), each with a one-line rationale; ratchet-only-shrinks.
- **`TestReadProjectionRegistryParity`** (in `tests/test_pipeline_db.py`) — *runs* keyset parity for every registered seeder against real PG vs the fake, asserting non-vacuity on both backends and reusing `_assert_keyset_parity`. This is what surfaces drift.
- **`tests/test_read_projection_audit.py`** — forces every read mirror into **exactly one** bucket (registry / hand-covered-via-AST / allowlist) or the suite fails. A new read method can't ship uncovered. AST-parses `test_pipeline_db.py` as text (never imports it → no PG bootstrap). Includes stale-registry, stale-allowlist, non-empty-rationale, and no-double-bucket guards.

## Drift surfaced + fixed (fake side only — never production SQL)
The registry's first run caught exactly one: the fake's `get_search_plan_stats_history` computed its projection as `get_search_history()` minus `candidates`, **leaking 8 U11 forensics columns** that production's narrow hand-listed `SELECT` deliberately excludes. Fixed to mirror production's exact 26-column projection. Production is source of truth; the fake now matches it.

## Partition
67 mirrors = **29 registry + 25 allowlist + 13 hand-covered**. No unclassified, no double-bucketing.

## Verification
- `pyright` (full repo): **0 errors, 0 warnings**
- Full suite (`scripts/run_tests.sh`): **`Ran 4754 tests … OK`**; vulture clean
- Adversarial keystone checks (independent): injecting a synthetic uncovered mirror is reported uncovered (teeth confirmed); the tightened AST heuristic rejects a name-only smoke test as coverage
- **Zero `lib/`/`web/`/`harness/`/`scripts/`/`migrations/`/`nix/` changes** — tests only

## Process
Built via the #522/#523 strategy: Sonnet implemented (review-banned), two Opus reviewers (audit-soundness lens + drift-fix/bucket-honesty lens) found 1 should-fix + several nits — including a real drift-hiding allowlist entry (`get_legacy_search_log_summary`, a genuine 9-column projection) and a universe gap (`search_requests`, a live-route `SELECT *`, escaped the audit). All fixes applied and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)