### PR TITLE
refactor: type completed-album processing seam

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -26,6 +26,7 @@ from lib.download_processing import (
     CompletionDispatched,
     CompletionFailed,
     CompletionResult,
+    ProcessAlbumFn,
 )
 from lib.download_materialization import (
     Materialized,
@@ -473,7 +474,7 @@ def _run_completed_processing(
     ctx: CratediggerContext,
     *,
     import_job_id: int,
-    process_album_fn: "Callable[..., CompletionResult] | None" = None,
+    process_album_fn: ProcessAlbumFn | None = None,
 ) -> CompletionResult:
     """Run or resume local post-download processing for a completed album.
 

--- a/lib/download_processing.py
+++ b/lib/download_processing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Protocol, TYPE_CHECKING
 
 from lib import download_materialization
 from lib import download_validation
@@ -52,6 +52,21 @@ class CompletionDeferred:
 
 CompletionResult = Completed | CompletionFailed | CompletionDispatched | CompletionDeferred
 """Return type of ``process_completed_album`` / ``_run_completed_processing``."""
+
+
+class ProcessAlbumFn(Protocol):
+    """Exact injectable shape of :func:`process_completed_album`."""
+
+    def __call__(
+        self,
+        album_data: GrabListEntry,
+        ctx: CratediggerContext,
+        *,
+        import_job_id: int,
+        validate_fn: download_validation.ValidateFn | None = None,
+        handle_valid_fn: download_validation.HandleValidFn | None = None,
+        dispatch_fn: DispatchCoreFn | None = None,
+    ) -> CompletionResult: ...
 
 
 def process_completed_album(
@@ -106,3 +121,6 @@ def process_completed_album(
                 return CompletionDeferred(detail=outcome.message)
             return CompletionDispatched(outcome=outcome)
     return Completed()
+
+
+_process_completed_album_conformance: ProcessAlbumFn = process_completed_album

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -10,6 +10,7 @@ from tests.fakes._shared import _EPOCH, _PERTH_TZ, _as_datetime, _utcnow
 from tests.fakes.beets import FakeBeetsDB
 from tests.fakes.cursors import FakeCursor
 from tests.fakes.dispatch import DispatchCoreCall, RecordingDispatchCore
+from tests.fakes.download import ProcessAlbumCall, RecordingProcessAlbum
 from tests.fakes.lookups import FakeDiscogsLookup, FakeMBLookup, http_error
 from tests.fakes.pipeline_db import (
     FakePipelineDB,
@@ -56,6 +57,8 @@ __all__ = [
     "SearchLogRow",
     "SearchTextCall",
     "RecordingDispatchCore",
+    "ProcessAlbumCall",
+    "RecordingProcessAlbum",
     "UserCooldownRow",
     "http_error",
 ]

--- a/tests/fakes/download.py
+++ b/tests/fakes/download.py
@@ -1,0 +1,59 @@
+"""Typed test double for completed-download processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from lib import download_validation
+from lib.dispatch import DispatchCoreFn
+from lib.download_processing import (
+    Completed,
+    CompletionResult,
+    ProcessAlbumFn,
+)
+from lib.grab_list import GrabListEntry
+
+if TYPE_CHECKING:
+    from lib.context import CratediggerContext
+
+
+@dataclass(frozen=True)
+class ProcessAlbumCall:
+    album_data: GrabListEntry
+    ctx: CratediggerContext
+    import_job_id: int
+    validate_fn: download_validation.ValidateFn | None
+    handle_valid_fn: download_validation.HandleValidFn | None
+    dispatch_fn: DispatchCoreFn | None
+
+
+@dataclass
+class RecordingProcessAlbum:
+    """Record exact completion calls while returning a real tagged result."""
+
+    outcome: CompletionResult = field(default_factory=Completed)
+    calls: list[ProcessAlbumCall] = field(default_factory=list)
+
+    def __call__(
+        self,
+        album_data: GrabListEntry,
+        ctx: CratediggerContext,
+        *,
+        import_job_id: int,
+        validate_fn: download_validation.ValidateFn | None = None,
+        handle_valid_fn: download_validation.HandleValidFn | None = None,
+        dispatch_fn: DispatchCoreFn | None = None,
+    ) -> CompletionResult:
+        self.calls.append(ProcessAlbumCall(
+            album_data=album_data,
+            ctx=ctx,
+            import_job_id=import_job_id,
+            validate_fn=validate_fn,
+            handle_valid_fn=handle_valid_fn,
+            dispatch_fn=dispatch_fn,
+        ))
+        return self.outcome
+
+
+_recorder_conformance: ProcessAlbumFn = RecordingProcessAlbum()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -26,14 +26,39 @@ from tests.fakes import (
     FakePipelineDB,
     FakeSlskdAPI,
     FakeYTMusic,
+    RecordingProcessAlbum,
 )
 from tests.helpers import (
     make_album_quality_evidence,
+    make_ctx_with_fake_db,
     make_download_file,
     make_grab_list_entry,
     make_request_row,
     make_validation_result,
 )
+
+
+class TestRecordingProcessAlbum(unittest.TestCase):
+    def test_records_exact_call_and_returns_configured_result(self) -> None:
+        from lib.download_processing import CompletionDeferred
+
+        entry = make_grab_list_entry()
+        db = FakePipelineDB()
+        ctx = make_ctx_with_fake_db(db)
+        outcome = CompletionDeferred(detail="release_lock_contention")
+        recorder = RecordingProcessAlbum(outcome=outcome)
+
+        result = recorder(entry, ctx, import_job_id=73)
+
+        self.assertIs(result, outcome)
+        self.assertEqual(len(recorder.calls), 1)
+        call = recorder.calls[0]
+        self.assertIs(call.album_data, entry)
+        self.assertIs(call.ctx, ctx)
+        self.assertEqual(call.import_job_id, 73)
+        self.assertIsNone(call.validate_fn)
+        self.assertIsNone(call.handle_valid_fn)
+        self.assertIsNone(call.dispatch_fn)
 
 
 class TestFakePipelineDB(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -33,7 +33,12 @@ from lib.quality import (
     ValidationResult,
 )
 from lib.staged_album import StagedAlbum
-from tests.fakes import FakePipelineDB, FakePipelineDBSource, FakeSlskdAPI
+from tests.fakes import (
+    FakePipelineDB,
+    FakePipelineDBSource,
+    FakeSlskdAPI,
+    RecordingProcessAlbum,
+)
 from tests.helpers import (
     make_album_quality_evidence,
     make_ctx_with_fake_db,
@@ -2677,11 +2682,17 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             id=42, status="downloading",
             current_spectral_grade="genuine",
             current_spectral_bitrate=245))
+        process_album = RecordingProcessAlbum(outcome=CompletionDeferred(
+            detail="release_lock_contention",
+        ))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: CompletionDeferred(
-                detail="release_lock_contention"),
+            process_album_fn=process_album,
+        )
+        self.assertEqual(
+            [call.import_job_id for call in process_album.calls],
+            [1],
         )
         self.assertEqual(db.request(42)["status"], "downloading")
         # Spectral untouched.
@@ -2698,10 +2709,15 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         from lib.download_processing import Completed
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
+        process_album = RecordingProcessAlbum(outcome=Completed())
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: Completed(),
+            process_album_fn=process_album,
+        )
+        self.assertEqual(
+            [call.import_job_id for call in process_album.calls],
+            [1],
         )
         self.assertEqual(db.request(42)["status"], "imported")
 
@@ -2713,11 +2729,17 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         from lib.download_processing import CompletionFailed
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
+        process_album = RecordingProcessAlbum(outcome=CompletionFailed(
+            reason="staged_path_missing",
+        ))
         dl_mod._run_completed_processing(
             self._entry(), 42, self._state(), db, self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: CompletionFailed(
-                reason="staged_path_missing"),
+            process_album_fn=process_album,
+        )
+        self.assertEqual(
+            [call.import_job_id for call in process_album.calls],
+            [1],
         )
         self.assertEqual(db.request(42)["status"], "wanted")
 
@@ -2728,12 +2750,25 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
         """
         from lib import download as dl_mod
         from lib import transitions
-        from lib.download_processing import CompletionFailed
+        from lib import download_validation
+        from lib.context import CratediggerContext
+        from lib.dispatch import DispatchCoreFn
+        from lib.download_processing import CompletionFailed, CompletionResult
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
 
-        def reject_inside_process(*_args, **_kwargs):
+        def reject_inside_process(
+            album_data: GrabListEntry,
+            ctx: CratediggerContext,
+            *,
+            import_job_id: int,
+            validate_fn: download_validation.ValidateFn | None = None,
+            handle_valid_fn: download_validation.HandleValidFn | None = None,
+            dispatch_fn: DispatchCoreFn | None = None,
+        ) -> CompletionResult:
+            del album_data, ctx, import_job_id
+            del validate_fn, handle_valid_fn, dispatch_fn
             transitions.finalize_request(
                 cast(Any, db),
                 42,
@@ -2771,6 +2806,9 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             message="Pre-import gate rejected",
         )
 
+        process_album = RecordingProcessAlbum(outcome=CompletionDispatched(
+            outcome=dispatch_outcome,
+        ))
         result = dl_mod._run_completed_processing(
             self._entry(),
             42,
@@ -2778,11 +2816,14 @@ class TestRunCompletedProcessingOutcomeBranching(unittest.TestCase):
             db,
             self._ctx(db),
             import_job_id=1,
-            process_album_fn=lambda *_a, **_kw: CompletionDispatched(
-                outcome=dispatch_outcome),
+            process_album_fn=process_album,
         )
 
         assert isinstance(result, CompletionDispatched)
+        self.assertEqual(
+            [call.import_job_id for call in process_album.calls],
+            [1],
+        )
         self.assertIs(result.outcome, dispatch_outcome)
         self.assertEqual(db.request(42)["status"], "downloading")
         self.assertEqual(db.status_history, [])

--- a/tests/test_issue_573_boundaries.py
+++ b/tests/test_issue_573_boundaries.py
@@ -49,6 +49,7 @@ def assert_completion_orchestrator_responsibilities(source: str) -> None:
         "CompletionFailed",
         "CompletionDispatched",
         "CompletionDeferred",
+        "ProcessAlbumFn",
     }
     assert functions == {"process_completed_album"}
 

--- a/tests/test_issue_633_boundaries.py
+++ b/tests/test_issue_633_boundaries.py
@@ -1,0 +1,123 @@
+"""Structural contracts for issue #633's process-album callable seam."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+def _annotation(node: ast.expr | None) -> str | None:
+    return ast.unparse(node) if node is not None else None
+
+
+class TestProcessAlbumProtocolBoundary(unittest.TestCase):
+    def test_protocol_exactly_matches_process_completed_album(self) -> None:
+        source = Path("lib/download_processing.py").read_text(encoding="utf-8")
+        tree = ast.parse(source, filename="lib/download_processing.py")
+        protocol = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "ProcessAlbumFn"
+        )
+        call = next(
+            node
+            for node in protocol.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__call__"
+        )
+        production = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "process_completed_album"
+        )
+
+        self.assertEqual([_annotation(base) for base in protocol.bases], ["Protocol"])
+        self.assertIsNone(call.args.vararg)
+        self.assertIsNone(call.args.kwarg)
+        self.assertIsNone(production.args.vararg)
+        self.assertIsNone(production.args.kwarg)
+        self.assertEqual(
+            [argument.arg for argument in call.args.args],
+            ["self", "album_data", "ctx"],
+        )
+        self.assertEqual(
+            [_annotation(argument.annotation) for argument in call.args.args],
+            [None, "GrabListEntry", "CratediggerContext"],
+        )
+        self.assertEqual(
+            [argument.arg for argument in call.args.kwonlyargs],
+            ["import_job_id", "validate_fn", "handle_valid_fn", "dispatch_fn"],
+        )
+        self.assertEqual(
+            [_annotation(argument.annotation) for argument in call.args.kwonlyargs],
+            [
+                "int",
+                "download_validation.ValidateFn | None",
+                "download_validation.HandleValidFn | None",
+                "DispatchCoreFn | None",
+            ],
+        )
+        self.assertEqual(_annotation(call.returns), "CompletionResult")
+        self.assertEqual(
+            [argument.arg for argument in call.args.args[1:]],
+            [argument.arg for argument in production.args.args],
+        )
+        self.assertEqual(
+            [_annotation(argument.annotation) for argument in call.args.args[1:]],
+            [_annotation(argument.annotation) for argument in production.args.args],
+        )
+        self.assertEqual(
+            [argument.arg for argument in call.args.kwonlyargs],
+            [argument.arg for argument in production.args.kwonlyargs],
+        )
+        self.assertEqual(
+            [_annotation(argument.annotation) for argument in call.args.kwonlyargs],
+            [_annotation(argument.annotation) for argument in production.args.kwonlyargs],
+        )
+        self.assertEqual(
+            [_annotation(default) for default in call.args.kw_defaults],
+            [_annotation(default) for default in production.args.kw_defaults],
+        )
+        self.assertEqual(_annotation(call.returns), _annotation(production.returns))
+
+    def test_production_function_has_pyright_conformance_binding(self) -> None:
+        source = Path("lib/download_processing.py").read_text(encoding="utf-8")
+        self.assertIn(
+            "_process_completed_album_conformance: ProcessAlbumFn = "
+            "process_completed_album",
+            source,
+        )
+
+    def test_download_seam_has_no_ellipsis_callable_escape(self) -> None:
+        source = Path("lib/download.py").read_text(encoding="utf-8")
+        self.assertNotIn("Callable[..., CompletionResult]", source)
+        self.assertIn("process_album_fn: ProcessAlbumFn | None", source)
+
+    def test_test_doubles_are_protocol_checked_without_broad_splats(self) -> None:
+        fake_source = Path("tests/fakes/download.py").read_text(encoding="utf-8")
+        self.assertIn(
+            "_recorder_conformance: ProcessAlbumFn = RecordingProcessAlbum()",
+            fake_source,
+        )
+
+        integration_source = Path("tests/test_integration_slices.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("process_album_fn=lambda", integration_source)
+        tree = ast.parse(
+            integration_source,
+            filename="tests/test_integration_slices.py",
+        )
+        exceptional_stub = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "reject_inside_process"
+        )
+        self.assertIsNone(exceptional_stub.args.vararg)
+        self.assertIsNone(exceptional_stub.args.kwarg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace `_run_completed_processing`'s permissive `Callable[..., CompletionResult]` injection seam with an exact `ProcessAlbumFn` protocol owned beside `process_completed_album`
- add pyright-visible conformance bindings for the production function and a shared typed `RecordingProcessAlbum` test double
- replace broad completion lambdas and splat stubs with the typed recorder or an exact-signature exceptional stub while preserving every completion transition outcome
- pin protocol/production AST parity, prohibit vararg/kwarg escapes, and self-test the recorder's real tagged `CompletionResult` behavior

Addresses item 2 of #633.

## Verification

- TDD RED: 4/4 boundary tests failed on the old seam (missing protocol/binding/recorder and surviving ellipsis callable)
- focused boundary, fake, and integration tests — 21 passed
- `nix-shell --run "pyright"` — 0 errors
- `nix-shell --run "bash scripts/find_dead_code.sh"` — Ruff clean; aggregate vulture clean
- `nix-shell --run "bash scripts/run_tests.sh"` — all JS suites and 5,386 Python tests passed
- `nix flake check` — 36 checks passed, including module VM
- pre-push exact-commit gate — every generated-test shard passed at push profile; Nix flake gate passed
