### PR TITLE
fix(web): artist-page orphan dedupe spans all annotated buckets (#575)

### DIFF
--- a/tests/test_js_artist_page.mjs
+++ b/tests/test_js_artist_page.mjs
@@ -219,6 +219,39 @@ console.log('I6 — owned albums absent from the discography become orphans');
   assertContains(html, 'Long Tail Demo', 'orphan album row rendered');
 }
 
+console.log('I6 — title-matched RG in ANY bucket suppresses the orphan (live 1998-split bug)');
+{
+  // The live case: an owned Discogs-tagged split 7" (no MB rg id) whose
+  // MB twin has no Official release — the RG lands in bootlegs with the
+  // in-library badge, and the owned album must NOT re-emit as an orphan.
+  const s = classify(
+    [rg('rg-split', { has_official: false, in_library: true, title: 'Split 7 Inch' })],
+    [libRow({ id: 11, album: 'Split 7 Inch', mb_releasegroupid: null, mb_albumid: '461708' })]);
+  assertEqual(s.bootlegs.length, 1, 'unofficial RG stays in bootlegs');
+  assertEqual(s.inLibraryOrphans.length, 0,
+    'owned album title-matched to a bootleg-bucket RG is not an orphan');
+
+  // Same shape via the appearances bucket (guest-credit RG in library).
+  const s2 = classify(
+    [rg('rg-guest', {
+      in_library: true, title: 'Guest Comp',
+      primary_artist_id: 'other', artist_credit: 'Someone Else',
+    })],
+    [libRow({ id: 12, album: 'Guest Comp', mb_releasegroupid: null })]);
+  assertEqual(s2.appearances.length, 1, 'guest RG stays in appearances');
+  assertEqual(s2.inLibraryOrphans.length, 0,
+    'owned album title-matched to an appearances-bucket RG is not an orphan');
+
+  // Known-bad self-test: a NOT-in-library bootleg RG with the same title
+  // must not suppress a genuine orphan — the dedupe keys on the
+  // annotation, not on mere title co-existence.
+  const s3 = classify(
+    [rg('rg-unowned', { has_official: false, in_library: false, title: 'Same Name' })],
+    [libRow({ id: 13, album: 'Same Name', mb_releasegroupid: null })]);
+  assertEqual(s3.inLibraryOrphans.length, 1,
+    'un-annotated same-title RG does not hide the owned album');
+}
+
 console.log('I6 — orphans alone still render the In library section');
 {
   const s = classify([], [libRow({ id: 7, album: 'Only Orphan', mb_releasegroupid: null })]);

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -63,9 +63,16 @@ export function classifyArtistRows({ artistId, artistName, releaseGroups, librar
   // discography (MB lacks the release, or the backend's title-fallback
   // match missed). Without this they'd be invisible on the whole page.
   // The title checks approximate the backend fallback so an album whose
-  // rg row DID render (under a different rg id) isn't shown twice.
+  // rg row DID render (under a different rg id) isn't shown twice. The
+  // dedupe set spans EVERY bucket that can carry an in-library-annotated
+  // RG — an owned split 7" whose MB twin is unofficial renders (badged)
+  // under Bootleg-only, and a guest-credit one under Appearances; both
+  // previously re-emitted as orphans because only the inLibrary bucket
+  // fed the set.
   const rgIds = new Set((releaseGroups || []).map(r => String(r.id)));
-  const inLibTitles = new Set(inLibrary.map(r => (r.title || '').toLowerCase()));
+  const inLibTitles = new Set((releaseGroups || [])
+    .filter(r => r.in_library === true)
+    .map(r => (r.title || '').toLowerCase()));
   const inLibraryOrphans = (libraryAlbums || []).filter(a =>
     a.in_library !== false
     && !(a.mb_releasegroupid && rgIds.has(String(a.mb_releasegroupid)))


### PR DESCRIPTION
Follow-up to #601, found by live operator poking: an owned Discogs-tagged split 7" double-rendered — under **Bootleg-only** (title-matched to its unofficial MB release group, correctly badged in-library) and again under **Library-only editions**. The orphan filter's title-dedupe set only covered the `inLibrary` bucket, so annotated RGs living in `bootlegs` or `appearances` never suppressed their owned twin.

Fix: the dedupe set now spans every release group with `in_library === true`, whichever bucket it landed in. RED-first pins for both bucket variants plus a known-bad self-test (an un-annotated same-title RG must NOT hide a genuine orphan — the dedupe keys on the annotation, not title co-existence).

Full suite 5,156 OK, pyright clean, 14 JS suites green (53 assertions in the artist-page file). Display-only logic change; live verification on the exact motivating artist after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)