### PR TITLE
feat(web): label the source toggle + explain primary/complement (#575)

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -59,7 +59,12 @@ Browser → https://music.ablz.au
 
 ## Frontend Features
 
-- **Source toggle** — MB / Discogs toggle in the browse tab header. Switches all search, artist, and release views between MusicBrainz and Discogs data sources.
+- **Source toggle** — a labelled **Source** MB / Discogs switch in the browse tab
+  header. The selected source is the *primary* discography for all search, artist,
+  and release views; the other source only *fills in* releases the primary is
+  missing, surfaced as the appended "Only on …" section. A live hint line under the
+  switch spells this out ("MusicBrainz is primary · Discogs fills the rest …") and
+  flips when you toggle, so the primary/complement relationship is never a mystery.
 - **Search** — debounced text search, returns artists (or releases in album mode)
 - **Unified artist page (#575 PR4)** — one scrolling page (the old
   Discography / Analysis / Library / Compare sub-tabs are gone), sectioned by

--- a/web/index.html
+++ b/web/index.html
@@ -359,6 +359,9 @@
   .p-btn { padding: 4px 12px; border: 1px solid #444; background: #222; color: #aaa; border-radius: 4px; cursor: pointer; font-size: 0.78em; }
   .p-btn:hover { background: #333; color: #eee; }
   .p-btn.active-status { border-color: #6a9; color: #6a9; background: #2a3a2a; }
+  .source-label { color: #777; font-size: 0.66em; text-transform: uppercase; letter-spacing: 0.6px; }
+  #source-hint { color: #777; font-size: 0.74em; margin: 0 0 10px 2px; }
+  #source-hint .src-primary { color: #6a9; font-weight: 600; }
   .p-btn.delete { border-color: #633; color: #d66; margin-left: auto; }
   .p-btn.delete:hover { background: #3a1a1a; }
   .p-group-header { padding: 8px 12px; color: #6a9; font-size: 0.85em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 12px; margin-bottom: 4px; display: flex; justify-content: space-between; cursor: pointer; }
@@ -500,11 +503,15 @@
       <button class="p-btn" id="search-type-label" onclick="setSearchType('label')">Label</button>
       <button class="p-btn" id="search-type-id" onclick="setSearchType('id')">ID</button>
     </div>
-    <div style="display:flex;gap:2px;margin-left:8px;border-left:1px solid #444;padding-left:8px;">
-      <button class="p-btn active-status" id="source-mb" onclick="setBrowseSource('mb')">MB</button>
-      <button class="p-btn" id="source-discogs" onclick="setBrowseSource('discogs')">Discogs</button>
+    <div style="display:flex;gap:6px;align-items:center;margin-left:8px;border-left:1px solid #444;padding-left:8px;">
+      <span class="source-label">Source</span>
+      <div style="display:flex;gap:2px;">
+        <button class="p-btn active-status" id="source-mb" title="Use MusicBrainz as the primary discography. Releases found only on Discogs are added at the bottom as “Only on Discogs”." onclick="setBrowseSource('mb')">MB</button>
+        <button class="p-btn" id="source-discogs" title="Use Discogs as the primary discography. Releases found only on MusicBrainz are added at the bottom as “Only on MusicBrainz”." onclick="setBrowseSource('discogs')">Discogs</button>
+      </div>
     </div>
   </div>
+  <div id="source-hint"><b class="src-primary">MusicBrainz</b> is primary · Discogs fills the rest (shown as "Only on Discogs" below)</div>
   <div id="results"></div>
   <div id="browse-artist" style="display:none;">
     <div id="browse-artist-header" style="margin:12px 0 8px;display:flex;align-items:center;gap:12px;">

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -31,6 +31,29 @@ async function findArtistOnSource(name, src) {
 }
 
 /**
+ * Reflect the active metadata source in the toggle buttons + the hint line.
+ * The selected source is the PRIMARY discography; the other source only
+ * fills in releases the primary is missing (the appended "Only on <other>"
+ * section). Called from every place that changes browseSource so the
+ * primary/complement story never goes stale. Single source of truth for
+ * the source-toggle chrome — the two call sites used to duplicate the
+ * button-class flip and neither touched the hint.
+ * @param {string} src - 'mb' | 'discogs'
+ */
+function applySourceUI(src) {
+  const mbBtn = document.getElementById('source-mb');
+  const dgBtn = document.getElementById('source-discogs');
+  if (mbBtn) mbBtn.className = 'p-btn' + (src === 'mb' ? ' active-status' : '');
+  if (dgBtn) dgBtn.className = 'p-btn' + (src === 'discogs' ? ' active-status' : '');
+  const hint = document.getElementById('source-hint');
+  if (hint) {
+    hint.innerHTML = src === 'discogs'
+      ? '<b class="src-primary">Discogs</b> is primary · MusicBrainz fills the rest (shown as "Only on MusicBrainz" below)'
+      : '<b class="src-primary">MusicBrainz</b> is primary · Discogs fills the rest (shown as "Only on Discogs" below)';
+  }
+}
+
+/**
  * Set the browse metadata source (mb or discogs). Preserves artist context
  * when possible: if an artist is currently selected, look up the equivalent
  * on the new source and re-render in place instead of dumping back to search.
@@ -46,10 +69,7 @@ export async function setBrowseSource(src) {
   // changed contexts.
   clearSearchTarget();
   state.browseSource = src;
-  const mbBtn = document.getElementById('source-mb');
-  const dgBtn = document.getElementById('source-discogs');
-  if (mbBtn) mbBtn.className = 'p-btn' + (src === 'mb' ? ' active-status' : '');
-  if (dgBtn) dgBtn.className = 'p-btn' + (src === 'discogs' ? ' active-status' : '');
+  applySourceUI(src);
   state.browseCache = {};
 
   // Sticky artist context across the toggle.
@@ -196,10 +216,7 @@ export async function resolveAndNavigate(q, requestToken) {
   // artist view, otherwise the discography fetch would hit the wrong API.
   if (state.browseSource !== parsed.family) {
     state.browseSource = parsed.family;
-    const mbBtn = document.getElementById('source-mb');
-    const dgBtn = document.getElementById('source-discogs');
-    if (mbBtn) mbBtn.className = 'p-btn' + (parsed.family === 'mb' ? ' active-status' : '');
-    if (dgBtn) dgBtn.className = 'p-btn' + (parsed.family === 'discogs' ? ' active-status' : '');
+    applySourceUI(parsed.family);
     state.browseCache = {};
   }
 


### PR DESCRIPTION
Operator-requested (via a channel mixup — the request landed in the playwright agent's chat, which implemented it; reviewed and shipped by the orchestrator): the MB/Discogs switch gave no hint of what it does or that the sources aren't either/or.

- A dimmed **Source** label so the buttons self-identify, plus full-name tooltips.
- A live hint line under the switch stating the relationship, flipping on toggle: "**MusicBrainz** is primary · Discogs fills the rest (shown as 'Only on Discogs' below)" — tying the toggle to the unified artist page's complement section from #601.
- Clean-as-you-go: both call sites that flip the source (setBrowseSource, search-by-ID resolver) now route through one `applySourceUI` helper — they previously duplicated the button flip, and the resolver path would have left the new hint stale.

Verified: prod-api dev-server screenshot loop (both states, hint flips — PNGs reviewed by the orchestrator), 14 JS suites green, full suite 5,156 OK, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)