### PR TITLE
docs: surface the docs-freshness gate in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ grep "^FAIL\|^ERROR" /tmp/cratedigger-test-output.txt
 nix-shell --run "python3 -m unittest tests.test_X -v"
 ```
 
-**ALWAYS `nix-shell --run` for Python** (`.claude/rules/nix-shell.md`). **Never re-run the full suite just to grep differently** — read the output file. The suite gates: JS syntax + JS tests, the vulture dead-code sweep, then unittest discovery. `.claude/rules/code-quality.md` covers the test taxonomy, shared fakes/builders, and the new-work checklist.
+**ALWAYS `nix-shell --run` for Python** (`.claude/rules/nix-shell.md`). **Never re-run the full suite just to grep differently** — read the output file. The suite gates: JS syntax + JS tests, the vulture dead-code sweep, then unittest discovery — which includes `tests/test_docs_audit.py`, so the suite **fails if a new beets plugin, module option, or `pipeline-cli` subcommand ships undocumented** (or a doc link goes dead); docs are part of "done". `.claude/rules/code-quality.md` covers the test taxonomy, shared fakes/builders, the new-work checklist, and the docs-freshness rule.
 
 **Generated (property-based) tests** (`tests/test_*_generated.py`, Hypothesis) run deterministically in the suite; after changing quality policy, run the randomized fuzz burst: `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz` on those modules. Failures shrink to minimal worlds — promote them to named `@example` pins or album-test-set scenarios, never JSON artifacts. **New features start by writing their invariants down, and every invariant ships as a PAIR — deterministic pin + generated property — in the same PR, with known-bad self-tests** (`.claude/rules/code-quality.md` § Red/Green TDD). When in doubt that the harness constrains anything, qualify it by fault injection. `docs/generated-testing.md`.
 


### PR DESCRIPTION
One-line addition to CLAUDE.md's always-loaded suite-gates description, pointing at `tests/test_docs_audit.py` (PR #580) so it's discoverable that the suite fails when a new beets plugin / module option / `pipeline-cli` subcommand ships undocumented, or a doc link goes dead. Docs-audit still green (14 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)