### PR TITLE
test(generated): Hypothesis property-based testing for quality decisions (#548 v1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 *.pyc
 *.egg-info/
 .mypy_cache/
+# Hypothesis example database (fuzz-tier failure replay; see docs/generated-testing.md)
+.hypothesis/
 .pyright/
 .pyright-venv
 .nixpkgs-src

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,8 @@ nix-shell --run "python3 -m unittest tests.test_X -v"
 
 **ALWAYS `nix-shell --run` for Python** (`.claude/rules/nix-shell.md`). **Never re-run the full suite just to grep differently** — read the output file. The suite gates: JS syntax + JS tests, the vulture dead-code sweep, then unittest discovery. `.claude/rules/code-quality.md` covers the test taxonomy, shared fakes/builders, and the new-work checklist.
 
+**Generated (property-based) tests** (`tests/test_*_generated.py`, Hypothesis) run deterministically in the suite; after changing quality policy, run the randomized fuzz burst: `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz` on those modules. Failures shrink to minimal worlds — promote them to named `@example` pins or album-test-set scenarios, never JSON artifacts. `docs/generated-testing.md`.
+
 ### Skipped tests are an anti-pattern
 
 **A test either runs or it doesn't exist.** No skip decorators, no env-gated tests, no "fixtures must be generated first" — every test runs on every `run_tests.sh` in a fresh dev shell. A skipped test is either irrelevant (delete it) or mis-designed (make it run: Nix-provided binaries, synthetic fixtures in `setUp`, or fakes). `tests/test_skip_audit.py` fails the suite on any skip; there is no allowlist. (History: the suite once said `OK (skipped=56)` for months while 56 tests had never executed once.)

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -1,0 +1,86 @@
+# Generated (property-based) testing
+
+Issue #548. Hypothesis-driven generated tests assert **policy invariants**
+over large generated state spaces instead of hand-picked examples. They are
+ordinary members of the unittest suite — no separate runner, no seed
+bookkeeping, no standing service.
+
+## Modules
+
+| Module | Target | Properties |
+|--------|--------|------------|
+| `tests/test_quality_generated.py` | the decision twins (`full_pipeline_decision` / `full_pipeline_decision_from_evidence`) | decisions are definitive (totality); raw verified-lossless FLAC never replaced by lossy; transparent lossy never accepts obvious downgrades; **twin parity** over the shared world language; evidence-only integrity facts (corrupt / bad-hash / nested / mixed) always reject in priority order; incomplete evidence fails closed |
+| `tests/test_evidence_generated.py` | `ensure_current_evidence_for_action` | converted current evidence requires source V0 (fix `6cf26a4`): never `loaded` without a V0 metric, scalar state backfills, otherwise fail closed |
+
+Every generated module also carries **known-bad self-tests** proving each
+invariant checker trips on a planted violating decision — the RED/GREEN
+guarantee that the harness detects what it claims to.
+
+## Two tiers, one knob
+
+`tests/_hypothesis_profiles.py` registers two profiles, selected by
+`CRATEDIGGER_HYPOTHESIS_PROFILE`:
+
+- **`suite`** (default) — deterministic (`derandomize=True`, no example
+  database), bounded examples. Runs on every `scripts/run_tests.sh`,
+  identical on every machine. This is the merge gate.
+- **`fuzz`** — randomized burst for local exploration. Fresh entropy per
+  run, big example budget, local example database (`.hypothesis/`,
+  gitignored) so found failures replay first on the next burst,
+  `print_blob=True` for exact reproduction.
+
+Run a burst whenever quality policy changes:
+
+```bash
+nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \
+    python3 -m unittest tests.test_quality_generated tests.test_evidence_generated -v"
+```
+
+It is pure and safe: no prod DB, no slskd, no beets, no network; the only
+filesystem writes are per-example tempdirs and the local `.hypothesis/`
+database. Repeat runs add entropy; there is nothing to resume and no seed
+cursor — coverage grows by improving strategies and invariants, not by
+consuming more seeds.
+
+## Promotion policy — failures become named tests, not artifacts
+
+When the fuzz tier finds a real failure, Hypothesis **shrinks** it to a
+minimal world and prints it (plus a `@reproduce_failure` blob). Promote it:
+
+1. Reproduce and fix (or conclude the invariant/world-mapping is wrong and
+   fix the test — say which in the commit).
+2. Commit the minimized world as a named `@example(...)` pin on the
+   property, or as a full named scenario in the album test set
+   (`tests/test_quality_classification.py::TestLiveBugReproductions` + its
+   evidence-pipeline parity twin) when the shape deserves prose.
+
+Never check in opaque failure artifacts (JSON corpora, seed logs). They
+freeze `asdict()` snapshots of dataclasses that churn, and a seed's meaning
+changes whenever a strategy changes — named examples evolve with the schema
+and stay readable.
+
+## The parity property
+
+`TestGeneratedParity` machine-checks "quality decisions live in ONE place":
+for every world expressible in the twins' **common language**, the simulator
+twin and the production evidence decider must produce identical outcomes.
+The world→evidence mapping is the same shared builder the hand-written
+parity tests use (`tests/helpers.py::build_parity_candidate_evidence` /
+`build_parity_current_evidence`), so a divergence can't hide behind two
+different encodings. The common-language constraints (candidate V0 probes
+only on FLAC candidates, derived `is_vbr`, explicit conversion facts) are
+documented at the strategy definition.
+
+## Writing new generated tests
+
+- Strategies generate anything the **schema** can express — no plausibility
+  filters. The V0-evidence bug lived in a state a plausible-worlds-only
+  generator would have skipped. If a state is truly impossible, fail-closed
+  handling of it is itself the invariant.
+- Invariant checkers are module-level functions so a known-bad self-test
+  can prove each one trips.
+- Import `tests._hypothesis_profiles` for the side effect before using
+  `@given` — that is what wires the module into the suite/fuzz tiers.
+- Reuse the shared fakes/builders (`tests/fakes/`, `tests/helpers.py`)
+  per `.claude/rules/code-quality.md`; leaf-seam mock rules apply to
+  generated tests like any other test.

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -28,9 +28,10 @@ let
   #
   # Dev-only additions:
   #   - vulture: static dead-code finder (scripts/find_dead_code.sh)
+  #   - hypothesis: property-based generated tests (docs/generated-testing.md)
   testPythonEnv = pkgs.python3.withPackages (ps:
     cratedigger.pythonPackages ps
-    ++ [ ps.vulture ]
+    ++ [ ps.vulture ps.hypothesis ]
   );
 in
 pkgs.mkShell {

--- a/tests/_hypothesis_profiles.py
+++ b/tests/_hypothesis_profiles.py
@@ -1,0 +1,44 @@
+"""Hypothesis profile selection for generated tests (issue #548).
+
+Importing this module registers two profiles and loads the one selected by
+``CRATEDIGGER_HYPOTHESIS_PROFILE``:
+
+* ``suite`` (default) — deterministic tier. ``derandomize=True`` makes
+  generation a fixed pseudo-random sweep, ``database=None`` keeps results
+  independent of local ``.hypothesis/`` state, so every ``run_tests.sh``
+  run behaves identically on every machine. This is the tier that gates
+  merges.
+* ``fuzz`` — randomized burst tier for local exploration when quality
+  policy changes. Uses a fresh entropy source per run plus the local
+  Hypothesis example database (``.hypothesis/``, gitignored), so failures
+  found in one burst replay first on the next. ``print_blob=True`` prints
+  a ``@reproduce_failure`` blob for exact replay.
+
+Deadlines are disabled in both tiers: wall-clock-per-example limits flake
+under load and none of the generated tests do I/O worth bounding.
+
+Promotion policy: a failure found by the fuzz tier is shrunk by Hypothesis
+to a minimal world — commit that world as a named ``@example(...)`` pin or
+as a scenario in the album test set. Never check in opaque artifacts.
+See docs/generated-testing.md.
+"""
+
+import os
+
+from hypothesis import HealthCheck, settings
+
+settings.register_profile(
+    "suite",
+    derandomize=True,
+    max_examples=150,
+    database=None,
+    deadline=None,
+)
+settings.register_profile(
+    "fuzz",
+    max_examples=20_000,
+    deadline=None,
+    print_blob=True,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile(os.environ.get("CRATEDIGGER_HYPOTHESIS_PROFILE", "suite"))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.quality import (
+    V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
     AlbumQualityEvidence,
     AlbumQualityEvidenceFile,
     AlbumQualityV0Metric,
@@ -176,6 +177,175 @@ def make_album_quality_evidence(
         target_format=target_format,
         v0_metric=v0_metric,
         verified_lossless_proof=verified_lossless_proof,
+    )
+
+
+def build_parity_candidate_evidence(
+    *,
+    is_flac: bool,
+    min_bitrate: int,
+    is_cbr: bool,
+    avg_bitrate: int | None = None,
+    spectral_grade: str | None = None,
+    spectral_bitrate: int | None = None,
+    post_conversion_min_bitrate: int | None = None,
+    candidate_v0_probe_avg: int | None = None,
+    candidate_v0_probe_min: int | None = None,
+    native_codec: str = "mp3",
+    native_format: str = "MP3",
+    mb_release_id: str = "mbid-parity-candidate",
+    audio_corrupt: bool = False,
+    folder_layout: str = "flat",
+    audio_file_count: int | None = None,
+    matched_bad_audio_hash_id: int | None = None,
+    matched_bad_audio_hash_path: str | None = None,
+    snapshot_fingerprint: str = "sha256:candidate-fingerprint",
+) -> AlbumQualityEvidence:
+    """Build an ``AlbumQualityEvidence`` candidate row matching the
+    simulator's flat-kwargs shape (post-U2/U3 schema).
+
+    This is the canonical simulator-world → evidence-row mapping. The
+    hand-written parity tests in ``tests/test_quality_classification.py``
+    and the generated parity property in ``tests/test_quality_generated.py``
+    both consume it, so a divergence between the decision twins can never
+    hide behind two different world encodings.
+    """
+    # For a FLAC source post-conversion, the candidate measurement
+    # reflects the V0 output the importer compares against.
+    if is_flac and post_conversion_min_bitrate is not None:
+        fmt = "MP3"
+        container = "flac"
+        codec = "flac"
+        storage_format = "flac"
+        measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=post_conversion_min_bitrate,
+            avg_bitrate_kbps=candidate_v0_probe_avg or post_conversion_min_bitrate,
+            median_bitrate_kbps=candidate_v0_probe_avg or post_conversion_min_bitrate,
+            format=fmt,
+            is_cbr=False,
+            spectral_grade=spectral_grade,
+            spectral_bitrate_kbps=spectral_bitrate,
+            was_converted_from="flac",
+        )
+    elif is_flac:
+        container = codec = "flac"
+        storage_format = "flac"
+        measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=min_bitrate or 900,
+            avg_bitrate_kbps=min_bitrate or 900,
+            median_bitrate_kbps=min_bitrate or 900,
+            format="FLAC",
+            is_cbr=False,
+            spectral_grade=spectral_grade,
+            spectral_bitrate_kbps=spectral_bitrate,
+        )
+    else:
+        container = codec = native_codec
+        if native_codec == "mp3":
+            storage_format = "mp3 v0" if not is_cbr else "mp3 320"
+        else:
+            storage_format = native_format.lower()
+        _avg = avg_bitrate if avg_bitrate is not None else min_bitrate
+        measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=min_bitrate,
+            avg_bitrate_kbps=_avg,
+            median_bitrate_kbps=_avg,
+            format=native_format,
+            is_cbr=is_cbr,
+            spectral_grade=spectral_grade,
+            spectral_bitrate_kbps=spectral_bitrate,
+        )
+
+    v0_metric = None
+    if candidate_v0_probe_avg is not None or candidate_v0_probe_min is not None:
+        v0_metric = AlbumQualityV0Metric(
+            min_bitrate_kbps=candidate_v0_probe_min,
+            avg_bitrate_kbps=candidate_v0_probe_avg,
+            median_bitrate_kbps=candidate_v0_probe_avg,
+            source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+            source_provenance="neutral_album_quality_evidence",
+        )
+
+    files = [AlbumQualityEvidenceFile(
+        relative_path=f"01.{container}",
+        size_bytes=1, mtime_ns=1,
+        extension=container, container=container, codec=codec,
+    )]
+    # ``audio_file_count`` defaults to len(files) for the standard
+    # parity scenarios. Tests covering empty_fileset explicitly pass
+    # ``audio_file_count=0`` and override ``files`` separately.
+    return AlbumQualityEvidence(
+        mb_release_id=mb_release_id,
+        snapshot_fingerprint=snapshot_fingerprint,
+        source_path="/Incoming/auto-import/candidate",
+        measurement=measurement,
+        measured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        files=files,
+        codec=codec,
+        container=container,
+        storage_format=storage_format,
+        v0_metric=v0_metric,
+        audio_corrupt=audio_corrupt,
+        folder_layout=folder_layout,
+        audio_file_count=(
+            audio_file_count if audio_file_count is not None else len(files)
+        ),
+        filetype_band=storage_format,
+        matched_bad_audio_hash_id=matched_bad_audio_hash_id,
+        matched_bad_audio_hash_path=matched_bad_audio_hash_path,
+    )
+
+
+def build_parity_current_evidence(
+    *,
+    min_bitrate: int | None,
+    avg_bitrate: int | None = None,
+    format: str = "MP3",
+    is_cbr: bool = False,
+    spectral_grade: str | None = None,
+    spectral_bitrate: int | None = None,
+    mb_release_id: str = "mbid-parity-candidate",
+    v0_metric: AlbumQualityV0Metric | None = None,
+    matched_bad_audio_hash_id: int | None = None,
+    matched_bad_audio_hash_path: str | None = None,
+) -> AlbumQualityEvidence | None:
+    """Build the existing-album evidence row for parity scenarios.
+
+    Returns ``None`` when ``min_bitrate`` is ``None`` — the fresh-request
+    shape where no current album exists.
+    """
+    if min_bitrate is None:
+        return None
+
+    container = format.lower().split()[0]
+    files = [AlbumQualityEvidenceFile(
+        relative_path=f"01.{container}",
+        size_bytes=1, mtime_ns=1,
+        extension=container, container=container, codec=container,
+    )]
+    return AlbumQualityEvidence(
+        mb_release_id=mb_release_id,
+        snapshot_fingerprint="sha256:current-fingerprint",
+        source_path="/Beets/current",
+        measurement=AudioQualityMeasurement(
+            min_bitrate_kbps=min_bitrate,
+            avg_bitrate_kbps=avg_bitrate if avg_bitrate is not None else min_bitrate,
+            median_bitrate_kbps=avg_bitrate if avg_bitrate is not None else min_bitrate,
+            format=format,
+            is_cbr=is_cbr,
+            spectral_grade=spectral_grade,
+            spectral_bitrate_kbps=spectral_bitrate,
+        ),
+        measured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        files=files,
+        codec=container,
+        container=container,
+        storage_format=format.lower(),
+        audio_file_count=len(files),
+        filetype_band=format.lower(),
+        v0_metric=v0_metric,
+        matched_bad_audio_hash_id=matched_bad_audio_hash_id,
+        matched_bad_audio_hash_path=matched_bad_audio_hash_path,
     )
 
 

--- a/tests/test_evidence_generated.py
+++ b/tests/test_evidence_generated.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Generated evidence-lifecycle tests — issue #548.
+
+Property-based port of the local fuzzer that found the V0-evidence bug
+fixed in ``6cf26a4`` (require source V0 for converted current evidence):
+a current-evidence row representing a lossless-source transcode must never
+become action-ready without its source V0 metric.
+
+For each generated world the test builds the real on-disk + DB state — a
+staged album folder, a ``FakePipelineDB`` request row (optionally carrying
+the legacy scalar V0 fields), and a stale converted current-evidence row
+with no V0 metric — then runs the production action loader
+(``ensure_current_evidence_for_action``) and asserts:
+
+1. the stale transcode row is never accepted as ``current_status=loaded``;
+2. when the request carries legacy scalar V0 state, it is backfilled into
+   the action evidence (available, with the scalar's avg);
+3. when no backfill source exists, the loader fails closed (not available).
+
+Profiles and promotion policy: tests/_hypothesis_profiles.py and
+docs/generated-testing.md. The exact minimized cases from the original
+RED run are committed in tests/test_import_evidence.py; the ``@example``
+pin below keeps the original failing shape replaying here forever.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from lib.beets_db import AlbumInfo
+from lib.import_evidence import ensure_current_evidence_for_action
+from lib.quality import AudioQualityMeasurement
+from lib.quality_evidence import snapshot_audio_files
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_album_quality_evidence, make_request_row
+
+
+@dataclass(frozen=True)
+class EvidenceLifecycleWorld:
+    """One stale-converted-current-evidence world."""
+    extension: str            # on-disk transcode container: "opus" | "mp3"
+    was_converted_from: str   # lossless source lineage: "flac"|"alac"|"wav"
+    request_has_v0_scalar: bool
+    source_v0_avg: int
+    source_v0_min: int
+    stale_min_bitrate: int
+    stale_avg_bitrate: int
+
+    @property
+    def storage_format(self) -> str:
+        return "Opus" if self.extension == "opus" else "MP3"
+
+
+@st.composite
+def evidence_lifecycle_worlds(draw) -> EvidenceLifecycleWorld:
+    avg = draw(st.integers(min_value=1, max_value=400))
+    stale_min = draw(st.integers(min_value=1, max_value=400))
+    return EvidenceLifecycleWorld(
+        extension=draw(st.sampled_from(("opus", "mp3"))),
+        was_converted_from=draw(st.sampled_from(("flac", "alac", "wav"))),
+        request_has_v0_scalar=draw(st.booleans()),
+        source_v0_avg=avg,
+        source_v0_min=max(avg - draw(st.integers(min_value=0, max_value=50)), 1),
+        stale_min_bitrate=stale_min,
+        stale_avg_bitrate=stale_min + draw(st.integers(min_value=0, max_value=50)),
+    )
+
+
+def assert_lifecycle_outcome(
+    *,
+    request_has_v0_scalar: bool,
+    source_v0_avg: int,
+    current_status: str | None,
+    available: bool,
+    result_v0_avg: int | None,
+) -> None:
+    """The action-loader invariant behind fix 6cf26a4."""
+    if current_status == "loaded":
+        raise AssertionError(
+            "lossless-source transcode current evidence loaded without "
+            "V0 metric")
+    if request_has_v0_scalar:
+        if not available or result_v0_avg != source_v0_avg:
+            raise AssertionError(
+                "legacy request V0 scalar was not backfilled into action "
+                f"evidence (available={available}, "
+                f"v0_avg={result_v0_avg}, expected={source_v0_avg})")
+    elif available:
+        raise AssertionError(
+            "missing essential V0 metric should fail closed when no "
+            "backfill source exists")
+
+
+def _run_world(world: EvidenceLifecycleWorld) -> tuple[str | None, bool, int | None]:
+    """Build the world's on-disk + DB state and run the action loader."""
+    root = tempfile.mkdtemp(prefix="cratedigger-evidence-gen-")
+    try:
+        audio_path = os.path.join(root, f"01 - Track.{world.extension}")
+        with open(audio_path, "wb") as handle:
+            handle.write(b"generated-audio")
+
+        request_id = 1
+        mbid = "evidence-generated-mbid"
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=request_id, mb_release_id=mbid))
+        if world.request_has_v0_scalar:
+            db.update_request_fields(
+                request_id,
+                current_spectral_grade="likely_transcode",
+                current_spectral_bitrate=128,
+                current_lossless_source_v0_probe_min_bitrate=world.source_v0_min,
+                current_lossless_source_v0_probe_avg_bitrate=world.source_v0_avg,
+                current_lossless_source_v0_probe_median_bitrate=world.source_v0_avg,
+            )
+
+        stale_current = make_album_quality_evidence(
+            mb_release_id=mbid,
+            files=snapshot_audio_files(root),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=world.stale_min_bitrate,
+                avg_bitrate_kbps=world.stale_avg_bitrate,
+                median_bitrate_kbps=world.stale_avg_bitrate,
+                format=world.storage_format,
+                is_cbr=False,
+                spectral_grade=None,
+                spectral_bitrate_kbps=None,
+                verified_lossless=False,
+                was_converted_from=world.was_converted_from,
+            ),
+            v0_metric=None,
+            codec=world.extension,
+            container=world.extension,
+            storage_format=world.storage_format,
+        )
+        db.upsert_album_quality_evidence(stale_current)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=mbid,
+            snapshot_fingerprint=stale_current.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_request_current_evidence(request_id, persisted.id)
+
+        result = ensure_current_evidence_for_action(
+            db,
+            request_id=request_id,
+            mb_release_id=mbid,
+            current_album_path=root,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=world.stale_min_bitrate,
+                avg_bitrate_kbps=world.stale_avg_bitrate,
+                median_bitrate_kbps=world.stale_avg_bitrate,
+                is_cbr=False,
+                album_path=root,
+                format=world.storage_format,
+            ),
+        )
+        result_v0_avg = (
+            result.evidence.v0_metric.avg_bitrate_kbps
+            if result.evidence is not None and result.evidence.v0_metric is not None
+            else None
+        )
+        return result.provenance.current_status, result.available, result_v0_avg
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# The exact world shape of the original RED run (seed 548 case 0 of the
+# pre-Hypothesis fuzzer): an opus transcode from flac with the legacy
+# request scalar present. Fix 6cf26a4; exact minimized twins live in
+# tests/test_import_evidence.py.
+_ORIGINAL_RED_WORLD = EvidenceLifecycleWorld(
+    extension="opus",
+    was_converted_from="flac",
+    request_has_v0_scalar=True,
+    source_v0_avg=171,
+    source_v0_min=171,
+    stale_min_bitrate=108,
+    stale_avg_bitrate=114,
+)
+
+
+class TestGeneratedEvidenceLifecycle(unittest.TestCase):
+    """Action-loader invariants over generated stale-current worlds."""
+
+    @given(world=evidence_lifecycle_worlds())
+    @example(world=_ORIGINAL_RED_WORLD)
+    def test_converted_current_requires_source_v0(self, world):
+        current_status, available, result_v0_avg = _run_world(world)
+        assert_lifecycle_outcome(
+            request_has_v0_scalar=world.request_has_v0_scalar,
+            source_v0_avg=world.source_v0_avg,
+            current_status=current_status,
+            available=available,
+            result_v0_avg=result_v0_avg,
+        )
+
+
+class TestLifecycleCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests for the lifecycle invariant checker."""
+
+    def test_trips_on_loaded_without_v0(self):
+        with self.assertRaises(AssertionError):
+            assert_lifecycle_outcome(
+                request_has_v0_scalar=True, source_v0_avg=171,
+                current_status="loaded", available=True, result_v0_avg=171)
+
+    def test_trips_on_missing_backfill(self):
+        with self.assertRaises(AssertionError):
+            assert_lifecycle_outcome(
+                request_has_v0_scalar=True, source_v0_avg=171,
+                current_status="rebuilt", available=False, result_v0_avg=None)
+
+    def test_trips_on_not_failing_closed(self):
+        with self.assertRaises(AssertionError):
+            assert_lifecycle_outcome(
+                request_has_v0_scalar=False, source_v0_avg=171,
+                current_status="rebuilt", available=True, result_v0_avg=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -15,7 +15,11 @@ import unittest
 # Add project root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from lib.quality import (full_pipeline_decision, AlbumQualityV0Metric)
+from lib.quality import full_pipeline_decision
+from tests.helpers import (
+    build_parity_candidate_evidence,
+    build_parity_current_evidence,
+)
 
 class TestLiveBugReproductions(unittest.TestCase):
     """Reproduce bugs found in live pipeline runs.
@@ -353,177 +357,10 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
     See CLAUDE.md § "Quality decisions live in one place" for the rule.
     """
 
-    def _build_candidate(
-        self,
-        *,
-        is_flac: bool,
-        min_bitrate: int,
-        is_cbr: bool,
-        avg_bitrate: int | None = None,
-        spectral_grade: str | None = None,
-        spectral_bitrate: int | None = None,
-        post_conversion_min_bitrate: int | None = None,
-        candidate_v0_probe_avg: int | None = None,
-        candidate_v0_probe_min: int | None = None,
-        native_codec: str = "mp3",
-        native_format: str = "MP3",
-        mb_release_id: str = "mbid-parity-candidate",
-        audio_corrupt: bool = False,
-        folder_layout: str = "flat",
-        audio_file_count: int | None = None,
-        matched_bad_audio_hash_id: int | None = None,
-        matched_bad_audio_hash_path: str | None = None,
-        snapshot_fingerprint: str = "sha256:candidate-fingerprint",
-    ):
-        """Build an ``AlbumQualityEvidence`` candidate row matching the
-        simulator's flat-kwargs shape (post-U2/U3 schema)."""
-        from datetime import datetime, timezone
-        from lib.quality import (
-            AlbumQualityEvidence,
-            AlbumQualityEvidenceFile,
-            AlbumQualityV0Metric,
-            AudioQualityMeasurement,
-            V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
-        )
-
-        # For a FLAC source post-conversion, the candidate measurement
-        # reflects the V0 output the importer compares against.
-        if is_flac and post_conversion_min_bitrate is not None:
-            fmt = "MP3"
-            container = "flac"
-            codec = "flac"
-            storage_format = "flac"
-            measurement = AudioQualityMeasurement(
-                min_bitrate_kbps=post_conversion_min_bitrate,
-                avg_bitrate_kbps=candidate_v0_probe_avg or post_conversion_min_bitrate,
-                median_bitrate_kbps=candidate_v0_probe_avg or post_conversion_min_bitrate,
-                format=fmt,
-                is_cbr=False,
-                spectral_grade=spectral_grade,
-                spectral_bitrate_kbps=spectral_bitrate,
-                was_converted_from="flac",
-            )
-        elif is_flac:
-            container = codec = "flac"
-            storage_format = "flac"
-            measurement = AudioQualityMeasurement(
-                min_bitrate_kbps=min_bitrate or 900,
-                avg_bitrate_kbps=min_bitrate or 900,
-                median_bitrate_kbps=min_bitrate or 900,
-                format="FLAC",
-                is_cbr=False,
-                spectral_grade=spectral_grade,
-                spectral_bitrate_kbps=spectral_bitrate,
-            )
-        else:
-            container = codec = native_codec
-            if native_codec == "mp3":
-                storage_format = "mp3 v0" if not is_cbr else "mp3 320"
-            else:
-                storage_format = native_format.lower()
-            _avg = avg_bitrate if avg_bitrate is not None else min_bitrate
-            measurement = AudioQualityMeasurement(
-                min_bitrate_kbps=min_bitrate,
-                avg_bitrate_kbps=_avg,
-                median_bitrate_kbps=_avg,
-                format=native_format,
-                is_cbr=is_cbr,
-                spectral_grade=spectral_grade,
-                spectral_bitrate_kbps=spectral_bitrate,
-            )
-
-        v0_metric = None
-        if candidate_v0_probe_avg is not None or candidate_v0_probe_min is not None:
-            v0_metric = AlbumQualityV0Metric(
-                min_bitrate_kbps=candidate_v0_probe_min,
-                avg_bitrate_kbps=candidate_v0_probe_avg,
-                median_bitrate_kbps=candidate_v0_probe_avg,
-                source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
-                source_provenance="neutral_album_quality_evidence",
-            )
-
-        files = [AlbumQualityEvidenceFile(
-            relative_path=f"01.{container}",
-            size_bytes=1, mtime_ns=1,
-            extension=container, container=container, codec=codec,
-        )]
-        # ``audio_file_count`` defaults to len(files) for the standard
-        # parity scenarios. Tests covering empty_fileset explicitly pass
-        # ``audio_file_count=0`` and override ``files`` separately.
-        return AlbumQualityEvidence(
-            mb_release_id=mb_release_id,
-            snapshot_fingerprint=snapshot_fingerprint,
-            source_path="/Incoming/auto-import/candidate",
-            measurement=measurement,
-            measured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
-            files=files,
-            codec=codec,
-            container=container,
-            storage_format=storage_format,
-            v0_metric=v0_metric,
-            audio_corrupt=audio_corrupt,
-            folder_layout=folder_layout,
-            audio_file_count=(
-                audio_file_count if audio_file_count is not None else len(files)
-            ),
-            filetype_band=storage_format,
-            matched_bad_audio_hash_id=matched_bad_audio_hash_id,
-            matched_bad_audio_hash_path=matched_bad_audio_hash_path,
-        )
-
-    def _build_current(
-        self,
-        *,
-        min_bitrate: int | None,
-        avg_bitrate: int | None = None,
-        format: str = "MP3",
-        is_cbr: bool = False,
-        spectral_grade: str | None = None,
-        spectral_bitrate: int | None = None,
-        mb_release_id: str = "mbid-parity-candidate",
-        v0_metric: AlbumQualityV0Metric | None = None,
-        matched_bad_audio_hash_id: int | None = None,
-        matched_bad_audio_hash_path: str | None = None,
-    ):
-        if min_bitrate is None:
-            return None
-        from datetime import datetime, timezone
-        from lib.quality import (
-            AlbumQualityEvidence,
-            AlbumQualityEvidenceFile,
-            AudioQualityMeasurement,
-        )
-
-        container = format.lower().split()[0]
-        files = [AlbumQualityEvidenceFile(
-            relative_path=f"01.{container}",
-            size_bytes=1, mtime_ns=1,
-            extension=container, container=container, codec=container,
-        )]
-        return AlbumQualityEvidence(
-            mb_release_id=mb_release_id,
-            snapshot_fingerprint="sha256:current-fingerprint",
-            source_path="/Beets/current",
-            measurement=AudioQualityMeasurement(
-                min_bitrate_kbps=min_bitrate,
-                avg_bitrate_kbps=avg_bitrate if avg_bitrate is not None else min_bitrate,
-                median_bitrate_kbps=avg_bitrate if avg_bitrate is not None else min_bitrate,
-                format=format,
-                is_cbr=is_cbr,
-                spectral_grade=spectral_grade,
-                spectral_bitrate_kbps=spectral_bitrate,
-            ),
-            measured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
-            files=files,
-            codec=container,
-            container=container,
-            storage_format=format.lower(),
-            audio_file_count=len(files),
-            filetype_band=format.lower(),
-            v0_metric=v0_metric,
-            matched_bad_audio_hash_id=matched_bad_audio_hash_id,
-            matched_bad_audio_hash_path=matched_bad_audio_hash_path,
-        )
+    # Canonical simulator-world -> evidence-row mapping, shared with the
+    # generated parity property in tests/test_quality_generated.py.
+    _build_candidate = staticmethod(build_parity_candidate_evidence)
+    _build_current = staticmethod(build_parity_current_evidence)
 
     def test_mountain_goats_flux_provisional_lossless_via_evidence(self):
         """Request 4514 shape, but routed through the production decider."""
@@ -834,12 +671,8 @@ class TestPreimportFactRejects(unittest.TestCase):
 
     # Reuse the parity helpers so the new tests share the exact shape used
     # by the rest of TestLiveBugReproductionsThroughEvidencePipeline.
-    _build_candidate = (
-        TestLiveBugReproductionsThroughEvidencePipeline._build_candidate
-    )
-    _build_current = (
-        TestLiveBugReproductionsThroughEvidencePipeline._build_current
-    )
+    _build_candidate = staticmethod(build_parity_candidate_evidence)
+    _build_current = staticmethod(build_parity_current_evidence)
 
     def test_audio_corrupt_routes_through_full_pipeline(self):
         from lib.quality import (

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -1,0 +1,772 @@
+#!/usr/bin/env python3
+"""Generated (property-based) quality-decision tests — issue #548.
+
+Hypothesis-driven properties over the quality decision twins:
+
+* ``full_pipeline_decision`` — the flat-kwargs simulator twin, driven
+  through ``simulate()`` (the canonical scenario language of the album
+  test set).
+* ``full_pipeline_decision_from_evidence`` — the production decider,
+  driven through the shared parity builders in ``tests/helpers.py``.
+
+Two tiers, selected by ``CRATEDIGGER_HYPOTHESIS_PROFILE`` (see
+``tests/_hypothesis_profiles.py``):
+
+* ``suite`` (default) — deterministic, bounded; runs on every
+  ``scripts/run_tests.sh`` like any other test.
+* ``fuzz`` — randomized burst for local exploration when quality policy
+  changes::
+
+      nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \\
+          python3 -m unittest tests.test_quality_generated -v"
+
+Promotion policy: when the fuzz tier finds a real failure, Hypothesis
+shrinks it to a minimal world — commit that world as a named
+``@example(...)`` pin here, or as a full scenario in the album test set
+(``tests/test_quality_classification.py``). No JSON corpus.
+Full usage guide: docs/generated-testing.md.
+"""
+
+import os
+import sys
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+
+import msgspec
+from hypothesis import example, given, settings
+from hypothesis import strategies as st
+
+from lib.quality import (
+    AlbumQualityEvidence,
+    AlbumQualityEvidenceDecisionFacts,
+    AlbumQualityEvidenceFile,
+    AlbumQualityV0Metric,
+    AudioQualityMeasurement,
+    QUALITY_UPGRADE_TIERS,
+    V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+    V0_SOURCE_LINEAGE_NATIVE_LOSSY_RESEARCH,
+    VerifiedLosslessProof,
+    full_pipeline_decision_from_evidence,
+)
+from lib.quality.filetypes import has_mixed_lossless_and_lossy
+from tests.helpers import (
+    build_parity_candidate_evidence,
+    build_parity_current_evidence,
+)
+from tests.test_simulator_scenarios import (
+    AlbumState,
+    DownloadScenario,
+    SimResult,
+    simulate,
+)
+
+_GRADES = (None, "genuine", "marginal", "suspect", "likely_transcode")
+_TARGET_FORMATS = (None, "flac", "lossless", "mp3 v0", "opus 128")
+_VL_TARGETS = (None, "opus 128", "mp3 v0")
+_LOSSY_FORMATS = ("MP3", "Opus", "AAC")
+_CURRENT_FORMATS = ("MP3", "Opus", "FLAC")
+
+
+def _bitrates(min_value: int = 1, max_value: int = 3000) -> st.SearchStrategy[int]:
+    return st.integers(min_value=min_value, max_value=max_value)
+
+
+def _optional_bitrates(max_value: int = 3000) -> st.SearchStrategy[int | None]:
+    return st.one_of(st.none(), _bitrates(max_value=max_value))
+
+
+# ===========================================================================
+# Invariant checkers — module functions so the known-bad self-tests below
+# can prove each one trips on a violating decision (harness RED/GREEN).
+# ===========================================================================
+
+_VALID_FINAL_STATUSES = ("imported", "wanted")
+
+
+def assert_decision_is_definitive(result: SimResult) -> None:
+    """Totality: every auto-mode decision is a well-formed, definitive one."""
+    if not isinstance(result.imported, bool):
+        raise AssertionError(f"imported is not bool: {result.imported!r}")
+    if not isinstance(result.keep_searching, bool):
+        raise AssertionError(
+            f"keep_searching is not bool: {result.keep_searching!r}")
+    if not isinstance(result.denylisted, bool):
+        raise AssertionError(f"denylisted is not bool: {result.denylisted!r}")
+    if result.final_status not in _VALID_FINAL_STATUSES:
+        raise AssertionError(
+            f"auto-mode decision must end imported/wanted, got "
+            f"final_status={result.final_status!r}")
+
+
+def assert_lossy_not_imported_over_verified_lossless(result: SimResult) -> None:
+    """A raw verified-lossless FLAC on disk is terminal quality — no lossy
+    candidate may replace it."""
+    if result.imported:
+        raise AssertionError(
+            "lossy candidate imported over raw verified-lossless FLAC: "
+            f"{result!r}")
+
+
+def assert_obvious_downgrade_not_accepted(result: SimResult) -> None:
+    """A transparent existing lossy album must not accept an obviously
+    lower-rank lossy candidate."""
+    if result.imported or result.stage3_quality_gate == "accept":
+        raise AssertionError(
+            f"obvious lower-rank lossy candidate accepted: {result!r}")
+
+
+_PARITY_FIELDS = (
+    "imported",
+    "keep_searching",
+    "denylisted",
+    "final_status",
+    "stage0_spectral_gate",
+    "stage1_spectral",
+    "stage2_import",
+    "stage3_quality_gate",
+)
+
+
+def assert_twins_agree(sim: SimResult, evidence_result: dict) -> None:
+    """The parity contract: same world → same outcome from both twins."""
+    diffs = []
+    for field in _PARITY_FIELDS:
+        sim_value = getattr(sim, field)
+        ev_value = evidence_result.get(field)
+        if sim_value != ev_value:
+            diffs.append(f"{field}: simulator={sim_value!r} evidence={ev_value!r}")
+    if diffs:
+        raise AssertionError(
+            "decision twins diverged on the same world:\n  " + "\n  ".join(diffs))
+
+
+# ===========================================================================
+# Wild simulator-space strategies (totality + policy invariants)
+#
+# Deliberately NO plausibility filters beyond what the types require: the
+# V0-evidence bug (fix 6cf26a4) lived in a state a "plausible worlds only"
+# generator would have skipped. Anything the schema can express is fair.
+# ===========================================================================
+
+@st.composite
+def album_states(draw) -> AlbumState:
+    return AlbumState(
+        name="generated_album",
+        min_bitrate=draw(_optional_bitrates(max_value=4000)),
+        is_cbr=draw(st.booleans()),
+        spectral_grade=draw(st.sampled_from(_GRADES)),
+        spectral_bitrate=draw(_optional_bitrates(max_value=4000)),
+        verified_lossless=draw(st.booleans()),
+        search_filetype_override=draw(
+            st.sampled_from((None, "lossless", QUALITY_UPGRADE_TIERS))),
+        target_format=draw(st.sampled_from(_TARGET_FORMATS)),
+        existing_format=draw(
+            st.sampled_from((None, "MP3", "Opus", "aac", "FLAC"))),
+        avg_bitrate=draw(_optional_bitrates(max_value=4000)),
+        existing_v0_probe_avg=draw(_optional_bitrates(max_value=4000)),
+    )
+
+
+@st.composite
+def download_scenarios(draw) -> DownloadScenario:
+    is_flac = draw(st.booleans())
+    converted_count = draw(st.integers(min_value=0, max_value=30)) if is_flac else 0
+    return DownloadScenario(
+        name="generated_download",
+        is_flac=is_flac,
+        min_bitrate=draw(_bitrates(max_value=4000)),
+        is_cbr=draw(st.booleans()),
+        spectral_grade=draw(st.sampled_from(_GRADES)),
+        spectral_bitrate=draw(_optional_bitrates(max_value=4000)),
+        converted_count=converted_count,
+        post_conversion_min_bitrate=(
+            draw(_optional_bitrates(max_value=400)) if is_flac else None),
+        new_format=(None if is_flac else draw(st.sampled_from(("MP3", "opus", "aac")))),
+        is_vbr=draw(st.sampled_from((None, True, False))),
+        avg_bitrate=draw(_optional_bitrates(max_value=4000)),
+        candidate_v0_probe_avg=draw(_optional_bitrates(max_value=400)),
+        candidate_v0_probe_min=draw(_optional_bitrates(max_value=400)),
+    )
+
+
+@st.composite
+def raw_verified_lossless_albums(draw) -> AlbumState:
+    """Existing album: raw verified-lossless FLAC on disk.
+
+    Grades are limited to the clean verified shapes — contradictory states
+    (verified_lossless=True + likely_transcode) are covered by the totality
+    property, not this policy assertion.
+    """
+    return AlbumState(
+        name="generated_raw_flac",
+        min_bitrate=draw(_bitrates(min_value=500, max_value=4000)),
+        is_cbr=False,
+        spectral_grade=draw(st.sampled_from((None, "genuine"))),
+        spectral_bitrate=None,
+        verified_lossless=True,
+        search_filetype_override=None,
+        existing_format="FLAC",
+        avg_bitrate=None,
+    )
+
+
+@st.composite
+def lossy_downloads(draw) -> DownloadScenario:
+    return DownloadScenario(
+        name="generated_lossy",
+        is_flac=False,
+        min_bitrate=draw(_bitrates(max_value=2000)),
+        is_cbr=draw(st.booleans()),
+        spectral_grade=draw(st.sampled_from(_GRADES)),
+        spectral_bitrate=draw(_optional_bitrates(max_value=400)),
+        new_format=draw(st.sampled_from(("MP3", "opus", "aac"))),
+        is_vbr=draw(st.sampled_from((None, True, False))),
+        avg_bitrate=draw(_optional_bitrates(max_value=2000)),
+    )
+
+
+@st.composite
+def obvious_lower_rank_lossy_downloads(draw) -> DownloadScenario:
+    bitrate = draw(_bitrates(max_value=190))
+    is_cbr = draw(st.booleans())
+    return DownloadScenario(
+        name="generated_lower_rank_lossy",
+        is_flac=False,
+        min_bitrate=bitrate,
+        is_cbr=is_cbr,
+        spectral_grade=draw(st.sampled_from(_GRADES)),
+        spectral_bitrate=draw(_optional_bitrates(max_value=190)),
+        new_format=draw(st.sampled_from(("MP3", "opus", "aac"))),
+        is_vbr=not is_cbr,
+        avg_bitrate=bitrate,
+    )
+
+
+_TRANSPARENT_EXISTING_SHAPES = (
+    # (min_bitrate, avg_bitrate, is_cbr) — MP3 320 CBR and MP3 V0.
+    (320, 320, True),
+    (245, 245, False),
+)
+
+
+@st.composite
+def transparent_mp3_albums(draw) -> AlbumState:
+    min_br, avg_br, is_cbr = draw(st.sampled_from(_TRANSPARENT_EXISTING_SHAPES))
+    return AlbumState(
+        name="generated_transparent_mp3",
+        min_bitrate=min_br,
+        is_cbr=is_cbr,
+        spectral_grade="genuine",
+        spectral_bitrate=None,
+        verified_lossless=False,
+        search_filetype_override=None,
+        existing_format="MP3",
+        avg_bitrate=avg_br,
+    )
+
+
+class TestGeneratedSimulatorInvariants(unittest.TestCase):
+    """Policy invariants over generated simulator worlds."""
+
+    @given(album=album_states(), download=download_scenarios())
+    def test_generated_decisions_are_definitive(self, album, download):
+        result = simulate(album, download)
+        assert_decision_is_definitive(result)
+
+    @given(album=raw_verified_lossless_albums(), download=lossy_downloads())
+    def test_raw_verified_lossless_never_imports_lossy_candidate(
+            self, album, download):
+        result = simulate(album, download)
+        assert_lossy_not_imported_over_verified_lossless(result)
+
+    @given(album=transparent_mp3_albums(),
+           download=obvious_lower_rank_lossy_downloads())
+    def test_transparent_existing_never_accepts_obvious_downgrade(
+            self, album, download):
+        result = simulate(album, download)
+        assert_obvious_downgrade_not_accepted(result)
+
+
+# ===========================================================================
+# Parity property — the twins must agree on every world both can express.
+#
+# The world space here is the twins' COMMON language, i.e. exactly what the
+# shared parity builders (tests/helpers.py) can encode:
+#   * candidate V0 probes only on FLAC candidates (a lossy candidate with a
+#     lossless-source V0 metric is not expressible in the flat kwargs);
+#   * ``is_vbr`` is always derived as ``not is_cbr`` (the evidence decider
+#     never receives an explicit is_vbr);
+#   * raw FLAC worlds have target flac/lossless, converted FLAC worlds have
+#     a lossy/None target (a "converted" candidate with a keep-FLAC target
+#     is a contradictory world description);
+#   * conversion facts are passed explicitly on both sides.
+# Divergence inside this space is a real parity-contract violation.
+# ===========================================================================
+
+@dataclass(frozen=True)
+class ParityWorld:
+    """One album-vs-candidate world expressed in the twins' common language."""
+    # Current (existing) album; current_min=None means no current album.
+    current_min: int | None
+    current_avg: int | None
+    current_format: str
+    current_is_cbr: bool
+    current_grade: str | None
+    current_spectral_bitrate: int | None
+    current_v0_avg: int | None
+    # Candidate download.
+    candidate_kind: str  # "lossy" | "flac_raw" | "flac_converted"
+    min_bitrate: int
+    is_cbr: bool
+    avg_bitrate: int | None
+    grade: str | None
+    spectral_bitrate: int | None
+    candidate_format: str
+    converted_count: int
+    post_conversion_min_bitrate: int | None
+    v0_avg: int | None
+    v0_min: int | None
+    # Action facts.
+    target_format: str | None
+    verified_lossless_target: str | None
+
+
+@st.composite
+def parity_worlds(draw) -> ParityWorld:
+    has_current = draw(st.booleans())
+    if has_current:
+        current_min = draw(_bitrates())
+        current_avg = draw(_bitrates())
+        current_format = draw(st.sampled_from(_CURRENT_FORMATS))
+        current_is_cbr = draw(st.booleans())
+        current_grade = draw(st.sampled_from(_GRADES))
+        current_spectral_bitrate = draw(_optional_bitrates(max_value=400))
+        current_v0_avg = draw(_optional_bitrates(max_value=400))
+    else:
+        current_min = current_avg = None
+        current_format = "MP3"
+        current_is_cbr = False
+        current_grade = None
+        current_spectral_bitrate = None
+        current_v0_avg = None
+
+    # candidate_format only matters for lossy worlds; FLAC kinds carry the
+    # placeholder "FLAC" (the evidence builder ignores native_codec/format
+    # when is_flac=True).
+    kind = draw(st.sampled_from(("lossy", "flac_raw", "flac_converted")))
+    grade = draw(st.sampled_from(_GRADES))
+    spectral_bitrate = draw(_optional_bitrates(max_value=400))
+    if kind == "lossy":
+        min_bitrate = draw(_bitrates(max_value=2000))
+        is_cbr = draw(st.booleans())
+        avg_bitrate = draw(_bitrates(max_value=2000))
+        candidate_format = draw(st.sampled_from(_LOSSY_FORMATS))
+        converted_count = 0
+        post_conversion = None
+        v0_avg = v0_min = None
+        target_format = draw(st.sampled_from(_TARGET_FORMATS))
+    elif kind == "flac_raw":
+        min_bitrate = draw(_bitrates(max_value=3000))
+        is_cbr = False
+        avg_bitrate = None
+        candidate_format = "FLAC"
+        converted_count = 0
+        post_conversion = None
+        v0_avg = draw(_optional_bitrates(max_value=400))
+        v0_min = draw(_optional_bitrates(max_value=400))
+        target_format = draw(st.sampled_from(("flac", "lossless")))
+    else:  # flac_converted
+        min_bitrate = draw(_bitrates(max_value=3000))
+        is_cbr = False
+        avg_bitrate = None
+        candidate_format = "FLAC"
+        converted_count = draw(st.integers(min_value=1, max_value=30))
+        post_conversion = draw(_bitrates(max_value=400))
+        v0_avg = draw(_optional_bitrates(max_value=400))
+        v0_min = draw(_optional_bitrates(max_value=400))
+        target_format = draw(st.sampled_from((None, "mp3 v0", "opus 128")))
+
+    return ParityWorld(
+        current_min=current_min,
+        current_avg=current_avg,
+        current_format=current_format,
+        current_is_cbr=current_is_cbr,
+        current_grade=current_grade,
+        current_spectral_bitrate=current_spectral_bitrate,
+        current_v0_avg=current_v0_avg,
+        candidate_kind=kind,
+        min_bitrate=min_bitrate,
+        is_cbr=is_cbr,
+        avg_bitrate=avg_bitrate,
+        grade=grade,
+        spectral_bitrate=spectral_bitrate,
+        candidate_format=candidate_format,
+        converted_count=converted_count,
+        post_conversion_min_bitrate=post_conversion,
+        v0_avg=v0_avg,
+        v0_min=v0_min,
+        target_format=target_format,
+        verified_lossless_target=draw(st.sampled_from(_VL_TARGETS)),
+    )
+
+
+_NATIVE_CODECS = {"MP3": "mp3", "Opus": "opus", "AAC": "aac", "FLAC": "flac"}
+
+
+def _parity_simulator_result(world: ParityWorld) -> SimResult:
+    is_flac = world.candidate_kind != "lossy"
+    album = AlbumState(
+        name="parity_current",
+        min_bitrate=world.current_min,
+        is_cbr=world.current_is_cbr,
+        spectral_grade=world.current_grade,
+        spectral_bitrate=world.current_spectral_bitrate,
+        verified_lossless=False,
+        search_filetype_override=None,
+        target_format=world.target_format,
+        existing_format=(
+            world.current_format if world.current_min is not None else None),
+        avg_bitrate=world.current_avg,
+        existing_v0_probe_avg=world.current_v0_avg,
+    )
+    download = DownloadScenario(
+        name="parity_candidate",
+        is_flac=is_flac,
+        min_bitrate=world.min_bitrate,
+        is_cbr=world.is_cbr,
+        spectral_grade=world.grade,
+        spectral_bitrate=world.spectral_bitrate,
+        converted_count=world.converted_count,
+        post_conversion_min_bitrate=world.post_conversion_min_bitrate,
+        new_format=(None if is_flac else world.candidate_format),
+        is_vbr=None,  # both twins derive is_vbr = not is_cbr
+        avg_bitrate=(None if is_flac else world.avg_bitrate),
+        candidate_v0_probe_avg=world.v0_avg,
+        candidate_v0_probe_min=world.v0_min,
+    )
+    return simulate(
+        album, download,
+        verified_lossless_target=world.verified_lossless_target,
+    )
+
+
+def _parity_evidence_result(world: ParityWorld) -> dict:
+    # flac_converted note: the simulator side carries the raw FLAC
+    # min_bitrate while the evidence measurement carries post_conversion —
+    # inert today because the FLAC-convert branch of full_pipeline_decision
+    # only consults post_conversion. If that branch ever starts reading the
+    # raw min, this mapping (not the twins) is what diverged.
+    candidate = build_parity_candidate_evidence(
+        is_flac=world.candidate_kind != "lossy",
+        min_bitrate=world.min_bitrate,
+        is_cbr=world.is_cbr,
+        avg_bitrate=world.avg_bitrate,
+        spectral_grade=world.grade,
+        spectral_bitrate=world.spectral_bitrate,
+        post_conversion_min_bitrate=world.post_conversion_min_bitrate,
+        candidate_v0_probe_avg=world.v0_avg,
+        candidate_v0_probe_min=world.v0_min,
+        native_codec=_NATIVE_CODECS[world.candidate_format],
+        native_format=world.candidate_format,
+    )
+    v0_metric = None
+    if world.current_v0_avg is not None:
+        v0_metric = AlbumQualityV0Metric(
+            min_bitrate_kbps=None,
+            avg_bitrate_kbps=world.current_v0_avg,
+            median_bitrate_kbps=world.current_v0_avg,
+            source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+            source_provenance="neutral_album_quality_evidence",
+        )
+    current = build_parity_current_evidence(
+        min_bitrate=world.current_min,
+        avg_bitrate=world.current_avg,
+        format=world.current_format,
+        is_cbr=world.current_is_cbr,
+        spectral_grade=world.current_grade,
+        spectral_bitrate=world.current_spectral_bitrate,
+        v0_metric=v0_metric,
+    )
+    facts = AlbumQualityEvidenceDecisionFacts(
+        import_mode="auto",
+        verified_lossless_target=world.verified_lossless_target,
+        target_format=world.target_format,
+        converted_count=world.converted_count,
+        post_conversion_min_bitrate=world.post_conversion_min_bitrate,
+    )
+    return full_pipeline_decision_from_evidence(candidate, current, facts=facts)
+
+
+# Promoted pins — live-bug shapes from the album test set, kept here so the
+# parity property always replays them first (the @example form of the
+# "failure becomes permanent regression" policy).
+_MOUNTAIN_GOATS_FLUX_WORLD = ParityWorld(
+    current_min=320, current_avg=320, current_format="MP3",
+    current_is_cbr=True, current_grade=None, current_spectral_bitrate=None,
+    current_v0_avg=None,
+    candidate_kind="flac_converted", min_bitrate=900, is_cbr=False,
+    avg_bitrate=None, grade="suspect", spectral_bitrate=160,
+    candidate_format="FLAC", converted_count=13,
+    post_conversion_min_bitrate=198, v0_avg=211, v0_min=198,
+    target_format=None, verified_lossless_target=None,
+)
+_HERETIC_PRIDE_WORLD = ParityWorld(
+    current_min=192, current_avg=192, current_format="MP3",
+    current_is_cbr=False, current_grade="genuine",
+    current_spectral_bitrate=None, current_v0_avg=None,
+    candidate_kind="lossy", min_bitrate=192, is_cbr=False, avg_bitrate=192,
+    grade="genuine", spectral_bitrate=None, candidate_format="MP3",
+    converted_count=0, post_conversion_min_bitrate=None, v0_avg=None,
+    v0_min=None, target_format=None, verified_lossless_target=None,
+)
+
+
+class TestGeneratedParity(unittest.TestCase):
+    """Machine-checks 'quality decisions live in ONE place' over the whole
+    generated common-language space, not just the hand-picked album set."""
+
+    @given(world=parity_worlds())
+    @example(world=_MOUNTAIN_GOATS_FLUX_WORLD)
+    @example(world=_HERETIC_PRIDE_WORLD)
+    def test_decision_twins_agree(self, world):
+        sim = _parity_simulator_result(world)
+        evidence_result = _parity_evidence_result(world)
+        assert_twins_agree(sim, evidence_result)
+
+
+# ===========================================================================
+# Evidence-side properties — reach the branches the simulator language
+# cannot express: the folder/audio-integrity early exits and the
+# fail-closed handling of incomplete evidence rows.
+# ===========================================================================
+
+_EVIDENCE_EXTS = ("mp3", "flac", "opus", "aac", "wav", "alac", "m4a")
+
+
+@st.composite
+def wild_ready_candidate_evidence(draw) -> AlbumQualityEvidence:
+    exts = draw(st.lists(st.sampled_from(_EVIDENCE_EXTS), min_size=1, max_size=4))
+    files = [
+        AlbumQualityEvidenceFile(
+            relative_path=f"{i:02d}.{ext}",
+            size_bytes=1, mtime_ns=1,
+            extension=ext, container=ext, codec=ext,
+        )
+        for i, ext in enumerate(exts)
+    ]
+    v0_metric = None
+    if draw(st.booleans()):
+        # Readiness floor: a stored V0 metric carries at least one bitrate.
+        v0_metric = AlbumQualityV0Metric(
+            min_bitrate_kbps=draw(_optional_bitrates(max_value=400)),
+            avg_bitrate_kbps=draw(_bitrates(max_value=400)),
+            median_bitrate_kbps=None,
+            source_lineage=draw(st.sampled_from((
+                V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+                V0_SOURCE_LINEAGE_NATIVE_LOSSY_RESEARCH,
+            ))),
+            source_provenance="generated",
+        )
+    # verified_lossless=True is only a ready (storable-for-action) state
+    # when a proof provenance rides along — pair them, as production does.
+    verified_lossless = draw(st.booleans())
+    proof = (
+        VerifiedLosslessProof(
+            proof_origin="generated", source="generated",
+            classifier="generated")
+        if verified_lossless else None
+    )
+    measurement = AudioQualityMeasurement(
+        min_bitrate_kbps=draw(_bitrates(max_value=4000)),
+        avg_bitrate_kbps=draw(_optional_bitrates(max_value=4000)),
+        median_bitrate_kbps=draw(_optional_bitrates(max_value=4000)),
+        format=draw(st.sampled_from(("MP3", "FLAC", "Opus", "AAC", "mp3 v0"))),
+        is_cbr=draw(st.booleans()),
+        spectral_grade=draw(st.sampled_from(_GRADES)),
+        spectral_bitrate_kbps=draw(_optional_bitrates(max_value=400)),
+        verified_lossless=verified_lossless,
+        was_converted_from=draw(st.sampled_from((None, "flac", "alac", "wav"))),
+    )
+    has_bad_hash = draw(st.booleans())
+    return AlbumQualityEvidence(
+        mb_release_id="generated-evidence",
+        snapshot_fingerprint="sha256:generated-fingerprint",
+        source_path="/Incoming/auto-import/generated",
+        measurement=measurement,
+        measured_at=datetime(2026, 7, 8, tzinfo=timezone.utc),
+        files=files,
+        codec=draw(st.sampled_from(_EVIDENCE_EXTS)),
+        container=draw(st.sampled_from(_EVIDENCE_EXTS)),
+        storage_format=draw(st.sampled_from(
+            ("mp3 320", "mp3 v0", "flac", "opus", "aac", "lossless"))),
+        v0_metric=v0_metric,
+        verified_lossless_proof=proof,
+        audio_corrupt=draw(st.booleans()),
+        folder_layout=draw(st.sampled_from(("flat", "nested"))),
+        audio_file_count=draw(st.sampled_from((0, len(files)))),
+        filetype_band="generated",
+        matched_bad_audio_hash_id=(1 if has_bad_hash else None),
+        matched_bad_audio_hash_path=("01.mp3" if has_bad_hash else None),
+    )
+
+
+def _expected_early_exit_key(candidate: AlbumQualityEvidence) -> str | None:
+    """Documented priority order of the integrity early exits."""
+    if candidate.audio_corrupt:
+        return "preimport_audio"
+    if candidate.matched_bad_audio_hash_id is not None:
+        return "preimport_bad_hash"
+    if candidate.folder_layout == "nested":
+        return "preimport_nested"
+    # files are always non-empty in this strategy, so empty_fileset (which
+    # requires count=0 AND no snapshot files) is unreachable here; it is
+    # pinned by TestPreimportFactRejects in test_quality_classification.py.
+    if has_mixed_lossless_and_lossy(candidate.files):
+        return "preimport_mixed_source"
+    return None
+
+
+_EARLY_EXIT_REJECT_VALUES = {
+    "preimport_audio": "reject_corrupt",
+    "preimport_bad_hash": "reject_bad_hash",
+    "preimport_nested": "reject_nested",
+    "preimport_empty_fileset": "reject_empty",
+    "preimport_mixed_source": "reject_mixed_source",
+}
+
+
+class TestGeneratedEvidenceDecider(unittest.TestCase):
+    """Properties of the production decider the simulator can't reach."""
+
+    @given(candidate=wild_ready_candidate_evidence(),
+           import_mode=st.sampled_from(("auto", "force")))
+    def test_integrity_facts_always_reject_in_priority_order(
+            self, candidate, import_mode):
+        facts = AlbumQualityEvidenceDecisionFacts(import_mode=import_mode)
+        result = full_pipeline_decision_from_evidence(
+            candidate, None, facts=facts)
+
+        self.assertIsInstance(result["imported"], bool)
+        expected_key = _expected_early_exit_key(candidate)
+        if expected_key is None:
+            for key, reject_value in _EARLY_EXIT_REJECT_VALUES.items():
+                self.assertNotEqual(
+                    result[key], reject_value,
+                    f"clean candidate tripped integrity reject {key}")
+            return
+
+        self.assertFalse(
+            result["imported"],
+            f"integrity fact {expected_key} must never import")
+        self.assertEqual(
+            result[expected_key], _EARLY_EXIT_REJECT_VALUES[expected_key])
+        for key, reject_value in _EARLY_EXIT_REJECT_VALUES.items():
+            if key != expected_key:
+                self.assertNotEqual(
+                    result[key], reject_value,
+                    f"{key} fired alongside higher-priority {expected_key}")
+        if import_mode == "auto":
+            self.assertEqual(result["final_status"], "wanted")
+            self.assertTrue(result["keep_searching"])
+        else:
+            self.assertIsNone(result["final_status"])
+            self.assertFalse(result["keep_searching"])
+
+    def test_incomplete_evidence_fails_closed(self):
+        """Evidence rows below the policy floor must raise, not decide."""
+        ready = build_parity_candidate_evidence(
+            is_flac=False, min_bitrate=245, is_cbr=False)
+        no_format = msgspec.structs.replace(
+            ready,
+            measurement=msgspec.structs.replace(ready.measurement, format=None),
+        )
+        with self.assertRaises(ValueError):
+            full_pipeline_decision_from_evidence(no_format, None)
+
+        no_bitrates = msgspec.structs.replace(
+            ready,
+            measurement=msgspec.structs.replace(
+                ready.measurement,
+                min_bitrate_kbps=None,
+                avg_bitrate_kbps=None,
+                median_bitrate_kbps=None,
+            ),
+        )
+        with self.assertRaises(ValueError):
+            full_pipeline_decision_from_evidence(no_bitrates, None)
+
+
+# ===========================================================================
+# Harness self-tests (RED/GREEN of the fuzzer itself) — each invariant
+# checker must trip on a planted violating decision, and a planted-bad
+# decider must be caught end-to-end through the Hypothesis machinery.
+# ===========================================================================
+
+def _planted_bad_import() -> SimResult:
+    return SimResult(
+        imported=True,
+        keep_searching=False,
+        denylisted=False,
+        final_status="imported",
+        stage0_spectral_gate="would_run",
+        stage1_spectral=None,
+        stage2_import="import",
+        stage3_quality_gate="accept",
+        backfill_override=None,
+        search_filetype_override_after=None,
+    )
+
+
+class TestInvariantCheckersTripOnViolations(unittest.TestCase):
+    """Known-bad self-tests: prove the harness detects what it claims to."""
+
+    def test_definitive_checker_trips_on_bogus_status(self):
+        bad = SimResult(
+            imported=False, keep_searching=False, denylisted=False,
+            final_status=None, stage0_spectral_gate=None,
+            stage1_spectral=None, stage2_import=None,
+            stage3_quality_gate=None, backfill_override=None,
+            search_filetype_override_after=None)
+        with self.assertRaises(AssertionError):
+            assert_decision_is_definitive(bad)
+
+    def test_verified_lossless_checker_trips_on_import(self):
+        with self.assertRaises(AssertionError):
+            assert_lossy_not_imported_over_verified_lossless(
+                _planted_bad_import())
+
+    def test_downgrade_checker_trips_on_accept(self):
+        with self.assertRaises(AssertionError):
+            assert_obvious_downgrade_not_accepted(_planted_bad_import())
+
+    def test_parity_checker_trips_on_divergence(self):
+        sim = _planted_bad_import()
+        evidence_result = {field: getattr(sim, field) for field in _PARITY_FIELDS}
+        evidence_result["stage2_import"] = "downgrade"
+        evidence_result["imported"] = False
+        with self.assertRaises(AssertionError):
+            assert_twins_agree(sim, evidence_result)
+
+    def test_hypothesis_harness_detects_planted_bad_decider(self):
+        """End-to-end RED proof: strategies + checker + Hypothesis catch a
+        decider that always imports."""
+
+        @given(album=raw_verified_lossless_albums(),
+               download=lossy_downloads())
+        @settings(max_examples=5, derandomize=True, database=None)
+        def prop(album, download):
+            del album, download  # the planted decider ignores its world
+            assert_lossy_not_imported_over_verified_lossless(
+                _planted_bad_import())
+
+        with self.assertRaises(AssertionError):
+            prop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Issue #548 v1 — generated (property-based) testing for the quality decision layer, rebuilt on Hypothesis after the critique in https://github.com/abl030/cratedigger/issues/548#issuecomment-4911346723 (the uncommitted MVP fuzz-loop scripts are discarded; this replaces them).

### What's here

- **`hypothesis` in the dev shell** (`nix/shell.nix`, dev-only dep alongside vulture).
- **Two tiers, one knob** (`tests/_hypothesis_profiles.py`): `suite` (default — derandomized, no example DB, 150 examples; deterministic on every machine, runs in every `run_tests.sh`) and `fuzz` (`CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz` — 20k examples, fresh entropy per run, local `.hypothesis/` failure database, `print_blob`). No seed cursors, no completed-seed logs, no bespoke worker loop.
- **`tests/test_quality_generated.py`**:
  - Wild-space simulator invariants: every auto decision is definitive; raw verified-lossless FLAC is never replaced by a lossy candidate; transparent lossy albums never accept obvious downgrades. Strategies generate anything the schema expresses — no plausibility filters.
  - **Parity property**: for every world in the twins' common language, `full_pipeline_decision` (via `simulate()`) and `full_pipeline_decision_from_evidence` must agree. This machine-checks "quality decisions live in ONE place" across the generated space instead of ~a dozen hand-picked albums. Live-bug shapes (Mountain Goats Flux, Heretic Pride) are pinned as `@example`s.
  - Evidence-side properties the simulator can't reach: the integrity facts (corrupt / bad-hash / nested / mixed) always reject in documented priority order under both auto and force modes; incomplete evidence rows fail closed with `ValueError`.
  - **Known-bad self-tests**: every invariant checker is proven to trip on a planted violating decision, plus an end-to-end RED proof through the Hypothesis machinery.
- **`tests/test_evidence_generated.py`**: Hypothesis port of the evidence-lifecycle fuzzer that found the V0-evidence bug (fix `6cf26a4`) — converted current evidence is never action-`loaded` without a source V0 metric, legacy scalar state backfills, otherwise fail closed. The original RED world is pinned as an `@example`.
- **Shared parity builders**: `_build_candidate`/`_build_current` moved from `tests/test_quality_classification.py` into `tests/helpers.py` (`build_parity_candidate_evidence` / `build_parity_current_evidence`), verbatim. The hand-written parity tests and the generated parity property now share one world→evidence encoding, so a twin divergence can't hide behind two mappings.
- **Promotion policy** (docs/generated-testing.md + CLAUDE.md pointer): fuzz-tier failures are shrunk by Hypothesis and committed as named `@example` pins or album-test-set scenarios. No JSON corpus, no seed artifacts.

### Verification

- Full-repo pyright: 0 errors.
- Suite profile: all new modules green; full `run_tests.sh` green.
- Fuzz burst (`CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz`, 20k examples/property): green on both modules — including ~20k parity worlds running both deciders with zero divergence, and wild-space totality with no crashes.

Closes nothing yet — #548 stays open for the follow-up targets (search-plan determinism properties, lifecycle state machines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
