### PR TITLE
fix(web): make MusicBrainz artist failures retryable

### DIFF
--- a/tests/test_browse_route_generated.py
+++ b/tests/test_browse_route_generated.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+import email.message
 import json
 import unittest
 from unittest.mock import patch
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 from hypothesis import given, strategies as st
 
@@ -15,6 +16,8 @@ from web.routes.browse import get_artist
 
 
 _CLEAN_ERROR = "MusicBrainz fallback unavailable, retry"
+_NOT_FOUND_ERROR = "MusicBrainz artist not found"
+_REJECTED_ERROR = "MusicBrainz request rejected"
 
 
 def assert_clean_retryable_failure(status: int, data: dict, raw_reason: str) -> None:
@@ -25,6 +28,30 @@ def assert_clean_retryable_failure(status: int, data: dict, raw_reason: str) -> 
         raise AssertionError(f"unstable retry payload: {data!r}")
     if raw_reason in json.dumps(data):
         raise AssertionError("raw MusicBrainz transport reason leaked")
+
+
+def assert_clean_http_failure(
+    status: int,
+    data: dict,
+    upstream_status: int,
+    raw_reason: str,
+) -> None:
+    """Assert stable status-aware handling for real HTTPError failures."""
+    if upstream_status == 404:
+        expected_status = 404
+        expected_data = {"error": _NOT_FOUND_ERROR, "retryable": False}
+    elif upstream_status == 429 or 500 <= upstream_status <= 599:
+        expected_status = 503
+        expected_data = {"error": _CLEAN_ERROR, "retryable": True}
+    else:
+        expected_status = upstream_status
+        expected_data = {"error": _REJECTED_ERROR, "retryable": False}
+    if status != expected_status or data != expected_data:
+        raise AssertionError(
+            f"unstable HTTP failure contract: status={status} data={data!r}"
+        )
+    if raw_reason in json.dumps(data):
+        raise AssertionError("raw MusicBrainz HTTP reason leaked")
 
 
 class _RecordingHandler:
@@ -46,6 +73,16 @@ class TestArtistMusicBrainzFailureGenerated(unittest.TestCase):
             assert_clean_retryable_failure(
                 503,
                 {"error": f"<urlopen error {raw_reason}>"},
+                raw_reason,
+            )
+
+    def test_http_contract_checker_rejects_known_bad_payload(self):
+        raw_reason = "raw HTTP secret"
+        with self.assertRaisesRegex(AssertionError, "unstable HTTP failure contract"):
+            assert_clean_http_failure(
+                503,
+                {"error": f"HTTP Error 404: {raw_reason}", "retryable": True},
+                404,
                 raw_reason,
             )
 
@@ -79,3 +116,51 @@ class TestArtistMusicBrainzFailureGenerated(unittest.TestCase):
         assert handler.status is not None
         assert handler.data is not None
         assert_clean_retryable_failure(handler.status, handler.data, raw_reason)
+
+    @given(
+        failing_call=st.sampled_from(("release_groups", "official_releases")),
+        upstream_status=st.one_of(
+            st.integers(min_value=400, max_value=499),
+            st.integers(min_value=500, max_value=599),
+        ),
+        reason_suffix=st.text(
+            alphabet=st.characters(
+                min_codepoint=0x20,
+                max_codepoint=0x7E,
+                blacklist_characters="\r\n",
+            ),
+            min_size=1,
+            max_size=80,
+        ),
+    )
+    def test_http_statuses_and_both_calls_keep_clean_status_aware_contract(
+        self,
+        failing_call: str,
+        upstream_status: int,
+        reason_suffix: str,
+    ) -> None:
+        raw_reason = f"raw-mb-http-secret::{reason_suffix}"
+        error = HTTPError(
+            url="https://musicbrainz.invalid/artist",
+            code=upstream_status,
+            msg=raw_reason,
+            hdrs=email.message.Message(),
+            fp=None,
+        )
+        handler = _RecordingHandler()
+        with patch("web.server.mb_api") as mock_mb:
+            if failing_call == "release_groups":
+                mock_mb.get_artist_release_groups.side_effect = error
+            else:
+                mock_mb.get_artist_release_groups.return_value = []
+                mock_mb.get_official_release_group_ids.side_effect = error
+            get_artist(handler, {}, self.ARTIST_ID)  # type: ignore[arg-type]
+
+        assert handler.status is not None
+        assert handler.data is not None
+        assert_clean_http_failure(
+            handler.status,
+            handler.data,
+            upstream_status,
+            raw_reason,
+        )

--- a/tests/test_browse_route_generated.py
+++ b/tests/test_browse_route_generated.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generated contract patrol for retryable MusicBrainz artist failures."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+from urllib.error import URLError
+
+from hypothesis import given, strategies as st
+
+from tests import _hypothesis_profiles  # noqa: F401 — registers active profile
+from web.routes.browse import get_artist
+
+
+_CLEAN_ERROR = "MusicBrainz fallback unavailable, retry"
+
+
+def assert_clean_retryable_failure(status: int, data: dict, raw_reason: str) -> None:
+    """Assert the stable route contract and absence of adapter details."""
+    if status != 503:
+        raise AssertionError(f"expected 503, got {status}")
+    if data != {"error": _CLEAN_ERROR, "retryable": True}:
+        raise AssertionError(f"unstable retry payload: {data!r}")
+    if raw_reason in json.dumps(data):
+        raise AssertionError("raw MusicBrainz transport reason leaked")
+
+
+class _RecordingHandler:
+    def __init__(self) -> None:
+        self.status: int | None = None
+        self.data: dict | None = None
+
+    def _json(self, data: dict, status: int = 200) -> None:
+        self.status = status
+        self.data = data
+
+
+class TestArtistMusicBrainzFailureGenerated(unittest.TestCase):
+    ARTIST_ID = "664c3e0e-42d8-48c1-b209-1efca19c0325"
+
+    def test_contract_checker_rejects_known_bad_payload(self):
+        raw_reason = "raw transport secret"
+        with self.assertRaisesRegex(AssertionError, "unstable retry payload"):
+            assert_clean_retryable_failure(
+                503,
+                {"error": f"<urlopen error {raw_reason}>"},
+                raw_reason,
+            )
+
+    @given(
+        failing_call=st.sampled_from(("release_groups", "official_releases")),
+        reason_suffix=st.text(
+            alphabet=st.characters(
+                min_codepoint=0x20,
+                max_codepoint=0x7E,
+                blacklist_characters="\r\n",
+            ),
+            min_size=1,
+            max_size=80,
+        ),
+    )
+    def test_all_transport_reasons_and_both_calls_keep_stable_contract(
+        self,
+        failing_call: str,
+        reason_suffix: str,
+    ) -> None:
+        raw_reason = f"raw-mb-transport-secret::{reason_suffix}"
+        handler = _RecordingHandler()
+        with patch("web.server.mb_api") as mock_mb:
+            if failing_call == "release_groups":
+                mock_mb.get_artist_release_groups.side_effect = URLError(raw_reason)
+            else:
+                mock_mb.get_artist_release_groups.return_value = []
+                mock_mb.get_official_release_group_ids.side_effect = URLError(raw_reason)
+            get_artist(handler, {}, self.ARTIST_ID)  # type: ignore[arg-type]
+
+        assert handler.status is not None
+        assert handler.data is not None
+        assert_clean_retryable_failure(handler.status, handler.data, raw_reason)

--- a/tests/test_js_browse.mjs
+++ b/tests/test_js_browse.mjs
@@ -11,7 +11,7 @@
 
 import assert from 'node:assert/strict';
 
-import { loadArtistPage, reloadBrowseArtist } from '../web/js/browse.js';
+import { loadArtistPage, reloadBrowseArtist, setBrowseSource } from '../web/js/browse.js';
 import { state } from '../web/js/state.js';
 
 const artistBody = {
@@ -20,10 +20,20 @@ const artistBody = {
   insertAdjacentHTML: () => {},
 };
 
+const elements = {
+  'browse-artist-body': artistBody,
+  'browse-artist-name': { textContent: '' },
+  'browse-artist': { style: { display: 'block' } },
+  results: { style: { display: 'none' } },
+  q: { value: '' },
+  'source-mb': { className: '' },
+  'source-discogs': { className: '' },
+  'source-hint': { innerHTML: '' },
+};
+
 globalThis.document = {
   getElementById(id) {
-    if (id === 'browse-artist-body') return artistBody;
-    return null;
+    return elements[id] || null;
   },
 };
 
@@ -43,6 +53,16 @@ function resetWorld() {
   state.searchTargetExpandId = null;
   state.searchTargetSource = null;
   artistBody.innerHTML = '';
+  elements['browse-artist-name'].textContent = '';
+  elements['browse-artist'].style.display = 'block';
+  elements.results.style.display = 'none';
+  elements.q.value = '';
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(r => { resolve = r; });
+  return { promise, resolve };
 }
 
 function assertSafeRetryFailure(aid, rawSecret) {
@@ -164,6 +184,101 @@ resetWorld();
   await oldLoad;
   assert.equal(artistBody.innerHTML, activeHtml, 'stale failure must not replace active content');
   assert.equal(state.browseCache['old-artist'], undefined);
+}
+
+// Source-switch race pin: invalidation happens before the cross-source artist
+// lookup awaits. An old MB failure cannot paint Retry after Discogs becomes
+// the active source, and the resulting current load/retry uses the Discogs id.
+resetWorld();
+{
+  const oldArtist = deferred();
+  const oldLibrary = deferred();
+  const sourceLookup = deferred();
+  const requests = [];
+  state.browseSource = 'mb';
+  state.browseArtist = { id: 'old-mb-id', name: 'Race Artist' };
+  globalThis.fetch = (url) => {
+    requests.push(url);
+    if (url.includes('/api/artist/old-mb-id?')) return oldArtist.promise;
+    if (url.includes('mbid=old-mb-id')) return oldLibrary.promise;
+    if (url.includes('/api/discogs/search?')) return sourceLookup.promise;
+    if (url.includes('/api/discogs/artist/new-discogs-id?')) {
+      return Promise.resolve(response(503, { error: 'current failure', retryable: true }));
+    }
+    if (url.includes('/api/library/artist?name=Race%20Artist')) {
+      return Promise.resolve(response(200, { albums: [] }));
+    }
+    throw new Error(`unexpected race request: ${url}`);
+  };
+
+  const oldLoad = loadArtistPage('old-mb-id', 'Race Artist');
+  const sourceSwitch = setBrowseSource('discogs');
+  oldArtist.resolve(response(503, { error: 'stale MB failure', retryable: true }));
+  oldLibrary.resolve(response(200, { albums: [] }));
+  await oldLoad;
+  assert.doesNotMatch(
+    artistBody.innerHTML,
+    />Retry</,
+    'old-source failure must be stale as soon as source switching starts',
+  );
+
+  sourceLookup.resolve(response(200, {
+    artists: [{ id: 'new-discogs-id', name: 'Race Artist' }],
+  }));
+  await sourceSwitch;
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(state.browseArtist, { id: 'new-discogs-id', name: 'Race Artist' });
+  assert(requests.some(url => url.includes('/api/discogs/artist/new-discogs-id?')));
+  assert.match(artistBody.innerHTML, />Retry</, 'current-source failure owns Retry');
+
+  requests.length = 0;
+  globalThis.fetch = async (url) => {
+    requests.push(url);
+    throw new Error('retry remains unavailable');
+  };
+  reloadBrowseArtist();
+  await new Promise(resolve => setImmediate(resolve));
+  assert(requests.some(url => url.includes('/api/discogs/artist/new-discogs-id?')));
+  assert(requests.some(url => url === '/api/library/artist?name=Race%20Artist'));
+  assert(!requests.some(url => url.includes('old-mb-id')));
+}
+
+// Generated/property sweep around the race: either fast-pair half, several
+// failure classes, and both source directions remain stale while lookup waits.
+for (const [oldSource, newSource] of [['mb', 'discogs'], ['discogs', 'mb']]) {
+  for (const failedPart of ['artist', 'library']) {
+    for (const status of [404, 429, 503]) {
+      resetWorld();
+      const oldFastA = deferred();
+      const oldFastB = deferred();
+      const sourceLookup = deferred();
+      let callIndex = 0;
+      state.browseSource = oldSource;
+      state.browseArtist = { id: `old-${oldSource}`, name: 'Generated Race' };
+      globalThis.fetch = () => {
+        const call = callIndex++;
+        if (call === 0) return oldFastA.promise;
+        if (call === 1) return oldFastB.promise;
+        if (call === 2) return sourceLookup.promise;
+        throw new Error(`unexpected generated race fetch ${call}`);
+      };
+
+      const oldLoad = loadArtistPage(`old-${oldSource}`, 'Generated Race');
+      const sourceSwitch = setBrowseSource(newSource);
+      oldFastA.resolve(failedPart === 'artist'
+        ? response(status, { error: 'stale generated failure' })
+        : response(200, { release_groups: [] }));
+      oldFastB.resolve(failedPart === 'library'
+        ? response(status, { error: 'stale generated failure' })
+        : response(200, { albums: [] }));
+      await oldLoad;
+      assert.doesNotMatch(artistBody.innerHTML, />Retry</);
+
+      sourceLookup.resolve(response(200, { artists: [] }));
+      await sourceSwitch;
+      assert.equal(state.browseArtist, null);
+    }
+  }
 }
 
 console.log('JS browse fast-pair failure tests passed');

--- a/tests/test_js_browse.mjs
+++ b/tests/test_js_browse.mjs
@@ -1,0 +1,169 @@
+/**
+ * Artist-page fast-pair failure tests (issue #603).
+ *
+ * Invariants:
+ *  B1 Either non-OK fast response, or a network rejection, leaves the
+ *     artist cache untouched and never renders a raw exception string.
+ *  B2 The active failed load renders a clear Retry action wired through
+ *     the existing window.reloadBrowseArtist binding.
+ *  B3 A stale failed load cannot replace the active page's content.
+ */
+
+import assert from 'node:assert/strict';
+
+import { loadArtistPage, reloadBrowseArtist } from '../web/js/browse.js';
+import { state } from '../web/js/state.js';
+
+const artistBody = {
+  innerHTML: '',
+  querySelector: () => null,
+  insertAdjacentHTML: () => {},
+};
+
+globalThis.document = {
+  getElementById(id) {
+    if (id === 'browse-artist-body') return artistBody;
+    return null;
+  },
+};
+
+function response(status, data) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return data; },
+  };
+}
+
+function resetWorld() {
+  state.browseSource = 'mb';
+  state.browseArtist = null;
+  state.browseCache = {};
+  state.searchTargetId = null;
+  state.searchTargetExpandId = null;
+  state.searchTargetSource = null;
+  artistBody.innerHTML = '';
+}
+
+function assertSafeRetryFailure(aid, rawSecret) {
+  assert.equal(state.browseCache[aid], undefined, 'failed fast pair must not populate cache');
+  assert.match(artistBody.innerHTML, />Retry</, 'failure state must offer Retry');
+  assert.match(
+    artistBody.innerHTML,
+    /onclick="window\.reloadBrowseArtist\(\)"/,
+    'Retry must call the existing public reload binding',
+  );
+  assert.doesNotMatch(artistBody.innerHTML, new RegExp(rawSecret), 'raw failure detail must stay hidden');
+}
+
+// Known-bad qualification: the checker trips on both persistence and leakage.
+resetWorld();
+state.browseCache.bad = { fast: {} };
+artistBody.innerHTML = '<div>raw-known-bad-secret</div>';
+assert.throws(
+  () => assertSafeRetryFailure('bad', 'raw-known-bad-secret'),
+  /failed fast pair must not populate cache/,
+);
+resetWorld();
+artistBody.innerHTML = '<button onclick="window.reloadBrowseArtist()">Retry</button> raw-known-bad-secret';
+assert.throws(
+  () => assertSafeRetryFailure('bad', 'raw-known-bad-secret'),
+  /raw failure detail must stay hidden/,
+);
+
+// Deterministic pin: the motivating MusicBrainz 503 body never becomes data.
+resetWorld();
+{
+  const aid = 'mb-503-pin';
+  const rawSecret = 'SSL UNEXPECTED_EOF private upstream detail';
+  globalThis.fetch = async (url) => url.includes('/api/library/artist')
+    ? response(200, { albums: [] })
+    : response(503, {
+      error: 'MusicBrainz fallback unavailable, retry',
+      retryable: true,
+      raw: rawSecret,
+    });
+  await loadArtistPage(aid, 'Transport Failure');
+  assertSafeRetryFailure(aid, rawSecret);
+}
+
+// Independent pin: the library half failing is just as cache-safe.
+resetWorld();
+{
+  const aid = 'library-500-pin';
+  const rawSecret = 'raw downstream database exception';
+  globalThis.fetch = async (url) => url.includes('/api/library/artist')
+    ? response(500, { error: rawSecret })
+    : response(200, { release_groups: [] });
+  await loadArtistPage(aid, 'Library Failure');
+  assertSafeRetryFailure(aid, rawSecret);
+}
+
+// Independent pin: rejected fetch promises use the same stable Retry state.
+resetWorld();
+{
+  const aid = 'network-pin';
+  const rawSecret = 'socket exploded at 10.0.0.9';
+  globalThis.fetch = async () => { throw new Error(rawSecret); };
+  await loadArtistPage(aid, 'Network Failure');
+  assertSafeRetryFailure(aid, rawSecret);
+}
+
+// Retry wiring: the public reload deletes any old artist cache and re-fetches.
+resetWorld();
+{
+  const aid = 'retry-pin';
+  let fetchCount = 0;
+  state.browseArtist = { id: aid, name: 'Retry Artist' };
+  state.browseCache[aid] = { stale: true };
+  globalThis.fetch = async () => {
+    fetchCount++;
+    throw new Error('still unavailable');
+  };
+  reloadBrowseArtist();
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(state.browseCache[aid], undefined);
+  assert(fetchCount > 0, 'Retry binding must start a fresh fetch');
+  assert.match(artistBody.innerHTML, />Retry</);
+}
+
+// Generated/property sweep: every non-OK status on either fast response keeps
+// the same cache-safe, non-leaking Retry contract.
+for (const status of [400, 401, 403, 404, 408, 409, 418, 429, 500, 502, 503, 504, 599]) {
+  for (const failedPart of ['artist', 'library']) {
+    resetWorld();
+    const aid = `generated-${failedPart}-${status}`;
+    const rawSecret = `raw-${failedPart}-secret-${status}`;
+    globalThis.fetch = async (url) => {
+      const isLibrary = url.includes('/api/library/artist');
+      const shouldFail = failedPart === 'library' ? isLibrary : !isLibrary;
+      if (shouldFail) return response(status, { error: rawSecret, retryable: status === 503 });
+      return response(200, isLibrary ? { albums: [] } : { release_groups: [] });
+    };
+    await loadArtistPage(aid, `Generated ${status}`);
+    assertSafeRetryFailure(aid, rawSecret);
+  }
+}
+
+// Stale-token pin: after a newer load owns the page, the older transport
+// failure may resolve but cannot overwrite the active Retry state.
+resetWorld();
+{
+  const pending = [];
+  globalThis.fetch = () => new Promise(resolve => pending.push(resolve));
+  const oldLoad = loadArtistPage('old-artist', 'Old Artist');
+  assert.equal(pending.length, 2, 'old fast pair started both requests');
+
+  globalThis.fetch = async () => { throw new Error('new active failure'); };
+  await loadArtistPage('new-artist', 'New Artist');
+  const activeHtml = artistBody.innerHTML;
+
+  for (const resolve of pending) {
+    resolve(response(503, { error: 'raw stale failure', retryable: true }));
+  }
+  await oldLoad;
+  assert.equal(artistBody.innerHTML, activeHtml, 'stale failure must not replace active content');
+  assert.equal(state.browseCache['old-artist'], undefined);
+}
+
+console.log('JS browse fast-pair failure tests passed');

--- a/tests/test_js_browse.mjs
+++ b/tests/test_js_browse.mjs
@@ -281,4 +281,114 @@ for (const [oldSource, newSource] of [['mb', 'discogs'], ['discogs', 'mb']]) {
   }
 }
 
+// Double-toggle ownership pin: lookups can resolve out of order. The newest
+// MB toggle must keep its MB artist/id/endpoint even if the older Discogs
+// lookup returns last with a valid but wrong-source match.
+resetWorld();
+{
+  const discogsLookup = deferred();
+  const mbLookup = deferred();
+  const requests = [];
+  state.browseSource = 'mb';
+  state.browseArtist = { id: 'starting-mb-id', name: 'Toggle Artist' };
+  globalThis.fetch = (url) => {
+    requests.push(url);
+    if (url.includes('/api/discogs/search?')) return discogsLookup.promise;
+    if (url.includes('/api/search?')) return mbLookup.promise;
+    if (url.includes('/api/artist/newest-mb-id?')) {
+      return Promise.resolve(response(200, { release_groups: [] }));
+    }
+    if (url.includes('mbid=newest-mb-id')) {
+      return Promise.resolve(response(200, { albums: [] }));
+    }
+    if (url.includes('/api/artist/compare?') || url.includes('/disambiguate')) {
+      return Promise.resolve(response(503, { error: 'decoration unavailable' }));
+    }
+    if (url.includes('stale-discogs-id')) {
+      return Promise.resolve(response(503, { error: 'stale lookup drove a load' }));
+    }
+    throw new Error(`unexpected double-toggle request: ${url}`);
+  };
+
+  const olderToggle = setBrowseSource('discogs');
+  const newestToggle = setBrowseSource('mb');
+  mbLookup.resolve(response(200, {
+    artists: [{ id: 'newest-mb-id', name: 'Toggle Artist' }],
+  }));
+  await newestToggle;
+  await new Promise(resolve => setImmediate(resolve));
+  const newestHtml = artistBody.innerHTML;
+  assert.equal(state.browseSource, 'mb');
+  assert.deepEqual(state.browseArtist, { id: 'newest-mb-id', name: 'Toggle Artist' });
+  assert(requests.some(url => url.includes('/api/artist/newest-mb-id?')));
+  assert.doesNotMatch(newestHtml, />Retry</);
+
+  discogsLookup.resolve(response(200, {
+    artists: [{ id: 'stale-discogs-id', name: 'Toggle Artist' }],
+  }));
+  await olderToggle;
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(state.browseSource, 'mb');
+  assert.deepEqual(
+    state.browseArtist,
+    { id: 'newest-mb-id', name: 'Toggle Artist' },
+    'older lookup must not overwrite the newest source artist',
+  );
+  assert(!requests.some(url => url.includes('stale-discogs-id')));
+  assert.equal(artistBody.innerHTML, newestHtml, 'older lookup must not repaint the newest page');
+}
+
+// Generated/property sweep for both directions. The newest lookup may own a
+// Retry state, but resolving the older valid match cannot change its artist,
+// endpoint family, or rendered content.
+for (const newestSource of ['mb', 'discogs']) {
+  resetWorld();
+  const olderSource = newestSource === 'mb' ? 'discogs' : 'mb';
+  const lookups = { mb: deferred(), discogs: deferred() };
+  const newestId = `newest-${newestSource}-id`;
+  const staleId = `stale-${olderSource}-id`;
+  const requests = [];
+  state.browseSource = newestSource;
+  state.browseArtist = { id: `starting-${newestSource}-id`, name: 'Generated Toggle' };
+  globalThis.fetch = (url) => {
+    requests.push(url);
+    if (url.includes('/api/discogs/search?')) return lookups.discogs.promise;
+    if (url.includes('/api/search?')) return lookups.mb.promise;
+    if (url.includes(newestId)) {
+      return Promise.resolve(response(503, { error: 'newest source unavailable' }));
+    }
+    if (url.includes('/api/library/artist?')) {
+      return Promise.resolve(response(200, { albums: [] }));
+    }
+    if (url.includes(staleId)) {
+      return Promise.resolve(response(503, { error: 'stale source load' }));
+    }
+    throw new Error(`unexpected generated double-toggle request: ${url}`);
+  };
+
+  const olderToggle = setBrowseSource(olderSource);
+  const newestToggle = setBrowseSource(newestSource);
+  lookups[newestSource].resolve(response(200, {
+    artists: [{ id: newestId, name: 'Generated Toggle' }],
+  }));
+  await newestToggle;
+  await new Promise(resolve => setImmediate(resolve));
+  const newestHtml = artistBody.innerHTML;
+  assert.match(newestHtml, />Retry</);
+
+  lookups[olderSource].resolve(response(200, {
+    artists: [{ id: staleId, name: 'Generated Toggle' }],
+  }));
+  await olderToggle;
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(state.browseSource, newestSource);
+  assert.deepEqual(state.browseArtist, { id: newestId, name: 'Generated Toggle' });
+  const expectedEndpoint = newestSource === 'discogs'
+    ? `/api/discogs/artist/${newestId}?`
+    : `/api/artist/${newestId}?`;
+  assert(requests.some(url => url.includes(expectedEndpoint)));
+  assert(!requests.some(url => url.includes(staleId)));
+  assert.equal(artistBody.innerHTML, newestHtml);
+}
+
 console.log('JS browse fast-pair failure tests passed');

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import unittest
 from unittest.mock import patch
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -440,6 +440,34 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
         _assert_required_fields(self, data["release_groups"][0], self.ARTIST_RG_REQUIRED_FIELDS,
                                 "artist release group")
 
+    def test_artist_release_groups_transport_failure_is_clean_retryable_503(self):
+        raw_reason = "[SSL: UNEXPECTED_EOF_WHILE_READING] private adapter detail"
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_artist_release_groups.side_effect = URLError(raw_reason)
+            status, data = self._get(f"/api/artist/{self.ARTIST_ID}")
+
+        self.assertEqual(status, 503)
+        self.assertEqual(data, {
+            "error": "MusicBrainz fallback unavailable, retry",
+            "retryable": True,
+        })
+        self.assertNotIn(raw_reason, str(data))
+        mock_mb.get_official_release_group_ids.assert_not_called()
+
+    def test_official_release_lookup_transport_failure_is_clean_retryable_503(self):
+        raw_reason = "socket reset by peer: private upstream address"
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_artist_release_groups.return_value = []
+            mock_mb.get_official_release_group_ids.side_effect = URLError(raw_reason)
+            status, data = self._get(f"/api/artist/{self.ARTIST_ID}")
+
+        self.assertEqual(status, 503)
+        self.assertEqual(data, {
+            "error": "MusicBrainz fallback unavailable, retry",
+            "retryable": True,
+        })
+        self.assertNotIn(raw_reason, str(data))
+
     def test_artist_release_groups_in_library_when_name_passed(self):
         """When the frontend passes ?name=, each RG gets in_library: bool
         based on a beets lookup. Without name, the field stays absent
@@ -770,6 +798,34 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
                                 "disambiguate pressing")
         _assert_required_fields(self, rg["tracks"][0], self.DISAMBIGUATE_TRACK_REQUIRED_FIELDS,
                                 "disambiguate track")
+
+
+class _FailingArtistRequestsDB(FakePipelineDB):
+    def list_requests_by_artist(
+        self,
+        artist_name: str,
+        mb_artist_id: str = "",
+    ) -> list[dict[str, object]]:
+        raise RuntimeError("downstream artist overlay unavailable")
+
+
+class TestArtistFailureBoundary(_FakeDbWebServerCase):
+    """Only MusicBrainz transport calls belong to the retryable mapping."""
+
+    DB_FACTORY = _FailingArtistRequestsDB
+    ARTIST_ID = "664c3e0e-42d8-48c1-b209-1efca19c0325"
+
+    def test_downstream_db_overlay_failure_is_not_remapped_as_musicbrainz(self):
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_artist_release_groups.return_value = []
+            mock_mb.get_official_release_group_ids.return_value = set()
+            status, data = self._get(
+                f"/api/artist/{self.ARTIST_ID}?name=Test%20Artist"
+            )
+
+        self.assertEqual(status, 500)
+        self.assertEqual(data, {"error": "downstream artist overlay unavailable"})
+        self.assertNotIn("retryable", data)
 
 
 class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -468,6 +468,48 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
         })
         self.assertNotIn(raw_reason, str(data))
 
+    def test_artist_release_groups_not_found_is_clean_non_retryable_404(self):
+        raw_reason = "raw upstream artist lookup details"
+        error = HTTPError(
+            url="https://musicbrainz.invalid/artist",
+            code=404,
+            msg=raw_reason,
+            hdrs=email.message.Message(),
+            fp=None,
+        )
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_artist_release_groups.side_effect = error
+            status, data = self._get(f"/api/artist/{self.ARTIST_ID}")
+
+        self.assertEqual(status, 404)
+        self.assertEqual(data, {
+            "error": "MusicBrainz artist not found",
+            "retryable": False,
+        })
+        self.assertNotIn(raw_reason, str(data))
+        mock_mb.get_official_release_group_ids.assert_not_called()
+
+    def test_official_release_lookup_not_found_is_clean_non_retryable_404(self):
+        raw_reason = "raw official release lookup details"
+        error = HTTPError(
+            url="https://musicbrainz.invalid/releases",
+            code=404,
+            msg=raw_reason,
+            hdrs=email.message.Message(),
+            fp=None,
+        )
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_artist_release_groups.return_value = []
+            mock_mb.get_official_release_group_ids.side_effect = error
+            status, data = self._get(f"/api/artist/{self.ARTIST_ID}")
+
+        self.assertEqual(status, 404)
+        self.assertEqual(data, {
+            "error": "MusicBrainz artist not found",
+            "retryable": False,
+        })
+        self.assertNotIn(raw_reason, str(data))
+
     def test_artist_release_groups_in_library_when_name_passed(self):
         """When the frontend passes ?name=, each RG gets in_library: bool
         based on a beets lookup. Without name, the field stays absent

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -62,6 +62,10 @@ function applySourceUI(src) {
 export async function setBrowseSource(src) {
   if (state.browseSource === src) return;
   searchArtistsRequestToken++;
+  // Invalidate the current artist page BEFORE the cross-source lookup
+  // awaits. Otherwise an old-source fast-pair failure can paint Retry
+  // while the new source is already selected but its artist ID is pending.
+  artistPageToken++;
   // Explicit user source-toggle clears any active search-by-ID ring.
   // The source-guard in applySearchTargetAfterDiscography would mask
   // the immediate symptom, but a paste→toggle-twice sequence (away
@@ -84,7 +88,6 @@ export async function setBrowseSource(src) {
     }
     toast(`No ${src === 'discogs' ? 'Discogs' : 'MusicBrainz'} match for ${prevName}`, true);
     state.browseArtist = null;
-    artistPageToken++;
     document.getElementById('browse-artist').style.display = 'none';
   }
 

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -65,7 +65,7 @@ export async function setBrowseSource(src) {
   // Invalidate the current artist page BEFORE the cross-source lookup
   // awaits. Otherwise an old-source fast-pair failure can paint Retry
   // while the new source is already selected but its artist ID is pending.
-  artistPageToken++;
+  const sourceSwitchToken = ++artistPageToken;
   // Explicit user source-toggle clears any active search-by-ID ring.
   // The source-guard in applySearchTargetAfterDiscography would mask
   // the immediate symptom, but a paste→toggle-twice sequence (away
@@ -80,6 +80,7 @@ export async function setBrowseSource(src) {
   if (state.browseArtist) {
     const prevName = state.browseArtist.name;
     const match = await findArtistOnSource(prevName, src);
+    if (sourceSwitchToken !== artistPageToken || state.browseSource !== src) return;
     if (match) {
       state.browseArtist = { id: String(match.id), name: match.name };
       document.getElementById('browse-artist-name').textContent = match.name;

--- a/web/js/browse.js
+++ b/web/js/browse.js
@@ -390,6 +390,29 @@ export function reloadBrowseArtist() {
 }
 
 /**
+ * Fetch one half of the artist page's fast pair as JSON.
+ * A JSON error body is not artist data: reject it before the pair can be
+ * cached or rendered. The caller deliberately renders a stable message
+ * instead of exposing response or exception details.
+ * @param {string} url
+ * @returns {Promise<Object>}
+ */
+async function fetchArtistPageJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`artist page request failed (${response.status})`);
+  return response.json();
+}
+
+/** Render the stable, retryable artist-page failure state. */
+function renderArtistPageFailure(el) {
+  el.innerHTML = `
+    <div class="loading artist-load-error">
+      <div>Artist page temporarily unavailable.</div>
+      <button class="p-btn" style="margin-top:10px" onclick="window.reloadBrowseArtist()">Retry</button>
+    </div>`;
+}
+
+/**
  * Load and render the unified artist page (issue #575 PR4).
  *
  * Fast pair first — the source discography (?name= so the backend
@@ -444,8 +467,8 @@ export async function loadArtistPage(aid, name) {
       ? `${API}/api/library/artist?name=${encodeURIComponent(name)}`
       : `${API}/api/library/artist?name=${encodeURIComponent(name)}&mbid=${aid}`;
     const [rgRes, libRes] = await Promise.all([
-      fetch(artistUrl).then(r => r.json()),
-      fetch(libUrl).then(r => r.json()),
+      fetchArtistPageJson(artistUrl),
+      fetchArtistPageJson(libUrl),
     ]);
     if (token !== artistPageToken) return;
     state.browseCache[aid] = { fast: { rgRes, libRes }, compare: null, disamb: null };
@@ -453,9 +476,9 @@ export async function loadArtistPage(aid, name) {
     // Fire-and-forget decorations; each guards on the token.
     fireCompareComplement(el, aid, name, token);
     fireAnalysis(el, aid, token);
-  } catch (e) {
+  } catch (_e) {
     if (token !== artistPageToken) return;
-    el.innerHTML = '<div class="loading">Failed to load</div>';
+    renderArtistPageFailure(el);
   }
 }
 

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -109,8 +109,15 @@ def _apply_rg_pipeline_overlay(rows: list[dict], by_rg: dict, by_release: dict) 
 
 def get_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]], artist_id: str) -> None:
     srv = _server()
-    rgs = srv.mb_api.get_artist_release_groups(artist_id)
-    official_rg_ids = srv.mb_api.get_official_release_group_ids(artist_id)
+    try:
+        rgs = srv.mb_api.get_artist_release_groups(artist_id)
+        official_rg_ids = srv.mb_api.get_official_release_group_ids(artist_id)
+    except urllib.error.URLError:
+        h._json({  # type: ignore[attr-defined]
+            "error": "MusicBrainz fallback unavailable, retry",
+            "retryable": True,
+        }, status=503)
+        return
     for rg in rgs:
         rg["has_official"] = rg["id"] in official_rg_ids
     # Row-level in-library badge: requires the artist's library albums.

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -112,6 +112,29 @@ def get_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]], artist_i
     try:
         rgs = srv.mb_api.get_artist_release_groups(artist_id)
         official_rg_ids = srv.mb_api.get_official_release_group_ids(artist_id)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            status = 404
+            payload = {
+                "error": "MusicBrainz artist not found",
+                "retryable": False,
+            }
+        elif exc.code == 429 or 500 <= exc.code <= 599:
+            status = 503
+            payload = {
+                "error": "MusicBrainz fallback unavailable, retry",
+                "retryable": True,
+            }
+        elif 400 <= exc.code <= 499:
+            status = exc.code
+            payload = {
+                "error": "MusicBrainz request rejected",
+                "retryable": False,
+            }
+        else:
+            raise
+        h._json(payload, status=status)  # type: ignore[attr-defined]
+        return
     except urllib.error.URLError:
         h._json({  # type: ignore[attr-defined]
             "error": "MusicBrainz fallback unavailable, retry",


### PR DESCRIPTION
Part of #603 (PR B: MusicBrainz fallback hygiene).

## Summary
- map transport `URLError` from only the two MusicBrainz calls in `/api/artist` to stable retryable `503` JSON
- map real `HTTPError` by status without raw details: `404` becomes a clean non-retryable not-found response, other 4xx remain clean/non-retryable, and 429/5xx become the stable retryable `503`
- reject non-OK artist/library fast-pair responses before cache or render, then show a stable Retry action through `window.reloadBrowseArtist`
- invalidate artist-page requests synchronously when the source changes, before the cross-source artist lookup awaits, so old-source failures cannot paint over the new context
- bind each cross-source lookup to that same request generation so an older lookup resolving last cannot replace the newest source/artist or call the wrong endpoint family
- preserve stale-load suppression and prove downstream DB/overlay errors are not remapped as MusicBrainz failures

## Invariants and tests
- deterministic route pins use real `urllib.error.URLError(reason)` and real `HTTPError` at both MB call sites; every clean response excludes raw reasons
- generated properties sweep both call sites, arbitrary transport reasons, and every HTTP 400-599 status, with known-bad checker qualification
- production `loadArtistPage` tests independently cover the clean 503 body, the library half failing, network rejection, Retry wiring, cache non-write, non-OK status sweep, and stale response suppression
- a realistic pending old-source fast-pair plus pending source-lookup race proves stale failures cannot render Retry; a both-direction/status patrol proves the invariant around it; the current load and Retry use the matched source/id
- a deterministic out-of-order double-toggle pin and both-direction property sweep prove the newest lookup owns the final source, artist ID family, endpoint family, and render
- downstream typed DB failure remains an ordinary non-retryable 500 outside the MB boundary

## Verification
- focused browse route + generated tests: 55 passed
- all JS suites and window-binding audit: green
- focused generated fuzz: 40,000 examples, green
- exact full suite: 5,373 tests in 149.772s, green
- exact full-repo `nix-shell --run "pyright"`: 0 errors
- dead-code sweep: clean
- real pre-push push-profile shards: green
- `nix flake check`: all 36 checks passed, including module VM

## Visual QA
The visible Retry UI did not change during the review correction. The accepted read-only live-db loop against Deloris remains representative:
- desktop 1000x900: stable message and centered Retry
- mobile 390x844: stable message and visible Retry
- after removing interception, Retry issued a fresh request, received HTTP 200, and rendered the real live discography

No production mutations were made. The already-ledgered 390px top-tab overflow is intentionally left for issue 603 PR C.
