### PR TITLE
Fix expanded pipeline actions on mobile

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -352,7 +352,7 @@
   /* Failure prose can carry raw paths + quoted transport errors — clamp
      it to two lines; the full text stays in the hover title. */
   .r-summary { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-align: left; }
-  .p-actions { display: flex; gap: 6px; margin-top: 8px; }
+  .p-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
   /* Manual-reason chip — small inline tag near the request title or status.
      Currently used for `search_exhausted` (red/amber) flips written by the
      variant ladder when all variants exhaust without finding a candidate. */


### PR DESCRIPTION
## Summary
- let pipeline action rows wrap instead of widening the whole page
- keep Recents evidence and expanded Download History readable at narrow viewports

## Live qualification
At a 430px Playwright viewport, expanding the real Archon attempt produced a 415px content viewport but 565px page scroll width. Applying this rule reduced page scroll width to 415px while preserving the evidence layout.

## Verification
- full suite: 5,450/5,450 passed at `46e652b6e05d9e22945fc755312f2a810577abd4`
- generated fuzz pre-push gate passed
- all 36 flake checks passed