### PR TITLE
fix(download): attempt-scoped canonical processing folders (#550 phase 2)

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -37,7 +37,7 @@ from lib.download_recovery import (
     reconcile_processing_current_path,
 )
 from lib.grab_list import GrabListEntry, DownloadFile
-from lib.processing_paths import directory_has_entries
+from lib.processing_paths import attempt_fingerprint, directory_has_entries
 from lib.quality import (ActiveDownloadState, ActiveDownloadFileState,
                          CooldownConfig,
                          DownloadDecision,
@@ -660,6 +660,9 @@ def _processing_path_ready_for_importer(
         request_id=request_id,
         staging_dir=ctx.cfg.beets_staging_dir,
         slskd_download_dir=ctx.cfg.slskd_download_dir,
+        attempt_fingerprint=attempt_fingerprint(
+            [(f.username, f.filename) for f in entry.files],
+        ),
     )
     if current_path_location.kind == "canonical":
         # The canonical processing folder may not exist yet — the
@@ -822,6 +825,9 @@ def _poll_one_active_download(
             staging_dir=ctx.cfg.beets_staging_dir,
             slskd_download_dir=ctx.cfg.slskd_download_dir,
             has_entries=directory_has_entries,
+            attempt_fingerprint=attempt_fingerprint(
+                [(f.username, f.filename) for f in state.files],
+            ),
         )
         if recovery_decision.blocked_reason == "multiple_populated_paths":
             rendered_candidates = ", ".join(

--- a/lib/download_processing.py
+++ b/lib/download_processing.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, TYPE_CHECKING
 
 from lib.download_recovery import ProcessingPathLocation, classify_processing_path
-from lib.grab_list import GrabListEntry
+from lib.grab_list import DownloadFile, GrabListEntry
 from lib.dispatch import (DispatchOutcome, QualityGateFn,
                           _build_download_info,
                           _record_rejection_and_maybe_requeue,
@@ -37,6 +37,7 @@ from lib.import_manifest import (
     tracked_audio_paths_for_downloads,
 )
 from lib.processing_paths import (
+    attempt_fingerprint,
     canonical_processing_path,
     normalize_processing_path,
     normalize_source_dirs,
@@ -249,6 +250,17 @@ def _is_request_scoped_auto_import_path(
     )
 
 
+def _attempt_fingerprint_for(files: list[DownloadFile]) -> str:
+    """Fingerprint this attempt's exact (username, filename) file set.
+
+    Every canonical-folder computation for the same album must derive
+    from this SAME persisted file set — at materialize, at resume
+    classification, and at recovery — or a mismatch classifies the
+    folder as ``external`` and strands it (issue #550 phase 2).
+    """
+    return attempt_fingerprint([(f.username, f.filename) for f in files])
+
+
 def _canonical_import_folder_path(
     album_data: GrabListEntry,
     slskd_download_dir: str,
@@ -258,6 +270,7 @@ def _canonical_import_folder_path(
         title=album_data.title,
         year=album_data.year,
         slskd_download_dir=slskd_download_dir,
+        attempt_fingerprint=_attempt_fingerprint_for(album_data.files),
     )
 
 
@@ -739,6 +752,7 @@ def _materialize_processing_dir(
         request_id=request_id or 0,
         staging_dir=ctx.cfg.beets_staging_dir,
         slskd_download_dir=ctx.cfg.slskd_download_dir,
+        attempt_fingerprint=_attempt_fingerprint_for(album_data.files),
     )
 
     if current_path_location.kind != "canonical":
@@ -1217,6 +1231,7 @@ def _handle_valid_result(
         request_id=request_id or 0,
         staging_dir=ctx.cfg.beets_staging_dir,
         slskd_download_dir=ctx.cfg.slskd_download_dir,
+        attempt_fingerprint=_attempt_fingerprint_for(album_data.files),
     )
 
     if wants_auto_import and not album_data.mb_release_id:

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -102,6 +102,12 @@ def _recovery_candidates(
     slskd_download_dir: str,
     attempt_fingerprint: str = "",
 ) -> tuple[ProcessingPathLocation, ...]:
+    # Deliberately NO bare (un-fingerprinted) canonical fallback candidate:
+    # forward-only data assumptions (scope.md). Rows that were mid-download
+    # across the #550-phase-2 deploy window are an operator one-shot at
+    # deploy time (drain or reset the in-flight cohort), not a permanent
+    # compat branch — a bare-path candidate would quietly re-open the
+    # cross-attempt accumulation this refactor exists to kill.
     canonical_path = canonical_processing_path(
         artist=artist,
         title=title,

--- a/lib/download_recovery.py
+++ b/lib/download_recovery.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Callable, Literal
 
 from lib.processing_paths import (
+    attempt_fingerprint,
     canonical_processing_path,
     normalize_processing_path,
     path_is_within_root,
@@ -99,12 +100,14 @@ def _recovery_candidates(
     request_id: int,
     staging_dir: str,
     slskd_download_dir: str,
+    attempt_fingerprint: str = "",
 ) -> tuple[ProcessingPathLocation, ...]:
     canonical_path = canonical_processing_path(
         artist=artist,
         title=title,
         year=year,
         slskd_download_dir=slskd_download_dir,
+        attempt_fingerprint=attempt_fingerprint,
     )
     return (
         ProcessingPathLocation(path=canonical_path, kind="canonical"),
@@ -190,6 +193,7 @@ def classify_processing_path(
     request_id: int,
     staging_dir: str,
     slskd_download_dir: str,
+    attempt_fingerprint: str = "",
 ) -> ProcessingPathLocation:
     """Classify a persisted current_path against the active download seam."""
     canonical_path = canonical_processing_path(
@@ -197,6 +201,7 @@ def classify_processing_path(
         title=title,
         year=year,
         slskd_download_dir=slskd_download_dir,
+        attempt_fingerprint=attempt_fingerprint,
     )
     if normalize_processing_path(current_path) == normalize_processing_path(
         canonical_path,
@@ -252,6 +257,7 @@ def resolve_missing_current_path(
     staging_dir: str,
     slskd_download_dir: str,
     has_entries: Callable[[str], bool],
+    attempt_fingerprint: str = "",
 ) -> ResumeRecoveryDecision:
     """Resolve a missing current_path by probing the known recovery locations."""
     candidates = _recovery_candidates(
@@ -261,6 +267,7 @@ def resolve_missing_current_path(
         request_id=request_id,
         staging_dir=staging_dir,
         slskd_download_dir=slskd_download_dir,
+        attempt_fingerprint=attempt_fingerprint,
     )
     return _resolve_recovery_candidates(
         candidates,
@@ -278,6 +285,7 @@ def reconcile_processing_current_path(
     staging_dir: str,
     slskd_download_dir: str,
     has_entries: Callable[[str], bool],
+    attempt_fingerprint: str = "",
 ) -> ResumeRecoveryDecision:
     """Resolve the best local path for a row already in local processing.
 
@@ -294,6 +302,7 @@ def reconcile_processing_current_path(
         request_id=request_id,
         staging_dir=staging_dir,
         slskd_download_dir=slskd_download_dir,
+        attempt_fingerprint=attempt_fingerprint,
     )
     if current_path is None:
         return _resolve_recovery_candidates(
@@ -309,6 +318,7 @@ def reconcile_processing_current_path(
         request_id=request_id,
         staging_dir=staging_dir,
         slskd_download_dir=slskd_download_dir,
+        attempt_fingerprint=attempt_fingerprint,
     )
     if current_location.kind != "canonical" or has_entries(current_location.path):
         return ResumeRecoveryDecision(
@@ -321,6 +331,21 @@ def reconcile_processing_current_path(
         candidates,
         has_entries=has_entries,
     )
+
+
+def _row_files_fingerprint(files: list[object]) -> str:
+    """Fingerprint a raw JSONB ``active_download_state.files`` list.
+
+    Mirrors ``lib.download_processing._attempt_fingerprint_for`` for the
+    typed ``DownloadFile`` side — MUST derive from the same (username,
+    filename) pairs so the repair scanner's classification never
+    disagrees with the runtime poller's (issue #550 phase 2).
+    """
+    return attempt_fingerprint([
+        (str(f.get("username") or ""), str(f.get("filename") or ""))
+        for f in files
+        if isinstance(f, dict)
+    ])
 
 
 def find_blocked_recovery_issues(
@@ -368,6 +393,7 @@ def find_blocked_recovery_issues(
             staging_dir=staging_dir,
             slskd_download_dir=slskd_download_dir,
             has_entries=has_entries,
+            attempt_fingerprint=_row_files_fingerprint(files),
         )
         if recovery_decision.blocked_reason == "multiple_populated_paths":
             rendered_candidates = ", ".join(
@@ -442,6 +468,7 @@ def find_blocked_processing_path_issues(
             staging_dir=staging_dir,
             slskd_download_dir=slskd_download_dir,
             has_entries=has_entries,
+            attempt_fingerprint=_row_files_fingerprint(files),
         )
         if recovery_decision.blocked_reason == "multiple_populated_paths":
             rendered_candidates = ", ".join(

--- a/lib/processing_paths.py
+++ b/lib/processing_paths.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
 from typing import Sequence
@@ -48,17 +50,59 @@ def path_is_within_root(path: str, root: str) -> bool:
         return False
 
 
+def attempt_fingerprint(pairs: Sequence[tuple[str, str]]) -> str:
+    """Short deterministic fingerprint of an attempt's (username, filename) set.
+
+    Mirrors the ``snapshot_fingerprint`` idiom in
+    ``lib/quality_evidence.py``: sort the pairs, JSON-encode with no
+    whitespace, SHA-256 the UTF-8 bytes, and take the first 8 hex chars —
+    enough entropy to distinguish concurrent attempts in a folder name
+    while staying short and readable.
+
+    Order-independent (the pairs are sorted before encoding) and
+    sensitive to every field: a different source user or a different
+    remote path for even one track produces a different fingerprint. The
+    empty set hashes the JSON encoding of ``[]`` (a stable, defined
+    digest), not an error — same documented behavior as
+    ``snapshot_fingerprint``.
+
+    Used to key each download attempt's canonical processing folder to
+    its own manifest (issue #550 phase 2) — see ``canonical_processing_path``.
+    """
+    encoded = json.dumps(
+        sorted(pairs),
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:8]
+
+
 def canonical_processing_path(
     *,
     artist: str,
     title: str,
     year: str,
     slskd_download_dir: str,
+    attempt_fingerprint: str = "",
 ) -> str:
-    """Return the canonical local processing directory for a completed album."""
+    """Return the canonical local processing directory for a completed album.
+
+    When ``attempt_fingerprint`` is non-empty, it is appended as a
+    `` [<fp>]`` suffix so each download attempt (a distinct manifest of
+    (username, filename) pairs) materializes into its own folder — no
+    attempt ever validates against files another attempt placed there
+    (issue #550 phase 2: the canonical folder used to be keyed only on
+    artist/title/year, so a stale prior attempt's leftover audio could
+    silently blend into a fresh attempt's validation scope). Empty (the
+    default) preserves the bare ``"Artist - Title (Year)"`` folder name
+    for callers that classify an already-persisted path rather than
+    compute a fresh one.
+    """
     import_folder_name = sanitize_processing_folder_name(
         f"{artist} - {title} ({year})",
     )
+    if attempt_fingerprint:
+        import_folder_name = f"{import_folder_name} [{attempt_fingerprint}]"
     return os.path.join(slskd_download_dir, import_folder_name)
 
 

--- a/lib/processing_paths.py
+++ b/lib/processing_paths.py
@@ -102,7 +102,16 @@ def canonical_processing_path(
         f"{artist} - {title} ({year})",
     )
     if attempt_fingerprint:
-        import_folder_name = f"{import_folder_name} [{attempt_fingerprint}]"
+        suffix = f" [{attempt_fingerprint}]"
+        # ext4 caps filenames at 255 bytes; a near-limit sanitized name that
+        # fit before must not start failing os.makedirs once suffixed
+        # (codex review r2) — truncate the base on a character boundary.
+        max_base_bytes = 255 - len(suffix.encode("utf-8"))
+        base_bytes = import_folder_name.encode("utf-8")
+        if len(base_bytes) > max_base_bytes:
+            import_folder_name = base_bytes[:max_base_bytes].decode(
+                "utf-8", errors="ignore").rstrip()
+        import_folder_name = f"{import_folder_name}{suffix}"
     return os.path.join(slskd_download_dir, import_folder_name)
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1487,6 +1487,7 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
     def test_persists_canonical_current_path_for_fresh_materialization(self):
         """The first local materialization must persist the canonical path to DB."""
         from lib.download_processing import Completed, process_completed_album
+        from lib.processing_paths import attempt_fingerprint
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             fake_db = FakePipelineDB()
@@ -1521,10 +1522,11 @@ class TestProcessCompletedAlbumReturnOwnership(unittest.TestCase):
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
+            fp = attempt_fingerprint([("user1", "user1\\Music\\01 - Track.mp3")])
             self.assertIsInstance(result, Completed)
             self.assertEqual(
                 fake_db.request(42)["active_download_state"]["current_path"],
-                os.path.join(tmpdir, "downloads", "Artist - Album (2024)"),
+                os.path.join(tmpdir, "downloads", f"Artist - Album (2024) [{fp}]"),
             )
 
     @patch("lib.beets.beets_validate")
@@ -1857,8 +1859,16 @@ class TestEventPathMaterialization(unittest.TestCase):
         cfg.beets_validation_enabled = False
         return album, ctx
 
-    def _moved(self, tmpdir):
-        return os.listdir(os.path.join(tmpdir, "Radiohead - Kid A (2000)"))
+    def _canonical_dir(self, tmpdir, files):
+        from lib.processing_paths import attempt_fingerprint, canonical_processing_path
+        fp = attempt_fingerprint([(f.username, f.filename) for f in files])
+        return canonical_processing_path(
+            artist="Radiohead", title="Kid A", year="2000",
+            slskd_download_dir=tmpdir, attempt_fingerprint=fp,
+        )
+
+    def _moved(self, tmpdir, files):
+        return os.listdir(self._canonical_dir(tmpdir, files))
 
     def test_stamped_file_moves_with_clean_basename(self):
         # slskd placed the file at an arbitrary event-reported location
@@ -1879,7 +1889,7 @@ class TestEventPathMaterialization(unittest.TestCase):
 
             self.assertIsInstance(result, Completed)
             self.assertFalse(os.path.exists(event_path))
-            self.assertEqual(self._moved(tmpdir), [self.FNAME])
+            self.assertEqual(self._moved(tmpdir, album.files), [self.FNAME])
 
     def test_stamped_forward_slash_remote_path_keeps_basename(self):
         # Destination basename extraction accepts slash-normalized remote
@@ -1908,7 +1918,7 @@ class TestEventPathMaterialization(unittest.TestCase):
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertIsInstance(result, Completed)
-            self.assertEqual(self._moved(tmpdir), [self.FNAME])
+            self.assertEqual(self._moved(tmpdir, album.files), [self.FNAME])
 
     def test_unstamped_file_is_hard_failure(self):
         # No event was ever ingested for this file (pre-bootstrap
@@ -2003,17 +2013,17 @@ class TestEventPathMaterialization(unittest.TestCase):
         from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
-            dst_dir = os.path.join(tmpdir, "Radiohead - Kid A (2000)")
+            album, ctx = self._album(
+                tmpdir, local_path=os.path.join(tmpdir, "Kid A", self.FNAME))
+            dst_dir = self._canonical_dir(tmpdir, album.files)
             os.makedirs(dst_dir)
             with open(os.path.join(dst_dir, self.FNAME), "w") as fp:
                 fp.write("fake audio")
-            album, ctx = self._album(
-                tmpdir, local_path=os.path.join(tmpdir, "Kid A", self.FNAME))
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertIsInstance(result, Completed)
-            self.assertEqual(self._moved(tmpdir), [self.FNAME])
+            self.assertEqual(self._moved(tmpdir, album.files), [self.FNAME])
 
     def test_unstamped_already_moved_resume_still_skips(self):
         # Even an unstamped file counts as already moved when the
@@ -2021,16 +2031,100 @@ class TestEventPathMaterialization(unittest.TestCase):
         from lib.download_processing import Completed, process_completed_album
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
-            dst_dir = os.path.join(tmpdir, "Radiohead - Kid A (2000)")
+            album, ctx = self._album(tmpdir, local_path=None)
+            dst_dir = self._canonical_dir(tmpdir, album.files)
             os.makedirs(dst_dir)
             with open(os.path.join(dst_dir, self.FNAME), "w") as fp:
                 fp.write("fake audio")
-            album, ctx = self._album(tmpdir, local_path=None)
 
             result = process_completed_album(album, [], ctx, import_job_id=1)
 
             self.assertIsInstance(result, Completed)
-            self.assertEqual(self._moved(tmpdir), [self.FNAME])
+            self.assertEqual(self._moved(tmpdir, album.files), [self.FNAME])
+
+
+class TestAttemptScopedCanonicalFolder(unittest.TestCase):
+    """Issue #550 phase 2: the canonical processing folder must be keyed
+    to the attempt's own manifest, not just artist/title/year.
+
+    Before this fix, two different download attempts for the same
+    artist/title/year (e.g. a retry that grabbed from a different
+    Soulseek user after the first attempt was abandoned) shared the
+    SAME canonical folder. A stale prior attempt's leftover audio
+    silently blended into a fresh attempt's validation scope, producing
+    a false ``untracked_audio`` rejection (#550 defect #2). This test
+    proves a fresh attempt's materialized folder contains ONLY that
+    attempt's own manifest files — never files another attempt placed.
+    """
+
+    def test_materialize_never_blends_files_from_a_different_attempt(self):
+        from lib.download_processing import (
+            Materialized,
+            _canonical_import_folder_path,
+            _materialize_processing_dir,
+        )
+        from lib.staged_album import StagedAlbum
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_root = os.path.join(tmpdir, "downloads")
+            os.makedirs(download_root)
+
+            # A prior, DIFFERENT attempt (different source user/filename)
+            # already materialized into the bare artist/title/year folder
+            # and left an alien file behind — exactly what the pre-#550p2
+            # canonical folder would have been, regardless of which files
+            # produced it.
+            stale_dir = os.path.join(
+                download_root, "Test Artist - Test Album (2020)")
+            os.makedirs(stale_dir)
+            with open(os.path.join(stale_dir, "alien-track.flac"), "wb") as fp:
+                fp.write(b"alien audio from a different attempt")
+
+            # This attempt's real, event-stamped source file — a
+            # different (username, filename) pair than whatever produced
+            # the stale folder above.
+            source_dir = os.path.join(download_root, "user2", "Music")
+            os.makedirs(source_dir)
+            source_file = os.path.join(source_dir, "01 - Track.flac")
+            with open(source_file, "wb") as fp:
+                fp.write(b"this attempt's real audio")
+
+            stamped = make_download_file(
+                filename="user2\\Music\\01 - Track.flac",
+                file_dir="user2\\Music",
+                username="user2",
+            )
+            stamped.local_path = source_file
+            album = make_grab_list_entry(
+                files=[stamped],
+                artist="Test Artist",
+                title="Test Album",
+                year="2020",
+                mb_release_id="",
+            )
+            ctx = _make_ctx()
+            cfg = cast(Any, ctx.cfg)
+            cfg.slskd_download_dir = download_root
+
+            staged_album = StagedAlbum.from_entry(
+                album,
+                default_path=_canonical_import_folder_path(
+                    album, ctx.cfg.slskd_download_dir),
+            )
+            result = _materialize_processing_dir(album, staged_album, ctx)
+
+            self.assertIsInstance(result, Materialized)
+            # This attempt's own manifest fingerprint must route it to a
+            # folder distinct from the stale one.
+            self.assertNotEqual(staged_album.current_path, stale_dir)
+            validation_scope = os.listdir(staged_album.current_path)
+            self.assertEqual(validation_scope, ["01 - Track.flac"])
+            self.assertNotIn("alien-track.flac", validation_scope)
+            # The stale folder (a different attempt's manifest) is
+            # untouched — proves this isn't accidental cleanup, just
+            # non-collision.
+            self.assertEqual(
+                os.listdir(stale_dir), ["alien-track.flac"])
 
 
 class TestMaterializeFailureAction(unittest.TestCase):
@@ -3189,6 +3283,7 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_active_completion_queues_and_persists_processing_state(self):
         """Completion should leave persisted state for the importer to resume."""
         from lib.download import poll_active_downloads
+        from lib.processing_paths import attempt_fingerprint
         row = self._make_downloading_row()
         ctx, fake_db = self._make_poll_ctx(
             downloading_rows=[row],
@@ -3211,8 +3306,10 @@ class TestPollActiveDownloads(unittest.TestCase):
         persisted = self._download_state(fake_db)
         self.assertIsNotNone(persisted["processing_started_at"])
         self.assertIsNotNone(persisted["current_path"])
+        fp = attempt_fingerprint([("user1", "user1\\Music\\01.flac")])
         self.assertTrue(
-            persisted["current_path"].endswith("Test Artist - Test Album (2020)")
+            persisted["current_path"].endswith(
+                f"Test Artist - Test Album (2020) [{fp}]")
         )
         self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
@@ -3258,27 +3355,30 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_legacy_processing_row_uses_canonical_fallback(self):
         """Legacy mid-processing rows without current_path still resume canonically."""
         from lib.download import poll_active_downloads
-        from lib.processing_paths import canonical_processing_path
+        from lib.processing_paths import attempt_fingerprint, canonical_processing_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             downloads_root = os.path.join(tmpdir, "downloads")
+            files = [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ]
+            fp = attempt_fingerprint([(f["username"], f["filename"]) for f in files])
             canonical_path = canonical_processing_path(
                 artist="Test Artist",
                 title="Test Album",
                 year="2020",
                 slskd_download_dir=downloads_root,
+                attempt_fingerprint=fp,
             )
             os.makedirs(canonical_path)
-            with open(os.path.join(canonical_path, "01.flac"), "w") as fp:
-                fp.write("audio")
+            with open(os.path.join(canonical_path, "01.flac"), "w") as fp_handle:
+                fp_handle.write("audio")
             row = self._make_downloading_row(state_dict={
                 "filetype": "flac",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
-                "files": [
-                    {"username": "user1", "filename": "user1\\Music\\01.flac",
-                     "file_dir": "user1\\Music", "size": 30000000},
-                ],
+                "files": files,
             })
             ctx, _fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
             cfg = cast(Any, ctx.cfg)
@@ -3346,16 +3446,27 @@ class TestPollActiveDownloads(unittest.TestCase):
     ):
         """A stale canonical current_path must recover to the staged location."""
         from lib.download import poll_active_downloads
-        from lib.processing_paths import canonical_processing_path, stage_to_ai_path
+        from lib.processing_paths import (
+            attempt_fingerprint, canonical_processing_path, stage_to_ai_path,
+        )
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             downloads_root = os.path.join(tmpdir, "downloads")
             staging_root = os.path.join(tmpdir, "staging")
+            files = [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ]
+            fp = attempt_fingerprint([(f["username"], f["filename"]) for f in files])
+            # current_path IS the real (fp'd) canonical location — it's
+            # just stale/empty on disk, which is what should trigger the
+            # staged-recovery fallback below.
             canonical_path = canonical_processing_path(
                 artist="Test Artist",
                 title="Test Album",
                 year="2020",
                 slskd_download_dir=downloads_root,
+                attempt_fingerprint=fp,
             )
             staged_path = stage_to_ai_path(
                 artist="Test Artist",
@@ -3365,18 +3476,15 @@ class TestPollActiveDownloads(unittest.TestCase):
                 auto_import=True,
             )
             os.makedirs(staged_path)
-            with open(os.path.join(staged_path, "01.flac"), "w") as fp:
-                fp.write("audio")
+            with open(os.path.join(staged_path, "01.flac"), "w") as fp_handle:
+                fp_handle.write("audio")
 
             row = self._make_downloading_row(state_dict={
                 "filetype": "flac",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
                 "current_path": canonical_path,
-                "files": [
-                    {"username": "user1", "filename": "user1\\Music\\01.flac",
-                     "file_dir": "user1\\Music", "size": 30000000},
-                ],
+                "files": files,
             })
             ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
             cfg = cast(Any, ctx.cfg)
@@ -3430,28 +3538,31 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_legacy_processing_row_blocks_when_canonical_and_legacy_stage_both_exist(self):
         """Split legacy state must not pick one side and requeue the other."""
         from lib.download import poll_active_downloads
+        from lib.processing_paths import attempt_fingerprint
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
+            files = [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ]
+            fp = attempt_fingerprint([(f["username"], f["filename"]) for f in files])
             canonical_path = os.path.join(
-                tmpdir, "downloads", "Test Artist - Test Album (2020)")
+                tmpdir, "downloads", f"Test Artist - Test Album (2020) [{fp}]")
             os.makedirs(canonical_path)
-            with open(os.path.join(canonical_path, "01.flac"), "w") as fp:
-                fp.write("audio")
+            with open(os.path.join(canonical_path, "01.flac"), "w") as fp_handle:
+                fp_handle.write("audio")
 
             staging_root = os.path.join(tmpdir, "staging")
             staged_path = os.path.join(staging_root, "Test Artist", "Test Album")
             os.makedirs(staged_path)
-            with open(os.path.join(staged_path, "01.flac"), "w") as fp:
-                fp.write("audio")
+            with open(os.path.join(staged_path, "01.flac"), "w") as fp_handle:
+                fp_handle.write("audio")
 
             row = self._make_downloading_row(state_dict={
                 "filetype": "flac",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
-                "files": [
-                    {"username": "user1", "filename": "user1\\Music\\01.flac",
-                     "file_dir": "user1\\Music", "size": 30000000},
-                ],
+                "files": files,
             })
             ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
             cfg = cast(Any, ctx.cfg)
@@ -3491,25 +3602,28 @@ class TestPollActiveDownloads(unittest.TestCase):
     def test_poll_missing_canonical_processing_path_queues_importer(self):
         """Missing canonical path can be pre-materialization, not post-move loss."""
         from lib.download import poll_active_downloads
-        from lib.processing_paths import canonical_processing_path
+        from lib.processing_paths import attempt_fingerprint, canonical_processing_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             download_root = os.path.join(tmpdir, "downloads")
+            files = [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000},
+            ]
+            fp = attempt_fingerprint([(f["username"], f["filename"]) for f in files])
             current_path = canonical_processing_path(
                 artist="Test Artist",
                 title="Test Album",
                 year="2020",
                 slskd_download_dir=download_root,
+                attempt_fingerprint=fp,
             )
             row = self._make_downloading_row(state_dict={
                 "filetype": "flac",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
                 "current_path": current_path,
-                "files": [
-                    {"username": "user1", "filename": "user1\\Music\\01.flac",
-                     "file_dir": "user1\\Music", "size": 30000000},
-                ],
+                "files": files,
             })
             ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
             cfg = cast(Any, ctx.cfg)
@@ -3545,15 +3659,24 @@ class TestPollActiveDownloads(unittest.TestCase):
         rmtrees the source and repoints current_path in the normal flow).
         """
         from lib.download import poll_active_downloads
-        from lib.processing_paths import canonical_processing_path
+        from lib.processing_paths import attempt_fingerprint, canonical_processing_path
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             download_root = os.path.join(tmpdir, "downloads")
+            files = [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000,
+                 # Unstamped: no event-stamped local_path, so
+                 # materialize cannot recover -> event_path_missing.
+                 "local_path": None},
+            ]
+            fp = attempt_fingerprint([(f["username"], f["filename"]) for f in files])
             canonical_path = canonical_processing_path(
                 artist="Test Artist",
                 title="Test Album",
                 year="2020",
                 slskd_download_dir=download_root,
+                attempt_fingerprint=fp,
             )
             # Dir EXISTS (empty) but the tracked file is absent.
             os.makedirs(canonical_path)
@@ -3562,13 +3685,7 @@ class TestPollActiveDownloads(unittest.TestCase):
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
                 "current_path": canonical_path,
-                "files": [
-                    {"username": "user1", "filename": "user1\\Music\\01.flac",
-                     "file_dir": "user1\\Music", "size": 30000000,
-                     # Unstamped: no event-stamped local_path, so
-                     # materialize cannot recover -> event_path_missing.
-                     "local_path": None},
-                ],
+                "files": files,
             })
             ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
             cfg = cast(Any, ctx.cfg)
@@ -3600,17 +3717,24 @@ class TestPollActiveDownloads(unittest.TestCase):
             MaterializeFailed,
             _materialize_processing_dir,
         )
-        from lib.processing_paths import canonical_processing_path
+        from lib.processing_paths import attempt_fingerprint, canonical_processing_path
         from lib.quality import ActiveDownloadState
         from lib.staged_album import StagedAlbum
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             download_root = os.path.join(tmpdir, "downloads")
+            files = [
+                {"username": "user1", "filename": "user1\\Music\\01.flac",
+                 "file_dir": "user1\\Music", "size": 30000000,
+                 "local_path": None},
+            ]
+            fp = attempt_fingerprint([(f["username"], f["filename"]) for f in files])
             canonical_path = canonical_processing_path(
                 artist="Test Artist",
                 title="Test Album",
                 year="2020",
                 slskd_download_dir=download_root,
+                attempt_fingerprint=fp,
             )
             os.makedirs(canonical_path)
             row = self._make_downloading_row(state_dict={
@@ -3618,11 +3742,7 @@ class TestPollActiveDownloads(unittest.TestCase):
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
                 "current_path": canonical_path,
-                "files": [
-                    {"username": "user1", "filename": "user1\\Music\\01.flac",
-                     "file_dir": "user1\\Music", "size": 30000000,
-                     "local_path": None},
-                ],
+                "files": files,
             })
             ctx, fake_db = self._make_poll_ctx(downloading_rows=[row], slskd_downloads=[])
             cfg = cast(Any, ctx.cfg)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -4200,16 +4200,17 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.request(1)["status"], "downloading")
         self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
 
-    def test_poll_overlong_album_title_does_not_starve_other_rows(self):
-        """ENAMETOOLONG in canonical-path makedirs must not abort the loop.
+    def test_poll_overlong_album_title_truncates_and_processes(self):
+        """Overlong artist/title now truncates to ext4's 255-byte limit.
 
-        Real failure: a Sade row with 240+ char artist + title produced a
-        canonical path > ext4's 255-byte component limit. ``os.makedirs``
-        raised ``OSError(36)`` which propagated through
-        ``_enqueue_completed_processing`` and killed the per-row for-loop
-        in ``poll_active_downloads``. Because ``get_downloading()`` orders
-        by ``updated_at ASC``, a single poison row starved every later
-        row from getting its import job enqueued.
+        History: a Sade row with 240+ char artist + title produced a
+        canonical path over the 255-byte component limit; os.makedirs
+        raised OSError(36) and (pre-guard) starved later rows. Since the
+        #550-phase-2 fingerprint suffix, canonical_processing_path
+        byte-truncates the base name, so the row now materializes and
+        imports instead of failing. Loop containment for genuinely
+        unexpected per-row exceptions stays pinned by
+        test_poll_continues_after_per_row_unexpected_exception.
         """
         from lib.download import poll_active_downloads
         long_name = "X" * 250
@@ -4247,16 +4248,17 @@ class TestPollActiveDownloads(unittest.TestCase):
             downloading_rows=[poison, healthy], slskd_downloads=[],
         )
 
-        # Must not raise — the poison row's ENAMETOOLONG must be caught
-        # inside _materialize_processing_dir (or by the per-row guard).
         poll_active_downloads(ctx)
 
         self.assertEqual(
             len(fake_db.list_import_jobs(request_id=2)), 1,
-            "Healthy row never got an import job — poison row killed the loop",
+            "Healthy row never got an import job",
         )
-        self.assertEqual(fake_db.request(1)["status"], "downloading")
-        self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 0)
+        # The overlong row now truncates and processes like any other.
+        self.assertEqual(len(fake_db.list_import_jobs(request_id=1)), 1)
+        state = fake_db.request(1)["active_download_state"]
+        folder = state["current_path"].rsplit("/", 1)[-1]
+        self.assertLessEqual(len(folder.encode("utf-8")), 255)
 
     def test_poll_continues_after_per_row_unexpected_exception(self):
         """Belt-and-braces: any unhandled per-row exception must not abort the loop.

--- a/tests/test_download_recovery.py
+++ b/tests/test_download_recovery.py
@@ -9,7 +9,7 @@ from lib.download_recovery import (
     reconcile_processing_current_path,
     resolve_missing_current_path,
 )
-from lib.processing_paths import canonical_processing_path
+from lib.processing_paths import attempt_fingerprint, canonical_processing_path
 
 
 class TestClassifyProcessingPath(unittest.TestCase):
@@ -500,6 +500,13 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
         self.assertIn("has no mb_release_id so auto-import cannot resume", issues[0].detail)
 
     def test_skips_stale_canonical_current_path_with_request_scoped_recovery(self):
+        # current_path IS the real (fingerprinted) canonical location for
+        # this row's files — it's just stale/empty on disk, which is what
+        # should trigger the staged-recovery fallback below (#550 phase 2:
+        # the canonical candidate must be keyed to the SAME file set as
+        # the persisted current_path or it never classifies as
+        # "canonical" in the first place).
+        fp = attempt_fingerprint([("user1", "track.flac")])
         issues = find_blocked_processing_path_issues(
             [{
                 "id": 1,
@@ -510,7 +517,9 @@ class TestFindBlockedProcessingPathIssues(unittest.TestCase):
                 "active_download_state": {
                     "filetype": "flac",
                     "processing_started_at": "2026-04-22T00:00:00+00:00",
-                    "current_path": "/tmp/downloads/Test Artist - Test Album (2020)",
+                    "current_path": (
+                        f"/tmp/downloads/Test Artist - Test Album (2020) [{fp}]"
+                    ),
                     "files": [{
                         "username": "user1",
                         "filename": "track.flac",

--- a/tests/test_processing_paths.py
+++ b/tests/test_processing_paths.py
@@ -1,0 +1,108 @@
+"""Tests for ``lib/processing_paths.py``."""
+
+import unittest
+
+from lib.processing_paths import attempt_fingerprint, canonical_processing_path
+
+
+class TestAttemptFingerprint(unittest.TestCase):
+    """Issue #550 phase 2: attempt-scoped canonical processing folders."""
+
+    def test_empty_set_hashes_the_empty_json_array(self):
+        import hashlib
+        import json
+
+        expected = hashlib.sha256(
+            json.dumps([], separators=(",", ":")).encode("utf-8")
+        ).hexdigest()[:8]
+
+        self.assertEqual(attempt_fingerprint([]), expected)
+
+    def test_order_independent(self):
+        forward = attempt_fingerprint([
+            ("user1", "Music/01.flac"),
+            ("user2", "Music/02.flac"),
+        ])
+        backward = attempt_fingerprint([
+            ("user2", "Music/02.flac"),
+            ("user1", "Music/01.flac"),
+        ])
+
+        self.assertEqual(forward, backward)
+
+    def test_sensitive_to_username_change(self):
+        pairs_a = attempt_fingerprint([("user1", "Music/01.flac")])
+        pairs_b = attempt_fingerprint([("user2", "Music/01.flac")])
+
+        self.assertNotEqual(pairs_a, pairs_b)
+
+    def test_sensitive_to_filename_change(self):
+        pairs_a = attempt_fingerprint([("user1", "Music/01.flac")])
+        pairs_b = attempt_fingerprint([("user1", "Music/02.flac")])
+
+        self.assertNotEqual(pairs_a, pairs_b)
+
+    def test_sensitive_to_file_count(self):
+        one_file = attempt_fingerprint([("user1", "Music/01.flac")])
+        two_files = attempt_fingerprint([
+            ("user1", "Music/01.flac"),
+            ("user1", "Music/02.flac"),
+        ])
+
+        self.assertNotEqual(one_file, two_files)
+
+    def test_deterministic_across_calls(self):
+        pairs = [("user1", "Music/01.flac"), ("user2", "Music/02.flac")]
+
+        self.assertEqual(attempt_fingerprint(pairs), attempt_fingerprint(pairs))
+
+    def test_is_short_hex(self):
+        fp = attempt_fingerprint([("user1", "Music/01.flac")])
+
+        self.assertEqual(len(fp), 8)
+        int(fp, 16)  # raises ValueError if not hex
+
+
+class TestCanonicalProcessingPathFingerprint(unittest.TestCase):
+    """``canonical_processing_path``'s optional ``attempt_fingerprint`` param."""
+
+    def test_empty_fingerprint_appends_nothing(self):
+        path = canonical_processing_path(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        self.assertEqual(path, "/tmp/downloads/Test Artist - Test Album (2020)")
+
+    def test_nonempty_fingerprint_appends_bracket_suffix(self):
+        path = canonical_processing_path(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            slskd_download_dir="/tmp/downloads",
+            attempt_fingerprint="deadbeef",
+        )
+
+        self.assertEqual(
+            path,
+            "/tmp/downloads/Test Artist - Test Album (2020) [deadbeef]",
+        )
+
+    def test_different_fingerprints_produce_different_paths(self):
+        base_kwargs = dict(
+            artist="Test Artist",
+            title="Test Album",
+            year="2020",
+            slskd_download_dir="/tmp/downloads",
+        )
+
+        path_a = canonical_processing_path(attempt_fingerprint="aaaaaaaa", **base_kwargs)
+        path_b = canonical_processing_path(attempt_fingerprint="bbbbbbbb", **base_kwargs)
+
+        self.assertNotEqual(path_a, path_b)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_processing_paths.py
+++ b/tests/test_processing_paths.py
@@ -106,3 +106,31 @@ class TestCanonicalProcessingPathFingerprint(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFingerprintSuffixNameLimit(unittest.TestCase):
+    """The fingerprint suffix must never push the folder name past ext4's
+    255-byte filename limit (codex review r2: near-limit names that fit
+    before would MaterializeFailed at os.makedirs forever)."""
+
+    def _name(self, artist: str) -> str:
+        path = canonical_processing_path(
+            artist=artist, title="T", year="2024",
+            slskd_download_dir="/dl",
+            attempt_fingerprint="aabbccdd",
+        )
+        return path.rsplit("/", 1)[-1]
+
+    def test_near_limit_ascii_name_stays_within_255_bytes(self):
+        name = self._name("a" * 250)
+        self.assertLessEqual(len(name.encode("utf-8")), 255)
+        self.assertTrue(name.endswith(" [aabbccdd]"))
+
+    def test_multibyte_name_truncates_on_character_boundary(self):
+        name = self._name("\u97f3" * 120)  # 3 bytes each -> 360 bytes
+        self.assertLessEqual(len(name.encode("utf-8")), 255)
+        self.assertTrue(name.endswith(" [aabbccdd]"))
+
+    def test_short_names_are_untouched(self):
+        self.assertEqual(
+            self._name("Artist"), "Artist - T (2024) [aabbccdd]")


### PR DESCRIPTION
## Summary

Kills **#550 defect #2** (canonical-folder accumulation — the amplifier behind the false `untracked_audio` rejects). The invariant: *every download attempt materializes into its own attempt-scoped processing folder derived from the manifest fingerprint — no attempt ever validates against files another attempt placed.*

- `attempt_fingerprint(pairs)`: 8-hex sha256 of the sorted `(username, filename)` manifest set — resume-stable within an attempt, distinct across re-selections; folder becomes `Artist - Title (Year) [<fp>]`.
- Threaded through the single choke point (`_canonical_import_folder_path`) so materialize, classify, recovery candidates, poll resume, pre-enqueue gate, and the preview worker flip together (exact-string canonical classification preserved).
- RED→GREEN: new invariant test pre-populates the canonical folder with alien audio and drives the real `_materialize_processing_dir` — RED on main (both attempts resolve to the same bare path), GREEN here.
- Byte-aware truncation keeps names ≤255 bytes — the Sade-class overlong-title row now truncates and imports instead of ENAMETOOLONG-failing (repurposed pin).

## Review audit trail
- **r1 (codex, P2)**: pre-upgrade in-flight `downloading` rows in bare canonical folders would strand at recovery → **documented equivalence** (scope.md forward-only: no permanent bare-path fallback — it would re-open defect #2; the one-deploy-window cohort is an operator one-shot at switch time, executed as part of this deploy).
- **r2 (codex, P2)**: fingerprint suffix could push near-limit names over ext4's 255-byte cap → **fixed + pinned** (RED-first byte-truncation tests, ASCII + multibyte).
- **r3 (codex)**: *"No actionable regressions… wiring consistent across materialization, polling recovery, and repair scanning."* Converged.

## Verification
Full suite 4,827 green · pyright 0 errors · generated fleet green at push tier · invariant grep gate clean. Defect #3 (reaper) and #4 (Wrong Match surfacing) remain on #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)