### PR TITLE
test: audit stale code references in living docs

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -238,6 +238,10 @@ Tools within the method, for quality-decision bugs specifically:
 - Don't build infrastructure without wiring it up. Every new function, dataclass, or mode must be called from production code. If it's only reachable via manual config nobody sets, it's dead code.
 - Before marking any feature complete, trace the full path from trigger to effect. Ask: "Does this actually run in production without manual intervention?" If not, it's not done.
 - A new dataclass that nothing constructs, a config option nobody sets, a fallback that never triggers — these are all incomplete work, not shipped features.
+- Comments and docstrings describe contracts and capabilities, not brittle
+  cardinality. Do not write claims such as "the seven methods" when the
+  surface can grow; name the methods only when each identity matters, or
+  describe the shared contract the open-ended set implements.
 
 ## No Parallel Code Paths
 - Never create a second function that calls the same subprocess (import_one.py, beets_harness.py, etc.). If a new entry point needs the pipeline, write an adapter that constructs the existing function's inputs and delegates. If the interface makes this painful, fix the interface — don't route around it.
@@ -249,7 +253,7 @@ Tools within the method, for quality-decision bugs specifically:
 - Both surfaces wrap the same service-layer method (e.g. `SearchPlanService.advance_for_request`). The CLI subcommand and the HTTP handler are thin adapters with matched outcome → exit-code / outcome → status-code mappings. Never duplicate logic across the two; route everything through the service.
 - Reference layout (worked example: `search-plan advance` in PR for the cursor-advance feature):
   - `lib/<thing>_service.py` — service method + typed `Result` dataclass (one outcome string per branch)
-  - `lib/pipeline_db.py` — atomic mutation with `FOR UPDATE` row lock
+  - `lib/pipeline_db/` — atomic mutation with `FOR UPDATE` row lock
   - `scripts/pipeline_cli/<family>.py` — CLI subcommand wrapping the service (the CLI is a package split by command family, issue #495; ``cli.py`` registers the handler in the dispatch dict, ``routes_meta.py`` adds the argparse subparser)
   - `web/routes/<thing>.py` — HTTP endpoint wrapping the service
   - `tests/test_<thing>_service.py` — authoritative coverage of every outcome branch
@@ -268,10 +272,10 @@ Before writing any new code, decide which test types you owe and what infrastruc
 | A new dispatch / orchestration path | An orchestration test asserting domain state + an integration slice | `FakePipelineDB`, `patch_dispatch_externals()`, `tests/test_integration_slices.py` |
 | A new web API endpoint | A contract test with `REQUIRED_FIELDS` AND `classified=True` on the route's `RouteRegistration` (enforced by `TestRouteContractAudit`) AND a paired `pipeline-cli` subcommand (CLI ⇄ API symmetry) | `_FakeDbWebServerCase` + `_assert_required_fields` from `tests/web/_harness.py`, the matching `tests/web/test_routes_<module>.py`, `scripts/pipeline_cli/` |
 | A new operator action (CLI subcommand or API endpoint) | A service-layer method with a typed `Result`, BOTH a CLI subcommand AND an API endpoint, exit-code and status-code tests for each | `tests/test_<service>.py` for the authoritative coverage; CLI/API tests check the wrapper only |
-| A new slskd interaction | An orchestration test using `FakeSlskdAPI` | `FakeSlskdAPI` from `tests/fakes.py` |
+| A new slskd interaction | An orchestration test using `FakeSlskdAPI` | `FakeSlskdAPI` from `tests/fakes/` |
 | A new typed dataclass | A pure test of construction + serialization, and a builder in `tests/helpers.py` if it crosses test boundaries | `tests/helpers.py` |
-| A new `PipelineDB` method | An equivalent stub on `FakePipelineDB`, with a self-test in `tests/test_fakes.py` | `tests/fakes.py`, `tests/test_fakes.py` |
-| A new `BeetsDB` method | Either (a) an equivalent stub on `FakeBeetsDB` with a self-test in `tests/test_fakes.py::TestFakeBeetsDB`, OR (b) drive the test against a real test SQLite DB if it's a read-only query | `tests/fakes.py`, `tests/test_fakes.py` |
+| A new `PipelineDB` method | An equivalent stub on `FakePipelineDB`, with a self-test in `tests/test_fakes.py` | `tests/fakes/`, `tests/test_fakes.py` |
+| A new `BeetsDB` method | Either (a) an equivalent stub on `FakeBeetsDB` with a self-test in `tests/test_fakes.py::TestFakeBeetsDB`, OR (b) drive the test against a real test SQLite DB if it's a read-only query | `tests/fakes/`, `tests/test_fakes.py` |
 | A feature with policy invariants (pure decisions, lifecycle / state machine, wire or event ingestion) | Generated properties + strategies in the same PR, each invariant checker with a known-bad self-test; invariants written down FIRST | `tests/_hypothesis_profiles.py`, checker/strategy patterns in `tests/test_*_generated.py`, `docs/generated-testing.md` |
 | A documented surface (a module option, a beets plugin, an operator action / CLI subcommand, the permission/ownership model, or a subsystem's documented behavior) | The doc update in the SAME PR (README / `docs/` / `examples/` / CLAUDE.md) — docs are part of done, not a follow-up | `tests/test_docs_audit.py` (structural coverage: plugins, CLI, dead-links, option descriptions); the relevant `docs/*.md` |
 
@@ -304,8 +308,8 @@ Four categories of tests. Each has different rules for what's acceptable. **All 
   - `validation_result` / `import_result` preserved
   - filesystem side effects (cleanup, staging)
 - Mocking is allowed for external edges (subprocess, meelo, plex), but the assertion target must be domain state.
-- **Use `FakePipelineDB` from `tests/fakes.py` for stateful collaborators instead of MagicMock.** It records request rows, download_logs, denylist entries, cooldowns, status history, spectral state updates. See `tests/test_fakes.py` for the full API.
-- **Use `FakeSlskdAPI` from `tests/fakes.py` for slskd interactions.** Stateful `transfers` and `users` fakes with `add_transfer()`, `queue_download_snapshots()`, `set_directory()`, `set_directory_error()`, configurable errors, and call recording.
+- **Use `FakePipelineDB` from `tests/fakes/` for stateful collaborators instead of MagicMock.** It records request rows, download_logs, denylist entries, cooldowns, status history, spectral state updates. See `tests/test_fakes.py` for the full API.
+- **Use `FakeSlskdAPI` from `tests/fakes/` for slskd interactions.** Stateful `transfers` and `users` fakes with `add_transfer()`, `queue_download_snapshots()`, `set_directory()`, `set_directory_error()`, configurable errors, and call recording.
 - Use `make_ctx_with_fake_db(fake_db)` from `tests/helpers.py` to wire `FakePipelineDB` into a `CratediggerContext`.
 - Use builders from `tests/helpers.py` — never hand-roll 20-field dicts.
 
@@ -335,7 +339,7 @@ Always use these instead of inventing parallel scaffolding:
 - `noop_quality_gate(**kwargs) -> None` — drop-in `quality_gate_fn` stub for dispatch tests that don't care about the post-import gate. Pair with `dispatch_import_core(..., quality_gate_fn=noop_quality_gate)`.
 - `RecordingQualityGate()` — recorder `quality_gate_fn` with `assert_called_once()` / `assert_not_called()` / `call_count` / `calls` (list of kwargs). For tests that assert the gate ran with specific args.
 
-**`tests/fakes.py`** — stateful fakes:
+**`tests/fakes/`** — stateful fakes:
 - `FakePipelineDB` — full PipelineDB stand-in: requests, download_logs, denylist, cooldowns, status history, spectral state, attempt counters. Includes `assert_log()` helper. Has `queue_execute_results(*cursors)` + `execute_calls` recording for tests driving raw-SQL CLI paths.
 - `FakeBeetsDB` — minimal BeetsDB stand-in: `album_exists`, `get_album_info(mb_release_id, cfg)`, `get_all_album_ids_for_release`, `get_item_paths`, `get_album_path_by_id`, `close` + context-manager + per-method call recorders + seed helpers (`set_album_exists`, `set_album_info`, `set_album_ids_for_release`, `set_item_paths`, `set_album_path_by_id`). Each method also has a `_default` field for "any key returns the same value" tests. Extend the surface only when a test exercises a new BeetsDB method.
 - `FakeSlskdAPI` — stateful slskd client: `transfers` (enqueue, get_all_downloads, cancel_download, queued snapshots), `users` (directory with per-directory results and errors), call recording.
@@ -350,7 +354,7 @@ Always use these instead of inventing parallel scaffolding:
 `MagicMock` and `patch(...)` are for the **outermost edge** of the test — where our code calls something external we don't own. They are forbidden as a substitute for our own stateful types or our own pure-logic functions. Zero-tolerance: enforced by `tests/test_mock_audit.py` against the allowlist in `tests/_mock_audit_scanner.py`.
 
 **Forbidden:**
-- `MagicMock()` assigned to a variable named `db`, `mock_db`, `failing_db`, `pdb`, `ctx`, `context`, `beets`, `beets_db`, `source`, `pipeline_db`, `slskd`, `fake_db`. Use `FakePipelineDB` / `FakeBeetsDB` / `FakeSlskdAPI` from `tests/fakes.py`.
+- `MagicMock()` assigned to a variable named `db`, `mock_db`, `failing_db`, `pdb`, `ctx`, `context`, `beets`, `beets_db`, `source`, `pipeline_db`, `slskd`, `fake_db`. Use `FakePipelineDB` / `FakeBeetsDB` / `FakeSlskdAPI` from `tests/fakes/`.
 - `patch("lib.X.our_function")` for any target not on the allowlist. If you're mocking your own logic, you're testing the mock.
 - `patch("lib.beets_db.BeetsDB.<method>")`. The class constructor is allowlisted; per-method stubbing isn't — use `FakeBeetsDB`.
 - Allowlisting a pure decision function. Drive the test with real inputs that produce the branch you care about — fixtures usually already exist in the decision's own coverage.
@@ -371,7 +375,7 @@ When adding a wrapper to the allowlist, include a one-line rationale next to the
 4. **Allowlist (last resort).** Only if the target is a thin wrapper around an external boundary.
 
 **Adding a new `PipelineDB` / `BeetsDB` / `SlskdAPI` method:**
-1. Add a state-respecting implementation to the corresponding `Fake*` in `tests/fakes.py`.
+1. Add a state-respecting implementation to the corresponding `Fake*` in `tests/fakes/`.
 2. Add a self-test in `tests/test_fakes.py`.
 3. Tests consume the fake; they do NOT do `mock_db.new_method.return_value = ...`.
 

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -67,10 +67,11 @@ result = resolve_youtube_album(
 **What this catches:** the round 1 #1 bug. `_resolve_mb_group` expected `mb_get_release(rg_mbid)` to return `None` on 404, but the real adapter raised `HTTPError`. Every test used `lambda: None` so the production crash never surfaced.
 
 **Helper rule:** if you find yourself writing `lambda m: None` to fake a mirror lookup, that is a smell — the production adapter doesn't return None on the documented failure mode. Either:
-- Use a documented stand-in (`tests/fakes.py::FakeMBLookup(raises_on_404=True)`), or
+- Use a documented stand-in (`tests/fakes/__init__.py::FakeMBLookup(raises_on_404=True)`), or
 - Inline the real exception class via `lambda m: (_ for _ in ()).throw(urllib.error.HTTPError(...))`.
 
-The first form is preferred — if the helper doesn't exist yet, add it to `tests/fakes.py` with the exception contract documented in its docstring.
+The first form is preferred — if the helper doesn't exist yet, add it to
+`tests/fakes/` with the exception contract documented in its docstring.
 
 ## Stronger enforcement (future work)
 
@@ -85,7 +86,7 @@ Make `PipelineDB.upsert_*` methods accept typed `msgspec.Struct` instances inste
 
 The album_title bug becomes impossible to express.
 
-### 2. `tests/test_pipeline_db_audit.py` (medium ROI, low effort)
+### 2. `tests/test_pipeline_db_write_audit.py` (medium ROI, low effort)
 
 A test that:
 - Introspects `PipelineDB` via `inspect` for every `upsert_*` / `add_*` / `update_*` method

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -49,8 +49,8 @@ Advisory locks are:
 
 ## Namespaces
 
-All namespace constants live in `lib/pipeline_db.py`. The key space is
-PostgreSQL's two-arg `pg_advisory_lock(int4, int4)` — first arg is the
+All namespace constants live in `lib/pipeline_db/_shared.py`. The key space is
+PostgreSQL's two-arg `pg_try_advisory_lock(int4, int4)` — first arg is the
 namespace, second is the per-lock key.
 
 | Namespace | Constant | Hex | ASCII | Key | Scope |
@@ -114,7 +114,7 @@ it.
 `zlib.crc32` mask of the (`.strip()`-normalised) release id string.
 Covers both MB UUIDs and Discogs numeric IDs since both share the
 `mb_release_id` column. See the docstring on `release_id_to_lock_key`
-in `lib/pipeline_db.py` for the collision analysis (probability
+in `lib/pipeline_db/_shared.py` for the collision analysis (probability
 ~N²/2^31; false collision delays an unrelated release by one cycle).
 
 ### PLAN — per-request plan-generation lock
@@ -341,7 +341,7 @@ session and returns False — revisit the ordering rules.
 | Force/manual outer | `lib/dispatch/entry_points.py` | `dispatch_import_from_db` | IMPORT | `request_id` |
 | Replace operator action | `lib/mbid_replace_service.py` | `MbidReplaceService.replace_request_mbid` | IMPORT | `request_id` |
 | Importer worker singleton | `scripts/importer.py` | `main` | IMPORTER | `1` |
-| Import queue dedupe | `lib/pipeline_db.py` | `enqueue_import_job` | unique index | `dedupe_key` |
+| Import queue dedupe | `lib/pipeline_db/` | `enqueue_import_job` | unique index | `dedupe_key` |
 | Plan generation | `lib/search_plan_service.py` | `SearchPlanService.generate_for_new_request` / `generate_for_request` | PLAN | `request_id` |
 | Wrong-match cleanup | `lib/wrong_match_cleanup_service.py` | `cleanup_wrong_match` | WMCL | `wrong_match_cleanup_lock_key(request_id, download_log_id, resolved_path)` |
 
@@ -358,7 +358,7 @@ are intentionally omitted — grep for `advisory_lock(` to find them.
 To add a new lock:
 
 1. Pick a namespace constant with an ASCII-recognisable hex value (make
-   `pg_locks` debuggable). Define it in `lib/pipeline_db.py` next to
+   `pg_locks` debuggable). Define it in `lib/pipeline_db/_shared.py` next to
    the existing `ADVISORY_LOCK_NAMESPACE_*` constants.
 2. Decide key derivation. Natural-int keys (request_id) are trivial.
    String keys need a stable hash — use `zlib.crc32(...) & 0x7FFFFFFF`

--- a/docs/async-downloads-plan.md
+++ b/docs/async-downloads-plan.md
@@ -45,7 +45,7 @@ The plan file is the living record. If the implementation diverges, the plan mus
 
 ### Commit 1: Schema migration — add `downloading` status and `active_download_state` JSONB
 
-**Files**: `lib/pipeline_db.py`
+**Files**: `lib/pipeline_db/`
 
 **Tests first** (RED): `tests/test_pipeline_db.py`
 - `test_downloading_status_allowed`: insert row, update to `downloading`, verify roundtrip
@@ -55,7 +55,7 @@ The plan file is the living record. If the implementation diverges, the plan mus
 
 **Implementation** (GREEN):
 
-`lib/pipeline_db.py` changes:
+`lib/pipeline_db/` changes:
 
 1. **Migrate status CHECK constraint** in `init_schema()` — add idempotent DDL:
    ```python
@@ -130,7 +130,7 @@ The plan file is the living record. If the implementation diverges, the plan mus
 
 ### Commit 2: ActiveDownloadState dataclass with JSON round-trip
 
-**Files**: `lib/quality.py` (where all typed dataclasses live)
+**Files**: `lib/quality/` (where the typed quality structures now live)
 
 **Tests first** (RED): `tests/test_import_result.py` (where dataclass serialization tests live)
 - `test_active_download_state_to_json`: serialize, verify JSON structure
@@ -141,7 +141,7 @@ The plan file is the living record. If the implementation diverges, the plan mus
 
 **Implementation** (GREEN):
 
-Add to `lib/quality.py`:
+Add to the `lib/quality/` package:
 
 ```python
 @dataclass
@@ -208,7 +208,8 @@ class ActiveDownloadState:
         return ActiveDownloadState.from_dict(json.loads(s))
 ```
 
-**Note**: `json` import already exists in `lib/quality.py` (used by `ImportResult.to_json()`).
+**Note**: the quality package owns the JSON round trip used by
+`ImportResult.to_json()`.
 
 **Convention**: Follow the existing `from_dict`/`from_json` pattern used by `ImportResult`, `ValidationResult`, etc. `from_dict` is the primary constructor (works directly with Python dicts, which is what psycopg2 returns for JSONB columns). `from_json` is a thin wrapper: `from_dict(json.loads(s))`.
 
@@ -644,7 +645,7 @@ if refreshed and refreshed["status"] == "downloading":
 
 ### Commit 6b: Defense-in-depth — clear `active_download_state` in existing DB methods
 
-**Files**: `lib/pipeline_db.py`
+**Files**: `lib/pipeline_db/`
 
 **Why**: `reset_to_wanted()` and `update_status()` are called from many places (quality gate,
 mark_done, reject_and_requeue, dispatch_import_core). If any of these runs on an album that still has
@@ -875,12 +876,12 @@ from lib.download import (cancel_and_delete as _cancel_and_delete_impl,
 - `web/routes/pipeline.py` ~line 293: validates allowed statuses for `post_pipeline_update` — do NOT add `downloading` here (users shouldn't manually set this status)
 - `web/routes/pipeline.py` ~line 395: validates allowed statuses for quality endpoint — add `"downloading"` if quality info should be viewable for in-progress downloads
 
-**pipeline-cli** (`scripts/pipeline_cli.py`):
+**pipeline-cli** (`scripts/pipeline_cli/`):
 - ~line 150: `for status in ["wanted", "imported", "manual"]` — add `"downloading"` to status count display
 - ~line 174: `VALID_STATUSES = ["wanted", "imported", "manual"]` — do NOT add `downloading` here (users shouldn't `pipeline-cli set <id> downloading`)
 - `pipeline-cli show`: display `active_download_state` when present (enqueued_at, file count, filetype)
 
-**Tests first** (RED): `tests/test_web_server.py`, `tests/test_pipeline_cli.py`
+**Tests first** (RED): `tests/web/`, `tests/test_pipeline_cli.py`
 - `test_status_counts_includes_downloading`: verify `/api/pipeline/status` returns downloading count
 - `test_pipeline_all_includes_downloading`: verify `get_pipeline_all` returns downloading albums
 - `test_pipeline_cli_status_shows_downloading`: verify `pipeline-cli status` shows downloading count

--- a/docs/audio-classification-research.md
+++ b/docs/audio-classification-research.md
@@ -30,7 +30,6 @@ The current detector lives primarily in:
 - `lib/spectral_check.py`
 - `lib/quality/`
 - `lib/download.py`
-- `scripts/spectral_corpus.py`
 
 ### Track-level method
 
@@ -164,8 +163,8 @@ The original corpus script was a consistency check, not a truth test.
 
 ## The Evaluation Harness
 
-To move beyond a pure same-model rescan, `scripts/spectral_corpus.py` was
-extended into a proper evaluation harness.
+To move beyond a pure same-model rescan, the now-retired spectral corpus
+runner was extended into a proper evaluation harness.
 
 The harness now does three kinds of work:
 
@@ -190,7 +189,7 @@ The harness also exports raw evidence:
 - cliff vs. HF-only suspect counts
 - nominal bitrate stats from the files on disk
 
-Helper tests live in `tests/test_spectral_corpus.py`.
+The runner's likewise-retired helper tests pinned its evidence shape.
 
 ## Synthetic Ground-Truth Findings
 
@@ -443,7 +442,7 @@ The best candidate for this is `vamp-lossy-encoding-detector`.
 
 If the integration friction is acceptable, it should be used as:
 
-- an offline comparison backend in `scripts/spectral_corpus.py`
+- an offline comparison backend in the retired spectral corpus runner
 - then an optional shadow backend in the live pipeline
 
 ### 3. Adopt profile-aware logic internally
@@ -503,7 +502,7 @@ The second is not.
 ### High priority
 
 - add a shadow backend for `vamp-lossy-encoding-detector`
-- extend `scripts/spectral_corpus.py` to compare Cratedigger vs. external detectors
+- extend the retired spectral corpus runner to compare Cratedigger vs. external detectors
 - record disagreement sets in machine-readable output
 - keep building a labeled edge corpus from:
   - failed imports
@@ -567,6 +566,5 @@ Relevant local files:
 - `lib/spectral_check.py`
 - `lib/quality/`
 - `lib/download.py`
-- `scripts/spectral_corpus.py`
-- `tests/test_spectral_corpus.py`
+- the retired spectral corpus runner and its helper tests
 - `docs/quality-verification.md`

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -187,7 +187,7 @@ The harness (`harness/beets_harness.py`) is a custom `ImportSession` subclass th
 
 ### Why the Harness Exists
 
-`beet import` is designed for interactive terminal use — it prints colored text, waits for keyboard input, and has no machine-readable output. The harness subclasses `ImportSession` and overrides `choose_match()`, `choose_item()`, `resolve_duplicate()`, and `should_resume()` to communicate via newline-delimited JSON instead.
+`beet import` is designed for interactive terminal use — it prints colored text, waits for keyboard input, and has no machine-readable output. The harness subclasses `ImportSession` and overrides `choose_match()`, `choose_item()`, `get_duplicate_action()`, and `should_resume()` to communicate via newline-delimited JSON instead.
 
 ### Running the Harness
 
@@ -554,7 +554,8 @@ A full library health check found:
 
 ### Validation Script
 
-`scripts/audio_health_check.py` in the tagging-workspace repo:
+`tagging-workspace/scripts/audio_health_check.py` in the separate
+tagging-workspace repo:
 ```bash
 python3 scripts/audio_health_check.py --ext mp3 --workers 8  # Full MP3 decode, 8 parallel
 python3 scripts/audio_health_check.py --ext flac              # FLAC integrity check

--- a/docs/beets-rpc-design.md
+++ b/docs/beets-rpc-design.md
@@ -129,7 +129,7 @@ that need beets' own cache coherence**.
 
 ### Client shape
 
-`lib/beets_rpc_client.py`, new file. Replaces `lib/beets_album_op.py`
+The proposed `beets_rpc_client` module replaces `lib/beets_album_op.py`
 subprocess primitives.
 
 ```python
@@ -180,7 +180,8 @@ Typed helpers return `msgspec.Struct` types, decoded via
 
 Once all callsites are ported:
 
-- **`lib/beets_album_op.py`** → replaced by `lib/beets_rpc_client.py`.
+- **`lib/beets_album_op.py`** → replaced by the proposed
+  `beets_rpc_client` module.
   5 invariants collapse to "spawn rpc, call method". No stdin
   prompts (we pass `delete_files=True` in JSON). No rc parsing (we
   get `{"ok": false, "error": {...}}`). No PATH/PYTHONPATH
@@ -286,11 +287,11 @@ its own — the old subprocess path stays until every callsite is
 ported.
 
 1. **Build `beets_rpc.py` server with `remove_album_by_id` only.**
-   Write it in `harness/beets_rpc.py`. Update
+   Write it in the proposed `beets_rpc` harness. Update
    `harness/run_beets_harness.sh` to be a no-arg spawn. Add unit
    tests for the one method. Don't wire into production yet.
 2. **Build `BeetsRpc` client with typed helpers.** Add
-   `FakeBeetsRpc` in `tests/fakes.py`. Write integration slice in
+   `FakeBeetsRpc` in `tests/fakes/`. Write integration slice in
    `tests/test_integration_slices.py` that spawns a real RPC
    against an ephemeral beets DB and asserts `remove_album_by_id`
    works.

--- a/docs/dead-code.md
+++ b/docs/dead-code.md
@@ -24,7 +24,9 @@ Deleting a vulture-flagged helper frequently exposes a **deeper orphan** that wa
 - **PR #358** — deleting `finalize_request_if_plan_current` orphaned `PipelineDB.is_request_plan_current` (its only reader)
 - **PR #360** — deleting `move_album` orphaned `BeetsOpResult.new_path` (only set by `move_album`)
 - **PR #363 → #364** — deleting `_select_variant_for_album` (in #356) exposed `build_query` and `select_variant`; deleting those exposed `strip_short_tokens`
-- **PR #355** — deleting all three public exports of `lib/import_service.py` left `_apply_request_spectral_fields` as a cascading orphan that justified deleting the whole module
+- **PR #355** — deleting all three public exports of the former import-service
+  module left `_apply_request_spectral_fields` as a cascading orphan that
+  justified deleting the whole module
 
 The mechanic is simple but easy to miss: vulture's whitelist contains an entry per known orphan, keyed by name. When a helper goes away, its callees lose their last reference but aren't in the whitelist yet (they were "used" before). The next `vulture --make-whitelist` run will surface them, and `bash scripts/find_dead_code.sh` will go red until you either delete them or accept them as new whitelist entries.
 

--- a/docs/meelo-primer.md
+++ b/docs/meelo-primer.md
@@ -254,9 +254,11 @@ Example: `2006 - Let Me Introduce My Friends` and `2007 - Let Me Introduce My Fr
 
 If both the embedded `album` tags differ (e.g., `Interpol` vs `Interpol [EP]`), Meelo correctly creates separate albums — these are different works, not different editions.
 
-See `docs/008-meelo-release-identity.md` for the full analysis.
+The full analysis is preserved in this primer's release-identity sections.
 
-After changing the regex, existing files need a **forced refresh** to pick up the new parsing (see Rescanning Library below). A one-off script `scripts/meelo_refresh_brackets.sh` was used to refresh all affected albums.
+After changing the regex, existing files need a **forced refresh** to pick up
+the new parsing (see Rescanning Library below). A disposable operator one-shot
+was used to refresh all affected albums; it was not retained as product code.
 
 ## Secrets
 
@@ -327,7 +329,7 @@ This is upstream design, documented at https://github.com/Arthi-chaud/Meelo/wiki
 
 ### Fixed: Release Collapsing (2026-03-13)
 
-Previously, two different pressings with the same album title collapsed into a single Meelo release because the regex captured the folder name as `Album` (not `Release`). Fixed by renaming the capture group to `Release` — embedded tags now provide `Album`, path provides `Release`. See `docs/008-meelo-release-identity.md` for full analysis.
+Previously, two different pressings with the same album title collapsed into a single Meelo release because the regex captured the folder name as `Album` (not `Release`). Fixed by renaming the capture group to `Release` — embedded tags now provide `Album`, path provides `Release`. The preceding release-identity section preserves the full analysis.
 
 ### Known Issue: Singles Classified as Studio Albums
 
@@ -656,4 +658,4 @@ Plex / Jellyfin (other media servers)
 | Wiki | https://github.com/Arthi-chaud/Meelo/wiki |
 | Albums & Releases | https://github.com/Arthi-chaud/Meelo/wiki/Albums-&-Releases |
 | Refreshing Metadata | https://github.com/Arthi-chaud/Meelo/wiki/Refreshing-Metadata |
-| Release identity analysis | docs/008-meelo-release-identity.md (local) |
+| Release identity analysis | Release-identity sections in this primer |

--- a/docs/multi-disc-current-behaviour.md
+++ b/docs/multi-disc-current-behaviour.md
@@ -43,10 +43,10 @@ not a multi-disc bug.
 Multi-disc requests preserve disc structure in three layers:
 
 * **`album_tracks` schema** (`migrations/001_initial.sql`, columns
-  populated by `PipelineDB.set_tracks` at `lib/pipeline_db.py:2912-2925`).
+  populated by `PipelineDB.set_tracks` in `lib/pipeline_db/misc.py`).
   The column is `disc_number INTEGER` and `set_tracks` reads
   `t.get("disc_number", 1)` per track. `get_tracks` returns rows
-  `ORDER BY disc_number, track_number` (`pipeline_db.py:2927-2934`), so
+  `ORDER BY disc_number, track_number` in that module, so
   iteration order is pressing order.
 * **`AlbumRecord.from_db_row`** (`album_source.py:69-149`) groups the
   fetched track rows into `discs: dict[int, list[track]]` keyed by
@@ -66,7 +66,7 @@ across 6 discs), Bruce Springsteen *Born to Run 30th Anniversary*
 (40 tracks across 4 discs), Eluvium *Life Through Bombardment Vol. 1*
 (47 tracks across 14 discs).
 
-`release_snapshot.py::_tracks_titles_and_artists` (lines 116-161) sorts
+`lib/release_snapshot.py::_tracks_titles_and_artists` sorts
 by `(disc_number, track_number)` before extracting titles. The output
 is a **flat** `tuple[str, ...]` — the generator never sees disc
 boundaries. This is fine because the generator's per-track slots use
@@ -314,8 +314,8 @@ contemplate this fallback ("If any of these fail, U10's body slips to
 a follow-up plan; the test scaffold lands in PR2 anyway as RED
 placeholders"). Concretely for PR2:
 
-* Add a single RED integration slice in
-  `tests/test_integration_slices.py::TestMultiDiscSiblingDiscoverySlice`
+* Add a single RED integration slice named
+  `TestMultiDiscSiblingDiscoverySlice` in `tests/test_integration_slices.py`
   that seeds `FakeSlskdAPI` with the case-1 Aerial pattern (search
   response returns only `Aerial\CD 1\` files; peer also has
   `Aerial\CD 2\` on disk but slskd didn't return it; under
@@ -329,8 +329,8 @@ placeholders"). Concretely for PR2:
 The follow-up plan can then either:
 
 1. **Browse-side sibling discovery** — `lib/browse.py` adds a
-   `discover_siblings(username, matched_dir, expected_disc_count)`
-   helper that uses `slskd.users.directory` against the parent and
+   `discover_siblings(username, matched_dir, expected_disc_count)` helper
+   that uses `slskd.users.directory` against the parent and
    filters children by the disc regex. `try_multi_enqueue` invokes
    it once per cycle per request when partial-match is detected.
 2. **Per-disc query emission** — generator emits a
@@ -358,7 +358,7 @@ clean but more disruptive. The follow-up plan owns that call.
 * `album_source.py` lines 23-149, 206-228 — `MediaRecord`,
   `AlbumRecord.from_db_row`, `DatabaseSource.get_tracks`.
 * `lib/staged_album.py` lines 29-34 — `staged_filename` disk prefix.
-* `lib/pipeline_db.py` lines 2912-2934 — `set_tracks`, `get_tracks`.
+* `lib/pipeline_db/misc.py` — `set_tracks`, `get_tracks`.
 * `tests/test_enqueue_fanout.py` line 1499 —
   `test_multi_disc_per_disc_uses_warm_cache_across_discs` (existing
   multi-disc fixture pattern).

--- a/docs/parallel-search.md
+++ b/docs/parallel-search.md
@@ -108,7 +108,7 @@ With 16 albums where each search takes 30-60s, this cuts search time from ~8-16 
 
 ### How it works
 
-- **`_submit_search(album, cfg, slskd)`** -- Sequential. Submits one search to slskd, returns `(search_id, query, album_id)`. Retries on 429 with exponential backoff.
+- **`_submit_plan_search(...)`** -- Sequential. Submits one persisted-plan search to slskd and retries transient submission contention with backoff.
 - **`_collect_search_results(search_id, ...)`** -- Parallel. Sleeps 5s, polls search state, fetches responses, builds `SearchResult` dataclass.
 - **`_search_and_queue_parallel(albums)`** -- Orchestrator. Submits all, then collects all via `ThreadPoolExecutor`, processes results as they arrive.
 - **`_merge_search_result(result)`** -- Main-thread only. Merges into `search_cache` and `user_upload_speed`.
@@ -174,15 +174,16 @@ Note: the benchmark currently fires concurrent `search_text()` calls, which work
 | File | Role |
 |------|------|
 | `lib/search.py` | `SearchResult` dataclass |
-| `cratedigger.py` | `_submit_search()`, `_collect_search_results()`, `_search_and_queue_parallel()` |
+| `cratedigger.py` | `_submit_plan_search()`, `_collect_search_results()`, `_search_and_queue_parallel()` |
 | `lib/config.py` | `parallel_searches` config field |
 | `scripts/bench_parallel_search.py` | Concurrency sweep benchmark |
-| `tests/test_slskd_live.py` | `TestParallelSearchTiming` live tests |
+| `tests/test_search_max_inflight.py` | Deterministic pipeline-depth and owner-thread merge tests |
 
-## Live testing
+## Focused testing
 
-The live tests in `test_slskd_live.py` (gated behind `SLSKD_TEST_FULL=1`) verify timing and result quality:
+The deterministic focused tests exercise the parallel pipeline without an
+environment gate:
 
 ```bash
-nix-shell --run "SLSKD_TEST_FULL=1 python3 -m unittest tests.test_slskd_live.TestParallelSearchTiming -v"
+nix-shell --run "python3 -m unittest tests.test_search_max_inflight -v"
 ```

--- a/docs/persisted-search-plans-rollout.md
+++ b/docs/persisted-search-plans-rollout.md
@@ -401,7 +401,7 @@ The dashboard `searches.windows[*]` block surfaces `cursor_wraps`,
 existing dashboard exposes. `cache_attribution_level='cycle_only'` is
 not a placeholder — `search_log` has no per-search cache columns; the
 dashboard cannot honestly imply per-slot cache numbers. See
-`lib/pipeline_db.py::CACHE_ATTRIBUTION_CYCLE_ONLY`.
+`lib/pipeline_db/_shared.py::CACHE_ATTRIBUTION_CYCLE_ONLY`.
 
 ---
 
@@ -498,7 +498,7 @@ Recent bumps:
 | `search-plan/2026-05-08-2` | 2026-05-08 | First post-rollout fix |
 | `search-plan/2026-05-19-1` | 2026-05-19 | Iteration 1 — entropy + matcher pre-filter |
 | `search-plan/2026-05-25-1` | 2026-05-25 | Iteration 2 PR2 — `literal_lossless` retired, `catalog_number` + `track_3_artist` slots added, distinctiveness-ranked tracks with `GENERIC_TITLE_TOKENS` blacklist, VA-specific strategy mix, stopwords collapsed to single `STOPWORDS` constant. Plan-regen wave on first 1-2 cycles post-deploy is expected and bounded by existing wave caps; monitor `journalctl -u cratedigger` for the wave to clear within ~10-15 min. |
-| (no bump) | 2026-05-26 | Iteration 2 PR3 — observability only; **`SEARCH_PLAN_GENERATOR_ID` deliberately not bumped**. PR3 wires the forensics writes (`rejection_reason`, `result_count_uncapped`, `query_token_count`, `query_distinct_token_count`, `expected_track_count`, `matcher_score_top1`, `query_template`) into `lib/pipeline_db.py::log_search`, materialises `album_requests.failure_class` at the cursor-wrap transaction in `lib/search_plan_service.py`, ships the dedicated `cratedigger-unfindable.service` + `cratedigger-unfindable.timer` (daily, K=100/run, ~7d per-request cadence) for the 4-bucket `unfindable_category` taxonomy, and captures `rescued_at` / `prior_unfindable_category` in the importer success path. No new migrations land (027-033 all shipped in PR1). Generator output is unchanged — none of the U11-U14 work touches `generate_search_plan` — so no plan-regen wave fires on rollout. |
+| (no bump) | 2026-05-26 | Iteration 2 PR3 — observability only; **`SEARCH_PLAN_GENERATOR_ID` deliberately not bumped**. PR3 wires the forensics writes (`rejection_reason`, `result_count_uncapped`, `query_token_count`, `query_distinct_token_count`, `expected_track_count`, `matcher_score_top1`, `query_template`) into `lib/pipeline_db/search_plan.py::log_search`, materialises `album_requests.failure_class` at the cursor-wrap transaction in `lib/search_plan_service.py`, ships the dedicated `cratedigger-unfindable.service` + `cratedigger-unfindable.timer` (daily, K=100/run, ~7d per-request cadence) for the 4-bucket `unfindable_category` taxonomy, and captures `rescued_at` / `prior_unfindable_category` in the importer success path. No new migrations land (027-033 all shipped in PR1). Generator output is unchanged — none of the U11-U14 work touches `generate_search_plan` — so no plan-regen wave fires on rollout. |
 
 Any change to those that does **not** bump the id will silently leave
 old plans active under a new generator's rules. Two regression guards:

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -371,7 +371,7 @@ Top 20 peer scores per search, sorted by `(matched_tracks DESC, avg_ratio DESC)`
  "missing_titles": ["..."], "file_count": 26}
 ```
 
-Empty array `[]` for `no_results` / `no_match` outcomes; `NULL` for `error`, `timeout`, `exhausted`, `empty_query`. Decoded at exactly one site per consumer (`web/routes/pipeline.py:get_pipeline_detail` and `scripts/pipeline_cli.py:cmd_show`) via `msgspec.convert(blob, type=list[CandidateScore])`.
+Empty array `[]` for `no_results` / `no_match` outcomes; `NULL` for `error`, `timeout`, `exhausted`, `empty_query`. Decoded at exactly one site per consumer (`web/routes/pipeline.py::get_pipeline_detail` and `scripts/pipeline_cli/show.py::cmd_show`) via `msgspec.convert(blob, type=list[CandidateScore])`.
 
 ### `final_state`
 
@@ -415,7 +415,7 @@ R-id it satisfies.
 
 Seven nullable scalars that let triage SQL skip JSONB introspection
 into `candidates`. Populated at log-write time by
-`lib/pipeline_db.py::log_search` via the matcher
+`lib/pipeline_db/search_plan.py::log_search` via the matcher
 (`lib/matching.py::check_for_match`) and search-executor layer.
 Historical rows pre-deploy carry `NULL` in all seven; new rows
 post-PR3 populate every applicable column.

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -336,7 +336,7 @@ search cycles only ask Soulseek for lossless tiers, so the lock
 doesn't fire repeatedly against new peers serving the same lossy
 file. No plan-generator change is needed — `generate_search_plan`
 produces query strategies, and the filetype filter is applied
-downstream in `enqueue.py::effective_search_tiers` from the request's
+downstream in `lib/enqueue.py::effective_search_tiers` from the request's
 override column.
 
 Known wart: library rows imported before this policy landed (2026-05-17)

--- a/docs/search-plan-iter2-deploy.md
+++ b/docs/search-plan-iter2-deploy.md
@@ -874,8 +874,8 @@ pipeline-cli routes --json
 - **Replaced-row inclusion in cohorts is pinned**: `status='replaced'`
   audit rows are intentionally returned by `filter=all`/`unfindable`
   so operators can spot patterns across replacement history. Pinned
-  by `tests/test_triage_service.py::TestListTriage::test_list_includes_replaced_rows`
-  and the `lib/pipeline_db.py::list_triage_page` docstring.
+  by `tests/test_triage_service.py::TestListTriage.test_list_includes_replaced_rows`
+  and the `lib/pipeline_db/misc.py::list_triage_page` docstring.
 
 ### Review summary
 

--- a/lib/pipeline_db/_shared.py
+++ b/lib/pipeline_db/_shared.py
@@ -162,7 +162,7 @@ ADVISORY_LOCK_NAMESPACE_YOUTUBE_INGEST = 0x59544942
 def release_id_to_lock_key(mb_release_id: str) -> int:
     """Map an ``mb_release_id`` string to a stable int32 advisory-lock key.
 
-    PostgreSQL's two-arg ``pg_advisory_lock(int4, int4)`` takes signed
+    PostgreSQL's two-arg ``pg_try_advisory_lock`` function takes signed
     int32 keys. ``mb_release_id`` is a str — either a MusicBrainz UUID
     (36 chars) or a Discogs numeric release id. ``zlib.crc32`` is
     stable across processes (Python's builtin ``hash`` is salted per
@@ -1130,5 +1130,4 @@ class TransferIdOwnership:
     """
     stamped: set[str]
     unstamped: set[str]
-
 

--- a/tests/_docs_reference_audit.py
+++ b/tests/_docs_reference_audit.py
@@ -1,0 +1,242 @@
+"""Structural reference scanners for the living-docs audit."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+_FROZEN_DOC_DIRS = frozenset({"plans", "brainstorms", "solutions"})
+REMOVAL_STABLE_REPO_ROOTS = frozenset({
+    ".agents",
+    ".claude",
+    ".codex",
+    "docs",
+    "examples",
+    "harness",
+    "lib",
+    "migrations",
+    "nix",
+    "scripts",
+    "tests",
+    "tools",
+    "web",
+})
+REMOVAL_STABLE_ROOT_FILES = frozenset({
+    ".gitignore",
+    ".mcp.json",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "LICENSE",
+    "README.md",
+    "TODO-audio-quality.md",
+    "TODO-type-safety.md",
+    "TODO.md",
+    "album_source.py",
+    "cratedigger.py",
+    "flake.lock",
+    "flake.nix",
+    "pyrightconfig.json",
+    "shell.nix",
+})
+_REMOVAL_STABLE_ROOT_FILE_FAMILIES_RE = re.compile(
+    r"TODO(?:[-_A-Za-z0-9]*)?\.md$"
+)
+_CODE_SPAN_RE = re.compile(
+    r"(?<!`)(?P<fence>`{1,2})(?!`)(?P<code>[^`\n]+?)(?P=fence)(?!`)"
+)
+_PY_SYMBOL_REFERENCE_RE = re.compile(
+    r"^(?P<path>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.py)"
+    r"::(?P<symbol>[A-Za-z_][A-Za-z0-9_.]*)"
+    r"(?:\([^`\n]*\))?$"
+)
+_CALL_FORM_RE = re.compile(
+    r"^(?P<identifier>_?[a-z][a-z0-9_]*_[a-z0-9_]*)\([^`\n]*\)$"
+)
+_LINE_SUFFIX_RE = re.compile(r":\d+(?:-\d+)?$")
+_TEMPLATE_MARKERS_RE = re.compile(r"[*?\[\]{}<>$]|(?:^|/)N{2,}[A-Za-z0-9_-]*")
+
+
+def _relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _code_spans(text: str) -> list[tuple[str, int]]:
+    """Return inline-code contents with their 1-based source line."""
+    return [
+        (match.group("code").strip(), text.count("\n", 0, match.start()) + 1)
+        for match in _CODE_SPAN_RE.finditer(text)
+    ]
+
+
+def _is_repo_path_candidate(value: str, repo_root: Path) -> bool:
+    if "/" not in value:
+        return ((repo_root / value).is_file()
+                or value in REMOVAL_STABLE_ROOT_FILES
+                or bool(_REMOVAL_STABLE_ROOT_FILE_FAMILIES_RE.fullmatch(value)))
+    root, _remainder = value.split("/", 1)
+    return root in REMOVAL_STABLE_REPO_ROOTS
+
+
+def _normalise_repo_path(value: str, repo_root: Path) -> str | None:
+    """Return a literal repo path, excluding glob/template conventions."""
+    without_anchor = value.split("#", 1)[0]
+    if without_anchor.startswith("./"):
+        without_anchor = without_anchor[2:]
+    without_line = _LINE_SUFFIX_RE.sub("", without_anchor)
+    if not _is_repo_path_candidate(without_line, repo_root):
+        return None
+    if _TEMPLATE_MARKERS_RE.search(without_line):
+        return None
+    return without_line.rstrip("/")
+
+
+def _symbol_occurs(symbol: str, source_text: str) -> bool:
+    """Check the referenced leaf symbol as an identifier in its target."""
+    leaf = symbol.rsplit(".", 1)[-1]
+    return re.search(rf"\b{re.escape(leaf)}\b", source_text) is not None
+
+
+def living_doc_files(repo_root: Path) -> list[Path]:
+    """Return documentation whose code references must stay current."""
+    files = {repo_root / "CLAUDE.md"}
+    files.update(repo_root.rglob("README.md"))
+    files.update((repo_root / ".claude" / "rules").rglob("*.md"))
+    for path in (repo_root / "docs").rglob("*.md"):
+        relative = path.relative_to(repo_root / "docs")
+        if relative.parts and relative.parts[0] in _FROZEN_DOC_DIRS:
+            continue
+        files.add(path)
+    living: list[Path] = []
+    for path in files:
+        repo_relative = path.relative_to(repo_root)
+        if repo_relative.parts[:2] == (".claude", "worktrees"):
+            continue
+        try:
+            docs_relative = path.relative_to(repo_root / "docs")
+        except ValueError:
+            pass
+        else:
+            if docs_relative.parts and docs_relative.parts[0] in _FROZEN_DOC_DIRS:
+                continue
+        living.append(path)
+    return sorted(living)
+
+
+def broken_repo_references(
+    path: Path,
+    text: str,
+    repo_root: Path,
+) -> list[str]:
+    """Return unresolved repo-path and ``path.py::symbol`` references."""
+    findings: list[str] = []
+    rel_source = _relative(path, repo_root)
+    for code, line in _code_spans(text):
+        normalised_code = code[2:] if code.startswith("./") else code
+        symbol_match = _PY_SYMBOL_REFERENCE_RE.fullmatch(normalised_code)
+        if symbol_match is not None:
+            repo_path = symbol_match.group("path")
+            symbol = symbol_match.group("symbol")
+            target = repo_root / repo_path
+            if not target.is_file():
+                findings.append(
+                    f"{rel_source}:{line}: missing path {repo_path}"
+                )
+                continue
+            target_text = target.read_text(encoding="utf-8")
+            if not _symbol_occurs(symbol, target_text):
+                findings.append(
+                    f"{rel_source}:{line}: {repo_path} has no symbol {symbol}"
+                )
+            continue
+
+        repo_path = _normalise_repo_path(code, repo_root)
+        if repo_path is None:
+            continue
+        if not (repo_root / repo_path).exists():
+            findings.append(f"{rel_source}:{line}: missing path {repo_path}")
+    return findings
+
+
+def missing_call_references(
+    path: Path,
+    text: str,
+    repo_root: Path,
+    code_identifiers: set[str],
+    allowlist: dict[str, str],
+    *,
+    scope: str,
+) -> list[str]:
+    """Return unresolved backticked snake_case call-form identifiers."""
+    rel_source = _relative(path, repo_root)
+    missing: set[str] = set()
+    for code, _line in _code_spans(text):
+        match = _CALL_FORM_RE.fullmatch(code)
+        if match is None:
+            continue
+        identifier = match.group("identifier")
+        key = f"{rel_source}::{scope}::{identifier}"
+        if identifier not in code_identifiers and key not in allowlist:
+            missing.add(key)
+    return sorted(missing)
+
+
+def python_code_identifiers(repo_root: Path) -> set[str]:
+    """Collect callable definitions/imports and names actually called."""
+    identifiers: set[str] = set()
+    roots = [repo_root / name for name in ("harness", "lib", "scripts", "tests", "web")]
+    paths = sorted(repo_root.glob("*.py"))
+    for root in roots:
+        paths.extend(sorted(root.rglob("*.py")))
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                identifiers.add(node.name)
+            elif isinstance(node, ast.alias):
+                identifiers.add(node.asname or node.name.rsplit(".", 1)[-1])
+            elif isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name):
+                    identifiers.add(node.func.id)
+                elif isinstance(node.func, ast.Attribute):
+                    identifiers.add(node.func.attr)
+    return identifiers
+
+
+_DocstringNode = ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+
+
+def _scoped_docstring_nodes(
+    tree: ast.Module,
+) -> list[tuple[str, _DocstringNode]]:
+    """Return docstring-capable nodes with stable qualified scopes."""
+    nodes: list[tuple[str, _DocstringNode]] = [("<module>", tree)]
+
+    def visit_body(body: list[ast.stmt], parents: tuple[str, ...]) -> None:
+        for node in body:
+            if not isinstance(
+                node,
+                (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
+            ):
+                continue
+            names = (*parents, node.name)
+            nodes.append((".".join(names), node))
+            visit_body(node.body, names)
+
+    visit_body(tree.body, ())
+    return nodes
+
+
+def lib_docstrings(repo_root: Path) -> list[tuple[Path, str, str]]:
+    """Return ``(path, scope, docstring)`` records under ``lib/``."""
+    sources: list[tuple[Path, str, str]] = []
+    for path in sorted((repo_root / "lib").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for scope, node in _scoped_docstring_nodes(tree):
+            docstring = ast.get_docstring(node, clean=False)
+            if docstring is not None:
+                sources.append((path, scope, docstring))
+    return sources

--- a/tests/test_docs_audit.py
+++ b/tests/test_docs_audit.py
@@ -1,7 +1,7 @@
-"""Docs-freshness structural audits (issue #570).
+"""Docs-freshness structural audits (issues #570 and #590).
 
 CLAUDE.md's "New Work Checklist" row for a documented surface says the doc
-update ships in the SAME PR as the code, not a follow-up. These four checks
+update ships in the SAME PR as the code, not a follow-up. These checks
 are the automatic forcing function: each is a structural coverage gate
 between a documented surface and the doc that's supposed to describe it, so
 a code PR that adds a beets plugin / CLI subcommand / module option without
@@ -12,17 +12,12 @@ tests/test_stopwords_audit.py, tests/test_lambda_audit.py,
 tests/web/test_route_audit.py): deterministic, no network, real repo files
 read straight off disk.
 
-    1. TestBeetsPluginDocCoverage    — nix/module.nix `plugins` string <->
-       docs/beets-primer.md "Active Plugins" table.
-    2. TestPipelineCliDocCoverage    — every pipeline-cli top-level
-       subcommand (introspected from routes_meta._build_parser(), never
-       regexed) <-> docs/debugging-cli.md.
-    3. TestDocLinksResolve           — every repo-local markdown link in
-       README.md / CLAUDE.md / docs/**/*.md resolves to a real file.
-    4. TestModuleOptionDescriptions  — every `mkOption { ... }` in
-       nix/module.nix carries a non-empty `description`. Seeded as a
-       ratchet (37 pre-existing gaps at write time — see
-       OPTIONS_WITHOUT_DESCRIPTION_OK); no NEW option may join without one.
+    - TestBeetsPluginDocCoverage — module plugins match the primer table.
+    - TestPipelineCliDocCoverage — CLI commands appear in the CLI doc.
+    - TestDocLinksResolve — repo-local markdown links resolve.
+    - TestModuleOptionDescriptions — module options carry descriptions.
+    - TestLivingCodeReferences — living repo paths and symbols resolve.
+    - TestBacktickedCallReferences — project-shaped call names still exist.
 """
 
 from __future__ import annotations
@@ -30,19 +25,311 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import subprocess
 import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from scripts.pipeline_cli.routes_meta import _build_parser  # noqa: E402
+from tests._docs_reference_audit import (  # noqa: E402
+    REMOVAL_STABLE_REPO_ROOTS,
+    REMOVAL_STABLE_ROOT_FILES,
+    broken_repo_references,
+    lib_docstrings,
+    living_doc_files,
+    missing_call_references,
+    python_code_identifiers,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = REPO_ROOT / "docs"
 MODULE_NIX = REPO_ROOT / "nix" / "module.nix"
 BEETS_PRIMER = DOCS_DIR / "beets-primer.md"
 DEBUGGING_CLI = DOCS_DIR / "debugging-cli.md"
+
+
+class TestReferenceScannerKnownBadCases(unittest.TestCase):
+    """Synthetic violations prove each reference check constrains input."""
+
+    def test_missing_repo_path_is_rejected(self) -> None:
+        findings = broken_repo_references(
+            REPO_ROOT / "README.md",
+            "See `lib/_missing_issue_590.py`.",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_missing_repo_path_in_discovered_tools_root_is_rejected(self) -> None:
+        findings = broken_repo_references(
+            REPO_ROOT / "README.md",
+            "See `tools/_missing_issue_590.py`.",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_missing_repo_path_in_absent_registered_root_is_rejected(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            findings = broken_repo_references(
+                root / "README.md",
+                "See `tools/_missing_issue_590.py`.",
+                root,
+            )
+        self.assertEqual(len(findings), 1)
+
+    def test_untracked_top_level_directory_is_not_a_repo_root(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "src").mkdir()
+            findings = broken_repo_references(
+                root / "README.md",
+                "The external project implements this in `src/import.rs`.",
+                root,
+            )
+        self.assertEqual(findings, [])
+
+    def test_missing_repo_path_with_dot_slash_is_rejected(self) -> None:
+        findings = broken_repo_references(
+            REPO_ROOT / "README.md",
+            "See `./lib/_missing_issue_590.py`.",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_missing_root_metadata_paths_are_rejected(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "README.md"
+            findings = broken_repo_references(
+                source,
+                "See `flake.lock` and `TODO-missing-issue-590.md`.",
+                root,
+            )
+        self.assertEqual(len(findings), 2)
+
+    def test_missing_ordinary_root_file_is_rejected(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            findings = broken_repo_references(
+                root / "README.md",
+                "See `cratedigger.py`.",
+                root,
+            )
+        self.assertEqual(len(findings), 1)
+
+    def test_missing_symbol_is_rejected(self) -> None:
+        findings = broken_repo_references(
+            REPO_ROOT / "README.md",
+            "See `lib/search.py::_missing_issue_590_symbol`.",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_nonexistent_call_identifier_is_rejected(self) -> None:
+        findings = missing_call_references(
+            REPO_ROOT / "lib" / "search.py",
+            "Calls ``_missing_issue_590_call()``.",
+            REPO_ROOT,
+            {"real_call"},
+            {},
+            scope="test_scope",
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_non_call_identifier_does_not_satisfy_call_reference(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "fixture.py").write_text(
+                "non_call_identifier = 1\n",
+                encoding="utf-8",
+            )
+            identifiers = python_code_identifiers(root)
+        findings = missing_call_references(
+            REPO_ROOT / "lib" / "search.py",
+            "Calls ``non_call_identifier()``.",
+            REPO_ROOT,
+            identifiers,
+            {},
+            scope="test_scope",
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_call_allowlist_is_scoped_to_one_docstring(self) -> None:
+        identifier = "missing_scoped_call"
+        allowlist = {
+            f"lib/search.py::first_scope::{identifier}": "Historical in first scope.",
+        }
+        allowed = missing_call_references(
+            REPO_ROOT / "lib" / "search.py",
+            f"Calls ``{identifier}()``.",
+            REPO_ROOT,
+            set(),
+            allowlist,
+            scope="first_scope",
+        )
+        rejected = missing_call_references(
+            REPO_ROOT / "lib" / "search.py",
+            f"Calls ``{identifier}()``.",
+            REPO_ROOT,
+            set(),
+            allowlist,
+            scope="second_scope",
+        )
+        self.assertEqual(allowed, [])
+        self.assertEqual(len(rejected), 1)
+
+
+# Genuinely historical call names may stay only with a one-line explanation.
+# Keys are ``repo-relative path::enclosing scope::identifier`` so line edits
+# do not churn them and one exemption cannot mask another docstring.
+STALE_CALL_REFERENCE_ALLOWLIST: dict[str, str] = {
+    "lib/download.py::harvest_terminal_transfer_evidence::remove_completed_downloads":
+        "Past-tense #589 docstring explains the unsafe bulk cleanup replaced by owned purging.",
+    "lib/release_cleanup.py::remove_album_by_selectors::remove_duplicates":
+        "Past-tense beets API mention documents the historical cross-MBID deletion hazard.",
+    "lib/slskd_transfers.py::purge_completed_transfers::remove_completed_downloads":
+        "Past-tense #589 docstring explains the unsafe bulk cleanup replaced by per-id purging.",
+}
+
+
+def _all_missing_call_references(
+    allowlist: dict[str, str],
+) -> list[str]:
+    identifiers = python_code_identifiers(REPO_ROOT)
+    missing: set[str] = set()
+    for path, scope, docstring in lib_docstrings(REPO_ROOT):
+        missing.update(missing_call_references(
+            path,
+            docstring,
+            REPO_ROOT,
+            identifiers,
+            allowlist,
+            scope=scope,
+        ))
+    return sorted(missing)
+
+
+class TestLivingCodeReferences(unittest.TestCase):
+    """Living docs may refer only to paths and symbols that still exist."""
+
+    def test_repo_paths_and_path_symbols_resolve(self) -> None:
+        findings: list[str] = []
+        for path in living_doc_files(REPO_ROOT):
+            findings.extend(broken_repo_references(
+                path,
+                path.read_text(encoding="utf-8"),
+                REPO_ROOT,
+            ))
+        self.assertEqual(
+            findings,
+            [],
+            "Stale repo path/symbol reference(s) in living docs:\n  - "
+            + "\n  - ".join(findings),
+        )
+
+    def test_living_doc_scope_is_not_vacuous(self) -> None:
+        files = living_doc_files(REPO_ROOT)
+        self.assertIn(REPO_ROOT / "CLAUDE.md", files)
+        self.assertIn(REPO_ROOT / "README.md", files)
+        self.assertIn(REPO_ROOT / ".claude" / "rules" / "code-quality.md", files)
+        self.assertIn(REPO_ROOT / "docs" / "beets-primer.md", files)
+        self.assertNotIn(
+            REPO_ROOT / "docs" / "plans"
+            / "2026-05-28-001-feat-youtube-rescue-ingest-api-plan.md",
+            files,
+        )
+
+    def test_frozen_tree_readmes_are_excluded_after_union(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            living = root / "docs" / "guide" / "nested" / "README.md"
+            frozen = [
+                root / "docs" / dirname / "nested" / "README.md"
+                for dirname in ("plans", "brainstorms", "solutions")
+            ]
+            for path in [living, *frozen]:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# Test\n", encoding="utf-8")
+            files = living_doc_files(root)
+        self.assertIn(living, files)
+        for path in frozen:
+            self.assertNotIn(path, files)
+
+    def test_tracked_top_level_surfaces_are_registered(self) -> None:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        tracked_paths = [
+            Path(value) for value in result.stdout.split("\0") if value
+        ]
+        tracked_roots = {
+            path.parts[0] for path in tracked_paths if len(path.parts) > 1
+        }
+        tracked_root_files = {
+            path.name for path in tracked_paths if len(path.parts) == 1
+        }
+        self.assertEqual(
+            tracked_roots - REMOVAL_STABLE_REPO_ROOTS,
+            set(),
+            "Register new tracked top-level directories in the removal-stable "
+            "repo-root set.",
+        )
+        self.assertEqual(
+            tracked_root_files - REMOVAL_STABLE_ROOT_FILES,
+            set(),
+            "Register new tracked root files in the removal-stable file set.",
+        )
+
+
+class TestBacktickedCallReferences(unittest.TestCase):
+    """Project-shaped calls in lib docstrings must exist."""
+
+    def test_call_identifiers_exist_in_python_code(self) -> None:
+        missing = _all_missing_call_references(STALE_CALL_REFERENCE_ALLOWLIST)
+        self.assertEqual(
+            missing,
+            [],
+            "Backticked snake_case call reference(s) have no Python identifier. "
+            "Fix live prose, or allowlist deliberate history with a one-line "
+            "rationale:\n  - " + "\n  - ".join(missing),
+        )
+
+    def test_allowlist_entries_still_need_exemption(self) -> None:
+        unresolved = set(_all_missing_call_references({}))
+        stale = sorted(set(STALE_CALL_REFERENCE_ALLOWLIST) - unresolved)
+        self.assertEqual(
+            stale,
+            [],
+            "Stale call-reference allowlist entries; remove them:\n  - "
+            + "\n  - ".join(stale),
+        )
+
+    def test_allowlist_rationales_are_one_nonempty_line(self) -> None:
+        invalid = sorted(
+            key for key, rationale in STALE_CALL_REFERENCE_ALLOWLIST.items()
+            if not rationale.strip() or "\n" in rationale
+        )
+        self.assertEqual(
+            invalid,
+            [],
+            "Call-reference allowlist entries need a one-line rationale:\n  - "
+            + "\n  - ".join(invalid),
+        )
+
+    def test_scan_inputs_are_not_vacuous(self) -> None:
+        identifiers = python_code_identifiers(REPO_ROOT)
+        self.assertIn("dispatch_import_core", identifiers)
+        self.assertIn("PipelineDB", identifiers)
+        docstrings = lib_docstrings(REPO_ROOT)
+        self.assertTrue(any(path == REPO_ROOT / "lib" / "search.py"
+                            for path, _scope, _docstring in docstrings))
 
 
 # ======================================================================
@@ -275,8 +562,7 @@ class TestDocLinksResolve(unittest.TestCase):
 # Check 4 — nix/module.nix option `description` coverage (ratchet)
 # ======================================================================
 
-# Pre-existing gaps at audit-creation time (issue #570) — 37 options
-# declared before this scan existed. Ratchet: no NEW option may join this
+# Pre-existing gaps at audit-creation time (issue #570). Ratchet: no NEW option may join this
 # list (test_no_new_options_without_description catches it); entries
 # should shrink to zero as each option earns a real description
 # (test_allowlist_entries_still_missing_description catches staleness).
@@ -399,7 +685,7 @@ class TestModuleOptionDescriptions(unittest.TestCase):
     description IS the documentation for most options, so a description-
     free option is effectively undocumented.
 
-    Ratchet, not a hard gate (issue #570): 37 pre-existing options lacked
+    Ratchet, not a hard gate (issue #570): pre-existing options lacked
     a description when this audit was written. See
     OPTIONS_WITHOUT_DESCRIPTION_OK. No NEW option may join that list.
     """


### PR DESCRIPTION
## Summary

- add hard stale repo-path and `path.py::symbol` audits across living documentation
- add a scoped, rationale-backed `snake_case()` audit for `lib/` docstrings
- add deterministic known-bad tests for missing paths, symbols, non-call identifiers, scope leakage, frozen docs, and root registration
- correct stale package/symbol references found by the new gate and ban drifting cardinality claims in code-quality guidance

Part of #590.

## Verification

- reviewer: CLEAN after three fix iterations
- `python3 -m unittest tests.test_docs_audit -v` — 33 passed
- pyright — 0 errors, 0 warnings
- `bash scripts/find_dead_code.sh` — clean
- full suite — 5239 passed
- pre-push generated fuzz burst — passed
- `nix flake check` — all 36 checks passed
