### PR TITLE
feat(web): unified artist page (#575 PR4)

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -61,10 +61,22 @@ Browser → https://music.ablz.au
 
 - **Source toggle** — MB / Discogs toggle in the browse tab header. Switches all search, artist, and release views between MusicBrainz and Discogs data sources.
 - **Search** — debounced text search, returns artists (or releases in album mode)
-- **Artist discography** — grouped by type (Albums, EPs, Singles, etc.)
-  - Split into "own work" vs "Appearances" using artist-credit matching
-  - Bootleg-only release groups collapsed at bottom
-- **In Library section** — shows what you already own from beets, with MB/Discogs badges
+- **Unified artist page (#575 PR4)** — one scrolling page (the old
+  Discography / Analysis / Library / Compare sub-tabs are gone), sectioned by
+  availability: **In library / In flight / Missing / Appearances /
+  Bootleg-only releases**, each grouped by type (Albums, EPs, Singles, etc.).
+  Ownership ("own work" vs Appearances) uses artist-credit matching; Missing =
+  official own-work release groups the beets library doesn't hold; In flight =
+  requests currently `downloading` or `manual` (`wanted` is ambient after the
+  full-library backfill and stays a badge). Two slow feeds decorate the page
+  after the fast render, without re-rendering: `/api/artist/compare` appends an
+  "Only on Discogs/MusicBrainz" complement section (silently skipped on hosts
+  without the Discogs mirror), and `/api/artist/<id>/disambiguate` adds
+  unique-track / covered-by chips to rows plus colour-dot recordings
+  breakdowns inside expanded release groups (MB artists only). Expanding an
+  in-library pressing's detail offers a lazy **Library detail** panel (path,
+  download history, status / min-bitrate / intent controls) fetched from
+  `/api/beets/album/<id>`.
 - **Release editions** — when you expand a release group, shows all editions sorted by date
   - Official releases first, bootleg/promo collapsed
   - Releases already in pipeline DB or beets library are badged

--- a/tests/test_js_analysis.mjs
+++ b/tests/test_js_analysis.mjs
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for web/js/analysis.js — the unique-track analysis overlay
+ * (issue #575 PR4): chip rendering + recording-dot computation.
+ * Run with: node tests/test_js_analysis.mjs
+ */
+
+import { analysisChipHtml, computeRecordingDots, renderRecordingsBlock } from '../web/js/analysis.js';
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual, expected, msg) {
+  if (actual === expected) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - expected '${expected}', got '${actual}'`);
+  }
+}
+
+function assertContains(haystack, needle, msg) {
+  if (haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - '${needle}' not in output`);
+  }
+}
+
+console.log('analysisChipHtml() — coverage precedence');
+{
+  assertContains(analysisChipHtml({ covered_by: 'Some <Comp>', unique_track_count: 3 }),
+    'covered by Some &lt;Comp&gt;', 'covered_by wins over unique count, escaped');
+  assertContains(analysisChipHtml({ covered_by: null, unique_track_count: 9 }),
+    '9 unique', 'unique count chip');
+  assertContains(analysisChipHtml({ covered_by: null, unique_track_count: 0 }),
+    '0 unique', 'zero-unique chip');
+}
+
+console.log('computeRecordingDots() — membership + exclusives');
+{
+  // Two pressings: P0 has r1,r2; P1 has r2,r3. r1 exclusive to P0,
+  // r3 exclusive to P1, r2 shared.
+  const rg = {
+    pressings: [
+      { release_id: 'p0', recording_ids: ['r1', 'r2'] },
+      { release_id: 'p1', recording_ids: ['r2', 'r3'] },
+    ],
+    tracks: [
+      { recording_id: 'r1', title: 'One', unique: true },
+      { recording_id: 'r2', title: 'Two', unique: true },
+      { recording_id: 'r3', title: 'Three', unique: true },
+    ],
+  };
+  const { trackToPressings, pressingExclusiveCounts, totalPressings } = computeRecordingDots(rg);
+  assertEqual(totalPressings, 2, 'two pressings');
+  assertEqual(trackToPressings['r1'].join(','), '0', 'r1 only on P0');
+  assertEqual(trackToPressings['r2'].join(','), '0,1', 'r2 on both');
+  assertEqual(trackToPressings['r3'].join(','), '1', 'r3 only on P1');
+  assertEqual(pressingExclusiveCounts.join(','), '1,1', 'one exclusive each');
+}
+
+console.log('renderRecordingsBlock() — markers stay with titles');
+{
+  const rg = {
+    pressings: [
+      { release_id: 'p0', recording_ids: ['r1', 'r2'] },
+      { release_id: 'p1', recording_ids: ['r2'] },
+    ],
+    tracks: [
+      { recording_id: 'r1', title: 'Only On P0', unique: true },
+      { recording_id: 'r2', title: 'Everywhere', unique: true },
+      { recording_id: 'r9', title: 'Comp Track', unique: false, also_on: ['Best Of'] },
+    ],
+  };
+  const html = renderRecordingsBlock(rg);
+  assertContains(html, 'Recordings:', 'heading present');
+  // Single-span rows: marker and title inside one <span> (the flex
+  // justify-between fix from PR3's screenshot loop).
+  assertContains(html, '●</span></span>Only On P0', 'dot adjacent to partial-coverage title');
+  assertContains(html, '★</span> Everywhere', 'star adjacent to all-pressings title');
+  assertContains(html, 'also on: Best Of', 'non-unique row keeps also-on note');
+  assertEqual(renderRecordingsBlock({ tracks: [] }), '', 'no tracks -> empty');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/test_js_artist_page.mjs
+++ b/tests/test_js_artist_page.mjs
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for web/js/artist_page.js — the unified artist page
+ * (issue #575 PR4): sectioning decisions + section rendering.
+ *
+ * Invariants under test (written before the implementation):
+ *  I1 Partition totality — every input release-group lands in exactly one
+ *     of {inLibrary, missing, appearances, bootlegs}; nothing dropped,
+ *     nothing duplicated.
+ *  I2 Bootleg precedence — !has_official → bootlegs, regardless of
+ *     ownership or library state.
+ *  I3 Appearance split — has_official && !own → appearances, where "own"
+ *     is the exact port of the old renderArtistDiscography credit logic.
+ *  I4 Library split — has_official && own && in_library === true →
+ *     inLibrary; anything else → missing.
+ *  I5 In-flight lens — inFlight rows come from the library feed with
+ *     pipeline_status ∈ {downloading, manual}; a row appearing there
+ *     never removes it from the release-group partition ("wanted" is
+ *     ambient — every backfilled album has one — so it stays a badge).
+ *
+ * Run with: node tests/test_js_artist_page.mjs
+ */
+
+import { classifyArtistRows, renderArtistSections } from '../web/js/artist_page.js';
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual, expected, msg) {
+  if (actual === expected) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - expected '${expected}', got '${actual}'`);
+  }
+}
+
+function assertContains(haystack, needle, msg) {
+  if (haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - '${needle}' not in output`);
+  }
+}
+
+function assertExcludes(haystack, needle, msg) {
+  if (!haystack.includes(needle)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - unexpectedly found '${needle}'`);
+  }
+}
+
+const ARTIST_ID = 'aaaaaaaa-1111-2222-3333-444444444444';
+const ARTIST_NAME = 'The Lucksmiths';
+
+/** Release-group row builder matching /api/artist/<id>?name= rows. */
+function rg(id, overrides = {}) {
+  return {
+    id,
+    title: `RG ${id}`,
+    type: 'Album',
+    secondary_types: [],
+    first_release_date: '2001-05-01',
+    artist_credit: ARTIST_NAME,
+    primary_artist_id: ARTIST_ID,
+    has_official: true,
+    in_library: false,
+    ...overrides,
+  };
+}
+
+/** LibraryAlbumRow-shaped builder matching /api/library/artist albums. */
+function libRow(overrides = {}) {
+  return {
+    id: 1,
+    album: 'An Album',
+    artist: ARTIST_NAME,
+    year: 2001,
+    mb_albumid: 'bbbbbbbb-1111-2222-3333-444444444444',
+    track_count: 10,
+    mb_releasegroupid: null,
+    release_group_title: null,
+    added: 0,
+    formats: 'MP3',
+    min_bitrate: 320000,
+    type: 'album',
+    label: '',
+    country: 'AU',
+    source: 'musicbrainz',
+    in_library: true,
+    beets_album_id: 1,
+    pipeline_status: null,
+    pipeline_id: null,
+    upgrade_queued: false,
+    library_rank: 'good',
+    ...overrides,
+  };
+}
+
+function classify(releaseGroups, libraryAlbums = []) {
+  return classifyArtistRows({
+    artistId: ARTIST_ID,
+    artistName: ARTIST_NAME,
+    releaseGroups,
+    libraryAlbums,
+  });
+}
+
+console.log('I1 — partition totality: every rg in exactly one section');
+{
+  // All 8 combos of has_official × own × in_library.
+  const world = [
+    rg('a', { has_official: true, in_library: true }),
+    rg('b', { has_official: true, in_library: false }),
+    rg('c', { has_official: true, in_library: true, primary_artist_id: 'other', artist_credit: 'Someone Else' }),
+    rg('d', { has_official: true, in_library: false, primary_artist_id: 'other', artist_credit: 'Someone Else' }),
+    rg('e', { has_official: false, in_library: true }),
+    rg('f', { has_official: false, in_library: false }),
+    rg('g', { has_official: false, in_library: true, primary_artist_id: 'other', artist_credit: 'Someone Else' }),
+    rg('h', { has_official: false, in_library: false, primary_artist_id: 'other', artist_credit: 'Someone Else' }),
+  ];
+  const s = classify(world);
+  const buckets = [s.inLibrary, s.missing, s.appearances, s.bootlegs];
+  const allIds = buckets.flat().map(r => r.id).sort();
+  assertEqual(allIds.join(','), 'a,b,c,d,e,f,g,h', 'union covers every input exactly once');
+  const seen = new Set();
+  let dup = false;
+  for (const id of buckets.flat().map(r => r.id)) {
+    if (seen.has(id)) dup = true;
+    seen.add(id);
+  }
+  assertEqual(dup, false, 'no rg appears in two sections');
+
+  assertEqual(s.inLibrary.map(r => r.id).join(','), 'a', 'own+official+in_library → inLibrary');
+  assertEqual(s.missing.map(r => r.id).join(','), 'b', 'own+official+not-in-library → missing');
+  assertEqual(s.appearances.map(r => r.id).join(','), 'c,d', 'official non-own → appearances');
+  assertEqual(s.bootlegs.map(r => r.id).join(','), 'e,f,g,h', 'I2: bootleg precedence beats own/library');
+}
+
+console.log('I3 — ownership credit logic (port of renderArtistDiscography)');
+{
+  const world = [
+    rg('id-match', { primary_artist_id: ARTIST_ID, artist_credit: 'Totally Different' }),
+    rg('exact-credit', { primary_artist_id: 'other', artist_credit: 'the lucksmiths' }),
+    rg('slash-credit', { primary_artist_id: 'other', artist_credit: 'The Lucksmiths / Someone' }),
+    rg('comma-credit', { primary_artist_id: 'other', artist_credit: 'The Lucksmiths, Someone' }),
+    rg('empty-credit', { primary_artist_id: 'other', artist_credit: '' }),
+    rg('foreign', { primary_artist_id: 'other', artist_credit: 'Someone Else' }),
+  ];
+  const s = classify(world);
+  const own = new Set(s.missing.map(r => r.id)); // all not-in-library → own goes to missing
+  assertEqual(own.has('id-match'), true, 'primary_artist_id match → own');
+  assertEqual(own.has('exact-credit'), true, 'case-insensitive credit match → own');
+  assertEqual(own.has('slash-credit'), true, 'credit "name /" prefix → own');
+  assertEqual(own.has('comma-credit'), true, 'credit "name," prefix → own');
+  assertEqual(own.has('empty-credit'), true, 'empty credit → own');
+  assertEqual(s.appearances.map(r => r.id).join(','), 'foreign', 'different id+credit → appearance');
+}
+
+console.log('I4 — in_library undefined falls to missing');
+{
+  const row = rg('u');
+  delete row.in_library;
+  const s = classify([row]);
+  assertEqual(s.missing.map(r => r.id).join(','), 'u', 'missing annotation → missing section');
+}
+
+console.log('I5 — in-flight lens: downloading/manual only');
+{
+  const albums = [
+    libRow({ id: 1, album: 'DL', pipeline_status: 'downloading', pipeline_id: 11 }),
+    libRow({ id: 2, album: 'Manual', pipeline_status: 'manual', pipeline_id: 12 }),
+    libRow({ id: 3, album: 'Wanted-ambient', pipeline_status: 'wanted', pipeline_id: 13 }),
+    libRow({ id: 4, album: 'Imported', pipeline_status: 'imported', pipeline_id: 14 }),
+    libRow({ id: 5, album: 'NoPipeline', pipeline_status: null }),
+    libRow({ id: 6, album: 'PipelineOnly-DL', in_library: false, beets_album_id: null, pipeline_status: 'downloading', pipeline_id: 16 }),
+  ];
+  const s = classify([], albums);
+  assertEqual(s.inFlight.map(a => a.album).join(','), 'DL,Manual,PipelineOnly-DL',
+    'downloading+manual rows only, regardless of in_library');
+}
+
+console.log('classifyArtistRows — empty world');
+{
+  const s = classify([], []);
+  assertEqual(
+    s.inLibrary.length + s.missing.length + s.appearances.length + s.bootlegs.length + s.inFlight.length,
+    0, 'all sections empty');
+}
+
+console.log('renderArtistSections — section headers, counts, defaults');
+{
+  const sections = classify([
+    rg('lib1', { in_library: true, title: 'Owned Album' }),
+    rg('miss1', { title: 'Missing Album' }),
+    rg('miss2', { title: 'Missing EP', type: 'EP' }),
+    rg('app1', { primary_artist_id: 'other', artist_credit: 'Someone Else', title: 'Guest Spot' }),
+    rg('boot1', { has_official: false, title: 'Live Tape' }),
+  ], [
+    libRow({ id: 9, album: 'DL Album', pipeline_status: 'downloading', pipeline_id: 9 }),
+  ]);
+  const html = renderArtistSections(sections, { artistId: ARTIST_ID, artistName: ARTIST_NAME });
+
+  assertContains(html, 'In library <span class="type-count">1</span>', 'In library header with count');
+  assertContains(html, 'In flight <span class="type-count">1</span>', 'In flight header with count');
+  assertContains(html, 'Missing <span class="type-count">2</span>', 'Missing header with count');
+  assertContains(html, 'Appearances <span class="type-count">1</span>', 'Appearances header with count');
+  assertContains(html, 'Bootleg-only releases <span class="type-count">1</span>', 'Bootlegs header with count');
+
+  assertContains(html, 'Owned Album', 'in-library rg row rendered');
+  assertContains(html, 'Missing Album', 'missing rg row rendered');
+  assertContains(html, 'Missing EP', 'missing EP row rendered');
+  assertContains(html, 'Guest Spot', 'appearance row rendered');
+  assertContains(html, 'Live Tape', 'bootleg row rendered');
+  assertContains(html, 'DL Album', 'in-flight row rendered');
+
+  // Expansion targets exist for rg rows (search-by-ID + pressings flow).
+  assertContains(html, 'id="rel-lib1"', 'in-library rg keeps its expansion target');
+  assertContains(html, 'id="rel-miss1"', 'missing rg keeps its expansion target');
+  // Rows carry data-rg-id for late analysis decoration.
+  assertContains(html, 'data-rg-id="miss1"', 'rg rows carry data-rg-id');
+
+  // Section toggles route through the shared primitive.
+  assertContains(html, 'window.toggleSection(this)', 'section headers use toggleSection');
+}
+
+console.log('renderArtistSections — empty sections are omitted');
+{
+  const sections = classify([rg('only', { in_library: true })], []);
+  const html = renderArtistSections(sections, { artistId: ARTIST_ID, artistName: ARTIST_NAME });
+  assertContains(html, 'In library', 'non-empty section rendered');
+  assertExcludes(html, 'In flight', 'empty in-flight omitted');
+  assertExcludes(html, 'Missing', 'empty missing omitted');
+  assertExcludes(html, 'Appearances', 'empty appearances omitted');
+  assertExcludes(html, 'Bootleg-only', 'empty bootlegs omitted');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/test_js_artist_page.mjs
+++ b/tests/test_js_artist_page.mjs
@@ -20,7 +20,7 @@
  * Run with: node tests/test_js_artist_page.mjs
  */
 
-import { classifyArtistRows, renderArtistSections } from '../web/js/artist_page.js';
+import { classifyArtistRows, renderArtistSections, renderOtherSourceSection } from '../web/js/artist_page.js';
 
 let passed = 0;
 let failed = 0;
@@ -186,8 +186,64 @@ console.log('classifyArtistRows — empty world');
 {
   const s = classify([], []);
   assertEqual(
-    s.inLibrary.length + s.missing.length + s.appearances.length + s.bootlegs.length + s.inFlight.length,
+    s.inLibrary.length + s.inLibraryOrphans.length + s.missing.length
+    + s.appearances.length + s.bootlegs.length + s.inFlight.length,
     0, 'all sections empty');
+}
+
+console.log('I6 — owned albums absent from the discography become orphans');
+{
+  const rgs = [
+    rg('rg-owned', { in_library: true, title: 'Matched Album' }),
+  ];
+  const albums = [
+    // rg id matches a rendered rg → covered by the rg row, not an orphan.
+    libRow({ id: 1, album: 'Matched Album', mb_releasegroupid: 'rg-owned' }),
+    // Backend title-fallback case: no rg id, but an in-library rg row
+    // with the same title rendered → not an orphan (no double-show).
+    libRow({ id: 2, album: 'Matched Album', mb_releasegroupid: null }),
+    // Genuinely absent from the source discography → orphan.
+    libRow({ id: 3, album: 'Long Tail Demo', mb_releasegroupid: 'rg-not-listed' }),
+    // Pipeline-only row (not actually in the library) → never an orphan.
+    libRow({ id: 4, album: 'Wanted Ghost', in_library: false, beets_album_id: null, pipeline_status: 'wanted' }),
+  ];
+  const s = classify(rgs, albums);
+  assertEqual(s.inLibraryOrphans.map(a => a.album).join(','), 'Long Tail Demo',
+    'only the unmatched owned album is an orphan');
+
+  const html = renderArtistSections(s, { artistId: ARTIST_ID, artistName: ARTIST_NAME });
+  assertContains(html, 'In library <span class="type-count">2</span>',
+    'section count includes orphans');
+  assertContains(html, 'Library-only editions <span class="type-count">1</span>',
+    'orphan subheader with count');
+  assertContains(html, 'Long Tail Demo', 'orphan album row rendered');
+}
+
+console.log('I6 — orphans alone still render the In library section');
+{
+  const s = classify([], [libRow({ id: 7, album: 'Only Orphan', mb_releasegroupid: null })]);
+  const html = renderArtistSections(s, { artistId: ARTIST_ID, artistName: ARTIST_NAME });
+  assertContains(html, 'In library <span class="type-count">1</span>',
+    'orphan-only In library section renders');
+  assertContains(html, 'Only Orphan', 'orphan row rendered');
+}
+
+console.log('renderOtherSourceSection — complement rows force the other source');
+{
+  const rows = [
+    { id: '999111', title: 'Discogs Only LP', type: 'Album', first_release_date: '1999-01-01' },
+    { id: '999222', title: 'Masterless Single', type: 'Single', first_release_date: '2000-01-01', is_masterless: true },
+  ];
+  const html = renderOtherSourceSection(rows, { artistName: ARTIST_NAME, source: 'discogs' });
+  assertContains(html, 'Only on Discogs <span class="type-count">2</span>', 'header + count');
+  assertContains(html, 'id="only-other-source"', 'idempotency marker id');
+  assertContains(html, "{source:'discogs'}", 'rows force the complement source');
+  assertContains(html, "{masterless:true,source:'discogs'}", 'masterless keeps its flag');
+  assertContains(html, 'data-release-id="999222"', 'masterless leaf carries data-release-id');
+  assertEqual(renderOtherSourceSection([], { artistName: ARTIST_NAME, source: 'discogs' }), '',
+    'empty bucket -> empty string');
+  const mbSide = renderOtherSourceSection([rows[0]], { artistName: ARTIST_NAME, source: 'mb' });
+  assertContains(mbSide, 'Only on MusicBrainz', 'mb complement label');
 }
 
 console.log('renderArtistSections — section headers, counts, defaults');
@@ -203,7 +259,9 @@ console.log('renderArtistSections — section headers, counts, defaults');
   ]);
   const html = renderArtistSections(sections, { artistId: ARTIST_ID, artistName: ARTIST_NAME });
 
-  assertContains(html, 'In library <span class="type-count">1</span>', 'In library header with count');
+  // The downloading row's rg isn't in the discography, so it also
+  // counts as a library-only orphan (in-flight is a lens — I5/I6).
+  assertContains(html, 'In library <span class="type-count">2</span>', 'In library header with count');
   assertContains(html, 'In flight <span class="type-count">1</span>', 'In flight header with count');
   assertContains(html, 'Missing <span class="type-count">2</span>', 'Missing header with count');
   assertContains(html, 'Appearances <span class="type-count">1</span>', 'Appearances header with count');

--- a/tests/test_js_search_plan.mjs
+++ b/tests/test_js_search_plan.mjs
@@ -1827,22 +1827,20 @@ console.log('F14: misc test gaps');
     'F14.1: debug line surfaces has_retryable_failure=');
 }
 
-// F14.2 — closeSearchPlanDetail with origin browse + non-null subView.
-// Asserts state.browseSubView is restored.
+// F14.2 — closeSearchPlanDetail with origin browse. Browse has no
+// sub-views since the unified artist page (#575 PR4); the back button
+// just restores the tab.
 {
   withFakeWindow((win, calls) => {
     state.searchPlanDetailContext = {
       requestId: 42,
       originTab: 'browse',
       originScrollY: 100,
-      originSubView: 'albums',
+      originSubView: null,
     };
-    state.browseSubView = 'singles';
     closeSearchPlanDetail();
-    assertEqual(state.browseSubView, 'albums',
-      'F14.2: browse-origin with subView="albums" restores state.browseSubView');
     assertEqual(calls.showTab[0], 'browse',
-      'F14.2: showTab("browse") still called');
+      'F14.2: browse-origin restores the Browse tab');
   });
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -25,15 +25,6 @@
   .artist-name { font-weight: 600; }
   .artist-dis { color: #777; font-size: 0.85em; }
   .rg-list { padding-left: 0; margin-top: 8px; }
-  .library-section { background: #1a1a2a; border-radius: 8px; padding: 10px; margin-bottom: 12px; }
-  .library-header { color: #6af; font-size: 0.8em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
-  .library-album { padding: 6px 10px; background: #222233; border-radius: 4px; margin-bottom: 3px; font-size: 0.85em; display: flex; justify-content: space-between; }
-  .library-album-title { flex: 1; }
-  .library-album-meta { color: #666; font-size: 0.8em; }
-  .library-src { font-size: 0.7em; padding: 1px 6px; border-radius: 3px; }
-  .library-src-mb { background: #1a3a2a; color: #6d6; }
-  .library-src-discogs { background: #3a2a1a; color: #da6; }
-  .library-src-muted { background: #2a2a2a; color: #555; }
   .type-section { margin-bottom: 12px; }
   .type-header { padding: 6px 10px; color: #6a9; font-size: 0.8em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; }
   .type-header:hover { color: #8cb; }
@@ -432,19 +423,6 @@
   .r-date-header { padding: 6px 12px; color: #6a9; font-size: 0.8em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 12px; margin-bottom: 4px; }
   .r-date-header.recents-date-header { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; flex-wrap: wrap; }
   .recents-date-metrics { color: #777; text-align: right; }
-  .lib-artist { margin-bottom: 12px; }
-  .lib-artist-header { padding: 10px 12px; background: #1a1a2a; border-radius: 6px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; }
-  .lib-artist-header:hover { background: #222238; }
-  .lib-artist-name { font-weight: 600; color: #8af; }
-  .lib-artist-count { color: #556; font-size: 0.8em; }
-  .lib-artist-body { display: none; padding-top: 4px; }
-  .lib-artist-body.open { display: block; }
-  .lib-rg { margin-bottom: 4px; }
-  .lib-rg-header { padding: 8px 12px; background: #1e1e2e; border-left: 3px solid #446; border-radius: 0 6px 6px 0; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 0.9em; }
-  .lib-rg-header:hover { background: #252535; }
-  .lib-rg-body { padding-left: 12px; display: none; }
-  .lib-rg-body.open { display: block; }
-  .lib-type-header { padding: 4px 12px; color: #6a9; font-size: 0.75em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 6px; }
   .lib-item { padding: 10px 12px; background: #1e1e1e; border-left: 3px solid #336; margin-bottom: 4px; border-radius: 0 6px 6px 0; cursor: pointer; }
   .lib-item:hover { background: #252525; }
   .lib-detail { background: #191919; padding: 10px 12px; margin: 0 0 4px 0; border-radius: 0 0 6px 6px; display: none; border-left: 3px solid #333; }
@@ -528,16 +506,7 @@
       <span style="cursor:pointer;font-size:18px;" onclick="closeBrowseArtist()">←</span>
       <span id="browse-artist-name" style="font-size:18px;font-weight:bold;"></span>
     </div>
-    <div class="browse-subnav" style="display:flex;gap:2px;margin-bottom:12px;">
-      <button class="p-btn active-status" id="subnav-discography" onclick="switchSubView('discography')">Discography</button>
-      <button class="p-btn" id="subnav-analysis" onclick="switchSubView('analysis')">Analysis</button>
-      <button class="p-btn" id="subnav-library" onclick="switchSubView('library')">Library</button>
-      <button class="p-btn" id="subnav-compare" onclick="switchSubView('compare')">Compare</button>
-    </div>
-    <div id="browse-discography"></div>
-    <div id="browse-analysis" style="display:none;"></div>
-    <div id="browse-library" style="display:none;"></div>
-    <div id="browse-compare" style="display:none;"></div>
+    <div id="browse-artist-body"></div>
   </div>
   <div id="browse-label" style="display:none;">
     <div id="browse-label-header" style="margin:12px 0 8px;display:flex;align-items:center;gap:12px;">

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,11 @@
   .type-count { color: #555; font-weight: 400; }
   .type-body { display: none; }
   .type-body.open { display: block; }
+  /* Top-level availability sections on the unified artist page (#575
+     PR4) — heavier than the nested Albums/EPs/Singles type headers so
+     the two levels read as a hierarchy. */
+  .type-header.section-header { font-size: 0.95em; color: #9dc; border-bottom: 1px solid #263; padding-bottom: 4px; }
+  .type-header.section-header:hover { color: #bef; }
   .rg { padding: 10px 12px; background: #1e1e1e; border-left: 3px solid #444; margin-bottom: 4px; cursor: pointer; border-radius: 0 6px 6px 0; }
   .rg:hover { background: #252525; }
   .rg-title { font-weight: 500; }

--- a/web/js/analysis.js
+++ b/web/js/analysis.js
@@ -157,6 +157,25 @@ export function applyAnalysisToExpansion(relEl, rgId) {
 }
 
 /**
+ * Decorate every ALREADY-EXPANDED release group once the disambiguate
+ * payload lands. The manual-expand path decorates via loadReleaseGroup's
+ * post-render hook, but an expansion that rendered BEFORE the payload
+ * arrived (search-by-ID auto-expand, or a fast manual click) would
+ * otherwise stay bare until collapsed and re-opened.
+ * @param {HTMLElement} containerEl - The artist-page container.
+ * @param {Object} disambData - /api/artist/<id>/disambiguate payload.
+ */
+export function applyAnalysisToOpenExpansions(containerEl, disambData) {
+  for (const rg of disambData.release_groups || []) {
+    const relEl = /** @type {HTMLElement|null} */ (
+      containerEl.querySelector(`#rel-${cssEscape(rg.release_group_id)}`));
+    if (relEl && relEl.innerHTML && !relEl.querySelector('.loading')) {
+      applyAnalysisToExpansion(relEl, rg.release_group_id);
+    }
+  }
+}
+
+/**
  * Remove a pipeline request from an artist-page row.
  * @param {number} pipelineId
  * @param {HTMLButtonElement} btn

--- a/web/js/analysis.js
+++ b/web/js/analysis.js
@@ -1,105 +1,70 @@
 // @ts-check
+/**
+ * Unique-track analysis overlay (issue #575 PR4).
+ *
+ * The old Analysis sub-view is gone; its intelligence now decorates the
+ * unified artist page. The disambiguate payload (state.disambData, from
+ * /api/artist/<id>/disambiguate) drives two decorations:
+ *
+ *  - applyAnalysisChips: "N unique" / "covered by X" chips on the
+ *    release-group rows (matched by data-rg-id), applied when the
+ *    payload lands — never a re-render, so expansion state survives.
+ *  - applyAnalysisToExpansion: colour dots + exclusive counts on the
+ *    pressing rows inside an expanded release group, plus the
+ *    recordings breakdown block, applied by loadReleaseGroup's
+ *    post-render hook.
+ */
 import { state, API, toast, updatePipelineStatus } from './state.js';
 import { esc } from './util.js';
-import { renderTypedSections } from './grouping.js';
-import { buildReleaseActionState } from './release_action_state.js';
-import { renderActionToolbar } from './release_actions.js';
-import { renderStatusBadges } from './badges.js';
 import { invalidateBrowseArtist } from './browse.js';
-import { renderReleaseRow, toggleExpand } from './render_primitives.js';
+import { cssEscape } from './discography.js';
 
 /** @type {string[]} */
 export const _PRESSING_COLORS = ['#6af','#fa6','#6d6','#f6a','#af6','#6ff','#ff6','#a6f'];
 
 /**
- * Render disambiguate/analysis results into a target element.
- * @param {HTMLElement} [targetEl]
+ * The per-release-group analysis chip: unique-track count or coverage.
+ * @param {Object} rg - Disambiguate release-group row
+ * @returns {string}
  */
-export function renderDisambiguateInto(targetEl) {
-  if (!state.disambData) return;
-  const el = targetEl || document.getElementById('disamb-content');
-  if (!el) return;
-  const d = state.disambData;
-  const rgs = d.release_groups || [];
-
-  const withUnique = rgs.filter(rg => rg.unique_track_count > 0).length;
-  const covered = rgs.filter(rg => rg.covered_by).length;
-
-  let html = `<div style="margin:12px 0;">
-    <strong>${esc(d.artist_name)}</strong> — ${rgs.length} release groups (excl. live), ${withUnique} with unique tracks, ${covered} fully covered
-  </div>`;
-
-  // Same Albums/EPs/Singles sectioning the other browse sub-tabs use.
-  // Analysis rows expose `primary_type` and `first_date` (not the
-  // standard `first_release_date`), so override the date extractor.
-  html += renderTypedSections(rgs, renderDisambRG, {
-    dateOf: (r) => String(r.first_date || ''),
-  });
-  el.innerHTML = html;
-}
-
-/**
- * Render a single release group row.
- * @param {Object} rg - Release group data
- * @returns {string} HTML string
- */
-export function renderDisambRG(rg) {
-  // Unified renderer. Analysis row uses `library_status` (truthy when
-  // any pressing is in library) — normalize to in_library so the
-  // shared renderer reads the same shape.
-  const badges = renderStatusBadges({
-    in_library: !!rg.library_status,
-    library_format: rg.library_format,
-    library_min_bitrate: rg.library_min_bitrate,
-    library_rank: rg.library_rank,
-    pipeline_status: rg.pipeline_status,
-  });
-
-  let statusBadge;
+export function analysisChipHtml(rg) {
   if (rg.covered_by) {
-    statusBadge = `<span style="color:#777;font-size:0.85em;margin-left:6px;">covered by ${esc(rg.covered_by)}</span>`;
-  } else if (rg.unique_track_count > 0) {
-    statusBadge = `<span style="color:#6d6;font-weight:600;margin-left:6px;">${rg.unique_track_count} unique</span>`;
-  } else {
-    statusBadge = '<span style="color:#555;margin-left:6px;">0 unique</span>';
+    return `<span style="color:#777;font-size:0.85em;margin-left:6px;">covered by ${esc(rg.covered_by)}</span>`;
   }
-
-  const opacity = rg.covered_by ? '0.5' : '1';
-
-  return renderReleaseRow({
-    onclick: `event.stopPropagation(); window.toggleDisambRGTracks('${rg.release_group_id}')`,
-    style: `cursor:pointer;opacity:${opacity};`,
-    titleHtml: `${esc(rg.title)}${badges}${statusBadge}`,
-    metaLines: [`${rg.first_date || '?'} — ${esc(rg.primary_type)} — ${rg.track_count}t — ${rg.release_ids.length} pressing${rg.release_ids.length > 1 ? 's' : ''}`],
-    detail: { id: `disamb-rg-${rg.release_group_id}` },
-  });
+  if (rg.unique_track_count > 0) {
+    return `<span style="color:#6d6;font-weight:600;margin-left:6px;">${rg.unique_track_count} unique</span>`;
+  }
+  return '<span style="color:#555;margin-left:6px;">0 unique</span>';
 }
 
 /**
- * Toggle track listing for a release group in the disambiguate view.
- * @param {string} rgId - Release group ID
+ * Decorate rendered release-group rows with analysis chips. Idempotent —
+ * a row that already carries a chip is skipped, so late re-application
+ * (cache-hit re-render) is safe.
+ * @param {HTMLElement} containerEl - The artist-page container.
+ * @param {Object} disambData - /api/artist/<id>/disambiguate payload.
  */
-export function toggleDisambRGTracks(rgId) {
-  const el = document.getElementById('disamb-rg-' + rgId);
-  toggleExpand(el, (target) => renderDisambRGTracksInto(target, rgId));
+export function applyAnalysisChips(containerEl, disambData) {
+  for (const rg of disambData.release_groups || []) {
+    const row = containerEl.querySelector(`.rg[data-rg-id="${cssEscape(rg.release_group_id)}"]`);
+    if (!row || row.querySelector('.disamb-chip')) continue;
+    const title = row.querySelector('.rg-title');
+    if (!title) continue;
+    title.insertAdjacentHTML('afterend', `<span class="disamb-chip">${analysisChipHtml(rg)}</span>`);
+  }
 }
 
 /**
- * Render the pressing/recording breakdown for one release group into a
- * detail panel. Sync loader for toggleExpand — reads the already-loaded
- * state.disambData, no fetch.
- * @param {HTMLElement} el
- * @param {string} rgId - Release group ID
+ * Per-recording pressing membership + per-pressing exclusive counts.
+ * Pure — Node-testable.
+ * @param {Object} rg - Disambiguate release-group row (pressings + tracks)
+ * @returns {{trackToPressings: Object<string, number[]>, pressingExclusiveCounts: number[], totalPressings: number}}
  */
-function renderDisambRGTracksInto(el, rgId) {
-  const rg = state.disambData.release_groups.find(rg => rg.release_group_id === rgId);
-  if (!rg) { el.innerHTML = ''; return; }
-
+export function computeRecordingDots(rg) {
   const pressingRecSets = (rg.pressings || []).map(p => new Set(p.recording_ids || []));
-
-  // For each recording, find which pressing(s) contain it
+  /** @type {Object<string, number[]>} */
   const trackToPressings = {};
-  for (const t of rg.tracks) {
+  for (const t of rg.tracks || []) {
     trackToPressings[t.recording_id] = [];
     for (let i = 0; i < pressingRecSets.length; i++) {
       if (pressingRecSets[i].has(t.recording_id)) {
@@ -107,8 +72,6 @@ function renderDisambRGTracksInto(el, rgId) {
       }
     }
   }
-
-  // "Exclusive" = tracks on this pressing that NO other pressing has
   const pressingExclusiveCounts = pressingRecSets.map((recSet, i) => {
     let count = 0;
     for (const recId of recSet) {
@@ -117,79 +80,84 @@ function renderDisambRGTracksInto(el, rgId) {
     }
     return count;
   });
-
-  let html = '';
-
-  // Show pressings with colour dots and unique counts
-  if (rg.pressings && rg.pressings.length > 0) {
-    html += '<div style="margin-bottom:8px;color:#888;font-size:0.85em;">Pressings:</div>';
-    html += rg.pressings.map((p, i) => {
-      const color = _PRESSING_COLORS[i % _PRESSING_COLORS.length];
-      const badges = renderStatusBadges({
-        id: p.release_id,
-        in_library: p.in_library,
-        library_format: p.library_format,
-        library_min_bitrate: p.library_min_bitrate,
-        library_rank: p.library_rank,
-        pipeline_status: p.pipeline_status,
-      });
-      const actionState = buildReleaseActionState({
-        id: p.release_id,
-        in_library: p.in_library,
-        beets_album_id: p.beets_album_id,
-        pipeline_status: p.pipeline_status,
-        pipeline_id: p.pipeline_id,
-        artist: state.disambData?.artist_name || '',
-        album: p.title || '',
-        track_count: p.track_count || 0,
-      });
-      const toolbar = renderActionToolbar(actionState, { size: 'small' });
-
-      const exCount = pressingExclusiveCounts[i];
-      const uLabel = exCount > 0 ? `<span style="color:${color};font-weight:600;margin-left:6px;">${exCount} exclusive</span>` : '';
-
-      return `<div style="display:flex;justify-content:space-between;align-items:center;padding:2px 0;gap:8px;">
-        <span><span style="color:${color};font-weight:bold;">●</span> ${esc(p.title)}${badges} <span style="color:#777;">${p.country || '?'} ${p.date || '?'} — ${esc(p.format)} — ${p.track_count}t</span>${uLabel}</span>
-        ${toolbar}
-      </div>`;
-    }).join('');
-  }
-
-  // Show tracks with colour dots matching which pressing(s) contain them
-  if (rg.tracks && rg.tracks.length > 0) {
-    html += '<div style="margin:8px 0 4px;color:#888;font-size:0.85em;">Recordings:</div>';
-    const totalPressings = pressingRecSets.length;
-    // One span per row — .lib-track is flex justify-between, so marker
-    // and title must live together or they get pushed to opposite edges.
-    html += rg.tracks.map(t => {
-      if (!t.unique) {
-        const alsoOn = t.also_on && t.also_on.length > 0
-          ? `<span style="color:#777;font-size:0.85em;margin-left:8px;">also on: ${t.also_on.map(esc).join(', ')}</span>`
-          : '';
-        return `<div class="lib-track" style="opacity:0.5;">
-          <span>${esc(t.title)}${alsoOn}</span>
-        </div>`;
-      }
-      const pIdxs = trackToPressings[t.recording_id] || [];
-      // If on all pressings, it's a common track — no dots needed
-      if (pIdxs.length === totalPressings) {
-        return `<div class="lib-track">
-          <span><span style="color:#6d6;font-weight:bold;">★</span> ${esc(t.title)}</span>
-        </div>`;
-      }
-      // Colour dots for tracks only on some pressings
-      const dots = pIdxs.map(i => `<span style="color:${_PRESSING_COLORS[i % _PRESSING_COLORS.length]};">●</span>`).join('');
-      return `<div class="lib-track">
-        <span><span style="margin-right:4px;">${dots || '★'}</span>${esc(t.title)}</span>
-      </div>`;
-    }).join('');
-  }
-
-  el.innerHTML = html;
+  return { trackToPressings, pressingExclusiveCounts, totalPressings: pressingRecSets.length };
 }
 
 /**
- * Remove a pipeline request from the disambiguate view.
+ * The recordings breakdown for an expanded release group: one row per
+ * recording, colour dots matching the pressing rows above it. Pure —
+ * Node-testable.
+ * @param {Object} rg - Disambiguate release-group row
+ * @returns {string}
+ */
+export function renderRecordingsBlock(rg) {
+  if (!rg.tracks || rg.tracks.length === 0) return '';
+  const { trackToPressings, totalPressings } = computeRecordingDots(rg);
+  let html = '<div style="margin:8px 0 4px;color:#888;font-size:0.85em;">Recordings:</div>';
+  // One span per row — .lib-track is flex justify-between, so marker
+  // and title must live together or they get pushed to opposite edges.
+  html += rg.tracks.map(t => {
+    if (!t.unique) {
+      const alsoOn = t.also_on && t.also_on.length > 0
+        ? `<span style="color:#777;font-size:0.85em;margin-left:8px;">also on: ${t.also_on.map(esc).join(', ')}</span>`
+        : '';
+      return `<div class="lib-track" style="opacity:0.5;">
+        <span>${esc(t.title)}${alsoOn}</span>
+      </div>`;
+    }
+    const pIdxs = trackToPressings[t.recording_id] || [];
+    // If on all pressings, it's a common track — no dots needed
+    if (pIdxs.length === totalPressings) {
+      return `<div class="lib-track">
+        <span><span style="color:#6d6;font-weight:bold;">★</span> ${esc(t.title)}</span>
+      </div>`;
+    }
+    // Colour dots for tracks only on some pressings
+    const dots = pIdxs.map(i => `<span style="color:${_PRESSING_COLORS[i % _PRESSING_COLORS.length]};">●</span>`).join('');
+    return `<div class="lib-track">
+      <span><span style="margin-right:4px;">${dots || '★'}</span>${esc(t.title)}</span>
+    </div>`;
+  }).join('');
+  return html;
+}
+
+/**
+ * Decorate an expanded release group's pressing rows with colour dots +
+ * exclusive counts and append the recordings breakdown. Called by
+ * loadReleaseGroup's post-render hook; no-op unless disambiguate data
+ * for this release group is loaded. Idempotent via the marker class on
+ * the appended block.
+ * @param {HTMLElement} relEl - The .releases container that just rendered.
+ * @param {string} rgId - Release-group id that was expanded.
+ */
+export function applyAnalysisToExpansion(relEl, rgId) {
+  const rg = state.disambData?.release_groups?.find(
+    (g) => g.release_group_id === rgId);
+  if (!rg) return;
+  if (relEl.querySelector('.disamb-recordings')) return;
+  const { pressingExclusiveCounts } = computeRecordingDots(rg);
+  (rg.pressings || []).forEach((p, i) => {
+    const row = relEl.querySelector(`.release[data-release-id="${cssEscape(String(p.release_id))}"]`);
+    if (!row) return;
+    const title = row.querySelector('.release-title');
+    if (!title) return;
+    const color = _PRESSING_COLORS[i % _PRESSING_COLORS.length];
+    title.insertAdjacentHTML('afterbegin', `<span style="color:${color};font-weight:bold;">● </span>`);
+    const exCount = pressingExclusiveCounts[i];
+    if (exCount > 0) {
+      title.insertAdjacentHTML('beforeend',
+        `<span style="color:${color};font-weight:600;margin-left:6px;">${exCount} exclusive</span>`);
+    }
+  });
+  const block = renderRecordingsBlock(rg);
+  if (block) {
+    relEl.insertAdjacentHTML('beforeend',
+      `<div class="disamb-recordings" style="padding:4px 10px 8px;">${block}</div>`);
+  }
+}
+
+/**
+ * Remove a pipeline request from an artist-page row.
  * @param {number} pipelineId
  * @param {HTMLButtonElement} btn
  */

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -24,7 +24,10 @@
  *      the credit rules; I4 in_library === true is the only inLibrary
  *      ticket; I5 inFlight is a lens over the library feed
  *      (downloading/manual only — "wanted" is ambient after the
- *      full-library backfill and stays a badge).
+ *      full-library backfill and stays a badge); I6 no owned album is
+ *      invisible — a library-feed row whose release group is absent
+ *      from the source discography renders as an orphan album row
+ *      inside the In library section.
  */
 import { renderTypedSections } from './grouping.js';
 import { renderRgRow } from './discography.js';
@@ -56,7 +59,19 @@ export function classifyArtistRows({ artistId, artistName, releaseGroups, librar
   }
   const inFlight = (libraryAlbums || []).filter(
     a => a.pipeline_status === 'downloading' || a.pipeline_status === 'manual');
-  return { inLibrary, inFlight, missing, appearances, bootlegs };
+  // I6 — owned albums whose release group never made it into the source
+  // discography (MB lacks the release, or the backend's title-fallback
+  // match missed). Without this they'd be invisible on the whole page.
+  // The title checks approximate the backend fallback so an album whose
+  // rg row DID render (under a different rg id) isn't shown twice.
+  const rgIds = new Set((releaseGroups || []).map(r => String(r.id)));
+  const inLibTitles = new Set(inLibrary.map(r => (r.title || '').toLowerCase()));
+  const inLibraryOrphans = (libraryAlbums || []).filter(a =>
+    a.in_library !== false
+    && !(a.mb_releasegroupid && rgIds.has(String(a.mb_releasegroupid)))
+    && !inLibTitles.has((a.album || '').toLowerCase())
+    && !inLibTitles.has((a.release_group_title || '').toLowerCase()));
+  return { inLibrary, inLibraryOrphans, inFlight, missing, appearances, bootlegs };
 }
 
 /**
@@ -96,9 +111,18 @@ export function renderArtistSections(sections, ctx) {
     { defaultOpen: defaultOpen ? 'Albums' : null });
 
   let html = '';
-  if (sections.inLibrary.length > 0) {
-    html += sectionWrap('In library', sections.inLibrary.length,
-      typed(sections.inLibrary, true), { open: true });
+  const orphans = sections.inLibraryOrphans || [];
+  if (sections.inLibrary.length > 0 || orphans.length > 0) {
+    let body = sections.inLibrary.length > 0 ? typed(sections.inLibrary, true) : '';
+    if (orphans.length > 0) {
+      body += `
+        <div class="type-header" style="color:#777;margin-top:6px;cursor:default;" onclick="event.stopPropagation()">
+          Library-only editions <span class="type-count">${orphans.length}</span>
+        </div>
+        ${orphans.map(renderLibraryAlbumRow).join('')}`;
+    }
+    html += sectionWrap('In library', sections.inLibrary.length + orphans.length,
+      body, { open: true });
   }
   if (sections.inFlight.length > 0) {
     html += sectionWrap('In flight', sections.inFlight.length,

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -72,7 +72,7 @@ function sectionWrap(title, count, bodyHtml, opts = {}) {
   const idAttr = opts.id ? ` id="${opts.id}"` : '';
   return `
     <div class="type-section"${idAttr}>
-      <div class="type-header" onclick="event.stopPropagation(); window.toggleSection(this)"${style}>
+      <div class="type-header section-header" onclick="event.stopPropagation(); window.toggleSection(this)"${style}>
         ${title} <span class="type-count">${count}</span>
       </div>
       <div class="type-body${opts.open ? ' open' : ''}">

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -1,0 +1,140 @@
+// @ts-check
+/**
+ * Unified artist page (issue #575 PR4).
+ *
+ * One scrolling page replaces the old Discography / Analysis / Library /
+ * Compare sub-tabs. The fast pair (source discography + library feed)
+ * renders immediately, sectioned into:
+ *
+ *   In library / In flight / Missing / Appearances / Bootleg-only
+ *
+ * All release-group rows share renderRgRow (badges, expansion target,
+ * data-rg-id), so search-by-ID ringing and the sibling-pressing Replace
+ * flow work in every section. Two slow feeds decorate the page after it
+ * renders, without re-rendering (expansion state survives):
+ *
+ *   - /api/artist/compare → an appended "Only on <other source>" section
+ *     (the deduped complement bucket; MB-preferred merge).
+ *   - /api/artist/<id>/disambiguate → unique-track chips on rows and
+ *     colour-dot recordings breakdowns inside expansions (analysis.js).
+ *
+ * Sectioning invariants (see tests/test_js_artist_page.mjs):
+ *   I1 every release-group lands in exactly one of {inLibrary, missing,
+ *      appearances, bootlegs}; I2 bootleg precedence; I3 ownership via
+ *      the credit rules; I4 in_library === true is the only inLibrary
+ *      ticket; I5 inFlight is a lens over the library feed
+ *      (downloading/manual only — "wanted" is ambient after the
+ *      full-library backfill and stays a badge).
+ */
+import { renderTypedSections } from './grouping.js';
+import { renderRgRow } from './discography.js';
+import { renderLibraryAlbumRow } from './library.js';
+
+/**
+ * Split the fast pair into the page's sections.
+ * @param {{artistId: string, artistName: string,
+ *          releaseGroups: Array<Object>, libraryAlbums: Array<Object>}} input
+ * @returns {{inLibrary: Object[], inFlight: Object[], missing: Object[],
+ *            appearances: Object[], bootlegs: Object[]}}
+ */
+export function classifyArtistRows({ artistId, artistName, releaseGroups, libraryAlbums }) {
+  const nameLC = (artistName || '').toLowerCase();
+  const inLibrary = [], missing = [], appearances = [], bootlegs = [];
+  for (const rg of releaseGroups || []) {
+    const credit = (rg.artist_credit || '').toLowerCase();
+    const isOwn = rg.primary_artist_id === artistId
+      || credit === nameLC || credit.startsWith(nameLC + ' /') || credit.startsWith(nameLC + ',') || !credit;
+    if (!rg.has_official) {
+      bootlegs.push(rg);
+    } else if (!isOwn) {
+      appearances.push(rg);
+    } else if (rg.in_library === true) {
+      inLibrary.push(rg);
+    } else {
+      missing.push(rg);
+    }
+  }
+  const inFlight = (libraryAlbums || []).filter(
+    a => a.pipeline_status === 'downloading' || a.pipeline_status === 'manual');
+  return { inLibrary, inFlight, missing, appearances, bootlegs };
+}
+
+/**
+ * A collapsible page section: type-header (count) + type-body.
+ * @param {string} title
+ * @param {number} count
+ * @param {string} bodyHtml
+ * @param {{open?: boolean, color?: string, id?: string}} [opts]
+ * @returns {string}
+ */
+function sectionWrap(title, count, bodyHtml, opts = {}) {
+  const style = opts.color ? ` style="color:${opts.color};"` : '';
+  const idAttr = opts.id ? ` id="${opts.id}"` : '';
+  return `
+    <div class="type-section"${idAttr}>
+      <div class="type-header" onclick="event.stopPropagation(); window.toggleSection(this)"${style}>
+        ${title} <span class="type-count">${count}</span>
+      </div>
+      <div class="type-body${opts.open ? ' open' : ''}">
+        ${bodyHtml}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render the unified artist page body. Empty sections are omitted.
+ * @param {{inLibrary: Object[], inFlight: Object[], missing: Object[],
+ *          appearances: Object[], bootlegs: Object[]}} sections
+ * @param {{artistId: string, artistName: string}} ctx
+ * @returns {string}
+ */
+export function renderArtistSections(sections, ctx) {
+  const nameLC = (ctx.artistName || '').toLowerCase();
+  const rgRow = (rg) => renderRgRow(rg, { artistName: ctx.artistName, nameLC });
+  const typed = (rgs, defaultOpen) => renderTypedSections(rgs, rgRow,
+    { defaultOpen: defaultOpen ? 'Albums' : null });
+
+  let html = '';
+  if (sections.inLibrary.length > 0) {
+    html += sectionWrap('In library', sections.inLibrary.length,
+      typed(sections.inLibrary, true), { open: true });
+  }
+  if (sections.inFlight.length > 0) {
+    html += sectionWrap('In flight', sections.inFlight.length,
+      sections.inFlight.map(renderLibraryAlbumRow).join(''), { open: true });
+  }
+  if (sections.missing.length > 0) {
+    html += sectionWrap('Missing', sections.missing.length,
+      typed(sections.missing, true), { open: true });
+  }
+  if (sections.appearances.length > 0) {
+    html += sectionWrap('Appearances', sections.appearances.length,
+      typed(sections.appearances, false), { color: '#777' });
+  }
+  if (sections.bootlegs.length > 0) {
+    html += sectionWrap('Bootleg-only releases', sections.bootlegs.length,
+      typed(sections.bootlegs, false), { color: '#555' });
+  }
+  return html;
+}
+
+/**
+ * The late-appended complement section: release groups that exist only
+ * on the OTHER metadata source (compare's deduped mb_only/discogs_only
+ * bucket). Rows force loadReleaseGroup onto the complement source.
+ * @param {Object[]} rows - rg-shaped rows from the compare bucket
+ * @param {{artistName: string, source: 'mb'|'discogs'}} ctx
+ * @returns {string} '' when the bucket is empty
+ */
+export function renderOtherSourceSection(rows, ctx) {
+  if (!rows || rows.length === 0) return '';
+  const nameLC = (ctx.artistName || '').toLowerCase();
+  const label = ctx.source === 'discogs' ? 'Discogs' : 'MusicBrainz';
+  const rgRow = (rg) => renderRgRow(rg, {
+    artistName: ctx.artistName, nameLC, source: ctx.source,
+  });
+  return sectionWrap(`Only on ${label}`, rows.length,
+    renderTypedSections(rows, rgRow, {}),
+    { color: '#a96', id: 'only-other-source' });
+}

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -2,7 +2,7 @@
 import { state, API, toast } from './state.js';
 import { esc, jsArg, parsePastedId } from './util.js';
 import { loadReleaseGroup, renderReleaseDetail, applySearchTargetAfterDiscography } from './discography.js';
-import { applyAnalysisChips } from './analysis.js';
+import { applyAnalysisChips, applyAnalysisToOpenExpansions } from './analysis.js';
 import { classifyArtistRows, renderArtistSections, renderOtherSourceSection } from './artist_page.js';
 import { searchLabels, renderLabelSearchResults, openLabelDetail, closeLabelDetail } from './labels.js';
 
@@ -511,6 +511,9 @@ async function fireAnalysis(el, aid, token) {
     if (state.browseCache[aid]) state.browseCache[aid].disamb = data;
     state.disambData = data;
     applyAnalysisChips(el, data);
+    // Expansions that rendered before the payload arrived (search-by-ID
+    // auto-expand) get their dots + recordings breakdown now.
+    applyAnalysisToOpenExpansions(el, data);
   } catch (_e) { /* decoration only */ }
 }
 

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -1,11 +1,9 @@
 // @ts-check
 import { state, API, toast } from './state.js';
 import { esc, jsArg, parsePastedId } from './util.js';
-import { renderArtistDiscography, loadReleaseGroup, renderReleaseDetail } from './discography.js';
-import { renderTypedSections, classify as groupingClassify } from './grouping.js';
-import { renderStatusBadges } from './badges.js';
-import { renderDisambiguateInto } from './analysis.js';
-import { renderLibraryResultsInto } from './library.js';
+import { loadReleaseGroup, renderReleaseDetail, applySearchTargetAfterDiscography } from './discography.js';
+import { applyAnalysisChips } from './analysis.js';
+import { classifyArtistRows, renderArtistSections, renderOtherSourceSection } from './artist_page.js';
 import { searchLabels, renderLabelSearchResults, openLabelDetail, closeLabelDetail } from './labels.js';
 
 /**
@@ -61,7 +59,7 @@ export async function setBrowseSource(src) {
     if (match) {
       state.browseArtist = { id: String(match.id), name: match.name };
       document.getElementById('browse-artist-name').textContent = match.name;
-      switchSubView(state.browseSubView || 'discography');
+      loadArtistPage(String(match.id), match.name);
       return;
     }
     toast(`No ${src === 'discogs' ? 'Discogs' : 'MusicBrainz'} match for ${prevName}`, true);
@@ -126,16 +124,10 @@ export function openBrowseArtist(id, name) {
     return;
   }
   state.browseArtist = {id, name};
-  state.browseSubView = 'discography';
   document.getElementById('results').style.display = 'none';
   document.getElementById('browse-artist').style.display = 'block';
   document.getElementById('browse-artist-name').textContent = name;
-  // Reset sub-nav
-  document.getElementById('subnav-discography').className = 'p-btn active-status';
-  document.getElementById('subnav-analysis').className = 'p-btn';
-  document.getElementById('subnav-library').className = 'p-btn';
-  // Load discography (the default view)
-  switchSubView('discography');
+  loadArtistPage(id, name);
 }
 
 /**
@@ -143,6 +135,8 @@ export function openBrowseArtist(id, name) {
  */
 export function closeBrowseArtist() {
   state.browseArtist = null;
+  // Cancel in-flight artist-page loads + decoration fetches.
+  artistPageToken++;
   // Closing the artist view clears any search-by-ID ring (R15).
   clearSearchTarget();
   document.getElementById('browse-artist').style.display = 'none';
@@ -272,7 +266,7 @@ async function openVaFallback(data, parsedId, requestToken) {
   // the hidden artist view DOM is preserved (display:none, not removed).
   document.getElementById('results').style.display = 'none';
   document.getElementById('browse-artist').style.display = 'none';
-  const dgEl = document.getElementById('browse-discography');
+  const dgEl = document.getElementById('browse-artist-body');
   if (dgEl) dgEl.innerHTML = '';
   const browseLabel = document.getElementById('browse-label');
   if (browseLabel) browseLabel.style.display = 'none';
@@ -360,41 +354,50 @@ export function invalidateBrowseArtist() {
 }
 
 /**
- * Switch between sub-views (discography, analysis, library) in the browse artist view.
- * @param {string} view - 'discography', 'analysis', or 'library'
+ * In-flight token for the unified artist page. Incremented on every
+ * load and on close, so stale fast-pair renders and late decoration
+ * fetches (compare / disambiguate) can never write over a newer page.
  */
-export function switchSubView(view) {
-  state.browseSubView = view;
-  ['discography', 'analysis', 'library', 'compare'].forEach(v => {
-    document.getElementById('browse-' + v).style.display = v === view ? 'block' : 'none';
-    document.getElementById('subnav-' + v).className = 'p-btn' + (v === view ? ' active-status' : '');
-  });
+let artistPageToken = 0;
+
+/**
+ * Reload the current browse artist's page from scratch (cache dropped).
+ * Bound on window for post-mutation refreshes (e.g. beets deletion).
+ */
+export function reloadBrowseArtist() {
   if (!state.browseArtist) return;
-  /** @type {string} */
-  const aid = state.browseArtist.id;
-  const name = state.browseArtist.name;
-  if (!state.browseCache[aid]) state.browseCache[aid] = {};
-  if (view === 'discography' && !state.browseCache[aid].discography) {
-    loadBrowseDiscography(aid, name);
-  }
-  if (view === 'analysis' && !state.browseCache[aid].analysis) {
-    loadBrowseAnalysis(aid, name);
-  }
-  if (view === 'library' && !state.browseCache[aid].library) {
-    loadBrowseLibrary(aid, name);
-  }
-  if (view === 'compare' && !state.browseCache[aid].compare) {
-    loadBrowseCompare(aid, name);
-  }
+  delete state.browseCache[state.browseArtist.id];
+  loadArtistPage(state.browseArtist.id, state.browseArtist.name);
 }
 
 /**
- * Load and render the discography for a browse artist.
- * @param {string} aid - MusicBrainz artist ID
+ * Load and render the unified artist page (issue #575 PR4).
+ *
+ * Fast pair first — the source discography (?name= so the backend
+ * annotates in_library) and the library feed — rendered as sections.
+ * Then two slow feeds decorate the rendered page in the background:
+ * the MB↔Discogs compare complement and the unique-track analysis.
+ * Both are token-guarded and cached per artist.
+ *
+ * @param {string} aid - MB artist UUID or numeric Discogs artist ID
  * @param {string} name - Artist name
  */
-export async function loadBrowseDiscography(aid, name) {
-  const el = document.getElementById('browse-discography');
+export async function loadArtistPage(aid, name) {
+  const token = ++artistPageToken;
+  const el = document.getElementById('browse-artist-body');
+  if (!el) return;
+
+  const cached = state.browseCache[aid];
+  if (cached && cached.fast) {
+    renderUnified(el, aid, name, cached.fast.rgRes, cached.fast.libRes);
+    if (cached.disamb) {
+      state.disambData = cached.disamb;
+      applyAnalysisChips(el, cached.disamb);
+    }
+    if (cached.compare) appendOtherSourceSection(el, name, cached.compare);
+    return;
+  }
+
   el.innerHTML = '<div class="loading">Loading discography...</div>';
   try {
     const isDiscogs = state.browseSource === 'discogs';
@@ -416,242 +419,101 @@ export async function loadBrowseDiscography(aid, name) {
       fetch(artistUrl).then(r => r.json()),
       fetch(libUrl).then(r => r.json()),
     ]);
-    if (!state.browseCache[aid]) state.browseCache[aid] = {};
-    state.browseCache[aid].discography = true;
-    renderArtistDiscography(el, aid, name, rgRes, libRes);
-  } catch (e) { el.innerHTML = '<div class="loading">Failed to load</div>'; }
-}
-
-/**
- * Load and render the disambiguate analysis for a browse artist.
- * @param {string} aid - MusicBrainz artist ID
- * @param {string} name - Artist name
- */
-export async function loadBrowseAnalysis(aid, name) {
-  const el = document.getElementById('browse-analysis');
-  if (state.browseSource === 'discogs') {
-    el.innerHTML = '<div class="loading" style="color:#888;">Analysis is not available for Discogs artists (requires MusicBrainz recording IDs).</div>';
-    return;
+    if (token !== artistPageToken) return;
+    state.browseCache[aid] = { fast: { rgRes, libRes }, compare: null, disamb: null };
+    renderUnified(el, aid, name, rgRes, libRes);
+    // Fire-and-forget decorations; each guards on the token.
+    fireCompareComplement(el, aid, name, token);
+    fireAnalysis(el, aid, token);
+  } catch (e) {
+    if (token !== artistPageToken) return;
+    el.innerHTML = '<div class="loading">Failed to load</div>';
   }
-  el.innerHTML = '<div class="loading">Loading analysis (this may take a few seconds)...</div>';
-  try {
-    const r = await fetch(`${API}/api/artist/${aid}/disambiguate`);
-    const data = await r.json();
-    if (!state.browseCache[aid]) state.browseCache[aid] = {};
-    state.browseCache[aid].analysis = true;
-    state.disambData = data;
-    renderDisambiguateInto(el);
-  } catch (e) { el.innerHTML = '<div style="color:#f66;">Failed to load analysis</div>'; }
 }
 
 /**
- * Load and render library results for a browse artist.
- * @param {string} aid - MusicBrainz artist ID
- * @param {string} name - Artist name
+ * Section + render the fast pair, then apply the search-by-ID hook.
+ * @param {HTMLElement} el
+ * @param {string} aid
+ * @param {string} name
+ * @param {Object} rgRes - /api/[discogs/]artist response
+ * @param {Object} libRes - /api/library/artist response
  */
-export async function loadBrowseLibrary(aid, name) {
-  const el = document.getElementById('browse-library');
-  el.innerHTML = '<div class="loading">Loading library...</div>';
-  try {
-    // See loadBrowseDiscography: skip mbid on Discogs path (numeric ID isn't
-    // a valid MB UUID, would suppress all non-Discogs-tagged albums).
-    const isDiscogs = state.browseSource === 'discogs';
-    const url = isDiscogs
-      ? `${API}/api/library/artist?name=${encodeURIComponent(name)}`
-      : `${API}/api/library/artist?name=${encodeURIComponent(name)}&mbid=${aid}`;
-    const r = await fetch(url);
-    const data = await r.json();
-    if (!state.browseCache[aid]) state.browseCache[aid] = {};
-    state.browseCache[aid].library = true;
-    renderLibraryResultsInto(el, data.albums || []);
-  } catch (e) { el.innerHTML = '<div class="loading">Failed to load</div>'; }
+function renderUnified(el, aid, name, rgRes, libRes) {
+  const sections = classifyArtistRows({
+    artistId: aid,
+    artistName: name,
+    releaseGroups: rgRes.release_groups || [],
+    libraryAlbums: libRes.albums || [],
+  });
+  el.innerHTML = renderArtistSections(sections, { artistId: aid, artistName: name });
+  applySearchTargetAfterDiscography(el);
 }
 
 /**
- * Load the merged MB+Discogs comparison for a browse artist.
- * @param {string} aid - Artist ID (MB UUID or numeric Discogs ID)
- * @param {string} name - Artist name
+ * Background decoration 1: the MB↔Discogs compare complement. Appends
+ * an "Only on <other source>" section with the deduped bucket from
+ * /api/artist/compare. Silent on failure — a mirror-less host 503s and
+ * the page simply stays single-source.
+ * @param {HTMLElement} el
+ * @param {string} aid
+ * @param {string} name
+ * @param {number} token
  */
-export async function loadBrowseCompare(aid, name) {
-  const el = document.getElementById('browse-compare');
-  el.innerHTML = '<div class="loading">Loading both sources (this may take ~5-15s)...</div>';
+async function fireCompareComplement(el, aid, name, token) {
   try {
     const isDiscogs = state.browseSource === 'discogs';
     const idParam = isDiscogs ? `discogs_id=${encodeURIComponent(aid)}` : `mbid=${encodeURIComponent(aid)}`;
-    const url = `${API}/api/artist/compare?name=${encodeURIComponent(name)}&${idParam}`;
-    const r = await fetch(url);
+    const r = await fetch(`${API}/api/artist/compare?name=${encodeURIComponent(name)}&${idParam}`);
+    if (token !== artistPageToken || !r.ok) return;
     const data = await r.json();
-    if (!state.browseCache[aid]) state.browseCache[aid] = {};
-    state.browseCache[aid].compare = true;
-    renderCompare(el, data);
-  } catch (_e) { el.innerHTML = '<div class="loading">Failed to load comparison</div>'; }
+    if (token !== artistPageToken) return;
+    if (state.browseCache[aid]) state.browseCache[aid].compare = data;
+    appendOtherSourceSection(el, name, data);
+    // A search-by-ID target may live in the complement (e.g. a Discogs
+    // release pasted while browsing MB) — re-run the ring hook now that
+    // its row exists.
+    applySearchTargetAfterDiscography(el);
+  } catch (_e) { /* decoration only — the page is already rendered */ }
 }
 
 /**
- * Render a row in the compare view. `mb` and `discogs` may be null when the
- * row only exists on one side. The row header is clickable to expand inline
- * pressings; source badges (MB/Discogs) navigate to that source's full
- * discography view for the same artist.
- *
- * @param {Object|null} mb
- * @param {Object|null} discogs
- */
-function compareRow(mb, discogs) {
-  const ref = mb || discogs;
-  const title = ref.title || '?';
-  const year = (ref.first_release_date || '').slice(0, 4) || '?';
-  const type = ref.type || '';
-  // Stable per-row key for the expansion divs. Use both IDs when present so
-  // each side has its own render target (avoids ID collisions when the same
-  // album appears as both 'both' and 'only' rows for different artists).
-  const slot = `${mb ? mb.id : 'x'}__${discogs ? discogs.id : 'x'}`;
-  // Show only the badges for sources that have this row. No muted
-  // placeholders — single-source rows just show one badge.
-  const badges = [];
-  if (mb) badges.push(`<span class="library-src library-src-mb" style="cursor:pointer;" onclick="event.stopPropagation(); window.openBrowseArtistFromCompare(${jsArg(mb.primary_artist_id)}, ${jsArg(mb.artist_credit || '')}, ${jsArg('mb')})">MB</span>`);
-  if (discogs) badges.push(`<span class="library-src library-src-discogs" style="cursor:pointer;" onclick="event.stopPropagation(); window.openBrowseArtistFromCompare(${jsArg(discogs.primary_artist_id)}, ${jsArg(discogs.artist_credit || '')}, ${jsArg('discogs')})">Discogs</span>`);
-  // Row-level in-library badge via the unified renderer. Pull quality
-  // fields off whichever side is in library (prefer MB when both — MB
-  // rows are the canonical match key).
-  const libSide = (mb && mb.in_library) ? mb : ((discogs && discogs.in_library) ? discogs : null);
-  const libBadge = libSide ? renderStatusBadges({
-    in_library: true,
-    library_format: libSide.library_format,
-    library_min_bitrate: libSide.library_min_bitrate,
-    library_rank: libSide.library_rank,
-  }) : '';
-  const mbId = mb ? mb.id : '';
-  const dgId = discogs ? discogs.id : '';
-  const dgMasterless = !!(discogs && discogs.is_masterless);
-  return `
-    <div class="rg">
-      <div style="display:flex;align-items:center;gap:8px;padding:4px 0;cursor:pointer;"
-           onclick="window.toggleCompareRow(${jsArg(slot)}, ${jsArg(mbId)}, ${jsArg(dgId)}, ${dgMasterless})">
-        <span style="color:#888;font-size:0.8em;width:10px;display:inline-block;" id="cmp-chev-${esc(slot)}">▶</span>
-        <span class="rg-year">${year}</span>
-        <span class="rg-title">${esc(title)}</span>
-        ${type ? `<span class="rg-meta" style="color:#777;">(${esc(type)})</span>` : ''}
-        ${libBadge}
-        <span style="margin-left:auto;display:flex;gap:4px;">${badges.join('')}</span>
-      </div>
-      <div id="cmp-pressings-${slot}" style="display:none;padding:4px 0 8px 16px;">
-        ${mb ? `<div style="font-size:0.75em;color:#6d6;margin-top:6px;">MusicBrainz pressings</div>
-                <div class="releases" id="rel-cmp-mb-${slot}"></div>` : ''}
-        ${discogs ? `<div style="font-size:0.75em;color:#da6;margin-top:6px;">Discogs pressings</div>
-                     <div class="releases" id="rel-cmp-dg-${slot}"></div>` : ''}
-      </div>
-    </div>`;
-}
-
-/**
- * Toggle the expansion of a compare row. On first open, fetches MB and/or
- * Discogs pressings via the shared loadReleaseGroup helper (with explicit
- * source so each side renders into its own div). Reusing loadReleaseGroup
- * means Add buttons, in-library badges, and pipelineStore overlays behave
- * identically to the Discography view.
- *
- * @param {string} slot
- * @param {string} mbId - empty string when the row has no MB side
- * @param {string} dgId - empty string when the row has no Discogs side
- * @param {boolean} [dgMasterless] - true when the Discogs side is a
- *   masterless release (id is a release id, not a master id).
- */
-export async function toggleCompareRow(slot, mbId, dgId, dgMasterless) {
-  const wrap = document.getElementById('cmp-pressings-' + slot);
-  const chev = document.getElementById('cmp-chev-' + slot);
-  if (!wrap) return;
-  const isOpen = wrap.style.display !== 'none';
-  wrap.style.display = isOpen ? 'none' : 'block';
-  if (chev) chev.textContent = isOpen ? '▶' : '▼';
-  if (isOpen) return;
-  // First-open fetches. loadReleaseGroup is idempotent — second call on the
-  // same el toggles, so we only call when the target is empty.
-  if (mbId) {
-    const mbEl = document.getElementById('rel-cmp-mb-' + slot);
-    if (mbEl && !mbEl.innerHTML) loadReleaseGroup(mbId, mbEl, { targetEl: mbEl, source: 'mb' });
-  }
-  if (dgId) {
-    const dgEl = document.getElementById('rel-cmp-dg-' + slot);
-    if (dgEl && !dgEl.innerHTML) loadReleaseGroup(dgId, dgEl, {
-      targetEl: dgEl, source: 'discogs', masterless: !!dgMasterless,
-    });
-  }
-}
-
-/**
+ * Append the complement section (idempotent — skipped if present).
  * @param {HTMLElement} el
- * @param {Object} data
+ * @param {string} name - Artist name
+ * @param {Object} data - /api/artist/compare response
  */
-function renderCompare(el, data) {
-  const mbName = data.mb_artist?.name || '—';
-  const dgName = data.discogs_artist?.name || '—';
-
-  // Combine all three buckets into one unified list. Each entry is a
-  // {mb, discogs} pair; either side may be null. Single-source rows
-  // just show the present source's badge (compareRow handles that).
-  const all = [
-    ...(data.both || []),
-    ...(data.mb_only || []).map((r) => ({ mb: r, discogs: null })),
-    ...(data.discogs_only || []).map((r) => ({ mb: null, discogs: r })),
-  ];
-
-  // Bootleg = MB row exists and is not has_official. Discogs CC0 has
-  // no official/bootleg distinction, so Discogs-only rows are always
-  // treated as official.
-  const bootleg = all.filter((p) => p.mb && p.mb.has_official === false);
-  const main = all.filter((p) => !(p.mb && p.mb.has_official === false));
-
-  const pairClassify = (p) => p.mb || p.discogs;
-  const renderRows = (rows, defaultOpen) => renderTypedSections(
-    rows, (p) => compareRow(p.mb, p.discogs),
-    {
-      classify: (p) => groupingClassify(pairClassify(p)),
-      dateOf: (p) => String(pairClassify(p).first_release_date || ''),
-      defaultOpen,
-    },
-  );
-
-  const mainHtml = main.length
-    ? renderRows(main, 'Albums')
-    : '<div style="padding:6px;color:#777;">none</div>';
-
-  const bootlegHtml = bootleg.length
-    ? `<div class="type-section">
-         <div class="type-header" onclick="event.stopPropagation(); window.toggleSection(this)" style="color:#555;">
-           Bootleg-only releases <span class="type-count">${bootleg.length}</span>
-         </div>
-         <div class="type-body">${renderRows(bootleg, null)}</div>
-       </div>`
-    : '';
-
-  el.innerHTML = `
-    <div style="font-size:13px;color:#888;margin-bottom:10px;">
-      MB artist: <b>${esc(mbName)}</b> · Discogs artist: <b>${esc(dgName)}</b>
-    </div>
-    ${mainHtml}
-    ${bootlegHtml}`;
+function appendOtherSourceSection(el, name, data) {
+  if (el.querySelector('#only-other-source')) return;
+  const isDiscogs = state.browseSource === 'discogs';
+  const rows = isDiscogs ? (data.mb_only || []) : (data.discogs_only || []);
+  const html = renderOtherSourceSection(rows, {
+    artistName: name,
+    source: isDiscogs ? 'mb' : 'discogs',
+  });
+  if (html) el.insertAdjacentHTML('beforeend', html);
 }
 
 /**
- * Switch source then open an artist (used by Compare row badges to jump into
- * the matched-source's discography view).
- * @param {string} id
- * @param {string} name
- * @param {string} src
+ * Background decoration 2: unique-track analysis chips (MB artists
+ * only — the disambiguate route needs MB recording IDs).
+ * @param {HTMLElement} el
+ * @param {string} aid
+ * @param {number} token
  */
-export function openBrowseArtistFromCompare(id, name, src) {
-  // Switch source synchronously without sticky-context lookup; we already
-  // know exactly which artist to open on the new source.
-  state.browseSource = src;
-  const mbBtn = document.getElementById('source-mb');
-  const dgBtn = document.getElementById('source-discogs');
-  if (mbBtn) mbBtn.className = 'p-btn' + (src === 'mb' ? ' active-status' : '');
-  if (dgBtn) dgBtn.className = 'p-btn' + (src === 'discogs' ? ' active-status' : '');
-  state.browseCache = {};
-  state.browseArtist = { id, name };
-  document.getElementById('browse-artist-name').textContent = name;
-  switchSubView('discography');
+async function fireAnalysis(el, aid, token) {
+  if (state.browseSource !== 'mb') return;
+  try {
+    const r = await fetch(`${API}/api/artist/${aid}/disambiguate`);
+    if (token !== artistPageToken || !r.ok) return;
+    const data = await r.json();
+    if (token !== artistPageToken) return;
+    if (state.browseCache[aid]) state.browseCache[aid].disamb = data;
+    state.disambData = data;
+    applyAnalysisChips(el, data);
+  } catch (_e) { /* decoration only */ }
 }
+
 
 /**
  * Search for artists or releases and render results.

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -64,6 +64,7 @@ export async function setBrowseSource(src) {
     }
     toast(`No ${src === 'discogs' ? 'Discogs' : 'MusicBrainz'} match for ${prevName}`, true);
     state.browseArtist = null;
+    artistPageToken++;
     document.getElementById('browse-artist').style.display = 'none';
   }
 
@@ -266,6 +267,7 @@ async function openVaFallback(data, parsedId, requestToken) {
   // the hidden artist view DOM is preserved (display:none, not removed).
   document.getElementById('results').style.display = 'none';
   document.getElementById('browse-artist').style.display = 'none';
+  artistPageToken++;
   const dgEl = document.getElementById('browse-artist-body');
   if (dgEl) dgEl.innerHTML = '';
   const browseLabel = document.getElementById('browse-label');
@@ -390,11 +392,20 @@ export async function loadArtistPage(aid, name) {
   const cached = state.browseCache[aid];
   if (cached && cached.fast) {
     renderUnified(el, aid, name, cached.fast.rgRes, cached.fast.libRes);
+    // Re-fire any decoration that never landed (navigated away before
+    // the fetch returned, or a transient failure) — a null slot must
+    // not become null-forever on cache hits.
     if (cached.disamb) {
       state.disambData = cached.disamb;
       applyAnalysisChips(el, cached.disamb);
+    } else {
+      fireAnalysis(el, aid, token);
     }
-    if (cached.compare) appendOtherSourceSection(el, name, cached.compare);
+    if (cached.compare) {
+      appendOtherSourceSection(el, name, cached.compare);
+    } else {
+      fireCompareComplement(el, aid, name, token);
+    }
     return;
   }
 

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -1,11 +1,11 @@
 // @ts-check
 import { API, state, toast, updatePipelineStatus } from './state.js';
 import { esc, externalReleaseUrl, sourceLabel, detectSource, normalizeReleaseId } from './util.js';
-import { renderTypedSections } from './grouping.js';
 import { buildReleaseActionState } from './release_action_state.js';
 import { renderActionToolbar, renderAcquireActionButton, renderRemoveFromBeetsButton, renderReplaceButton } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
 import { invalidateBrowseArtist } from './browse.js';
+import { applyAnalysisToExpansion } from './analysis.js';
 import { renderLabelLinks } from './labels.js';
 import { renderSearchPlanButton } from './search_plan.js';
 import { loadActiveRgs, hasActiveRg, invalidateActiveRgs } from './active_rgs.js';
@@ -14,118 +14,49 @@ import {
 } from './render_primitives.js';
 
 /**
- * Render the artist discography into a target element.
- * @param {HTMLElement} rgEl - Container element
- * @param {string} id - MusicBrainz artist ID
- * @param {string} artistName - Artist name
- * @param {Object} data - API response with release_groups
- * @param {Object} libData - API response with library albums
+ * One release-group row: year + title + badges + expansion target.
+ * Shared by every section of the unified artist page (issue #575 PR4) —
+ * In library, Missing, Appearances, Bootlegs, and the late-appended
+ * "Only on <other source>" complement.
+ *
+ * @param {Object} rg - Release-group row from /api/artist or /api/discogs/artist
+ *   (or a compare-bucket row for complement sections).
+ * @param {{artistName: string, nameLC: string, source?: string}} ctx -
+ *   nameLC is the lowercased artist name (credit-note suppression);
+ *   source forces loadReleaseGroup onto 'mb'/'discogs' for rows that do
+ *   not belong to state.browseSource (compare complement rows).
+ * @returns {string}
  */
-export function renderArtistDiscography(rgEl, id, artistName, data, libData) {
-    const groups = data.release_groups || [];
-    const libraryAlbums = libData.albums || [];
-
-    // Split: own work vs appearances, filter bootleg-only release groups
-    // Compare by artist ID (handles name changes like Kanye West → Ye)
-    const nameLC = artistName.toLowerCase();
-    const own = [], appearances = [], bootlegOnly = [];
-    for (const rg of groups) {
-      const credit = (rg.artist_credit || '').toLowerCase();
-      const isOwn = rg.primary_artist_id === id
-        || credit === nameLC || credit.startsWith(nameLC + ' /') || credit.startsWith(nameLC + ',') || !credit;
-
-      if (!rg.has_official) {
-        bootlegOnly.push(rg);
-      } else if (isOwn) {
-        own.push(rg);
-      } else {
-        appearances.push(rg);
-      }
-    }
-
-    function renderRgRow(rg) {
-      const year = rg.first_release_date ? rg.first_release_date.slice(0, 4) : '';
-      const creditNote = rg.artist_credit && rg.artist_credit.toLowerCase() !== nameLC
-        ? `<span class="rg-meta"> - ${esc(rg.artist_credit)}</span>` : '';
-      const badges = renderStatusBadges(rg);
-      // Masterless Discogs releases have no child master to expand; the rg row
-      // is the leaf, so it carries data-release-id for search-by-ID ringing.
-      const leafAttr = rg.is_masterless ? ` data-release-id="${rg.id}"` : '';
-      // Search-plan inspector button — only when this rg has a pipeline
-      // request. RG-level pipeline_id surfaces from the analysis tab's
-      // disambData snapshot via pipelineStore (see release_action_state.js).
-      const spBtn = renderSearchPlanButton({
-        pipelineId: buildReleaseActionState({
-          ...rg,
-          artist: artistName,
-          album: rg.title,
-        }).pipelineId,
-      });
-      const opts = rg.is_masterless ? "{masterless:true}" : "{}";
-      return `
-        <div class="rg"${leafAttr}>
-          <div onclick="event.stopPropagation(); window.loadReleaseGroup('${rg.id}', this, ${opts})">
-            <span class="rg-year">${year}</span> <span class="rg-title">${esc(rg.title)}</span>${creditNote}${badges}${spBtn}
-          </div>
-          <div class="releases" id="rel-${rg.id}"></div>
-        </div>
-      `;
-    }
-
-    function renderSection(rgs, defaultOpen) {
-      return renderTypedSections(rgs, renderRgRow,
-        { defaultOpen: defaultOpen ? 'Albums' : null });
-    }
-
-    // Library section — what you already own
-    let html = '';
-    if (libraryAlbums.length > 0) {
-      const discogs = libraryAlbums.filter(a => a.source === 'discogs');
-      const mb = libraryAlbums.filter(a => a.source === 'musicbrainz');
-      html += `<div class="library-section">
-        <div class="library-header">In Library (${libraryAlbums.length})</div>
-        ${mb.map(a => `
-          <div class="library-album">
-            <span class="library-album-title">${a.year || '?'} ${esc(a.album)} (${a.track_count}t)</span>
-            <span class="library-src library-src-mb">MB</span>
-          </div>
-        `).join('')}
-        ${discogs.map(a => `
-          <div class="library-album">
-            <span class="library-album-title">${a.year || '?'} ${esc(a.album)} (${a.track_count}t)</span>
-            <span class="library-src library-src-discogs">Discogs</span>
-          </div>
-        `).join('')}
-      </div>`;
-    }
-
-    html += renderSection(own, true);
-    if (appearances.length > 0) {
-      html += `
-        <div class="type-section">
-          <div class="type-header" onclick="event.stopPropagation(); window.toggleSection(this)" style="color:#777;">
-            Appearances <span class="type-count">${appearances.length}</span>
-          </div>
-          <div class="type-body">
-            ${renderSection(appearances, false)}
-          </div>
-        </div>
-      `;
-    }
-    if (bootlegOnly.length > 0) {
-      html += `
-        <div class="type-section">
-          <div class="type-header" onclick="event.stopPropagation(); window.toggleSection(this)" style="color:#555;">
-            Bootleg-only releases <span class="type-count">${bootlegOnly.length}</span>
-          </div>
-          <div class="type-body">
-            ${renderSection(bootlegOnly, false)}
-          </div>
-        </div>
-      `;
-    }
-    rgEl.innerHTML = html;
-    applySearchTargetAfterDiscography(rgEl);
+export function renderRgRow(rg, ctx) {
+  const year = rg.first_release_date ? rg.first_release_date.slice(0, 4) : '';
+  const creditNote = rg.artist_credit && rg.artist_credit.toLowerCase() !== ctx.nameLC
+    ? `<span class="rg-meta"> - ${esc(rg.artist_credit)}</span>` : '';
+  const badges = renderStatusBadges(rg);
+  // Masterless Discogs releases have no child master to expand; the rg row
+  // is the leaf, so it carries data-release-id for search-by-ID ringing.
+  const leafAttr = rg.is_masterless ? ` data-release-id="${rg.id}"` : '';
+  // Search-plan inspector button — only when this rg has a pipeline
+  // request. RG-level pipeline_id surfaces from the analysis overlay's
+  // disambData snapshot via pipelineStore (see release_action_state.js).
+  const spBtn = renderSearchPlanButton({
+    pipelineId: buildReleaseActionState({
+      ...rg,
+      artist: ctx.artistName,
+      album: rg.title,
+    }).pipelineId,
+  });
+  const optParts = [];
+  if (rg.is_masterless) optParts.push('masterless:true');
+  if (ctx.source) optParts.push(`source:'${ctx.source}'`);
+  const opts = `{${optParts.join(',')}}`;
+  return `
+    <div class="rg" data-rg-id="${esc(rg.id)}"${leafAttr}>
+      <div onclick="event.stopPropagation(); window.loadReleaseGroup('${rg.id}', this, ${opts})">
+        <span class="rg-year">${year}</span> <span class="rg-title">${esc(rg.title)}</span>${creditNote}${badges}${spBtn}
+      </div>
+      <div class="releases" id="rel-${rg.id}"></div>
+    </div>
+  `;
 }
 
 /**
@@ -144,9 +75,9 @@ export function renderArtistDiscography(rgEl, id, artistName, data, libData) {
  * typed section is invisible even after the inner releases load (those
  * wrappers default to display:none until the .open class is added).
  *
- * @param {HTMLElement} rgEl - The discography container that just rendered.
+ * @param {HTMLElement} rgEl - The artist-page container that just rendered.
  */
-function applySearchTargetAfterDiscography(rgEl) {
+export function applySearchTargetAfterDiscography(rgEl) {
   const expandId = state.searchTargetExpandId;
   if (!expandId) return;
   // Source guard: only apply ring when the discography source matches
@@ -205,7 +136,7 @@ function openCollapsedAncestors(el, stopEl) {
  * @param {string} s
  * @returns {string}
  */
-function cssEscape(s) {
+export function cssEscape(s) {
   if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(s);
   return String(s).replace(/[^a-zA-Z0-9_-]/g, ch => `\\${ch}`);
 }
@@ -366,6 +297,10 @@ export async function loadReleaseGroup(id, el, opts = {}) {
     if (isStale()) return;
     relEl.innerHTML = html;
     applySearchTargetAfterReleases(relEl);
+    // Analysis overlay (unified artist page): when disambiguate data for
+    // this release group is loaded, decorate pressing rows with colour
+    // dots / exclusive counts and append the recordings breakdown.
+    applyAnalysisToExpansion(relEl, id);
   } catch (e) {
     if (isStale()) return;
     relEl.innerHTML = '<div class="loading">Failed to load</div>';
@@ -525,6 +460,17 @@ export function renderReleaseDetail(targetEl, releaseId, data, opts = {}) {
     hideDisabled: true,
   });
   html += '</div>';
+
+  // Deep library detail (path, download history, status / min-bitrate /
+  // intent controls) — absorbed from the old Library sub-view (#575 PR4).
+  // Lazy: fetches /api/beets/album/<id> on first open.
+  if (data.beets_album_id) {
+    html += `
+      <div class="type-header" style="margin-top:8px;padding:4px 0;" onclick="event.stopPropagation(); window.toggleReleaseLibDetail(${Number(data.beets_album_id)})">
+        Library detail <span class="type-count">history · controls</span>
+      </div>
+      <div class="lib-detail" id="libdet-${Number(data.beets_album_id)}"></div>`;
+  }
 
   targetEl.innerHTML = html;
 }

--- a/web/js/grouping.js
+++ b/web/js/grouping.js
@@ -1,8 +1,8 @@
 // @ts-check
 
 /**
- * Shared release-grouping helpers used by every browse-artist sub-tab
- * (Discography / Library / Analysis / Compare). Centralises the
+ * Shared release-grouping helpers used by the unified artist page and
+ * the label view. Centralises the
  * Albums/EPs/Singles/Compilations/Live/Remixes/DJ Mixes/Demos/Other
  * sectioning so every view sorts the same way.
  *

--- a/web/js/labels.js
+++ b/web/js/labels.js
@@ -338,7 +338,6 @@ export function openLabelDetailFromList(rowEl, index) {
 export async function openLabelDetail(labelId, labelName) {
   const requestToken = ++labelDetailRequestToken;
   state.browseLabel = { id: labelId, name: labelName };
-  state.browseSubView = 'label';
   state.labelPage = 1;
 
   const results = document.getElementById('results');

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -18,7 +18,7 @@ function refreshAfterBeetsDeletion(albumId) {
 
   const browseArtist = document.getElementById('browse-artist');
   if (browseArtist && browseArtist.style.display !== 'none' && state.browseArtist) {
-    window.switchSubView?.(state.browseSubView || 'discography');
+    window.reloadBrowseArtist?.();
     return;
   }
 
@@ -40,164 +40,116 @@ function refreshAfterBeetsDeletion(albumId) {
 }
 
 /**
- * Render library results into a target element (thin wrapper).
- * @param {HTMLElement} targetEl
- * @param {Object[]} albums
+ * One library-album (or pipeline-only request) row with its detail
+ * placeholder. Feeds the unified artist page's In-flight section
+ * (issue #575 PR4); in-library rows expand via toggleLibDetail,
+ * pipeline-only rows via the pipeline toggleDetail.
+ * @param {Object} a - LibraryAlbumRow-shaped row from /api/library/artist
+ * @returns {string}
  */
-export function renderLibraryResultsInto(targetEl, albums) {
-  renderLibraryResults(albums, targetEl);
-}
+export function renderLibraryAlbumRow(a) {
+  const added = a.added ? new Date(a.added * 1000 + 8 * 3600000).toISOString().slice(0, 10) : '?';
+  const mbid = normalizeReleaseId(a.mb_albumid);
+  const inLibrary = a.in_library !== false;
+  const beetsAlbumId = a.beets_album_id ?? null;
+  const pipelineId = a.pipeline_id || null;
+  const detailId = inLibrary
+    ? `lib-${beetsAlbumId}`
+    : `lib-pipeline-${pipelineId || a.id}`;
+  const detailToggle = inLibrary && beetsAlbumId
+    ? `window.toggleLibDetail(${beetsAlbumId})`
+    : `window.toggleDetail('${detailId}', ${pipelineId || a.id})`;
 
-/**
- * Render library albums grouped by artist, then by release group.
- * @param {Object[]} albums
- * @param {HTMLElement} [targetEl]
- */
-export function renderLibraryResults(albums, targetEl) {
-  const el = targetEl || document.getElementById('library-content');
-  if (albums.length === 0) {
-    el.innerHTML = '<div class="loading">No results</div>';
-    return;
-  }
-  // Group by artist
-  const byArtist = {};
-  for (const a of albums) {
-    const artist = a.artist || 'Unknown';
-    if (!byArtist[artist]) byArtist[artist] = [];
-    byArtist[artist].push(a);
-  }
-  const artists = Object.keys(byArtist).sort((a, b) => a.localeCompare(b));
-  // Sort albums within each artist by year
-  for (const a of artists) {
-    byArtist[a].sort((x, y) => (x.year || 0) - (y.year || 0));
-  }
+  const actionState = mbid ? buildReleaseActionState({
+    id: mbid,
+    in_library: inLibrary,
+    beets_album_id: beetsAlbumId,
+    pipeline_status: a.pipeline_status || null,
+    pipeline_id: pipelineId,
+    artist: a.artist || '',
+    album: a.album || '',
+    track_count: a.track_count || 0,
+  }) : null;
+  const toolbar = actionState ? renderActionToolbar(actionState, { size: 'small' }) : '';
 
-  // Auto-expand if only one artist
-  const autoOpen = artists.length === 1;
-
-  el.innerHTML = artists.map(artist => {
-    const artistAlbums = byArtist[artist];
-
-    // Group by release group within artist
-    const rgOrder = [];
-    const byRG = {};
-    for (const a of artistAlbums) {
-      const rgKey = a.mb_releasegroupid || ('_' + a.id);
-      if (!byRG[rgKey]) {
-        byRG[rgKey] = { title: a.release_group_title || a.album, year: a.year, albums: [] };
-        rgOrder.push(rgKey);
-      }
-      byRG[rgKey].albums.push(a);
-    }
-    const rgCount = rgOrder.length;
-
-    function renderAlbum(a) {
-      const added = a.added ? new Date(a.added * 1000 + 8 * 3600000).toISOString().slice(0, 10) : '?';
-      const mbid = normalizeReleaseId(a.mb_albumid);
-      const inLibrary = a.in_library !== false;
-      const beetsAlbumId = a.beets_album_id ?? null;
-      const pipelineId = a.pipeline_id || null;
-      const detailId = inLibrary
-        ? `lib-${beetsAlbumId}`
-        : `lib-pipeline-${pipelineId || a.id}`;
-      const detailToggle = inLibrary && beetsAlbumId
-        ? `window.toggleLibDetail(${beetsAlbumId})`
-        : `window.toggleDetail('${detailId}', ${pipelineId || a.id})`;
-
-      const actionState = mbid ? buildReleaseActionState({
-        id: mbid,
-        in_library: inLibrary,
-        beets_album_id: beetsAlbumId,
-        pipeline_status: a.pipeline_status || null,
-        pipeline_id: pipelineId,
-        artist: a.artist || '',
-        album: a.album || '',
-        track_count: a.track_count || 0,
-      }) : null;
-      const toolbar = actionState ? renderActionToolbar(actionState, { size: 'small' }) : '';
-
-      const badges = renderStatusBadges({
-        id: mbid,
-        in_library: inLibrary,
-        library_format: a.formats,
-        library_min_bitrate: a.min_bitrate ? Math.round(a.min_bitrate / 1000) : 0,
-        library_rank: a.library_rank,
-        pipeline_status: a.pipeline_status,
-      });
-      return `
-        <div class="lib-item" onclick="${detailToggle}">
-          <div class="p-top">
-            <div>
-              <div class="p-title">${esc(a.album)}${badges}</div>
-            </div>
-            <div style="display:flex;align-items:center;gap:6px;">
-              ${toolbar}
-              <span style="font-size:0.75em;color:#666;">${a.track_count}t</span>
-            </div>
-          </div>
-          <div class="p-meta">
-            <span>${a.year || '?'}</span>
-            ${a.country ? `<span>${a.country}</span>` : ''}
-            ${a.type ? `<span>${a.type}</span>` : ''}
-            <span>added ${added}</span>
-          </div>
+  const badges = renderStatusBadges({
+    id: mbid,
+    in_library: inLibrary,
+    library_format: a.formats,
+    library_min_bitrate: a.min_bitrate ? Math.round(a.min_bitrate / 1000) : 0,
+    library_rank: a.library_rank,
+    pipeline_status: a.pipeline_status,
+  });
+  return `
+    <div class="lib-item" onclick="${detailToggle}">
+      <div class="p-top">
+        <div>
+          <div class="p-title">${esc(a.album)}${badges}</div>
         </div>
-        <div class="lib-detail" id="${detailId}"></div>
-      `;
-    }
-
-    // Build per-RG display rows, then group them by Album/EP/Single/etc.
-    // so an artist with mixed types renders the same sectioning the
-    // Discography sub-tab uses. Within a section, sort by year.
-    const rgRows = rgOrder.map(rgKey => {
-      const rg = byRG[rgKey];
-      const sample = rg.albums[0];
-      const html = rg.albums.length === 1
-        ? renderAlbum(sample)
-        : `<div class="lib-rg">
-             <div class="lib-rg-header" onclick="window.toggleSection(this)">
-               <span>${rg.year || '?'} ${esc(rg.title)}</span>
-               <span class="lib-artist-count">${rg.albums.length} versions</span>
-             </div>
-             <div class="lib-rg-body">
-               ${rg.albums.map(renderAlbum).join('')}
-             </div>
-           </div>`;
-      return {
-        // Fields classify() reads
-        type: sample.type || '',
-        secondary_types: [],
-        // Sort key
-        first_release_date: String(rg.year || ''),
-        _html: html,
-      };
-    });
-    const albumsHtml = renderTypedSections(rgRows, (r) => r._html);
-
-    return `
-      <div class="lib-artist">
-        <div class="lib-artist-header" onclick="window.toggleSection(this)">
-          <span class="lib-artist-name">${esc(artist)}</span>
-          <span class="lib-artist-count">${rgCount} release${rgCount !== 1 ? 's' : ''}</span>
-        </div>
-        <div class="lib-artist-body${autoOpen ? ' open' : ''}">
-          ${albumsHtml}
+        <div style="display:flex;align-items:center;gap:6px;">
+          ${toolbar}
+          <span style="font-size:0.75em;color:#666;">${a.track_count}t</span>
         </div>
       </div>
-    `;
-  }).join('');
+      <div class="p-meta">
+        <span>${a.year || '?'}</span>
+        ${a.country ? `<span>${a.country}</span>` : ''}
+        ${a.type ? `<span>${a.type}</span>` : ''}
+        <span>added ${added}</span>
+      </div>
+    </div>
+    <div class="lib-detail" id="${detailId}"></div>
+  `;
 }
 
 /**
- * Toggle the detail panel for a library album.
+ * Fetch /api/beets/album/<id> and render the deep library detail body.
+ * Shared by toggleLibDetail (album rows) and toggleReleaseLibDetail
+ * (the release-detail sub-panel on the unified artist page).
+ * @param {number} id - Beets album ID
+ * @returns {Promise<string>}
+ */
+async function fetchLibraryDetailBody(id) {
+  const r = await fetch(`${API}/api/beets/album/${id}`);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const data = await r.json();
+  return renderLibraryDetailBody(data, id);
+}
+
+/**
+ * Toggle the detail panel for a library album row.
  * @param {number} id - Beets album ID
  */
 export async function toggleLibDetail(id) {
   const el = document.getElementById('lib-' + id);
   await toggleExpand(el, async (target) => {
-    const r = await fetch(`${API}/api/beets/album/${id}`);
-    if (!r.ok) throw new Error(`HTTP ${r.status}`);
-    const data = await r.json();
+    target.innerHTML = await fetchLibraryDetailBody(id);
+  });
+}
+
+/**
+ * Toggle the deep library detail inside an expanded release-detail panel
+ * (the unified artist page's replacement for the old Library sub-view's
+ * album detail). Targets the `libdet-<id>` placeholder emitted by
+ * renderReleaseDetail.
+ * @param {number} id - Beets album ID
+ */
+export async function toggleReleaseLibDetail(id) {
+  const el = document.getElementById('libdet-' + id);
+  await toggleExpand(el, async (target) => {
+    target.innerHTML = await fetchLibraryDetailBody(id);
+  });
+}
+
+/**
+ * The deep library detail body: path, source link, label, tracks,
+ * download history, pipeline status / min-bitrate / intent controls,
+ * acquire + delete + bad-rip actions.
+ * @param {Object} data - /api/beets/album/<id> payload
+ * @param {number} id - Beets album ID
+ * @returns {string}
+ */
+export function renderLibraryDetailBody(data, id) {
     const releaseId = normalizeReleaseId(data.mb_albumid);
     let html = '';
     if (data.path) {
@@ -281,8 +233,7 @@ export async function toggleLibDetail(id) {
       stopPropagation: true,
     });
     html += '</div>';
-    target.innerHTML = html;
-  });
+    return html;
 }
 
 /**

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { API, state, toast, updatePipelineStatus } from './state.js';
 import { esc, jsArg, overrideToIntent, normalizeReleaseId } from './util.js';
-import { renderTypedSections } from './grouping.js';
 import { buildReleaseActionState } from './release_action_state.js';
 import { renderActionToolbar, renderAcquireActionButton, renderRemoveFromBeetsButton, renderBadRipButton } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
@@ -149,7 +148,7 @@ export async function toggleReleaseLibDetail(id) {
  * @param {number} id - Beets album ID
  * @returns {string}
  */
-export function renderLibraryDetailBody(data, id) {
+function renderLibraryDetailBody(data, id) {
     const releaseId = normalizeReleaseId(data.mb_albumid);
     let html = '';
     if (data.path) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -6,14 +6,14 @@
  */
 
 import { state } from './state.js';
-import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, switchSubView, invalidateBrowseArtist, openBrowseArtistFromCompare, toggleCompareRow, closeVaFallback } from './browse.js';
-import { renderArtistDiscography, loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
+import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, reloadBrowseArtist, invalidateBrowseArtist, closeVaFallback } from './browse.js';
+import { loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
 import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter, onPipelineSearchInput } from './pipeline.js';
 import { loadLongTail, setLongTailBand, onLongTailSearchInput } from './long_tail.js';
 import { toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue, longTailAcceptSibling, longTailSetIntent, longTailSetImported, longTailDeleteRequest } from './long_tail_console.js';
-import { renderLibraryResults, renderLibraryResultsInto, toggleLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
-import { renderDisambiguateInto, toggleDisambRGTracks, disambRemove } from './analysis.js';
+import { toggleLibDetail, toggleReleaseLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
+import { disambRemove } from './analysis.js';
 import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, reloadWrongMatchExplorer, maybeLoadWrongMatchExplorer, refreshWrongMatches, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup, bulkTriageWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold, toggleWrongMatchesReplacedFilter } from './wrong-matches.js';
 import { openLabelDetail, openLabelDetailFromList, closeLabelDetail, onLabelFilterChange, onLabelYearFilterInput, toggleLabelIncludeSublabels, goToLabelPage } from './labels.js';
 import { toggleSearchPlanSummary, openSearchPlanDetail, closeSearchPlanDetail, searchPlanRegenerate, searchPlanAdvance, searchPlanLoadOlder, searchPlanRefreshDetail, searchPlanSubmitAdvance, searchPlanCancelAdvance } from './search_plan.js';
@@ -149,13 +149,10 @@ Object.assign(window, {
   setSearchType,
   setBrowseSource,
   openBrowseArtist,
-  openBrowseArtistFromCompare,
-  toggleCompareRow,
   closeBrowseArtist,
+  reloadBrowseArtist,
   closeVaFallback,
-  switchSubView,
   searchArtists,
-  renderArtistDiscography,
   loadReleaseGroup,
   addRelease,
   toggleReleaseDetail,
@@ -182,17 +179,14 @@ Object.assign(window, {
   onLongTailSearchInput,
   toggleLongTailDetail,
   toggleLongTailPeers,
-  renderLibraryResults,
-  renderLibraryResultsInto,
   toggleLibDetail,
+  toggleReleaseLibDetail,
   banSource,
   setLibQuality,
   upgradeAlbum,
   setIntent,
   confirmDeleteBeets,
   executeBeetsDeletion,
-  renderDisambiguateInto,
-  toggleDisambRGTracks,
   disambRemove,
   loadWrongMatches,
   toggleWrongMatchGroup,

--- a/web/js/search_plan.js
+++ b/web/js/search_plan.js
@@ -624,8 +624,6 @@ export function snapshotActiveTab() {
     subView = state.pipelineView ?? 'queue';
   } else if (tab === 'recents') {
     subView = state.recentsSub ?? 'history';
-  } else if (tab === 'browse') {
-    subView = state.browseSubView ?? null;
   }
   const scrollY = (typeof window !== 'undefined' && typeof window.scrollY === 'number')
     ? window.scrollY
@@ -739,9 +737,6 @@ export function closeSearchPlanDetail() {
     if (tab === 'recents'
       && (subView === 'history' || subView === 'downloading' || subView === 'queue')) {
       state.recentsSub = subView;
-    }
-    if (tab === 'browse' && typeof subView === 'string') {
-      state.browseSubView = subView;
     }
   }
   state.searchPlanDetailContext = null;

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -129,7 +129,7 @@ export function updatePipelineStatus(mbid, status, pipelineId) {
   // Browse-search inverted Replace button cache so the next render
   // re-fetches.
   invalidateActiveRgs();
-  // Update disambData pressings (analysis tab)
+  // Update disambData pressings (the artist page's analysis overlay)
   if (state.disambData) {
     for (const rg of state.disambData.release_groups) {
       for (const p of (rg.pressings || [])) {

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -40,7 +40,7 @@ import { invalidateActiveRgs } from './active_rgs.js';
  * @property {string} query             Current search-box substring filter.
  */
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseSubView: string, browseCache: Object, pipelineData: Object|null, pipelineSearchQuery: string, pipelineSearchResults: Array<Object>|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseCache: Object, pipelineData: Object|null, pipelineSearchQuery: string, pipelineSearchResults: Array<Object>|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
@@ -48,7 +48,6 @@ export const state = {
   browseLabel: null,
   labelFilters: { yearMin: null, yearMax: null, format: '', hideHeld: false },
   labelPage: 1,
-  browseSubView: 'discography',
   browseCache: {},
   pipelineData: null,
   pipelineSearchQuery: '',


### PR DESCRIPTION
Part of #575 (phase 4 of the plan of record). The Browse artist view's four sub-tabs (Discography / Analysis / Library / Compare) become **one scrolling page** sectioned by availability.

## The page

- **Fast render** from the existing route pair (source discography with `?name=` `in_library` annotation + `/api/library/artist` — now fetched once; the old Discography path fetched the library feed twice). Sections:
  - **In library** — official own-work release groups the library holds, plus **Library-only editions** (owned albums whose release group is absent from the source discography — previously these vanished from the Library-tab-less page entirely; invariant I6).
  - **In flight** — requests currently `downloading` or `manual`. `wanted` is deliberately ambient (post-backfill, every owned album has an upgrade request) and stays a badge.
  - **Missing** — official own-work release groups *not* in the library. New surface: pure presentation over the `annotate_in_library` flag the backend already computed.
  - **Appearances / Bootleg-only releases** — as before, collapsed.
- All rg rows share `renderRgRow` (PR3 primitives) with badges, expansion targets, and `data-rg-id` — so search-by-ID ringing and the sibling-pressing Replace flow work in **every** section, including Missing.
- **Two background decorations** land after render, never re-rendering (expansion state survives), token-guarded and cached per artist:
  - `/api/artist/compare` → an appended **"Only on Discogs/MusicBrainz"** section (the deduped complement bucket; MB-preferred merge). Silent on 503 — mirror-less hosts stay single-source.
  - `/api/artist/<id>/disambiguate` → **"N unique" / "covered by X"** chips on rows, and colour dots + exclusive counts + a Recordings breakdown inside expanded release groups (MB artists only). Already-open expansions (search-by-ID auto-expand) are decorated when the payload arrives.
- The Library sub-view's deep album detail survives as a lazy **Library detail** panel inside the release detail (path, download history, status / min-bitrate / intent controls, via `/api/beets/album/<id>`).

## Demolition

`switchSubView` + four loaders, the compare machinery (`renderCompare`/`compareRow`/`toggleCompareRow`/`openBrowseArtistFromCompare`), `renderArtistDiscography`, `renderDisambiguateInto`/`toggleDisambRGTracks`, `renderLibraryResults(Into)`, the subnav + four containers, `state.browseSubView` (incl. search_plan's browse-subview stash/restore), and the orphaned `.library-*`/`.lib-artist*`/`.lib-rg*` CSS. **No backend changes** — every route untouched, contract tests untouched.

## Verification

- Invariants written first, pinned in `tests/test_js_artist_page.mjs` (48 assertions): partition totality, bootleg precedence, ownership credit rules, in-flight lens, orphan visibility, complement-source forcing. `tests/test_js_analysis.mjs` (13) pins chips + recording-dot math.
- Full suite 5,156 OK; pyright 0 errors; all 14 JS suites green; pre-push fuzz burst + flake check (module VM) passed.
- **Screenshot loop, 3 rounds** on the live-db dev server (real pipeline data, PNGs read by the orchestrator): all sections on The Lucksmiths / Mach‐Hommy / 417.3, expansion dots + recordings, Library-detail panel, In-flight manual row, search-by-ID ring + auto-expand decoration, cache-hit decoration re-fire after an early exit, section-header hierarchy (computed-style-diff verified). Zero JS exceptions across all rounds.
- Opus review: no blockers; both should-fix findings addressed (cache-hit null-decoration re-fire; I6 orphan fallback), token-bump nits closed, stale comments swept, escaping nit accepted (rg ids are UUIDs/numerics, never mirror free text).

## Notes

- The one 500 seen during the loop was `web/mb.py` falling back to public MusicBrainz over HTTPS and getting rate-limit-dropped — transient, environmental, pre-existing failure mode (the old sub-tab path had the identical two-fetch behavior).
- Next: PR5 — absorb the queues, reconcile the badge vocabularies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)