### PR TITLE
perf: cut the push dance — shard the fuzz burst, content-address the runtime source

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -56,10 +56,13 @@ guarantee that the harness detects what it claims to.
   database), bounded examples. Runs on every `scripts/run_tests.sh`,
   identical on every machine. This is the merge gate.
 - **`push`** — quick randomized burst (2k examples) that `scripts/pre-push`
-  runs on every `git push`, before the flake check. Fresh entropy per push
-  means exploration accumulates over time with zero operator effort; a
-  push-found failure is remembered in `.hypothesis/` and replays first in
-  dev. Escape hatch, as for the whole hook: `git push --no-verify`.
+  runs on every `git push`, before the flake check. The generated modules
+  run as parallel single-module processes (wall-clock = slowest module,
+  not the sum; the shared `.hypothesis/` database is multi-process safe).
+  Fresh entropy per push means exploration accumulates over time with
+  zero operator effort; a push-found failure is remembered in
+  `.hypothesis/` and replays first in dev. Escape hatch, as for the whole
+  hook: `git push --no-verify`.
 - **`fuzz`** — deep randomized burst (20k examples) for local exploration.
   Fresh entropy per run, local example database (`.hypothesis/`,
   gitignored) so found failures replay first on the next burst,

--- a/flake.nix
+++ b/flake.nix
@@ -18,21 +18,39 @@
         inherit system;
         pkgs = import nixpkgs { inherit system; };
       });
+      # Runtime source only — the store path every unit's PYTHONPATH and
+      # the CLI wrappers embed. Docs, tests, examples, tooling and repo
+      # metadata are dev-only: keeping them out of the fileset means a
+      # docs/tests-only commit produces the identical (content-addressed)
+      # src path, so the package and moduleVm stay cache hits on push.
+      runtimeSrc = nixpkgs.lib.fileset.toSource {
+        root = ./.;
+        fileset = nixpkgs.lib.fileset.unions [
+          ./cratedigger.py
+          ./album_source.py
+          ./lib
+          ./web
+          ./harness
+          ./scripts
+          ./migrations
+        ];
+      };
+      # Content-addressed version (first 8 chars of runtimeSrc's store
+      # hash): unique per runtime content, deliberately NOT per commit —
+      # a rev-coupled version would invalidate the package + moduleVm on
+      # every push regardless of what changed. Release tags (vYYYY.MM.DD,
+      # U9) record verified states in git itself.
       version = "0-unstable-"
-        + (builtins.substring 0 8 (self.lastModifiedDate or "19700101"))
-        + (if self ? shortRev then "-${self.shortRev}" else "-dirty");
+        + builtins.substring 0 8 (baseNameOf (toString runtimeSrc));
     in {
       devShells = forAllSystems ({ pkgs, ... }: {
         default = import ./nix/shell.nix { inherit pkgs; };
       });
 
-      # Tag-based versions are not readable in pure flake eval, so the
-      # version above is date+rev (sortable, unique per commit); release
-      # tags (vYYYY.MM.DD, U9) record verified states in git itself.
       packages = forAllSystems ({ pkgs, ... }: rec {
         default = import ./nix/wrappers.nix {
           inherit pkgs version;
-          src = ./.;
+          src = runtimeSrc;
         };
         cratedigger = default;
       });
@@ -53,6 +71,10 @@
       # standard trade for closure fidelity.
       nixosModules.default = { config, lib, pkgs, ... }: {
         imports = [ ./nix/module.nix ];
+        # Same filtered source the moduleVm check boots — consumers run
+        # exactly what was verified, and docs/tests-only bumps of the
+        # cratedigger-src input leave the rendered units unchanged.
+        services.cratedigger.src = lib.mkDefault runtimeSrc;
         services.cratedigger.packageSet = lib.mkDefault (import nixpkgs {
           system = pkgs.stdenv.hostPlatform.system;
         });
@@ -70,8 +92,23 @@
         moduleVm = import ./nix/tests/module-vm.nix {
           inherit pkgs system;
           cratediggerModule = self.nixosModules.default;
-          cratediggerSrc = ./.;
+          cratediggerSrc = runtimeSrc;
         };
+
+        # Eval-level guard for the src threading: the exported wrapper must
+        # default services.cratedigger.src to the filtered runtimeSrc (the
+        # same source the moduleVm boots). A regression to the raw module
+        # default (../. — the whole tree) would silently re-couple consumer
+        # closures to docs/tests churn. Pure evaluation, like packageSetPin.
+        runtimeSrcPin = let
+          srcVal = (nixpkgs.lib.nixosSystem {
+            modules = [ self.nixosModules.default {
+              nixpkgs.pkgs = import nixpkgs { inherit system; };
+            } ];
+          }).config.services.cratedigger.src;
+        in
+          assert toString srcVal == toString runtimeSrc;
+          pkgs.runCommand "cratedigger-runtime-src-pin-ok" { } "touch $out";
 
         # Eval-level guard for the packageSet threading. The "consumer" is
         # simulated with a marked nixpkgs instantiation installed as the

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -5,11 +5,12 @@
 #
 # Install: ln -sf ../../scripts/pre-push .git/hooks/pre-push
 #
-# Cost: the FIRST run per machine builds the moduleVm (a full NixOS VM
-# boot — several minutes) plus the eval checks and the CLI bundle.
-# Subsequent runs are Nix cache hits unless the relevant inputs changed;
-# a source change re-runs the VM (cratediggerSrc = ./.), which is the
-# point — the tree you push is the tree that booted.
+# Cost: a runtime-source change (lib/, web/, scripts/, harness/,
+# migrations/, the two root .py files) rebuilds the package + moduleVm —
+# ~1 min with KVM. Docs/tests-only pushes reuse the cached VM: the flake
+# filters src to the runtime fileset and the version is content-addressed
+# to it, so the derivation only changes when runtime content does. The
+# tree you push is still the tree that booted.
 #
 # Deliberate escape hatch: `git push --no-verify`.
 set -euo pipefail
@@ -21,13 +22,38 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Randomized generated-test burst (issue #548) — fresh entropy on every
 # push, so exploration of the decision/event state spaces accumulates
 # over time. Modules are discovered by pattern (test_*_generated.py); a
-# hand-maintained list would drift (issue #520 lesson). Runs BEFORE the
-# flake check: seconds of fuzz fail faster than minutes of VM boot.
-# A failure prints the shrunk world + a @reproduce_failure blob and is
-# remembered in .hypothesis/ — promote it per docs/generated-testing.md.
-echo "pre-push: generated-test fuzz burst (push profile)..." >&2
-(cd "$REPO_ROOT" && nix-shell --run \
-  "CRATEDIGGER_HYPOTHESIS_PROFILE=push python3 -m unittest discover -s tests -t . -p 'test_*_generated.py'")
+# hand-maintained list would drift (issue #520 lesson). Modules run in
+# PARALLEL, one process each: the burst is CPU-bound and single-threaded
+# per module, so wall-clock is the slowest module, not the sum. The
+# shared .hypothesis/ example database is multi-process safe. Runs
+# BEFORE the flake check: fuzz fails faster than a VM boot.
+# A failed module prints its full output (shrunk world + a
+# @reproduce_failure blob) and is remembered in .hypothesis/ — promote
+# it per docs/generated-testing.md.
+echo "pre-push: generated-test fuzz burst (push profile, sharded)..." >&2
+(cd "$REPO_ROOT" && nix-shell --run '
+  set -euo pipefail
+  logdir=$(mktemp -d)
+  trap "rm -rf $logdir" EXIT
+  pids=(); mods=()
+  for f in tests/test_*_generated.py; do
+    mod=${f%.py}; mod=${mod//\//.}
+    CRATEDIGGER_HYPOTHESIS_PROFILE=push python3 -m unittest "$mod" \
+      > "$logdir/$mod.log" 2>&1 &
+    pids+=($!); mods+=("$mod")
+  done
+  fail=0
+  for i in "${!pids[@]}"; do
+    if wait "${pids[$i]}"; then
+      echo "  ${mods[$i]}: OK" >&2
+    else
+      echo "  ${mods[$i]}: FAILED" >&2
+      cat "$logdir/${mods[$i]}.log" >&2
+      fail=1
+    fi
+  done
+  exit "$fail"
+')
 echo "pre-push: fuzz burst OK" >&2
 
 echo "pre-push: nix flake check (moduleVm + eval guards + CLI bundle)..." >&2


### PR DESCRIPTION
## Why

The pre-push dance was ~8–9 min before this week: 3m18s serial fuzz burst + ~5 min software-emulated VM boot. Enabling nested virt on doc1 (infra, no code) cut the VM to ~54s, leaving two structural problems:

1. The fuzz burst ran all generated modules serially — wall-clock was the *sum* of 8 CPU-bound modules.
2. The flake version embedded `self.shortRev`, so **every commit** invalidated the package + moduleVm derivations — every push paid a full VM rebuild even for docs/tests-only changes, and the whole-tree `src = ./.` meant any file at all was in the cache key.

## What

**Commit 1 — flake.nix:**
- `runtimeSrc` = `lib.fileset.toSource` over the runtime files only (`cratedigger.py`, `album_source.py`, `lib/`, `web/`, `harness/`, `scripts/`, `migrations/`).
- Version is content-addressed to that store path (first 8 hash chars) instead of date+rev — derivations change iff runtime content changes.
- `nixosModules.default` now defaults `services.cratedigger.src` to the same filtered source the moduleVm boots (consumers run exactly what was verified; `mkDefault`, so an explicit consumer `src` still wins).
- New eval-only `runtimeSrcPin` check (packageSetPin pattern) guards the src threading against regression to the raw whole-tree default.

**Commit 2 — scripts/pre-push (+ doc):**
- The generated-test burst runs each `tests/test_*_generated.py` as a parallel process inside one nix-shell. Discovery stays pattern-based (#520). A failed module prints its full log (shrunk world + `@reproduce_failure` blob); the shared `.hypothesis/` DB is multi-process safe.

## Measured

| Step | Before | After |
|------|--------|-------|
| Fuzz burst | 3m18s (serial) | **1m21s** (slowest module) |
| Flake check, runtime change | ~1m10s | ~1m10s (unchanged — the tree you push is the tree that booted) |
| Flake check, docs/tests-only push | ~1m10s (forced by rev-version) | **~15s** (pure cache hit) |
| Whole dance, typical | ~4m30s | **~2m30s** (docs-only: ~1m40s) |

## Verified

- `nix flake check` green (all checks incl. new `runtimeSrcPin`); moduleVm boots from the filtered src (migrator, pipeline-cli, web, beets plugins).
- drvPath proof: docs edit → **identical** moduleVm drv; lib edit → different drv.
- The push of this very branch hit the flake-check cache post-commit — first live confirmation of the content-addressing.
- `nix run .#pipeline-cli -- --help` works from the filtered source.
- Full suite 4843 tests OK; pyright 0 errors.
- Opus review: no blockers, no should-fixes; nits are accepted trade-offs (no `nullglob` is fail-closed; `scripts/` stays whole in the fileset per the #520 anti-drift rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)