### PR TITLE
fix(web): rejected detail leads with its reason, not a quality story (#608 follow-up)

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -104,9 +104,15 @@ Browser → https://music.ablz.au
   Source / Spectral / Bitrate / Distance vocabulary (em-dash when unknown, one
   label/value pair per row so columns never shift), with the server-classified
   badge as the header — the same words as the list badges, never the raw
-  outcome enum. Force imports show `overridden` in the Distance row instead of
-  beets' misleading 0.000. Debug internals (Preview / Reason / Stages) sit
-  behind a collapsed `forensics` toggle per attempt.
+  outcome enum. The verdict (the entry's story) renders first, directly under
+  the header and red on failure-family rows, so a rejection whose quality
+  evidence all reads positive never buries its reason below the grid (request
+  8781: `mbid_missing` under a "transparent vs transparent" comparison). The
+  expanded pipeline/Recents detail panel puts Download History above the
+  track list for the same reason. Force imports show `overridden` in the
+  Distance row instead of beets' misleading 0.000. Debug internals (Detail /
+  Preview / Reason / Stages) sit behind a collapsed `forensics` toggle per
+  attempt.
 - **Comparison basis rendering (request 6039)** — rows whose
   `import_result` JSONB carries the persisted `comparison_basis` render the
   decision's own comparison: the verdict line names the deciding metric,

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -628,5 +628,116 @@ console.log('renderDownloadHistoryItem() omits the Compared row without a basis'
   assertExcludes(html, 'Compared', 'no Compared row on legacy rows');
 }
 
+console.log('renderDownloadHistoryItem() leads with the verdict, red on rejections');
+{
+  // Request 8781 / download_log 36660: a Rejected row whose quality
+  // evidence all read positive (transparent vs transparent, verified
+  // lossless bypass) buried the actual rejection reason (mbid_missing)
+  // as a dim line BELOW the grid — the detail view told a quality story
+  // for a match failure. The verdict now renders directly under the
+  // header, before the evidence grid, in the reject colour.
+  const html = renderDownloadHistoryItem({
+    outcome: 'rejected',
+    badge: 'Rejected',
+    badge_class: 'badge-rejected',
+    soulseek_username: 'tunnik',
+    created_at: '2026-07-10T23:19:10+00:00',
+    downloaded_label: 'WAV (converted to OPUS V2)',
+    spectral_grade: 'genuine',
+    verdict: 'mbid_missing',
+    comparison_basis: {
+      verdict: 'equivalent', branch: 'cross_family_same_rank',
+      new_rank: 'transparent', existing_rank: 'transparent',
+      new_metric: 'avg', existing_metric: 'avg',
+      new_value_kbps: 216, existing_value_kbps: 256,
+      new_format: 'opus 128', existing_format: 'aac',
+      spectral_clamped: false, tolerance_kbps: null,
+      verified_lossless_bypass: true,
+    },
+  });
+
+  assertContains(html, 'p-hist-verdict-reject', 'rejected verdict gets the reject class');
+  const verdictPos = html.indexOf('mbid_missing');
+  const gridPos = html.indexOf('p-hist-grid');
+  if (verdictPos !== -1 && gridPos !== -1 && verdictPos < gridPos) {
+    passed++;
+  } else {
+    failed++;
+    console.error('  FAIL: rejection verdict should render before the evidence grid');
+  }
+}
+
+console.log('renderDownloadHistoryItem() colors the verdict red across the failure family');
+{
+  for (const outcome of ['rejected', 'failed', 'timeout', 'user_offline', 'curator_ban']) {
+    const html = renderDownloadHistoryItem({
+      outcome,
+      soulseek_username: 'testuser',
+      created_at: '2026-07-10T23:19:10+00:00',
+      verdict: 'some failure story',
+    });
+    assertContains(html, 'p-hist-verdict-reject', `${outcome} verdict gets the reject class`);
+  }
+}
+
+console.log('renderDownloadHistoryItem() keeps success verdicts unstyled and above the grid');
+{
+  const html = renderDownloadHistoryItem({
+    outcome: 'success',
+    soulseek_username: 'dbqs',
+    created_at: '2026-07-10T14:46:05+00:00',
+    actual_min_bitrate: 194,
+    verdict: 'Upgrade: MP3 V2 to MP3 320',
+  });
+  assertContains(html, 'p-hist-verdict', 'verdict line present on success rows');
+  assertExcludes(html, 'p-hist-verdict-reject', 'success verdict keeps the default colour');
+  const verdictPos = html.indexOf('Upgrade: MP3 V2 to MP3 320');
+  const gridPos = html.indexOf('p-hist-grid');
+  if (verdictPos !== -1 && gridPos !== -1 && verdictPos < gridPos) {
+    passed++;
+  } else {
+    failed++;
+    console.error('  FAIL: success verdict should also render before the grid');
+  }
+}
+
+console.log('renderDownloadHistoryItem() surfaces beets_detail behind the forensics toggle');
+{
+  // mbid_not_found rows carry the explanation ("Target MBID X not in
+  // candidates") in beets_detail — previously dropped on the floor.
+  const html = renderDownloadHistoryItem({
+    outcome: 'rejected',
+    soulseek_username: 'tunnik',
+    created_at: '2026-07-10T22:28:12+00:00',
+    verdict: 'mbid_not_found',
+    beets_detail: 'Target MBID 3de1b986-1b7d-4769-ba9a-5d2b398d0331 not in candidates',
+  });
+  assertContains(html, '<details class="p-hist-forensics">',
+    'forensics toggle present when beets_detail exists');
+  assertContains(html, 'Target MBID 3de1b986-1b7d-4769-ba9a-5d2b398d0331 not in candidates',
+    'beets_detail reachable in forensics');
+  const detailsStart = html.indexOf('<details');
+  const detailPos = html.indexOf('Target MBID');
+  if (detailsStart !== -1 && detailPos > detailsStart) {
+    passed++;
+  } else {
+    failed++;
+    console.error('  FAIL: beets_detail should live inside the forensics toggle');
+  }
+}
+
+console.log('renderDownloadHistoryItem() omits the forensics Detail row when beets_detail repeats the verdict');
+{
+  const html = renderDownloadHistoryItem({
+    outcome: 'rejected',
+    soulseek_username: 'testuser',
+    created_at: '2026-07-10T22:28:12+00:00',
+    verdict: 'audio_corrupt',
+    beets_detail: 'audio_corrupt',
+  });
+  assertExcludes(html, '<details class="p-hist-forensics">',
+    'no forensics toggle for a redundant beets_detail');
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/web/index.html
+++ b/web/index.html
@@ -331,6 +331,7 @@
   .p-hist-value { color: #888; overflow-wrap: anywhere; }
   .p-hist-was { color: #666; font-size: 0.9em; }
   .p-hist-verdict { color: #bbb; padding: 2px 0 0 8px; font-size: 0.95em; }
+  .p-hist-verdict-reject { color: #d88; }
   .p-hist-forensics { margin: 2px 0 0 8px; }
   .p-hist-forensics summary { cursor: pointer; user-select: none; color: #556; font-size: 0.9em; }
   .p-hist-forensics summary:hover, .p-hist-forensics[open] summary { color: #889; }

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -164,13 +164,18 @@ export function renderEvidenceStrip(h) {
 /**
  * Render a single download history item as one consistent label/value grid.
  *
+ * The verdict (the entry's story — "mbid_missing", "Upgrade: …") renders
+ * FIRST, under the header, red on failure-family rows: the evidence grid
+ * is context, not the outcome, and a rejection whose quality evidence all
+ * reads positive must not bury its reason below the grid.
+ *
  * Fixed schema (issue #575): the core vocabulary — Source / Spectral /
  * Bitrate / Distance — renders on EVERY entry, with an em-dash when a
  * side has no data, so adjacent entries never jump shape. Existing-side
  * data appears inline as "(was Xkbps)" inside the value cell, so each
  * metric is apples-to-apples on the same row. Semantic extras (V0 probe
  * for lossless sources, Stored as, Bad extension, the Triage operator
- * audit) render only when present; internal debug rows (Preview /
+ * audit) render only when present; internal debug rows (Detail / Preview /
  * Reason / Stages) live behind a collapsed forensics toggle.
  *
  * The header uses the server-classified badge — the SAME vocabulary as
@@ -202,6 +207,19 @@ export function renderDownloadHistoryItem(h) {
     <span style="color:#888;">${esc(user)}</span>
     <span style="color:#555;">${date}</span>
   </div>`;
+
+  // The verdict is the entry's story — it leads, before the evidence
+  // grid. On failure-family rows it takes the reject colour: a rejected
+  // download whose quality evidence all reads positive (transparent vs
+  // transparent, verified lossless bypass) must not tell a quality
+  // success story with the actual reason buried as a dim line below
+  // the grid (request 8781 / download_log 36660: mbid_missing).
+  const FAILURE_OUTCOMES = ['rejected', 'failed', 'timeout', 'user_offline', 'curator_ban'];
+  const verdict = h.verdict || h.beets_scenario || '';
+  if (verdict) {
+    const rejectCls = FAILURE_OUTCOMES.includes(outcome) ? ' p-hist-verdict-reject' : '';
+    html += `<div class="p-hist-verdict${rejectCls}">${esc(verdict)}</div>`;
+  }
 
   const rows = [];
 
@@ -301,6 +319,12 @@ export function renderDownloadHistoryItem(h) {
   }
 
   const forensicRows = [];
+  // The raw beets/harness detail (e.g. "Target MBID … not in candidates")
+  // explains WHY a match-failure verdict fired — reachable, but debug-tier.
+  // Skipped when it just repeats the verdict.
+  if (h.beets_detail && h.beets_detail !== verdict) {
+    forensicRows.push(['Detail', esc(h.beets_detail)]);
+  }
   const previewParts = [
     h.wrong_match_triage_preview_verdict,
     h.wrong_match_triage_preview_decision,
@@ -336,11 +360,6 @@ export function renderDownloadHistoryItem(h) {
     }
     fhtml += '</div>';
     html += `<details class="p-hist-forensics"><summary>forensics</summary>${fhtml}</details>`;
-  }
-
-  const verdict = h.verdict || h.beets_scenario || '';
-  if (verdict) {
-    html += `<div class="p-hist-verdict">${esc(verdict)}</div>`;
   }
 
   return `<div class="p-hist-item">${html}</div>`;

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -459,6 +459,17 @@ export async function toggleDetail(elId, requestId) {
       html += renderDetailRow('Quality', qualitySummary);
     }
 
+    // Download history — before the track list. The history is why the
+    // operator expanded the row (a Recents card IS a download event); on
+    // mobile a 14-track library listing pushed a rejection's story three
+    // screens down, so the detail read as a healthy library album
+    // (request 8781: mbid_missing invisible without scrolling).
+    if (history.length > 0) {
+      html += '<div class="p-history"><div class="p-detail-label" style="margin-bottom:4px;">Download History (' + history.length + ')</div>';
+      html += history.map(renderDownloadHistoryItem).join('');
+      html += '</div>';
+    }
+
     // Tracks — labeled to clarify what we're looking at
     if (beetsTracks.length > 0) {
       html += '<div class="p-tracks"><div class="p-detail-label" style="margin-bottom:4px;">In Library (' + beetsTracks.length + ' tracks)</div>';
@@ -467,13 +478,6 @@ export async function toggleDetail(elId, requestId) {
     } else if (tracks.length > 0) {
       html += '<div class="p-tracks"><div class="p-detail-label" style="margin-bottom:4px;">Expected Tracks from MusicBrainz (' + tracks.length + ')</div>';
       html += tracks.map(renderExpectedTrackRow).join('');
-      html += '</div>';
-    }
-
-    // Download history
-    if (history.length > 0) {
-      html += '<div class="p-history"><div class="p-detail-label" style="margin-bottom:4px;">Download History (' + history.length + ')</div>';
-      html += history.map(renderDownloadHistoryItem).join('');
       html += '</div>';
     }
 


### PR DESCRIPTION
## Defect (operator-reported, post-#608)

Request 8781 / download_log 36660 — "you seem pretty sad for a girl so in love" (Olivia Rodrigo), rejected 07:19 by the harness with `mbid_missing` (rc=4: the wanted pressing wasn't among beets' match candidates).

The collapsed Recents card was honest: evidence strip + `mbid_missing · tunnik`. Expanding it told a quality **success** story:

- On mobile, the first screenful was the MB link, a healthy "Quality: AAC V0 spectral: genuine", and a 14-track library listing — Download History sat three screens down.
- The history entry's grid led with `Compared: avg 216k (transparent) vs avg 256k (transparent) · verified lossless bypass` (bright blue), while the actual reason rendered as a dim grey `mbid_missing` line *below* the grid.

The quality evidence is honest (quality passed via the verified-lossless bypass; the *match* failed) — but the detail view buried the verdict under the context.

## Fix (frontend only)

- **Verdict leads.** `renderDownloadHistoryItem` renders the verdict directly under the header, before the evidence grid, with a reject-red modifier (`.p-hist-verdict-reject`) on failure-family outcomes (`rejected` / `failed` / `timeout` / `user_offline` / `curator_ban`). Success verdicts keep the default grey.
- **History above tracks.** `toggleDetail`'s panel puts Download History above the track list — the history is why the operator expanded the row. (`library.js`'s album panel keeps tracks-first deliberately: it's intrinsically a library view, and it gets the verdict-leads fix via the shared renderer.)
- **`beets_detail` surfaced.** Now reachable behind the collapsed forensics toggle as a `Detail` row (e.g. `Target MBID 3de1b986-… not in candidates` on `mbid_not_found` rows — previously dropped on the floor), skipped when it just repeats the verdict.

## Verification

- New pins in `tests/test_js_history.mjs`: verdict-before-grid position (on the exact 36660 shape incl. its basis), reject class across the failure family, success verdict unstyled + still before the grid, `beets_detail` inside forensics, redundant `beets_detail` omitted. RED before the fix (11 failures), GREEN after.
- Full suite: 5193 tests OK; pyright 0 errors; `node --check` clean.
- Live-db dev-server screenshot loop on the motivating row, mobile + desktop, PNGs read by the orchestrating agent: the expanded card now opens on Download History with `mbid_missing` in red directly under the Rejected header.
- Opus review pass: no correctness bugs; stale `docs/webui-primer.md` prose fixed in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)