### PR TITLE
fix(tests): truncate suite output up front — early gate failure left a stale false-green

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 
 OUT="/tmp/cratedigger-test-output.txt"
 
+# Truncate up front: an early gate failure (JS/vulture) exits before the
+# Python tee ever writes $OUT, leaving the PREVIOUS run's green unittest
+# output behind — "grep the output file" then reads as a false pass
+# (bit the 2026-07-11 honest-metrics session mid-review).
+: > "$OUT"
+
 # JS syntax check
 echo "=== JS syntax check ==="
 for f in web/js/*.js; do


### PR DESCRIPTION
One-line footgun fix from the honest-metrics session (#612): `run_tests.sh` only writes `/tmp/cratedigger-test-output.txt` via the final Python `tee`. When the JS or vulture gate fails, the script exits before touching it — the file retains the PREVIOUS run's green unittest output, and the documented "grep the output file instead of re-running" workflow reads a false pass. (Observed live: a broken JS pin + a grep saying `0` failures with a byte-identical `Ran 5200 tests in 138.783s OK` tail.)

Truncating `$OUT` at script start makes an early-gated run leave an empty file — the grep can't be fooled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)