### PR TITLE
perms(#570): setgid + group-writable library modes for non-root/group-users layout

### DIFF
--- a/harness/beets_harness.py
+++ b/harness/beets_harness.py
@@ -641,10 +641,14 @@ class HarnessImportSession(ImportSession):
 def main():
     import argparse
 
-    # Belt-and-suspenders for systemd's UMask=0000 — see lib/permissions.py / GH #84.
-    # Runs inside the Nix beets env where lib/ is not on sys.path, so inline
-    # the single-line policy rather than import the helper.
-    os.umask(0)
+    # Belt-and-suspenders for the group-writable import boundary — see
+    # lib/permissions.py / GH #84. The systemd unit's UMask=0000 is a
+    # permissive floor; this explicit 0o002 (not 0) is what narrows newly
+    # created files/dirs to group-writable so the shared group can write
+    # alongside the media. Runs inside the Nix beets env where lib/ is not
+    # on sys.path, so inline the single-line policy rather than import the
+    # helper.
+    os.umask(0o002)
 
     parser = argparse.ArgumentParser(
         description="Beets interactive import harness — JSON over stdin/stdout"

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1512,9 +1512,10 @@ def main():
     global _import_total_start  # noqa: PLW0603
     _import_total_start = time.monotonic()
 
-    # Belt-and-suspenders for systemd's UMask=0000 — see lib/permissions.py / GH #84.
-    # Done in main() (not at module import) so importing this module for tests
-    # doesn't leak a zero umask into the test process.
+    # Belt-and-suspenders for the group-writable import boundary (umask 0o002) —
+    # see lib/permissions.py / GH #84. Done in main() (not at module import) so
+    # importing this module for tests doesn't leak the process umask into the
+    # test process.
     reset_umask()
 
     parser = argparse.ArgumentParser(description="One-shot beets import for a single album")
@@ -2199,7 +2200,9 @@ def main():
 
     # --- Force library modes ---
     # Guards against any subprocess layer that dropped umask and created
-    # 0o755 dirs despite the systemd unit's UMask=0000 — see GH #84.
+    # non-setgid / non-group-writable dirs — post-import belt-and-suspenders
+    # that enforces LIBRARY_DIR_MODE (0o2775, setgid + group-writable) on every
+    # album/artist dir, covering dirs the beets permissions plugin misses. GH #84.
     fix_library_modes(album_path)
     _log_timing("postflight_verification", stage_start)
 

--- a/lib/permissions.py
+++ b/lib/permissions.py
@@ -10,15 +10,22 @@ other user (abl030) from running beets commands against the library.
 
 Rather than chase the elusive umask-reset through every layer, we:
 
-1. Explicitly `os.umask(0)` at every pipeline entry point (belt-and-suspenders
-   over systemd's `UMask=0000`).
+1. Explicitly `os.umask(0o002)` at every pipeline entry point — the systemd
+   units' `UMask=0000` is a permissive floor; this explicit call is what
+   actually narrows newly-created files/dirs to group-writable.
 2. After a successful import, recursively chmod the imported album dir and
    its parent (artist dir) to guarantee the final on-disk mode regardless of
    which layer dropped the umask.
 
-The final modes (`0o777` for dirs, `0o666` for files) are the values the
-service would have produced under `umask=0`, so this is not looser than the
-intended policy — it just enforces it unconditionally.
+The final dir mode is `0o2775` (setgid + rwxrwxr-x): setgid so every new
+child directory beets creates underneath inherits the library's group
+(rather than the creating process's primary group), and group-writable so
+gid-consumers — media servers like Jellyfin — can write NFO/artwork
+alongside the media without needing to own the files. This is the boundary
+for the non-root service user + group-`users` library layout: a plain
+`0o775` with no setgid bit silently strips setgid on every import and
+defeats the whole design, so `fix_library_modes` re-asserts it unconditionally
+rather than trusting whatever the umask happened to produce.
 """
 from __future__ import annotations
 
@@ -27,34 +34,46 @@ import os
 
 logger = logging.getLogger(__name__)
 
-LIBRARY_DIR_MODE = 0o777
+LIBRARY_DIR_MODE = 0o2775
 
 
 def reset_umask() -> None:
-    """Set the process umask to 0, matching the systemd unit's UMask=0000.
+    """Set the process umask to the group-writable 0o002.
 
     Call this at every pipeline entry point (cratedigger.py main(), import_one.py
     main(), beets_harness.py main()) so subprocesses further down the chain
-    inherit it. Do NOT call this at module-import time — the umask is
-    process-wide and would leak into any code that imports the module.
+    inherit it. The systemd units run with a permissive `UMask=0000` as the
+    floor; this explicit `0o002` (not `0`) is what actually governs the final
+    on-disk mode — group-writable so the shared group can create/write
+    alongside the media, without also handing out world-write. Do NOT call
+    this at module-import time — the umask is process-wide and would leak
+    into any code that imports the module.
     """
-    os.umask(0)
+    os.umask(0o002)
 
 
 def fix_library_modes(path: str) -> None:
     """Recursively chmod a library path's *directories* to LIBRARY_DIR_MODE.
 
     Issue #84 is specifically about directory accessibility — beets is
-    intermittently creating artist/album dirs as 0o755 despite the systemd
-    unit's UMask=0000, which blocks other users from running `beet fetchart`
-    etc. File modes are set by beets' own `shutil.copystat` when it moves
-    tracks in from staging, so we deliberately do NOT touch files here — that
-    would risk broadening file permissions beyond what the source had.
+    intermittently creating artist/album dirs as 0o755 despite the process's
+    group-writable `0o002` umask (`reset_umask`), which blocks other
+    users/services in the group from running `beet fetchart` etc. or
+    writing alongside the media. File modes are set by beets' own
+    `shutil.copystat` when it moves tracks in from staging, so we
+    deliberately do NOT touch files here — that would risk broadening file
+    permissions beyond what the source had.
 
     If `path` is a directory:
       - the directory itself and its immediate parent (typically the artist
-        dir above an album dir) are chmod'd to `LIBRARY_DIR_MODE` (0o777)
+        dir above an album dir) are chmod'd to `LIBRARY_DIR_MODE` (`0o2775` —
+        setgid + group-writable)
       - every descendant directory → `LIBRARY_DIR_MODE`
+
+    This is the belt-and-suspenders guarantee for the setgid/group-writable
+    import boundary: it re-asserts `0o2775` (including the setgid bit) even
+    on empty/intermediate dirs the beets `permissions` plugin's per-item
+    listener doesn't reach, so the bit can never be silently stripped.
 
     Non-existent or non-directory paths are a no-op. Per-entry chmod failures
     are logged and swallowed so one stubborn child cannot block the pass.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -107,7 +107,7 @@
     chroma.auto = false;
     permissions = {
       file = "0664";
-      dir = "0775";
+      dir = "02775";
     };
     fetchart = {
       auto = true;
@@ -1088,7 +1088,9 @@ in {
         example = "systemctl restart slskd.service";
         description = ''
           Shell command to run when the health check fails. Empty = log and skip
-          the run. The command is invoked as root (or services.cratedigger.user) and
+          the run. The command is invoked as root (the health-check ExecStartPre is
+          "+"-prefixed, so it runs as root even when services.cratedigger.user is
+          non-root — e.g. so `systemctl restart slskd.service` works) and
           retries are attempted for up to a minute after it returns.
         '';
       };
@@ -1433,7 +1435,14 @@ in {
         User = cfg.user;
         Group = cfg.group;
         UMask = "0000";
-        ExecStartPre = lib.optional cfg.healthCheck.enable slskdHealthCheck ++ [preStartScript];
+        # slskdHealthCheck is prefixed with "+" so it always runs as root,
+        # regardless of cfg.user: its onFailureCommand (e.g. `systemctl
+        # restart slskd.service`) needs root, and once cfg.user is
+        # non-root a bare ExecStartPre would run as that user and be
+        # unable to restart slskd. preStartScript must NOT get "+" — it
+        # renders config as cfg.user so ownership on the rendered files
+        # matches the service that reads them.
+        ExecStartPre = lib.optional cfg.healthCheck.enable "+${slskdHealthCheck}" ++ [preStartScript];
         Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${cratediggerPkg}/bin/cratedigger";
         WorkingDirectory = cfg.stateDir;
@@ -1484,13 +1493,14 @@ in {
         User = cfg.user;
         Group = cfg.group;
         UMask = "0000";
-        # Same ExecStartPre shape as cratedigger.service: gate on
-        # slskd reachability when the operator has health-check
-        # enabled, then render the config. The detection job hits
-        # slskd just as much as the main loop does, so a slskd
-        # outage should fail the unit fast rather than write
-        # garbage probe-failed rows for every cohort member.
-        ExecStartPre = lib.optional cfg.healthCheck.enable slskdHealthCheck ++ [preStartScript];
+        # Same ExecStartPre shape as cratedigger.service (including the
+        # "+" root-escalation prefix on slskdHealthCheck — see the comment
+        # there): gate on slskd reachability when the operator has
+        # health-check enabled, then render the config. The detection job
+        # hits slskd just as much as the main loop does, so a slskd
+        # outage should fail the unit fast rather than write garbage
+        # probe-failed rows for every cohort member.
+        ExecStartPre = lib.optional cfg.healthCheck.enable "+${slskdHealthCheck}" ++ [preStartScript];
         Environment = "PIPELINE_DB_DSN=${pipelineDsn}";
         ExecStart = "${unfindableDetectionPkg}/bin/cratedigger-unfindable";
         WorkingDirectory = cfg.stateDir;

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -651,9 +651,9 @@ class TestMainCLIParsing(unittest.TestCase):
     """Test the CLI argument parsing and config loading path in main()."""
 
     def setUp(self):
-        # cratedigger.main() calls reset_umask() (sets umask to 0 for the pipeline's
-        # subprocess chain, GH #84). Restore the prior umask so later tests in
-        # the same process keep their expected default.
+        # cratedigger.main() calls reset_umask() (sets umask to 0o002 for the
+        # pipeline's subprocess chain, GH #84). Restore the prior umask so
+        # later tests in the same process keep their expected default.
         self._saved_umask = os.umask(0o022)
         os.umask(self._saved_umask)
         self.addCleanup(os.umask, self._saved_umask)

--- a/tests/test_force_import.py
+++ b/tests/test_force_import.py
@@ -38,7 +38,7 @@ class TestImportOneForceFlag(unittest.TestCase):
     """Test that import_one.main() toggles MAX_DISTANCE from the real CLI flag."""
 
     def setUp(self) -> None:
-        # import_one.main() calls reset_umask() (sets umask to 0 for the
+        # import_one.main() calls reset_umask() (sets umask to 0o002 for the
         # subprocess chain, GH #84). Restore so later tests keep their default.
         self._saved_umask = os.umask(0o022)
         os.umask(self._saved_umask)

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -272,11 +272,18 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
         ``fix_library_modes`` (lib/permissions.py) deliberately touches
         directories only, never files, so the ``permissions`` plugin (its
         ``art_set -> fix_art`` listener) is what covers both initial import
-        AND manual ``beet fetchart`` re-fetches."""
+        AND manual ``beet fetchart`` re-fetches.
+
+        ``dir`` is ``02775`` (setgid + group-writable), not a plain
+        ``0775`` — setgid so child dirs beets creates underneath inherit
+        the library group, group-writable so gid-consumers (Jellyfin) can
+        write alongside the media. This mirrors ``lib.permissions.
+        LIBRARY_DIR_MODE`` (``0o2775``); a bare ``0775`` here would leave
+        beets itself stripping the setgid bit on every import."""
         text = MODULE_NIX.read_text(encoding="utf-8")
         self.assertIn("permissions", self.PRODUCTION_PLUGINS.split())
         self.assertIn(
-            'permissions = {\n      file = "0664";\n      dir = "0775";\n    };',
+            'permissions = {\n      file = "0664";\n      dir = "02775";\n    };',
             text,
         )
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -10,12 +10,12 @@ from lib.permissions import LIBRARY_DIR_MODE, fix_library_modes, reset_umask
 
 
 class TestResetUmask(unittest.TestCase):
-    def test_sets_umask_to_zero(self):
+    def test_sets_umask_to_group_writable(self):
         prior = os.umask(0o027)
         try:
             reset_umask()
             current = os.umask(0)
-            self.assertEqual(current, 0)
+            self.assertEqual(current, 0o002)
         finally:
             os.umask(prior)
 
@@ -49,6 +49,19 @@ class TestFixLibraryModes(unittest.TestCase):
             self.assertEqual(self._mode(album), LIBRARY_DIR_MODE)
             self.assertEqual(self._mode(artist), LIBRARY_DIR_MODE,
                              "artist (parent) dir must also be chmod'd")
+
+    def test_dir_mode_is_setgid_and_group_writable(self):
+        """The invariant this whole helper exists to guarantee: setgid
+        (0o2000) so child dirs inherit the library group, and 0o775 so
+        gid-consumers (Jellyfin) can write NFO/artwork alongside media. A
+        plain 0o775 with no setgid bit silently defeats the design."""
+        with tempfile.TemporaryDirectory() as root:
+            _, album, _, _ = self._make_tree(root)
+            fix_library_modes(album)
+            mode = self._mode(album)
+            self.assertTrue(mode & 0o2000, "setgid bit must be set")
+            self.assertEqual(mode & 0o775, 0o775, "must be group-writable rwxrwxr-x")
+            self.assertEqual(LIBRARY_DIR_MODE, 0o2775)
 
     def test_recursive_on_subdirs(self):
         with tempfile.TemporaryDirectory() as root:


### PR DESCRIPTION
Phase B of #570 follow-up: make cratedigger's file-permission policy correct in-tree so the out-of-tree `cratedigger-group-permissions.patch` can be deleted and the library can move to a **setgid, group-`users`, non-root-service** layout (fixes the group-ownership twin from #570: Jellyfin gid-100 currently can't write NFO/art into `root:music-import 775` dirs).

- `lib/permissions.py`: `LIBRARY_DIR_MODE 0o777 -> 0o2775` (setgid + group-writable — child dirs inherit the group, gid-consumers write alongside media); `reset_umask 0 -> 0o002`.
- `harness/beets_harness.py`: inline entry-point umask `0 -> 0o002`.
- `nix/module.nix`: beets `permissions.dir "0775" -> "02775"` (setgid); `+`-prefix the `slskdHealthCheck` ExecStartPre so its `onFailureCommand` (`systemctl restart slskd`) still runs as root once the service user is non-root, while `preStartScript` keeps running as the service user.
- `fix_library_modes` stays as post-import belt-and-suspenders (now `0o2775`), covering dirs the beets permissions plugin's per-item listener misses.

**Verified:** full suite 4962 OK · full-repo pyright 0 · moduleVm VM-boot gate pass · opus review clean (the `+`-prefix has no order flip and no sandbox dependency; setgid modes agree between the plugin and `fix_library_modes`).

Pairs with the nixosconfig cutover (dedicated `cratedigger` user, `group = users`, setgid tree via tmpfiles, discogs-token `z` rule) that deletes the patch and bumps `cratedigger-src` to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
