### PR TITLE
fix(web): masterless pressing rows keep the pipeline overlay; heading tracks unnumbered (#575)

### DIFF
--- a/tests/test_js_discography.mjs
+++ b/tests/test_js_discography.mjs
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for web/js/discography.js pure helpers.
+ * Run with: node tests/test_js_discography.mjs
+ */
+
+import { synthesizeMasterlessRow } from '../web/js/discography.js';
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual, expected, msg) {
+  if (actual === expected) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg} - expected '${expected}', got '${actual}'`);
+  }
+}
+
+console.log('synthesizeMasterlessRow() — overlay fields survive the synthesis');
+{
+  // The live bug (request 8838, Deloris "Feather Figure/Elastic Bones"):
+  // the payload carried pipeline_status=wanted but the synthetic pressing
+  // row dropped it, rendering a green "Add request" on an
+  // already-requested release.
+  const row = synthesizeMasterlessRow({
+    id: '8317023',
+    title: 'Feather Figure/Elastic Bones',
+    date: '2005-06-00',
+    country: 'Australia',
+    status: 'Official',
+    formats: [{ name: 'CD' }],
+    tracks: new Array(10).fill({ title: 't' }),
+    labels: [{ id: 1, name: 'Dot Dash' }],
+    release_group_id: null,
+    in_library: false,
+    beets_album_id: null,
+    pipeline_status: 'wanted',
+    pipeline_id: 8838,
+  });
+  assertEqual(row.pipeline_status, 'wanted', 'pipeline_status forwarded');
+  assertEqual(row.pipeline_id, 8838, 'pipeline_id forwarded');
+  assertEqual(row.in_library, false, 'in_library forwarded');
+  assertEqual(row.beets_album_id, null, 'beets_album_id forwarded');
+  assertEqual(row.id, '8317023', 'id kept');
+  assertEqual(row.title, 'Feather Figure/Elastic Bones', 'title kept');
+  assertEqual(row.format, 'CD', 'formats joined');
+  assertEqual(row.track_count, 10, 'track count derived');
+  assertEqual(row.status, 'Official', 'status kept');
+}
+
+console.log('synthesizeMasterlessRow() — in-library payload keeps quality fields');
+{
+  const row = synthesizeMasterlessRow({
+    id: '999',
+    title: 'Owned One',
+    tracks: [],
+    formats: [],
+    in_library: true,
+    beets_album_id: 42,
+    pipeline_status: 'imported',
+    pipeline_id: 7,
+    library_format: 'FLAC',
+    library_min_bitrate: 900,
+    library_rank: 'lossless',
+  });
+  assertEqual(row.in_library, true, 'in_library true forwarded');
+  assertEqual(row.beets_album_id, 42, 'beets_album_id forwarded');
+  assertEqual(row.library_format, 'FLAC', 'library_format forwarded');
+  assertEqual(row.library_min_bitrate, 900, 'library_min_bitrate forwarded');
+  assertEqual(row.library_rank, 'lossless', 'library_rank forwarded');
+  assertEqual(row.format, '?', 'empty formats fall back to ?');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/test_js_render_primitives.mjs
+++ b/tests/test_js_render_primitives.mjs
@@ -112,6 +112,14 @@ console.log('renderExpectedTrackRow()');
 
   const disc1 = renderExpectedTrackRow({ disc_number: 1, track_number: 9, title: 'X' });
   assertContains(disc1, '>9. X', 'no disc prefix on disc 1');
+
+  // Discogs index/heading rows (sub-EP titles on a combined release)
+  // arrive with track_number 0 — render as an unnumbered heading, not
+  // "0. Feather Figure Single".
+  const heading = renderExpectedTrackRow({ disc_number: 1, track_number: 0, title: 'Feather Figure Single' });
+  assertExcludes(heading, '0.', 'no zero prefix on heading rows');
+  assertContains(heading, 'Feather Figure Single', 'heading title rendered');
+  assertContains(heading, 'lib-track-heading', 'heading rows are visually distinct');
 }
 
 console.log('renderReleaseRow()');

--- a/web/index.html
+++ b/web/index.html
@@ -437,6 +437,8 @@
   .lib-detail.open { display: block; }
   .lib-track { font-size: 0.78em; color: #888; padding: 1px 0; display: flex; justify-content: space-between; }
   .lib-track-meta { color: #555; }
+  /* Discogs index/heading rows inside a track list (sub-EP / side titles). */
+  .lib-track-heading { color: #6a9; font-weight: 600; margin-top: 5px; }
   .p-btn.upgrade-btn { border-color: #5a5a1a; color: #da6; }
   .p-btn.upgrade-btn:hover { background: #3a3a1a; }
   .p-btn.remove-request { border-color: #855; color: #e7b16a; background: #2a1d14; }

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -142,6 +142,38 @@ export function cssEscape(s) {
 }
 
 /**
+ * Synthesize the single pressing row for a masterless Discogs release
+ * from its /api/discogs/release payload, so the rest of the rendering
+ * path is unchanged. MUST forward the pipeline/library overlay fields —
+ * dropping them rendered an already-requested masterless release with a
+ * green "Add request" button and no badge (Deloris "Feather
+ * Figure/Elastic Bones", request 8838).
+ * @param {Object} data - /api/discogs/release payload
+ * @returns {Object} A release row shaped like /api/discogs/master rows.
+ */
+export function synthesizeMasterlessRow(data) {
+  return {
+    id: data.id,
+    title: data.title || '',
+    date: data.date || '',
+    country: data.country || '',
+    status: data.status || 'Official',
+    track_count: (data.tracks || []).length,
+    format: (data.formats || []).map(f => f && f.name).filter(Boolean).join(', ') || '?',
+    media_count: (data.formats || []).length,
+    labels: data.labels || [],
+    release_group_id: data.release_group_id ?? null,
+    in_library: data.in_library,
+    beets_album_id: data.beets_album_id ?? null,
+    pipeline_status: data.pipeline_status ?? null,
+    pipeline_id: data.pipeline_id ?? null,
+    library_format: data.library_format,
+    library_min_bitrate: data.library_min_bitrate,
+    library_rank: data.library_rank,
+  };
+}
+
+/**
  * Load and display releases for a release group.
  *
  * @param {string} id - MusicBrainz release group ID or Discogs master ID
@@ -193,17 +225,7 @@ export async function loadReleaseGroup(id, el, opts = {}) {
     if (data.error) throw new Error(data.error);
     /** @type {Array<any>} */
     const releaseRows = masterless
-      ? [{
-          id: data.id,
-          title: data.title || '',
-          date: data.date || '',
-          country: data.country || '',
-          status: data.status || 'Official',
-          track_count: (data.tracks || []).length,
-          format: (data.formats || []).map(f => f && f.name).filter(Boolean).join(', ') || '?',
-          media_count: (data.formats || []).length,
-          labels: data.labels || [],
-        }]
+      ? [synthesizeMasterlessRow(data)]
       : (data.releases || []);
     const all = releaseRows.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
     const official = all.filter(r => r.status === 'Official' || !r.status);

--- a/web/js/render_primitives.js
+++ b/web/js/render_primitives.js
@@ -59,6 +59,13 @@ export function renderBeetsTrackRow(t) {
  * @returns {string}
  */
 export function renderExpectedTrackRow(t) {
+  // Discogs index/heading rows (sub-EP or side titles) carry
+  // track_number 0 — render as an unnumbered heading, not "0. <title>".
+  if (!t.track_number) {
+    return `<div class="lib-track lib-track-heading">
+      <span>${esc(t.title)}</span>
+    </div>`;
+  }
   const dur = formatDuration(t.length_seconds);
   return `<div class="lib-track">
       <span>${t.disc_number && t.disc_number > 1 ? t.disc_number + '.' : ''}${t.track_number}. ${esc(t.title)} ${dur ? '<span style="color:#555;">' + dur + '</span>' : ''}</span>


### PR DESCRIPTION
Operator report on the unified artist page: Deloris "Feather Figure/Elastic Bones" (request 8838, `wanted`) showed a green **Add request** button; clicking it just toasted "Already in pipeline" — unlike every other requested release.

Root cause: the release is **masterless** on Discogs, and `loadReleaseGroup`'s masterless branch synthesized its single pressing row from scratch — dropping `pipeline_status` / `pipeline_id` / `in_library` / `beets_album_id` / `library_*` even though `/api/discogs/release/8317023` carried them correctly. The synthesis is now an exported pure helper (`synthesizeMasterlessRow`) that forwards the whole overlay, pinned in a new `tests/test_js_discography.mjs` suite using the exact live payload shape.

Also from the same report: Discogs index/heading rows (sub-EP titles, `track_number 0`) rendered as "0. Feather Figure Single" — `renderExpectedTrackRow` now renders them as unnumbered `.lib-track-heading` rows (pinned RED-first).

15 JS suites green, full suite 5,156 OK, pyright clean. Live verification on the exact motivating row after deploy (the dev host has no Discogs mirror, so this path only exists on production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)