### PR TITLE
feat(web): show the on-disk codec on the HAVE side (#575 PR2 follow-up)

### DIFF
--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -458,6 +458,48 @@ console.log('renderEvidenceStrip() requires a number — a codec label alone is 
   }
 }
 
+console.log('renderEvidenceStrip() shows the on-disk format on the HAVE side');
+{
+  // The Mothertongue case (#575): AAC 256 replacing unverified MP3 256.
+  // Without the format, "IN M4A V0 · 256k HAVE 256k" reads as a
+  // pointless re-download; the codec class WAS the upgrade.
+  const strip = renderEvidenceStrip({
+    downloaded_label: 'M4A V0',
+    actual_min_bitrate: 256,
+    spectral_grade: 'genuine',
+    existing_format: 'MP3',
+    existing_min_bitrate: 256,
+  });
+  assertContains(strip, 'MP3 256k', 'HAVE side leads with the on-disk format');
+}
+
+console.log('renderDownloadHistoryItem() includes the on-disk format in the Bitrate (was X) suffix');
+{
+  const html = renderDownloadHistoryItem({
+    outcome: 'success',
+    soulseek_username: 'japanman797',
+    created_at: '2026-07-10T10:30:00+00:00',
+    downloaded_label: 'M4A V0',
+    actual_min_bitrate: 256,
+    existing_format: 'MP3',
+    existing_min_bitrate: 256,
+  });
+  assertContains(html, '(was MP3 256kbps)',
+    'Bitrate was-suffix names the on-disk codec');
+}
+
+console.log('renderDownloadHistoryItem() keeps the bare (was X) when existing format unknown');
+{
+  const html = renderDownloadHistoryItem({
+    outcome: 'success',
+    soulseek_username: 'testuser',
+    created_at: '2026-07-10T10:30:00+00:00',
+    actual_min_bitrate: 320,
+    existing_min_bitrate: 256,
+  });
+  assertContains(html, '(was 256kbps)', 'legacy rows keep the bare suffix');
+}
+
 console.log('renderEvidenceStrip() escapes injected values');
 {
   const strip = renderEvidenceStrip({

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -420,6 +420,41 @@ class TestQualityLabel(unittest.TestCase):
 # classify_log_entry — badge classification
 # ============================================================================
 
+class TestClassifyExistingFormat(unittest.TestCase):
+    """existing_format surfaces the on-disk codec from import_result so
+    rank-driven upgrades at equal bitrate read coherently (issue #575:
+    a 'Bitrate 256kbps (was 256kbps)' upgrade was really AAC replacing
+    unverified MP3 — the format was the deciding metric and was never
+    shown)."""
+
+    def test_existing_format_derived_from_import_result(self):
+        result = classify_log_entry(_entry(
+            outcome="success",
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "existing_measurement": {
+                    "format": "MP3",
+                    "is_cbr": True,
+                    "min_bitrate_kbps": 256,
+                    "avg_bitrate_kbps": 256,
+                },
+            },
+        ))
+        self.assertEqual(result.existing_format, "MP3")
+
+    def test_existing_format_none_without_import_result(self):
+        result = classify_log_entry(_entry(outcome="success"))
+        self.assertIsNone(result.existing_format)
+
+    def test_existing_format_none_when_measurement_absent(self):
+        result = classify_log_entry(_entry(
+            outcome="success",
+            import_result={"version": 2, "decision": "import"},
+        ))
+        self.assertIsNone(result.existing_format)
+
+
 class TestClassifyBadge(unittest.TestCase):
     """Test that classify_log_entry returns the correct badge for each scenario."""
 

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -58,6 +58,9 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         # The evidence strip's codec prefix (issue #575 PR2) — classifier
         # field the raw LogEntry columns don't carry; must be forwarded.
         "downloaded_label",
+        # The on-disk codec at download time (from import_result JSONB) —
+        # rank-driven upgrades at equal bitrate are unreadable without it.
+        "existing_format",
         # Issue #130: post-import `beet move` failures surface as typed
         # reason + detail so the frontend can render a warning chip.
         # Null on clean rows; the field must always be present.
@@ -78,7 +81,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         "downloaded_label", "verdict", "beets_scenario", "beets_distance",
         "disambiguation_failure", "disambiguation_detail", "bad_extensions",
         "spectral_grade", "spectral_bitrate", "existing_min_bitrate",
-        "existing_spectral_bitrate",
+        "existing_spectral_bitrate", "existing_format",
         "source", "youtube_metadata",
         "wrong_match_triage_action", "wrong_match_triage_summary",
         "wrong_match_triage_reason", "wrong_match_triage_preview_verdict",

--- a/web/classify.py
+++ b/web/classify.py
@@ -132,6 +132,11 @@ class ClassifiedEntry:
     wrong_match_triage_preview_decision: Optional[str] = None
     wrong_match_triage_stage_chain: list[str] = field(default_factory=list)
     wrong_match_triage_detail: Optional[str] = None
+    # The on-disk codec at download time, from import_result JSONB
+    # (existing_measurement.format). Rank-driven upgrades at equal
+    # bitrate are unreadable without it (issue #575: AAC 256 replacing
+    # unverified MP3 256 rendered as "256kbps (was 256kbps)").
+    existing_format: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +176,7 @@ def classify_log_entry(entry: LogEntry) -> ClassifiedEntry:
     badge, badge_class, border_color, verdict = _classify(entry)
     summary = _build_summary(entry, badge, verdict)
     downloaded_label = _build_downloaded_label(entry)
+    existing_format = _extract_existing_format(entry)
     disambig_reason, disambig_detail = _extract_disambiguation_failure(entry)
     bad_extensions = _extract_bad_extensions(entry)
     triage = _extract_wrong_match_triage(entry)
@@ -188,7 +194,18 @@ def classify_log_entry(entry: LogEntry) -> ClassifiedEntry:
         wrong_match_triage_preview_decision=triage["preview_decision"],
         wrong_match_triage_stage_chain=triage["stage_chain"],
         wrong_match_triage_detail=triage["detail"],
+        existing_format=existing_format,
     )
+
+
+def _extract_existing_format(entry: LogEntry) -> Optional[str]:
+    """The on-disk codec at download time, from
+    ``import_result.existing_measurement.format``. None when the blob is
+    missing/legacy — renderers fall back to the bare bitrate suffix."""
+    ir = _parse_import_result(entry)
+    if ir is None or ir.existing_measurement is None:
+        return None
+    return ir.existing_measurement.format
 
 
 def _extract_disambiguation_failure(

--- a/web/download_history_view.py
+++ b/web/download_history_view.py
@@ -60,6 +60,7 @@ class DownloadHistoryViewRow(msgspec.Struct, frozen=True):
     spectral_bitrate: int | None
     existing_min_bitrate: int | None
     existing_spectral_bitrate: int | None
+    existing_format: str | None
     final_format: str | None
     v0_probe_kind: str | None
     v0_probe_min_bitrate: int | None
@@ -115,6 +116,7 @@ def build_download_history_row(
             "badge_class": classified.badge_class,
             "border_color": classified.border_color,
             "downloaded_label": classified.downloaded_label,
+            "existing_format": classified.existing_format,
             "verdict": classified.verdict,
             "disambiguation_failure": classified.disambiguation_failure,
             "disambiguation_detail": classified.disambiguation_detail,

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -92,7 +92,16 @@ export function renderEvidenceStrip(h) {
   }
 
   const haveParts = [];
-  if (h.existing_min_bitrate) haveParts.push(`${esc(h.existing_min_bitrate)}k`);
+  // Lead with "MP3 256k" as one piece — the codec class is often the
+  // deciding metric (a rank upgrade at equal bitrate is unreadable
+  // without it).
+  if (h.existing_format && h.existing_min_bitrate) {
+    haveParts.push(`${esc(h.existing_format)} ${esc(h.existing_min_bitrate)}k`);
+  } else if (h.existing_format) {
+    haveParts.push(esc(h.existing_format));
+  } else if (h.existing_min_bitrate) {
+    haveParts.push(`${esc(h.existing_min_bitrate)}k`);
+  }
   if (h.existing_spectral_bitrate) haveParts.push(`~${esc(h.existing_spectral_bitrate)}k`);
   if (
     h.existing_v0_probe_avg_bitrate
@@ -190,12 +199,15 @@ export function renderDownloadHistoryItem(h) {
   }
 
   // Bitrate row — apples-to-apples between candidate and existing on
-  // min bitrate (kbps).
+  // min bitrate (kbps). The was-side names the on-disk codec when known:
+  // "256kbps (was MP3 256kbps)" explains a rank upgrade that the bare
+  // numbers would contradict.
   const candidateMin = h.actual_min_bitrate;
   const existingMin = h.existing_min_bitrate;
   if (candidateMin || existingMin) {
     const candidate = candidateMin ? `${esc(candidateMin)}kbps` : '—';
-    const was = existingMin ? `${esc(existingMin)}kbps` : null;
+    const wasFmt = h.existing_format ? `${esc(h.existing_format)} ` : '';
+    const was = existingMin ? `${wasFmt}${esc(existingMin)}kbps` : null;
     rows.push(['Bitrate', withWas(candidate, was)]);
   } else {
     rows.push(['Bitrate', '—']);

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -77,6 +77,9 @@ def get_pipeline_log(h, params: dict[str, list[str]]) -> None:
         # The evidence strip's codec prefix ("IN MP3 320 …") — a
         # ClassifiedEntry-only field the raw LogEntry columns don't carry.
         item["downloaded_label"] = classified.downloaded_label
+        # On-disk codec at download time (import_result JSONB) for the
+        # strip's HAVE side and the Bitrate (was X) suffix.
+        item["existing_format"] = classified.existing_format
         # Issue #130: surface post-import `beet move` failures so the
         # Recents tab can render a warning chip without forcing the
         # operator to query JSONB manually. Null on clean rows.


### PR DESCRIPTION
## Summary

Operator-reported: an Upgraded card read `Bitrate 256kbps (was 256kbps)` — "like it was 256 and now 256???". The decision record shows why: AAC 256 (spectral genuine) replaced an **unverified MP3** 256 — a codec-rank upgrade the display couldn't express because no wire field carried the on-disk format.

- `ClassifiedEntry.existing_format` derived from `import_result.existing_measurement.format` (degrades to None on legacy blobs)
- Forwarded through `/api/pipeline/log` + `DownloadHistoryViewRow`, both contract-pinned
- Strip: `IN M4A V0 · 256k · genuine HAVE MP3 256k` · Detail: `256kbps (was MP3 256kbps)`

## Verification
- RED→GREEN: 3 classify tests, 3 JS assertions, 2 contract pins
- Full suite 5,156 OK · pyright 0 · Opus review clean (1 cosmetic nit accepted: labelled formats like "mp3 320" may render tier+bitrate together — data-dependent, symmetric with the IN side)
- Live screenshot round on the motivating card (request 8640) via the dev-server loop

Part of #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)