### PR TITLE
test: audit repo-owned skill path references

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -11,7 +11,7 @@ Run pyright + full test suite + type safety grep gate. Use this before committin
 
 1. Run pyright on all key files:
 ```bash
-pyright lib/quality lib/beets.py lib/beets_db.py lib/pipeline_db.py lib/dispatch lib/download.py harness/import_one.py harness/beets_harness.py album_source.py cratedigger.py scripts/pipeline_cli web/routes/pipeline.py web/routes/imports.py web/routes/library.py web/routes/browse.py tests/test_validation_result.py tests/test_import_result.py tests/test_quality_decisions.py tests/test_beets_db.py tests/test_pipeline_db.py tests/test_album_source.py tests/test_import_dispatch.py tests/web
+pyright lib/quality lib/beets.py lib/beets_db.py lib/pipeline_db lib/dispatch lib/download.py harness/import_one.py harness/beets_harness.py album_source.py cratedigger.py scripts/pipeline_cli web/routes/pipeline.py web/routes/imports.py web/routes/library.py web/routes/browse.py tests/test_validation_result.py tests/test_import_result.py tests/test_quality_decisions.py tests/test_beets_db.py tests/test_pipeline_db.py tests/test_album_source.py tests/test_import_dispatch.py tests/web
 ```
 
 Must be **0 errors**. Do not proceed if there are new errors (psycopg2/slskd_api "could not be resolved" warnings are OK — they're C extensions).

--- a/tests/_docs_reference_audit.py
+++ b/tests/_docs_reference_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
 from pathlib import Path
 
 _FROZEN_DOC_DIRS = frozenset({"plans", "brainstorms", "solutions"})
@@ -45,6 +46,16 @@ _REMOVAL_STABLE_ROOT_FILE_FAMILIES_RE = re.compile(
 _CODE_SPAN_RE = re.compile(
     r"(?<!`)(?P<fence>`{1,2})(?!`)(?P<code>[^`\n]+?)(?P=fence)(?!`)"
 )
+_FENCE_OPEN_RE = re.compile(
+    r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>[^\r\n]*)$",
+)
+_FENCED_COMMAND_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_./~${}-])"
+    r"(?P<code>(?:\./)?[A-Za-z0-9_.-]+"
+    r"(?:/[A-Za-z0-9_.*?{}\[\]<>$-]+)*"
+    r"(?:#[A-Za-z0-9_.-]+)?(?::\d+(?:-\d+)?)?)"
+    r"(?![A-Za-z0-9_./-])"
+)
 _PY_SYMBOL_REFERENCE_RE = re.compile(
     r"^(?P<path>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.py)"
     r"::(?P<symbol>[A-Za-z_][A-Za-z0-9_.]*)"
@@ -55,6 +66,18 @@ _CALL_FORM_RE = re.compile(
 )
 _LINE_SUFFIX_RE = re.compile(r":\d+(?:-\d+)?$")
 _TEMPLATE_MARKERS_RE = re.compile(r"[*?\[\]{}<>$]|(?:^|/)N{2,}[A-Za-z0-9_-]*")
+
+# These RST families are relative to the Beets source tree resolved by the
+# beets-docs skill, not Cratedigger. The source and exact upstream families
+# are both pinned so Cratedigger-owned ``docs/`` references remain audited.
+_SKILL_EXTERNAL_REFERENCE_RULES = {
+    ".claude/skills/beets-docs/SKILL.md": (
+        re.compile(
+            r"docs/(?:(?:reference|plugins|guides)/[^/]+\.rst|faq\.rst)"
+        ),
+        "Beets RST path resolved below the skill's BEETS_SRC directory.",
+    ),
+}
 
 
 def _relative(path: Path, repo_root: Path) -> str:
@@ -70,6 +93,66 @@ def _code_spans(text: str) -> list[tuple[str, int]]:
         (match.group("code").strip(), text.count("\n", 0, match.start()) + 1)
         for match in _CODE_SPAN_RE.finditer(text)
     ]
+
+
+def _command_token_spans(
+    text: str,
+    *,
+    first_line: int,
+) -> list[tuple[str, int]]:
+    """Return safely delimited command tokens with source lines."""
+    return [
+        (
+            match.group("code"),
+            first_line + text.count("\n", 0, match.start("code")),
+        )
+        for match in _FENCED_COMMAND_TOKEN_RE.finditer(text)
+    ]
+
+
+def _fenced_command_token_spans(text: str) -> list[tuple[str, int]]:
+    """Return tokens inside CommonMark fenced code blocks."""
+    lines = text.splitlines(keepends=True)
+    spans: list[tuple[str, int]] = []
+    index = 0
+    while index < len(lines):
+        opening_line = lines[index].rstrip("\r\n")
+        opening = _FENCE_OPEN_RE.fullmatch(opening_line)
+        if opening is None:
+            index += 1
+            continue
+
+        fence = opening.group("fence")
+        if fence[0] == "`" and "`" in opening.group("info"):
+            index += 1
+            continue
+        closing_re = re.compile(
+            rf"^ {{0,3}}{re.escape(fence[0])}{{{len(fence)},}}[ \t]*$"
+        )
+        content_start = index + 1
+        closing_index = content_start
+        while closing_index < len(lines):
+            candidate = lines[closing_index].rstrip("\r\n")
+            if closing_re.fullmatch(candidate):
+                break
+            closing_index += 1
+
+        block_text = "".join(lines[content_start:closing_index])
+        spans.extend(_command_token_spans(
+            block_text,
+            first_line=content_start + 1,
+        ))
+        index = closing_index + 1
+    return spans
+
+
+def _is_external_skill_reference(rel_source: str, code: str) -> bool:
+    """Return whether a path is explicitly relative to an upstream tree."""
+    rule = _SKILL_EXTERNAL_REFERENCE_RULES.get(rel_source)
+    if rule is None:
+        return False
+    pattern, _rationale = rule
+    return pattern.fullmatch(code) is not None
 
 
 def _is_repo_path_candidate(value: str, repo_root: Path) -> bool:
@@ -126,6 +209,48 @@ def living_doc_files(repo_root: Path) -> list[Path]:
     return sorted(living)
 
 
+def tracked_skill_instruction_files(repo_root: Path) -> list[Path]:
+    """Return git-tracked, repo-owned skill instruction files only."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", ".claude/skills/**/SKILL.md"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sorted(
+        repo_root / value
+        for value in result.stdout.split("\0")
+        if value
+    )
+
+
+def _broken_repo_reference(
+    path: Path,
+    code: str,
+    line: int,
+    repo_root: Path,
+) -> str | None:
+    rel_source = _relative(path, repo_root)
+    normalised_code = code[2:] if code.startswith("./") else code
+    symbol_match = _PY_SYMBOL_REFERENCE_RE.fullmatch(normalised_code)
+    if symbol_match is not None:
+        repo_path = symbol_match.group("path")
+        symbol = symbol_match.group("symbol")
+        target = repo_root / repo_path
+        if not target.is_file():
+            return f"{rel_source}:{line}: missing path {repo_path}"
+        target_text = target.read_text(encoding="utf-8")
+        if not _symbol_occurs(symbol, target_text):
+            return f"{rel_source}:{line}: {repo_path} has no symbol {symbol}"
+        return None
+
+    repo_path = _normalise_repo_path(code, repo_root)
+    if repo_path is None or (repo_root / repo_path).exists():
+        return None
+    return f"{rel_source}:{line}: missing path {repo_path}"
+
+
 def broken_repo_references(
     path: Path,
     text: str,
@@ -133,31 +258,35 @@ def broken_repo_references(
 ) -> list[str]:
     """Return unresolved repo-path and ``path.py::symbol`` references."""
     findings: list[str] = []
-    rel_source = _relative(path, repo_root)
     for code, line in _code_spans(text):
-        normalised_code = code[2:] if code.startswith("./") else code
-        symbol_match = _PY_SYMBOL_REFERENCE_RE.fullmatch(normalised_code)
-        if symbol_match is not None:
-            repo_path = symbol_match.group("path")
-            symbol = symbol_match.group("symbol")
-            target = repo_root / repo_path
-            if not target.is_file():
-                findings.append(
-                    f"{rel_source}:{line}: missing path {repo_path}"
-                )
-                continue
-            target_text = target.read_text(encoding="utf-8")
-            if not _symbol_occurs(symbol, target_text):
-                findings.append(
-                    f"{rel_source}:{line}: {repo_path} has no symbol {symbol}"
-                )
-            continue
+        finding = _broken_repo_reference(path, code, line, repo_root)
+        if finding is not None:
+            findings.append(finding)
+    return findings
 
-        repo_path = _normalise_repo_path(code, repo_root)
-        if repo_path is None:
+
+def broken_skill_instruction_references(
+    path: Path,
+    text: str,
+    repo_root: Path,
+) -> list[str]:
+    """Return stale repo paths in tracked skill prose and command blocks."""
+    rel_source = _relative(path, repo_root)
+    spans: list[tuple[str, int]] = []
+    for code, line in _code_spans(text):
+        spans.append((code, line))
+        spans.extend(_command_token_spans(code, first_line=line))
+    spans.extend(_fenced_command_token_spans(text))
+
+    findings: list[str] = []
+    seen_findings: set[str] = set()
+    for code, line in spans:
+        if _is_external_skill_reference(rel_source, code):
             continue
-        if not (repo_root / repo_path).exists():
-            findings.append(f"{rel_source}:{line}: missing path {repo_path}")
+        finding = _broken_repo_reference(path, code, line, repo_root)
+        if finding is not None and finding not in seen_findings:
+            findings.append(finding)
+            seen_findings.add(finding)
     return findings
 
 

--- a/tests/test_docs_audit.py
+++ b/tests/test_docs_audit.py
@@ -17,6 +17,7 @@ read straight off disk.
     - TestDocLinksResolve — repo-local markdown links resolve.
     - TestModuleOptionDescriptions — module options carry descriptions.
     - TestLivingCodeReferences — living repo paths and symbols resolve.
+    - TestSkillInstructionCodeReferences — tracked skill paths resolve.
     - TestBacktickedCallReferences — project-shaped call names still exist.
 """
 
@@ -38,10 +39,12 @@ from tests._docs_reference_audit import (  # noqa: E402
     REMOVAL_STABLE_REPO_ROOTS,
     REMOVAL_STABLE_ROOT_FILES,
     broken_repo_references,
+    broken_skill_instruction_references,
     lib_docstrings,
     living_doc_files,
     missing_call_references,
     python_code_identifiers,
+    tracked_skill_instruction_files,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -127,6 +130,95 @@ class TestReferenceScannerKnownBadCases(unittest.TestCase):
             REPO_ROOT,
         )
         self.assertEqual(len(findings), 1)
+
+    def test_missing_repo_path_in_fenced_skill_command_is_rejected(self) -> None:
+        findings = broken_skill_instruction_references(
+            REPO_ROOT / ".claude" / "skills" / "check" / "SKILL.md",
+            """Run the check:\n```bash\npyright lib/_missing_issue_620.py\n```\n""",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_commonmark_fence_variants_cannot_hide_stale_paths(self) -> None:
+        cases = {
+            "indented backticks": (
+                "   ```bash\npyright lib/_missing_indented_issue_620.py\n   ```\n"
+            ),
+            "long backticks": (
+                "````bash\npyright lib/_missing_long_issue_620.py\n`````\n"
+            ),
+            "tilde fence": (
+                "~~~bash\npyright lib/_missing_tilde_issue_620.py\n~~~\n"
+            ),
+        }
+        path = REPO_ROOT / ".claude" / "skills" / "check" / "SKILL.md"
+        for label, text in cases.items():
+            with self.subTest(label=label):
+                findings = broken_skill_instruction_references(
+                    path,
+                    text,
+                    REPO_ROOT,
+                )
+                self.assertEqual(len(findings), 1)
+
+    def test_missing_root_file_in_fenced_skill_command_is_rejected(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / ".claude" / "skills" / "check" / "SKILL.md"
+            findings = broken_skill_instruction_references(
+                source,
+                "```bash\npyright album_source.py\n```\n",
+                root,
+            )
+        self.assertTrue(any(
+            "missing path album_source.py" in finding
+            for finding in findings
+        ))
+
+    def test_missing_inline_repo_path_in_skill_is_rejected(self) -> None:
+        findings = broken_skill_instruction_references(
+            REPO_ROOT / ".claude" / "skills" / "check" / "SKILL.md",
+            "See `lib/_missing_inline_issue_620.py`.",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_missing_path_in_inline_skill_command_is_rejected_once(self) -> None:
+        findings = broken_skill_instruction_references(
+            REPO_ROOT / ".claude" / "skills" / "check" / "SKILL.md",
+            "Run `pyright lib/_missing_inline_command_issue_620.py`.",
+            REPO_ROOT,
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_upstream_beets_doc_path_is_excluded_only_for_beets_skill(self) -> None:
+        text = "See `docs/reference/_missing_upstream_issue_620.rst`."
+        beets_findings = broken_skill_instruction_references(
+            REPO_ROOT / ".claude" / "skills" / "beets-docs" / "SKILL.md",
+            text,
+            REPO_ROOT,
+        )
+        check_findings = broken_skill_instruction_references(
+            REPO_ROOT / ".claude" / "skills" / "check" / "SKILL.md",
+            text,
+            REPO_ROOT,
+        )
+        self.assertEqual(beets_findings, [])
+        self.assertEqual(len(check_findings), 1)
+
+    def test_cratedigger_doc_in_beets_skill_is_not_exempt(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / ".claude" / "skills" / "beets-docs" / "SKILL.md"
+            findings = broken_skill_instruction_references(
+                source,
+                "See `docs/beets-primer.md`.",
+                root,
+            )
+        self.assertTrue(any(
+            "missing path docs/beets-primer.md" in finding
+            for finding in findings
+        ))
 
     def test_nonexistent_call_identifier_is_rejected(self) -> None:
         findings = missing_call_references(
@@ -286,6 +378,84 @@ class TestLivingCodeReferences(unittest.TestCase):
             set(),
             "Register new tracked root files in the removal-stable file set.",
         )
+
+
+class TestSkillInstructionCodeReferences(unittest.TestCase):
+    """Tracked repo-owned skill instructions may only name live paths."""
+
+    def test_repo_paths_resolve(self) -> None:
+        findings: list[str] = []
+        for path in tracked_skill_instruction_files(REPO_ROOT):
+            findings.extend(broken_skill_instruction_references(
+                path,
+                path.read_text(encoding="utf-8"),
+                REPO_ROOT,
+            ))
+        self.assertEqual(
+            findings,
+            [],
+            "Stale repo path reference(s) in tracked skill instructions:\n  - "
+            + "\n  - ".join(findings),
+        )
+
+    def test_scope_is_repo_owned_tracked_skills_only(self) -> None:
+        files = tracked_skill_instruction_files(REPO_ROOT)
+        for skill_name in ("beets-docs", "check", "debug-download", "deploy"):
+            self.assertIn(
+                REPO_ROOT / ".claude" / "skills" / skill_name / "SKILL.md",
+                files,
+            )
+        for path in files:
+            relative = path.relative_to(REPO_ROOT)
+            self.assertEqual(relative.parts[:2], (".claude", "skills"))
+            self.assertEqual(relative.name, "SKILL.md")
+
+    def test_known_bad_stale_path_in_tracked_skill_is_rejected(self) -> None:
+        path = REPO_ROOT / ".claude" / "skills" / "check" / "SKILL.md"
+        self.assertIn(path, tracked_skill_instruction_files(REPO_ROOT))
+        text = path.read_text(encoding="utf-8")
+        stale_text = text.replace(
+            "lib/pipeline_db",
+            "lib/_missing_issue_620.py",
+            1,
+        )
+        self.assertNotEqual(stale_text, text)
+        findings = broken_skill_instruction_references(
+            path,
+            stale_text,
+            REPO_ROOT,
+        )
+        self.assertTrue(any(
+            "missing path lib/_missing_issue_620.py" in finding
+            for finding in findings
+        ))
+
+    def test_generated_plugin_and_untracked_skill_trees_are_excluded(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            tracked = root / ".claude" / "skills" / "owned" / "SKILL.md"
+            untracked = root / ".claude" / "skills" / "local" / "SKILL.md"
+            plugin = (
+                root / ".codex" / "plugins" / "cache" / "external"
+                / "SKILL.md"
+            )
+            for path in (tracked, untracked, plugin):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# Test\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(
+                [
+                    "git", "add", "--",
+                    tracked.relative_to(root).as_posix(),
+                    plugin.relative_to(root).as_posix(),
+                ],
+                cwd=root,
+                check=True,
+            )
+            files = tracked_skill_instruction_files(root)
+        self.assertIn(tracked, files)
+        self.assertNotIn(untracked, files)
+        self.assertNotIn(plugin, files)
 
 
 class TestBacktickedCallReferences(unittest.TestCase):


### PR DESCRIPTION
## Summary

- fix the shared check skill to type-check the current `lib/pipeline_db/` package
- discover only git-tracked repo-owned `.claude/skills/**/SKILL.md` instructions
- audit repo paths in inline commands and CommonMark fenced command blocks, including root-file arguments
- keep upstream Beets RST references narrowly exempt while auditing Cratedigger-owned docs
- add deterministic known-bad and scope tests for stale paths, fence variants, untracked skills, and plugin caches

Closes #620.

## Verification

- reviewer: CLEAN after one fix iteration
- documented check-skill pyright command verbatim — 0 errors, 0 warnings
- focused docs/skill audit — 44 passed
- dict-access, dead-code, and diff gates — clean
- full suite — 5274 passed
- pre-push generated fuzz burst — passed
- `nix flake check` — passed
