### PR TITLE
fix(web): polish pressing actions and mobile tabs

### DIFF
--- a/tests/test_js_discography.mjs
+++ b/tests/test_js_discography.mjs
@@ -3,7 +3,13 @@
  * Run with: node tests/test_js_discography.mjs
  */
 
-import { synthesizeMasterlessRow, splitPressings, statusChipHtml } from '../web/js/discography.js';
+import {
+  renderPressingRow,
+  renderRgRow,
+  synthesizeMasterlessRow,
+  splitPressings,
+  statusChipHtml,
+} from '../web/js/discography.js';
 
 let passed = 0;
 let failed = 0;
@@ -15,6 +21,25 @@ function assertEqual(actual, expected, msg) {
     failed++;
     console.error(`  FAIL: ${msg} - expected '${expected}', got '${actual}'`);
   }
+}
+
+function assertContains(haystack, needle, msg) {
+  assertEqual(haystack.includes(needle), true, msg);
+}
+
+function assertExcludes(haystack, needle, msg) {
+  assertEqual(haystack.includes(needle), false, msg);
+}
+
+/** Independent expected encoder: JSON JS literal, then HTML attribute escaping. */
+function expectedJsArg(value) {
+  return JSON.stringify(String(value))
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/\\/g, '&#92;');
 }
 
 console.log('synthesizeMasterlessRow() — overlay fields survive the synthesis');
@@ -166,6 +191,71 @@ console.log('statusChipHtml() — non-official pressings get a provenance chip')
   assertEqual(statusChipHtml('Promotion').includes('badge-nonofficial'), true, 'chip uses the nonofficial badge class');
   assertEqual(statusChipHtml('Bootleg').includes('bootleg'), true, 'Bootleg -> bootleg chip');
   assertEqual(statusChipHtml('Pseudo-Release').includes('pseudo-release'), true, 'other statuses lowercased verbatim');
+}
+
+console.log('Release-id onclick arguments — adversarial deterministic pin');
+{
+  const id = "rg'\"\\</div><script>alert(1)</script>";
+  const arg = expectedJsArg(id);
+  const rgHtml = renderRgRow(
+    { id, title: 'Adversarial RG', first_release_date: '2003', is_masterless: true },
+    { artistName: 'The Wrens', nameLC: 'the wrens', source: 'mb' },
+  );
+  const pressingHtml = renderPressingRow({
+    id,
+    title: 'Adversarial pressing',
+    status: 'Official',
+    in_library: false,
+    pipeline_status: null,
+    country: 'US',
+    date: '2003',
+    format: 'CD',
+    track_count: 13,
+  }, { artistName: 'The Wrens', parentRgId: 'parent', canReplace: false });
+
+  assertContains(rgHtml, `window.loadReleaseGroup(${arg}, this`, 'RG click passes one encoded JS string argument');
+  assertExcludes(rgHtml, `window.loadReleaseGroup('${id}'`, 'known-bad raw single-quoted RG interpolation is absent');
+  assertContains(pressingHtml, `window.toggleReleaseDetail(${arg})`, 'pressing click passes one encoded JS string argument');
+  assertExcludes(pressingHtml, `window.toggleReleaseDetail('${id}')`, 'known-bad raw single-quoted pressing interpolation is absent');
+  assertExcludes(pressingHtml, '>Remove from beets</button>', 'unowned pressing omits disabled beets action');
+  assertContains(pressingHtml, '>Add request</button>', 'unowned pressing keeps Add request');
+  assertContains(pressingHtml, '>Replace</button>', 'unowned pressing keeps Replace');
+}
+
+console.log('Release-id onclick arguments — generated critical-character property sweep');
+{
+  const atoms = ['a', "'", '"', '\\', '<', '>', '&', '\n', '\u2028'];
+  const ids = ['plain-id', ...atoms];
+  for (const left of atoms) {
+    for (const right of atoms) ids.push(`id${left}${right}tail`);
+  }
+  for (const id of ids) {
+    const arg = expectedJsArg(id);
+    const rgHtml = renderRgRow(
+      { id, title: 'RG', first_release_date: '2000' },
+      { artistName: 'Artist', nameLC: 'artist' },
+    );
+    const pressingHtml = renderPressingRow({
+      id,
+      title: 'Pressing',
+      status: 'Official',
+      in_library: true,
+      beets_album_id: 42,
+      country: 'AU',
+      date: '2000',
+      format: 'CD',
+      track_count: 10,
+    }, { artistName: 'Artist', parentRgId: 'parent', canReplace: true });
+    assertContains(rgHtml, `window.loadReleaseGroup(${arg}, this`, `RG id round-trips safely: ${JSON.stringify(id)}`);
+    assertContains(pressingHtml, `window.toggleReleaseDetail(${arg})`, `pressing id round-trips safely: ${JSON.stringify(id)}`);
+    assertContains(pressingHtml, 'window.confirmDeleteBeets(42', `owned removal survives: ${JSON.stringify(id)}`);
+  }
+
+  const badId = "break'out";
+  const oldHandler = `window.toggleReleaseDetail('${badId}')`;
+  let oldCompiles = true;
+  try { new Function('window', oldHandler); } catch (_) { oldCompiles = false; }
+  assertEqual(oldCompiles, false, 'known-bad raw interpolation checker rejects apostrophe ID');
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_library.mjs
+++ b/tests/test_js_library.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_library.mjs
  */
 
-import { buildDeleteConfirmHtml } from '../web/js/library.js';
+import { buildDeleteConfirmHtml, renderLibraryDetailBody } from '../web/js/library.js';
 
 let passed = 0;
 let failed = 0;
@@ -46,6 +46,68 @@ console.log('buildDeleteConfirmHtml() omits pipeline note without release id');
   const html = buildDeleteConfirmHtml(7, 'Bodyjar', 'Plastic Skies', 12, null, '');
   assertContains(html, 'window.executeBeetsDeletion(7, this, null, &quot;&quot;)', 'empty release id still encoded safely');
   assertExcludes(html, 'matching pipeline request/history', 'no pipeline note without release id');
+}
+
+/** Independent expected encoder: JSON JS literal, then HTML attribute escaping. */
+function expectedJsArg(value) {
+  return JSON.stringify(String(value))
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/\\/g, '&#92;');
+}
+
+function libraryDetail(releaseId) {
+  return renderLibraryDetailBody({
+    mb_albumid: releaseId,
+    pipeline_id: 1712,
+    pipeline_status: 'wanted',
+    pipeline_source: 'request',
+    artist: 'Artist',
+    album: 'Album',
+    tracks: [],
+  }, 42);
+}
+
+console.log('Library quality controls — adversarial deterministic release-id pin');
+{
+  const id = "release'\"\\</button><script>alert(1)</script>";
+  const html = libraryDetail(id);
+  const arg = expectedJsArg(id);
+  assertContains(html, `window.setLibQuality(${arg}, 'wanted', null)`, 'wanted control encodes release id');
+  assertContains(html, `window.setLibQuality(${arg}, 'manual', null)`, 'manual control encodes release id');
+  assertContains(html, `window.setLibQuality(${arg}, null, parseInt(v))`, 'min-bitrate control encodes release id');
+  assertExcludes(html, `window.setLibQuality('${id}'`, 'known-bad raw single-quoted interpolation is absent');
+}
+
+console.log('Library quality controls — generated critical-character property sweep');
+{
+  const atoms = ['a', "'", '"', '\\', '<', '>', '&', '\n', '\u2028'];
+  const ids = ['plain-id'];
+  for (const left of atoms) {
+    for (const right of atoms) ids.push(`id${left}${right}tail`);
+  }
+  for (const id of ids) {
+    const html = libraryDetail(id);
+    const arg = expectedJsArg(id);
+    const encodedCalls = html.split(`window.setLibQuality(${arg},`).length - 1;
+    assertContains(html, `window.setLibQuality(${arg},`, `library ID encoded: ${JSON.stringify(id)}`);
+    if (encodedCalls !== 5) {
+      failed++;
+      console.error(`  FAIL: all five quality controls encode ${JSON.stringify(id)} — got ${encodedCalls}`);
+    } else {
+      passed++;
+    }
+  }
+
+  const badId = "break'out";
+  const oldHandler = `window.setLibQuality('${badId}', 'wanted', null)`;
+  let oldCompiles = true;
+  try { new Function('window', oldHandler); } catch (_) { oldCompiles = false; }
+  if (!oldCompiles) passed++;
+  else { failed++; console.error('  FAIL: known-bad raw library interpolation unexpectedly compiles'); }
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_release_actions.mjs
+++ b/tests/test_js_release_actions.mjs
@@ -286,6 +286,58 @@ clearStore();
   assertEqual(html, '', 'detail disabled delete action can be omitted');
 }
 
+console.log('Child pressing toolbar — hides only meaningless disabled beets removal');
+clearStore();
+{
+  // Deterministic pin: a fresh unowned pressing must keep Add + Replace
+  // affordances at its call site while dropping the disabled beets action.
+  const state = buildReleaseActionState({ id: 'pressing-unowned', in_library: false });
+  const oldHtml = renderActionToolbar(state);
+  const html = renderActionToolbar(state, { hideDisabledRemove: true });
+  assertContains(oldHtml, '<button class="btn"', 'known-bad default toolbar contains disabled beets button');
+  assertContains(oldHtml, '>Remove from beets</button>', 'known-bad old child rendering shows meaningless action');
+  assertContains(html, '>Add request</button>', 'Add request remains visible');
+  assertExcludes(html, '>Remove from beets</button>', 'disabled beets action is omitted');
+}
+
+console.log('Child pressing toolbar — state-space sweep preserves acquire action and enabled removal');
+clearStore();
+{
+  const cases = [
+    { in_library: false, beets_album_id: null, pipeline_status: null, pipeline_id: null },
+    { in_library: false, beets_album_id: null, pipeline_status: 'wanted', pipeline_id: 101 },
+    { in_library: false, beets_album_id: null, pipeline_status: 'downloading', pipeline_id: 102 },
+    { in_library: false, beets_album_id: null, pipeline_status: 'imported', pipeline_id: 103 },
+    { in_library: false, beets_album_id: null, pipeline_status: 'manual', pipeline_id: 104 },
+    { in_library: true, beets_album_id: null, pipeline_status: null, pipeline_id: null },
+    { in_library: true, beets_album_id: 42, pipeline_status: null, pipeline_id: null },
+    { in_library: true, beets_album_id: 43, pipeline_status: 'wanted', pipeline_id: 105 },
+  ];
+  const acquireLabels = ['Add request', 'Upgrade', 'Remove request'];
+  for (const [i, input] of cases.entries()) {
+    const state = buildReleaseActionState({ id: `pressing-${i}`, ...input });
+    const baseline = renderActionToolbar(state);
+    const compact = renderActionToolbar(state, { hideDisabledRemove: true });
+    for (const label of acquireLabels) {
+      assertEqual(
+        compact.includes(`>${label}</button>`),
+        baseline.includes(`>${label}</button>`),
+        `case ${i}: ${label} visibility is unchanged`,
+      );
+    }
+    assertEqual(
+      compact.includes('>Remove from beets</button>'),
+      state.canRemoveBeets,
+      `case ${i}: beets removal renders exactly when enabled`,
+    );
+    assertEqual(
+      compact.includes('window.confirmDeleteBeets'),
+      state.canRemoveBeets,
+      `case ${i}: enabled beets handler is retained`,
+    );
+  }
+}
+
 console.log('Acquire button — manual review → disabled Add request');
 clearStore();
 {

--- a/web/index.html
+++ b/web/index.html
@@ -55,6 +55,8 @@
      beneath it instead of crushing the text into a sliver. Must come
      AFTER the base .release-info rule — same specificity, order wins. */
   @media (max-width: 640px) {
+    .tabs { gap: 4px; }
+    .tab { padding: 8px 8px; font-size: 13px; white-space: nowrap; }
     .release { flex-wrap: wrap; justify-content: flex-start; }
     .release-info { flex: 1 1 100%; min-width: 0; }
   }

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { API, state, toast, updatePipelineStatus } from './state.js';
-import { esc, externalReleaseUrl, sourceLabel, detectSource, normalizeReleaseId } from './util.js';
+import { esc, externalReleaseUrl, sourceLabel, detectSource, jsArg, normalizeReleaseId } from './util.js';
 import { buildReleaseActionState } from './release_action_state.js';
 import { renderActionToolbar, renderAcquireActionButton, renderRemoveFromBeetsButton, renderReplaceButton } from './release_actions.js';
 import { renderStatusBadges } from './badges.js';
@@ -34,7 +34,7 @@ export function renderRgRow(rg, ctx) {
   const badges = renderStatusBadges(rg);
   // Masterless Discogs releases have no child master to expand; the rg row
   // is the leaf, so it carries data-release-id for search-by-ID ringing.
-  const leafAttr = rg.is_masterless ? ` data-release-id="${rg.id}"` : '';
+  const leafAttr = rg.is_masterless ? ` data-release-id="${esc(rg.id)}"` : '';
   // Search-plan inspector button — only when this rg has a pipeline
   // request. RG-level pipeline_id surfaces from the analysis overlay's
   // disambData snapshot via pipelineStore (see release_action_state.js).
@@ -51,10 +51,10 @@ export function renderRgRow(rg, ctx) {
   const opts = `{${optParts.join(',')}}`;
   return `
     <div class="rg" data-rg-id="${esc(rg.id)}"${leafAttr}>
-      <div onclick="event.stopPropagation(); window.loadReleaseGroup('${rg.id}', this, ${opts})">
+      <div onclick="event.stopPropagation(); window.loadReleaseGroup(${jsArg(rg.id)}, this, ${opts})">
         <span class="rg-year">${year}</span> <span class="rg-title">${esc(rg.title)}</span>${creditNote}${badges}${spBtn}
       </div>
-      <div class="releases" id="rel-${rg.id}"></div>
+      <div class="releases" id="rel-${esc(rg.id)}"></div>
     </div>
   `;
 }
@@ -216,6 +216,87 @@ export function statusChipHtml(status) {
 }
 
 /**
+ * Render one child pressing row in a release-group expansion.
+ *
+ * Child rows omit only the unavailable beets-removal action. Their acquire,
+ * Replace, and search-plan actions keep the same state semantics as every
+ * other browse surface; an enabled beets removal remains visible.
+ *
+ * @param {Object} rel - Pressing row with pipeline/library overlay fields.
+ * @param {{artistName: string, parentRgId: string|null, canReplace: boolean}} ctx
+ * @returns {string}
+ */
+export function renderPressingRow(rel, ctx) {
+  const badges = renderStatusBadges(rel);
+  const actionState = buildReleaseActionState({
+    ...rel,
+    artist: ctx.artistName,
+    album: rel.title,
+  });
+  const toolbar = renderActionToolbar(actionState, {
+    size: 'small',
+    hideDisabledRemove: true,
+  });
+  // Search-plan inspector button — Browse-tab only renders when the
+  // release has an active pipeline request (see release_action_state.js
+  // for the pipelineStore lookup).
+  const spBtn = renderSearchPlanButton({ pipelineId: actionState.pipelineId });
+  // Replace button — two variants:
+  //
+  //   - ``isCurrent`` (acquireKind === 'remove_request'): this row
+  //     IS the active/imported request. Standard mode — clicking
+  //     opens the picker on this request's release group so the
+  //     operator can switch to a sibling pressing.
+  //
+  //   - Otherwise: inverted mode. Clicking asks the operator which
+  //     active request in this RG should be replaced with the
+  //     clicked row's MBID. Enabled only when an existing
+  //     non-replaced row already targets a sibling MBID in the same RG.
+  //
+  // ``releaseGroupId`` may be null for legacy rows; the picker
+  // lazy-resolves it via ``POST /api/pipeline/<id>/resolve-rg``
+  // (standard) or ``GET /api/release/<mbid>`` (inverted) before
+  // fetching siblings.
+  const rgForReplace = rel.release_group_id || ctx.parentRgId || null;
+  const isCurrent = actionState.acquireKind === 'remove_request';
+  let replaceBtn = '';
+  if (isCurrent) {
+    if (actionState.pipelineId) {
+      replaceBtn = renderReplaceButton({
+        mode: 'standard',
+        sourceRequestId: actionState.pipelineId,
+        releaseGroupId: rgForReplace,
+        sourceLabel: `${ctx.artistName} — ${rel.title || ''}`,
+      }, {
+        className: 'btn',
+        style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
+        stopPropagation: true,
+      });
+    }
+  } else {
+    replaceBtn = renderReplaceButton({
+      mode: 'inverted',
+      targetMbid: rel.id,
+      releaseGroupId: rgForReplace,
+      targetLabel: `${ctx.artistName} — ${rel.title || ''}`,
+    }, {
+      className: 'btn',
+      style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
+      enabled: ctx.canReplace,
+      stopPropagation: true,
+    });
+  }
+  return renderReleaseRow({
+    dataReleaseId: rel.id,
+    onclick: `event.stopPropagation(); window.toggleReleaseDetail(${jsArg(rel.id)})`,
+    titleHtml: `${esc(rel.title)}${statusChipHtml(rel.status)}${badges}`,
+    metaLines: [`${rel.country || '?'} ${rel.date || '?'} - ${rel.format} - ${rel.track_count}t - ${rel.status || '?'}`],
+    actionsHtml: `${toolbar}${replaceBtn}${spBtn}`,
+    detail: { id: `reldet-${rel.id}` },
+  });
+}
+
+/**
  * Load and display releases for a release group.
  *
  * @param {string} id - MusicBrainz release group ID or Discogs master ID
@@ -278,73 +359,15 @@ export async function loadReleaseGroup(id, el, opts = {}) {
     // that path because ``hasActiveRg`` will look up a non-MB id.
     const parentRgId = isDiscogs ? null : id;
 
-    function renderRelease(rel) {
-      const badges = renderStatusBadges(rel);
-      const actionState = buildReleaseActionState({
-        ...rel,
-        artist: state.browseArtist?.name || '',
-        album: rel.title,
-      });
-      const toolbar = renderActionToolbar(actionState, { size: 'small' });
-      // Search-plan inspector button — Browse-tab only renders when the
-      // release has an active pipeline request (see release_action_state.js
-      // for the pipelineStore lookup).
-      const spBtn = renderSearchPlanButton({ pipelineId: actionState.pipelineId });
-      // Replace button — two variants:
-      //
-      //   - ``isCurrent`` (acquireKind === 'remove_request'): this row
-      //     IS the active/imported request. Standard mode — clicking
-      //     opens the picker on this request's release group so the
-      //     operator can switch to a sibling pressing.
-      //
-      //   - Otherwise: inverted mode. Clicking asks the operator which
-      //     active request in this RG should be replaced with the
-      //     clicked row's MBID. Enabled only when an existing
-      //     non-replaced row already targets a sibling MBID in the same
-      //     RG (``hasActiveRg``).
-      //
-      // ``releaseGroupId`` may be null for legacy rows; the picker
-      // lazy-resolves it via ``POST /api/pipeline/<id>/resolve-rg``
-      // (standard) or ``GET /api/release/<mbid>`` (inverted) before
-      // fetching siblings.
+    const artistName = state.browseArtist?.name || '';
+    const renderRelease = (rel) => {
       const rgForReplace = rel.release_group_id || parentRgId || null;
-      const isCurrent = actionState.acquireKind === 'remove_request';
-      let replaceBtn = '';
-      if (isCurrent) {
-        if (actionState.pipelineId) {
-          replaceBtn = renderReplaceButton({
-            mode: 'standard',
-            sourceRequestId: actionState.pipelineId,
-            releaseGroupId: rgForReplace,
-            sourceLabel: `${state.browseArtist?.name || ''} — ${rel.title || ''}`,
-          }, {
-            className: 'btn',
-            style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
-            stopPropagation: true,
-          });
-        }
-      } else {
-        replaceBtn = renderReplaceButton({
-          mode: 'inverted',
-          targetMbid: rel.id,
-          releaseGroupId: rgForReplace,
-          targetLabel: `${state.browseArtist?.name || ''} — ${rel.title || ''}`,
-        }, {
-          className: 'btn',
-          style: 'padding:2px 8px;font-size:0.7em;white-space:nowrap;',
-          enabled: hasActiveRg(rgForReplace),
-          stopPropagation: true,
-        });
-      }
-      return renderReleaseRow({
-        dataReleaseId: rel.id,
-        onclick: `event.stopPropagation(); window.toggleReleaseDetail('${rel.id}')`,
-        titleHtml: `${esc(rel.title)}${statusChipHtml(rel.status)}${badges}`,
-        metaLines: [`${rel.country || '?'} ${rel.date || '?'} - ${rel.format} - ${rel.track_count}t - ${rel.status || '?'}`],
-        actionsHtml: `${toolbar}${replaceBtn}${spBtn}`,
-        detail: { id: `reldet-${rel.id}` },
+      return renderPressingRow(rel, {
+        artistName,
+        parentRgId,
+        canReplace: hasActiveRg(rgForReplace),
       });
-    }
+    };
 
     let html = visible.map(renderRelease).join('');
     if (hidden.length > 0) {

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -148,8 +148,9 @@ export async function toggleReleaseLibDetail(id) {
  * @param {number} id - Beets album ID
  * @returns {string}
  */
-function renderLibraryDetailBody(data, id) {
+export function renderLibraryDetailBody(data, id) {
     const releaseId = normalizeReleaseId(data.mb_albumid);
+    const releaseArg = jsArg(releaseId);
     let html = '';
     if (data.path) {
       html += renderDetailRow('Path', esc(data.path), { valueStyle: 'font-size:0.85em;word-break:break-all;' });
@@ -178,15 +179,15 @@ function renderLibraryDetailBody(data, id) {
       const pStatus = data.pipeline_status || '';
       html += `<div class="p-actions" style="margin-top:10px;">
         <span class="p-detail-label" style="line-height:28px;">Status:</span>
-        <button class="p-btn ${pStatus === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality('${releaseId}', 'wanted', null)">wanted</button>
-        <button class="p-btn ${pStatus === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality('${releaseId}', 'imported', null)">imported</button>
-        <button class="p-btn ${pStatus === 'manual' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality('${releaseId}', 'manual', null)">manual</button>
+        <button class="p-btn ${pStatus === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'wanted', null)">wanted</button>
+        <button class="p-btn ${pStatus === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'imported', null)">imported</button>
+        <button class="p-btn ${pStatus === 'manual' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'manual', null)">manual</button>
       </div>`;
       html += `<div class="p-actions" style="margin-top:6px;">
         <span class="p-detail-label" style="line-height:28px;">Min bitrate:</span>
         <input type="number" id="lib-minbr-${id}" value="" placeholder="${data.pipeline_min_bitrate || ''}" style="width:60px;padding:2px 6px;background:#222;color:#eee;border:1px solid #444;border-radius:4px;font-size:0.8em;" onclick="event.stopPropagation()">
-        <button class="p-btn" onclick="event.stopPropagation(); var v=document.getElementById('lib-minbr-${id}').value; if(v) window.setLibQuality('${releaseId}', null, parseInt(v))">Set</button>
-        <button class="p-btn" onclick="event.stopPropagation(); window.setLibQuality('${releaseId}', 'imported', null)">Accept</button>
+        <button class="p-btn" onclick="event.stopPropagation(); var v=document.getElementById('lib-minbr-${id}').value; if(v) window.setLibQuality(${releaseArg}, null, parseInt(v))">Set</button>
+        <button class="p-btn" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'imported', null)">Accept</button>
       </div>`;
       const currentIntent = overrideToIntent(data.target_format);
       html += `<div class="p-actions" style="margin-top:6px;">

--- a/web/js/release_actions.js
+++ b/web/js/release_actions.js
@@ -221,6 +221,7 @@ export function renderReplaceButton(args, opts = {}) {
  * @param {ReleaseActionState} state
  * @param {Object} [opts]
  * @param {string} [opts.size] - 'normal' or 'small' for compact layouts
+ * @param {boolean} [opts.hideDisabledRemove] - omit beets removal when unavailable
  * @returns {string}
  */
 export function renderActionToolbar(state, opts = {}) {
@@ -240,6 +241,7 @@ export function renderActionToolbar(state, opts = {}) {
     enabledStyle: `${baseStyle}background:#3a2a2a;color:#f88;`,
     disabledStyle: baseStyle,
     stopPropagation: true,
+    hideDisabled: opts.hideDisabledRemove,
   });
 
   return `<span class="action-toolbar" style="display:inline-flex;gap:4px;flex-wrap:wrap;">${acquireBtn}${removeBeetsBtn}</span>`;


### PR DESCRIPTION
Part of #603.

## Summary

- omit only the unavailable `Remove from beets` action from expanded child pressing rows; enabled removal and Add/Upgrade/Remove-request/Replace/Search-plan actions remain intact
- route release IDs through `jsArg()` in release-group, child-pressing, and equivalent library quality-control onclick handlers
- tighten only the <=640px top-tab gap/padding so a 390px phone viewport has no horizontal overflow
- keep the operator-selected `Bootleg-only releases` wording unchanged; leave the library detail ordering and Recents evidence vocabulary/data untouched

## Invariants and TDD

- deterministic child-row pins plus a state-space sweep prove the compact toolbar changes only unavailable beets removal; the old toolbar is qualified as known-bad
- deterministic quote/apostrophe/backslash/tag-breakout IDs plus generated critical-character sweeps cover both discography render paths and all five library quality controls; raw interpolation is qualified as known-bad
- RED: 7 child-toolbar failures and missing pure-render exports; GREEN: release-actions 95/0, discography 411/0, library 174/0, window-binding audit green (71 handlers)

## Live-db visual verification

Read-only browser loop on the exact The Wrens / The Meadowlands expansion:

- 390px: tabs `scrollWidth == clientWidth == 343`; document/body `scrollWidth == clientWidth == 375`; pressing rows `scrollWidth == clientWidth == 304`; mobile toolbar starts 4px below its info column
- 700px and 1000px: no pressing-row overflow or button overlap; desktop tab geometry unchanged
- every unowned Meadowlands pressing shows Add request + Replace with no disabled beets action; both owned pressings retain enabled beets removal alongside Remove-request/Upgrade, Replace, and Search-plan
- representative long 390px Recents evidence strip remains complete at 316px wide / 42px high (three lines), with no overflow or field changes

No mutation controls were clicked.

## Checks

- all `tests/test_js_*.mjs` and `node --check web/js/*.js`
- full suite: 5,373 tests, zero failures
- full pyright: 0 errors, 0 warnings
- dead-code sweep: no findings
- push-profile generated-test fuzz burst: all shards green
- `nix flake check`: all checks passed, including module VM
