### PR TITLE
fix(web): never hide owned/in-flight pressings; mobile pressing-row layout

### DIFF
--- a/docs/debug-webui-rendering.md
+++ b/docs/debug-webui-rendering.md
@@ -19,7 +19,7 @@ The server-side pagination fix is deployed and working:
 
 ## Frontend code to investigate
 
-The rendering logic is in `web/index.html`, function `loadReleaseGroup()` (around line 268):
+The rendering logic is in `web/js/discography.js`, function `loadReleaseGroup()` (around line 268):
 
 ```javascript
 async function loadReleaseGroup(id, el) {
@@ -30,8 +30,7 @@ async function loadReleaseGroup(id, el) {
     const r = await fetch(`${API}/api/release-group/${id}`);
     const data = await r.json();
     const all = (data.releases || []).sort(...);
-    const official = all.filter(r => r.status === 'Official' || !r.status);
-    const bootleg = all.filter(r => r.status && r.status !== 'Official');
+    const { visible, hidden } = splitPressings(all);  // owned/in-flight never hidden
     // ... renderRelease() for each, set relEl.innerHTML
   } catch (e) { relEl.innerHTML = '<div class="loading">Failed to load</div>'; }
 }

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -83,7 +83,11 @@ Browser → https://music.ablz.au
   download history, status / min-bitrate / intent controls) fetched from
   `/api/beets/album/<id>`.
 - **Release editions** — when you expand a release group, shows all editions sorted by date
-  - Official releases first, bootleg/promo collapsed
+  - Official releases first, bootleg/promo collapsed — EXCEPT pressings that
+    are in the library or have a pipeline request, which are always hoisted
+    into the visible list with a `promo`/`bootleg` provenance chip
+    (`splitPressings` in `web/js/discography.js`; an owned pressing is never
+    hidden, whatever its status)
   - Releases already in pipeline DB or beets library are badged
   - Click release metadata to open MB release page in new tab
 - **Add button** — adds release to pipeline DB (same logic as `pipeline-cli add`)

--- a/tests/test_js_analysis.mjs
+++ b/tests/test_js_analysis.mjs
@@ -74,7 +74,8 @@ console.log('renderRecordingsBlock() — markers stay with titles');
     ],
   };
   const html = renderRecordingsBlock(rg);
-  assertContains(html, 'Recordings:', 'heading present');
+  assertContains(html, 'Recordings', 'heading present');
+  assertContains(html, 'type-header', 'heading styled as a section header (separates the block from Bootleg / Promo)');
   // Single-span rows: marker and title inside one <span> (the flex
   // justify-between fix from PR3's screenshot loop).
   assertContains(html, '●</span></span>Only On P0', 'dot adjacent to partial-coverage title');

--- a/tests/test_js_discography.mjs
+++ b/tests/test_js_discography.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_discography.mjs
  */
 
-import { synthesizeMasterlessRow } from '../web/js/discography.js';
+import { synthesizeMasterlessRow, splitPressings, statusChipHtml } from '../web/js/discography.js';
 
 let passed = 0;
 let failed = 0;
@@ -70,6 +70,102 @@ console.log('synthesizeMasterlessRow() — in-library payload keeps quality fiel
   assertEqual(row.library_min_bitrate, 900, 'library_min_bitrate forwarded');
   assertEqual(row.library_rank, 'lossless', 'library_rank forwarded');
   assertEqual(row.format, '?', 'empty formats fall back to ?');
+}
+
+console.log('splitPressings() — owned/in-flight pressings are never hidden (The Meadowlands pin)');
+{
+  // Live confusion (request 4228, The Wrens "The Meadowlands"): the
+  // library copy is the 2002 US Promotion pressing, which the old split
+  // buried inside the collapsed Bootleg / Promo section — the expansion
+  // contradicted the row's "in library · wanted" badges.
+  const rows = [
+    { id: 'cef6b0f6', status: 'Promotion', in_library: true, pipeline_status: 'wanted' },
+    { id: '2aa0ae0e', status: 'Bootleg', in_library: false, pipeline_status: null },
+    { id: 'fef45b67', status: 'Official', in_library: false, pipeline_status: 'downloading' },
+    { id: 'a0fadcc2', status: 'Official', in_library: false, pipeline_status: null },
+  ];
+  const { visible, hidden } = splitPressings(rows);
+  assertEqual(visible.some(r => r.id === 'cef6b0f6'), true, 'owned promo is visible');
+  assertEqual(hidden.some(r => r.id === 'cef6b0f6'), false, 'owned promo not hidden');
+  assertEqual(hidden.length, 1, 'only the unowned bootleg is hidden');
+  assertEqual(hidden[0].id, '2aa0ae0e', 'unowned bootleg stays in the collapsed bucket');
+  assertEqual(visible.length, 3, 'officials + owned promo visible');
+}
+
+console.log('splitPressings() — partition + hoist invariants over the status/ownership space');
+{
+  const statuses = [undefined, '', 'Official', 'Promotion', 'Bootleg', 'Pseudo-Release'];
+  const ownerships = [
+    { in_library: false, pipeline_status: null },
+    { in_library: true, pipeline_status: null },
+    { in_library: false, pipeline_status: 'downloading' },
+    { in_library: true, pipeline_status: 'wanted' },
+    { in_library: false, pipeline_status: 'imported' },
+    { in_library: false, pipeline_status: 'manual' },
+    { in_library: false, pipeline_status: 'replaced' },
+    { in_library: true, pipeline_status: 'replaced' },
+  ];
+  let n = 0;
+  const rows = [];
+  for (const status of statuses) {
+    for (const own of ownerships) {
+      rows.push({ id: `r${n++}`, status, ...own });
+    }
+  }
+  const { visible, hidden } = splitPressings(rows);
+  assertEqual(visible.length + hidden.length, rows.length, 'every row lands in exactly one bucket');
+  for (const r of rows) {
+    const inVisible = visible.includes(r);
+    const inHidden = hidden.includes(r);
+    assertEqual(inVisible !== inHidden, true, `${r.id} in exactly one bucket`);
+    // 'replaced' is the terminal frozen-audit status — an abandoned
+    // request is NOT an active claim on the pressing and must not pin it.
+    const owned = r.in_library === true
+      || (!!r.pipeline_status && r.pipeline_status !== 'replaced');
+    const official = r.status === 'Official' || !r.status;
+    if (owned || official) {
+      assertEqual(inVisible, true, `${r.id} (status=${r.status}, owned=${owned}) must be visible`);
+    } else {
+      assertEqual(inHidden, true, `${r.id} (status=${r.status}, unowned non-official) must be hidden`);
+    }
+  }
+}
+
+console.log('splitPressings() — a replaced-only pipeline row does not pin (frozen audit, badge-less)');
+{
+  // badges.js renders no badge for 'replaced', so hoisting such a row
+  // would put an unexplained bootleg in the main list. Only in_library
+  // or an ACTIVE pipeline status pins.
+  const rows = [
+    { id: 'abandoned', status: 'Bootleg', in_library: false, pipeline_status: 'replaced' },
+    { id: 'owned-abandoned', status: 'Promotion', in_library: true, pipeline_status: 'replaced' },
+  ];
+  const { visible, hidden } = splitPressings(rows);
+  assertEqual(hidden.length, 1, 'unowned replaced bootleg stays collapsed');
+  assertEqual(hidden[0].id, 'abandoned', 'the replaced-only row is the hidden one');
+  assertEqual(visible.length, 1, 'library ownership still pins a replaced row');
+  assertEqual(visible[0].id, 'owned-abandoned', 'in_library wins over replaced');
+}
+
+console.log('splitPressings() — known-bad self-check: the OLD split violates the hoist invariant');
+{
+  // Prove the assertion above actually constrains something: the
+  // pre-fix split (status-only) hides the owned promo.
+  const rows = [{ id: 'x', status: 'Promotion', in_library: true, pipeline_status: null }];
+  const oldHidden = rows.filter(r => r.status && r.status !== 'Official');
+  assertEqual(oldHidden.length, 1, 'old split hides the owned promo (the bug)');
+  assertEqual(splitPressings(rows).hidden.length, 0, 'new split does not');
+}
+
+console.log('statusChipHtml() — non-official pressings get a provenance chip');
+{
+  assertEqual(statusChipHtml('Official'), '', 'Official -> no chip');
+  assertEqual(statusChipHtml(''), '', 'empty -> no chip');
+  assertEqual(statusChipHtml(undefined), '', 'missing -> no chip');
+  assertEqual(statusChipHtml('Promotion').includes('promo'), true, 'Promotion -> promo chip');
+  assertEqual(statusChipHtml('Promotion').includes('badge-nonofficial'), true, 'chip uses the nonofficial badge class');
+  assertEqual(statusChipHtml('Bootleg').includes('bootleg'), true, 'Bootleg -> bootleg chip');
+  assertEqual(statusChipHtml('Pseudo-Release').includes('pseudo-release'), true, 'other statuses lowercased verbatim');
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/web/index.html
+++ b/web/index.html
@@ -42,7 +42,7 @@
   .rg-year { color: #777; font-size: 0.85em; }
   .rg-meta { color: #777; font-size: 0.8em; }
   .releases { margin-top: 6px; padding-left: 12px; }
-  .release { display: flex; justify-content: space-between; align-items: center; padding: 8px 10px; background: #222; border-radius: 6px; margin-bottom: 0; cursor: pointer; }
+  .release { display: flex; justify-content: space-between; align-items: center; gap: 4px 6px; padding: 8px 10px; background: #222; border-radius: 6px; margin-bottom: 0; cursor: pointer; }
   /* Search-by-ID target ring. Persistent until close-artist / mode-switch / next paste. */
   .release.search-target { background: #1a2a22; box-shadow: 0 0 0 2px #6a9; }
   .rg.search-target { background: #1a2a22; border-left-color: #6a9; box-shadow: 0 0 0 2px #6a9; }
@@ -50,6 +50,14 @@
   .release-info { flex: 1; }
   .release-title { font-size: 0.9em; }
   .release-meta { color: #777; font-size: 0.75em; }
+  /* Phone widths: the action buttons don't shrink, so give the
+     title/meta column the full first line and let the buttons wrap
+     beneath it instead of crushing the text into a sliver. Must come
+     AFTER the base .release-info rule — same specificity, order wins. */
+  @media (max-width: 640px) {
+    .release { flex-wrap: wrap; justify-content: flex-start; }
+    .release-info { flex: 1 1 100%; min-width: 0; }
+  }
   .release-detail { background: #1a1a1a; padding: 10px 12px; margin: 0 0 4px 0; border-radius: 0 0 6px 6px; display: none; font-size: 0.85em; }
   .release-detail.open { display: block; }
   .release-detail .lib-track { font-size: 0.85em; color: #888; padding: 1px 0; display: flex; justify-content: space-between; }
@@ -59,7 +67,8 @@
   .btn-add { background: #2a5a2a; color: #8d8; }
   .btn-add:hover { background: #3a6a3a; }
   .btn-add:disabled { background: #333; color: #666; cursor: default; }
-  .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.7em; font-weight: 600; margin-left: 6px; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.7em; font-weight: 600; margin-left: 6px; white-space: nowrap; }
+  .badge-nonofficial { background: #2f2a38; color: #a9b; }
   .badge-new { background: #1a4a2a; color: #6d6; }
   .badge-upgraded { background: #1a4a2a; color: #6d6; }
   .badge-rejected { background: #4a1a1a; color: #d66; }

--- a/web/js/analysis.js
+++ b/web/js/analysis.js
@@ -29,12 +29,12 @@ export const _PRESSING_COLORS = ['#6af','#fa6','#6d6','#f6a','#af6','#6ff','#ff6
  */
 export function analysisChipHtml(rg) {
   if (rg.covered_by) {
-    return `<span style="color:#777;font-size:0.85em;margin-left:6px;">covered by ${esc(rg.covered_by)}</span>`;
+    return `<span style="color:#777;font-size:0.85em;margin-left:6px;white-space:nowrap;">covered by ${esc(rg.covered_by)}</span>`;
   }
   if (rg.unique_track_count > 0) {
-    return `<span style="color:#6d6;font-weight:600;margin-left:6px;">${rg.unique_track_count} unique</span>`;
+    return `<span style="color:#6d6;font-weight:600;margin-left:6px;white-space:nowrap;">${rg.unique_track_count} unique</span>`;
   }
-  return '<span style="color:#555;margin-left:6px;">0 unique</span>';
+  return '<span style="color:#555;margin-left:6px;white-space:nowrap;">0 unique</span>';
 }
 
 /**
@@ -93,7 +93,11 @@ export function computeRecordingDots(rg) {
 export function renderRecordingsBlock(rg) {
   if (!rg.tracks || rg.tracks.length === 0) return '';
   const { trackToPressings, totalPressings } = computeRecordingDots(rg);
-  let html = '<div style="margin:8px 0 4px;color:#888;font-size:0.85em;">Recordings:</div>';
+  // Styled like the collapsible sub-section headers (Bootleg / Promo)
+  // so the block reads as its own section of the expansion, not as a
+  // tracklist of whichever pressing row happens to render above it.
+  let html = '<div class="type-header" style="cursor:default;padding-left:0;" '
+    + 'onclick="event.stopPropagation()">Recordings <span class="type-count">across pressings</span></div>';
   // One span per row — .lib-track is flex justify-between, so marker
   // and title must live together or they get pushed to opposite edges.
   html += rg.tracks.map(t => {
@@ -146,13 +150,15 @@ export function applyAnalysisToExpansion(relEl, rgId) {
     const exCount = pressingExclusiveCounts[i];
     if (exCount > 0) {
       title.insertAdjacentHTML('beforeend',
-        `<span style="color:${color};font-weight:600;margin-left:6px;">${exCount} exclusive</span>`);
+        `<span style="color:${color};font-weight:600;margin-left:6px;white-space:nowrap;">${exCount} exclusive</span>`);
     }
   });
   const block = renderRecordingsBlock(rg);
   if (block) {
+    // border-top separator: without it the block visually attaches to
+    // the Bootleg / Promo sub-section rendered directly above it.
     relEl.insertAdjacentHTML('beforeend',
-      `<div class="disamb-recordings" style="padding:4px 10px 8px;">${block}</div>`);
+      `<div class="disamb-recordings" style="padding:4px 10px 8px;margin-top:10px;border-top:1px solid #2a2a2a;">${block}</div>`);
   }
 }
 

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -174,6 +174,48 @@ export function synthesizeMasterlessRow(data) {
 }
 
 /**
+ * Split a release group's date-sorted pressing rows into the visible
+ * list and the collapsed Bootleg / Promo bucket.
+ *
+ * Invariant: a pressing the operator owns (``in_library``) or has an
+ * ACTIVE pipeline request on is NEVER hidden, whatever its status — the
+ * collapsed bucket only ever holds unowned, inactive non-official
+ * pressings. The Wrens "The Meadowlands" (request 4228) is the pin: its
+ * library copy is a Promotion pressing, and the old status-only split
+ * buried it in the collapsed section, making the expansion contradict
+ * the row header's "in library · wanted" badges.
+ *
+ * ``replaced`` does not pin: it's the terminal frozen-audit status (the
+ * overlay carries it through unfiltered), renders no badge, and an
+ * abandoned request is not a claim on the pressing.
+ *
+ * @param {Array<Object>} rows - Pressing rows (overlay fields present).
+ * @returns {{visible: Object[], hidden: Object[]}}
+ */
+export function splitPressings(rows) {
+  const pinned = (r) => r.in_library === true
+    || (!!r.pipeline_status && r.pipeline_status !== 'replaced');
+  const official = (r) => r.status === 'Official' || !r.status;
+  return {
+    visible: rows.filter(r => official(r) || pinned(r)),
+    hidden: rows.filter(r => !official(r) && !pinned(r)),
+  };
+}
+
+/**
+ * Provenance chip for non-official pressings ("promo", "bootleg", ...).
+ * Rendered on every non-official pressing row so a hoisted row (see
+ * splitPressings) carries its provenance into the main list.
+ * @param {string|undefined} status - MB release status.
+ * @returns {string} '' for Official / missing status.
+ */
+export function statusChipHtml(status) {
+  if (!status || status === 'Official') return '';
+  const label = status === 'Promotion' ? 'promo' : status.toLowerCase();
+  return `<span class="badge badge-nonofficial">${esc(label)}</span>`;
+}
+
+/**
  * Load and display releases for a release group.
  *
  * @param {string} id - MusicBrainz release group ID or Discogs master ID
@@ -228,8 +270,7 @@ export async function loadReleaseGroup(id, el, opts = {}) {
       ? [synthesizeMasterlessRow(data)]
       : (data.releases || []);
     const all = releaseRows.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
-    const official = all.filter(r => r.status === 'Official' || !r.status);
-    const bootleg = all.filter(r => r.status && r.status !== 'Official');
+    const { visible, hidden } = splitPressings(all);
 
     // For MB release-group endpoints the parent ``id`` IS the
     // release_group_id. For Discogs masters it is the master id, which
@@ -298,21 +339,21 @@ export async function loadReleaseGroup(id, el, opts = {}) {
       return renderReleaseRow({
         dataReleaseId: rel.id,
         onclick: `event.stopPropagation(); window.toggleReleaseDetail('${rel.id}')`,
-        titleHtml: `${esc(rel.title)}${badges}`,
+        titleHtml: `${esc(rel.title)}${statusChipHtml(rel.status)}${badges}`,
         metaLines: [`${rel.country || '?'} ${rel.date || '?'} - ${rel.format} - ${rel.track_count}t - ${rel.status || '?'}`],
         actionsHtml: `${toolbar}${replaceBtn}${spBtn}`,
         detail: { id: `reldet-${rel.id}` },
       });
     }
 
-    let html = official.map(renderRelease).join('');
-    if (bootleg.length > 0) {
+    let html = visible.map(renderRelease).join('');
+    if (hidden.length > 0) {
       html += `
         <div class="type-header" onclick="event.stopPropagation(); window.toggleSection(this)" style="color:#777;margin-top:6px;">
-          Bootleg / Promo <span class="type-count">${bootleg.length}</span>
+          Bootleg / Promo <span class="type-count">${hidden.length}</span>
         </div>
         <div class="type-body">
-          ${bootleg.map(renderRelease).join('')}
+          ${hidden.map(renderRelease).join('')}
         </div>
       `;
     }


### PR DESCRIPTION
Motivated by The Wrens "The Meadowlands" (request 4228): the library copy is a **Promotion** pressing, so the expansion's status-only split buried it in the collapsed Bootleg / Promo section — the row header said "in library · wanted" while the expansion appeared to show nothing owned. At phone widths the pressing rows also collapsed into overlapping text/buttons.

## Changes

- **`splitPressings`** (new pure fn in `web/js/discography.js`): a pressing that is `in_library` or has an ACTIVE pipeline request is never hidden, whatever its MB status. `replaced` (terminal frozen-audit, renders no badge) does not pin. Hoisted rows carry a dim `promo`/`bootleg` provenance chip (`statusChipHtml`, `.badge-nonofficial`).
- **Mobile layout**: at ≤640px `.release` wraps so action buttons drop below the title/meta column; `.badge` gets `white-space: nowrap` so badges/chips wrap as whole units. (The media block must sit AFTER the base `.release-info` rule — same specificity, source order wins; round 1 of the screenshot loop caught exactly this.)
- **Recordings breakdown** gets a type-header heading + border-top separator so it stops visually attaching to the Bootleg / Promo section above it.

## Tests

Meadowlands deterministic pin; partition + hoist invariant sweep over status × ownership (incl. `replaced`/`imported`/`manual`); known-bad self-check proving the OLD split violates the invariant; `statusChipHtml` table. Full suite 5203 OK, pyright clean.

## Verification

Live-db dev-server screenshot loop at 390px and 1280px on the real Meadowlands data (3 rounds; round 1 caught the CSS-order defect). Opus review round: `replaced`-hoist edge found and fixed with RED-first tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)