### PR TITLE
test(generated): request-lifecycle state machine + invariant-first TDD rules (#548)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -110,8 +110,38 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
 - Tests owe: at least one RED test that feeds the wrong type at the boundary and asserts `msgspec.ValidationError`. This is the regression guard that makes the boundary worth having.
 
 ## Testing — Red/Green TDD
-- Write tests FIRST (RED), then implement (GREEN)
-- Every new function, dataclass, and decision branch needs test coverage
+
+- **Start every feature by writing its invariants down.** Before
+  implementing, state the policy invariants the feature must uphold, in the
+  issue or plan ("replaced rows are frozen", "the event stamp is the only
+  location source", "a below-gate import never stops the search"). The
+  invariants decide which tests you owe — code follows the tests, tests
+  follow the invariants.
+- Write tests FIRST (RED), then implement (GREEN). This applies to BOTH
+  tiers:
+  - **Standard tests** (unit / seam / orchestration / slice, per the
+    taxonomy below) — RED reproduction or contract first.
+  - **Generated tests** (Hypothesis, `docs/generated-testing.md`) — if the
+    feature has a generated-testable surface (pure decisions, lifecycles /
+    state machines, wire or event ingestion), the property + strategy ship
+    in the SAME PR as the feature, not as a follow-up. An invariant that
+    only lives in prose is not an invariant.
+- **Every invariant checker owes a known-bad self-test**: a planted
+  violating decision/state proving the checker trips. A property that has
+  never failed anything is unfalsifiable until proven otherwise. Keep
+  checkers as module-level functions so the self-test can call them
+  directly (pattern: `TestInvariantCheckersTripOnViolations` in
+  `tests/test_quality_generated.py`).
+- **Qualify the harness by fault injection when in doubt.** "Do these tests
+  actually constrain the code?" is an empirical question: plant mutants in
+  production code (revert a real past fix; break an adapter derivation;
+  flip a decision comparison; remove an early-exit guard; target each
+  property's claimed coverage) and run the relevant tests against each. A
+  surviving mutant is either a missing invariant (add it) or an entropy
+  budget miss (pin the decisive world as an `@example`). The driver is an
+  operator/agent one-shot — never committed (`scope.md`); record the kill
+  matrix in the issue/PR. Canonical run: issue #548, 2026-07-08 — 13
+  mutants, incl. reverting fix `6cf26a4`, led to PR #555.
 - Use `nix-shell --run "bash scripts/run_tests.sh"` for full suite
 - Read `/tmp/cratedigger-test-output.txt` instead of re-running the 2-minute suite
 - For single modules during dev: `nix-shell --run "python3 -m unittest tests.<module> -v"`
@@ -205,6 +235,7 @@ Before writing any new code, decide which test types you owe and what infrastruc
 | A new typed dataclass | A pure test of construction + serialization, and a builder in `tests/helpers.py` if it crosses test boundaries | `tests/helpers.py` |
 | A new `PipelineDB` method | An equivalent stub on `FakePipelineDB`, with a self-test in `tests/test_fakes.py` | `tests/fakes.py`, `tests/test_fakes.py` |
 | A new `BeetsDB` method | Either (a) an equivalent stub on `FakeBeetsDB` with a self-test in `tests/test_fakes.py::TestFakeBeetsDB`, OR (b) drive the test against a real test SQLite DB if it's a read-only query | `tests/fakes.py`, `tests/test_fakes.py` |
+| A feature with policy invariants (pure decisions, lifecycle / state machine, wire or event ingestion) | Generated properties + strategies in the same PR, each invariant checker with a known-bad self-test; invariants written down FIRST | `tests/_hypothesis_profiles.py`, checker/strategy patterns in `tests/test_*_generated.py`, `docs/generated-testing.md` |
 
 Routes are the strictest gate: `TestRouteContractAudit` will fail at test time if you add a route to `web/routes/` without classifying it. This is intentional — it prevents shipping endpoints the frontend can rely on without contract coverage.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ nix-shell --run "python3 -m unittest tests.test_X -v"
 
 **ALWAYS `nix-shell --run` for Python** (`.claude/rules/nix-shell.md`). **Never re-run the full suite just to grep differently** — read the output file. The suite gates: JS syntax + JS tests, the vulture dead-code sweep, then unittest discovery. `.claude/rules/code-quality.md` covers the test taxonomy, shared fakes/builders, and the new-work checklist.
 
-**Generated (property-based) tests** (`tests/test_*_generated.py`, Hypothesis) run deterministically in the suite; after changing quality policy, run the randomized fuzz burst: `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz` on those modules. Failures shrink to minimal worlds — promote them to named `@example` pins or album-test-set scenarios, never JSON artifacts. `docs/generated-testing.md`.
+**Generated (property-based) tests** (`tests/test_*_generated.py`, Hypothesis) run deterministically in the suite; after changing quality policy, run the randomized fuzz burst: `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz` on those modules. Failures shrink to minimal worlds — promote them to named `@example` pins or album-test-set scenarios, never JSON artifacts. **New features start by writing their invariants down, and features with a generated-testable surface ship properties + known-bad self-tests in the same PR** (`.claude/rules/code-quality.md` § Red/Green TDD). When in doubt that the harness constrains anything, qualify it by fault injection. `docs/generated-testing.md`.
 
 ### Skipped tests are an anti-pattern
 

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -12,6 +12,7 @@ bookkeeping, no standing service.
 | `tests/test_quality_generated.py` | the decision twins (`full_pipeline_decision` / `full_pipeline_decision_from_evidence`) | decisions are definitive (totality); raw verified-lossless FLAC never replaced by lossy; transparent lossy never accepts obvious downgrades; **twin parity** over the shared world language; evidence-only integrity facts (corrupt / bad-hash / nested / mixed) always reject in priority order; classification layer (`classify_full_pipeline_decision` / `evidence_decision_name` — cleanup eligibility) coherent with every generated decision; incomplete evidence fails closed |
 | `tests/test_evidence_generated.py` | `ensure_current_evidence_for_action` | converted current evidence requires source V0 (fix `6cf26a4`): never `loaded` without a V0 metric, scalar state backfills, otherwise fail closed |
 | `tests/test_slskd_events_generated.py` | `ingest_download_file_events` (event stamping — the ONLY source of completed-file locations) | stamping oracle (newest decodable event per key in the new-events window, nothing else); totality + exactly-once over wild feeds (dup ids, garbage timestamps, undecodable payloads, pruned/absent cursors, rows leaving `downloading` mid-ingest); duplicate-id invariance (mid-pagination shape) |
+| `tests/test_request_lifecycle_generated.py` | `transitions.finalize_request` + `supersede_request_mbid` driven as a `RuleBasedStateMachine` over random operation sequences | statuses stay in the legal set; `replaced` rows are terminal and byte-frozen; identity (mbid/source/created_at) immutable; every replaced row has exactly one linked descendant; `active_download_state` only on `downloading` rows; the DB guards (claim, downloading→wanted) no-op on ineligible rows |
 
 Every generated module also carries **known-bad self-tests** proving each
 invariant checker trips on a planted violating decision — the RED/GREEN
@@ -102,16 +103,49 @@ unexecuted **decision-policy** branches. (The 2026-07-08 run found exactly
 one: the classification layer, now covered by
 `test_decision_classification_is_coherent`.)
 
+## Qualifying the harness — fault injection
+
+"Does this suite actually constrain the code?" is an empirical question,
+answered the way hardware verification qualifies a testbench: **plant
+mutants in production code and count kills** against the generated tests
+only. How to pick mutants:
+
+- revert a real past bug fix (the strongest single check);
+- break each adapter derivation the parity property claims to pin;
+- flip decision comparisons; remove early-exit guards and readiness gates;
+- for each property, plant the exact violation it claims to catch.
+
+Interpret results per mutant: **killed** = the property works; **killed
+only at push/fuzz entropy** = suite-budget miss, acceptable because the
+pre-push hook runs the entropy tier on every push; **survived all tiers** =
+either a missing invariant (add it, with a known-bad self-test) or a world
+the strategies rarely make decisive (pin the decisive world as an
+`@example`). The mutation driver is an operator/agent one-shot — never
+committed (`.claude/rules/scope.md`); record the kill matrix in the
+issue/PR.
+
+Canonical run (issue #548, 2026-07-08): 13 mutants — including reverting
+fix `6cf26a4`, which the generated lifecycle property killed independently
+of its hand-written regression tests — 10 killed outright, 1 at push-tier
+entropy, 2 survivors fixed in PR #555 (`assert_below_gate_never_stops_search`
+and the `_SPECTRAL_OVERRIDE_DECISIVE_WORLD` parity pin).
+
 ## Writing new generated tests
 
+- **Invariants come first.** New features with a generated-testable surface
+  (pure decisions, lifecycles/state machines, wire or event ingestion)
+  write their policy invariants down in the issue/plan before
+  implementation, and ship the generated properties in the same PR — see
+  `.claude/rules/code-quality.md` § "Testing — Red/Green TDD".
 - Strategies generate anything the **schema** can express — no plausibility
   filters. The V0-evidence bug lived in a state a plausible-worlds-only
   generator would have skipped. If a state is truly impossible, fail-closed
   handling of it is itself the invariant.
 - Invariant checkers are module-level functions so a known-bad self-test
-  can prove each one trips.
+  can prove each one trips. Every checker owes one — a property that has
+  never failed anything is unfalsifiable until proven otherwise.
 - Import `tests._hypothesis_profiles` for the side effect before using
-  `@given` — that is what wires the module into the suite/fuzz tiers.
+  `@given` — that is what wires the module into the suite/push/fuzz tiers.
 - Reuse the shared fakes/builders (`tests/fakes/`, `tests/helpers.py`)
   per `.claude/rules/code-quality.md`; leaf-seam mock rules apply to
   generated tests like any other test.

--- a/tests/test_request_lifecycle_generated.py
+++ b/tests/test_request_lifecycle_generated.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Generated request-lifecycle tests — issue #548 follow-up.
+
+A Hypothesis ``RuleBasedStateMachine`` drives random sequences of REAL
+production transitions — ``lib/transitions.py::finalize_request`` (the
+single status-mutation funnel) and ``PipelineDB.supersede_request_mbid``
+(Replace) — against a ``FakePipelineDB``, then asserts the archivist
+lifecycle invariants after every step:
+
+* every row's status stays in the legal set (the CHECK constraint's
+  vocabulary — the fake doesn't enforce it, so the machine must);
+* ``replaced`` rows are terminal and FROZEN — nothing mutates them after
+  the supersede, ever (the request is the source of truth; operator
+  actions supersede rows, they don't rewrite them);
+* request identity (mb_release_id / source / created_at) is immutable
+  for every row from creation onward;
+* every replaced row has a linked descendant pointing back via
+  ``replaces_request_id`` (unique structurally — a replaced row cannot be
+  superseded again) — Replace creates a new row, not a mutation;
+* ``active_download_state`` exists only on ``downloading`` rows;
+* the guarded transitions really guard: a download claim on a non-wanted
+  row and a downloading→wanted requeue on a non-downloading row are
+  no-ops that leave the row untouched.
+
+Rule eligibility mirrors production caller guards: the DB-guarded
+operations (claim, download-fail requeue) deliberately target ANY row —
+the guard is the contract under test — while unguarded transitions
+(→imported/→manual/→wanted-reset, supersede) select rows by the statuses
+their production callers act on, exactly as the live system does (the
+DAG in ``VALID_TRANSITIONS`` warns but does not block; enforcement lives
+in caller row-selection).
+
+Profiles, promotion policy, fault-injection qualification:
+docs/generated-testing.md.
+"""
+
+import copy
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    RuleBasedStateMachine,
+    invariant,
+    precondition,
+    rule,
+)
+
+from lib.transitions import RequestTransition, finalize_request
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_active_download_state_json
+
+LEGAL_STATUSES = frozenset(
+    {"wanted", "downloading", "imported", "manual", "replaced"})
+
+_IDENTITY_FIELDS = ("mb_release_id", "source", "created_at")
+
+_RETRY_COUNTERS = ("search_attempts", "download_attempts", "validation_attempts")
+
+
+# ===========================================================================
+# Invariant checkers — module functions so the known-bad self-tests below
+# can prove each one trips (harness RED/GREEN).
+# ===========================================================================
+
+def assert_statuses_legal(rows: list[dict]) -> None:
+    for row in rows:
+        if row["status"] not in LEGAL_STATUSES:
+            raise AssertionError(
+                f"request {row['id']} has illegal status {row['status']!r}")
+
+
+def assert_replaced_row_frozen(snapshot: dict, row: dict) -> None:
+    """A replaced row is a frozen audit record — byte-identical forever."""
+    if row != snapshot:
+        diffs = {
+            key: (snapshot.get(key), row.get(key))
+            for key in set(snapshot) | set(row)
+            if snapshot.get(key) != row.get(key)
+        }
+        raise AssertionError(
+            f"replaced request {snapshot['id']} mutated after supersede: {diffs}")
+
+
+def assert_identity_immutable(identity: tuple, row: dict) -> None:
+    current = tuple(row[field] for field in _IDENTITY_FIELDS)
+    if current != identity:
+        raise AssertionError(
+            f"request {row['id']} identity drifted: {identity} -> {current}")
+
+
+def assert_download_state_coherent(row: dict) -> None:
+    if row["status"] != "downloading" and row.get("active_download_state"):
+        raise AssertionError(
+            f"request {row['id']} carries active_download_state while "
+            f"{row['status']!r}")
+
+
+def assert_replacement_linked(replaced_id: int, descendant: dict | None) -> None:
+    if descendant is None:
+        raise AssertionError(
+            f"replaced request {replaced_id} has no linked descendant row")
+    if descendant.get("replaces_request_id") != replaced_id:
+        raise AssertionError(
+            f"descendant of {replaced_id} does not point back "
+            f"(replaces_request_id={descendant.get('replaces_request_id')!r})")
+
+
+class RequestLifecycleMachine(RuleBasedStateMachine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.db = FakePipelineDB()
+        self.ids: list[int] = []
+        self.identity: dict[int, tuple] = {}
+        self.frozen: dict[int, dict] = {}
+        self._mbid_counter = 0
+
+    # -- helpers ------------------------------------------------------
+
+    def _unique_mbid(self) -> str:
+        self._mbid_counter += 1
+        return f"lifecycle-mbid-{self._mbid_counter:04d}"
+
+    def _row(self, request_id: int) -> dict:
+        row = self.db.request(request_id)
+        assert row is not None
+        return row
+
+    def _ids_with_status(self, *statuses: str) -> list[int]:
+        return [
+            rid for rid in self.ids
+            if self._row(rid)["status"] in statuses
+        ]
+
+    def _track(self, request_id: int) -> None:
+        self.ids.append(request_id)
+        row = self._row(request_id)
+        self.identity[request_id] = tuple(
+            row[field] for field in _IDENTITY_FIELDS)
+
+    # -- rules (production entry points only) --------------------------
+
+    @rule()
+    def create_request(self) -> None:
+        rid = self.db.add_request(
+            "Lifecycle Artist", f"Album {self._mbid_counter}", "request",
+            mb_release_id=self._unique_mbid())
+        self._track(rid)
+
+    @precondition(lambda self: self.ids)
+    @rule(data=st.data())
+    def claim_download(self, data) -> None:
+        """DB-guarded: succeeds only from 'wanted'; targets ANY row."""
+        rid = data.draw(st.sampled_from(self.ids), label="claim target")
+        before = copy.deepcopy(self._row(rid))
+        ok = finalize_request(self.db, rid, RequestTransition.to_downloading(
+            state_json=make_active_download_state_json([])))
+        row = self._row(rid)
+        if before["status"] == "wanted":
+            if not ok or row["status"] != "downloading":
+                raise AssertionError(
+                    f"wanted->downloading claim failed: ok={ok}, "
+                    f"status={row['status']!r}")
+        else:
+            if ok or row != before:
+                raise AssertionError(
+                    f"claim on {before['status']!r} row must be a no-op "
+                    f"(ok={ok})")
+
+    @precondition(lambda self: self._ids_with_status("downloading"))
+    @rule(data=st.data())
+    def import_success(self, data) -> None:
+        rid = data.draw(
+            st.sampled_from(self._ids_with_status("downloading")),
+            label="import target")
+        ok = finalize_request(self.db, rid, RequestTransition.to_imported(
+            from_status="downloading",
+            imported_path=f"/Beets/lifecycle/{rid}",
+            min_bitrate=245,
+        ))
+        row = self._row(rid)
+        if not ok or row["status"] != "imported":
+            raise AssertionError(
+                f"downloading->imported failed: ok={ok}, "
+                f"status={row['status']!r}")
+
+    @precondition(lambda self: self.ids)
+    @rule(data=st.data())
+    def download_fail_requeue(self, data) -> None:
+        """DB-guarded: succeeds only from 'downloading'; targets ANY row.
+        Preserves retry counters and records the failed attempt."""
+        rid = data.draw(st.sampled_from(self.ids), label="requeue target")
+        before = copy.deepcopy(self._row(rid))
+        ok = finalize_request(self.db, rid, RequestTransition.to_wanted(
+            from_status="downloading", attempt_type="download"))
+        row = self._row(rid)
+        if before["status"] == "downloading":
+            if not ok or row["status"] != "wanted":
+                raise AssertionError(
+                    f"downloading->wanted requeue failed: ok={ok}, "
+                    f"status={row['status']!r}")
+            if row["download_attempts"] != (before["download_attempts"] or 0) + 1:
+                raise AssertionError(
+                    "failed download attempt was not recorded "
+                    f"({before['download_attempts']} -> "
+                    f"{row['download_attempts']})")
+        else:
+            if ok or row != before:
+                raise AssertionError(
+                    f"downloading->wanted on {before['status']!r} row must "
+                    f"be a no-op (ok={ok})")
+
+    @precondition(lambda self: self._ids_with_status("wanted", "downloading"))
+    @rule(data=st.data())
+    def flag_manual(self, data) -> None:
+        rid = data.draw(
+            st.sampled_from(self._ids_with_status("wanted", "downloading")),
+            label="manual target")
+        from_status = self._row(rid)["status"]
+        ok = finalize_request(
+            self.db, rid, RequestTransition.to_manual(from_status=from_status))
+        row = self._row(rid)
+        if not ok or row["status"] != "manual":
+            raise AssertionError(
+                f"{from_status}->manual failed: ok={ok}, "
+                f"status={row['status']!r}")
+
+    @precondition(lambda self: self._ids_with_status("imported", "manual"))
+    @rule(data=st.data())
+    def requeue_from_terminal(self, data) -> None:
+        """Operator requeue (upgrade / retry-from-manual): clears counters."""
+        rid = data.draw(
+            st.sampled_from(self._ids_with_status("imported", "manual")),
+            label="requeue-from-terminal target")
+        from_status = self._row(rid)["status"]
+        ok = finalize_request(
+            self.db, rid, RequestTransition.to_wanted(from_status=from_status))
+        row = self._row(rid)
+        if not ok or row["status"] != "wanted":
+            raise AssertionError(
+                f"{from_status}->wanted requeue failed: ok={ok}, "
+                f"status={row['status']!r}")
+        for counter in _RETRY_COUNTERS:
+            if row[counter] != 0:
+                raise AssertionError(
+                    f"requeue did not clear {counter} (={row[counter]})")
+
+    @precondition(
+        lambda self: self._ids_with_status("wanted", "imported", "manual"))
+    @rule(data=st.data())
+    def replace(self, data) -> None:
+        """Replace (issue-#282 shape): the old row flips to 'replaced' and
+        freezes; a NEW linked row is created. Downloading rows are excluded
+        because the replace service converges active downloads before the
+        supersede (Phase 0) — the machine mirrors that caller guard."""
+        rid = data.draw(
+            st.sampled_from(
+                self._ids_with_status("wanted", "imported", "manual")),
+            label="replace target")
+        new_id = self.db.supersede_request_mbid(
+            rid,
+            new_mb_release_id=self._unique_mbid(),
+            new_mb_release_group_id=None,
+            new_mb_artist_id=None,
+            new_artist_name="Lifecycle Artist",
+            new_album_title=f"Album {rid} (correct pressing)",
+            new_year=None,
+            new_country=None,
+            new_tracks=[],
+        )
+        self._track(new_id)
+        old_row = self._row(rid)
+        if old_row["status"] != "replaced":
+            raise AssertionError(
+                f"supersede left old row status={old_row['status']!r}")
+        # The frozen audit snapshot: byte-identical from here on.
+        self.frozen[rid] = copy.deepcopy(old_row)
+        assert_replacement_linked(
+            rid, self.db.get_request_by_replaces_request_id(rid))
+
+    # -- invariants (checked after every rule) --------------------------
+
+    @invariant()
+    def statuses_stay_legal(self) -> None:
+        assert_statuses_legal([self._row(rid) for rid in self.ids])
+
+    @invariant()
+    def replaced_rows_stay_frozen(self) -> None:
+        for rid, snapshot in self.frozen.items():
+            assert_replaced_row_frozen(snapshot, self._row(rid))
+
+    @invariant()
+    def identity_never_drifts(self) -> None:
+        for rid, identity in self.identity.items():
+            assert_identity_immutable(identity, self._row(rid))
+
+    @invariant()
+    def download_state_only_while_downloading(self) -> None:
+        for rid in self.ids:
+            assert_download_state_coherent(self._row(rid))
+
+    @invariant()
+    def every_replaced_row_has_a_descendant(self) -> None:
+        for rid in self.frozen:
+            assert_replacement_linked(
+                rid, self.db.get_request_by_replaces_request_id(rid))
+
+
+TestRequestLifecycleMachine = RequestLifecycleMachine.TestCase
+
+
+class TestLifecycleCheckersTripOnViolations(unittest.TestCase):
+    """Known-bad self-tests for every lifecycle invariant checker."""
+
+    def test_trips_on_illegal_status(self):
+        with self.assertRaises(AssertionError):
+            assert_statuses_legal([{"id": 1, "status": "zombie"}])
+
+    def test_trips_on_thawed_replaced_row(self):
+        snapshot = {"id": 1, "status": "replaced", "min_bitrate": 245}
+        thawed = {"id": 1, "status": "replaced", "min_bitrate": 320}
+        with self.assertRaises(AssertionError):
+            assert_replaced_row_frozen(snapshot, thawed)
+
+    def test_trips_on_resurrected_replaced_row(self):
+        snapshot = {"id": 1, "status": "replaced"}
+        resurrected = {"id": 1, "status": "wanted"}
+        with self.assertRaises(AssertionError):
+            assert_replaced_row_frozen(snapshot, resurrected)
+
+    def test_trips_on_identity_drift(self):
+        row = {"id": 1, "mb_release_id": "mbid-B", "source": "request",
+               "created_at": "t0"}
+        with self.assertRaises(AssertionError):
+            assert_identity_immutable(("mbid-A", "request", "t0"), row)
+
+    def test_trips_on_stray_download_state(self):
+        with self.assertRaises(AssertionError):
+            assert_download_state_coherent(
+                {"id": 1, "status": "imported",
+                 "active_download_state": "{}"})
+
+    def test_trips_on_missing_descendant(self):
+        with self.assertRaises(AssertionError):
+            assert_replacement_linked(1, None)
+        with self.assertRaises(AssertionError):
+            assert_replacement_linked(1, {"replaces_request_id": 99})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third #548 slice — codifies today's lessons into the always-loaded rules, then applies them to the next-highest-value fuzz target.

### Rules/docs: invariant-first TDD, both tiers, falsifiable harnesses

- `.claude/rules/code-quality.md` § Red/Green TDD: **start every feature by writing its invariants down**; features with a generated-testable surface (pure decisions, lifecycles, wire/event ingestion) ship their Hypothesis properties **in the same PR**; **every invariant checker owes a known-bad self-test**; when in doubt that the harness constrains anything, **qualify it by fault injection** (one-shot driver, never committed; kill matrix recorded in the issue). New-work-checklist row added.
- `docs/generated-testing.md`: "Qualifying the harness — fault injection" section (how to pick mutants, how to interpret killed / killed-at-entropy / survived), with the canonical 2026-07-08 run. CLAUDE.md pointer updated.

### Request-lifecycle state machine (`tests/test_request_lifecycle_generated.py`)

A `RuleBasedStateMachine` drives random operation sequences through the **real** production transition funnel — `transitions.finalize_request` / `RequestTransition` — plus `supersede_request_mbid` (Replace), against `FakePipelineDB`. After every step:

- statuses stay in the legal set (the fake doesn't enforce the PG CHECK — the machine does);
- **`replaced` rows are terminal and byte-frozen** — and this is non-vacuous: the guarded rules deliberately fire claims and requeues at replaced rows through the real `finalize_request`;
- identity (mbid / source / created_at) is immutable; replaced rows keep their linked descendant;
- `active_download_state` exists only on `downloading` rows;
- the DB guards no-op on ineligible rows, with counters preserved/bumped/cleared per the real side-effect table.

Known-bad self-tests for all five checkers. **Qualified at birth by fault injection**: three mutants planted in `lib/transitions.py` (claim lies about success; downloading→wanted guard bypassed to unguarded `update_status`; operator requeue stops clearing counters) — all killed at the deterministic suite tier, baseline green.

### Verification

- pyright 0 errors; full suite green (4787 tests); deep fuzz burst green (20k stateful runs ≈ ~1M rule executions in 5 min); Opus review verdict **ship** (precision nit fixed); pre-push hook (push-tier fuzz incl. the new machine + flake check) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)