### PR TITLE
test(generated): slskd event-stream properties + fuzz-on-push hook (#548)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -10,7 +10,7 @@
 - Always verify deployed code: `ssh doc2 'grep "<unique string>" /nix/store/*/lib/quality/pipeline.py 2>/dev/null'`. For module changes: `ssh doc2 'cat /etc/systemd/system/cratedigger.service'` or check the rendered `/var/lib/cratedigger/config.ini`.
 - Before deploying changes to `nix/module.nix`, run the VM check: `nix build .#checks.x86_64-linux.moduleVm`.
 - **Every `nix flake update` in cratedigger must re-run the real-beets drift gate** (`tests/test_harness_beets2_contract.py` inside the re-pinned shell, plus the full suite): since tier-2 packaging, the flake.lock — not the consumer's nixpkgs — decides the beets version production runs. A lock bump is a beets upgrade until proven otherwise.
-- After live verification of a deploy-worthy state, tag it `vYYYY.MM.DD` (suffix `-N` for same-day). The pre-push hook (`scripts/pre-push`, runs `nix flake check`) gates every push; the tag records the verified state.
+- After live verification of a deploy-worthy state, tag it `vYYYY.MM.DD` (suffix `-N` for same-day). The pre-push hook (`scripts/pre-push`, runs the generated-test fuzz burst then `nix flake check`) gates every push; the tag records the verified state.
 - Use the `/deploy` command for the full sequence.
 
 ## Database migrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ nix-shell --run "python3 -m unittest tests.test_X -v"
 ### Hooks
 
 - Pre-commit (`ln -sf ../../scripts/pre-commit .git/hooks/pre-commit`): pyright on staged `.py`.
-- Pre-push (`ln -sf ../../scripts/pre-push .git/hooks/pre-push`): `nix flake check` (VM boot gate + eval guards + CLI bundle). Escape hatch: `git push --no-verify`.
+- Pre-push (`ln -sf ../../scripts/pre-push .git/hooks/pre-push`): randomized generated-test burst (push profile, fresh entropy each push — `docs/generated-testing.md`), then `nix flake check` (VM boot gate + eval guards + CLI bundle). Escape hatch: `git push --no-verify`.
 - **Tag convention:** `vYYYY.MM.DD` (suffix `-N`) cut AFTER live verification on doc2.
 
 ### Claude Code commands

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -9,31 +9,37 @@ bookkeeping, no standing service.
 
 | Module | Target | Properties |
 |--------|--------|------------|
-| `tests/test_quality_generated.py` | the decision twins (`full_pipeline_decision` / `full_pipeline_decision_from_evidence`) | decisions are definitive (totality); raw verified-lossless FLAC never replaced by lossy; transparent lossy never accepts obvious downgrades; **twin parity** over the shared world language; evidence-only integrity facts (corrupt / bad-hash / nested / mixed) always reject in priority order; incomplete evidence fails closed |
+| `tests/test_quality_generated.py` | the decision twins (`full_pipeline_decision` / `full_pipeline_decision_from_evidence`) | decisions are definitive (totality); raw verified-lossless FLAC never replaced by lossy; transparent lossy never accepts obvious downgrades; **twin parity** over the shared world language; evidence-only integrity facts (corrupt / bad-hash / nested / mixed) always reject in priority order; classification layer (`classify_full_pipeline_decision` / `evidence_decision_name` — cleanup eligibility) coherent with every generated decision; incomplete evidence fails closed |
 | `tests/test_evidence_generated.py` | `ensure_current_evidence_for_action` | converted current evidence requires source V0 (fix `6cf26a4`): never `loaded` without a V0 metric, scalar state backfills, otherwise fail closed |
+| `tests/test_slskd_events_generated.py` | `ingest_download_file_events` (event stamping — the ONLY source of completed-file locations) | stamping oracle (newest decodable event per key in the new-events window, nothing else); totality + exactly-once over wild feeds (dup ids, garbage timestamps, undecodable payloads, pruned/absent cursors, rows leaving `downloading` mid-ingest); duplicate-id invariance (mid-pagination shape) |
 
 Every generated module also carries **known-bad self-tests** proving each
 invariant checker trips on a planted violating decision — the RED/GREEN
 guarantee that the harness detects what it claims to.
 
-## Two tiers, one knob
+## Three tiers, one knob
 
-`tests/_hypothesis_profiles.py` registers two profiles, selected by
+`tests/_hypothesis_profiles.py` registers three profiles, selected by
 `CRATEDIGGER_HYPOTHESIS_PROFILE`:
 
 - **`suite`** (default) — deterministic (`derandomize=True`, no example
   database), bounded examples. Runs on every `scripts/run_tests.sh`,
   identical on every machine. This is the merge gate.
-- **`fuzz`** — randomized burst for local exploration. Fresh entropy per
-  run, big example budget, local example database (`.hypothesis/`,
+- **`push`** — quick randomized burst (2k examples) that `scripts/pre-push`
+  runs on every `git push`, before the flake check. Fresh entropy per push
+  means exploration accumulates over time with zero operator effort; a
+  push-found failure is remembered in `.hypothesis/` and replays first in
+  dev. Escape hatch, as for the whole hook: `git push --no-verify`.
+- **`fuzz`** — deep randomized burst (20k examples) for local exploration.
+  Fresh entropy per run, local example database (`.hypothesis/`,
   gitignored) so found failures replay first on the next burst,
   `print_blob=True` for exact reproduction.
 
-Run a burst whenever quality policy changes:
+Run a deep burst whenever quality policy changes:
 
 ```bash
 nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \
-    python3 -m unittest tests.test_quality_generated tests.test_evidence_generated -v"
+    python3 -m unittest discover -s tests -t . -p 'test_*_generated.py' -v"
 ```
 
 It is pure and safe: no prod DB, no slskd, no beets, no network; the only
@@ -70,6 +76,31 @@ parity tests use (`tests/helpers.py::build_parity_candidate_evidence` /
 different encodings. The common-language constraints (candidate V0 probes
 only on FLAC candidates, derived `is_vbr`, explicit conversion facts) are
 documented at the strategy definition.
+
+## Coverage steering — measure before generating more
+
+Random generation from a fixed strategy saturates: after the first burst,
+more examples stop buying new behavior. When deciding where the *next*
+property should aim, measure which branches the generated tests actually
+execute (this is the functional-coverage idea from CPU verification —
+steer generation at the holes, don't bookkeep seeds):
+
+```bash
+# Scope --source to the production code the properties target — this
+# example covers the decision twins; use --source=lib to also see
+# lib/slskd_events.py and lib/import_evidence.py (module files need the
+# package dir, not the .py path).
+nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \
+    coverage run --branch --source=lib/quality \
+    -m unittest discover -s tests -t . -p 'test_*_generated.py' \
+  && coverage report --show-missing"
+```
+
+Read the misses critically: config parsing, wire helpers, and
+simulator-only shims belong to other tests — the actionable holes are
+unexecuted **decision-policy** branches. (The 2026-07-08 run found exactly
+one: the classification layer, now covered by
+`test_decision_classification_is_coherent`.)
 
 ## Writing new generated tests
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -29,9 +29,10 @@ let
   # Dev-only additions:
   #   - vulture: static dead-code finder (scripts/find_dead_code.sh)
   #   - hypothesis: property-based generated tests (docs/generated-testing.md)
+  #   - coverage: branch-coverage steering for the fuzz tier (same doc)
   testPythonEnv = pkgs.python3.withPackages (ps:
     cratedigger.pythonPackages ps
-    ++ [ ps.vulture ps.hypothesis ]
+    ++ [ ps.vulture ps.hypothesis ps.coverage ]
   );
 in
 pkgs.mkShell {

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -14,6 +14,22 @@
 # Deliberate escape hatch: `git push --no-verify`.
 set -euo pipefail
 
+# Hooks are installed as .git/hooks symlinks, so BASH_SOURCE points into
+# .git/ — resolve the repo root through git instead (works in worktrees).
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Randomized generated-test burst (issue #548) — fresh entropy on every
+# push, so exploration of the decision/event state spaces accumulates
+# over time. Modules are discovered by pattern (test_*_generated.py); a
+# hand-maintained list would drift (issue #520 lesson). Runs BEFORE the
+# flake check: seconds of fuzz fail faster than minutes of VM boot.
+# A failure prints the shrunk world + a @reproduce_failure blob and is
+# remembered in .hypothesis/ — promote it per docs/generated-testing.md.
+echo "pre-push: generated-test fuzz burst (push profile)..." >&2
+(cd "$REPO_ROOT" && nix-shell --run \
+  "CRATEDIGGER_HYPOTHESIS_PROFILE=push python3 -m unittest discover -s tests -t . -p 'test_*_generated.py'")
+echo "pre-push: fuzz burst OK" >&2
+
 echo "pre-push: nix flake check (moduleVm + eval guards + CLI bundle)..." >&2
 nix flake check
 echo "pre-push: flake check OK" >&2

--- a/tests/_hypothesis_profiles.py
+++ b/tests/_hypothesis_profiles.py
@@ -1,26 +1,30 @@
 """Hypothesis profile selection for generated tests (issue #548).
 
-Importing this module registers two profiles and loads the one selected by
-``CRATEDIGGER_HYPOTHESIS_PROFILE``:
+Importing this module registers three profiles and loads the one selected
+by ``CRATEDIGGER_HYPOTHESIS_PROFILE``:
 
 * ``suite`` (default) — deterministic tier. ``derandomize=True`` makes
   generation a fixed pseudo-random sweep, ``database=None`` keeps results
   independent of local ``.hypothesis/`` state, so every ``run_tests.sh``
   run behaves identically on every machine. This is the tier that gates
   merges.
-* ``fuzz`` — randomized burst tier for local exploration when quality
-  policy changes. Uses a fresh entropy source per run plus the local
-  Hypothesis example database (``.hypothesis/``, gitignored), so failures
-  found in one burst replay first on the next. ``print_blob=True`` prints
-  a ``@reproduce_failure`` blob for exact replay.
+* ``push`` — quick randomized burst the pre-push hook runs on every
+  ``git push`` (scripts/pre-push). Fresh entropy per push accumulates
+  exploration over time; the local example database makes any push-found
+  failure replay first in dev. Sized to seconds, not minutes.
+* ``fuzz`` — deep randomized burst for local exploration when quality
+  policy changes. Fresh entropy per run plus the local Hypothesis example
+  database (``.hypothesis/``, gitignored), so failures found in one burst
+  replay first on the next. ``print_blob=True`` prints a
+  ``@reproduce_failure`` blob for exact replay.
 
-Deadlines are disabled in both tiers: wall-clock-per-example limits flake
+Deadlines are disabled in every tier: wall-clock-per-example limits flake
 under load and none of the generated tests do I/O worth bounding.
 
-Promotion policy: a failure found by the fuzz tier is shrunk by Hypothesis
-to a minimal world — commit that world as a named ``@example(...)`` pin or
-as a scenario in the album test set. Never check in opaque artifacts.
-See docs/generated-testing.md.
+Promotion policy: a failure found by the push/fuzz tiers is shrunk by
+Hypothesis to a minimal world — commit that world as a named
+``@example(...)`` pin or as a scenario in the album test set. Never check
+in opaque artifacts. See docs/generated-testing.md.
 """
 
 import os
@@ -33,6 +37,13 @@ settings.register_profile(
     max_examples=150,
     database=None,
     deadline=None,
+)
+settings.register_profile(
+    "push",
+    max_examples=2_000,
+    deadline=None,
+    print_blob=True,
+    suppress_health_check=[HealthCheck.too_slow],
 )
 settings.register_profile(
     "fuzz",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ hand-rolling dicts or dataclass constructors with many fields.
 
 from __future__ import annotations
 
+import json
 import types
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -15,6 +16,8 @@ from unittest.mock import MagicMock, patch
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.quality import (
     V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+    ActiveDownloadFileState,
+    ActiveDownloadState,
     AlbumQualityEvidence,
     AlbumQualityEvidenceFile,
     AlbumQualityV0Metric,
@@ -347,6 +350,53 @@ def build_parity_current_evidence(
         matched_bad_audio_hash_id=matched_bad_audio_hash_id,
         matched_bad_audio_hash_path=matched_bad_audio_hash_path,
     )
+
+
+def make_file_complete_event_data(
+    *,
+    username: str,
+    filename: str,
+    local_filename: str,
+    transfer_id: str = "t-1",
+    size: int = 1000,
+) -> str:
+    """The JSON ``data`` string of a slskd DownloadFileComplete event,
+    exactly as the live feed emits it (camelCase, nested transfer DTO)."""
+    return json.dumps({
+        "version": 0,
+        "localFilename": local_filename,
+        "remoteFilename": filename,
+        "transfer": {
+            "id": transfer_id,
+            "username": username,
+            "filename": filename,
+            "size": size,
+        },
+    })
+
+
+def make_active_download_file_state(
+    username: str = "peer1",
+    filename: str = "music\\Artist\\Album\\01 track.flac",
+    size: int = 1000,
+) -> ActiveDownloadFileState:
+    return ActiveDownloadFileState(
+        username=username,
+        filename=filename,
+        file_dir=filename.rsplit("\\", 1)[0] if "\\" in filename else "music",
+        size=size,
+    )
+
+
+def make_active_download_state_json(
+    files: list[ActiveDownloadFileState],
+    filetype: str = "flac",
+) -> str:
+    return ActiveDownloadState(
+        filetype=filetype,
+        enqueued_at="2026-07-01T00:00:00+00:00",
+        files=files,
+    ).to_json()
 
 
 def make_evidence(

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -51,6 +51,8 @@ from lib.quality import (
     V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
     V0_SOURCE_LINEAGE_NATIVE_LOSSY_RESEARCH,
     VerifiedLosslessProof,
+    classify_full_pipeline_decision,
+    evidence_decision_name,
     full_pipeline_decision_from_evidence,
 )
 from lib.quality.filetypes import has_mixed_lossless_and_lossy
@@ -639,6 +641,51 @@ _EARLY_EXIT_REJECT_VALUES = {
     "preimport_mixed_source": "reject_mixed_source",
 }
 
+_EARLY_EXIT_FACT_NAMES = {
+    "preimport_audio": "audio_corrupt",
+    "preimport_bad_hash": "bad_audio_hash",
+    "preimport_nested": "nested_layout",
+    "preimport_empty_fileset": "empty_fileset",
+    "preimport_mixed_source": "mixed_source",
+}
+
+_VALID_VERDICTS = ("confident_reject", "would_import", "uncertain")
+
+
+def assert_classification_coherent(
+    decision: dict, expected_early_exit_key: str | None) -> None:
+    """The classification layer (cleanup eligibility + dispatch decision
+    name) must be coherent with the decision dict it classifies.
+
+    Added after the fuzz-tier coverage diagnostic showed
+    ``classify_full_pipeline_decision`` / ``evidence_decision_name``
+    (which gate wrong-match folder cleanup) were the one decision-policy
+    layer no generated test reached.
+    """
+    verdict, cleanup_eligible, reason = classify_full_pipeline_decision(decision)
+    name = evidence_decision_name(decision)
+    if verdict not in _VALID_VERDICTS:
+        raise AssertionError(f"unknown classification verdict: {verdict!r}")
+    if not name or not isinstance(name, str):
+        raise AssertionError(f"evidence_decision_name returned {name!r}")
+    if cleanup_eligible and verdict != "confident_reject":
+        raise AssertionError(
+            f"cleanup_eligible without confident_reject: {verdict!r}/{reason!r}")
+    if expected_early_exit_key is not None:
+        fact = _EARLY_EXIT_FACT_NAMES[expected_early_exit_key]
+        if (verdict, cleanup_eligible, reason) != ("confident_reject", True, fact):
+            raise AssertionError(
+                f"integrity fact {fact} classified as "
+                f"({verdict!r}, {cleanup_eligible!r}, {reason!r})")
+        if name != fact:
+            raise AssertionError(
+                f"integrity fact {fact} named {name!r} for dispatch")
+    elif decision.get("imported"):
+        if verdict != "would_import" or cleanup_eligible:
+            raise AssertionError(
+                f"imported decision classified as "
+                f"({verdict!r}, cleanup_eligible={cleanup_eligible!r})")
+
 
 class TestGeneratedEvidenceDecider(unittest.TestCase):
     """Properties of the production decider the simulator can't reach."""
@@ -676,6 +723,15 @@ class TestGeneratedEvidenceDecider(unittest.TestCase):
         else:
             self.assertIsNone(result["final_status"])
             self.assertFalse(result["keep_searching"])
+
+    @given(candidate=wild_ready_candidate_evidence(),
+           import_mode=st.sampled_from(("auto", "force")))
+    def test_decision_classification_is_coherent(self, candidate, import_mode):
+        facts = AlbumQualityEvidenceDecisionFacts(import_mode=import_mode)
+        result = full_pipeline_decision_from_evidence(
+            candidate, None, facts=facts)
+        assert_classification_coherent(
+            result, _expected_early_exit_key(candidate))
 
     def test_incomplete_evidence_fails_closed(self):
         """Evidence rows below the policy floor must raise, not decide."""
@@ -743,6 +799,27 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_downgrade_checker_trips_on_accept(self):
         with self.assertRaises(AssertionError):
             assert_obvious_downgrade_not_accepted(_planted_bad_import())
+
+    def test_classification_checker_trips_on_bad_verdict(self):
+        # A dict claiming both imported and a reject-stage decision would
+        # classify confident_reject while imported — the checker must trip.
+        bad = {
+            "imported": True,
+            "stage2_import": "downgrade",
+            "stage3_quality_gate": None,
+        }
+        with self.assertRaises(AssertionError):
+            assert_classification_coherent(bad, None)
+
+    def test_classification_checker_trips_on_misnamed_fact(self):
+        # An audio-corrupt early exit whose dict carries the wrong reject
+        # value yields a quality-flavoured name instead of the fact name.
+        bad = {
+            "preimport_audio": "reject_nested",  # planted wrong value
+            "imported": False,
+        }
+        with self.assertRaises(AssertionError):
+            assert_classification_coherent(bad, "preimport_audio")
 
     def test_parity_checker_trips_on_divergence(self):
         sim = _planted_bad_import()

--- a/tests/test_slskd_events.py
+++ b/tests/test_slskd_events.py
@@ -16,47 +16,11 @@ from lib.slskd_events import (
     ingest_download_file_events,
 )
 from tests.fakes import FakePipelineDB, FakeSlskdAPI
-
-
-def _file_complete_data(
-    *,
-    username: str,
-    filename: str,
-    local_filename: str,
-    transfer_id: str = "t-1",
-    size: int = 1000,
-) -> str:
-    return json.dumps({
-        "version": 0,
-        "localFilename": local_filename,
-        "remoteFilename": filename,
-        "transfer": {
-            "id": transfer_id,
-            "username": username,
-            "filename": filename,
-            "size": size,
-        },
-    })
-
-
-def _state_json(files: list[ActiveDownloadFileState]) -> str:
-    return ActiveDownloadState(
-        filetype="flac",
-        enqueued_at="2026-07-01T00:00:00+00:00",
-        files=files,
-    ).to_json()
-
-
-def _file_state(
-    username: str = "peer1",
-    filename: str = "music\\Artist\\Album\\01 track.flac",
-) -> ActiveDownloadFileState:
-    return ActiveDownloadFileState(
-        username=username,
-        filename=filename,
-        file_dir="music\\Artist\\Album",
-        size=1000,
-    )
+from tests.helpers import (
+    make_active_download_file_state as _file_state,
+    make_active_download_state_json as _state_json,
+    make_file_complete_event_data as _file_complete_data,
+)
 
 
 class SlskdEventIngestCase(unittest.TestCase):

--- a/tests/test_slskd_events_generated.py
+++ b/tests/test_slskd_events_generated.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Generated slskd event-ingestion tests — issue #548 follow-up.
+
+Property-based tests over ``lib/slskd_events.py::ingest_download_file_events``
+— the pass that stamps authoritative completed-file locations from the
+slskd events feed (the stamp is the ONLY source of completed-file
+locations; issue #146).
+
+Three properties over generated feed histories:
+
+1. **Stamping oracle** — for worlds with a clean cursor (its id present in
+   the feed, unique event ids), every downloading file ends up stamped
+   with exactly the newest decodable DownloadFileComplete event for its
+   ``(username, remote filename)`` key inside the new-events window — and
+   nothing else: no invented paths, no stamps from behind the cursor, no
+   writes to rows that left ``downloading`` mid-ingest.
+2. **Totality + exactly-once** — for arbitrary worlds (duplicate event
+   ids, garbage timestamps, undecodable payloads, pruned cursors,
+   bootstrap): ingestion never raises, every stamped path originates from
+   the feed, and an immediate second pass over the unchanged feed is a
+   no-op (``no_new_events``/``empty_feed``, identical states and cursor).
+3. **Duplicate-id invariance** — a feed with duplicated events (the
+   mid-pagination offset-shift shape) produces exactly the same outcome
+   as the same feed deduplicated.
+
+Multi-page scans and the page-cap ``cursor_gap`` path stay pinned by the
+hand tests in tests/test_slskd_events.py (they need >500-event feeds).
+
+Profiles and promotion policy: tests/_hypothesis_profiles.py and
+docs/generated-testing.md.
+"""
+
+import json
+import os
+import sys
+import unittest
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from lib.quality import ActiveDownloadState
+from lib.slskd_events import EventIngestResult, ingest_download_file_events
+from tests.fakes import FakePipelineDB, FakeSlskdAPI
+from tests.helpers import (
+    make_active_download_file_state,
+    make_active_download_state_json,
+    make_file_complete_event_data,
+)
+
+_FILE_COMPLETE = "DownloadFileComplete"
+_DIR_COMPLETE = "DownloadDirectoryComplete"
+_OTHER_TYPES = ("SearchRequestResponded", "RoomMessageReceived")
+
+# Small pools force key collisions between rows and events (that's match
+# probability, not a plausibility filter — matching is exact-string).
+_USERNAMES = ("peer0", "peer1", "péer♪2", "PEER3")
+_FILENAMES = (
+    "Music\\Artist\\Album\\01 track.flac",
+    "Music\\Artist\\Album\\02 track.flac",
+    "Music\\Ártîst 音\\Å l b u m\\01.mp3",
+    "@@direct\\weird/../path.opus",
+    "single.flac",
+)
+
+_VALID_OUTCOMES = ("bootstrapped", "ingested", "no_new_events", "empty_feed")
+
+
+@dataclass(frozen=True)
+class FeedEvent:
+    """One generated feed event (newest-first position implied by index)."""
+    id: str
+    timestamp: str
+    type: str
+    username: str | None
+    filename: str | None
+    local_filename: str | None
+    decodable: bool
+
+
+@dataclass(frozen=True)
+class RequestWorld:
+    request_id: int
+    file_keys: tuple[tuple[str, str], ...]  # (username, remote filename)
+    leaves_mid_ingest: bool
+
+
+@dataclass(frozen=True)
+class EventWorld:
+    rows: tuple[RequestWorld, ...]
+    events: tuple[FeedEvent, ...]  # newest-first
+    # None = bootstrap (no cursor row). An int in 0..len(events) is the
+    # index of the cursor event; len(events) means a synthetic cursor
+    # older than the whole feed (its id is absent, timestamp pre-dates
+    # every event), i.e. the entire feed is new.
+    cursor_index: int | None
+    garbage_cursor_timestamp: bool = False
+
+
+def _timestamp_for(index: int, garbage: bool) -> str:
+    if garbage:
+        return "not-a-timestamp"
+    # Newest-first: larger index = older. Fractions mimic slskd's 7-digit form.
+    return f"2026-07-08T11:{59 - index:02d}:00.1234567Z"
+
+
+@st.composite
+def _feed_events(draw, *, row_keys: tuple[tuple[str, str], ...],
+                 count: int, unique_ids: bool,
+                 allow_garbage_timestamps: bool) -> tuple[FeedEvent, ...]:
+    key_pool = list(row_keys) + [
+        ("peer-unrelated", "Music\\Other\\01.flac"),
+        ("peer0", "Music\\Other\\02.flac"),
+    ]
+    events: list[FeedEvent] = []
+    for i in range(count):
+        garbage_ts = allow_garbage_timestamps and draw(
+            st.booleans() if i > 0 else st.just(False))
+        kind = draw(st.sampled_from(
+            (_FILE_COMPLETE,) * 6 + (_DIR_COMPLETE,) + _OTHER_TYPES))
+        if kind == _FILE_COMPLETE:
+            username, filename = draw(st.sampled_from(key_pool))
+            events.append(FeedEvent(
+                id=f"ev-{i}",
+                timestamp=_timestamp_for(i, garbage_ts),
+                type=kind,
+                username=username,
+                filename=filename,
+                local_filename=f"/downloads/complete/{i}",
+                decodable=draw(st.booleans() | st.just(True)),
+            ))
+        else:
+            events.append(FeedEvent(
+                id=f"ev-{i}",
+                timestamp=_timestamp_for(i, garbage_ts),
+                type=kind,
+                username=None,
+                filename=None,
+                local_filename=None,
+                decodable=False,
+            ))
+    if not unique_ids and events:
+        # Duplicate some events at older positions (mid-pagination shape).
+        dup_count = draw(st.integers(min_value=0, max_value=len(events)))
+        for _ in range(dup_count):
+            source = draw(st.integers(min_value=0, max_value=len(events) - 1))
+            events.insert(source + 1, events[source])
+    return tuple(events)
+
+
+@st.composite
+def _rows(draw) -> tuple[RequestWorld, ...]:
+    row_count = draw(st.integers(min_value=1, max_value=3))
+    rows = []
+    for rid in range(1, row_count + 1):
+        keys = draw(st.lists(
+            st.tuples(st.sampled_from(_USERNAMES), st.sampled_from(_FILENAMES)),
+            min_size=1, max_size=3, unique=True))
+        rows.append(RequestWorld(
+            request_id=rid,
+            file_keys=tuple(keys),
+            leaves_mid_ingest=draw(st.booleans()),
+        ))
+    return tuple(rows)
+
+
+@st.composite
+def oracle_worlds(draw) -> EventWorld:
+    """Clean-cursor worlds where the expected stamps are computable."""
+    rows = draw(_rows())
+    row_keys = tuple(k for row in rows for k in row.file_keys)
+    count = draw(st.integers(min_value=1, max_value=10))
+    events = draw(_feed_events(
+        row_keys=row_keys, count=count, unique_ids=True,
+        allow_garbage_timestamps=False))
+    cursor_index = draw(st.integers(min_value=0, max_value=len(events)))
+    return EventWorld(rows=rows, events=events, cursor_index=cursor_index)
+
+
+@st.composite
+def wild_worlds(draw) -> EventWorld:
+    """Anything the feed can throw: dup ids, garbage timestamps, pruned or
+    absent cursors, undecodable payloads, empty feeds."""
+    rows = draw(_rows())
+    row_keys = tuple(k for row in rows for k in row.file_keys)
+    count = draw(st.integers(min_value=0, max_value=10))
+    events = draw(_feed_events(
+        row_keys=row_keys, count=count, unique_ids=draw(st.booleans()),
+        allow_garbage_timestamps=True))
+    cursor_index = draw(st.one_of(
+        st.none(), st.integers(min_value=0, max_value=len(events))))
+    return EventWorld(
+        rows=rows, events=events, cursor_index=cursor_index,
+        garbage_cursor_timestamp=draw(st.booleans()),
+    )
+
+
+def _build_harness(world: EventWorld) -> tuple[FakePipelineDB, FakeSlskdAPI, list]:
+    """Seed fakes from the world; returns (db, slskd, prefetched rows)."""
+    db = FakePipelineDB()
+    slskd = FakeSlskdAPI()
+
+    for row in world.rows:
+        db.seed_request({
+            "id": row.request_id,
+            "status": "downloading",
+            "artist_name": "Artist",
+            "album_title": f"Album {row.request_id}",
+            "active_download_state": json.loads(make_active_download_state_json([
+                make_active_download_file_state(username=u, filename=f)
+                for u, f in row.file_keys
+            ])),
+        })
+
+    raw_events = []
+    for event in world.events:
+        if event.type == _FILE_COMPLETE and event.decodable:
+            assert event.username is not None and event.filename is not None
+            assert event.local_filename is not None
+            data = make_file_complete_event_data(
+                username=event.username,
+                filename=event.filename,
+                local_filename=event.local_filename,
+            )
+        else:
+            data = "{not-json"
+        raw_events.append(slskd.events.make_event(
+            id=event.id, timestamp=event.timestamp,
+            type=event.type, data=data))
+    slskd.events.set_events(raw_events)
+
+    if world.cursor_index is not None:
+        if world.cursor_index < len(world.events):
+            cursor_event = world.events[world.cursor_index]
+            cursor_ts = (
+                "also-not-a-timestamp" if world.garbage_cursor_timestamp
+                else cursor_event.timestamp)
+            db.upsert_slskd_event_cursor(cursor_event.id, cursor_ts)
+        else:
+            # Synthetic cursor older than the entire feed: id absent,
+            # timestamp pre-dates every generated event.
+            cursor_ts = (
+                "also-not-a-timestamp" if world.garbage_cursor_timestamp
+                else "2026-07-08T09:00:00.0000000Z")
+            db.upsert_slskd_event_cursor("ev-absent", cursor_ts)
+
+    downloading = db.get_downloading()
+    for row in world.rows:
+        if row.leaves_mid_ingest:
+            db.update_request_fields(row.request_id, status="wanted")
+    return db, slskd, downloading
+
+
+def _stamped_paths(db: FakePipelineDB, world: EventWorld) -> dict:
+    """(request_id, key) → local_path for every world file, from the DB."""
+    stamped = {}
+    for row in world.rows:
+        state = ActiveDownloadState.from_dict(
+            db.request(row.request_id)["active_download_state"])
+        for file_state in state.files:
+            stamped[(row.request_id, (file_state.username, file_state.filename))] = (
+                file_state.local_path)
+    return stamped
+
+
+def expected_oracle_stamps(world: EventWorld) -> dict:
+    """The invariant: newest decodable file event per key in the new window."""
+    assert world.cursor_index is not None
+    window = world.events[:world.cursor_index]
+    newest_per_key: dict[tuple[str, str], str] = {}
+    for event in window:  # newest-first: first occurrence wins
+        if event.type == _FILE_COMPLETE and event.decodable:
+            assert event.username is not None and event.filename is not None
+            assert event.local_filename is not None
+            newest_per_key.setdefault(
+                (event.username, event.filename), event.local_filename)
+    expected = {}
+    for row in world.rows:
+        for key in row.file_keys:
+            expected[(row.request_id, key)] = (
+                None if row.leaves_mid_ingest else newest_per_key.get(key))
+    return expected
+
+
+def assert_stamps_match(expected: dict, actual: dict) -> None:
+    """Stamping-oracle checker (module-level for the known-bad self-test)."""
+    if expected.keys() != actual.keys():
+        raise AssertionError(
+            f"file-key sets diverged: {expected.keys() ^ actual.keys()}")
+    diffs = [
+        f"{key}: expected={expected[key]!r} actual={actual[key]!r}"
+        for key in expected if expected[key] != actual[key]
+    ]
+    if diffs:
+        raise AssertionError(
+            "stamped local paths diverged from the event oracle:\n  "
+            + "\n  ".join(diffs))
+
+
+def assert_result_well_formed(result: EventIngestResult) -> None:
+    if result.outcome not in _VALID_OUTCOMES:
+        raise AssertionError(f"unknown ingest outcome: {result.outcome!r}")
+    for field in ("events_seen", "file_events", "files_stamped",
+                  "requests_updated"):
+        if getattr(result, field) < 0:
+            raise AssertionError(f"negative counter {field}: {result!r}")
+
+
+class TestGeneratedEventStamping(unittest.TestCase):
+    """Property 1: the stamping oracle on clean-cursor worlds."""
+
+    @given(world=oracle_worlds())
+    def test_stamps_match_newest_decodable_event_in_window(self, world):
+        db, slskd, downloading = _build_harness(world)
+        result = ingest_download_file_events(db, slskd, downloading)
+
+        assert_result_well_formed(result)
+        expected = expected_oracle_stamps(world)
+        assert_stamps_match(expected, _stamped_paths(db, world))
+
+        window = world.events[:world.cursor_index]
+        self.assertEqual(
+            result.outcome, "ingested" if window else "no_new_events")
+        self.assertEqual(result.events_seen, len(window))
+        self.assertEqual(
+            result.file_events,
+            sum(1 for e in window if e.type == _FILE_COMPLETE))
+        self.assertEqual(
+            result.files_stamped,
+            sum(1 for path in expected.values() if path is not None))
+        self.assertEqual(
+            result.requests_updated,
+            sum(
+                1 for row in world.rows
+                if not row.leaves_mid_ingest and any(
+                    expected[(row.request_id, key)] is not None
+                    for key in row.file_keys)
+            ))
+
+        cursor = db.get_slskd_event_cursor()
+        assert cursor is not None
+        if window:
+            self.assertEqual(cursor["last_event_id"], world.events[0].id)
+
+
+class TestGeneratedEventIngestTotality(unittest.TestCase):
+    """Property 2: totality + exactly-once on arbitrary worlds."""
+
+    @given(world=wild_worlds())
+    def test_ingest_never_crashes_and_second_pass_is_noop(self, world):
+        db, slskd, downloading = _build_harness(world)
+        generated_paths = {
+            e.local_filename for e in world.events
+            if e.local_filename is not None}
+
+        first = ingest_download_file_events(db, slskd, downloading)
+        assert_result_well_formed(first)
+
+        stamped_after_first = _stamped_paths(db, world)
+        for path in stamped_after_first.values():
+            if path is not None and path not in generated_paths:
+                raise AssertionError(
+                    f"stamped path {path!r} does not originate from the feed")
+        cursor_after_first = db.get_slskd_event_cursor()
+
+        second = ingest_download_file_events(
+            db, slskd, db.get_downloading())
+        assert_result_well_formed(second)
+        self.assertIn(second.outcome, ("no_new_events", "empty_feed"))
+        self.assertEqual(stamped_after_first, _stamped_paths(db, world))
+        self.assertEqual(cursor_after_first, db.get_slskd_event_cursor())
+
+
+class TestGeneratedEventDuplicateInvariance(unittest.TestCase):
+    """Property 3: duplicated events (mid-pagination shape) change nothing."""
+
+    @given(world=oracle_worlds(), data=st.data())
+    def test_duplicate_ids_are_invariant(self, world, data):
+        events = list(world.events)
+        if events:
+            dup_count = data.draw(
+                st.integers(min_value=1, max_value=len(events)),
+                label="dup_count")
+            for _ in range(dup_count):
+                source = data.draw(
+                    st.integers(min_value=0, max_value=len(events) - 1),
+                    label="dup_source")
+                events.insert(source + 1, events[source])
+        # The cursor event's id now locates the scan stop; recompute its
+        # index so the duplicated world is the SAME world description.
+        if world.cursor_index is not None and world.cursor_index < len(world.events):
+            cursor_id = world.events[world.cursor_index].id
+            new_cursor_index = next(
+                i for i, e in enumerate(events) if e.id == cursor_id)
+        else:
+            new_cursor_index = len(events)
+        dup_world = EventWorld(
+            rows=world.rows, events=tuple(events),
+            cursor_index=new_cursor_index)
+
+        base_db, base_slskd, base_rows = _build_harness(world)
+        base_result = ingest_download_file_events(
+            base_db, base_slskd, base_rows)
+
+        dup_db, dup_slskd, dup_rows = _build_harness(dup_world)
+        dup_result = ingest_download_file_events(dup_db, dup_slskd, dup_rows)
+
+        self.assertEqual(
+            _stamped_paths(base_db, world), _stamped_paths(dup_db, dup_world))
+        self.assertEqual(base_result.outcome, dup_result.outcome)
+        self.assertEqual(base_result.files_stamped, dup_result.files_stamped)
+        self.assertEqual(
+            base_result.requests_updated, dup_result.requests_updated)
+        self.assertEqual(base_result.events_seen, dup_result.events_seen)
+
+
+class TestEventCheckersTripOnViolations(unittest.TestCase):
+    """Known-bad self-tests for the event-ingest checkers."""
+
+    def test_stamp_checker_trips_on_wrong_path(self):
+        key = (1, ("peer0", "single.flac"))
+        with self.assertRaises(AssertionError):
+            assert_stamps_match({key: "/downloads/complete/0"}, {key: None})
+
+    def test_stamp_checker_trips_on_invented_stamp(self):
+        key = (1, ("peer0", "single.flac"))
+        with self.assertRaises(AssertionError):
+            assert_stamps_match({key: None}, {key: "/invented/path"})
+
+    def test_result_checker_trips_on_unknown_outcome(self):
+        with self.assertRaises(AssertionError):
+            assert_result_well_formed(EventIngestResult(outcome="exploded"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second slice of issue #548 (follows the merged #553): generated tests for the slskd event-ingestion subsystem, a fuzz-on-push git hook, and the coverage-steering workflow — with the one policy hole it found already closed.

### Coverage diagnostic first (the "measure before generating more" step)

Ran the fuzz tier under branch coverage over `lib/quality`: the #553 generators already saturate the decision core (95% of `decisions.py`; both deciders in `pipeline.py` nearly fully covered — remaining misses are config parsing, wire helpers, and simulator-only shims owned by other tests). Exactly **one unreached decision-policy surface**: the classification layer (`classify_full_pipeline_decision` / `evidence_decision_name`), which gates wrong-match folder **cleanup eligibility**. This PR adds `test_decision_classification_is_coherent` to close it, and documents the steering recipe in `docs/generated-testing.md`.

### slskd event-stream properties (`tests/test_slskd_events_generated.py`)

Targets `ingest_download_file_events` — the pass whose stamps are the **only** source of completed-file locations (#146):

1. **Stamping oracle** — on clean-cursor worlds, every downloading file ends up stamped with exactly the newest decodable `DownloadFileComplete` event for its `(username, remote filename)` key inside the new-events window, and nothing else: no invented paths, no stamps from behind the cursor, no writes to rows that left `downloading` mid-ingest. Counters (`events_seen`/`file_events`/`files_stamped`/`requests_updated`) and cursor advance are asserted against the world description (declarative window — not a re-run of the scan logic).
2. **Totality + exactly-once** — wild feeds (duplicate ids, garbage timestamps, undecodable payloads, pruned/absent cursors): never raises, every stamp originates from the feed, and an immediate second pass over the unchanged feed is a no-op.
3. **Duplicate-id invariance** — the mid-pagination offset-shift shape (same event repeated across pages) produces byte-identical outcomes to the deduplicated feed.

Plus known-bad self-tests per checker. Event payload builders moved to `tests/helpers.py`, shared with the hand-written `test_slskd_events.py` (one payload shape, no drift).

### Fuzzing runs on every push

New `push` Hypothesis profile (2k examples, fresh entropy each push, local `.hypothesis/` failure DB); `scripts/pre-push` now runs all `test_*_generated.py` modules under it (pattern discovery — no hand-maintained list) **before** `nix flake check`, so seconds of fuzz fail faster than minutes of VM boot. Measured ~42s. Escape hatch unchanged: `git push --no-verify`. Entropy now accumulates across every push with zero operator effort.

### Verification

- Full-repo pyright: 0 errors.
- Full suite green (4778 tests); hand-written `test_slskd_events.py` still green after the builder extraction.
- Push profile: 24 generated tests in 42s.
- Deep fuzz burst (20k examples/property): green on the event + quality modules — no divergence, no crashes.
- Opus review verdict: ship (it independently confirmed the `REPO_ROOT` hook fix; its one doc nit is addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
