### PR TITLE
Resolve relative Beets paths for existing spectral audit

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -90,24 +90,62 @@ _preview_temp_root: str | None = None
 _import_total_start: float | None = None
 
 
+@dataclass(frozen=True)
+class ExistingSpectralPathResolution:
+    """Existing path split between audit reachability and legacy policy."""
+
+    audit_path: str | None = None
+    legacy_policy_path_usable: bool = False
+    failure: SpectralAnalysisDetail | None = None
+
+
 def _resolve_existing_spectral_path(
     beets: BeetsDB,
     mbid: str,
     already_in_beets: bool,
-) -> tuple[str | None, SpectralAnalysisDetail | None]:
+    beets_library_root: str = "",
+) -> ExistingSpectralPathResolution:
     """Resolve existing files without allowing audit lookup to abort import."""
     if not already_in_beets:
-        return None, None
+        return ExistingSpectralPathResolution()
     try:
-        path = beets.get_album_path(mbid)
+        raw_path = beets.get_album_path(mbid)
     except Exception as exc:
-        return None, SpectralAnalysisDetail(
-            attempted=True,
-            error=f"{type(exc).__name__}: {exc}",
+        return ExistingSpectralPathResolution(
+            failure=SpectralAnalysisDetail(
+                attempted=True,
+                error=f"{type(exc).__name__}: {exc}",
+            ),
         )
-    if path and os.path.isdir(path):
-        return path, None
-    return None, None
+    legacy_policy_path_usable = bool(raw_path and os.path.isdir(raw_path))
+    audit_path = raw_path
+    if audit_path and not os.path.isabs(audit_path) and beets_library_root:
+        audit_path = os.path.join(beets_library_root, audit_path)
+    if audit_path and os.path.isdir(audit_path):
+        return ExistingSpectralPathResolution(
+            audit_path=audit_path,
+            legacy_policy_path_usable=legacy_policy_path_usable,
+        )
+    return ExistingSpectralPathResolution(
+        legacy_policy_path_usable=legacy_policy_path_usable,
+    )
+
+
+def _existing_spectral_policy_inputs(
+    resolution: ExistingSpectralPathResolution,
+    audit: SpectralAnalysisDetail | None,
+    *,
+    candidate_spectral_ok: bool,
+) -> tuple[str | None, int | None]:
+    """Preserve the pre-audit existing-side inputs used by quality policy."""
+    if (
+        not candidate_spectral_ok
+        or not resolution.legacy_policy_path_usable
+        or audit is None
+        or not audit.attempted
+    ):
+        return None, None
+    return audit.grade, audit.bitrate_kbps
 
 # Rank config for BeetsDB.get_album_info() mixed-format reduction + (commit 5)
 # quality_rank() / compare_quality() / quality_gate_decision(). main() replaces
@@ -1583,6 +1621,9 @@ def main():
     parser.add_argument("--quality-evidence-action-file", default=None,
                         help="Action-time quality evidence payload authorizing "
                              "mutation without candidate remeasurement.")
+    parser.add_argument("--beets-library-root", default="",
+                        help="Library root used only to resolve relative Beets "
+                             "paths for existing-side spectral audit.")
     parser.add_argument("--existing-v0-probe-min-bitrate", type=int, default=None,
                         help="Current comparable lossless-source V0 probe min bitrate")
     parser.add_argument("--existing-v0-probe-avg-bitrate", type=int, default=None,
@@ -1689,11 +1730,16 @@ def main():
     existing_spectral_bitrate: int | None = None
     stage_start = time.monotonic()
     from lib.measurement import collect_attempt_spectral_audit
-    existing_path, existing_lookup_failure = _resolve_existing_spectral_path(
-        beets, mbid, already_in_beets)
-    r.spectral = collect_attempt_spectral_audit(work_path, existing_path)
-    if existing_lookup_failure is not None:
-        r.spectral.existing = existing_lookup_failure
+    existing_path_resolution = _resolve_existing_spectral_path(
+        beets,
+        mbid,
+        already_in_beets,
+        beets_library_root=args.beets_library_root,
+    )
+    r.spectral = collect_attempt_spectral_audit(
+        work_path, existing_path_resolution.audit_path)
+    if existing_path_resolution.failure is not None:
+        r.spectral.existing = existing_path_resolution.failure
     candidate_audit = r.spectral.candidate
     existing_audit = r.spectral.existing
     candidate_spectral_ok = (
@@ -1716,12 +1762,17 @@ def main():
             _log(f"  [SPECTRAL candidate] error: {candidate_audit.error}")
 
     # Existing-side audit is an independent attempt. Only feed it to the
-    # legacy decision variables when candidate analysis succeeded, preserving
-    # the exact pre-audit decision inputs on candidate failure.
+    # legacy decision variables when candidate analysis succeeded AND the raw
+    # Beets path passed the same isdir gate used before audit-only root
+    # resolution. Root resolution expands evidence without changing policy.
+    existing_spectral_grade, existing_spectral_bitrate = (
+        _existing_spectral_policy_inputs(
+            existing_path_resolution,
+            existing_audit,
+            candidate_spectral_ok=candidate_spectral_ok,
+        )
+    )
     if existing_audit is not None and existing_audit.attempted:
-        if candidate_spectral_ok:
-            existing_spectral_grade = existing_audit.grade
-            existing_spectral_bitrate = existing_audit.bitrate_kbps
         r.spectral.existing_suspect_pct = existing_audit.suspect_pct or 0.0
         _log(f"  existing_spectral_grade={existing_audit.grade}")
         if existing_audit.bitrate_kbps is not None:

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -412,6 +412,9 @@ def dispatch_import_core(
                 ),
                 existing_v0_probe=existing_v0_probe,
                 quality_evidence_action_file=quality_evidence_action_file,
+                beets_library_root=(
+                    cfg.beets_directory if cfg is not None else ""
+                ),
             )
             _remove_quality_evidence_action_file(quality_evidence_action_file)
             quality_evidence_action_file = None

--- a/lib/dispatch/subprocess_runner.py
+++ b/lib/dispatch/subprocess_runner.py
@@ -41,6 +41,7 @@ def build_import_one_command(
     quality_rank_config_json: str | None = None,
     existing_v0_probe: V0ProbeEvidence | None = None,
     quality_evidence_action_file: str | None = None,
+    beets_library_root: str = "",
 ) -> list[str]:
     """Build the single shared import_one.py command line."""
     cmd = [
@@ -67,6 +68,8 @@ def build_import_one_command(
         cmd.extend(["--quality-rank-config", quality_rank_config_json])
     if quality_evidence_action_file:
         cmd.extend(["--quality-evidence-action-file", quality_evidence_action_file])
+    if beets_library_root:
+        cmd.extend(["--beets-library-root", beets_library_root])
     if existing_v0_probe is not None:
         if existing_v0_probe.min_bitrate_kbps is not None:
             cmd.extend([
@@ -101,6 +104,7 @@ def run_import_one(
     quality_rank_config_json: str | None = None,
     existing_v0_probe: V0ProbeEvidence | None = None,
     quality_evidence_action_file: str | None = None,
+    beets_library_root: str = "",
     timeout: int = 1800,
 ) -> ImportOneRun:
     """Run import_one.py and parse its ImportResult sentinel."""
@@ -118,6 +122,7 @@ def run_import_one(
         quality_rank_config_json=quality_rank_config_json,
         existing_v0_probe=existing_v0_probe,
         quality_evidence_action_file=quality_evidence_action_file,
+        beets_library_root=beets_library_root,
     )
     result = sp.run(
         cmd,

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -776,6 +776,7 @@ def measure_and_persist_candidate_evidence(
                 beets_harness_path=cfg.beets_harness_path,
                 quality_rank_config_json=cfg.quality_ranks.to_json(),
                 existing_v0_probe=existing_v0_probe,
+                beets_library_root=cfg.beets_directory,
             )
         except Exception as exc:
             return _measurement_failed_result(
@@ -1187,6 +1188,7 @@ def preview_import_from_path(
             beets_harness_path=cfg.beets_harness_path,
             quality_rank_config_json=cfg.quality_ranks.to_json(),
             existing_v0_probe=existing_v0_probe,
+            beets_library_root=cfg.beets_directory,
         )
         verdict, cleanup_eligible, reason, chain = _classify_import_result(
             run.import_result,

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -840,10 +840,12 @@ class TestDispatchCoreSeams(unittest.TestCase):
     def _get_cmd(self, **kwargs):
         from lib.dispatch import dispatch_import_core
         ir = kwargs.pop("ir", make_import_result())
+        beets_directory = kwargs.pop("beets_directory", "")
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
         cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
+            beets_directory=beets_directory,
             pipeline_db_enabled=True,
         )
         tmpdir = tempfile.mkdtemp()
@@ -892,6 +894,12 @@ class TestDispatchCoreSeams(unittest.TestCase):
         idx = cmd.index("--target-format")
         self.assertEqual(cmd[idx + 1], "flac")
 
+    def test_dispatch_threads_beets_library_root_to_harness(self):
+        cmd = self._get_cmd(beets_directory="/srv/music/Beets")
+
+        idx = cmd.index("--beets-library-root")
+        self.assertEqual(cmd[idx + 1], "/srv/music/Beets")
+
     def test_shared_import_one_command_supports_preview_without_request_id(self):
         from lib.dispatch import build_import_one_command
 
@@ -906,6 +914,18 @@ class TestDispatchCoreSeams(unittest.TestCase):
         self.assertIn("--dry-run", cmd)
         self.assertIn("--preserve-source", cmd)
         self.assertNotIn("--request-id", cmd)
+
+    def test_shared_import_one_command_omits_empty_beets_library_root(self):
+        from lib.dispatch import build_import_one_command
+
+        cmd = build_import_one_command(
+            path="/tmp/album",
+            mb_release_id="mbid-123",
+            beets_harness_path=_HARNESS,
+            beets_library_root="",
+        )
+
+        self.assertNotIn("--beets-library-root", cmd)
 
     def test_shared_import_one_command_does_not_accept_preview_result_file(self):
         from lib.dispatch import build_import_one_command

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import unittest
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -60,6 +61,223 @@ class TestImportBootstrap(unittest.TestCase):
 
 
 class TestExistingSpectralPathResolution(unittest.TestCase):
+    def test_relative_path_resolves_against_explicit_library_root(self):
+        from harness import import_one
+
+        class RelativePathBeets(FakeBeetsDB):
+            def get_album_path(self, mb_release_id: str) -> str | None:
+                return os.path.join("Artist", "Album")
+
+        with tempfile.TemporaryDirectory() as library_root:
+            album_path = os.path.join(library_root, "Artist", "Album")
+            os.makedirs(album_path)
+
+            resolution = import_one._resolve_existing_spectral_path(
+                cast(Any, RelativePathBeets()),
+                "mbid-123",
+                True,
+                beets_library_root=library_root,
+            )
+
+        self.assertEqual(resolution.audit_path, album_path)
+        self.assertFalse(resolution.legacy_policy_path_usable)
+        self.assertIsNone(resolution.failure)
+
+    def test_empty_library_root_preserves_relative_path_as_unresolved(self):
+        from harness import import_one
+
+        class RelativePathBeets(FakeBeetsDB):
+            def get_album_path(self, mb_release_id: str) -> str | None:
+                return os.path.join("Artist", "Album")
+
+        resolution = import_one._resolve_existing_spectral_path(
+            cast(Any, RelativePathBeets()),
+            "mbid-123",
+            True,
+            beets_library_root="",
+        )
+
+        self.assertIsNone(resolution.audit_path)
+        self.assertFalse(resolution.legacy_policy_path_usable)
+        self.assertIsNone(resolution.failure)
+
+    def test_raw_usable_path_remains_legacy_policy_eligible(self):
+        from harness import import_one
+        from lib.quality import SpectralAnalysisDetail
+
+        class AbsolutePathBeets(FakeBeetsDB):
+            def __init__(self, album_path: str) -> None:
+                super().__init__()
+                self.album_path = album_path
+
+            def get_album_path(self, mb_release_id: str) -> str | None:
+                return self.album_path
+
+        with tempfile.TemporaryDirectory() as album_path:
+            resolution = import_one._resolve_existing_spectral_path(
+                cast(Any, AbsolutePathBeets(album_path)),
+                "mbid-123",
+                True,
+                beets_library_root="/unused",
+            )
+
+        inputs = import_one._existing_spectral_policy_inputs(
+            resolution,
+            SpectralAnalysisDetail(
+                attempted=True, grade="suspect", bitrate_kbps=96,
+            ),
+            candidate_spectral_ok=True,
+        )
+
+        self.assertEqual(resolution.audit_path, album_path)
+        self.assertTrue(resolution.legacy_policy_path_usable)
+        self.assertEqual(inputs, ("suspect", 96))
+
+    def test_root_resolved_audit_does_not_change_legacy_quality_policy(self):
+        from harness import import_one
+        from lib.beets_db import AlbumInfo
+        from lib.measurement import collect_attempt_spectral_audit
+        from lib.quality import AudioQualityMeasurement, QualityRankConfig
+
+        class RelativePathBeets(FakeBeetsDB):
+            def get_album_path(self, mb_release_id: str) -> str | None:
+                return os.path.join("Artist", "Album")
+
+        with tempfile.TemporaryDirectory() as library_root:
+            album_path = os.path.join(library_root, "Artist", "Album")
+            os.makedirs(album_path)
+            resolution = import_one._resolve_existing_spectral_path(
+                cast(Any, RelativePathBeets()),
+                "mbid-123",
+                True,
+                beets_library_root=library_root,
+            )
+
+            def analyze(path: str, trim_seconds: int = 30):
+                if path == album_path:
+                    return SimpleNamespace(
+                        grade="suspect",
+                        estimated_bitrate_kbps=48,
+                        suspect_pct=100.0,
+                        tracks=[SimpleNamespace(
+                            grade="suspect",
+                            hf_deficit_db=80.0,
+                            cliff_detected=True,
+                            cliff_freq_hz=14000,
+                            estimated_bitrate_kbps=48,
+                            error=None,
+                        )],
+                    )
+                return SimpleNamespace(
+                    grade="suspect",
+                    estimated_bitrate_kbps=128,
+                    suspect_pct=100.0,
+                    tracks=[],
+                )
+
+            with patch("lib.measurement.spectral_analyze", side_effect=analyze):
+                legacy_audit = collect_attempt_spectral_audit(
+                    "/candidate", None
+                )
+                resolved_audit = collect_attempt_spectral_audit(
+                    "/candidate", resolution.audit_path
+                )
+
+        assert legacy_audit.candidate is not None
+        assert resolved_audit.candidate is not None
+        assert resolved_audit.existing is not None
+        policy_grade, policy_bitrate = (
+            import_one._existing_spectral_policy_inputs(
+                resolution,
+                resolved_audit.existing,
+                candidate_spectral_ok=True,
+            )
+        )
+        existing_info = AlbumInfo(
+            album_id=1,
+            track_count=1,
+            min_bitrate_kbps=128,
+            avg_bitrate_kbps=128,
+            median_bitrate_kbps=128,
+            is_cbr=True,
+            album_path="Artist/Album",
+            format="MP3",
+        )
+        legacy_existing = import_one.build_existing_measurement(
+            existing_info,
+            override_min_bitrate=None,
+            existing_spectral_grade=None,
+            existing_spectral_bitrate=None,
+        )
+        fixed_existing = import_one.build_existing_measurement(
+            existing_info,
+            override_min_bitrate=None,
+            existing_spectral_grade=policy_grade,
+            existing_spectral_bitrate=policy_bitrate,
+        )
+        policy_mutant_existing = import_one.build_existing_measurement(
+            existing_info,
+            override_min_bitrate=None,
+            existing_spectral_grade=resolved_audit.existing.grade,
+            existing_spectral_bitrate=resolved_audit.existing.bitrate_kbps,
+        )
+        legacy_new_measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=128,
+            avg_bitrate_kbps=128,
+            median_bitrate_kbps=128,
+            format="MP3",
+            is_cbr=True,
+            spectral_grade=legacy_audit.candidate.grade,
+            spectral_bitrate_kbps=legacy_audit.candidate.bitrate_kbps,
+        )
+        fixed_new_measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=128,
+            avg_bitrate_kbps=128,
+            median_bitrate_kbps=128,
+            format="MP3",
+            is_cbr=True,
+            spectral_grade=resolved_audit.candidate.grade,
+            spectral_bitrate_kbps=resolved_audit.candidate.bitrate_kbps,
+        )
+        legacy_decision = import_one.quality_decision_stage(
+            legacy_new_measurement,
+            legacy_existing,
+            False,
+            QualityRankConfig.defaults(),
+        )
+        fixed_decision = import_one.quality_decision_stage(
+            fixed_new_measurement,
+            fixed_existing,
+            False,
+            QualityRankConfig.defaults(),
+        )
+        policy_mutant_decision = import_one.quality_decision_stage(
+            fixed_new_measurement,
+            policy_mutant_existing,
+            False,
+            QualityRankConfig.defaults(),
+        )
+
+        self.assertEqual(fixed_new_measurement, legacy_new_measurement)
+        self.assertEqual(fixed_existing, legacy_existing)
+        self.assertEqual(fixed_decision.decision, legacy_decision.decision)
+        self.assertEqual(
+            fixed_decision.comparison_basis,
+            legacy_decision.comparison_basis,
+        )
+        self.assertNotEqual(
+            policy_mutant_decision.decision,
+            legacy_decision.decision,
+        )
+        assert legacy_audit.existing is not None
+        self.assertEqual(resolved_audit.candidate, legacy_audit.candidate)
+        self.assertFalse(legacy_audit.existing.attempted)
+        self.assertTrue(resolved_audit.existing.attempted)
+        self.assertEqual(resolved_audit.existing.grade, "suspect")
+        self.assertEqual(resolved_audit.existing.bitrate_kbps, 48)
+        self.assertEqual(resolved_audit.existing.suspect_pct, 100.0)
+        self.assertEqual(len(resolved_audit.existing.per_track), 1)
+
     def test_lookup_exception_becomes_audit_error_instead_of_crashing(self):
         from harness import import_one
 
@@ -67,14 +285,17 @@ class TestExistingSpectralPathResolution(unittest.TestCase):
             def get_album_path(self, mb_release_id: str) -> str | None:
                 raise RuntimeError("beets path lookup failed")
 
-        path, failure = import_one._resolve_existing_spectral_path(
+        resolution = import_one._resolve_existing_spectral_path(
             cast(Any, RaisingBeets()), "mbid-123", True)
 
-        self.assertIsNone(path)
-        self.assertIsNotNone(failure)
-        assert failure is not None
-        self.assertTrue(failure.attempted)
-        self.assertEqual(failure.error, "RuntimeError: beets path lookup failed")
+        self.assertIsNone(resolution.audit_path)
+        self.assertIsNotNone(resolution.failure)
+        assert resolution.failure is not None
+        self.assertTrue(resolution.failure.attempted)
+        self.assertEqual(
+            resolution.failure.error,
+            "RuntimeError: beets path lookup failed",
+        )
 
 
 class TestPipelineDbUpdate(unittest.TestCase):

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -267,6 +267,7 @@ class TestImportPreviewPath(unittest.TestCase):
             with patch("lib.config.read_runtime_config",
                        return_value=CratediggerConfig(
                            beets_harness_path="/fake/harness/run_beets_harness.sh",
+                           beets_directory="/srv/music/Beets",
                            pipeline_db_enabled=True,
                        )), \
                  patch("lib.import_preview.inspect_local_files",
@@ -304,6 +305,10 @@ class TestImportPreviewPath(unittest.TestCase):
             self.assertEqual(db.denylist, [])
             self.assertTrue(mock_run.call_args.kwargs["dry_run"])
             self.assertIsNone(mock_run.call_args.kwargs["request_id"])
+            self.assertEqual(
+                mock_run.call_args.kwargs["beets_library_root"],
+                "/srv/music/Beets",
+            )
             self.assertEqual(
                 mock_run.call_args.kwargs["existing_v0_probe"].avg_bitrate_kbps,
                 171,
@@ -515,6 +520,51 @@ class TestImportPreviewPath(unittest.TestCase):
                 self.assertEqual(preview.decision, decision)
                 assert preview.import_result is not None
                 self.assertEqual(preview.import_result.spectral, audit)
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_measurement_preview_threads_beets_library_root_to_harness(self):
+        from lib.dispatch.types import ImportOneRun
+
+        db = self._db()
+        source = self._source_dir()
+        captured: dict[str, Any] = {}
+
+        def run_import(*args: Any, **kwargs: Any) -> ImportOneRun:
+            captured.update(kwargs)
+            return ImportOneRun(
+                command=(), returncode=1, stdout="", stderr="no sentinel",
+                import_result=None,
+            )
+
+        try:
+            with patch(
+                "lib.config.read_runtime_config",
+                return_value=CratediggerConfig(
+                    beets_harness_path="/fake/harness/run_beets_harness.sh",
+                    beets_directory="/srv/music/Beets",
+                    pipeline_db_enabled=True,
+                ),
+            ), patch(
+                "lib.import_preview.inspect_local_files",
+                return_value=LocalFileInspection(filetype="mp3"),
+            ), patch(
+                "lib.import_preview.measure_preimport_state",
+                return_value=PreimportMeasurement(
+                    folder_layout="flat", audio_file_count=1,
+                ),
+            ):
+                measure_and_persist_candidate_evidence(
+                    db,
+                    request_id=42,
+                    path=source,
+                    run_import_fn=run_import,
+                )
+
+            self.assertEqual(
+                captured["beets_library_root"], "/srv/music/Beets"
+            )
         finally:
             import shutil
             shutil.rmtree(source, ignore_errors=True)

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -1,10 +1,15 @@
 """Generated invariant for independent two-sided spectral attempt audit."""
 
+import os
+import tempfile
 import unittest
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 
 from hypothesis import given, strategies as st
+
+from tests.fakes import FakeBeetsDB
 
 
 def _both_sides_attempted(calls: list[str]) -> bool:
@@ -19,12 +24,103 @@ def _policy_snapshot_unchanged(before, after) -> bool:
     return _policy_snapshot(after) == before
 
 
+def _relative_path_resolved(path: str | None, expected: str) -> bool:
+    return path is not None and path == expected and os.path.isabs(path)
+
+
+def _audit_only_policy_inputs_unchanged(
+    inputs: tuple[str | None, int | None],
+) -> bool:
+    return inputs == (None, None)
+
+
 class TestAttemptAuditCheckerQualification(unittest.TestCase):
     def test_checker_rejects_short_circuiting_known_bad_trace(self):
         self.assertFalse(_both_sides_attempted(["candidate"]))
 
+    def test_relative_path_checker_rejects_unresolved_known_bad_path(self):
+        self.assertFalse(
+            _relative_path_resolved("Artist/Album", "/library/Artist/Album")
+        )
+
+    def test_audit_only_policy_checker_rejects_known_bad_inputs(self):
+        self.assertFalse(
+            _audit_only_policy_inputs_unchanged(("suspect", 96))
+        )
+
 
 class TestAttemptAuditGenerated(unittest.TestCase):
+    @given(
+        artist=st.text(
+            alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")),
+            min_size=1,
+            max_size=12,
+        ),
+        album=st.text(
+            alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")),
+            min_size=1,
+            max_size=12,
+        ),
+    )
+    def test_relative_existing_path_resolves_under_explicit_library_root(
+        self, artist: str, album: str,
+    ):
+        from harness import import_one
+
+        relative_path = os.path.join(artist, album)
+
+        class RelativePathBeets(FakeBeetsDB):
+            def get_album_path(self, mb_release_id: str) -> str | None:
+                return relative_path
+
+        with tempfile.TemporaryDirectory() as library_root:
+            expected = os.path.join(library_root, relative_path)
+            os.makedirs(expected)
+            resolution = import_one._resolve_existing_spectral_path(
+                cast(Any, RelativePathBeets()),
+                "mbid-generated",
+                True,
+                beets_library_root=library_root,
+            )
+
+            self.assertTrue(
+                _relative_path_resolved(resolution.audit_path, expected)
+            )
+            self.assertFalse(resolution.legacy_policy_path_usable)
+            self.assertIsNone(resolution.failure)
+
+    @given(
+        grade=st.sampled_from(["genuine", "suspect", "likely_transcode"]),
+        bitrate=st.one_of(st.none(), st.integers(min_value=32, max_value=400)),
+        candidate_spectral_ok=st.booleans(),
+    )
+    def test_root_resolved_audit_never_becomes_legacy_policy_input(
+        self,
+        grade: str,
+        bitrate: int | None,
+        candidate_spectral_ok: bool,
+    ):
+        from harness import import_one
+        from lib.quality import SpectralAnalysisDetail
+
+        resolution = import_one.ExistingSpectralPathResolution(
+            audit_path="/library/Artist/Album",
+            legacy_policy_path_usable=False,
+        )
+        audit = SpectralAnalysisDetail(
+            attempted=True,
+            grade=grade,
+            bitrate_kbps=bitrate,
+        )
+
+        inputs = import_one._existing_spectral_policy_inputs(
+            resolution,
+            audit,
+            candidate_spectral_ok=candidate_spectral_ok,
+        )
+
+        self.assertTrue(_audit_only_policy_inputs_unchanged(inputs))
+
     @given(
         candidate_fails=st.booleans(),
         existing_fails=st.booleans(),


### PR DESCRIPTION
## Outcome

Existing-side spectral analysis can now find library albums whose Beets item paths are stored relative to the configured library root. The root is threaded explicitly into the import harness from every preview and dispatch caller, and is used only to resolve the existing-side audit path.

## Live RCA

Production request `8853` reproduced the acceptance blocker:

- `pipeline-cli import-preview --request-id 8853 --path '/mnt/virtio/music/slskd/failed_imports/The Rolling Stones - England’s Newest Hit Makers (1964) [1fb637b8]' --json`
- Result reported `already_in_beets: true` and a genuine candidate, but `spectral.existing.attempted: false`.
- The import harness constructed `BeetsDB()` without a library root. Beets returned its stored relative item path, so the old `os.path.isdir(relative_path)` check could not find the existing album from the harness working directory.

## Fix

- Add optional `beets_library_root` plumbing through `build_import_one_command` and `run_import_one`.
- Pass `cfg.beets_directory` from both preview paths and the dispatch path.
- Add a harness `--beets-library-root` argument, omitted when empty to preserve legacy behavior.
- Resolve a relative Beets path against that root only for existing-side spectral audit collection.
- Keep BeetsDB return shapes unchanged.

## Decision neutrality

The first implementation exposed a coupling: newly resolved audit grade/floor values could enter `existing_measurement` and alter import policy. The final implementation uses a named `ExistingSpectralPathResolution` with two separate facts:

- `audit_path`: may be absolutized with the configured root so evidence is collected.
- `legacy_policy_path_usable`: records whether the raw path passed the exact pre-fix `os.path.isdir(raw_path)` gate.

Existing audit grade/floor enter legacy policy only when candidate analysis succeeded **and** the raw path was already usable before this fix. Root resolution therefore expands audit evidence without changing decisions.

The deterministic regression uses a relative existing path whose resolved `suspect / 48k` audit would change the outcome from `downgrade` to `import` if leaked into policy. It proves the fixed decision, new measurement, existing measurement, and comparison basis are identical to the pre-fix baseline while `spectral.existing` alone becomes attempted with grade, floor, suspect percentage, and per-track detail. Generated coverage varies audit grade/floor and proves audit-only paths never become legacy policy inputs; its known-bad checker rejects the leaking shape. A companion pin preserves the old behavior for raw paths that were already usable.

## Verification

- Exact signed SHA: `bbeaa895d19ef8cc8a7af25fd253a780b84e6b85`.
- Full suite: 5,450/5,450 passed.
- Exact clean artifact: `/tmp/fix-spectral-existing-library-root-bc0f62c15a-bbeaa895d19e.utkqkeuq`.
- Output SHA-256: `a2df85cdf62eed336793804779273ec01531d91f5057cf8303596467782c8387`.
- Focused affected modules plus stateful mock audit: 150 passed.
- Pyright: 0 errors, 0 warnings.
- Dead-code sweep: clean.
- Pre-push generated fuzz: all modules passed.
- `nix flake check`: all 36 checks passed.
- Two independent reviewer personas returned clean at the exact final SHA.
