### PR TITLE
fix(quality): honest metric labels — no fabricated avg, min says min, V0 everywhere

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -86,7 +86,7 @@ that audit trail.
 - `spectral_bitrate INTEGER` — estimated original bitrate from spectral.
 - `existing_min_bitrate INTEGER` — beets min bitrate before this download.
 - `existing_spectral_bitrate INTEGER` — spectral estimate of existing files before download.
-- `v0_probe_kind TEXT` — lineage for this attempt's optional V0 probe evidence. `lossless_source_v0` is comparable; `native_lossy_research_v0` and `on_disk_research_v0` are audit-only.
+- `v0_probe_kind TEXT` — lineage for this attempt's optional V0 probe evidence. V0 probes run on every candidate and are operator-facing across the UI (Recents strip/detail, Wrong Matches; research kinds render qualified — "(from lossy)" / "(on-disk re-encode)"). Only `lossless_source_v0` is comparable for the provisional-lossless policy lane; `native_lossy_research_v0` and `on_disk_research_v0` are real V0-transcode research measurements excluded from that lane.
 - `v0_probe_min_bitrate INTEGER`, `v0_probe_avg_bitrate INTEGER`, `v0_probe_median_bitrate INTEGER` — min/avg/median track bitrates for this attempt's probe.
 - `existing_v0_probe_kind TEXT` — lineage of the comparable probe state used before this attempt, when present.
 - `existing_v0_probe_min_bitrate INTEGER`, `existing_v0_probe_avg_bitrate INTEGER`, `existing_v0_probe_median_bitrate INTEGER` — point-in-time baseline probe values used for history rendering and audit.

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -275,6 +275,17 @@ verbatim when present; rows predating the field fall back to the legacy
 min-based labels. Never re-derive a comparison for display — that
 re-derivation is how the display learned to lie.
 
+**Metric labels are truthful at synthesis too (download_log 36660):** the
+same lie can be injected one seam earlier — the decision layer used to
+synthesize comparison measurements with `avg` fabricated `= min` (the
+lossless-conversion path carries only the post-conversion min across the
+flat decision interface), so a persisted basis read "avg 216k" while the
+files' real avg was 255. Synthesized measurements now leave unmeasured
+stats `None`; `_selected_bitrate_with_source` falls back to the min AND
+labels it `min`. Guarded by the `assert_basis_metrics_truthful` generated
+property (`tests/test_quality_generated.py`) and the request-8781 pins in
+`tests/test_quality_classification.py`.
+
 ## TODO
 
 - [ ] Integrate spectral gradient check into pipeline (import_one.py or cratedigger.py)

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -112,7 +112,11 @@ Browser → https://music.ablz.au
   track list for the same reason. Force imports show `overridden` in the
   Distance row instead of beets' misleading 0.000. Debug internals (Detail /
   Preview / Reason / Stages) sit behind a collapsed `forensics` toggle per
-  attempt.
+  attempt. Every bitrate says which statistic it is: the min-vs-min row is
+  labelled "Min bitrate" and strip mins render as `min 216k` (request 8781:
+  an unlabelled 216 beside an avg-labelled 255 read as a contradiction).
+  V0 probes render for every candidate — research probes of lossy sources
+  qualified "(from lossy)" — matching the Wrong Matches convention.
 - **Comparison basis rendering (request 6039)** — rows whose
   `import_result` JSONB carries the persisted `comparison_basis` render the
   decision's own comparison: the verdict line names the deciding metric,

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -714,8 +714,11 @@ def _probe_lossless_source_as_v0(album_path: str) -> V0ProbeEvidence | None:
 
 def _probe_native_lossy_as_v0(album_path: str) -> V0ProbeEvidence | None:
     """Non-destructively encode native lossy sources to temp V0 files and
-    measure them. Audit-only research evidence; never eligible for the
-    lossless-source provisional comparison (kind != lossless_source_v0).
+    measure them. A real, independent measurement (NOT the container
+    bitrate) — surfaced across the UI (Recents strip/detail, Wrong
+    Matches) as operator-facing comparison data, qualified "(from lossy)".
+    Never eligible for the lossless-source provisional POLICY comparison
+    (kind != lossless_source_v0).
     """
     lossy_files = sorted(
         f for f in os.listdir(album_path)
@@ -1811,8 +1814,9 @@ def main():
         if r.v0_probe:
             _log(f"  source_v0_probe_avg={r.v0_probe.avg_bitrate_kbps}kbps")
     elif not keep_lossless and not supported_lossless_source:
-        # Native lossy candidate: emit a research probe (audit-only,
-        # never eligible for the lossless-source provisional comparison).
+        # Native lossy candidate: emit a research probe. V0 runs on every
+        # candidate — the operator compares these across the UI; the kind
+        # keeps it out of the lossless-source provisional POLICY lane.
         r.v0_probe = _probe_native_lossy_as_v0(work_path)
         if r.v0_probe:
             _log(f"  native_lossy_research_v0_avg={r.v0_probe.avg_bitrate_kbps}kbps")

--- a/lib/quality/decisions.py
+++ b/lib/quality/decisions.py
@@ -391,12 +391,18 @@ def build_existing_quality_measurement(
         if override_min_bitrate is not None
         else min_bitrate_kbps
     )
-    raw_avg = avg_bitrate_kbps if avg_bitrate_kbps is not None else min_bitrate_kbps
-    raw_median = (
-        median_bitrate_kbps
-        if median_bitrate_kbps is not None
-        else raw_avg
-    )
+    # No fabricated fallbacks: an unmeasured avg/median stays None so the
+    # persisted basis labels the classified value "min" instead of claiming
+    # an avg nobody measured (dl 36660 display-lie class). Value-neutral
+    # under the AVG (deployed) and MIN metrics — selection falls back to
+    # the same min the old fabrication aliased. Only a hypothetical
+    # bitrate_metric=median config sees different stage-2 values, and
+    # median was never honest on this path (no real median crosses the
+    # flat interface). The CBR+override clamp below is different — that's
+    # deliberate policy (a CBR album's avg IS its min), pinned by its own
+    # tests.
+    raw_avg = avg_bitrate_kbps
+    raw_median = median_bitrate_kbps
     if is_cbr and override_min_bitrate is not None:
         effective_avg = override_min_bitrate
         effective_median = override_min_bitrate

--- a/lib/quality/pipeline.py
+++ b/lib/quality/pipeline.py
@@ -261,16 +261,16 @@ def full_pipeline_decision(
     # carry a min_bitrate) still classify against the MP3 VBR/CBR band
     # tables. Production always provides a real format via BeetsDB.
     #
-    # avg/median fall back to min_bitrate when the caller didn't supply a
-    # separate avg (legacy scenarios). Supplying existing_avg_bitrate matters
-    # under the default cfg.bitrate_metric=AVG policy — otherwise a VBR album
-    # with avg=245 but min=180 gets ranked off min=180 (GOOD instead of
-    # TRANSPARENT) and downstream comparisons misrepresent production.
+    # Supplying existing_avg_bitrate matters under the default
+    # cfg.bitrate_metric=AVG policy — otherwise a VBR album with avg=245 but
+    # min=180 gets ranked off min=180 (GOOD instead of TRANSPARENT) and
+    # downstream comparisons misrepresent production. When the caller didn't
+    # measure an avg, nothing is fabricated: metric selection falls back to
+    # min and the persisted basis says "min" (dl 36660 display-lie class).
     effective_existing_format = existing_format if existing_format is not None else "MP3"
     existing_m = build_existing_quality_measurement(
         min_bitrate_kbps=existing_min_bitrate,
         avg_bitrate_kbps=existing_avg_bitrate,
-        median_bitrate_kbps=existing_avg_bitrate,
         format=effective_existing_format,
         is_cbr=existing_is_cbr,
         override_min_bitrate=override_min_bitrate,
@@ -295,10 +295,13 @@ def full_pipeline_decision(
             spectral_grade in SPECTRAL_TRANSCODE_GRADES
             and v0_probe_overrides_spectral(candidate_probe_full)
         )
+        # avg/median stay None — only the min crosses this interface. A
+        # fabricated avg=min makes _selected_bitrate_with_source label a min
+        # value "avg" in the persisted basis (dl 36660: "avg 216k" beside an
+        # honest "V0 255kbps avg" on the same card). None falls back to the
+        # min with the honest "min" label; the classified value is identical.
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
-            avg_bitrate_kbps=min_bitrate,
-            median_bitrate_kbps=min_bitrate,
             format=stage2_new_format,
             spectral_grade=spectral_grade,
             spectral_bitrate_kbps=spectral_bitrate)
@@ -391,10 +394,12 @@ def full_pipeline_decision(
             converted_count=converted_count,
             is_transcode=policy_is_transcode,
         )
+        # avg/median stay None — the flat interface carries only the
+        # post-conversion MIN for this side. See the flac-keep site above:
+        # a fabricated avg=min is how the persisted basis learned to call a
+        # min value "avg" (dl 36660).
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=import_br,
-            avg_bitrate_kbps=import_br,
-            median_bitrate_kbps=import_br,
             format=stage2_new_format,
             verified_lossless=will_be_verified,
             spectral_grade=spectral_grade,
@@ -500,11 +505,12 @@ def full_pipeline_decision(
             explicit_format=new_format,
             native_codec_family="MP3",
         )
-        _mp3_avg = avg_bitrate if avg_bitrate is not None else min_bitrate
+        # No fabricated fallbacks: when the caller measured no avg, the
+        # basis metric falls back to (and honestly says) "min". Median is
+        # not part of this interface at all.
         new_m = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
-            avg_bitrate_kbps=_mp3_avg,
-            median_bitrate_kbps=_mp3_avg,
+            avg_bitrate_kbps=avg_bitrate,
             format=stage2_new_format,
             is_cbr=is_cbr,
             spectral_grade=spectral_grade,
@@ -545,7 +551,10 @@ def full_pipeline_decision(
 
         result["imported"] = True
         gate_bitrate = min_bitrate
-        gate_avg_bitrate = _mp3_avg
+        # Real avg only; the gate's metric selection falls back to min when
+        # avg is unmeasured (same classified value as the old fabricated
+        # fallback — gate_m is internal and never persisted as a basis).
+        gate_avg_bitrate = avg_bitrate
         gate_cbr = is_cbr
         gate_format = stage2_new_format
 

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -103,8 +103,8 @@ console.log('renderDownloadHistoryItem() shows Bitrate row with inline (was X) c
   // Single grid, every metric on its own row. Existing data inline as "(was X)".
   assertContains(html, 'class="p-hist-grid"',
     'one consistent grid renders for every entry');
-  assertContains(html, 'class="p-hist-label">Bitrate</span>',
-    'Bitrate row label present');
+  assertContains(html, 'class="p-hist-label">Min bitrate</span>',
+    'Min bitrate row label present');
   assertContains(html, 'class="p-hist-label">Spectral</span>',
     'Spectral row label present');
   assertContains(html, '192kbps', 'candidate bitrate rendered');
@@ -188,13 +188,15 @@ console.log('renderDownloadHistoryItem() omits the V0 probe (was X) suffix when 
     'Bitrate row keeps the apples-to-apples min comparison');
 }
 
-console.log('renderDownloadHistoryItem() drops the V0 probe row for non-lossless candidates');
+console.log('renderDownloadHistoryItem() renders the V0 probe row for research probes too');
 {
-  // Non-lossless candidates carry a v0_probe (kind=native_lossy_research_v0)
-  // in the DB so backend policy can read it, but the same number already
-  // appears in the Bitrate row — rendering it twice would be redundant
-  // and the "(measurement)" qualifier was misleading. Drop it from the
-  // UI surface.
+  // V0 probes run on EVERY candidate (native-lossy sources get a real
+  // ffmpeg V0-transcode probe, kind=native_lossy_research_v0) and are
+  // load-bearing for the operator — Wrong Matches has surfaced them
+  // regardless of lineage all along. The "(from lossy)" qualifier keeps
+  // the gold-standard lossless-source probes distinguishable. Note the
+  // probe (247) is an independent measurement, NOT the container bitrate
+  // (232) — the old "redundant with Bitrate" rationale was stale.
   const html = renderDownloadHistoryItem({
     outcome: 'rejected',
     soulseek_username: 'testuser',
@@ -206,12 +208,31 @@ console.log('renderDownloadHistoryItem() drops the V0 probe row for non-lossless
     downloaded_label: 'MP3 V0',
   });
 
-  assertExcludes(html, 'V0 probe',
-    'no V0 probe row when kind is not lossless_source_v0');
-  assertExcludes(html, '(measurement)',
-    'no leftover (measurement) suffix anywhere');
+  assertContains(html, 'V0 probe',
+    'V0 probe row renders for research probes');
+  assertContains(html, '247kbps avg (from lossy)',
+    'research probe carries the from-lossy qualifier');
   assertContains(html, '232kbps',
     'candidate bitrate still rendered from actual_min_bitrate');
+}
+
+console.log('renderDownloadHistoryItem() V0 was-suffix is kind-aware');
+{
+  // dl 36660: lossless-source candidate probe (255) vs the library
+  // album's native-lossy research probe (250). Both render — the
+  // qualifier says which is which instead of hiding the comparison.
+  const html = renderDownloadHistoryItem({
+    outcome: 'rejected',
+    soulseek_username: 'tunnik',
+    created_at: '2026-07-10T23:19:10+00:00',
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_avg_bitrate: 255,
+    existing_v0_probe_kind: 'native_lossy_research_v0',
+    existing_v0_probe_avg_bitrate: 250,
+  });
+  assertContains(html, '255kbps avg', 'lossless-source probe renders bare');
+  assertContains(html, '(was 250kbps avg (from lossy))',
+    'existing research probe renders with its qualifier');
 }
 
 console.log('renderDownloadHistoryItem() keeps a consistent row vocabulary across codecs');
@@ -250,8 +271,8 @@ console.log('renderDownloadHistoryItem() keeps a consistent row vocabulary acros
       'Source row in every entry');
     assertContains(html, 'class="p-hist-label">Spectral</span>',
       'Spectral row in every entry');
-    assertContains(html, 'class="p-hist-label">Bitrate</span>',
-      'Bitrate row in every entry');
+    assertContains(html, 'class="p-hist-label">Min bitrate</span>',
+      'Min bitrate row in every entry');
   }
 }
 
@@ -297,19 +318,22 @@ console.log('formatV0Probe() helper picks the right kind suffix per source linea
     failed++;
     console.error('  FAIL: lossless probe should render bare ("260kbps avg")');
   } else { passed++; }
-  // ``native_lossy_research_v0`` still produces a "(measurement)" tag
-  // for any caller that uses the helper directly (e.g. debug surfaces).
-  // The download-history renderer hides the V0 probe row entirely for
-  // non-lossless candidates because the same number appears in Bitrate.
-  if (formatV0Probe(247, 'native_lossy_research_v0') !== '247kbps avg (measurement)') {
+  // ``native_lossy_research_v0`` is a real ffmpeg V0-transcode probe of a
+  // lossy source — qualified "(from lossy)" so it never reads as the
+  // gold-standard lossless-source probe.
+  if (formatV0Probe(247, 'native_lossy_research_v0') !== '247kbps avg (from lossy)') {
     failed++;
-    console.error('  FAIL: native_lossy_research_v0 should add "(measurement)" suffix');
+    console.error('  FAIL: native_lossy_research_v0 should add "(from lossy)" suffix');
   } else { passed++; }
   if (formatV0Probe(200, undefined) !== '200kbps avg') {
     failed++;
     console.error('  FAIL: missing kind should render bare');
   } else { passed++; }
-  if (formatV0Probe(180, 'on_disk_research_v0') !== '180kbps avg (on_disk_research_v0)') {
+  if (formatV0Probe(180, 'on_disk_research_v0') !== '180kbps avg (on-disk re-encode)') {
+    failed++;
+    console.error('  FAIL: on_disk_research_v0 should render the on-disk re-encode qualifier');
+  } else { passed++; }
+  if (formatV0Probe(180, 'future_probe_kind') !== '180kbps avg (future_probe_kind)') {
     failed++;
     console.error('  FAIL: unknown kind should fall back to raw label');
   } else { passed++; }
@@ -344,7 +368,7 @@ console.log('renderDownloadHistoryItem() always renders the core row vocabulary 
     verdict: 'Download failed: file exceeded retry limit',
   });
 
-  for (const label of ['Source', 'Spectral', 'Bitrate', 'Distance']) {
+  for (const label of ['Source', 'Spectral', 'Min bitrate', 'Distance']) {
     assertContains(html, `class="p-hist-label">${label}</span>`,
       `${label} row present even without data`);
   }
@@ -425,10 +449,10 @@ console.log('renderEvidenceStrip() builds the compact IN/HAVE comparison');
   assertContains(strip, 'class="r-evidence"', 'strip wrapper class');
   assertContains(strip, 'IN', 'IN side labelled');
   assertContains(strip, 'MP3 320', 'incoming label rendered');
-  assertContains(strip, '245k', 'incoming measured bitrate rendered');
+  assertContains(strip, 'min 245k', 'incoming measured bitrate rendered with the min label');
   assertContains(strip, '~160k', 'incoming spectral floor rendered');
   assertContains(strip, 'HAVE', 'HAVE side labelled');
-  assertContains(strip, '320k', 'on-disk bitrate rendered');
+  assertContains(strip, 'min 320k', 'on-disk bitrate rendered with the min label');
 }
 
 console.log('renderEvidenceStrip() returns empty string when no evidence exists');
@@ -470,7 +494,7 @@ console.log('renderEvidenceStrip() shows the on-disk format on the HAVE side');
     existing_format: 'MP3',
     existing_min_bitrate: 256,
   });
-  assertContains(strip, 'MP3 256k', 'HAVE side leads with the on-disk format');
+  assertContains(strip, 'MP3 min 256k', 'HAVE side leads with the on-disk format, min-labelled');
 }
 
 console.log('renderDownloadHistoryItem() includes the on-disk format in the Bitrate (was X) suffix');
@@ -498,6 +522,24 @@ console.log('renderDownloadHistoryItem() keeps the bare (was X) when existing fo
     existing_min_bitrate: 256,
   });
   assertContains(html, '(was 256kbps)', 'legacy rows keep the bare suffix');
+}
+
+console.log('renderEvidenceStrip() shows research V0 probes with the from-lossy qualifier');
+{
+  // V0 runs on everything; the strip shows whichever probe each side has,
+  // qualified so research probes never read as lossless-source proof.
+  const strip = renderEvidenceStrip({
+    downloaded_label: 'MP3 V0',
+    actual_min_bitrate: 232,
+    v0_probe_kind: 'native_lossy_research_v0',
+    v0_probe_avg_bitrate: 247,
+    existing_format: 'AAC',
+    existing_min_bitrate: 256,
+    existing_v0_probe_kind: 'native_lossy_research_v0',
+    existing_v0_probe_avg_bitrate: 250,
+  });
+  assertContains(strip, 'V0 247k avg (from lossy)', 'IN research probe qualified');
+  assertContains(strip, 'V0 250k avg (from lossy)', 'HAVE research probe qualified');
 }
 
 console.log('renderEvidenceStrip() escapes injected values');

--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -421,8 +421,8 @@ console.log('renderRecentsItems() shows the compact IN/HAVE evidence strip on qu
     existing_min_bitrate: 320,
   }]);
   assertContains(html, 'r-evidence', 'evidence strip rendered on quality rows');
-  assertContains(html, '245k', 'incoming bitrate in strip');
-  assertContains(html, '320k', 'on-disk bitrate in strip');
+  assertContains(html, 'min 245k', 'incoming bitrate in strip, min-labelled');
+  assertContains(html, 'min 320k', 'on-disk bitrate in strip');
 }
 
 console.log('renderRecentsItems() omits the evidence strip when a row has no measurements');

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -340,6 +340,52 @@ class TestLiveBugReproductions(unittest.TestCase):
         self.assertNotEqual(r["stage2_import"], "import")
         self.assertFalse(r["imported"])
 
+    def test_olivia_rodrigo_wav_basis_metric_is_honest_min(self):
+        """BUG: the persisted basis labeled a min value "avg" (dl 36660).
+
+        Request 8781, 2026-07-11. WAV source converted to Opus (real files:
+        min 216 / avg 255) vs on-disk AAC avg 256. The decision pipeline
+        synthesized the compared measurement with avg fabricated = the
+        post-conversion MIN, so the persisted basis read "avg 216k" while
+        the V0-probe row on the same card honestly said "255kbps avg" —
+        the display-lie class #608 exists to kill, injected one seam
+        earlier at measurement synthesis. The basis must label the value
+        it classified as what it really is: the min.
+        """
+        r = full_pipeline_decision(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="genuine",
+            existing_min_bitrate=256,
+            existing_avg_bitrate=256,
+            existing_format="AAC",
+            post_conversion_min_bitrate=216,
+            converted_count=14,
+            verified_lossless_target="opus 128",
+            candidate_v0_probe_avg=255,
+            candidate_v0_probe_min=216,
+            existing_v0_probe_avg=250,
+            existing_v0_probe_kind="native_lossy_research_v0",
+        )
+        # Quality passed via the verified-lossless bypass (the rejection in
+        # production was mbid_missing, downstream of this decision).
+        self.assertEqual(r["stage2_import"], "import")
+        self.assertTrue(r["imported"])
+        basis = r["comparison_basis"]
+        assert basis is not None
+        self.assertEqual(basis["branch"], "cross_family_same_rank")
+        self.assertEqual(basis["verdict"], "equivalent")
+        self.assertTrue(basis["verified_lossless_bypass"])
+        # The honest labels: the candidate side classified the
+        # post-conversion MIN (no real avg crosses the decision interface);
+        # the existing side classified its real avg.
+        self.assertEqual(basis["new_metric"], "min",
+                         "a fabricated avg must not label a min value")
+        self.assertEqual(basis["new_value_kbps"], 216)
+        self.assertEqual(basis["existing_metric"], "avg")
+        self.assertEqual(basis["existing_value_kbps"], 256)
+
 
 class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
     """Every TestLiveBugReproductions scenario must produce the same outcome
@@ -642,6 +688,59 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
 
         self.assertNotEqual(r["stage2_import"], "import")
         self.assertFalse(r["imported"])
+
+    def test_olivia_rodrigo_wav_basis_metric_via_evidence(self):
+        """dl 36660 through the production decider: the basis labels the
+        classified candidate value "min" — the evidence carries a real avg
+        (255) but the decision interface classifies the post-conversion
+        min, and the label must say so."""
+        from lib.quality import (
+            AlbumQualityEvidenceDecisionFacts,
+            AlbumQualityV0Metric,
+            full_pipeline_decision_from_evidence,
+        )
+        from lib.quality.evidence_types import (
+            V0_SOURCE_LINEAGE_NATIVE_LOSSY_RESEARCH,
+        )
+
+        candidate = self._build_candidate(
+            is_flac=True,
+            min_bitrate=0,
+            is_cbr=False,
+            spectral_grade="genuine",
+            post_conversion_min_bitrate=216,
+            candidate_v0_probe_avg=255,
+            candidate_v0_probe_min=216,
+        )
+        current = self._build_current(
+            min_bitrate=256, avg_bitrate=256,
+            format="AAC", is_cbr=False,
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=208,
+                avg_bitrate_kbps=250,
+                median_bitrate_kbps=251,
+                source_lineage=V0_SOURCE_LINEAGE_NATIVE_LOSSY_RESEARCH,
+            ),
+        )
+
+        r = full_pipeline_decision_from_evidence(
+            candidate, current,
+            facts=AlbumQualityEvidenceDecisionFacts(
+                import_mode="auto",
+                verified_lossless_target="opus 128",
+            ),
+        )
+
+        self.assertEqual(r["stage2_import"], "import")
+        basis = r["comparison_basis"]
+        assert basis is not None
+        self.assertEqual(basis["branch"], "cross_family_same_rank")
+        self.assertTrue(basis["verified_lossless_bypass"])
+        self.assertEqual(basis["new_metric"], "min",
+                         "a fabricated avg must not label a min value")
+        self.assertEqual(basis["new_value_kbps"], 216)
+        self.assertEqual(basis["existing_metric"], "avg")
+        self.assertEqual(basis["existing_value_kbps"], 256)
 
 
 class TestPreimportFactRejects(unittest.TestCase):
@@ -989,7 +1088,6 @@ class TestPreimportFactRejects(unittest.TestCase):
         self.assertIsNone(r["final_status"])
         self.assertFalse(r["denylisted"])
         self.assertFalse(r["keep_searching"])
-
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -53,6 +53,7 @@ from lib.quality import (
     V0_SOURCE_LINEAGE_NATIVE_LOSSY_RESEARCH,
     VerifiedLosslessProof,
     classify_full_pipeline_decision,
+    compute_effective_override_bitrate,
     evidence_decision_name,
     full_pipeline_decision_from_evidence,
 )
@@ -192,6 +193,41 @@ def assert_basis_consistent(result: SimResult) -> None:
     if branch == "transcode_rank_regression" and verdict != "worse":
         raise AssertionError(
             f"transcode rank regression must be worse: {basis!r}")
+
+
+def assert_basis_metrics_truthful(
+    album: AlbumState, download: DownloadScenario, result: SimResult,
+) -> None:
+    """A basis side never claims a statistic the world didn't measure.
+
+    Download_log 36660: the decision layer synthesized the compared
+    candidate measurement with avg fabricated = the post-conversion MIN,
+    so the persisted basis read "avg 216k" beside an honest "255kbps avg"
+    V0-probe row on the same card. The rule: the flat decision interface
+    carries a real candidate avg only on the native-lossy path — both FLAC
+    paths classify the (post-conversion) min and must say "min". The
+    existing side has a real avg only when the album measured one, except
+    the deliberate CBR spectral-override clamp (its own pinned policy,
+    where a CBR album's avg IS its min). "median" never crosses the flat
+    interface on either side.
+    """
+    basis = result.comparison_basis
+    if basis is None:
+        return
+    if "median" in (basis["new_metric"], basis["existing_metric"]):
+        raise AssertionError(
+            f"median never crosses the flat interface: {basis!r}")
+    if basis["new_metric"] == "avg" and (
+            download.is_flac or download.avg_bitrate is None):
+        raise AssertionError(
+            f"candidate basis claims 'avg' but the world measured none: {basis!r}")
+    if basis["existing_metric"] == "avg" and album.avg_bitrate is None:
+        clamped_cbr = album.is_cbr and compute_effective_override_bitrate(
+            album.min_bitrate, album.spectral_bitrate, album.spectral_grade,
+        ) != album.min_bitrate
+        if not clamped_cbr:
+            raise AssertionError(
+                f"existing basis claims 'avg' but the album measured none: {basis!r}")
 
 
 _PARITY_FIELDS = (
@@ -402,6 +438,11 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
     def test_generated_basis_never_contradicts_decision(self, album, download):
         result = simulate(album, download)
         assert_basis_consistent(result)
+
+    @given(album=album_states(), download=download_scenarios())
+    def test_generated_basis_metrics_are_truthful(self, album, download):
+        result = simulate(album, download)
+        assert_basis_metrics_truthful(album, download, result)
 
     @given(album=transparent_mp3_albums(), download=download_scenarios())
     def test_measured_decisions_with_existing_carry_basis(
@@ -1005,6 +1046,59 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         bad = self._planted_basis(branch="vibes")
         with self.assertRaises(AssertionError):
             assert_basis_consistent(self._result_with_basis("import", bad))
+
+    def test_metric_truthfulness_trips_on_fabricated_flac_avg(self):
+        # The dl 36660 shape: a FLAC-source world whose basis claims the
+        # candidate classified an "avg" — no real avg crosses the flat
+        # interface on the FLAC paths.
+        album = AlbumState(
+            "planted", 256, False, None, None, False, None,
+            existing_format="AAC", avg_bitrate=256)
+        download = DownloadScenario(
+            "planted", is_flac=True, min_bitrate=0, is_cbr=False,
+            post_conversion_min_bitrate=216, converted_count=14)
+        bad = self._planted_basis(
+            new_metric="avg", new_value_kbps=216,
+            branch="cross_family_same_rank", verdict="equivalent",
+            new_rank="transparent", existing_rank="transparent")
+        with self.assertRaises(AssertionError):
+            assert_basis_metrics_truthful(
+                album, download, self._result_with_basis("downgrade", bad))
+
+    def test_metric_truthfulness_trips_on_fabricated_existing_avg(self):
+        album = AlbumState(
+            "planted", 256, False, None, None, False, None,
+            existing_format="MP3", avg_bitrate=None)
+        download = DownloadScenario(
+            "planted", is_flac=False, min_bitrate=200, is_cbr=False,
+            avg_bitrate=245)
+        bad = self._planted_basis(existing_metric="avg")
+        with self.assertRaises(AssertionError):
+            assert_basis_metrics_truthful(
+                album, download, self._result_with_basis("import", bad))
+
+    def test_metric_truthfulness_trips_on_median_claim(self):
+        album = AlbumState(
+            "planted", 256, False, None, None, False, None,
+            existing_format="MP3", avg_bitrate=256)
+        download = DownloadScenario(
+            "planted", is_flac=False, min_bitrate=200, is_cbr=False,
+            avg_bitrate=245)
+        bad = self._planted_basis(new_metric="median")
+        with self.assertRaises(AssertionError):
+            assert_basis_metrics_truthful(
+                album, download, self._result_with_basis("import", bad))
+
+    def test_metric_truthfulness_passes_honest_labels(self):
+        album = AlbumState(
+            "planted", 194, False, None, None, False, None,
+            existing_format="MP3", avg_bitrate=196)
+        download = DownloadScenario(
+            "planted", is_flac=False, min_bitrate=194, is_cbr=False,
+            avg_bitrate=288)
+        good = self._planted_basis()
+        assert_basis_metrics_truthful(
+            album, download, self._result_with_basis("import", good))
 
     def test_basis_checker_passes_a_coherent_basis(self):
         good = self._planted_basis()

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -4,11 +4,13 @@ import { awstDateTime, esc } from './util.js';
 /**
  * Render a single V0 probe value with its provenance suffix.
  *
- * - ``lossless_source_v0`` is the gold standard — render bare ("260kbps avg"),
- *   the source proof itself is the message.
- * - ``native_lossy_research_v0`` means "we measured the candidate's avg
- *   bitrate, but it's not a comparable lossless-source probe" — render
- *   "(measurement)" so the reader doesn't misread it as an upgrade signal.
+ * V0 probes run on EVERY candidate and are load-bearing operator data
+ * (Wrong Matches has surfaced them regardless of lineage all along):
+ * - ``lossless_source_v0`` is the gold standard — render bare ("260kbps
+ *   avg"), the source proof itself is the message.
+ * - ``native_lossy_research_v0`` is a real ffmpeg V0-transcode probe of a
+ *   lossy source — render "(from lossy)" so it never reads as
+ *   lossless-source proof.
  * - Anything else falls back to showing the raw kind so debug rows are
  *   still legible.
  * @param {number|string} avg
@@ -21,8 +23,26 @@ function formatV0Probe(avg, kind) {
     return base;
   }
   if (kind === 'native_lossy_research_v0') {
-    return `${base} (measurement)`;
+    return `${base} (from lossy)`;
   }
+  if (kind === 'on_disk_research_v0') {
+    return `${base} (on-disk re-encode)`;
+  }
+  return `${base} (${esc(kind)})`;
+}
+
+/**
+ * Compact strip form of a V0 probe: "V0 255k avg", research probes
+ * qualified "(from lossy)" — same vocabulary as formatV0Probe.
+ * @param {number|string} avg
+ * @param {string|undefined} kind
+ * @returns {string}
+ */
+function stripV0Phrase(avg, kind) {
+  const base = `V0 ${esc(avg)}k avg`;
+  if (!kind || kind === 'lossless_source_v0') return base;
+  if (kind === 'native_lossy_research_v0') return `${base} (from lossy)`;
+  if (kind === 'on_disk_research_v0') return `${base} (on-disk re-encode)`;
   return `${base} (${esc(kind)})`;
 }
 
@@ -119,7 +139,10 @@ export function renderEvidenceStrip(h) {
     inParts.push(basisSidePhrase(basis, 'new'));
   } else {
     if (h.downloaded_label) inParts.push(esc(h.downloaded_label));
-    if (h.actual_min_bitrate) inParts.push(`${esc(h.actual_min_bitrate)}k`);
+    // Labelled "min": bare numbers on a card that also shows avg-labelled
+    // basis and V0 values invite exactly the min-vs-avg confusion the
+    // basis exists to kill (request 8781 operator report).
+    if (h.actual_min_bitrate) inParts.push(`min ${esc(h.actual_min_bitrate)}k`);
   }
   if (h.spectral_grade) {
     // With a basis, the clamped rank value already carries the floor —
@@ -129,29 +152,30 @@ export function renderEvidenceStrip(h) {
       : h.spectral_grade === 'suspect' ? '#d66' : '#aa8';
     inParts.push(`<span style="color:${sgColor};">${floor}${esc(h.spectral_grade)}</span>`);
   }
-  if (h.v0_probe_avg_bitrate && h.v0_probe_kind === 'lossless_source_v0') {
-    inParts.push(`V0 ${esc(h.v0_probe_avg_bitrate)}k avg`);
+  // V0 on every candidate: whichever probe ran, show it (qualified when
+  // it's a research probe of a lossy source, so lineages stay legible).
+  if (h.v0_probe_avg_bitrate) {
+    inParts.push(stripV0Phrase(h.v0_probe_avg_bitrate, h.v0_probe_kind));
   }
 
   const haveParts = [];
-  // Lead with "MP3 256k" as one piece — the codec class is often the
+  // Lead with "MP3 min 256k" as one piece — the codec class is often the
   // deciding metric (a rank upgrade at equal bitrate is unreadable
-  // without it).
+  // without it), and the min label keeps it distinct from the avg-labelled
+  // basis/V0 values on the same card.
   if (basis) {
     haveParts.push(basisSidePhrase(basis, 'existing'));
   } else if (h.existing_format && h.existing_min_bitrate) {
-    haveParts.push(`${esc(h.existing_format)} ${esc(h.existing_min_bitrate)}k`);
+    haveParts.push(`${esc(h.existing_format)} min ${esc(h.existing_min_bitrate)}k`);
   } else if (h.existing_format) {
     haveParts.push(esc(h.existing_format));
   } else if (h.existing_min_bitrate) {
-    haveParts.push(`${esc(h.existing_min_bitrate)}k`);
+    haveParts.push(`min ${esc(h.existing_min_bitrate)}k`);
   }
   if (h.existing_spectral_bitrate) haveParts.push(`~${esc(h.existing_spectral_bitrate)}k`);
-  if (
-    h.existing_v0_probe_avg_bitrate
-    && h.existing_v0_probe_kind === 'lossless_source_v0'
-  ) {
-    haveParts.push(`V0 ${esc(h.existing_v0_probe_avg_bitrate)}k avg`);
+  if (h.existing_v0_probe_avg_bitrate) {
+    haveParts.push(stripV0Phrase(
+      h.existing_v0_probe_avg_bitrate, h.existing_v0_probe_kind));
   }
 
   if (inParts.length === 0 && haveParts.length === 0) return '';
@@ -170,7 +194,7 @@ export function renderEvidenceStrip(h) {
  * reads positive must not bury its reason below the grid.
  *
  * Fixed schema (issue #575): the core vocabulary — Source / Spectral /
- * Bitrate / Distance — renders on EVERY entry, with an em-dash when a
+ * Min bitrate / Distance — renders on EVERY entry, with an em-dash when a
  * side has no data, so adjacent entries never jump shape. Existing-side
  * data appears inline as "(was Xkbps)" inside the value cell, so each
  * metric is apples-to-apples on the same row. Semantic extras (V0 probe
@@ -235,27 +259,25 @@ export function renderDownloadHistoryItem(h) {
     rows.push(['Spectral', '—']);
   }
 
-  // V0 probe row: only for true lossless-source probes (kind ==
-  // 'lossless_source_v0'). Non-lossless candidates carry a v0_probe
-  // populated from their avg bitrate measurement — useful for
-  // backend policy decisions, but redundant with the Bitrate row in
-  // the UI, where the same number already appears.
+  // V0 probe row: rendered for EVERY probe kind — V0 runs on every
+  // candidate (lossless sources get the gold-standard source probe;
+  // native-lossy sources get a real ffmpeg V0-transcode research probe)
+  // and the numbers are load-bearing operator data. formatV0Probe
+  // qualifies research probes "(from lossy)" on BOTH sides, so a
+  // mixed-lineage comparison stays legible instead of being hidden.
   //
-  // The "(was X)" suffix is V0-probe-avg vs V0-probe-avg only — a true
-  // apples-to-apples comparison against the library album's recorded
-  // lossless-source probe. We deliberately do NOT fall back to the
-  // existing raw min bitrate: painting a V0-probe avg next to a
-  // container min bitrate reads as a fake upgrade (e.g. "239kbps avg
-  // (was 92kbps)" compares two different metrics). When there's no
-  // comparable existing probe, the row shows the candidate alone; the
-  // Bitrate row below already carries the min-vs-min comparison.
-  if (
-    h.v0_probe_avg_bitrate
-    && h.v0_probe_kind === 'lossless_source_v0'
-  ) {
+  // The "(was X)" suffix is V0-probe vs V0-probe only. We deliberately
+  // do NOT fall back to the existing raw min bitrate: painting a
+  // V0-probe avg next to a container min bitrate reads as a fake
+  // upgrade (e.g. "239kbps avg (was 92kbps)" compares two different
+  // metrics). When there's no existing probe, the row shows the
+  // candidate alone; the Min bitrate row below already carries the
+  // min-vs-min comparison.
+  if (h.v0_probe_avg_bitrate) {
     const candidate = formatV0Probe(h.v0_probe_avg_bitrate, h.v0_probe_kind);
     const was = h.existing_v0_probe_avg_bitrate
-      ? `${esc(h.existing_v0_probe_avg_bitrate)}kbps avg`
+      ? formatV0Probe(
+        h.existing_v0_probe_avg_bitrate, h.existing_v0_probe_kind)
       : null;
     rows.push(['V0 probe', withWas(candidate, was)]);
   }
@@ -273,19 +295,21 @@ export function renderDownloadHistoryItem(h) {
     rows.push(['Compared', compared]);
   }
 
-  // Bitrate row — apples-to-apples between candidate and existing on
-  // min bitrate (kbps). The was-side names the on-disk codec when known:
-  // "256kbps (was MP3 256kbps)" explains a rank upgrade that the bare
-  // numbers would contradict.
+  // Min bitrate row — apples-to-apples between candidate and existing on
+  // min bitrate (kbps), and the label SAYS min: an unlabelled "Bitrate:
+  // 216kbps" beside avg-labelled Compared/V0 rows is exactly the
+  // min-vs-avg confusion the operator hit on request 8781. The was-side
+  // names the on-disk codec when known: "256kbps (was MP3 256kbps)"
+  // explains a rank upgrade that the bare numbers would contradict.
   const candidateMin = h.actual_min_bitrate;
   const existingMin = h.existing_min_bitrate;
   if (candidateMin || existingMin) {
     const candidate = candidateMin ? `${esc(candidateMin)}kbps` : '—';
     const wasFmt = h.existing_format ? `${esc(h.existing_format)} ` : '';
     const was = existingMin ? `${wasFmt}${esc(existingMin)}kbps` : null;
-    rows.push(['Bitrate', withWas(candidate, was)]);
+    rows.push(['Min bitrate', withWas(candidate, was)]);
   } else {
-    rows.push(['Bitrate', '—']);
+    rows.push(['Min bitrate', '—']);
   }
 
   if (h.final_format) {


### PR DESCRIPTION
## Operator report (request 8781 / download_log 36660)

"What's 216k and what's 255k?" — the card contradicted itself. The WAV→Opus candidate's real stats are **min 216 / avg 255**, the on-disk AAC is avg 256, yet the persisted basis read "**avg** 216k", the V0 row said "255kbps avg", and the grid's "Bitrate: 216kbps" never said it was a min.

## Root cause

The decision layer synthesizes comparison measurements on the lossless paths (only the post-conversion **min** crosses the flat decision interface) and used to fabricate `avg = median = min`. `compare_quality` then honestly recorded "I classified avg=216" into the basis — the #608 display-lie class, injected one seam earlier, at measurement synthesis.

## Fix

- **No fabricated stats** (`lib/quality/pipeline.py`, `lib/quality/decisions.py`): unmeasured avg/median stay `None`; metric selection falls back to the same min value and the basis label says `min`. Value-neutral under the AVG (deployed) and MIN metrics — every consumer (rank, tiebreak, spectral clamp, gate) classifies the identical number. The CBR+override clamp is deliberately untouched (own pinned policy).
- **The UI says which statistic every number is** (`web/js/history.js`): grid row renamed **Min bitrate**; legacy strip mins render `min 216k` / `MP3 min 256k`.
- **V0 probes render for every candidate kind** — per operator: V0 runs on everything and is load-bearing. Research probes (real ffmpeg V0-transcode measurements of lossy sources — NOT the container bitrate) now show in the Recents strip + detail row on both sides, qualified `(from lossy)` / `(on-disk re-encode)`, matching the Wrong Matches convention. Stale "audit-only / redundant with Bitrate" comments rewritten (`harness/import_one.py`, `history.js`, `docs/pipeline-db-schema.md`).

## Invariant pair + verification

- Deterministic pins: the 8781 shape through **both** deciders (`test_quality_classification.py`) — basis `min 216` vs `avg 256`, `cross_family_same_rank`, `verified_lossless_bypass`. RED before the fix.
- Generated property: `assert_basis_metrics_truthful` (a basis side never claims a statistic the world didn't measure) + 4 known-bad self-tests; a replanted fabricated-avg mutant is killed by the property.
- Full suite 5200 OK · pyright 0 · `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz` burst on the quality generated module OK · live-db screenshot loop on the motivating row (mobile + desktop), PNGs read by the orchestrator.
- Opus review: no correctness findings; its three low findings (median-config scope note, `on_disk_research_v0` qualifier, recents pin tightening) addressed in the commit.

## Deploy note

Persisted pre-fix bases keep the wrong "avg" label in `download_log.import_result` JSONB. At deploy, a one-shot relabels the small since-#608 cohort where `new_value == new_measurement.min != new_measurement.avg` (no committed backfill script, per the single-operator rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)