### PR TITLE
docs: capture the UI dev-server screenshot loop (#575)

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -14,4 +14,5 @@ paths:
 - Static JS served at `/js/*.js` — `node --check` validates syntax in CI
 - Fetch-on-input UI must stamp requests with a module-scoped in-flight token and discard stale responses before rendering
 - The web UI reads download_log JSONB columns (import_result, validation_result) — use the typed field names from the dataclasses, not arbitrary strings
+- **Visible UI changes are verified with the dev-server screenshot loop BEFORE pushing** — live-db dev server + CDP chromium + playwright agent, and the main agent Reads the PNGs itself. Tests+review alone shipped three visually-obvious defects on #575. Full recipe + gotchas: `docs/solutions/ui-dev-server-screenshot-loop.md`
 - After changes: `ssh doc2 'sudo systemctl restart cratedigger-web'`

--- a/docs/solutions/ui-dev-server-screenshot-loop.md
+++ b/docs/solutions/ui-dev-server-screenshot-loop.md
@@ -1,0 +1,82 @@
+# UI work: the dev-server screenshot loop (verify with photos before pushing)
+
+**Proven on #575 PR2/PR2b (2026-07-10).** UI changes are verified by
+*looking at them* on real pipeline data BEFORE pushing — unit tests and
+code review both passed while three visually-obvious defects were live.
+The loop caught, per round:
+
+1. **Round 1** — the tab-wide "everything centered" root cause: the
+   `recents-content` / `pipeline-content` / `wrong-matches-content`
+   containers carried `class="loading"` (`text-align: center`)
+   *permanently* — JS replaces `innerHTML` but never touched the class.
+   Invisible to tests; obvious in a screenshot.
+2. **Round 3** — `/api/pipeline/log` never forwarded `downloaded_label`,
+   so the evidence strips shipped without codec labels. The JS unit test
+   passed (it seeded the field into its mock); only the photo of real
+   API data showed it missing. Classic mock-hides-the-contract.
+3. **Round 4** — operator-reported "256kbps (was 256kbps)" nonsense
+   verified fixed on the exact motivating row (request 8640) before push.
+
+The general lesson: **for UI work, "the test passes" and "the reviewer
+approved" do not establish "it looks right on real data".** Screenshots
+of the live-db dev server do.
+
+## The recipe (doc1)
+
+```bash
+# 1. Tunnel to the pipeline DB (doc2-local subnet)
+ssh -N -L 15432:10.20.0.11:5432 doc2 &
+
+# 2. Dev server, live read-only DB + per-thread beets handles
+export PIPELINE_DB_DSN="postgresql://cratedigger:$(ssh doc2 'sudo cat /run/secrets/cratedigger-pgpass' | grep '^PGPASSWORD=' | cut -d= -f2)@127.0.0.1:15432/cratedigger"
+setsid nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
+  --host 127.0.0.1 --port 8096 --beets-db /mnt/virtio/Music/beets-library.db" \
+  > /tmp/devserver.log 2>&1 < /dev/null &
+
+# 3. Headless Chromium with CDP open (playwright-mcp managed-launch is
+#    broken on doc1 — it tries to install a browser into the read-only
+#    nix store; the wrapper auto-ATTACHES when 9222 answers)
+/nix/store/<hash>-playwright-browsers/chromium-*/chrome-linux64/chrome \
+  --headless=new --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/some-writable-profile --no-first-run about:blank &
+```
+
+4. Spawn the **playwright agent** with a read-only brief: navigate
+   `http://127.0.0.1:8096`, exercise the changed surface, screenshot each
+   state (viewport ~1000×900), and report what it sees. Explicitly forbid
+   mutating buttons (delete / force import / converge / Replace / status
+   toggles). Resume the SAME agent for later rounds (it keeps context).
+5. **The main agent must Read the PNGs itself.** The sub-agent's text
+   report is a summary — the centering root-cause and layout jank were
+   found by looking at the pixels, not by reading the report.
+6. Fix → restart the dev server if Python changed (static `web/` files
+   are served live; JS/HTML edits only need a browser reload) → rerun the
+   round. Target the exact motivating row/card when the work started from
+   an operator complaint.
+
+## Gotchas (each cost a debugging detour once)
+
+- **Screenshot save roots**: the playwright MCP only writes inside its
+  allowed roots (the repo checkout + `.playwright-mcp/`). Screenshots land
+  in the WORKTREE — `mv` them out before `git add -A`.
+- **`pkill` self-match**: `pkill -f web_dev_server.py` inside a compound
+  command kills your own shell (the pattern matches the command string).
+  Use the bracket trick: `pkill -f 'web_dev_[s]erver.py'` — and never put
+  a pkill and the thing it must not kill in one compound command.
+- **Shared-SQLite crash**: fixed in-tree (the dev server sets
+  `beets_db_path` only, per-thread handles) — if "SQLite objects created
+  in a thread…" 500s reappear, something re-introduced a shared handle.
+- **Stale dev servers shadow the port**: `nohup nix-shell --run …` spawns
+  a python child that survives killing the wrapper. Check
+  `ss -ltnp | grep 8096` / `pgrep -af web_dev_[s]erver` before trusting
+  a 200 — you may be talking to the OLD code.
+- **MCP servers that started in managed mode never attach to CDP
+  retroactively** — the CDP check happens at wrapper startup. The
+  playwright agent (fresh server per invocation) attaches; the main
+  session's already-running server does not.
+
+## Related
+
+- `docs/web-dev-server.md` — the dev-server modes and remote-dev tunnels.
+- `docs/playwright-mcp.md` — MCP setup per machine.
+- Issue #575 — the UI consolidation arc this loop was built for.

--- a/docs/web-dev-server.md
+++ b/docs/web-dev-server.md
@@ -39,3 +39,11 @@ tunnel.
 
 `--beets-db` is optional in this flow. Wrong Matches does not need it; only
 beets-backed library badges and lookups do.
+
+## Screenshot verification loop
+
+UI changes are verified visually against this dev server (live-db mode)
+before pushing — screenshots of real pipeline data catch what unit tests
+and code review miss. The full agent-driven recipe (CDP chromium,
+playwright agent rounds, gotchas) lives in
+[docs/solutions/ui-dev-server-screenshot-loop.md](solutions/ui-dev-server-screenshot-loop.md).


### PR DESCRIPTION
Compounding lesson from #575 PR2/PR2b: visible UI changes are verified with the live-db dev-server screenshot loop before pushing — it caught three defects that tests + review both missed. Full recipe + gotchas in `docs/solutions/ui-dev-server-screenshot-loop.md`, pointers from `.claude/rules/web.md` and `docs/web-dev-server.md`.

Docs-only; no deploy needed (next code deploy carries it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)