### PR TITLE
refactor(enqueue): centralize claim outcome resolution

### DIFF
--- a/lib/enqueue.py
+++ b/lib/enqueue.py
@@ -41,6 +41,13 @@ MatchFn = Callable[
 :func:`lib.matching.check_for_match`; tests can pass a stub callable that
 controls per-user match outcomes instead of patching the module attribute."""
 
+_ClaimResolutionStatus = Literal[
+    "accepted",
+    "verified_no_acceptance",
+    "poll_recovery",
+    "failed",
+]
+
 
 @dataclass(frozen=True)
 class EnqueueAttempt:
@@ -700,6 +707,52 @@ def _handle_claimed_partial_failure(
     return claim.entry.files
 
 
+def _resolve_enqueue_claim_outcome(
+    *,
+    outcome: SlskdEnqueueOutcome,
+    claim: DownloadOwnershipClaim,
+    previously_accepted: list[DownloadFile],
+    ctx: CratediggerContext,
+    rejected_reason: str,
+    ambiguous_reason: str,
+) -> tuple[_ClaimResolutionStatus, list[DownloadFile] | None]:
+    """Resolve one enqueue result against the request ownership claim."""
+    if outcome.status == "accepted" and outcome.downloads is not None:
+        return "accepted", outcome.downloads
+
+    if outcome.status == "rejected":
+        if previously_accepted:
+            owned = _handle_claimed_partial_failure(
+                claim,
+                previously_accepted,
+                ctx,
+            )
+        else:
+            owned = _reset_claim_after_verified_no_acceptance(
+                claim,
+                ctx,
+                reason=rejected_reason,
+            )
+        if owned is not None:
+            return "poll_recovery", owned
+        if previously_accepted and not claim.claimed:
+            cancel_and_delete(previously_accepted, ctx)
+        return "verified_no_acceptance", None
+
+    if claim.claimed:
+        _stamp_enqueue_failure_reason(claim.entry.files, outcome.reason)
+        owned = _leave_claim_for_poll_recovery(
+            claim,
+            ctx,
+            reason=ambiguous_reason,
+        )
+        return "poll_recovery", owned
+
+    if previously_accepted:
+        cancel_and_delete(previously_accepted, ctx)
+    return "failed", None
+
+
 def _enqueue_with_claim_outcome(
     *,
     claim: DownloadOwnershipClaim,
@@ -985,8 +1038,17 @@ def try_enqueue(
                 file_dir=match_result.file_dir,
                 ctx=ctx,
             )
-            if outcome.status == "accepted" and outcome.downloads is not None:
-                downloads = outcome.downloads
+            resolution, resolved_downloads = _resolve_enqueue_claim_outcome(
+                outcome=outcome,
+                claim=claim,
+                previously_accepted=[],
+                ctx=ctx,
+                rejected_reason="slskd rejected enqueue",
+                ambiguous_reason="slskd enqueue outcome was ambiguous",
+            )
+            if resolution == "accepted":
+                assert resolved_downloads is not None
+                downloads = resolved_downloads
                 if not _persist_claimed_download_state(claim, downloads, ctx):
                     cancel_and_delete(downloads, ctx)
                     had_enqueue_failure = True
@@ -1004,26 +1066,21 @@ def try_enqueue(
                     candidates=tuple(accumulated),
                     pre_filter_skip_count=pre_filter_skips[0],
                 )
-            if outcome.status == "rejected":
-                owned = _reset_claim_after_verified_no_acceptance(
-                    claim,
-                    ctx,
-                    reason="slskd rejected enqueue",
+            if resolution == "poll_recovery":
+                _log_album_browse(
+                    artist_name, album_name, allowed_filetype, "single",
+                    matched=True, match_wave=match_wave,
+                    eligible=len(eligible),
+                    peers=ctx.peers_browsed - peers_before,
+                    waves=ctx.fanout_waves - waves_before,
                 )
-                if owned is not None:
-                    _log_album_browse(
-                        artist_name, album_name, allowed_filetype, "single",
-                        matched=True, match_wave=match_wave,
-                        eligible=len(eligible),
-                        peers=ctx.peers_browsed - peers_before,
-                        waves=ctx.fanout_waves - waves_before,
-                    )
-                    return EnqueueAttempt(
-                        matched=True,
-                        downloads=owned,
-                        candidates=tuple(accumulated),
-                        pre_filter_skip_count=pre_filter_skips[0],
-                    )
+                return EnqueueAttempt(
+                    matched=True,
+                    downloads=resolved_downloads,
+                    candidates=tuple(accumulated),
+                    pre_filter_skip_count=pre_filter_skips[0],
+                )
+            if resolution == "verified_no_acceptance":
                 # Verified-no-acceptance: surface the rejection in
                 # download_log so the failure is visible immediately
                 # rather than disappearing into a silent status flip.
@@ -1039,26 +1096,6 @@ def try_enqueue(
                         outcome="user_offline",
                         error_message=outcome.reason or "user offline at enqueue",
                     )
-            elif claim.claimed:
-                _stamp_enqueue_failure_reason(claim.entry.files, outcome.reason)
-                owned = _leave_claim_for_poll_recovery(
-                    claim,
-                    ctx,
-                    reason="slskd enqueue outcome was ambiguous",
-                )
-                _log_album_browse(
-                    artist_name, album_name, allowed_filetype, "single",
-                    matched=True, match_wave=match_wave,
-                    eligible=len(eligible),
-                    peers=ctx.peers_browsed - peers_before,
-                    waves=ctx.fanout_waves - waves_before,
-                )
-                return EnqueueAttempt(
-                    matched=True,
-                    downloads=owned,
-                    candidates=tuple(accumulated),
-                    pre_filter_skip_count=pre_filter_skips[0],
-                )
             had_enqueue_failure = True
             logger.info(
                 f"Failed to enqueue download to slskd for "
@@ -1312,8 +1349,25 @@ def try_multi_enqueue(
                     file_dir=file_dir,
                     ctx=ctx,
                 )
-                if outcome.status == "accepted" and outcome.downloads is not None:
-                    downloads = outcome.downloads
+                resolution, resolved_downloads = _resolve_enqueue_claim_outcome(
+                    outcome=outcome,
+                    claim=claim,
+                    previously_accepted=all_downloads,
+                    ctx=ctx,
+                    rejected_reason=(
+                        "slskd rejected first multi-disc enqueue"
+                        if not all_downloads
+                        else "slskd rejected multi-disc enqueue"
+                    ),
+                    ambiguous_reason=(
+                        "slskd enqueue outcome was ambiguous"
+                        if not all_downloads
+                        else "multi-disc enqueue outcome was ambiguous"
+                    ),
+                )
+                if resolution == "accepted":
+                    assert resolved_downloads is not None
+                    downloads = resolved_downloads
                     for file in downloads:
                         file.disk_no = disk["disk_no"]
                         file.disk_count = disk["disk_count"]
@@ -1324,62 +1378,13 @@ def try_multi_enqueue(
                         f"Failed to enqueue download to slskd for "
                         f"{artist_name} - {album_name} from {username}"
                     )
-                    if len(all_downloads) > 0:
-                        if outcome.status == "rejected":
-                            recovered = _handle_claimed_partial_failure(
-                                claim, all_downloads, ctx,
-                            )
-                            if recovered is not None:
-                                return EnqueueAttempt(
-                                    matched=True,
-                                    downloads=recovered,
-                                    candidates=tuple(accumulated),
-                                    pre_filter_skip_count=pre_filter_skips[0],
-                                )
-                        elif claim.claimed:
-                            _stamp_enqueue_failure_reason(
-                                claim.entry.files, outcome.reason)
-                            owned = _leave_claim_for_poll_recovery(
-                                claim,
-                                ctx,
-                                reason="multi-disc enqueue outcome was ambiguous",
-                            )
-                            return EnqueueAttempt(
-                                matched=True,
-                                downloads=owned,
-                                candidates=tuple(accumulated),
-                                pre_filter_skip_count=pre_filter_skips[0],
-                            )
-                        if not claim.claimed:
-                            cancel_and_delete(all_downloads, ctx)
-                    else:
-                        if outcome.status == "rejected":
-                            owned = _reset_claim_after_verified_no_acceptance(
-                                claim,
-                                ctx,
-                                reason="slskd rejected first multi-disc enqueue",
-                            )
-                            if owned is not None:
-                                return EnqueueAttempt(
-                                    matched=True,
-                                    downloads=owned,
-                                    candidates=tuple(accumulated),
-                                    pre_filter_skip_count=pre_filter_skips[0],
-                                )
-                        elif claim.claimed:
-                            _stamp_enqueue_failure_reason(
-                                claim.entry.files, outcome.reason)
-                            owned = _leave_claim_for_poll_recovery(
-                                claim,
-                                ctx,
-                                reason="slskd enqueue outcome was ambiguous",
-                            )
-                            return EnqueueAttempt(
-                                matched=True,
-                                downloads=owned,
-                                candidates=tuple(accumulated),
-                                pre_filter_skip_count=pre_filter_skips[0],
-                            )
+                    if resolution == "poll_recovery":
+                        return EnqueueAttempt(
+                            matched=True,
+                            downloads=resolved_downloads,
+                            candidates=tuple(accumulated),
+                            pre_filter_skip_count=pre_filter_skips[0],
+                        )
                     return EnqueueAttempt(
                         matched=False,
                         enqueue_failed=True,

--- a/tests/test_enqueue_fanout.py
+++ b/tests/test_enqueue_fanout.py
@@ -23,7 +23,7 @@ import configparser
 import json
 import unittest
 from dataclasses import replace
-from typing import Any, cast
+from typing import Any, Sequence, cast
 from unittest.mock import MagicMock, patch
 
 from cratedigger import TrackRecord
@@ -555,6 +555,45 @@ class TestEnqueueFailureTracking(unittest.TestCase):
 
 
 class TestDownloadOwnershipPreclaim(unittest.TestCase):
+    @staticmethod
+    def _two_disc_release_and_tracks() -> tuple[MagicMock, list[TrackRecord]]:
+        release = MagicMock()
+        release.media = [MagicMock(medium_number=1), MagicMock(medium_number=2)]
+        tracks = cast(
+            "list[TrackRecord]",
+            [
+                {"albumId": 1, "title": "Disc1 Track", "mediumNumber": 1},
+                {"albumId": 1, "title": "Disc2 Track", "mediumNumber": 2},
+            ],
+        )
+        return release, tracks
+
+    @staticmethod
+    def _match_two_discs(
+        tracks: Sequence[TrackRecord],
+        _allowed_filetype: str,
+        file_dirs: list[str],
+        username: str,
+        _ctx: CratediggerContext,
+    ) -> MatchResult:
+        disc_no = tracks[0]["mediumNumber"]
+        expected_user = "u00" if disc_no == 1 else "u01"
+        if username != expected_user:
+            return _nomatch()
+        file_dir = file_dirs[0]
+        return MatchResult(
+            matched=True,
+            directory={
+                "directory": file_dir,
+                "files": [{
+                    "filename": f"d{disc_no}.flac",
+                    "size": 111 * disc_no,
+                }],
+            },
+            file_dir=file_dir,
+            candidates=[],
+        )
+
     def test_filtered_empty_match_does_not_claim_or_enqueue(self):
         cfg = replace(_make_cfg(browse_top_k=20), download_filtering=True)
         db = FakePipelineDB()
@@ -1258,6 +1297,93 @@ class TestDownloadOwnershipPreclaim(unittest.TestCase):
 
         self.assertTrue(attempt.matched)
         self.assertEqual(db.status_history, [(1, "downloading")])
+
+    def test_multi_disc_first_ambiguous_outcome_stamps_all_planned_files(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db)
+        results = _make_results(["u00", "u01"])
+        release, tracks = self._two_disc_release_and_tracks()
+        reason = "first disc enqueue response was uncertain"
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 return_value=SlskdEnqueueOutcome(
+                     status="unknown",
+                     reason=reason,
+                 ),
+             ):
+            attempt = try_multi_enqueue(
+                release,
+                tracks,
+                results,
+                "flac",
+                ctx,
+                match_fn=self._match_two_discs,
+            )
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        state_raw = db.request(1)["active_download_state"]
+        state = json.loads(state_raw) if isinstance(state_raw, str) else state_raw
+        self.assertEqual(len(state["files"]), 2)
+        self.assertEqual(
+            [file["last_exception"] for file in state["files"]],
+            [f"enqueue failed: {reason}"] * 2,
+        )
+
+    def test_multi_disc_later_ambiguous_outcome_keeps_accepted_transfer(self):
+        cfg = _make_cfg(browse_top_k=20)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1, status="wanted"))
+        slskd = FakeSlskdAPI()
+        ctx = _ctx_with_download_ownership(cfg=cfg, db=db, slskd=slskd)
+        results = _make_results(["u00", "u01"])
+        release, tracks = self._two_disc_release_and_tracks()
+        reason = "second disc enqueue response was uncertain"
+        enqueue_calls = 0
+
+        def fake_enqueue(*, username, files, file_dir, ctx, **_ledger_kwargs):
+            nonlocal enqueue_calls
+            enqueue_calls += 1
+            if enqueue_calls == 2:
+                return SlskdEnqueueOutcome(status="unknown", reason=reason)
+            return SlskdEnqueueOutcome(status="accepted", downloads=[
+                DownloadFile(
+                    filename=files[0]["filename"],
+                    id="transfer-1",
+                    file_dir=file_dir,
+                    username=username,
+                    size=files[0]["size"],
+                ),
+            ])
+
+        with patch("lib.enqueue._fanout_browse_users", return_value=set()), \
+             patch(
+                 "lib.enqueue.slskd_enqueue_with_outcome",
+                 side_effect=fake_enqueue,
+             ):
+            attempt = try_multi_enqueue(
+                release,
+                tracks,
+                results,
+                "flac",
+                ctx,
+                match_fn=self._match_two_discs,
+            )
+
+        self.assertTrue(attempt.matched)
+        self.assertEqual(db.request(1)["status"], "downloading")
+        self.assertEqual(slskd.transfers.cancel_download_calls, [])
+        state_raw = db.request(1)["active_download_state"]
+        state = json.loads(state_raw) if isinstance(state_raw, str) else state_raw
+        self.assertEqual(len(state["files"]), 2)
+        self.assertEqual(
+            [file["last_exception"] for file in state["files"]],
+            [f"enqueue failed: {reason}"] * 2,
+        )
 
     def test_multi_disc_partial_failure_resets_after_verified_cancel(self):
         cfg = _make_cfg(browse_top_k=20)


### PR DESCRIPTION
## Summary

Enqueue result handling now has one ownership-resolution path, so accepted, rejected, and ambiguous outcomes cannot silently drift between single- and multi-disc downloads. This reduces the chance of repeating the evidence-loss class fixed in #564 while preserving the existing recovery behavior.

The resolver owns claim reset, partial-transfer cleanup, failure-evidence stamping, and poll-recovery selection. The callers retain only their browse logging and result mapping. A first review round identified that multi-disc ambiguous outcomes lacked parity coverage; this PR now pins both first-disc ambiguity and ambiguity after an earlier disc was accepted.

Related: #572

## Validation

- Full suite: 5,203 tests passed after rebasing onto current `main`.
- Targeted enqueue/recovery suite: 225 tests passed during independent review.
- Pyright: 0 errors, 0 warnings, 0 informations.
- Independent full review round 2: 9 reviewer lenses, no findings or residual risks.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is an internal behavior-preserving refactor with no schema, configuration, API, or operator-visible change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
