### PR TITLE
docs(rules): generated-first bug hunting is the house method (#548/#550)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -167,19 +167,47 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
 - No decision logic inline in cratedigger.py — call the pure function, branch on result
 - Every pure function must have direct unit tests (not just tested through integration)
 
-## Pipeline Decision Debugging — Simulator-First TDD
-- When debugging or changing import pipeline behavior (quality gate, backfill, spectral propagation, search tier selection), **always start with the CLI simulator** (`pipeline-cli quality <id>`).
-- Add scenarios to the simulator FIRST that expose the bug or show the expected behavior. The simulator is the test suite for pipeline decisions — if you can't see the problem in the simulator output, you don't understand it yet.
-- Only edit production code once the simulator scenarios clearly show what's wrong and what "right" looks like. The scenarios tell you what code to change.
-- Run the simulator against real albums in the live DB (not mocked state) to verify. Pick albums that represent the edge case: e.g. CBR 320 with no spectral, verified lossless lo-fi, suspect FLAC transcodes.
-- The simulator must show the full rejection cycle: import/reject decision → spectral propagation → backfill decision → next search tiers. Not just the import decision in isolation.
+## Bug Hunting — Generated-First (the house method)
 
-## Pipeline Bug Reproduction — Red/Green on Real Code Paths
-- When a live pipeline bug involves **interactions between components** (spectral propagation → decision function → DB write → rejection), don't just test the pure decision function in isolation — write a unit test that calls the actual orchestration function (e.g. `lib.measurement.measure_preimport_state` + `dispatch_import_from_db`) with mocked state matching the live scenario.
-- **RED first**: reproduce the exact live scenario as a test. Mock up the album state from `pipeline-cli show <id>` (status, spectral fields, min_bitrate). Run the test and confirm it fails with the same symptom as production.
-- **GREEN**: fix the production code, confirm the test passes.
-- **Guard both directions**: add a test for the fixed case AND a test that the original valid behavior still works (e.g. propagation still works when an album IS on disk but lacks spectral data).
-- This catches bugs that pure function tests miss — state mutations, propagation ordering, in-memory corruption before the decision function runs.
+Proven on #550 (2026-07-08): a live production bug that static analysis and
+disk forensics could NOT reproduce was found, reproduced, RCA'd and fixed in
+one session by a generated harness driving the real code path. This is how
+bugs are hunted here — reach for it BEFORE log-trawling, before speculative
+instrumentation, before reading code until a theory falls out.
+
+1. **Write down the invariant the symptom violates** ("the manifest that
+   reaches validation covers every file grabbed"). If you can't state one,
+   you don't understand the symptom yet.
+2. **Probe the cheapest suspicious seam with real production functions**
+   (a throwaway nix-shell heredoc driving e.g. the real matcher over a
+   seeded cache — minutes, not committed).
+3. **Build/extend a generated harness** in `tests/test_*_generated.py`:
+   strategies over the world space (no plausibility filters), the invariant
+   as a checker, REAL production entry points, fakes/leaf-seam stubs only
+   at the allowlisted edges. Let Hypothesis find and shrink the
+   reproduction.
+4. **RED → fix → GREEN** in one PR: the shrunk world becomes a
+   deterministic regression pin, the invariant becomes a permanent
+   property, a must-still-work guard proves the fix doesn't fail-closed
+   legitimate behavior, and a known-bad self-test proves the checker trips.
+5. **Qualify when in doubt** — plant a mutant reverting your fix; the
+   property must kill it.
+
+Tools within the method, for quality-decision bugs specifically:
+
+- **Simulator scenarios** (`pipeline-cli quality <id>`,
+  `tests/test_simulator_scenarios.py`): the flat-kwargs twin is the
+  canonical scenario language — add the failing scenario to the album test
+  set and run the simulator against real albums in the live DB to verify.
+  The simulator must show the full rejection cycle (import/reject →
+  spectral propagation → backfill → next tiers), not the import decision
+  in isolation.
+- **Real-code-path orchestration repros**: when a bug lives in component
+  interactions (propagation → decision → DB write), drive the actual
+  orchestration function (`measure_preimport_state`,
+  `dispatch_import_from_db`) with state matching the live scenario — pure
+  decision tests alone miss state mutations and ordering. Guard both
+  directions: the fixed case AND the still-valid original behavior.
 
 ## Frontend (JavaScript)
 - ES6 modules in `web/js/` — no inline `<script>` in HTML

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,11 @@ nix-shell --run "python3 -m unittest tests.test_X -v"
 
 Browser automation for `music.ablz.au` — per-machine `.mcp.json` (gitignored). Always HTTPS (http times out). `docs/playwright-mcp.md`.
 
-## Debugging quality decisions
+## Hunting bugs — generated-first (the house method)
 
-`pipeline-cli show / quality / debug-download / search-plan show / query` are the diagnostic entry points. Start with the simulator (`pipeline-cli quality <id>`) and add a failing scenario FIRST (`.claude/rules/code-quality.md` § "Simulator-First TDD"). Command reference + triage signals in `docs/debugging-cli.md`.
+**Bugs are hunted with generated tests, not log-trawling.** Write down the invariant the symptom violates, probe the cheapest suspicious seam with real production functions, then build a generated harness (`tests/test_*_generated.py`) that drives the REAL code path over generated worlds and let Hypothesis find + shrink the reproduction — RED → fix → GREEN in one PR, with the shrunk world pinned forever. Proven on #550: a live bug that static analysis and disk forensics could not reproduce fell to this method in one session. Full workflow: `.claude/rules/code-quality.md` § "Bug Hunting — Generated-First" + `docs/generated-testing.md`.
+
+For quality-decision bugs the simulator is the tool within the method: `pipeline-cli show / quality / debug-download / search-plan show / query` are the diagnostic entry points; add the failing scenario to the album test set and verify against real albums in the live DB. Command reference + triage signals in `docs/debugging-cli.md`.
 
 ## Finding dead code
 

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -5,6 +5,31 @@ over large generated state spaces instead of hand-picked examples. They are
 ordinary members of the unittest suite — no separate runner, no seed
 bookkeeping, no standing service.
 
+## Bug hunting — the house method
+
+This is the primary bug-hunting workflow (proven on #550, where a live
+production bug unreproducible by static analysis + disk forensics fell in
+one session): **invariant → probe → generated harness → shrink → fix**.
+
+1. Write down the invariant the symptom violates.
+2. Probe the cheapest suspicious seam with REAL production functions (a
+   throwaway nix-shell heredoc — minutes, never committed).
+3. Build/extend a `tests/test_*_generated.py` harness: strategies over the
+   world space, the invariant as a checker, real entry points, stubs only
+   at allowlisted leaf seams. Hypothesis finds and shrinks the repro.
+4. RED → fix → GREEN in one PR: shrunk world pinned, invariant permanent,
+   must-still-work guard, known-bad self-test.
+5. When in doubt, plant a mutant reverting the fix — the property must
+   kill it.
+
+Case study (#550 defect #1): invariant "an accepted multi-disc grab covers
+every disc with unique transfer identities" → probe showed the real matcher
+cross-matches sibling disc folders → harness drove real `try_multi_enqueue`
+and reproduced `matched=True` with 16 entries / 11 unique files → two-layer
+fix (source exclusion + fail-closed coverage gate) merged with the property
+in PR #557. Full workflow rule: `.claude/rules/code-quality.md` § "Bug
+Hunting — Generated-First".
+
 ## Modules
 
 | Module | Target | Properties |


### PR DESCRIPTION
Replaces the Simulator-First-TDD and Red/Green-on-Real-Code-Paths debugging doctrine with one 'Bug Hunting — Generated-First' workflow (simulator + orchestration-repro patterns remain as tools within it); CLAUDE.md leads with the method; #550 case study documented in docs/generated-testing.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)