### PR TITLE
fix(#570): Discogs mb_albumid poisoning + album-art 0600 unreadable

### DIFF
--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -74,7 +74,7 @@ match:
     original_year: true
 
 # Active plugins
-plugins: musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline
+plugins: musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline permissions
 ```
 
 ### Active Plugins
@@ -94,6 +94,13 @@ plugins: musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missi
 | `fromfilename` | Guesses metadata from filenames when tags are missing | — |
 | `ftintitle` | Moves "feat." from artist to title field | — |
 | `the` | Handles "The" prefix in artist names | — |
+| `permissions` | Sets imported file/art mode to 0664 and dir mode to 0775 | Yes |
+
+`permissions` exists so media servers (Jellyfin) can read album art: beets'
+native `fetchart` writes art via `mkstemp` (forces 0600) then renames it into
+place, and nothing else chmods it. `fix_library_modes` (`lib/permissions.py`)
+only touches directories, never files, so this plugin covers both initial
+import and manual `beet fetchart` re-fetches (issue #570 defect 1).
 
 ### Cover Art Config
 

--- a/harness/beets_harness.py
+++ b/harness/beets_harness.py
@@ -218,6 +218,59 @@ def _mbid_swap_event(task, candidate) -> dict | None:
     }
 
 
+def _neutralize_discogs_provider_ids(candidate) -> bool:
+    """Blank the mb_* mirrors of a Discogs candidate's numeric provider ids
+    so beets does not poison mb_albumid / mb_releasegroupid (issue #570).
+
+    Beets core maps AlbumInfo.album_id -> mb_albumid and releasegroup_id ->
+    mb_releasegroupid (Info.MEDIA_FIELD_MAP). The Discogs plugin fills those
+    with NUMERIC Discogs ids, so an un-neutralized apply writes a bare integer
+    into MUSICBRAINZ_ALBUMID and Jellyfin's `new Guid()` throws. The id is
+    preserved in discogs_albumid (a flexattr the plugin already set), which is
+    the layout the rest of cratedigger assumes (duplicate_keys = [mb_albumid,
+    discogs_albumid], lib/beets_album_op.py, lib/beets_db.py).
+
+    We set the mirrors to "" (not None) so beets' item_data KEEPS and APPLIES
+    the empty value, overwriting any previously-poisoned mb_albumid on
+    re-import rather than merely skipping it. item_data / raw_data are
+    @cached_property on beets' Info; if anything read them before we mutated,
+    the cache would hide the change — so we bust both caches to stay
+    order-independent.
+
+    `_apply_decision` is shared by `choose_match` (album; info is an
+    AlbumInfo, whose __init__ always sets both album_id and releasegroup_id)
+    and `choose_item` (singleton; info is a TrackInfo, which has neither
+    attribute). We only blank attributes that already exist on `info`, so
+    the singleton path stays a true no-op — it never ADDS a stray
+    album_id=""/releasegroup_id="" to a TrackInfo that beets would then
+    apply.
+
+    Returns True iff it neutralized a Discogs candidate (i.e. at least one
+    mirror attribute existed and was blanked). MusicBrainz candidates (UUID
+    album_id) and Discogs TrackInfo (neither attribute present) are left
+    untouched.
+    """
+    info = getattr(candidate, "info", None)
+    if info is None:
+        return False
+    if (getattr(info, "data_source", "") or "") != "Discogs":
+        return False
+    blanked = False
+    for attr in ("album_id", "releasegroup_id"):
+        if hasattr(info, attr):
+            setattr(info, attr, "")
+            blanked = True
+    if not blanked:
+        return False
+    # bust beets' @cached_property caches so the neutralized values are what
+    # apply_metadata / find_duplicates consume regardless of prior access.
+    cache = getattr(info, "__dict__", None)
+    if isinstance(cache, dict):
+        cache.pop("item_data", None)
+        cache.pop("raw_data", None)
+    return True
+
+
 def _append_mutation_log(event: dict, log_path: str | None = None) -> None:
     """Append one JSONL event. Never raises — the audit log must not break
     the import itself. Failures are logged to stderr for operator visibility."""
@@ -484,6 +537,8 @@ class HarnessImportSession(ImportSession):
                 ev = _mbid_swap_event(task, task.candidates[idx])
                 if ev is not None:
                     _append_mutation_log(ev)
+                # Keep Discogs numeric ids out of mb_albumid/mb_releasegroupid (#570).
+                _neutralize_discogs_provider_ids(task.candidates[idx])
                 return task.candidates[idx]
             else:
                 _send({

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -103,8 +103,12 @@
         original_year = true;
       };
     };
-    plugins = "musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline";
+    plugins = "musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missing duplicates edit fromfilename ftintitle the inline permissions";
     chroma.auto = false;
+    permissions = {
+      file = "0664";
+      dir = "0775";
+    };
     fetchart = {
       auto = true;
       minwidth = bc.fetchart.minwidth;

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -37,7 +37,8 @@ let
     plugins = cfg["plugins"].split()
     expected = (
         "musicbrainz discogs fetchart embedart lyrics lastgenre scrub "
-        "info missing duplicates edit fromfilename ftintitle the inline"
+        "info missing duplicates edit fromfilename ftintitle the inline "
+        "permissions"
     ).split()
     assert plugins == expected, plugins
 
@@ -279,7 +280,8 @@ pkgs.testers.nixosTest {
     loaded = {p.strip() for p in plugins_line.split(":", 1)[1].split(",")}
     for plugin in (
         "musicbrainz discogs fetchart embedart lyrics lastgenre scrub "
-        "info missing duplicates edit fromfilename ftintitle the inline"
+        "info missing duplicates edit fromfilename ftintitle the inline "
+        "permissions"
     ).split():
         assert plugin in loaded, f"plugin {plugin} not loaded: {version_out}"
     # Tokenless/stranger posture: config loads without crash or prompt.

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -14,6 +14,14 @@ catch beets-version API drift — which is exactly how the 2026-06-29 beets
     stale override was silently never called, so upgrade imports kept both
     album rows and failed the post-import "multiple beets album rows" guard.
 
+Also guards issue #570 defect 2: ``AlbumInfo.MEDIA_FIELD_MAP`` (real beets,
+not a mock) maps ``album_id -> mb_albumid`` / ``releasegroup_id ->
+mb_releasegroupid``, so ``_neutralize_discogs_provider_ids`` must hold
+against the REAL ``item_data`` a Discogs apply would write — the mocked
+harness unit tests (tests/test_harness_discogs_neutralize.py /
+tests/test_harness_discogs_neutralize_generated.py) can't see this mapping
+at all.
+
 This test runs the REAL harness against the REAL beets in the dev shell, in a
 subprocess so the sibling harness tests' ``sys.modules`` beets mocks cannot
 leak in. If a future beets bump breaks either API, this fails loudly instead of
@@ -73,6 +81,53 @@ assert skip is DuplicateAction.SKIP, skip
 assert default is DuplicateAction.SKIP, default  # absent action -> defensive SKIP
 assert sent and sent[0]["type"] == "resolve_duplicate", sent[:1]
 print("CONTRACT_OK")
+
+# --- Breakage #3 (issue #570): beets' AlbumInfo.MEDIA_FIELD_MAP maps
+# album_id -> mb_albumid and releasegroup_id -> mb_releasegroupid. The
+# Discogs plugin fills those with NUMERIC Discogs ids, so an
+# un-neutralized apply writes a bare integer into mb_albumid /
+# MUSICBRAINZ_ALBUMID (Jellyfin's `new Guid()` throws on it). Drive the
+# REAL AlbumInfo.item_data (what apply_metadata actually consumes) through
+# the harness's neutralizer to prove the fix holds against beets 2.12,
+# not just the mocked-beets unit tests.
+import types
+
+from beets.autotag.hooks import AlbumInfo
+
+discogs_info = AlbumInfo(
+    tracks=[], album="X", album_id="1505049",
+    releasegroup_id="99999", data_source="Discogs",
+    discogs_albumid="1505049")
+# Read item_data FIRST, before neutralizing, so beets' @cached_property is
+# hot with the POISONED value below. This makes the cache-bust in
+# _neutralize_discogs_provider_ids (the __dict__.pop("item_data"/"raw_data")
+# calls) load-bearing for this test: without it, item_data would keep
+# serving this stale snapshot after neutralization and the assertions below
+# would still pass on the OLD poisoned data, not the new blanked one.
+poisoned_item_data = dict(discogs_info.item_data)
+assert poisoned_item_data.get("mb_albumid") == "1505049", \
+    poisoned_item_data.get("mb_albumid")
+did_neutralize = h._neutralize_discogs_provider_ids(
+    types.SimpleNamespace(info=discogs_info))
+discogs_item_data = dict(discogs_info.item_data)
+assert did_neutralize is True, did_neutralize
+assert not discogs_item_data.get("mb_albumid"), discogs_item_data.get("mb_albumid")
+assert not discogs_item_data.get("mb_releasegroupid"), \
+    discogs_item_data.get("mb_releasegroupid")
+assert discogs_item_data.get("discogs_albumid") == "1505049", \
+    discogs_item_data.get("discogs_albumid")
+
+mb_info = AlbumInfo(
+    tracks=[], album="Y",
+    album_id="11111111-2222-3333-4444-555555555555",
+    data_source="MusicBrainz")
+did_neutralize_mb = h._neutralize_discogs_provider_ids(
+    types.SimpleNamespace(info=mb_info))
+mb_item_data = dict(mb_info.item_data)
+assert did_neutralize_mb is False, did_neutralize_mb
+assert mb_item_data.get("mb_albumid") == "11111111-2222-3333-4444-555555555555", \
+    mb_item_data.get("mb_albumid")
+print("DISCOGS_NEUTRALIZE_OK")
 '''
 
 
@@ -93,6 +148,7 @@ class TestHarnessBeets2Contract(unittest.TestCase):
         )
         self.assertIn("LIBRARY_OK", proc.stdout)
         self.assertIn("CONTRACT_OK", proc.stdout)
+        self.assertIn("DISCOGS_NEUTRALIZE_OK", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_harness_discogs_neutralize.py
+++ b/tests/test_harness_discogs_neutralize.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Deterministic pin for harness/beets_harness.py's Discogs id neutralizer
+(issue #570 defect 2).
+
+INVARIANT: An applied Discogs match leaves `mb_albumid` and
+`mb_releasegroupid` empty — never a bare-numeric Discogs id. The identifier
+lives ONLY in `discogs_albumid`. MusicBrainz matches keep their UUID
+`album_id`/`mb_albumid` unchanged.
+
+Root cause: beets' `AlbumInfo.MEDIA_FIELD_MAP` maps `album_id -> mb_albumid`
+and `releasegroup_id -> mb_releasegroupid`. The Discogs plugin fills those
+fields with NUMERIC Discogs ids, so an un-neutralized apply writes a bare
+integer into `MUSICBRAINZ_ALBUMID` — Jellyfin's `new Guid(tag)` throws
+`FormatException` and aborts the album's whole MusicBrainz metadata fetch.
+
+The generated property (over a wider candidate world space) and the
+real-beets subprocess contract for the same invariant live in
+tests/test_harness_discogs_neutralize_generated.py and
+tests/test_harness_beets2_contract.py respectively.
+
+The harness imports `beets` at module top-level, so we mock those modules
+in sys.modules before importing it — same preamble as
+tests/test_harness_serialization.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_beets_mocks = {
+    "beets": MagicMock(),
+    "beets.config": MagicMock(),
+    "beets.library": MagicMock(),
+    "beets.plugins": MagicMock(),
+    "beets.importer": MagicMock(),
+    "beets.importer.actions": MagicMock(),
+    "beets.importer.session": MagicMock(),
+    "beets.importer.tasks": MagicMock(),
+}
+for name, mock in _beets_mocks.items():
+    sys.modules.setdefault(name, mock)
+
+# ImportSession needs to be a class so subclassing works.
+setattr(sys.modules["beets.importer.session"], "ImportSession",
+        type("ImportSession", (object,), {}))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from harness import beets_harness  # noqa: E402
+
+
+def discogs_provider_ids_neutralized(info) -> bool:
+    """True iff `info` is safe to apply: a Discogs AlbumInfo must not carry a
+    numeric album_id/releasegroup_id that beets would map into mb_albumid/
+    mb_releasegroupid. Non-Discogs infos are always considered safe.
+
+    Test-only invariant checker for `harness.beets_harness
+    ._neutralize_discogs_provider_ids` (production never reads this return
+    value, so it does not belong in the production module — see issue #570
+    review). The single definition lives here; other test modules
+    (tests/test_harness_discogs_neutralize_generated.py) import it from this
+    module rather than defining a divergent copy.
+    """
+    if (getattr(info, "data_source", "") or "") != "Discogs":
+        return True
+    return not (getattr(info, "album_id", "") or "") and not (getattr(info, "releasegroup_id", "") or "")
+
+
+def _candidate(data_source: str, album_id, releasegroup_id) -> SimpleNamespace:
+    """A lightweight AlbumMatch-like stub — the helper is duck-typed and
+    only ever reads/writes `.info.data_source` / `.info.album_id` /
+    `.info.releasegroup_id`."""
+    info = SimpleNamespace(
+        data_source=data_source, album_id=album_id,
+        releasegroup_id=releasegroup_id)
+    return SimpleNamespace(info=info)
+
+
+class TestNeutralizeDiscogsProviderIds(unittest.TestCase):
+    """Pin: a Discogs candidate's numeric ids get blanked; a MusicBrainz
+    candidate is left untouched (must-still-work guard)."""
+
+    def test_discogs_candidate_numeric_ids_blanked(self):
+        cand = _candidate("Discogs", "1505049", "339103")
+        neutralized = beets_harness._neutralize_discogs_provider_ids(cand)
+        self.assertTrue(neutralized)
+        self.assertEqual(cand.info.album_id, "")
+        self.assertEqual(cand.info.releasegroup_id, "")
+        self.assertTrue(discogs_provider_ids_neutralized(cand.info))
+
+    def test_musicbrainz_candidate_unchanged(self):
+        uuid = "11111111-2222-3333-4444-555555555555"
+        cand = _candidate("MusicBrainz", uuid, "")
+        neutralized = beets_harness._neutralize_discogs_provider_ids(cand)
+        self.assertFalse(neutralized)
+        self.assertEqual(cand.info.album_id, uuid)
+        self.assertTrue(discogs_provider_ids_neutralized(cand.info))
+
+    def test_missing_info_returns_false(self):
+        cand = SimpleNamespace(info=None)
+        self.assertFalse(beets_harness._neutralize_discogs_provider_ids(cand))
+
+    def test_blank_data_source_left_untouched(self):
+        """An empty data_source (never happens for a real candidate, but the
+        helper must not misclassify it as Discogs)."""
+        cand = _candidate("", "some-id", "")
+        neutralized = beets_harness._neutralize_discogs_provider_ids(cand)
+        self.assertFalse(neutralized)
+        self.assertEqual(cand.info.album_id, "some-id")
+
+
+class TestDiscogsProviderIdsNeutralizedChecker(unittest.TestCase):
+    """Known-bad self-test: `discogs_provider_ids_neutralized` — the
+    invariant checker itself — must trip (return False) on exactly the
+    un-neutralized shape that shipped the #570 bug."""
+
+    def test_trips_on_unneutralized_discogs_album_id(self):
+        info = SimpleNamespace(
+            data_source="Discogs", album_id="1505049", releasegroup_id="")
+        self.assertFalse(discogs_provider_ids_neutralized(info))
+
+    def test_trips_on_unneutralized_discogs_releasegroup_id(self):
+        info = SimpleNamespace(
+            data_source="Discogs", album_id="", releasegroup_id="99999")
+        self.assertFalse(discogs_provider_ids_neutralized(info))
+
+    def test_passes_on_neutralized_discogs_info(self):
+        info = SimpleNamespace(
+            data_source="Discogs", album_id="", releasegroup_id="")
+        self.assertTrue(discogs_provider_ids_neutralized(info))
+
+    def test_non_discogs_always_considered_safe(self):
+        info = SimpleNamespace(
+            data_source="MusicBrainz", album_id="1234", releasegroup_id="5678")
+        self.assertTrue(discogs_provider_ids_neutralized(info))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_discogs_neutralize_generated.py
+++ b/tests/test_harness_discogs_neutralize_generated.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Generated property for the Discogs id neutralizer (issue #570 defect 2).
+
+INVARIANT: An applied Discogs match leaves `mb_albumid` and
+`mb_releasegroupid` empty — never a bare-numeric Discogs id. The identifier
+lives ONLY in `discogs_albumid`. MusicBrainz (and any other non-Discogs)
+matches keep their `album_id` unchanged.
+
+`harness.beets_harness._neutralize_discogs_provider_ids` is the fix;
+`tests.test_harness_discogs_neutralize.discogs_provider_ids_neutralized` is
+the invariant checker it exists to satisfy (test-only — production never
+reads its return value, so it lives in the test layer, not in the harness
+module; this module imports the single definition rather than duplicating
+it). This module patrols the invariant over a generated candidate world
+space (data_source x id-shape), pins the deterministic scenarios from
+tests/test_harness_discogs_neutralize.py as `@example`s, and proves the
+checker actually trips via a known-bad self-test — the pattern established
+in tests/test_disk_reaper_generated.py.
+
+The real-beets subprocess contract (real `AlbumInfo`, real
+`MEDIA_FIELD_MAP`, real `item_data`) lives in
+tests/test_harness_beets2_contract.py — this module only exercises the pure
+duck-typed helper, so it mocks `beets` in sys.modules like every other
+harness unit test (tests/test_harness_serialization.py).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+_beets_mocks = {
+    "beets": MagicMock(),
+    "beets.config": MagicMock(),
+    "beets.library": MagicMock(),
+    "beets.plugins": MagicMock(),
+    "beets.importer": MagicMock(),
+    "beets.importer.actions": MagicMock(),
+    "beets.importer.session": MagicMock(),
+    "beets.importer.tasks": MagicMock(),
+}
+for name, mock in _beets_mocks.items():
+    sys.modules.setdefault(name, mock)
+
+setattr(sys.modules["beets.importer.session"], "ImportSession",
+        type("ImportSession", (object,), {}))
+
+from harness import beets_harness  # noqa: E402
+from tests.test_harness_discogs_neutralize import (  # noqa: E402
+    discogs_provider_ids_neutralized,
+)
+
+
+# ============================================================================
+# World space
+# ============================================================================
+
+_DATA_SOURCES = ("MusicBrainz", "Discogs", "", "iTunes")
+_ID_SHAPES = (
+    "",  # absent
+    "1505049",  # bare-numeric Discogs id
+    "11111111-2222-3333-4444-555555555555",  # MusicBrainz-shaped UUID
+)
+
+
+@dataclass(frozen=True)
+class _CandidateWorld:
+    data_source: str
+    album_id: str
+    releasegroup_id: str
+
+
+@st.composite
+def _candidate_worlds(draw) -> _CandidateWorld:
+    return _CandidateWorld(
+        data_source=draw(st.sampled_from(_DATA_SOURCES)),
+        album_id=draw(st.sampled_from(_ID_SHAPES)),
+        releasegroup_id=draw(st.sampled_from(_ID_SHAPES)),
+    )
+
+
+def _build_candidate(world: _CandidateWorld) -> SimpleNamespace:
+    info = SimpleNamespace(
+        data_source=world.data_source, album_id=world.album_id,
+        releasegroup_id=world.releasegroup_id)
+    return SimpleNamespace(info=info)
+
+
+# ============================================================================
+# Invariant checker (module-level so the known-bad self-test can call it
+# directly — CLAUDE.md "Bug Hunting — Generated-First" / code-quality.md
+# Red/Green TDD)
+# ============================================================================
+
+def assert_discogs_neutralize_invariant(
+    candidate, original_data_source: str, original_album_id: str,
+) -> None:
+    """After `_neutralize_discogs_provider_ids(candidate)` has run:
+
+    * `discogs_provider_ids_neutralized(candidate.info)` must be True for
+      EVERY candidate, regardless of data_source.
+    * a non-Discogs candidate's `album_id` must be byte-identical to what it
+      was before neutralization (the must-still-work guard: MusicBrainz
+      candidates are never touched).
+    * a Discogs candidate must never carry a truthy `album_id` or
+      `releasegroup_id` after neutralization (the broader end-invariant —
+      restated directly rather than only through the checker function, so a
+      bug in the checker itself can't hide a real violation).
+    """
+    info = candidate.info
+    if not discogs_provider_ids_neutralized(info):
+        raise AssertionError(
+            "discogs_provider_ids_neutralized reports unsafe after "
+            f"neutralization: data_source={info.data_source!r} "
+            f"album_id={info.album_id!r} "
+            f"releasegroup_id={info.releasegroup_id!r}")
+
+    if original_data_source != "Discogs" and info.album_id != original_album_id:
+        raise AssertionError(
+            f"non-Discogs album_id must remain unchanged: "
+            f"data_source={original_data_source!r} "
+            f"before={original_album_id!r} after={info.album_id!r}")
+
+    if original_data_source == "Discogs" and (
+            info.album_id or info.releasegroup_id):
+        raise AssertionError(
+            "Discogs info must never carry a truthy album_id/"
+            f"releasegroup_id after neutralization: "
+            f"album_id={info.album_id!r} "
+            f"releasegroup_id={info.releasegroup_id!r}")
+
+
+# ============================================================================
+# Generated property
+# ============================================================================
+
+class TestGeneratedDiscogsNeutralizeInvariant(unittest.TestCase):
+    """Property: over the full data_source x id-shape world space,
+    neutralization always leaves the candidate safe, and never touches a
+    non-Discogs candidate's album_id."""
+
+    @given(world=_candidate_worlds())
+    @example(world=_CandidateWorld(
+        data_source="Discogs", album_id="1505049", releasegroup_id="339103"))
+    @example(world=_CandidateWorld(
+        data_source="MusicBrainz",
+        album_id="11111111-2222-3333-4444-555555555555",
+        releasegroup_id=""))
+    def test_every_candidate_is_safe_after_neutralization(self, world):
+        candidate = _build_candidate(world)
+        original_album_id = candidate.info.album_id
+        beets_harness._neutralize_discogs_provider_ids(candidate)
+        assert_discogs_neutralize_invariant(
+            candidate, world.data_source, original_album_id)
+
+
+# ============================================================================
+# Known-bad self-tests
+# ============================================================================
+
+class TestDiscogsNeutralizeCheckerTripsOnViolations(unittest.TestCase):
+    """Plant violations that skip (or undo) the fix and prove the checker
+    trips on each — the discipline that would have caught #570 before it
+    shipped."""
+
+    def test_trips_when_discogs_candidate_never_neutralized(self):
+        """The exact live-bug shape: a Discogs candidate whose numeric ids
+        were never blanked (e.g. the fix wasn't called at all)."""
+        candidate = _build_candidate(_CandidateWorld(
+            data_source="Discogs", album_id="1505049",
+            releasegroup_id="339103"))
+        # Deliberately skip calling _neutralize_discogs_provider_ids.
+        with self.assertRaises(AssertionError):
+            assert_discogs_neutralize_invariant(candidate, "Discogs", "1505049")
+
+    def test_trips_when_only_album_id_was_blanked(self):
+        """A partial fix that forgets releasegroup_id must still trip."""
+        candidate = _build_candidate(_CandidateWorld(
+            data_source="Discogs", album_id="", releasegroup_id="339103"))
+        with self.assertRaises(AssertionError):
+            assert_discogs_neutralize_invariant(candidate, "Discogs", "1505049")
+
+    def test_trips_when_non_discogs_album_id_mutated(self):
+        """A regression that blanks EVERY candidate's album_id (not just
+        Discogs) must trip the must-still-work guard."""
+        candidate = _build_candidate(_CandidateWorld(
+            data_source="MusicBrainz", album_id="", releasegroup_id=""))
+        original_album_id = "11111111-2222-3333-4444-555555555555"
+        with self.assertRaises(AssertionError):
+            assert_discogs_neutralize_invariant(
+                candidate, "MusicBrainz", original_album_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -246,7 +246,8 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
 
     PRODUCTION_PLUGINS = (
         "musicbrainz discogs fetchart embedart lyrics lastgenre scrub "
-        "info missing duplicates edit fromfilename ftintitle the inline"
+        "info missing duplicates edit fromfilename ftintitle the inline "
+        "permissions"
     )
 
     def test_duplicate_keys_is_a_literal_under_import(self) -> None:
@@ -261,6 +262,23 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
     def test_plugin_list_is_fixed_and_contains_musicbrainz(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")
         self.assertIn(f'plugins = "{self.PRODUCTION_PLUGINS}";', text)
+
+    def test_permissions_plugin_configured_with_media_server_friendly_modes(
+        self,
+    ) -> None:
+        """Issue #570 defect 1: beets' native ``fetchart`` writes album art
+        via ``mkstemp`` (forces 0600) then renames it into place — nothing
+        else chmods it, so art is unreadable by media servers.
+        ``fix_library_modes`` (lib/permissions.py) deliberately touches
+        directories only, never files, so the ``permissions`` plugin (its
+        ``art_set -> fix_art`` listener) is what covers both initial import
+        AND manual ``beet fetchart`` re-fetches."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("permissions", self.PRODUCTION_PLUGINS.split())
+        self.assertIn(
+            'permissions = {\n      file = "0664";\n      dir = "0775";\n    };',
+            text,
+        )
 
     def test_config_yaml_rendered_atomically_into_beetsdir(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #570 (both defects). Root-caused, fixed, and verified against real beets 2.12 + the live library.

## Defect 2 — Discogs matches poison `mb_albumid` with a non-UUID id
Beets' native `discogs` plugin sets `AlbumInfo.album_id`/`releasegroup_id` to **numeric** Discogs ids, and beets core maps `album_id -> mb_albumid` (`Info.MEDIA_FIELD_MAP`). Every Discogs import therefore wrote a bare integer into `mb_albumid` and the `MUSICBRAINZ_ALBUMID` tag → Jellyfin's `new Guid(tag)` throws and aborts the album's whole MusicBrainz metadata fetch. **Live: 408/8407 albums poisoned, all also carrying the id in `discogs_albumid`.** The codebase already *assumes* `mb_albumid` is empty for Discogs rows (the "plugin patch" its comments reference never existed) — this restores that invariant.

**Fix:** when applying a chosen Discogs candidate, `_neutralize_discogs_provider_ids` blanks `info.album_id`/`releasegroup_id` to `""` (busting beets' `item_data`/`raw_data` `@cached_property`) so beets applies empty `mb_*` while `discogs_albumid` survives. Duplicate detection still works via the `AndQuery` on `discogs_albumid`. A `hasattr` gate keeps the shared `choose_item` (singleton/`TrackInfo`) path a true no-op.

## Defect 1 — album art lands mode 0600 (unreadable by media servers)
fetchart writes art via `mkstemp` (forces 0600 regardless of umask) then renames it in; nothing chmods it, and `fix_library_modes` touches directories only. Since the importer moved to a group-writable umask, every `cover.*` lands 0600 → Jellyfin `UnauthorizedAccessException`.

**Fix:** enable the beets `permissions` plugin (`file 0664`, `dir 0775`). Its `art_set -> fix_art` listener covers **both** initial import and manual `beet fetchart` re-fetches — coverage extending `fix_library_modes` would miss.

## Tests (per code-quality / test-fidelity rules)
- Defect 2 ships the invariant **PAIR**: deterministic pin + Hypothesis property, each with a known-bad self-test, **plus a real-beets-2.12 subprocess contract** that drives the fix through the actual `AlbumInfo.item_data` mapping and proves the cache-bust is load-bearing — the guard the mocked harness tests structurally cannot provide.
- Defect 1 updates the rendered-config contract test + the module-vm plugin-list gate.
- Verified: full suite **4961 tests OK**, full-repo pyright **0 errors**, `moduleVm` VM-boot gate **pass**, dead-code sweep clean, pre-push `nix flake check` + fuzz burst pass.

## Deploy note (not in this PR)
The 408 already-poisoned albums are remediated by an operator one-shot at deploy (`mb_albumid`/`mb_releasegroupid` cleared + `beet write`), run with the 5-min timer masked so no re-import can double-import a still-poisoned album mid-transition.

## Follow-up (coordinated, separate PRs)
Group-ownership twin (dirs land `root:music-import`; Jellyfin gid-100 can't save NFO/art), running cratedigger off root, `dir` → `02775` setgid + group `users`, and retiring the out-of-tree `cratedigger-group-permissions.patch` via configurable module options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
