### PR TITLE
Fix bad-rip cleanup for relative Beets paths

### DIFF
--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -431,6 +431,14 @@ printf 'a\n' | beet import ...  # Blindly accepts ANY match without inspection.
                                 # Use the harness instead — it lets you verify MBID and distance.
 ```
 
+Cratedigger's explicit Bad rip and Replace actions are the narrow exceptions:
+they route destructive removal through `lib/release_cleanup.py`, which invokes
+the pinned Beets with the exact release selector. The rendered Beets `clutter`
+list includes the exact derived filename `cratedigger.json`, allowing Beets to
+prune a directory whose managed audio and sidecar are all gone. Any file that
+does not match the configured clutter patterns prevents pruning and remains
+untouched.
+
 ## The Beets SQLite Database
 
 Located at `/mnt/virtio/Music/beets-library.db`. Two main tables:

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -63,6 +63,13 @@ class ReleaseLocation:
 DEFAULT_BEETS_DB = os.environ.get("BEETS_DB", "/mnt/virtio/Music/beets-library.db")
 
 
+def _resolve_library_path(path: str, library_root: str) -> str:
+    """Anchor a Beets-relative path to its configured library root."""
+    if library_root and not os.path.isabs(path):
+        return os.path.join(library_root, path)
+    return path
+
+
 def _reduce_album_format(
     formats_on_disk: set[str],
     cfg: "QualityRankConfig",
@@ -159,6 +166,13 @@ class BeetsDB:
         if isinstance(raw, bytes):
             return raw.decode("utf-8", errors="replace")
         return str(raw)
+
+    def _resolve_path(self, raw: object) -> str:
+        """Decode a stored path and apply the one library-root policy."""
+        return _resolve_library_path(
+            self._decode_path(raw),
+            self._library_root,
+        )
 
     def locate(self, release_id: str) -> ReleaseLocation:
         """Resolve a pipeline ``mb_release_id`` to a ``ReleaseLocation``.
@@ -395,9 +409,7 @@ class BeetsDB:
         # relative to the library root in production; absolutize so
         # downstream FS consumers (snapshot_audio_files, spectral_analyze,
         # os.path.isdir checks) work regardless of cwd.
-        first_path = self._decode_path(rows[0][1])
-        if self._library_root and not os.path.isabs(first_path):
-            first_path = os.path.join(self._library_root, first_path)
+        first_path = self._resolve_path(rows[0][1])
         album_path = os.path.dirname(first_path)
 
         # Reduce multi-format albums via cfg.mixed_format_precedence.
@@ -436,7 +448,7 @@ class BeetsDB:
         rows = self._conn.execute(
             "SELECT id, path FROM items WHERE album_id = ?", (album_id,)
         ).fetchall()
-        return [(r[0], self._decode_path(r[1])) for r in rows]
+        return [(r[0], self._resolve_path(r[1])) for r in rows]
 
     def get_album_path(self, mb_release_id: str) -> Optional[str]:
         """Get the directory path for an album's tracks. Returns None if not found."""
@@ -460,7 +472,7 @@ class BeetsDB:
         ).fetchone()
         if not row or not row[0]:
             return None
-        return os.path.dirname(self._decode_path(row[0]))
+        return os.path.dirname(self._resolve_path(row[0]))
 
     # ── Web UI query methods ────────────────────────────────────────
 
@@ -598,7 +610,7 @@ class BeetsDB:
             "id": i[0], "title": i[1], "artist": i[2], "track": i[3],
             "disc": i[4], "length": i[5], "format": i[6],
             "bitrate": i[7], "samplerate": i[8], "bitdepth": i[9],
-            "path": self._decode_path(i[10]) if i[10] else None,
+            "path": self._resolve_path(i[10]) if i[10] else None,
         } for i in items]
         album_path = os.path.dirname(tracks[0]["path"]) if tracks and tracks[0]["path"] else None
         identity = ReleaseIdentity.from_fields(album[4], album[10])
@@ -608,7 +620,7 @@ class BeetsDB:
             "mb_albumid": identity.release_id if identity else None,
             "type": album[5],
             "label": album[6], "country": album[7],
-            "artpath": self._decode_path(album[8]) if album[8] else None,
+            "artpath": self._resolve_path(album[8]) if album[8] else None,
             "added": album[9], "tracks": tracks, "path": album_path,
             "source": identity.source if identity else "unknown",
         }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -60,13 +60,20 @@
   #   - paths / asciify_paths — path-affecting keys; drift here plus the
   #     importer's post-import `beet move` reproduces the 2026-05-18
   #     asciify mass-split (1,178 albums).
+  #   - clutter includes the exact derived sidecar name `cratedigger.json` so
+  #     the canonical `beet remove -d` bad-rip/Replace cleanup can prune a
+  #     sidecar-only album directory. Files outside the configured clutter
+  #     patterns still block Beets pruning.
   beetsSettings = let
     bc = cfg.beets.config;
   in {
     directory = bc.directory;
     library = bc.library;
     asciify_paths = true;
-    clutter = ["Thumbs.DB" "Thumbs.db" ".DS_Store" "*.jpg" "*.png" "AlbumArt*" "Folder.*" "desktop.ini"];
+    clutter = [
+      "Thumbs.DB" "Thumbs.db" ".DS_Store" "*.jpg" "*.png" "AlbumArt*"
+      "Folder.*" "desktop.ini" "cratedigger.json"
+    ];
     import = {
       copy = false;
       write = true;

--- a/tests/test_bad_rip_generated.py
+++ b/tests/test_bad_rip_generated.py
@@ -1,0 +1,143 @@
+"""Generated invariants for bad-rip path and sidecar cleanup."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from beets import util as beets_util
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from lib.beets_db import _resolve_library_path
+from lib.sidecar import SIDECAR_FILENAME
+
+
+_COMPONENT = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Ll", "Lu", "Nd"),
+        whitelist_characters=" -_'’",
+    ),
+    min_size=1,
+    max_size=30,
+).filter(lambda value: value not in {".", ".."})
+
+
+def assert_resolved_path_invariant(
+    *, stored_path: str, library_root: str, resolved_path: str,
+) -> None:
+    """A configured root anchors relative paths and preserves absolutes."""
+    expected = (
+        stored_path
+        if os.path.isabs(stored_path)
+        else os.path.join(library_root, stored_path)
+    )
+    if resolved_path != expected:
+        raise AssertionError(
+            f"resolved {resolved_path!r}, expected {expected!r}"
+        )
+
+
+def assert_clutter_cleanup_invariant(
+    *, had_foreign_file: bool, album_dir_exists: bool,
+    sidecar_exists: bool, foreign_file_exists: bool,
+) -> None:
+    """Only a sidecar-only directory may be pruned."""
+    if had_foreign_file:
+        if not (album_dir_exists and sidecar_exists and foreign_file_exists):
+            raise AssertionError("foreign content was not preserved")
+    elif album_dir_exists or sidecar_exists:
+        raise AssertionError("sidecar-only directory survived cleanup")
+
+
+class TestBadRipGenerated(unittest.TestCase):
+    @given(
+        components=st.lists(_COMPONENT, min_size=2, max_size=5),
+        absolute=st.booleans(),
+    )
+    @example(
+        components=[
+            "The Rolling Stones",
+            "1964 - England's Newest Hit Makers",
+            "01 Not Fade Away.opus",
+        ],
+        absolute=False,
+    )
+    def test_beets_paths_resolve_for_filesystem_consumers(
+        self, components: list[str], absolute: bool,
+    ) -> None:
+        root = "/mnt/virtio/Music/Beets"
+        relative = os.path.join(*components)
+        stored = os.path.join(os.sep, "other", relative) if absolute else relative
+        resolved = _resolve_library_path(stored, root)
+        assert_resolved_path_invariant(
+            stored_path=stored,
+            library_root=root,
+            resolved_path=resolved,
+        )
+
+    @given(
+        had_foreign_file=st.booleans(),
+        foreign_name=_COMPONENT.filter(lambda value: value != SIDECAR_FILENAME),
+    )
+    @example(had_foreign_file=False, foreign_name="operator.keep")
+    @example(had_foreign_file=True, foreign_name="operator.keep")
+    def test_beets_clutter_prunes_only_derived_sidecar(
+        self, had_foreign_file: bool, foreign_name: str,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            album_dir = os.path.join(root, "Artist", "Album")
+            os.makedirs(album_dir)
+            sidecar = os.path.join(album_dir, SIDECAR_FILENAME)
+            with open(sidecar, "w", encoding="utf-8") as handle:
+                handle.write("{}")
+            foreign = os.path.join(album_dir, foreign_name)
+            if had_foreign_file:
+                with open(foreign, "w", encoding="utf-8") as handle:
+                    handle.write("keep")
+
+            beets_util.prune_dirs(
+                album_dir,
+                root,
+                clutter=[SIDECAR_FILENAME],
+            )
+
+            assert_clutter_cleanup_invariant(
+                had_foreign_file=had_foreign_file,
+                album_dir_exists=os.path.isdir(album_dir),
+                sidecar_exists=os.path.isfile(sidecar),
+                foreign_file_exists=os.path.isfile(foreign),
+            )
+
+
+class TestInvariantCheckersTripOnKnownBad(unittest.TestCase):
+    def test_relative_path_left_unanchored_trips(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "expected"):
+            assert_resolved_path_invariant(
+                stored_path="Artist/Album/01.flac",
+                library_root="/music",
+                resolved_path="Artist/Album/01.flac",
+            )
+
+    def test_sidecar_only_directory_left_behind_trips(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "survived"):
+            assert_clutter_cleanup_invariant(
+                had_foreign_file=False,
+                album_dir_exists=True,
+                sidecar_exists=True,
+                foreign_file_exists=False,
+            )
+
+    def test_foreign_file_deleted_trips(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "preserved"):
+            assert_clutter_cleanup_invariant(
+                had_foreign_file=True,
+                album_dir_exists=False,
+                sidecar_exists=False,
+                foreign_file_exists=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -930,6 +930,46 @@ class TestGetItemPaths(unittest.TestCase):
         self.assertEqual(len(paths), 2)
         self.assertEqual(paths[0][1], "/m/a/01.mp3")
 
+    def test_relative_paths_and_album_dir_resolve_against_library_root(
+        self,
+    ) -> None:
+        """Bad-rip hashing must never receive cwd-relative Beets paths."""
+        _insert_album(self.db_path, 1, "rolling-stones-release", [
+            (
+                128000,
+                "The Rolling Stones/1964 - England's Newest Hit Makers/"
+                "01 Not Fade Away.opus",
+            ),
+        ])
+        library_root = "/mnt/virtio/Music/Beets"
+        with BeetsDB(self.db_path, library_root=library_root) as db:
+            paths = db.get_item_paths("rolling-stones-release")
+            album_path = db.get_album_path_by_id(1)
+
+        expected_album = os.path.join(
+            library_root,
+            "The Rolling Stones/1964 - England's Newest Hit Makers",
+        )
+        self.assertEqual(
+            paths,
+            [(1, os.path.join(expected_album, "01 Not Fade Away.opus"))],
+        )
+        self.assertEqual(album_path, expected_album)
+
+    def test_absolute_item_paths_pass_through_with_library_root(self) -> None:
+        _insert_album(self.db_path, 1, "absolute-release", [
+            (320000, "/other/library/Artist/Album/01.flac"),
+        ])
+        with BeetsDB(
+            self.db_path,
+            library_root="/mnt/virtio/Music/Beets",
+        ) as db:
+            paths = db.get_item_paths("absolute-release")
+            album_path = db.get_album_path_by_id(1)
+
+        self.assertEqual(paths, [(1, "/other/library/Artist/Album/01.flac")])
+        self.assertEqual(album_path, "/other/library/Artist/Album")
+
     def test_not_found(self) -> None:
         with BeetsDB(self.db_path) as db:
             paths = db.get_item_paths("nonexistent")

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -128,6 +128,48 @@ assert did_neutralize_mb is False, did_neutralize_mb
 assert mb_item_data.get("mb_albumid") == "11111111-2222-3333-4444-555555555555", \
     mb_item_data.get("mb_albumid")
 print("DISCOGS_NEUTRALIZE_OK")
+
+# --- Bad-rip derived-sidecar cleanup contract. ``beet remove -d`` delegates
+# to Album.remove(delete=True), which prunes a directory only when every
+# remaining file matches the exact clutter list. Our sidecar is derived state;
+# an unknown sentinel must still block pruning.
+from beets import config
+
+def cleanup_world(*, foreign_file):
+    with tempfile.TemporaryDirectory() as d:
+        album_dir = os.path.join(d, "The Rolling Stones", "1964 - Album")
+        os.makedirs(album_dir)
+        audio_path = os.path.join(album_dir, "01.flac")
+        with open(audio_path, "wb") as f:
+            f.write(b"audio")
+        sidecar_path = os.path.join(album_dir, "cratedigger.json")
+        with open(sidecar_path, "w", encoding="utf-8") as f:
+            f.write("{}")
+        sentinel_path = os.path.join(album_dir, "operator.keep")
+        if foreign_file:
+            with open(sentinel_path, "w", encoding="utf-8") as f:
+                f.write("keep")
+
+        lib = library.Library(os.path.join(d, "lib.db"), d)
+        item = library.Item(
+            title="Track", artist="Artist", album="Album",
+            albumartist="Artist", path=audio_path,
+        )
+        album = lib.add_album([item])
+        config["clutter"].set(["cratedigger.json"])
+        album.remove(delete=True)
+
+        assert not os.path.exists(audio_path), audio_path
+        if foreign_file:
+            assert os.path.isdir(album_dir), album_dir
+            assert os.path.isfile(sidecar_path), sidecar_path
+            assert os.path.isfile(sentinel_path), sentinel_path
+        else:
+            assert not os.path.exists(album_dir), album_dir
+
+cleanup_world(foreign_file=False)
+cleanup_world(foreign_file=True)
+print("BAD_RIP_CLEANUP_OK")
 '''
 
 
@@ -149,6 +191,7 @@ class TestHarnessBeets2Contract(unittest.TestCase):
         self.assertIn("LIBRARY_OK", proc.stdout)
         self.assertIn("CONTRACT_OK", proc.stdout)
         self.assertIn("DISCOGS_NEUTRALIZE_OK", proc.stdout)
+        self.assertIn("BAD_RIP_CLEANUP_OK", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -263,6 +263,16 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
         text = MODULE_NIX.read_text(encoding="utf-8")
         self.assertIn(f'plugins = "{self.PRODUCTION_PLUGINS}";', text)
 
+    def test_cratedigger_sidecar_is_exact_beets_clutter(self) -> None:
+        """Beet remove may prune our sidecar, never arbitrary leftovers."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        match = re.search(r"clutter = \[(.*?)\];", text, re.DOTALL)
+        self.assertIsNotNone(match)
+        assert match is not None
+        clutter = match.group(1)
+        self.assertIn('"cratedigger.json"', clutter)
+        self.assertNotIn('"cratedigger.*"', clutter)
+
     def test_permissions_plugin_configured_with_media_server_friendly_modes(
         self,
     ) -> None:

--- a/tests/web/test_server_threading.py
+++ b/tests/web/test_server_threading.py
@@ -12,11 +12,13 @@ the three load-bearing properties:
    configured, while the injected-handle path (this very harness)
    keeps returning the shared object.
 """
+import configparser
 import http.client
 import os
 import sys
 import threading
 import time
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -236,6 +238,84 @@ class TestPerThreadDbHandles(unittest.TestCase):
         t.start(); t.join(timeout=10)
         self.assertEqual(seen, [sentinel])
         self.assertIs(srv._db(), sentinel)
+
+
+class TestPerThreadBeetsHandles(unittest.TestCase):
+    """Production Beets handles carry the configured library root."""
+
+    def setUp(self):
+        from web import server as srv
+        self._srv = srv
+        self._saved_path = srv.beets_db_path
+        self._saved_root = srv.beets_library_root
+        self._saved_injected = srv._beets
+        self._saved_dsn = srv._db_dsn
+        self._saved_mb_api_base = srv.mb_api.MB_API_BASE
+        self._saved_discogs_api_base = srv._discogs.DISCOGS_API_BASE
+
+    def tearDown(self):
+        self._srv._close_thread_handles()
+        self._srv.beets_db_path = self._saved_path
+        self._srv.beets_library_root = self._saved_root
+        self._srv._beets = self._saved_injected
+        self._srv._db_dsn = self._saved_dsn
+        self._srv.mb_api.MB_API_BASE = self._saved_mb_api_base
+        self._srv._discogs.DISCOGS_API_BASE = self._saved_discogs_api_base
+
+    def test_constructor_receives_library_root(self):
+        from lib.config import CratediggerConfig
+
+        srv = self._srv
+        ini = configparser.ConfigParser()
+        ini["Beets"] = {"directory": "/mnt/virtio/Music/Beets"}
+        cfg = CratediggerConfig.from_ini(ini)
+        with tempfile.NamedTemporaryFile() as db_file:
+            srv.beets_db_path = db_file.name
+            srv._beets = None
+
+            with patch("lib.config.read_runtime_config", return_value=cfg):
+                srv._configure_beets_library_root_from_runtime_config()
+                handle = srv._beets_db()
+
+            self.assertIsNotNone(handle)
+            assert handle is not None
+            self.assertEqual(
+                handle._library_root,  # noqa: SLF001 - constructor seam
+                "/mnt/virtio/Music/Beets",
+            )
+
+    def test_main_executes_runtime_root_wiring(self):
+        """Production boot must load the root before opening the server."""
+        from lib.config import CratediggerConfig
+
+        class BootStop(Exception):
+            pass
+
+        srv = self._srv
+        ini = configparser.ConfigParser()
+        ini["Beets"] = {"directory": "/boot-config/Music/Beets"}
+        cfg = CratediggerConfig.from_ini(ini)
+        with tempfile.NamedTemporaryFile() as db_file, patch.object(
+            sys,
+            "argv",
+            [
+                "server.py",
+                "--dsn",
+                str(TEST_DSN),
+                "--beets-db",
+                db_file.name,
+            ],
+        ), patch(
+            "lib.config.read_runtime_config",
+            return_value=cfg,
+        ), patch(
+            "web.server.ThreadingHTTPServer",
+            side_effect=BootStop,
+        ):
+            with self.assertRaises(BootStop):
+                srv.main()
+
+        self.assertEqual(srv.beets_library_root, "/boot-config/Music/Beets")
 
 
 if __name__ == "__main__":

--- a/web/server.py
+++ b/web/server.py
@@ -113,6 +113,7 @@ _db_dsn = None
 # shared handle and the caller owns its thread-safety.
 db: PipelineDB | None = None
 beets_db_path: str | None = None
+beets_library_root: str = ""
 _beets: BeetsDB | None = None
 
 # Per-thread DB handles. Threads are mostly long-lived: the Handler
@@ -183,9 +184,20 @@ def _beets_db() -> BeetsDB | None:
         return None
     handle = getattr(_thread_state, "beets", None)
     if handle is None:
-        handle = BeetsDB(beets_db_path)
+        handle = BeetsDB(
+            beets_db_path,
+            library_root=beets_library_root,
+        )
         _thread_state.beets = handle
     return handle
+
+
+def _configure_beets_library_root_from_runtime_config() -> None:
+    """Load the canonical Beets directory for per-thread path resolution."""
+    from lib.config import read_runtime_config
+
+    global beets_library_root
+    beets_library_root = read_runtime_config().beets_directory
 
 
 def _close_thread_handles() -> None:
@@ -504,7 +516,7 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main():
-    global beets_db_path
+    global beets_db_path, beets_library_root
 
     parser = argparse.ArgumentParser(description="Cratedigger Web UI")
     parser.add_argument("--port", type=int, default=8085)
@@ -545,6 +557,11 @@ def main():
     # then serves a clear 503 mirror-required (R13).
     from web.api_bases import configure_api_bases_from_runtime_config
     configure_api_bases_from_runtime_config()
+    # The same module-rendered [Beets] directory value that drives the
+    # importer must anchor paths read from the relative-path Beets DB. Without
+    # it, filesystem consumers such as bad-rip hashing resolve paths from the
+    # web service's cwd and silently miss every imported track.
+    _configure_beets_library_root_from_runtime_config()
     if args.mb_api:
         mb_api.MB_API_BASE = args.mb_api
     if args.discogs_api:


### PR DESCRIPTION
## Summary

- anchor Beets paths to the configured library root before bad-rip hashing and other filesystem consumers
- classify the exact derived `cratedigger.json` sidecar as Beets clutter so canonical remove cleanup prunes sidecar-only directories while preserving non-clutter files
- add deterministic live-case pins, generated path/cleanup invariants with known-bad self-tests, and a real pinned-Beets removal contract

## Verification

- `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz nix-shell --run "python3 -m unittest tests.test_bad_rip_generated -v"`
- `nix-shell --run "pyright"`
- `nix-shell --run "bash scripts/run_tests.sh"` (5213 tests)
- `nix build .#checks.x86_64-linux.moduleVm`
- pre-push generated fuzz burst + `nix flake check`

## Live incident cleanup

Request 8853 was returned to a clean `wanted` state before implementation: download log 36697 was removed through `pipeline-cli wrong-match-delete`, and the positively identified sidecar-only album directory was pruned with an exact-MBID fail-closed one-shot.
